### PR TITLE
replace skimage in examples

### DIFF
--- a/examples/add_image.py
+++ b/examples/add_image.py
@@ -3,16 +3,16 @@ Displays one image using the add_image API and then adjust some of its
 properties
 """
 
-from skimage import data
-from skimage.color import rgb2gray
+from imageio import imread
 from napari import ViewerApp
 from napari.util import app_context
 
 
+astro = imread('imageio:astronaut.png').mean(axis=2) / 255
+
 with app_context():
     # create the viewer with an image
-    viewer = ViewerApp(astronaut=rgb2gray(data.astronaut()),
-                       title='napari example')
+    viewer = ViewerApp(astronaut=astro, title='napari example')
 
     # adjust some of the layer properties
     layer = viewer.layers[0]

--- a/examples/add_markers.py
+++ b/examples/add_markers.py
@@ -4,18 +4,19 @@ add_image APIs
 """
 
 import numpy as np
-from skimage import data
-from skimage.color import rgb2gray
+from imageio import imread
 from napari import ViewerApp
 from napari.util import app_context
 
+
+astro = imread('imageio:astronaut.png').mean(axis=2) / 255
 
 with app_context():
     # create the viewer and window
     viewer = ViewerApp()
 
     # add the image
-    viewer.add_image(rgb2gray(data.astronaut()))
+    viewer.add_image(astro)
     # add the markers
     markers = np.array([[100, 100], [200, 200], [333, 111]])
     size = np.array([10, 20, 20])

--- a/examples/add_shapes.py
+++ b/examples/add_shapes.py
@@ -5,18 +5,19 @@ your shapes.
 """
 
 import numpy as np
-from skimage import data
-from skimage.color import rgb2gray
+from imageio import imread
 from napari import ViewerApp
 from napari.util import app_context
 
+
+photographer = imread('imageio:camera.png')
 
 with app_context():
     # create the viewer and window
     viewer = ViewerApp()
 
     # add the image
-    layer = viewer.add_image(data.camera(), name='photographer')
+    layer = viewer.add_image(photographer, name='photographer')
     layer.colormap = 'gray'
 
     # create a list of polygons

--- a/examples/add_vectors_coords.py
+++ b/examples/add_vectors_coords.py
@@ -9,16 +9,17 @@ Each vector position is defined by an (x, y, x-proj, y-proj) element
 
 from napari import ViewerApp
 from napari.util import app_context
-from skimage import data
-
+from imageio import imread
 import numpy as np
 
+
+photographer = imread('imageio:camera.png')
 
 with app_context():
     # create the viewer and window
     viewer = ViewerApp()
 
-    layer = viewer.add_image(data.camera(), name='photographer')
+    layer = viewer.add_image(photographer, name='photographer')
     layer.colormap = 'gray'
 
     # sample vector coord-like data

--- a/examples/add_vectors_image.py
+++ b/examples/add_vectors_image.py
@@ -8,8 +8,8 @@ Each vector position is defined by an (x-proj, y-proj) element
 
 from napari import ViewerApp
 from napari.util import app_context
-
 import numpy as np
+
 
 with app_context():
     # create the viewer and window

--- a/examples/annotate-2d.py
+++ b/examples/annotate-2d.py
@@ -4,15 +4,17 @@ add_image APIs
 """
 
 import numpy as np
-from skimage import data
-from skimage.color import rgb2gray
+from imageio import imread
 from napari import ViewerApp
 from napari.util import app_context
+
+
+astro = imread('imageio:astronaut.png').mean(axis=2) / 255
 
 print("click to add markers; close the window when finished.")
 
 with app_context():
-    viewer = ViewerApp(rgb2gray(data.astronaut()))
+    viewer = ViewerApp(astro)
     markers = viewer.add_markers(np.zeros((0, 2)))
     markers.mode = 'add'
 

--- a/examples/labels-0-2d.py
+++ b/examples/labels-0-2d.py
@@ -3,7 +3,7 @@ Display a labels layer above of an image layer using the add_labels and
 add_image APIs
 """
 
-from skimage import data
+from imageio import imread
 from skimage.filters import threshold_otsu
 from skimage.segmentation import clear_border
 from skimage.measure import label
@@ -12,12 +12,13 @@ from napari import ViewerApp
 from napari.util import app_context
 
 
+coins = imread('imageio:coins.png')[50:-50, 50:-50]
+
 with app_context():
-    image = data.coins()[50:-50, 50:-50]
 
     # apply threshold
-    thresh = threshold_otsu(image)
-    bw = closing(image > thresh, square(4))
+    thresh = threshold_otsu(coins)
+    bw = closing(coins > thresh, square(4))
 
     # remove artifacts connected to image border
     cleared = remove_small_objects(clear_border(bw), 20)
@@ -26,7 +27,7 @@ with app_context():
     label_image = label(cleared)
 
     # initialise viewer with astro image
-    viewer = ViewerApp(coins=image, multichannel=False)
+    viewer = ViewerApp(coins=coins, multichannel=False)
     viewer.layers[0].colormap = 'gray'
 
     # add the labels

--- a/examples/labels-2d.py
+++ b/examples/labels-2d.py
@@ -3,18 +3,18 @@ Display a labels layer above of an image layer using the add_labels and
 add_image APIs
 """
 
-from skimage import data
-from skimage.color import rgb2gray
+from imageio import imread
 from skimage.segmentation import slic
 from napari import ViewerApp
 from napari.util import app_context
 
 
+astro = imread('imageio:astronaut.png')
+
 with app_context():
-    astro = data.astronaut()
 
     # initialise viewer with astro image
-    viewer = ViewerApp(astronaut=rgb2gray(astro), multichannel=False)
+    viewer = ViewerApp(astronaut=astro.mean(axis=2) / 255, multichannel=False)
     viewer.layers[0].colormap = 'gray'
 
     # add the labels

--- a/examples/layers.py
+++ b/examples/layers.py
@@ -3,18 +3,22 @@ Display multiple image layers using the add_image API and then reorder them
 using the layers swap method and remove one
 """
 
-from skimage import data
-from skimage.color import rgb2gray
+from imageio import imread
 from napari import ViewerApp
 from napari.util import app_context
 
 
+astro = imread('imageio:astronaut.png').mean(axis=2) / 255
+photographer = imread('imageio:camera.png')
+coins = imread('imageio:coins.png')
+moon = imread('imageio:moon.png')
+
 with app_context():
     # create the viewer with several image layers
-    viewer = ViewerApp(astronaut=rgb2gray(data.astronaut()),
-                       photographer=data.camera(),
-                       coins=data.coins(),
-                       moon=data.moon())
+    viewer = ViewerApp(astronaut=astro,
+                       photographer=photographer,
+                       coins=coins,
+                       moon=moon)
 
     # remove the coins layer
     viewer.layers.remove('coins')

--- a/examples/notebook.ipynb
+++ b/examples/notebook.ipynb
@@ -26,7 +26,7 @@
     "# ensure it has time to finish executing before they are\n",
     "# called\n",
     "\n",
-    "from skimage import data\n",
+    "from imageio import imread\n",
     "from napari import ViewerApp"
    ]
   },
@@ -43,7 +43,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer = ViewerApp(data.moon())"
+    "astro = imread('imageio:astronaut.png').mean(axis=2)/255\n",
+    "viewer = ViewerApp(astro)"
    ]
   },
   {
@@ -70,7 +71,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/examples/set_colormaps.py
+++ b/examples/set_colormaps.py
@@ -4,10 +4,11 @@ Add named or unnamed vispy colormaps to existing layers.
 
 import numpy as np
 import vispy.color
-from skimage import data
+from imageio import imread
 import napari
 
-histo = data.astronaut() / 255
+
+histo = imread('imageio:astronaut.png') / 255
 
 rch, gch, bch = np.transpose(histo, (2, 0, 1))
 

--- a/examples/set_theme.py
+++ b/examples/set_theme.py
@@ -2,14 +2,16 @@
 Displays an image and sets the theme to 'light'.
 """
 
-from skimage import data
+from imageio import imread
 from napari import ViewerApp
 from napari.util import app_context
 
 
+astro = imread('imageio:astronaut.png')
+
 with app_context():
     # create the viewer with an image
-    viewer = ViewerApp(astronaut=data.astronaut(),
+    viewer = ViewerApp(astronaut=astro,
                        title='napari')
 
     # set the theme to 'light'

--- a/examples/shapes_to_labels.py
+++ b/examples/shapes_to_labels.py
@@ -5,18 +5,20 @@ your shapes.
 """
 
 import numpy as np
-from skimage import data
-from skimage.color import rgb2gray
+from imageio import imread
 from napari import ViewerApp
 from napari.util import app_context
 from vispy.color import Colormap
+
+
+photographer = imread('imageio:camera.png')
 
 with app_context():
     # create the viewer and window
     viewer = ViewerApp()
 
     # add the image
-    img_layer = viewer.add_image(data.camera(), name='photographer')
+    img_layer = viewer.add_image(photographer, name='photographer')
     img_layer.colormap = 'gray'
 
     # create a list of polygons

--- a/examples/to_svg.py
+++ b/examples/to_svg.py
@@ -5,18 +5,20 @@ your shapes.
 """
 
 import numpy as np
-from skimage import data
-from skimage.color import rgb2gray
+from imageio import imread
 from napari import ViewerApp
 from napari.util import app_context
 from vispy.color import Colormap
+
+
+photographer = imread('imageio:camera.png')
 
 with app_context():
     # create the viewer and window
     viewer = ViewerApp()
 
     # add the image
-    img_layer = viewer.add_image(data.camera(), name='photographer')
+    img_layer = viewer.add_image(photographer, name='photographer')
     img_layer.colormap = 'gray'
 
     # create a list of polygons

--- a/examples/zarr_nD_image.py
+++ b/examples/zarr_nD_image.py
@@ -5,15 +5,14 @@ Display one 4-D image layer using the add_image API
 import dask.array as da
 import zarr
 import numpy as np
-from skimage import data
 from napari import ViewerApp
 from napari.util import app_context
 
 
-with app_context():
-    data = zarr.zeros((102_000, 200, 210), chunks=(100, 200, 210))
-    data[53_000:53_100, 100:110, 110:120] = 1
+data = zarr.zeros((102_000, 200, 210), chunks=(100, 200, 210))
+data[53_000:53_100, 100:110, 110:120] = 1
+array = da.from_zarr(data)
+print(array.shape)
 
-    array = da.from_zarr(data)
-    print(array.shape)
+with app_context():
     viewer = ViewerApp(array, clim_range=[0, 1], multichannel=False)


### PR DESCRIPTION
# Description
This PR partially addresses #179 which proposes that examples should only depend on things that `napari` actually depends on. As we now depend on `imageio` for conversion to png in #259 we can now use imageio for loading example images. imageio doesn't download those images automatically, but only when they are requested. They are cached so that this only needs to happen once. [See here for more info and a list of standard images](https://imageio.readthedocs.io/en/stable/standardimages.html).

There are still examples that depend on `skimage` for computation - like `labels-0-2d.py`, and `labels-2d.py`. Also we are still using `skimage.data.binary_blobs` in a couple places like `nD_image.py`. Finally there are our `dask_nD_image.py` and `zarr_nD_image.py` examples. Curious what we want to do about all these? For now I think it's fine to just fix the ones that this PR fixes and we can revisit more in the future.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
#179 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run examples

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
