### PR TITLE
Fix color map to work with unlimited labels.

### DIFF
--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -30,10 +30,12 @@ class Labels(Layer):
         Whether the image is multichannel. Guesses if None.
     name : str, keyword-only
         Name of the layer.
+    num_colors : int, optional
+        Number of unique colors to use. Default used if not given.
     **kwargs : dict
         Parameters that will be translated to metadata.
     """
-    def __init__(self, label_image, meta=None, *, name=None, **kwargs):
+    def __init__(self, label_image, meta=None, *, name=None, num_colors=256, **kwargs):
         if name is None and meta is not None:
             if 'name' in meta:
                 name = meta['name']
@@ -49,7 +51,8 @@ class Labels(Layer):
         self._meta = meta
         self.interpolation = 'nearest'
         self.colormap_name = 'random'
-        self.colormap = colormaps.label_colormap()
+        self.colormap = colormaps.label_colormap(num_colors)
+        self.opacity = 0.7
 
 
         # update flags
@@ -69,7 +72,7 @@ class Labels(Layer):
 
     def label_color(self, label):
         """Return the color corresponding to a specific label."""
-        return self.colormap.map(self._low_discrepancy_image(label, self.seed))
+        return self.colormap.map(colormaps._low_discrepancy_image(np.array([label]), self.seed))
 
     @property
     def image(self):

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -42,14 +42,15 @@ class Labels(Layer):
         super().__init__(visual, name)
         self.events.add(colormap=Event)
 
+        self.seed = 0.5
         self._raw_image = label_image
         self._max_label = np.max(label_image)
-        self._image = label_image / self._max_label
+        self._image = colormaps._low_discrepancy_image(label_image, self.seed)
         self._meta = meta
         self.interpolation = 'nearest'
         self.colormap_name = 'random'
-        self.colormap = colormaps.label_colormap(label_image,
-                                                 max_label=self._max_label)
+        self.colormap = colormaps.label_colormap(label_image)
+
 
         # update flags
         self._need_display_update = False
@@ -61,13 +62,13 @@ class Labels(Layer):
         self.events.colormap()
 
     def new_colormap(self):
-        seed = np.random.random((3,))
+        self.seed = np.random.rand()
         self.colormap = colormaps.label_colormap(self._image, seed=seed)
         self.events.colormap()
 
     def label_color(self, label):
         """Return the color corresponding to a specific label."""
-        return self.colormap.map(label / self._max_label)
+        return self.colormap.map(self._low_discrepancy_image(label, self.seed))
 
     @property
     def image(self):

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -45,11 +45,11 @@ class Labels(Layer):
         self.seed = 0.5
         self._raw_image = label_image
         self._max_label = np.max(label_image)
-        self._image = colormaps._low_discrepancy_image(label_image, self.seed)
+        self._image = colormaps._low_discrepancy_image(self._raw_image, self.seed)
         self._meta = meta
         self.interpolation = 'nearest'
         self.colormap_name = 'random'
-        self.colormap = colormaps.label_colormap(label_image)
+        self.colormap = colormaps.label_colormap()
 
 
         # update flags
@@ -63,8 +63,9 @@ class Labels(Layer):
 
     def new_colormap(self):
         self.seed = np.random.rand()
-        self.colormap = colormaps.label_colormap(self._image, seed=seed)
-        self.events.colormap()
+        self._image = colormaps._low_discrepancy_image(self._raw_image, self.seed)
+        self.refresh()
+    
 
     def label_color(self, label):
         """Return the color corresponding to a specific label."""

--- a/napari/util/colormaps/colormaps.py
+++ b/napari/util/colormaps/colormaps.py
@@ -65,6 +65,7 @@ def _validate_rgb(colors, *, tolerance=0.):
     filtered_colors = np.clip(colors[valid], 0, 1)
     return filtered_colors
 
+
 def _low_discrepancy_image(image, seed=0.5):
     """Generate a 1d discrepancy sequence of coordinates.
     Parameters
@@ -180,3 +181,4 @@ def label_colormap(num_colors=256, seed=0.5):
     cmap = vispy.color.Colormap(colors=colors, controls=control_points,
                                 interpolation='zero')
     return cmap
+ZZ

--- a/napari/util/colormaps/colormaps.py
+++ b/napari/util/colormaps/colormaps.py
@@ -78,7 +78,7 @@ def _low_discrepancy_image(image, seed=0.5):
 
     Returns
     -------
-        image_out : array of float
+    image_out : array of float
         The set of ``labels`` remapped to [0, 1] quasirandomly.
 
     """

--- a/napari/util/colormaps/colormaps.py
+++ b/napari/util/colormaps/colormaps.py
@@ -183,4 +183,3 @@ def label_colormap(num_colors=256, seed=0.5):
     cmap = vispy.color.Colormap(colors=colors, controls=control_points,
                                 interpolation='zero')
     return cmap
-ZZ

--- a/napari/util/colormaps/colormaps.py
+++ b/napari/util/colormaps/colormaps.py
@@ -65,6 +65,10 @@ def _validate_rgb(colors, *, tolerance=0.):
     filtered_colors = np.clip(colors[valid], 0, 1)
     return filtered_colors
 
+def _low_discrepancy_image(image, seed=0.5):
+    phi = 1.6180339887498948482
+    image_out = (seed + image / phi) % 1
+    return image_out
 
 def _low_discrepancy(dim, n, seed=0.5):
     """Generate a 1d, 2d, or 3d low discrepancy sequence of coordinates.
@@ -134,7 +138,7 @@ def _color_random(n, *, colorspace='lab', tolerance=0.0, seed=0.5):
     return rgb[:n]
 
 
-def label_colormap(labels, seed=0.5, max_label=None):
+def label_colormap(labels, seed=0.5, num_colors=10):
     """Produce a colormap suitable for use with a given label set.
 
     Parameters
@@ -157,17 +161,11 @@ def label_colormap(labels, seed=0.5, max_label=None):
     -----
     0 always maps to fully transparent.
     """
-    unique_labels = np.unique(labels)
-    if unique_labels[0] != 0:
-        unique_labels = np.concatenate([[0], unique_labels])
-    n = len(unique_labels)
-    max_label = max_label or np.max(unique_labels)
-    unique_labels_float = unique_labels / max_label
-    midpoints = np.convolve(unique_labels_float, [0.5, 0.5], mode='valid')
+    midpoints = np.linspace(0, 1, num_colors - 1)
     control_points = np.concatenate(([0.], midpoints, [1.]))
     # make sure to add an alpha channel to the colors
-    colors = np.concatenate((_color_random(n, seed=seed),
-                             np.full((n, 1), 0.7)), axis=1)
+    colors = np.concatenate((_color_random(num_colors, seed=seed),
+                             np.full((num_colors, 1), 1)), axis=1)
     colors[0, :] = 0  # ensure alpha is 0 for label 0
     cmap = vispy.color.Colormap(colors=colors, controls=control_points,
                                 interpolation='zero')

--- a/napari/util/colormaps/colormaps.py
+++ b/napari/util/colormaps/colormaps.py
@@ -66,6 +66,20 @@ def _validate_rgb(colors, *, tolerance=0.):
     return filtered_colors
 
 def _low_discrepancy_image(image, seed=0.5):
+    """Generate a 1d discrepancy sequence of coordinates.
+    Parameters
+    ----------
+    labels : array of int
+        A set of labels or label image.
+    seed : float
+        The seed from which to start the quasirandom sequence.
+
+    Returns
+    -------
+        image_out : array of float
+        The set of ``labels`` remapped to [0, 1] quasirandomly.
+
+    """
     phi = 1.6180339887498948482
     image_out = (seed + image / phi) % 1
     return image_out
@@ -138,24 +152,20 @@ def _color_random(n, *, colorspace='lab', tolerance=0.0, seed=0.5):
     return rgb[:n]
 
 
-def label_colormap(labels, seed=0.5, num_colors=10):
+def label_colormap(num_colors=256, seed=0.5):
     """Produce a colormap suitable for use with a given label set.
 
     Parameters
     ----------
-    labels : array of int
-        A set of labels or label image.
+    num_colors : int, optional
+        Number of unique colors to use. Default used if not given.
     seed : float or array of float, length 3
-        The seed for the low discrepancy sequence generator.
-    max_label : int, optional
-        The maximum label in `labels`. Computed if not given.
+-       The seed for the random color generator.
 
     Returns
     -------
     cmap : vispy.color.Colormap
-        A colormap for use with ``labels``. The labels are remapped so that
-        the maximum label falls on 1.0, since vispy requires colormaps to map
-        within [0, 1].
+        A colormap for use with labels are remapped to [0, 1].
 
     Notes
     -----

--- a/napari/util/colormaps/colormaps.py
+++ b/napari/util/colormaps/colormaps.py
@@ -68,6 +68,7 @@ def _validate_rgb(colors, *, tolerance=0.):
 
 def _low_discrepancy_image(image, seed=0.5):
     """Generate a 1d discrepancy sequence of coordinates.
+
     Parameters
     ----------
     labels : array of int

--- a/napari/util/colormaps/colormaps.py
+++ b/napari/util/colormaps/colormaps.py
@@ -86,6 +86,7 @@ def _low_discrepancy_image(image, seed=0.5):
     image_out = (seed + image / phi) % 1
     return image_out
 
+
 def _low_discrepancy(dim, n, seed=0.5):
     """Generate a 1d, 2d, or 3d low discrepancy sequence of coordinates.
 


### PR DESCRIPTION
# Description
This is a quick rework of the labels layer to map segments into color space instead of using look-up table.  Without this change, label layers fail with > ~1000 unique labels due to an overly larger shader being generated in vispy.

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# References
Resolves an undocumented bug.

# How has this been tested?
Interactively with example/labels-2d.py  and example/labels-3d.py 

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
