### PR TITLE
fix error with nD markers

### DIFF
--- a/napari/layers/_markers_layer/model.py
+++ b/napari/layers/_markers_layer/model.py
@@ -2,7 +2,6 @@ from typing import Union
 from collections import Iterable
 
 import numpy as np
-from numpy import clip, integer, ndarray, append, insert, delete, empty
 from copy import copy
 
 from .._base_layer import Layer
@@ -392,15 +391,13 @@ class Markers(Layer):
         self._update()
 
     def _get_coord(self, position, indices):
-        max_shape = self.viewer.dims.max_shape
+        shape = self._get_shape()
         transform = self._node.canvas.scene.node_transform(self._node)
         pos = transform.map(position)
-        pos = [clip(pos[1], 0, max_shape[0]-1), clip(pos[0], 0,
-                                                     max_shape[1]-1)]
         coord = copy(indices)
-        coord[0] = pos[1]
-        coord[1] = pos[0]
-        return coord
+        coord[0] = pos[0]
+        coord[1] = pos[1]
+        return coord[:len(shape)]
 
     def get_message(self, coord, value):
         """Returns coordinate and value string for given mouse coordinates
@@ -436,8 +433,7 @@ class Markers(Layer):
         ----------
         coord : sequence of indices to add marker at
         """
-        self._size = append(self._size, [np.repeat(10, self.ndim)], axis=0)
-        self.data = append(self.data, [coord], axis=0)
+        self.data = np.append(self.data, [coord], axis=0)
         self._selected_markers = len(self.data)-1
 
     def _remove(self):
@@ -445,8 +441,7 @@ class Markers(Layer):
         """
         index = self._selected_markers
         if index is not None:
-            self._size = delete(self._size, index, axis=0)
-            self.data = delete(self.data, index, axis=0)
+            self.data = np.delete(self.data, index, axis=0)
             self._selected_markers = None
 
     def _move(self, coord):


### PR DESCRIPTION
# Description
This PR fixes an indexing error that occurred when adding a new marker to a viewer that contained both 2D and 3D layers. It also allows markers to be added outside the current image bounds and at non-integer locations. The PR makes the markers layer more independent of other layers by removing a call to the `viewer.dims.max_shape`

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] Tested with the examples scripts including`add_markers.py` and `nD_markers.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
