### PR TITLE
remove viewer from individual layer object

### DIFF
--- a/napari/components/_layers/model.py
+++ b/napari/components/_layers/model.py
@@ -20,7 +20,7 @@ def _remove(event):
     layers = event.source
     layer = event.item
     layer._order = 0
-    layer.viewer = None
+    layer._parent = None
 
 
 def _reorder(event):
@@ -44,11 +44,6 @@ class Layers(ListModel):
     def __init__(self):
         super().__init__(basetype=Layer,
                          lookup={str: lambda q, e: q == e.name})
-
-        # Connect the add events before setting the viewer so that the
-        # addition will cause the first layer dims to update before any
-        # of the layer properties get set. Note that callbacks get called in
-        # the reverse order that they are made in (i.e. last made called first)
 
         self.events.added.connect(_add)
         self.events.removed.connect(_remove)

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -284,7 +284,6 @@ class Viewer:
 
         self.layers.append(layer)
         layer.indices = self.dims.indices
-        layer.viewer = self
         layer._parent = self._view.scene
 
         if self.theme is not None and has_clims(layer):

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -39,7 +39,6 @@ class Layer(VisualWrapper, ABC):
     ndim
     shape
     selected
-    viewer
     indices
 
     Methods
@@ -50,7 +49,6 @@ class Layer(VisualWrapper, ABC):
     def __init__(self, central_node, name=None):
         super().__init__(central_node)
         self._selected = False
-        self._viewer = None
         self._qt_properties = None
         self._qt_controls = None
         self._freeze = False
@@ -184,25 +182,6 @@ class Layer(VisualWrapper, ABC):
             self.events.select()
         else:
             self.events.deselect()
-
-    @property
-    def viewer(self):
-        """Viewer: Parent viewer widget.
-        """
-        if self._viewer is not None:
-            return self._viewer()
-
-    @viewer.setter
-    def viewer(self, viewer):
-        prev = self.viewer
-        if viewer == prev:
-            return
-
-        if viewer is None:
-            self._viewer = None
-            parent = None
-        else:
-            self._viewer = weakref.ref(viewer)
 
     @property
     def status(self):


### PR DESCRIPTION
# Description
This PR fixes #94 by removing the `viewer` from the base `Layer`. All functionality is preserved, but now it is no longer possible to have any circular referencing. Our object hierarchy within the model goes `viewer.dims` and `viewer.layers[layer_name]`.

There still needs to be more refactoring to achieve the separation of qt and non-qt components. The Layers still contain `_qt_properties` and `_qt_controls` attributes, and a `_parent` attribute that has the vispy parent `node` (which comes from the SceneCanvas in `QtViewer`. This further refactoring will come in follow-up PRs.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
#94 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run examples and interact with them

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
