### PR TITLE
fix notebook

### DIFF
--- a/examples/notebook.ipynb
+++ b/examples/notebook.ipynb
@@ -21,6 +21,10 @@
    "outputs": [],
    "source": [
     "%gui qt5\n",
+    "# Note that this Magics command needs to be run in a cell\n",
+    "# before any of the Napari objects are instantiated to\n",
+    "# ensure it has time to finish executing before they are\n",
+    "# called\n",
     "\n",
     "from skimage import data\n",
     "from napari_gui import Window, Viewer"

--- a/examples/notebook.ipynb
+++ b/examples/notebook.ipynb
@@ -4,7 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Setup and show image"
+    "# Display an image using Napari"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initial setup"
    ]
   },
   {
@@ -16,12 +23,24 @@
     "%gui qt5\n",
     "\n",
     "from skimage import data\n",
-    "from napari_gui import Window, Viewer\n",
-    "\n",
-    "# create the viewer and window\n",
+    "from napari_gui import Window, Viewer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create the viewer and window, and add an image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "viewer = Viewer()\n",
     "window = Window(viewer)\n",
-    "# add the image\n",
     "viewer.add_image(data.moon())"
    ]
   },


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
This PR fixes the notebook by splitting the `%gui qt5` line and the actual calls to the viewer / window into two cells. When they were in just one cell the notebook would always crash as the qt stuff didn't have time to launch before the viewer / window stuff gets called. This will be worth highlighting when @AhmetCanSolak puts the notebook example into the docs.

This bug was introduced and noted in #143

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run `examples/notebook.ipynb`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality