### PR TITLE
Fix svg canvas

### DIFF
--- a/examples/to_svg.py
+++ b/examples/to_svg.py
@@ -79,4 +79,4 @@ with app_context():
     layer = viewer.add_vectors(pos, width=2)
 
     svg = viewer.to_svg()
-    # svg = viewer.to_svg(file='viewer.svg')
+    #svg = viewer.to_svg(file='viewer.svg')

--- a/examples/to_svg.py
+++ b/examples/to_svg.py
@@ -79,4 +79,4 @@ with app_context():
     layer = viewer.add_vectors(pos, width=2)
 
     svg = viewer.to_svg()
-    #svg = viewer.to_svg(file='viewer.svg')
+    # svg = viewer.to_svg(file='viewer.svg')

--- a/examples/to_svg.py
+++ b/examples/to_svg.py
@@ -5,18 +5,20 @@ your shapes.
 """
 
 import numpy as np
-from skimage import data
-from skimage.color import rgb2gray
+from imageio import imread
 from napari import ViewerApp
 from napari.util import app_context
 from vispy.color import Colormap
+
+
+photographer = imread('imageio:camera.png')
 
 with app_context():
     # create the viewer and window
     viewer = ViewerApp()
 
     # add the image
-    img_layer = viewer.add_image(data.camera(), name='photographer')
+    img_layer = viewer.add_image(photographer, name='photographer')
     img_layer.colormap = 'gray'
 
     # create a list of polygons
@@ -79,4 +81,4 @@ with app_context():
     layer = viewer.add_vectors(pos, width=2)
 
     svg = viewer.to_svg()
-    # svg = viewer.to_svg(file='viewer.svg')
+    svg = viewer.to_svg(file='viewer.svg')

--- a/examples/to_svg.py
+++ b/examples/to_svg.py
@@ -5,20 +5,19 @@ your shapes.
 """
 
 import numpy as np
-from imageio import imread
+from skimage import data
+from skimage.color import rgb2gray
 from napari import ViewerApp
 from napari.util import app_context
 from vispy.color import Colormap
 
-
-photographer = imread('imageio:camera.png')
 
 with app_context():
     # create the viewer and window
     viewer = ViewerApp()
 
     # add the image
-    img_layer = viewer.add_image(photographer, name='photographer')
+    img_layer = viewer.add_image(data.camera(), name='photographer')
     img_layer.colormap = 'gray'
 
     # create a list of polygons

--- a/examples/to_svg.py
+++ b/examples/to_svg.py
@@ -81,4 +81,4 @@ with app_context():
     layer = viewer.add_vectors(pos, width=2)
 
     svg = viewer.to_svg()
-    svg = viewer.to_svg(file='viewer.svg')
+    # svg = viewer.to_svg(file='viewer.svg')

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -243,8 +243,7 @@ class Viewer:
         xml = Element('svg', height=f'{shape[0]}', width=f'{shape[1]}',
                       version='1.1', **props)
 
-        transform = ("translate(" + str(-min_shape[1]) + " " +
-                     str(-min_shape[0]) + ")")
+        transform = f'translate({-min_shape[1]} {-min_shape[0]})'
         xml_transform = Element('g', transform=transform)
 
         for layer in self.layers:
@@ -367,8 +366,11 @@ class Viewer:
         This assumes that all layers are stacked.
         """
 
-        min_shape = [min for min, max, step in self._calc_layers_ranges()]
-        max_shape = [max for min, max, step in self._calc_layers_ranges()]
+        min_shape = []
+        max_shape = []
+        for min, max, step in self._calc_layers_ranges():
+            min_shape.append(min)
+            max_shape.append(max)
 
         return min_shape, max_shape
 

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -207,7 +207,8 @@ class Viewer:
         return self.canvas.render(region, size, bgcolor)
 
     def to_svg(self, file=None, view_box=None):
-        """Convert the viewer state to an SVG.
+        """Convert the viewer state to an SVG. Non visible layers will be
+        ignored.
 
         Parameters
         ----------

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -229,22 +229,26 @@ class Viewer:
         """
 
         if view_box is None:
-            min_shape = self._calc_min_shape()[-2:]
-            max_shape = self._calc_max_shape()[-2:]
-            range = np.array(max_shape) - np.array(min_shape)
-            view_box = min_shape[::-1] + list(range)[::-1]
+            min_shape = np.array(self._calc_min_shape()[-2:])
+            max_shape = np.array(self._calc_max_shape()[-2:])
+            range = max_shape - min_shape
 
         props = {'xmlns': 'http://www.w3.org/2000/svg',
                  'xmlns:xlink': 'http://www.w3.org/1999/xlink'}
+                 
+        xml = Element('svg', height=f'{range[0]}', width=f'{range[1]}',
+                      version='1.1', **props)
 
-        xml = Element('svg', viewBox=f'{view_box}', version='1.1',
-                      **props)
+        transform = ("translate(" + str(-min_shape[1]) + " " +
+                     str(-min_shape[0])+ ")")
+        xml_transform = Element('g', transform=transform)
 
         for layer in self.layers:
             if layer.visible:
                 xml_list = layer.to_xml_list()
                 for x in xml_list:
-                    xml.append(x)
+                    xml_transform.append(x)
+        xml.append(xml_transform)
 
         svg = ('<?xml version=\"1.0\" standalone=\"no\"?>\n' +
                '<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n' +

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -235,12 +235,12 @@ class Viewer:
 
         props = {'xmlns': 'http://www.w3.org/2000/svg',
                  'xmlns:xlink': 'http://www.w3.org/1999/xlink'}
-                 
+
         xml = Element('svg', height=f'{range[0]}', width=f'{range[1]}',
                       version='1.1', **props)
 
         transform = ("translate(" + str(-min_shape[1]) + " " +
-                     str(-min_shape[0])+ ")")
+                     str(-min_shape[0]) + ")")
         xml_transform = Element('g', transform=transform)
 
         for layer in self.layers:

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -350,15 +350,22 @@ class Layer(VisualWrapper, ABC):
             either a str or bytes object representing a path, or an object
             implementing the `os.PathLike` protocol. If passed the svg will be
             written to this file
+        view_box : 4-tuple, optional
+            View box of SVG canvas to be generated specified as `min-x`,
+            `min-y`, `width` and `height`. If not specified, calculated
+            from the last two dimensions of the layer.
 
         Returns
         ----------
         svg : string
-            String with the svg specification of the currently viewed image
+            String with the svg specification of the currently viewed layers
         """
 
-        if canvas_shape is None:
-            canvas_shape = self.shape[-2:]
+        if view_box is None:
+            min_shape = [0, 0]
+            max_shape = self.shape[-2:]
+            range = np.array(max_shape) - np.array(min_shape)
+            view_box = min_shape[::-1] + list(range)[::-1]
 
         props = {'xmlns': 'http://www.w3.org/2000/svg',
                  'xmlns:xlink': 'http://www.w3.org/1999/xlink'}

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -339,8 +339,8 @@ class Layer(VisualWrapper, ABC):
         return []
 
     def to_svg(self, file=None, canvas_shape=None):
-        """Returns an svg string with all the currently viewed image as a png
-        or writes to svg to a file.
+        """Convert the current layer state to an SVG.
+
 
         Parameters
         ----------
@@ -357,18 +357,21 @@ class Layer(VisualWrapper, ABC):
         Returns
         ----------
         svg : string
-            String with the svg specification of the currently viewed layers
+            SVG representation of the layer.
         """
 
         if view_box is None:
-            min_shape = np.array([r[0] for r in self.range[-2:]])
-            max_shape = np.array([r[1] for f in self.range[-2:]])
-            range = max_shape - min_shape
+            min_shape = [r[0] for r in self.range[-2:]]
+            max_shape = [r[1] for f in self.range[-2:]]
+            shape = np.subtract(max_shape, min_shape)
+        else:
+            shape = view_box[2:]
+            min_shape = view_box[:2]
 
         props = {'xmlns': 'http://www.w3.org/2000/svg',
                  'xmlns:xlink': 'http://www.w3.org/1999/xlink'}
 
-        xml = Element('svg', height=f'{range[0]}', width=f'{range[1]}',
+        xml = Element('svg', height=f'{shape[0]}', width=f'{shape[1]}',
                       version='1.1', **props)
 
         transform = ("translate(" + str(-min_shape[1]) + " " +

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -163,8 +163,7 @@ class Layer(VisualWrapper, ABC):
         """list of 3-tuple of int: ranges of data for slicing specifed by
         (min, max, step).
         """
-        shape = self._get_shape()
-        return [(0, max, 1) for max in shape]
+        return [(0, max, 1) for max in self.shape]
 
     @property
     def selected(self):
@@ -362,21 +361,24 @@ class Layer(VisualWrapper, ABC):
         """
 
         if view_box is None:
-            min_shape = [0, 0]
-            max_shape = self.shape[-2:]
-            range = np.array(max_shape) - np.array(min_shape)
-            view_box = min_shape[::-1] + list(range)[::-1]
+            min_shape = np.array([r[0] for r in self.range[-2:]])
+            max_shape = np.array([r[1] for f in self.range[-2:]])
+            range = max_shape - min_shape
 
         props = {'xmlns': 'http://www.w3.org/2000/svg',
                  'xmlns:xlink': 'http://www.w3.org/1999/xlink'}
-        xml = Element('svg', width=f'{canvas_shape[0]}',
-                      height=f'{canvas_shape[1]}', version='1.1',
-                      **props)
+
+        xml = Element('svg', height=f'{range[0]}', width=f'{range[1]}',
+                      version='1.1', **props)
+
+        transform = ("translate(" + str(-min_shape[1]) + " " +
+                     str(-min_shape[0])+ ")")
+        xml_transform = Element('g', transform=transform)
 
         xml_list = self.to_xml_list()
-
         for x in xml_list:
-            xml.append(x)
+            xml_transform.append(x)
+        xml.append(xml_transform)
 
         svg = ('<?xml version=\"1.0\" standalone=\"no\"?>\n' +
                '<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n' +

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -372,7 +372,7 @@ class Layer(VisualWrapper, ABC):
                       version='1.1', **props)
 
         transform = ("translate(" + str(-min_shape[1]) + " " +
-                     str(-min_shape[0])+ ")")
+                     str(-min_shape[0]) + ")")
         xml_transform = Element('g', transform=transform)
 
         xml_list = self.to_xml_list()

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -374,8 +374,7 @@ class Layer(VisualWrapper, ABC):
         xml = Element('svg', height=f'{shape[0]}', width=f'{shape[1]}',
                       version='1.1', **props)
 
-        transform = ("translate(" + str(-min_shape[1]) + " " +
-                     str(-min_shape[0]) + ")")
+        transform = f'translate({-min_shape[1]} {-min_shape[0]})'
         xml_transform = Element('g', transform=transform)
 
         xml_list = self.to_xml_list()

--- a/napari/layers/_image_layer/model.py
+++ b/napari/layers/_image_layer/model.py
@@ -390,8 +390,8 @@ class Image(Layer):
         image_str = imwrite('<bytes>', mapped_image, format='png')
         image_str = "data:image/png;base64," + str(b64encode(image_str))[2:-1]
         props = {'xlink:href': image_str}
-        width = str(self.shape[-2])
-        height = str(self.shape[-1])
+        width = str(self.shape[-1])
+        height = str(self.shape[-2])
         opacity = str(self.opacity)
         xml = Element('image', width=width, height=height, opacity=opacity,
                       **props)

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -520,8 +520,8 @@ class Labels(Layer):
         image_str = imwrite('<bytes>', mapped_image, format='png')
         image_str = "data:image/png;base64," + str(b64encode(image_str))[2:-1]
         props = {'xlink:href': image_str}
-        width = str(self.shape[-2])
-        height = str(self.shape[-1])
+        width = str(self.shape[-1])
+        height = str(self.shape[-2])
         opacity = str(self.opacity)
         xml = Element('image', width=width, height=height, opacity=opacity,
                       **props)

--- a/napari/layers/_markers_layer/model.py
+++ b/napari/layers/_markers_layer/model.py
@@ -329,6 +329,20 @@ class Markers(Layer):
         else:
             return np.max(self.coords, axis=0) + 1
 
+    @property
+    def range(self):
+        """list of 3-tuple of int: ranges of data for slicing specifed by
+        (min, max, step).
+        """
+        if len(self.coords) == 0:
+            maxs = np.ones(self.coords.shape[1], dtype=int)
+            mins = np.zeros(self.coords.shape[1], dtype=int)
+        else:
+            maxs = np.max(self.coords, axis=0) + 1
+            mins = np.min(self.coords, axis=0)
+
+        return [(min, max, 1) for min, max in zip(mins, maxs)]
+
     def _slice_markers(self, indices):
         """Determines the slice of markers given the indices.
 

--- a/napari/layers/_shapes_layer/model.py
+++ b/napari/layers/_shapes_layer/model.py
@@ -445,6 +445,20 @@ class Shapes(Layer):
         else:
             return np.max(self.data._vertices, axis=0) + 1
 
+    @property
+    def range(self):
+        """list of 3-tuple of int: ranges of data for slicing specifed by
+        (min, max, step).
+        """
+        if len(self.data._vertices) == 0:
+            maxs = [1, 1]
+            mins = [0, 0]
+        else:
+            maxs = np.max(self.data._vertices, axis=0) + 1
+            mins = np.min(self.data._vertices, axis=0)
+
+        return [(min, max, 1) for min, max in zip(mins, maxs)]
+
     def add_shapes(self, data, *, shape_type='rectangle', edge_width=1,
                    edge_color='black', face_color='white', opacity=0.7,
                    z_index=0):

--- a/napari/layers/_vectors_layer/model.py
+++ b/napari/layers/_vectors_layer/model.py
@@ -377,6 +377,20 @@ class Vectors(Layer):
         else:
             return np.max(self.vectors, axis=0) + 1
 
+    @property
+    def range(self):
+        """list of 3-tuple of int: ranges of data for slicing specifed by
+        (min, max, step).
+        """
+        if len(self.vectors) == 0:
+            maxs = [1, 1]
+            mins = [0, 0]
+        else:
+            maxs = np.max(self.vectors, axis=0) + 1
+            mins = np.min(self.vectors, axis=0)
+
+        return [(min, max, 1) for min, max in zip(mins, maxs)]
+
     def _generate_meshes(self, vectors, width):
         """Generates list of mesh vertices and triangles from a list of vectors
 


### PR DESCRIPTION
# Description
This PR is a follow-on from #259 that includes the uncommited changes described at the end of that PR (my git mistake) and additional changes to support the canvas properly containing shapes with negative coordinates. The results are now as follows:

![image](https://user-images.githubusercontent.com/6531703/57868422-d05d3280-77b7-11e9-9216-7927bbe864bc.png)


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
#259, #178 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] `example/to_svg.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
