### PR TITLE
add keybindings framework 

### DIFF
--- a/examples/custom_keybindings.py
+++ b/examples/custom_keybindings.py
@@ -14,12 +14,14 @@ with app_context():
 
     viewer.add_image(blobs, name='blobs')
 
+    @viewer.bind_key('a')
     def accept_image(viewer):
         msg = 'this is a good image'
         viewer.status = msg
         print(msg)
         next(viewer)
 
+    @viewer.bind_key('r')
     def reject_image(viewer):
         msg = 'this is a bad image'
         viewer.status = msg
@@ -30,9 +32,6 @@ with app_context():
         blobs = data.binary_blobs(length=128, blob_size_fraction=0.05,
                                   n_dim=2, volume_fraction=.25).astype(float)
         viewer.layers[0].image = blobs
-
-    custom_key_bindings = {'a': accept_image, 'r': reject_image}
-    viewer.key_bindings = custom_key_bindings
 
     # change viewer title
     viewer.title = 'quality control images'

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -8,8 +8,7 @@ from ...util.event import EmitterGroup, Event
 from ...util.theme import palettes
 from ...util.misc import has_clims
 from .._dims import Dims
-from ...util.keybindings import (bind_key_method, unbind_key_method,
-                                 rebind_key_method, bind_keys_method, bind_keys)
+from ...util.keybindings import bind_key_method, unbind_keys_method, bind_keys
 
 
 class ViewerModel:
@@ -187,14 +186,8 @@ class ViewerModel:
     bind_key = bind_key_method(keybindings='_keybindings',
                                class_keybindings='default_keybindings')
 
-    unbind_key = unbind_key_method(keybindings='_keybindings',
-                                   class_keybindings='default_keybindings')
-
-    rebind_key = rebind_key_method(keybindings='_keybindings',
-                                   class_keybindings='default_keybindings')
-
-    bind_keys = bind_keys_method(keybindings='_keybindings',
-                                 class_keybindings='default_keybindings')
+    unbind_keys = unbind_keys_method(keybindings='_keybindings',
+                                     class_keybindings='default_keybindings')
 
     def reset_keybindings(self):
         self.keybindings = self.default_keybindings

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -8,6 +8,8 @@ from ...util.event import EmitterGroup, Event
 from ...util.theme import palettes
 from ...util.misc import has_clims
 from .._dims import Dims
+from ...util.keybindings import (bind_key_method, unbind_key_method,
+                                 rebind_key_method, bind_keys_method, bind_keys)
 
 
 class ViewerModel:
@@ -22,13 +24,20 @@ class ViewerModel:
         List of contained layers.
     dims : Dimensions
         Contains axes, indices, dimensions and sliders.
+<<<<<<< HEAD
     key_bindings : dict of string: callable
         Custom key bindings. The dictionary key is a string containing the key
         pressed and the value is the function to be bound to the key event.
         The function should accept the viewer object as an input argument.
         These key bindings are executed instead of any layer specific key
         bindings.
+=======
+    camera : vispy.scene.Camera
+        ViewerWidget camera.
+>>>>>>> add keybinding convenience functions; convert existing keybindings
     """
+    default_keybindings = {}
+
     def __init__(self, title='napari'):
         super().__init__()
         from .._layers_list import LayersList
@@ -57,7 +66,8 @@ class ViewerModel:
         self._cursor_size = None
         self._interactive = True
         self._active_layer = None
-        self.key_bindings = {}
+        self._keybindings = {}
+        self.keybindings = self.default_keybindings
 
         # TODO: this should be eventually removed!
         # attached by QtViewer when it is constructed by the model
@@ -161,6 +171,33 @@ class ViewerModel:
             return
         self._active_layer = active_layer
         self.events.active_layer(item=self._active_layer)
+
+    @property
+    def keybindings(self):
+        return self._keybindings.copy()
+
+    @keybindings.setter
+    def keybindings(self, keybindings):
+        if keybindings == self.keybindings:
+            return
+        kb = {}
+        bind_keys(kb, keybindings.items())
+        self._keybindings = kb
+
+    bind_key = bind_key_method(keybindings='_keybindings',
+                               class_keybindings='default_keybindings')
+
+    unbind_key = unbind_key_method(keybindings='_keybindings',
+                                   class_keybindings='default_keybindings')
+
+    rebind_key = rebind_key_method(keybindings='_keybindings',
+                                   class_keybindings='default_keybindings')
+
+    bind_keys = bind_keys_method(keybindings='_keybindings',
+                                 class_keybindings='default_keybindings')
+
+    def reset_keybindings(self):
+        self.keybindings = self.default_keybindings
 
     def reset_view(self):
         """Resets the camera's view.

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -6,8 +6,7 @@ import numpy as np
 import weakref
 
 from ...util.event import Event
-from ...util.keybindings import (bind_key_method, unbind_key_method,
-                                 rebind_key_method, bind_keys_method, bind_keys)
+from ...util.keybindings import bind_key_method, unbind_keys_method, bind_keys
 from ._visual_wrapper import VisualWrapper
 
 
@@ -381,14 +380,8 @@ class Layer(VisualWrapper, ABC):
     bind_key = bind_key_method(keybindings='_keybindings',
                                class_keybindings='default_keybindings')
 
-    unbind_key = unbind_key_method(keybindings='_keybindings',
-                                   class_keybindings='default_keybindings')
-
-    rebind_key = rebind_key_method(keybindings='_keybindings',
-                                   class_keybindings='default_keybindings')
-
-    bind_keys = bind_keys_method(keybindings='_keybindings',
-                                 class_keybindings='default_keybindings')
+    unbind_keys = unbind_keys_method(keybindings='_keybindings',
+                                     class_keybindings='default_keybindings')
 
     def reset_keybindings(self):
         self.keybindings = self.default_keybindings

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -6,6 +6,8 @@ import numpy as np
 import weakref
 
 from ...util.event import Event
+from ...util.keybindings import (bind_key_method, unbind_key_method,
+                                 rebind_key_method, bind_keys_method, bind_keys)
 from ._visual_wrapper import VisualWrapper
 
 
@@ -26,6 +28,7 @@ class Layer(VisualWrapper, ABC):
         * `_get_shape()`: called by `shape` property
         * `_refresh()`: called by `refresh` method
         * `data` property (setter & getter)
+        * `default_keybindings` class variable (dictionary)
 
     May define the following:
         * `_set_view_slice(indices)`: called to set currently viewed slice
@@ -69,6 +72,8 @@ class Layer(VisualWrapper, ABC):
                         cursor=Event,
                         cursor_size=Event)
         self.name = name
+        self._keybindings = {}
+        self.keybindings = self.default_keybindings
 
     def __str__(self):
         """Return self.name
@@ -361,6 +366,33 @@ class Layer(VisualWrapper, ABC):
 
         return svg
 
+    @property
+    def keybindings(self):
+        return self._keybindings.copy()
+
+    @keybindings.setter
+    def keybindings(self, keybindings):
+        if keybindings == self.keybindings:
+            return
+        kb = {}
+        bind_keys(kb, keybindings.items())
+        self._keybindings = kb
+
+    bind_key = bind_key_method(keybindings='_keybindings',
+                               class_keybindings='default_keybindings')
+
+    unbind_key = unbind_key_method(keybindings='_keybindings',
+                                   class_keybindings='default_keybindings')
+
+    rebind_key = rebind_key_method(keybindings='_keybindings',
+                                   class_keybindings='default_keybindings')
+
+    bind_keys = bind_keys_method(keybindings='_keybindings',
+                                 class_keybindings='default_keybindings')
+
+    def reset_keybindings(self):
+        self.keybindings = self.default_keybindings
+
     def on_mouse_move(self, event):
         """Called whenever mouse moves over canvas.
         """
@@ -373,15 +405,5 @@ class Layer(VisualWrapper, ABC):
 
     def on_mouse_release(self, event):
         """Called whenever mouse released in canvas.
-        """
-        return
-
-    def on_key_press(self, event):
-        """Called whenever key pressed in canvas.
-        """
-        return
-
-    def on_key_release(self, event):
-        """Called whenever key released in canvas.
         """
         return

--- a/napari/layers/_image_layer/model.py
+++ b/napari/layers/_image_layer/model.py
@@ -100,6 +100,8 @@ class Image(Layer):
     default_colormap = 'magma'
     default_interpolation = 'nearest'
 
+    default_keybindings = {}
+
     def __init__(self, image, meta=None, multichannel=None, *, name=None,
                  clim_range=None, **kwargs):
         if name is None and meta is not None:

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -599,40 +599,35 @@ class Labels(Layer):
         """
         self._last_cursor_coord = None
 
-    def on_key_press(self, event):
-        """Called whenever key pressed in canvas.
+    def _activate_paint_mode(self):
+        self.mode = Mode.PAINT
 
-        Parameters
-        ----------
-        event : Event
-            Vispy event
-        """
-        if event.native.isAutoRepeat():
-            return
-        else:
-            if event.key == ' ':
-                if self.mode != Mode.PAN_ZOOM:
-                    self._mode_history = self.mode
-                    self.mode = Mode.PAN_ZOOM
-                else:
-                    self._mode_history = Mode.PAN_ZOOM
-            elif event.key == 'p':
-                self.mode = Mode.PAINT
-            elif event.key == 'f':
-                self.mode = Mode.FILL
-            elif event.key == 'z':
-                self.mode = Mode.PAN_ZOOM
-            elif event.key == 'l':
-                self.mode = Mode.PICKER
+    def _activate_fill_mode(self):
+        self.mode = Mode.FILL
 
-    def on_key_release(self, event):
-        """Called whenever key released in canvas.
+    def _activate_pan_zoom_mode(self):
+        self.mode = Mode.PAN_ZOOM
 
-        Parameters
-        ----------
-        event : Event
-            Vispy event
-        """
-        if event.key == ' ':
-            if self._mode_history != Mode.PAN_ZOOM:
-                self.mode = self._mode_history
+    def _activate_picker_mode(self):
+        self.mode = Mode.PICKER
+
+    def _hold_to_pan_zoom(self):
+        # on press
+        prev_mode = self.mode
+
+        if self.mode != Mode.PAN_ZOOM:
+            self.mode = Mode.PAN_ZOOM
+
+        yield
+
+        # on release
+        if prev_mode != Mode.PAN_ZOOM:
+            self.mode = prev_mode
+
+    default_keybindings = {
+        'Space': _hold_to_pan_zoom,
+        'p': _activate_paint_mode,
+        'f': _activate_fill_mode,
+        'z': _activate_pan_zoom_mode,
+        'l': _activate_picker_mode
+    }

--- a/napari/layers/_markers_layer/model.py
+++ b/napari/layers/_markers_layer/model.py
@@ -499,34 +499,41 @@ class Markers(Layer):
                 self._add(coord)
         self.status = self.get_message(coord, self._selected_markers)
 
-    def on_key_press(self, event):
-        """Called whenever key pressed in canvas.
-        """
-        if event.native.isAutoRepeat():
-            return
-        else:
-            if event.key == ' ':
-                if self.mode != 'pan/zoom':
-                    self._mode_history = self.mode
-                    self.mode = 'pan/zoom'
-                else:
-                    self._mode_history = 'pan/zoom'
-            elif event.key == 'Shift':
-                if self.mode == 'add':
-                    self.cursor = 'forbidden'
-            elif event.key == 'a':
-                self.mode = 'add'
-            elif event.key == 's':
-                self.mode = 'select'
-            elif event.key == 'z':
-                self.mode = 'pan/zoom'
+    def _activate_add_mode(self):
+        self.mode = 'add'
 
-    def on_key_release(self, event):
-        """Called whenever key released in canvas.
-        """
-        if event.key == ' ':
-            if self._mode_history != 'pan/zoom':
-                self.mode = self._mode_history
-        elif event.key == 'Shift':
-            if self.mode == 'add':
-                self.cursor = 'cross'
+    def _activate_select_mode(self):
+        self.mode = 'select'
+
+    def _activate_pan_zoom_mode(self):
+        self.mode = 'pan/zoom'
+
+    def _hold_to_pan_zoom(self):
+        if self.mode != 'pan/zoom':
+            # on key press
+            prev_mode = self.mode
+            self.mode = 'pan/zoom'
+
+            yield
+
+            # on key release
+            self.mode = prev_mode
+
+    def _hold_to_delete(self):
+        # on key press
+        if self.mode == 'add':
+            self.cursor = 'forbidden'
+
+        yield
+
+        # on key release
+        if self.mode == 'add':  # check again in case modes were switched
+            self.cursor = 'cross'
+
+    default_keybindings = {
+        'Space': _hold_to_pan_zoom,
+        'Shift': _hold_to_delete,
+        'a': _activate_add_mode,
+        's': _activate_select_mode,
+        'z': _activate_pan_zoom_mode
+    }

--- a/napari/layers/_vectors_layer/model.py
+++ b/napari/layers/_vectors_layer/model.py
@@ -40,6 +40,7 @@ class Vectors(Layer):
     mode : str
         control panel mode
     """
+    default_keybindings = {}
 
     def __init__(self,
                  vectors,

--- a/napari/util/keybindings.py
+++ b/napari/util/keybindings.py
@@ -1,0 +1,539 @@
+import re
+import types
+from collections import OrderedDict
+from enum import Enum
+from typing import Sequence, Iterable, Mapping, ByteString, Callable
+
+from vispy.util import keys
+
+
+STRINGTYPES = str, ByteString
+UNDEFINED = object()
+
+
+SPECIAL_KEYS = [keys.SHIFT,
+                keys.CONTROL,
+                keys.ALT,
+                keys.META,
+                keys.UP,
+                keys.DOWN,
+                keys.LEFT,
+                keys.RIGHT,
+                keys.PAGEUP,
+                keys.PAGEDOWN,
+                keys.INSERT,
+                keys.DELETE,
+                keys.HOME,
+                keys.END,
+                keys.ESCAPE,
+                keys.BACKSPACE,
+                keys.F1,
+                keys.F2,
+                keys.F3,
+                keys.F4,
+                keys.F5,
+                keys.F6,
+                keys.F7,
+                keys.F8,
+                keys.F9,
+                keys.F10,
+                keys.F11,
+                keys.F12,
+                keys.SPACE,
+                keys.ENTER,
+                keys.TAB]
+
+MODIFIER_KEYS = OrderedDict(C=keys.CONTROL,
+                            M=keys.ALT,
+                            S=keys.SHIFT,
+                            s=keys.META)
+
+
+shorthand_modifier_patt = re.compile(f"([{''.join(MODIFIER_KEYS)}])(?=-)")
+
+
+class BindOperation:
+    BIND = 'bind'
+    UNBIND = 'unbind'
+    REBIND = 'rebind'
+
+
+def _expand_shorthand(shorthand_seq):
+    """Expand shorthand form of a key sequence.
+
+    C -> Control
+    M -> Alt
+    S -> Shift
+    s -> Meta
+    """
+    return re.sub(shorthand_modifier_patt,
+                  lambda m: MODIFIER_KEYS[m.group(0)].name,
+                  shorthand_seq)
+
+
+def parse_seq(seq):
+    """Parse a key sequence into its components in a comparable format.
+
+    Parameters
+    ----------
+    seq : str
+        Key sequence.
+
+    Returns
+    -------
+    key : str
+        Base key of the sequence.
+    modifiers : set of str
+        Modifier keys of the sequence.
+    """
+    parsed = re.split('-(?=.+)', seq)
+    modifiers, key = parsed[:-1], parsed[-1]
+
+    return key, set(modifiers)
+
+
+def components_to_seq(key, modifiers):
+    """Combine components to become a key sequence.
+
+    Modifier keys will always be combined in the same order:
+    Control, Alt, Shift, Meta
+
+    Shift pressed with any letter will be consumed
+    to transform it to upper case, e.g. Shift + w => W.
+    Otherwise, the letter will be lower case.
+    Shift will also be consumed without transformation when pressed
+    with any other non-special key unless Control is also a modifier.
+
+    Parameters
+    ----------
+    key : str or vispy.app.Key
+        Base key.
+    modifiers : sequence of str or vispy.app.Key
+        Modifier keys.
+
+    Returns
+    -------
+    seq : str
+        Generated key sequence.
+    """
+    if len(key) == 1 and key.isalpha():  # it's a letter
+        if 'Shift' not in modifiers:
+            key = key.lower()
+            cond = lambda m: True  # noqa: E731
+        else:
+            # Shift is consumed to create upper-case letter
+            key = key.upper()
+            cond = lambda m: m != 'Shift'  # noqa: E731
+    elif key in SPECIAL_KEYS:
+        # remove redundant information i.e. an output of 'Shift-Shift'
+        cond = lambda m: m != key  # noqa: E731
+    else:
+        # Shift is consumed to transform key
+
+        # bug found on OSX: Command will cause Shift to not
+        # transform the key so do not consume it
+        # note: 'Control' is OSX Command key
+        cond = lambda m: m != 'Shift' or 'Control' in modifiers  # noqa: E731
+
+    modifiers = tuple(key.name for key in
+                      filter(lambda key: key in modifiers and cond(key),
+                             MODIFIER_KEYS.values()))
+
+    return '-'.join(modifiers + (key,))
+
+
+def normalize_key_sequence(seq):
+    """Normalize key sequence to make it easily comparable.
+
+    All aliases are converted and modifier orders are fixed to:
+    Control, Alt, Shift, Meta
+
+    Parameters
+    ----------
+    seq : str
+        Key sequence.
+
+    Shift pressed with any letter will be consumed
+    to transform it to upper case, e.g. Shift + w => W.
+    Otherwise, the letter will be lower case.
+    Shift will also be consumed without transformation when pressed
+    with any other non-special key unless Control is also a modifier.
+
+    Returns
+    -------
+    normalized_seq : str
+        Normalized key sequence.
+    """
+    seq = _expand_shorthand(seq)
+
+    key, modifiers = parse_seq(seq)
+
+    if len(key) != 1 and key not in SPECIAL_KEYS:
+        raise TypeError(f'invalid key {key}')
+
+    for modifier in modifiers:
+        if modifier not in MODIFIER_KEYS.values():
+            raise TypeError(f'invalid modifier key {modifier}')
+
+    return components_to_seq(key, modifiers)
+
+
+def _determine_binding_op(arg):
+    """Determine the binding operation based on the argument passed.
+
+    None     -> BindOperation.UNBIND
+    str      -> BindOperation.REBIND
+    callable -> BindOperation.BIND
+    """
+    if arg is None:
+        return BindOperation.UNBIND
+    elif isinstance(arg, str):
+        return BindOperation.REBIND
+    elif isinstance(arg, Callable):
+        return BindOperation.BIND
+    raise TypeError('expected arg to be a string, callable, or None; '
+                    f'got {type(arg)}')
+
+
+def _bind_key(keybindings, seq, func):
+    """Bind a key sequence to a keymap.
+    """
+    keybindings[seq] = func
+
+
+def _unbind_key(keybindings, seq):
+    """Unbind a function from a keymap based on its sequence and return it.
+    """
+    return keybindings.pop(seq)
+
+
+def _rebind_key(keybindings, new_seq, orig_seq):
+    """Rebind a function from one key sequence to another.
+    """
+    func = _unbind_key(keybindings, orig_seq)
+    _bind_key(keybindings, new_seq, func)
+
+
+def bind_key(keybindings, seq, func):
+    """Bind a key sequence to a keymap.
+
+    Parameters
+    ----------
+    keybindings : dict of str: callable
+        Keymap to modify.
+    seq : str
+        Key sequence.
+    func : callable, str, or None
+        Callable to bind to the key sequence.
+        If a string is passed, instead perform a rebind operation.
+        If ``None`` is passed, unbind instead.
+    """
+    seq = normalize_key_sequence(seq)
+
+    bind_op = _determine_binding_op(func)
+
+    if bind_op == BindOperation.UNBIND:
+        try:
+            _unbind_key(keybindings, seq)
+        except KeyError:
+            pass
+    elif bind_op == BindOperation.REBIND:
+        orig_seq = normalize_key_sequence(func)
+        _rebind_key(keybindings, seq, orig_seq)
+    else:
+        _bind_key(keybindings, seq, func)
+
+
+def unbind_key(keybindings, seq):
+    """Unbind a function from a keymap.
+
+    Parameters
+    ----------
+    keybindings : dict of str: callable
+        Keymap to modify.
+    seq : str
+        Key sequence.
+
+    Returns
+    -------
+    func : callable
+       Unbound function.
+
+    Raises
+    ------
+    KeyError
+        When the key sequence is not found in the keymap.
+    """
+    seq = normalize_key_sequence(seq)
+    return _unbind_key(keybindings, seq)
+
+
+def rebind_key(keybindings, new_seq, orig_seq):
+    """Rebind a function from one key sequence to another.
+
+    Parameters
+    ----------
+    keybindings : dict of str: callable
+        Keymap to modify.
+    new_seq : str
+        Key sequence to rebind to.
+    orig_seq : str
+        Key sequence to unbind from.
+
+    Raises
+    ------
+    KeyError
+        When the original key sequence is not found in the keymap.
+    """
+    new_seq = normalize_key_sequence(new_seq)
+    orig_seq = normalize_key_sequence(orig_seq)
+
+    _rebind_key(keybindings, new_seq, orig_seq)
+
+
+def _bind_keys_validate_pair(pair):
+    """Raise a TypeError if the given pair is not
+    a 2-sequence of (str, (callable, str, or None))
+    """
+    if not (isinstance(pair, Sequence) and not isinstance(pair, STRINGTYPES)):
+        raise TypeError(f'expected {pair} to be a sequence, got {type(pair)}')
+    key, op = pair
+    if not isinstance(key, str):
+        raise TypeError(f'key {key} must be a string, not {type(key)}')
+    _determine_binding_op(op)
+
+
+def unbind_keys(keybindings, seqs, error=True):
+    """Unbind functions from a keymap.
+
+    Parameters
+    ----------
+    keybindings : dict of str: callable
+        Keymap to modify.
+    error : bool
+        Whether to error when a function is not found in the keymap.
+        Defaults to ``True``.
+
+    Returns
+    -------
+    funcs : list of callable
+        Unbound functions.
+
+    Raises
+    ------
+    KeyError
+        When a function is not found in the keymap
+        and ``error`` is set to ``True``.
+    """
+    funcs = []
+
+    for seq in seqs:
+        try:
+            funcs.append(unbind_key(keybindings, seq))
+        except KeyError:
+            if error:
+                # rebind unbound functions
+                bind_keys(keybindings, zip(seqs[:len(funcs)], funcs))
+                raise
+
+    return funcs
+
+
+def rebind_keys(keybindings, key_pairs):
+    """Rebind functions to different key sequences.
+
+    Parameters
+    ----------
+    keybindings : dict of str: callable
+        Keymap to modify.
+    key_pairs : iterable of 2-sequence of (str, str)
+        Key pairs mapping new key sequences to original key sequences.
+
+    Raises
+    ------
+    KeyError
+        When a function is not found in the keymap.
+
+    Notes
+    -----
+    First, all unbinding operations are performed, then all binding operations.
+    This allows the effective swapping of key sequences between two functions.
+    """
+    new_seqs = []
+    orig_seqs = []
+
+    for new_seq, orig_seq in key_pairs:
+        new_seqs.append(new_seq)
+        orig_seqs.append(orig_seq)
+
+    funcs = unbind_keys(keybindings, orig_seqs)
+    bind_keys(keybindings, zip(new_seqs, funcs))
+
+
+def bind_keys(keybindings, key_pairs):
+    """Bind, unbind, or rebind multiple key sequences at the same time.
+
+    Parameters
+    ----------
+    keybindings : dict of str: callable
+        Keymap to modify.
+    key_pairs : iterable of 2-sequence of (str, (callable, str, or None))
+        Key pairs mapping key sequences to functions.
+        If a string is passed, instead perform a rebind operation.
+        If ``None`` is passed, unbind instead.
+
+    Notes
+    -----
+    Unbindings are performed first, followed by rebindings,
+    and finally new bindings.
+    """
+    to_rebind = []
+    to_unbind = []
+    to_bind = []
+
+    for pair in key_pairs:
+        _bind_keys_validate_pair(pair)
+        _, arg = pair
+        op = _determine_binding_op(arg)
+
+        if op == BindOperation.REBIND:
+            to_rebind.append(pair)
+        elif op == BindOperation.UNBIND:
+            to_unbind.append(pair[0])
+        elif op == BindOperation.BIND:
+            to_bind.append(pair)
+
+    if to_unbind:
+        unbind_keys(keybindings, to_unbind, error=False)
+
+    if to_rebind:
+        rebind_keys(keybindings, to_rebind)
+
+    for seq, func in to_bind:
+        bind_key(keybindings, seq, func)
+
+
+def _bind_keys_normalize_input(args, kwargs):
+    """Normalize args and kwargs to key-operation pairs.
+
+    Parameters
+    ----------
+    args : 1-tuple of dict of str: (callable, str, or None), \
+           1-tuple of iterable of 2-sequence of (str, (callable, str, or None)), \  # noqa
+           or tuple of 2-sequence of (str, (callable, str, or None))
+        Binding operations taken as positional arguments.
+    kwargs : dict of str: (callable, str, or None)
+        Binding operations taken as keyword arguments.
+
+    Returns
+    -------
+    ops : tuple of 2-sequence of (str, (callable, str, or None))
+        Binding operations in a singular format.
+    """
+    if len(args) == 1:
+        # bind_keys((('asdf', func), ('sdf', None)))
+        # is equivalent to
+        # bind_keys(('asdf', func), ('sdf', None))
+        args = args[0]
+
+        if isinstance(args, Mapping):
+            args = args.items()  # dict -> (N, 2) view
+
+        if isinstance(args, Iterable):
+            if isinstance(args, STRINGTYPES):
+                raise TypeError()
+            args = tuple(args)
+
+    args += tuple(kwargs.items())
+
+    return args
+
+
+def _bind_key_method(keybindings, seq, func=UNDEFINED):
+    """Bind a function to a key sequence.
+
+    Parameters
+    ----------
+    seq : str
+        Key sequence.
+    func : callable, str, or None, optional
+        Callable to bind to the key sequence.
+        If a string is passed, instead perform a rebind operation.
+        If ``None`` is passed, unbind instead.
+        If not provided, this becomes a decorator.
+    """
+    if func is UNDEFINED:  # used as a decorator
+        def inner(func):
+            bind_key(keybindings, seq, func)
+            return func
+
+        return inner
+
+    bind_key(keybindings, seq, func)
+
+
+def _bind_keys_method(keybindings, *args, **kwargs):
+    """Bind, unbind, or rebind multiple key sequences at the same time.
+
+    `o.bind_keys({seq1: op1, seq2: op2, ..., seqn: opn})`
+
+    `o.bind_keys((seq1, op1), (seq2, op2), ..., (seqn, opn))`
+
+    `o.bind_keys([(seq1, op1), (seq2, op2), ..., (seqn, opn)])`
+
+    `o.bind_keys(seq1=op1, seq2=op2, ..., seqn=opn})`
+
+    Parameters
+    ----------
+    operations : dict of str: (callable, str, or None) \
+                 or iterable of 2-sequence of (str, (callable, str, or None))
+        Binding operations to perform.
+
+    Notes
+    -----
+    Unbindings are performed first, followed by rebindings,
+    and finally new bindings.
+    """
+    bind_keys(keybindings, _bind_keys_normalize_input(args, kwargs))
+
+
+class KeybindingDescriptor:
+    """Method descriptor that binds `cls._method` to an instance's
+    and optionally a class's keybindings, similarly to how `self` is bound
+    in normal methods.
+
+    Parameters
+    ----------
+    keybindings : str, keyword-only
+        Name of the instance attribute of type ``dict of str: callable``
+        to use as a keymap.
+    class_keybindings : str, keyword-only, optional
+        Name of the class attribute of type ``dict of str: callable``
+        to use as a keymap.
+    """
+    def __init__(self, *, keybindings, class_keybindings=None):
+        self.keybindings = keybindings
+        self.class_keybindings = class_keybindings
+
+    def __get__(self, instance, klass):
+        if instance is None:  # used on class
+            if self.class_keybindings is None:
+                # no class keybindings; behave normally
+                return self._method
+
+            keybindings = getattr(klass, self.class_keybindings)
+        else:
+            keybindings = getattr(instance, self.keybindings)
+
+        return types.MethodType(self._method, keybindings)
+
+
+def _keybinding_method(name, method):
+    return type(name, (KeybindingDescriptor,),
+                {'_method': staticmethod(method)})
+
+
+bind_key_method = _keybinding_method('bind_key', _bind_key_method)
+unbind_key_method = _keybinding_method('unbind_key', unbind_key)
+rebind_key_method = _keybinding_method('rebind_key', rebind_key)
+bind_keys_method = _keybinding_method('bind_keys', _bind_keys_method)

--- a/napari/util/keybindings.py
+++ b/napari/util/keybindings.py
@@ -1,3 +1,37 @@
+"""Keys are represented in the form ``[modifier-]key``, e.g. ``a``,
+``Control-c``, or ``Control-Alt-Delete``.
+Valid modifiers are Control, Alt, Shift, and Meta,
+and can be represented with the shorthands C, M, S, and s, respectively.
+
+Shift pressed with any letter will be consumed
+to transform it to upper case, e.g. Shift + w => W.
+Otherwise, the letter will be lower case.
+Shift will also be consumed without transformation when pressed
+with any other non-special key unless Control is also a modifier.
+
+Special keys include Shift, Control, Alt, Meta, Up, Down, Left, Right,
+PageUp, PageDown, Insert, Delete, Home, End, Escape, Backspace, F1,
+F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, Space, Enter, and Tab
+
+Functions take in only one argument: the parent that the function
+was bound to. This is the viewer or layer.
+
+By default, all functions are assumed to work on key presses only,
+but can be denoted to work on release too by separating the function
+into two statements with the yield keyword::
+
+    @viewer.bind_key('h')
+    def hello_world(viewer):
+        # on key press
+        viewer.status = 'hello world!'
+
+        yield
+
+        # on key release
+        viewer.status = 'goodbye world :('
+
+"""
+
 import re
 import types
 from collections import OrderedDict
@@ -6,8 +40,12 @@ from typing import Sequence, Iterable, Mapping, ByteString, Callable
 
 from vispy.util import keys
 
+from .misc import formatdoc
+
 
 STRINGTYPES = str, ByteString
+
+DOC_EXPLANATION = __doc__.replace('\n', '\n    ')
 
 
 SPECIAL_KEYS = [keys.SHIFT,
@@ -462,6 +500,7 @@ def _bind_key_method_normalize_input(args, kwargs):
     return args
 
 
+@formatdoc
 def _bind_key_method(keybindings, *args, **kwargs):
     """Bind, unbind, or rebind one or more key sequences at the same time.
 
@@ -469,7 +508,7 @@ def _bind_key_method(keybindings, *args, **kwargs):
 
     ``@o.bind_key(seq)`` (used as a decorator)
 
-    ``o.bind_key({seq1: op1, seq2: op2, ..., seqn: opn})``
+    ``o.bind_key({{seq1: op1, seq2: op2, ..., seqn: opn}})``
 
     ``o.bind_key((seq1, op1), (seq2, op2), ..., (seqn, opn))``
 
@@ -490,6 +529,8 @@ def _bind_key_method(keybindings, *args, **kwargs):
     -----
     Unbindings are performed first, followed by rebindings,
     and finally new bindings.
+
+    {DOC_EXPLANATION}
     """
     if len(args) == 1 and isinstance(args[0], str):
         def inner(func):

--- a/napari/util/tests/test_keybindings.py
+++ b/napari/util/tests/test_keybindings.py
@@ -1,0 +1,230 @@
+import pytest
+from ..keybindings import (_bind_keys_normalize_input, _bind_keys_validate_pair,
+                           _determine_binding_op, _expand_shorthand,
+                           BindOperation, bind_key, bind_keys, bind_key_method,
+                           bind_keys_method, components_to_seq,
+                           normalize_key_sequence, parse_seq, rebind_key,
+                           rebind_key_method, rebind_keys, unbind_key,
+                           unbind_key_method, unbind_keys)
+
+
+def test_expand_shorthand():
+    assert _expand_shorthand('x') == 'x'
+    assert _expand_shorthand('C-x') == 'Control-x'
+    assert _expand_shorthand('C-M-S-s-x') == 'Control-Alt-Shift-Meta-x'
+
+
+def test_parse_seq():
+    assert parse_seq('x') == ('x', set())
+    assert parse_seq('Control-x') == ('x', {'Control'})
+    assert parse_seq('Control-Alt-Shift-Meta-x') \
+        == ('x', {'Control', 'Alt', 'Shift', 'Meta'})
+
+
+def test_components_to_seq():
+    assert components_to_seq('x', []) == 'x'
+    assert components_to_seq('x', ['Control']) == 'Control-x'
+
+    # test consuming
+    assert components_to_seq('x', []) == 'x'
+    assert components_to_seq('x', ['Shift']) == 'X'
+    assert components_to_seq('X', []) == 'x'
+
+    assert components_to_seq('@', ['Shift']) == '@'
+    assert components_to_seq('2', ['Control', 'Shift']) == 'Control-Shift-2'
+
+    # test ordering
+    assert components_to_seq('2', ['Control', 'Alt', 'Shift', 'Meta']) \
+        == 'Control-Alt-Shift-Meta-2'
+    assert components_to_seq('2', ['Alt', 'Shift', 'Control', 'Meta']) \
+        == 'Control-Alt-Shift-Meta-2'
+
+
+def test_normalize_key_sequence():
+    assert normalize_key_sequence('x') == 'x'
+    assert normalize_key_sequence('C-x') == 'Control-x'
+    assert normalize_key_sequence('Meta-Alt-x') == 'Alt-Meta-x'
+    assert normalize_key_sequence('S-M-C-s-2') == 'Control-Alt-Shift-Meta-2'
+
+
+def test_determine_binding_op():
+    assert _determine_binding_op(None) == BindOperation.UNBIND
+    assert _determine_binding_op('SPAM') == BindOperation.REBIND
+    assert _determine_binding_op(lambda: 42) == BindOperation.BIND
+
+    with pytest.raises(TypeError):
+        _determine_binding_op(1)
+
+
+def test_unbind_key():
+    f = lambda: 42
+    kb = dict(a=f)
+
+    assert unbind_key(kb, 'a') is f
+    assert kb == {}
+
+    with pytest.raises(KeyError):
+        unbind_key(kb, 'a')
+
+
+def test_rebind_key():
+    f = lambda: 42
+    kb = dict(a=f)
+
+    rebind_key(kb, 'b', 'a')
+    assert kb == dict(b=f)
+
+
+def test_bind_key():
+    kb = {}
+
+    # bind
+    f = lambda: 42
+    bind_key(kb, 'a', f)
+    assert kb == dict(a=f)
+
+    # rebind
+    bind_key(kb, 'b', 'a')
+    assert kb == dict(b=f)
+
+    # overwrite
+    l = lambda: 'SPAM'
+    bind_key(kb, 'b', l)
+    assert kb == dict(b=l)
+
+    # unbind
+    bind_key(kb, 'b', None)
+    assert kb == {}
+
+
+def test_unbind_keys():
+    kb = dict(a=lambda: 42,
+              b=lambda: 'SPAM',
+              c=lambda: 'aliiiens')
+
+    assert [kb['a']] == unbind_keys(kb, ['a'])
+    assert kb == dict(b=kb['b'],
+                      c=kb['c'])
+
+    assert list(kb.values()) == unbind_keys(kb, list(kb.keys()))
+    assert kb == {}
+
+
+def test_rebind_keys():
+    mp = {
+        'a': lambda: print(42),
+        'b': lambda: print('SPAM!')
+    }
+
+    kb = mp.copy()
+
+    # swapped
+    rebind_keys(kb, [('a', 'b'),
+                     ('b', 'a')])
+    assert kb == dict(a=mp['b'], b=mp['a'])
+
+    rebind_keys(kb, [('c', 'b')])
+    assert kb == dict(a=mp['b'], c=mp['a'])
+
+
+def test_bind_keys_normalize_input():
+    norm = lambda *args, **kwargs: _bind_keys_normalize_input(args, kwargs)
+    out = (('a', 'b'),
+           ('c', 'd'))
+
+    assert (norm(('a', 'b'),
+                 ('c', 'd'))
+            == out)
+
+    assert (norm((('a', 'b'),
+                  ('c', 'd')))
+            == out)
+
+    assert norm(a='b', c='d') == out
+
+    assert (norm({'a': 'b',
+                  'c': 'd'})
+            == out)
+
+
+def test_bind_keys():
+    mp = {
+        'a': lambda: 42,
+        'b': lambda: 'SPAM',
+        'c': lambda: 'aliiiens'
+    }
+
+    kb = {}
+
+    # bind keys
+    bind_keys(kb, mp.items())
+    assert kb == mp
+
+    # rebind keys
+    bind_keys(kb, [('b', 'a'),
+                   ('d', 'b')])
+    assert kb['b'] is mp['a']
+    assert kb['d'] is mp['b']
+
+    # unbind keys
+    bind_keys(kb, [('b', None),
+                   ('c', None)])
+    assert kb == dict(d=kb['d'])
+
+    # sort/ordering
+    bind_keys(kb, [('a', 'd'),
+                   ('a', None),
+                   ('b', mp['a'])])
+    assert kb == dict(a=mp['b'], b=mp['a'])
+
+
+def test_keybinding_descriptors():
+    class Foo:
+        default_keybindings = {}
+
+        def __init__(self):
+            self.keybindings = self.default_keybindings.copy()
+
+        bind_key = bind_key_method(keybindings='keybindings',
+                                   class_keybindings='default_keybindings')
+        unbind_key = unbind_key_method(keybindings='keybindings',
+                                       class_keybindings='default_keybindings')
+        rebind_key = rebind_key_method(keybindings='keybindings',
+                                       class_keybindings='default_keybindings')
+        bind_keys = bind_keys_method(keybindings='keybindings',
+                                     class_keybindings='default_keybindings')
+
+    f = lambda: 42
+
+    Foo.bind_key('a', f)
+    assert 'a' in Foo.default_keybindings
+
+    @Foo.bind_key('b')
+    def bar(): ...
+    assert Foo.default_keybindings['b'] is bar
+
+    assert Foo.unbind_key('b') is bar
+    assert list(Foo.default_keybindings.keys()) == ['a']
+
+    Foo.rebind_key('b', 'a')
+    assert Foo.default_keybindings == dict(b=f)
+
+    foo = Foo()
+    assert foo.keybindings == Foo.default_keybindings
+
+    foo.bind_keys(a=lambda: 'SPAM')
+    assert set(foo.keybindings) == {'a', 'b'}
+    assert foo.keybindings != Foo.default_keybindings
+
+    f2 = lambda: 'aliiiens'
+    foo.bind_keys(('c', f2),
+                  ('a', None),
+                  ('a', 'b'))
+    assert foo.keybindings == dict(a=f,
+                                   c=f2)
+
+    foo.bind_keys({'c': None})
+    assert foo.keybindings == dict(a=f)
+
+    foo.bind_keys([('a', None)])
+    assert foo.keybindings == {}


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
Add machinery for the adding, validation, and dispatch of keybindings on the viewer and its layers.

### Changes
- remove `on_key_press` and `on_key_release` methods from all layers
- on the viewer and its layers, store all initial keybinding information under the `default_keybindings` class variable, which is used to initialize the `keybindings` instance attribute
- add convenience methods for adding, removing, and rebinding keybindings

## Syntax
### key sequences
Key sequences are represented in the form `[modifier-]key`, e.g. `a`, `Control-c`, or `Control-Alt-Delete`. Valid modifiers are `Control`, `Alt`, `Shift`, and `Meta`, and can be represented as in Emacs with the shorthands `C`, `M`, `S`, and `s`, respectively.

Shift pressed with any letter will be consumed
to transform it to upper case, e.g. Shift + w => W.
Otherwise, the letter will be lower case.
Shift will also be consumed without transformation when pressed
with any other non-special key unless Control is also a modifier.

Special keys include Shift, Control, Alt, Meta, Up, Down, Left, Right,
PageUp, PageDown, Insert, Delete, Home, End, Escape, Backspace, F1,
F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, Space, Enter, and Tab

### function format
Functions take in only one argument: the parent that the function was attached to. This is the viewer or layer.

By default, all functions are assumed to work on key presses only, but can be denoted to work on release too by separating the function into two statements with the `yield` keyword:
```python
def hello_world(viewer):
    # on key press
    viewer.status = 'hello world!'

    yield

    # on key release
    viewer.status = 'goodbye world :('
```

### bind a key
```python
viewer.bind_key('n', load_next_image)

@viewer.bind_key('p')
def load_prev_image(viewer): ...
```

### unbind a key
```python
viewer.unbind_keys('n')
viewer.bind_key('p', None)
```

### rebind a key
```python
viewer.bind_key('Left', 'p')
```

### bind multiple keys
```python
viewer.bind_key(('n', load_next_image),
                ('p', load_prev_image))

keybindings = [('Right', 'n'),
               ('Left', 'p')]
viewer.bind_key(keybindings)

keybindings = {
    'Control-s': save,
    'Control-u', undo
}
viewer.bind_key(keybindings)

viewer.bind_key(a=None)
```

### unbind multiple keys
```python
viewer.unbind_keys('a', 'b', 'c')
viewer.unbind_keys(['a', 'b', 'c'])
viewer.unbind_keys()
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] the test suite for my feature passes
- [x] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
