### PR TITLE
Add menubar to napari main window

### DIFF
--- a/napari/_view.py
+++ b/napari/_view.py
@@ -3,10 +3,11 @@ from .viewer import Viewer
 
 def view(
     *images,
+    title='napari',
+    hide_menubar=True,
     meta=None,
     multichannel=None,
     clim_range=None,
-    title='napari',
     **named_images,
 ):
     """View one or more input images.
@@ -17,6 +18,8 @@ def view(
         Arrays to render as image layers.
     title : string, optional
         The title of the viewer window.
+    hide_menubar : bool, optional
+        If False, a menubar will be shown.
     meta : dictionary, optional
         A dictionary of metadata attributes. If multiple images are provided,
         the metadata applies to all of them.
@@ -47,7 +50,7 @@ def view(
     :class:`napari.Viewer` class (preferred), or update the layers directly on
     the returned :class:`napari.Viewer` object.
     """
-    viewer = Viewer(title=title)
+    viewer = Viewer(title=title, hide_menubar=hide_menubar)
     for image in images:
         viewer.add_image(
             image, meta=meta, multichannel=multichannel, clim_range=clim_range

--- a/napari/_view.py
+++ b/napari/_view.py
@@ -4,7 +4,6 @@ from .viewer import Viewer
 def view(
     *images,
     title='napari',
-    hide_menubar=True,
     meta=None,
     multichannel=None,
     clim_range=None,
@@ -18,8 +17,6 @@ def view(
         Arrays to render as image layers.
     title : string, optional
         The title of the viewer window.
-    hide_menubar : bool, optional
-        If False, a menubar will be shown.
     meta : dictionary, optional
         A dictionary of metadata attributes. If multiple images are provided,
         the metadata applies to all of them.
@@ -50,7 +47,7 @@ def view(
     :class:`napari.Viewer` class (preferred), or update the layers directly on
     the returned :class:`napari.Viewer` object.
     """
-    viewer = Viewer(title=title, hide_menubar=hide_menubar)
+    viewer = Viewer(title=title)
     for image in images:
         viewer.add_image(
             image, meta=meta, multichannel=multichannel, clim_range=clim_range

--- a/napari/components/_window/view.py
+++ b/napari/components/_window/view.py
@@ -1,5 +1,4 @@
-from qtpy.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QLabel
-from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QLabel, QAction
 
 from ...util.theme import template
 
@@ -29,8 +28,12 @@ class Window:
         self._qt_window.setWindowTitle(self.qt_viewer.viewer.title)
         self._qt_center.setLayout(QHBoxLayout())
         self._status_bar = self._qt_window.statusBar()
-        self._status_bar.showMessage('Ready')
+        self.main_menu = self._qt_window.menuBar()
 
+        self._add_window_menu()
+        self._add_view_menu()
+
+        self._status_bar.showMessage('Ready')
         self._help = QLabel('')
         self._status_bar.addPermanentWidget(self._help)
 
@@ -48,6 +51,24 @@ class Window:
 
         if show:
             self.show()
+
+    def _add_window_menu(self):
+        exit_action = QAction("Close window", self._qt_window)
+        exit_action.setShortcut("Ctrl+W")
+        exit_action.setStatusTip('Close napari window')
+        exit_action.triggered.connect(self._qt_window.close)
+        self.window_menu = self.main_menu.addMenu('&Window')
+        self.window_menu.addAction(exit_action)
+
+    def _add_view_menu(self):
+        toggle_visible = QAction('Toggle menubar visibility', self._qt_window)
+        toggle_visible.setShortcut('Alt')
+        toggle_visible.setStatusTip('Show/hide the menubar')
+        toggle_visible.triggered.connect(
+            lambda: self.main_menu.setVisible(not self.main_menu.isVisible())
+        )
+        self.view_menu = self.main_menu.addMenu('&View')
+        self.view_menu.addAction(toggle_visible)
 
     def resize(self, width, height):
         """Resize the window.

--- a/napari/components/_window/view.py
+++ b/napari/components/_window/view.py
@@ -25,7 +25,7 @@ class Window:
         Contained viewer widget.
     """
 
-    def __init__(self, qt_viewer, *, show=True, hide_menubar=True):
+    def __init__(self, qt_viewer, *, show=True):
 
         self.qt_viewer = qt_viewer
 
@@ -37,7 +37,7 @@ class Window:
         self._qt_center.setLayout(QHBoxLayout())
         self._status_bar = self._qt_window.statusBar()
 
-        self._add_menubar(hidden=hide_menubar)
+        self._add_menubar()
 
         self._add_window_menu()
         self._add_view_menu()
@@ -61,7 +61,7 @@ class Window:
         if show:
             self.show()
 
-    def _add_menubar(self, *, hidden=True):
+    def _add_menubar(self):
         self.main_menu = self._qt_window.menuBar()
         # Menubar shortcuts are only active when the menubar is visible.
         # Therefore, we set a global shortcut not associated with the menubar
@@ -76,8 +76,6 @@ class Window:
             self._toggle_menubar_visible
         )
         self._main_menu_shortcut.setEnabled(False)
-        if hidden:
-            self._toggle_menubar_visible()
 
     def _toggle_menubar_visible(self):
         """Toggle visibility of app menubar.

--- a/napari/components/_window/view.py
+++ b/napari/components/_window/view.py
@@ -67,7 +67,8 @@ class Window:
         # Therefore, we set a global shortcut not associated with the menubar
         # to toggle visibility, *but*, in order to not shadow the menubar
         # shortcut, we disable it, and only enable it when the menubar is
-        # hidden.
+        # hidden. See this stackoverflow link for details:
+        # https://stackoverflow.com/questions/50537642/how-to-keep-the-shortcuts-of-a-hidden-widget-in-pyqt5
         self._main_menu_shortcut = QShortcut(
             QKeySequence('Ctrl+M'), self._qt_window
         )

--- a/napari/components/_window/view.py
+++ b/napari/components/_window/view.py
@@ -39,8 +39,9 @@ class Window:
 
         self._add_menubar()
 
-        self._add_window_menu()
+        self._add_file_menu()
         self._add_view_menu()
+        self._add_window_menu()
 
         self._status_bar.showMessage('Ready')
         self._help = QLabel('')
@@ -91,13 +92,13 @@ class Window:
             self.main_menu.setVisible(True)
             self._main_menu_shortcut.setEnabled(False)
 
-    def _add_window_menu(self):
-        exit_action = QAction("Close window", self._qt_window)
-        exit_action.setShortcut("Ctrl+W")
-        exit_action.setStatusTip('Close napari window')
-        exit_action.triggered.connect(self._qt_window.close)
-        self.window_menu = self.main_menu.addMenu('&Window')
-        self.window_menu.addAction(exit_action)
+    def _add_file_menu(self):
+        open_images = QAction('Open', self._qt_window)
+        open_images.setShortcut('Ctrl+O')
+        open_images.setStatusTip('Open image file(s)')
+        open_images.triggered.connect(self.qt_viewer._open_images)
+        self.file_menu = self.main_menu.addMenu('&File')
+        self.file_menu.addAction(open_images)
 
     def _add_view_menu(self):
         toggle_visible = QAction('Toggle menubar visibility', self._qt_window)
@@ -106,6 +107,14 @@ class Window:
         toggle_visible.triggered.connect(self._toggle_menubar_visible)
         self.view_menu = self.main_menu.addMenu('&View')
         self.view_menu.addAction(toggle_visible)
+
+    def _add_window_menu(self):
+        exit_action = QAction("Close window", self._qt_window)
+        exit_action.setShortcut("Ctrl+W")
+        exit_action.setStatusTip('Close napari window')
+        exit_action.triggered.connect(self._qt_window.close)
+        self.window_menu = self.main_menu.addMenu('&Window')
+        self.window_menu.addAction(exit_action)
 
     def resize(self, width, height):
         """Resize the window.

--- a/napari/main.py
+++ b/napari/main.py
@@ -25,7 +25,7 @@ def main():
     )
     args = parser.parse_args()
     with app_context():
-        v = Viewer(hide_menubar=False)
+        v = Viewer()
         images = io.ImageCollection(args.images, conserve_memory=False)
         if args.layers:
             for image in images:
@@ -35,6 +35,4 @@ def main():
                 image = images[0]
             else:
                 image = np.stack(images, axis=0)
-            v.add_image(
-                image, multichannel=args.multichannel, hide_menubar=False
-            )
+            v.add_image(image, multichannel=args.multichannel)

--- a/napari/main.py
+++ b/napari/main.py
@@ -11,7 +11,7 @@ from . import Viewer
 
 def main():
     parser = argparse.ArgumentParser(usage=__doc__)
-    parser.add_argument('images', nargs='+', help='Images to view.')
+    parser.add_argument('images', nargs='*', help='Images to view.')
     parser.add_argument(
         '--layers',
         action='store_true',
@@ -31,8 +31,9 @@ def main():
             for image in images:
                 v.add_image(image, multichannel=args.multichannel)
         else:
-            if len(images) == 1:
-                image = images[0]
-            else:
-                image = np.stack(images, axis=0)
-            v.add_image(image, multichannel=args.multichannel)
+            if len(images) > 0:
+                if len(images) == 1:
+                    image = images[0]
+                else:
+                    image = np.stack(images, axis=0)
+                v.add_image(image, multichannel=args.multichannel)

--- a/napari/main.py
+++ b/napari/main.py
@@ -1,0 +1,40 @@
+"""
+napari command line viewer.
+"""
+import argparse
+import numpy as np
+from skimage import io
+
+from .util import app_context
+from . import Viewer
+
+
+def main():
+    parser = argparse.ArgumentParser(usage=__doc__)
+    parser.add_argument('images', nargs='+', help='Images to view.')
+    parser.add_argument(
+        '--layers',
+        action='store_true',
+        help='Treat multiple input images as layers.',
+    )
+    parser.add_argument(
+        '-m',
+        '--multichannel',
+        help='Treat images as RGB.',
+        action='store_true',
+    )
+    args = parser.parse_args()
+    with app_context():
+        v = Viewer(hide_menubar=False)
+        images = io.ImageCollection(args.images, conserve_memory=False)
+        if args.layers:
+            for image in images:
+                v.add_image(image, multichannel=args.multichannel)
+        else:
+            if len(images) == 1:
+                image = images[0]
+            else:
+                image = np.stack(images, axis=0)
+            v.add_image(
+                image, multichannel=args.multichannel, hide_menubar=False
+            )

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -68,9 +68,10 @@ def is_multichannel(meta):
 def guess_multichannel(shape):
     """If last dim is 3 or 4 assume image is multichannel.
     """
+    ndim = len(shape)
     last_dim = shape[-1]
 
-    if last_dim in (3, 4):
+    if ndim > 2 and last_dim < 5:
         return True
     else:
         return False

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -11,9 +11,9 @@ class Viewer(ViewerModel):
         The title of the viewer window.
     """
 
-    def __init__(self, title='napari'):
+    def __init__(self, title='napari', hide_menubar=True):
         super().__init__(title=title)
         qt_viewer = QtViewer(self)
-        self.window = Window(qt_viewer)
+        self.window = Window(qt_viewer, hide_menubar=hide_menubar)
         self.screenshot = self.window.qt_viewer.screenshot
         self.camera = self.window.qt_viewer.view.camera

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -11,9 +11,9 @@ class Viewer(ViewerModel):
         The title of the viewer window.
     """
 
-    def __init__(self, title='napari', hide_menubar=True):
+    def __init__(self, title='napari'):
         super().__init__(title=title)
         qt_viewer = QtViewer(self)
-        self.window = Window(qt_viewer, hide_menubar=hide_menubar)
+        self.window = Window(qt_viewer)
         self.screenshot = self.window.qt_viewer.screenshot
         self.camera = self.window.qt_viewer.view.camera

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ if __name__ == '__main__':
         requires=REQUIRES,
         python_requires=f'>={MIN_PY_VER}',
         packages=PACKAGES,
+        entry_points={'console_scripts': ['napari=napari.main:main']},
         include_package_data=True,
         zip_safe=False,  # the package can run out of an .egg file
     )


### PR DESCRIPTION
# Description
Eventually, this menu will contain all the options we want out of napari, including file opening, adding plugins, and running plugins. For now, I leave it turned off for the programmatically-launched viewer, so this shouldn't affect functionality in any way, except adding the ability to toggle it on.

This is motivated by parallel work on https://github.com/napari/napari-app, where I'd like napari to behave like a native app, with a proper menubar.

As you'll see in the code, when the menubar is hidden, none of its shortcuts are active, which is annoying, but I didn't find a workaround. Suggestions most welcome!

I also don't know what this does on macOS (menubars shouldn't be hidden on mac, since the main menubar is always visible), so testing would also be appreciated! If the menubar items disappear when setting the menubar to invisible, I might favour adding a check to keep it always on on mac.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)


# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
