### PR TITLE
Labels pyramid

### DIFF
--- a/napari/_qt/layers/qt_points_layer.py
+++ b/napari/_qt/layers/qt_points_layer.py
@@ -25,6 +25,7 @@ class QtPointsControls(QtLayerControls):
         self.layer.events.size.connect(self._on_size_change)
         self.layer.events.edge_color.connect(self._on_edge_color_change)
         self.layer.events.face_color.connect(self._on_face_color_change)
+        self.layer.events.editable.connect(self._on_editable_change)
 
         sld = QSlider(Qt.Horizontal)
         sld.setFocusPolicy(Qt.NoFocus)
@@ -182,6 +183,11 @@ class QtPointsControls(QtLayerControls):
             self.faceComboBox.setCurrentIndex(index)
         color = Color(self.layer.face_color).hex
         self.faceColorSwatch.setStyleSheet("background-color: " + color)
+
+    def _on_editable_change(self, event):
+        self.select_button.setEnabled(self.layer.editable)
+        self.addition_button.setEnabled(self.layer.editable)
+        self.delete_button.setEnabled(self.layer.editable)
 
 
 class QtPanZoomButton(QRadioButton):

--- a/napari/_qt/layers/qt_shapes_layer.py
+++ b/napari/_qt/layers/qt_shapes_layer.py
@@ -24,6 +24,7 @@ class QtShapesControls(QtLayerControls):
         self.layer.events.edge_width.connect(self._on_edge_width_change)
         self.layer.events.edge_color.connect(self._on_edge_color_change)
         self.layer.events.face_color.connect(self._on_face_color_change)
+        self.layer.events.editable.connect(self._on_editable_change)
 
         sld = QSlider(Qt.Horizontal)
         sld.setFocusPolicy(Qt.NoFocus)
@@ -205,6 +206,20 @@ class QtShapesControls(QtLayerControls):
             self.faceComboBox.setCurrentIndex(index)
         color = Color(self.layer.face_color).hex
         self.faceColorSwatch.setStyleSheet("background-color: " + color)
+
+    def _on_editable_change(self, event):
+        self.select_button.setEnabled(self.layer.editable)
+        self.direct_button.setEnabled(self.layer.editable)
+        self.rectangle_button.setEnabled(self.layer.editable)
+        self.ellipse_button.setEnabled(self.layer.editable)
+        self.line_button.setEnabled(self.layer.editable)
+        self.path_button.setEnabled(self.layer.editable)
+        self.polygon_button.setEnabled(self.layer.editable)
+        self.vertex_remove_button.setEnabled(self.layer.editable)
+        self.vertex_insert_button.setEnabled(self.layer.editable)
+        self.delete_button.setEnabled(self.layer.editable)
+        self.move_back_button.setEnabled(self.layer.editable)
+        self.move_front_button.setEnabled(self.layer.editable)
 
 
 class QtModeButton(QRadioButton):

--- a/napari/components/tests/test_viewer_model.py
+++ b/napari/components/tests/test_viewer_model.py
@@ -201,17 +201,13 @@ def test_swappable_dims():
 
     labels_data = np.random.randint(20, size=(7, 12, 10, 15))
     viewer.add_labels(labels_data)
-    assert np.all(
-        viewer.layers['Labels']._data_labels == labels_data[0, 0, :, :]
-    )
+    assert np.all(viewer.layers['Labels']._data_raw == labels_data[0, 0, :, :])
 
     # Swap dims
     viewer.dims.order = [0, 2, 1, 3]
     assert viewer.dims.order == [0, 2, 1, 3]
     assert np.all(viewer.layers['Image']._data_view == image_data[0, :, 0, :])
-    assert np.all(
-        viewer.layers['Labels']._data_labels == labels_data[0, :, 0, :]
-    )
+    assert np.all(viewer.layers['Labels']._data_raw == labels_data[0, :, 0, :])
 
 
 def test_svg():

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -619,6 +619,7 @@ class ViewerModel(KeymapMixin):
         self,
         data,
         *,
+        is_pyramid=None,
         num_colors=50,
         seed=0.5,
         n_dimensional=False,
@@ -637,8 +638,14 @@ class ViewerModel(KeymapMixin):
 
         Parameters
         ----------
-        data : array
-            Labels data.
+        data : array or list of array
+            Labels data as an array or pyramid.
+        is_pyramid : bool
+            Whether the data is an image pyramid or not. Pyramid data is
+            represented by a list of array like image data. If not specified by
+            the user and if the data is a list of arrays that decrease in shape
+            then it will be taken to be a pyramid. The first image in the list
+            should be the largest.
         num_colors : int
             Number of unique colors to use in colormap.
         seed : float
@@ -669,6 +676,7 @@ class ViewerModel(KeymapMixin):
         """
         layer = layers.Labels(
             data,
+            is_pyramid=is_pyramid,
             num_colors=num_colors,
             seed=seed,
             n_dimensional=n_dimensional,

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -167,6 +167,8 @@ class Layer(KeymapMixin, ABC):
         )
         self.name = name
 
+        self.events.data.connect(lambda e: self._set_editable())
+        self.dims.events.ndisplay.connect(lambda e: self._set_editable())
         self.dims.events.ndisplay.connect(lambda e: self._set_view_slice())
         self.dims.events.order.connect(lambda e: self._set_view_slice())
         self.dims.events.ndisplay.connect(lambda e: self._update_dims())

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -137,6 +137,7 @@ class Layer(KeymapMixin, ABC):
         self.coordinates = (0,) * ndim
         self._position = (0,) * self.dims.ndisplay
         self.is_pyramid = False
+        self._editable = True
 
         self._thumbnail_shape = (32, 32, 4)
         self._thumbnail = np.zeros(self._thumbnail_shape, dtype=np.uint8)
@@ -162,6 +163,7 @@ class Layer(KeymapMixin, ABC):
             interactive=Event,
             cursor=Event,
             cursor_size=Event,
+            editable=Event,
         )
         self.name = name
 
@@ -251,6 +253,19 @@ class Layer(KeymapMixin, ABC):
     def visible(self, visibility):
         self._visible = visibility
         self.events.visible()
+
+    @property
+    def editable(self):
+        """bool: Whether the current layer data is editable from the viewer."""
+        return self._editable
+
+    @editable.setter
+    def editable(self, editable):
+        if self._editable == editable:
+            return
+        self._editable = editable
+        self._set_editable(editable=editable)
+        self.events.editable()
 
     @property
     def scale(self):
@@ -349,6 +364,10 @@ class Layer(KeymapMixin, ABC):
     @abstractmethod
     def _get_ndim(self):
         raise NotImplementedError()
+
+    def _set_editable(self, editable=None):
+        if editable is None:
+            self.editable = True
 
     def _get_range(self):
         extent = self._get_extent()

--- a/napari/layers/image/tests/test_pyramid.py
+++ b/napari/layers/image/tests/test_pyramid.py
@@ -273,13 +273,13 @@ def test_metadata():
 
 def test_value():
     """Test getting the value of the data at the current coordinates."""
-    shapes = [(40, 20), (20, 10), (10, 5)]
+    shapes = [(40, 20), (20, 10)]
     np.random.seed(0)
     data = [np.random.random(s) for s in shapes]
     layer = Image(data, is_pyramid=True)
     value = layer.get_value()
     assert layer.coordinates == (0, 0)
-    assert value == (2, data[-1][0, 0])
+    assert value == (1, data[-1][0, 0])
 
 
 def test_message():

--- a/napari/layers/image/tests/test_pyramid.py
+++ b/napari/layers/image/tests/test_pyramid.py
@@ -273,13 +273,16 @@ def test_metadata():
 
 def test_value():
     """Test getting the value of the data at the current coordinates."""
-    shapes = [(40, 20), (20, 10)]
+    shapes = [(40, 20), (20, 10), (10, 5)]
     np.random.seed(0)
     data = [np.random.random(s) for s in shapes]
     layer = Image(data, is_pyramid=True)
     value = layer.get_value()
     assert layer.coordinates == (0, 0)
-    assert value == (1, data[-1][0, 0])
+    # Note that here, because the shapes of the pyramid are all very small
+    # data that will be rendered will only ever come from the bottom two
+    # levels of the pyramid.
+    assert value == (1, data[1][0, 0])
 
 
 def test_message():

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -187,8 +187,6 @@ class Labels(Image):
         self.dims.events.ndisplay.connect(lambda e: self._reset_history())
         self.dims.events.order.connect(lambda e: self._reset_history())
         self.dims.events.axis.connect(lambda e: self._reset_history())
-        self.events.data.connect(lambda e: self._set_editable())
-        self.dims.events.ndisplay.connect(lambda e: self._set_editable())
 
     @property
     def contiguous(self):
@@ -329,6 +327,7 @@ class Labels(Image):
         self._set_view_slice()
 
     def _set_editable(self, editable=None):
+        """Set editable mode based on layer properties."""
         if editable is None:
             if self.is_pyramid or self.dims.ndisplay == 3:
                 self.editable = False

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -182,10 +182,13 @@ class Labels(Image):
 
         # Trigger generation of view slice and thumbnail
         self._update_dims()
+        self._set_editable()
 
         self.dims.events.ndisplay.connect(lambda e: self._reset_history())
         self.dims.events.order.connect(lambda e: self._reset_history())
         self.dims.events.axis.connect(lambda e: self._reset_history())
+        self.events.data.connect(lambda e: self._set_editable())
+        self.dims.events.ndisplay.connect(lambda e: self._set_editable())
 
     @property
     def contiguous(self):
@@ -293,6 +296,9 @@ class Labels(Image):
         if isinstance(mode, str):
             mode = Mode(mode)
 
+        if not self.editable:
+            mode = Mode.PAN_ZOOM
+
         if mode == self._mode:
             return
 
@@ -321,6 +327,17 @@ class Labels(Image):
 
         self.events.mode(mode=mode)
         self._set_view_slice()
+
+    def _set_editable(self, editable=None):
+        if editable is None:
+            if self.is_pyramid or self.dims.ndisplay == 3:
+                self.editable = False
+            else:
+                self.editable = True
+
+        if self.editable == False:
+            self.mode = Mode.PAN_ZOOM
+            self._reset_history()
 
     def _raw_to_displayed(self, raw):
         """Determine displayed image from a saved raw image and a saved seed.

--- a/napari/layers/labels/tests/test_labels.py
+++ b/napari/layers/labels/tests/test_labels.py
@@ -15,6 +15,7 @@ def test_random_labels():
     assert layer.shape == shape
     assert layer.dims.range == [(0, m, 1) for m in shape]
     assert layer._data_view.shape == shape[-2:]
+    assert layer.editable == True
 
 
 def test_all_zeros_labels():
@@ -38,6 +39,12 @@ def test_3D_labels():
     assert layer.ndim == len(shape)
     assert layer.shape == shape
     assert layer._data_view.shape == shape[-2:]
+    assert layer.editable == True
+
+    layer.dims.ndisplay = 3
+    assert layer.dims.ndisplay == 3
+    assert layer.editable == False
+    assert layer.mode == 'pan_zoom'
 
 
 def test_changing_labels():
@@ -96,6 +103,12 @@ def test_changing_modes():
     layer.mode = 'pan_zoom'
     assert layer.mode == 'pan_zoom'
     assert layer.interactive == True
+
+    layer.mode = 'paint'
+    assert layer.mode == 'paint'
+    layer.editable = False
+    assert layer.mode == 'pan_zoom'
+    assert layer.editable == False
 
 
 def test_name():

--- a/napari/layers/labels/tests/test_pyramid.py
+++ b/napari/layers/labels/tests/test_pyramid.py
@@ -1,0 +1,66 @@
+import numpy as np
+from xml.etree.ElementTree import Element
+from vispy.color import Colormap
+from napari.layers import Labels
+
+
+def test_random_pyramid():
+    """Test instantiating Labels layer with random 2D pyramid data."""
+    shapes = [(40, 20), (20, 10), (10, 5)]
+    np.random.seed(0)
+    data = [np.random.randint(20, size=s) for s in shapes]
+    layer = Labels(data, is_pyramid=True)
+    assert layer.data == data
+    assert layer.is_pyramid == True
+    assert layer.editable == False
+    assert layer.ndim == len(shapes[0])
+    assert layer.shape == shapes[0]
+    assert layer.rgb == False
+    assert layer._data_view.ndim == 2
+
+
+def test_infer_pyramid():
+    """Test instantiating Labels layer with random 2D pyramid data."""
+    shapes = [(40, 20), (20, 10), (10, 5)]
+    np.random.seed(0)
+    data = [np.random.randint(20, size=s) for s in shapes]
+    layer = Labels(data)
+    assert layer.data == data
+    assert layer.is_pyramid == True
+    assert layer.editable == False
+    assert layer.ndim == len(shapes[0])
+    assert layer.shape == shapes[0]
+    assert layer.rgb == False
+    assert layer._data_view.ndim == 2
+
+
+def test_3D_pyramid():
+    """Test instantiating Labels layer with 3D data."""
+    shapes = [(8, 40, 20), (4, 20, 10), (2, 10, 5)]
+    np.random.seed(0)
+    data = [np.random.randint(20, size=s) for s in shapes]
+    layer = Labels(data, is_pyramid=True)
+    assert layer.data == data
+    assert layer.is_pyramid == True
+    assert layer.editable == False
+    assert layer.ndim == len(shapes[0])
+    assert layer.shape == shapes[0]
+    assert layer.rgb == False
+    assert layer._data_view.ndim == 2
+
+
+def test_create_random_pyramid():
+    """Test instantiating Labels layer with random 2D data."""
+    shape = (20_000, 20)
+    np.random.seed(0)
+    data = np.random.randint(20, size=shape)
+    layer = Labels(data)
+    assert np.all(layer.data == data)
+    assert layer.is_pyramid == True
+    assert layer.editable == False
+    assert layer._data_pyramid[0].shape == shape
+    assert layer._data_pyramid[1].shape == (shape[0] / 2, shape[1])
+    assert layer.ndim == len(shape)
+    assert layer.shape == shape
+    assert layer.rgb == False
+    assert layer._data_view.ndim == 2

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -463,6 +463,10 @@ class Points(Layer):
     def mode(self, mode):
         if isinstance(mode, str):
             mode = Mode(mode)
+
+        if not self.editable:
+            mode = Mode.PAN_ZOOM
+
         if mode == self._mode:
             return
         old_mode = self._mode
@@ -490,6 +494,17 @@ class Points(Layer):
         self._mode = mode
 
         self.events.mode(mode=mode)
+
+    def _set_editable(self, editable=None):
+        """Set editable mode based on layer properties."""
+        if editable is None:
+            if self.dims.ndisplay == 3:
+                self.editable = False
+            else:
+                self.editable = True
+
+        if self.editable == False:
+            self.mode = Mode.PAN_ZOOM
 
     def _slice_data(self, indices):
         """Determines the slice of points given the indices.

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -519,6 +519,9 @@ class Shapes(Layer):
         if isinstance(mode, str):
             mode = Mode(mode)
 
+        if not self.editable:
+            mode = Mode.PAN_ZOOM
+
         if mode == self._mode:
             return
         old_mode = self._mode
@@ -564,6 +567,17 @@ class Shapes(Layer):
         if not (mode in draw_modes and old_mode in draw_modes):
             self._finish_drawing()
         self._set_view_slice()
+
+    def _set_editable(self, editable=None):
+        """Set editable mode based on layer properties."""
+        if editable is None:
+            if self.dims.ndisplay == 3:
+                self.editable = False
+            else:
+                self.editable = True
+
+        if self.editable == False:
+            self.mode = Mode.PAN_ZOOM
 
     def add(
         self,

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -671,6 +671,10 @@ QtModeButton {
   border-radius: 3px;
 }
 
+QtModeButton:disabled {
+  background-color: {{ background }};
+}
+
 QtModeButton::indicator {
   subcontrol-position:
   center center;

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -552,6 +552,10 @@ QtLayerControls > QRadioButton {
    border-radius: 3px;
 }
 
+QtLayerControls > QRadioButton:disabled {
+  background-color: {{ background }};
+}
+
 QtLayerControls > QRadioButton::indicator:checked {
   background-color: {{ secondary }};
   border-radius: 3px;
@@ -565,6 +569,10 @@ QtLayerControls > QRadioButton::indicator:unchecked:hover {
 QtLayerControls > QPushButton {
    background-color: {{ primary }};
    border-radius: 3px;
+}
+
+QtLayerControls > QPushButton:disabled {
+  background-color: {{ background }};
 }
 
 QtLayerControls > QPushButton:hover {

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -69,6 +69,26 @@ def is_pyramid(data):
         return False
 
 
+def trim_pyramid(pyramid):
+    """Trim very small arrays of top of pyramid.
+
+    Parameters
+    ----------
+    pyramid : list of array
+        Pyramid data
+
+    Returns
+    -------
+    trimmed : list of array
+        Trimmed pyramid data
+    """
+    keep = [np.any(np.greater_equal(p.shape, 2 ** 6 - 1)) for p in pyramid]
+    if np.sum(keep) >= 2:
+        return [p for k, p in zip(keep, pyramid) if k]
+    else:
+        return pyramid[:2]
+
+
 def should_be_pyramid(shape):
     """Check if any data axes needs to be pyramidified
 
@@ -148,10 +168,11 @@ def get_pyramid_and_rgb(data, pyramid=None, rgb=None):
             data_pyramid = fast_pyramid(
                 data, downscale=downscale, max_layer=max_layer
             )
+            data_pyramid = trim_pyramid(data_pyramid)
         else:
             data_pyramid = None
     else:
-        data_pyramid = data
+        data_pyramid = trim_pyramid(data)
 
     return ndim, rgb, pyramid, data_pyramid
 

--- a/napari/util/tests/test_misc.py
+++ b/napari/util/tests/test_misc.py
@@ -6,6 +6,7 @@ from napari.util.misc import (
     should_be_pyramid,
     get_pyramid_and_rgb,
     fast_pyramid,
+    trim_pyramid,
 )
 
 
@@ -41,6 +42,30 @@ def test_is_pyramid():
 
     data = [np.random.random((10, 15, 6)), np.random.random((10, 7, 3))]
     assert is_pyramid(data)
+
+
+def test_trim_pyramid():
+
+    data = [np.random.random((20, 30)), np.random.random((10, 15))]
+    trimmed = trim_pyramid(data)
+    assert np.all([np.all(t == d) for t, d in zip(data, trimmed)])
+
+    data = [
+        np.random.random((40, 60)),
+        np.random.random((20, 30)),
+        np.random.random((10, 15)),
+    ]
+    trimmed = trim_pyramid(data)
+    assert np.all([np.all(t == d) for t, d in zip(data[:2], trimmed)])
+
+    data = [
+        np.random.random((400, 10)),
+        np.random.random((200, 10)),
+        np.random.random((100, 10)),
+        np.random.random((50, 10)),
+    ]
+    trimmed = trim_pyramid(data)
+    assert np.all([np.all(t == d) for t, d in zip(data[:3], trimmed)])
 
 
 def test_should_be_pyramid():

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -289,6 +289,7 @@ def view_points(
 def view_labels(
     data,
     *,
+    is_pyramid=None,
     num_colors=50,
     seed=0.5,
     n_dimensional=False,
@@ -307,8 +308,14 @@ def view_labels(
 
     Parameters
     ----------
-    data : array
-        Labels data.
+    data : array or list of array
+        Labels data as an array or pyramid.
+    is_pyramid : bool
+        Whether the data is an image pyramid or not. Pyramid data is
+        represented by a list of array like image data. If not specified by
+        the user and if the data is a list of arrays that decrease in shape
+        then it will be taken to be a pyramid. The first image in the list
+        should be the largest.
     num_colors : int
         Number of unique colors to use in colormap.
     seed : float
@@ -340,6 +347,7 @@ def view_labels(
     viewer = Viewer()
     viewer.add_labels(
         data,
+        is_pyramid=is_pyramid,
         num_colors=num_colors,
         seed=seed,
         n_dimensional=n_dimensional,


### PR DESCRIPTION
# Description
This PR extends pyramid support to the Labels layer following the same conventions as the Image. It does this by making Labels subclass Image which actually reduces a lot of duplicate code.

I also make the thumbnails now always be blended into a black background.

It also introduces a new concept of layers being "editable" or not and sets the Labels layer to not being editable when it is a pyramid or being rendered in 3D (which would have caused bugs). One day we may extend painting to the pyramid or 3D but for now those are more advanced features. People have also requested the ability to disable editing for datasets where it doesn't make sense. When disabled the paint / fill / pick buttons now have a different background color to indicate they are no longer selectable. If people are ok with this I will extend the editable property to the shapes and points layers where we also need to disable editing for 3D rendering.

Here is what this looks like for the 3D rendering case:

![editable_labels](https://user-images.githubusercontent.com/6531703/65823078-4365c380-e204-11e9-8bc2-940847b518db.gif)

This closes #538. @ambrosejcarr does this look good to you? 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added pyramid test to the Labels tests

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
