### PR TITLE
Generate svg from shapes layer

### DIFF
--- a/examples/shapes_to_labels.py
+++ b/examples/shapes_to_labels.py
@@ -60,3 +60,7 @@ with app_context():
     labels = layer.data.to_labels([512, 512]).transpose(1, 0)
     labels_layer = viewer.add_labels(labels, name='labels')
     labels_layer.visible = False
+
+    svg = layer.to_svg()
+    with open('shape.svg', 'w') as file:
+        file.write(svg)

--- a/examples/shapes_to_labels.py
+++ b/examples/shapes_to_labels.py
@@ -62,5 +62,6 @@ with app_context():
     labels_layer.visible = False
 
     svg = layer.to_svg()
-    with open('shape.svg', 'w') as file:
-        file.write(svg)
+    # To save svg file
+    # with open('shape.svg', 'w') as f:
+    #     f.write(svg)

--- a/napari/layers/_shapes_layer/model.py
+++ b/napari/layers/_shapes_layer/model.py
@@ -1191,8 +1191,8 @@ class Shapes(Layer):
 
         Parameters
         ----------
-        canvas_shape : np.ndarray | tuple | None
-            2-tuple defining shape of svg canvas to be generated. If non
+        canvas_shape : tuple, optional
+            2 tuple defining shape of svg canvas to be generated. If not
             specified, takes the max of all the vertiecs
         shape_type : {'line', 'rectangle', 'ellipse', 'path', 'polygon'} |
                      None, optional

--- a/napari/layers/_shapes_layer/model.py
+++ b/napari/layers/_shapes_layer/model.py
@@ -1,4 +1,5 @@
 import numpy as np
+from xml.etree.ElementTree import Element, tostring
 from copy import copy, deepcopy
 from contextlib import contextmanager
 
@@ -1182,6 +1183,46 @@ class Shapes(Layer):
                     self._drag_start = coord
                 self._drag_box = np.array([self._drag_start, coord])
                 self._set_highlight()
+
+    def to_svg(self, canvas_shape=None, shape_type=None):
+        """Returns an svg string with all the shapes contained in the layer.
+        Passing a `shape_type` argument leads to only shapes from that
+        particular `shape_type` being returned.
+
+        Parameters
+        ----------
+        canvas_shape : np.ndarray | tuple | None
+            2-tuple defining shape of svg canvas to be generated. If non
+            specified, takes the max of all the vertiecs
+        shape_type : {'line', 'rectangle', 'ellipse', 'path', 'polygon'} |
+                     None, optional
+            String of shape type to be included.
+
+        Returns
+        ----------
+        svg : string
+            String with the svg specification of the shapes contained in the
+            layer
+        """
+
+        if canvas_shape is None:
+            canvas_shape = self.data._vertices.max(axis=0).astype(np.int)
+
+        xml = Element('svg', width=f'{canvas_shape[0]}',
+                      height=f'{canvas_shape[1]}', version='1.1',
+                      xmlns='http://www.w3.org/2000/svg')
+
+        xml_list = self.data.to_xml(shape_type=shape_type)
+
+        for x in xml_list:
+            xml.append(x)
+
+        svg = ('<?xml version=\"1.0\" standalone=\"no\"?>\n' +
+               '<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n' +
+               '\"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n' +
+               tostring(xml, encoding='unicode', method='xml'))
+
+        return svg
 
     def on_mouse_press(self, event):
         """Called whenever mouse pressed in canvas.

--- a/napari/layers/_shapes_layer/model.py
+++ b/napari/layers/_shapes_layer/model.py
@@ -1191,12 +1191,12 @@ class Shapes(Layer):
 
         Parameters
         ----------
-        canvas_shape : tuple, optional
-            2 tuple defining shape of svg canvas to be generated. If not
-            specified, takes the max of all the vertiecs
-        shape_type : {'line', 'rectangle', 'ellipse', 'path', 'polygon'} |
-                     None, optional
-            String of shape type to be included.
+        canvas_shape : 2-tuple, optional
+            Shape of SVG canvas to be generated. If not specified, takes the
+            max of all the vertices
+        shape_type : {'line', 'rectangle', 'ellipse', 'path', 'polygon'},
+            optional
+            String of shape type to be included
 
         Returns
         ----------

--- a/napari/layers/_shapes_layer/shape_list.py
+++ b/napari/layers/_shapes_layer/shape_list.py
@@ -568,7 +568,7 @@ class ShapeList():
                          """)
         else:
             cls = self._types[shape_type]
-            data = [s.data for s in self.shapes if isinstance(shape, cls)]
+            data = [s.data for s in self.shapes if isinstance(s, cls)]
         return data
 
     def to_masks(self, mask_shape=None, shape_type=None):
@@ -604,7 +604,7 @@ class ShapeList():
         else:
             cls = self._types[shape_type]
             data = [s.to_mask(mask_shape) for s in self.shapes if
-                    isinstance(shape, cls)]
+                    isinstance(s, cls)]
         masks = np.array(data)
 
         return masks
@@ -657,3 +657,36 @@ class ShapeList():
                     labels[mask] = index[ind]
 
         return labels
+
+    def to_xml(self, shape_type=None):
+        """Returns a list of xml elements defining each shape according to the
+        svg specification. Z ordering of the shapes will be taken into account.
+        Passing a `shape_type` argument leads to only xml from that particular
+        `shape_type` being returned.
+
+        Parameters
+        ----------
+        shape_type : {'line', 'rectangle', 'ellipse', 'path', 'polygon'} |
+                     None, optional
+            String of shape type to be included.
+
+        Returns
+        ----------
+        xml : list
+            List of xml elements defining each shape according to the
+            svg specification
+        """
+
+        if shape_type is None:
+            xml = [self.shapes[ind].to_xml() for ind in self._z_order[::-1]]
+        elif shape_type not in self._types.keys():
+            raise ValueError("""shape_type not recognized, must be one of
+                         "{'line', 'rectangle', 'ellipse', 'path',
+                         'polygon'}"
+                         """)
+        else:
+            cls = self._types[shape_type]
+            xml = [self.shapes[ind].to_xml() for ind in self._z_order[::-1] if
+                   isinstance(self.shapes[ind], cls)]
+
+        return xml

--- a/napari/layers/_shapes_layer/shape_list.py
+++ b/napari/layers/_shapes_layer/shape_list.py
@@ -659,16 +659,14 @@ class ShapeList():
         return labels
 
     def to_xml(self, shape_type=None):
-        """Returns a list of xml elements defining each shape according to the
-        svg specification. Z ordering of the shapes will be taken into account.
-        Passing a `shape_type` argument leads to only xml from that particular
-        `shape_type` being returned.
+        """Convert the shapes to a list of xml elements according to the svg
+        specification. Z ordering of the shapes will be taken into account.
 
         Parameters
         ----------
-        shape_type : {'line', 'rectangle', 'ellipse', 'path', 'polygon'} |
-                     None, optional
-            String of shape type to be included.
+        shape_type : {'line', 'rectangle', 'ellipse', 'path', 'polygon'},
+            optional
+            String of which shape types should to be included in the xml.
 
         Returns
         ----------
@@ -680,10 +678,9 @@ class ShapeList():
         if shape_type is None:
             xml = [self.shapes[ind].to_xml() for ind in self._z_order[::-1]]
         elif shape_type not in self._types.keys():
-            raise ValueError("""shape_type not recognized, must be one of
-                         "{'line', 'rectangle', 'ellipse', 'path',
-                         'polygon'}"
-                         """)
+            raise ValueError('shape_type not recognized, must be one of '
+                             "{'line', 'rectangle', 'ellipse', 'path', "
+                             "'polygon'}")
         else:
             cls = self._types[shape_type]
             xml = [self.shapes[ind].to_xml() for ind in self._z_order[::-1] if

--- a/napari/layers/_shapes_layer/shapes/ellipse.py
+++ b/napari/layers/_shapes_layer/shapes/ellipse.py
@@ -126,7 +126,8 @@ class Ellipse(Shape):
 
             # rotate back to axis aligned
             c, s = np.cos(angle), np.sin(-angle)
-            rotation = np.array([[c, s], [-s, c]])
+            rotation = np.array([[c, s],
+                                 [-s, c]])
             coords = coords @ rotation.T
 
             # shift back to center
@@ -141,8 +142,8 @@ class Ellipse(Shape):
         cx = str(cen[0])
         cy = str(cen[1])
         size = abs(coords[2] - coords[0])
-        rx = str(size[0]/2)
-        ry = str(size[1]/2)
+        rx = str(size[0] / 2)
+        ry = str(size[1] / 2)
 
         element = Element('ellipse', cx=cx, cy=cy, rx=rx, ry=ry, **props)
         return element

--- a/napari/layers/_shapes_layer/shapes/ellipse.py
+++ b/napari/layers/_shapes_layer/shapes/ellipse.py
@@ -115,12 +115,34 @@ class Ellipse(Shape):
         element : Element
             xml element specifying the shape according to svg.
         """
-        x = f'{self.data[0, 0]}'
-        y = f'{self.data[0, 1]}'
-        rx = f'{self.data[1, 0] - self.data[0, 0]}'
-        ry = f'{self.data[3, 1] - self.data[0, 1]}'
+        props = self.svg_props
 
-        element = Element('rect', x=x, y=y, width=rx, height=ry,
-                          **self.svg_props)
+        offset = self.data[1] - self.data[0]
+        angle = -np.arctan2(offset[0], -offset[1])
+        if not angle == 0:
+            # if shape has been rotated, shift to origin
+            cen = self.data.mean(axis=0)
+            cords = self.data - cen
 
+            # rotate back to axis aligned
+            c, s = np.cos(angle), np.sin(-angle)
+            rotation = np.array([[c, s], [-s, c]])
+            cords = cords @ rotation.T
+
+            # shift back to center
+            cords = cords + cen
+
+            # define rotation around center
+            transform = f'rotate({np.degrees(-angle)} {cen[0]} {cen[1]})'
+            props['transform'] = transform
+        else:
+            cords = self.data
+
+        cx = f'{cen[0]}'
+        cy = f'{cen[1]}'
+        size = abs(cords[2] - cords[0])
+        rx = f'{size[0]/2}'
+        ry = f'{size[1]/2}'
+
+        element = Element('ellipse', cx=cx, cy=cy, rx=rx, ry=ry, **props)
         return element

--- a/napari/layers/_shapes_layer/shapes/ellipse.py
+++ b/napari/layers/_shapes_layer/shapes/ellipse.py
@@ -112,7 +112,7 @@ class Ellipse(Shape):
 
         Returns
         ----------
-        element : Element
+        element : xml.etree.ElementTree.Element
             xml element specifying the shape according to svg.
         """
         props = self.svg_props
@@ -122,27 +122,27 @@ class Ellipse(Shape):
         if not angle == 0:
             # if shape has been rotated, shift to origin
             cen = self.data.mean(axis=0)
-            cords = self.data - cen
+            coords = self.data - cen
 
             # rotate back to axis aligned
             c, s = np.cos(angle), np.sin(-angle)
             rotation = np.array([[c, s], [-s, c]])
-            cords = cords @ rotation.T
+            coords = coords @ rotation.T
 
             # shift back to center
-            cords = cords + cen
+            coords = coords + cen
 
             # define rotation around center
             transform = f'rotate({np.degrees(-angle)} {cen[0]} {cen[1]})'
             props['transform'] = transform
         else:
-            cords = self.data
+            coords = self.data
 
-        cx = f'{cen[0]}'
-        cy = f'{cen[1]}'
-        size = abs(cords[2] - cords[0])
-        rx = f'{size[0]/2}'
-        ry = f'{size[1]/2}'
+        cx = str(cen[0])
+        cy = str(cen[1])
+        size = abs(coords[2] - coords[0])
+        rx = str(size[0]/2)
+        ry = str(size[1]/2)
 
         element = Element('ellipse', cx=cx, cy=cy, rx=rx, ry=ry, **props)
         return element

--- a/napari/layers/_shapes_layer/shapes/ellipse.py
+++ b/napari/layers/_shapes_layer/shapes/ellipse.py
@@ -1,4 +1,5 @@
 import numpy as np
+from xml.etree.ElementTree import Element
 from .shape import Shape
 from ..shape_util import (triangulate_edge, triangulate_ellipse,
                           center_radii_to_corners, rectangle_to_box,
@@ -104,3 +105,22 @@ class Ellipse(Shape):
         mask = poly_to_mask(mask_shape, self._face_vertices)
 
         return mask
+
+    def to_xml(self):
+        """Generates an xml element that defintes the shape according to the
+        svg specification.
+
+        Returns
+        ----------
+        element : Element
+            xml element specifying the shape according to svg.
+        """
+        x = f'{self.data[0, 0]}'
+        y = f'{self.data[0, 1]}'
+        rx = f'{self.data[1, 0] - self.data[0, 0]}'
+        ry = f'{self.data[3, 1] - self.data[0, 1]}'
+
+        element = Element('rect', x=x, y=y, width=rx, height=ry,
+                          fill='red', stroke='navy', **{'stroke-width': '10'})
+
+        return element

--- a/napari/layers/_shapes_layer/shapes/ellipse.py
+++ b/napari/layers/_shapes_layer/shapes/ellipse.py
@@ -121,6 +121,6 @@ class Ellipse(Shape):
         ry = f'{self.data[3, 1] - self.data[0, 1]}'
 
         element = Element('rect', x=x, y=y, width=rx, height=ry,
-                          fill='red', stroke='navy', **{'stroke-width': '10'})
+                          **self.svg_props)
 
         return element

--- a/napari/layers/_shapes_layer/shapes/line.py
+++ b/napari/layers/_shapes_layer/shapes/line.py
@@ -1,4 +1,5 @@
 import numpy as np
+from xml.etree.ElementTree import Element
 from .shape import Shape
 from ..shape_util import create_box
 
@@ -172,3 +173,22 @@ class Polygon(Shape):
         mask = np.zeros(mask_shape, dtype=bool)
 
         return mask
+
+    def to_xml(self):
+        """Generates an xml element that defintes the shape according to the
+        svg specification.
+
+        Returns
+        ----------
+        element : Element
+            xml element specifying the shape according to svg.
+        """
+        x = f'{self.data[0, 0]}'
+        y = f'{self.data[0, 1]}'
+        rx = f'{self.data[1, 0] - self.data[0, 0]}'
+        ry = f'{self.data[3, 1] - self.data[0, 1]}'
+
+        element = Element('rect', x=x, y=y, width=rx, height=ry,
+                          fill='red', stroke='navy', **{'stroke-width': '10'})
+
+        return element

--- a/napari/layers/_shapes_layer/shapes/line.py
+++ b/napari/layers/_shapes_layer/shapes/line.py
@@ -53,104 +53,6 @@ class Line(Shape):
             self._box = create_box(data)
         self._data = data
 
-
-class Path(Shape):
-    """Class for a single path
-
-    Parameters
-    ----------
-    data : np.ndarray
-        Nx2 array of vertices specifying the shape.
-    edge_width : float
-        thickness of lines and edges.
-    edge_color : str | tuple
-        If string can be any color name recognized by vispy or hex value if
-        starting with `#`. If array-like must be 1-dimensional array with 3 or
-        4 elements.
-    face_color : str | tuple
-        If string can be any color name recognized by vispy or hex value if
-        starting with `#`. If array-like must be 1-dimensional array with 3 or
-        4 elements.
-    opacity : float
-        Opacity of the shape, must be between 0 and 1.
-    z_index : int
-        Specifier of z order priority. Shapes with higher z order are displayed
-        ontop of others.
-    """
-    def __init__(self, data, *, edge_width=1, edge_color='black',
-                 face_color='white', opacity=1, z_index=0):
-
-        super().__init__(edge_width=edge_width, edge_color=edge_color,
-                         face_color=face_color, opacity=opacity,
-                         z_index=z_index)
-        self.data = np.array(data)
-
-    @property
-    def data(self):
-        """np.ndarray: Nx2 array of vertices.
-        """
-        return self._data
-
-    @data.setter
-    def data(self, data):
-        if len(data) < 2:
-            raise ValueError("""Data shape does not match a path. Path
-                             expects at least two vertices""")
-        else:
-            # For path connect every all data
-            self._set_meshes(data, face=False, closed=False)
-            self._box = create_box(data)
-        self._data = data
-
-
-class Polygon(Shape):
-    """Class for a single polygon
-
-    Parameters
-    ----------
-    data : np.ndarray
-        Nx2 array of vertices specifying the shape.
-    edge_width : float
-        thickness of lines and edges.
-    edge_color : str | tuple
-        If string can be any color name recognized by vispy or hex value if
-        starting with `#`. If array-like must be 1-dimensional array with 3 or
-        4 elements.
-    face_color : str | tuple
-        If string can be any color name recognized by vispy or hex value if
-        starting with `#`. If array-like must be 1-dimensional array with 3 or
-        4 elements.
-    opacity : float
-        Opacity of the shape, must be between 0 and 1.
-    z_index : int
-        Specifier of z order priority. Shapes with higher z order are displayed
-        ontop of others.
-    """
-    def __init__(self, data, *, edge_width=1, edge_color='black',
-                 face_color='white', opacity=1, z_index=0):
-
-        super().__init__(edge_width=edge_width, edge_color=edge_color,
-                         face_color=face_color, opacity=opacity,
-                         z_index=z_index)
-        self._closed = True
-        self.data = np.array(data)
-
-    @property
-    def data(self):
-        """np.ndarray: Nx2 array of vertices.
-        """
-        return self._data
-
-    @data.setter
-    def data(self, data):
-        if len(data) < 2:
-            raise ValueError("""Data shape does not match a polygon.
-                             Polygon expects at least two vertices""")
-        else:
-            self._set_meshes(data)
-            self._box = create_box(data)
-        self._data = data
-
     def to_mask(self, mask_shape=None):
         """Converts the shape vertices to a boolean mask with `True` for points
         lying inside the shape. For a Line returns an array of `False` as
@@ -183,12 +85,12 @@ class Polygon(Shape):
         element : Element
             xml element specifying the shape according to svg.
         """
-        x = f'{self.data[0, 0]}'
-        y = f'{self.data[0, 1]}'
-        rx = f'{self.data[1, 0] - self.data[0, 0]}'
-        ry = f'{self.data[3, 1] - self.data[0, 1]}'
+        x1 = f'{self.data[0, 0]}'
+        y1 = f'{self.data[0, 1]}'
+        x2 = f'{self.data[1, 0]}'
+        y2 = f'{self.data[1, 1]}'
 
-        element = Element('rect', x=x, y=y, width=rx, height=ry,
-                          fill='red', stroke='navy', **{'stroke-width': '10'})
+        element = Element('line', x1=x1, y1=y1, x2=x2, y2=y2,
+                          **self.svg_props)
 
         return element

--- a/napari/layers/_shapes_layer/shapes/line.py
+++ b/napari/layers/_shapes_layer/shapes/line.py
@@ -82,13 +82,13 @@ class Line(Shape):
 
         Returns
         ----------
-        element : Element
+        element : xml.etree.ElementTree.Element
             xml element specifying the shape according to svg.
         """
-        x1 = f'{self.data[0, 0]}'
-        y1 = f'{self.data[0, 1]}'
-        x2 = f'{self.data[1, 0]}'
-        y2 = f'{self.data[1, 1]}'
+        x1 = str(self.data[0, 0])
+        y1 = str(self.data[0, 1])
+        x2 = str(self.data[1, 0])
+        y2 = str(self.data[1, 1])
 
         element = Element('line', x1=x1, y1=y1, x2=x2, y2=y2,
                           **self.svg_props)

--- a/napari/layers/_shapes_layer/shapes/path.py
+++ b/napari/layers/_shapes_layer/shapes/path.py
@@ -82,7 +82,7 @@ class Path(Shape):
 
         Returns
         ----------
-        element : Element
+        element : xml.etree.ElementTree.Element
             xml element specifying the shape according to svg.
         """
         points = ' '.join([str(d[0]) +',' + str(d[1]) for d in self.data])

--- a/napari/layers/_shapes_layer/shapes/path.py
+++ b/napari/layers/_shapes_layer/shapes/path.py
@@ -85,12 +85,11 @@ class Path(Shape):
         element : Element
             xml element specifying the shape according to svg.
         """
-        x = f'{self.data[0, 0]}'
-        y = f'{self.data[0, 1]}'
-        rx = f'{self.data[1, 0] - self.data[0, 0]}'
-        ry = f'{self.data[3, 1] - self.data[0, 1]}'
+        points = ' '.join([str(d[0]) +',' + str(d[1]) for d in self.data])
 
-        element = Element('rect', x=x, y=y, width=rx, height=ry,
-                          fill='red', stroke='navy', **{'stroke-width': '10'})
+        props = self.svg_props
+        props['fill'] = 'none'
+
+        element = Element('polyline', points=points, **props)
 
         return element

--- a/napari/layers/_shapes_layer/shapes/path.py
+++ b/napari/layers/_shapes_layer/shapes/path.py
@@ -1,4 +1,5 @@
 import numpy as np
+from xml.etree.ElementTree import Element
 from .shape import Shape
 from ..shape_util import create_box
 
@@ -74,3 +75,22 @@ class Path(Shape):
         mask = np.zeros(mask_shape, dtype=bool)
 
         return mask
+
+    def to_xml(self):
+        """Generates an xml element that defintes the shape according to the
+        svg specification.
+
+        Returns
+        ----------
+        element : Element
+            xml element specifying the shape according to svg.
+        """
+        x = f'{self.data[0, 0]}'
+        y = f'{self.data[0, 1]}'
+        rx = f'{self.data[1, 0] - self.data[0, 0]}'
+        ry = f'{self.data[3, 1] - self.data[0, 1]}'
+
+        element = Element('rect', x=x, y=y, width=rx, height=ry,
+                          fill='red', stroke='navy', **{'stroke-width': '10'})
+
+        return element

--- a/napari/layers/_shapes_layer/shapes/path.py
+++ b/napari/layers/_shapes_layer/shapes/path.py
@@ -85,7 +85,7 @@ class Path(Shape):
         element : xml.etree.ElementTree.Element
             xml element specifying the shape according to svg.
         """
-        points = ' '.join([str(d[0]) +',' + str(d[1]) for d in self.data])
+        points = ' '.join([str(d[0]) + ',' + str(d[1]) for d in self.data])
 
         props = self.svg_props
         props['fill'] = 'none'

--- a/napari/layers/_shapes_layer/shapes/polygon.py
+++ b/napari/layers/_shapes_layer/shapes/polygon.py
@@ -81,7 +81,7 @@ class Polygon(Shape):
 
         Returns
         ----------
-        element : Element
+        element : xml.etree.ElementTree.Element
             xml element specifying the shape according to svg.
         """
         points = ' '.join([str(d[0]) +',' + str(d[1]) for d in self.data])

--- a/napari/layers/_shapes_layer/shapes/polygon.py
+++ b/napari/layers/_shapes_layer/shapes/polygon.py
@@ -1,4 +1,5 @@
 import numpy as np
+from xml.etree.ElementTree import Element
 from .shape import Shape
 from ..shape_util import create_box, poly_to_mask
 
@@ -73,3 +74,22 @@ class Polygon(Shape):
         mask = poly_to_mask(mask_shape, self.data)
 
         return mask
+
+    def to_xml(self):
+        """Generates an xml element that defintes the shape according to the
+        svg specification.
+
+        Returns
+        ----------
+        element : Element
+            xml element specifying the shape according to svg.
+        """
+        x = f'{self.data[0, 0]}'
+        y = f'{self.data[0, 1]}'
+        rx = f'{self.data[1, 0] - self.data[0, 0]}'
+        ry = f'{self.data[3, 1] - self.data[0, 1]}'
+
+        element = Element('rect', x=x, y=y, width=rx, height=ry,
+                          fill='red', stroke='navy', **{'stroke-width': '10'})
+
+        return element

--- a/napari/layers/_shapes_layer/shapes/polygon.py
+++ b/napari/layers/_shapes_layer/shapes/polygon.py
@@ -84,12 +84,8 @@ class Polygon(Shape):
         element : Element
             xml element specifying the shape according to svg.
         """
-        x = f'{self.data[0, 0]}'
-        y = f'{self.data[0, 1]}'
-        rx = f'{self.data[1, 0] - self.data[0, 0]}'
-        ry = f'{self.data[3, 1] - self.data[0, 1]}'
+        points = ' '.join([str(d[0]) +',' + str(d[1]) for d in self.data])
 
-        element = Element('rect', x=x, y=y, width=rx, height=ry,
-                          fill='red', stroke='navy', **{'stroke-width': '10'})
+        element = Element('polygon', points=points, **self.svg_props)
 
         return element

--- a/napari/layers/_shapes_layer/shapes/polygon.py
+++ b/napari/layers/_shapes_layer/shapes/polygon.py
@@ -84,7 +84,7 @@ class Polygon(Shape):
         element : xml.etree.ElementTree.Element
             xml element specifying the shape according to svg.
         """
-        points = ' '.join([str(d[0]) +',' + str(d[1]) for d in self.data])
+        points = ' '.join([str(d[0]) + ',' + str(d[1]) for d in self.data])
 
         element = Element('polygon', points=points, **self.svg_props)
 

--- a/napari/layers/_shapes_layer/shapes/rectangle.py
+++ b/napari/layers/_shapes_layer/shapes/rectangle.py
@@ -112,11 +112,11 @@ class Rectangle(Shape):
             transform = f'rotate({np.degrees(-angle)} {cen[0]} {cen[1]})'
             props['transform'] = transform
         else:
-            cords = self.data
+            coords = self.data
 
-        x = str(cords.min(axis=0)[0])
-        y = str(cords.min(axis=0)[1])
-        size = abs(cords[2] - cords[0])
+        x = str(coords.min(axis=0)[0])
+        y = str(coords.min(axis=0)[1])
+        size = abs(coords[2] - coords[0])
         width = str(size[0])
         height = str(size[1])
 

--- a/napari/layers/_shapes_layer/shapes/rectangle.py
+++ b/napari/layers/_shapes_layer/shapes/rectangle.py
@@ -95,7 +95,8 @@ class Rectangle(Shape):
         y = f'{self.data[0, 1]}'
         rx = f'{self.data[1, 0] - self.data[0, 0]}'
         ry = f'{self.data[3, 1] - self.data[0, 1]}'
+
         element = Element('rect', x=x, y=y, width=rx, height=ry,
-                          fill='red', stroke='navy', **{'stroke-width': '10'})
+                          **self.svg_props)
 
         return element

--- a/napari/layers/_shapes_layer/shapes/rectangle.py
+++ b/napari/layers/_shapes_layer/shapes/rectangle.py
@@ -88,7 +88,7 @@ class Rectangle(Shape):
 
         Returns
         ----------
-        element : Element
+        element : xml.etree.ElementTree.Element
             xml element specifying the shape according to svg.
         """
         props = self.svg_props
@@ -98,15 +98,15 @@ class Rectangle(Shape):
         if not angle == 0:
             # if shape has been rotated, shift to origin
             cen = self.data.mean(axis=0)
-            cords = self.data - cen
+            coords = self.data - cen
 
             # rotate back to axis aligned
             c, s = np.cos(angle), np.sin(-angle)
             rotation = np.array([[c, s], [-s, c]])
-            cords = cords @ rotation.T
+            coords = coords @ rotation.T
 
             # shift back to center
-            cords = cords + cen
+            coords = coords + cen
 
             # define rotation around center
             transform = f'rotate({np.degrees(-angle)} {cen[0]} {cen[1]})'
@@ -114,11 +114,11 @@ class Rectangle(Shape):
         else:
             cords = self.data
 
-        x = f'{cords.min(axis=0)[0]}'
-        y = f'{cords.min(axis=0)[1]}'
+        x = str(cords.min(axis=0)[0])
+        y = str(cords.min(axis=0)[1])
         size = abs(cords[2] - cords[0])
-        width = f'{size[0]}'
-        height = f'{size[1]}'
+        width = str(size[0])
+        height = str(size[1])
 
         element = Element('rect', x=x, y=y, width=width, height=height,
                           **props)

--- a/napari/layers/_shapes_layer/shapes/rectangle.py
+++ b/napari/layers/_shapes_layer/shapes/rectangle.py
@@ -102,7 +102,8 @@ class Rectangle(Shape):
 
             # rotate back to axis aligned
             c, s = np.cos(angle), np.sin(-angle)
-            rotation = np.array([[c, s], [-s, c]])
+            rotation = np.array([[c, s],
+                                 [-s, c]])
             coords = coords @ rotation.T
 
             # shift back to center

--- a/napari/layers/_shapes_layer/shapes/rectangle.py
+++ b/napari/layers/_shapes_layer/shapes/rectangle.py
@@ -91,12 +91,35 @@ class Rectangle(Shape):
         element : Element
             xml element specifying the shape according to svg.
         """
-        x = f'{self.data[0, 0]}'
-        y = f'{self.data[0, 1]}'
-        rx = f'{self.data[1, 0] - self.data[0, 0]}'
-        ry = f'{self.data[3, 1] - self.data[0, 1]}'
+        props = self.svg_props
 
-        element = Element('rect', x=x, y=y, width=rx, height=ry,
-                          **self.svg_props)
+        offset = self.data[1] - self.data[0]
+        angle = -np.arctan2(offset[0], -offset[1])
+        if not angle == 0:
+            # if shape has been rotated, shift to origin
+            cen = self.data.mean(axis=0)
+            cords = self.data - cen
 
+            # rotate back to axis aligned
+            c, s = np.cos(angle), np.sin(-angle)
+            rotation = np.array([[c, s], [-s, c]])
+            cords = cords @ rotation.T
+
+            # shift back to center
+            cords = cords + cen
+
+            # define rotation around center
+            transform = f'rotate({np.degrees(-angle)} {cen[0]} {cen[1]})'
+            props['transform'] = transform
+        else:
+            cords = self.data
+
+        x = f'{cords.min(axis=0)[0]}'
+        y = f'{cords.min(axis=0)[1]}'
+        size = abs(cords[2] - cords[0])
+        width = f'{size[0]}'
+        height = f'{size[1]}'
+
+        element = Element('rect', x=x, y=y, width=width, height=height,
+                          **props)
         return element

--- a/napari/layers/_shapes_layer/shapes/rectangle.py
+++ b/napari/layers/_shapes_layer/shapes/rectangle.py
@@ -1,6 +1,8 @@
 import numpy as np
+from xml.etree.ElementTree import Element
 from .shape import Shape
 from ..shape_util import find_corners, rectangle_to_box, poly_to_mask
+
 
 class Rectangle(Shape):
     """Class for a single rectangle
@@ -79,3 +81,21 @@ class Rectangle(Shape):
         mask = poly_to_mask(mask_shape, self.data)
 
         return mask
+
+    def to_xml(self):
+        """Generates an xml element that defintes the shape according to the
+        svg specification.
+
+        Returns
+        ----------
+        element : Element
+            xml element specifying the shape according to svg.
+        """
+        x = f'{self.data[0, 0]}'
+        y = f'{self.data[0, 1]}'
+        rx = f'{self.data[1, 0] - self.data[0, 0]}'
+        ry = f'{self.data[3, 1] - self.data[0, 1]}'
+        element = Element('rect', x=x, y=y, width=rx, height=ry,
+                          fill='red', stroke='navy', **{'stroke-width': '10'})
+
+        return element

--- a/napari/layers/_shapes_layer/shapes/shape.py
+++ b/napari/layers/_shapes_layer/shapes/shape.py
@@ -300,3 +300,8 @@ class Shape(ABC):
     def to_mask(self, mask_shape=None):
         # user writes own docstring
         raise NotImplementedError()
+
+    @abstractmethod
+    def to_xml(self):
+        # user writes own docstring
+        raise NotImplementedError()

--- a/napari/layers/_shapes_layer/shapes/shape.py
+++ b/napari/layers/_shapes_layer/shapes/shape.py
@@ -159,6 +159,28 @@ class Shape(ABC):
         self._opacity = opacity
 
     @property
+    def svg_props(self):
+        """dict: color and width properties in the svg specification
+        """
+        width = f'{self.edge_width}'
+        face_color = (255*self.face_color.rgba).astype('int')
+        fill = f'rgb{tuple(face_color[:3])}'
+        edge_color = (255*self.edge_color.rgba).astype('int')
+        stroke = f'rgb{tuple(edge_color[:3])}'
+        opacity = f'{self.opacity}'
+
+        # Currently not using fill or stroke opacity - only global opacity
+        # as otherwise leads to unexpected behavior when reading svg into
+        # other applications
+        # fill_opacity = f'{self.opacity*self.face_color.rgba[3]}'
+        # stroke_opacity = f'{self.opacity*self.edge_color.rgba[3]}'
+
+        props = {'fill': fill, 'stroke': stroke, 'stroke-width': width,
+                 'opacity': opacity}
+
+        return props
+
+    @property
     def z_index(self):
         """int: z order priority of shape. Shapes with higher z order displayed
         ontop of others.

--- a/napari/layers/_shapes_layer/shapes/shape.py
+++ b/napari/layers/_shapes_layer/shapes/shape.py
@@ -162,12 +162,12 @@ class Shape(ABC):
     def svg_props(self):
         """dict: color and width properties in the svg specification
         """
-        width = f'{self.edge_width}'
-        face_color = (255*self.face_color.rgba).astype('int')
+        width = str(self.edge_width)
+        face_color = (255 * self.face_color.rgba).astype(np.int)
         fill = f'rgb{tuple(face_color[:3])}'
-        edge_color = (255*self.edge_color.rgba).astype('int')
+        edge_color = (255 * self.edge_color.rgba).astype(np.int)
         stroke = f'rgb{tuple(edge_color[:3])}'
-        opacity = f'{self.opacity}'
+        opacity = str(self.opacity)
 
         # Currently not using fill or stroke opacity - only global opacity
         # as otherwise leads to unexpected behavior when reading svg into


### PR DESCRIPTION
# Description
As requested in #178 this PR supports generating an svg from the shapes layer by adding a `to_svg` method onto the shapes layer. It will generate an svg string that can then be written to a file. It will include all the support shape types and their correct colors, line widths, opacities, and z_order. In the future the `to_svg` method could be moved to the `viewer` so that an `svg` of all the layers could be generated. We would need to then add svg support to the other layer types such as images / markers / vectors etc.

Here is a screenshot of one of the generated svg files opened in another graphic editing app

![image](https://user-images.githubusercontent.com/6531703/56450005-1f599a00-62d6-11e9-9839-cda79874d117.png)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] running `examples/shapes_to_labels.py` will now also generate an svg file. Maybe people don't like that this example now writes a file. If so I can remove that.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
