### PR TITLE
standardize keybindings framework

### DIFF
--- a/examples/custom_key_bindings.py
+++ b/examples/custom_key_bindings.py
@@ -14,12 +14,14 @@ with napari.gui_qt():
 
     viewer.add_image(blobs, name='blobs')
 
+    @viewer.bind_key('a')
     def accept_image(viewer):
         msg = 'this is a good image'
         viewer.status = msg
         print(msg)
         next(viewer)
 
+    @viewer.bind_key('r')
     def reject_image(viewer):
         msg = 'this is a bad image'
         viewer.status = msg
@@ -32,8 +34,15 @@ with napari.gui_qt():
         ).astype(float)
         viewer.layers[0].data = blobs
 
-    custom_key_bindings = {'a': accept_image, 'r': reject_image}
-    viewer.key_bindings = custom_key_bindings
+    @napari.Viewer.bind_key('w')
+    def hello(viewer):
+        # on press
+        viewer.status = 'hello world!'
+
+        yield
+
+        # on release
+        viewer.status = 'goodbye world :('
 
     # change viewer title
     viewer.title = 'quality control images'

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -1,5 +1,6 @@
 import os.path
 from glob import glob
+import inspect
 from pathlib import Path
 
 from qtpy.QtCore import QCoreApplication, Qt, QSize
@@ -12,6 +13,7 @@ from .qt_layerlist import QtLayerList
 from ..resources import resources_dir
 from ..util.theme import template
 from ..util.misc import is_multichannel
+from ..util.keybindings import components_to_key_combo
 from ..util.io import read
 
 from .qt_controls import QtControls
@@ -90,6 +92,8 @@ class QtViewer(QSplitter):
         }
 
         self._update_palette(viewer.palette)
+
+        self._key_release_generators = {}
 
         self.viewer.events.interactive.connect(self._on_interactive)
         self.viewer.events.cursor.connect(self._on_cursor)
@@ -214,20 +218,44 @@ class QtViewer(QSplitter):
     def on_key_press(self, event):
         """Called whenever key pressed in canvas.
         """
-        if (
-            event.text in self.viewer.key_bindings
-            and not event.native.isAutoRepeat()
-        ):
-            self.viewer.key_bindings[event.text](self.viewer)
+        if event.native.isAutoRepeat() or event.key is None:
             return
 
+        comb = components_to_key_combo(event.key.name, event.modifiers)
+
         layer = self.viewer.active_layer
+
+        # TODO: remove me once keybinding system converted
         if layer is not None:
             layer.on_key_press(event)
+
+        if layer is not None and comb in layer.keymap:
+            parent = layer
+        elif comb in self.viewer.keymap:
+            parent = self.viewer
+        else:
+            return
+
+        func = parent.keymap[comb]
+        gen = func(parent)
+
+        if inspect.isgeneratorfunction(func):
+            try:
+                next(gen)
+            except StopIteration:  # only one statement
+                pass
+            else:
+                self._key_release_generators[event.key] = gen
 
     def on_key_release(self, event):
         """Called whenever key released in canvas.
         """
+        try:
+            next(self._key_release_generators[event.key])
+        except (KeyError, StopIteration):
+            pass
+
+        # TODO: remove me once keybinding system converted
         layer = self.viewer.active_layer
         if layer is not None:
             layer.on_key_release(event)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -6,10 +6,11 @@ from .dims import Dims
 from .layerlist import LayerList
 from .. import layers
 from ..util.event import EmitterGroup, Event
+from ..util.keybindings import KeymapMixin
 from ..util.theme import palettes
 
 
-class ViewerModel:
+class ViewerModel(KeymapMixin):
     """Viewer containing the rendered scene, layers, and controlling elements
     including dimension sliders, and control bars for color limits.
 
@@ -31,6 +32,7 @@ class ViewerModel:
         Preset color palettes.
     """
 
+    class_keymap = {}
     themes = palettes
 
     def __init__(self, title='napari'):

--- a/napari/layers/base/_visual_wrapper.py
+++ b/napari/layers/base/_visual_wrapper.py
@@ -36,6 +36,7 @@ class VisualWrapper:
     """
 
     def __init__(self, central_node):
+        super().__init__()
         self._node = central_node
         self._blending = Blending.TRANSLUCENT
         self._parent = None

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -6,10 +6,11 @@ import numpy as np
 from skimage import img_as_ubyte
 
 from ...util.event import Event
+from ...util.keybindings import KeymapMixin
 from ._visual_wrapper import VisualWrapper
 
 
-class Layer(VisualWrapper, ABC):
+class Layer(VisualWrapper, KeymapMixin, ABC):
     """Base layer class.
 
     Parameters
@@ -26,6 +27,7 @@ class Layer(VisualWrapper, ABC):
         * `_get_shape()`: called by `shape` property
         * `_refresh()`: called by `refresh` method
         * `data` property (setter & getter)
+        * `class_keymap` class variable (dictionary)
 
     May define the following:
         * `_set_view_slice(indices)`: called to set currently viewed slice

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -90,6 +90,9 @@ class Image(Layer):
     """
 
     _colormaps = AVAILABLE_COLORMAPS
+
+    class_keymap = {}
+
     default_interpolation = str(Interpolation.NEAREST)
 
     def __init__(

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -90,6 +90,8 @@ class Labels(Layer):
         after painting is done. Used for interpolating brush strokes.
     """
 
+    class_keymap = {}
+
     def __init__(
         self,
         labels,

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -101,6 +101,8 @@ class Points(Layer):
     _highlight_color = (0, 0.6, 1)
     _highlight_width = 1.5
 
+    class_keymap = {}
+
     def __init__(
         self,
         coords,

--- a/napari/layers/pyramid/pyramid.py
+++ b/napari/layers/pyramid/pyramid.py
@@ -81,6 +81,8 @@ class Pyramid(Image):
 
     _max_tile_shape = np.array([1600, 1600])
 
+    class_keymap = {}
+
     def __init__(self, pyramid, *args, **kwargs):
 
         with self.freeze_refresh():

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -181,6 +181,8 @@ class Shapes(Layer):
         'polygon': Polygon,
     }
 
+    class_keymap = {}
+
     def __init__(
         self,
         data,

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -62,6 +62,8 @@ class Vectors(Layer):
     # If more vectors are present then they are randomly subsampled
     _max_vectors_thumbnail = 1024
 
+    class_keymap = {}
+
     def __init__(
         self, vectors, *, edge_width=1, edge_color='red', length=1, name=None
     ):

--- a/napari/util/keybindings.py
+++ b/napari/util/keybindings.py
@@ -1,0 +1,380 @@
+"""Key combinations are represented in the form ``[modifier-]key``,
+e.g. ``a``, ``Control-c``, or ``Control-Alt-Delete``.
+Valid modifiers are Control, Alt, Shift, and Meta.
+
+Letters will always be read as upper-case.
+Due to the native implementation of the key system, Shift pressed in certain
+key combinations may yield inconsistent or unexpected results.
+Therefore, it is not recommended to use Shift with non-letter keys.
+On OSX, Control is swapped with Meta such that pressing Command reads as
+Control.
+
+Special keys include Shift, Control, Alt, Meta, Up, Down, Left, Right,
+PageUp, PageDown, Insert, Delete, Home, End, Escape, Backspace, F1,
+F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, Space, Enter, and Tab
+
+Functions take in only one argument: the parent that the function
+was bound to. This is the viewer or layer.
+
+By default, all functions are assumed to work on key presses only,
+but can be denoted to work on release too by separating the function
+into two statements with the yield keyword::
+
+    @viewer.bind_key('h')
+    def hello_world(viewer):
+        # on key press
+        viewer.status = 'hello world!'
+
+        yield
+
+        # on key release
+        viewer.status = 'goodbye world :('
+
+"""
+
+import re
+import types
+from collections import OrderedDict, UserDict
+
+from vispy.util import keys
+
+
+SPECIAL_KEYS = [
+    keys.SHIFT,
+    keys.CONTROL,
+    keys.ALT,
+    keys.META,
+    keys.UP,
+    keys.DOWN,
+    keys.LEFT,
+    keys.RIGHT,
+    keys.PAGEUP,
+    keys.PAGEDOWN,
+    keys.INSERT,
+    keys.DELETE,
+    keys.HOME,
+    keys.END,
+    keys.ESCAPE,
+    keys.BACKSPACE,
+    keys.F1,
+    keys.F2,
+    keys.F3,
+    keys.F4,
+    keys.F5,
+    keys.F6,
+    keys.F7,
+    keys.F8,
+    keys.F9,
+    keys.F10,
+    keys.F11,
+    keys.F12,
+    keys.SPACE,
+    keys.ENTER,
+    keys.TAB,
+]
+
+MODIFIER_KEYS = [keys.CONTROL, keys.ALT, keys.SHIFT, keys.META]
+
+
+def parse_key_combo(key_combo):
+    """Parse a key combination into its components in a comparable format.
+
+    Parameters
+    ----------
+    key_combo : str
+        Key combination.
+
+    Returns
+    -------
+    key : str
+        Base key of the combination.
+    modifiers : set of str
+        Modifier keys of the combination.
+    """
+    parsed = re.split('-(?=.+)', key_combo)
+    *modifiers, key = parsed
+
+    return key, set(modifiers)
+
+
+def components_to_key_combo(key, modifiers):
+    """Combine components to become a key combination.
+
+    Modifier keys will always be combined in the same order:
+    Control, Alt, Shift, Meta
+
+    Letters will always be read as upper-case.
+    Due to the native implementation of the key system, Shift pressed in certain
+    key combinations may yield inconsistent or unexpected results.
+    Therefore, it is not recommended to use Shift with non-letter keys.
+    On OSX, Control is swapped with Meta such that pressing Command reads as
+    Control.
+
+    Parameters
+    ----------
+    key : str or vispy.app.Key
+        Base key.
+    modifiers : combination of str or vispy.app.Key
+        Modifier keys.
+
+    Returns
+    -------
+    key_combo : str
+        Generated key combination.
+    """
+    if len(key) == 1 and key.isalpha():  # it's a letter
+        key = key.upper()
+        cond = lambda m: True  # noqa: E731
+    elif key in SPECIAL_KEYS:
+        # remove redundant information i.e. an output of 'Shift-Shift'
+        cond = lambda m: m != key  # noqa: E731
+    else:
+        # Shift is consumed to transform key
+
+        # bug found on OSX: Command will cause Shift to not
+        # transform the key so do not consume it
+        # note: 'Control' is OSX Command key
+        cond = lambda m: m != 'Shift' or 'Control' in modifiers  # noqa: E731
+
+    modifiers = tuple(
+        key.name
+        for key in filter(
+            lambda key: key in modifiers and cond(key), MODIFIER_KEYS
+        )
+    )
+
+    return '-'.join(modifiers + (key,))
+
+
+def normalize_key_combo(key_combo):
+    """Normalize key combination to make it easily comparable.
+
+    All aliases are converted and modifier orders are fixed to:
+    Control, Alt, Shift, Meta
+
+    Letters will always be read as upper-case.
+    Due to the native implementation of the key system, Shift pressed in certain
+    key combinations may yield inconsistent or unexpected results.
+    Therefore, it is not recommended to use Shift with non-letter keys.
+    On OSX, Control is swapped with Meta such that pressing Command reads as
+    Control.
+
+    Parameters
+    ----------
+    key_combo : str
+        Key combination.
+
+    Returns
+    -------
+    normalized_key_combo : str
+        Normalized key combination.
+    """
+    key, modifiers = parse_key_combo(key_combo)
+
+    if len(key) != 1 and key not in SPECIAL_KEYS:
+        raise TypeError(f'invalid key {key}')
+
+    for modifier in modifiers:
+        if modifier not in MODIFIER_KEYS:
+            raise TypeError(f'invalid modifier key {modifier}')
+
+    return components_to_key_combo(key, modifiers)
+
+
+UNDEFINED = object()
+
+
+def bind_key(keymap, key, func=UNDEFINED, *, overwrite=False):
+    """Bind a key combination to a keymap.
+
+    Parameters
+    ----------
+    keymap : dict of str: callable
+        Keymap to modify.
+    key : str
+        Key combination.
+    func : callable or None
+        Callable to bind to the key combination.
+        If ``None`` is passed, unbind instead.
+    overwrite : bool, keyword-only, optional
+        Whether to overwrite the key combination if it already exists.
+
+    Returns
+    -------
+    unbound : callable or None
+        Callable unbound by this operation, if any.
+
+    Notes
+    -----
+    Key combinations are represented in the form ``[modifier-]key``,
+    e.g. ``a``, ``Control-c``, or ``Control-Alt-Delete``.
+    Valid modifiers are Control, Alt, Shift, and Meta.
+
+    Letters will always be read as upper-case.
+    Due to the native implementation of the key system, Shift pressed in certain
+    key combinations may yield inconsistent or unexpected results.
+    Therefore, it is not recommended to use Shift with non-letter keys.
+    On OSX, Control is swapped with Meta such that pressing Command reads as
+    Control.
+
+    Special keys include Shift, Control, Alt, Meta, Up, Down, Left, Right,
+    PageUp, PageDown, Insert, Delete, Home, End, Escape, Backspace, F1,
+    F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, Space, Enter, and Tab
+
+    Functions take in only one argument: the parent that the function
+    was bound to. This is the viewer or layer.
+
+    By default, all functions are assumed to work on key presses only,
+    but can be denoted to work on release too by separating the function
+    into two statements with the yield keyword::
+
+        @viewer.bind_key('h')
+        def hello_world(viewer):
+            # on key press
+            viewer.status = 'hello world!'
+
+            yield
+
+            # on key release
+            viewer.status = 'goodbye world :('
+
+    """
+    if func is UNDEFINED:
+
+        def inner(func):
+            bind_key(keymap, key, func, overwrite=overwrite)
+            return func
+
+        return inner
+
+    key = normalize_key_combo(key)
+
+    if func is not None and key in keymap and not overwrite:
+        raise ValueError(
+            f'key combination {key} already used! '
+            "specify 'overwrite=True' to bypass this check"
+        )
+
+    unbound = keymap.pop(key, None)
+
+    if func is not None:
+        if not callable(func):
+            raise TypeError("'func' must be a callable")
+        keymap[key] = func
+
+    return unbound
+
+
+class KeybindingDescriptor:
+    """Descriptor which transforms ``func`` into a method with the first argument bound
+    to ``class_keymap`` or ``_keymap`` depending on if it was called
+    from the class or the instance, respectively.
+
+    Parameters
+    ----------
+    func : callable
+        Function to bind.
+    """
+
+    def __init__(self, func):
+        self.__func__ = func
+
+    def __get__(self, instance, klass):
+        if instance is None:  # used on class
+            try:
+                keymap = klass.class_keymap
+            except AttributeError:
+                return self.__func__
+        else:
+            keymap = instance._keymap
+
+        return types.MethodType(self.__func__, keymap)
+
+
+class InheritedKeymap(UserDict):
+    """Dictionary which inherits from another.
+
+    Values of ``None`` are treated as though the key doesn't exist.
+
+    Parameters
+    ----------
+    parent : callable() -> dict
+        Parent keymap.
+    contents : dict, optional
+        Contents with which to initialize.
+    """
+
+    def __init__(self, parent, contents={}):
+        super().__init__(contents)
+        self._parent = parent
+
+    def __getitem__(self, key):
+        try:
+            val = super().__getitem__(key)
+        except KeyError:
+            val = self._parent()[key]
+
+        if val is None:
+            raise KeyError(key)
+
+        return val
+
+    def __contains__(self, key):
+        try:
+            self[key]
+        except KeyError:
+            return False
+        else:
+            return True
+
+    def __delitem__(self, key):
+        self[key] = None
+
+    def copy(self):
+        return InheritedKeymap(self._parent, self.data.copy())
+
+    def pop(self, key, default=UNDEFINED):
+        try:
+            default = self[key]
+        except KeyError:
+            if default is UNDEFINED:
+                raise
+        else:
+            del self[key]
+
+        return default
+
+
+class KeymapMixin:
+    """Mix-in to add keymap functionality. Must still define ``class_keymap``
+    in every subclass.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        if cls is KeymapMixin:
+            raise TypeError('cannot instantiate mix-in class')
+        else:
+            if not hasattr(cls, 'class_keymap'):
+                raise TypeError(
+                    "KeymapMixin must define 'class_keymap' class attribute"
+                )
+
+        return object.__new__(cls)
+
+    def __init__(self):
+        self.keymap = {}
+
+    @property
+    def keymap(self):
+        """InheritedKeymap : Keymap used for shortcuts.
+        Inherits from ``class_keymap``.
+
+        Do not directly set key bindings; use ``bind_key`` instead.
+        """
+        return self._keymap.copy()
+
+    @keymap.setter
+    def keymap(self, keymap):
+        self._keymap = InheritedKeymap(lambda: self.class_keymap, keymap)
+
+    bind_key = KeybindingDescriptor(bind_key)

--- a/napari/util/tests/test_keybindings.py
+++ b/napari/util/tests/test_keybindings.py
@@ -1,0 +1,149 @@
+import pytest
+from .. import keybindings
+from ..keybindings import (
+    bind_key,
+    components_to_key_combo,
+    KeymapMixin,
+    InheritedKeymap,
+    normalize_key_combo,
+    parse_key_combo,
+)
+
+
+def test_parse_key_combo():
+    assert parse_key_combo('X') == ('X', set())
+    assert parse_key_combo('Control-X') == ('X', {'Control'})
+    assert parse_key_combo('Control-Alt-Shift-Meta-X') == (
+        'X',
+        {'Control', 'Alt', 'Shift', 'Meta'},
+    )
+
+
+def test_components_to_key_combo():
+    assert components_to_key_combo('X', []) == 'X'
+    assert components_to_key_combo('X', ['Control']) == 'Control-X'
+
+    # test consuming
+    assert components_to_key_combo('X', []) == 'X'
+    assert components_to_key_combo('X', ['Shift']) == 'Shift-X'
+    assert components_to_key_combo('x', []) == 'X'
+
+    assert components_to_key_combo('@', ['Shift']) == '@'
+    assert (
+        components_to_key_combo('2', ['Control', 'Shift']) == 'Control-Shift-2'
+    )
+
+    # test ordering
+    assert (
+        components_to_key_combo('2', ['Control', 'Alt', 'Shift', 'Meta'])
+        == 'Control-Alt-Shift-Meta-2'
+    )
+    assert (
+        components_to_key_combo('2', ['Alt', 'Shift', 'Control', 'Meta'])
+        == 'Control-Alt-Shift-Meta-2'
+    )
+
+
+def test_normalize_key_combo():
+    assert normalize_key_combo('x') == 'X'
+    assert normalize_key_combo('Control-X') == 'Control-X'
+    assert normalize_key_combo('Meta-Alt-X') == 'Alt-Meta-X'
+    assert (
+        normalize_key_combo('Shift-Alt-Control-Meta-2')
+        == 'Control-Alt-Shift-Meta-2'
+    )
+
+
+def test_bind_key():
+    kb = {}
+
+    # bind
+    f = lambda: 42
+    bind_key(kb, 'A', f)
+    assert kb == dict(A=f)
+
+    with pytest.raises(TypeError):  # must check for callable
+        bind_key(kb, 'B', 'not a callable')
+
+    # overwrite
+    l = lambda: 'SPAM'
+
+    with pytest.raises(ValueError):
+        bind_key(kb, 'A', l)
+
+    bind_key(kb, 'A', l, overwrite=True)
+    assert kb == dict(A=l)
+
+    # unbind
+    bind_key(kb, 'A', None)
+    assert kb == {}
+
+
+def test_bind_key_decorator():
+    kb = {}
+
+    @bind_key(kb, 'A')
+    def foo():
+        ...
+
+    assert kb == dict(A=foo)
+
+
+def test_InheritedKeymap():
+    d = {}
+    k = InheritedKeymap(lambda: d, {'A': 0})
+    assert k['A'] == 0
+
+    d['B'] = 1
+    assert 'B' in k
+    assert k['B'] == 1
+
+    assert k.copy()['A'] == 0
+    assert k.copy()['B'] == 1
+
+    k['B'] = 2
+    assert k['B'] == 2
+
+    assert k.pop('B') == 2
+    assert k.data['B'] is None
+    with pytest.raises(KeyError):
+        k['B']
+
+
+def test_KeymapMixin():
+    class Foo(KeymapMixin):
+        class_keymap = {}
+
+        def __init__(self, discard):
+            super().__init__()
+
+    foo = Foo(None)
+
+    foo.bind_key('A', lambda: 42)
+    assert foo.keymap['A']() == 42
+
+    @Foo.bind_key('B')
+    def bar():
+        return 'SPAM'
+
+    assert Foo.class_keymap['B'] is bar
+    assert foo.keymap['B'] is bar
+
+    foo.bind_key('B', lambda: 'aliiiens', overwrite=True)
+    assert Foo.class_keymap['B'] is bar
+    assert foo.keymap['B']() == 'aliiiens'
+
+    foo.bind_key('B', None)
+    assert foo.keymap.data['B'] is None
+    with pytest.raises(KeyError):
+        foo.keymap['B']
+
+
+def test_bind_key_doc():
+    doc = bind_key.__doc__
+    doc = doc.split('Notes\n    -----\n')[-1]
+    import textwrap
+
+    doc = textwrap.dedent(doc)
+
+    assert doc == keybindings.__doc__


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
Add machinery for the adding, validation, and dispatch of keybindings on the viewer and its layers.

Supersedes #251.

## Syntax
### key combinations
Keys are represented in the form `[modifier-]key`, e.g. `a`,
`Control-c`, or `Control-Alt-Delete`.
Valid modifiers are Control, Alt, Shift, and Meta.

Letters will always be read as upper-case.
Due to the native implementation of the key system, Shift pressed in certain
key combinations may yield inconsistent or unexpected results.
Therefore, it is not recommended to use Shift with non-letter keys.
On OSX, Control is swapped with Meta such that pressing Command reads as
Control.

Special keys include Shift, Control, Alt, Meta, Up, Down, Left, Right,
PageUp, PageDown, Insert, Delete, Home, End, Escape, Backspace, F1,
F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, Space, Enter, and Tab

### function format
Functions take in only one argument: the parent that the function was bound to. This is the viewer or layer.

By default, all functions are assumed to work on key presses only, but can be denoted to work on release too by separating the function into two statements with the `yield` keyword:
```python
def hello_world(viewer):
    # on key press
    viewer.status = 'hello world!'

    yield

    # on key release
    viewer.status = 'goodbye world :('
```

### bind a key
```python
viewer.bind_key('n', load_next_image)

@viewer.bind_key('p')
def load_prev_image(viewer): ...
```

### unbind a key
```python
viewer.bind_key('p', None)
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
see #210, #251

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] the test suite for my feature passes
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
