### PR TITLE
fix range slider imports

### DIFF
--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -1,0 +1,1 @@
+from .range_slider import QHRangeSlider, QVRangeSlider

--- a/napari/_qt/range_slider/__init__.py
+++ b/napari/_qt/range_slider/__init__.py
@@ -1,0 +1,1 @@
+from .range_slider import QHRangeSlider, QVRangeSlider

--- a/napari/components/_dims/view.py
+++ b/napari/components/_dims/view.py
@@ -2,7 +2,7 @@ from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QWidget, QGridLayout, QRadioButton, QSizePolicy
 from typing import Union
 
-from ..._qt.range_slider.range_slider import QVRangeSlider, QHRangeSlider
+from ..._qt import QHRangeSlider
 from .model import Dims
 from ._constants import DimsMode
 

--- a/napari/layers/_image_layer/view/controls.py
+++ b/napari/layers/_image_layer/view/controls.py
@@ -1,5 +1,5 @@
 from qtpy.QtWidgets import QHBoxLayout, QWidget
-from ...._qt.range_slider.range_slider import QVRangeSlider
+from ...._qt import QVRangeSlider
 
 
 class QtImageControls(QWidget):


### PR DESCRIPTION
# Description
This PR allows you to directly import the our `QHRangeSlider` and `QVRangeSlider` directly from our `_qt` folder. It also removes an unused import from the dims view.

!-- Tell us about your new feature, improvement, or fix! -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run `examples/nD_markers.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
