### PR TITLE
use __init_subclass__ in keymap mixin to create empty class keymap

### DIFF
--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -99,8 +99,6 @@ class Image(Layer):
 
     _colormaps = AVAILABLE_COLORMAPS
 
-    class_keymap = {}
-
     default_interpolation = str(Interpolation.NEAREST)
 
     def __init__(

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -96,8 +96,6 @@ class Labels(Layer):
         after painting is done. Used for interpolating brush strokes.
     """
 
-    class_keymap = {}
-
     def __init__(
         self,
         labels,

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -109,8 +109,6 @@ class Points(Layer):
     _highlight_color = (0, 0.6, 1)
     _highlight_width = 1.5
 
-    class_keymap = {}
-
     def __init__(
         self,
         coords,

--- a/napari/layers/pyramid/pyramid.py
+++ b/napari/layers/pyramid/pyramid.py
@@ -89,8 +89,6 @@ class Pyramid(Image):
 
     _max_tile_shape = np.array([1600, 1600])
 
-    class_keymap = {}
-
     def __init__(self, pyramid, *args, **kwargs):
 
         with self.freeze_refresh():

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -209,8 +209,6 @@ class Shapes(Layer):
     _highlight_color = (0, 0.6, 1)
     _highlight_width = 1.5
 
-    class_keymap = {}
-
     def __init__(
         self,
         data,

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -70,8 +70,6 @@ class Vectors(Layer):
     # If more vectors are present then they are randomly subsampled
     _max_vectors_thumbnail = 1024
 
-    class_keymap = {}
-
     def __init__(
         self,
         vectors,

--- a/napari/layers/volume/volume.py
+++ b/napari/layers/volume/volume.py
@@ -70,7 +70,6 @@ class Volume(Layer):
         Volume data for the currently viewed slice, must be 3-dimensional
     """
 
-    class_keymap = {}
     _colormaps = AVAILABLE_COLORMAPS
     _default_rendering = Rendering.MIP.value
 

--- a/napari/util/keybindings.py
+++ b/napari/util/keybindings.py
@@ -353,16 +353,18 @@ class KeymapMixin:
     def __new__(cls, *args, **kwargs):
         if cls is KeymapMixin:
             raise TypeError('cannot instantiate mix-in class')
-        else:
-            if not hasattr(cls, 'class_keymap'):
-                raise TypeError(
-                    "KeymapMixin must define 'class_keymap' class attribute"
-                )
 
         return object.__new__(cls)
 
     def __init__(self):
         self.keymap = {}
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        if 'class_keymap' not in cls.__dict__:
+            # if in __dict__, was defined in class and not inherited
+            cls.class_keymap = {}
 
     @property
     def keymap(self):

--- a/napari/util/tests/test_keybindings.py
+++ b/napari/util/tests/test_keybindings.py
@@ -1,4 +1,7 @@
+import inspect
+
 import pytest
+
 from .. import keybindings
 from ..keybindings import (
     bind_key,
@@ -112,12 +115,9 @@ def test_InheritedKeymap():
 
 def test_KeymapMixin():
     class Foo(KeymapMixin):
-        class_keymap = {}
+        ...
 
-        def __init__(self, discard):
-            super().__init__()
-
-    foo = Foo(None)
+    foo = Foo()
 
     foo.bind_key('A', lambda: 42)
     assert foo.keymap['A']() == 42
@@ -138,12 +138,19 @@ def test_KeymapMixin():
     with pytest.raises(KeyError):
         foo.keymap['B']
 
+    class Bar(Foo):
+        ...
+
+    assert Bar.class_keymap is not Foo.class_keymap
+
+    class Baz(Foo):
+        class_keymap = dict(A=42)
+
+    assert Baz.class_keymap == dict(A=42)
+
 
 def test_bind_key_doc():
-    doc = bind_key.__doc__
-    doc = doc.split('Notes\n    -----\n')[-1]
-    import textwrap
+    doc = inspect.getdoc(bind_key)
+    doc = doc.split('Notes\n-----\n')[-1]
 
-    doc = textwrap.dedent(doc)
-
-    assert doc == keybindings.__doc__
+    assert doc == inspect.getdoc(keybindings)


### PR DESCRIPTION
# Description
automatically create an empty class keymap in all classes that inherit from `KeymapMixin` if it is not defined within that class

# References
see https://github.com/napari/napari/pull/389#discussion_r300839195
[PEP 487](https://www.python.org/dev/peps/pep-0487/) (new in Python 3.6)