### PR TITLE
fix missing weakref import in layer.py

### DIFF
--- a/gui/elements/qt/_layer.py
+++ b/gui/elements/qt/_layer.py
@@ -1,5 +1,6 @@
 from PyQt5.QtWidgets import QSlider, QComboBox, QHBoxLayout, QGroupBox, QVBoxLayout, QCheckBox
 from PyQt5.QtCore import Qt
+import weakref 
 
 class QtLayer(QGroupBox):
     def __init__(self, layer):


### PR DESCRIPTION
This PR adds a missing import (`weakref`) to `napari-gui/napari_gui/elements/qt/_layer.py`

- [x] Bug fix (non-breaking change which fixes an issue)

## Final Checklist:
- [x] My PR is the possible minimum work for the desired functionality
