### PR TITLE
support more image dtypes

### DIFF
--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -56,7 +56,7 @@ class VispyImageLayer(VispyBaseLayer):
         dtype = np.dtype(data.dtype)
         if dtype not in texture_dtypes:
             try:
-                dtype = dict(i=np.int16, f=np.float64)[dtype.kind]
+                dtype = dict(i=np.int16, f=np.float32)[dtype.kind]
             except KeyError:  # not an int or float
                 raise TypeError(
                     f'type {dtype} not allowed for texture; must be one of {set(texture_dtypes)}'
@@ -90,7 +90,7 @@ class VispyImageLayer(VispyBaseLayer):
         if self.layer.dims.ndisplay == 3:
             self._on_data_change()
         else:
-            self.node.clim = [0, 1]  # self.layer.clim
+            self.node.clim = self.layer.clim
 
     def reset(self):
         self._reset_base()

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -4,6 +4,15 @@ import numpy as np
 from .vispy_base_layer import VispyBaseLayer
 from ..layers import Image
 
+texture_dtypes = [
+    np.dtype(np.int8),
+    np.dtype(np.uint8),
+    np.dtype(np.int16),
+    np.dtype(np.uint16),
+    np.dtype(np.float32),
+    np.dtype(np.float64),
+]
+
 
 class VispyImageLayer(VispyBaseLayer):
     def __init__(self, layer):
@@ -43,11 +52,22 @@ class VispyImageLayer(VispyBaseLayer):
         self.reset()
 
     def _on_data_change(self):
+        data = self.layer._data_view
+        dtype = np.dtype(data.dtype)
+        if dtype not in texture_dtypes:
+            try:
+                dtype = dict(i=np.int16, f=np.float64)[dtype.kind]
+            except KeyError:  # not an int or float
+                raise TypeError(
+                    f'type {dtype} not allowed for texture; must be one of {set(texture_dtypes)}'
+                )
+            data = data.astype(dtype)
+
         if self.layer.dims.ndisplay == 3:
-            self.node.set_data(self.layer._data_view, clim=self.layer.clim)
+            self.node.set_data(data, clim=self.layer.clim)
         else:
             self.node._need_colortransform_update = True
-            self.node.set_data(self.layer._data_view)
+            self.node.set_data(data)
         self.node.update()
 
     def _on_interpolation_change(self):
@@ -68,9 +88,9 @@ class VispyImageLayer(VispyBaseLayer):
 
     def _on_clim_change(self):
         if self.layer.dims.ndisplay == 3:
-            self.node.set_data(self.layer._data_view, clim=self.layer.clim)
+            self._on_data_change()
         else:
-            self.node.clim = self.layer.clim
+            self.node.clim = [0, 1]  # self.layer.clim
 
     def reset(self):
         self._reset_base()

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -10,7 +10,6 @@ texture_dtypes = [
     np.dtype(np.int16),
     np.dtype(np.uint16),
     np.dtype(np.float32),
-    np.dtype(np.float64),
 ]
 
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -344,6 +344,12 @@ class Image(Layer):
             image = np.max(self._data_thumbnail, axis=0)
         else:
             image = self._data_thumbnail
+
+        # float16 not supported by ndi.zoom
+        dtype = np.dtype(image.dtype)
+        if dtype in [np.dtype(np.float16)]:
+            image = image.astype(np.float32)
+
         zoom_factor = np.divide(
             self._thumbnail_shape[:2], image.shape[:2]
         ).min()
@@ -425,6 +431,7 @@ class Image(Layer):
             image = np.max(self._data_thumbnail, axis=0)
         else:
             image = self._data_thumbnail
+
         image = np.clip(image, self.clim[0], self.clim[1])
         image = image - self.clim[0]
         color_range = self.clim[1] - self.clim[0]

--- a/napari/tests/test_dtypes.py
+++ b/napari/tests/test_dtypes.py
@@ -13,6 +13,7 @@ dtypes = [
     np.dtype(np.uint32),
     np.dtype(np.int64),
     np.dtype(np.uint64),
+    np.dtype(np.float16),
     np.dtype(np.float32),
     np.dtype(np.float64),
 ]

--- a/napari/tests/test_dtypes.py
+++ b/napari/tests/test_dtypes.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pytest
+from napari import Viewer
+
+
+dtypes = [
+    np.dtype(np.bool),
+    np.dtype(np.int8),
+    np.dtype(np.uint8),
+    np.dtype(np.int16),
+    np.dtype(np.uint16),
+    np.dtype(np.int32),
+    np.dtype(np.uint32),
+    np.dtype(np.int64),
+    np.dtype(np.uint64),
+    np.dtype(np.float32),
+    np.dtype(np.float64),
+]
+
+
+@pytest.mark.parametrize('dtype', dtypes)
+def test_image_dytpes(qtbot, dtype):
+    """Test different dtype images."""
+    np.random.seed(0)
+    viewer = Viewer()
+    view = viewer.window.qt_viewer
+    qtbot.addWidget(view)
+
+    # add dtype image data
+    data = np.random.randint(20, size=(30, 40)).astype(dtype)
+    viewer.add_image(data)
+    assert np.all(viewer.layers[0].data == data)
+
+    # Close the viewer
+    viewer.window.close()
+
+
+@pytest.mark.parametrize('dtype', dtypes)
+def test_pyramid_dytpes(qtbot, dtype):
+    """Test different dtype pyramids."""
+    np.random.seed(0)
+    viewer = Viewer()
+    view = viewer.window.qt_viewer
+    qtbot.addWidget(view)
+
+    # add dtype pyramid data
+    data = [
+        np.random.randint(20, size=(30, 40)).astype(dtype),
+        np.random.randint(20, size=(15, 20)).astype(dtype),
+    ]
+    viewer.add_pyramid(data)
+    assert np.all(viewer.layers[0].data == data)
+
+    # Close the viewer
+    viewer.window.close()

--- a/napari/tests/test_view_function.py
+++ b/napari/tests/test_view_function.py
@@ -1,0 +1,40 @@
+import numpy as np
+from napari import view
+
+
+def test_view_function(qtbot):
+    """Test creating viewer with image data."""
+    np.random.seed(0)
+    data = np.random.random((10, 15))
+
+    viewer = view(data)
+    qtbot.addWidget(viewer.window.qt_viewer)
+
+    assert viewer.title == 'napari'
+    assert viewer.window.qt_viewer.viewer == viewer
+
+    assert len(viewer.layers) == 1
+    assert np.all(viewer.layers[0].data == data)
+    assert viewer.dims.ndim == 2
+
+    # Close the viewer
+    viewer.window.close()
+
+
+def test_multiple_images(qtbot):
+    """Test creating viewer with mutliple images."""
+    np.random.seed(0)
+    data_a = np.random.random((10, 15))
+    data_b = np.random.random((20, 15))
+    data_c = np.random.random((10, 25))
+
+    viewer = view(data_a=data_a, data_b=data_b, data_c=data_c)
+    qtbot.addWidget(viewer.window.qt_viewer)
+
+    assert len(viewer.layers) == 3
+    assert np.all(viewer.layers['data_a'].data == data_a)
+    assert np.all(viewer.layers['data_b'].data == data_b)
+    assert np.all(viewer.layers['data_c'].data == data_c)
+
+    # Close the viewer
+    viewer.window.close()

--- a/napari/view_function.py
+++ b/napari/view_function.py
@@ -6,11 +6,10 @@ def view(
     title='napari',
     metadata=None,
     multichannel=None,
-    contrast_limits_range=None,
+    contrast_limits=None,
     **named_images,
 ):
     """View one or more input images.
-
     Parameters
     ----------
     *images : ndarray
@@ -25,21 +24,19 @@ def view(
         rather than spatial attributes. If not provided, napari will attempt
         to make an educated guess. If provided, and multiple images are given,
         the same value applies to all images.
-    contrast_limits_range : list | array | None
-        Length two list or array with the default color limit range for the
-        image. If not passed will be calculated as the min and max of the
-        image. Passing a value prevents this calculation which can be useful
+    contrast_limits : list (2,)
+        Color limits to be used for determining the colormap bounds for
+        luminance images. If not passed is calculated as the min and max of
+        the image. Passing a value prevents this calculation which can be useful
         when working with very large datasets that are dynamically loaded.
         If provided, and multiple images are given, the same value applies to
         all images.
     **named_images : dict of str -> ndarray, optional
         Arrays to render as image layers, keyed by layer name.
-
     Returns
     -------
     viewer : napari.Viewer
         A Viewer widget displaying the images.
-
     Notes
     -----
     This convenience function is used to view one or few images with identical
@@ -53,14 +50,14 @@ def view(
             image,
             metadata=metadata,
             multichannel=multichannel,
-            contrast_limits_range=contrast_limits_range,
+            contrast_limits=contrast_limits,
         )
     for name, image in named_images.items():
         viewer.add_image(
             image,
             metadata=metadata,
             multichannel=multichannel,
-            contrast_limits_range=contrast_limits_range,
+            contrast_limits=contrast_limits,
             name=name,
         )
     return viewer


### PR DESCRIPTION
# Description
This PR fixes #447 by extending support to all common dtpyes using the method suggested by @kne42. I have verified that there was a real error caused by #447 and that these changes fix it, and I have added tests that should catch the previous error - however these tests also passed before making the changes in this PR implying that the code that is causing the error in #447 was not being run in our tests. I'm not sure why that is the case, it's maybe because of multithreading issues, like the vispy draw is being run on another thread that can die without causing the test to fail? I'm not sure, i tried adding in all sorts of `canvas.update` calls etc to try and make sure the code was being run, but i couldn't get the tests to fail (though if i tried running similar code in a script it would fail). Any ideas on the cause of this @kne42? We should try and figure out before we merge. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] add `tests/test_dtypes.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
