### PR TITLE
Fix Crash with stacked binary tiffs.

### DIFF
--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -372,7 +372,7 @@ class Image(Layer):
                 v_str = '[' + str.join(', ', [f'{v:0.3}' for v in value]) + ']'
                 msg = msg + v_str
         else:
-            if isinstance(value, np.integer):
+            if isinstance(value, (np.integer, np.bool_)):
                 msg = msg + str(value)
             else:
                 msg = msg + f'{value:0.3}'

--- a/napari/layers/image/tests/test_image.py
+++ b/napari/layers/image/tests/test_image.py
@@ -43,6 +43,18 @@ def test_integer_image():
     assert layer._data_view.shape == shape[-2:]
 
 
+def test_bool_image():
+    """Test instantiating Image layer with bool data."""
+    shape = (10, 15)
+    data = np.zeros(shape, dtype=bool)
+    layer = Image(data)
+    assert np.all(layer.data == data)
+    assert layer.ndim == len(shape)
+    assert layer.shape == shape
+    assert layer.multichannel == False
+    assert layer._data_view.shape == shape[-2:]
+
+
 def test_3D_image():
     """Test instantiating Image layer with random 3D data."""
     shape = (10, 15, 6)


### PR DESCRIPTION
Apparently the dtypes can also be booleans.

# Description
Some tiff in the wild appear to be binay (skimage.io.read return an nd-array of booleans), 
I unfortunately was not able to generate a boolean-tiff, and can't share my current sample publicly.


## Type of change

- [x] Bug-fix (non-breaking change which fixes an issue)


# How has this been tested?

`napari <file>` does not crash with the following anymore

```
Traceback (most recent call last):
  File "/Users/mbussonnier/dev/napari/napari/_qt/qt_viewer.py", line 146, in _open_images
    self._add_files(filenames)
  File "/Users/mbussonnier/dev/napari/napari/_qt/qt_viewer.py", line 165, in _add_files
    image, multichannel=is_multichannel(image.shape)
  File "/Users/mbussonnier/dev/napari/napari/components/viewer_model.py", line 360, in add_image
    layer = layers.Image(image, *args, **kwargs)
  File "/Users/mbussonnier/dev/napari/napari/layers/image/image.py", line 155, in __init__
    self._set_view_slice()
  File "/Users/mbussonnier/dev/napari/napari/layers/image/image.py", line 275, in _set_view_slice
    self.status = self.get_message(coord, value)
  File "/Users/mbussonnier/dev/napari/napari/layers/image/image.py", line 378, in get_message
    msg = msg + f'{value:0.3}'
ValueError: Precision not allowed in integer format specifier
```

## Final checklist:

- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works


-- 

I'm not entirely sure this is the right fix... should the image maybe always be casts as integers even if boolean ?
