### PR TITLE
Ignore precision loss warnings from thumbnails

### DIFF
--- a/examples/add_pyramid.py
+++ b/examples/add_pyramid.py
@@ -1,6 +1,7 @@
 """
 Displays an image pyramid
 """
+import warnings
 
 from skimage import data
 from skimage.util import img_as_ubyte
@@ -17,7 +18,10 @@ base = np.tile(astronaut, (16, 16))
 pyramid = list(
     pyramid_gaussian(base, downscale=2, max_layer=5, multichannel=False)
 )
-pyramid = [img_as_ubyte(p) for p in pyramid]
+# ignore skimage precision loss warning
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    pyramid = [img_as_ubyte(p) for p in pyramid]
 print('pyramid level shapes: ', [p.shape for p in pyramid])
 
 with app_context():

--- a/examples/nD_pyramid.py
+++ b/examples/nD_pyramid.py
@@ -1,6 +1,7 @@
 """
 Displays an image pyramid
 """
+import warnings
 
 from skimage import data
 from skimage.util import img_as_ubyte
@@ -20,7 +21,10 @@ print('base shape', base.shape)
 pyramid = list(
     pyramid_gaussian(base, downscale=2, max_layer=4, multichannel=False)
 )
-pyramid = [img_as_ubyte(p) for p in pyramid]
+# ignore skimage precision loss warning
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    pyramid = [img_as_ubyte(p) for p in pyramid]
 print('pyramid level shapes: ', [p.shape for p in pyramid])
 
 with app_context():

--- a/examples/nD_pyramid_non_uniform.py
+++ b/examples/nD_pyramid_non_uniform.py
@@ -1,6 +1,7 @@
 """
 Displays an image pyramid
 """
+import warnings
 
 from skimage import data
 from skimage.util import img_as_ubyte
@@ -20,7 +21,10 @@ pyramid = list(
 pyramid = [
     np.array([p * (abs(5 - i) + 1) / 6 for i in range(10)]) for p in pyramid
 ]
-pyramid = [img_as_ubyte(p) for p in pyramid]
+# ignore skimage precision loss warning
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    pyramid = [img_as_ubyte(p) for p in pyramid]
 print('pyramid level shapes: ', [p.shape for p in pyramid])
 
 with app_context():

--- a/napari/layers/_image_layer/model.py
+++ b/napari/layers/_image_layer/model.py
@@ -1,4 +1,4 @@
-from warnings import warn
+import warnings
 from xml.etree.ElementTree import Element
 from base64 import b64encode
 from imageio import imwrite
@@ -246,7 +246,7 @@ class Image(Layer):
             )
             self._colormaps[name] = colormap
         else:
-            warn(f'invalid value for colormap: {colormap}')
+            warnings.warn(f'invalid value for colormap: {colormap}')
             name = self.colormap_name
         self.colormap_name = name
         self._node.cmap = self._colormaps[name]
@@ -332,9 +332,14 @@ class Image(Layer):
             )
             if image.shape[2] == 4:  # image is RGBA
                 downsampled[..., 3] = downsampled[..., 3] * self.opacity
-                colormapped = img_as_ubyte(downsampled)
+
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    colormapped = img_as_ubyte(downsampled)
             else:  # image is RGB
-                colormapped = img_as_ubyte(downsampled)
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    colormapped = img_as_ubyte(downsampled)
                 alpha = np.full(
                     downsampled.shape[:2] + (1,),
                     int(255 * self.opacity),
@@ -353,7 +358,10 @@ class Image(Layer):
             colormapped = self.colormap[1].map(downsampled)
             colormapped = colormapped.reshape(downsampled.shape + (4,))
             colormapped[..., 3] *= self.opacity
-            colormapped = img_as_ubyte(colormapped)
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                colormapped = img_as_ubyte(colormapped)
         self.thumbnail = colormapped
 
     def get_value(self):

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Union
 import numpy as np
 from scipy import ndimage as ndi
@@ -546,7 +547,9 @@ class Labels(Layer):
         colormapped = self.colormap.map(downsampled)
         colormapped = colormapped.reshape(downsampled.shape + (4,))
         colormapped[..., 3] *= self.opacity
-        self.thumbnail = img_as_ubyte(colormapped)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.thumbnail = img_as_ubyte(colormapped)
 
     def to_xml_list(self):
         """Generates a list with a single xml element that defines the


### PR DESCRIPTION
# Description
This PR ignores the precision loss warnings from skimage when converting the thumbnail image to uint8.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
This is a temporary fix for #349 until skimage 0.16 is released.

# How has this been tested?
- [ ] `/examples/add_image.py`
- [ ] `/examples/labels-2d.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
