### PR TITLE
theme setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ You can also paint pixel-wise labels, useful for creating masks for segmentation
 
 ![image](resources/screenshot-add-labels.png)
 
+You can change the theme after creating the viewer by setting the `viewer.theme` property. The viewer currently supports `light` and `dark` themes, with `dark` as the default. Run `examples/set_theme.py` to see an example of changing themes.
+
 ## plans
 
 We're working on several features, including 

--- a/examples/set_theme.py
+++ b/examples/set_theme.py
@@ -1,0 +1,16 @@
+"""
+Displays an image and sets the theme to 'light'.
+"""
+
+from skimage import data
+from napari import ViewerApp
+from napari.util import app_context
+
+
+with app_context():
+    # create the viewer with an image
+    viewer = ViewerApp(astronaut=data.astronaut(),
+                       title='napari light theme')
+
+    # set the theme to 'light'
+    viewer.theme = 'foo'

--- a/examples/set_theme.py
+++ b/examples/set_theme.py
@@ -14,4 +14,3 @@ with app_context():
 
     # set the theme to 'light'
     viewer.theme = 'light'
-

--- a/examples/set_theme.py
+++ b/examples/set_theme.py
@@ -1,0 +1,16 @@
+"""
+Displays an image and sets the theme to 'light'.
+"""
+
+from skimage import data
+from napari import ViewerApp
+from napari.util import app_context
+
+
+with app_context():
+    # create the viewer with an image
+    viewer = ViewerApp(astronaut=data.astronaut(),
+                       title='napari light theme')
+
+    # set the theme to 'light'
+    viewer.theme = 'light'

--- a/napari/_qt/range_slider/range_slider.py
+++ b/napari/_qt/range_slider/range_slider.py
@@ -6,9 +6,6 @@ from qtpy import QtCore, QtGui
 from qtpy.QtWidgets import QWidget
 
 from ...util.misc import str_to_rgb
-from ...util.theme import palettes
-palette = palettes['dark']
-
 
 class QRangeSlider(QWidget):
     """
@@ -44,6 +41,7 @@ class QRangeSlider(QWidget):
         self.start_pos = None
         self.display_min = None
         self.display_max = None
+        self.setColors('rgb(100,100,100)', 'rgb(200,200,200)')
         self.setEnabled(True)
 
         if slider_range:
@@ -260,23 +258,21 @@ class QRangeSlider(QWidget):
         self.updateDisplayValues()
         self.update()
 
+    def setColors(self, background, foreground):
+        self.bar_color = QtGui.QColor(
+            *str_to_rgb(foreground))
+        self.background_color = QtGui.QColor(
+            *str_to_rgb(background))
+        self.handle_color = QtGui.QColor(
+            *str_to_rgb(foreground))
+        self.handle_border_color = QtGui.QColor(
+            *str_to_rgb(foreground))
+
     def setEnabled(self, bool):
         if bool:
             self.enabled = True
-            self.bar_color = QtGui.QColor(
-                *str_to_rgb(palette['highlight']))
-            self.background_color = QtGui.QColor(
-                *str_to_rgb(palette['foreground']))
-            self.handle_color = QtGui.QColor(
-                *str_to_rgb(palette['highlight']))
-            self.handle_border_color = QtGui.QColor(
-                *str_to_rgb(palette['highlight']))
         else:
             self.enabled = False
-            self.bar_color = QtCore.Qt.gray
-            self.background_color = QtCore.Qt.gray
-            self.handle_color = QtCore.Qt.gray
-            self.handle_border_color = QtCore.Qt.gray
         self.update()
 
 

--- a/napari/components/_layers/view/main.py
+++ b/napari/components/_layers/view/main.py
@@ -130,8 +130,8 @@ class QtDivider(QFrame):
         self.setSelected(False)
         self.setFixedSize(50, 2)
 
-    def setSelected(self, bool):
-        if bool:
+    def setSelected(self, state):
+        if state:
             self.setProperty('selected', True)
             self.style().polish(self)
         else:

--- a/napari/components/_layers/view/main.py
+++ b/napari/components/_layers/view/main.py
@@ -130,8 +130,8 @@ class QtDivider(QFrame):
         self.setSelected(False)
         self.setFixedSize(50, 2)
 
-    def setSelected(self, state):
-        if state:
+    def setSelected(self, selected):
+        if selected:
             self.setProperty('selected', True)
             self.style().polish(self)
         else:

--- a/napari/components/_layers/view/main.py
+++ b/napari/components/_layers/view/main.py
@@ -2,9 +2,6 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QPushButton,
                             QFrame, QCheckBox, QScrollArea)
 
-from ....util.theme import palettes
-palette = palettes['dark']
-
 
 class QtLayers(QScrollArea):
 
@@ -128,10 +125,6 @@ class QtLayers(QScrollArea):
 
 
 class QtDivider(QFrame):
-    unselectedStlyesheet = "QFrame {;}"
-    selectedStlyesheet = """QFrame {border: 2px solid %s;
-        background-color: white; border-radius: 3px;}""" % palette['text']
-
     def __init__(self):
         super().__init__()
         self.setSelected(False)
@@ -139,6 +132,8 @@ class QtDivider(QFrame):
 
     def setSelected(self, bool):
         if bool:
-            self.setStyleSheet(self.selectedStlyesheet)
+            self.setProperty('selected', 'true')
+            self.style().polish(self)
         else:
-            self.setStyleSheet(self.unselectedStlyesheet)
+            self.setProperty('selected', 'false')
+            self.style().polish(self)

--- a/napari/components/_layers/view/main.py
+++ b/napari/components/_layers/view/main.py
@@ -135,5 +135,5 @@ class QtDivider(QFrame):
             self.setProperty('selected', 'true')
             self.style().polish(self)
         else:
-            self.setProperty('selected', 'false')
+            self.setProperty('selected', False)
             self.style().polish(self)

--- a/napari/components/_layers/view/main.py
+++ b/napari/components/_layers/view/main.py
@@ -132,7 +132,7 @@ class QtDivider(QFrame):
 
     def setSelected(self, bool):
         if bool:
-            self.setProperty('selected', 'true')
+            self.setProperty('selected', True)
             self.style().polish(self)
         else:
             self.setProperty('selected', False)

--- a/napari/components/_layers_list/view/list.py
+++ b/napari/components/_layers_list/view/list.py
@@ -1,9 +1,6 @@
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QPushButton,
-                             QFrame, QCheckBox, QScrollArea)
-
-from ....util.theme import palettes
-palette = palettes['dark']
+                            QFrame, QCheckBox, QScrollArea)
 
 
 class QtLayersList(QScrollArea):
@@ -127,10 +124,6 @@ class QtLayersList(QScrollArea):
 
 
 class QtDivider(QFrame):
-    unselectedStlyesheet = "QFrame {;}"
-    selectedStlyesheet = """QFrame {border: 2px solid %s;
-        background-color: white; border-radius: 3px;}""" % palette['text']
-
     def __init__(self):
         super().__init__()
         self.setSelected(False)
@@ -138,6 +131,8 @@ class QtDivider(QFrame):
 
     def setSelected(self, bool):
         if bool:
-            self.setStyleSheet(self.selectedStlyesheet)
+            self.setProperty('selected', 'true')
+            self.style().polish(self)
         else:
-            self.setStyleSheet(self.unselectedStlyesheet)
+            self.setProperty('selected', 'false')
+            self.style().polish(self)

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -4,6 +4,8 @@ from copy import copy
 from itertools import zip_longest
 
 from ...util.event import EmitterGroup, Event
+from ...util.theme import palettes
+from ...util.misc import has_clims
 
 
 class Viewer:
@@ -206,6 +208,10 @@ class Viewer:
             Layer to add.
         """
         self.layers.append(layer)
+        if self.theme is not None and has_clims(layer):
+            palette = palettes[self.theme]
+            layer._qt_controls.climSlider.setColors(
+                palette['foreground'], palette['highlight'])
         if len(self.layers) == 1:
             self.reset_view()
 

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -4,6 +4,8 @@ from copy import copy
 from itertools import zip_longest
 
 from ...util.event import EmitterGroup, Event
+from ...util.theme import palettes
+from ...util.misc import has_clims
 from .._dims import Dims
 
 
@@ -215,6 +217,12 @@ class Viewer:
         layer.events.deselect.connect(self._update_layer_selection)
         self.layers.append(layer)
         layer.viewer = self
+
+        if self.theme is not None and has_clims(layer):
+            palette = palettes[self.theme]
+            layer._qt_controls.climSlider.setColors(
+                palette['foreground'], palette['highlight'])
+
         if len(self.layers) == 1:
             self.reset_view()
 

--- a/napari/components/_viewer/view/main.py
+++ b/napari/components/_viewer/view/main.py
@@ -10,16 +10,8 @@ from ....resources import resources_dir
 from .controls import QtControls
 from .buttons import QtLayersButtons
 
-import os.path as osp
-from ....resources import resources_dir
-from ....util.theme import template, palettes
-palette = palettes['dark']
-
 
 class QtViewer(QSplitter):
-    with open(osp.join(resources_dir, 'stylesheet.qss'), 'r') as f:
-        raw_stylesheet = f.read()
-        themed_stylesheet = template(raw_stylesheet, **palette)
 
     def __init__(self, viewer):
         super().__init__()
@@ -27,7 +19,6 @@ class QtViewer(QSplitter):
         QCoreApplication.setAttribute(
             Qt.AA_UseStyleSheetPropagationInWidgetStyles, True
         )
-        self.setStyleSheet(self.themed_stylesheet)
 
         self.viewer = viewer
         self.viewer._qtviewer = self

--- a/napari/components/_viewer/view/main.py
+++ b/napari/components/_viewer/view/main.py
@@ -7,16 +7,8 @@ from ..._dims.view import QtDims
 from ....resources import resources_dir
 from .controls import QtControls
 
-import os.path as osp
-from ....resources import resources_dir
-from ....util.theme import template, palettes
-palette = palettes['dark']
-
 
 class QtViewer(QSplitter):
-    with open(osp.join(resources_dir, 'stylesheet.qss'), 'r') as f:
-        raw_stylesheet = f.read()
-        themed_stylesheet = template(raw_stylesheet, **palette)
 
     def __init__(self, viewer):
         super().__init__()
@@ -24,7 +16,6 @@ class QtViewer(QSplitter):
         QCoreApplication.setAttribute(
             Qt.AA_UseStyleSheetPropagationInWidgetStyles, True
         )
-        self.setStyleSheet(self.themed_stylesheet)
 
         self.viewer = viewer
         self.viewer._qtviewer = self
@@ -54,6 +45,7 @@ class QtViewer(QSplitter):
         dimsview = QtDims(self.viewer.dims)
         layout.addWidget(dimsview)
         center.setLayout(layout)
+        self.dims = dimsview
 
         # Add controls, center, and layerlist
         self.control_panel = QtControls(viewer)

--- a/napari/components/_window/view.py
+++ b/napari/components/_window/view.py
@@ -2,8 +2,6 @@ from qtpy.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QLabel
 from qtpy.QtCore import Qt
 
 from .._viewer import Viewer
-from ...util.theme import palettes
-palette = palettes['dark']
 
 
 class Window:
@@ -32,14 +30,9 @@ class Window:
         self._help = QLabel('')
         self._status_bar.addPermanentWidget(self._help)
 
-        self._status_bar.setStyleSheet("""QStatusBar { background: %s;
-            color: %s}""" % (palette['background'], palette['text']))
-
         self.viewer = viewer
         self._qt_center.layout().addWidget(self.viewer._qtviewer)
         self._qt_center.layout().setContentsMargins(4, 0, 4, 0)
-        self._qt_center.setStyleSheet(
-            'QWidget { background: %s;}' % palette['background'])
 
         self.viewer.events.status.connect(self._status_changed)
         self.viewer.events.help.connect(self._help_changed)

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -32,11 +32,11 @@ QSplitter::handle:vertical {
     height: 2px;
 }
 
-QtDivider[selected="true"] {
+QtDivider[selected=true] {
   background-color: {{ text }}; 
 }
 
-QtDivider[selected="false"] {
+QtDivider[selected=false] {
   background-color: {{ background }}; 
 }
 

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -32,6 +32,14 @@ QSplitter::handle:vertical {
     height: 2px;
 }
 
+QtDivider[selected="true"] {
+  background-color: {{ text }}; 
+}
+
+QtDivider[selected="false"] {
+  background-color: {{ background }}; 
+}
+
 /* ------------------------------------------------------ */
 
 QSlider {

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -24,6 +24,18 @@ def ensure_iterable(arg, color=False):
         return itertools.repeat(arg)
 
 
+def has_clims(arg):
+    """Check if a layer has clims.
+    """
+    if hasattr(arg, '_qt_controls'):
+        if hasattr(arg._qt_controls, 'climSlider'):
+            return True
+        else:
+            return False
+    else:
+        return False
+
+
 def is_iterable(arg, color=False):
     """Determine if a single argument is an iterable. If a color is being
     provided and the argument is a 1-D array of length 3 or 4 then the input

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -33,6 +33,9 @@ class ViewerApp(Viewer):
     **named_images : dict of str -> ndarray, optional
         Arrays to render as image layers, keyed by layer name.
     """
+    with open(osp.join(resources_dir, 'stylesheet.qss'), 'r') as f:
+        raw_stylesheet = f.read()
+
     def __init__(self, *images, meta=None, multichannel=None, clim_range=None,
                  title='napari', **named_images):
         super().__init__(title=title)
@@ -50,9 +53,9 @@ class ViewerApp(Viewer):
     def theme(self):
         """string: Color theme.
         """
-        if hasattr(self, '_theme'):
+        try:
             return self._theme
-        else:
+        except AttributeError:
             return None
 
     @theme.setter
@@ -68,14 +71,12 @@ class ViewerApp(Viewer):
         palette = palettes[theme]
 
         # template and apply the primary stylesheet
-        with open(osp.join(resources_dir, 'stylesheet.qss'), 'r') as f:
-            raw_stylesheet = f.read()
-            themed_stylesheet = template(raw_stylesheet, **palette)
+        themed_stylesheet = template(self.raw_stylesheet, **palette)
         self._qtviewer.setStyleSheet(themed_stylesheet)
 
         # set window styles which don't use the primary stylesheet
-        self.window._status_bar.setStyleSheet("""QStatusBar { background: %s;
-            color: %s}""" % (palette['background'], palette['text']))
+        self.window._status_bar.setStyleSheet('QStatusBar { background: %s;'
+            'color: %s}' % (palette['background'], palette['text']))
         self.window._qt_center.setStyleSheet(
             'QWidget { background: %s;}' % palette['background'])
 

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -75,8 +75,9 @@ class ViewerApp(Viewer):
         self._qtviewer.setStyleSheet(themed_stylesheet)
 
         # set window styles which don't use the primary stylesheet
-        self.window._status_bar.setStyleSheet('QStatusBar { background: %s;'
-            'color: %s}' % (palette['background'], palette['text']))
+        self.window._status_bar.setStyleSheet(
+            'QStatusBar { background: %s;color: %s}'
+            % (palette['background'], palette['text']))
         self.window._qt_center.setStyleSheet(
             'QWidget { background: %s;}' % palette['background'])
 

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -62,7 +62,7 @@ class ViewerApp(Viewer):
         self._theme = theme
 
         if theme not in palettes.keys():
-            raise KeyError("Theme '%s' not found, options are %s." 
+            raise KeyError("Theme '%s' not found, options are %s."
                            % (theme, list(palettes.keys())))
 
         palette = palettes[theme]


### PR DESCRIPTION
# Description
This PR makes it possible to set the theme based on a new `theme` property available on the viewer.

The API is simply to set the value of `viewer.theme` to either `light` or `dark`. This can eventually include any of the other themes we make available. Upon setting, the current color palette of the viewer will be adjusted.

![settheme](https://user-images.githubusercontent.com/3387500/57275656-0716a880-7054-11e9-963b-99b27189744b.gif)

I added an example under `examples/set_theme.py` that views an image and sets the theme to `light` 
rather than the default `dark`.

Implementation notes
- I was able to consolidate almost all the style handling inside `viewer` (where the `theme` property is defined).
- It was a bit ugly to handle correct styling on the clim slider for new image layers created *after* the theme has been set. To do this, I added a check to the `add_layer` method to set the clims slider colors based on the current theme *if* the new layer is an image layer. Unless we find a way to make the clims styled via `qss`, I don't see a way around this.
- I modified the range slider to have a `setColor` method and to decouple its color changes from the `enabled` / `disabled` flag.
- I fixed it so the `QtDivider` stylings come from the `qss`, making for one less place we needed to awkwardly patch the stylings.
- If an invalid theme is provided, it'll raise a KeyError with an informative error message `"Theme 'foo' not found, options are ['dark', 'light']."`

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## References
As usual, lots of help from @sofroniewn @kne42 and @shanaxel42 !

## How has this been tested?
- [x] Added an example

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
