### PR TITLE
fix OSX CI

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
 imageio>=2.5.0
-ipykernel>=5.1.1
+ipykernel==5.1.1
 numpy>=1.10.0
 qtpy>=1.7.0
 qtconsole>=4.5.1


### PR DESCRIPTION
# Description
fix OSX CI by pinning `ipykernel` to `5.1.1`. for some reason `5.1.2` was causing errors with `pluggy` and the `asyncio` event loop