### PR TITLE
fix image dims update

### DIFF
--- a/examples/change_image_dims.py
+++ b/examples/change_image_dims.py
@@ -1,0 +1,22 @@
+"""
+Change image shape directly on the layer
+"""
+
+import numpy as np
+from skimage import data
+from napari import ViewerApp
+from napari.util import app_context
+
+
+with app_context():
+    viewer = ViewerApp()
+
+    # add 3D data
+    blobs = data.binary_blobs(length=128, blob_size_fraction=0.05,
+                              n_dim=3, volume_fraction=.25).astype(float)
+
+    layer = viewer.add_image(blobs[:64])
+
+    # switch to 3D data
+    layer.image = blobs[:3]
+    #viewer._on_layers_change(None)

--- a/examples/change_image_dims.py
+++ b/examples/change_image_dims.py
@@ -1,5 +1,5 @@
 """
-Change image shape directly on the layer
+Change image shape and dims directly on the layer
 """
 
 import numpy as np
@@ -18,4 +18,10 @@ with app_context():
     layer = viewer.add_image(blobs[:64])
 
     # switch number of displayed dimensions
+    layer.image = blobs[0]
+
+    # switch number of displayed dimensions
+    layer.image = blobs[:64]
+
+    # switch the shape of the displayed data
     layer.image = blobs[:3]

--- a/examples/change_image_dims.py
+++ b/examples/change_image_dims.py
@@ -11,12 +11,11 @@ from napari.util import app_context
 with app_context():
     viewer = ViewerApp()
 
-    # add 3D data
+    # add data
     blobs = data.binary_blobs(length=128, blob_size_fraction=0.05,
                               n_dim=3, volume_fraction=.25).astype(float)
 
     layer = viewer.add_image(blobs[:64])
 
-    # switch to 3D data
+    # switch number of displayed dimensions
     layer.image = blobs[:3]
-    #viewer._on_layers_change(None)

--- a/examples/change_image_dims.py
+++ b/examples/change_image_dims.py
@@ -4,12 +4,12 @@ Change image shape and dims directly on the layer
 
 import numpy as np
 from skimage import data
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 
 
 with app_context():
-    viewer = ViewerApp()
+    viewer = Viewer()
 
     # add data
     blobs = data.binary_blobs(length=128, blob_size_fraction=0.05,

--- a/napari/components/_dims/model.py
+++ b/napari/components/_dims/model.py
@@ -65,11 +65,13 @@ class Dims:
         return copy(self._range)
 
     @range.setter
-    def range(self, range):
-        if range == self.range:
+    def range(self, value):
+        if value == self.range:
             return
-        self.ndim = len(range)
-        self._range = range
+        self.ndim = len(value)
+        self._range = value
+        axes = list(range(self.ndim))
+        self.events.axis(axis=axes)
 
     @property
     def point(self):

--- a/napari/components/_dims/model.py
+++ b/napari/components/_dims/model.py
@@ -70,8 +70,8 @@ class Dims:
             return
         self.ndim = len(value)
         self._range = value
-        axes = list(range(self.ndim))
-        self.events.axis(axis=axes)
+        for axis in range(self.ndim):
+            self.events.axis(axis=axis)
 
     @property
     def point(self):

--- a/napari/components/_dims/view.py
+++ b/napari/components/_dims/view.py
@@ -170,7 +170,8 @@ class QtDims(QWidget):
         ----------
         number_of_sliders : new number of sliders
         """
-        for slider_num in range(number_of_sliders + 1):
+        # remove extra sliders so that only number_of_sliders are left
+        for slider_num in range(self.nsliders - number_of_sliders):
             slider = self.sliders.pop()
             self.layout().removeWidget(slider)
             slider.deleteLater()

--- a/napari/components/_dims/view.py
+++ b/napari/components/_dims/view.py
@@ -171,7 +171,7 @@ class QtDims(QWidget):
         number_of_sliders : new number of sliders
         """
         # remove extra sliders so that only number_of_sliders are left
-        for slider_num in range(self.nsliders, number_of_sliders):
+        for slider_num in range(number_of_sliders, self.nsliders):
             slider = self.sliders.pop()
             self.layout().removeWidget(slider)
             slider.deleteLater()

--- a/napari/components/_dims/view.py
+++ b/napari/components/_dims/view.py
@@ -171,7 +171,7 @@ class QtDims(QWidget):
         number_of_sliders : new number of sliders
         """
         # remove extra sliders so that only number_of_sliders are left
-        for slider_num in range(self.nsliders - number_of_sliders):
+        for slider_num in range(self.nsliders, number_of_sliders):
             slider = self.sliders.pop()
             self.layout().removeWidget(slider)
             slider.deleteLater()

--- a/napari/components/_dims/view.py
+++ b/napari/components/_dims/view.py
@@ -170,10 +170,11 @@ class QtDims(QWidget):
         ----------
         number_of_sliders : new number of sliders
         """
-        for slider_num in range(self.nsliders, number_of_sliders):
+        for slider_num in range(number_of_sliders + 1):
             slider = self.sliders.pop()
             self.layout().removeWidget(slider)
             slider.deleteLater()
+        self.setMinimumHeight(self.nsliders * self.SLIDERHEIGHT)
 
     def _create_range_slider_widget(self, axis):
         """

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -281,6 +281,7 @@ class Viewer:
         layer.events.cursor.connect(self._update_cursor)
         layer.events.cursor_size.connect(self._update_cursor_size)
         layer.events.name.connect(self._update_name)
+        layer.events.data.connect(self._on_layers_change)
 
         self.layers.append(layer)
         layer.indices = self.dims.indices

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -62,6 +62,7 @@ class Layer(VisualWrapper, ABC):
         self._name = ''
         self.events.add(select=Event,
                         deselect=Event,
+                        data=Event,
                         name=Event,
                         status=Event,
                         help=Event,

--- a/napari/layers/_image_layer/model.py
+++ b/napari/layers/_image_layer/model.py
@@ -145,7 +145,7 @@ class Image(Layer):
     @image.setter
     def image(self, image):
         self._image = image
-
+        self.events.data()
         self.refresh()
 
     @property
@@ -169,6 +169,7 @@ class Image(Layer):
     @data.setter
     def data(self, data):
         self._image, self._meta = data
+        self.events.data()
         self.refresh()
 
     def _get_shape(self):

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -125,6 +125,7 @@ class Labels(Layer):
     @image.setter
     def image(self, image):
         self._image = image
+        self.events.data()
         self.refresh()
 
     @property
@@ -147,6 +148,7 @@ class Labels(Layer):
     @data.setter
     def data(self, data):
         self._image, self._meta = data
+        self.events.data()
         self.refresh()
 
     @property

--- a/napari/layers/_markers_layer/model.py
+++ b/napari/layers/_markers_layer/model.py
@@ -118,7 +118,7 @@ class Markers(Layer):
                     new_size = np.repeat(10, self._size.shape[1])
                 size = np.repeat([new_size], adding, axis=0)
                 self.size = np.concatenate((self._size, size), axis=0)
-
+        self.events.data()
         self.refresh()
 
     @property

--- a/napari/layers/_shapes_layer/model.py
+++ b/napari/layers/_shapes_layer/model.py
@@ -183,7 +183,7 @@ class Shapes(Layer):
         # Freeze refreshes to prevent drawing before the layer is constructed
         with self.freeze_refresh():
             # Add the shape data
-            self.data = ShapeList()
+            self._data = ShapeList()
             self.add_shapes(data, shape_type=shape_type, edge_width=edge_width,
                             edge_color=edge_color, face_color=face_color,
                             opacity=opacity, z_index=z_index)
@@ -260,6 +260,7 @@ class Shapes(Layer):
     @data.setter
     def data(self, data):
         self._data = data
+        self.events.data()
         self.refresh()
 
     @property

--- a/napari/layers/_vectors_layer/model.py
+++ b/napari/layers/_vectors_layer/model.py
@@ -136,6 +136,7 @@ class Vectors(Layer):
         self._mesh_vertices = vertices
         self._mesh_triangles = triangles
 
+        self.events.data()
         self.refresh()
 
     def _convert_to_vector_type(self, vectors):


### PR DESCRIPTION
# Description
This PR fixes #280 where changing the `image` data wouldn't trigger an update to the dims. This has now been fixed for an `Image` layer and the other layer types by adding a `data` event that gets triggered by changing this data and that in turn triggers a call to `_on_layers_change`. I have added an example `change_image_dims.py` that shows this behavior. Note that both changing the shape of the image data say `[64, 512, 512]` to `[4, 512, 512]` and the number of dims say `3D` to `2D` all should now work.

@gregjohnso if you can give this a spin and let us know if this now has the expected behviour that would be great!

In the process I have noticed two other bugs though that I will fix separately and I have filed separate issues for - #286, changing the dims slider no longer updates status message in the bottom left corner - and #287, the dims slider can currently go to one too many slots, i.e. load a shape `[4, 512, 512]` image and the dims slider will have 5 possible positions, with the last one no longer changing the data.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run the new `examples/change_image_dims.py`


## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
