### PR TITLE
fix escape selecting shape error

### DIFF
--- a/napari/layers/_shapes_layer/model.py
+++ b/napari/layers/_shapes_layer/model.py
@@ -770,6 +770,7 @@ class Shapes(Layer):
         self.selected_shapes = []
         self._drag_start = None
         self._drag_box = None
+        self._is_selecting = False
         self._fixed_vertex = None
         self._moving_shape = None
         self._moving_vertex = None


### PR DESCRIPTION
# Description
This very short PR fixes a bug when pressing the escape key and selecting a region in the shapes layer. It does this by disabling the `_is_selecting` flag on the button press.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] `examples/add_shapes.py`
