### PR TITLE
Unique layer naming

### DIFF
--- a/examples/layers.ipynb
+++ b/examples/layers.ipynb
@@ -37,7 +37,7 @@
    "outputs": [],
    "source": [
     "from napari_gui import imshow\n",
-    "viewer = imshow(data.camera())"
+    "viewer = imshow(data.camera(), name='camera')"
    ]
   },
   {
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "marker_list = array([[100, 100], [200, 200], [333, 111]])\n",
-    "viewer.add_markers(marker_list, size=array([10, 20, 20]))"
+    "viewer.add_markers(marker_list, size=array([10, 20, 20]), name='spots')"
    ]
   },
   {
@@ -63,7 +63,57 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer.add_image(rgb2gray(data.astronaut()),{})"
+    "viewer.add_image(rgb2gray(data.astronaut()), {}, name='astronaut')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reorder layers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer.layers.swap(0, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer.layers.reorder('astronaut', 'camera', 'spots')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer.layers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Remove first layer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer.layers.pop(0)"
    ]
   },
   {
@@ -82,8 +132,8 @@
     "from napari_gui import Window, Viewer\n",
     "viewer = Viewer()\n",
     "window = Window(viewer)\n",
-    "viewer.add_image(data.camera(),{})\n",
-    "viewer.add_image(data.camera(),{})"
+    "viewer.add_image(data.camera(), {})\n",
+    "viewer.add_image(data.camera(), {})"
    ]
   },
   {
@@ -127,47 +177,6 @@
    "source": [
     "marker_list = array([[200, 200], [50, 150], [100, 400]])\n",
     "viewer.add_markers(marker_list, size=10, face_color='blue')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Reorder layers"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "viewer.layers.swap(0,1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "viewer.layers.swap(0,3)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Remove first layer"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "viewer.layers.pop(1)"
    ]
   },
   {
@@ -265,9 +274,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:napari-gui]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-napari-gui-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -279,7 +288,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/gui/components/_layers_list/model.py
+++ b/gui/components/_layers_list/model.py
@@ -92,7 +92,7 @@ class LayersList:
         layer : Layer
             Matching layer.
         
-        Throws
+        Raises
         ------
         KeyError
             When the query returns no results.
@@ -169,7 +169,7 @@ class LayersList:
 
         Returns
         -------
-        match : int, Layer tuple or None
+        match : (int, Layer) tuple or None
             Matching index, layer pair, if found.
         """
         if start is None:

--- a/gui/components/_layers_list/model.py
+++ b/gui/components/_layers_list/model.py
@@ -5,28 +5,48 @@ from vispy.util.event import EmitterGroup, Event
 from ...layers import Layer
 
 from ...util.naming import inc_name_count
+from ...util.list import ListModel
 from .view import QtLayersPanel
 
 
-class ItemEvent(Event):
-    def __init__(self, type, item, **kwargs):
-        super().__init__(type, **kwargs)
-        self._item = item
 
-    @property
-    def item(self):
-        return self._item
-
-
-def _check_layer(obj, error=False):
-    result = isinstance(obj, Layer)
-    if error and not result:
-        raise TypeError(f'expected {obj} to be Layer; '
-                        f'got {type(obj)}') from None
-    return result
+def _add(event):
+    """Callback when an item is added to set its order and viewer.
+    """
+    layers = event.source
+    layer = event.item
+    layer.name = layers._coerce_name(layer.name, layer)
+    layer._order = -len(layers)
+    layer.viewer = layers.viewer
+    layer.events.select.connect(layers.viewer._update_layer_selection)
+    layer.events.deselect.connect(layers.viewer._update_layer_selection)
 
 
-class LayersList:
+def _remove(event):
+    """Callback when an item is removed to remove its viewer
+    and reset its order.
+    """
+    layers = event.source
+    layer = event.item
+    layer.viewer = None
+    layer._order = 0
+    layer.events.select.disconnect(layers.viewer._update_layer_selection)
+    layer.events.deselect.disconnect(layers.viewer._update_layer_selection)
+
+
+def _reorder(event):
+    """Callback when the list is reordered to propagate those changes
+    to the node draw order.
+    """
+    layers = event.source
+    for i in range(len(layers)):
+        layers[i]._order = -i
+    canvas = layers.viewer._canvas
+    canvas._draw_order.clear()
+    canvas.update()
+
+        
+class LayersList(ListModel):
     """List-like layer collection with built-in reordering and callback hooks.
 
     Parameters
@@ -38,85 +58,27 @@ class LayersList:
     ----------
     viewer : Viewer
         Parent viewer.
-    events : vispy.util.event.EmitterGroup
+    changed : vispy.util.event.EmitterGroup
         Event hooks:
-            * add_item(item): whenever an item is added
-            * remove_item(item): whenever an item is removed
-            * reorder(): whenever the list is reordered
+            * added(item, index): whenever an item is added
+            * removed(item): whenever an item is removed
+            * reordered(): whenever the list is reordered
     """
-    __slots__ = ('__weakref__', '_list', '_qt', '_viewer', 'events')
-
     def __init__(self, viewer=None):
-        self._list = []
+        super().__init__(basetype=Layer,
+                         lookup={str: lambda q, e: q == e.name})
         self._viewer = None
-        self.events = EmitterGroup(source=self,
-                                   auto_connect=True,
-                                   add_item=ItemEvent,
-                                   remove_item=ItemEvent,
-                                   reorder=Event)
 
-        self.events.add_item.connect(self._add)
-        self.events.remove_item.connect(self._remove)
-        self.events.reorder.connect(self._reorder)
+        self.changed.added.connect(_add)
+        self.changed.removed.connect(_remove)
+        self.changed.reordered.connect(_reorder)
 
         # property setting - happens last
         self.viewer = viewer
         self._qt = QtLayersPanel(self)
 
-    def __str__(self): return str(self._list)
-
-    def __repr__(self): return repr(self._list)
-
-    def __iter__(self): return iter(self._list)
-
-    def __len__(self): return len(self._list)
-
-    def __contains__(self, item):
-        try:
-            self[item]
-        except KeyError:
-            return False
-        else:
-            return True
-
-    def __getitem__(self, query):
-        """Get item in list.
-
-        Parameters
-        ----------
-        query : str, int, or slice
-            Querying index, slice or layer name.
-        
-        Returns
-        -------
-        layer : Layer
-            Matching layer.
-        
-        Raises
-        ------
-        KeyError
-            When the query returns no results.
-        """
-        # TODO: handle slicing ourselves
-        try:
-            if isinstance(query, str):
-                match = self._name_match(query)
-                if match:
-                    return match[1]
-            else:
-                return self._list[query]
-        except IndexError:
-            pass
-
-        if isinstance(query, str):
-            msg = (f'{repr(query)} does not match any layer names; '
-                   f'try one of {set(layer.name for layer in self)}')
-        elif isinstance(query, int):
-            msg = f'invalid index {query}'
-        else:
-            msg = f'invalid slice {query}'
-
-        raise KeyError(msg)
+    def __newlike__(self, iterable):
+        return ListModel(self._basetype, iterable, self._lookup)
 
     @property
     def viewer(self):
@@ -134,53 +96,24 @@ class LayersList:
             return
 
         if prev is not None:
-            self.events.add_item.disconnect(prev.dims._on_layers_change)
-            self.events.remove_item.disconnect(prev.dims._on_layers_change)
-            self.events.add_item.disconnect(prev._update_layer_selection)
-            self.events.remove_item.disconnect(prev._update_layer_selection)
-            self.events.reorder.disconnect(prev._update_layer_selection)
+            self.changed.added.disconnect(prev.dims._on_layers_change)
+            self.changed.removed.disconnect(prev.dims._on_layers_change)
+            self.changed.added.disconnect(prev._update_layer_selection)
+            self.changed.removed.disconnect(prev._update_layer_selection)
+            self.changed.reordered.disconnect(prev._update_layer_selection)
 
         for layer in self:
             layer.viewer = viewer
 
         if viewer is not None:
-            self.events.add_item.connect(viewer.dims._on_layers_change)
-            self.events.remove_item.connect(viewer.dims._on_layers_change)
-            self.events.add_item.connect(viewer._update_layer_selection)
-            self.events.remove_item.connect(viewer._update_layer_selection)
-            self.events.reorder.connect(viewer._update_layer_selection)
+            self.changed.added.connect(viewer.dims._on_layers_change)
+            self.changed.removed.connect(viewer.dims._on_layers_change)
+            self.changed.added.connect(viewer._update_layer_selection)
+            self.changed.removed.connect(viewer._update_layer_selection)
+            self.changed.reordered.connect(viewer._update_layer_selection)
             viewer = weakref.ref(viewer)
 
         self._viewer = viewer
-
-    def _name_match(self, name, start=None, stop=None, ignore=None):
-        """Check if a name matches a layer within the interval.
-
-        Parameters
-        ----------
-        name : str
-            Name of the layer.
-        start : int, optional
-            Start of the interval.
-        stop : int, optional
-            End of the interval.
-        ignore : Layer, optional
-            Layer to ignore if the names match.
-
-        Returns
-        -------
-        match : (int, Layer) tuple or None
-            Matching index, layer pair, if found.
-        """
-        if start is None:
-            start = 0
-            
-        for i, layer in enumerate(self._list[start:stop]):
-            if ignore:
-                if layer is ignore:
-                    continue
-            if layer.name == name:
-                return i + start, layer
 
     def _coerce_name(self, name, layer=None):
         """Coerce a name into a unique equivalent.
@@ -197,243 +130,16 @@ class LayersList:
         new_name : str
             Coerced, unique name.
         """
-        while self._name_match(name, ignore=layer):
-            name = inc_name_count(name)
+        for l in self:
+            if l is layer:
+                continue
+            if l.name == name:
+                name = inc_name_count(name)
+            
         return name
 
-    def _to_index(self, obj):
-        """Ensures that an object is a proper integer index.
-
-        Parameters
-        ----------
-        obj : str, int, or Layer
-            Object to be converted.
-
-        Returns
-        -------
-        index : int
-            Index of the object if it is not already an int.
-        """
-        if _check_layer(obj) or isinstance(obj, str):
-            return self.index(obj)
-        
-        if not isinstance(obj, int):
-            raise TypeError(f'expected {obj} to be str, int, or Layer; '
-                            f'got {type(obj)}') from None
-        return obj
-
-    def _reordered_list(self, ordering):
-        """Generates the reordered list given an ordering.
-
-        Parameters
-        ----------
-        ordering : iterable of int
-            Ordering of the indices to use.
-
-        Yields
-        ------
-        layer : Layer
-            Next layer in the ordered list.
-
-        Raises
-        ------
-        ValueError
-            When the improper indices are used.
-        """
-        expected = list(range(len(self)))
-
-        for o in ordering:
-            if not isinstance(o, int):
-                raise TypeError(f'expected {o} to be int; '
-                                f'got {type(o)}') from None
-            try:
-                expected.remove(o)
-            except ValueError:
-                raise ValueError(f'duplicate index: {o}') from None
-            yield self._list[o]
-
-        if expected:
-            raise ValueError(f'indices {tuple(expected)} not provided')
-
-    def append(self, layer):
-        """Appends a layer to the list.
-
-        Parameters
-        ----------
-        layer : Layer
-            Layer to append.
-        """
-        _check_layer(layer, error=True)
-
-        self._list.append(layer)
-        self.events.add_item(item=layer, index=len(self) - 1)
-
-    def insert(self, id, layer):
-        """Inserts a layer before another layer.
-
-        Parameters
-        ----------
-        id : str, int, or Lyaer
-            Layer, its name, or its index to insert before.
-        layer : Layer
-            Layer to insert.
-        """
-        _check_layer(layer, error=True)
-        index = self._to_index(id)
-
-        self._list.insert(index, layer)
-        self.events.add_item(item=layer, index=index - 1)
-
-    def pop(self, id=-1):
-        """Removes and returns a layer given its identifier.
-
-        Parameters
-        ----------
-        id : str or int, optional
-            Name or index of layer to remove.
-
-        Returns
-        -------
-        layer : Layer
-            Removed layer.
-        """
-        index = self._to_index(id)
-        layer = self._list.pop(index)
-        self.events.remove_item(item=layer)
-        return layer
-
-    def remove(self, id):
-        """Removes a layer from the list given its identifier.
-
-        Parameters
-        ----------
-        id : Layer, str, or int
-            Layer or its name to remove.
-        """
-        self.pop(id)
-
-    def __delitem__(self, id):
-        """Removes an item given its identifier.
-
-        Parameters
-        ----------
-        id : str or int
-            Index of the item to remove.
-        """
-        self.remove(id)
-
-    def swap(self, a, b):
-        """Swaps the ordering of two elements in the list.
-
-        Parameters
-        ----------
-        a : str, Layer, or int
-            Layer to swap or its index.
-        b : str, Layer, or int
-            Layer to swap or its index.
-        """
-        i = self._to_index(a)
-        j = self._to_index(b)
-
-        self._list[i], self._list[j] = self._list[j], self._list[i]
-        self.events.reorder()
-
-    def reorder(self, *ordering):
-        """Reorders the list given an iterable of its elements
-        or their indices.
-
-        Parameters
-        ----------
-        ordering : iterable of str, Layer, or int
-            Ordering of the layers. Can also be used as *args.
-
-        Notes
-        -----
-        LayerList.reorder(i, j, k, ...)
-        LayerList.reorder([i, j, k, ...])
-        """
-        if not isinstance(ordering[0], (int, str, Layer)):
-            ordering = ordering[0]
-            if not isinstance(ordering, Sequence):
-                raise TypeError(f'expected {ordering} to be Sequence; '
-                                f'got {type(ordering)}') from None
-
-        self._list[:] = self._reordered_list(self._to_index(o)
-                                             for o in ordering)
-        self.events.reorder()
-
-    def index(self, query, start=None, stop=None):
-        """Finds the index of an layer in the list.
-
-        Parameters
-        ----------
-        query : Layer or str
-            Querying layer or its name.
-        start : int, optional
-            Start of slice index to look.
-        stop : int, optional
-            Stop of slice index to look.
-
-        Returns
-        -------
-        index : int
-            Index of the layer.
-
-        Raises
-        ------
-        ValueError
-            When the query does not find a match.
-        """
-        if isinstance(query, str):
-            match = self._name_match(query, start, stop)
-            if not match:
-                raise ValueError(query)
-            return match[0]
-
-        args = (query,)
-        if stop is not None and start is None:
-            start = 0
-
-        if start is not None:
-            args += (start,)
-
-        if stop is not None:
-            args += (stop,)
-
-        return self._list.index(*args)
-
-    def _add(self, event):
-        """Callback when an item is added to set its order and viewer.
-        """
-        layer = event.item
-        layer.name = self._coerce_name(layer.name, layer)
-        layer._order = -len(self)
-        layer.viewer = self.viewer
-        layer.events.select.connect(self.viewer._update_layer_selection)
-        layer.events.deselect.connect(self.viewer._update_layer_selection)
-
-    def _remove(self, event):
-        """Callback when an item is removed to remove its viewer
-        and reset its order.
-        """
-        layer = event.item
-        layer.viewer = None
-        layer._order = 0
-        layer.events.select.disconnect(self.viewer._update_layer_selection)
-        layer.events.deselect.disconnect(self.viewer._update_layer_selection)
-
-    def _reorder(self, event):
-        """Callback when the list is reordered to propagate those changes
-        to the node draw order.
-        """
-        for i in range(len(self)):
-            self[i]._order = -i
-        canvas = self.viewer._canvas
-        canvas._draw_order.clear()
-        canvas.update()
-
     def _move_layers(self, index, insert):
-        """Reorder list by moving the item at index and insterting it
+        """Reorder list by moving the item at index and inserting it
         at the insert index. If additional items are selected these will
         get inserted at the insert index too. This allows for rearranging
         the list based on dragging and dropping a selection of items, where
@@ -459,7 +165,7 @@ class LayersList:
         offset = sum([i < insert for i in selected])
         for insert_idx, elem_idx in enumerate(selected, start=insert - offset):
             indices.insert(insert_idx, elem_idx)
-        self.reorder(indices)
+        self[:] = self[tuple(indices)]
 
     def unselect_all(self):
         for layer in self:

--- a/gui/components/_layers_list/model.py
+++ b/gui/components/_layers_list/model.py
@@ -398,6 +398,7 @@ class LayersList:
         """Callback when an item is added to set its order and viewer.
         """
         layer = event.item
+        layer.name = self._coerce_name(layer.name, layer)
         layer._order = -len(self)
         layer.viewer = self.viewer
         layer.events.select.connect(self.viewer._update_layer_selection)

--- a/gui/components/_layers_list/model.py
+++ b/gui/components/_layers_list/model.py
@@ -108,7 +108,15 @@ class LayersList:
         except IndexError:
             pass
 
-        raise KeyError(query)
+        if isinstance(query, str):
+            msg = (f'{repr(query)} does not match any layer names; '
+                   f'try one of {set(layer.name for layer in self)}')
+        elif isinstance(query, int):
+            msg = f'invalid index {query}'
+        else:
+            msg = f'invalid slice {query}'
+
+        raise KeyError(msg)
 
     @property
     def viewer(self):

--- a/gui/components/_layers_list/view/list.py
+++ b/gui/components/_layers_list/view/list.py
@@ -20,9 +20,9 @@ class QtLayersList(QScrollArea):
         self.setAcceptDrops(True)
         self.setToolTip('Layer list')
 
-        self.layers.events.add_item.connect(self._add)
-        self.layers.events.remove_item.connect(self._remove)
-        self.layers.events.reorder.connect(self._reorder)
+        self.layers.changed.added.connect(self._add)
+        self.layers.changed.removed.connect(self._remove)
+        self.layers.changed.reordered.connect(self._reorder)
 
     def _add(self, event):
         """Inserts a layer widget at a specific index

--- a/gui/components/_viewer/view/controls.py
+++ b/gui/components/_viewer/view/controls.py
@@ -14,8 +14,8 @@ class QtControls(QStackedWidget):
         self.addWidget(self.empty_widget)
         self.display(None)
 
-        self.viewer.layers.events.add_item.connect(self._add)
-        self.viewer.layers.events.remove_item.connect(self._remove)
+        self.viewer.layers.changed.added.connect(self._add)
+        self.viewer.layers.changed.removed.connect(self._remove)
 
     def display(self, layer):
         if layer is None or layer._qt_controls is None:

--- a/gui/layers/_base_layer/model.py
+++ b/gui/layers/_base_layer/model.py
@@ -24,6 +24,7 @@ class Layer(VisualWrapper, ABC):
 
     Attributes
     ----------
+    name
     ndim
     shape
     selected
@@ -40,7 +41,7 @@ class Layer(VisualWrapper, ABC):
         self._viewer = None
         self._qt_properties = None
         self._qt_controls = None
-        self.name = 'layer'
+        self.name = None
         self._freeze = False
         self._status = 'Ready'
         self._help = ''
@@ -51,6 +52,35 @@ class Layer(VisualWrapper, ABC):
                                    select=Event,
                                    deselect=Event)
 
+    def __str__(self):
+        """Return self.name
+        """
+        return self.name
+
+    def __repr__(self):
+        cls = type(self)
+        return f"<{cls.__name__} layer {repr(self.name)} at {hex(id(self))}>"
+        
+    @classmethod
+    def _basename(cls):
+        return f'{cls.__name__} 0'
+        
+    @property
+    def name(self):
+        """str: Layer's unique name.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        if not name:
+            name = self._basename()
+
+        if self.viewer:
+            name = self.viewer.layers._coerce_name(name, self)
+            
+        self._name = name
+        
     @property
     @abstractmethod
     def data(self):
@@ -184,6 +214,7 @@ class Layer(VisualWrapper, ABC):
             Previous viewer.
         """
         if self.viewer is not None:
+            self.name = self.name
             self.refresh()
 
     def _set_view_slice(self, indices):

--- a/gui/layers/_base_layer/model.py
+++ b/gui/layers/_base_layer/model.py
@@ -52,7 +52,6 @@ class Layer(VisualWrapper, ABC):
         self._viewer = None
         self._qt_properties = None
         self._qt_controls = None
-        self.name = name
         self._freeze = False
         self._status = 'Ready'
         self._help = ''
@@ -61,7 +60,9 @@ class Layer(VisualWrapper, ABC):
         self.events = EmitterGroup(source=self,
                                    auto_connect=True,
                                    select=Event,
-                                   deselect=Event)
+                                   deselect=Event,
+                                   name=Event)
+        self.name = name
 
     def __str__(self):
         """Return self.name
@@ -86,11 +87,12 @@ class Layer(VisualWrapper, ABC):
     def name(self, name):
         if not name:
             name = self._basename()
-
+        
         if self.viewer:
             name = self.viewer.layers._coerce_name(name, self)
             
         self._name = name
+        self.events.name()
         
     @property
     @abstractmethod
@@ -225,7 +227,6 @@ class Layer(VisualWrapper, ABC):
             Previous viewer.
         """
         if self.viewer is not None:
-            self.name = self.name
             self.refresh()
 
     def _set_view_slice(self, indices):

--- a/gui/layers/_base_layer/model.py
+++ b/gui/layers/_base_layer/model.py
@@ -11,16 +11,27 @@ from .._visual_wrapper import VisualWrapper
 class Layer(VisualWrapper, ABC):
     """Base layer class.
 
+    Parameters
+    ----------
+    central_node : vispy.scene.visuals.VisualNode
+        Visual node that controls all others.
+    name : str, optional
+        Name of the layer. If not provided, is automatically generated
+        from `cls._basename()`
+
+    Notes
+    -----
     Must define the following:
-        * ``_get_shape()``: called by ``shape`` property
-        * ``_refresh()``: called by ``refresh`` method
-        * ``data`` property (setter & getter)
+        * `_get_shape()`: called by `shape` property
+        * `_refresh()`: called by `refresh` method
+        * `data` property (setter & getter)
 
     May define the following:
-        * ``_set_view_slice(indices)``: called to set currently viewed slice
-        * ``_after_set_viewer()``: called after the viewer is set
-        * ``_qt_properties``: QtWidget inserted into the layer list GUI
-        * ``_qt_controls``: QtWidget inserted into the controls panel GUI
+        * `_set_view_slice(indices)`: called to set currently viewed slice
+        * `_after_set_viewer()`: called after the viewer is set
+        * `_qt_properties`: QtWidget inserted into the layer list GUI
+        * `_qt_controls`: QtWidget inserted into the controls panel GUI
+        * `_basename()`: base/default name of the layer
 
     Attributes
     ----------
@@ -35,13 +46,13 @@ class Layer(VisualWrapper, ABC):
     refresh()
         Refresh the current view.
     """
-    def __init__(self, central_node):
+    def __init__(self, central_node, name=None):
         super().__init__(central_node)
         self._selected = False
         self._viewer = None
         self._qt_properties = None
         self._qt_controls = None
-        self.name = None
+        self.name = name
         self._freeze = False
         self._status = 'Ready'
         self._help = ''

--- a/gui/layers/_base_layer/view/properties.py
+++ b/gui/layers/_base_layer/view/properties.py
@@ -21,9 +21,11 @@ class QtLayer(QFrame):
 
     def __init__(self, layer):
         super().__init__()
+
         self.layer = layer
-        self.layer.events.select.connect(self._on_select)
-        self.layer.events.deselect.connect(self._on_deselect)
+        layer.events.select.connect(self._on_select)
+        layer.events.deselect.connect(self._on_deselect)
+        layer.events.name.connect(self._on_layer_name_change)
 
         self.setObjectName('layer')
         self.layer.selected = True
@@ -43,8 +45,8 @@ class QtLayer(QFrame):
         textbox.setToolTip('Layer name')
         textbox.setFixedWidth(80)
         textbox.setAcceptDrops(False)
-        textbox.editingFinished.connect(
-            lambda text=textbox: self.changeText(text))
+        textbox.editingFinished.connect(self.changeText)
+        self.nameTextBox = textbox
         self.grid_layout.addWidget(textbox, 0, 1)
 
         self.grid_layout.addWidget(QLabel('opacity:'), 1, 0)
@@ -94,8 +96,8 @@ class QtLayer(QFrame):
         else:
             self.layer.visible = False
 
-    def changeText(self, text):
-        self.layer.name = text.text()
+    def changeText(self):
+        self.layer.name = self.nameTextBox.text()
 
     def changeBlending(self, text):
         self.layer.blending = text
@@ -168,3 +170,7 @@ class QtLayer(QFrame):
 
     def update(self):
         return
+
+    def _on_layer_name_change(self, event):
+        with self.layer.events.blocker(self._on_layer_name_change):
+            self.nameTextBox.setText(self.layer.name)

--- a/gui/layers/_image_layer/model.py
+++ b/gui/layers/_image_layer/model.py
@@ -57,6 +57,7 @@ AVAILABLE_COLORMAPS = {k: vispy_or_mpl_colormap(k)
                        list(color.get_colormaps())}
 
 
+
 @add_to_viewer
 class Image(Layer):
     """Image layer.
@@ -67,15 +68,17 @@ class Image(Layer):
         Image data.
     meta : dict
         Image metadata.
+    name : str, keyword-only
+        Name of the layer.
     """
     _colormaps = AVAILABLE_COLORMAPS
 
     default_cmap = 'magma'
     default_interpolation = 'nearest'
 
-    def __init__(self, image, meta):
+    def __init__(self, image, meta, *, name=None):
         self.visual = ImageNode(None, method='auto')
-        super().__init__(self.visual)
+        super().__init__(self.visual, name)
 
         self._image = image
         self._meta = meta

--- a/gui/layers/_image_layer/model.py
+++ b/gui/layers/_image_layer/model.py
@@ -87,8 +87,6 @@ class Image(Layer):
         self._need_display_update = False
         self._need_visual_update = False
 
-        self.name = 'image'
-
         self._clim_range = self._clim_range_default()
         self._node.clim = [np.min(self.image), np.max(self.image)]
 

--- a/gui/layers/_image_layer/model.py
+++ b/gui/layers/_image_layer/model.py
@@ -77,6 +77,11 @@ class Image(Layer):
     default_interpolation = 'nearest'
 
     def __init__(self, image, meta, *, name=None):
+        try:
+            name = meta['name']
+        except KeyError:
+            pass
+        
         self.visual = ImageNode(None, method='auto')
         super().__init__(self.visual, name)
 

--- a/gui/layers/_markers_layer/model.py
+++ b/gui/layers/_markers_layer/model.py
@@ -100,8 +100,6 @@ class Markers(Layer):
             self._need_display_update = False
             self._need_visual_update = False
 
-            self.name = 'markers'
-
             self.events.add(mode=Event)
             self._qt_properties = QtMarkersLayer(self)
             self._qt_controls = QtMarkersControls(self)

--- a/gui/layers/_markers_layer/model.py
+++ b/gui/layers/_markers_layer/model.py
@@ -23,57 +23,39 @@ class Markers(Layer):
     Parameters
     ----------
     coords : np.ndarray
-        coordinates for each marker.
-
+        Coordinates for each marker.
     symbol : str
-        symbol to be used as a marker
-
+        Symbol to be used as a marker
     size : int, float, np.ndarray, list
-        size of the marker. If given as a scalar, all markers are the
+        Size of the marker. If given as a scalar, all markers are the
         same size. If given as a list/array, size must be the same
         length as coords and sets the marker size for each marker
         in coords (element-wise). If n_dimensional is True then can be a list
         of length dims or can be an array of shape Nxdims where N is the number
         of markers and dims is the number of dimensions
-
     edge_width : int, float, None
-        width of the symbol edge in px
-            vispy docs say: "exactly one edge_width and
-            edge_width_rel must be supplied"
-
+        Width of the symbol edge in pixels.
     edge_width_rel : int, float, None
-        width of the marker edge as a fraction of the marker size.
-
-            vispy docs say: "exactly one edge_width and
-            edge_width_rel must be supplied"
-
+        Width of the marker edge as a fraction of the marker size.
     edge_color : Color, ColorArray
-        color of the marker border
-
+        Color of the marker border.
     face_color : Color, ColorArray
-        color of the marker body
-
+        Color of the marker body.
     scaling : bool
-        if True, marker rescales when zooming
-
+        If True, marker rescales when zooming.
     n_dimensional : bool
-        if True, renders markers not just in central plane but also in all
-        n dimensions according to specified marker size
+        If True, renders markers not just in central plane but also in all
+        n-dimensions according to specified marker size.
 
+    Notes
+    -----
     See vispy's marker visual docs for more details:
     http://api.vispy.org/en/latest/visuals.html#vispy.visuals.MarkersVisual
-
-
-
     """
-
-    def __init__(
-        self, coords, symbol='o', size=10, edge_width=1,
-            edge_width_rel=None, edge_color='black', face_color='white',
-            scaling=True, n_dimensional=False):
-
-        visual = MarkersNode()
-        super().__init__(visual)
+    def __init__(self, coords, symbol='o', size=10, edge_width=1,
+                 edge_width_rel=None, edge_color='black', face_color='white',
+                 scaling=True, n_dimensional=False, *, name=None):
+        super().__init__(MarkersNode(), name)
 
         # Freeze refreshes
         with self.freeze_refresh():
@@ -95,7 +77,7 @@ class Markers(Layer):
             self._mode = 'pan/zoom'
             self._mode_history = self._mode
             self._status = self._mode
-
+            
             # update flags
             self._need_display_update = False
             self._need_visual_update = False

--- a/gui/layers/_register.py
+++ b/gui/layers/_register.py
@@ -41,7 +41,11 @@ class CallSignature(inspect.Signature):
 
     
     def __str__(self):
-        """do not render separators"""
+        """do not render separators
+
+        commented code is what was taken out from 
+        the copy/pasted inspect module code :)
+        """
         result = []
         # render_pos_only_separator = False
         # render_kw_only_separator = True

--- a/gui/layers/_register.py
+++ b/gui/layers/_register.py
@@ -20,6 +20,7 @@ def camel_to_snake(name):
 
 class CallDefault(inspect.Parameter):
     def __str__(self):
+        """wrap defaults"""
         kind = self.kind
         formatted = self._name
 
@@ -37,6 +38,54 @@ class CallDefault(inspect.Parameter):
 
 class CallSignature(inspect.Signature):
     _parameter_cls = CallDefault
+
+    
+    def __str__(self):
+        """do not render separators"""
+        result = []
+        # render_pos_only_separator = False
+        # render_kw_only_separator = True
+        for param in self.parameters.values():
+            formatted = str(param)
+
+            # kind = param.kind
+
+            # if kind == inspect._POSITIONAL_ONLY:
+            #     render_pos_only_separator = True
+            # elif render_pos_only_separator:
+            #     # It's not a positional-only parameter, and the flag
+            #     # is set to 'True' (there were pos-only params before.)
+            #     result.append('/')
+            #     render_pos_only_separator = False
+
+            # if kind == inspect._VAR_POSITIONAL:
+            #     # OK, we have an '*args'-like parameter, so we won't need
+            #     # a '*' to separate keyword-only arguments
+            #     render_kw_only_separator = False
+            # elif kind == inspect._KEYWORD_ONLY and render_kw_only_separator:
+            #     # We have a keyword-only parameter to render and we haven't
+            #     # rendered an '*args'-like parameter before, so add a '*'
+            #     # separator to the parameters list ("foo(arg1, *, arg2)" case)
+            #     result.append('*')
+            #     # This condition should be only triggered once, so
+            #     # reset the flag
+            #     render_kw_only_separator = False
+
+            result.append(formatted)
+
+        # if render_pos_only_separator:
+        #     # There were only positional-only parameters, hence the
+        #     # flag was not reset to 'False'
+        #     result.append('/')
+
+        rendered = '({})'.format(', '.join(result))
+
+        if self.return_annotation is not inspect._empty:
+            anno = inspect.formatannotation(self.return_annotation)
+            rendered += ' -> {}'.format(anno)
+
+        return rendered
+
 
 
 def create_func(cls, name=None, doc=None):
@@ -109,3 +158,5 @@ def add_to_viewer(cls=None, *, name=None, doc=None):
 
     def inner(cls):
         return _register(cls, name=name, doc=doc)
+
+    return inner

--- a/gui/util/list/__init__.py
+++ b/gui/util/list/__init__.py
@@ -1,0 +1,4 @@
+from ._base import List
+from ._model import ListModel
+from ._multi import MultiIndexList
+from ._typed import TypedList

--- a/gui/util/list/_base.py
+++ b/gui/util/list/_base.py
@@ -1,0 +1,145 @@
+from collections.abc import Iterable
+
+
+class List(list):
+    """Inheritable list that better connects related/dependent functions,
+    allowing for an easier time making modifications with reusable components.
+    
+    It has the following new methods:
+    `__locitem__(key)` : transform a key into the index of its corresponding item
+    `__prsitem__(key)` : parse a key such as `0:1` into indices
+    `__newlike__(iterable)` : create a new instance given an iterable
+    
+    TODO: handle operators (e.g. +, *, etc.)
+    """
+    def __contains__(self, key):
+        try:
+            self.index(key)
+            return True
+        except ValueError:
+            return False
+        
+    def __iter__(self):
+        for i in range(len(self)):
+            yield self[i]
+        
+    def __getitem__(self, key):
+        indices = self.__prsitem__(key)
+        can_iter = isinstance(indices, Iterable)
+        
+        if can_iter:
+            return self.__newlike__(super(List, self).__getitem__(i) for i in indices)
+            
+        return super().__getitem__(indices)
+    
+    def __setitem__(self, key, value):
+        super().__setitem__(self.__locitem__(key), value)
+        
+    def __delitem__(self, key):
+        super().remove(key)
+        
+    def __prsitem__(self, key):
+        """Parse a key into list indices.
+        
+        Default implementation handles slices
+        
+        Parameters
+        ----------
+        key : any
+            Key to parse.
+        
+        Returns
+        -------
+        indices : int or iterable of int
+            Key parsed into indices.
+        """
+        if isinstance(key, slice):
+            start = key.start
+            stop = key.stop
+            step = key.step
+            
+            if start is not None:
+                try:
+                    start = self.__locitem__(start)
+                except IndexError:
+                    if start != len(self):
+                        raise
+            
+            if stop is not None:
+                try:
+                    stop = self.__locitem__(stop)
+                except IndexError:
+                    if stop != len(self):
+                        raise
+            
+            return range(*slice(start, stop, step).indices(len(self)))
+        else:
+            return self.__locitem__(key)
+        
+    def __locitem__(self, key):
+        """Parse a key into a list index.
+        
+        Default implementation handles integers.
+        
+        Parameters
+        ----------
+        key : any
+            Key to parse.
+            
+        Returns
+        -------
+        index : int
+            Location of the object ``key`` is referencing.
+            
+        Raises
+        ------
+        IndexError
+            When the index is out of bounds.
+        KeyError
+            When the key is otherwise invalid.
+        """ 
+        if not isinstance(key, int):
+            raise TypeError(f'expected int; got {type(key)}')
+        
+        if key < 0:
+            key += len(self)
+            
+        if not (0 <= key < len(self)):
+            raise IndexError(f'expected index to be in [0, {len(self)}); got {key}')
+            
+        return key
+    
+    def __newlike__(self, iterable):
+        """Create a new instance from an iterable with the same properties as this one.
+        
+        Parameters
+        ----------
+        iterable : iterable
+            Elements to make the new list from.
+            
+        Returns
+        -------
+        new_list : List
+            New list created from the iterable with the same properties.
+        """
+        cls = type(self)
+        return cls(iterable)
+        
+    def copy(self):
+        return self.__newlike__(self)
+        
+    def count(self, key):
+        super().count(self.__locitem__(key))
+    
+    def extend(self, iterable):
+        for e in iterable:
+            self.append(e)
+            
+    def insert(self, index, object):
+        super().insert(self.__locitem__(index), object)
+        
+    def pop(self, index):
+        return super().pop(self.__locitem__(index))
+        
+    def remove(self, object):
+        self.pop(self.__locitem__(object))

--- a/gui/util/list/_model.py
+++ b/gui/util/list/_model.py
@@ -1,0 +1,56 @@
+from vispy.util.event import EmitterGroup
+
+from ._multi import MultiIndexList
+from ._typed import TypedList
+
+
+class ListModel(MultiIndexList, TypedList):
+    """List with events, tuple-indexing, typing, and filtering.
+    
+    Parameters
+    ----------
+    basetype : type
+        Type of the elements in the list.
+    iterable : iterable, optional
+        Elements to initialize the list with.
+    lookup : dict of type : function(object, ``basetype``) -> bool
+        Functions that determine if an object is a reference to an
+        element of the list.
+
+    Attributes
+    ----------
+    changed : vispy.util.event.EmitterGroup
+        Group of events for adding, removing, and reordering elements
+        within the list.
+    """
+    def __init__(self, basetype, iterable=(), lookup=None):
+        super().__init__(basetype, iterable, lookup)
+        self.changed = EmitterGroup(source=self,
+                                    auto_connect=True,
+                                    added=None,
+                                    removed=None,
+                                    reordered=None)
+
+    def __setitem__(self, query, values):
+        indices = tuple(self.__prsitem__(query))
+        new_indices = tuple(values)
+        
+        if sorted(indices) != sorted(self.index(v) for v in new_indices):
+            raise TypeError('must be a reordering of indices; '
+                            'setting of list items not allowed')
+        
+        super().__setitem__(indices, new_indices)
+        self.changed.reordered()
+
+    def insert(self, index, object):
+        super().insert(index, object)
+        self.changed.added(item=object, index=self.__locitem__(index))
+        
+    def append(self, object):
+        super(TypedList, self).append(object)
+        self.changed.added(item=object, index=len(self) - 1)
+        
+    def pop(self, key):
+        obj = super().pop(key)
+        self.changed.removed(item=obj)
+        return obj

--- a/gui/util/list/_multi.py
+++ b/gui/util/list/_multi.py
@@ -1,0 +1,53 @@
+from collections.abc import Iterable
+from ._base import List
+
+
+class MultiIndexList(List):
+    """Allow indexing with tuples.
+    """
+    def __prsitem__(self, keys):
+        if not isinstance(keys, tuple):
+            return super().__prsitem__(keys)
+            
+        indices = []
+        
+        for key in keys:
+            i = self.__prsitem__(key)
+            can_iter = isinstance(i, Iterable)
+            if can_iter:
+                indices.extend(i)
+            else:
+                indices.append(i)
+                
+        # TODO: how to handle duplicates?
+                
+        return indices
+    
+    def __setitem__(self, key, value):
+        indices = self.__prsitem__(key)
+        can_iter = isinstance(indices, Iterable)
+        
+        if can_iter:
+            if hasattr(value, '__getitem__') and hasattr(value, '__len__'):
+                # value is a vector
+                if len(value) != len(indices):
+                    raise ValueError(f'expected {len(indices)} values; '
+                                     f'got {len(value)}')
+                for o, i in enumerate(indices):
+                    super().__setitem__(i, value[o])
+            else:
+                # value is a scalar
+                for i in indices:
+                    super().__setitem__(i, value)
+        else:
+            super().__setitem__(indices, value)
+            
+    def __delitem__(self, key):
+        indices = self.__prsitem__(key)
+        can_iter = isinstance(indices, Iterable)
+        
+        if can_iter:
+            for i in indices:
+                super().__delitem__(i)
+        else:        
+            super().__delitem__(indices)

--- a/gui/util/list/_typed.py
+++ b/gui/util/list/_typed.py
@@ -1,0 +1,80 @@
+from ._base import List
+
+
+def cpprint(obj):
+    return obj.__name__
+
+
+class TypedList(List):
+    """Enforce list elements to be of a specific type and allow indexing with their unique properties.
+    
+    Parameters
+    ----------
+    basetype : type
+        Type of the elements in the list.
+    iterable : iterable, optional
+        Elements to initialize the list with.
+    lookup : dict of type : function(object, ``basetype``) -> bool
+        Functions that determine if an object is a reference to an
+        element of the list.
+    """
+    def __init__(self, basetype, iterable=(), lookup=None):
+        if lookup is None:
+            lookup = {}
+        self._basetype = basetype
+        self._lookup = lookup
+        super().__init__(self._check(e) for e in iterable)
+        
+    def __setitem__(self, key, value):
+        self._check(value)
+        super().__setitem__(key, value)
+        
+    def __locitem__(self, key):
+        if not isinstance(key, int):
+            key = self.index(key)
+        return super().__locitem__(key)
+    
+    def __newlike__(self, iterable):
+        cls = type(self)
+        return cls(self._basetype, iterable, self._lookup)
+    
+    def _check(self, e):
+        if not isinstance(e, self._basetype):
+            raise TypeError(f'expected {cpprint(self._basetype)}; '
+                            f'got {cpprint(type(e))}')
+        return e
+        
+    def insert(self, key, object):
+        self._check(object)
+        super().insert(key, object)
+        
+    def append(object):
+        self._check(object)
+        super().append(object)
+        
+    def index(self, value, start=None, stop=None):
+        q = value
+        basetype = self._basetype
+        
+        if not isinstance(q, basetype):
+            lookup = self._lookup
+            
+            for t in lookup:
+                if isinstance(q, t):
+                    break
+            else:
+                raise TypeError(f'expected object of type {cpprint(basetype)} '
+                                f'or one of {set(cpprint(t) for t in lookup)}; '
+                                f'got {cpprint(type(q))}')
+                
+            ref = lookup[t]
+            
+            for e in self[start:stop]:
+                if ref(q, e):
+                    break
+            else:
+                raise KeyError(f'could not find element {q} was referencing')
+                
+            q = e
+                
+        return super().index(q)

--- a/gui/util/misc.py
+++ b/gui/util/misc.py
@@ -1,5 +1,6 @@
 """Miscellaneous utility functions.
 """
+import inspect
 
 
 def is_multichannel(meta):
@@ -99,6 +100,17 @@ def compute_max_shape(shapes, max_dims=None):
                 if dim_len > max_shape[dim]:
                     max_shape[dim] = dim_len
     return tuple(max_shape)
+
+
+def formatdoc(obj):
+    """Substitute globals and locals into an object's docstring.
+    """
+    frame = inspect.currentframe().f_back
+    try:
+        obj.__doc__ = obj.__doc__.format(**{**frame.f_globals, **frame.f_locals})
+        return obj
+    finally:
+        del frame
 
 
 _app = None

--- a/gui/util/naming.py
+++ b/gui/util/naming.py
@@ -1,6 +1,7 @@
 """Automatically generate names.
 """
 import re
+from .misc import formatdoc
 
 
 sep = ' '
@@ -22,10 +23,11 @@ def _inc_name_count_sub(match):
     return count
 
 
+@formatdoc
 def inc_name_count(name):
-    """Increase a name's count matching `{}` by ``1``.
+    """Increase a name's count matching `{numbered_patt}` by ``1``.
 
-    If the name is not already numbered, append '{}{}'.
+    If the name is not already numbered, append '{sep}{start}'.
 
     Parameters
     ----------
@@ -36,5 +38,5 @@ def inc_name_count(name):
     -------
     incremented_name : str
         Numbered name incremented by ``1``.
-    """.format(numbered_patt, sep, start)
+    """
     return numbered_patt.sub(_inc_name_count_sub, name)

--- a/gui/util/naming.py
+++ b/gui/util/naming.py
@@ -1,0 +1,40 @@
+"""Automatically generate names.
+"""
+import re
+
+
+sep = ' '
+start = 1
+
+numbered_patt = re.compile(r'(?<!\d)(?:\d+|)$')
+
+
+def _inc_name_count_sub(match):
+    count = match.group(0)
+    
+    try:
+        count = int(count)
+    except ValueError:  # not an int
+        count = f'{sep}{start}'
+    else:
+        count = f'{count + 1}'
+        
+    return count
+
+
+def inc_name_count(name):
+    """Increase a name's count matching `{}` by ``1``.
+
+    If the name is not already numbered, append '{}{}'.
+
+    Parameters
+    ----------
+    name : str
+        Original name.
+
+    Returns
+    -------
+    incremented_name : str
+        Numbered name incremented by ``1``.
+    """.format(numbered_patt, sep, start)
+    return numbered_patt.sub(_inc_name_count_sub, name)

--- a/gui/util/tests/test_naming.py
+++ b/gui/util/tests/test_naming.py
@@ -1,0 +1,35 @@
+from ..naming import numbered_patt, inc_name_count, sep, start
+
+
+def test_re_base_num():
+    assert numbered_patt.search('layer 12').group(0) == '12'
+
+
+def test_re_base_empty():
+    assert numbered_patt.search('layer').group(0) == ''
+
+
+def test_re_other_digs():
+    assert numbered_patt.search('layer3 123').group(0) == '123'
+
+
+def test_re_no_space():
+    assert numbered_patt.search('layer7').group(0) == '7'
+
+    
+def test_re_first_dig():
+    assert numbered_patt.search('42').group(0) == '42'
+
+
+def test_re_sub_base_num():
+    assert numbered_patt.sub('8', 'layer 7') == 'layer 8'
+
+
+def test_re_sub_base_empty():
+    assert numbered_patt.sub(' 3', 'layer') == 'layer 3'
+
+
+def test_inc_name_count():
+    assert inc_name_count('layer 7') == 'layer 8'
+    assert inc_name_count('layer') == f'layer{sep}{start}'
+    assert inc_name_count('41') == '42'


### PR DESCRIPTION
# Description
Enforce unique layer naming:
- automatically generate names from a base until a unique one is found
- allow `LayerList` to be indexed using strings (names)
- update Qt layer widget with the name of the layer when set programmatically

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
See #4 
closes #47

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] util/tests/test_naming passes
- [x] `layers.ipynb` works as expected

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
