### PR TITLE
add n dimensional markers display

### DIFF
--- a/examples/layers.ipynb
+++ b/examples/layers.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,11 +30,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/nicholassofroniew/anaconda3/lib/python3.6/site-packages/vispy/visuals/isocurve.py:22: UserWarning: VisPy is not yet compatible with matplotlib 2.2+\n",
+      "  warnings.warn(\"VisPy is not yet compatible with matplotlib 2.2+\")\n"
+     ]
+    }
+   ],
    "source": [
     "from napari_gui import imshow\n",
     "window = imshow(data.camera())"
@@ -49,9 +58,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<napari_gui.layers._image_layer.Image at 0x10a7bc128>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "window.viewer.add_image(rgb2gray(data.astronaut()),{})"
    ]
@@ -65,9 +85,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<napari_gui.layers._image_layer.Image at 0x120d1aa58>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from napari_gui import Window, Viewer\n",
     "viewer = Viewer()\n",
@@ -85,9 +116,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<napari_gui.layers._image_layer.Image at 0x121c6c748>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "viewer.add_image(rgb2gray(data.astronaut()),{})"
    ]
@@ -101,9 +143,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<napari_gui.layers._markers_layer.Markers at 0x1209a3278>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "marker_list = array([[100, 100], [200, 200], [333, 111]])\n",
     "viewer.add_markers(marker_list, size=array([10, 20, 20]))"
@@ -231,7 +284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +294,7 @@
     "viewer.add_image(random.rand(500, 500, 20, 10),{})\n",
     "viewer.add_image(random.rand(500, 500, 20, 10),{})\n",
     "marker_list = array([[200, 200, 0, 0], [50, 150, 0, 0], [100, 400, 1, 0], [300, 200, 0, 1], [400, 100, 0, 1]])\n",
-    "viewer.add_markers(marker_list, size=[10, 10, 3, 3], face_color='blue', n_dimensional=True)\n",
+    "viewer.add_markers(marker_list, size=[10, 10, 6, 0.5], face_color='blue', n_dimensional=True)\n",
     "window.show()"
    ]
   },

--- a/examples/layers.ipynb
+++ b/examples/layers.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,20 +29,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/nicholassofroniew/anaconda3/lib/python3.6/site-packages/vispy/visuals/isocurve.py:22: UserWarning: VisPy is not yet compatible with matplotlib 2.2+\n",
-      "  warnings.warn(\"VisPy is not yet compatible with matplotlib 2.2+\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from napari_gui import imshow\n",
     "window = imshow(data.camera())"
@@ -57,20 +48,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<napari_gui.layers._image_layer.Image at 0x125d94278>"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "window.viewer.add_image(rgb2gray(data.astronaut()),{})"
    ]
@@ -84,20 +64,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<napari_gui.layers._image_layer.Image at 0x124ca2ba8>"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from napari_gui import Window, Viewer\n",
     "viewer = Viewer()\n",
@@ -115,20 +84,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<napari_gui.layers._image_layer.Image at 0x1248b4438>"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "viewer.add_image(rgb2gray(data.astronaut()),{})"
    ]
@@ -142,20 +100,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<napari_gui.layers._markers_layer.Markers at 0x12490ecf8>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "marker_list = array([[100, 100], [200, 200], [333, 111]])\n",
     "viewer.add_markers(marker_list, size=array([10, 20, 20]))"
@@ -163,20 +110,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<napari_gui.layers._markers_layer.Markers at 0x1250866a0>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "marker_list = array([[200, 200], [50, 150], [100, 400]])\n",
     "viewer.add_markers(marker_list, size=10, face_color='blue')"
@@ -248,7 +184,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,18 +207,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/nicholassofroniew/anaconda3/lib/python3.6/site-packages/vispy/visuals/isocurve.py:22: UserWarning: VisPy is not yet compatible with matplotlib 2.2+\n",
-      "  warnings.warn(\"VisPy is not yet compatible with matplotlib 2.2+\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from napari_gui import Window, Viewer\n",
     "viewer = Viewer()\n",
@@ -303,18 +230,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/nicholassofroniew/anaconda3/lib/python3.6/site-packages/vispy/visuals/isocurve.py:22: UserWarning: VisPy is not yet compatible with matplotlib 2.2+\n",
-      "  warnings.warn(\"VisPy is not yet compatible with matplotlib 2.2+\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from napari_gui import Window, Viewer\n",
     "viewer = Viewer()\n",

--- a/examples/layers.ipynb
+++ b/examples/layers.ipynb
@@ -17,7 +17,8 @@
     "\n",
     "from skimage import data\n",
     "from skimage.color import rgb2gray\n",
-    "from numpy import array, random"
+    "from numpy import array, random\n",
+    "import numpy as np"
    ]
   },
   {

--- a/examples/layers.ipynb
+++ b/examples/layers.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,11 +29,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/nicholassofroniew/anaconda3/lib/python3.6/site-packages/vispy/visuals/isocurve.py:22: UserWarning: VisPy is not yet compatible with matplotlib 2.2+\n",
+      "  warnings.warn(\"VisPy is not yet compatible with matplotlib 2.2+\")\n"
+     ]
+    }
+   ],
    "source": [
     "from napari_gui import imshow\n",
     "window = imshow(data.camera())"
@@ -48,9 +57,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<napari_gui.layers._image_layer.Image at 0x125d94278>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "window.viewer.add_image(rgb2gray(data.astronaut()),{})"
    ]
@@ -64,9 +84,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<napari_gui.layers._image_layer.Image at 0x124ca2ba8>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from napari_gui import Window, Viewer\n",
     "viewer = Viewer()\n",
@@ -84,9 +115,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<napari_gui.layers._image_layer.Image at 0x1248b4438>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "viewer.add_image(rgb2gray(data.astronaut()),{})"
    ]
@@ -100,9 +142,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<napari_gui.layers._markers_layer.Markers at 0x12490ecf8>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "marker_list = array([[100, 100], [200, 200], [333, 111]])\n",
     "viewer.add_markers(marker_list, size=array([10, 20, 20]))"
@@ -110,9 +163,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<napari_gui.layers._markers_layer.Markers at 0x1250866a0>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "marker_list = array([[200, 200], [50, 150], [100, 400]])\n",
     "viewer.add_markers(marker_list, size=10, face_color='blue')"
@@ -184,7 +248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,6 +259,70 @@
     "viewer.add_image(random.rand(500, 500, 20, 10),{})\n",
     "marker_list = array([[200, 200, 0, 0], [50, 150, 0, 0], [100, 400, 1, 0]])\n",
     "viewer.add_markers(marker_list, size=10, face_color='blue')\n",
+    "window.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Add multidim markers with one size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/nicholassofroniew/anaconda3/lib/python3.6/site-packages/vispy/visuals/isocurve.py:22: UserWarning: VisPy is not yet compatible with matplotlib 2.2+\n",
+      "  warnings.warn(\"VisPy is not yet compatible with matplotlib 2.2+\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "from napari_gui import Window, Viewer\n",
+    "viewer = Viewer()\n",
+    "window = Window(viewer, show=False)\n",
+    "viewer.add_image(random.rand(500, 500, 20, 10),{})\n",
+    "viewer.add_image(random.rand(500, 500, 20, 10),{})\n",
+    "marker_list = array([[200, 200, 0, 0], [50, 150, 0, 0], [100, 400, 1, 0], [300, 200, 0, 1], [400, 100, 0, 1]])\n",
+    "viewer.add_markers(marker_list, size=10, face_color='blue', n_dimensional=True)\n",
+    "window.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Add multidim markers with list of sizes for, one for each dimension"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/nicholassofroniew/anaconda3/lib/python3.6/site-packages/vispy/visuals/isocurve.py:22: UserWarning: VisPy is not yet compatible with matplotlib 2.2+\n",
+      "  warnings.warn(\"VisPy is not yet compatible with matplotlib 2.2+\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "from napari_gui import Window, Viewer\n",
+    "viewer = Viewer()\n",
+    "window = Window(viewer, show=False)\n",
+    "viewer.add_image(random.rand(500, 500, 20, 10),{})\n",
+    "viewer.add_image(random.rand(500, 500, 20, 10),{})\n",
+    "marker_list = array([[200, 200, 0, 0], [50, 150, 0, 0], [100, 400, 1, 0], [300, 200, 0, 1], [400, 100, 0, 1]])\n",
+    "viewer.add_markers(marker_list, size=[10, 10, 3, 3], face_color='blue', n_dimensional=True)\n",
     "window.show()"
    ]
   },

--- a/examples/layers.ipynb
+++ b/examples/layers.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,20 +30,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/nicholassofroniew/anaconda3/lib/python3.6/site-packages/vispy/visuals/isocurve.py:22: UserWarning: VisPy is not yet compatible with matplotlib 2.2+\n",
-      "  warnings.warn(\"VisPy is not yet compatible with matplotlib 2.2+\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from napari_gui import imshow\n",
     "window = imshow(data.camera())"
@@ -58,20 +49,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<napari_gui.layers._image_layer.Image at 0x10a7bc128>"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "window.viewer.add_image(rgb2gray(data.astronaut()),{})"
    ]
@@ -85,20 +65,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<napari_gui.layers._image_layer.Image at 0x120d1aa58>"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from napari_gui import Window, Viewer\n",
     "viewer = Viewer()\n",
@@ -116,20 +85,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<napari_gui.layers._image_layer.Image at 0x121c6c748>"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "viewer.add_image(rgb2gray(data.astronaut()),{})"
    ]
@@ -143,20 +101,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<napari_gui.layers._markers_layer.Markers at 0x1209a3278>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "marker_list = array([[100, 100], [200, 200], [333, 111]])\n",
     "viewer.add_markers(marker_list, size=array([10, 20, 20]))"
@@ -247,7 +194,7 @@
     "window = Window(viewer, show=False)\n",
     "viewer.add_image(random.rand(500, 500, 20, 10),{})\n",
     "viewer.add_image(random.rand(500, 500, 20, 10),{})\n",
-    "marker_list = array([[200, 200, 0, 0], [50, 150, 0, 0], [100, 400, 1, 0]])\n",
+    "marker_list = array([[200, 200, 0, 0], [50, 150, 0, 0], [100, 400, 1, 0], [300, 200, 0, 1], [400, 100, 0, 1]])\n",
     "viewer.add_markers(marker_list, size=10, face_color='blue')\n",
     "window.show()"
    ]
@@ -284,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +241,7 @@
     "viewer.add_image(random.rand(500, 500, 20, 10),{})\n",
     "viewer.add_image(random.rand(500, 500, 20, 10),{})\n",
     "marker_list = array([[200, 200, 0, 0], [50, 150, 0, 0], [100, 400, 1, 0], [300, 200, 0, 1], [400, 100, 0, 1]])\n",
-    "viewer.add_markers(marker_list, size=[10, 10, 6, 0.5], face_color='blue', n_dimensional=True)\n",
+    "viewer.add_markers(marker_list, size=[10, 10, 6, 0], face_color='blue', n_dimensional=True)\n",
     "window.show()"
    ]
   },

--- a/gui/layers/_markers_layer.py
+++ b/gui/layers/_markers_layer.py
@@ -129,6 +129,19 @@ class Markers(Layer):
         self.coords = data
 
     @property
+    def n_dimensional(self) -> str:
+        """ bool: if True, renders markers not just in central plane but also in all
+        n dimensions according to specified marker size
+        """
+        return self._n_dimensional
+
+    @n_dimensional.setter
+    def n_dimensional(self, n_dimensional: bool) -> None:
+        self._n_dimensional = n_dimensional
+
+        self.refresh()
+
+    @property
     def symbol(self) -> str:
         """ str: marker symbol
         """
@@ -265,7 +278,7 @@ class Markers(Layer):
         # Get a list of the coords for the markers in this slice
         coords = self.coords
         if len(coords) > 0:
-            if self._n_dimensional is True and self.ndim > 2:
+            if self.n_dimensional is True and self.ndim > 2:
                 distances = abs(coords[:, 2:] - indices[2:])
                 size_array = self._size[:,2:]/2
                 matches = np.all(distances <= size_array, axis=1)

--- a/gui/layers/_markers_layer.py
+++ b/gui/layers/_markers_layer.py
@@ -245,6 +245,8 @@ class Markers(Layer):
 
     def _get_shape(self):
         if len(self.coords) == 0:
+            # when no markers given, return (1,) * dim
+            # we use coords.shape[1] as the dimensionality of the image
             return np.ones(self.coords.shape[1], dtype=int)
         else:
             return np.max(self.coords, axis=0) + 1

--- a/gui/layers/_markers_layer.py
+++ b/gui/layers/_markers_layer.py
@@ -292,7 +292,10 @@ class Markers(Layer):
                 size_array = self._size[:,2:]/2
                 matches = np.all(distances <= size_array, axis=1)
                 in_slice_markers = coords[matches, :2]
-                scale_per_dim = (size_array[matches] - distances[matches])/size_array[matches]
+                size_matches = size_array[matches]
+                size_matches[size_matches==0] = 1
+                scale_per_dim = (size_matches - distances[matches])/size_matches
+                scale_per_dim[size_matches==0] = 1
                 scale = np.prod(scale_per_dim, axis=1)
                 return in_slice_markers, matches, scale
             else:

--- a/gui/layers/_markers_layer.py
+++ b/gui/layers/_markers_layer.py
@@ -77,24 +77,13 @@ class Markers(Layer):
         self._coords = coords
 
         # Save the marker style params
-        size_array = np.array(size)
-        if len(size_array.shape) == 2:
-            assert(size_array.shape == self._coords.shape), \
-             'If size is a 2D array, must be the same shape as '\
-             'coords'
-            self._size = size_array
-        elif len(size_array.shape) == 1:
-            assert (len(size_array) == len(self._coords) or  len(size_array) == self.ndim), \
-            'If size is a list/ 1D array, must be the same length as '\
-            'either coords or ndim'
-            if len(size_array) == self.ndim:
-                self._size = np.broadcast_to(size_array, self._coords.shape)
-            else:
-                self._size = np.broadcast_to(size_array, self._coords.shape[::-1]).T
-        elif len(size_array.shape) == 0:
-            self._size = np.broadcast_to(size_array, self._coords.shape)
-        else:
-            raise TypeError('size should be float or ndarray of dim less than 2')
+        try:
+            self._size = np.broadcast_to(size, self._coords.shape)
+        except:
+            try:
+                self._size = np.broadcast_to(size, self._coords.shape[::-1]).T
+            except:
+                raise ValueError("Size is not compatible for broadcasting")
         self._size_original = size
 
 
@@ -161,24 +150,13 @@ class Markers(Layer):
     @size.setter
     def size(self, size: Union[int, float, np.ndarray, list]) -> None:
 
-        size_array = np.array(size)
-        if len(size_array.shape) == 2:
-            assert(size_array.shape == self._coords.shape), \
-             'If size is a 2D array, must be the same shape as '\
-             'coords'
-            self._size = size_array
-        elif len(size_array.shape) == 1:
-            assert (len(size_array) == len(self._coords) or  len(size_array) == self.ndim), \
-            'If size is a list/ 1D array, must be the same length as '\
-            'either coords or ndim'
-            if len(size_array) == self.ndim:
-                self._size = np.broadcast_to(size_array, self._coords.shape)
-            else:
-                self._size = np.broadcast_to(size_array, self._coords.shape[::-1]).T
-        elif len(size_array.shape) == 0:
-            self._size = np.broadcast_to(size_array, self._coords.shape)
-        else:
-            raise TypeError('size should be float or ndarray of dim less than 2')
+        try:
+            self._size = np.broadcast_to(size, self._coords.shape)
+        except:
+            try:
+                self._size = np.broadcast_to(size, self._coords.shape[::-1]).T
+            except:
+                raise ValueError("Size is not compatible for broadcasting")
         self._size_original = size
         self.refresh()
 

--- a/gui/layers/qt/_markers_layer.py
+++ b/gui/layers/qt/_markers_layer.py
@@ -1,5 +1,5 @@
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QLabel, QComboBox, QSlider
+from PyQt5.QtWidgets import QLabel, QComboBox, QSlider, QCheckBox
 from collections import Iterable
 import numpy as np
 from ._base_layer import QtLayer
@@ -64,6 +64,14 @@ class QtMarkersLayer(QtLayer):
         self.grid_layout.addWidget(QLabel('symbol:'), 6, 0)
         self.grid_layout.addWidget(symbol_comboBox, 6, 1)
 
+        ndim_cb = QCheckBox()
+        ndim_cb.setToolTip('N-dimensional markers')
+        ndim_cb.setChecked(self.layer.n_dimensional)
+        ndim_cb.stateChanged.connect(lambda state=ndim_cb:
+                                     self.change_ndim(state))
+        self.grid_layout.addWidget(QLabel('n-dim:'), 7, 0)
+        self.grid_layout.addWidget(ndim_cb, 7, 1)
+
         self.setExpanded(False)
 
     def changeFaceColor(self, text):
@@ -77,3 +85,9 @@ class QtMarkersLayer(QtLayer):
 
     def changeSize(self, value):
         self.layer.size = value
+
+    def change_ndim(self, state):
+        if state == Qt.Checked:
+            self.layer.n_dimensional = True
+        else:
+            self.layer.n_dimensional = False


### PR DESCRIPTION
# Description
This PR allows for markers specified in one plane to be seen in the n-dimensional space around them with the appropriate size. I.e. in 3D - before a marker of size 10 would only appear in the exact 2D plane where it's center lies. Now it will appear in +/- 5 planes with size scaled appropriately. This will be useful for viewing nD markers data. This behavior is turned off by default. To enable it set the new `n_dimensional` flag to true. The marker sizes can either be:

- a single scalar which then applies to each marker and each dimension equally
- a list of length dimensions, where each number then gets applied to each marker equally
- a list of length marker where each number then gets applied to each dimension equally
- an array of shape number of markers by number of dimensions,  where each number then gets applied appropriately.

This feature was requested by @ambrosejcarr and @kevinyamauchi seemed interested in it too - any feedback from them would be appreciated.

![image](https://user-images.githubusercontent.com/6531703/52181346-a00ffc00-27a5-11e9-8f11-e118aa19e00f.png)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: I have tested this with the `examples/layers.ipynb`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
