### PR TITLE
fix markers sizing

### DIFF
--- a/examples/add_markers.py
+++ b/examples/add_markers.py
@@ -62,6 +62,7 @@ with app_context():
 
     # change the layer marker size
     layer.size = 20
+    layer.size = np.array([10, 50, 20])
 
     # change the layer mode
     layer.mode = 'add'

--- a/napari/layers/_markers_layer/model.py
+++ b/napari/layers/_markers_layer/model.py
@@ -38,14 +38,10 @@ class Markers(Layer):
         of markers and dims is the number of dimensions
     edge_width : int, float, None
         Width of the symbol edge in pixels.
-    edge_width_rel : int, float, None
-        Width of the marker edge as a fraction of the marker size.
     edge_color : Color, ColorArray
         Color of the marker border.
     face_color : Color, ColorArray
         Color of the marker body.
-    scaling : bool
-        If True, marker rescales when zooming.
     n_dimensional : bool
         If True, renders markers not just in central plane but also in all
         n-dimensions according to specified marker size.
@@ -56,8 +52,8 @@ class Markers(Layer):
     http://api.vispy.org/en/latest/visuals.html#vispy.visuals.MarkersVisual
     """
     def __init__(self, coords, symbol='o', size=10, edge_width=1,
-                 edge_width_rel=None, edge_color='black', face_color='white',
-                 scaling=True, n_dimensional=False, *, name=None):
+                 edge_color='black', face_color='white', n_dimensional=False,
+                 *, name=None):
         super().__init__(MarkersNode(), name)
 
         self.events.add(mode=Event,
@@ -76,10 +72,8 @@ class Markers(Layer):
             self.symbol = symbol
             self.size = size
             self.edge_width = edge_width
-            self.edge_width_rel = edge_width_rel
             self.edge_color = edge_color
             self.face_color = face_color
-            self.scaling = scaling
             self.n_dimensional = n_dimensional
             self._colors = get_color_names()
             self._selected_markers = None
@@ -208,24 +202,6 @@ class Markers(Layer):
         self.refresh()
 
     @property
-    def edge_width_rel(self) -> Union[None, int, float]:
-        """None, int, float: width of the marker edge as a fraction
-            of the marker size.
-
-            vispy docs say: "exactly one edge_width and
-            edge_width_rel must be supplied", but I don't know
-            what that means... -KY
-        """
-
-        return self._edge_width_rel
-
-    @edge_width_rel.setter
-    def edge_width_rel(self, edge_width_rel: Union[None, float]) -> None:
-        self._edge_width_rel = edge_width_rel
-
-        self.refresh()
-
-    @property
     def edge_color(self) -> str:
         """Color, ColorArray: the marker edge color
         """
@@ -274,19 +250,6 @@ class Markers(Layer):
                  'opacity': opacity}
 
         return props
-
-    @property
-    def scaling(self) -> bool:
-        """bool: if True, marker rescales when zooming
-        """
-
-        return self._scaling
-
-    @scaling.setter
-    def scaling(self, scaling: bool) -> None:
-        self._scaling = scaling
-
-        self.refresh()
 
     @property
     def mode(self):
@@ -420,9 +383,8 @@ class Markers(Layer):
 
         self._node.set_data(
             data, size=sizes, edge_width=self.edge_width,
-            symbol=self.symbol, edge_width_rel=self.edge_width_rel,
-            edge_color=self.edge_color, face_color=self.face_color,
-            scaling=self.scaling)
+            symbol=self.symbol, edge_color=self.edge_color,
+            face_color=self.face_color, scaling=True)
         self._need_visual_update = True
         self._update()
 

--- a/napari/layers/_markers_layer/view/properties.py
+++ b/napari/layers/_markers_layer/view/properties.py
@@ -93,6 +93,7 @@ class QtMarkersLayer(QtLayer):
         self.layer.symbol = text
 
     def changeSize(self, value):
+        """Rescale marker sizes according to the value of the size slider."""
         avg = np.mean(self.layer.size) or 1
         self.layer.size = self.layer.size / avg * value
 

--- a/napari/layers/_markers_layer/view/properties.py
+++ b/napari/layers/_markers_layer/view/properties.py
@@ -20,7 +20,7 @@ class QtMarkersLayer(QtLayer):
         sld = QSlider(Qt.Horizontal, self)
         sld.setFocusPolicy(Qt.NoFocus)
         sld.setFixedWidth(110)
-        sld.setMinimum(0)
+        sld.setMinimum(1)
         sld.setMaximum(100)
         sld.setSingleStep(1)
         value = self.layer.size
@@ -93,7 +93,10 @@ class QtMarkersLayer(QtLayer):
         self.layer.symbol = text
 
     def changeSize(self, value):
-        self.layer.size = value
+        avg = np.asarray(self.layer.size).mean()
+        if avg == 0:
+            avg = 1
+        self.layer.size = self.layer.size/avg*value
 
     def change_ndim(self, state):
         if state == Qt.Checked:

--- a/napari/layers/_markers_layer/view/properties.py
+++ b/napari/layers/_markers_layer/view/properties.py
@@ -93,10 +93,8 @@ class QtMarkersLayer(QtLayer):
         self.layer.symbol = text
 
     def changeSize(self, value):
-        avg = np.asarray(self.layer.size).mean()
-        if avg == 0:
-            avg = 1
-        self.layer.size = self.layer.size/avg*value
+        avg = np.mean(self.layer.size) or 1
+        self.layer.size = self.layer.size / avg * value
 
     def change_ndim(self, state):
         if state == Qt.Checked:


### PR DESCRIPTION
# Description
This PR addresses #261 by dropping support for relative edge widths and non-scaling markers. This moves the markers layer more in line with the shapes layers. It also makes the markers size slider preserve the relative size differences between markers as suggested by @kevinyamauchi

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
#261

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run `examples/add_markers.py`. Note that adding markers is currently flipped, but #275 fixes that.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
