### PR TITLE
Refactor thumbnail type conversion

### DIFF
--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -1,7 +1,9 @@
+import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from xml.etree.ElementTree import Element, tostring
 import numpy as np
+from skimage import img_as_ubyte
 
 from ...util.event import Event
 from ._visual_wrapper import VisualWrapper
@@ -163,6 +165,10 @@ class Layer(VisualWrapper, ABC):
 
     @thumbnail.setter
     def thumbnail(self, thumbnail):
+        if thumbnail.dtype != 'uint8':
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                thumbnail = img_as_ubyte(thumbnail)
         self._thumbnail = thumbnail
         self.events.thumbnail()
 

--- a/napari/layers/_base_layer/model.py
+++ b/napari/layers/_base_layer/model.py
@@ -165,7 +165,7 @@ class Layer(VisualWrapper, ABC):
 
     @thumbnail.setter
     def thumbnail(self, thumbnail):
-        if thumbnail.dtype != 'uint8':
+        if thumbnail.dtype != np.uint8:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 thumbnail = img_as_ubyte(thumbnail)

--- a/napari/layers/_image_layer/model.py
+++ b/napari/layers/_image_layer/model.py
@@ -5,7 +5,6 @@ from imageio import imwrite
 
 import numpy as np
 from scipy import ndimage as ndi
-from skimage.util import img_as_ubyte
 
 import vispy.color
 
@@ -332,9 +331,9 @@ class Image(Layer):
             )
             if image.shape[2] == 4:  # image is RGBA
                 downsampled[..., 3] = downsampled[..., 3] * self.opacity
-                colormapped = img_as_ubyte(downsampled)
+                colormapped = downsampled
             else:  # image is RGB
-                colormapped = img_as_ubyte(downsampled)
+                colormapped = downsampled
                 alpha = np.full(
                     downsampled.shape[:2] + (1,),
                     int(255 * self.opacity),
@@ -353,7 +352,6 @@ class Image(Layer):
             colormapped = self.colormap[1].map(downsampled)
             colormapped = colormapped.reshape(downsampled.shape + (4,))
             colormapped[..., 3] *= self.opacity
-            colormapped = img_as_ubyte(colormapped)
         self.thumbnail = colormapped
 
     def get_value(self):

--- a/napari/layers/_image_layer/model.py
+++ b/napari/layers/_image_layer/model.py
@@ -330,16 +330,14 @@ class Image(Layer):
                 image, (zoom_factor, zoom_factor, 1), prefilter=False, order=0
             )
             if image.shape[2] == 4:  # image is RGBA
-                downsampled[..., 3] = downsampled[..., 3] * self.opacity
-                colormapped = downsampled
+                colormapped[..., 3] = downsampled[..., 3] * self.opacity
             else:  # image is RGB
-                colormapped = downsampled
                 alpha = np.full(
                     downsampled.shape[:2] + (1,),
                     int(255 * self.opacity),
                     dtype=np.uint8,
                 )
-                colormapped = np.concatenate([colormapped, alpha], axis=2)
+                colormapped = np.concatenate([downsampled, alpha], axis=2)
         else:
             downsampled = ndi.zoom(
                 image, zoom_factor, prefilter=False, order=0

--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -1,7 +1,6 @@
 from typing import Union
 import numpy as np
 from scipy import ndimage as ndi
-from skimage.util import img_as_ubyte
 from xml.etree.ElementTree import Element
 from base64 import b64encode
 from imageio import imwrite
@@ -546,7 +545,7 @@ class Labels(Layer):
         colormapped = self.colormap.map(downsampled)
         colormapped = colormapped.reshape(downsampled.shape + (4,))
         colormapped[..., 3] *= self.opacity
-        self.thumbnail = img_as_ubyte(colormapped)
+        self.thumbnail = colormapped
 
     def to_xml_list(self):
         """Generates a list with a single xml element that defines the

--- a/napari/layers/_points_layer/model.py
+++ b/napari/layers/_points_layer/model.py
@@ -2,7 +2,6 @@ from typing import Union
 from xml.etree.ElementTree import Element
 import numpy as np
 from scipy import ndimage as ndi
-from skimage.util import img_as_ubyte
 from .._base_layer import Layer
 from ..._vispy.scene.visuals import Markers as MarkersNode
 from ...util.event import Event
@@ -454,7 +453,6 @@ class Points(Layer):
             for c in coords:
                 colormapped[c[0], c[1], :] = Color(self.face_color).rgba
         colormapped[..., 3] *= self.opacity
-        colormapped = img_as_ubyte(colormapped)
         self.thumbnail = colormapped
 
     def _add(self, coord):


### PR DESCRIPTION
# Description
This PR moves the image type conversion when generating thumbnails to the base layer. Also, it ignores the precision loss warnings from skimage when converting the thumbnail image to uint8.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
This is the solution discussed in #355  and is a temporary fix for #349 until skimage 0.16 is released.

# How has this been tested?
I ran examples for each layer type altered
- [x] `/examples/add_image.py`
- [x] `/examples/add_points.py`
- [x] `/examples/labels-2d.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
