### PR TITLE
linux ci: install libqt5x11extras5

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,7 @@ task:
         DISPLAY: ":99"
       system_script:
         - apt-get update
-        - apt-get install -y libgl1-mesa-glx xvfb
+        - apt-get install -y libgl1-mesa-glx xvfb libqt5x11extras5
       conda_script:
         - curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > install.sh
         - bash install.sh -b -p $HOME/conda


### PR DESCRIPTION
# Description
Fix Linux CI by installing `libqt5x11extras5`. Cannot trivially fix Windows builds due to a bug with `conda` but I raised an issue and looking at the repository it seems that the maintainers are currently working to address it.