### PR TITLE
add layer viewer update events

### DIFF
--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -285,6 +285,7 @@ class Viewer:
         self.layers.append(layer)
         layer.indices = self.dims.indices
         layer.viewer = self
+        layer._parent = self._view.scene
 
         if self.theme is not None and has_clims(layer):
             palette = palettes[self.theme]

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -275,6 +275,11 @@ class Viewer:
         """
         layer.events.select.connect(self._update_active_layer)
         layer.events.deselect.connect(self._update_active_layer)
+        layer.events.status.connect(self._update_status)
+        layer.events.help.connect(self._update_help)
+        layer.events.interactive.connect(self._update_interactive)
+        layer.events.cursor.connect(self._update_cursor)
+        layer.events.cursor_size.connect(self._update_cursor_size)
         self.layers.append(layer)
         layer.indices = self.dims.indices
         layer.viewer = self
@@ -391,3 +396,23 @@ class Viewer:
         """
         self._canvas._draw_order.clear()
         self._canvas.update()
+
+    def _update_status(self, event):
+        """Set the viewer status with the `event.status` string."""
+        self.status = event.status
+
+    def _update_help(self, event):
+        """Set the viewer help with the `event.help` string."""
+        self.help = event.help
+
+    def _update_interactive(self, event):
+        """Set the viewer interactivity with the `event.interactive` bool."""
+        self.interactive = event.interactive
+
+    def _update_cursor(self, event):
+        """Set the viewer cursor with the `event.cursor` string."""
+        self.cursor = event.cursor
+
+    def _update_cursor_size(self, event):
+        """Set the viewer cursor_size with the `event.cursor_size` int."""
+        self.cursor_size = event.cursor_size

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -280,6 +280,8 @@ class Viewer:
         layer.events.interactive.connect(self._update_interactive)
         layer.events.cursor.connect(self._update_cursor)
         layer.events.cursor_size.connect(self._update_cursor_size)
+        layer.events.name.connect(self._update_name)
+
         self.layers.append(layer)
         layer.indices = self.dims.indices
         layer.viewer = self
@@ -416,3 +418,8 @@ class Viewer:
     def _update_cursor_size(self, event):
         """Set the viewer cursor_size with the `event.cursor_size` int."""
         self.cursor_size = event.cursor_size
+
+    def _update_name(self, event):
+        """Coerce name of the layer in `event.layer`."""
+        layer = event.source
+        layer.name = self.layers._coerce_name(layer.name, layer)

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -64,7 +64,12 @@ class Layer(VisualWrapper, ABC):
         self._cursor_position = (0, 0)
         self.events.add(select=Event,
                         deselect=Event,
-                        name=Event)
+                        name=Event,
+                        status=Event,
+                        help=Event,
+                        interactive=Event,
+                        cursor=Event,
+                        cursor_size=Event)
         self.name = name
 
     def __str__(self):
@@ -215,7 +220,7 @@ class Layer(VisualWrapper, ABC):
     def status(self, status):
         if status == self.status:
             return
-        self.viewer.status = status
+        self.events.status(status=status)
         self._status = status
 
     @property
@@ -229,7 +234,7 @@ class Layer(VisualWrapper, ABC):
     def help(self, help):
         if help == self.help:
             return
-        self.viewer.help = help
+        self.events.help(help=help)
         self._help = help
 
     @property
@@ -242,7 +247,7 @@ class Layer(VisualWrapper, ABC):
     def interactive(self, interactive):
         if interactive == self.interactive:
             return
-        self.viewer.interactive = interactive
+        self.events.interactive(interactive=interactive)
         self._interactive = interactive
 
     @property
@@ -255,7 +260,7 @@ class Layer(VisualWrapper, ABC):
     def cursor(self, cursor):
         if cursor == self.cursor:
             return
-        self.viewer.cursor = cursor
+        self.events.cursor(cursor=cursor)
         self._cursor = cursor
 
     @property
@@ -268,7 +273,7 @@ class Layer(VisualWrapper, ABC):
     def cursor_size(self, cursor_size):
         if cursor_size == self.cursor_size:
             return
-        self.viewer.cursor_size = cursor_size
+        self.events.cursor_size(cursor_size=cursor_size)
         self._cursor_size = cursor_size
 
     @property

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -29,7 +29,6 @@ class Layer(VisualWrapper, ABC):
 
     May define the following:
         * `_set_view_slice(indices)`: called to set currently viewed slice
-        * `_after_set_viewer()`: called after the viewer is set
         * `_qt_properties`: QtWidget inserted into the layer list GUI
         * `_qt_controls`: QtWidget inserted into the controls panel GUI
         * `_basename()`: base/default name of the layer
@@ -204,10 +203,6 @@ class Layer(VisualWrapper, ABC):
             parent = None
         else:
             self._viewer = weakref.ref(viewer)
-            parent = viewer._view.scene
-
-        self._parent = parent
-        self._after_set_viewer(prev)
 
     @property
     def status(self):
@@ -284,17 +279,6 @@ class Layer(VisualWrapper, ABC):
         scale_factor = transform.map([1, 1])[:2] - transform.map([0, 0])[:2]
 
         return scale_factor[0]
-
-    def _after_set_viewer(self, prev):
-        """Triggered after a new viewer is set.
-
-        Parameters
-        ----------
-        prev : Viewer
-            Previous viewer.
-        """
-        if self.viewer is not None:
-            self.refresh()
 
     def _update(self):
         """Update the underlying visual."""

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -62,6 +62,7 @@ class Layer(VisualWrapper, ABC):
         self._interactive = True
         self._indices = ()
         self._cursor_position = (0, 0)
+        self._name = ''
         self.events.add(select=Event,
                         deselect=Event,
                         name=Event,
@@ -93,12 +94,10 @@ class Layer(VisualWrapper, ABC):
 
     @name.setter
     def name(self, name):
+        if name == self.name:
+            return
         if not name:
             name = self._basename()
-
-        if self.viewer:
-            name = self.viewer.layers._coerce_name(name, self)
-
         self._name = name
         self.events.name()
 


### PR DESCRIPTION
# Description
This short PR switches the layer to viewer updates to using events rather than a layer directly setting properties on the viewer. This steps us further in the direction desired in the refactor described in #94 by making it easier in the future to remove the `viewer` property from the `layer` entirely and remove our circular dependencies.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
#94

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run examples

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
