### PR TITLE
fix node ordering

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -149,12 +149,7 @@ class QtViewer(QSplitter):
         vispy_layer = create_vispy_visual(layer)
         vispy_layer.camera = self.view.camera
         vispy_layer.node.parent = self.view.scene
-        # Workaround for bug in #22, and different handling of ordering
-        # for 2D and 3D rendering
-        if self.viewer.dims.ndisplay == 2:
-            vispy_layer.order = -len(layers)
-        else:
-            vispy_layer.order = len(layers)
+        vispy_layer.order = len(layers)
         self.layer_to_visual[layer] = vispy_layer
 
     def _remove_layer(self, event):
@@ -169,12 +164,7 @@ class QtViewer(QSplitter):
         """When the list is reordered, propagate changes to draw order."""
         for i, layer in enumerate(self.viewer.layers):
             vispy_layer = self.layer_to_visual[layer]
-            # Workaround for bug in #22, and different handling of ordering
-            # for 2D and 3D rendering
-            if self.viewer.dims.ndisplay == 2:
-                vispy_layer.order = -i
-            else:
-                vispy_layer.order = i
+            vispy_layer.order = i
         self.canvas._draw_order.clear()
         self.canvas.update()
 
@@ -187,7 +177,6 @@ class QtViewer(QSplitter):
                 self.view.camera.flip = (0, 1, 0)
 
                 self.view.camera.viewbox_key_event = viewbox_key_event
-                self._reorder_layers(None)
                 self.viewer.reset_view()
         else:
             # Set 2D camera
@@ -199,7 +188,6 @@ class QtViewer(QSplitter):
                 self.view.camera.flip = (0, 1, 0)
 
                 self.view.camera.viewbox_key_event = viewbox_key_event
-                self._reorder_layers(None)
                 self.viewer.reset_view()
 
     def screenshot(self):

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -38,7 +38,6 @@ class VispyImageLayer(VispyBaseLayer):
 
     def _on_display_change(self):
         parent = self.node.parent
-        order = abs(self.node.order)
         self.node.parent = None
 
         if self.layer.dims.ndisplay == 2:
@@ -47,7 +46,6 @@ class VispyImageLayer(VispyBaseLayer):
             self.node = VolumeNode(np.zeros((1, 1, 1)))
 
         self.node.parent = parent
-        self.order = order
         self.layer._update_dims()
         self.layer._set_view_slice()
         self.reset()

--- a/napari/_vispy/vispy_points_layer.py
+++ b/napari/_vispy/vispy_points_layer.py
@@ -37,7 +37,6 @@ class VispyPointsLayer(VispyBaseLayer):
 
     def _on_display_change(self):
         parent = self.node.parent
-        order = abs(self.node.order)
         self.node.transforms = ChainTransform()
         self.node.parent = None
 
@@ -47,7 +46,6 @@ class VispyPointsLayer(VispyBaseLayer):
             self.node = Markers()
 
         self.node.parent = parent
-        self.order = order
         self.layer._update_dims()
         self.layer._set_view_slice()
         self.reset()


### PR DESCRIPTION
# Description
This PR fixes the z-ordering problems encountered in #22 and dramatically simplifies the ordering code and switching between 2D and 3D rendering. It does this by using setting `depth_test=False` within our blending code. This hasn't caused any problems with our current layers. We'll have to see how the `Surface` layer does with it after #503 merges, but I'm confident it won't make the behavior there worse.

I'll also note that since #22 was identified there have been a number of improvements to vispy, and so it is very possible that this fix wouldn't have worked then. Once we merge this, I'll go back to https://github.com/vispy/vispy/issues/1541 and close that issue with a comment, sound good @kne42? 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
