### PR TITLE
improve layer selection / name editing

### DIFF
--- a/napari/components/_layers_list/model.py
+++ b/napari/components/_layers_list/model.py
@@ -165,9 +165,16 @@ class LayersList(ListModel):
             indices.insert(insert_idx, elem_idx)
         self[:] = self[tuple(indices)]
 
-    def unselect_all(self):
+    def unselect_all(self, ignore=None):
+        """Unselects all layers expect any specified in ignore.
+
+        Parameters
+        ----------
+        ignore : Layer | None
+            Layer that should not be unselected if specified.
+        """
         for layer in self:
-            if layer.selected:
+            if layer.selected and layer != ignore:
                 layer.selected = False
 
     def remove_selected(self):

--- a/napari/layers/_base_layer/view/properties.py
+++ b/napari/layers/_base_layer/view/properties.py
@@ -1,7 +1,7 @@
 from PyQt5.QtWidgets import (QSlider, QLineEdit, QGridLayout, QFrame,
                              QVBoxLayout, QCheckBox, QWidget, QApplication,
                              QLabel, QComboBox)
-from PyQt5.QtCore import Qt, QMimeData
+from PyQt5.QtCore import Qt, QMimeData, QEvent
 from PyQt5.QtGui import QDrag
 
 
@@ -18,7 +18,6 @@ class QtLayer(QFrame):
         layer.events.visible.connect(self._on_visible_change)
 
         self.setObjectName('layer')
-        self.layer.selected = True
 
         self.grid_layout = QGridLayout()
 
@@ -31,9 +30,11 @@ class QtLayer(QFrame):
 
         textbox = QLineEdit(self)
         textbox.setText(layer.name)
+        textbox.home(False)
         textbox.setToolTip('Layer name')
         textbox.setFixedWidth(80)
         textbox.setAcceptDrops(False)
+        textbox.setEnabled(True)
         textbox.editingFinished.connect(self.changeText)
         self.nameTextBox = textbox
         self.grid_layout.addWidget(textbox, 0, 1)
@@ -70,14 +71,17 @@ class QtLayer(QFrame):
         self.setFixedWidth(200)
         self.grid_layout.setColumnMinimumWidth(0, 100)
         self.grid_layout.setColumnMinimumWidth(1, 100)
+        self.layer.selected = True
 
     def _on_select(self, event):
         self.setProperty('selected', True)
+        self.nameTextBox.setEnabled(True)
         self.style().unpolish(self)
         self.style().polish(self)
 
     def _on_deselect(self, event):
         self.setProperty('selected', False)
+        self.nameTextBox.setEnabled(False)
         self.style().unpolish(self)
         self.style().polish(self)
 
@@ -112,7 +116,7 @@ class QtLayer(QFrame):
         elif modifiers == Qt.ControlModifier:
             self.layer.selected = not self.layer.selected
         else:
-            self.layer.viewer.layers.unselect_all()
+            self.layer.viewer.layers.unselect_all(ignore=self.layer)
             self.layer.selected = True
 
     def mousePressEvent(self, event):
@@ -166,6 +170,7 @@ class QtLayer(QFrame):
     def _on_layer_name_change(self, event):
         with self.layer.events.name.blocker():
             self.nameTextBox.setText(self.layer.name)
+            self.nameTextBox.home(False)
 
     def _on_opacity_change(self, event):
         with self.layer.events.opacity.blocker():

--- a/napari/layers/_base_layer/view/properties.py
+++ b/napari/layers/_base_layer/view/properties.py
@@ -1,7 +1,7 @@
 from PyQt5.QtWidgets import (QSlider, QLineEdit, QGridLayout, QFrame,
                              QVBoxLayout, QCheckBox, QWidget, QApplication,
                              QLabel, QComboBox)
-from PyQt5.QtCore import Qt, QMimeData, QEvent
+from PyQt5.QtCore import Qt, QMimeData
 from PyQt5.QtGui import QDrag
 
 

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -50,8 +50,17 @@ QtLayer > QCheckBox::indicator:checked {
 }
 
 QtLayer > QLineEdit {
-    background-color: lightGray;
+    background-color: white;
+    color: black;
     border: none;
+    border-radius: 3px;
+}
+
+QtLayer > QLineEdit:disabled {
+    background-color: lightGray;
+    color: black;
+    border: none;
+    border-radius: 3px;
 }
 
 QtLayer {


### PR DESCRIPTION
# Description
This short PR addresses #124 (layer selection) and #71 (styling of layer name). It also makes #131 better, but does not fully solve that problem.

Now the layer name box is disabled when the layer is not selected so that clicking into that area selects the layer. Once the layer is selected, the background color of the box changes so that it is clear that it can be edited if clicked on again.

This PR also has the text for the layer name be left aligned visible now to make readability easier

Clicking on the visible icon doesn't automatically select the layer, nor is the visibility icon disabled if the layer is not selected (and similarly for the other properties if the widget is expanded). I think this behavior if fine, but curious what others think

![layer_properties](https://user-images.githubusercontent.com/6531703/55379271-5dcb1880-54d1-11e9-82a2-855b438e77e5.gif)

An unnecessary deselection / reselection option is now removed too (meaning issues like in #131 are less likely to occur). Note that for #131 the remaining problem is around qt updating its stylings not the underlying selection logic, as if the focus is changed from the window to a new application and back to the window again then the stylings update.

In a future PR I plan to make more use of classes in the layer properties widgets, and I think we will want to remove the "double-click" to expand and replace it with a click button to expand / contract

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run examples

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
