### PR TITLE
clean up black pre-commit hook & exclusion pattern

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,6 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3
-      require_serial: true
-      exclude: 'vendored'
+      # force black to run on whole repo & keep settings from pyproject.toml
+      pass_filenames: false
+      args: [.]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,19 @@
 target-version = ['py36', 'py37']
 skip-string-normalization = true
 line-length = 79
-exclude = 'vendored'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+  | examples
+  | vendored
+)/
+'''


### PR DESCRIPTION
# Description
clean up how black is used in napari:
- expand exclusion pattern to include build-related files
- exclude examples and free them from `black`'s iron grip (let's be real, they look hideous)
- force `black` to run on entire repo in the pre-commit hook. while it will take a little bit longer (realistically almost no time at all), it will ensure that `black` conforms to the exclusion patterns as defined in `pyproject.toml`. we can alternatively define a meta hook to auto-update the pre-commit config so that the exclusion patterns match, but that's probably not necessary