### PR TITLE
Add anisotropy factors to points

### DIFF
--- a/examples/nD_points.py
+++ b/examples/nD_points.py
@@ -32,5 +32,5 @@ with napari.gui_qt():
         ]
     )
     viewer.add_points(
-        points, size=[0, 6, 10, 10], face_color='blue', n_dimensional=True
+        points, anisotropy=[0, 0.5, 1, 1], size=10, face_color='blue', n_dimensional=True
     )

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -557,14 +557,15 @@ class ViewerModel(KeymapMixin):
             Symbol to be used for the point markers. Must be one of the
             following: arrow, clobber, cross, diamond, disc, hbar, ring,
             square, star, tailed_arrow, triangle_down, triangle_up, vbar, x.
-        size : float, tuple
+        size : float, tuple, list, array (N,)
             Size of the point marker. If given as a scalar, all points are made
-            the same size. If given as a tuple, size must be the same length
-            as the number of points.
-        anisotropy : tuple, optional
+            the same size. If given as a tuple, list, or 1-D array size must be
+            the same length as the number of points.
+        anisotropy : tuple, list, array (D,), optional
             List of anisotropy factors, must be one per dimension. These act as
-            pre-multipliers on the size of each point. If not provided,
-            defaults as 1 for each dimension.
+            pre-multipliers on the size of each point. Note that the anisotropy
+            is only displayed for dimensions out of plane for the view. If not
+            provided, defaults as 1 for each dimension.
         edge_width : float
             Width of the symbol edge in pixels.
         edge_color : str

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -534,6 +534,7 @@ class ViewerModel(KeymapMixin):
         *,
         symbol='o',
         size=10,
+        anisotropy=None,
         edge_width=1,
         edge_color='black',
         face_color='white',
@@ -556,10 +557,14 @@ class ViewerModel(KeymapMixin):
             Symbol to be used for the point markers. Must be one of the
             following: arrow, clobber, cross, diamond, disc, hbar, ring,
             square, star, tailed_arrow, triangle_down, triangle_up, vbar, x.
-        size : float, array
+        size : float, tuple
             Size of the point marker. If given as a scalar, all points are made
-            the same size. If given as an array, size must be the same
-            broadcastable to the same shape as the data.
+            the same size. If given as a tuple, size must be the same length
+            as the number of points.
+        anisotropy : tuple, optional
+            List of anisotropy factors, must be one per dimension. These act as
+            pre-multipliers on the size of each point. If not provided,
+            defaults as 1 for each dimension.
         edge_width : float
             Width of the symbol edge in pixels.
         edge_color : str
@@ -600,6 +605,7 @@ class ViewerModel(KeymapMixin):
             data,
             symbol=symbol,
             size=size,
+            anisotropy=anisotropy,
             edge_width=edge_width,
             edge_color=edge_color,
             face_color=face_color,

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -23,14 +23,15 @@ class Points(Layer):
         Symbol to be used for the point markers. Must be one of the
         following: arrow, clobber, cross, diamond, disc, hbar, ring,
         square, star, tailed_arrow, triangle_down, triangle_up, vbar, x.
-    size : float, tuple
+    size : float, tuple, list, array (N,)
         Size of the point marker. If given as a scalar, all points are made
-        the same size. If given as a tuple, size must be the same length
-        as the number of points.
-    anisotropy : tuple, optional
+        the same size. If given as a tuple, list, or 1-D array size must be
+        the same length as the number of points.
+    anisotropy : tuple, list, array (D,), optional
         List of anisotropy factors, must be one per dimension. These act as
-        pre-multipliers on the size of each point. If not provided,
-        defaults as 1 for each dimension.
+        pre-multipliers on the size of each point. Note that the anisotropy
+        is only displayed for dimensions out of plane for the view. If not
+        provided, defaults as 1 for each dimension.
     edge_width : float
         Width of the symbol edge in pixels.
     edge_color : str
@@ -66,9 +67,10 @@ class Points(Layer):
     size : float
         Size of the marker for the next point to be added or the currently
         selected point.
-    anisotropy : tuple
+    anisotropy : array (D,)
         List of anisotropy factors, must be one per dimension. These act as
-        pre-multipliers on the size of each point.
+        pre-multipliers on the size of each point. Note that the anisotropy
+        is only displayed for dimensions out of plane for the view.
     edge_width : float
         Width of the marker edges in pixels for all points
     edge_color : str
@@ -347,13 +349,15 @@ class Points(Layer):
         self.events.size()
 
     @property
-    def anisotropy(self) -> Union[tuple]:
+    def anisotropy(self) -> np.ndarray:
         """tuple: anisotropy factor for each dimension."""
 
         return self._anisotropy
 
     @anisotropy.setter
-    def anisotropy(self, anisotropy: Union[None, tuple]) -> None:
+    def anisotropy(
+        self, anisotropy: Union[None, list, tuple, np.ndarray]
+    ) -> None:
         if anisotropy is None:
             anisotropy = np.ones(self.dims.ndim)
         if np.all(self._anisotropy == anisotropy):

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -204,6 +204,7 @@ def view_points(
     *,
     symbol='o',
     size=10,
+    anisotropy=None,
     edge_width=1,
     edge_color='black',
     face_color='white',
@@ -226,10 +227,14 @@ def view_points(
         Symbol to be used for the point markers. Must be one of the
         following: arrow, clobber, cross, diamond, disc, hbar, ring,
         square, star, tailed_arrow, triangle_down, triangle_up, vbar, x.
-    size : float, array
+    size : float, tuple
         Size of the point marker. If given as a scalar, all points are made
-        the same size. If given as an array, size must be the same
-        broadcastable to the same shape as the data.
+        the same size. If given as a tuple, size must be the same length
+        as the number of points.
+    anisotropy : tuple, optional
+        List of anisotropy factors, must be one per dimension. These act as
+        pre-multipliers on the size of each point. If not provided,
+        defaults as 1 for each dimension.
     edge_width : float
         Width of the symbol edge in pixels.
     edge_color : str
@@ -271,6 +276,7 @@ def view_points(
         data,
         symbol=symbol,
         size=size,
+        anisotropy=anisotropy,
         edge_width=edge_width,
         edge_color=edge_color,
         face_color=face_color,

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -227,14 +227,15 @@ def view_points(
         Symbol to be used for the point markers. Must be one of the
         following: arrow, clobber, cross, diamond, disc, hbar, ring,
         square, star, tailed_arrow, triangle_down, triangle_up, vbar, x.
-    size : float, tuple
+    size : float, tuple, list, array (N,)
         Size of the point marker. If given as a scalar, all points are made
-        the same size. If given as a tuple, size must be the same length
-        as the number of points.
-    anisotropy : tuple, optional
+        the same size. If given as a tuple, list, or 1-D array size must be
+        the same length as the number of points.
+    anisotropy : tuple, list, array (D,), optional
         List of anisotropy factors, must be one per dimension. These act as
-        pre-multipliers on the size of each point. If not provided,
-        defaults as 1 for each dimension.
+        pre-multipliers on the size of each point. Note that the anisotropy
+        is only displayed for dimensions out of plane for the view. If not
+        provided, defaults as 1 for each dimension.
     edge_width : float
         Width of the symbol edge in pixels.
     edge_color : str


### PR DESCRIPTION
# Description
This PR closes #480 by introducing an `anisotropy` keyword arg to the Points layer and making the points sizes a 1-D array to resolve potential broadcasting ambiguity. The `anisotropy` factor is global for the layer (i.e. applies to all Points), but I think that is a good abstraction.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added anisotropy test to `test_points.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
