### PR TITLE
layer active when only one selected

### DIFF
--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -260,7 +260,7 @@ class Viewer:
                 active_layer = None
                 break
 
-        if active_layer == None:
+        if active_layer is None:
             self.status = 'Ready'
             self.help = ''
             self.cursor = 'standard'

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -250,10 +250,19 @@ class Viewer:
             layer._set_view_slice(self.dims.indices)
 
     def _update_active_layer(self, event):
+        """Set the active layer by iterating over the layers list and
+        finding the first selected layer. If multiple layers are selected the
+        iteration stops and the active layer is set to be None
+
+        Parameters
+        ----------
+        event : Event
+            No Event parameters are used
+        """
         # iteration goes backwards to find top most selected layer if any
         # if multiple layers are selected sets the active layer to None
         active_layer = None
-        for layer in self.layers[::-1]:
+        for layer in self.layers:
             if active_layer is None and layer.selected:
                 active_layer = layer
             elif active_layer is not None and layer.selected:

--- a/napari/components/_viewer/view/controls.py
+++ b/napari/components/_viewer/view/controls.py
@@ -23,7 +23,7 @@ class QtControls(QStackedWidget):
             layer = None
         else:
             layer = event.item
-            
+
         if layer is None or layer._qt_controls is None:
             self.setCurrentWidget(self.empty_widget)
         else:

--- a/napari/components/_viewer/view/controls.py
+++ b/napari/components/_viewer/view/controls.py
@@ -12,12 +12,18 @@ class QtControls(QStackedWidget):
         self.setMinimumSize(QSize(40, 40))
         self.empty_widget = QWidget()
         self.addWidget(self.empty_widget)
-        self.display(None)
+        self._display(None)
 
         self.viewer.layers.events.added.connect(self._add)
         self.viewer.layers.events.removed.connect(self._remove)
+        self.viewer.events.active_layer.connect(self._display)
 
-    def display(self, layer):
+    def _display(self, event):
+        if event is None:
+            layer = None
+        else:
+            layer = event.item
+            
         if layer is None or layer._qt_controls is None:
             self.setCurrentWidget(self.empty_widget)
         else:

--- a/napari/components/_viewer/view/controls.py
+++ b/napari/components/_viewer/view/controls.py
@@ -19,6 +19,13 @@ class QtControls(QStackedWidget):
         self.viewer.events.active_layer.connect(self._display)
 
     def _display(self, event):
+        """Change the displayed controls to be those of the target layer.
+
+        Parameters
+        ----------
+        event : Event
+            Event with the target layer at `event.item`.
+        """
         if event is None:
             layer = None
         else:
@@ -30,11 +37,25 @@ class QtControls(QStackedWidget):
             self.setCurrentWidget(layer._qt_controls)
 
     def _add(self, event):
+        """Add the controls target layer to the list of control widgets.
+
+        Parameters
+        ----------
+        event : Event
+            Event with the target layer at `event.item`.
+        """
         layer = event.item
         if layer._qt_controls is not None:
             self.addWidget(layer._qt_controls)
 
     def _remove(self, event):
+        """Remove the controls target layer from the list of control widgets.
+
+        Parameters
+        ----------
+        event : Event
+            Event with the target layer at `event.item`.
+        """
         layer = event.item
         if layer._qt_controls is not None:
             self.removeWidget(layer._qt_controls)

--- a/napari/components/_viewer/view/main.py
+++ b/napari/components/_viewer/view/main.py
@@ -87,21 +87,21 @@ class QtViewer(QSplitter):
     def on_mouse_move(self, event):
         """Called whenever mouse moves over canvas.
         """
-        layer = self.viewer._top
+        layer = self.viewer.active_layer
         if layer is not None:
             layer.on_mouse_move(event)
 
     def on_mouse_press(self, event):
         """Called whenever mouse pressed in canvas.
         """
-        layer = self.viewer._top
+        layer = self.viewer.active_layer
         if layer is not None:
             layer.on_mouse_press(event)
 
     def on_mouse_release(self, event):
         """Called whenever mouse released in canvas.
         """
-        layer = self.viewer._top
+        layer = self.viewer.active_layer
         if layer is not None:
             layer.on_mouse_release(event)
 
@@ -113,14 +113,14 @@ class QtViewer(QSplitter):
             self.viewer.key_bindings[event.text](self.viewer)
             return
 
-        layer = self.viewer._top
+        layer = self.viewer.active_layer
         if layer is not None:
             layer.on_key_press(event)
 
     def on_key_release(self, event):
         """Called whenever key released in canvas.
         """
-        layer = self.viewer._top
+        layer = self.viewer.active_layer
         if layer is not None:
             layer.on_key_release(event)
 

--- a/napari/layers/_image_layer/view/controls.py
+++ b/napari/layers/_image_layer/view/controls.py
@@ -25,14 +25,10 @@ class QtImageControls(QWidget):
         self.climSlider.rangeChanged.connect(self.clim_slider_changed)
 
     def clim_slider_changed(self, slidermin, slidermax):
-        from ..model import Image
-        for layer in self.layer.viewer.layers:
-            if isinstance(layer, Image) and layer.selected:
-                valmin, valmax = layer._clim_range
-                cmin = valmin+slidermin*(valmax-valmin)
-                cmax = valmin+slidermax*(valmax-valmin)
-                layer.clim = [cmin, cmax]
-                layer._qt_controls.clim_slider_update(None)
+        valmin, valmax = self.layer._clim_range
+        cmin = valmin+slidermin*(valmax-valmin)
+        cmax = valmin+slidermax*(valmax-valmin)
+        self.layer.clim = [cmin, cmax]
 
     def clim_slider_update(self, event):
         valmin, valmax = self.layer._clim_range

--- a/napari/layers/_image_layer/view/controls.py
+++ b/napari/layers/_image_layer/view/controls.py
@@ -26,15 +26,15 @@ class QtImageControls(QWidget):
 
     def clim_slider_changed(self, slidermin, slidermax):
         valmin, valmax = self.layer._clim_range
-        cmin = valmin+slidermin*(valmax-valmin)
-        cmax = valmin+slidermax*(valmax-valmin)
-        self.layer.clim = [cmin, cmax]
+        cmin = valmin + slidermin * (valmax - valmin)
+        cmax = valmin + slidermax * (valmax - valmin)
+        self.layer.clim = cmin, cmax
 
     def clim_slider_update(self, event):
         valmin, valmax = self.layer._clim_range
         cmin, cmax = self.layer.clim
-        slidermin = (cmin - valmin)/(valmax - valmin)
-        slidermax = (cmax - valmin)/(valmax - valmin)
+        slidermin = (cmin - valmin) / (valmax - valmin)
+        slidermax = (cmax - valmin) / (valmax - valmin)
         self.climSlider.blockSignals(True)
         self.climSlider.setValues((slidermin, slidermax))
         self.climSlider.blockSignals(False)


### PR DESCRIPTION
# Description
This PR forces the layer controls on the left hand side to only directly modify the layer to which they belong. This will make removing the `viewer` easier from an individual `layer` as now there is no way for a layer to go in and modify many layers when those elements are changed. If multiple layers are now selected the control panel on the left disappears, even if those layers are all of the same type. This PR also removes the functionality that allowed multiple clims to be simultaneously adjusted when multiple layers were selected. In practice I have found this functionality confusing and not very helpful. If others (@royerloic) feel strongly that we should support this in some way we can discuss how best to, but the current solution of allowing one layer direct access to all the other layers runs very much against the refactoring that we were trying to achieve.

I may still need to edit / improve some doc strings, but otherwise this is good to go. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run `example/layers.py` now when multiple layers selected the control panel goes away and it is no longer possible to simultaneously adjust the clims of multiple layers

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
