### PR TITLE
Unify layer mode Enums

### DIFF
--- a/examples/add_shapes.py
+++ b/examples/add_shapes.py
@@ -47,6 +47,9 @@ with app_context():
                      opacity=0.75)
     layer.refresh()
 
+    # Set the layer mode with a string
+    layer.mode = 'select'
+
     layer._qt_properties.setExpanded(True)
 
 # Print the shape coordinate data

--- a/examples/labels-2d.py
+++ b/examples/labels-2d.py
@@ -21,4 +21,7 @@ with app_context():
     # we add 1 because SLIC returns labels from 0, which we consider background
     labels = slic(astro, multichannel=True, compactness=20) + 1
     label_layer = viewer.add_labels(labels, name='segmentation')
+
+    # Set the labels layer mode to picker with a string
+    label_layer.mode = 'picker'
     print(f'The color of label 5 is {label_layer.label_color(5)}')

--- a/napari/layers/_labels_layer/_constants.py
+++ b/napari/layers/_labels_layer/_constants.py
@@ -1,8 +1,10 @@
-from enum import Enum
+from enum import auto
 import sys
 
+from ...util.misc import StringEnum
 
-class Mode(Enum):
+
+class Mode(StringEnum):
     """MODE: Interactive mode. The normal, default mode is PAN_ZOOM, which
     allows for normal interactivity with the canvas.
 
@@ -22,10 +24,10 @@ class Mode(Enum):
     pixel. If the background label `0` is selected than any pixels will be
     changed to background and this tool functions like an eraser.
     """
-    PAN_ZOOM = 0
-    PICKER = 1
-    PAINT = 2
-    FILL = 3
+    PAN_ZOOM = auto()
+    PICKER = auto()
+    PAINT = auto()
+    FILL = auto()
 
 
 BACKSPACE = 'delete' if sys.platform == 'darwin' else 'backspace'

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import numpy as np
 from scipy import ndimage as ndi
 from xml.etree.ElementTree import Element
@@ -235,10 +237,14 @@ class Labels(Layer):
         pixels will be changed to background and this tool functions like an
         eraser.
         """
-        return self._mode
+        return str(self._mode)
 
     @mode.setter
-    def mode(self, mode):
+    def mode(self, mode: Union[str, Mode]):
+
+        if isinstance(mode, str):
+            mode = Mode(mode.upper())
+
         if mode == self._mode:
             return
         old_mode = self._mode
@@ -542,18 +548,18 @@ class Labels(Layer):
         self.coordinates = event.pos
         coord, label = self.get_value()
 
-        if self.mode == Mode.PAN_ZOOM:
+        if self._mode == Mode.PAN_ZOOM:
             # If in pan/zoom mode do nothing
             pass
-        elif self.mode == Mode.PICKER:
+        elif self._mode == Mode.PICKER:
             self.selected_label = label
-        elif self.mode == Mode.PAINT:
+        elif self._mode == Mode.PAINT:
             # Start painting with new label
             new_label = self.selected_label
             self.paint(coord, new_label)
             self._last_cursor_coord = coord
             self.status = self.get_message(coord, new_label)
-        elif self.mode == Mode.FILL:
+        elif self._mode == Mode.FILL:
             # Fill clicked on region with new label
             old_label = label
             new_label = self.selected_label
@@ -576,7 +582,7 @@ class Labels(Layer):
         self.coordinates = event.pos
         coord, label = self.get_value()
 
-        if self.mode == Mode.PAINT and event.is_dragging:
+        if self._mode == Mode.PAINT and event.is_dragging:
             new_label = self.selected_label
             if self._last_cursor_coord is None:
                 interp_coord = [coord]
@@ -614,8 +620,8 @@ class Labels(Layer):
             return
         else:
             if event.key == ' ':
-                if self.mode != Mode.PAN_ZOOM:
-                    self._mode_history = self.mode
+                if self._mode != Mode.PAN_ZOOM:
+                    self._mode_history = self._mode
                     self.mode = Mode.PAN_ZOOM
                 else:
                     self._mode_history = Mode.PAN_ZOOM

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -245,7 +245,7 @@ class Labels(Layer):
     def mode(self, mode: Union[str, Mode]):
 
         if isinstance(mode, str):
-            mode = Mode(mode.upper())
+            mode = Mode(mode)
 
         if mode == self._mode:
             return

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -247,7 +247,7 @@ class Labels(Layer):
 
         if mode == self._mode:
             return
-        old_mode = self._mode
+
         if mode == Mode.PAN_ZOOM:
             self.cursor = 'standard'
             self.interactive = True

--- a/napari/layers/_labels_layer/view/controls.py
+++ b/napari/layers/_labels_layer/view/controls.py
@@ -1,7 +1,6 @@
-from qtpy.QtCore import Qt
 from qtpy.QtGui import QPainter, QColor
 from qtpy.QtWidgets import (QButtonGroup, QVBoxLayout, QRadioButton, QFrame,
-                             QPushButton, QWidget)
+                            QWidget)
 
 from .._constants import Mode
 

--- a/napari/layers/_markers_layer/_constants.py
+++ b/napari/layers/_markers_layer/_constants.py
@@ -1,4 +1,20 @@
-from enum import Enum
+from enum import Enum, auto
+
+from ...util.misc import StringEnum
+
+
+class Mode(StringEnum):
+    """
+    Mode: Interactive mode. The normal, default mode is PAN_ZOOM, which
+    allows for normal interactivity with the canvas.
+
+    ADD allows markers to be added by clicking
+
+    SELECT allows the user to select markers by clicking on them
+    """
+    ADD = auto()
+    SELECT = auto()
+    PAN_ZOOM = auto()
 
 
 class Symbol(Enum):

--- a/napari/layers/_markers_layer/model.py
+++ b/napari/layers/_markers_layer/model.py
@@ -259,7 +259,7 @@ class Markers(Layer):
     @mode.setter
     def mode(self, mode):
         if isinstance(mode, str):
-            mode = Mode(mode.upper())
+            mode = Mode(mode)
         if mode == self._mode:
             return
 

--- a/napari/layers/_markers_layer/model.py
+++ b/napari/layers/_markers_layer/model.py
@@ -12,7 +12,7 @@ from vispy.color import get_color_names, Color
 
 from .view import QtMarkersLayer
 from .view import QtMarkersControls
-from ._constants import Symbol, SYMBOL_ALIAS
+from ._constants import Symbol, SYMBOL_ALIAS, Mode
 
 
 @add_to_viewer
@@ -77,7 +77,7 @@ class Markers(Layer):
             self.n_dimensional = n_dimensional
             self._colors = get_color_names()
             self._selected_markers = None
-            self._mode = 'pan/zoom'
+            self._mode = Mode.PAN_ZOOM
             self._mode_history = self._mode
             self._status = self._mode
             self._markers_view = np.empty((0, 2))
@@ -255,32 +255,32 @@ class Markers(Layer):
     def mode(self):
         """None, str: Interactive mode
         """
-        return self._mode
+        return str(self._mode)
 
     @mode.setter
     def mode(self, mode):
-        if mode == self.mode:
+        if isinstance(mode, str):
+            mode = Mode(mode.upper())
+        if mode == self._mode:
             return
-        if mode == 'add':
+
+        if mode == Mode.ADD:
             self.cursor = 'cross'
             self.interactive = False
             self.help = 'hold <space> to pan/zoom'
-            self.status = mode
-            self._mode = mode
-        elif mode == 'select':
+        elif mode == Mode.SELECT:
             self.cursor = 'pointing'
             self.interactive = False
             self.help = 'hold <space> to pan/zoom'
-            self.status = mode
-            self._mode = mode
-        elif mode == 'pan/zoom':
+        elif mode == Mode.PAN_ZOOM:
             self.cursor = 'standard'
             self.interactive = True
             self.help = ''
-            self.status = mode
-            self._mode = mode
         else:
             raise ValueError("Mode not recognized")
+
+        self.status = str(mode)
+        self._mode = mode
 
         self.events.mode(mode=mode)
 
@@ -477,7 +477,7 @@ class Markers(Layer):
             return
         self.coordinates = event.pos
         coord = self.coordinates
-        if self.mode == 'select' and event.is_dragging:
+        if self._mode == Mode.SELECT and event.is_dragging:
             self._move(coord)
         else:
             self._selected_markers = self._select_marker(coord)
@@ -494,7 +494,7 @@ class Markers(Layer):
         self._selected_markers = self._select_marker(coord)
         shift = 'Shift' in event.modifiers
 
-        if self.mode == 'add':
+        if self._mode == Mode.ADD:
             if shift:
                 self._remove()
             else:
@@ -508,26 +508,26 @@ class Markers(Layer):
             return
         else:
             if event.key == ' ':
-                if self.mode != 'pan/zoom':
+                if self._mode != Mode.PAN_ZOOM:
                     self._mode_history = self.mode
-                    self.mode = 'pan/zoom'
+                    self.mode = Mode.PAN_ZOOM
                 else:
-                    self._mode_history = 'pan/zoom'
+                    self._mode_history = Mode.PAN_ZOOM
             elif event.key == 'Shift':
-                if self.mode == 'add':
+                if self._mode == Mode.ADD:
                     self.cursor = 'forbidden'
             elif event.key == 'a':
-                self.mode = 'add'
+                self.mode = Mode.ADD
             elif event.key == 's':
-                self.mode = 'select'
+                self.mode = Mode.SELECT
             elif event.key == 'z':
-                self.mode = 'pan/zoom'
+                self.mode = Mode.PAN_ZOOM
 
     def on_key_release(self, event):
         """Called whenever key released in canvas.
         """
         if event.key == ' ':
-            if self._mode_history != 'pan/zoom':
+            if self._mode_history != Mode.PAN_ZOOM:
                 self.mode = self._mode_history
         elif event.key == 'Shift':
             if self.mode == 'add':

--- a/napari/layers/_markers_layer/model.py
+++ b/napari/layers/_markers_layer/model.py
@@ -2,7 +2,6 @@ from typing import Union
 from xml.etree.ElementTree import Element
 
 import numpy as np
-from copy import copy
 
 from .._base_layer import Layer
 from .._register import add_to_viewer

--- a/napari/layers/_markers_layer/view/controls.py
+++ b/napari/layers/_markers_layer/view/controls.py
@@ -2,6 +2,8 @@ from qtpy.QtCore import Qt
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QButtonGroup, QVBoxLayout, QRadioButton, QFrame
 
+from .._constants import Mode
+
 
 class QtMarkersControls(QFrame):
     def __init__(self, layer):
@@ -33,11 +35,11 @@ class QtMarkersControls(QFrame):
 
     def set_mode(self, event):
         mode = event.mode
-        if mode == 'add':
+        if mode == Mode.ADD:
             self.addition_button.setChecked(True)
-        elif mode == 'select':
+        elif mode == Mode.SELECT:
             self.select_button.setChecked(True)
-        elif mode == 'pan/zoom':
+        elif mode == Mode.PAN_ZOOM:
             self.panzoom_button.setChecked(True)
         else:
             raise ValueError("Mode not recongnized")
@@ -56,7 +58,7 @@ class QtPanZoomButton(QRadioButton):
     def _set_mode(self, bool):
         with self.layer.events.mode.blocker():
             if bool:
-                self.layer.mode = 'pan/zoom'
+                self.layer.mode = Mode.PAN_ZOOM
 
 
 class QtSelectButton(QRadioButton):
@@ -72,7 +74,7 @@ class QtSelectButton(QRadioButton):
     def _set_mode(self, bool):
         with self.layer.events.mode.blocker():
             if bool:
-                self.layer.mode = 'select'
+                self.layer.mode = Mode.SELECT
 
 
 class QtAdditionButton(QRadioButton):
@@ -88,4 +90,4 @@ class QtAdditionButton(QRadioButton):
     def _set_mode(self, bool):
         with self.layer.events.mode.blocker():
             if bool:
-                self.layer.mode = 'add'
+                self.layer.mode = Mode.ADD

--- a/napari/layers/_markers_layer/view/controls.py
+++ b/napari/layers/_markers_layer/view/controls.py
@@ -1,5 +1,3 @@
-from qtpy.QtCore import Qt
-from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QButtonGroup, QVBoxLayout, QRadioButton, QFrame
 
 from .._constants import Mode

--- a/napari/layers/_shapes_layer/_constants.py
+++ b/napari/layers/_shapes_layer/_constants.py
@@ -1,8 +1,9 @@
-from enum import Enum
+from enum import auto
 import sys
 
+from ...util.misc import StringEnum
 
-class Mode(Enum):
+class Mode(StringEnum):
     """Mode: Interactive mode. The normal, default mode is PAN_ZOOM, which
     allows for normal interactivity with the canvas.
 
@@ -19,16 +20,16 @@ class Mode(Enum):
     The ADD_RECTANGLE, ADD_ELLIPSE, ADD_LINE, ADD_PATH, and ADD_POLYGON
     modes all allow for their corresponding shape type to be added.
     """
-    PAN_ZOOM = 0
-    SELECT = 1
-    DIRECT = 2
-    ADD_RECTANGLE = 3
-    ADD_ELLIPSE = 4
-    ADD_LINE = 5
-    ADD_PATH = 6
-    ADD_POLYGON = 7
-    VERTEX_INSERT = 8
-    VERTEX_REMOVE = 9
+    PAN_ZOOM = auto()
+    SELECT = auto()
+    DIRECT = auto()
+    ADD_RECTANGLE = auto()
+    ADD_ELLIPSE = auto()
+    ADD_LINE = auto()
+    ADD_PATH = auto()
+    ADD_POLYGON = auto()
+    VERTEX_INSERT = auto()
+    VERTEX_REMOVE = auto()
 
 class Box():
     """Box: Constants associated with the vertices of the interaction box

--- a/napari/layers/_shapes_layer/_constants.py
+++ b/napari/layers/_shapes_layer/_constants.py
@@ -3,6 +3,7 @@ import sys
 
 from ...util.misc import StringEnum
 
+
 class Mode(StringEnum):
     """Mode: Interactive mode. The normal, default mode is PAN_ZOOM, which
     allows for normal interactivity with the canvas.

--- a/napari/layers/_shapes_layer/model.py
+++ b/napari/layers/_shapes_layer/model.py
@@ -238,7 +238,7 @@ class Shapes(Layer):
 
             self._mode = Mode.PAN_ZOOM
             self._mode_history = self._mode
-            self._status = str(self._mode)
+            self._status = self.mode
             self._help = 'enter a selection mode to edit shape properties'
 
             self.events.add(mode=Event,
@@ -388,10 +388,13 @@ class Shapes(Layer):
         The ADD_RECTANGLE, ADD_ELLIPSE, ADD_LINE, ADD_PATH, and ADD_POLYGON
         modes all allow for their corresponding shape type to be added.
         """
-        return self._mode
+        return str(self._mode)
 
     @mode.setter
     def mode(self, mode):
+        if isinstance(mode, str):
+            mode = Mode(mode.upper())
+
         if mode == self._mode:
             return
         old_mode = self._mode
@@ -647,7 +650,7 @@ class Shapes(Layer):
             Width of the box edge
         """
         if len(self.selected_shapes) > 0:
-            if self.mode == Mode.SELECT:
+            if self._mode == Mode.SELECT:
                 # If in select mode just show the interaction boudning box
                 # including its vertices and the rotation handle
                 box = self._selected_box[Box.WITH_HANDLE]
@@ -663,7 +666,7 @@ class Shapes(Layer):
                 # the line around the edge
                 pos = box[Box.LINE_HANDLE][:, ::-1]
                 width = 1.5
-            elif self.mode in ([Mode.DIRECT, Mode.ADD_PATH, Mode.ADD_POLYGON,
+            elif self._mode in ([Mode.DIRECT, Mode.ADD_PATH, Mode.ADD_POLYGON,
                                 Mode.ADD_RECTANGLE, Mode.ADD_ELLIPSE,
                                 Mode.ADD_LINE, Mode.VERTEX_INSERT,
                                 Mode.VERTEX_REMOVE]):
@@ -671,7 +674,7 @@ class Shapes(Layer):
                 inds = np.isin(self.data._index, self.selected_shapes)
                 vertices = self.data._vertices[inds][:, ::-1]
                 # If currently adding path don't show box over last vertex
-                if self.mode == Mode.ADD_PATH:
+                if self._mode == Mode.ADD_PATH:
                     vertices = vertices[:-1]
 
                 if self._hover_shape is None:
@@ -762,13 +765,13 @@ class Shapes(Layer):
         self._moving_vertex = None
         self._hover_shape = None
         self._hover_vertex = None
-        if self._is_creating is True and self.mode == Mode.ADD_PATH:
+        if self._is_creating is True and self._mode == Mode.ADD_PATH:
             vertices = self.data._vertices[self.data._index == index]
             if len(vertices) <= 2:
                 self.data.remove(index)
             else:
                 self.data.edit(index, vertices[:-1])
-        if self._is_creating is True and self.mode == Mode.ADD_POLYGON:
+        if self._is_creating is True and self._mode == Mode.ADD_POLYGON:
             vertices = self.data._vertices[self.data._index == index]
             if len(vertices) <= 2:
                 self.data.remove(index)
@@ -864,7 +867,7 @@ class Shapes(Layer):
         """
         # Check selected shapes
         if len(self.selected_shapes) > 0:
-            if self.mode == Mode.SELECT:
+            if self._mode == Mode.SELECT:
                 # Check if inside vertex of interaction box or rotation handle
                 box = self._selected_box[Box.WITH_HANDLE]
                 distances = abs(box - coord[:2])
@@ -876,7 +879,7 @@ class Shapes(Layer):
                 matches = np.all(distances <= sizes, axis=1).nonzero()
                 if len(matches[0]) > 0:
                     return self.selected_shapes[0], matches[0][-1]
-            elif self.mode in ([Mode.DIRECT, Mode.VERTEX_INSERT,
+            elif self._mode in ([Mode.DIRECT, Mode.VERTEX_INSERT,
                                 Mode.VERTEX_REMOVE]):
                 # Check if inside vertex of shape
                 inds = np.isin(self.data._index, self.selected_shapes)
@@ -969,8 +972,8 @@ class Shapes(Layer):
             Position of mouse cursor in image coordinates.
         """
         vertex = self._moving_vertex
-        if self.mode in ([Mode.SELECT, Mode.ADD_RECTANGLE, Mode.ADD_ELLIPSE,
-                         Mode.ADD_LINE]):
+        if self._mode in ([Mode.SELECT, Mode.ADD_RECTANGLE, Mode.ADD_ELLIPSE,
+                          Mode.ADD_LINE]):
             if len(self.selected_shapes) > 0:
                 self._is_moving = True
                 if vertex is None:
@@ -1091,7 +1094,7 @@ class Shapes(Layer):
                     self._drag_start = coord
                 self._drag_box = np.array([self._drag_start, coord])
                 self._set_highlight()
-        elif self.mode in [Mode.DIRECT, Mode.ADD_PATH, Mode.ADD_POLYGON]:
+        elif self._mode in [Mode.DIRECT, Mode.ADD_PATH, Mode.ADD_POLYGON]:
             if len(self.selected_shapes) > 0:
                 if vertex is not None:
                     self._is_moving = True
@@ -1118,7 +1121,7 @@ class Shapes(Layer):
                     self._drag_start = coord
                 self._drag_box = np.array([self._drag_start, coord])
                 self._set_highlight()
-        elif self.mode in [Mode.VERTEX_INSERT, Mode.VERTEX_REMOVE]:
+        elif self._mode in [Mode.VERTEX_INSERT, Mode.VERTEX_REMOVE]:
             if len(self.selected_shapes) > 0:
                 pass
             else:
@@ -1161,10 +1164,10 @@ class Shapes(Layer):
         coord = self.coordinates[-2:]
         shift = 'Shift' in event.modifiers
 
-        if self.mode == Mode.PAN_ZOOM:
+        if self._mode == Mode.PAN_ZOOM:
             # If in pan/zoom mode do nothing
             pass
-        elif self.mode in [Mode.SELECT, Mode.DIRECT]:
+        elif self._mode in [Mode.SELECT, Mode.DIRECT]:
             if not self._is_moving and not self._is_selecting:
                 shape, vertex = self._shape_at(coord)
                 self._moving_shape = shape
@@ -1186,18 +1189,18 @@ class Shapes(Layer):
                         self.selected_shapes = []
                 self._set_highlight()
                 self.status = self.get_message(coord, shape, vertex)
-        elif self.mode in ([Mode.ADD_RECTANGLE, Mode.ADD_ELLIPSE,
+        elif self._mode in ([Mode.ADD_RECTANGLE, Mode.ADD_ELLIPSE,
                             Mode.ADD_LINE]):
             # Start drawing a rectangle / ellipse / line
             size = self._vertex_size * self.scale_factor / 4
             new_z_index = max(self.data._z_index, default=-1) + 1
-            if self.mode == Mode.ADD_RECTANGLE:
+            if self._mode == Mode.ADD_RECTANGLE:
                 data = np.array([coord, coord+size])
                 shape_type = 'rectangle'
-            elif self.mode == Mode.ADD_ELLIPSE:
+            elif self._mode == Mode.ADD_ELLIPSE:
                 data = np.array([coord+size / 2, [size, size]])
                 shape_type = 'ellipse'
-            elif self.mode == Mode.ADD_LINE:
+            elif self._mode == Mode.ADD_LINE:
                 data = np.array([coord, coord+size])
                 shape_type = 'line'
             self.add_shapes(data, shape_type=shape_type,
@@ -1214,7 +1217,7 @@ class Shapes(Layer):
             self._is_creating = True
             self._set_highlight()
             self.refresh()
-        elif self.mode in [Mode.ADD_PATH, Mode.ADD_POLYGON]:
+        elif self._mode in [Mode.ADD_PATH, Mode.ADD_POLYGON]:
             if self._is_creating is False:
                 # Start drawing a path
                 data = np.array([coord, coord])
@@ -1236,7 +1239,7 @@ class Shapes(Layer):
             else:
                 # Add to an existing path or polygon
                 index = self._moving_shape
-                if self.mode == Mode.ADD_POLYGON:
+                if self._mode == Mode.ADD_POLYGON:
                     new_type = Polygon
                 else:
                     new_type = None
@@ -1249,7 +1252,7 @@ class Shapes(Layer):
                 self._selected_box = self.interaction_box(self.selected_shapes)
             self.status = self.get_message(coord, self._hover_shape,
                                            self._hover_vertex)
-        elif self.mode == Mode.VERTEX_INSERT:
+        elif self._mode == Mode.VERTEX_INSERT:
             if len(self.selected_shapes) == 0:
                 # If none selected return immediately
                 return
@@ -1310,7 +1313,7 @@ class Shapes(Layer):
             self._hover_vertex = vertex
             self.refresh()
             self.status = self.get_message(coord, shape, vertex)
-        elif self.mode == Mode.VERTEX_REMOVE:
+        elif self._mode == Mode.VERTEX_REMOVE:
             shape, vertex = self._shape_at(coord)
             if vertex is not None:
                 # have clicked on a current vertex so remove
@@ -1370,10 +1373,10 @@ class Shapes(Layer):
         self.coordinates = event.pos
         coord = self.coordinates[-2:]
 
-        if self.mode == Mode.PAN_ZOOM:
+        if self._mode == Mode.PAN_ZOOM:
             # If in pan/zoom mode just look at coord all
             shape, vertex = self._shape_at(coord)
-        elif self.mode == Mode.SELECT:
+        elif self._mode == Mode.SELECT:
             if event.is_dragging:
                 # Drag any selected shapes
                 self._move(coord)
@@ -1387,7 +1390,7 @@ class Shapes(Layer):
                 self._set_highlight()
             shape = self._hover_shape
             vertex = self._hover_vertex
-        elif self.mode == Mode.DIRECT:
+        elif self._mode == Mode.DIRECT:
             if event.is_dragging:
                 # Drag any selected shapes
                 self._move(coord)
@@ -1401,7 +1404,7 @@ class Shapes(Layer):
                 self._set_highlight()
             shape = self._hover_shape
             vertex = self._hover_vertex
-        elif self.mode in ([Mode.ADD_RECTANGLE, Mode.ADD_ELLIPSE,
+        elif self._mode in ([Mode.ADD_RECTANGLE, Mode.ADD_ELLIPSE,
                             Mode.ADD_LINE]):
             # While drawing a shape or doing nothing
             if self._is_creating and event.is_dragging:
@@ -1411,7 +1414,7 @@ class Shapes(Layer):
                 vertex = self._hover_vertex
             else:
                 shape, vertex = self._shape_at(coord)
-        elif self.mode in [Mode.ADD_PATH, Mode.ADD_POLYGON]:
+        elif self._mode in [Mode.ADD_PATH, Mode.ADD_POLYGON]:
             # While drawing a path or doing nothing
             if self._is_creating:
                 # Drag any selected shapes
@@ -1420,7 +1423,7 @@ class Shapes(Layer):
                 vertex = self._hover_vertex
             else:
                 shape, vertex = self._shape_at(coord)
-        elif self.mode in [Mode.VERTEX_INSERT, Mode.VERTEX_REMOVE]:
+        elif self._mode in [Mode.VERTEX_INSERT, Mode.VERTEX_REMOVE]:
             self._hover_shape, self._hover_vertex = self._shape_at(coord)
             self._set_highlight()
             shape = self._hover_shape
@@ -1445,10 +1448,10 @@ class Shapes(Layer):
         coord = self.coordinates[-2:]
         shift = 'Shift' in event.modifiers
 
-        if self.mode == Mode.PAN_ZOOM:
+        if self._mode == Mode.PAN_ZOOM:
             # If in pan/zoom mode do nothing
             pass
-        elif self.mode == Mode.SELECT:
+        elif self._mode == Mode.SELECT:
             shape, vertex = self._shape_at(coord)
             if not self._is_moving and not self._is_selecting and not shift:
                 if shape is not None:
@@ -1469,7 +1472,7 @@ class Shapes(Layer):
             self._hover_vertex = shape
             self._set_highlight()
             self.status = self.get_message(coord, shape, vertex)
-        elif self.mode == Mode.DIRECT:
+        elif self._mode == Mode.DIRECT:
             shape, vertex = self._shape_at(coord)
             if not self._is_moving and not self._is_selecting and not shift:
                 if shape is not None:
@@ -1490,12 +1493,12 @@ class Shapes(Layer):
             self._hover_vertex = shape
             self._set_highlight()
             self.status = self.get_message(coord, shape, vertex)
-        elif self.mode in ([Mode.ADD_RECTANGLE, Mode.ADD_ELLIPSE,
+        elif self._mode in ([Mode.ADD_RECTANGLE, Mode.ADD_ELLIPSE,
                             Mode.ADD_LINE]):
             self._finish_drawing()
             shape, vertex = self._shape_at(coord)
             self.status = self.get_message(coord, shape, vertex)
-        elif self.mode in ([Mode.ADD_PATH, Mode.ADD_POLYGON,
+        elif self._mode in ([Mode.ADD_PATH, Mode.ADD_POLYGON,
                             Mode.VERTEX_INSERT, Mode.VERTEX_REMOVE]):
             pass
         else:
@@ -1513,8 +1516,8 @@ class Shapes(Layer):
             return
         else:
             if event.key == ' ':
-                if self.mode != Mode.PAN_ZOOM:
-                    self._mode_history = self.mode
+                if self._mode != Mode.PAN_ZOOM:
+                    self._mode_history = self._mode
                     self._selected_shapes_history = copy(self.selected_shapes)
                     self.mode = Mode.PAN_ZOOM
                 else:
@@ -1553,13 +1556,13 @@ class Shapes(Layer):
             elif event.key == 'x':
                 self.mode = Mode.VERTEX_REMOVE
             elif event.key == 'c' and 'Control' in event.modifiers:
-                if self.mode in [Mode.DIRECT, Mode.SELECT]:
+                if self._mode in [Mode.DIRECT, Mode.SELECT]:
                     self._copy_shapes()
             elif event.key == 'v' and 'Control' in event.modifiers:
                 if self.mode in [Mode.DIRECT, Mode.SELECT]:
                     self._paste_shapes()
             elif event.key == 'a':
-                if self.mode in [Mode.DIRECT, Mode.SELECT]:
+                if self._mode in [Mode.DIRECT, Mode.SELECT]:
                     self.selected_shapes = list(range(len(self.data.shapes)))
                     self._set_highlight()
             elif event.key == 'Backspace':

--- a/napari/layers/_shapes_layer/model.py
+++ b/napari/layers/_shapes_layer/model.py
@@ -394,7 +394,7 @@ class Shapes(Layer):
     @mode.setter
     def mode(self, mode):
         if isinstance(mode, str):
-            mode = Mode(mode.upper())
+            mode = Mode(mode)
 
         if mode == self._mode:
             return

--- a/napari/layers/_shapes_layer/view/controls.py
+++ b/napari/layers/_shapes_layer/view/controls.py
@@ -1,7 +1,5 @@
-from qtpy.QtCore import Qt
-from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (QButtonGroup, QVBoxLayout, QRadioButton, QFrame,
-                             QPushButton)
+                            QPushButton)
 
 from .._constants import Mode
 

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -47,7 +47,7 @@ def is_iterable(arg, color=False):
     elif np.isscalar(arg):
         return False
     elif color and isinstance(arg, (list, np.ndarray)):
-        if np.array(arg).ndim == 1 and (len(arg) == 3 or len(arg)==4):
+        if np.array(arg).ndim == 1 and (len(arg) == 3 or len(arg) == 4):
             return False
         else:
             return True
@@ -218,6 +218,13 @@ class StringEnum(Enum):
         """ autonaming function assigns each value its own name as a value
         """
         return name
+
+    @classmethod
+    def _missing_(cls, value):
+        """ function called with provided value does not match any of the class
+           member values. This function tries again with an upper case string.
+        """
+        return cls(value.upper())
 
     def __str__(self):
         """String representation: The string method returns the

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -212,11 +212,13 @@ def segment_normal_vector(a, b):
         unit_norm = normal/norm
     return unit_norm
 
+
 class StringEnum(Enum):
     def _generate_next_value_(name, start, count, last_values):
         """ autonaming function assigns each value its own name as a value
         """
         return name
+
     def __str__(self):
         """String representation: The string method returns the
         valid vispy symbol string for the Markers visual.

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -1,5 +1,6 @@
 """Miscellaneous utility functions.
 """
+from enum import Enum
 import re
 import numpy as np
 import inspect
@@ -210,3 +211,14 @@ def segment_normal_vector(a, b):
     else:
         unit_norm = normal/norm
     return unit_norm
+
+class StringEnum(Enum):
+    def _generate_next_value_(name, start, count, last_values):
+        """ autonaming function assigns each value its own name as a value
+        """
+        return name
+    def __str__(self):
+        """String representation: The string method returns the
+        valid vispy symbol string for the Markers visual.
+        """
+        return self.value

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -230,4 +230,4 @@ class StringEnum(Enum):
         """String representation: The string method returns the
         valid vispy symbol string for the Markers visual.
         """
-        return self.value
+        return self.value.lower()

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -219,12 +219,11 @@ class StringEnum(Enum):
         """
         return name.lower()
 
-    @classmethod
-    def _missing_(cls, value):
+    def _missing_(self, value):
         """ function called with provided value does not match any of the class
            member values. This function tries again with an upper case string.
         """
-        return cls(value.lower())
+        return self(value.lower())
 
     def __str__(self):
         """String representation: The string method returns the

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -217,17 +217,17 @@ class StringEnum(Enum):
     def _generate_next_value_(name, start, count, last_values):
         """ autonaming function assigns each value its own name as a value
         """
-        return name
+        return name.lower()
 
     @classmethod
     def _missing_(cls, value):
         """ function called with provided value does not match any of the class
            member values. This function tries again with an upper case string.
         """
-        return cls(value.upper())
+        return cls(value.lower())
 
     def __str__(self):
         """String representation: The string method returns the
         valid vispy symbol string for the Markers visual.
         """
-        return self.value.lower()
+        return self.value


### PR DESCRIPTION
# Description
As discussed in #265, this PR unifies the layer mode variables. All layer mode variables are now Enums. The mode property can now be set with a string and returns a string. I made the following changes:
- Created a `StringEnum` class that automatically assigns members the string of their name as a value per the [example recommended by @kne42](https://docs.python.org/3/library/enum.html#using-automatic-values) .
- `Labels`: Change the `Labels.mode` setter and property to  accept/return strings.
- `Markers`: Change `Markers.mode` to an Enum. Keep the string-based property and setter.
- `Shapes`: Change the `Shapes.mode` setter and property to  accept/return strings.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
This is the first PR in #265 .

# How has this been tested?
- [x] labels: ran `labels-2d.py` and added mode setting with a string.
- [x] shapes: ran `add_shapes.py` and added mode setting with a string.
- [x] markers: ran `add_markers.py` and added mode setting with a string.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
