### PR TITLE
stop vispy error catching

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -72,6 +72,7 @@ class QtViewer(QSplitter):
             self.viewerButtons.consoleButton.setEnabled(False)
 
         self.canvas = SceneCanvas(keys=None, vsync=True)
+        self.canvas.events.ignore_callback_errors = False
         self.canvas.native.setMinimumSize(QSize(200, 200))
         self.canvas.context.set_depth_func('lequal')
 
@@ -350,8 +351,8 @@ class QtViewer(QSplitter):
     def on_draw(self, event):
         """Called whenever drawn in canvas. Called for all layers, not just top
         """
-        for layer in self.viewer.layers:
-            self.layer_to_visual[layer].on_draw(event)
+        for visual in self.layer_to_visual.values():
+            visual.on_draw(event)
 
     def keyPressEvent(self, event):
         self.canvas._backend._keyEvent(self.canvas.events.key_press, event)


### PR DESCRIPTION
# Description
As had been previously observed in our own event system which is based on the one from vispy, the default behavior of the event system is to ignore errors. We want this behavior turned off so that we know about errors. This PR now does this for the vispy event system on the canvas. Doing so exposed a couple errors on my local tests that I then fixed. Doing so in #544 exposed some windows failures that might actually be causing real user errors that we were previously missing - see #527 and #428.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
