### PR TITLE
fix nD fill

### DIFF
--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -423,7 +423,7 @@ class Labels(Layer):
             slice_coord = tuple(int_coord)
         else:
             # work with just the sliced image
-            slice_indices = self._get_indices(slice_indices)
+            slice_indices = self._get_indices(indices)
             labels = self._slice_image(indices, image=self._raw_image)
             slice_coord = tuple(int_coord[:2])
             displayed = self._image[slice_indices]
@@ -447,7 +447,7 @@ class Labels(Layer):
         if not (self.n_dimensional or self._raw_image.ndim == 2):
             # if working with just the slice, update the rest of the raw image
             self._raw_image[slice_indices] = labels
-            self._image[slice_coord] = displayed
+            self._image[slice_indices] = displayed
 
         self.refresh()
 


### PR DESCRIPTION
# Description
This PR fixes the fill bucket when using an nD image but you want to only fill a slice.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)