### PR TITLE
Blending Enum

### DIFF
--- a/napari/layers/_base_layer/_constants.py
+++ b/napari/layers/_base_layer/_constants.py
@@ -1,5 +1,4 @@
 from enum import auto
-import sys
 
 from ...util.misc import StringEnum
 

--- a/napari/layers/_base_layer/_constants.py
+++ b/napari/layers/_base_layer/_constants.py
@@ -1,0 +1,27 @@
+from enum import auto
+import sys
+
+from ...util.misc import StringEnum
+
+
+class Blending(StringEnum):
+    """BLENDING: Blending mode for the layer.
+
+    Selects a preset blending mode in vispy that determines how
+            RGB and alpha values get mixed.
+            Blending.OPAQUE
+                Allows for only the top layer to be visible and corresponds to
+                depth_test=True, cull_face=False, blend=False.
+            Blending.TRANSLUCENT
+                Allows for multiple layers to be blended with different opacity
+                and corresponds to depth_test=True, cull_face=False,
+                blend=True, blend_func=('src_alpha', 'one_minus_src_alpha').
+            Blending.ADDITIVE
+                Allows for multiple layers to be blended together with
+                different colors and opacity. Useful for creating overlays. It
+                corresponds to depth_test=False, cull_face=False, blend=True,
+                blend_func=('src_alpha', 'one').
+    """
+    TRANSLUCENT = auto()
+    ADDITIVE = auto()
+    OPAQUE = auto()

--- a/napari/layers/_base_layer/_visual_wrapper.py
+++ b/napari/layers/_base_layer/_visual_wrapper.py
@@ -3,6 +3,8 @@ from vispy.visuals.transforms import STTransform
 from vispy.gloo import get_state_presets
 from ...util.event import EmitterGroup, Event
 
+from ._constants import Blending
+
 
 class VisualWrapper:
     """Wrapper around ``vispy.scene.VisualNode`` objects.
@@ -35,7 +37,7 @@ class VisualWrapper:
     """
     def __init__(self, central_node):
         self._node = central_node
-        self._blending = 'translucent'
+        self._blending = Blending.TRANSLUCENT
         self._parent = None
         self.events = EmitterGroup(source=self,
                                    auto_connect=True,
@@ -43,7 +45,6 @@ class VisualWrapper:
                                    opacity=Event,
                                    visible=Event)
 
-    _blending_modes = set(get_state_presets().keys())
 
     @property
     def _master_transform(self):
@@ -100,31 +101,30 @@ class VisualWrapper:
 
     @property
     def blending(self):
-        """{'opaque', 'translucent', 'additive'}: Blending mode.
+        """Blending: Blending mode.
             Selects a preset blending mode in vispy that determines how
             RGB and alpha values get mixed.
-            'opaque'
+            Blending.OPAQUE
                 Allows for only the top layer to be visible and corresponds to
                 depth_test=True, cull_face=False, blend=False.
-            'translucent'
+            Blending.TRANSLUCENT
                 Allows for multiple layers to be blended with different opacity
                 and corresponds to depth_test=True, cull_face=False,
                 blend=True, blend_func=('src_alpha', 'one_minus_src_alpha').
-            'additive'
+            Blending.ADDITIVE
                 Allows for multiple layers to be blended together with
                 different colors and opacity. Useful for creating overlays. It
                 corresponds to depth_test=False, cull_face=False, blend=True,
                 blend_func=('src_alpha', 'one').
         """
-        return self._blending
+        return str(self._blending)
 
     @blending.setter
     def blending(self, blending):
-        if blending not in self._blending_modes:
-            raise ValueError('expected one of '
-                             "{'opaque', 'translucent', 'additive'}; "
-                             f'got {blending}')
-        self._node.set_gl_state(blending)
+        if isinstance(blending, str):
+            blending = Blending(blending)
+
+        self._node.set_gl_state(blending.value)
         self._blending = blending
         self._node.update()
         self.events.blending()

--- a/napari/layers/_base_layer/_visual_wrapper.py
+++ b/napari/layers/_base_layer/_visual_wrapper.py
@@ -1,6 +1,5 @@
 # TODO: create & use our own transform class
 from vispy.visuals.transforms import STTransform
-from vispy.gloo import get_state_presets
 from ...util.event import EmitterGroup, Event
 
 from ._constants import Blending
@@ -44,7 +43,6 @@ class VisualWrapper:
                                    blending=Event,
                                    opacity=Event,
                                    visible=Event)
-
 
     @property
     def _master_transform(self):

--- a/napari/layers/_base_layer/view/properties.py
+++ b/napari/layers/_base_layer/view/properties.py
@@ -2,6 +2,8 @@ from qtpy.QtWidgets import (QSlider, QLineEdit, QGridLayout, QFrame, QLabel,
                             QVBoxLayout, QCheckBox, QWidget, QComboBox)
 from qtpy.QtCore import Qt
 
+from .._constants import Blending
+
 
 class QtLayer(QFrame):
     def __init__(self, layer):
@@ -53,8 +55,8 @@ class QtLayer(QFrame):
         self.grid_layout.addWidget(sld, 1, 1)
 
         blend_comboBox = QComboBox()
-        for blend in self.layer._blending_modes:
-            blend_comboBox.addItem(blend)
+        for blend in Blending:
+            blend_comboBox.addItem(str(blend))
         index = blend_comboBox.findText(
             self.layer.blending, Qt.MatchFixedString)
         blend_comboBox.setCurrentIndex(index)

--- a/napari/layers/_base_layer/view/properties.py
+++ b/napari/layers/_base_layer/view/properties.py
@@ -1,5 +1,5 @@
 from qtpy.QtWidgets import (QSlider, QLineEdit, QGridLayout, QFrame, QLabel,
-                            QVBoxLayout, QCheckBox, QWidget, QComboBox)
+                            QCheckBox, QComboBox)
 from qtpy.QtCore import Qt
 
 from .._constants import Blending


### PR DESCRIPTION
# Description
As discussed in #265, this PR introduces an Enum to represent the layer blending options (`Blending`). The `Blending` is inherits from the `StringEnum` class introduced in  #311 and thus has string values and is implemented such that the `Layer.blending` property can be set with a string and returns a string.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# References
This is PR#2 in #265.

# How has this been tested?
To test compatibility with layers, I ran the following examples
- [x] `Layer.Shapes`: `/examples/add_shapes.py`
- [x] `Layer.Markers`: `/examples/add_markers.py`
- [x] `Layer.Labels`: `/examples/labels-2d.py`
- [x] `Layer.Vectors`: `/examples/add_vectors_coords.py`

To test the ability to set `Layer.blending` with a string, I ran:
- [x] `/examples/add_image.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
