### PR TITLE
add support for custom key bindings

### DIFF
--- a/examples/custom_key_bindings.py
+++ b/examples/custom_key_bindings.py
@@ -1,0 +1,32 @@
+"""
+Display one 4-D image layer using the add_image API
+"""
+
+import numpy as np
+from skimage import data
+from napari import ViewerApp
+from napari.util import app_context
+
+
+with app_context():
+    viewer = ViewerApp()
+    blobs = data.binary_blobs(length=128, blob_size_fraction=0.05,
+                              n_dim=2, volume_fraction=.25).astype(float)
+
+    viewer.add_image(blobs)
+
+    def accept_image(viewer):
+        print('this is a good image')
+        next(viewer)
+
+    def reject_image(viewer):
+       print('this is a bad image')
+       next(viewer)
+
+    def next(viewer):
+        blobs = data.binary_blobs(length=128, blob_size_fraction=0.05,
+                                  n_dim=2, volume_fraction=.25).astype(float)
+        viewer.layers[0].image = blobs
+
+    custom_key_bindings = {'a':accept_image, 'r':reject_image}
+    viewer.key_bindings = custom_key_bindings

--- a/examples/custom_key_bindings.py
+++ b/examples/custom_key_bindings.py
@@ -20,13 +20,13 @@ with app_context():
         next(viewer)
 
     def reject_image(viewer):
-       print('this is a bad image')
-       next(viewer)
+        print('this is a bad image')
+        next(viewer)
 
     def next(viewer):
         blobs = data.binary_blobs(length=128, blob_size_fraction=0.05,
                                   n_dim=2, volume_fraction=.25).astype(float)
         viewer.layers[0].image = blobs
 
-    custom_key_bindings = {'a':accept_image, 'r':reject_image}
+    custom_key_bindings = {'a': accept_image, 'r': reject_image}
     viewer.key_bindings = custom_key_bindings

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -38,6 +38,7 @@ class Viewer:
         self._cursor_size = None
         self._interactive = True
         self._top = None
+        self._key_bindings = {}
 
         self._qt = QtViewer(self)
 
@@ -133,6 +134,18 @@ class Viewer:
             return
         self._active_markers = active_markers
         self.events.active_markers(index=self._active_markers)
+
+    @property
+    def key_bindings(self):
+        """dict: custom key bindings
+        """
+        return self._key_bindings
+
+    @key_bindings.setter
+    def key_bindings(self, key_bindings):
+        if key_bindings == self.key_bindings:
+            return
+        self._key_bindings = key_bindings
 
     def reset_view(self):
         """Resets the camera's view.

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -18,6 +18,12 @@ class Viewer:
         Contains axes, indices, dimensions and sliders.
     camera : vispy.scene.Camera
         Viewer camera.
+    key_bindings : dict of string: callable
+        Custom key bindings. The dictionary key is a string containing the key
+        pressed and the value is the function to be bound to the key event.
+        The function should accept the viewer object as an input argument.
+        These key bindings are executed instead of any layer specific key
+        bindings.
     """
     def __init__(self):
         super().__init__()
@@ -38,7 +44,7 @@ class Viewer:
         self._cursor_size = None
         self._interactive = True
         self._top = None
-        self._key_bindings = {}
+        self.key_bindings = {}
 
         self._qt = QtViewer(self)
 
@@ -134,18 +140,6 @@ class Viewer:
             return
         self._active_markers = active_markers
         self.events.active_markers(index=self._active_markers)
-
-    @property
-    def key_bindings(self):
-        """dict: custom key bindings
-        """
-        return self._key_bindings
-
-    @key_bindings.setter
-    def key_bindings(self, key_bindings):
-        if key_bindings == self.key_bindings:
-            return
-        self._key_bindings = key_bindings
 
     def reset_view(self):
         """Resets the camera's view.

--- a/napari/components/_viewer/view/main.py
+++ b/napari/components/_viewer/view/main.py
@@ -101,6 +101,10 @@ class QtViewer(QSplitter):
         if layer is not None:
             layer.on_key_press(event)
 
+        if (event.text in self.viewer.key_bindings and not
+                event.native.isAutoRepeat()):
+            self.viewer.key_bindings[event.text](self.viewer)
+
     def on_key_release(self, event):
         """Called whenever key released in canvas.
         """

--- a/napari/components/_viewer/view/main.py
+++ b/napari/components/_viewer/view/main.py
@@ -97,13 +97,14 @@ class QtViewer(QSplitter):
     def on_key_press(self, event):
         """Called whenever key pressed in canvas.
         """
-        layer = self.viewer._top
-        if layer is not None:
-            layer.on_key_press(event)
-
         if (event.text in self.viewer.key_bindings and not
                 event.native.isAutoRepeat()):
             self.viewer.key_bindings[event.text](self.viewer)
+            return
+
+        layer = self.viewer._top
+        if layer is not None:
+            layer.on_key_press(event)
 
     def on_key_release(self, event):
         """Called whenever key released in canvas.


### PR DESCRIPTION
# Description
This PR adds support for custom key bindings as requested in #200 by @gregjohnso and discussed further in #210.

The PR adds a property `viewer.key_bindings` that can be set with a dictionary of key names (represented as strings) as keys functions as values, where the function must take a single input argument, the viewer. The key presses get triggered on the press of the key, but will only get triggered once even if the key is held down. The PR doesn't support key_release events, or any custom mouse events, but these could be added in the future. The layer specific key press events will also continue to execute.

The PR adds a new example, `custom_key_bindings.py` that shows changing the image data and printing a statement with custom key presses.

![custom_keybindings](https://user-images.githubusercontent.com/6531703/56635161-7b475a00-6619-11e9-9021-9526411b15c9.gif)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] `examples/custom_key_bindings.py` and press `a` or `r`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
