### PR TITLE
Use triangles for vectors

### DIFF
--- a/examples/add_vectors_coords.py
+++ b/examples/add_vectors_coords.py
@@ -37,7 +37,3 @@ with app_context():
 
     # add the vectors
     layer = viewer.add_vectors(pos, width=0.4)
-
-    print(layer.vectors.shape)
-    print(layer._mesh_vertices.shape)
-    print(layer._mesh_triangles.shape)

--- a/examples/add_vectors_coords.py
+++ b/examples/add_vectors_coords.py
@@ -9,6 +9,7 @@ Each vector position is defined by an (x, y, x-proj, y-proj) element
 
 from napari import ViewerApp
 from napari.util import app_context
+from skimage import data
 
 import numpy as np
 
@@ -17,6 +18,9 @@ with app_context():
     # create the viewer and window
     viewer = ViewerApp()
 
+    layer = viewer.add_image(data.camera(), name='photographer')
+    layer.colormap = 'gray'
+
     # sample vector coord-like data
     n = 1000
     pos = np.zeros((n, 4), dtype=np.float32)
@@ -24,13 +28,16 @@ with app_context():
     radius_space = np.linspace(0, 100, n)
 
     # assign x-y position
-    pos[:, 0] = radius_space*np.cos(phi_space)
-    pos[:, 1] = radius_space*np.sin(phi_space)
+    pos[:, 0] = radius_space*np.cos(phi_space) + 256
+    pos[:, 1] = radius_space*np.sin(phi_space) + 256
 
     # assign x-y projection
-    pos[:, 2] = radius_space*np.cos(phi_space)
-    pos[:, 3] = radius_space*np.sin(phi_space)
+    pos[:, 2] = 2*radius_space*np.cos(phi_space)
+    pos[:, 3] = 2*radius_space*np.sin(phi_space)
 
     # add the vectors
-    viewer.add_vectors(pos)
+    layer = viewer.add_vectors(pos)
 
+    print(layer.vectors.shape)
+    print(layer._mesh_vertices.shape)
+    print(layer._mesh_triangles.shape)

--- a/examples/add_vectors_coords.py
+++ b/examples/add_vectors_coords.py
@@ -36,7 +36,7 @@ with app_context():
     pos[:, 3] = 2*radius_space*np.sin(phi_space)
 
     # add the vectors
-    layer = viewer.add_vectors(pos)
+    layer = viewer.add_vectors(pos, width=0.4)
 
     print(layer.vectors.shape)
     print(layer._mesh_vertices.shape)

--- a/examples/add_vectors_image.py
+++ b/examples/add_vectors_image.py
@@ -15,7 +15,7 @@ with app_context():
     # create the viewer and window
     viewer = ViewerApp()
 
-    image = 0.2*np.random.rand(25, 100) + 0.5
+    image = 0.2*np.random.rand(24, 100) + 0.5
     layer = viewer.add_image(image, clim_range = [0, 1], name='background')
     layer.colormap = 'gray'
 
@@ -33,4 +33,4 @@ with app_context():
     pos[:, :, 1] = rand2.reshape((n, m))
 
     # add the vectors
-    vect = viewer.add_vectors(pos)
+    vect = viewer.add_vectors(pos, width=0.2, length=2.5)

--- a/examples/add_vectors_image.py
+++ b/examples/add_vectors_image.py
@@ -15,22 +15,23 @@ with app_context():
     # create the viewer and window
     viewer = ViewerApp()
 
-    image = 0.2*np.random.random((24, 100)) + 0.5
+    n = 100
+    m = 200
+
+    image = 0.2*np.random.random((n, m)) + 0.5
     layer = viewer.add_image(image, clim_range=[0, 1], name='background')
     layer.colormap = 'gray'
 
     # sample vector image-like data
     # n x m grid of slanted lines
     # random data on the open interval (-1, 1)
-    n = 100
-    m = 50
-    pos = np.zeros(shape=(n, m, 2), dtype=np.float32)
+    pos = np.zeros(shape=(m, n, 2), dtype=np.float32)
     rand1 = 2*(np.random.random_sample(n * m)-0.5)
     rand2 = 2*(np.random.random_sample(n * m)-0.5)
 
     # assign projections for each vector
-    pos[:, :, 0] = rand1.reshape((n, m))
-    pos[:, :, 1] = rand2.reshape((n, m))
+    pos[:, :, 0] = rand1.reshape((m, n))
+    pos[:, :, 1] = rand2.reshape((m, n))
 
     # add the vectors
     vect = viewer.add_vectors(pos, width=0.2, length=2.5)

--- a/examples/add_vectors_image.py
+++ b/examples/add_vectors_image.py
@@ -15,6 +15,10 @@ with app_context():
     # create the viewer and window
     viewer = ViewerApp()
 
+    image = 0.2*np.random.rand(25, 100) + 0.5
+    layer = viewer.add_image(image, clim_range = [0, 1], name='background')
+    layer.colormap = 'gray'
+
     # sample vector image-like data
     # n x m grid of slanted lines
     # random data on the open interval (-1, 1)
@@ -30,5 +34,3 @@ with app_context():
 
     # add the vectors
     vect = viewer.add_vectors(pos)
-
-

--- a/examples/add_vectors_image.py
+++ b/examples/add_vectors_image.py
@@ -16,7 +16,7 @@ with app_context():
     viewer = ViewerApp()
 
     image = 0.2*np.random.rand(24, 100) + 0.5
-    layer = viewer.add_image(image, clim_range = [0, 1], name='background')
+    layer = viewer.add_image(image, clim_range=[0, 1], name='background')
     layer.colormap = 'gray'
 
     # sample vector image-like data

--- a/examples/add_vectors_image.py
+++ b/examples/add_vectors_image.py
@@ -15,7 +15,7 @@ with app_context():
     # create the viewer and window
     viewer = ViewerApp()
 
-    image = 0.2*np.random.rand(24, 100) + 0.5
+    image = 0.2*np.random.random((24, 100)) + 0.5
     layer = viewer.add_image(image, clim_range=[0, 1], name='background')
     layer.colormap = 'gray'
 

--- a/napari/layers/_shapes_layer/shape_util.py
+++ b/napari/layers/_shapes_layer/shape_util.py
@@ -1,4 +1,5 @@
 import numpy as np
+from ...util import segment_normal
 from vispy.geometry import PolygonData
 
 
@@ -652,29 +653,3 @@ def triangulate_edge(path, closed=False, limit=3, bevel=False):
     triangles = np.array(triangles)
 
     return centers, offsets, triangles
-
-
-def segment_normal(a, b):
-    """Determines the unit normal of the vector from a to b.
-
-    Parameters
-    ----------
-    a : np.ndarray
-        Length 2 array of first point
-    b : np.ndarray
-        Length 2 array of second point
-
-    Returns
-    -------
-    unit_norm : np.ndarray
-        Length the unit normal of the vector from a to b. If a == b,
-        then return [1, 0]
-    """
-    d = b-a
-    normal = np.array([d[1], -d[0]])
-    norm = np.linalg.norm(normal)
-    if norm == 0:
-        unit_norm = np.array([1, 0])
-    else:
-        unit_norm = normal/norm
-    return unit_norm

--- a/napari/layers/_vectors_layer/model.py
+++ b/napari/layers/_vectors_layer/model.py
@@ -395,10 +395,8 @@ class Vectors(Layer):
         signs[::2] = -1
         offests = offests*signs
 
-        np.array([[1, 0] if i%2 == 0 else [-1, 0] for i in range(2*len(vectors))])
-
         vertices = centers + width*offests/2
-        triangles = np.array([[2*i, 2*i+1, 2*i+2] if i%2 == 0 else
+        triangles = np.array([[2*i, 2*i+1, 2*i+2] if i % 2 == 0 else
                               [2*i-1, 2*i, 2*i+1] for i in
                               range(len(vectors)//2)]).astype(np.uint32)
 

--- a/napari/layers/_vectors_layer/model.py
+++ b/napari/layers/_vectors_layer/model.py
@@ -388,9 +388,16 @@ class Vectors(Layer):
             Nx3 array of vertex indices that form the mesh triangles
         """
         centers = np.array([vectors[i//2] for i in range(2*len(vectors))])
-        offests = np.array([[1, 0] if i%2 == 0 else [-1, 0] for i in range(2*len(vectors))])
+        offests = np.array([segment_normal(vectors[2*i], vectors[2*i+1]) for i
+                            in range(len(vectors)//2)])
+        offests = offests[[i//4 for i in range(4*len(offests))]]
+        signs = np.ones((len(offests), 2))
+        signs[::2] = -1
+        offests = offests*signs
 
-        vertices = centers + width*offests
+        np.array([[1, 0] if i%2 == 0 else [-1, 0] for i in range(2*len(vectors))])
+
+        vertices = centers + width*offests/2
         triangles = np.array([[2*i, 2*i+1, 2*i+2] if i%2 == 0 else
                               [2*i-1, 2*i, 2*i+1] for i in
                               range(len(vectors)//2)]).astype(np.uint32)
@@ -429,3 +436,29 @@ class Vectors(Layer):
 
         self._need_visual_update = True
         self._update()
+
+
+def segment_normal(a, b):
+    """Determines the unit normal of the vector from a to b.
+
+    Parameters
+    ----------
+    a : np.ndarray
+        Length 2 array of first point
+    b : np.ndarray
+        Length 2 array of second point
+
+    Returns
+    -------
+    unit_norm : np.ndarray
+        Length the unit normal of the vector from a to b. If a == b,
+        then return [1, 0]
+    """
+    d = b-a
+    normal = np.array([d[1], -d[0]])
+    norm = np.linalg.norm(normal)
+    if norm == 0:
+        unit_norm = np.array([0, 0])
+    else:
+        unit_norm = normal/norm
+    return unit_norm

--- a/napari/layers/_vectors_layer/model.py
+++ b/napari/layers/_vectors_layer/model.py
@@ -5,7 +5,7 @@ from scipy import signal
 
 from .._base_layer import Layer
 from .._register import add_to_viewer
-from ..._vispy.scene.visuals import Line as LinesNode
+from ..._vispy.scene.visuals import Mesh
 from ...util.event import Event
 from vispy.color import get_color_names
 
@@ -24,29 +24,19 @@ class Vectors(Layer):
             x and y are coordinates
             u and v are x and y projections of the vector
         (N, M, 2) is an (N, M) image of (u, v) projections
-
         Returns np.ndarray of the current display (including averaging, length)
-
     averaging : int
         (int, int) kernel over which to convolve and subsample the data
         not implemented for (N, 4) data
-
     width : int
         width of the line in pixels
-
     length : float
         length of the line
         not implemented for (N, 4) data
-
     color : str
         one of "get_color_names" from vispy.color
-
     mode : str
         control panel mode
-
-    See vispy's line visual docs for more details:
-    http://api.vispy.org/en/latest/scene.html
-    vispy.scene.visuals.Line
     """
 
     def __init__(self,
@@ -57,12 +47,13 @@ class Vectors(Layer):
                  length=1,
                  name=None):
 
-        visual = LinesNode(antialias=True)
+        visual = Mesh()
         super().__init__(visual)
 
         # events for non-napari calculations
         self.events.add(length=Event,
-                        average=Event)
+                        width=Event,
+                        averaging=Event)
 
         # Store underlying data model
         self._data_types = ('image', 'coords')
@@ -82,10 +73,14 @@ class Vectors(Layer):
         self._need_visual_update = False
 
         # assign vector data and establish default behavior
-        self._raw_dat = None
+        self._raw_data = None
         self._original_data = vectors
         self._current_data = vectors
+
         self._vectors = self._convert_to_vector_type(vectors)
+        vertices, triangles = self._generate_meshes(self._vectors, self.width)
+        self._mesh_vertices = vertices
+        self._mesh_triangles = triangles
 
         if name is None:
             self.name = 'vectors'
@@ -97,20 +92,20 @@ class Vectors(Layer):
     # ====================== Property getter and setters =====================
     @property
     def _original_data(self) -> np.ndarray:
-        return self._raw_dat
+        return self._raw_data
 
     @_original_data.setter
-    def _original_data(self, dat: np.ndarray):
+    def _original_data(self, data: np.ndarray):
         """Must preserve data used at construction. Specifically for default
         averaging/length adjustments.
         averaging/length adjustments recalculate the underlying data
 
         Parameters
         ----------
-        dat : np.ndarray
+        data : np.ndarray
         """
-        if self._raw_dat is None:
-            self._raw_dat = dat
+        if self._raw_data is None:
+            self._raw_data = data
 
     @property
     def vectors(self) -> np.ndarray:
@@ -135,8 +130,12 @@ class Vectors(Layer):
 
         self._vectors = self._convert_to_vector_type(self._current_data)
 
+        vertices, triangles = self._generate_meshes(self._vectors, self.width)
+        self._mesh_vertices = vertices
+        self._mesh_triangles = triangles
+
         self.viewer._child_layer_changed = True
-        self._refresh()
+        self.refresh()
 
     def _convert_to_vector_type(self, vectors):
         """Check on input data for proper shape and dtype
@@ -216,7 +215,7 @@ class Vectors(Layer):
         vect : np.ndarray of shape (N, 4)
         """
         # create empty vector of necessary shape
-        #   one coordinate for each endpoint of the vector
+        # one coordinate for each endpoint of the vector
         pos = np.empty((2 * len(vect), 2), dtype=np.float32)
 
         # create pairs of points
@@ -234,7 +233,7 @@ class Vectors(Layer):
     @property
     def averaging(self) -> int:
         return self._averaging
-    
+
     @averaging.setter
     def averaging(self, value: int):
         """Calculates an average vector over a kernel
@@ -245,26 +244,26 @@ class Vectors(Layer):
         """
         self._averaging = value
 
-        # emit signal back to qt_properties for averaging
-        self.events.average()
+        self.events.averaging()
+        self._update_avg()
 
-        self._refresh()
+        self.refresh()
 
-    def _default_avg(self):
-        """Default method for calculating average
+    def _update_avg(self):
+        """Method for calculating average
         Implemented ONLY for image-like vector data
         """
         if self._data_type == 'coords':
+            # default averaging is supported only for 'matrix' dataTypes
             return
-            # return "default averaging is supported only for 'matrix' dataTypes"
         elif self._data_type == 'image':
 
             x, y = self._averaging, self._averaging
 
             if (x,y) == (1, 1):
                 self.vectors = self._original_data
+                # calling original data
                 return
-                # return "calling original data"
 
             tempdat = self._original_data
             range_x = tempdat.shape[0]
@@ -275,14 +274,16 @@ class Vectors(Layer):
             kernel = np.ones(shape=(x, y)) / (x*y)
 
             output_mat = np.zeros_like(tempdat)
-            output_mat_x = signal.convolve2d(tempdat[:, :, 0], kernel, mode='same', boundary='wrap')
-            output_mat_y = signal.convolve2d(tempdat[:, :, 1], kernel, mode='same', boundary='wrap')
+            output_mat_x = signal.convolve2d(tempdat[:, :, 0], kernel,
+                                             mode='same', boundary='wrap')
+            output_mat_y = signal.convolve2d(tempdat[:, :, 1], kernel,
+                                             mode='same', boundary='wrap')
 
             output_mat[:, :, 0] = output_mat_x
             output_mat[:, :, 1] = output_mat_y
 
-            self.vectors = output_mat[x_offset:range_x-x_offset:x, y_offset:range_y-y_offset:y]
-            self.length = self._length
+            self.vectors = (output_mat[x_offset:range_x-x_offset:x,
+                                       y_offset:range_y-y_offset:y])
 
     @property
     def width(self) -> Union[int, float]:
@@ -294,7 +295,14 @@ class Vectors(Layer):
         widths greater than 1px only guaranteed to work with "agg" method
         """
         self._width = width
-        self._refresh()
+
+        vertices, triangles = self._generate_meshes(self.vectors, self._width)
+        self._mesh_vertices = vertices
+        self._mesh_triangles = triangles
+
+        self.events.width()
+
+        self.refresh()
 
     @property
     def length(self) -> Union[int, float]:
@@ -309,15 +317,14 @@ class Vectors(Layer):
         length : int or float multiplicative factor
         """
         self._length = length
-
-        # emit signal back to qt_properties for length
+        self._update_length()
         self.events.length()
 
-        self._refresh()
+        self.refresh()
 
-    def _default_length(self):
+    def _update_length(self):
         """
-        Default method for calculating vector lengths
+        Method for calculating vector lengths
         Implemented ONLY for image-like vector data
         """
 
@@ -325,6 +332,10 @@ class Vectors(Layer):
             return "length adjustment not allowed for coordinate-style data"
         elif self._data_type == 'image':
             self._vectors = self._convert_to_vector_type(self._current_data)
+            vertices, triangles = self._generate_meshes(self.vectors,
+                                                        self.width)
+            self._mesh_vertices = vertices
+            self._mesh_triangles = triangles
 
     @property
     def color(self) -> str:
@@ -335,7 +346,7 @@ class Vectors(Layer):
         """Color, ColorArray: color of the body of the marker
         """
         self._color = color
-        self._refresh()
+        self.refresh()
 
     # =========================== Napari Layer ABC methods ===================
     @property
@@ -358,6 +369,34 @@ class Vectors(Layer):
         self._need_display_update = True
         self._update()
 
+    def _generate_meshes(self, vectors, width):
+        """Generates list of mesh vertices and triangles from a list of vectors
+
+        Parameters
+        ----------
+        vectors : np.ndarray
+            Nx2 array where each pair of vertices corresponds to an independent
+            line segment
+        width : float
+            width of the line to be drawn
+
+        Returns
+        ----------
+        vertices : np.ndarray
+            2Nx2 array of vertices of all triangles for the lines
+        triangles : np.ndarray
+            Nx3 array of vertex indices that form the mesh triangles
+        """
+        centers = np.array([vectors[i//2] for i in range(2*len(vectors))])
+        offests = np.array([[1, 0] if i%2 == 0 else [-1, 0] for i in range(2*len(vectors))])
+
+        vertices = centers + width*offests
+        triangles = np.array([[2*i, 2*i+1, 2*i+2] if i%2 == 0 else
+                              [2*i-1, 2*i, 2*i+1] for i in
+                              range(len(vectors)//2)]).astype(np.uint32)
+
+        return vertices, triangles
+
     def _update(self):
         """Update the underlying visual.
         """
@@ -378,21 +417,15 @@ class Vectors(Layer):
         indices : sequence of int or slice
             Indices to slice with.
         """
-        
-        in_slice_vectors = self.vectors
 
-        # Display vectors if there are any in this slice
-        if len(in_slice_vectors) > 0:
-            data = np.array(in_slice_vectors) + 0.5
+        vertices = self._mesh_vertices
+        faces = self._mesh_triangles
+
+        if len(faces) == 0:
+            self._node.set_data(vertices=None, faces=None)
         else:
-            # if no vectors in this slice send dummy data
-            data = np.empty((0, 2))
+            self._node.set_data(vertices=vertices, faces=faces,
+                                color=self.color)
 
-        self._node.set_data(
-            data[::-1],
-            width=self.width,
-            color=self.color,
-            connect='segments')
         self._need_visual_update = True
         self._update()
-

--- a/napari/layers/_vectors_layer/model.py
+++ b/napari/layers/_vectors_layer/model.py
@@ -7,6 +7,7 @@ from .._base_layer import Layer
 from .._register import add_to_viewer
 from ..._vispy.scene.visuals import Mesh
 from ...util.event import Event
+from ...util import segment_normal
 from vispy.color import get_color_names
 
 from .view import QtVectorsLayer
@@ -434,29 +435,3 @@ class Vectors(Layer):
 
         self._need_visual_update = True
         self._update()
-
-
-def segment_normal(a, b):
-    """Determines the unit normal of the vector from a to b.
-
-    Parameters
-    ----------
-    a : np.ndarray
-        Length 2 array of first point
-    b : np.ndarray
-        Length 2 array of second point
-
-    Returns
-    -------
-    unit_norm : np.ndarray
-        Length the unit normal of the vector from a to b. If a == b,
-        then return [1, 0]
-    """
-    d = b-a
-    normal = np.array([d[1], -d[0]])
-    norm = np.linalg.norm(normal)
-    if norm == 0:
-        unit_norm = np.array([0, 0])
-    else:
-        unit_norm = normal/norm
-    return unit_norm

--- a/napari/layers/_vectors_layer/model.py
+++ b/napari/layers/_vectors_layer/model.py
@@ -389,8 +389,7 @@ class Vectors(Layer):
             Nx3 array of vertex indices that form the mesh triangles
         """
         centers = np.array([vectors[i//2] for i in range(2*len(vectors))])
-        offests = np.array([segment_normal(vectors[2*i], vectors[2*i+1]) for i
-                            in range(len(vectors)//2)])
+        offests = segment_normal(vectors[::2, :], vectors[1::2, :])
         offests = offests[[i//4 for i in range(4*len(offests))]]
         signs = np.ones((len(offests), 2))
         signs[::2] = -1
@@ -399,7 +398,7 @@ class Vectors(Layer):
         vertices = centers + width*offests/2
         triangles = np.array([[2*i, 2*i+1, 2*i+2] if i % 2 == 0 else
                               [2*i-1, 2*i, 2*i+1] for i in
-                              range(len(vectors)//2)]).astype(np.uint32)
+                              range(len(vectors))]).astype(np.uint32)
 
         return vertices, triangles
 

--- a/napari/layers/_vectors_layer/view/properties.py
+++ b/napari/layers/_vectors_layer/view/properties.py
@@ -1,8 +1,8 @@
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QLabel, QComboBox, QDoubleSpinBox, QSpinBox, QGridLayout
+from PyQt5.QtWidgets import (QLabel, QComboBox, QDoubleSpinBox, QSpinBox,
+                             QGridLayout)
 import numpy as np
-import scipy.signal as signal
 
 from ..._base_layer import QtLayer
 
@@ -13,7 +13,7 @@ class QtVectorsLayer(QtLayer):
         super().__init__(layer)
 
         self.layer.events.averaging.connect(self._on_avg_change)
-        self.layer.events.width.connect(self.change_width)
+        self.layer.events.width.connect(self._on_width_change)
         self.layer.events.length.connect(self._on_len_change)
 
         # vector color adjustment and widget
@@ -30,10 +30,11 @@ class QtVectorsLayer(QtLayer):
         self.grid_layout.addWidget(face_comboBox, 3, 1)
 
         # line width in pixels
-        self.width_field = QSpinBox()
+        self.width_field = QDoubleSpinBox()
+        self.width_field.setSingleStep(0.1)
+        self.width_field.setMinimum(0.1)
         value = self.layer.width
         self.width_field.setValue(value)
-        self.width_field.setMinimum(1)
         self.width_field.valueChanged.connect(self.change_width)
         self.grid_layout.addWidget(QLabel('width:'), 4, 0)
         self.grid_layout.addWidget(self.width_field, 4, 1)
@@ -82,6 +83,6 @@ class QtVectorsLayer(QtLayer):
         with self.layer.events.length.blocker():
             self.length_field.setValue(self.layer.length)
 
-    def _on_len_change(self, event):
+    def _on_width_change(self, event):
         with self.layer.events.width.blocker():
             self.width_field.setValue(self.layer.width)

--- a/napari/layers/_vectors_layer/view/properties.py
+++ b/napari/layers/_vectors_layer/view/properties.py
@@ -12,8 +12,9 @@ class QtVectorsLayer(QtLayer):
     def __init__(self, layer):
         super().__init__(layer)
 
-        self.layer.events.average.connect(self.change_avg)
-        self.layer.events.length.connect(self.change_len)
+        self.layer.events.averaging.connect(self._on_avg_change)
+        self.layer.events.width.connect(self.change_width)
+        self.layer.events.length.connect(self._on_len_change)
 
         # vector color adjustment and widget
         face_comboBox = QComboBox()
@@ -29,13 +30,13 @@ class QtVectorsLayer(QtLayer):
         self.grid_layout.addWidget(face_comboBox, 3, 1)
 
         # line width in pixels
-        width_field = QSpinBox()
+        self.width_field = QSpinBox()
         value = self.layer.width
-        width_field.setValue(value)
-        width_field.setMinimum(1)
-        width_field.valueChanged.connect(self.change_width)
+        self.width_field.setValue(value)
+        self.width_field.setMinimum(1)
+        self.width_field.valueChanged.connect(self.change_width)
         self.grid_layout.addWidget(QLabel('width:'), 4, 0)
-        self.grid_layout.addWidget(width_field, 4, 1)
+        self.grid_layout.addWidget(self.width_field, 4, 1)
 
         # averaging spinbox
         self.averaging_spinbox = QSpinBox()
@@ -69,17 +70,18 @@ class QtVectorsLayer(QtLayer):
 
     def change_width(self, value):
         self.layer.width = value
-    
+
     def change_length(self, value):
         self.layer.length = value
 
-    def change_avg(self, event):
-        self.layer._default_avg()
+    def _on_avg_change(self, event):
+        with self.layer.events.averaging.blocker():
+            self.averaging_spinbox.setValue(self.layer.averaging)
 
-    def change_len(self, event):
-        self.layer._default_length()
+    def _on_len_change(self, event):
+        with self.layer.events.length.blocker():
+            self.length_field.setValue(self.layer.length)
 
-
-
-
-
+    def _on_len_change(self, event):
+        with self.layer.events.width.blocker():
+            self.width_field.setValue(self.layer.width)

--- a/napari/util/__init__.py
+++ b/napari/util/__init__.py
@@ -1,2 +1,2 @@
-from .misc import is_multichannel
+from .misc import is_multichannel, segment_normal
 from .app import app_context

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -149,6 +149,39 @@ def segment_normal(a, b):
     Parameters
     ----------
     a : np.ndarray
+        Length 2 array of first point or Nx2 array of points
+    b : np.ndarray
+        Length 2 array of second point or Nx2 array of points
+
+    Returns
+    -------
+    unit_norm : np.ndarray
+        Length the unit normal of the vector from a to b. If a == b,
+        then returns [0, 0] or Nx2 array of vectors
+    """
+    d = b-a
+
+    if d.ndim == 1:
+        normal = np.array([d[1], -d[0]])
+        norm = np.linalg.norm(normal)
+        if norm == 0:
+            norm = 1
+    else:
+        normal = np.stack([d[:, 1], -d[:, 0]], axis=0).transpose(1, 0)
+        norm = np.linalg.norm(normal, axis=1, keepdims=True)
+        ind = norm == 0
+        norm[ind] = 1
+    unit_norm = normal/norm
+
+    return unit_norm
+
+
+def segment_normal_vector(a, b):
+    """Determines the unit normal of the vector from a to b.
+
+    Parameters
+    ----------
+    a : np.ndarray
         Length 2 array of first point
     b : np.ndarray
         Length 2 array of second point

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -141,3 +141,29 @@ def formatdoc(obj):
         return obj
     finally:
         del frame
+
+
+def segment_normal(a, b):
+    """Determines the unit normal of the vector from a to b.
+
+    Parameters
+    ----------
+    a : np.ndarray
+        Length 2 array of first point
+    b : np.ndarray
+        Length 2 array of second point
+
+    Returns
+    -------
+    unit_norm : np.ndarray
+        Length the unit normal of the vector from a to b. If a == b,
+        then returns [0, 0]
+    """
+    d = b-a
+    normal = np.array([d[1], -d[0]])
+    norm = np.linalg.norm(normal)
+    if norm == 0:
+        unit_norm = np.array([0, 0])
+    else:
+        unit_norm = normal/norm
+    return unit_norm


### PR DESCRIPTION
# Description
This PR changes the rendering of the vectors from openGL lines to be mesh objects made from triangles. It makes no changes to the API or functionality, but should prevent a bug around setting lines to arbitrary widths that we had encountered using vispy Lines and a bug around our osx build detailed in #213 

It should make it easy in a follow-up PR to add support for arrowheads if desired.

Finally adding an vectors layer to an empty viewer will cause an error as detailed in #214, but that is a broader issue that can be fixed later.

@bryantChhun do you want to give this a check to make sure all functionality is preserved and is behaving as expected. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run `examples/add_vectors_coords.py` and `examples/add_vectors_image.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
