### PR TITLE
Fix axis shape one

### DIFF
--- a/examples/5D_image.py
+++ b/examples/5D_image.py
@@ -9,4 +9,4 @@ import napari
 
 with napari.gui_qt():
 
-    viewer = napari.view(np.random.random((10, 20, 15, 30, 40)))
+    viewer = napari.view(np.random.random((10, 1, 15, 30, 40)))

--- a/napari/_qt/qt_dims.py
+++ b/napari/_qt/qt_dims.py
@@ -1,6 +1,5 @@
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QWidget, QGridLayout, QSizePolicy
-import numpy as np
 
 from . import QHRangeSlider
 from ..components.dims import Dims
@@ -96,7 +95,6 @@ class QtDims(QWidget):
         axis : int
             Axis index.
         """
-        # print('range', range, slider_index, self._slider_axis)
 
         if axis not in self._slider_axis:
             return
@@ -158,7 +156,7 @@ class QtDims(QWidget):
             slider = self._create_range_slider_widget(dim_axis)
             self.layout().addWidget(slider)
             self.sliders.insert(0, slider)
-            self._slider_axis = list(np.add(self._slider_axis, 1))
+            self._slider_axis = [a + 1 for a in self._slider_axis]
             self._slider_axis.insert(0, 0)
             self.setMinimumHeight(self.nsliders * self.SLIDERHEIGHT)
 

--- a/napari/_qt/qt_range_slider.py
+++ b/napari/_qt/qt_range_slider.py
@@ -243,10 +243,14 @@ class QRangeSlider(QWidget):
 
     def updateDisplayValues(self):
         size = self.rangeSliderSize()
-        range = int(size * (self.scale_min - self.start) / self.scale)
-        self.display_min = range + self.bar_width / 2
-        range = int(size * (self.scale_max - self.start) / self.scale)
-        self.display_max = range + self.bar_width / 2
+        if self.scale == 0:
+            range_min = 0
+            range_max = 0
+        else:
+            range_min = int(size * (self.scale_min - self.start) / self.scale)
+            range_max = int(size * (self.scale_max - self.start) / self.scale)
+        self.display_min = range_min + self.bar_width / 2
+        self.display_max = range_max + self.bar_width / 2
 
     def updateScaleValues(self):
         size = self.rangeSliderSize()

--- a/napari/layers/image/tests/test_image.py
+++ b/napari/layers/image/tests/test_image.py
@@ -56,9 +56,35 @@ def test_3D_image():
     assert layer._data_view.shape == shape[-2:]
 
 
+def test_3D_image_shape_1():
+    """Test instantiating Image layer with random 3D data with shape 1 axis."""
+    shape = (1, 10, 15)
+    np.random.seed(0)
+    data = np.random.random(shape)
+    layer = Image(data)
+    assert np.all(layer.data == data)
+    assert layer.ndim == len(shape)
+    assert layer.shape == shape
+    assert layer.multichannel == False
+    assert layer._data_view.shape == shape[-2:]
+
+
 def test_4D_image():
     """Test instantiating Image layer with random 4D data."""
     shape = (10, 15, 6, 8)
+    np.random.seed(0)
+    data = np.random.random(shape)
+    layer = Image(data)
+    assert np.all(layer.data == data)
+    assert layer.ndim == len(shape)
+    assert layer.shape == shape
+    assert layer.multichannel == False
+    assert layer._data_view.shape == shape[-2:]
+
+
+def test_5D_image_shape_1():
+    """Test instantiating Image layer with random 5D data with shape 1 axis."""
+    shape = (4, 1, 2, 10, 15)
     np.random.seed(0)
     data = np.random.random(shape)
     layer = Image(data)


### PR DESCRIPTION
# Description
This PR fixes #408 which had nothing to do with xarray (error was reproducible with numpy) and caused by trying to view an image with shape (1, N, M). The viewer tried to generate a dims slider for the axis with shape 1, but that is not needed as their is only one value. Trying generated the divide by zero. Now the viewer will not generate a slider for such an axis.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] This PR modifies the `5D_image.py` example to include an axis with shape 1 which will catch the old bug, and adds a couple similar tests to the image model.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
