### PR TITLE
DOC: specify that IPython needs to be started with `gui=qt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For more information see our [installation tutorial](https://napari.github.io/na
 
 ## simple example
 
-From inside an IPython shell or Jupyter notebook you can open up an interactive viewer by calling
+From inside an IPython shell (started with `ipython --gui=qt`) or Jupyter notebook you can open up an interactive viewer by calling
 
 ```python
 %gui qt5


### PR DESCRIPTION
# Description
I just ran into https://github.com/napari/napari/issues/384, and I think that this would have helped me avoid that.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Addresses https://github.com/napari/napari/issues/384

# How has this been tested?
N/A

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality