### PR TITLE
fix default selection logic

### DIFF
--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -287,6 +287,8 @@ class Viewer:
         if len(self.layers) == 1:
             self.reset_view()
 
+        self.layers.unselect_all(ignore=layer)
+
     def _new_markers(self):
         if self.dims.ndim == 0:
             empty_markers = np.empty((0, 2))


### PR DESCRIPTION
# Description
This PR fixes #241 by making it so only the most recently added layer is selected. Especially given the changes in #257 where the controls are no longer visible if multiple layers are selected this behavior seems highly desirable.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
#241, #257 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run `examples/add_shapes.py` - now only the shapes layer is selected

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
