### PR TITLE
add viewer keybindings

### DIFF
--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -27,6 +27,7 @@ if StrictVersion(QtCore.__version__) < StrictVersion('5.12.3'):
     warn(message=warn_message)
 
 from .viewer import Viewer
+from . import keybindings
 from .view_function import view
 from ._qt import gui_qt
 from ._version import get_versions

--- a/napari/_qt/qt_dims.py
+++ b/napari/_qt/qt_dims.py
@@ -44,6 +44,8 @@ class QtDims(QWidget):
         self.sliders = []
         self._displayed = []
 
+        self.last_used = None
+
         # Initialises the layout:
         layout = QGridLayout()
         layout.setContentsMargins(0, 0, 0, 0)
@@ -119,6 +121,7 @@ class QtDims(QWidget):
         elif mode == DimsMode.INTERVAL:
             slider.expand()
             slider.setValues(self.dims.interval[axis])
+        self.last_used = axis
 
     def _update_range(self, axis: int):
         """
@@ -235,6 +238,7 @@ class QtDims(QWidget):
         slider.deleteLater()
         nsliders = np.sum(self._displayed)
         self.setMinimumHeight(nsliders * self.SLIDERHEIGHT)
+        self.last_used = None
 
     def _create_range_slider_widget(self, axis):
         """
@@ -282,6 +286,12 @@ class QtDims(QWidget):
 
         # linking the listener to the slider:
         slider.rangeChanged.connect(slider_change_listener)
+
+        def slider_focused_listener():
+            self.last_used = self.sliders.index(slider)
+
+        # linking focus listener to the last used:
+        slider.focused.connect(slider_focused_listener)
 
         # Listener to be used for sending events back to model:
         def collapse_change_listener(collapsed):

--- a/napari/_qt/qt_range_slider.py
+++ b/napari/_qt/qt_range_slider.py
@@ -13,6 +13,7 @@ class QRangeSlider(QWidget):
 
     rangeChanged = QtCore.Signal(float, float)
     collapsedChanged = QtCore.Signal(bool)
+    focused = QtCore.Signal()
 
     def __init__(self, slider_range, values, parent=None):
         QWidget.__init__(self, parent)
@@ -194,6 +195,7 @@ class QRangeSlider(QWidget):
             self.start_display_min = self.display_min
             self.start_display_max = self.display_max
             self.start_pos = pos
+        self.focused.emit()
 
     def collapse(self):
         if self.default_collapse_logic:

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -259,6 +259,7 @@ class QtViewer(QSplitter):
         self.console.style_sheet = themed_stylesheet
         self.console.syntax_style = palette['syntax_style']
         self.setStyleSheet(themed_stylesheet)
+        self.canvas.bgcolor = palette['canvas']
 
     def _toggle_console(self):
         """Toggle console visible and not visible."""
@@ -293,7 +294,10 @@ class QtViewer(QSplitter):
     def on_key_press(self, event):
         """Called whenever key pressed in canvas.
         """
-        if event.native.isAutoRepeat() or event.key is None:
+        if (
+            event.native.isAutoRepeat()
+            and event.key.name not in ['Up', 'Down', 'Left', 'Right']
+        ) or event.key is None:
             return
 
         comb = components_to_key_combo(event.key.name, event.modifiers)
@@ -331,6 +335,14 @@ class QtViewer(QSplitter):
         """
         for layer in self.viewer.layers:
             layer.on_draw(event)
+
+    def keyPressEvent(self, event):
+        self.canvas._backend._keyEvent(self.canvas.events.key_press, event)
+        event.accept()
+
+    def keyReleaseEvent(self, event):
+        self.canvas._backend._keyEvent(self.canvas.events.key_release, event)
+        event.accept()
 
     def dragEnterEvent(self, event):
         if event.mimeData().hasUrls():

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -298,6 +298,8 @@ class QtViewer(QSplitter):
             event.native.isAutoRepeat()
             and event.key.name not in ['Up', 'Down', 'Left', 'Right']
         ) or event.key is None:
+            # pass is no key is present or if key is held down, unless the
+            # key being held down is one of the navigation keys
             return
 
         comb = components_to_key_combo(event.key.name, event.modifiers)

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -130,9 +130,14 @@ class LayerList(ListModel):
             if layer.selected and layer != ignore:
                 layer.selected = False
 
+    def select_all(self):
+        """Selects all layers."""
+        for layer in self:
+            if not layer.selected:
+                layer.selected = True
+
     def remove_selected(self):
-        """Removes selected items from list.
-        """
+        """Removes selected items from list."""
         to_delete = []
         for i in range(len(self)):
             if self[i].selected:
@@ -140,3 +145,41 @@ class LayerList(ListModel):
         to_delete.reverse()
         for i in to_delete:
             self.pop(i)
+        if len(to_delete) > 0:
+            first_to_delete = to_delete[-1]
+            if first_to_delete == 0 and len(self) > 0:
+                self[0].selected = True
+            elif first_to_delete > 0:
+                self[first_to_delete - 1].selected = True
+
+    def select_next(self):
+        """Selects next item from list.
+        """
+        selected = []
+        for i in range(len(self)):
+            if self[i].selected:
+                selected.append(i)
+        if len(selected) > 0:
+            if selected[-1] == len(self) - 1:
+                self.unselect_all(ignore=self[selected[-1]])
+            elif selected[-1] < len(self) - 1:
+                self.unselect_all(ignore=self[selected[-1] + 1])
+                self[selected[-1] + 1].selected = True
+        elif len(self) > 0:
+            self[-1].selected = True
+
+    def select_previous(self):
+        """Selects previous item from list.
+        """
+        selected = []
+        for i in range(len(self)):
+            if self[i].selected:
+                selected.append(i)
+        if len(selected) > 0:
+            if selected[0] == 0:
+                self.unselect_all(ignore=self[0])
+            elif selected[0] > 0:
+                self.unselect_all(ignore=self[selected[0] - 1])
+                self[selected[0] - 1].selected = True
+        elif len(self) > 0:
+            self[0].selected = True

--- a/napari/components/tests/test_layers_list.py
+++ b/napari/components/tests/test_layers_list.py
@@ -182,32 +182,46 @@ def test_remove_selected():
     layers.remove_selected()
     assert list(layers) == [layer_a, layer_b]
 
-    # remove no layers as none selected
+    # check that the next to last layer is now selected
+    assert [l.selected for l in layers] == [False, True]
+
     layers.remove_selected()
-    assert list(layers) == [layer_a, layer_b]
+    assert list(layers) == [layer_a]
+    assert [l.selected for l in layers] == [True]
 
     # select and remove first layer only
+    layers.append(layer_b)
     layers.append(layer_c)
-    layer_c.selected = False
+    assert list(layers) == [layer_a, layer_b, layer_c]
     layer_a.selected = True
+    layer_b.selected = False
+    layer_c.selected = False
     layers.remove_selected()
     assert list(layers) == [layer_b, layer_c]
+    assert [l.selected for l in layers] == [True, False]
 
     # select and remove first and last layer of four
     layers.append(layer_a)
     layers.append(layer_d)
+    assert list(layers) == [layer_b, layer_c, layer_a, layer_d]
+    layer_a.selected = False
     layer_b.selected = True
+    layer_c.selected = False
+    layer_d.selected = True
     layers.remove_selected()
     assert list(layers) == [layer_c, layer_a]
+    assert [l.selected for l in layers] == [True, False]
 
     # select and remove middle two layers of four
     layers.append(layer_b)
     layers.append(layer_d)
     layer_a.selected = True
     layer_b.selected = True
+    layer_c.selected = False
     layer_d.selected = False
     layers.remove_selected()
     assert list(layers) == [layer_c, layer_d]
+    assert [l.selected for l in layers] == [True, False]
 
     # select and remove all layers
     for l in layers:

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -22,17 +22,10 @@ class ViewerModel(KeymapMixin):
         List of contained layers.
     dims : Dimensions
         Contains axes, indices, dimensions and sliders.
-    key_bindings : dict of string: callable
-        Custom key bindings. The dictionary key is a string containing the key
-        pressed and the value is the function to be bound to the key event.
-        The function should accept the viewer object as an input argument.
-        These key bindings are executed instead of any layer specific key
-        bindings.
     themes : dict of str: dict of str: str
         Preset color palettes.
     """
 
-    class_keymap = {}
     themes = palettes
 
     def __init__(self, title='napari'):
@@ -65,7 +58,6 @@ class ViewerModel(KeymapMixin):
         self._cursor_size = None
         self._interactive = True
         self._active_layer = None
-        self.key_bindings = {}
 
         self._palette = None
         self.theme = 'dark'

--- a/napari/keybindings.py
+++ b/napari/keybindings.py
@@ -1,0 +1,81 @@
+import numpy as np
+
+from .viewer import Viewer
+
+
+@Viewer.bind_key('Control-F')
+def toggle_fullscreen(viewer):
+    if viewer.window._qt_window.isFullScreen():
+        viewer.window._qt_window.showNormal()
+    else:
+        viewer.window._qt_window.showFullScreen()
+
+
+@Viewer.bind_key('Control-T')
+def toggle_theme(viewer):
+    theme_names = list(viewer.themes.keys())
+    cur_theme = theme_names.index(viewer.theme)
+    viewer.theme = theme_names[(cur_theme + 1) % len(theme_names)]
+
+
+@Viewer.bind_key('Left')
+def increment_dims_left(viewer):
+    axis = viewer.window.qt_viewer.dims.last_used
+    if axis is not None:
+        cur_point = viewer.dims.point[axis]
+        axis_range = viewer.dims.range[axis]
+        new_point = np.clip(
+            cur_point - axis_range[2],
+            axis_range[0],
+            axis_range[1] - axis_range[2],
+        )
+        viewer.dims.set_point(axis, new_point)
+
+
+@Viewer.bind_key('Right')
+def increment_dims_right(viewer):
+    axis = viewer.window.qt_viewer.dims.last_used
+    if axis is not None:
+        cur_point = viewer.dims.point[axis]
+        axis_range = viewer.dims.range[axis]
+        new_point = np.clip(
+            cur_point + axis_range[2],
+            axis_range[0],
+            axis_range[1] - axis_range[2],
+        )
+        viewer.dims.set_point(axis, new_point)
+
+
+@Viewer.bind_key('Up')
+def dims_focus_up(viewer):
+    displayed = list(np.nonzero(viewer.window.qt_viewer.dims._displayed)[0])
+    if len(displayed) == 0:
+        return
+
+    axis = viewer.window.qt_viewer.dims.last_used
+    if axis is None:
+        viewer.window.qt_viewer.dims.last_used = displayed[-1]
+    else:
+        index = (displayed.index(axis) + 1) % len(displayed)
+        viewer.window.qt_viewer.dims.last_used = displayed[index]
+
+
+@Viewer.bind_key('Down')
+def dims_focus_down(viewer):
+    displayed = list(np.nonzero(viewer.window.qt_viewer.dims._displayed)[0])
+    if len(displayed) == 0:
+        return
+
+    axis = viewer.window.qt_viewer.dims.last_used
+    if axis is None:
+        viewer.window.qt_viewer.dims.last_used = displayed[0]
+    else:
+        index = (displayed.index(axis) - 1) % len(displayed)
+        viewer.window.qt_viewer.dims.last_used = displayed[index]
+
+
+Viewer.bind_key('Control-Backspace', lambda v: v.layers.remove_selected())
+Viewer.bind_key('Control-A', lambda v: v.layers.select_all())
+Viewer.bind_key('Control-[', lambda v: v.layers.select_previous())
+Viewer.bind_key('Control-]', lambda v: v.layers.select_next())
+Viewer.bind_key('Control-R', lambda v: v.reset_view())

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -106,7 +106,6 @@ class Layer(VisualWrapper, KeymapMixin, ABC):
         * `_get_shape()`: called by `shape` property
         * `_refresh()`: called by `refresh` method
         * `data` property (setter & getter)
-        * `class_keymap` class variable (dictionary)
 
     May define the following:
         * `_set_view_slice(indices)`: called to set currently viewed slice

--- a/napari/util/theme.py
+++ b/napari/util/theme.py
@@ -13,6 +13,7 @@ palettes = {
         'icon': 'rgb(209, 210, 212)',
         'syntax_style': 'native',
         'console': 'rgb(0, 0, 0)',
+        'canvas': 'black',
     },
     'light': {
         'folder': 'light',
@@ -25,6 +26,7 @@ palettes = {
         'icon': 'rgb(107, 105, 103)',
         'syntax_style': 'default',
         'console': 'rgb(255, 255, 255)',
+        'canvas': 'white',
     },
 }
 


### PR DESCRIPTION
# Description
This PR adds standard keybindings to the viewer and improves the keybindings focus, fixing #260

It adds 

`ctrl-F` to toggle fullscreen mode - fixing #136. Note that `escape` will not exit fullscreen mode as we are using escape to end polygon drawing on the shapes layer, but that can be changed if desired @royerloic. 

`ctrl-D` to delete any selected layers. also after selected layers are deleted the next layer is selected - fixing #424

`crtl-R` to reset the camera zoom

`ctrl-A` to select all layers

`ctrl-[` and `ctrl-]` to select the previous or next selected layer, superseeding some of the keybindings that were to be added in #460 (I'd remove the keybindings from that PR now @jni)

`ctrl-T` to toggle the theme (which now includes changing of the vispy canvas background color).

`Left` and `Right` to move the dimensions of the last used or focused axis, fixing #227 and a request from @d-v-b.

`Up` and `Down` to swap which is the focused axis.

I'll note that I havn't looked at menubar integration for any of these keybindings, and that I had to add the keybindings to the `Viewer` as adding them to the `ViewerModel` didn't seem to work. @kne42 do you think this is being done properly in this PR?

Finally @kne42 I had to use `Control-Backspace` instead of `Control-Delete` for it to work properly on my mac - are we handling differences between backspace and delete properly on a mac? should these be aliased? i know on windows they can be different.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
