### PR TITLE
test add_* signatures and improve docstring testing

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -292,7 +292,7 @@ class ViewerModel(KeymapMixin):
         return svg
 
     def add_layer(self, layer):
-        """Adds a layer to the viewer.
+        """Add a layer to the viewer.
 
         Parameters
         ----------
@@ -399,7 +399,7 @@ class ViewerModel(KeymapMixin):
         return layer
 
     def add_pyramid(self, pyramid, *args, **kwargs):
-        """Adds an image pyramid layer to the layers list.
+        """Add an image pyramid layer to the layers list.
 
         Parameters
         ----------
@@ -469,7 +469,7 @@ class ViewerModel(KeymapMixin):
         name=None,
         **kwargs,
     ):
-        """Adds a volume layer to the layers list.
+        """Add a volume layer to the layers list.
 
         Parameters
         ----------

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -316,7 +316,22 @@ class ViewerModel(KeymapMixin):
         if len(self.layers) == 1:
             self.reset_view()
 
-    def add_image(self, image, *args, **kwargs):
+    def add_image(
+        self,
+        image,
+        *,
+        metadata=None,
+        multichannel=None,
+        colormap='gray',
+        clim=None,
+        clim_range=None,
+        interpolation='nearest',
+        opacity=1,
+        blending='translucent',
+        visible=True,
+        name=None,
+        **kwargs,
+    ):
         """Add an image layer to the layers list.
 
         Parameters
@@ -366,7 +381,20 @@ class ViewerModel(KeymapMixin):
         layer : :class:`napari.layers.Image`
             The newly-created image layer.
         """
-        layer = layers.Image(image, *args, **kwargs)
+        layer = layers.Image(
+            image,
+            metadata=metadata,
+            multichannel=multichannel,
+            colormap=colormap,
+            clim=clim,
+            clim_range=clim_range,
+            interpolation=interpolation,
+            opacity=opacity,
+            blending=blending,
+            visible=visible,
+            name=name,
+            **kwargs,
+        )
         self.add_layer(layer)
         return layer
 
@@ -426,7 +454,20 @@ class ViewerModel(KeymapMixin):
         self.add_layer(layer)
         return layer
 
-    def add_volume(self, volume, *args, **kwargs):
+    def add_volume(
+        self,
+        volume,
+        *,
+        metadata=None,
+        colormap='gray',
+        clim=None,
+        clim_range=None,
+        opacity=1,
+        blending='translucent',
+        visible=True,
+        name=None,
+        **kwargs,
+    ):
         """Adds a volume layer to the layers list.
 
         Parameters
@@ -470,7 +511,18 @@ class ViewerModel(KeymapMixin):
         layer : :class:`napari.layers.Volume`
             The newly-created volume layer.
         """
-        layer = layers.Volume(volume, *args, **kwargs)
+        layer = layers.Volume(
+            volume,
+            metadata=metadata,
+            colormap=colormap,
+            clim=clim,
+            clim_range=clim_range,
+            opacity=opacity,
+            blending=blending,
+            visible=visible,
+            name=name,
+            **kwargs,
+        )
         if self.dims.ndim == 2:
             self.dims.ndim = 3
         self.dims.set_display(-3, True)
@@ -478,7 +530,21 @@ class ViewerModel(KeymapMixin):
         self.dims.events.display(axis=self.dims.ndim - 3)
         return layer
 
-    def add_points(self, points, *args, **kwargs):
+    def add_points(
+        self,
+        coords,
+        *,
+        symbol='o',
+        size=10,
+        edge_width=1,
+        edge_color='black',
+        face_color='white',
+        n_dimensional=False,
+        opacity=1,
+        blending='translucent',
+        visible=True,
+        name=None,
+    ):
         """Add a points layer to the layers list.
 
         Parameters
@@ -523,11 +589,35 @@ class ViewerModel(KeymapMixin):
         See vispy's marker visual docs for more details:
         http://api.vispy.org/en/latest/visuals.html#vispy.visuals.MarkersVisual
         """
-        layer = layers.Points(points, *args, **kwargs)
+        layer = layers.Points(
+            points,
+            symbol=symbol,
+            size=size,
+            edge_width=edge_width,
+            edge_color=edge_color,
+            face_color=face_color,
+            n_dimensional=n_dimensional,
+            opacity=opacity,
+            blending=blending,
+            visible=visible,
+            name=name,
+        )
         self.add_layer(layer)
         return layer
 
-    def add_labels(self, label_image, *args, **kwargs):
+    def add_labels(
+        self,
+        labels,
+        *,
+        metadata=None,
+        num_colors=50,
+        seed=0.5,
+        opacity=0.7,
+        blending='translucent',
+        visible=True,
+        name=None,
+        **kwargs,
+    ):
         """Add a labels (or segmentation) layer to the layers list.
 
         An image-like layer where every pixel contains an integer ID
@@ -559,11 +649,34 @@ class ViewerModel(KeymapMixin):
         layer : :class:`napari.layers.Labels`
             The newly-created labels layer.
         """
-        layer = layers.Labels(label_image, *args, **kwargs)
+        layer = layers.Labels(
+            labels,
+            metadata=metadata,
+            num_color=num_colors,
+            seed=seed,
+            opacity=opacity,
+            blending=blending,
+            visible=visible,
+            name=name,
+            **kwargs,
+        )
         self.add_layer(layer)
         return layer
 
-    def add_shapes(self, shapes, **kwargs):
+    def add_shapes(
+        self,
+        data,
+        *,
+        shape_type='rectangle',
+        edge_width=1,
+        edge_color='black',
+        face_color='white',
+        z_index=0,
+        opacity=0.7,
+        blending='translucent',
+        visible=True,
+        name=None,
+    ):
         """Add a shapes layer to the layers list.
 
         Parameters
@@ -617,11 +730,33 @@ class ViewerModel(KeymapMixin):
         layer : :class:`napari.layers.Shapes`
             The newly-created shapes layer.
         """
-        layer = layers.Shapes(shapes, **kwargs)
+        layer = layers.Shapes(
+            data,
+            shape_type=shape_type,
+            edge_width=edge_width,
+            edge_color=edge_color,
+            face_color=face_color,
+            z_index=z_index,
+            opacity=opacity,
+            blending=blending,
+            visible=visible,
+            name=name,
+        )
         self.add_layer(layer)
         return layer
 
-    def add_vectors(self, vectors, *args, **kwargs):
+    def add_vectors(
+        self,
+        vectors,
+        *,
+        edge_width=1,
+        edge_color='red',
+        length=1,
+        opacity=1,
+        blending='translucent',
+        visible=True,
+        name=None,
+    ):
         """Add a vectors layer to the layers list.
 
         Parameters
@@ -654,7 +789,16 @@ class ViewerModel(KeymapMixin):
         layer : :class:`napari.layers.Vectors`
             The newly-created vectors layer.
         """
-        layer = layers.Vectors(vectors, *args, **kwargs)
+        layer = layers.Vectors(
+            vectors,
+            edge_width=edge_width,
+            edge_color=edge_color,
+            length=1,
+            opacity=1,
+            blending=blending,
+            visible=visible,
+            name=name,
+        )
         self.add_layer(layer)
         return layer
 

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -465,6 +465,7 @@ class ViewerModel(KeymapMixin):
         opacity=1,
         blending='translucent',
         visible=True,
+        spacing=None,
         name=None,
         **kwargs,
     ):
@@ -500,7 +501,7 @@ class ViewerModel(KeymapMixin):
             {'opaque', 'translucent', and 'additive'}.
         visible : bool
             Whether the layer visual is currently being displayed.
-        spacing : list
+        spacing : list, optional
             List of anisotropy factors to scale the volume by. Must be one for
             each dimension.
         name : str, keyword-only
@@ -520,6 +521,7 @@ class ViewerModel(KeymapMixin):
             opacity=opacity,
             blending=blending,
             visible=visible,
+            spacing=spacing,
             name=name,
             **kwargs,
         )
@@ -590,7 +592,7 @@ class ViewerModel(KeymapMixin):
         http://api.vispy.org/en/latest/visuals.html#vispy.visuals.MarkersVisual
         """
         layer = layers.Points(
-            points,
+            coords,
             symbol=symbol,
             size=size,
             edge_width=edge_width,
@@ -652,7 +654,7 @@ class ViewerModel(KeymapMixin):
         layer = layers.Labels(
             labels,
             metadata=metadata,
-            num_color=num_colors,
+            num_colors=num_colors,
             seed=seed,
             opacity=opacity,
             blending=blending,
@@ -793,8 +795,8 @@ class ViewerModel(KeymapMixin):
             vectors,
             edge_width=edge_width,
             edge_color=edge_color,
-            length=1,
-            opacity=1,
+            length=length,
+            opacity=opacity,
             blending=blending,
             visible=visible,
             name=name,

--- a/napari/tests/test_viewer_layer_parity.py
+++ b/napari/tests/test_viewer_layer_parity.py
@@ -3,27 +3,42 @@ Ensure that layers and their convenience methods on the viewer
 have the same signatures and docstrings.
 """
 
-from napari.layers import Image, Pyramid, Points, Labels, Shapes, Vectors
-from napari import Viewer
+import inspect
+
+import pytest
+
+from napari import layers as module, Viewer
 
 
-def test_docstrings():
-    for obj in (Image, Pyramid, Points, Labels, Shapes, Vectors):
-        method = f'add_{obj.__name__.lower()}'
-        obj_doc = obj.__doc__
-        i = [
-            idx
-            for idx, section in enumerate(obj.__doc__.split('\n\n'))
-            if section.strip().startswith('Parameters')
-        ][0]
-        # We only check the parameters section, which is the first
-        # section after separating by empty line. We also strip empty
-        # line and white space that occurs at the end of a class docstring
-        obj_param = obj_doc.split('\n\n')[i].rstrip('\n ')
-        method_doc = getattr(Viewer, method).__doc__
-        # For the method docstring, we also need to
-        # remove the extra indentation of the method docstring compared
-        # to the class
-        method_param = method_doc.split('\n\n')[i].replace('\n    ', '\n')[4:]
-        fail_msg = f"Docstrings don't match for class {obj.__name__}"
-        assert obj_param == method_param, fail_msg
+layers = []
+
+for name in dir(module):
+    obj = getattr(module, name)
+
+    if obj is module.Layer or not inspect.isclass(obj):
+        continue
+
+    if issubclass(obj, module.Layer):
+        layers.append(obj)
+
+
+@pytest.mark.parametrize('layer', layers, ids=lambda layer: layer.__name__)
+def test_docstring(layer):
+    method = f'add_{layer.__name__.lower()}'
+    layer_doc = layer.__doc__
+    i = [
+        idx
+        for idx, section in enumerate(layer.__doc__.split('\n\n'))
+        if section.strip().startswith('Parameters')
+    ][0]
+    # We only check the parameters section, which is the first
+    # section after separating by empty line. We also strip empty
+    # line and white space that occurs at the end of a class docstring
+    layer_param = layer_doc.split('\n\n')[i].rstrip('\n ')
+    method_doc = getattr(Viewer, method).__doc__
+    # For the method docstring, we also need to
+    # remove the extra indentation of the method docstring compared
+    # to the class
+    method_param = method_doc.split('\n\n')[i].replace('\n    ', '\n')[4:]
+    fail_msg = f"Docstrings don't match for class {layer.__name__}"
+    assert layer_param == method_param, fail_msg

--- a/napari/tests/test_viewer_layer_parity.py
+++ b/napari/tests/test_viewer_layer_parity.py
@@ -1,3 +1,8 @@
+"""
+Ensure that layers and their convenience methods on the viewer
+have the same signatures and docstrings.
+"""
+
 from napari.layers import Image, Pyramid, Points, Labels, Shapes, Vectors
 from napari import Viewer
 

--- a/napari/tests/test_viewer_layer_parity.py
+++ b/napari/tests/test_viewer_layer_parity.py
@@ -8,6 +8,7 @@ import inspect
 import pytest
 
 from napari import layers as module, Viewer
+from napari.util.misc import camel_to_snake
 
 
 layers = []
@@ -24,21 +25,23 @@ for name in dir(module):
 
 @pytest.mark.parametrize('layer', layers, ids=lambda layer: layer.__name__)
 def test_docstring(layer):
-    method = f'add_{layer.__name__.lower()}'
-    layer_doc = layer.__doc__
+    method = getattr(Viewer, f'add_{camel_to_snake(layer.__name__)}')
+    layer_doc = inspect.getdoc(layer)
+
     i = [
         idx
-        for idx, section in enumerate(layer.__doc__.split('\n\n'))
-        if section.strip().startswith('Parameters')
+        for idx, section in enumerate(layer_doc.split('\n\n'))
+        if section.startswith('Parameters')
     ][0]
+
+    # 'inspect.getdoc' automatically removes common indentation
+    method_doc = inspect.getdoc(method)
+
     # We only check the parameters section, which is the first
     # section after separating by empty line. We also strip empty
     # line and white space that occurs at the end of a class docstring
     layer_param = layer_doc.split('\n\n')[i].rstrip('\n ')
-    method_doc = getattr(Viewer, method).__doc__
-    # For the method docstring, we also need to
-    # remove the extra indentation of the method docstring compared
-    # to the class
-    method_param = method_doc.split('\n\n')[i].replace('\n    ', '\n')[4:]
+    method_param = method_doc.split('\n\n')[i].rstrip('\n ')
+
     fail_msg = f"Docstrings don't match for class {layer.__name__}"
     assert layer_param == method_param, fail_msg

--- a/napari/tests/test_viewer_layer_parity.py
+++ b/napari/tests/test_viewer_layer_parity.py
@@ -45,3 +45,14 @@ def test_docstring(layer):
 
     fail_msg = f"Docstrings don't match for class {layer.__name__}"
     assert layer_param == method_param, fail_msg
+
+
+@pytest.mark.parametrize('layer', layers, ids=lambda layer: layer.__name__)
+def test_signature(layer):
+    method = getattr(Viewer, f'add_{camel_to_snake(layer.__name__)}')
+
+    class_signature = inspect.signature(layer.__init__)
+    method_signature = inspect.signature(method)
+
+    fail_msg = f"Signatures don't match for class {layer.__name__}"
+    assert class_signature == method_signature, fail_msg

--- a/napari/util/_register.py
+++ b/napari/util/_register.py
@@ -1,7 +1,7 @@
 import re
 import inspect
 
-from .misc import camel_to_snake
+from .misc import camel_to_snake, callsignature
 
 
 template = """def {name}(self, {signature}):
@@ -11,85 +11,13 @@ template = """def {name}(self, {signature}):
 """
 
 
-class CallDefault(inspect.Parameter):
-    def __str__(self):
-        """wrap defaults"""
-        kind = self.kind
-        formatted = self._name
-
-        # Fill in defaults
-        if self._default is not inspect._empty:
-            formatted = '{}={}'.format(formatted, formatted)
-
-        if kind == inspect._VAR_POSITIONAL:
-            formatted = '*' + formatted
-        elif kind == inspect._VAR_KEYWORD:
-            formatted = '**' + formatted
-
-        return formatted
-
-
-class CallSignature(inspect.Signature):
-    _parameter_cls = CallDefault
-
-    def __str__(self):
-        """do not render separators
-
-        commented code is what was taken out from
-        the copy/pasted inspect module code :)
-        """
-        result = []
-        # render_pos_only_separator = False
-        # render_kw_only_separator = True
-        for param in self.parameters.values():
-            formatted = str(param)
-
-            # kind = param.kind
-
-            # if kind == inspect._POSITIONAL_ONLY:
-            #     render_pos_only_separator = True
-            # elif render_pos_only_separator:
-            #     # It's not a positional-only parameter, and the flag
-            #     # is set to 'True' (there were pos-only params before.)
-            #     result.append('/')
-            #     render_pos_only_separator = False
-
-            # if kind == inspect._VAR_POSITIONAL:
-            #     # OK, we have an '*args'-like parameter, so we won't need
-            #     # a '*' to separate keyword-only arguments
-            #     render_kw_only_separator = False
-            # elif kind == inspect._KEYWORD_ONLY and render_kw_only_separator:
-            #     # We have a keyword-only parameter to render and we haven't
-            #     # rendered an '*args'-like parameter before, so add a '*'
-            #     # separator to the parameters list ("foo(arg1, *, arg2)" case)
-            #     result.append('*')
-            #     # This condition should be only triggered once, so
-            #     # reset the flag
-            #     render_kw_only_separator = False
-
-            result.append(formatted)
-
-        # if render_pos_only_separator:
-        #     # There were only positional-only parameters, hence the
-        #     # flag was not reset to 'False'
-        #     result.append('/')
-
-        rendered = '({})'.format(', '.join(result))
-
-        if self.return_annotation is not inspect._empty:
-            anno = inspect.formatannotation(self.return_annotation)
-            rendered += ' -> {}'.format(anno)
-
-        return rendered
-
-
 def create_func(cls, name=None, doc=None):
     module = inspect.getmodule(cls)
 
     module_name = module.__name__
     cls_name = cls.__name__
     sig = inspect.signature(cls)
-    call_args = CallSignature.from_callable(cls)
+    call_args = callsignature(cls)
 
     if name is None:
         name = camel_to_snake(cls_name)

--- a/napari/util/_register.py
+++ b/napari/util/_register.py
@@ -1,19 +1,14 @@
 import re
 import inspect
 
+from .misc import camel_to_snake
+
 
 template = """def {name}(self, {signature}):
     layer = {cls_name}({call_args})
     self.add_layer(layer)
     return layer
 """
-
-pattern = re.compile(r'(.)([A-Z][a-z]+)')
-
-
-def camel_to_snake(name):
-    # https://gist.github.com/jaytaylor/3660565
-    return pattern.sub(r'\1_\2', name).lower()
 
 
 class CallDefault(inspect.Parameter):

--- a/napari/util/keybindings.py
+++ b/napari/util/keybindings.py
@@ -350,12 +350,6 @@ class KeymapMixin:
     in every subclass.
     """
 
-    def __new__(cls, *args, **kwargs):
-        if cls is KeymapMixin:
-            raise TypeError('cannot instantiate mix-in class')
-
-        return object.__new__(cls)
-
     def __init__(self):
         self.keymap = {}
 

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -266,3 +266,11 @@ class StringEnum(Enum):
         string of the Enum name
         """
         return self.value
+
+
+camel_to_snake_pattern = re.compile(r'(.)([A-Z][a-z]+)')
+
+
+def camel_to_snake(name):
+    # https://gist.github.com/jaytaylor/3660565
+    return camel_to_snake_pattern.sub(r'\1_\2', name).lower()

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -274,3 +274,78 @@ camel_to_snake_pattern = re.compile(r'(.)([A-Z][a-z]+)')
 def camel_to_snake(name):
     # https://gist.github.com/jaytaylor/3660565
     return camel_to_snake_pattern.sub(r'\1_\2', name).lower()
+
+
+class CallDefault(inspect.Parameter):
+    def __str__(self):
+        """wrap defaults"""
+        kind = self.kind
+        formatted = self._name
+
+        # Fill in defaults
+        if self._default is not inspect._empty:
+            formatted = '{}={}'.format(formatted, formatted)
+
+        if kind == inspect._VAR_POSITIONAL:
+            formatted = '*' + formatted
+        elif kind == inspect._VAR_KEYWORD:
+            formatted = '**' + formatted
+
+        return formatted
+
+
+class CallSignature(inspect.Signature):
+    _parameter_cls = CallDefault
+
+    def __str__(self):
+        """do not render separators
+
+        commented code is what was taken out from
+        the copy/pasted inspect module code :)
+        """
+        result = []
+        # render_pos_only_separator = False
+        # render_kw_only_separator = True
+        for param in self.parameters.values():
+            formatted = str(param)
+
+            # kind = param.kind
+
+            # if kind == inspect._POSITIONAL_ONLY:
+            #     render_pos_only_separator = True
+            # elif render_pos_only_separator:
+            #     # It's not a positional-only parameter, and the flag
+            #     # is set to 'True' (there were pos-only params before.)
+            #     result.append('/')
+            #     render_pos_only_separator = False
+
+            # if kind == inspect._VAR_POSITIONAL:
+            #     # OK, we have an '*args'-like parameter, so we won't need
+            #     # a '*' to separate keyword-only arguments
+            #     render_kw_only_separator = False
+            # elif kind == inspect._KEYWORD_ONLY and render_kw_only_separator:
+            #     # We have a keyword-only parameter to render and we haven't
+            #     # rendered an '*args'-like parameter before, so add a '*'
+            #     # separator to the parameters list ("foo(arg1, *, arg2)" case)
+            #     result.append('*')
+            #     # This condition should be only triggered once, so
+            #     # reset the flag
+            #     render_kw_only_separator = False
+
+            result.append(formatted)
+
+        # if render_pos_only_separator:
+        #     # There were only positional-only parameters, hence the
+        #     # flag was not reset to 'False'
+        #     result.append('/')
+
+        rendered = '({})'.format(', '.join(result))
+
+        if self.return_annotation is not inspect._empty:
+            anno = inspect.formatannotation(self.return_annotation)
+            rendered += ' -> {}'.format(anno)
+
+        return rendered
+
+
+callsignature = CallSignature.from_callable

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,5 @@
 dask[array]
+numpydoc
 pytest
 pytest-faulthandler
 pytest-qt


### PR DESCRIPTION
## Changes
- rename docstring test
- improve coverage & implementation of docstring test for layers and their convenience methods
- add signature test for layers and their convenience methods
- remove `__new__` method from `KeymapMixin` to stop it from overriding class signatures