### PR TITLE
fix pyramid guessing

### DIFF
--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -203,7 +203,9 @@ class Image(Layer):
 
     @data.setter
     def data(self, data):
-        ndim, rgb, is_pyramid, data_pyramid = get_pyramid_and_rgb(data)
+        ndim, rgb, is_pyramid, data_pyramid = get_pyramid_and_rgb(
+            data, pyramid=self.is_pyramid, rgb=self.rgb
+        )
         self.is_pyramid = is_pyramid
         self.rgb = rgb
         self._data = data

--- a/napari/util/tests/test_misc.py
+++ b/napari/util/tests/test_misc.py
@@ -166,6 +166,12 @@ def test_get_pyramid_and_rgb():
     assert not rgb
     assert ndim == 2
 
+    ndim, rgb, pyramid, data_pyramid = get_pyramid_and_rgb(data, pyramid=False)
+    assert not pyramid
+    assert data_pyramid is None
+    assert not rgb
+    assert ndim == 2
+
 
 def test_callsignature():
     # no arguments


### PR DESCRIPTION
# Description
This PR closes #554 by making sure that if the keyword argument `is_pyramid=False` get's passed along with non-pyramid data then a pyramid will not be auto-computed. This at least gives the user a way to turn off pyramid generation (If you have a pyramid and `is_pyramid=False` you'll get an error now, but we could instead just overwrite the value to be `is_pyramid=True`, or we could just give you the base / top of the pyramid as an image but I think that would be more weird).

Right now pyramid generation will happen on any axis > 8192, which can be annoying if you have big timeseries data in say a dask array that you want to lazily load as you scroll through, but which you never want to view as a pyramid in that non-displayed dimension.

Finally right now the default is `is_pyramid=None` at which point guessing and autocreation will happen.

@jni do you have thoughts on what the best behaviour here is?

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] I added a test inside `test_misc.py` to catch the new behavior.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
