### PR TITLE
use stylesheet for styling of range slider

### DIFF
--- a/napari/_qt/range_slider/range_slider.py
+++ b/napari/_qt/range_slider/range_slider.py
@@ -5,8 +5,6 @@ Range slider, extended QWidget slider for napari.
 from qtpy import QtCore, QtGui
 from qtpy.QtWidgets import QWidget
 
-from ...util.misc import str_to_rgb
-
 class QRangeSlider(QWidget):
     """
     QRangeSlider class, super class for QVRangeSlider and QHRangeSlider.
@@ -41,7 +39,12 @@ class QRangeSlider(QWidget):
         self.start_pos = None
         self.display_min = None
         self.display_max = None
-        self.setColors('rgb(100,100,100)', 'rgb(200,200,200)')
+
+        self.setBarColor(QtGui.QColor(200, 200, 200))
+        self.setBackgroundColor(QtGui.QColor(100, 100, 100))
+        self.setHandleColor(QtGui.QColor(200, 200, 200))
+        self.setHandleBorderColor(QtGui.QColor(200, 200, 200))
+
         self.setEnabled(True)
 
         if slider_range:
@@ -258,15 +261,45 @@ class QRangeSlider(QWidget):
         self.updateDisplayValues()
         self.update()
 
-    def setColors(self, background, foreground):
-        self.bar_color = QtGui.QColor(
-            *str_to_rgb(foreground))
-        self.background_color = QtGui.QColor(
-            *str_to_rgb(background))
-        self.handle_color = QtGui.QColor(
-            *str_to_rgb(foreground))
-        self.handle_border_color = QtGui.QColor(
-            *str_to_rgb(foreground))
+    def getBarColor(self):
+        return self.bar_color
+
+    def setBarColor(self, barColor):
+        self.bar_color = barColor
+
+    barColor = QtCore.Property(QtGui.QColor, getBarColor, setBarColor)
+
+    def getBackgroundColor(self):
+        return self.background_color
+
+    def setBackgroundColor(self, backgroundColor):
+        self.background_color = backgroundColor
+
+    backgroundColor = QtCore.Property(
+        QtGui.QColor,
+        getBackgroundColor,
+        setBackgroundColor
+    )
+
+    def getHandleColor(self):
+        return self.handle_color
+
+    def setHandleColor(self, handleColor):
+        self.handle_color = handleColor
+
+    handleColor = QtCore.Property(QtGui.QColor, getHandleColor, setHandleColor)
+
+    def getHandleBorderColor(self):
+        return self.handle_border_color
+
+    def setHandleBorderColor(self, handleBorderColor):
+        self.handle_border_color = handleBorderColor
+
+    handleBorderColor = QtCore.Property(
+        QtGui.QColor,
+        getHandleBorderColor,
+        setHandleBorderColor
+    )
 
     def setEnabled(self, bool):
         if bool:

--- a/napari/components/_viewer/view/main.py
+++ b/napari/components/_viewer/view/main.py
@@ -92,9 +92,6 @@ class QtViewer(QSplitter):
             lambda event: self._update_palette(event.palette)
         )
         self.viewer.layers.events.reordered.connect(self._update_canvas)
-        self.viewer.layers.events.added.connect(
-            lambda e: self._update_palette(viewer.palette)
-        )  # TODO: remove this hack when range slider uses stylesheet
 
     def screenshot(self, region=None, size=None, bgcolor=None):
         """Render the scene to an offscreen buffer and return the image array.
@@ -151,18 +148,6 @@ class QtViewer(QSplitter):
         # template and apply the primary stylesheet
         themed_stylesheet = template(self.raw_stylesheet, **palette)
         self.setStyleSheet(themed_stylesheet)
-
-        # set styles on clim slider
-        for layer in self.viewer.layers:
-            if has_clims(layer):
-                layer._qt_controls.climSlider.setColors(
-                    palette['foreground'],
-                    palette['highlight']
-                )
-
-        # set styles on dims sliders
-        for slider in self.dims.sliders:
-            slider.setColors(palette['foreground'], palette['highlight'])
 
     def on_mouse_move(self, event):
         """Called whenever mouse moves over canvas.

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -1,3 +1,12 @@
+QRangeSlider {
+  qproperty-barColor: {{ highlight }};
+  qproperty-backgroundColor: {{ foreground }};
+  qproperty-handleColor: {{ highlight }};
+  qproperty-handleBorderColor: {{ highlight }};
+}
+
+/* ------------------------------------------------------ */
+
 QWidget {
   background-color: {{ background }};
   border: 0px;


### PR DESCRIPTION
# Description
allows use of stylesheet for styling custom widget `QRangeSlider`

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
- resolves #305 
- https://wiki.qt.io/Qt_Style_Sheets_and_Custom_Painting_Example
- https://wiki.qt.io/Qt_for_Python_UsingQtProperties

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] ran nD_image.py
- [x] ran set_theme.py
- [x] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
