### PR TITLE
Update NumPy pad call for 1.16.4

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -393,7 +393,7 @@ class Layer(KeymapMixin, ABC):
 
         padding_needed = np.subtract(self._thumbnail_shape, thumbnail.shape)
         pad_amounts = [(p // 2, (p + 1) // 2) for p in padding_needed]
-        thumbnail = np.pad(thumbnail, pad_amounts)
+        thumbnail = np.pad(thumbnail, pad_amounts, mode='constant')
 
         # blend thumbnail with opaque black background
         background = np.zeros(self._thumbnail_shape, dtype=np.uint8)


### PR DESCRIPTION
# Description
When using ~~1.17~~ 1.16.4, I got an error during thumbnail generation from not giving a `mode=` keyword argument to `np.pad`. This fixes that issue.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
