### PR TITLE
automate running/testing of examples

### DIFF
--- a/napari/util/app.py
+++ b/napari/util/app.py
@@ -1,10 +1,26 @@
+import os
 import sys
 from contextlib import contextmanager
+
 from PyQt5.QtWidgets import QApplication
+from PyQt5.QtCore import QTimer
 
 
 @contextmanager
 def app_context():
+    """Generate app context.
+
+    Notes
+    -----
+    If the `NAPARI_TEST` environment variable is set to anything but `0`,
+    will automatically quit after 0.5 seconds.
+    """
     app = QApplication.instance() or QApplication(sys.argv)
     yield
+    if os.environ.get('NAPARI_TEST', '0') != '0':
+        # quit app after 0.5 seconds
+        timer = QTimer()
+        timer.setInterval(500)
+        timer.timeout.connect(app.quit)
+        timer.start()
     app.exec()

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-faulthandler
+scikit-image

--- a/test_examples.py
+++ b/test_examples.py
@@ -1,0 +1,28 @@
+import os
+import os.path as osp
+
+import pytest
+
+
+os.environ['NAPARI_TEST'] = '1'
+
+root_dir = osp.dirname(__file__)
+examples_dir = osp.join(root_dir, 'examples')
+excludes = ['__init__.py']
+
+paths = []
+for filename in os.listdir(examples_dir):
+    if filename not in excludes and osp.splitext(filename)[1] == '.py':
+        paths.append(osp.join(examples_dir, filename))
+
+
+def path_id(name):
+    if name.startswith(root_dir):
+        return name[len(root_dir) + 1:]
+    return name
+
+
+@pytest.mark.parametrize('path', paths, ids=path_id)
+def test_example(path):
+    with open(path, 'r') as f:
+        exec(f.read(), {})


### PR DESCRIPTION
# Description
- add `scikit-image` testing dependency
- insert code into `app_context` causing execution loop to last 0.5 seconds
if the `NAPARI_TEST` environment variable is set to a non-`0` value
- add tests to automatically run all `example/*.py` files