### PR TITLE
Add pytest-faulthandler to test requirements

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,1 +1,2 @@
 pytest
+pytest-faulthandler


### PR DESCRIPTION
We recently enabled this on scikit-image and it makes it much easier to
tell where things went wrong when you have a Python interpreter crash
(e.g. from segfaulting or similar).

Prompted by our failing Linux builds, which are probably due to the PyQt 5.12 release.