### PR TITLE
[FIX] paint color inidicator update when shuffle color

### DIFF
--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -322,6 +322,7 @@ class Labels(Layer):
 
     def new_colormap(self):
         self._seed = np.random.rand()
+        self.selected_label = self._selected_label
         self.refresh()
 
     def get_color(self, label):

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -318,7 +318,7 @@ class Labels(Layer):
 
     def new_colormap(self):
         self._seed = np.random.rand()
-        self.selected_label = self.get_color(self.selected_label)
+        self._selected_color = self.get_color(self.selected_label)
         self.refresh()
 
     def get_color(self, label):

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -230,11 +230,7 @@ class Labels(Layer):
     @selected_label.setter
     def selected_label(self, selected_label):
         self._selected_label = selected_label
-        if selected_label == 0:
-            # If background
-            self._selected_color = None
-        else:
-            self._selected_color = self.get_color(selected_label)
+        self._selected_color = self.get_color(selected_label)
         self.events.selected_label()
 
     @property
@@ -322,7 +318,7 @@ class Labels(Layer):
 
     def new_colormap(self):
         self._seed = np.random.rand()
-        self.selected_label = self._selected_label
+        self.selected_label = self.get_color(self.selected_label)
         self.refresh()
 
     def get_color(self, label):


### PR DESCRIPTION
# Description
This PR fixes the issue as described in #414: after the "shuffle color" button is pressed, the paint brush color is changed but the color indicator still displays the original color. The issue is fixed by updating selected_label when new_colormap() function is called.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
close issue #414

# How has this been tested?
Tested on local computer. Checked that the color indicator is changed when "shuffle color" is pressed.

## Final checklist:
- [x ] My PR is the minimum possible work for the desired functionality