### PR TITLE
Allow other array-like data

### DIFF
--- a/examples/dask_nD_image.py
+++ b/examples/dask_nD_image.py
@@ -1,0 +1,17 @@
+"""
+Display one 4-D image layer using the add_image API
+"""
+
+import dask.array as da
+import numpy as np
+from skimage import data
+from napari import ViewerApp
+from napari.util import app_context
+
+
+with app_context():
+    # TODO: change axis back to 0 once dims displayed in sane order
+    blobs = da.stack([data.binary_blobs(length=128, blob_size_fraction=0.05,
+                                        n_dim=3, volume_fraction=f)
+                     for f in np.linspace(0.05, 0.5, 10)], axis=-1)
+    viewer = ViewerApp(blobs.astype(float))

--- a/napari/layers/_image_layer/model.py
+++ b/napari/layers/_image_layer/model.py
@@ -118,7 +118,7 @@ class Image(Layer):
         self._need_visual_update = False
 
         self._clim_range = self._clim_range_default()
-        self._node.clim = [np.min(self.image), np.max(self.image)]
+        self._node.clim = [self.image.min(), self.image.max()]
 
         cmin, cmax = self.clim
         self._clim_msg = f'{cmin: 0.3}, {cmax: 0.3}'
@@ -344,7 +344,7 @@ class Image(Layer):
         return tuple(interpolation_names)
 
     def _clim_range_default(self):
-        return [np.min(self.image), np.max(self.image)]
+        return [self.image.min(), self.image.max()]
 
     def get_value(self, position, indices):
         """Returns coordinates, values, and a string for a given mouse position

--- a/napari/layers/_image_layer/model.py
+++ b/napari/layers/_image_layer/model.py
@@ -222,7 +222,7 @@ class Image(Layer):
         """
         sliced_image = self._slice_image(indices)
 
-        self._node.set_data(sliced_image)
+        self._node.set_data(np.asarray(sliced_image))
 
         self._need_visual_update = True
         self._update()

--- a/napari/layers/_image_layer/model.py
+++ b/napari/layers/_image_layer/model.py
@@ -210,7 +210,9 @@ class Image(Layer):
             except TypeError:
                 pass
 
-        return self.image[tuple(indices)]
+        self._image_view = np.asarray(self.image[tuple(indices)])
+
+        return self._image_view
 
     def _set_view_slice(self, indices):
         """Sets the view given the indices to slice with.
@@ -222,7 +224,7 @@ class Image(Layer):
         """
         sliced_image = self._slice_image(indices)
 
-        self._node.set_data(np.asarray(sliced_image))
+        self._node.set_data(sliced_image)
 
         self._need_visual_update = True
         self._update()
@@ -372,7 +374,7 @@ class Image(Layer):
         coord = copy(indices)
         coord[0] = int(pos[0])
         coord[1] = int(pos[1])
-        value = self._slice_image(coord)
+        value = self._image_view[tuple(coord[:2])]
         msg = f'{coord}, {self.name}' + ', value '
         if isinstance(value, ndarray):
             if isinstance(value[0], integer):

--- a/napari/layers/_image_layer/model.py
+++ b/napari/layers/_image_layer/model.py
@@ -118,7 +118,7 @@ class Image(Layer):
         self._need_visual_update = False
 
         self._clim_range = self._clim_range_default()
-        self._node.clim = [self.image.min(), self.image.max()]
+        self._node.clim = [float(self.image.min()), float(self.image.max())]
 
         cmin, cmax = self.clim
         self._clim_msg = f'{cmin: 0.3}, {cmax: 0.3}'
@@ -344,7 +344,7 @@ class Image(Layer):
         return tuple(interpolation_names)
 
     def _clim_range_default(self):
-        return [self.image.min(), self.image.max()]
+        return [float(self.image.min()), float(self.image.max())]
 
     def get_value(self, position, indices):
         """Returns coordinates, values, and a string for a given mouse position

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-faulthandler
+dask[array]
 scikit-image


### PR DESCRIPTION
# Description

This makes some minor changes that allow other array-like objects as input to the viewer instead of requiring NumPy arrays. This should allow it to work trivially on Dask Arrays. An example is included using a Dask Array as input instead.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
