### PR TITLE
suppress vispy warning

### DIFF
--- a/gui/components/__init__.py
+++ b/gui/components/__init__.py
@@ -10,7 +10,11 @@ Viewer
     Data viewer displaying the currently rendered scene and
     layer-related controls.
 """
-from ._window import Window, QtApplication
+import warnings
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=UserWarning)
+    from ._window import Window, QtApplication
 from ._viewer import Viewer
 from ._layers_list import LayersList
 from ._dims import Dims

--- a/gui/components/__init__.py
+++ b/gui/components/__init__.py
@@ -12,8 +12,11 @@ Viewer
 """
 import warnings
 
+vispy_warning = "VisPy is not yet compatible with matplotlib 2.2+"
+
 with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=UserWarning)
+    warnings.filterwarnings("ignore", category=UserWarning,
+                            message=vispy_warning)
     from ._window import Window, QtApplication
 from ._viewer import Viewer
 from ._layers_list import LayersList


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
This PR addresses issue #116 and suppresses the vispy warning (about matplotlib versions when using isocurves). See #116 for a discussion of motivation. Catching the warning if currently done on the import of the `window` in init file of `components` - please let me know if it should be somewhere else.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] `examples/layers.ipynb`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality