### PR TITLE
fix remove layer

### DIFF
--- a/napari/components/_layers_list/model.py
+++ b/napari/components/_layers_list/model.py
@@ -20,7 +20,7 @@ def _remove(event):
     layers = event.source
     layer = event.item
     layer._order = 0
-    layer._parent = None
+    layer._node.parent = None
 
 
 def _reorder(event):


### PR DESCRIPTION
# Description
This PR fixes an error preventing visuals from being removed from the vispy scene graph, introduced in #295.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run `examples/layer.py` the image of the coin should now be deleted

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
