### PR TITLE
fix menubar focus mac

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -146,7 +146,6 @@ class Window:
         """
         self._qt_window.resize(self._qt_window.layout().sizeHint())
         self._qt_window.show()
-        self._qt_window.raise_()
 
     def _update_palette(self, palette):
         # set window styles which don't use the primary stylesheet


### PR DESCRIPTION
# Description
This closes #380 where I needed to leave the focus of napari to another application and then come back to napari before the menubar worked.

I'm not quite sure why the `raise_` call was in there or if there are any negative issues of dropping it on other platforms, but I can confirm that on a mac everything still functions as expected, including usage from the notebook.

Maybe some other people can verify performance on different platforms, but this bug fix seems pretty desirable.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
