### PR TITLE
QT returns a warning instead of an error

### DIFF
--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -3,6 +3,7 @@ from distutils.version import StrictVersion
 from pathlib import Path
 from qtpy import API_NAME
 
+
 if API_NAME == 'PySide2':
     # Set plugin path appropriately if using PySide2. This is a bug fix
     # for when both PyQt5 and Pyside2 are installed
@@ -22,9 +23,12 @@ if StrictVersion(QtCore.__version__) < StrictVersion('5.12.3'):
     Warning: napari was tested with QT library `>=5.12.3`.
     The version installed is {}. Please report any issues with this
     specific QT version at https://github.com/Napari/napari/issues.
-    """.format(QtCore.__version__)
-    warning = WarningMessage(message=warn_message, category=Warning,
-                             filename=None, lineno=None)
+    """.format(
+        QtCore.__version__
+    )
+    warning = WarningMessage(
+        message=warn_message, category=Warning, filename=None, lineno=None
+    )
     print(warning.message)
 
 

--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -14,10 +14,19 @@ if API_NAME == 'PySide2':
 
 from qtpy import QtCore
 
+# When QT is not the specific version, we raise a warning:
+from warnings import WarningMessage
+
 if StrictVersion(QtCore.__version__) < StrictVersion('5.12.3'):
-    raise ValueError(
-        'QT library must be `>=5.12.3`, got ' + QtCore.__version__
-    )
+    warn_message = """
+    Warning: napari was tested with QT library `>=5.12.3`.
+    The version installed is {}. Please report any issues with this
+    specific QT version at https://github.com/Napari/napari/issues.
+    """.format(QtCore.__version__)
+    warning = WarningMessage(message=warn_message, category=Warning,
+                             filename=None, lineno=None)
+    print(warning.message)
+
 
 from .viewer import Viewer
 from .view_function import view

--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -16,21 +16,15 @@ if API_NAME == 'PySide2':
 from qtpy import QtCore
 
 # When QT is not the specific version, we raise a warning:
-from warnings import WarningMessage
+from warnings import warn
 
 if StrictVersion(QtCore.__version__) < StrictVersion('5.12.3'):
-    warn_message = """
-    Warning: napari was tested with QT library `>=5.12.3`.
-    The version installed is {}. Please report any issues with this
+    warn_message = f"""
+    napari was tested with QT library `>=5.12.3`.
+    The version installed is {QtCore.__version__}. Please report any issues with this
     specific QT version at https://github.com/Napari/napari/issues.
-    """.format(
-        QtCore.__version__
-    )
-    warning = WarningMessage(
-        message=warn_message, category=Warning, filename=None, lineno=None
-    )
-    print(warning.message)
-
+    """
+    warn(message=warn_message)
 
 from .viewer import Viewer
 from .view_function import view


### PR DESCRIPTION
# Description
QT version returns a warning instead of raising an error.
Uses the warning package.

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality (I guess)
- [X] I have commented my code, particularly in hard-to-understand areas (I guess)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
