### PR TITLE
fix empty markers

### DIFF
--- a/napari/layers/_markers_layer/model.py
+++ b/napari/layers/_markers_layer/model.py
@@ -101,15 +101,21 @@ class Markers(Layer):
     def coords(self, coords: np.ndarray):
         self._coords = coords
 
+        # Adjust the size array when the number of markers has changed
         if len(coords) < len(self._size):
+            # If there are now less markers, remove the sizes of the missing
+            # ones
             with self.freeze_refresh():
                 self.size = self._size[:len(coords)]
         elif len(coords) > len(self._size):
+            # If there are now more markers, add the sizes of last one
+            # or add the default size
             with self.freeze_refresh():
                 adding = len(coords)-len(self._size)
                 if len(self._size) > 0:
                     new_size = self._size[-1]
                 else:
+                    # Add the default size, with a value for each dimension
                     new_size = np.repeat(10, self._size.shape[1])
                 size = np.repeat([new_size], adding, axis=0)
                 self.size = np.concatenate((self._size, size), axis=0)
@@ -445,6 +451,7 @@ class Markers(Layer):
         """
         index = self._selected_markers
         if index is not None:
+            self._size = np.delete(self._size, index, axis=0)
             self.data = np.delete(self.data, index, axis=0)
             self._selected_markers = None
 

--- a/napari/layers/_markers_layer/model.py
+++ b/napari/layers/_markers_layer/model.py
@@ -107,7 +107,11 @@ class Markers(Layer):
         elif len(coords) > len(self._size):
             with self.freeze_refresh():
                 adding = len(coords)-len(self._size)
-                size = np.repeat([self._size[-1]], adding, axis=0)
+                if len(self._size) > 0:
+                    new_size = self._size[-1]
+                else:
+                    new_size = np.repeat(10, self._size.shape[1])
+                size = np.repeat([new_size], adding, axis=0)
                 self.size = np.concatenate((self._size, size), axis=0)
 
         self.viewer._child_layer_changed = True


### PR DESCRIPTION
# Description
fixes bug in `examples/annotate-2d.py` when starting with empty markers layer that was introduced in #183.
 
There are still bugs in when starting with an empty viewer, but they will be resolved when we fix the dims.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] `examples/annotate-2d.py`, `examples/add_markers.py`, `examples/nD_markers.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
