### PR TITLE
clip rgba images

### DIFF
--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -327,9 +327,12 @@ class Image(Layer):
         else:
             order = self.dims.displayed_order
 
-        self._data_view = np.asarray(self.data[self.dims.indices]).transpose(
-            order
-        )
+        image = np.asarray(self.data[self.dims.indices]).transpose(order)
+
+        if self.multichannel:
+            self._data_view = np.clip(image, 0, 1)
+        else:
+            self._data_view = image
 
         self._data_thumbnail = self._data_view
         self._update_thumbnail()

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -329,7 +329,7 @@ class Image(Layer):
 
         image = np.asarray(self.data[self.dims.indices]).transpose(order)
 
-        if self.multichannel:
+        if self.multichannel and image.dtype.kind == 'f':
             self._data_view = np.clip(image, 0, 1)
         else:
             self._data_view = image

--- a/napari/layers/image/tests/test_image.py
+++ b/napari/layers/image/tests/test_image.py
@@ -20,6 +20,31 @@ def test_random_image():
     assert layer._data_view.shape == shape[-2:]
 
 
+def test_negative_image():
+    """Test instantiating Image layer with negative data."""
+    shape = (10, 15)
+    np.random.seed(0)
+    # Data between -1.0 and 1.0
+    data = 2 * np.random.random(shape) - 1.0
+    layer = Image(data)
+    assert np.all(layer.data == data)
+    assert layer.ndim == len(shape)
+    assert layer.shape == shape
+    assert layer.dims.range == [(0, m, 1) for m in shape]
+    assert layer.multichannel == False
+    assert layer._data_view.shape == shape[-2:]
+
+    # Data between -10 and 10
+    data = 20 * np.random.random(shape) - 10
+    layer = Image(data)
+    assert np.all(layer.data == data)
+    assert layer.ndim == len(shape)
+    assert layer.shape == shape
+    assert layer.dims.range == [(0, m, 1) for m in shape]
+    assert layer.multichannel == False
+    assert layer._data_view.shape == shape[-2:]
+
+
 def test_all_zeros_image():
     """Test instantiating Image layer with all zeros data."""
     shape = (10, 15)
@@ -127,6 +152,29 @@ def test_rgba_image():
     shape = (10, 15, 4)
     np.random.seed(0)
     data = np.random.random(shape)
+    layer = Image(data)
+    assert np.all(layer.data == data)
+    assert layer.ndim == len(shape) - 1
+    assert layer.shape == shape[:-1]
+    assert layer.multichannel == True
+    assert layer._data_view.shape == shape[-3:]
+
+
+def test_negative_rgba_image():
+    """Test instantiating Image layer with negative RGBA data."""
+    shape = (10, 15, 4)
+    np.random.seed(0)
+    # Data between -1.0 and 1.0
+    data = 2 * np.random.random(shape) - 1
+    layer = Image(data)
+    assert np.all(layer.data == data)
+    assert layer.ndim == len(shape) - 1
+    assert layer.shape == shape[:-1]
+    assert layer.multichannel == True
+    assert layer._data_view.shape == shape[-3:]
+
+    # Data between -10 and 10
+    data = 20 * np.random.random(shape) - 10
     layer = Image(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape) - 1

--- a/napari/layers/pyramid/pyramid.py
+++ b/napari/layers/pyramid/pyramid.py
@@ -186,7 +186,7 @@ class Pyramid(Image):
 
         image = np.asarray(self.data[-1][tuple(indices)]).transpose(order)
 
-        if self.multichannel:
+        if self.multichannel and image.dtype.kind == 'f':
             self._data_thumbnail = np.clip(image, 0, 1)
         else:
             self._data_thumbnail = image
@@ -219,7 +219,7 @@ class Pyramid(Image):
 
         image = np.asarray(self.data[level][tuple(indices)]).transpose(order)
 
-        if self.multichannel:
+        if self.multichannel and image.dtype.kind == 'f':
             self._data_view = np.clip(image, 0, 1)
         else:
             self._data_view = image

--- a/napari/layers/pyramid/pyramid.py
+++ b/napari/layers/pyramid/pyramid.py
@@ -183,9 +183,13 @@ class Pyramid(Image):
         downsampled = np.round(downsampled.astype(float)).astype(int)
         downsampled = np.clip(downsampled, 0, self.level_shapes[-1, nd] - 1)
         indices[nd] = downsampled
-        self._data_thumbnail = np.asarray(
-            self.data[-1][tuple(indices)]
-        ).transpose(order)
+
+        image = np.asarray(self.data[-1][tuple(indices)]).transpose(order)
+
+        if self.multichannel:
+            self._data_thumbnail = np.clip(image, 0, 1)
+        else:
+            self._data_thumbnail = image
 
         # Slice currently viewed level
         indices = np.array(self.dims.indices)
@@ -213,9 +217,12 @@ class Pyramid(Image):
         else:
             self.translate = [0] * self.ndim
 
-        self._data_view = np.asarray(
-            self.data[level][tuple(indices)]
-        ).transpose(order)
+        image = np.asarray(self.data[level][tuple(indices)]).transpose(order)
+
+        if self.multichannel:
+            self._data_view = np.clip(image, 0, 1)
+        else:
+            self._data_view = image
 
         self._update_thumbnail()
         self._update_coordinates()


### PR DESCRIPTION
# Description
This PR fixes #523 in the loose sense that it prevents the error message from being triggered by cliping our float rgb / rgba images between `0` and `1`. This clipping was already happening within vispy so there is no actual change in what was getting rendered before we added thumbnails and it's not quite clear what the expectations someone has for rgb / rgba images.

A deeper problem maybe is that the desired behavior by @bioimage-analysis was to have independent channels of data, which suggests we should either follow the deprecation suggestions in #481 or at least rename the `multichannel` keyword to `rgb` or `rgba` or something else more clear.

I'd still say we merge this fix and then continue that discussion separately

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added tests for negative images and negative rgb images

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
