### PR TITLE
fix int clim value

### DIFF
--- a/examples/add_image.py
+++ b/examples/add_image.py
@@ -40,7 +40,7 @@ with app_context():
 
     # change the layer colormap and color limits
     layer.colormap = 'gray'
-    layer.clim = (0.1, 0.9)
+    layer.clim = (0, 0.9)
 
     # change the layer interpolation mode
     layer.interpolation = 'bicubic'

--- a/napari/layers/_image_layer/model.py
+++ b/napari/layers/_image_layer/model.py
@@ -275,7 +275,7 @@ class Image(Layer):
 
     @clim.setter
     def clim(self, clim):
-        self._clim_msg = f'{clim[0]: 0.3}, {clim[1]: 0.3}'
+        self._clim_msg = f'{float(clim[0]): 0.3}, {float(clim[1]): 0.3}'
         self.status = self._clim_msg
         self._node.clim = clim
         self.events.clim()


### PR DESCRIPTION
# Description
This PR fixes #154 by casting a clim value to a float before displaying it. This will result in pretty ugly values though like `255.000` when ints are needed. There's a broader thread about how to display numbers in #93, but for now I just wanted to fix this bug.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run `example/add_image.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
