### PR TITLE
Pyramid layer

### DIFF
--- a/examples/add_pyramid.py
+++ b/examples/add_pyramid.py
@@ -28,5 +28,10 @@ with app_context():
     viewer.add_pyramid(pyramid)
 
     camera = viewer.window.qt_viewer.view.camera
-    camera.rect = (-.1*pyramid[0].shape[1], 0, 1.2*pyramid[0].shape[1],
-                   pyramid[0].shape[0])
+
+    # Set the view box of the camera to include the whole base image of the
+    # pyramid with a little padding. The view box is a 4-tuple of the x, y
+    # corner position followed by width and height
+    base_shape = pyramid[0].shape
+    camera.rect = (-0.1 * base_shape[1], -0.1 * base_shape[0],
+                   1.2 * base_shape[1], 1.2 * base_shape[0])

--- a/examples/add_pyramid.py
+++ b/examples/add_pyramid.py
@@ -1,0 +1,32 @@
+"""
+Displays an image pyramid
+"""
+
+from skimage import data
+from skimage.color import rgb2gray
+from skimage.transform import pyramid_gaussian
+import napari
+from napari.util import app_context
+import numpy as np
+
+
+image = data.astronaut()
+rows, cols, dim = image.shape
+
+
+# create pyramid from astronaut image
+astronaut=rgb2gray(data.astronaut())
+base = np.tile(astronaut, (16, 16))
+pyramid = list(pyramid_gaussian(base, downscale=2, multichannel=False))[:-8]
+print([p.shape[:2] for p in pyramid])
+
+with app_context():
+    # create the viewer
+    viewer = napari.Viewer()
+
+    # add image pyramid
+    viewer.add_pyramid(pyramid)
+
+    camera = viewer.window.qt_viewer.view.camera
+    camera.rect = (-.1*pyramid[0].shape[1], 0, 1.2*pyramid[0].shape[1],
+                   pyramid[0].shape[0])

--- a/examples/add_pyramid.py
+++ b/examples/add_pyramid.py
@@ -25,7 +25,7 @@ with app_context():
     viewer = napari.Viewer()
 
     # add image pyramid
-    viewer.add_pyramid(pyramid)
+    viewer.add_pyramid(pyramid, clim_range=[0, 255])
 
     camera = viewer.window.qt_viewer.view.camera
 

--- a/examples/add_pyramid.py
+++ b/examples/add_pyramid.py
@@ -15,7 +15,7 @@ rows, cols, dim = image.shape
 
 
 # create pyramid from astronaut image
-astronaut=rgb2gray(data.astronaut())
+astronaut = rgb2gray(data.astronaut())
 base = np.tile(astronaut, (16, 16))
 pyramid = list(pyramid_gaussian(base, downscale=2, multichannel=False))[:-8]
 print([p.shape[:2] for p in pyramid])

--- a/examples/add_pyramid.py
+++ b/examples/add_pyramid.py
@@ -26,11 +26,9 @@ with app_context():
     # add image pyramid
     viewer.add_pyramid(pyramid, clim_range=[0, 255])
 
-    camera = viewer.window.qt_viewer.view.camera
-
     # Set the view box of the camera to include the whole base image of the
     # pyramid with a little padding. The view box is a 4-tuple of the x, y
     # corner position followed by width and height
     base_shape = pyramid[0].shape
-    camera.rect = (-0.1 * base_shape[1], -0.1 * base_shape[0],
+    viewer.camera.rect = (-0.1 * base_shape[1], -0.1 * base_shape[0],
                    1.2 * base_shape[1], 1.2 * base_shape[0])

--- a/examples/add_pyramid.py
+++ b/examples/add_pyramid.py
@@ -3,22 +3,21 @@ Displays an image pyramid
 """
 
 from skimage import data
+from skimage.util import img_as_ubyte
+from skimage.color import rgb2gray
 from skimage.transform import pyramid_gaussian
 import napari
 from napari.util import app_context
 import numpy as np
 
 
-image = data.astronaut()
-rows, cols, dim = image.shape
-
 # create pyramid from astronaut image
-astronaut = data.astronaut().mean(axis=2) / 255
+astronaut = rgb2gray(data.astronaut())
 base = np.tile(astronaut, (16, 16))
 pyramid = list(pyramid_gaussian(base, downscale=2, max_layer=5,
                                 multichannel=False))
-pyramid = [(255*p).astype('uint8') for p in pyramid]
-print([p.shape[:2] for p in pyramid])
+pyramid = [img_as_ubyte(p) for p in pyramid]
+print('pyramid level shapes: ', [p.shape for p in pyramid])
 
 with app_context():
     # create the viewer

--- a/examples/add_pyramid.py
+++ b/examples/add_pyramid.py
@@ -3,7 +3,6 @@ Displays an image pyramid
 """
 
 from skimage import data
-from skimage.color import rgb2gray
 from skimage.transform import pyramid_gaussian
 import napari
 from napari.util import app_context
@@ -13,11 +12,12 @@ import numpy as np
 image = data.astronaut()
 rows, cols, dim = image.shape
 
-
 # create pyramid from astronaut image
-astronaut = rgb2gray(data.astronaut())
+astronaut = data.astronaut().mean(axis=2) / 255
 base = np.tile(astronaut, (16, 16))
-pyramid = list(pyramid_gaussian(base, downscale=2, multichannel=False))[:-8]
+pyramid = list(pyramid_gaussian(base, downscale=2, max_layer=5,
+                                multichannel=False))
+pyramid = [(255*p).astype('uint8') for p in pyramid]
 print([p.shape[:2] for p in pyramid])
 
 with app_context():

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -61,7 +61,7 @@ class ViewerModel:
 
         # TODO: this should be eventually removed!
         # attached by QtViewer when it is constructed by the model
-        self._scene = None
+        self._view = None
 
         self.dims.events.axis.connect(lambda e: self._update_layers())
         self.layers.events.added.connect(self._on_layers_change)
@@ -244,8 +244,8 @@ class ViewerModel:
         layer.events.name.connect(self._update_name)
 
         self.layers.append(layer)
+        layer.parent = self._view
         layer.indices = self.dims.indices
-        layer._parent = self._scene
 
         if self.theme is not None and has_clims(layer):
             palette = palettes[self.theme]

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -284,8 +284,8 @@ class ViewerModel:
         layer.events.name.connect(self._update_name)
         layer.events.data.connect(self._on_layers_change)
 
-        self.layers.append(layer)
         layer.parent = self._view
+        self.layers.append(layer)
         layer.indices = self.dims.indices
 
         if len(self.layers) == 1:

--- a/napari/components/_viewer/view/main.py
+++ b/napari/components/_viewer/view/main.py
@@ -28,19 +28,19 @@ class QtViewer(QSplitter):
         self.canvas.connect(self.on_mouse_release)
         self.canvas.connect(self.on_key_press)
         self.canvas.connect(self.on_key_release)
+        self.canvas.connect(self.on_draw)
 
         self.view = self.canvas.central_widget.add_view()
-
-        # TO DO: Remove
-        self.viewer._scene = self.view.scene
 
         # Set 2D camera (the camera will scale to the contents in the scene)
         self.view.camera = PanZoomCamera(aspect=1)
         # flip y-axis to have correct aligment
         self.view.camera.flip = (0, 1, 0)
         self.view.camera.set_range()
-
         self.view.camera.viewbox_key_event = viewbox_key_event
+
+        # TO DO: Remove
+        self.viewer._view = self.view
 
         center = QWidget()
         center_layout = QVBoxLayout()
@@ -172,6 +172,11 @@ class QtViewer(QSplitter):
         if layer is not None:
             layer.on_key_release(event)
 
+    def on_draw(self, event):
+        """Called whenever drawn in canvas. Called for all layers, not just top
+        """
+        for layer in self.viewer.layers:
+            layer.on_draw(event)
 
 def viewbox_key_event(event):
     """ViewBox key event handler

--- a/napari/layers/__init__.py
+++ b/napari/layers/__init__.py
@@ -12,4 +12,5 @@ from ._markers_layer import Markers
 from ._vectors_layer import Vectors
 from ._shapes_layer import Shapes
 from ._labels_layer import Labels
+from ._pyramid_layer import Pyramid
 from ._register import add_to_viewer

--- a/napari/layers/_base_layer/_visual_wrapper.py
+++ b/napari/layers/_base_layer/_visual_wrapper.py
@@ -36,6 +36,7 @@ class VisualWrapper:
     def __init__(self, central_node):
         self._node = central_node
         self._blending = 'translucent'
+        self._parent = None
         self.events = EmitterGroup(source=self,
                                    auto_connect=True,
                                    blending=Event,
@@ -72,14 +73,15 @@ class VisualWrapper:
         self._node.order = order
 
     @property
-    def _parent(self):
-        """vispy.scene.Node: Parent node.
+    def parent(self):
+        """vispy.View: View containing parent node and camera.
         """
-        return self._node.parent
+        return self._parent
 
-    @_parent.setter
-    def _parent(self, parent):
-        self._node.parent = parent
+    @parent.setter
+    def parent(self, parent):
+        self._parent = parent
+        self._node.parent = parent.scene
 
     @property
     def opacity(self):

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -57,8 +57,8 @@ class Layer(VisualWrapper, ABC):
         self._cursor = 'standard'
         self._cursor_size = None
         self._interactive = True
-        self._indices = ()
-        self._cursor_position = (0, 0)
+        self._indices = (0, 0)
+        self._position = (0, 0)
         self._coordinates = (0, 0)
         self._name = ''
         self.events.add(select=Event,
@@ -110,33 +110,45 @@ class Layer(VisualWrapper, ABC):
         if indices == self.indices:
             return
         self._indices = indices[-self.ndim:]
-        self.coordinates = None
+        self._update_coordinates()
         self._set_view_slice()
 
     @property
     def coordinates(self):
-        """Tuple of float: Coordinates of the cursor in the respective image
-        space of each layer.
-
-        The setter expects the a 2-tuple of coordinates in canvas space
-        ordered (x, y) and then transforms them to image space and inserts
-        them into the correct position of the layer indices. The length of the
-        tuple is equal to the number of dimensions of the layer. If ``None`` is
-        passed then (0, 0) will replace necessary the layer indices.
+        """Tuple of float: Coordinates of the cursor in the image space of each
+        layer. The length of the tuple is equal to the number of dimensions of
+        the layer.
         """
         return self._coordinates
 
     @coordinates.setter
-    def coordinates(self, cursor_position):
-        if cursor_position is not None:
-            transform = self._node.canvas.scene.node_transform(self._node)
-            position = tuple(transform.map(cursor_position)[:2])
-        else:
-            position = (0, 0)
+    def coordinates(self, coordinates):
+        if self._coordinates == coordinates:
+            return
+        self._coordinates = coordinates
+
+    @property
+    def position(self):
+        """2-tuple of int: Cursor position in canvas ordered (x, y)."""
+        return self._position
+
+    @position.setter
+    def position(self, position):
+        if self._position == position:
+            return
+        self._position = position
+        self._update_coordinates()
+
+    def _update_coordinates(self):
+        """Insert the cursor position (x, y) into the correct position in the
+        tuple of indices and update the cursor coordinates.
+        """
+        transform = self._node.canvas.scene.node_transform(self._node)
+        position = transform.map(list(self.position))[:2]
         coords = list(self.indices)
         coords[-2] = position[1]
         coords[-1] = position[0]
-        self._coordinates = tuple(coords)
+        self.coordinates = tuple(coords)
 
     @property
     @abstractmethod
@@ -389,5 +401,10 @@ class Layer(VisualWrapper, ABC):
 
     def on_key_release(self, event):
         """Called whenever key released in canvas.
+        """
+        return
+
+    def on_draw(self, event):
+        """Called whenever the canvas is drawn.
         """
         return

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -40,6 +40,9 @@ class Layer(VisualWrapper, ABC):
     shape
     selected
     indices
+    coordinates : tuple of float
+        Coordinates of the cursor in the image space of each layer. The length
+        of the tuple is equal to the number of dimensions of the layer.
 
     Methods
     -------
@@ -59,7 +62,7 @@ class Layer(VisualWrapper, ABC):
         self._interactive = True
         self._indices = (0, 0)
         self._position = (0, 0)
-        self._coordinates = (0, 0)
+        self.coordinates = (0, 0)
         self._name = ''
         self.events.add(select=Event,
                         deselect=Event,
@@ -112,20 +115,6 @@ class Layer(VisualWrapper, ABC):
         self._indices = indices[-self.ndim:]
         self._update_coordinates()
         self._set_view_slice()
-
-    @property
-    def coordinates(self):
-        """Tuple of float: Coordinates of the cursor in the image space of each
-        layer. The length of the tuple is equal to the number of dimensions of
-        the layer.
-        """
-        return self._coordinates
-
-    @coordinates.setter
-    def coordinates(self, coordinates):
-        if self._coordinates == coordinates:
-            return
-        self._coordinates = coordinates
 
     @property
     def position(self):

--- a/napari/layers/_image_layer/model.py
+++ b/napari/layers/_image_layer/model.py
@@ -406,11 +406,10 @@ class Image(Layer):
         return [xml]
 
     def on_mouse_move(self, event):
-        """Called whenever mouse moves over canvas. Converts the `event.pos`
-        from canvas coordinates to `self.coordinates` in image coordinates.
+        """Called whenever mouse moves over canvas.
         """
         if event.pos is None:
             return
-        self.coordinates = event.pos
+        self.position = tuple(event.pos)
         coord, value = self.get_value()
         self.status = self.get_message(coord, value)

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -529,8 +529,7 @@ class Labels(Layer):
         return [xml]
 
     def on_mouse_press(self, event):
-        """Called whenever mouse pressed in canvas.  Converts the `event.pos`
-        from canvas coordinates to `self.coordinates` in image coordinates.
+        """Called whenever mouse pressed in canvas.
 
         Parameters
         ----------
@@ -539,7 +538,7 @@ class Labels(Layer):
         """
         if event.pos is None:
             return
-        self.coordinates = event.pos
+        self.position = tuple(event.pos)
         coord, label = self.get_value()
 
         if self.mode == Mode.PAN_ZOOM:
@@ -563,8 +562,7 @@ class Labels(Layer):
             raise ValueError("Mode not recongnized")
 
     def on_mouse_move(self, event):
-        """Called whenever mouse moves over canvas.  Converts the `event.pos`
-        from canvas coordinates to `self.coordinates` in image coordinates.
+        """Called whenever mouse moves over canvas.
 
         Parameters
         ----------
@@ -573,7 +571,7 @@ class Labels(Layer):
         """
         if event.pos is None:
             return
-        self.coordinates = event.pos
+        self.position = tuple(event.pos)
         coord, label = self.get_value()
 
         if self.mode == Mode.PAINT and event.is_dragging:

--- a/napari/layers/_markers_layer/model.py
+++ b/napari/layers/_markers_layer/model.py
@@ -470,12 +470,11 @@ class Markers(Layer):
         return xml_list
 
     def on_mouse_move(self, event):
-        """Called whenever mouse moves over canvas. Converts the `event.pos`
-        from canvas coordinates to `self.coordinates` in image coordinates.
+        """Called whenever mouse moves over canvas.
         """
         if event.pos is None:
             return
-        self.coordinates = event.pos
+        self.position = tuple(event.pos)
         coord = self.coordinates
         if self.mode == 'select' and event.is_dragging:
             self._move(coord)
@@ -484,12 +483,11 @@ class Markers(Layer):
         self.status = self.get_message(coord, self._selected_markers)
 
     def on_mouse_press(self, event):
-        """Called whenever mouse pressed in canvas. Converts the `event.pos`
-        from canvas coordinates to `self.coordinates` in image coordinates.
+        """Called whenever mouse pressed in canvas.
         """
         if event.pos is None:
             return
-        self.coordinates = event.pos
+        self.position = tuple(event.pos)
         coord = self.coordinates
         self._selected_markers = self._select_marker(coord)
         shift = 'Shift' in event.modifiers

--- a/napari/layers/_pyramid_layer/__init__.py
+++ b/napari/layers/_pyramid_layer/__init__.py
@@ -1,0 +1,1 @@
+from .model import Pyramid

--- a/napari/layers/_pyramid_layer/model.py
+++ b/napari/layers/_pyramid_layer/model.py
@@ -238,7 +238,8 @@ class Pyramid(Image):
         return msg
 
     def on_draw(self, event):
-        """Called whenever the canvas is drawn.
+        """Called whenever the canvas is drawn, which happens whenever new
+        data is sent to the canvas or the camera is moved.
         """
         size = self._parent.camera.rect.size
         pyramid_level = self.compute_pyramid_level(size)

--- a/napari/layers/_pyramid_layer/model.py
+++ b/napari/layers/_pyramid_layer/model.py
@@ -222,14 +222,13 @@ class Pyramid(Image):
         msg : string
             String containing a message that can be used as a status update.
         """
-
         if isinstance(value, np.ndarray):
             if value.dtype == np.int:
                 v_str = str(value)
             else:
                 v_str = '[' + str.join(', ', [f'{v:0.3}' for v in value]) + ']'
         else:
-            if isinstance(value, np.integer):
+            if isinstance(value, np.integer) or isinstance(value, int):
                 v_str = str(value)
             else:
                 v_str = f'{value:0.3}'

--- a/napari/layers/_pyramid_layer/model.py
+++ b/napari/layers/_pyramid_layer/model.py
@@ -1,0 +1,241 @@
+import numpy as np
+from copy import copy
+
+from ...util.event import Event
+
+from .._register import add_to_viewer
+from .._image_layer import Image
+from .._image_layer.view import QtImageLayer
+from .._image_layer.view import QtImageControls
+
+
+@add_to_viewer
+class Pyramid(Image):
+    """Image pyramid layer.
+
+    Parameters
+    ----------
+    pyramid : list
+        List of np.ndarry image data, with base of pyramid at `0`.
+    meta : dict, optional
+        Image metadata.
+    multichannel : bool, optional
+        Whether the image is multichannel. Guesses if None.
+    name : str, keyword-only
+        Name of the layer.
+    clim_range : list | array | None
+        Length two list or array with the default color limit range for the
+        image. If not passed will be calculated as the min and max of the
+        image. Passing a value prevents this calculation which can be useful
+        when working with very large datasets that are dynamically loaded.
+    **kwargs : dict
+        Parameters that will be translated to metadata.
+    """
+
+    def __init__(self, pyramid, meta=None, multichannel=None, *, name=None,
+                 clim_range=None, **kwargs):
+
+        self._pyramid = pyramid
+        self._image_shapes = np.array([im.shape[:2] for im in pyramid])
+        avg_shape = self._image_shapes.max(axis=1)
+        self._image_downsamples = avg_shape[0]/avg_shape
+        self._pyramid_level = len(pyramid)-1
+
+        self._max_tile_shape = np.array([1200, 1200])
+        self._top_left = np.array([0, 0])
+
+        super().__init__(pyramid[self._pyramid_level], meta=meta,
+                         multichannel=multichannel, name=name,
+                         clim_range=clim_range, **kwargs)
+        self.scale = [self._image_downsamples[self._pyramid_level]] * 2
+
+    @property
+    def pyramid(self):
+        """list: List of np.ndarry image data, with base of pyramid at `0`.
+        """
+        return self._pyramid
+
+    @pyramid.setter
+    def pyramid(self, pyramid):
+        self._pyramid = pyramid
+
+        self.refresh()
+
+    @property
+    def pyramid_level(self):
+        """int: Level of pyramid to show, with base of pyramid at `0`.
+        """
+        return self._pyramid_level
+
+    @pyramid_level.setter
+    def pyramid_level(self, level):
+        if self._pyramid_level == level:
+            return
+        self._pyramid_level = level
+        self.scale = [self._image_downsamples[self.pyramid_level]] * 2
+        self._top_left = self.find_top_left()
+        self._update_image_from_pyramid()
+        self._update_coordinates()
+        self.refresh()
+
+    @property
+    def top_left(self):
+        """int: Location of top left pixel.
+        """
+        return self._top_left
+
+    @top_left.setter
+    def top_left(self, top_left):
+        if np.all(self._top_left == top_left):
+            return
+        self._top_left = top_left
+        self._update_image_from_pyramid()
+        self._update_coordinates()
+        self.refresh()
+
+    def _update_image_from_pyramid(self):
+        """Updates the image data from the pyramid based on requested tile
+        and pyramid level
+        """
+        if np.any(self._image_shapes[self.pyramid_level] >
+                  self._max_tile_shape):
+            slices = [slice(self._top_left[i], self._top_left[i] +
+                            self._max_tile_shape[i], 1) for i in range(2)]
+            self._image = self.pyramid[self.pyramid_level][tuple(slices)]
+            self.translate = self._top_left[::-1]*self.scale[:2]
+        else:
+            self._image = self.pyramid[self.pyramid_level]
+            self.translate = [0, 0]
+
+    def _get_shape(self):
+        """Shape of base of pyramid
+
+        Returns
+        ----------
+        shape : np.ndarry
+            Shape of base of pyramid
+        """
+        if self.multichannel:
+            return self.pyramid[0].shape[:-1]
+        return self.pyramid[0].shape
+
+    def get_value(self):
+        """Returns coordinates, values, and a string for a given mouse position
+        and set of indices.
+
+        Returns
+        ----------
+        coord : sequence of int
+            Position of mouse cursor in data.
+        value : int or float or sequence of int or float
+            Value of the data at the coord.
+        msg : string
+            String containing a message that can be used as
+            a status update.
+        """
+        coord = np.round(self.coordinates).astype(int)
+        if self.multichannel:
+            shape = self._image_view.shape[:-1]
+        else:
+            shape = self._image_view.shape
+        coord[-2:] = np.clip(coord[-2:], 0, np.asarray(shape) - 1)
+        value = self._image_view[tuple(coord[-2:])]
+
+
+        pos_in_slice = (self.coordinates[-2:] + self.translate[[1, 0]] / self.scale[:2])
+        # Make sure pos in slice doesn't go off edge
+        shape = self._image_shapes[self._pyramid_level]
+        coord = np.clip(pos_in_slice, 0, np.asarray(shape) - 1)
+        coord = np.round(coord*self.scale[:2]).astype(int)
+
+        #print(pos_in_slice, shape, coord, self.scale[:2])
+
+        return coord, value
+
+    def compute_pyramid_level(self, camera):
+        """Computed what level of the pyramid should be viewed given the
+        current camera position.
+
+        Parameters
+        ----------
+        camera : Camera
+            Vispy PanZoomCamera object.
+
+        Returns
+        ----------
+        level : int
+            Level of the pyramid to be viewing.
+        """
+        size = camera.rect.size
+        level = np.round(np.clip(np.log2(np.array(size).min())-8, 0,
+                                 len(self.pyramid)-1)).astype('int')
+        return level
+
+    def find_top_left(self):
+        """Finds the top left pixel of the canvas. Depends on the current
+        pan and zoom position
+
+        Returns
+        ----------
+        top_left : np.ndarry
+            Length two array with coordinates of top left pixel.
+        """
+
+        # Find image coordinate of top left canvas pixel
+        transform = self._node.canvas.scene.node_transform(self._node)
+        pos = transform.map([0, 0])[:2] + self.translate[:2]/self.scale[:2]
+
+        shape = self._image_shapes[0]
+
+        # Clip according to the max image shape
+        pos = [np.clip(pos[1], 0, shape[0]-1),
+               np.clip(pos[0], 0, shape[1]-1)]
+
+        # Convert to offset for image array
+        top_left = np.array(pos)
+        scale = self._max_tile_shape/4
+        top_left = scale*np.floor(top_left/scale)
+
+        return top_left.astype(int)
+
+    def get_message(self, coord, value):
+        """Generate a status message based on the coordinates and information
+        about what shapes are hovered over
+
+        Parameters
+        ----------
+        coord : sequence of int
+            Position of mouse cursor in image coordinates.
+        value : int or float or sequence of int or float
+            Value of the data at the coord.
+
+        Returns
+        ----------
+        msg : string
+            String containing a message that can be used as a status update.
+        """
+
+        msg = f'{coord}, {self.pyramid_level}, {self.name}' + ', value '
+        if isinstance(value, np.ndarray):
+            if isinstance(value[0], np.integer):
+                msg = msg + str(value)
+            else:
+                v_str = '[' + str.join(', ', [f'{v:0.3}' for v in value]) + ']'
+                msg = msg + v_str
+        else:
+            if isinstance(value, np.integer):
+                msg = msg + str(value)
+            else:
+                msg = msg + f'{value:0.3}'
+
+        return msg
+
+    def on_draw(self, event):
+        """Called whenever the canvas is drawn.
+        """
+        camera = self._parent.camera
+        pyramid_level = self.compute_pyramid_level(camera)
+        if pyramid_level != self.pyramid_level:
+            self.pyramid_level = pyramid_level
+        else:
+            self.top_left = self.find_top_left()

--- a/napari/layers/_pyramid_layer/model.py
+++ b/napari/layers/_pyramid_layer/model.py
@@ -141,9 +141,9 @@ class Pyramid(Image):
         coord[-2:] = np.clip(coord[-2:], 0, np.asarray(shape) - 1)
         value = self._image_view[tuple(coord[-2:])]
 
-
         pos_in_slice = (self.coordinates[-2:] +
                         self.translate[[1, 0]] / self.scale[:2])
+
         # Make sure pos in slice doesn't go off edge
         shape = self._image_shapes[self._pyramid_level]
         coord = np.clip(pos_in_slice, 0, np.asarray(shape) - 1)

--- a/napari/layers/_pyramid_layer/model.py
+++ b/napari/layers/_pyramid_layer/model.py
@@ -99,9 +99,9 @@ class Pyramid(Image):
         """
         if np.any(self._image_shapes[self.pyramid_level] >
                   self._max_tile_shape):
-            slices = [slice(self._top_left[i], self._top_left[i] +
-                            self._max_tile_shape[i], 1) for i in range(2)]
-            self._image = self.pyramid[self.pyramid_level][tuple(slices)]
+            slices = tuple(slice(self._top_left[i], self._top_left[i] +
+                           self._max_tile_shape[i], 1) for i in range(2))
+            self._image = self.pyramid[self.pyramid_level][slices]
             self.translate = self._top_left[::-1]*self.scale[:2]
         else:
             self._image = self.pyramid[self.pyramid_level]
@@ -138,35 +138,35 @@ class Pyramid(Image):
             shape = self._image_view.shape[:-1]
         else:
             shape = self._image_view.shape
-        coord[-2:] = np.clip(coord[-2:], 0, np.asarray(shape) - 1)
+        coord[-2:] = np.clip(coord[-2:], 0, np.subtract(shape, 1))
         value = self._image_view[tuple(coord[-2:])]
 
-        pos_in_slice = (self.coordinates[-2:] +
-                        self.translate[[1, 0]] / self.scale[:2])
+        pos_in_slice = (self.coordinates[-2:]
+                        + self.translate[[1, 0]] / self.scale[:2])
 
         # Make sure pos in slice doesn't go off edge
         shape = self._image_shapes[self._pyramid_level]
-        coord = np.clip(pos_in_slice, 0, np.asarray(shape) - 1)
-        coord = np.round(coord*self.scale[:2]).astype(int)
+        coord = np.clip(pos_in_slice, 0, np.subtract(shape, 1))
+        coord = np.round(coord * self.scale[:2]).astype(int)
 
         return coord, value
 
-    def compute_pyramid_level(self, camera):
+    def compute_pyramid_level(self, size):
         """Computed what level of the pyramid should be viewed given the
-        current camera position.
+        current size of the requested field of view.
 
         Parameters
         ----------
-        camera : Camera
-            Vispy PanZoomCamera object.
+        size : 2-tuple
+            Requested size of field of view in image coordinates
 
         Returns
         ----------
         level : int
             Level of the pyramid to be viewing.
         """
-        # Requested field of view from the camera in log units
-        size = np.log2(np.array(camera.rect.size).max())
+        # Convert requested field of view from the camera into log units
+        size = np.log2(np.max(size))
 
         # Max allowed tile in log units
         max_size = np.log2(self._max_tile_shape.max())
@@ -175,7 +175,7 @@ class Pyramid(Image):
         diff = size - max_size + 1
 
         # Find closed downsample level to diff
-        level = np.argmin(abs(np.log2(self._image_downsamples)-diff))
+        level = np.argmin(abs(np.log2(self._image_downsamples) - diff))
 
         return level
 
@@ -185,19 +185,19 @@ class Pyramid(Image):
 
         Returns
         ----------
-        top_left : np.ndarry
-            Length two array with coordinates of top left pixel.
+        top_left : (2,) int array
+            Coordinates of top left pixel.
         """
 
         # Find image coordinate of top left canvas pixel
         transform = self._node.canvas.scene.node_transform(self._node)
-        pos = transform.map([0, 0])[:2] + self.translate[:2]/self.scale[:2]
+        pos = transform.map([0, 0])[:2] + self.translate[:2] / self.scale[:2]
 
         shape = self._image_shapes[0]
 
         # Clip according to the max image shape
-        pos = [np.clip(pos[1], 0, shape[0]-1),
-               np.clip(pos[0], 0, shape[1]-1)]
+        pos = [np.clip(pos[1], 0, shape[0] - 1),
+               np.clip(pos[0], 0, shape[1] - 1)]
 
         # Convert to offset for image array
         top_left = np.array(pos)
@@ -214,7 +214,7 @@ class Pyramid(Image):
         ----------
         coord : sequence of int
             Position of mouse cursor in image coordinates.
-        value : int or float or sequence of int or float
+        value : int, float, or sequence of int or float
             Value of the data at the coord.
 
         Returns
@@ -223,26 +223,25 @@ class Pyramid(Image):
             String containing a message that can be used as a status update.
         """
 
-        msg = f'{coord}, {self.pyramid_level}, {self.name}' + ', value '
         if isinstance(value, np.ndarray):
-            if isinstance(value[0], np.integer):
-                msg = msg + str(value)
+            if value.dtype == np.int:
+                v_str = str(value)
             else:
                 v_str = '[' + str.join(', ', [f'{v:0.3}' for v in value]) + ']'
-                msg = msg + v_str
         else:
             if isinstance(value, np.integer):
-                msg = msg + str(value)
+                v_str = str(value)
             else:
-                msg = msg + f'{value:0.3}'
+                v_str = f'{value:0.3}'
 
+        msg = f'{coord}, {self.pyramid_level}, {self.name}, value {v_str}'
         return msg
 
     def on_draw(self, event):
         """Called whenever the canvas is drawn.
         """
-        camera = self._parent.camera
-        pyramid_level = self.compute_pyramid_level(camera)
+        size = self._parent.camera.rect.size
+        pyramid_level = self.compute_pyramid_level(size)
         if pyramid_level != self.pyramid_level:
             self.pyramid_level = pyramid_level
         else:

--- a/napari/layers/_shapes_layer/model.py
+++ b/napari/layers/_shapes_layer/model.py
@@ -1147,8 +1147,7 @@ class Shapes(Layer):
         return self.data.to_xml_list(shape_type=shape_type)
 
     def on_mouse_press(self, event):
-        """Called whenever mouse pressed in canvas. Converts the `event.pos`
-        from canvas coordinates to `self.coordinates` in image coordinates.
+        """Called whenever mouse pressed in canvas.
 
         Parameters
         ----------
@@ -1157,7 +1156,7 @@ class Shapes(Layer):
         """
         if event.pos is None:
             return
-        self.coordinates = event.pos
+        self.position = tuple(event.pos)
         coord = self.coordinates[-2:]
         shift = 'Shift' in event.modifiers
 
@@ -1357,8 +1356,7 @@ class Shapes(Layer):
             raise ValueError("Mode not recongnized")
 
     def on_mouse_move(self, event):
-        """Called whenever mouse moves over canvas. Converts the `event.pos`
-        from canvas coordinates to `self.coordinates` in image coordinates.
+        """Called whenever mouse moves over canvas.
 
         Parameters
         ----------
@@ -1367,7 +1365,7 @@ class Shapes(Layer):
         """
         if event.pos is None:
             return
-        self.coordinates = event.pos
+        self.position = tuple(event.pos)
         coord = self.coordinates[-2:]
 
         if self.mode == Mode.PAN_ZOOM:
@@ -1431,8 +1429,7 @@ class Shapes(Layer):
         self.status = self.get_message(coord, shape, vertex)
 
     def on_mouse_release(self, event):
-        """Called whenever mouse released in canvas. Converts the `event.pos`
-        from canvas coordinates to `self.coordinates` in image coordinates.
+        """Called whenever mouse released in canvas.
 
         Parameters
         ----------
@@ -1441,7 +1438,7 @@ class Shapes(Layer):
         """
         if event.pos is None:
             return
-        self.coordinates = event.pos
+        self.position = tuple(event.pos)
         coord = self.coordinates[-2:]
         shift = 'Shift' in event.modifiers
 

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -23,6 +23,7 @@ class Viewer(ViewerModel):
         qt_viewer = QtViewer(self)
         self.window = Window(qt_viewer)
         self.screenshot = self.window.qt_viewer.screenshot
+        self.camera = self.window.qt_viewer.view.camera
         self.theme = 'dark'
 
     @property


### PR DESCRIPTION
# Description
This PR supersedes #211 and address loading multiresolution data as stored in an image pyramid, and discussed in #103.

It does this by creating a new layer type called pyramid that inherits the image layer. It takes a list of images that form the pyramid with the base level at 0. The pyramid need not be based on 2x downsampling, though that is the usecase I have most throughly tested.

I've added an example called `examples/add_pyramid.py` which creates some pyramid data to view in this way. The data created there is quite small, for ease of testing, and must fit in memory. I've also verified that the layer works using zarr / dask arrays and dynamic loading. I'll note that my `zarr` examples with a 100,000 x 200,000 base image has much better performance than the `add_pyramid.py` example though I'm not quite sure why.

This PR is ready for review and I'd like to get it in before more refactoring happens. Also right now it only supports 2D images, but in the future we can make it support nD.

Here's a gif of the included example:

![pyramid_astro](https://user-images.githubusercontent.com/6531703/58376056-3cf1d300-7f16-11e9-9083-39b43b9dc4eb.gif)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] `examples/add_pyramid.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
