### PR TITLE
remove broadcast from shapes

### DIFF
--- a/examples/nD_shapes.py
+++ b/examples/nD_shapes.py
@@ -41,11 +41,7 @@ with app_context():
 
     corners = np.random.uniform(0, 128, size=(2, 2))
     layer = viewer.add_shapes(
-        corners,
-        shape_type='rectangle',
-        ndim=3,
-        broadcast=True,
-        name='broadcasted',
+        corners, shape_type='rectangle', name='broadcasted'
     )
 
     masks = layer.to_masks(mask_shape=(128, 128, 128))

--- a/napari/components/_viewer/model.py
+++ b/napari/components/_viewer/model.py
@@ -496,12 +496,6 @@ class ViewerModel:
         ndim : int, optional
             Dimensions of shape data. Once set cannot be changed. Defaults to
             2.
-        broadcast : bool, optional
-            If True, shapes are broadcast across all dimensions if `ndim`
-            > 2. If False only shapes in the currently sliced layer are
-            visible. While it is possible to swith between these two views,
-            when you are in one view you will only be able to see and edit
-            shapes in that view.
         name : str, keyword-only
             Name of the layer.
 

--- a/napari/layers/_shapes_layer/model.py
+++ b/napari/layers/_shapes_layer/model.py
@@ -218,6 +218,8 @@ class Shapes(Layer):
             )
 
             if len(self._data) > 1:
+                # If multiple ShapeLists present and 2D slice key still there
+                # from initialization then remove 2D slice key
                 if () in self._data:
                     del self._data[()]
 
@@ -525,8 +527,6 @@ class Shapes(Layer):
             return (1,) * (self._input_ndim - 2) + slice_shape
         else:
             slice_keys = list(self.data.keys())
-            if () in slice_keys:
-                slice_keys.remove(())
             max_val = np.array(slice_keys).max(axis=0)
             return tuple(max_val) + slice_shape
 

--- a/napari/layers/_shapes_layer/model.py
+++ b/napari/layers/_shapes_layer/model.py
@@ -552,7 +552,7 @@ class Shapes(Layer):
         max_val = np.array(slice_keys).max(axis=0)
 
         mins = tuple(min_val) + tuple(mins)
-        mins = tuple(max_val) + tuple(mins)
+        mins = tuple(max_val) + tuple(maxs)
 
         return tuple((min, max, 1) for min, max in zip(mins, maxs))
 

--- a/napari/layers/_shapes_layer/model.py
+++ b/napari/layers/_shapes_layer/model.py
@@ -547,6 +547,13 @@ class Shapes(Layer):
             maxs = np.max(self.slice_data._vertices, axis=0) + 1
             mins = np.min(self.slice_data._vertices, axis=0)
 
+        slice_keys = list(self.data.keys())
+        min_val = np.array(slice_keys).min(axis=0)
+        max_val = np.array(slice_keys).max(axis=0)
+
+        mins = tuple(min_val) + tuple(mins)
+        mins = tuple(max_val) + tuple(mins)
+
         return tuple((min, max, 1) for min, max in zip(mins, maxs))
 
     def add_shapes(

--- a/napari/layers/_shapes_layer/model.py
+++ b/napari/layers/_shapes_layer/model.py
@@ -531,13 +531,9 @@ class Shapes(Layer):
         else:
             slice_shape = tuple(np.max(self.slice_data._vertices, axis=0) + 1)
 
-        if len(self.data.keys()) == 1:
-            # return the shape padded to the necessary dimensions
-            return (1,) * (self._input_ndim - 2) + slice_shape
-        else:
-            slice_keys = list(self.data.keys())
-            max_val = np.array(slice_keys).max(axis=0)
-            return tuple(max_val) + slice_shape
+        slice_keys = list(self.data.keys())
+        max_val = np.array(slice_keys).max(axis=0)
+        return tuple(max_val) + slice_shape
 
     @property
     def range(self):

--- a/napari/layers/_shapes_layer/view/properties.py
+++ b/napari/layers/_shapes_layer/view/properties.py
@@ -12,7 +12,6 @@ class QtShapesProperties(QtLayerProperties):
         self.layer.events.edge_width.connect(self._on_edge_width_change)
         self.layer.events.edge_color.connect(self._on_edge_color_change)
         self.layer.events.face_color.connect(self._on_face_color_change)
-        self.layer.events.broadcast.connect(self._on_broadcast_change)
 
         sld = QSlider(Qt.Horizontal, self)
         sld.setFocusPolicy(Qt.NoFocus)
@@ -72,17 +71,6 @@ class QtShapesProperties(QtLayerProperties):
         )
         self.grid_layout.addWidget(edge_comboBox, row, self.property_column)
 
-        broadcast_cb = QCheckBox()
-        broadcast_cb.setToolTip('broadcast shapes')
-        broadcast_cb.setChecked(self.layer.broadcast)
-        broadcast_cb.stateChanged.connect(
-            lambda state=broadcast_cb: self.change_broadcast(state)
-        )
-        self.broadcastCheckBox = broadcast_cb
-        row = self.grid_layout.rowCount()
-        self.grid_layout.addWidget(QLabel('broadcast:'), row, self.name_column)
-        self.grid_layout.addWidget(broadcast_cb, row, self.property_column)
-
         self.setExpanded(False)
 
     def changeFaceColor(self, text):
@@ -93,9 +81,6 @@ class QtShapesProperties(QtLayerProperties):
 
     def changeWidth(self, value):
         self.layer.edge_width = float(value) / 2
-
-    def change_broadcast(self, state):
-        self.layer.broadcast = state == Qt.Checked
 
     def _on_edge_width_change(self, event):
         with self.layer.events.edge_width.blocker():
@@ -116,7 +101,3 @@ class QtShapesProperties(QtLayerProperties):
                 self.layer.face_color, Qt.MatchFixedString
             )
             self.faceComboBox.setCurrentIndex(index)
-
-    def _on_broadcast_change(self, event):
-        with self.layer.events.broadcast.blocker():
-            self.broadcastCheckBox.setChecked(self.layer.broadcast)


### PR DESCRIPTION
# Description
This PR fixes #344 by removing the broadcast mode from shapes. 2D shape layers are automatically broadcast across the nD viewer and so the extra mode was confusing at best. The only downside, as pointed out by @jni is that now it is no longer possible to add a 2D shapes layer from the GUI when an nD image is present. We should probably fix that another way though


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run `example/add_shapes.py` and `example/nD_shapes.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
