### PR TITLE
fix screenshot

### DIFF
--- a/examples/to_screenshot.py
+++ b/examples/to_screenshot.py
@@ -6,6 +6,7 @@ your shapes.
 
 import numpy as np
 from skimage import data
+from skimage.io import imsave
 import napari
 from vispy.color import Colormap
 
@@ -120,5 +121,7 @@ with napari.gui_qt():
     # add the vectors
     layer = viewer.add_vectors(pos, edge_width=2)
 
-    svg = viewer.to_svg()
-    # svg = viewer.to_svg(file='viewer.svg')
+    # take screenshot
+    screenshot = viewer.screenshot()
+    viewer.add_image(screenshot, multichannel=True, name='screenshot')
+    # imsave('screenshot.png', screenshot)

--- a/examples/to_svg.py
+++ b/examples/to_svg.py
@@ -6,6 +6,7 @@ your shapes.
 
 import numpy as np
 from skimage import data
+from skimage.io import imsave
 import napari
 from vispy.color import Colormap
 
@@ -122,3 +123,8 @@ with napari.gui_qt():
 
     svg = viewer.to_svg()
     # svg = viewer.to_svg(file='viewer.svg')
+
+    # take screenshot
+    screenshot = viewer.screenshot()
+    viewer.add_image(screenshot, multichannel=True, name='screenshot')
+    # imsave('screenshot.png', screenshot)


### PR DESCRIPTION
# Description
This PR fixes #181 ultimately by extracting the pixels sent to the screen from the `Qt` element directly. I was unable to fix the behavior of vispy's `render` and I had trouble getting vispy `_screenshot` to work directly, but we don't actually need either of these as we have the `Qt` objects and so can just grab the `QImage` that is actually being displayed and convert it back to a numpy array. 

The syntax is slightly different for `PySide2` vs `PyQt5`, but it's easy to handle. I've verified now this method works with both backends and with scripting usage and notebook usage. I added a line to the `to_svg` example to capture a screenshot. See here for a saved png

![screenshot](https://user-images.githubusercontent.com/6531703/61644343-59ca2e80-ac59-11e9-87d4-122dc071d3e9.png)

I'm pretty excited about this feature as it will now allow us to make awesome animations and movies!

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] `examples/to_svg`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
