### PR TITLE
fix blending update

### DIFF
--- a/napari/layers/_base_layer/_visual_wrapper.py
+++ b/napari/layers/_base_layer/_visual_wrapper.py
@@ -124,6 +124,7 @@ class VisualWrapper:
                              f'got {blending}')
         self._node.set_gl_state(blending)
         self._blending = blending
+        self._node.update()
         self.events.blending()
 
     @property


### PR DESCRIPTION
# Description
This PR fixes #186 by explicitly calling a vispy node `update` after setting the gl state. When modifying our other properties like `opacity` the `update` call is not needed as a property is being set on the node which triggers the update automatically. When using the `set_gl_state` this is not the case and so we must also call the `update`.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run `example/layers.py` and adjust blending mode

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
