### PR TITLE
Thumbnails

### DIFF
--- a/napari/components/_layers_list/model.py
+++ b/napari/components/_layers_list/model.py
@@ -20,7 +20,7 @@ def _remove(event):
     layers = event.source
     layer = event.item
     layer._order = 0
-    layer._view = None
+    layer._parent = None
 
 
 def _reorder(event):

--- a/napari/components/_layers_list/model.py
+++ b/napari/components/_layers_list/model.py
@@ -20,7 +20,7 @@ def _remove(event):
     layers = event.source
     layer = event.item
     layer._order = 0
-    layer._parent = None
+    layer._view = None
 
 
 def _reorder(event):

--- a/napari/components/_layers_list/view/main.py
+++ b/napari/components/_layers_list/view/main.py
@@ -75,7 +75,8 @@ class QtLayersList(QScrollArea):
         # Layers Widget itself and should be ignored.
         widget = self.childAt(event.pos())
         layer = (getattr(widget, 'layer', None) or
-                 getattr(widget.parentWidget(), 'layer', None))
+                 getattr(widget.parentWidget(), 'layer', None) or
+                 getattr(widget.parentWidget().parentWidget(), 'layer', None))
 
         if layer is not None:
             self.drag_start_position = event.pos()

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -63,11 +63,14 @@ class Layer(VisualWrapper, ABC):
         self._indices = (0, 0)
         self._position = (0, 0)
         self.coordinates = (0, 0)
+        self._thumbnail_shape = (28, 28, 4)
+        self._thumbnail = np.zeros(self._thumbnail_shape, dtype=np.uint8)
         self._name = ''
         self.events.add(select=Event,
                         deselect=Event,
                         data=Event,
                         name=Event,
+                        thumbnail=Event,
                         status=Event,
                         help=Event,
                         interactive=Event,
@@ -154,6 +157,19 @@ class Layer(VisualWrapper, ABC):
     @abstractmethod
     def _get_shape(self):
         raise NotImplementedError()
+
+    @property
+    def thumbnail(self):
+        """np.ndarray: Integer array of thumbnail for the layer
+        """
+        return self._thumbnail
+
+    @thumbnail.setter
+    def thumbnail(self, thumbnail):
+        if thumbnail == self.thumbnail:
+            return
+        self._thumbnail = thumbnail
+        self.events.thumbnail()
 
     @property
     def ndim(self):

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -63,7 +63,7 @@ class Layer(VisualWrapper, ABC):
         self._indices = (0, 0)
         self._position = (0, 0)
         self.coordinates = (0, 0)
-        self._thumbnail_shape = (28, 28, 4)
+        self._thumbnail_shape = (28, 28, 3)
         self._thumbnail = np.zeros(self._thumbnail_shape, dtype=np.uint8)
         self._name = ''
         self.events.add(select=Event,
@@ -166,8 +166,6 @@ class Layer(VisualWrapper, ABC):
 
     @thumbnail.setter
     def thumbnail(self, thumbnail):
-        if thumbnail == self.thumbnail:
-            return
         self._thumbnail = thumbnail
         self.events.thumbnail()
 

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -63,7 +63,7 @@ class Layer(VisualWrapper, ABC):
         self._indices = (0, 0)
         self._position = (0, 0)
         self.coordinates = (0, 0)
-        self._thumbnail_shape = (28, 28, 3)
+        self._thumbnail_shape = (32, 32, 4)
         self._thumbnail = np.zeros(self._thumbnail_shape, dtype=np.uint8)
         self._name = ''
         self.events.add(select=Event,

--- a/napari/layers/_base_layer/view/properties.py
+++ b/napari/layers/_base_layer/view/properties.py
@@ -33,8 +33,8 @@ class QtLayer(QFrame):
         tb = QLabel(self)
         tb.setObjectName('thumbmnail')
         tb.setToolTip('Layer thumbmnail')
-        image = QImage(self.layer.thumbnail, self.layer._thumbnail_shape[0],
-                       self.layer._thumbnail_shape[1], QImage.Format_RGB888)
+        image = QImage(self.layer.thumbnail, self.layer.thumbnail.shape[0],
+                       self.layer.thumbnail.shape[1], QImage.Format_RGB888)
         tb.setPixmap(QPixmap.fromImage(image))
         self.thumbnail_label = tb
         self.grid_layout.addWidget(tb, 0, 1, 1, 1)
@@ -162,6 +162,6 @@ class QtLayer(QFrame):
             self.visibleCheckBox.setChecked(self.layer.visible)
 
     def _on_thumbnail_change(self, event):
-        image = QImage(self.layer.thumbnail, self.layer._thumbnail_shape[0],
-                       self.layer._thumbnail_shape[1], QImage.Format_RGB888)
+        image = QImage(self.layer.thumbnail, self.layer.thumbnail.shape[0],
+                       self.layer.thumbnail.shape[1], QImage.Format_RGB888)
         self.thumbnail_label.setPixmap(QPixmap.fromImage(image))

--- a/napari/layers/_base_layer/view/properties.py
+++ b/napari/layers/_base_layer/view/properties.py
@@ -38,7 +38,7 @@ class QtLayer(QFrame):
                        self.layer.thumbnail.shape[0], QImage.Format_RGBA8888)
         tb.setPixmap(QPixmap.fromImage(image))
         self.thumbnail_label = tb
-        self.grid_layout.addWidget(tb, 0, 1, 1, 1)
+        self.grid_layout.addWidget(tb, 0, 1, 1, 1, Qt.AlignLeft)
 
         textbox = QLineEdit(self)
         textbox.setText(layer.name)

--- a/napari/layers/_base_layer/view/properties.py
+++ b/napari/layers/_base_layer/view/properties.py
@@ -20,6 +20,7 @@ class QtLayer(QFrame):
         self.setObjectName('layer')
 
         self.grid_layout = QGridLayout()
+        self.setContentsMargins(0, 0, 0, 0)
 
         cb = QCheckBox(self)
         cb.setObjectName('visibility')
@@ -34,7 +35,7 @@ class QtLayer(QFrame):
         tb.setObjectName('thumbmnail')
         tb.setToolTip('Layer thumbmnail')
         image = QImage(self.layer.thumbnail, self.layer.thumbnail.shape[0],
-                       self.layer.thumbnail.shape[1], QImage.Format_RGB888)
+                       self.layer.thumbnail.shape[1], QImage.Format_RGBA8888)
         tb.setPixmap(QPixmap.fromImage(image))
         self.thumbnail_label = tb
         self.grid_layout.addWidget(tb, 0, 1, 1, 1)
@@ -128,10 +129,10 @@ class QtLayer(QFrame):
         if bool:
             self.expanded = True
             rows = self.grid_layout.rowCount()
-            self.setFixedHeight(55*(rows-1))
+            self.setFixedHeight(60*(rows-1) - 50)
         else:
             self.expanded = False
-            self.setFixedHeight(55)
+            self.setFixedHeight(60)
         rows = self.grid_layout.rowCount()
         for i in range(1, rows):
             for j in range(4):
@@ -163,5 +164,5 @@ class QtLayer(QFrame):
 
     def _on_thumbnail_change(self, event):
         image = QImage(self.layer.thumbnail, self.layer.thumbnail.shape[0],
-                       self.layer.thumbnail.shape[1], QImage.Format_RGB888)
+                       self.layer.thumbnail.shape[1], QImage.Format_RGBA8888)
         self.thumbnail_label.setPixmap(QPixmap.fromImage(image))

--- a/napari/layers/_base_layer/view/properties.py
+++ b/napari/layers/_base_layer/view/properties.py
@@ -34,10 +34,8 @@ class QtLayer(QFrame):
         tb = QLabel(self)
         tb.setObjectName('thumbmnail')
         tb.setToolTip('Layer thumbmnail')
-        image = QImage(self.layer.thumbnail, self.layer.thumbnail.shape[1],
-                       self.layer.thumbnail.shape[0], QImage.Format_RGBA8888)
-        tb.setPixmap(QPixmap.fromImage(image))
         self.thumbnail_label = tb
+        self._on_thumbnail_change(None)
         self.grid_layout.addWidget(tb, 0, 1, 1, 1, Qt.AlignLeft)
 
         textbox = QLineEdit(self)
@@ -164,6 +162,8 @@ class QtLayer(QFrame):
             self.visibleCheckBox.setChecked(self.layer.visible)
 
     def _on_thumbnail_change(self, event):
-        image = QImage(self.layer.thumbnail, self.layer.thumbnail.shape[1],
-                       self.layer.thumbnail.shape[0], QImage.Format_RGBA8888)
+        thumbnail = self.layer.thumbnail
+        # Note that QImage expects the image width followed by height
+        image = QImage(thumbnail, thumbnail.shape[1], thumbnail.shape[0],
+                       QImage.Format_RGBA8888)
         self.thumbnail_label.setPixmap(QPixmap.fromImage(image))

--- a/napari/layers/_base_layer/view/properties.py
+++ b/napari/layers/_base_layer/view/properties.py
@@ -34,8 +34,8 @@ class QtLayer(QFrame):
         tb = QLabel(self)
         tb.setObjectName('thumbmnail')
         tb.setToolTip('Layer thumbmnail')
-        image = QImage(self.layer.thumbnail, self.layer.thumbnail.shape[0],
-                       self.layer.thumbnail.shape[1], QImage.Format_RGBA8888)
+        image = QImage(self.layer.thumbnail, self.layer.thumbnail.shape[1],
+                       self.layer.thumbnail.shape[0], QImage.Format_RGBA8888)
         tb.setPixmap(QPixmap.fromImage(image))
         self.thumbnail_label = tb
         self.grid_layout.addWidget(tb, 0, 1, 1, 1)
@@ -134,8 +134,9 @@ class QtLayer(QFrame):
             self.expanded = False
             self.setFixedHeight(60)
         rows = self.grid_layout.rowCount()
+        columns = self.grid_layout.columnCount()
         for i in range(1, rows):
-            for j in range(4):
+            for j in range(columns):
                 item = self.grid_layout.itemAtPosition(i, j)
                 if item is not None:
                     if self.expanded:
@@ -163,6 +164,6 @@ class QtLayer(QFrame):
             self.visibleCheckBox.setChecked(self.layer.visible)
 
     def _on_thumbnail_change(self, event):
-        image = QImage(self.layer.thumbnail, self.layer.thumbnail.shape[0],
-                       self.layer.thumbnail.shape[1], QImage.Format_RGBA8888)
+        image = QImage(self.layer.thumbnail, self.layer.thumbnail.shape[1],
+                       self.layer.thumbnail.shape[0], QImage.Format_RGBA8888)
         self.thumbnail_label.setPixmap(QPixmap.fromImage(image))

--- a/napari/layers/_image_layer/model.py
+++ b/napari/layers/_image_layer/model.py
@@ -338,23 +338,24 @@ class Image(Layer):
         zoom_factor = np.divide(self._thumbnail_shape[:2],
                                 self._image_view.shape[:2]).min()
         if self.multichannel:
-            zoomed = ndi.zoom(self._image_view, (zoom_factor, zoom_factor, 1),
-                              prefilter=False, order=0)
+            downsampled = ndi.zoom(self._image_view,
+                                   (zoom_factor, zoom_factor, 1),
+                                   prefilter=False, order=0)
             if self._image_view.shape[2] == 4:
-                mapped = zoomed
+                mapped = downsampled
             else:
-                ones = 255 * np.ones(list(zoomed.shape[:2]) + [1])
-                mapped = np.concatenate([zoomed, ones], axis=2)
+                ones = 255 * np.ones(list(downsampled.shape[:2]) + [1])
+                mapped = np.concatenate([downsampled, ones], axis=2)
         else:
-            zoomed = ndi.zoom(self._image_view, zoom_factor,
-                              prefilter=False, order=0)
+            downsampled = ndi.zoom(self._image_view, zoom_factor,
+                                   prefilter=False, order=0)
             low, high = self.clim
-            zoomed = np.clip(zoomed, low, high)
+            downsampled = np.clip(downsampled, low, high)
             color_range = high - low
             if color_range != 0:
-                zoomed = (zoomed - low) / color_range
-            mapped = self.colormap[1].map(zoomed) * 255
-            mapped = mapped.reshape(list(zoomed.shape) + [4])
+                downsampled = (downsampled - low) / color_range
+            mapped = self.colormap[1].map(downsampled) * 255
+            mapped = mapped.reshape(list(downsampled.shape) + [4])
         mapped[:, :, 3] = mapped[:, :, 3] * self.opacity
         self.thumbnail = mapped.astype('uint8')
 

--- a/napari/layers/_image_layer/model.py
+++ b/napari/layers/_image_layer/model.py
@@ -336,7 +336,7 @@ class Image(Layer):
         """Update thumbnail with current image data and colormap.
         """
         zoom_factor = np.divide(self._thumbnail_shape[:2],
-                                 self._image_view.shape[:2]).min()
+                                self._image_view.shape[:2]).min()
         if self.multichannel:
             thumbnail = ndi.zoom(self._image_view,
                                  (zoom_factor, zoom_factor, 1))

--- a/napari/layers/_image_layer/model.py
+++ b/napari/layers/_image_layer/model.py
@@ -355,7 +355,7 @@ class Image(Layer):
                 zoomed = (zoomed - low) / color_range
             mapped = self.colormap[1].map(zoomed) * 255
             mapped = mapped.reshape(list(zoomed.shape) + [4])
-        mapped[:, :, 3] = mapped[:, :, 3]*self.opacity
+        mapped[:, :, 3] = mapped[:, :, 3] * self.opacity
         self.thumbnail = mapped.astype('uint8')
 
     def get_value(self):

--- a/napari/layers/_image_layer/view/properties.py
+++ b/napari/layers/_image_layer/view/properties.py
@@ -10,6 +10,7 @@ class QtImageLayer(QtLayer):
         self.layer.events.colormap.connect(self._on_colormap_change)
         self.layer.events.interpolation.connect(self._on_interpolation_change)
 
+        row = self.grid_layout.rowCount()
         comboBox = QComboBox()
         for cmap in self.layer.colormaps:
             comboBox.addItem(cmap)
@@ -18,10 +19,11 @@ class QtImageLayer(QtLayer):
         comboBox.setCurrentIndex(index)
         comboBox.activated[str].connect(
             lambda text=comboBox: self.changeColor(text))
-        self.grid_layout.addWidget(QLabel('colormap:'), 3, 0, 1, 2)
-        self.grid_layout.addWidget(comboBox, 3, 2, 1, 2)
+        self.grid_layout.addWidget(QLabel('colormap:'), row, 0)
+        self.grid_layout.addWidget(comboBox, row, 1)
         self.colormap_combobox = comboBox
 
+        row = self.grid_layout.rowCount()
         interp_comboBox = QComboBox()
         for interp in self.layer._interpolation_names:
             interp_comboBox.addItem(interp)
@@ -31,8 +33,8 @@ class QtImageLayer(QtLayer):
         interp_comboBox.activated[str].connect(
             lambda text=interp_comboBox: self.changeInterpolation(text))
         self.interpComboBox = interp_comboBox
-        self.grid_layout.addWidget(QLabel('interpolation:'), 4, 0, 1, 2)
-        self.grid_layout.addWidget(interp_comboBox, 4, 2, 1, 2)
+        self.grid_layout.addWidget(QLabel('interpolation:'), row, 0)
+        self.grid_layout.addWidget(interp_comboBox, row, 1)
 
         self.setExpanded(False)
 

--- a/napari/layers/_image_layer/view/properties.py
+++ b/napari/layers/_image_layer/view/properties.py
@@ -18,8 +18,8 @@ class QtImageLayer(QtLayer):
         comboBox.setCurrentIndex(index)
         comboBox.activated[str].connect(
             lambda text=comboBox: self.changeColor(text))
-        self.grid_layout.addWidget(QLabel('colormap:'), 3, 0)
-        self.grid_layout.addWidget(comboBox, 3, 1)
+        self.grid_layout.addWidget(QLabel('colormap:'), 3, 0, 1, 2)
+        self.grid_layout.addWidget(comboBox, 3, 2, 1, 2)
         self.colormap_combobox = comboBox
 
         interp_comboBox = QComboBox()
@@ -31,8 +31,8 @@ class QtImageLayer(QtLayer):
         interp_comboBox.activated[str].connect(
             lambda text=interp_comboBox: self.changeInterpolation(text))
         self.interpComboBox = interp_comboBox
-        self.grid_layout.addWidget(QLabel('interpolation:'), 4, 0)
-        self.grid_layout.addWidget(interp_comboBox, 4, 1)
+        self.grid_layout.addWidget(QLabel('interpolation:'), 4, 0, 1, 2)
+        self.grid_layout.addWidget(interp_comboBox, 4, 2, 1, 2)
 
         self.setExpanded(False)
 

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -511,7 +511,7 @@ class Labels(Layer):
         zoomed = self.raw_to_displayed(zoomed)
         mapped = self.colormap.map(zoomed) * 255
         mapped = mapped.reshape(list(zoomed.shape) + [4])
-        mapped[:, :, 3] = mapped[:, :, 3]*self.opacity
+        mapped[:, :, 3] = mapped[:, :, 3] * self.opacity
         self.thumbnail = mapped.astype('uint8')
 
     def to_xml_list(self):

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -506,11 +506,11 @@ class Labels(Layer):
         """
         zoom_factor = np.divide(self._thumbnail_shape[:2],
                                 self._image_view.shape[:2]).min()
-        zoomed = np.round(ndi.zoom(self._image_view, zoom_factor,
-                                   prefilter=False, order=0))
-        zoomed = self.raw_to_displayed(zoomed)
-        mapped = self.colormap.map(zoomed) * 255
-        mapped = mapped.reshape(list(zoomed.shape) + [4])
+        downsampled = np.round(ndi.zoom(self._image_view, zoom_factor,
+                                        prefilter=False, order=0))
+        downsampled = self.raw_to_displayed(downsampled)
+        mapped = self.colormap.map(downsampled) * 255
+        mapped = mapped.reshape(list(downsampled.shape) + [4])
         mapped[:, :, 3] = mapped[:, :, 3] * self.opacity
         self.thumbnail = mapped.astype('uint8')
 

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy import ndimage as ndi
+from skimage.util import img_as_ubyte
 from xml.etree.ElementTree import Element
 from base64 import b64encode
 from imageio import imwrite
@@ -509,10 +510,10 @@ class Labels(Layer):
         downsampled = np.round(ndi.zoom(self._image_view, zoom_factor,
                                         prefilter=False, order=0))
         downsampled = self.raw_to_displayed(downsampled)
-        mapped = self.colormap.map(downsampled) * 255
-        mapped = mapped.reshape(list(downsampled.shape) + [4])
-        mapped[:, :, 3] = mapped[:, :, 3] * self.opacity
-        self.thumbnail = mapped.astype('uint8')
+        colormapped = self.colormap.map(downsampled)
+        colormapped = colormapped.reshape(downsampled.shape + (4,))
+        colormapped[..., 3] *= self.opacity
+        self.thumbnail = img_as_ubyte(colormapped)
 
     def to_xml_list(self):
         """Generates a list with a single xml element that defines the

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -505,7 +505,7 @@ class Labels(Layer):
         """Update thumbnail with current image data and colors.
         """
         zoom_factor = np.divide(self._thumbnail_shape[:2],
-                                 self._image_view.shape[:2]).min()
+                                self._image_view.shape[:2]).min()
         thumbnail = np.round(ndi.zoom(self._image_view, zoom_factor))
         thumbnail = self.raw_to_displayed(thumbnail)
         mapped = self.colormap.map(thumbnail) * 255

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -506,15 +506,13 @@ class Labels(Layer):
         """
         zoom_factor = np.divide(self._thumbnail_shape[:2],
                                 self._image_view.shape[:2]).min()
-        thumbnail = np.round(ndi.zoom(self._image_view, zoom_factor))
-        thumbnail = self.raw_to_displayed(thumbnail)
-        mapped = self.colormap.map(thumbnail) * 255
-        mapped = mapped.reshape(list(thumbnail.shape) + [4])
-        total_padding = np.subtract(self.thumbnail.shape, mapped.shape)
-        padding = [(p//2, (p+1)//2) for p in total_padding]
-        padded = np.pad(mapped, padding, 'constant')
-        padded[:, :, 3] = padded[:, :, 3]*self.opacity
-        self.thumbnail = padded.astype('uint8')
+        zoomed = np.round(ndi.zoom(self._image_view, zoom_factor,
+                                   prefilter=False, order=0))
+        zoomed = self.raw_to_displayed(zoomed)
+        mapped = self.colormap.map(zoomed) * 255
+        mapped = mapped.reshape(list(zoomed.shape) + [4])
+        mapped[:, :, 3] = mapped[:, :, 3]*self.opacity
+        self.thumbnail = mapped.astype('uint8')
 
     def to_xml_list(self):
         """Generates a list with a single xml element that defines the

--- a/napari/layers/_labels_layer/view/properties.py
+++ b/napari/layers/_labels_layer/view/properties.py
@@ -23,8 +23,9 @@ class QtLabelsLayer(QtLayer):
         self.colormap_update.setFixedHeight(25)
         shuffle_label = QLabel('shuffle colors:')
         shuffle_label.setObjectName('shuffle-label')
-        self.grid_layout.addWidget(shuffle_label, 3, 0, 1, 2)
-        self.grid_layout.addWidget(self.colormap_update, 3, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(shuffle_label, row, 0)
+        self.grid_layout.addWidget(self.colormap_update, row, 1)
 
         # selection spinbox
         self.selection_spinbox = QSpinBox()
@@ -34,8 +35,9 @@ class QtLabelsLayer(QtLayer):
         self.selection_spinbox.setValue(self.layer.selected_label)
         self.selection_spinbox.setFixedWidth(75)
         self.selection_spinbox.valueChanged.connect(self.changeSelection)
-        self.grid_layout.addWidget(QLabel('label:'), 4, 0, 1, 2)
-        self.grid_layout.addWidget(self.selection_spinbox, 4, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(QLabel('label:'), row, 0)
+        self.grid_layout.addWidget(self.selection_spinbox, row, 1)
 
         sld = QSlider(Qt.Horizontal, self)
         sld.setFocusPolicy(Qt.NoFocus)
@@ -51,8 +53,9 @@ class QtLabelsLayer(QtLayer):
         sld.setValue(int(value))
         sld.valueChanged[int].connect(lambda value=sld: self.changeSize(value))
         self.brush_size_slider = sld
-        self.grid_layout.addWidget(QLabel('brush size:'), 5, 0, 1, 2)
-        self.grid_layout.addWidget(sld, 5, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(QLabel('brush size:'), row, 0)
+        self.grid_layout.addWidget(sld, row, 1)
 
         contig_cb = QCheckBox()
         contig_cb.setToolTip('contiguous editing')
@@ -60,8 +63,9 @@ class QtLabelsLayer(QtLayer):
         contig_cb.stateChanged.connect(lambda state=contig_cb:
                                        self.change_contig(state))
         self.contig_checkbox = contig_cb
-        self.grid_layout.addWidget(QLabel('contiguous:'), 6, 0, 1, 2)
-        self.grid_layout.addWidget(contig_cb, 6, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(QLabel('contiguous:'), row, 0)
+        self.grid_layout.addWidget(contig_cb, row, 1)
 
         ndim_cb = QCheckBox()
         ndim_cb.setToolTip('n-dimensional editing')
@@ -69,8 +73,9 @@ class QtLabelsLayer(QtLayer):
         ndim_cb.stateChanged.connect(lambda state=ndim_cb:
                                      self.change_ndim(state))
         self.ndim_checkbox = ndim_cb
-        self.grid_layout.addWidget(QLabel('n-dim:'), 7, 0, 1, 2)
-        self.grid_layout.addWidget(ndim_cb, 7, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(QLabel('n-dim:'), row, 0)
+        self.grid_layout.addWidget(ndim_cb, row, 1)
 
         self.setExpanded(False)
 

--- a/napari/layers/_labels_layer/view/properties.py
+++ b/napari/layers/_labels_layer/view/properties.py
@@ -23,8 +23,8 @@ class QtLabelsLayer(QtLayer):
         self.colormap_update.setFixedHeight(25)
         shuffle_label = QLabel('shuffle colors:')
         shuffle_label.setObjectName('shuffle-label')
-        self.grid_layout.addWidget(shuffle_label, 3, 0)
-        self.grid_layout.addWidget(self.colormap_update, 3, 1)
+        self.grid_layout.addWidget(shuffle_label, 3, 0, 1, 2)
+        self.grid_layout.addWidget(self.colormap_update, 3, 2, 1, 2)
 
         # selection spinbox
         self.selection_spinbox = QSpinBox()
@@ -34,8 +34,8 @@ class QtLabelsLayer(QtLayer):
         self.selection_spinbox.setValue(self.layer.selected_label)
         self.selection_spinbox.setFixedWidth(75)
         self.selection_spinbox.valueChanged.connect(self.changeSelection)
-        self.grid_layout.addWidget(QLabel('label:'), 4, 0)
-        self.grid_layout.addWidget(self.selection_spinbox, 4, 1)
+        self.grid_layout.addWidget(QLabel('label:'), 4, 0, 1, 2)
+        self.grid_layout.addWidget(self.selection_spinbox, 4, 2, 1, 2)
 
         sld = QSlider(Qt.Horizontal, self)
         sld.setFocusPolicy(Qt.NoFocus)
@@ -51,8 +51,8 @@ class QtLabelsLayer(QtLayer):
         sld.setValue(int(value))
         sld.valueChanged[int].connect(lambda value=sld: self.changeSize(value))
         self.brush_size_slider = sld
-        self.grid_layout.addWidget(QLabel('brush size:'), 5, 0)
-        self.grid_layout.addWidget(sld, 5, 1)
+        self.grid_layout.addWidget(QLabel('brush size:'), 5, 0, 1, 2)
+        self.grid_layout.addWidget(sld, 5, 2, 1, 2)
 
         contig_cb = QCheckBox()
         contig_cb.setToolTip('contiguous editing')
@@ -60,8 +60,8 @@ class QtLabelsLayer(QtLayer):
         contig_cb.stateChanged.connect(lambda state=contig_cb:
                                        self.change_contig(state))
         self.contig_checkbox = contig_cb
-        self.grid_layout.addWidget(QLabel('contiguous:'), 6, 0)
-        self.grid_layout.addWidget(contig_cb, 6, 1)
+        self.grid_layout.addWidget(QLabel('contiguous:'), 6, 0, 1, 2)
+        self.grid_layout.addWidget(contig_cb, 6, 2, 1, 2)
 
         ndim_cb = QCheckBox()
         ndim_cb.setToolTip('n-dimensional editing')
@@ -69,8 +69,8 @@ class QtLabelsLayer(QtLayer):
         ndim_cb.stateChanged.connect(lambda state=ndim_cb:
                                      self.change_ndim(state))
         self.ndim_checkbox = ndim_cb
-        self.grid_layout.addWidget(QLabel('n-dim:'), 7, 0)
-        self.grid_layout.addWidget(ndim_cb, 7, 1)
+        self.grid_layout.addWidget(QLabel('n-dim:'), 7, 0, 1, 2)
+        self.grid_layout.addWidget(ndim_cb, 7, 2, 1, 2)
 
         self.setExpanded(False)
 

--- a/napari/layers/_markers_layer/view/properties.py
+++ b/napari/layers/_markers_layer/view/properties.py
@@ -31,8 +31,8 @@ class QtMarkersLayer(QtLayer):
         sld.setValue(int(value))
         sld.valueChanged[int].connect(lambda value=sld: self.changeSize(value))
         self.sizeSlider = sld
-        self.grid_layout.addWidget(QLabel('size:'), 3, 0)
-        self.grid_layout.addWidget(sld, 3, 1)
+        self.grid_layout.addWidget(QLabel('size:'), 3, 0, 1, 2)
+        self.grid_layout.addWidget(sld, 3, 2, 1, 2)
 
         face_comboBox = QComboBox()
         colors = self.layer._colors
@@ -44,8 +44,8 @@ class QtMarkersLayer(QtLayer):
         face_comboBox.activated[str].connect(
             lambda text=face_comboBox: self.changeFaceColor(text))
         self.faceComboBox = face_comboBox
-        self.grid_layout.addWidget(QLabel('face_color:'), 4, 0)
-        self.grid_layout.addWidget(face_comboBox, 4, 1)
+        self.grid_layout.addWidget(QLabel('face_color:'), 4, 0, 1, 2)
+        self.grid_layout.addWidget(face_comboBox, 4, 2, 1, 2)
 
         edge_comboBox = QComboBox()
         colors = self.layer._colors
@@ -57,8 +57,8 @@ class QtMarkersLayer(QtLayer):
         edge_comboBox.activated[str].connect(
             lambda text=edge_comboBox: self.changeEdgeColor(text))
         self.edgeComboBox = edge_comboBox
-        self.grid_layout.addWidget(QLabel('edge_color:'), 5, 0)
-        self.grid_layout.addWidget(edge_comboBox, 5, 1)
+        self.grid_layout.addWidget(QLabel('edge_color:'), 5, 0, 1, 2)
+        self.grid_layout.addWidget(edge_comboBox, 5, 2, 1, 2)
 
         symbol_comboBox = QComboBox()
         for s in Symbol:
@@ -69,8 +69,8 @@ class QtMarkersLayer(QtLayer):
         symbol_comboBox.activated[str].connect(
             lambda text=symbol_comboBox: self.changeSymbol(text))
         self.symbolComboBox = symbol_comboBox
-        self.grid_layout.addWidget(QLabel('symbol:'), 6, 0)
-        self.grid_layout.addWidget(symbol_comboBox, 6, 1)
+        self.grid_layout.addWidget(QLabel('symbol:'), 6, 0, 1, 2)
+        self.grid_layout.addWidget(symbol_comboBox, 6, 2, 1, 2)
 
         ndim_cb = QCheckBox()
         ndim_cb.setToolTip('N-dimensional markers')
@@ -78,8 +78,8 @@ class QtMarkersLayer(QtLayer):
         ndim_cb.stateChanged.connect(lambda state=ndim_cb:
                                      self.change_ndim(state))
         self.ndimCheckBox = ndim_cb
-        self.grid_layout.addWidget(QLabel('n-dim:'), 7, 0)
-        self.grid_layout.addWidget(ndim_cb, 7, 1)
+        self.grid_layout.addWidget(QLabel('n-dim:'), 7, 0, 1, 2)
+        self.grid_layout.addWidget(ndim_cb, 7, 2, 1, 2)
 
         self.setExpanded(False)
 

--- a/napari/layers/_markers_layer/view/properties.py
+++ b/napari/layers/_markers_layer/view/properties.py
@@ -31,8 +31,9 @@ class QtMarkersLayer(QtLayer):
         sld.setValue(int(value))
         sld.valueChanged[int].connect(lambda value=sld: self.changeSize(value))
         self.sizeSlider = sld
-        self.grid_layout.addWidget(QLabel('size:'), 3, 0, 1, 2)
-        self.grid_layout.addWidget(sld, 3, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(QLabel('size:'), row, 0)
+        self.grid_layout.addWidget(sld, row, 1)
 
         face_comboBox = QComboBox()
         colors = self.layer._colors
@@ -44,8 +45,9 @@ class QtMarkersLayer(QtLayer):
         face_comboBox.activated[str].connect(
             lambda text=face_comboBox: self.changeFaceColor(text))
         self.faceComboBox = face_comboBox
-        self.grid_layout.addWidget(QLabel('face_color:'), 4, 0, 1, 2)
-        self.grid_layout.addWidget(face_comboBox, 4, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(QLabel('face_color:'), row, 0)
+        self.grid_layout.addWidget(face_comboBox, row, 1)
 
         edge_comboBox = QComboBox()
         colors = self.layer._colors
@@ -57,8 +59,9 @@ class QtMarkersLayer(QtLayer):
         edge_comboBox.activated[str].connect(
             lambda text=edge_comboBox: self.changeEdgeColor(text))
         self.edgeComboBox = edge_comboBox
-        self.grid_layout.addWidget(QLabel('edge_color:'), 5, 0, 1, 2)
-        self.grid_layout.addWidget(edge_comboBox, 5, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(QLabel('edge_color:'), row, 0)
+        self.grid_layout.addWidget(edge_comboBox, row, 1)
 
         symbol_comboBox = QComboBox()
         for s in Symbol:
@@ -69,8 +72,9 @@ class QtMarkersLayer(QtLayer):
         symbol_comboBox.activated[str].connect(
             lambda text=symbol_comboBox: self.changeSymbol(text))
         self.symbolComboBox = symbol_comboBox
-        self.grid_layout.addWidget(QLabel('symbol:'), 6, 0, 1, 2)
-        self.grid_layout.addWidget(symbol_comboBox, 6, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(QLabel('symbol:'), row, 0)
+        self.grid_layout.addWidget(symbol_comboBox, row, 1)
 
         ndim_cb = QCheckBox()
         ndim_cb.setToolTip('N-dimensional markers')
@@ -78,8 +82,9 @@ class QtMarkersLayer(QtLayer):
         ndim_cb.stateChanged.connect(lambda state=ndim_cb:
                                      self.change_ndim(state))
         self.ndimCheckBox = ndim_cb
-        self.grid_layout.addWidget(QLabel('n-dim:'), 7, 0, 1, 2)
-        self.grid_layout.addWidget(ndim_cb, 7, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(QLabel('n-dim:'), row, 0)
+        self.grid_layout.addWidget(ndim_cb, row, 1)
 
         self.setExpanded(False)
 

--- a/napari/layers/_shapes_layer/view/properties.py
+++ b/napari/layers/_shapes_layer/view/properties.py
@@ -28,8 +28,8 @@ class QtShapesLayer(QtLayer):
         sld.valueChanged[int].connect(lambda value=sld:
                                       self.changeWidth(value))
         self.widthSlider = sld
-        self.grid_layout.addWidget(QLabel('width:'), 3, 0)
-        self.grid_layout.addWidget(sld, 3, 1)
+        self.grid_layout.addWidget(QLabel('width:'), 3, 0, 1, 2)
+        self.grid_layout.addWidget(sld, 3, 2, 1, 2)
 
         face_comboBox = QComboBox()
         colors = self.layer._colors
@@ -42,8 +42,8 @@ class QtShapesLayer(QtLayer):
         face_comboBox.activated[str].connect(lambda text=face_comboBox:
                                              self.changeFaceColor(text))
         self.faceComboBox = face_comboBox
-        self.grid_layout.addWidget(QLabel('face_color:'), 4, 0)
-        self.grid_layout.addWidget(face_comboBox, 4, 1)
+        self.grid_layout.addWidget(QLabel('face_color:'), 4, 0, 1, 2)
+        self.grid_layout.addWidget(face_comboBox, 4, 2, 1, 2)
 
         edge_comboBox = QComboBox()
         colors = self.layer._colors
@@ -56,8 +56,8 @@ class QtShapesLayer(QtLayer):
         edge_comboBox.activated[str].connect(lambda text=edge_comboBox:
                                              self.changeEdgeColor(text))
         self.edgeComboBox = edge_comboBox
-        self.grid_layout.addWidget(QLabel('edge_color:'), 5, 0)
-        self.grid_layout.addWidget(edge_comboBox, 5, 1)
+        self.grid_layout.addWidget(QLabel('edge_color:'), 5, 0, 1, 2)
+        self.grid_layout.addWidget(edge_comboBox, 5, 2, 1, 2)
 
         self.setExpanded(False)
 

--- a/napari/layers/_shapes_layer/view/properties.py
+++ b/napari/layers/_shapes_layer/view/properties.py
@@ -28,8 +28,9 @@ class QtShapesLayer(QtLayer):
         sld.valueChanged[int].connect(lambda value=sld:
                                       self.changeWidth(value))
         self.widthSlider = sld
-        self.grid_layout.addWidget(QLabel('width:'), 3, 0, 1, 2)
-        self.grid_layout.addWidget(sld, 3, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(QLabel('width:'), row, 0)
+        self.grid_layout.addWidget(sld, row, 1)
 
         face_comboBox = QComboBox()
         colors = self.layer._colors
@@ -42,8 +43,9 @@ class QtShapesLayer(QtLayer):
         face_comboBox.activated[str].connect(lambda text=face_comboBox:
                                              self.changeFaceColor(text))
         self.faceComboBox = face_comboBox
-        self.grid_layout.addWidget(QLabel('face_color:'), 4, 0, 1, 2)
-        self.grid_layout.addWidget(face_comboBox, 4, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(QLabel('face_color:'), row, 0)
+        self.grid_layout.addWidget(face_comboBox, row, 1)
 
         edge_comboBox = QComboBox()
         colors = self.layer._colors
@@ -56,8 +58,9 @@ class QtShapesLayer(QtLayer):
         edge_comboBox.activated[str].connect(lambda text=edge_comboBox:
                                              self.changeEdgeColor(text))
         self.edgeComboBox = edge_comboBox
-        self.grid_layout.addWidget(QLabel('edge_color:'), 5, 0, 1, 2)
-        self.grid_layout.addWidget(edge_comboBox, 5, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(QLabel('edge_color:'), row, 0)
+        self.grid_layout.addWidget(edge_comboBox, row, 1)
 
         self.setExpanded(False)
 

--- a/napari/layers/_vectors_layer/view/properties.py
+++ b/napari/layers/_vectors_layer/view/properties.py
@@ -25,8 +25,9 @@ class QtVectorsLayer(QtLayer):
             face_comboBox.setCurrentIndex(index)
         face_comboBox.activated[str].connect(
             lambda text=face_comboBox: self.change_face_color(text))
-        self.grid_layout.addWidget(QLabel('color:'), 3, 0, 1, 2)
-        self.grid_layout.addWidget(face_comboBox, 3, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(QLabel('color:'), row, 0)
+        self.grid_layout.addWidget(face_comboBox, row, 1)
 
         # line width in pixels
         self.width_field = QDoubleSpinBox()
@@ -35,8 +36,9 @@ class QtVectorsLayer(QtLayer):
         value = self.layer.width
         self.width_field.setValue(value)
         self.width_field.valueChanged.connect(self.change_width)
-        self.grid_layout.addWidget(QLabel('width:'), 4, 0, 1, 2)
-        self.grid_layout.addWidget(self.width_field, 4, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(QLabel('width:'), row, 0)
+        self.grid_layout.addWidget(self.width_field, row, 1)
 
         # averaging spinbox
         self.averaging_spinbox = QSpinBox()
@@ -44,8 +46,9 @@ class QtVectorsLayer(QtLayer):
         self.averaging_spinbox.setValue(1)
         self.averaging_spinbox.setMinimum(1)
         self.averaging_spinbox.valueChanged.connect(self.change_average_type)
-        self.grid_layout.addWidget(QLabel('avg kernel'), 5, 0, 1, 2)
-        self.grid_layout.addWidget(self.averaging_spinbox, 5, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(QLabel('avg kernel'), row, 0)
+        self.grid_layout.addWidget(self.averaging_spinbox, row, 1)
 
         # line length
         self.length_field = QDoubleSpinBox()
@@ -54,8 +57,9 @@ class QtVectorsLayer(QtLayer):
         self.length_field.setValue(value)
         self.length_field.setMinimum(0.1)
         self.length_field.valueChanged.connect(self.change_length)
-        self.grid_layout.addWidget(QLabel('length:'), 6, 0, 1, 2)
-        self.grid_layout.addWidget(self.length_field, 6, 2, 1, 2)
+        row = self.grid_layout.rowCount()
+        self.grid_layout.addWidget(QLabel('length:'), row, 0)
+        self.grid_layout.addWidget(self.length_field, row, 1)
 
         self.setExpanded(False)
 

--- a/napari/layers/_vectors_layer/view/properties.py
+++ b/napari/layers/_vectors_layer/view/properties.py
@@ -25,8 +25,8 @@ class QtVectorsLayer(QtLayer):
             face_comboBox.setCurrentIndex(index)
         face_comboBox.activated[str].connect(
             lambda text=face_comboBox: self.change_face_color(text))
-        self.grid_layout.addWidget(QLabel('color:'), 3, 0)
-        self.grid_layout.addWidget(face_comboBox, 3, 1)
+        self.grid_layout.addWidget(QLabel('color:'), 3, 0, 1, 2)
+        self.grid_layout.addWidget(face_comboBox, 3, 2, 1, 2)
 
         # line width in pixels
         self.width_field = QDoubleSpinBox()
@@ -35,8 +35,8 @@ class QtVectorsLayer(QtLayer):
         value = self.layer.width
         self.width_field.setValue(value)
         self.width_field.valueChanged.connect(self.change_width)
-        self.grid_layout.addWidget(QLabel('width:'), 4, 0)
-        self.grid_layout.addWidget(self.width_field, 4, 1)
+        self.grid_layout.addWidget(QLabel('width:'), 4, 0, 1, 2)
+        self.grid_layout.addWidget(self.width_field, 4, 2, 1, 2)
 
         # averaging spinbox
         self.averaging_spinbox = QSpinBox()
@@ -44,8 +44,8 @@ class QtVectorsLayer(QtLayer):
         self.averaging_spinbox.setValue(1)
         self.averaging_spinbox.setMinimum(1)
         self.averaging_spinbox.valueChanged.connect(self.change_average_type)
-        self.grid_layout.addWidget(QLabel('avg kernel'), 5, 0)
-        self.grid_layout.addWidget(self.averaging_spinbox, 5, 1)
+        self.grid_layout.addWidget(QLabel('avg kernel'), 5, 0, 1, 2)
+        self.grid_layout.addWidget(self.averaging_spinbox, 5, 2, 1, 2)
 
         # line length
         self.length_field = QDoubleSpinBox()
@@ -54,8 +54,8 @@ class QtVectorsLayer(QtLayer):
         self.length_field.setValue(value)
         self.length_field.setMinimum(0.1)
         self.length_field.valueChanged.connect(self.change_length)
-        self.grid_layout.addWidget(QLabel('length:'), 6, 0)
-        self.grid_layout.addWidget(self.length_field, 6, 1)
+        self.grid_layout.addWidget(QLabel('length:'), 6, 0, 1, 2)
+        self.grid_layout.addWidget(self.length_field, 6, 2, 1, 2)
 
         self.setExpanded(False)
 

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -42,11 +42,11 @@ QSplitter::handle:vertical {
 }
 
 QtDivider[selected=true] {
-  background-color: {{ text }}; 
+  background-color: {{ text }};
 }
 
 QtDivider[selected=false] {
-  background-color: {{ background }}; 
+  background-color: {{ background }};
 }
 
 /* ------------------------------------------------------ */
@@ -167,6 +167,7 @@ QtLayer > QLineEdit {
     border: none;
     border-radius: 0px;
     font-size: 18px;
+    margin-right: 10px;
     padding-right: 10px;
     qproperty-alignment: left;
 }

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -139,17 +139,24 @@ QtLayer[selected="true"] {
     border: 1px solid {{ text }};
 }
 
-QtLayer > QSlider {
+QtLayer > QFrame {
+    background-color: {{ foreground }};
+    border: 0px;
+    padding: 0px;
+    margin: 0px;
+}
+
+QtLayer > QFrame > QSlider {
    background-color: {{ foreground }};
 }
 
-QtLayer > QSlider::groove:horizontal {
+QtLayer > QFrame > QSlider::groove:horizontal {
    border: 0px;
    background: {{ primary }};
    height: 8px;
 }
 
-QtLayer > QSlider::handle:horizontal {
+QtLayer > QFrame > QSlider::handle:horizontal {
    background: {{ secondary }};
    border: 0px;
    width: 16px;
@@ -158,27 +165,25 @@ QtLayer > QSlider::handle:horizontal {
    border-radius: 8px;
 }
 
-QtLayer > QSlider::sub-page:horizontal {
+QtLayer > QFrame > QSlider::sub-page:horizontal {
     background: {{ secondary }};
 }
 
-QtLayer > QLineEdit {
+QtLayer > QFrame > QLineEdit {
     background-color: {{ foreground }};
     border: none;
     border-radius: 0px;
     font-size: 18px;
-    margin-right: 10px;
-    padding-right: 10px;
     qproperty-alignment: left;
 }
 
-QtLayer > QLineEdit:disabled {
+QtLayer > QFrame > QLineEdit:disabled {
     background-color: {{ foreground }};
     border: none;
     border-radius: 3px;
 }
 
-QtLayer > QComboBox {
+QtLayer > QFrame > QComboBox {
    background-color: {{ primary }};
    padding-left: 6px;
    padding-right: 10px;
@@ -186,7 +191,7 @@ QtLayer > QComboBox {
    padding-bottom: 3px;
 }
 
-QtLayer > QComboBox::drop-down {
+QtLayer > QFrame > QComboBox::drop-down {
    subcontrol-origin: padding;
    subcontrol-position: top right;
    width: 30px;
@@ -194,13 +199,13 @@ QtLayer > QComboBox::drop-down {
    border-bottom-right-radius: 10px;
 }
 
-QtLayer > QComboBox::down-arrow {
+QtLayer > QFrame > QComboBox::down-arrow {
    image: url(":/icons/{{ folder }}/drop_down.svg");
    width: 14px;
    height: 14px;
 }
 
-QtLayer > QSpinBox {
+QtLayer > QFrame > QSpinBox {
    background-color: {{ primary }};
    padding-left: 14px;
    padding-right: 6px;
@@ -208,7 +213,7 @@ QtLayer > QSpinBox {
    padding-bottom: 3px;
 }
 
-QtLayer > QSpinBox::up-button {
+QtLayer > QFrame > QSpinBox::up-button {
     background-color: {{ primary }};
     subcontrol-origin: margin;
     subcontrol-position: center right;
@@ -217,7 +222,7 @@ QtLayer > QSpinBox::up-button {
     right: 6px;
 }
 
-QtLayer > QSpinBox::down-button {
+QtLayer > QFrame > QSpinBox::down-button {
     background-color: {{ primary }};
     subcontrol-origin: margin;
     subcontrol-position: center left;
@@ -226,39 +231,40 @@ QtLayer > QSpinBox::down-button {
     left: 6px;
 }
 
-QtLayer > QSpinBox::up-arrow {
+QtLayer > QFrame >  QSpinBox::up-arrow {
    image: url(":/icons/{{ folder }}/plus.svg");
    width: 14px;
    height: 14px;
 }
 
-QtLayer > QSpinBox::down-arrow {
+QtLayer > QFrame > QSpinBox::down-arrow {
    image: url(":/icons/{{ folder }}/minus.svg");
    width: 14px;
    height: 14px;
 }
 
-QtLayer > QPushButton#shuffle {
+QtLayer > QFrame > QPushButton#shuffle {
   background-color: {{ secondary }};
   border: 3px solid {{ secondary }};
   text-align: left;
   padding-left: 5px;
 }
 
-QtLayer > QLabel#shuffle-label {
+QtLayer > QFrame > QLabel#shuffle-label {
   margin-top: 4px;
 }
 
-QtLayer > QPushButton#shuffle:pressed {
+QtLayer > QFrame > QPushButton#shuffle:pressed {
   background-color: {{ foreground }};
   border: 3px solid {{ secondary }};
 }
 
-QtLayer > QCheckBox#visibility {
+QtLayer > QFrame > QCheckBox#visibility {
    background-color: {{ foreground }};
+   spacing: 0px;
 }
 
-QtLayer > QCheckBox#visibility::indicator:unchecked {
+QtLayer > QFrame > QCheckBox#visibility::indicator:unchecked {
    border: 0px;
    border-radius: 4px;
    width: 24px;
@@ -266,7 +272,7 @@ QtLayer > QCheckBox#visibility::indicator:unchecked {
    image: url(":/icons/{{ folder }}/visibility_off.svg");
 }
 
-QtLayer > QCheckBox#visibility::indicator:checked {
+QtLayer > QFrame > QCheckBox#visibility::indicator:checked {
    background-color: {{ foreground }};
    border: 0px;
    width: 24px;
@@ -274,19 +280,19 @@ QtLayer > QCheckBox#visibility::indicator:checked {
    image: url(":/icons/{{ folder }}/visibility.svg");
 }
 
-QtLayer > QCheckBox {
+QtLayer > QFrame > QCheckBox {
   background-color: {{ foreground }};
   spacing: 50px;
 }
 
-QtLayer > QCheckBox::indicator {
+QtLayer > QFrame > QCheckBox::indicator {
    border: 3px solid {{ secondary }};
    border-radius: 4px;
    width: 13px;
    height: 13px;
 }
 
-QtLayer > QCheckBox::indicator:checked {
+QtLayer > QFrame > QCheckBox::indicator:checked {
    background-color: {{ secondary }};
    width: 13px;
    height: 13px;

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -2,6 +2,7 @@ imageio>=2.5.0
 numpy>=1.10.0
 qtpy>=1.7.0
 scipy>=1.2.0
+scikit-image>=0.15.0
 vispy>=0.5.3
 PyOpenGL>=3.1.0
 PyQt5>=5.10.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,4 @@
 dask[array]
 pytest
 pytest-faulthandler
-scikit-image
 zarr


### PR DESCRIPTION
# Description
This PR adds support for image thumbnails to the `Image` and `Labels` layers as requested in #294. Support for the `Shapes`, `Markers`, and `Vectors` layers can come in follow up PRs, but I want to see that we all agree we are on the right track here before implementing them.

The `_image_view` is downsample, and then passed through the appropriate clims, colormap, and opacity settings. Right now I do the downsampling with `scipy.ndimage.zoom`, but this can lead to some weird artifacts for the labels layer, or a binary image due to the nature of the downsampling. I'm curious what others think. Should we do a `mean` or `median` downsample instead to avoid this?

Also the images right now are max 32x2x pixels, which is still pretty small, but maybe ok. I didn't implement yet the color bar suggestion from @AhmetCanSolak and @freeman-lab as I was worried the pictures would then look even smaller. It is not clear to me that it is needed, but I'm open to doing it in a follow up PR.

Here are some screen shots:
from `examples/layers.py`
![image](https://user-images.githubusercontent.com/6531703/58770887-48707a00-8566-11e9-83db-bffa6a65d6ea.png)
and from `examples/labels-0-2d.py`
![image](https://user-images.githubusercontent.com/6531703/58770901-59b98680-8566-11e9-8372-a8032c1834cc.png)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run examples

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
