### PR TITLE
fix selected default

### DIFF
--- a/napari/layers/_base_layer/view/properties.py
+++ b/napari/layers/_base_layer/view/properties.py
@@ -120,7 +120,7 @@ class QtLayerProperties(QFrame):
         self.grid_layout.setColumnMinimumWidth(0, 100)
         self.grid_layout.setColumnMinimumWidth(1, 100)
 
-        self.setSelected(True)
+        self.setSelected(self.layer.selected)
 
     def setSelected(self, state):
         self.setProperty('selected', state)


### PR DESCRIPTION
# Description
This PR refactors the setting of layer selected properties away from being hardcoded to reading the value of the layer instead, improving on #347 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run `example/add_points.py` and look at selection stylings

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
