### PR TITLE
Add release notes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -77,3 +77,29 @@ Don't forget to push the new tag to the repo!
 ```bash
 $ git push upstream --tags
 ```
+
+## generating release notes
+
+1. Review and cleanup ``docs/release/release_dev.txt``.
+
+2. Make a list of merges, contributors, and reviewers by running
+   ``generate_release_notes.py -h`` and following that file's usage. For minor or major releases generate the list to include everything since the last minor or major release.
+   For other releases generate the list to include
+   everything since the last release for which there
+   are release notes (which should just be the last release).
+
+3. Paste this list at the end of the ``release_dev.txt``.
+
+4. Scan the PR titles for highlights, deprecations, API changes,
+   and bugfixes, and mention these in the relevant sections of the notes.
+   Try to present the information in an expressive way by mentioning
+   the affected functions, elaborating on the changes and their
+   consequences. If possible, organize semantically close PRs in groups.
+
+5. Rename the file to ``doc/release/release_<major>_<minor>.txt`` for a minor release and ``doc/release/release_<major>_<minor>_<release>.txt`` otherwise
+
+6. Copy ``doc/release/release_template.txt`` to
+   ``doc/release/release_dev.txt`` for the next release.
+
+7. Copy relevant deprecations from ``release_<major>_<minor>_<release>.txt``
+   to ``release_dev.txt``.

--- a/docs/release/release_0_1.rst
+++ b/docs/release/release_0_1.rst
@@ -1,0 +1,160 @@
+Announcement: napari 0.1.0
+==========================
+
+We're happy to announce the release of napari v0.1.0!
+napari is a fast, interactive, multi-dimensional image viewer for Python.
+It's designed for browsing, annotating, and analyzing large multi-dimensional
+images. It's built on top of Qt (for the GUI), vispy (for performant GPU-base
+rendering), and the scientific Python stack (numpy, scipy).
+
+This is our first major release, timed for the 2019 SciPy Conference in Austin.
+It marks our transition from pre-alpha to alpha, and establishes a reasonable
+API for adding images, shapes, and other basic layer types to an interactive
+viewer. It supports launching a viewer with python scripting or from Jupyter
+notebooks.
+
+For more information, examples, and documentation, please visit our website:
+https://github.com/napari/napari
+
+Other Pull Requests
+*******************
+- Add shapes (#100)
+- Vectors Layer (#129)
+- setup css basics (#167)
+- Update shields on README (#169)
+- Add dimension sliders (#171)
+- New more convenient ViewerApp API (#172)
+- WIP: Labels layer (#175)
+- automate running/testing of examples (#176)
+- fix error with nD markers (#183)
+-  fix sphinx-apidoc command on CONTRIBUTING.MD (#187)
+- Allow other array-like data (#188)
+- Add example using a Zarr array (#191)
+- readme updates (#192)
+- fix empty markers (#194)
+- Interactive labels (#195)
+- improve layer selection / name editing (#196)
+- Rasterize shapes (#197)
+- Fix color map to work with unlimited labels. (#203)
+- Make clim range an input argument (#205)
+- Use triangles for vectors (#215)
+- support clipping appropriately (#216)
+- fix nD fill (#217)
+- fix nD paint (#218)
+- vectors layer speed up (#219)
+- Generate svg from shapes layer (#220)
+- allow for other arrays used with labels (#228)
+- fix drawing lines in shapes layer (#230)
+- fix empty polygons in shapes layer (#231)
+- add support for custom key bindings (#232)
+- Deduplicate marker symbols (#233)
+- switch to qtpy (#235)
+- new styles (#236)
+- add support for settable viewer title (#237)
+- fix escape selecting shape error (#242)
+- updated screenshots (#244)
+- unify titlebar (#245)
+- refactor layers list (#246)
+- remove app (#247)
+- fix range slider imports (#248)
+- Refactor layer indices and coords (#249)
+- remove example data utils file (#250)
+- theme setting (#253)
+- layer active when only one selected (#257)
+- tiny theme related fixes (#258)
+- Viewer to svg (#259)
+- Fix svg canvas (#264)
+- remove async utils (#267)
+- refactor draggable layers (#271)
+- fix bbox call on new markers (#272)
+- fix default selection logic (#273)
+- add layer viewer update events (#274)
+- flip markers (#275)
+- fix markers sizing (#276)
+- fix blending update (#277)
+- fix int clim value (#278)
+- remove viewer from individual layer object (#279)
+- Black formatter PR (#282)
+- revert layers list (#284)
+- fix image dims update (#288)
+- fix status updates on dims changes (#289)
+- Refactor viewer syntax (#290)
+- Simplify the colormaps list and add the single-color colormaps (#291)
+- Remove qtviewer from viewer (#292)
+- refactor theme setting (#293)
+- Pyramid layer (#295)
+- Nd shapes (#297)
+- WIP: Stop using add_to_viewer syntax for basic layers (#303)
+- fix click on layer list (#306)
+- use stylesheet for styling of range slider (#307)
+- Unify layer mode Enums (#311)
+- Thumbnails (#314)
+- fix remove layer (#315)
+- Blending Enum (#317)
+- Change Image.interpolation to Enum (#319)
+- Reformatting whole repo with Black (#322)
+- Nd pyramids (#323)
+- Expand button (#324)
+- Revert "Reformatting whole repo with Black" (#327)
+- Black Format CI task (#329)
+- Refactor layer qt properties and controls (#330)
+- black format pyramid examples (#333)
+- fix labels colormap (#340)
+- fix black ignore (#341)
+- Nd vectors (#343)
+- remove broadcast from shapes (#345)
+- fix layer select styling (#347)
+- Change layers.Markers to layers.Points (#348)
+- add points thumbnail (#352)
+- fix resource compiling instructions (#353)
+- Improve resource building contrib (#354)
+- Add menubar to napari main window (#356)
+- fix selected default (#361)
+- Add dims test and fix 5D images (#362)
+- Shape thumbnails (#364)
+- [FIX] setting remote upstream in contributing guidelines  (#366)
+- Refactor thumbnail type conversion (#370)
+- Selectable points (#371)
+- Test layers list model and view (#373)
+- vectors thumbnails (#377)
+- add drag and drop (#378)
+- standardize keybindings framework (#389)
+- Refactor directory structure (#390)
+- Test image and pyramid layers (#391)
+- Rename app_context gui_qt (#392)
+- Test labels layer (#393)
+- Test points layer (#394)
+- Test vectors (#396)
+- modified multiple images overlaid figure (#399)
+- Test shapes (#400)
+- add viewer model tests (#401)
+- update readme for alpha release (#402)
+
+12 authors added to this release [alphabetical by first name or login]
+----------------------------------------------------------------------
+- Ahmet Can Solak
+- Bryant
+- Eric Perlman
+- jakirkham (jakirkham)
+- Jeremy Freeman
+- Juan Nunez-Iglesias
+- kevinyamauchi (kevinyamauchi)
+- Kira Evans
+- Loic Royer
+- Mars Huang
+- Nicholas Sofroniew
+- Pranathi Vemuri
+
+
+10 reviewers added to this release [alphabetical by first name or login]
+------------------------------------------------------------------------
+- Ahmet Can Solak
+- Bryant
+- Charlotte Weaver
+- Jeremy Freeman
+- Juan Nunez-Iglesias
+- kevinyamauchi
+- Kira Evans
+- Loic Royer
+- Nicholas Sofroniew
+- Shannon Axelrod

--- a/docs/release/release_0_1.rst
+++ b/docs/release/release_0_1.rst
@@ -7,7 +7,7 @@ It's designed for browsing, annotating, and analyzing large multi-dimensional
 images. It's built on top of Qt (for the GUI), vispy (for performant GPU-base
 rendering), and the scientific Python stack (numpy, scipy).
 
-This is our first major release, timed for the 2019 SciPy Conference in Austin.
+This is our first minor release, timed for the 2019 SciPy Conference in Austin.
 It marks our transition from pre-alpha to alpha, and establishes a reasonable
 API for adding images, shapes, and other basic layer types to an interactive
 viewer. It supports launching a viewer with python scripting or from Jupyter

--- a/docs/release/release_0_1.rst
+++ b/docs/release/release_0_1.rst
@@ -16,7 +16,7 @@ notebooks.
 For more information, examples, and documentation, please visit our website:
 https://github.com/napari/napari
 
-Other Pull Requests
+Pull Requests
 *******************
 - Add shapes (#100)
 - Vectors Layer (#129)

--- a/docs/release/release_0_1_3.rst
+++ b/docs/release/release_0_1_3.rst
@@ -1,0 +1,58 @@
+Announcement: napari 0.1.3
+==========================
+
+We're happy to announce the release of napari v0.1.3!
+napari is a fast, interactive, multi-dimensional image viewer for Python.
+It's designed for browsing, annotating, and analyzing large multi-dimensional
+images. It's built on top of Qt (for the GUI), vispy (for performant GPU-base
+rendering), and the scientific Python stack (numpy, scipy).
+
+For more information, examples, and documentation, please visit our website:
+https://github.com/napari/napari
+
+New Features
+------------
+- Support for volumetric rendering of images
+
+Other Pull Requests
+*******************
+- Tutorials (#395)
+- fix import in cli (#403)
+- 3D volume viewer - volume layer (#405)
+- remove vispy backport (#406)
+- Fix axis shape one (#409)
+- Xarray example (#410)
+- fix clim setter (#411)
+- switch to pyside2 (#412)
+- fix delete markers (#413)
+- [FIX] paint color inidicator update when shuffle color (#416)
+- QT returns a warning instead of an error (#418)
+- Fix Crash with stacked binary tiffs. (#422)
+- cleanup shape classes (#423)
+- move tutorials to napari-tutorials repo (#425)
+- fix vispy 0.6.0 colormap bug (#426)
+- fix points keypress (#427)
+- minimal vispy 0.6 colormap fix (#430)
+- Fix dims sliders (#431)
+- add _vispy init (#433)
+- Expose args for blending, visible, opacity (#434)
+- more dims fixes (#435)
+- fix screenshot (#437)
+- fix dims mixing (#438)
+
+6 authors added to this release [alphabetical by first name or login]
+---------------------------------------------------------------------
+- Ahmet Can Solak
+- Alexandre de Siqueira
+- Mars Huang
+- Matthias Bussonnier
+- Nicholas Sofroniew
+- Pranathi Vemuri
+
+
+4 reviewers added to this release [alphabetical by first name or login]
+-----------------------------------------------------------------------
+- Juan Nunez-Iglesias
+- Kira Evans
+- Nicholas Sofroniew
+- Pranathi Vemuri

--- a/docs/release/release_0_1_3.rst
+++ b/docs/release/release_0_1_3.rst
@@ -14,7 +14,7 @@ New Features
 ------------
 - Support for volumetric rendering of images
 
-Other Pull Requests
+Pull Requests
 *******************
 - Tutorials (#395)
 - fix import in cli (#403)

--- a/docs/release/release_0_1_5.rst
+++ b/docs/release/release_0_1_5.rst
@@ -1,0 +1,69 @@
+Announcement: napari 0.1.5
+==========================
+
+We're happy to announce the release of napari v0.1.5!
+napari is a fast, interactive, multi-dimensional image viewer for Python.
+It's designed for browsing, annotating, and analyzing large multi-dimensional
+images. It's built on top of Qt (for the GUI), vispy (for performant GPU-base
+rendering), and the scientific Python stack (numpy, scipy).
+
+
+For more information, examples, and documentation, please visit our website:
+https://github.com/napari/napari
+
+New Features
+------------
+- Support for swappable dimensions
+- Support for 3D rendering for more layer types
+
+Other Pull Requests
+*******************
+- Expose args for blending, visible, opacity (#434)
+- test add_* signatures and improve docstring testing (#439)
+- add qt console (#443)
+- adapt existing keybindings to use new system (#444)
+- fix aspect ratio (#446)
+- Swappable dimensions (#451)
+- use __init_subclass__ in keymap mixin to create empty class keymap (#452)
+- use pytest-qt (#453)
+- use codecov (#455)
+- expose scaling factor for volume (#463)
+- fix size policy on layers list (#466)
+- Allow out of range float images (#468)
+- add viewer keybindings (#472)
+- fix windows ci build (#479)
+- fix OSX CI (#482)
+- remove vispy backport (#483)
+- clean up black pre-commit hook & exclusion pattern (#484)
+- remove vispy code from layer models (#485)
+- host docs (#486)
+- Fix keybindings (#487)
+- layer views (#488)
+- Include requirements/default.txt in sdist (#491)
+- Integrate 3D rendering with layers (#493)
+- revert "layer views (#488)" (#494)
+- support more image dtypes (#498)
+- rename clim (#499)
+- fix cursor position (#501)
+- don't ignore errors in events (#505)
+- fix contributing guidelines (#506)
+- create release guide (#508)
+- fix node ordering (#509)
+- fix call signature to work with keyword-only arguments (#510)
+- prevent selected label from being reduced below 0 (#512)
+
+4 authors added to this release [alphabetical by first name or login]
+---------------------------------------------------------------------
+- Christoph Gohlke
+- Juan Nunez-Iglesias
+- Kira Evans
+- Nicholas Sofroniew
+
+
+5 reviewers added to this release [alphabetical by first name or login]
+-----------------------------------------------------------------------
+- Ahmet Can Solak
+- Juan Nunez-Iglesias
+- Kira Evans
+- Loic Royer
+- Nicholas Sofroniew

--- a/docs/release/release_0_1_5.rst
+++ b/docs/release/release_0_1_5.rst
@@ -16,7 +16,7 @@ New Features
 - Support for swappable dimensions
 - Support for 3D rendering for more layer types
 
-Other Pull Requests
+Pull Requests
 *******************
 - Expose args for blending, visible, opacity (#434)
 - test add_* signatures and improve docstring testing (#439)

--- a/docs/release/release_dev.rst
+++ b/docs/release/release_dev.rst
@@ -1,0 +1,44 @@
+Announcement: napari 0.X.0
+================================
+
+We're happy to announce the release of napari v0.X.0!
+
+napari is a fast, interactive, multi-dimensional image viewer for Python.
+It's designed for browsing, annotating, and analyzing large multi-dimensional
+images. It's built on top of Qt (for the GUI), vispy (for performant GPU-base
+rendering), and the scientific Python stack (numpy, scipy).
+
+For more information, examples, and documentation, please visit our website:
+
+https://github.com/napari/napari
+
+
+New Features
+------------
+- Add `viewer.add_multichannel` method to rapidly add expand a multichannel
+array along one particular axis with different colormaps (#528).
+- Add a `Surface` layer to render already generated meshes. Support nD meshes
+rendered in 2D or 3D (#503).
+
+Improvements
+------------
+
+
+
+API Changes
+-----------
+
+
+
+Bugfixes
+--------
+
+
+
+Deprecations
+------------
+- Drop `napari.view` method. Replaced with `napari.view_*` methods in (#542)
+
+
+Contributors to this release
+----------------------------

--- a/docs/release/release_template.rst
+++ b/docs/release/release_template.rst
@@ -1,0 +1,42 @@
+Announcement: napari 0.X.0
+================================
+
+We're happy to announce the release of napari v0.X.0!
+
+napari is a fast, interactive, multi-dimensional image viewer for Python.
+It's designed for browsing, annotating, and analyzing large multi-dimensional
+images. It's built on top of Qt (for the GUI), vispy (for performant GPU-base
+rendering), and the scientific Python stack (numpy, scipy).
+
+For more information, examples, and documentation, please visit our website:
+
+https://github.com/napari/napari
+
+
+New Features
+------------
+
+
+
+Improvements
+------------
+
+
+
+API Changes
+-----------
+
+
+
+Bugfixes
+--------
+
+
+
+Deprecations
+------------
+
+
+
+Contributors to this release
+----------------------------

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -1,0 +1,240 @@
+"""Generate the release notes automatically from Github pull requests.
+Start with:
+```
+export GH_TOKEN=<your-gh-api-token>
+```
+Then, for a major release:
+```
+python /path/to/generate_release_notes.py v0.14.0 master --version 0.15.0
+```
+For a minor release:
+```
+python /path/to/generate_release_notes.py v.14.2 v0.14.x --version 0.14.3
+```
+You should probably redirect the output with:
+```
+python /path/to/generate_release_notes.py [args] | tee release_notes.rst
+```
+You'll require PyGitHub and tqdm, which you can install with:
+```
+pip install -r requirements/_release_tools.txt
+```
+References
+https://github.com/scikit-image/scikit-image/blob/master/tools/generate_release_notes.py
+https://github.com/scikit-image/scikit-image/issues/3404
+https://github.com/scikit-image/scikit-image/issues/3405
+"""
+import os
+import argparse
+from datetime import datetime
+from collections import OrderedDict
+import string
+from warnings import warn
+
+from github import Github
+
+try:
+    from tqdm import tqdm
+except ImportError:
+    from warnings import warn
+
+    warn(
+        'tqdm not installed. This script takes approximately 5 minutes '
+        'to run. To view live progressbars, please install tqdm. '
+        'Otherwise, be patient.'
+    )
+
+    def tqdm(i, **kwargs):
+        return i
+
+
+GH_USER = 'napari'
+GH_REPO = 'napari'
+GH_TOKEN = os.environ.get('GH_TOKEN')
+if GH_TOKEN is None:
+    raise RuntimeError(
+        "It is necessary that the environment variable `GH_TOKEN` "
+        "be set to avoid running into problems with rate limiting. "
+        "One can be acquired at https://github.com/settings/tokens.\n\n"
+        "You do not need to select any permission boxes while generating "
+        "the token."
+    )
+
+g = Github(GH_TOKEN)
+repository = g.get_repo(f'{GH_USER}/{GH_REPO}')
+
+
+parser = argparse.ArgumentParser(usage=__doc__)
+parser.add_argument('from_commit', help='The starting tag.')
+parser.add_argument('to_commit', help='The head branch.')
+parser.add_argument(
+    '--version', help="Version you're about to release.", default='0.2.0'
+)
+
+args = parser.parse_args()
+
+for tag in repository.get_tags():
+    if tag.name == args.from_commit:
+        previous_tag = tag
+        break
+else:
+    raise RuntimeError(f'Desired tag ({args.from_commit}) not found')
+
+# For some reason, go get the github commit from the commit to get
+# the correct date
+github_commit = previous_tag.commit.commit
+previous_tag_date = datetime.strptime(
+    github_commit.last_modified, '%a, %d %b %Y %H:%M:%S %Z'
+)
+
+
+all_commits = list(
+    tqdm(
+        repository.get_commits(sha=args.to_commit, since=previous_tag_date),
+        desc=f'Getting all commits between {args.from_commit} '
+        f'and {args.to_commit}',
+    )
+)
+all_hashes = set(c.sha for c in all_commits)
+
+authors = set()
+reviewers = set()
+committers = set()
+users = dict()  # keep track of known usernames
+
+
+def find_author_info(commit):
+    """Return committer and author of a commit.
+    Parameters
+    ----------
+    commit : Github commit
+        The commit to query.
+    Returns
+    -------
+    committer : str or None
+        The git committer.
+    author : str
+        The git author.
+    """
+    committer = None
+    if commit.committer is not None:
+        committer = commit.committer.name or commit.committer.login
+    git_author = commit.raw_data['commit']['author']['name']
+    if commit.author is not None:
+        author = commit.author.name or commit.author.login + f' ({git_author})'
+    else:
+        # Users that deleted their accounts will appear as None
+        author = git_author
+    return committer, author
+
+
+def add_to_users(users, new_user):
+    if new_user.name is None:
+        users[new_user.login] = new_user.login
+    else:
+        users[new_user.login] = new_user.name
+
+
+for commit in tqdm(all_commits, desc='Getting commiters and authors'):
+    committer, author = find_author_info(commit)
+    if committer is not None:
+        committers.add(committer)
+        # users maps github ids to a unique name.
+        add_to_users(users, commit.committer)
+        committers.add(users[commit.committer.login])
+
+    if commit.author is not None:
+        add_to_users(users, commit.author)
+    authors.add(author)
+
+# this gets found as a commiter
+committers.discard('GitHub Web Flow')
+authors.discard('Azure Pipelines Bot')
+
+highlights = OrderedDict()
+
+highlights['New Feature'] = {}
+highlights['Improvement'] = {}
+highlights['Bugfix'] = {}
+highlights['API Change'] = {}
+highlights['Deprecations'] = {}
+highlights['Build Tool'] = {}
+other_pull_requests = {}
+
+for pull in tqdm(
+    g.search_issues(
+        f'repo:{GH_USER}/{GH_REPO} '
+        f'merged:>{previous_tag_date.isoformat()} '
+        'sort:created-asc'
+    ),
+    desc='Pull Requests...',
+):
+    pr = repository.get_pull(pull.number)
+    if pr.merge_commit_sha in all_hashes:
+        summary = pull.title
+        for review in pr.get_reviews():
+            if review.user.login not in users:
+                users[review.user.login] = review.user.name
+            reviewers.add(users[review.user.login])
+        for key, key_dict in highlights.items():
+            pr_title_prefix = (key + ': ').lower()
+            if summary.lower().startswith(pr_title_prefix):
+                key_dict[pull.number] = {
+                    'summary': summary[len(pr_title_prefix) :]
+                }
+                break
+        else:
+            other_pull_requests[pull.number] = {'summary': summary}
+
+
+# add Other PRs to the ordered dict to make doc generation easier.
+highlights['Other Pull Request'] = other_pull_requests
+
+
+# Now generate the release notes
+announcement_title = f'Announcement: napari {args.version}'
+print(announcement_title)
+print('=' * len(announcement_title))
+
+print(
+    f"""
+We're happy to announce the release of napari v{args.version}!
+napari is a fast, interactive, multi-dimensional image viewer for Python.
+It's designed for browsing, annotating, and analyzing large multi-dimensional
+images. It's built on top of Qt (for the GUI), vispy (for performant GPU-base
+rendering), and the scientific Python stack (numpy, scipy).
+"""
+)
+
+print(
+    """
+For more information, examples, and documentation, please visit our website:
+https://github.com/napari/napari
+"""
+)
+
+for section, pull_request_dicts in highlights.items():
+    if not pull_request_dicts:
+        continue
+    print(f'{section}s\n{"*" * (len(section)+1)}')
+    for number, pull_request_info in pull_request_dicts.items():
+        print(f'- {pull_request_info["summary"]} (#{number})')
+
+
+contributors = OrderedDict()
+
+contributors['authors'] = authors
+# contributors['committers'] = committers
+contributors['reviewers'] = reviewers
+
+for section_name, contributor_set in contributors.items():
+    print()
+    committer_str = (
+        f'{len(contributor_set)} {section_name} added to this '
+        'release [alphabetical by first name or login]'
+    )
+    print(committer_str)
+    print('-' * len(committer_str))
+    for c in sorted(contributor_set, key=str.lower):
+        print(f'- {c}')
+    print()

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -188,7 +188,7 @@ for pull in tqdm(
 
 
 # add Other PRs to the ordered dict to make doc generation easier.
-highlights['Other Pull Request'] = other_pull_requests
+highlights['Pull Request'] = other_pull_requests
 
 
 # Now generate the release notes

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -3,13 +3,13 @@ Start with:
 ```
 export GH_TOKEN=<your-gh-api-token>
 ```
-Then, for a major release:
+Then, for to include everything from a certain release to master:
 ```
 python /path/to/generate_release_notes.py v0.14.0 master --version 0.15.0
 ```
-For a minor release:
+Or two include only things between two releases:
 ```
-python /path/to/generate_release_notes.py v.14.2 v0.14.x --version 0.14.3
+python /path/to/generate_release_notes.py v.14.2 v0.14.3 --version 0.14.3
 ```
 You should probably redirect the output with:
 ```

--- a/requirements/_release_tools.txt
+++ b/requirements/_release_tools.txt
@@ -1,0 +1,2 @@
+pygithub
+tqdm


### PR DESCRIPTION
# Description
This PR adds release notes for our previous `0.1.0` release and some intermediate release. It adds instructions to our release guide on how to generate the release notes and a file `generate_release_notes.py` for doing so. In general the approach we have taken mirrors that taken by scikit-image.

We also now have a `release_template.rst` that is a blank template for future release notes, and a 
`release_dev.rst` that is an in progress copy of the notes for the next release.

The approach I took was for minor releases (something like `0.1`) to generate all the release notes since the last minor release (say `0.0`). Then for normal releases, like `0.1.4` to generate release notes since the last time release notes were generated (which should be `0.1.3` in this case).

How does this sound @AhmetCanSolak @royerloic @jni?

I'm less concerned with retroactively making all these release notes super accurate (though I'm glad we have something), but I'm more interested in establishing good practices going forward.
