### PR TITLE
expose scaling factor for volume

### DIFF
--- a/examples/add_volume.py
+++ b/examples/add_volume.py
@@ -12,4 +12,4 @@ with napari.gui_qt():
     )
     viewer = napari.Viewer()
     # add the volume
-    viewer.add_volume(blobs)
+    viewer.add_volume(blobs, spacing=[3, 1, 1])

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -459,6 +459,9 @@ class ViewerModel(KeymapMixin):
             {'opaque', 'translucent', and 'additive'}.
         visible : bool
             Whether the layer visual is currently being displayed.
+        spacing : list
+            List of anisotropy factors to scale the volume by. Must be one for
+            each dimension.
         name : str, keyword-only
             Name of the layer.
 

--- a/napari/layers/volume/tests/test_volume.py
+++ b/napari/layers/volume/tests/test_volume.py
@@ -94,6 +94,21 @@ def test_name():
     assert layer.name == 'img'
 
 
+def test_spacing():
+    """Test instantiating anisotropic 3D volume."""
+    shape = (10, 15, 20)
+    spacing = [3, 1, 1]
+    full_shape = tuple(np.multiply(shape, spacing))
+    np.random.seed(0)
+    data = np.random.random(shape)
+    layer = Volume(data, spacing=spacing)
+    assert np.all(layer.data == data)
+    assert layer.ndim == len(shape)
+    assert layer.shape == full_shape
+    assert layer.range == tuple((0, m, 1) for m in full_shape)
+    assert layer._data_view.shape == shape[-3:]
+
+
 def test_visiblity():
     """Test setting layer visiblity."""
     np.random.seed(0)

--- a/napari/layers/volume/volume.py
+++ b/napari/layers/volume/volume.py
@@ -113,7 +113,7 @@ class Volume(Layer):
             self._data = volume
             self.metadata = metadata or {}
 
-            self.spacing = spacing or [1] * self.ndim
+            self.spacing = spacing or [1] * len(volume.shape)
 
             # Intitialize volume views and thumbnails with zeros
             self._data_view = np.zeros((1, 1, 1))
@@ -159,7 +159,7 @@ class Volume(Layer):
         self.refresh()
 
     def _get_shape(self):
-        return np.multiply(self.data.shape, self.spacing)
+        return tuple(np.multiply(self.data.shape, self.spacing))
 
     @property
     def spacing(self):

--- a/napari/layers/volume/volume.py
+++ b/napari/layers/volume/volume.py
@@ -44,6 +44,9 @@ class Volume(Layer):
         {'opaque', 'translucent', and 'additive'}.
     visible : bool
         Whether the layer visual is currently being displayed.
+    spacing : list, optional
+        List of anisotropy factors to scale the volume by. Must be one for
+        each dimension.
     name : str, keyword-only
         Name of the layer.
 
@@ -63,6 +66,9 @@ class Volume(Layer):
         luminance volumes.
     clim_range : list (2,) of float
         Range for the color limits for luminace volumes.
+    spacing : list
+        List of anisotropy factors to scale the volume by. Must be one for
+        each dimension.
 
     Extended Summary
     ----------
@@ -84,6 +90,7 @@ class Volume(Layer):
         opacity=1,
         blending='translucent',
         visible=True,
+        spacing=None,
         name=None,
         **kwargs,
     ):
@@ -105,6 +112,8 @@ class Volume(Layer):
             # Set data
             self._data = volume
             self.metadata = metadata or {}
+
+            self.spacing = spacing or [1] * self.ndim
 
             # Intitialize volume views and thumbnails with zeros
             self._data_view = np.zeros((1, 1, 1))
@@ -150,7 +159,17 @@ class Volume(Layer):
         self.refresh()
 
     def _get_shape(self):
-        return self.data.shape
+        return np.multiply(self.data.shape, self.spacing)
+
+    @property
+    def spacing(self):
+        """list: Anisotropy factors to scale the volume by."""
+        return self._spacing
+
+    @spacing.setter
+    def spacing(self, spacing):
+        self._spacing = spacing
+        self.scale = [self._spacing[s] for s in [-1, -2, -3]]
 
     @property
     def colormap(self):

--- a/napari/layers/volume/volume.py
+++ b/napari/layers/volume/volume.py
@@ -169,7 +169,8 @@ class Volume(Layer):
     @spacing.setter
     def spacing(self, spacing):
         self._spacing = spacing
-        self.scale = [self._spacing[s] for s in [-1, -2, -3]]
+        displayed = [-3, -2, -1]
+        self.scale = [self._spacing[s] for s in displayed[::-1]]
 
     @property
     def colormap(self):


### PR DESCRIPTION
# Description
This PR exposing a scaling factor of length equal to number of dimensions on the volume layer - it's a little bit of a quick fix as right now updating the scaling factor won't update the camera rotation center, but that functionality is implemented in #451 which will hopefully merge soon.

This partially addresses #436. I think though I'd rather expose scaling on all layers and have it work with the range slider etc. too. I think that can go into #451 or even later PRs though, and this will at least get something better than what we have previous.

![spacing](https://user-images.githubusercontent.com/6531703/62430404-3c717780-b6d1-11e9-977c-7c911fb6f089.gif)

Note this is a cube with a `[3, 1, 1]` spacing

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] modified `examples/add_volume.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
