### PR TITLE
Allow out of range float images

### DIFF
--- a/napari/layers/image/tests/test_image.py
+++ b/napari/layers/image/tests/test_image.py
@@ -1,5 +1,7 @@
 import numpy as np
 from xml.etree.ElementTree import Element
+
+import pytest
 from vispy.color import Colormap
 from napari.layers import Image
 
@@ -412,3 +414,17 @@ def test_xml_list():
     assert type(xml) == list
     assert len(xml) == 1
     assert type(xml[0]) == Element
+
+
+@pytest.mark.parametrize('dtype', [np.float32, np.float64])
+def test_out_of_range_image(dtype):
+    data = -1.7 - 0.001 * np.random.random((10, 15)).astype(dtype)
+    layer = Image(data)
+    layer._update_thumbnail()
+
+
+@pytest.mark.parametrize('dtype', [np.float32, np.float64])
+def test_out_of_range_no_contrast(dtype):
+    data = np.full((10, 15), -3.2, dtype=dtype)
+    layer = Image(data)
+    layer._update_thumbnail()


### PR DESCRIPTION
# Description

Attempting to fix #449, but the tests added in this commit pass without any fixes!

@royerloic was naughty in his reporting and did not provide a minimum reproducible example. ;)

Assuming CI is happy, I suggest we merge these tests and wait for @royerloic to clarify his issues.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: the test suite for my feature covers out of range and out of range with no contrast floats for both float32 and float64
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
