### PR TITLE
fix nD paint

### DIFF
--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -560,7 +560,7 @@ class Labels(Layer):
         int_coord[1] = int(round(coord[1]))
         label = self._slice_image(int_coord, image=self._raw_image)
 
-        return coord[:len(self.shape)], label
+        return coord[:self.image.ndim], label
 
     def get_message(self, coord, label):
         """Generates a string based on the coordinates and information about

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -559,7 +559,8 @@ class Labels(Layer):
         int_coord[0] = int(round(coord[0]))
         int_coord[1] = int(round(coord[1]))
         label = self._slice_image(int_coord, image=self._raw_image)
-        return coord, label
+
+        return coord[:len(self.shape)], label
 
     def get_message(self, coord, label):
         """Generates a string based on the coordinates and information about


### PR DESCRIPTION
# Description
Fixes painting when the labels layer is of less dimensions than the current max dim layer in the viewer (i.e. painting a 2D labels layer, when also a 3D image layer is loaded in the viewer)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
