### PR TITLE
enable `python -m napari`

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -2,6 +2,8 @@
 napari command line viewer.
 """
 import argparse
+import sys
+
 import numpy as np
 from skimage import io
 
@@ -36,3 +38,7 @@ def main():
                 else:
                     image = np.stack(images, axis=0)
                 v.add_image(image, multichannel=args.multichannel)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ if __name__ == '__main__':
         requires=REQUIRES,
         python_requires=f'>={MIN_PY_VER}',
         packages=PACKAGES,
-        entry_points={'console_scripts': ['napari=napari.main:main']},
+        entry_points={'console_scripts': ['napari=napari.__main__:main']},
         include_package_data=True,
         zip_safe=False,  # the package can run out of an .egg file
     )


### PR DESCRIPTION
enable `python -m napari` by renaming `napari/main.py` to `napari.__main__.py` (see https://docs.python.org/3/library/__main__.html)