### PR TITLE
Add napari CLI to launch a viewer for input images

### DIFF
--- a/napari/main.py
+++ b/napari/main.py
@@ -1,0 +1,27 @@
+"""
+napari command line viewer.
+"""
+import argparse
+import numpy as np
+from skimage import io
+
+from .util import app_context
+from . import ViewerApp
+
+
+def main():
+    parser = argparse.ArgumentParser(usage=__doc__)
+    parser.add_argument('images', nargs='+', help='Images to view.')
+    parser.add_argument('--layers', action='store_true',
+                        help='Treat multiple input images as layers.')
+    parser.add_argument('-m', '--multichannel', help='Treat images as RGB.',
+                        action='store_true')
+    args = parser.parse_args()
+    with app_context():
+        images = io.ImageCollection(args.images, conserve_memory=False)
+        if args.layers:
+            ViewerApp(*images, multichannel=args.multichannel)
+        else:
+            # TODO: change to stack axis=0 when dims fixed
+            image = np.stack(images, axis=-2 if args.multichannel else -1)
+            ViewerApp(image, multichannel=args.multichannel)

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ if __name__ == '__main__':
         requires=REQUIRES,
         python_requires=f'>={MIN_PY_VER}',
         packages=PACKAGES,
+        entry_points={'console_scripts': ['napari=napari.main:main']},
         include_package_data=True,
         zip_safe=False  # the package can run out of an .egg file
     )


### PR DESCRIPTION
# Description

```
napari *.tif
```

now launches a napari viewer with all the images concatenated along the z axis.

Lots of edge cases are not taken into account here but thought I'd get this started!

## Type of change
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
