### PR TITLE
[WIP] save / load viewer with zarr

### DIFF
--- a/examples/add_image.py
+++ b/examples/add_image.py
@@ -5,6 +5,7 @@ Display one image using the add_image API.
 from skimage import data
 from skimage.color import rgb2gray
 import napari
+import os.path
 
 
 with napari.gui_qt():
@@ -12,3 +13,4 @@ with napari.gui_qt():
     viewer = napari.view(
         astronaut=rgb2gray(data.astronaut()), title='napari example'
     )
+    viewer.title = os.path.splitext(os.path.basename(__file__))[0]

--- a/examples/add_labels.py
+++ b/examples/add_labels.py
@@ -9,6 +9,7 @@ from skimage.segmentation import clear_border
 from skimage.measure import label
 from skimage.morphology import closing, square, remove_small_objects
 import napari
+import os.path
 
 
 with napari.gui_qt():
@@ -29,3 +30,4 @@ with napari.gui_qt():
 
     # add the labels
     label_layer = viewer.add_labels(label_image, name='segmentation')
+    viewer.title = os.path.splitext(os.path.basename(__file__))[0]

--- a/examples/add_points.py
+++ b/examples/add_points.py
@@ -7,6 +7,7 @@ import numpy as np
 from skimage import data
 from skimage.color import rgb2gray
 import napari
+import os.path
 
 
 with napari.gui_qt():
@@ -62,3 +63,4 @@ with napari.gui_qt():
 
     # change the layer mode
     layer.mode = 'add'
+    viewer.title = os.path.splitext(os.path.basename(__file__))[0]

--- a/examples/add_vectors.py
+++ b/examples/add_vectors.py
@@ -10,6 +10,7 @@ Each vector position is defined by an (x, y, x-proj, y-proj) element
 import napari
 from skimage import data
 import numpy as np
+import os.path
 
 
 with napari.gui_qt():
@@ -34,3 +35,4 @@ with napari.gui_qt():
 
     # add the vectors
     layer = viewer.add_vectors(pos, edge_width=3)
+    viewer.title = os.path.splitext(os.path.basename(__file__))[0]

--- a/examples/add_vectors_image.py
+++ b/examples/add_vectors_image.py
@@ -8,6 +8,7 @@ Each vector position is defined by an (x-proj, y-proj) element
 
 import napari
 import numpy as np
+import os.path
 
 
 with napari.gui_qt():
@@ -33,5 +34,6 @@ with napari.gui_qt():
 
     # add the vectors
     vect = viewer.add_vectors(pos, edge_width=0.2, length=2.5)
+    viewer.title = os.path.splitext(os.path.basename(__file__))[0]
 
     print(image.shape, pos.shape)

--- a/examples/add_volume.py
+++ b/examples/add_volume.py
@@ -4,6 +4,7 @@ Display one 3-D volume layer using the add_volume API
 
 from skimage import data
 import napari
+import os.path
 
 
 with napari.gui_qt():
@@ -13,3 +14,4 @@ with napari.gui_qt():
     viewer = napari.Viewer(ndisplay=3)
     # add the volume
     viewer.add_image(blobs, scale=[3, 1, 1])
+    viewer.title = os.path.splitext(os.path.basename(__file__))[0]

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -106,12 +106,26 @@ class Window:
             self._main_menu_shortcut.setEnabled(False)
 
     def _add_file_menu(self):
+        open_viewer = QAction('Open', self._qt_window)
+        open_viewer.setShortcut('Ctrl+O')
+        open_viewer.setStatusTip('Open viewer')
+        open_viewer.triggered.connect(self.qt_viewer._open_viewer)
+        self.file_menu = self.main_menu.addMenu('&File')
+        self.file_menu.addAction(open_viewer)
+
         open_images = QAction('Open', self._qt_window)
-        open_images.setShortcut('Ctrl+O')
+        open_images.setShortcut('Ctrl+Shift+O')
         open_images.setStatusTip('Open image file(s)')
         open_images.triggered.connect(self.qt_viewer._open_images)
         self.file_menu = self.main_menu.addMenu('&File')
         self.file_menu.addAction(open_images)
+
+        save_viewer = QAction('Save', self._qt_window)
+        save_viewer.setShortcut('Ctrl+S')
+        save_viewer.setStatusTip('Save viewer')
+        save_viewer.triggered.connect(self.qt_viewer._save_viewer)
+        self.file_menu = self.main_menu.addMenu('&File')
+        self.file_menu.addAction(save_viewer)
 
     def _add_view_menu(self):
         toggle_visible = QAction('Toggle menubar visibility', self._qt_window)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -106,41 +106,42 @@ class Window:
             self._main_menu_shortcut.setEnabled(False)
 
     def _add_file_menu(self):
+        self.file_menu = self.main_menu.addMenu('&File')
+
         open_viewer = QAction('Open', self._qt_window)
         open_viewer.setShortcut('Ctrl+O')
         open_viewer.setStatusTip('Open viewer')
         open_viewer.triggered.connect(self.qt_viewer._open_viewer)
-        self.file_menu = self.main_menu.addMenu('&File')
         self.file_menu.addAction(open_viewer)
 
-        open_images = QAction('Open', self._qt_window)
+        open_images = QAction('Open images', self._qt_window)
         open_images.setShortcut('Ctrl+Shift+O')
         open_images.setStatusTip('Open image file(s)')
         open_images.triggered.connect(self.qt_viewer._open_images)
-        self.file_menu = self.main_menu.addMenu('&File')
         self.file_menu.addAction(open_images)
 
         save_viewer = QAction('Save', self._qt_window)
         save_viewer.setShortcut('Ctrl+S')
         save_viewer.setStatusTip('Save viewer')
         save_viewer.triggered.connect(self.qt_viewer._save_viewer)
-        self.file_menu = self.main_menu.addMenu('&File')
         self.file_menu.addAction(save_viewer)
 
     def _add_view_menu(self):
+        self.view_menu = self.main_menu.addMenu('&View')
+
         toggle_visible = QAction('Toggle menubar visibility', self._qt_window)
         toggle_visible.setShortcut('Ctrl+M')
         toggle_visible.setStatusTip('Hide Menubar')
         toggle_visible.triggered.connect(self._toggle_menubar_visible)
-        self.view_menu = self.main_menu.addMenu('&View')
         self.view_menu.addAction(toggle_visible)
 
     def _add_window_menu(self):
+        self.window_menu = self.main_menu.addMenu('&Window')
+
         exit_action = QAction("Close window", self._qt_window)
         exit_action.setShortcut("Ctrl+W")
         exit_action.setStatusTip('Close napari window')
         exit_action.triggered.connect(self._qt_window.close)
-        self.window_menu = self.main_menu.addMenu('&Window')
         self.window_menu.addAction(exit_action)
 
     def resize(self, width, height):

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -233,12 +233,8 @@ class QtViewer(QSplitter):
             caption='Select folder',
             directory=self._last_visited_dir,
         )
-        if os.path.splitext(filename)[1] == '.bundle':
-            base_filename = os.path.splitext(filename)[0]
-        else:
-            base_filename = filename
 
-        if os.path.splitext(base_filename)[1] == '.napari':
+        if os.path.splitext(filename)[1] == '.napari':
             self.viewer.from_zarr(filename)
             self._last_visited_dir = os.path.dirname(filename)
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -233,7 +233,12 @@ class QtViewer(QSplitter):
             caption='Select folder',
             directory=self._last_visited_dir,
         )
-        if os.path.splitext(filename)[1] == '.napari':
+        if os.path.splitext(filename)[1] == '.bundle':
+            base_filename = os.path.splitext(filename)[0]
+        else:
+            base_filename = filename
+
+        if os.path.splitext(base_filename)[1] == '.napari':
             self.viewer.from_zarr(filename)
             self._last_visited_dir = os.path.dirname(filename)
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -293,11 +293,14 @@ class QtViewer(QSplitter):
 
     def _on_reset_view(self, event):
         if isinstance(self.view.camera, ArcballCamera):
+            self.view.camera._quaternion = self.view.camera._quaternion.create_from_axis_angle(
+                *event.quaternion
+            )
             self.view.camera.center = event.center
             self.view.camera.scale_factor = event.scale_factor
         else:
             # Assumes default camera has the same properties as PanZoomCamera
-            self.view.camera.rect = event.viewbox
+            self.view.camera.rect = event.rect
 
     def _update_palette(self, palette):
         # template and apply the primary stylesheet

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1010,4 +1010,10 @@ class ViewerModel(KeymapMixin):
             for array_name, array in g.arrays():
                 if array_name not in ['data', 'thumbnail']:
                     args[array_name] = array
-            self._add_layer[layer_type](g['data'], **args)
+            if isinstance(g['data'], zarr.Group):
+                data = []
+                for array_name, array in g['data'].arrays():
+                    data.append(array)
+            else:
+                data = g['data']
+            self._add_layer[layer_type](data, **args)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1007,4 +1007,7 @@ class ViewerModel(KeymapMixin):
             layer_type = g.attrs['layer_type']
             args = copy(g.attrs.asdict())
             del args['layer_type']
+            for array_name, array in g.arrays():
+                if array_name not in ['data', 'thumbnail']:
+                    args[array_name] = array
             self._add_layer[layer_type](g['data'], **args)

--- a/napari/keybindings.py
+++ b/napari/keybindings.py
@@ -101,6 +101,10 @@ def dims_focus_down(viewer):
 
 Viewer.bind_key('Control-Backspace', lambda v: v.layers.remove_selected())
 Viewer.bind_key('Control-A', lambda v: v.layers.select_all())
+Viewer.bind_key(
+    'Control-Shift-Backspace',
+    lambda v: (v.layers.select_all(), v.layers.remove_selected()),
+)
 Viewer.bind_key('Control-[', lambda v: v.layers.select_previous())
 Viewer.bind_key('Control-]', lambda v: v.layers.select_next())
 Viewer.bind_key('Control-R', lambda v: v.reset_view())

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -584,8 +584,8 @@ class Layer(KeymapMixin, ABC):
         gp.attrs['layer_type'] = type(self).__name__
         gp.attrs['name'] = self.name
         gp.attrs['metadata'] = self.metadata
-        gp.attrs['scale'] = self.scale
-        gp.attrs['translate'] = self.translate
+        gp.attrs['scale'] = list(self.scale)
+        gp.attrs['translate'] = list(self.translate)
         gp.attrs['opacity'] = self.opacity
         gp.attrs['blending'] = self.blending
         gp.attrs['visible'] = self.visible

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -101,6 +101,8 @@ class Layer(KeymapMixin, ABC):
         * `_basename()`: base/default name of the layer
     """
 
+    _thumbnail_shape = (32, 32, 4)
+
     def __init__(
         self,
         ndim,
@@ -135,7 +137,6 @@ class Layer(KeymapMixin, ABC):
         self.coordinates = (0,) * ndim
         self._position = (0,) * self.dims.ndisplay
 
-        self._thumbnail_shape = (32, 32, 4)
         self._thumbnail = np.zeros(self._thumbnail_shape, dtype=np.uint8)
         self._update_properties = True
         self._name = ''

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -577,10 +577,10 @@ class Layer(KeymapMixin, ABC):
 
         return svg
 
-    def to_zarr(self, root, i):
+    def to_zarr(self, root):
         """Append a zarr group with layer data."""
 
-        gp = root.create_group('layer ' + str(i))
+        gp = root.create_group(self.name)
         gp.attrs['layer_type'] = type(self).__name__
         gp.attrs['name'] = self.name
         gp.attrs['metadata'] = self.metadata
@@ -589,6 +589,14 @@ class Layer(KeymapMixin, ABC):
         gp.attrs['opacity'] = self.opacity
         gp.attrs['blending'] = self.blending
         gp.attrs['visible'] = self.visible
+        gp.array(
+            'thumbnail',
+            self.thumbnail,
+            shape=self.thumbnail.shape,
+            chunks=(None, None, None),
+            dtype=self.thumbnail.dtype,
+        )
+
         self._add_zarr_data(gp)
 
         return root

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -577,6 +577,26 @@ class Layer(KeymapMixin, ABC):
 
         return svg
 
+    def to_zarr(self, root, i):
+        """Append a zarr group with layer data."""
+
+        gp = root.create_group('layer ' + str(i))
+        gp.attrs['layer_type'] = type(self).__name__
+        gp.attrs['name'] = self.name
+        gp.attrs['metadata'] = self.metadata
+        gp.attrs['scale'] = self.scale
+        gp.attrs['translate'] = self.translate
+        gp.attrs['opacity'] = self.opacity
+        gp.attrs['blending'] = self.blending
+        gp.attrs['visible'] = self.visible
+        self._add_zarr_data(gp)
+
+        return root
+
+    def _add_zarr_data(self, gp):
+        """Add layer data to zarr group."""
+        return
+
     def on_mouse_move(self, event):
         """Called whenever mouse moves over canvas."""
         return

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -448,3 +448,18 @@ class Image(Layer):
             'image', width=width, height=height, opacity=opacity, **props
         )
         return [xml]
+
+    def _add_zarr_data(self, gp):
+        """Add layer data to zarr group."""
+        gp.array(
+            'data',
+            self.data,
+            shape=self.data.shape,
+            chunks=(128,) * len(self.data.shape),
+            dtype=self.data.dtype,
+        )
+        gp.attrs['multichannel'] = self.multichannel
+        gp.attrs['colormap'] = self.colormap[0]
+        gp.attrs['contrast_limits'] = self.contrast_limits
+        gp.attrs['interpolation'] = self.interpolation
+        gp.attrs['rendering'] = self.rendering

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -533,6 +533,19 @@ class Labels(Layer):
         )
         return [xml]
 
+    def _add_zarr_data(self, gp):
+        """Add layer data to zarr group."""
+        gp.array(
+            'data',
+            self.data,
+            shape=self.data.shape,
+            chunks=(128,) * len(self.data.shape),
+            dtype=self.data.dtype,
+        )
+        gp.attrs['num_colors'] = self.num_colors
+        gp.attrs['seed'] = self.seed
+        gp.attrs['n_dimensional'] = self.n_dimensional
+
     def on_mouse_press(self, event):
         """Called whenever mouse pressed in canvas.
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -220,7 +220,7 @@ class Points(Layer):
                 ensure_iterable(face_color, color=True), 0, len(self.data)
             )
         )
-        self.sizes = size
+        self.sizes = np.asarray(size)
 
         # Trigger generation of view slice and thumbnail
         self._update_dims()
@@ -828,10 +828,10 @@ class Points(Layer):
             chunks=(128,) * len(self.sizes.shape),
             dtype=self.sizes.dtype,
         )
+        gp.array('edge_color', self.edge_colors, dtype=str)
+        gp.array('face_color', self.face_colors, dtype=str)
         gp.attrs['symbol'] = self.symbol
         gp.attrs['edge_width'] = self.edge_width
-        gp.attrs['edge_color'] = self.edge_color
-        gp.attrs['face_color'] = self.face_color
 
     def on_mouse_move(self, event):
         """Called whenever mouse moves over canvas.

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -821,9 +821,15 @@ class Points(Layer):
             chunks=(128,) * len(self.data.shape),
             dtype=self.data.dtype,
         )
+        gp.array(
+            'size',
+            self.sizes,
+            shape=self.sizes.shape,
+            chunks=(128,) * len(self.sizes.shape),
+            dtype=self.sizes.dtype,
+        )
         gp.attrs['symbol'] = self.symbol
         gp.attrs['edge_width'] = self.edge_width
-        gp.attrs['size'] = self.size
         gp.attrs['edge_color'] = self.edge_color
         gp.attrs['face_color'] = self.face_color
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -155,7 +155,7 @@ class Points(Layer):
         self._colors = get_color_names()
 
         # Save the point coordinates
-        self._data = data
+        self._data = np.asarray(data)
         self.dims.clip = False
 
         # Save the point style params
@@ -811,6 +811,21 @@ class Points(Layer):
             xml_list.append(element)
 
         return xml_list
+
+    def _add_zarr_data(self, gp):
+        """Add layer data to zarr group."""
+        gp.array(
+            'data',
+            self.data,
+            shape=self.data.shape,
+            chunks=(128,) * len(self.data.shape),
+            dtype=self.data.dtype,
+        )
+        gp.attrs['symbol'] = self.symbol
+        gp.attrs['edge_width'] = self.edge_width
+        gp.attrs['size'] = self.size
+        gp.attrs['edge_color'] = self.edge_color
+        gp.attrs['face_color'] = self.face_color
 
     def on_mouse_move(self, event):
         """Called whenever mouse moves over canvas.

--- a/napari/layers/pyramid/pyramid.py
+++ b/napari/layers/pyramid/pyramid.py
@@ -245,3 +245,20 @@ class Pyramid(Image):
             value = None
 
         return value
+
+    def _add_zarr_data(self, gp):
+        """Add layer data to zarr group."""
+        gp.create_group('data')
+        for i, d in enumerate(self.data):
+            gp['data'].array(
+                str(i),
+                d,
+                shape=d.shape,
+                chunks=(128,) * len(d.shape),
+                dtype=d.dtype,
+            )
+        gp.attrs['multichannel'] = self.multichannel
+        gp.attrs['colormap'] = self.colormap[0]
+        gp.attrs['contrast_limits'] = self.contrast_limits
+        gp.attrs['interpolation'] = self.interpolation
+        gp.attrs['rendering'] = self.rendering

--- a/napari/layers/pyramid/pyramid.py
+++ b/napari/layers/pyramid/pyramid.py
@@ -248,6 +248,7 @@ class Pyramid(Image):
 
     def _add_zarr_data(self, gp):
         """Add layer data to zarr group."""
+        gp.attrs['layer_type'] = type(self).__name__
         gp.create_group('data')
         for i, d in enumerate(self.data):
             gp['data'].array(

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1387,6 +1387,21 @@ class Shapes(Layer):
 
         return labels
 
+    def _add_zarr_data(self, gp):
+        """Add layer data to zarr group."""
+        gp.array(
+            'data',
+            self.data,
+            shape=self.data.shape,
+            chunks=(128,) * len(self.data.shape),
+            dtype=self.data.dtype,
+        )
+        gp.attrs['shape_type'] = 'polygon'
+        gp.attrs['edge_width'] = self.edge_width
+        gp.attrs['size'] = self.size
+        gp.attrs['edge_color'] = self.edge_color
+        gp.attrs['z_index'] = 0
+
     def on_mouse_press(self, event):
         """Called whenever mouse pressed in canvas.
 

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1389,18 +1389,35 @@ class Shapes(Layer):
 
     def _add_zarr_data(self, gp):
         """Add layer data to zarr group."""
+        gp.array('data', self.data, dtype='array:f8')
+        ew = np.array(self.edge_widths)
         gp.array(
-            'data',
-            self.data,
-            shape=self.data.shape,
-            chunks=(128,) * len(self.data.shape),
-            dtype=self.data.dtype,
+            'edge_width',
+            ew,
+            shape=ew.shape,
+            chunks=(128,) * len(ew.shape),
+            dtype=ew.dtype,
         )
-        gp.attrs['shape_type'] = 'polygon'
-        gp.attrs['edge_width'] = self.edge_width
-        gp.attrs['size'] = self.size
-        gp.attrs['edge_color'] = self.edge_color
-        gp.attrs['z_index'] = 0
+        op = np.array(self.opacities)
+        gp.array(
+            'opacity',
+            op,
+            shape=op.shape,
+            chunks=(128,) * len(op.shape),
+            dtype=op.dtype,
+        )
+        z = np.array(self.z_indices)
+        gp.array(
+            'z_index',
+            z,
+            shape=z.shape,
+            chunks=(128,) * len(z.shape),
+            dtype=z.dtype,
+        )
+        gp.array('shape_type', self.shape_types, dtype=str)
+        gp.array('edge_color', self.edge_colors, dtype=str)
+        gp.array('face_color', self.face_colors, dtype=str)
+        del gp.attrs['opacity']
 
     def on_mouse_press(self, event):
         """Called whenever mouse pressed in canvas.

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -121,7 +121,7 @@ class Vectors(Layer):
         self._length = length
 
         # assign vector data and establish default behavior
-        self.data = data
+        self.data = np.asarray(data)
 
     @property
     def data(self) -> np.ndarray:
@@ -354,3 +354,16 @@ class Vectors(Layer):
         """
 
         return None
+
+    def _add_zarr_data(self, gp):
+        """Add layer data to zarr group."""
+        gp.array(
+            'data',
+            self.data,
+            shape=self.data.shape,
+            chunks=(128,) * len(self.data.shape),
+            dtype=self.data.dtype,
+        )
+        gp.attrs['edge_width'] = self.edge_width
+        gp.attrs['edge_color'] = self.edge_color
+        gp.attrs['length'] = self.length

--- a/napari/main.py
+++ b/napari/main.py
@@ -28,10 +28,19 @@ def main():
         v = Viewer()
         if len(args.images) == 0:
             return
-        if os.path.splitext(args.images[0])[1] == '.napari':
-            v.from_zarr(args.images[0])
-        elif os.path.splitext(args.images[0][:-1])[1] == '.napari':
-            v.from_zarr(args.images[0][:-1])
+
+        filename = args.images[0]
+        if os.path.splitext(filename)[1] == '.bundle':
+            base_filename = os.path.splitext(filename)[0]
+        elif os.path.splitext(filename[:-1])[1] == '.bundle':
+            base_filename = os.path.splitext(filename[:-1])[0]
+        else:
+            base_filename = filename
+
+        if os.path.splitext(base_filename)[1] == '.napari':
+            v.from_zarr(filename)
+        elif os.path.splitext(base_filename[:-1])[1] == '.napari':
+            v.from_zarr(filename[:-1])
         else:
             images = io.ImageCollection(args.images, conserve_memory=False)
             if args.layers:

--- a/napari/main.py
+++ b/napari/main.py
@@ -4,6 +4,7 @@ napari command line viewer.
 import argparse
 import numpy as np
 from skimage import io
+import os.path
 
 from . import Viewer, gui_qt
 
@@ -25,14 +26,21 @@ def main():
     args = parser.parse_args()
     with gui_qt():
         v = Viewer()
-        images = io.ImageCollection(args.images, conserve_memory=False)
-        if args.layers:
-            for image in images:
-                v.add_image(image, multichannel=args.multichannel)
+        if len(args.images) == 0:
+            return
+        if os.path.splitext(args.images[0])[1] == '.napari':
+            v.from_zarr(args.images[0])
+        elif os.path.splitext(args.images[0][:-1])[1] == '.napari':
+            v.from_zarr(args.images[0][:-1])
         else:
-            if len(images) > 0:
-                if len(images) == 1:
-                    image = images[0]
-                else:
-                    image = np.stack(images, axis=0)
-                v.add_image(image, multichannel=args.multichannel)
+            images = io.ImageCollection(args.images, conserve_memory=False)
+            if args.layers:
+                for image in images:
+                    v.add_image(image, multichannel=args.multichannel)
+            else:
+                if len(images) > 0:
+                    if len(images) == 1:
+                        image = images[0]
+                    else:
+                        image = np.stack(images, axis=0)
+                    v.add_image(image, multichannel=args.multichannel)

--- a/napari/main.py
+++ b/napari/main.py
@@ -30,16 +30,9 @@ def main():
             return
 
         filename = args.images[0]
-        if os.path.splitext(filename)[1] == '.bundle':
-            base_filename = os.path.splitext(filename)[0]
-        elif os.path.splitext(filename[:-1])[1] == '.bundle':
-            base_filename = os.path.splitext(filename[:-1])[0]
-        else:
-            base_filename = filename
-
-        if os.path.splitext(base_filename)[1] == '.napari':
+        if os.path.splitext(filename)[1] == '.napari':
             v.from_zarr(filename)
-        elif os.path.splitext(base_filename[:-1])[1] == '.napari':
+        elif os.path.splitext(filename[:-1])[1] == '.napari':
             v.from_zarr(filename[:-1])
         else:
             images = io.ImageCollection(args.images, conserve_memory=False)

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -331,23 +331,18 @@ def set_icon(folder, icon):
         with open(resource_file, "w") as resource:
             resource.write(f"read 'icns' (-16455)\"{icon_file}\";")
 
+        # Create an Icon file
+        # Set icon of the folder
+        # Set Icon file to be invisible
+        # Remove the temporary resource file
+        # Set folder to be a package
         cmds = [
-            [
-                'Rez',
-                '-a',
-                resource_file,
-                '-o',
-                hidden_icon_file,
-            ],  # Create an Icon file
-            ['SetFile', '-a', 'C', folder],  # Set icon of the folder
-            [
-                'SetFile',
-                '-a',
-                'V',
-                hidden_icon_file,
-            ],  # Set Icon file to be invisible
+            ['Rez', '-a', resource_file, '-o', hidden_icon_file],
+            ['SetFile', '-a', 'C', folder],
+            ['SetFile', '-a', 'V', hidden_icon_file],
             ['rm', '-rf', resource_file],
-        ]  # Remove the temporary resource file
+            ['SetFile', '-a', 'B', folder],
+        ]
 
         for c in cmds:
             subprocess.run(c)

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -5,6 +5,8 @@ from ._qt.qt_main_window import Window
 from .components import ViewerModel
 from ._version import get_versions
 from .util.misc import make_thumbnail
+from imageio import imwrite
+import os.path
 
 __version__ = get_versions()['version']
 del get_versions
@@ -77,12 +79,23 @@ class Viewer(ViewerModel):
         )
 
         root.array(
+            'screenshot',
+            screenshot,
+            shape=screenshot.shape,
+            chunks=(None, None, None),
+            dtype=screenshot.dtype,
+        )
+
+        root.array(
             'thumbnail',
             thumbnail,
             shape=thumbnail.shape,
             chunks=(None, None, None),
             dtype=thumbnail.dtype,
         )
+
+        if store is not None:
+            imwrite(os.path.join(store, 'screenshot.png'), screenshot)
 
         return root
 

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -4,7 +4,7 @@ from ._qt.qt_viewer import QtViewer
 from ._qt.qt_main_window import Window
 from .components import ViewerModel
 from ._version import get_versions
-from .util.misc import make_thumbnail
+from .util.misc import make_square, set_icon
 from imageio import imwrite
 import os.path
 
@@ -74,10 +74,6 @@ class Viewer(ViewerModel):
         layer_gp.attrs['layer_names'] = layer_names
 
         screenshot = self.screenshot()
-        thumbnail = make_thumbnail(
-            screenshot, self._thumbnail_shape, multichannel=True
-        )
-
         root.array(
             'screenshot',
             screenshot,
@@ -86,16 +82,12 @@ class Viewer(ViewerModel):
             dtype=screenshot.dtype,
         )
 
-        root.array(
-            'thumbnail',
-            thumbnail,
-            shape=thumbnail.shape,
-            chunks=(None, None, None),
-            dtype=thumbnail.dtype,
-        )
-
         if store is not None:
-            imwrite(os.path.join(store, 'screenshot.png'), screenshot)
+            icon = make_square(screenshot)
+            imwrite(os.path.join(store, 'screenshot.icns'), icon)
+            imwrite(os.path.join(store, 'screenshot.ico'), icon)
+
+            set_icon(store, 'screenshot')
 
         return root
 

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -8,6 +8,8 @@ class Viewer(ViewerModel):
 
     Parameters
     ----------
+    file : path or zarr.hierarchy.Group
+        Path to napari zarr file or zarr object
     title : string
         The title of the viewer window.
     ndisplay : int
@@ -18,10 +20,13 @@ class Viewer(ViewerModel):
         ndisplay is 2 or 3.
     """
 
-    def __init__(self, title='napari', ndisplay=2, order=None):
+    def __init__(self, *, file=None, title='napari', ndisplay=2, order=None):
         super().__init__(title=title, ndisplay=ndisplay, order=order)
         qt_viewer = QtViewer(self)
         self.window = Window(qt_viewer)
         self.screenshot = self.window.qt_viewer.screenshot
         self.camera = self.window.qt_viewer.view.camera
         self.update_console = self.window.qt_viewer.console.push
+
+        if not file is None:
+            self.from_zarr(file)

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,6 +1,13 @@
+import zarr
+from copy import copy
 from ._qt.qt_viewer import QtViewer
 from ._qt.qt_main_window import Window
 from .components import ViewerModel
+from ._version import get_versions
+from .util.misc import make_thumbnail
+
+__version__ = get_versions()['version']
+del get_versions
 
 
 class Viewer(ViewerModel):
@@ -20,13 +27,97 @@ class Viewer(ViewerModel):
         ndisplay is 2 or 3.
     """
 
+    _thumbnail_shape = (32, 32, 4)
+
     def __init__(self, *, file=None, title='napari', ndisplay=2, order=None):
         super().__init__(title=title, ndisplay=ndisplay, order=order)
         qt_viewer = QtViewer(self)
         self.window = Window(qt_viewer)
         self.screenshot = self.window.qt_viewer.screenshot
-        self.camera = self.window.qt_viewer.view.camera
         self.update_console = self.window.qt_viewer.console.push
 
         if not file is None:
             self.from_zarr(file)
+
+    def to_zarr(self, store=None):
+        """Create a zarr group with viewer data."""
+        root = zarr.group(store=store)
+        root.attrs['napari'] = True
+        root.attrs['version'] = __version__
+        root.attrs['ndim'] = self.dims.ndim
+        root.attrs['ndisplay'] = self.dims.ndisplay
+        root.attrs['order'] = [int(o) for o in self.dims.order]
+        root.attrs['dims_point'] = [int(p) for p in self.dims.point]
+        root.attrs['title'] = self.title
+        root.attrs['theme'] = self.theme
+        root.attrs['metadata'] = {}
+        if self.dims.ndisplay == 3:
+            camera = self.window.qt_viewer.view.camera
+            camera_dict = {
+                'center': camera.center,
+                'scale_factor': camera.scale_factor,
+                'quaternion': camera._quaternion.get_axis_angle(),
+            }
+        else:
+            r = self.window.qt_viewer.view.camera.rect
+            camera_dict = {'rect': [r.left, r.bottom, r.width, r.height]}
+        root.attrs['camera'] = camera_dict
+
+        layer_gp = root.create_group('layers')
+
+        layer_names = []
+        for layer in self.layers:
+            layer_gp = layer.to_zarr(layer_gp)
+            layer_names.append(layer.name)
+        layer_gp.attrs['layer_names'] = layer_names
+
+        screenshot = self.screenshot()
+        thumbnail = make_thumbnail(
+            screenshot, self._thumbnail_shape, multichannel=True
+        )
+
+        root.array(
+            'thumbnail',
+            thumbnail,
+            shape=thumbnail.shape,
+            chunks=(None, None, None),
+            dtype=thumbnail.dtype,
+        )
+
+        return root
+
+    def from_zarr(self, root):
+        """Load a zarr group with viewer data."""
+        if type(root) == str:
+            root = zarr.open(root)
+
+        if 'napari' not in root.attrs:
+            print('zarr object not recognized as a napari zarr')
+            return
+
+        self.dims.ndim = root.attrs['ndim']
+        self.dims.ndisplay = root.attrs['ndisplay']
+        self.dims.order = root.attrs['order']
+        for i, p in enumerate(root.attrs['dims_point']):
+            self.dims.set_point(i, p)
+        self.title = root.attrs['title']
+        self.theme = root.attrs['theme']
+
+        for name in root['layers'].attrs['layer_names']:
+            g = root['layers/' + name]
+            layer_type = g.attrs['layer_type']
+            args = copy(g.attrs.asdict())
+            del args['layer_type']
+            for array_name, array in g.arrays():
+                if array_name not in ['data', 'thumbnail']:
+                    args[array_name] = array
+            if isinstance(g['data'], zarr.Group):
+                data = []
+                for array_name, array in g['data'].arrays():
+                    data.append(array)
+            else:
+                data = g['data']
+            self._add_layer[layer_type](data, **args)
+
+            camera_dict = root.attrs['camera']
+            self.events.reset_view(**camera_dict)

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -6,6 +6,7 @@ qtconsole>=4.5.1
 scipy>=1.2.0
 scikit-image>=0.15.0
 vispy>=0.6.1
+zarr>=2.3.2
 IPython>=7.7.0
 PyOpenGL>=3.1.0
 PySide2>=5.12.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,4 +4,3 @@ pytest
 pytest-faulthandler
 pytest-qt
 xarray
-zarr


### PR DESCRIPTION
# Description
This PR begins to add preliminary support for serializing the viewer state and saving it to a zarr file, and then being able to load the zarr file and auto-populate the viewer, as discussed in #490. It adds zarr as a dependency to napari.

The implementation is a little crude right now and a some corner cases are not tested - particularly for the `Shapes` and `Points` layer where there are some properties that are lists / arrays in addition to the main data properties, and where the data property can be a ragged array.

Also the camera state is not captured in the file yet. Capturing the camera state could be useful if you wanted someone to be able to return to the exact zoom you were at when you saved the file. Not sure though if that's strictly needed.

Right now you can use this functionality with
```python
root = viewer.to_zarr()
```
which returns the zarr object, here called `root` or with
```python
viewer.to_zarr(path)
```
where `path` should be a string path

You can then load a zarr file with
```python
viewer.from_zarr(root)
```
or
```python
viewer.from_zarr(path)
```
to load directly from a zarr object or path.  

Although it is still early some feedback on whether people think this is a good direction or not would be appreciated @royerloic @jni @kne42 @jakirkham. Note I see this functionality as complementary to saving individual layers (say as tif or jpeg) as discussed in #379, but really as way to capture the entire viewer state and all its data in one file.

Here is an example gif of the functionality where I load some data / make some edits, save a zarr file, clear the viewer, and then load in that zarr file:

![to_zarr](https://user-images.githubusercontent.com/6531703/64312576-6e3e5e00-cf5d-11e9-8b93-d8696b5a9e04.gif)

Some future things to do are to see if there is a way to set the icon of the zarr file to be a thumbnail of the whole viewer.

Also I'll note that right now the zarr file can just be read in using `zarr.open(path)` and all the raw and meta data accessed through normal zarr access patterns. There's a special attribute at the top level of the zarr file `napari` that is meant to indicate that the zarr file is a napari zarr file. We should probably add some version information to the file as well - like generated with napari version ... etc.


