### PR TITLE
[FIX] paint color inidicator update when shuffle color

### DIFF
--- a/napari/layers/_labels_layer/model.py
+++ b/napari/layers/_labels_layer/model.py
@@ -115,7 +115,7 @@ class Labels(Layer):
 
     def new_colormap(self):
         self.seed = np.random.rand()
-
+        self.selected_label = self._selected_label
         self.refresh()
 
     def label_color(self, label):


### PR DESCRIPTION
# Description
This PR fixes the issue as described in #414: after the "shuffle color" button is pressed, the paint brush color is changed but the color indicator still displays the original color. The issue is fixed by updating selected_label when new_colormap() function is called.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
close issue #414

# How has this been tested?
Tested on local computer. Checked that the color indicator is changed when "shuffle color" is pressed.

## Final checklist:
- [x ] My PR is the minimum possible work for the desired functionality
