### PR TITLE
Horizontal Splitters 

### DIFF
--- a/gui/elements/_window.py
+++ b/gui/elements/_window.py
@@ -1,4 +1,5 @@
-from PyQt5.QtWidgets import QMainWindow, QWidget, QHBoxLayout
+from PyQt5.QtCore import Qt, QSize
+from PyQt5.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QSplitter
 
 from ._viewer import Viewer
 
@@ -31,9 +32,17 @@ class Window:
         """
         viewer = Viewer(self)
         self.viewers.append(viewer)
-        self._qt_central_widget.layout().addLayout(viewer.controls._qt)
-        self._qt_central_widget.layout().addWidget(viewer._qt)
-        self._qt_central_widget.layout().addWidget(viewer.layers._qt)
+
+        # To split vertical sliders, viewer and layerlist, minimumsizes given for demo purposes/NOT FINAL
+        horizontalSplitter = QSplitter(Qt.Horizontal)
+        viewer.controls._qt.setMinimumSize(QSize(60, 60))
+        horizontalSplitter.addWidget(viewer.controls._qt)
+        viewer._qt.setMinimumSize(QSize(500, 500))
+        horizontalSplitter.addWidget(viewer._qt)
+        viewer.layers._qt.setMinimumSize(QSize(150, 150))
+        horizontalSplitter.addWidget(viewer.layers._qt)
+
+        self._qt_central_widget.layout().addWidget(horizontalSplitter)
         return viewer
 
     def resize(self, *args):

--- a/gui/elements/_window.py
+++ b/gui/elements/_window.py
@@ -37,9 +37,9 @@ class Window:
         horizontalSplitter = QSplitter(Qt.Horizontal)
         viewer.controls._qt.setMinimumSize(QSize(60, 60))
         horizontalSplitter.addWidget(viewer.controls._qt)
-        viewer._qt.setMinimumSize(QSize(500, 500))
+        viewer._qt.setMinimumSize(QSize(100, 100))
         horizontalSplitter.addWidget(viewer._qt)
-        viewer.layers._qt.setMinimumSize(QSize(150, 150))
+        viewer.layers._qt.setMinimumSize(QSize(250, 250))
         horizontalSplitter.addWidget(viewer.layers._qt)
 
         self._qt_central_widget.layout().addWidget(horizontalSplitter)

--- a/gui/elements/qt/_controls.py
+++ b/gui/elements/qt/_controls.py
@@ -1,10 +1,13 @@
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QHBoxLayout, QSlider
+from PyQt5.QtWidgets import QHBoxLayout, QWidget
 
+from napari_gui.util.range_slider import QVRangeSlider
 
-class QtControls(QHBoxLayout):
+class QtControls(QWidget):
     def __init__(self):
         super().__init__()
 
-        self.addWidget(QSlider(Qt.Vertical))
-        self.addWidget(QSlider(Qt.Vertical))
+        self.hbox_layout = QHBoxLayout()
+        self.hbox_layout.addWidget(QVRangeSlider())
+        self.hbox_layout.addWidget(QVRangeSlider())
+        self.setLayout(self.hbox_layout)

--- a/gui/elements/qt/_controls.py
+++ b/gui/elements/qt/_controls.py
@@ -1,7 +1,8 @@
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QHBoxLayout, QWidget
 
-from napari_gui.util.range_slider import QVRangeSlider
+from ...util.range_slider import QVRangeSlider
+
 
 class QtControls(QWidget):
     def __init__(self):


### PR DESCRIPTION
# What does this PR do? Why are doing this? References?
Horizontal splitters are introduced to enable collapsable gui which will bring flexibility to user. Splitting canvas from horizontal (slicing or whatever) sliders on the bottom will be another PR after discussing some points about its implementation with @kne42 . Also, changed sliders in `gui/elements/qt/_controls.py` soon there will be an update to our custom slider to make integration into gui easier. Please provide reviews and comments.

## Type of change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
- [X] `examples/demo.py`
![initial](https://i.imgur.com/QByBJlZ.png)
![collapsed](https://i.imgur.com/Clo6ltF.png)

## Final Checklist:
- [X] My PR is the possible minimum work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works

