### PR TITLE
flip markers

### DIFF
--- a/napari/layers/_markers_layer/model.py
+++ b/napari/layers/_markers_layer/model.py
@@ -419,7 +419,7 @@ class Markers(Layer):
         self._sizes_view = sizes
 
         self._node.set_data(
-            data, size=sizes, edge_width=self.edge_width,
+            data[:, [1, 0]], size=sizes, edge_width=self.edge_width,
             symbol=self.symbol, edge_width_rel=self.edge_width_rel,
             edge_color=self.edge_color, face_color=self.face_color,
             scaling=self.scaling)
@@ -497,8 +497,8 @@ class Markers(Layer):
         xml_list = []
 
         for d, s in zip(self._markers_view, self._sizes_view):
-            cx = str(d[0])
-            cy = str(d[1])
+            cx = str(d[1])
+            cy = str(d[0])
             r = str(s/2)
             element = Element('circle', cx=cx, cy=cy, r=r, **self.svg_props)
             xml_list.append(element)


### PR DESCRIPTION
# Description
This PR fixes a bug in the markers layer introduced during either the dims refactor #115 or moving the get_coords and indices #193, where the interactivity for the markers layer was flipped relative to expected - i.e. clicking on the point (x, y) put a marker at (y, x). Also a marker at (300, 100) will now display at row 300 column 100, which is what conforms to our other dims ordering. I had to fix the svg generation too. Can someone please check this is all consistent for the markers. It probably isn't a bad time to double check all our layer types for this too.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] `examples/add_markers.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
