### PR TITLE
Initial work on updating status bar

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -686,16 +686,13 @@ class ViewerModel(KeymapMixin):
             layer.indices = self.dims.indices
 
     def _update_active_layer(self, event):
-        """Set the active layer by iterating over the layers list and
-        finding the first selected layer. If multiple layers are selected the
-        iteration stops and the active layer is set to be None
+        """Set the active layer to be the topmost visible layer.
 
         Parameters
         ----------
         event : Event
             No Event parameters are used
         """
-        # iteration goes backwards to find top most visible layer if any
         active_layer = None
         for layer in self.layers[::-1]:
             if layer.visible:

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -299,8 +299,7 @@ class ViewerModel(KeymapMixin):
         layer : Layer
             Layer to add.
         """
-        layer.events.select.connect(self._update_active_layer)
-        layer.events.deselect.connect(self._update_active_layer)
+        layer.events.visible.connect(self._update_active_layer)
         layer.events.status.connect(self._update_status)
         layer.events.help.connect(self._update_help)
         layer.events.interactive.connect(self._update_interactive)
@@ -696,14 +695,11 @@ class ViewerModel(KeymapMixin):
         event : Event
             No Event parameters are used
         """
-        # iteration goes backwards to find top most selected layer if any
-        # if multiple layers are selected sets the active layer to None
+        # iteration goes backwards to find top most visible layer if any
         active_layer = None
-        for layer in self.layers:
-            if active_layer is None and layer.selected:
+        for layer in self.layers[::-1]:
+            if layer.visible:
                 active_layer = layer
-            elif active_layer is not None and layer.selected:
-                active_layer = None
                 break
 
         if active_layer is None:

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -9,7 +9,7 @@ import vispy.color
 
 from ..base import Layer
 from vispy.scene.visuals import Image as ImageNode
-from ...util import status_messages
+from ...util.status_messages import status_format
 from ...util.misc import (
     is_multichannel,
     calc_data_range,
@@ -385,7 +385,7 @@ class Image(Layer):
         msg = f'{self.name} {coord}'
         if value is not None:
             msg += ': '
-            msg += status_messages.format(value)
+            msg += status_format(value)
 
         return msg
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -6,8 +6,10 @@ import numpy as np
 from copy import copy
 from scipy import ndimage as ndi
 import vispy.color
+
 from ..base import Layer
 from vispy.scene.visuals import Image as ImageNode
+from ...util import status_messages
 from ...util.misc import (
     is_multichannel,
     calc_data_range,
@@ -364,15 +366,14 @@ class Image(Layer):
 
         return coord, value
 
-    def get_message(self, coord, value):
-        """Generate a status message based on the coordinates and information
-        about what shapes are hovered over
+    def get_message(self, coord, value=None):
+        """Generate status message based on coordinates and image.
 
         Parameters
         ----------
         coord : sequence of int
             Position of mouse cursor in image coordinates.
-        value : int or float or sequence of int or float
+        value : int or float or sequence of int or float, optional
             Value of the data at the coord.
 
         Returns
@@ -381,18 +382,10 @@ class Image(Layer):
             String containing a message that can be used as a status update.
         """
 
-        msg = f'{coord}, {self.name}' + ', value '
-        if isinstance(value, np.ndarray):
-            if isinstance(value[0], np.integer):
-                msg = msg + str(value)
-            else:
-                v_str = '[' + str.join(', ', [f'{v:0.3}' for v in value]) + ']'
-                msg = msg + v_str
-        else:
-            if isinstance(value, (np.integer, np.bool_)):
-                msg = msg + str(value)
-            else:
-                msg = msg + f'{value:0.3}'
+        msg = f'{self.name} {coord}'
+        if value is not None:
+            msg += ': '
+            msg += status_messages.format(value)
 
         return msg
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -356,9 +356,11 @@ class Image(Layer):
             shape = self._data_view.shape[:-1]
         else:
             shape = self._data_view.shape
-        coord[-2:] = np.clip(coord[-2:], 0, np.asarray(shape) - 1)
 
-        value = self._data_view[tuple(coord[-2:])]
+        if all(0 <= c < s for c, s in zip(coord[-2:], shape)):
+            value = self._data_view[tuple(coord[-2:])]
+        else:
+            value = None
 
         return coord, value
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -8,7 +8,6 @@ from imageio import imwrite
 
 from ..base import Layer
 from vispy.scene.visuals import Image as ImageNode
-from ...util.status_messages import status_format
 from ...util.colormaps import colormaps
 from ...util.event import Event
 from ...util.misc import interpolate_coordinates
@@ -495,7 +494,11 @@ class Labels(Layer):
             String containing a message that can be used as a status update.
         """
         int_coord = np.round(coord).astype(int)
-        msg = f'{self.name} {int_coord} label {value}'
+        if value is not None:
+            value_str = ' label {value}'
+        else:
+            value_str = ''
+        msg = f'{self.name} {int_coord}{value_str}'
 
         return msg
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -717,7 +717,7 @@ class Points(Layer):
         ----------
         coord : sequence of int
             Position of mouse cursor in data.
-        value : int
+        value : int or None
             Index of the point at the coord if any.
 
         Returns
@@ -727,11 +727,11 @@ class Points(Layer):
             a status update.
         """
         int_coord = np.round(coord).astype(int)
-        msg = f'{int_coord}, {self.name}'
+        msg = f'{self.name} {int_coord}'
         if value is None:
             pass
         else:
-            msg = msg + ', index ' + str(value)
+            msg += f', index {value}'
         return msg
 
     def _update_thumbnail(self):

--- a/napari/layers/pyramid/pyramid.py
+++ b/napari/layers/pyramid/pyramid.py
@@ -253,8 +253,10 @@ class Pyramid(Image):
             shape = self._data_view.shape
 
         # TODO: Change dims selection when dims model changes
-        coord[-2:] = np.clip(coord[-2:], 0, np.subtract(shape, 1))
-        value = self._data_view[tuple(coord[-2:])]
+        if all(0 <= c < s for c, s in zip(coord[-2:], shape)):
+            value = self._data_view[tuple(coord[-2:])]
+        else:
+            value = None
 
         pos_in_slice = (
             self.coordinates[-2:] + self.translate[[1, 0]] / self.scale[:2]

--- a/napari/layers/pyramid/pyramid.py
+++ b/napari/layers/pyramid/pyramid.py
@@ -1,4 +1,6 @@
 import numpy as np
+
+from napari.util.status_messages import status_format
 from ..image import Image
 
 
@@ -343,18 +345,8 @@ class Pyramid(Image):
         msg : string
             String containing a message that can be used as a status update.
         """
-        if isinstance(value, np.ndarray):
-            if isinstance(value[0], np.integer) or isinstance(value[0], int):
-                v_str = str(value)
-            else:
-                v_str = '[' + str.join(', ', [f'{v:0.3}' for v in value]) + ']'
-        else:
-            if isinstance(value, np.integer) or isinstance(value, int):
-                v_str = str(value)
-            else:
-                v_str = f'{value:0.3}'
-
-        msg = f'{coord}, {self.data_level}, {self.name}, value {v_str}'
+        v_str = ' ' + status_format(value) if value is not None else ''
+        msg = f'{self.name} {coord} (level {self.data_level}){v_str}'
         return msg
 
     def on_draw(self, event):

--- a/napari/layers/pyramid/pyramid.py
+++ b/napari/layers/pyramid/pyramid.py
@@ -234,8 +234,7 @@ class Pyramid(Image):
         return self.data[0].shape
 
     def get_value(self):
-        """Returns coordinates, values, and a string for a given mouse position
-        and set of indices.
+        """Return coordinates in base level and value in current level.
 
         Returns
         ----------

--- a/napari/layers/pyramid/pyramid.py
+++ b/napari/layers/pyramid/pyramid.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from napari.util.status_messages import status_format
+from ...util.status_messages import status_format
 from ..image import Image
 
 

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1208,11 +1208,11 @@ class Shapes(Layer):
             String containing a message that can be used as a status update.
         """
         int_coord = np.round(coord).astype(int)
-        msg = f'{int_coord}, {self.name}'
+        msg = f'{self.name} {int_coord}'
         if shape is not None:
-            msg = msg + ', shape ' + str(shape)
+            msg += ', shape ' + str(shape)
             if vertex is not None:
-                msg = msg + ', vertex ' + str(vertex)
+                msg += ', vertex ' + str(vertex)
         return msg
 
     def move_to_front(self):

--- a/napari/util/status_messages.py
+++ b/napari/util/status_messages.py
@@ -3,7 +3,8 @@ import numpy as np
 
 
 def format_float(value):
-    return f'{value:0.3}'
+    """Nice float formatting into strings."""
+    return f'{value:0.3g}'
 
 
 def status_format(value):
@@ -18,6 +19,13 @@ def status_format(value):
     -------
     formatted : str
         The string resulting from formatting.
+
+    Examples
+    --------
+    >>> values = np.array([1, 10, 100, 1000, 1e6, 6.283, 123.932021,
+    ...                    1123.9392001, 2 * np.pi, np.exp(1)])
+    >>> status_format(values)
+    '[1, 10, 100, 1e+03, 1e+06, 6.28, 124, 1.12e+03, 6.28, 2.72]'
     """
     if isinstance(value, Iterable):
         return '[' + str.join(', ', [status_format(v) for v in value]) + ']'

--- a/napari/util/status_messages.py
+++ b/napari/util/status_messages.py
@@ -6,7 +6,7 @@ def format_float(value):
     return f'{value:0.3}'
 
 
-def format(value):
+def status_format(value):
     """Return a "nice" string representation of a value.
 
     Parameters
@@ -20,7 +20,7 @@ def format(value):
         The string resulting from formatting.
     """
     if isinstance(value, Iterable):
-        return '[' + str.join([format(v) for v in value]) + ']'
+        return '[' + str.join(', ', [status_format(v) for v in value]) + ']'
     if value is None:
         return ''
     if isinstance(value, float) or np.issubdtype(type(value), np.floating):

--- a/napari/util/status_messages.py
+++ b/napari/util/status_messages.py
@@ -1,0 +1,31 @@
+from collections import Iterable
+import numpy as np
+
+
+def format_float(value):
+    return f'{value:0.3}'
+
+
+def format(value):
+    """Return a "nice" string representation of a value.
+
+    Parameters
+    ----------
+    value : any type
+        The value to be printed.
+
+    Returns
+    -------
+    formatted : str
+        The string resulting from formatting.
+    """
+    if isinstance(value, Iterable):
+        return '[' + str.join([format(v) for v in value]) + ']'
+    if value is None:
+        return ''
+    if isinstance(value, float) or np.issubdtype(type(value), np.floating):
+        return format_float(value)
+    elif isinstance(value, int) or np.issubdtype(type(value), np.integer):
+        return str(value)
+    else:
+        return str(value)

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -18,3 +18,10 @@ class Viewer(ViewerModel):
         self.window = Window(qt_viewer)
         self.screenshot = self.window.qt_viewer.screenshot
         self.camera = self.window.qt_viewer.view.camera
+
+
+@Viewer.bind_key('v')
+def toggle_topmost_visible(viewer):
+    if len(viewer.layers) > 0:
+        layer = viewer.layers[-1]
+        layer.visible = not layer.visible

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,3 +1,4 @@
+from itertools import zip_longest
 from ._qt.qt_viewer import QtViewer
 from ._qt.qt_main_window import Window
 from .components import ViewerModel
@@ -21,7 +22,28 @@ class Viewer(ViewerModel):
 
 
 @Viewer.bind_key('v')
-def toggle_topmost_visible(viewer):
+def toggle_last_visible(viewer):
     if len(viewer.layers) > 0:
         layer = viewer.layers[-1]
         layer.visible = not layer.visible
+
+
+@Viewer.bind_key('[')
+def make_next_invisible_layer_visible(viewer):
+    if len(viewer.layers) == 1:
+        viewer.layers[0].visible = True
+    else:
+        last_layers = viewer.layers[-1:0:-1]
+        layers = viewer.layers[-2::-1]
+        for last_layer, layer in zip_longest(last_layers, layers):
+            if not last_layer.visible and (layer is None or layer.visible):
+                last_layer.visible = True
+                break
+
+
+@Viewer.bind_key(']')
+def make_next_visible_layer_invisible(viewer):
+    for layer in viewer.layers[::-1]:
+        if layer.visible:
+            layer.visible = False
+            break


### PR DESCRIPTION
# Description

This PR makes the following changes:

- active layer is now the topmost visible layer, regardless of selection. (See below for discussion.)
- printing of status messages based on value is now handled centrally, and much improved. I haven't changed over the obvious (integer) prints. In a future PR, I think this machinery can be used to print shape info, rather than just the shape index.
- if the cursor is out of range of the data, no value is shown, rather than showing the value at the nearest edge.
- a new keyboard shortcut is added, toggling visibility of the topmost layer.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How has this been tested?
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# Discussion points

I'm still not sure about the active layer behavior. Now, it's a bit more cumbersome to mess with a layer's settings: for example, if I have a points layer and an image layer underneath it, I have to hide the points layer before I can adjust the clims on the image. However, this does solve the problem of adjusting settings on an invisible layer.

My suggestion, which I can implement here or in a followup PR depending on preferences, is that the active layer be defined as:
- if no layers are selected, the topmost visible layer.
- if a layer is selected, it is the active layer *if it is at all visible*, which means that only the following layers are in front of it:
  * image, labels, and pyramid with opacity < 1
  * points, shapes, or vectors, with any opacity (since these are generally sparse, visually)

I'll wait for thoughts before working on that logic.

Regarding the keyboard shortcut, topmost is kinda clunky, it turns out. My suggested improvement, which I can implement here or in a followup, is:

- Ctrl-V: hide the next visible layer (ie the active layer)
- Ctrl-Shift-V: show the next not-visible layer (ie the layer above the active layer), if any
- V: undo the last visibility change

Thoughts? And I just realised the shortcuts will have to change because Ctrl-V is taken. Suggestions welcome!