### PR TITLE
fix bbox call on new markers

### DIFF
--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -301,7 +301,7 @@ class Viewer:
         if self.dims.ndim == 0:
             empty_labels = np.zeros((512, 512), dtype=int)
         else:
-            empty_labels = np.zeros(self._calc_max_shape(), dtype=int)
+            empty_labels = np.zeros(self._calc_bbox()[1], dtype=int)
         self.add_labels(empty_labels)
 
     def _update_layers(self):


### PR DESCRIPTION
# Description
This PR fixes a bug introduced in #264 where a call to `_calc_max_shape` was not replaced with the new `_calc_bbox`. This PR fixes that.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run `example/add_image.py` and click add new marker button

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
