### PR TITLE
add freeze to block / enable refreshes in layers

### DIFF
--- a/gui/layers/_base_layer.py
+++ b/gui/layers/_base_layer.py
@@ -37,6 +37,7 @@ class Layer(VisualWrapper, ABC):
         self._viewer = None
         self._qt = None
         self.name = 'layer'
+        self._freeze = False
         self.events = EmitterGroup(source=self,
                                    auto_connect=True,
                                    select=Event,
@@ -135,8 +136,10 @@ class Layer(VisualWrapper, ABC):
         """
 
     def refresh(self):
-        """Fully refreshes the layer.
+        """Fully refreshes the layer. If layer is frozen refresh will not occur
         """
+        if self._freeze:
+            return
         self._refresh()
 
     def get_value(self, position, indices):

--- a/gui/layers/_base_layer.py
+++ b/gui/layers/_base_layer.py
@@ -1,4 +1,6 @@
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
+
 import weakref
 
 from vispy.util.event import EmitterGroup, Event
@@ -141,6 +143,12 @@ class Layer(VisualWrapper, ABC):
         if self._freeze:
             return
         self._refresh()
+
+    @contextmanager
+    def freeze_refresh(self):
+        self._freeze = True
+        yield
+        self._freeze = False
 
     def get_value(self, position, indices):
         """Returns coordinates, values, and a string for a given mouse position

--- a/gui/layers/_markers_layer.py
+++ b/gui/layers/_markers_layer.py
@@ -67,17 +67,20 @@ class Markers(Layer):
         visual = MarkersNode()
         super().__init__(visual)
 
+        # Block any refreshes during parameter setting
+        self._freeze = True
+
         # Save the marker coordinates
         self._coords = coords
 
         # Save the marker style params
-        self._symbol = symbol
-        self._size = size
-        self._edge_width = edge_width
-        self._edge_width_rel = edge_width_rel
-        self._edge_color = edge_color
-        self._face_color = face_color
-        self._scaling = scaling
+        self.symbol = symbol
+        self.size = size
+        self.edge_width = edge_width
+        self.edge_width_rel = edge_width_rel
+        self.edge_color = edge_color
+        self.face_color = face_color
+        self.scaling = scaling
         self._marker_types = marker_types
         self._colors = get_color_names()
 
@@ -88,6 +91,9 @@ class Markers(Layer):
         self.name = 'markers'
         self._qt = QtMarkersLayer(self)
         self._selected_markers = None
+
+        # Reenable refreshes
+        self._freeze = False
 
     @property
     def coords(self) -> np.ndarray:
@@ -100,7 +106,7 @@ class Markers(Layer):
         self._coords = coords
 
         self.viewer._child_layer_changed = True
-        self._refresh()
+        self.refresh()
 
     @property
     def data(self) -> np.ndarray:
@@ -435,4 +441,4 @@ class Markers(Layer):
             pass
         else:
             self.data[index] = coord
-            self._refresh()
+            self.refresh()

--- a/gui/layers/_markers_layer.py
+++ b/gui/layers/_markers_layer.py
@@ -67,33 +67,29 @@ class Markers(Layer):
         visual = MarkersNode()
         super().__init__(visual)
 
-        # Block any refreshes during parameter setting
-        self._freeze = True
+        # Freeze refreshes
+        with self.freeze_refresh():
+            # Save the marker coordinates
+            self._coords = coords
 
-        # Save the marker coordinates
-        self._coords = coords
+            # Save the marker style params
+            self.symbol = symbol
+            self.size = size
+            self.edge_width = edge_width
+            self.edge_width_rel = edge_width_rel
+            self.edge_color = edge_color
+            self.face_color = face_color
+            self.scaling = scaling
+            self._marker_types = marker_types
+            self._colors = get_color_names()
 
-        # Save the marker style params
-        self.symbol = symbol
-        self.size = size
-        self.edge_width = edge_width
-        self.edge_width_rel = edge_width_rel
-        self.edge_color = edge_color
-        self.face_color = face_color
-        self.scaling = scaling
-        self._marker_types = marker_types
-        self._colors = get_color_names()
+            # update flags
+            self._need_display_update = False
+            self._need_visual_update = False
 
-        # update flags
-        self._need_display_update = False
-        self._need_visual_update = False
-
-        self.name = 'markers'
-        self._qt = QtMarkersLayer(self)
-        self._selected_markers = None
-
-        # Reenable refreshes
-        self._freeze = False
+            self.name = 'markers'
+            self._qt = QtMarkersLayer(self)
+            self._selected_markers = None
 
     @property
     def coords(self) -> np.ndarray:


### PR DESCRIPTION
# Description
This is a very small PR that adds a `_freeze` property to layers that can block the `refresh` method. It's purpose is to allow setters to be called during layer construction but to prevent their refresh methods from executing. It will also be useful when manipulating parts of layers that need to be manipulated together and then have a refresh called at the end of the process rather than on every manipulation along the way. (i.e. adding new markers where both the size property and the data property may need to change, but you only want to refresh after both have changed). Most concretely this freeze property will be used in #102 to remove the duplicate code that is currently in the constructor for setting the `size` property.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: test with `examples/layers.ipynb`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
