### PR TITLE
range_slider collapse/expand bug fix

### DIFF
--- a/gui/util/range_slider.py
+++ b/gui/util/range_slider.py
@@ -128,10 +128,10 @@ class QRangeSlider(QtWidgets.QWidget):
         self.bc_min, self.bc_max = self.scale_min, self.scale_max
         while int(self.scale_min) < int(self.scale_max):
             step = (self.scale_max - self.scale_min) / 2
-            self.setValues(self.scale_min+step, self.scale_max-step)
+            self.setValues([self.scale_min+step, self.scale_max-step])
 
     def expand(self):
-        self.setValues(self.bc_min, self.bc_max)
+        self.setValues([self.bc_min, self.bc_max])
 
     def mouseReleaseEvent(self, event):
         if not (self.moving == "none"):


### PR DESCRIPTION
# What does this PR do? Why are doing this? References?
Collapse/expand methods were broken after changing back to PyQt style naming convention on method names. This PR propose a fix to that simple problem.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Testes manually, please test while reviewing.

## Final Checklist:
- [X] My PR is the possible minimum work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
