### PR TITLE
Unify layer creation API

### DIFF
--- a/examples/layers.ipynb
+++ b/examples/layers.ipynb
@@ -36,8 +36,8 @@
    },
    "outputs": [],
    "source": [
-    "from napari_gui import imshow\n",
-    "viewer = imshow(data.camera())"
+    "import napari_gui as gui\n",
+    "viewer = gui.imshow(data.camera())"
    ]
   },
   {
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer.add_image(rgb2gray(data.astronaut()),{})"
+    "viewer.add_image(rgb2gray(data.astronaut()))"
    ]
   },
   {
@@ -82,8 +82,8 @@
     "from napari_gui import Window, Viewer\n",
     "viewer = Viewer()\n",
     "window = Window(viewer)\n",
-    "viewer.add_image(data.camera(),{})\n",
-    "viewer.add_image(data.camera(),{})"
+    "viewer.add_image(data.camera())\n",
+    "viewer.add_image(data.camera())"
    ]
   },
   {
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer.add_image(rgb2gray(data.astronaut()),{})"
+    "viewer.add_image(rgb2gray(data.astronaut()))"
    ]
   },
   {
@@ -183,7 +183,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer = imshow(data.astronaut())"
+    "viewer = gui.imshow(data.astronaut())"
    ]
   },
   {
@@ -279,7 +279,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/examples/markers.ipynb
+++ b/examples/markers.ipynb
@@ -2,15 +2,11 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "%gui qt5\n",
-    "\n",
-    "# in case napari isn't in the path \n",
-    "import sys\n",
-    "sys.path.insert(1, '..')\n",
     "\n",
     "import napari_gui as gui\n",
     "from skimage import data\n",
@@ -19,40 +15,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Create a viewer with a random 5D image (e.g., [x, y, z, c, t])\n",
-    "rand_im = gui.imshow(np.random.rand(500, 500, 5, 3, 2))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# ? gives usage instructions for add_markers\n",
-    "rand_im.add_markers?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<napari_gui.layers._markers_layer.Markers at 0x129ea0550>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "# Create a list of marker coords\n",
     "marker_list = np.array([[50, 30, 0, 0, 0],\n",
@@ -62,43 +27,44 @@
     "                        [70, 30, 4, 2, 1]])\n",
     "\n",
     "# Create the layer with markers\n",
-    "rand_im.add_markers(marker_list)"
+    "viewer = gui.scatter(marker_list)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[<napari_gui.layers._image_layer.Image object at 0x11bec8cc0>, <napari_gui.layers._markers_layer.Markers object at 0x11ff13d30>]\n"
-     ]
-    }
-   ],
+   "outputs": [],
+   "source": [
+    "# Create a viewer with a random 5D image (e.g., [x, y, z, c, t])\n",
+    "viewer.add_image(np.random.rand(500, 500, 5, 3, 2))\n",
+    "viewer.layers.swap(0, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# We can also change the marker styling by updating the layer properties\n",
-    "print(rand_im.layers)\n",
-    "\n",
-    "rand_im.layers[1].size = np.array([20, 20, 20, 5, 5])\n",
-    "rand_im.layers[1].symbol= '+'"
+    "viewer.layers[1].size = np.array([20, 20, 20, 5, 5])\n",
+    "viewer.layers[1].symbol= '+'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Sizes can also be set with lists\n",
-    "rand_im.layers[1].size = [10, 10, 10, 5, 5]"
+    "viewer.layers[1].size = [10, 10, 10, 5, 5]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,13 +74,12 @@
     "                        [33, 90, 0, 0, 0],\n",
     "                        [99, 40, 1, 1, 1],\n",
     "                        [50, 30, 4, 2, 1]])\n",
-    "\n",
-    "rand_im.layers[1].data = marker_list2"
+    "viewer.layers[1].data = marker_list2"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +90,7 @@
     "                        [99, 40, 1, 1, 1],\n",
     "                        [50, 30, 4, 2, 1]])\n",
     "\n",
-    "rand_im.layers[1].coords = marker_list3"
+    "viewer.layers[1].coords = marker_list3"
    ]
   },
   {
@@ -138,9 +103,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:napari-gui]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-napari-gui-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -152,7 +117,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,4 +1,4 @@
-from .util.misc import imshow
+from .util.misc import imshow, scatter
 from .components import Window, Viewer
 
 from ._version import get_versions

--- a/gui/components/_viewer/model.py
+++ b/gui/components/_viewer/model.py
@@ -176,29 +176,6 @@ class Viewer:
             empty_markers = empty((0, self.dimensions.max_dims))
         self.add_markers(empty_markers)
 
-    def imshow(self, image, meta=None, multichannel=None, **kwargs):
-        """Shows an image in the viewer.
-
-        Parameters
-        ----------
-        image : np.ndarray
-            Image data.
-        meta : dict, optional
-            Image metadata.
-        multichannel : bool, optional
-            Whether the image is multichannel. Guesses if None.
-        **kwargs : dict
-            Parameters that will be translated to metadata.
-
-        Returns
-        -------
-        layer : Image
-            Layer for the image.
-        """
-        meta = guess_metadata(image, meta, multichannel, kwargs)
-
-        return self.add_image(image, meta)
-
     def _update_layers(self):
         """Updates the contained layers.
         """

--- a/gui/layers/_image_layer/model.py
+++ b/gui/layers/_image_layer/model.py
@@ -10,6 +10,7 @@ from ...util import is_multichannel
 from ...util.interpolation import (interpolation_names,
                                   interpolation_index_to_name as _index_to_name,  # noqa
                                   interpolation_name_to_index as _name_to_index)  # noqa
+from ...util.misc import guess_metadata
 
 from vispy import color
 from ..colormaps import matplotlib_colormaps
@@ -65,17 +66,23 @@ class Image(Layer):
     ----------
     image : np.ndarray
         Image data.
-    meta : dict
+    meta : dict, optional
         Image metadata.
+    multichannel : bool, optional
+        Whether the image is multichannel. Guesses if None.
+    **kwargs : dict
+        Parameters that will be translated to metadata.
     """
     _colormaps = AVAILABLE_COLORMAPS
 
     default_cmap = 'magma'
     default_interpolation = 'nearest'
 
-    def __init__(self, image, meta):
+    def __init__(self, image, meta=None, multichannel=None, **kwargs):
         self.visual = ImageNode(None, method='auto')
         super().__init__(self.visual)
+
+        meta = guess_metadata(image, meta, multichannel, kwargs)
 
         self._image = image
         self._meta = meta

--- a/gui/layers/_register.py
+++ b/gui/layers/_register.py
@@ -109,3 +109,5 @@ def add_to_viewer(cls=None, *, name=None, doc=None):
 
     def inner(cls):
         return _register(cls, name=name, doc=doc)
+
+    return inner

--- a/gui/util/misc.py
+++ b/gui/util/misc.py
@@ -1,5 +1,9 @@
 """Miscellaneous utility functions.
 """
+import __main__
+
+
+INTERACTIVE = not hasattr(__main__, '__file__')
 
 
 def is_multichannel(meta):
@@ -121,19 +125,88 @@ def imshow(image, meta=None, multichannel=None, **kwargs):
 
     Returns
     -------
-    window: Window
-        Window object.
+    viewer : Viewer
+        Viewer containing the image.
     """
     from ..components import Window, Viewer, QtApplication
-
-    meta = guess_metadata(image, meta, multichannel, kwargs)
 
     global _app
     _app = _app or QtApplication.instance() or QtApplication([])
 
     window = Window(Viewer(), show=False)
     _windows.append(window)
-    layer = window.viewer.add_image(image, meta)
+    layer = window.viewer.add_image(image, meta, multichannel, **kwargs)
     window.show()
+
+    if not INTERACTIVE:
+        _app.exec()
+
+    return window.viewer
+
+
+def scatter(coords, symbol='o', size=10, edge_width=1,
+            edge_width_rel=None, edge_color='black', face_color='white',
+            scaling=True, n_dimensional=False):
+    """Displays a scatterplot with markers of the given properties.
+
+    Parameters
+    ----------
+    coords : np.ndarray
+        coordinates for each marker.
+
+    symbol : str
+        symbol to be used as a marker
+
+    size : int, float, np.ndarray, list
+        size of the marker. If given as a scalar, all markers are the
+        same size. If given as a list/array, size must be the same
+        length as coords and sets the marker size for each marker
+        in coords (element-wise). If n_dimensional is True then can be a list
+        of length dims or can be an array of shape Nxdims where N is the number
+        of markers and dims is the number of dimensions
+
+    edge_width : int, float, None
+        width of the symbol edge in px
+            vispy docs say: "exactly one edge_width and
+            edge_width_rel must be supplied"
+
+    edge_width_rel : int, float, None
+        width of the marker edge as a fraction of the marker size.
+
+            vispy docs say: "exactly one edge_width and
+            edge_width_rel must be supplied"
+
+    edge_color : Color, ColorArray
+        color of the marker border
+
+    face_color : Color, ColorArray
+        color of the marker body
+
+    scaling : bool
+        if True, marker rescales when zooming
+
+    n_dimensional : bool
+        if True, renders markers not just in central plane but also in all
+        n dimensions according to specified marker size
+
+    Returns
+    -------
+    viewer : Viewer
+        Viewer containing the markers.
+    """
+    from ..components import Window, Viewer, QtApplication
+
+    global _app
+    _app = _app or QtApplication.instance() or QtApplication([])
+
+    window = Window(Viewer(), show=False)
+    _windows.append(window)
+    layer = window.viewer.add_markers(coords, symbol, size, edge_width,
+                                      edge_width_rel, edge_color,
+                                      face_color, scaling, n_dimensional)
+    window.show()
+
+    if not INTERACTIVE:
+        _app.exec()
 
     return window.viewer

--- a/gui/util/misc.py
+++ b/gui/util/misc.py
@@ -105,7 +105,6 @@ def compute_max_shape(shapes, max_dims=None):
     return tuple(max_shape)
 
 
-_app = None
 _windows = []
 
 
@@ -130,8 +129,7 @@ def imshow(image, meta=None, multichannel=None, **kwargs):
     """
     from ..components import Window, Viewer, QtApplication
 
-    global _app
-    _app = _app or QtApplication.instance() or QtApplication([])
+    app = QtApplication.instance() or QtApplication([])
 
     window = Window(Viewer(), show=False)
     _windows.append(window)
@@ -139,7 +137,7 @@ def imshow(image, meta=None, multichannel=None, **kwargs):
     window.show()
 
     if not INTERACTIVE:
-        _app.exec()
+        app.exec()
 
     return window.viewer
 
@@ -196,8 +194,7 @@ def scatter(coords, symbol='o', size=10, edge_width=1,
     """
     from ..components import Window, Viewer, QtApplication
 
-    global _app
-    _app = _app or QtApplication.instance() or QtApplication([])
+    app = QtApplication.instance() or QtApplication([])
 
     window = Window(Viewer(), show=False)
     _windows.append(window)
@@ -207,6 +204,6 @@ def scatter(coords, symbol='o', size=10, edge_width=1,
     window.show()
 
     if not INTERACTIVE:
-        _app.exec()
+        app.exec()
 
     return window.viewer


### PR DESCRIPTION
# Description
- unify signature/functionality of `gui.imshow` and `viewer.add_image`
- remove `viewer.imshow`
- add `gui.scatter` convenience method for creating a markers layer
- make corresponding changes to the example notebooks
- bugfix `add_to_viewer` decorator

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How has this been tested?
- ran updated `markers.ipynb`
- ran update `layers.ipynb`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
