### PR TITLE
fix points keypress

### DIFF
--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -964,12 +964,9 @@ class Points(Layer):
                     self._paste_data()
             elif event.key == 'a':
                 if self._mode == Mode.SELECT:
-                    if len(self._data_view) > 0:
-                        self.selected_data = self._indices_view[
-                            list(range(len(self._data_view)))
-                        ]
-                    else:
-                        self.selected_data = []
+                    self.selected_data = self._indices_view[
+                        : len(self._data_view)
+                    ]
                     self._set_highlight()
             elif event.key == 'Backspace':
                 if self._mode == Mode.SELECT:

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -964,9 +964,12 @@ class Points(Layer):
                     self._paste_data()
             elif event.key == 'a':
                 if self._mode == Mode.SELECT:
-                    self.selected_data = self._indices_view[
-                        list(range(len(self._data_view)))
-                    ]
+                    if len(self._data_view) > 0:
+                        self.selected_data = self._indices_view[
+                            list(range(len(self._data_view)))
+                        ]
+                    else:
+                        self.selected_data = []
                     self._set_highlight()
             elif event.key == 'Backspace':
                 if self._mode == Mode.SELECT:


### PR DESCRIPTION
# Description
This PR fixes #417, where the select all key `a` was pressed with no points in the layer. The reason the `add` mode was not enabled as that is enabled by clicking `p` for points - we need to work on our key choices for our keybindings, but this PR just fixes the bug.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] click `a` in empty points layer

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
