### PR TITLE
Implement workaround for opacity-order bug

### DIFF
--- a/gui/layers/_visual_wrapper.py
+++ b/gui/layers/_visual_wrapper.py
@@ -27,6 +27,10 @@ class VisualWrapper:
 
     @_order.setter
     def _order(self, order):
+        # workaround for opacity (see: #22)
+        order = -order
+        self.z_index = order
+        # end workaround
         self._node.order = order
 
     @property


### PR DESCRIPTION
Hacky workaround to fix opacity until the bug as detailed in vispy/vispy#1541 is fixed.

See:
- #12 
- https://github.com/Napari/napari-gui/pull/21#issuecomment-433547202