### PR TITLE
fix labels colormap

### DIFF
--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -88,10 +88,10 @@ class Labels(Layer):
         self._need_display_update = False
         self._need_visual_update = False
 
-        self.events.opacity.connect(lambda e: self._update_thumbnail())
-
         self._node.clim = [0.0, 1.0]
-        self.events.colormap()
+        self._node.cmap = self.colormap
+
+        self.events.opacity.connect(lambda e: self._update_thumbnail())
 
     def raw_to_displayed(self, raw):
         """Determines displayed image from a saved raw image and a saved seed.


### PR DESCRIPTION
# Description
This PR fixes #339 by directly setting the labels colormap instead of relying on an event triggering an update in the layer properties (which are now constructed after the layer, since #330) 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run `examples/labels-0-2d.py` and see colormap is correct again

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
