### PR TITLE
[FIX] setting remote upstream in contributing guidelines 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ $ cd napari
 
 Set the `upstream` remote to the base `napari` repository:
 ```sh
-$ git add upstream https://github.com/napari/napari.git
+$ git remote add upstream https://github.com/napari/napari.git
 ```
 
 Install the required dependencies:


### PR DESCRIPTION
# Description
This PR fixes a typo in the contributing guidelines. Specifically, adding the word "remote" when adding an upstream repo. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
