### PR TITLE
black format pyramid examples

### DIFF
--- a/examples/nD_pyramid.py
+++ b/examples/nD_pyramid.py
@@ -17,8 +17,9 @@ base = np.tile(astronaut, (4, 4))
 base = np.array([base * (32 - i) / 32 for i in range(32)])
 print('base shape', base.shape)
 
-pyramid = list(pyramid_gaussian(base, downscale=2, max_layer=4,
-                                multichannel=False))
+pyramid = list(
+    pyramid_gaussian(base, downscale=2, max_layer=4, multichannel=False)
+)
 pyramid = [img_as_ubyte(p) for p in pyramid]
 print('pyramid level shapes: ', [p.shape for p in pyramid])
 

--- a/examples/nD_pyramid_non_uniform.py
+++ b/examples/nD_pyramid_non_uniform.py
@@ -14,10 +14,12 @@ import numpy as np
 # create pyramid from astronaut image
 astronaut = rgb2gray(data.astronaut())
 base = np.tile(astronaut, (4, 4))
-pyramid = list(pyramid_gaussian(base, downscale=2, max_layer=4,
-                                multichannel=False))
-pyramid = [np.array([p * (abs(5 - i) + 1) / 6 for i in range(10)])
-           for p in pyramid]
+pyramid = list(
+    pyramid_gaussian(base, downscale=2, max_layer=4, multichannel=False)
+)
+pyramid = [
+    np.array([p * (abs(5 - i) + 1) / 6 for i in range(10)]) for p in pyramid
+]
 pyramid = [img_as_ubyte(p) for p in pyramid]
 print('pyramid level shapes: ', [p.shape for p in pyramid])
 


### PR DESCRIPTION
# Description
This PR formats the pyramid examples according to `black` so that out `black` test now passes
 
## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run examples

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
