### PR TITLE
unify titlebar

### DIFF
--- a/napari/components/_window/view.py
+++ b/napari/components/_window/view.py
@@ -21,6 +21,7 @@ class Window:
     """
     def __init__(self, viewer, show=True):
         self._qt_window = QMainWindow()
+        self._qt_window.setUnifiedTitleAndToolBarOnMac(True)
         self._qt_center = QWidget()
         self._qt_window.setCentralWidget(self._qt_center)
         self._qt_window.setWindowTitle(viewer.title)


### PR DESCRIPTION
# Description
This PR unifies the titlebar and toolbar on Mac for those users where it is not done by default. It prevents the title from appearing twice. It has been discussed in #239 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
