### PR TITLE
Remove qtviewer from viewer

### DIFF
--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -5,7 +5,7 @@ vispy_warning = "VisPy is not yet compatible with matplotlib 2.2+"
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=UserWarning,
                             message=vispy_warning)
-    from .components import Window, ViewerWidget
+    from .components import Window
     from .viewer import Viewer
 
 from ._view import view

--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -5,7 +5,6 @@ vispy_warning = "VisPy is not yet compatible with matplotlib 2.2+"
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=UserWarning,
                             message=vispy_warning)
-    from .components import Window
     from .viewer import Viewer
 
 from ._view import view

--- a/napari/components/__init__.py
+++ b/napari/components/__init__.py
@@ -6,7 +6,7 @@ Classes
 -------
 Window
     Window containing file menus, toolbars, and viewers.
-ViewerWidget
+ViewerModel
     Data viewer displaying the currently rendered scene and
     layer-related controls.
 """
@@ -19,6 +19,6 @@ with warnings.catch_warnings():
                             message=vispy_warning)
 
     from ._window import Window, QtApplication
-from ._viewer import ViewerWidget
+from ._viewer import ViewerModel, QtViewer
 from ._layers_list import LayersList
 from ._dims import Dims

--- a/napari/components/__init__.py
+++ b/napari/components/__init__.py
@@ -10,15 +10,7 @@ ViewerModel
     Data viewer displaying the currently rendered scene and
     layer-related controls.
 """
-import warnings
-
-vispy_warning = "VisPy is not yet compatible with matplotlib 2.2+"
-
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=UserWarning,
-                            message=vispy_warning)
-
-    from ._window import Window, QtApplication
-from ._viewer import ViewerModel, QtViewer
+from ._window import Window, QtApplication
+from ._viewer import ViewerModel
 from ._layers_list import LayersList
 from ._dims import Dims

--- a/napari/components/_viewer/__init__.py
+++ b/napari/components/_viewer/__init__.py
@@ -1,2 +1,1 @@
 from .model import ViewerModel
-from .view import QtViewer

--- a/napari/components/_viewer/__init__.py
+++ b/napari/components/_viewer/__init__.py
@@ -1,1 +1,2 @@
-from .model import ViewerWidget
+from .model import ViewerModel
+from .view import QtViewer

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -60,7 +60,7 @@ class ViewerModel:
         self.key_bindings = {}
 
         # TODO: this should be eventually removed!
-        # attaced by QtViewer when it is constructed by the model
+        # attached by QtViewer when it is constructed by the model
         self._scene = None
 
         self.dims.events.axis.connect(lambda e: self._update_layers())

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -40,6 +40,10 @@ class ViewerWidget:
                                    status=Event,
                                    help=Event,
                                    title=Event,
+                                   interactive=Event,
+                                   cursor=Event,
+                                   cursor_size=Event,
+                                   reset_view=Event,
                                    active_layer=Event)
 
         # Initial dimension must be set to at least the number of visible
@@ -134,8 +138,8 @@ class ViewerWidget:
     def interactive(self, interactive):
         if interactive == self.interactive:
             return
-        self._qtviewer.view.interactive = interactive
         self._interactive = interactive
+        self.events.interactive()
 
     @property
     def cursor(self):

--- a/napari/components/_viewer/view/main.py
+++ b/napari/components/_viewer/view/main.py
@@ -73,6 +73,11 @@ class QtViewer(QSplitter):
                 'standard': QCursor()
             }
 
+        self.viewer.events.interactive.connect(self._on_interactive)
+
+    def _on_interactive(self, event):
+        self.view.interactive = self.viewer.interactive
+
     def set_cursor(self, cursor, size=10):
         if cursor == 'square':
             if size < 10 or size > 300:

--- a/napari/components/_window/view.py
+++ b/napari/components/_window/view.py
@@ -5,19 +5,22 @@ from .._viewer import ViewerWidget
 
 
 class Window:
-    """Application window that contains the menu bar and viewers.
+    """Application window that contains the menu bar and viewer.
 
     Parameters
     ----------
-    viewer : ViewerWidget
-        Contained viewer.
+    qt_viewer : QtViewer
+        Contained viewer widget.
 
     Attributes
     ----------
-    viewer : ViewerWidget
-        Contained viewer.
+    qt_viewer : QtViewer
+        Contained viewer widget.
     """
-    def __init__(self, viewer, show=True):
+    def __init__(self, qt_viewer, show=True):
+
+        self.qt_viewer = qt_viewer
+        
         self._qt_window = QMainWindow()
         self._qt_window.setUnifiedTitleAndToolBarOnMac(True)
         self._qt_center = QWidget()
@@ -30,13 +33,12 @@ class Window:
         self._help = QLabel('')
         self._status_bar.addPermanentWidget(self._help)
 
-        self.viewer = viewer
-        self._qt_center.layout().addWidget(self.viewer._qtviewer)
+        self._qt_center.layout().addWidget(self.qt_viewer)
         self._qt_center.layout().setContentsMargins(4, 0, 4, 0)
 
-        self.viewer.events.status.connect(self._status_changed)
-        self.viewer.events.help.connect(self._help_changed)
-        self.viewer.events.title.connect(self._title_changed)
+        self.qt_viewer.viewer.events.status.connect(self._status_changed)
+        self.qt_viewer.viewer.events.help.connect(self._help_changed)
+        self.qt_viewer.viewer.events.title.connect(self._title_changed)
 
         if show:
             self.show()

--- a/napari/components/_window/view.py
+++ b/napari/components/_window/view.py
@@ -1,8 +1,6 @@
 from qtpy.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QLabel
 from qtpy.QtCore import Qt
 
-from .._viewer import ViewerWidget
-
 
 class Window:
     """Application window that contains the menu bar and viewer.
@@ -20,12 +18,12 @@ class Window:
     def __init__(self, qt_viewer, show=True):
 
         self.qt_viewer = qt_viewer
-        
+
         self._qt_window = QMainWindow()
         self._qt_window.setUnifiedTitleAndToolBarOnMac(True)
         self._qt_center = QWidget()
         self._qt_window.setCentralWidget(self._qt_center)
-        self._qt_window.setWindowTitle(viewer.title)
+        self._qt_window.setWindowTitle(self.qt_viewer.viewer.title)
         self._qt_center.setLayout(QHBoxLayout())
         self._status_bar = self._qt_window.statusBar()
         self._status_bar.showMessage('Ready')

--- a/napari/layers/_register.py
+++ b/napari/layers/_register.py
@@ -1,7 +1,7 @@
 import re
 import inspect
 
-from ..components import ViewerWidget
+from ..components import ViewerModel
 
 
 template = """def {name}(self, {signature}):
@@ -135,7 +135,7 @@ def create_func(cls, name=None, doc=None):
 
 def _register(cls, *, name=None, doc=None):
     func = create_func(cls, name=name, doc=doc)
-    setattr(ViewerWidget, func.__name__, func)
+    setattr(ViewerModel, func.__name__, func)
     return cls
 
 

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -22,7 +22,7 @@ class Viewer(ViewerModel):
         super().__init__(title=title)
         qt_viewer = QtViewer(self)
         self.window = Window(qt_viewer)
-        self.screenshot = self.window.qtviewer.screenshot
+        self.screenshot = self.window.qt_viewer.screenshot
         self.theme = 'dark'
 
     @property
@@ -48,7 +48,7 @@ class Viewer(ViewerModel):
 
         # template and apply the primary stylesheet
         themed_stylesheet = template(self.raw_stylesheet, **palette)
-        self.window.qtviewer.setStyleSheet(themed_stylesheet)
+        self.window.qt_viewer.setStyleSheet(themed_stylesheet)
 
         # set window styles which don't use the primary stylesheet
         self.window._status_bar.setStyleSheet(
@@ -64,5 +64,5 @@ class Viewer(ViewerModel):
                     palette['foreground'], palette['highlight'])
 
         # set styles on dims sliders
-        for slider in self.window.qtviewer.dims.sliders:
+        for slider in self.window.qt_viewer.dims.sliders:
             slider.setColors(palette['foreground'], palette['highlight'])

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,13 +1,13 @@
 import os.path as osp
 
 from .components._viewer.view import QtViewer
-from .components import Window, ViewerWidget
+from .components import Window, ViewerModel
 from .resources import resources_dir
 from .util.theme import template, palettes
 from .util.misc import has_clims
 
 
-class Viewer(ViewerWidget):
+class Viewer(ViewerModel):
     """Napari ndarray viewer.
 
     Parameters
@@ -20,8 +20,9 @@ class Viewer(ViewerWidget):
 
     def __init__(self, title='napari'):
         super().__init__(title=title)
-        self._qtviewer = QtViewer(self)
-        self.window = Window(self)
+        qt_viewer = QtViewer(self)
+        self.window = Window(qt_viewer)
+        self.screenshot = self.window.qtviewer.screenshot
         self.theme = 'dark'
 
     @property
@@ -47,7 +48,7 @@ class Viewer(ViewerWidget):
 
         # template and apply the primary stylesheet
         themed_stylesheet = template(self.raw_stylesheet, **palette)
-        self._qtviewer.setStyleSheet(themed_stylesheet)
+        self.window.qtviewer.setStyleSheet(themed_stylesheet)
 
         # set window styles which don't use the primary stylesheet
         self.window._status_bar.setStyleSheet(
@@ -63,5 +64,5 @@ class Viewer(ViewerWidget):
                     palette['foreground'], palette['highlight'])
 
         # set styles on dims sliders
-        for slider in self._qtviewer.dims.sliders:
+        for slider in self.window.qtviewer.dims.sliders:
             slider.setColors(palette['foreground'], palette['highlight'])


### PR DESCRIPTION
# Description
This PR would address more of our MVC refactor for example #92 by removing the `_qtviewer` from the `ViewerWidget` which will be renamed `ViewerModel`. It is currently not running as I need to fix some imports

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run examples

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
