### PR TITLE
switch to pyside2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Development Status](https://img.shields.io/pypi/status/napari.svg)](https://github.com/napari/napari)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
-**napari** is a fast, interactive, multi-dimensional image viewer for Python. It's designed for browsing, annotating, and analyzing large multi-dimensional images. It's built on top of `PyQt` (for the GUI), `vispy` (for performant GPU-based rendering), and the scientific Python stack (`numpy`, `scipy`).
+**napari** is a fast, interactive, multi-dimensional image viewer for Python. It's designed for browsing, annotating, and analyzing large multi-dimensional images. It's built on top of `Qt` (for the GUI), `vispy` (for performant GPU-based rendering), and the scientific Python stack (`numpy`, `scipy`).
 
 We're developing **napari** in the open! But the project is in an **alpha** stage, and there will still occasionally be **breaking changes** from patch to patch. You can follow progress on this repository, test out new versions as we release them, and contribute ideas and code.
 

--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -1,17 +1,29 @@
-import warnings
+import os
+from distutils.version import StrictVersion
+from pathlib import Path
+from qtpy import API_NAME
 
-vispy_warning = "VisPy is not yet compatible with matplotlib 2.2+"
+if API_NAME == 'PySide2':
+    # Set plugin path appropriately if using PySide2. This is a bug fix
+    # for when both PyQt5 and Pyside2 are installed
+    import PySide2
 
-with warnings.catch_warnings():
-    warnings.filterwarnings(
-        "ignore", category=UserWarning, message=vispy_warning
+    os.environ['QT_PLUGIN_PATH'] = str(
+        Path(PySide2.__file__).parent / 'Qt' / 'plugins'
     )
-    from .viewer import Viewer
 
+from qtpy import QtCore
+
+if StrictVersion(QtCore.__version__) < StrictVersion('5.12.3'):
+    raise ValueError(
+        'QT library must be `>=5.12.3`, got ' + QtCore.__version__
+    )
+
+from .viewer import Viewer
 from .view_function import view
 from ._qt import gui_qt
-
 from ._version import get_versions
+
 
 __version__ = get_versions()['version']
 del get_versions

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from qtpy.QtCore import QCoreApplication, Qt, QSize
 from qtpy.QtWidgets import QWidget, QVBoxLayout, QSplitter, QFileDialog
 from qtpy.QtGui import QCursor, QPixmap
+from qtpy import API_NAME
 from vispy.scene import SceneCanvas, PanZoomCamera
+from vispy.app import use_app
 
 from .qt_dims import QtDims
 from .qt_layerlist import QtLayerList
@@ -18,6 +20,10 @@ from ..util.io import read
 
 from .qt_controls import QtControls
 from .qt_layer_buttons import QtLayersButtons
+
+
+# set vispy application to the appropriate qt backend
+use_app(API_NAME)
 
 
 class QtViewer(QSplitter):

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -5,5 +5,4 @@ scipy>=1.2.0
 scikit-image>=0.15.0
 vispy>=0.6.0
 PyOpenGL>=3.1.0
-PyQt5>=5.10.1
-SIP>=0.1.5
+PySide2>=5.12.3


### PR DESCRIPTION
# Description
This PR supersedes #331  now that vispy `0.6` has been released by allowing us to use either `PySide2` or `PyQt5`. Right now we follow the conventions of [`qtpt`](https://github.com/spyder-ide/qtpy#requirements) such that you need one of `PySide2` or `PyQt5` installed. If both are installed `PyQt5` will be used first unless you set the `QT_API` environment variable to `PySide2` - which is worth noting for our existing developers that already have `PyQt5` installed.

I have dropped `PyQt5` and `SIP` from our requirements though and replaced it with `PySide2`. @csweaver - once this merges we can press full steam ahead with creating our bundled app as discussed in #376.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run examples

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
