### PR TITLE
refactor draggable layers

### DIFF
--- a/napari/components/_layers/view/main.py
+++ b/napari/components/_layers/view/main.py
@@ -92,6 +92,8 @@ class QtLayers(QScrollArea):
         modifiers = event.modifiers()
         layer = self.layers[self.drag_name]
         if modifiers == Qt.ShiftModifier:
+            # If shift select all layers in between currently selected one and
+            # clicked one
             index = self.layers.index(layer)
             lastSelected = None
             for i in range(len(self.layers)):
@@ -102,8 +104,10 @@ class QtLayers(QScrollArea):
             for i in range(r[0], r[1] + 1):
                 self.layers[i].selected = True
         elif modifiers == Qt.ControlModifier:
+            # If control click toggle selected state
             layer.selected = not layer.selected
         else:
+            # If otherwise unselect all and leave clicked one selected
             self.layers.unselect_all(ignore=layer)
             layer.selected = True
 

--- a/napari/components/_layers/view/main.py
+++ b/napari/components/_layers/view/main.py
@@ -108,7 +108,9 @@ class QtLayers(QScrollArea):
 
     def mouseMoveEvent(self, event):
         widget = self.childAt(event.pos())
-        if hasattr(widget, 'layer'):
+        if widget is None:
+            return
+        elif hasattr(widget, 'layer'):
             layer = widget.layer
         elif hasattr(widget.parentWidget(), 'layer'):
             layer = widget.parentWidget().layer
@@ -123,14 +125,7 @@ class QtLayers(QScrollArea):
         drag = QDrag(self)
         drag.setMimeData(mimeData)
         drag.setHotSpot(event.pos() - self.rect().topLeft())
-        dropAction = drag.exec_(Qt.MoveAction | Qt.CopyAction)
-
-        if dropAction == Qt.CopyAction:
-            if not layer.selected:
-                index = self.layers.index(layer)
-                self.layers.pop(index)
-            else:
-                self.layers.remove_selected()
+        dropAction = drag.exec_()
         event.accept()
 
     def dragLeaveEvent(self, event):

--- a/napari/components/_viewer/view/buttons.py
+++ b/napari/components/_viewer/view/buttons.py
@@ -48,8 +48,14 @@ class QtDeleteButton(QPushButton):
         self.update()
 
     def dropEvent(self, event):
-        event.setDropAction(Qt.CopyAction)
         event.accept()
+        layer_name = event.mimeData().text()
+        layer = self.viewer.layers[layer_name]
+        if not layer.selected:
+            index = self.viewer.layers.index(layer)
+            self.viewer.layers.pop(index)
+        else:
+            self.viewer.layers.remove_selected()
 
 
 class QtNewMarkersButton(QPushButton):

--- a/napari/components/_viewer/view/buttons.py
+++ b/napari/components/_viewer/view/buttons.py
@@ -52,8 +52,7 @@ class QtDeleteButton(QPushButton):
         layer_name = event.mimeData().text()
         layer = self.viewer.layers[layer_name]
         if not layer.selected:
-            index = self.viewer.layers.index(layer)
-            self.viewer.layers.pop(index)
+            self.viewer.layers.remove(layer)
         else:
             self.viewer.layers.remove_selected()
 

--- a/napari/layers/_base_layer/view/properties.py
+++ b/napari/layers/_base_layer/view/properties.py
@@ -1,5 +1,5 @@
-from qtpy.QtWidgets import (QSlider, QLineEdit, QGridLayout, QFrame,
-                             QVBoxLayout, QCheckBox, QWidget, QLabel, QComboBox)
+from qtpy.QtWidgets import (QSlider, QLineEdit, QGridLayout, QFrame, QLabel
+                            QVBoxLayout, QCheckBox, QWidget, QComboBox)
 from qtpy.QtCore import Qt
 
 

--- a/napari/layers/_base_layer/view/properties.py
+++ b/napari/layers/_base_layer/view/properties.py
@@ -1,4 +1,4 @@
-from qtpy.QtWidgets import (QSlider, QLineEdit, QGridLayout, QFrame, QLabel
+from qtpy.QtWidgets import (QSlider, QLineEdit, QGridLayout, QFrame, QLabel,
                             QVBoxLayout, QCheckBox, QWidget, QComboBox)
 from qtpy.QtCore import Qt
 

--- a/napari/layers/_base_layer/view/properties.py
+++ b/napari/layers/_base_layer/view/properties.py
@@ -1,8 +1,6 @@
 from qtpy.QtWidgets import (QSlider, QLineEdit, QGridLayout, QFrame,
-                             QVBoxLayout, QCheckBox, QWidget, QApplication,
-                             QLabel, QComboBox)
-from qtpy.QtCore import Qt, QMimeData
-from qtpy.QtGui import QDrag
+                             QVBoxLayout, QCheckBox, QWidget, QLabel, QComboBox)
+from qtpy.QtCore import Qt
 
 
 class QtLayer(QFrame):
@@ -104,51 +102,16 @@ class QtLayer(QFrame):
         self.layer.blending = text
 
     def mouseReleaseEvent(self, event):
-        modifiers = event.modifiers()
-        if modifiers == Qt.ShiftModifier:
-            index = self.layer.viewer.layers.index(self.layer)
-            lastSelected = None
-            for i in range(len(self.layer.viewer.layers)):
-                if self.layer.viewer.layers[i].selected:
-                    lastSelected = i
-            r = [index, lastSelected]
-            r.sort()
-            for i in range(r[0], r[1]+1):
-                self.layer.viewer.layers[i].selected = True
-        elif modifiers == Qt.ControlModifier:
-            self.layer.selected = not self.layer.selected
-        else:
-            self.layer.viewer.layers.unselect_all(ignore=self.layer)
-            self.layer.selected = True
+        event.ignore()
 
     def mousePressEvent(self, event):
-        self.dragStartPosition = event.pos()
+        event.ignore()
 
     def mouseMoveEvent(self, event):
-        distance = (event.pos() - self.dragStartPosition).manhattanLength()
-        if distance < QApplication.startDragDistance():
-            return
-        mimeData = QMimeData()
-        if not self.layer.selected:
-            name = self.layer.name
-        else:
-            name = ''
-            for layer in self.layer.viewer.layers:
-                if layer.selected:
-                    name = layer.name + '; ' + name
-            name = name[:-2]
-        mimeData.setText(name)
-        drag = QDrag(self)
-        drag.setMimeData(mimeData)
-        drag.setHotSpot(event.pos() - self.rect().topLeft())
-        dropAction = drag.exec_(Qt.MoveAction | Qt.CopyAction)
+        event.ignore()
 
-        if dropAction == Qt.CopyAction:
-            if not self.layer.selected:
-                index = self.layer.viewer.layers.index(self.layer)
-                self.layer.viewer.layers.pop(index)
-            else:
-                self.layer.viewer.layers.remove_selected()
+    def mouseDoubleClickEvent(self, event):
+        self.setExpanded(not self.expanded)
 
     def setExpanded(self, bool):
         if bool:
@@ -165,9 +128,6 @@ class QtLayer(QFrame):
                     self.grid_layout.itemAtPosition(i, j).widget().show()
                 else:
                     self.grid_layout.itemAtPosition(i, j).widget().hide()
-
-    def mouseDoubleClickEvent(self, event):
-        self.setExpanded(not self.expanded)
 
     def _on_layer_name_change(self, event):
         with self.layer.events.name.blocker():


### PR DESCRIPTION
# Description
This PR moves the draggable layers functionality from the individual `QtLayer` object to the `QtLayers` object. This means that the layer objects themselves no longer need to introspect into the layers list to edit other layers - i.e. calls like `layer.viewer.layers[ind]` are now gone. This will help remove our circular referencing as desired in #94. Now the individual `QtLayer` just passes through its mouse events (using `event.ignore`) to its parent the `QtLayers` which has access to everything it needs to do the rearrangement. Thanks to @shanaxel42 for the tips on how to do this.

As an added benefit - this PR should now fix the layer selection bug in #243. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
#94, #243
 
# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run `example/layers.py` and rearrange layers

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
