### PR TITLE
add points thumbnail

### DIFF
--- a/napari/layers/_points_layer/model.py
+++ b/napari/layers/_points_layer/model.py
@@ -3,7 +3,6 @@ from xml.etree.ElementTree import Element
 import numpy as np
 from scipy import ndimage as ndi
 from skimage.util import img_as_ubyte
-from copy import copy
 from .._base_layer import Layer
 from ..._vispy.scene.visuals import Markers as MarkersNode
 from ...util.event import Event
@@ -436,6 +435,7 @@ class Points(Layer):
         """Update thumbnail with current points and colors.
         """
         colormapped = np.zeros(self._thumbnail_shape)
+        colormapped[..., 3] = 1
         if len(self._points_view) > 0:
             min_vals = [self.range[-2][0], self.range[-1][0]]
             shape = np.ceil(

--- a/napari/layers/_points_layer/model.py
+++ b/napari/layers/_points_layer/model.py
@@ -448,6 +448,9 @@ class Points(Layer):
             coords = np.floor(
                 (self._points_view - min_vals + 0.5) * zoom_factor
             ).astype(int)
+            coords = np.clip(
+                coords, 0, np.subtract(self._thumbnail_shape[:2], 1)
+            )
             for c in coords:
                 colormapped[c[0], c[1], :] = Color(self.face_color).rgba
         colormapped[..., 3] *= self.opacity

--- a/napari/layers/_points_layer/model.py
+++ b/napari/layers/_points_layer/model.py
@@ -1,6 +1,9 @@
 from typing import Union
 from xml.etree.ElementTree import Element
 import numpy as np
+from scipy import ndimage as ndi
+from skimage.util import img_as_ubyte
+from copy import copy
 from .._base_layer import Layer
 from ..._vispy.scene.visuals import Markers as MarkersNode
 from ...util.event import Event
@@ -90,6 +93,8 @@ class Points(Layer):
             # update flags
             self._need_display_update = False
             self._need_visual_update = False
+
+        self.events.opacity.connect(lambda e: self._update_thumbnail())
 
     @property
     def coords(self) -> np.ndarray:
@@ -400,6 +405,7 @@ class Points(Layer):
         self._need_visual_update = True
         self._update()
         self.status = self.get_message(self.coordinates, self._selected_points)
+        self._update_thumbnail()
 
     def get_message(self, coord, value):
         """Returns coordinate and value string for given mouse coordinates
@@ -425,6 +431,28 @@ class Points(Layer):
         else:
             msg = msg + ', index ' + str(value)
         return msg
+
+    def _update_thumbnail(self):
+        """Update thumbnail with current points and colors.
+        """
+        colormapped = np.zeros(self._thumbnail_shape)
+        if len(self._points_view) > 0:
+            min_vals = [self.range[-2][0], self.range[-1][0]]
+            shape = np.ceil(
+                [
+                    self.range[-2][1] - self.range[-2][0] + 1,
+                    self.range[-1][1] - self.range[-1][0] + 1,
+                ]
+            ).astype(int)
+            zoom_factor = np.divide(self._thumbnail_shape[:2], shape).min()
+            coords = np.floor(
+                (self._points_view - min_vals + 0.5) * zoom_factor
+            ).astype(int)
+            for c in coords:
+                colormapped[c[0], c[1], :] = Color(self.face_color).rgba
+        colormapped[..., 3] *= self.opacity
+        colormapped = img_as_ubyte(colormapped)
+        self.thumbnail = colormapped
 
     def _add(self, coord):
         """Adds object at given mouse position


### PR DESCRIPTION
# Description
This PR adds a thumbnail to the points layer. It does this my first downsampling the points and placing them in a grid the size of the thumbnail that is determined by their location within the points layer. This means that each point maps to at least one pixel in the 32x32 thumbnail - so no points are missing, but nearby points might get mapped to the same pixel and appear as one dot. Also the placement within the thumbnail is determined by the min / max of the points layer, so adding points at the extremes of the points layer can cause all the points to shift position, and there is always one point located in the corner of the thumbnail if there are more that one point present. In practice I find this behavior ok.

Also the `size` parameter of the points is ignored when rendering the thumbnail, they are all treated equally as exactly one pixel in size. Finally the edge color of the point is also ignored, only the face_color is used, which I think is fine too, though I will note that dark colors (even blue) are hard to see.

Here is what it looks like in practice:

![points_thumbnails](https://user-images.githubusercontent.com/6531703/59812283-3b6fbc80-92c2-11e9-8507-b821dc0b9ed6.gif)

Thoughts @kevinyamauchi?
 
## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] `examples/add_points.py`, `examples/nD_points.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
