### PR TITLE
fix aspect ratio

### DIFF
--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1292,7 +1292,7 @@ class Shapes(Layer):
                     offset_perp = np.array([offset[1], -offset[0]])
 
                     fixed = self._fixed_vertex
-                    new = copy(coord)
+                    new = list(coord)
 
                     if self._fixed_aspect and self._fixed_index % 2 == 0:
                         if (new - fixed)[0] == 0:


### PR DESCRIPTION
# Description
This PR fixes a bug when trying to resize with fixed aspect ratio. We needed a list instead of a tuple.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run `examples/add_shapes.py` and resize a shape with the shift key pressed

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
