### PR TITLE
Refactor viewer syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ From inside an IPython shell or Jupyter notebook you can open up an interactive 
 %gui qt5
 from skimage import data
 from napari import ViewerApp
-viewer = ViewerApp(data.astronaut())
+viewer = Viewer(data.astronaut())
 ```
 
 ![image](resources/screenshot-add-image.png)
@@ -66,7 +66,7 @@ from napari import ViewerApp
 from napari.util import app_context
 
 with app_context():
-    viewer = ViewerApp(data.astronaut())
+    viewer = Viewer(data.astronaut())
 ```
 
 ## features
@@ -83,7 +83,7 @@ from napari.util import app_context
 
 with app_context():
     # create the viewer with four layers
-    viewer = ViewerApp(astronaut=rgb2gray(data.astronaut()),
+    viewer = Viewer(astronaut=rgb2gray(data.astronaut()),
                        photographer=data.camera(),
                        coins=data.coins(),
                        moon=data.moon())
@@ -105,7 +105,7 @@ from napari.util import app_context
 
 with app_context():
     # setup viewer
-    viewer = ViewerApp()
+    viewer = Viewer()
     viewer.add_image(rgb2gray(data.astronaut()))
     # create three xy coordinates
     points = np.array([[100, 100], [200, 200], [333, 111]])
@@ -141,7 +141,7 @@ with app_context():
                                         n_dim=3, volume_fraction=f)
                      for f in np.linspace(0.05, 0.5, 10)], axis=-1)
     # add data to the viewer
-    viewer = ViewerApp(blobs.astype(float))
+    viewer = Viewer(blobs.astype(float))
 ```
 
 ![image](resources/screenshot-nD-image.png)

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ From inside an IPython shell or Jupyter notebook you can open up an interactive 
 ```python
 %gui qt5
 from skimage import data
-from napari import ViewerApp
-viewer = Viewer(data.astronaut())
+import napari
+viewer = napari.view(data.astronaut(), multichannel=True)
 ```
 
 ![image](resources/screenshot-add-image.png)
@@ -62,11 +62,11 @@ To do the same thing inside a script call
 
 ```python
 from skimage import data
-from napari import ViewerApp
+import napari
 from napari.util import app_context
 
 with app_context():
-    viewer = Viewer(data.astronaut())
+    viewer = napari.view(data.astronaut())
 ```
 
 ## features
@@ -78,15 +78,15 @@ For example, you can add multiple images in different layers and adjust them
 ```python
 from skimage import data
 from skimage.color import rgb2gray
-from napari import ViewerApp
+import napari
 from napari.util import app_context
 
 with app_context():
     # create the viewer with four layers
-    viewer = Viewer(astronaut=rgb2gray(data.astronaut()),
-                       photographer=data.camera(),
-                       coins=data.coins(),
-                       moon=data.moon())
+    viewer = napari.view(astronaut=rgb2gray(data.astronaut()),
+                         photographer=data.camera(),
+                         coins=data.coins(),
+                         moon=data.moon())
     # remove a layer
     viewer.layers.remove('coins')
     # swap layer order
@@ -98,14 +98,15 @@ with app_context():
 You can add markers on top of an image
 
 ```python
+import numpy as np
 from skimage import data
 from skimage.color import rgb2gray
-from napari import ViewerApp
+import napari
 from napari.util import app_context
 
 with app_context():
-    # setup viewer
-    viewer = Viewer()
+    # set up viewer
+    viewer = napari.Viewer()
     viewer.add_image(rgb2gray(data.astronaut()))
     # create three xy coordinates
     points = np.array([[100, 100], [200, 200], [333, 111]])
@@ -132,7 +133,7 @@ You can render and quickly browse slices of multi-dimensional arrays
 
 import numpy as np
 from skimage import data
-from napari import ViewerApp
+import napari
 from napari.util import app_context
 
 with app_context():
@@ -141,7 +142,7 @@ with app_context():
                                         n_dim=3, volume_fraction=f)
                      for f in np.linspace(0.05, 0.5, 10)], axis=-1)
     # add data to the viewer
-    viewer = Viewer(blobs.astype(float))
+    viewer = napari.view(blobs.astype(float))
 ```
 
 ![image](resources/screenshot-nD-image.png)

--- a/examples/add_image.py
+++ b/examples/add_image.py
@@ -5,14 +5,14 @@ properties
 
 from skimage import data
 from skimage.color import rgb2gray
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 
 
 with app_context():
     # create the viewer with an image
-    viewer = ViewerApp(astronaut=rgb2gray(data.astronaut()),
-                       title='napari example')
+    viewer = Viewer(astronaut=rgb2gray(data.astronaut()),
+                    title='napari example')
 
     # adjust some of the layer properties
     layer = viewer.layers[0]

--- a/examples/add_image.py
+++ b/examples/add_image.py
@@ -5,14 +5,14 @@ properties
 
 from skimage import data
 from skimage.color import rgb2gray
-from napari import Viewer
+import napari
 from napari.util import app_context
 
 
 with app_context():
     # create the viewer with an image
-    viewer = Viewer(astronaut=rgb2gray(data.astronaut()),
-                    title='napari example')
+    viewer = napari.view(astronaut=rgb2gray(data.astronaut()),
+                         title='napari example')
 
     # adjust some of the layer properties
     layer = viewer.layers[0]

--- a/examples/add_markers.py
+++ b/examples/add_markers.py
@@ -1,18 +1,18 @@
 """
-Display one markers layer ontop of one image layer using the add_markers and
+Display a markers layer on top of an image layer using the add_markers and
 add_image APIs
 """
 
 import numpy as np
 from skimage import data
 from skimage.color import rgb2gray
-from napari import Viewer
+import napari
 from napari.util import app_context
 
 
 with app_context():
-    # create the viewer and window
-    viewer = Viewer()
+    # create the viewer window
+    viewer = napari.Viewer()
 
     # add the image
     viewer.add_image(rgb2gray(data.astronaut()))

--- a/examples/add_markers.py
+++ b/examples/add_markers.py
@@ -6,13 +6,13 @@ add_image APIs
 import numpy as np
 from skimage import data
 from skimage.color import rgb2gray
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 
 
 with app_context():
     # create the viewer and window
-    viewer = ViewerApp()
+    viewer = Viewer()
 
     # add the image
     viewer.add_image(rgb2gray(data.astronaut()))

--- a/examples/add_shapes.py
+++ b/examples/add_shapes.py
@@ -6,14 +6,13 @@ your shapes.
 
 import numpy as np
 from skimage import data
-from skimage.color import rgb2gray
-from napari import Viewer
+import napari
 from napari.util import app_context
 
 
 with app_context():
     # create the viewer and window
-    viewer = Viewer()
+    viewer = napari.Viewer()
 
     # add the image
     layer = viewer.add_image(data.camera(), name='photographer')

--- a/examples/add_shapes.py
+++ b/examples/add_shapes.py
@@ -7,13 +7,13 @@ your shapes.
 import numpy as np
 from skimage import data
 from skimage.color import rgb2gray
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 
 
 with app_context():
     # create the viewer and window
-    viewer = ViewerApp()
+    viewer = Viewer()
 
     # add the image
     layer = viewer.add_image(data.camera(), name='photographer')

--- a/examples/add_vectors_coords.py
+++ b/examples/add_vectors_coords.py
@@ -7,7 +7,7 @@ Each vector position is defined by an (x, y, x-proj, y-proj) element
 
 """
 
-from napari import Viewer
+import napari
 from napari.util import app_context
 from skimage import data
 
@@ -16,7 +16,7 @@ import numpy as np
 
 with app_context():
     # create the viewer and window
-    viewer = Viewer()
+    viewer = napari.Viewer()
 
     layer = viewer.add_image(data.camera(), name='photographer')
     layer.colormap = 'gray'

--- a/examples/add_vectors_coords.py
+++ b/examples/add_vectors_coords.py
@@ -7,7 +7,7 @@ Each vector position is defined by an (x, y, x-proj, y-proj) element
 
 """
 
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 from skimage import data
 
@@ -16,7 +16,7 @@ import numpy as np
 
 with app_context():
     # create the viewer and window
-    viewer = ViewerApp()
+    viewer = Viewer()
 
     layer = viewer.add_image(data.camera(), name='photographer')
     layer.colormap = 'gray'

--- a/examples/add_vectors_image.py
+++ b/examples/add_vectors_image.py
@@ -6,14 +6,14 @@ Each vector position is defined by an (x-proj, y-proj) element
     where each vector is centered on a pixel of the NxM grid
 """
 
-from napari import Viewer
+import napari
 from napari.util import app_context
 
 import numpy as np
 
 with app_context():
     # create the viewer and window
-    viewer = Viewer()
+    viewer = napari.Viewer()
 
     n = 100
     m = 200

--- a/examples/add_vectors_image.py
+++ b/examples/add_vectors_image.py
@@ -6,14 +6,14 @@ Each vector position is defined by an (x-proj, y-proj) element
     where each vector is centered on a pixel of the NxM grid
 """
 
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 
 import numpy as np
 
 with app_context():
     # create the viewer and window
-    viewer = ViewerApp()
+    viewer = Viewer()
 
     n = 100
     m = 200

--- a/examples/annotate-2d.py
+++ b/examples/annotate-2d.py
@@ -6,13 +6,13 @@ add_image APIs
 import numpy as np
 from skimage import data
 from skimage.color import rgb2gray
-from napari import Viewer
+import napari
 from napari.util import app_context
 
 print("click to add markers; close the window when finished.")
 
 with app_context():
-    viewer = Viewer(rgb2gray(data.astronaut()))
+    viewer = napari.view(rgb2gray(data.astronaut()))
     markers = viewer.add_markers(np.zeros((0, 2)))
     markers.mode = 'add'
 

--- a/examples/annotate-2d.py
+++ b/examples/annotate-2d.py
@@ -6,13 +6,13 @@ add_image APIs
 import numpy as np
 from skimage import data
 from skimage.color import rgb2gray
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 
 print("click to add markers; close the window when finished.")
 
 with app_context():
-    viewer = ViewerApp(rgb2gray(data.astronaut()))
+    viewer = Viewer(rgb2gray(data.astronaut()))
     markers = viewer.add_markers(np.zeros((0, 2)))
     markers.mode = 'add'
 

--- a/examples/annotate-2d.py
+++ b/examples/annotate-2d.py
@@ -5,14 +5,13 @@ add_image APIs
 
 import numpy as np
 from skimage import data
-from skimage.color import rgb2gray
 import napari
 from napari.util import app_context
 
 print("click to add markers; close the window when finished.")
 
 with app_context():
-    viewer = napari.view(rgb2gray(data.astronaut()))
+    viewer = napari.view(data.astronaut(), multichannel=True)
     markers = viewer.add_markers(np.zeros((0, 2)))
     markers.mode = 'add'
 

--- a/examples/custom_key_bindings.py
+++ b/examples/custom_key_bindings.py
@@ -2,14 +2,13 @@
 Display one 4-D image layer using the add_image API
 """
 
-import numpy as np
 from skimage import data
-from napari import Viewer
+import napari
 from napari.util import app_context
 
 
 with app_context():
-    viewer = Viewer()
+    viewer = napari.Viewer()
     blobs = data.binary_blobs(length=128, blob_size_fraction=0.05,
                               n_dim=2, volume_fraction=.25).astype(float)
 

--- a/examples/custom_key_bindings.py
+++ b/examples/custom_key_bindings.py
@@ -4,12 +4,12 @@ Display one 4-D image layer using the add_image API
 
 import numpy as np
 from skimage import data
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 
 
 with app_context():
-    viewer = ViewerApp()
+    viewer = Viewer()
     blobs = data.binary_blobs(length=128, blob_size_fraction=0.05,
                               n_dim=2, volume_fraction=.25).astype(float)
 

--- a/examples/dask_nD_image.py
+++ b/examples/dask_nD_image.py
@@ -5,7 +5,7 @@ Display one 4-D image layer using the add_image API
 import dask.array as da
 import numpy as np
 from skimage import data
-from napari import Viewer
+import napari
 from napari.util import app_context
 
 
@@ -13,4 +13,4 @@ with app_context():
     blobs = da.stack([data.binary_blobs(length=128, blob_size_fraction=0.05,
                                         n_dim=3, volume_fraction=f)
                      for f in np.linspace(0.05, 0.5, 10)], axis=0)
-    viewer = Viewer(blobs.astype(float))
+    viewer = napari.view(blobs.astype(float))

--- a/examples/dask_nD_image.py
+++ b/examples/dask_nD_image.py
@@ -5,7 +5,7 @@ Display one 4-D image layer using the add_image API
 import dask.array as da
 import numpy as np
 from skimage import data
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 
 
@@ -13,4 +13,4 @@ with app_context():
     blobs = da.stack([data.binary_blobs(length=128, blob_size_fraction=0.05,
                                         n_dim=3, volume_fraction=f)
                      for f in np.linspace(0.05, 0.5, 10)], axis=0)
-    viewer = ViewerApp(blobs.astype(float))
+    viewer = Viewer(blobs.astype(float))

--- a/examples/labels-0-2d.py
+++ b/examples/labels-0-2d.py
@@ -8,7 +8,7 @@ from skimage.filters import threshold_otsu
 from skimage.segmentation import clear_border
 from skimage.measure import label
 from skimage.morphology import closing, square, remove_small_objects
-from napari import Viewer
+import napari
 from napari.util import app_context
 
 
@@ -25,8 +25,8 @@ with app_context():
     # label image regions
     label_image = label(cleared)
 
-    # initialise viewer with astro image
-    viewer = Viewer(coins=image, multichannel=False)
+    # initialise viewer with coins image
+    viewer = napari.view(coins=image, multichannel=False)
     viewer.layers[0].colormap = 'gray'
 
     # add the labels

--- a/examples/labels-0-2d.py
+++ b/examples/labels-0-2d.py
@@ -8,7 +8,7 @@ from skimage.filters import threshold_otsu
 from skimage.segmentation import clear_border
 from skimage.measure import label
 from skimage.morphology import closing, square, remove_small_objects
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 
 
@@ -26,7 +26,7 @@ with app_context():
     label_image = label(cleared)
 
     # initialise viewer with astro image
-    viewer = ViewerApp(coins=image, multichannel=False)
+    viewer = Viewer(coins=image, multichannel=False)
     viewer.layers[0].colormap = 'gray'
 
     # add the labels

--- a/examples/labels-2d.py
+++ b/examples/labels-2d.py
@@ -6,7 +6,7 @@ add_image APIs
 from skimage import data
 from skimage.color import rgb2gray
 from skimage.segmentation import slic
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 
 
@@ -14,7 +14,7 @@ with app_context():
     astro = data.astronaut()
 
     # initialise viewer with astro image
-    viewer = ViewerApp(astronaut=rgb2gray(astro), multichannel=False)
+    viewer = Viewer(astronaut=rgb2gray(astro), multichannel=False)
     viewer.layers[0].colormap = 'gray'
 
     # add the labels

--- a/examples/labels-2d.py
+++ b/examples/labels-2d.py
@@ -6,7 +6,7 @@ add_image APIs
 from skimage import data
 from skimage.color import rgb2gray
 from skimage.segmentation import slic
-from napari import Viewer
+import napari
 from napari.util import app_context
 
 
@@ -14,7 +14,7 @@ with app_context():
     astro = data.astronaut()
 
     # initialise viewer with astro image
-    viewer = Viewer(astronaut=rgb2gray(astro), multichannel=False)
+    viewer = napari.view(astronaut=rgb2gray(astro), multichannel=False)
     viewer.layers[0].colormap = 'gray'
 
     # add the labels

--- a/examples/labels-3d.py
+++ b/examples/labels-3d.py
@@ -5,13 +5,13 @@ add_image APIs
 
 from skimage import data
 from scipy import ndimage as ndi
-from napari import Viewer
+import napari
 from napari.util import app_context
 
 
 with app_context():
     blobs = data.binary_blobs(length=128, volume_fraction=0.1, n_dim=3)
-    v = Viewer(blobs=blobs)
+    v = napari.view(blobs=blobs)
     v.layers[0].colormap = 'gray'
     labeled = ndi.label(blobs)[0]
     label_layer = v.add_labels(labeled, name='blob ID')

--- a/examples/labels-3d.py
+++ b/examples/labels-3d.py
@@ -5,13 +5,13 @@ add_image APIs
 
 from skimage import data
 from scipy import ndimage as ndi
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 
 
 with app_context():
     blobs = data.binary_blobs(length=128, volume_fraction=0.1, n_dim=3)
-    v = ViewerApp(blobs=blobs)
+    v = Viewer(blobs=blobs)
     v.layers[0].colormap = 'gray'
     labeled = ndi.label(blobs)[0]
     label_layer = v.add_labels(labeled, name='blob ID')

--- a/examples/layers.py
+++ b/examples/layers.py
@@ -5,16 +5,16 @@ using the layers swap method and remove one
 
 from skimage import data
 from skimage.color import rgb2gray
-from napari import Viewer
+from napari import view
 from napari.util import app_context
 
 
 with app_context():
     # create the viewer with several image layers
-    viewer = Viewer(astronaut=rgb2gray(data.astronaut()),
-                    photographer=data.camera(),
-                    coins=data.coins(),
-                    moon=data.moon())
+    viewer = view(astronaut=rgb2gray(data.astronaut()),
+                  photographer=data.camera(),
+                  coins=data.coins(),
+                  moon=data.moon())
 
     # remove the coins layer
     viewer.layers.remove('coins')

--- a/examples/layers.py
+++ b/examples/layers.py
@@ -5,16 +5,16 @@ using the layers swap method and remove one
 
 from skimage import data
 from skimage.color import rgb2gray
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 
 
 with app_context():
     # create the viewer with several image layers
-    viewer = ViewerApp(astronaut=rgb2gray(data.astronaut()),
-                       photographer=data.camera(),
-                       coins=data.coins(),
-                       moon=data.moon())
+    viewer = Viewer(astronaut=rgb2gray(data.astronaut()),
+                    photographer=data.camera(),
+                    coins=data.coins(),
+                    moon=data.moon())
 
     # remove the coins layer
     viewer.layers.remove('coins')

--- a/examples/nD_image.py
+++ b/examples/nD_image.py
@@ -4,7 +4,7 @@ Display one 4-D image layer using the add_image API
 
 import numpy as np
 from skimage import data
-from napari import Viewer
+import napari
 from napari.util import app_context
 
 
@@ -12,4 +12,4 @@ with app_context():
     blobs = np.stack([data.binary_blobs(length=128, blob_size_fraction=0.05,
                                         n_dim=3, volume_fraction=f)
                      for f in np.linspace(0.05, 0.5, 10)], axis=0)
-    viewer = Viewer(blobs.astype(float))
+    viewer = napari.view(blobs.astype(float))

--- a/examples/nD_image.py
+++ b/examples/nD_image.py
@@ -4,7 +4,7 @@ Display one 4-D image layer using the add_image API
 
 import numpy as np
 from skimage import data
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 
 
@@ -12,4 +12,4 @@ with app_context():
     blobs = np.stack([data.binary_blobs(length=128, blob_size_fraction=0.05,
                                         n_dim=3, volume_fraction=f)
                      for f in np.linspace(0.05, 0.5, 10)], axis=0)
-    viewer = ViewerApp(blobs.astype(float))
+    viewer = Viewer(blobs.astype(float))

--- a/examples/nD_markers.py
+++ b/examples/nD_markers.py
@@ -6,7 +6,7 @@ accross the dimensions, specified by their size
 
 import numpy as np
 from skimage import data
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 
 
@@ -14,7 +14,7 @@ with app_context():
     blobs = np.stack([data.binary_blobs(length=128, blob_size_fraction=0.05,
                                         n_dim=3, volume_fraction=f)
                       for f in np.linspace(0.05, 0.5, 10)], axis=0)
-    viewer = ViewerApp(blobs.astype(float))
+    viewer = Viewer(blobs.astype(float))
 
     # add the markers
     markers = np.array([[0, 0, 100, 100], [0, 0, 50, 120], [1, 0, 100, 40],

--- a/examples/nD_markers.py
+++ b/examples/nD_markers.py
@@ -6,7 +6,7 @@ accross the dimensions, specified by their size
 
 import numpy as np
 from skimage import data
-from napari import Viewer
+import napari
 from napari.util import app_context
 
 
@@ -14,7 +14,7 @@ with app_context():
     blobs = np.stack([data.binary_blobs(length=128, blob_size_fraction=0.05,
                                         n_dim=3, volume_fraction=f)
                       for f in np.linspace(0.05, 0.5, 10)], axis=0)
-    viewer = Viewer(blobs.astype(float))
+    viewer = napari.view(blobs.astype(float))
 
     # add the markers
     markers = np.array([[0, 0, 100, 100], [0, 0, 50, 120], [1, 0, 100, 40],

--- a/examples/notebook.ipynb
+++ b/examples/notebook.ipynb
@@ -27,7 +27,7 @@
     "# called\n",
     "\n",
     "from skimage import data\n",
-    "from napari import ViewerApp"
+    "from napari import Viewer"
    ]
   },
   {
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer = ViewerApp(data.moon())"
+    "viewer = Viewer(data.moon())"
    ]
   },
   {

--- a/examples/notebook.ipynb
+++ b/examples/notebook.ipynb
@@ -27,7 +27,7 @@
     "# called\n",
     "\n",
     "from skimage import data\n",
-    "from napari import Viewer"
+    "import napari"
    ]
   },
   {
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer = Viewer(data.moon())"
+    "viewer = napari.view(data.moon())"
    ]
   },
   {

--- a/examples/set_colormaps.py
+++ b/examples/set_colormaps.py
@@ -16,7 +16,7 @@ green = vispy.color.Colormap([[0., 0., 0.], [0., 1., 0.]])
 blue = vispy.color.Colormap([[0., 0., 0.], [0., 0., 1.]])
 
 with napari.util.app_context():
-    v = napari.ViewerApp()
+    v = napari.Viewer()
 
     rlayer = v.add_image(rch, name='red channel')
     rlayer.blending = 'additive'

--- a/examples/set_theme.py
+++ b/examples/set_theme.py
@@ -3,14 +3,14 @@ Displays an image and sets the theme to 'light'.
 """
 
 from skimage import data
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 
 
 with app_context():
     # create the viewer with an image
-    viewer = ViewerApp(astronaut=data.astronaut(),
-                       title='napari')
+    viewer = Viewer(astronaut=data.astronaut(),
+                    title='napari')
 
     # set the theme to 'light'
     viewer.theme = 'light'

--- a/examples/set_theme.py
+++ b/examples/set_theme.py
@@ -3,14 +3,15 @@ Displays an image and sets the theme to 'light'.
 """
 
 from skimage import data
-from napari import Viewer
+import napari
 from napari.util import app_context
 
 
 with app_context():
     # create the viewer with an image
-    viewer = Viewer(astronaut=data.astronaut(),
-                    title='napari')
+    viewer = napari.view(astronaut=data.astronaut(),
+                         multichannel=True,
+                         title='napari')
 
     # set the theme to 'light'
     viewer.theme = 'light'

--- a/examples/shapes_to_labels.py
+++ b/examples/shapes_to_labels.py
@@ -6,14 +6,13 @@ your shapes.
 
 import numpy as np
 from skimage import data
-from skimage.color import rgb2gray
-from napari import Viewer
+import napari
 from napari.util import app_context
 from vispy.color import Colormap
 
 with app_context():
     # create the viewer and window
-    viewer = Viewer()
+    viewer = napari.Viewer()
 
     # add the image
     img_layer = viewer.add_image(data.camera(), name='photographer')

--- a/examples/shapes_to_labels.py
+++ b/examples/shapes_to_labels.py
@@ -7,13 +7,13 @@ your shapes.
 import numpy as np
 from skimage import data
 from skimage.color import rgb2gray
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 from vispy.color import Colormap
 
 with app_context():
     # create the viewer and window
-    viewer = ViewerApp()
+    viewer = Viewer()
 
     # add the image
     img_layer = viewer.add_image(data.camera(), name='photographer')

--- a/examples/to_svg.py
+++ b/examples/to_svg.py
@@ -7,14 +7,14 @@ your shapes.
 import numpy as np
 from skimage import data
 from skimage.color import rgb2gray
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 from vispy.color import Colormap
 
 
 with app_context():
     # create the viewer and window
-    viewer = ViewerApp()
+    viewer = Viewer()
 
     # add the image
     img_layer = viewer.add_image(data.camera(), name='photographer')

--- a/examples/to_svg.py
+++ b/examples/to_svg.py
@@ -6,15 +6,14 @@ your shapes.
 
 import numpy as np
 from skimage import data
-from skimage.color import rgb2gray
-from napari import Viewer
+import napari
 from napari.util import app_context
 from vispy.color import Colormap
 
 
 with app_context():
     # create the viewer and window
-    viewer = Viewer()
+    viewer = napari.Viewer()
 
     # add the image
     img_layer = viewer.add_image(data.camera(), name='photographer')

--- a/examples/zarr_nD_image.py
+++ b/examples/zarr_nD_image.py
@@ -4,9 +4,7 @@ Display one 4-D image layer using the add_image API
 
 import dask.array as da
 import zarr
-import numpy as np
-from skimage import data
-from napari import Viewer
+import napari
 from napari.util import app_context
 
 
@@ -16,4 +14,6 @@ with app_context():
 
     array = da.from_zarr(data)
     print(array.shape)
-    viewer = Viewer(array, clim_range=[0, 1], multichannel=False)
+    # For big data, we should specify the clim range, or napari will try
+    # to find the min and max of the full image.
+    viewer = napari.view(array, clim_range=[0, 1], multichannel=False)

--- a/examples/zarr_nD_image.py
+++ b/examples/zarr_nD_image.py
@@ -6,7 +6,7 @@ import dask.array as da
 import zarr
 import numpy as np
 from skimage import data
-from napari import ViewerApp
+from napari import Viewer
 from napari.util import app_context
 
 
@@ -16,4 +16,4 @@ with app_context():
 
     array = da.from_zarr(data)
     print(array.shape)
-    viewer = ViewerApp(array, clim_range=[0, 1], multichannel=False)
+    viewer = Viewer(array, clim_range=[0, 1], multichannel=False)

--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -6,7 +6,7 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=UserWarning,
                             message=vispy_warning)
     from .components import Window, ViewerWidget
-    from .viewer import ViewerApp
+    from .viewer import Viewer
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -8,6 +8,8 @@ with warnings.catch_warnings():
     from .components import Window, ViewerWidget
     from .viewer import Viewer
 
+from ._view import view
+
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -5,7 +5,7 @@ vispy_warning = "VisPy is not yet compatible with matplotlib 2.2+"
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=UserWarning,
                             message=vispy_warning)
-    from .components import Window, Viewer
+    from .components import Window, ViewerWidget
     from .viewer import ViewerApp
 
 from ._version import get_versions

--- a/napari/_view.py
+++ b/napari/_view.py
@@ -1,0 +1,51 @@
+from .viewer import Viewer
+
+
+def view(*images, meta=None, multichannel=None, clim_range=None,
+         title='napari', **named_images):
+    """View one or more input images.
+
+    Parameters
+    ----------
+    *images : ndarray
+        Arrays to render as image layers.
+    title : string, optional
+        The title of the viewer window.
+    meta : dictionary, optional
+        A dictionary of metadata attributes. If multiple images are provided,
+        the metadata applies to all of them.
+    multichannel : bool, optional
+        Whether to consider the last dimension of the image(s) as channels
+        rather than spatial attributes. If not provided, napari will attempt
+        to make an educated guess. If provided, and multiple images are given,
+        the same value applies to all images.
+    clim_range : list | array | None
+        Length two list or array with the default color limit range for the
+        image. If not passed will be calculated as the min and max of the
+        image. Passing a value prevents this calculation which can be useful
+        when working with very large datasets that are dynamically loaded.
+        If provided, and multiple images are given, the same value applies to
+        all images.
+    **named_images : dict of str -> ndarray, optional
+        Arrays to render as image layers, keyed by layer name.
+
+    Returns
+    -------
+    viewer : napari.Viewer
+        A Viewer widget displaying the images.
+
+    Notes
+    -----
+    This convenience function is used to view one or few images with identical
+    parameters (colormap etc). To customize each image layer, either use the
+    :class:`napari.Viewer` class (preferred), or update the layers directly on
+    the returned :class:`napari.Viewer` object.
+    """
+    viewer = Viewer(title=title)
+    for image in images:
+        viewer.add_image(image, meta=meta, multichannel=multichannel,
+                         clim_range=clim_range)
+    for name, image in named_images.items():
+        viewer.add_image(image, meta=meta, multichannel=multichannel,
+                         clim_range=clim_range, name=name)
+    return viewer

--- a/napari/components/__init__.py
+++ b/napari/components/__init__.py
@@ -6,7 +6,7 @@ Classes
 -------
 Window
     Window containing file menus, toolbars, and viewers.
-Viewer
+ViewerWidget
     Data viewer displaying the currently rendered scene and
     layer-related controls.
 """
@@ -19,6 +19,6 @@ with warnings.catch_warnings():
                             message=vispy_warning)
 
     from ._window import Window, QtApplication
-from ._viewer import Viewer
+from ._viewer import ViewerWidget
 from ._layers_list import LayersList
 from ._dims import Dims

--- a/napari/components/_viewer/__init__.py
+++ b/napari/components/_viewer/__init__.py
@@ -1,1 +1,1 @@
-from .model import Viewer
+from .model import ViewerWidget

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -10,7 +10,7 @@ from ...util.misc import has_clims
 from .._dims import Dims
 
 
-class Viewer:
+class ViewerWidget:
     """Viewer containing the rendered scene, layers, and controlling elements
     including dimension sliders, and control bars for color limits.
 
@@ -23,7 +23,7 @@ class Viewer:
     dims : Dimensions
         Contains axes, indices, dimensions and sliders.
     camera : vispy.scene.Camera
-        Viewer camera.
+        ViewerWidget camera.
     key_bindings : dict of string: callable
         Custom key bindings. The dictionary key is a string containing the key
         pressed and the value is the function to be bound to the key event.
@@ -80,7 +80,7 @@ class Viewer:
 
     @property
     def camera(self):
-        """vispy.scene.Camera: Viewer camera.
+        """vispy.scene.Camera: ViewerWidget camera.
         """
         return self._view.camera
 

--- a/napari/components/_window/view.py
+++ b/napari/components/_window/view.py
@@ -1,7 +1,7 @@
 from qtpy.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QLabel
 from qtpy.QtCore import Qt
 
-from .._viewer import Viewer
+from .._viewer import ViewerWidget
 
 
 class Window:
@@ -9,12 +9,12 @@ class Window:
 
     Parameters
     ----------
-    viewer : Viewer
+    viewer : ViewerWidget
         Contained viewer.
 
     Attributes
     ----------
-    viewer : Viewer
+    viewer : ViewerWidget
         Contained viewer.
     """
     def __init__(self, viewer, show=True):

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -1,6 +1,5 @@
 import numpy as np
 from scipy import ndimage as ndi
-from copy import copy
 from xml.etree.ElementTree import Element
 from base64 import b64encode
 from imageio import imwrite
@@ -15,8 +14,7 @@ from .._register import add_to_viewer
 
 from .view import QtLabelsLayer
 from .view import QtLabelsControls
-from ._constants import Mode, BACKSPACE
-from vispy.color import Colormap
+from ._constants import Mode
 
 
 @add_to_viewer

--- a/napari/layers/_register.py
+++ b/napari/layers/_register.py
@@ -1,7 +1,7 @@
 import re
 import inspect
 
-from ..components import Viewer
+from ..components import ViewerWidget
 
 
 template = """def {name}(self, {signature}):
@@ -135,7 +135,7 @@ def create_func(cls, name=None, doc=None):
 
 def _register(cls, *, name=None, doc=None):
     func = create_func(cls, name=name, doc=doc)
-    setattr(Viewer, func.__name__, func)
+    setattr(ViewerWidget, func.__name__, func)
     return cls
 
 

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -8,7 +8,7 @@ from .util.theme import template, palettes
 from .util.misc import has_clims
 
 
-class ViewerApp(ViewerWidget):
+class Viewer(ViewerWidget):
     """Napari ndarray viewer.
 
     Parameters

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,14 +1,14 @@
 import os.path as osp
 
 from .components._viewer.view import QtViewer
-from .components import Window, Viewer
+from .components import Window, ViewerWidget
 from .layers._image_layer.model import Image
 from .resources import resources_dir
 from .util.theme import template, palettes
 from .util.misc import has_clims
 
 
-class ViewerApp(Viewer):
+class ViewerApp(ViewerWidget):
     """Napari ndarray viewer.
 
     Parameters

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -2,7 +2,6 @@ import os.path as osp
 
 from .components._viewer.view import QtViewer
 from .components import Window, ViewerWidget
-from .layers._image_layer.model import Image
 from .resources import resources_dir
 from .util.theme import template, palettes
 from .util.misc import has_clims
@@ -13,40 +12,16 @@ class Viewer(ViewerWidget):
 
     Parameters
     ----------
-    *images : ndarray
-        Arrays to render as image layers.
-    meta : dictionary, optional
-        A dictionary of metadata attributes. If multiple images are provided,
-        the metadata applies to all of them.
-    multichannel : bool, optional
-        Whether to consider the last dimension of the image(s) as channels
-        rather than spatial attributes. If not provided, napari will attempt
-        to make an educated guess. If provided, and multiple images are given,
-        the same value applies to all images.
-    clim_range : list | array | None
-        Length two list or array with the default color limit range for the
-        image. If not passed will be calculated as the min and max of the
-        image. Passing a value prevents this calculation which can be useful
-        when working with very large datasets that are dynamically loaded.
-        If provided, and multiple images are given, the same value applies to
-        all images.
-    **named_images : dict of str -> ndarray, optional
-        Arrays to render as image layers, keyed by layer name.
+    title : string
+        The title of the viewer window.
     """
     with open(osp.join(resources_dir, 'stylesheet.qss'), 'r') as f:
         raw_stylesheet = f.read()
 
-    def __init__(self, *images, meta=None, multichannel=None, clim_range=None,
-                 title='napari', **named_images):
+    def __init__(self, title='napari'):
         super().__init__(title=title)
         self._qtviewer = QtViewer(self)
         self.window = Window(self)
-        for image in images:
-            self.add_image(image, meta=meta, multichannel=multichannel,
-                           clim_range=clim_range)
-        for name, image in named_images.items():
-            self.add_image(image, meta=meta, multichannel=multichannel,
-                           clim_range=clim_range, name=name)
         self.theme = 'dark'
 
     @property


### PR DESCRIPTION
# Description
Fixes #134.

I leave the extended discussion about LayerWidget/LayerModel etc for a later discussion and refactor. (I don't like that model because there is not necessarily a view for every model — views might instead combine information from different models.)

I removed the extra constructor arguments in the final commit, and that could be reverted. Specifically, I wonder what arguments make sense for an empty viewer. If there are not many, then we might as well allow the constructor to take in some images that mirror the `view` signature. But, as a counterpoint, there should be one obvious way to do things. So I'm happy with the way this PR stands. The examples now include a mix of using `napari.view(images)` and `napari.Viewer()`. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] This change requires a documentation update


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: the test suite for my feature covers `napari.view` and `napari.Viewer`, and `ViewerWidget` by extension.
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
