### PR TITLE
add layer model benchmarks

### DIFF
--- a/benchmarks/benchmark_labels_layer.py
+++ b/benchmarks/benchmark_labels_layer.py
@@ -1,0 +1,116 @@
+# See "Writing benchmarks" in the asv docs for more information.
+# https://asv.readthedocs.io/en/latest/writing_benchmarks.html
+# or the napari documentation on benchmarking
+# https://github.com/napari/napari/blob/master/BENCHMARKS.md
+import numpy as np
+from napari.layers import Labels
+
+
+class Labels2DSuite:
+    """Benchmarks for the Labels layer with 2D data"""
+
+    params = [2 ** i for i in range(4, 13)]
+
+    def setup(self, n):
+        np.random.seed(0)
+        self.data = np.random.randint(20, size=(n, n))
+        self.layer = Labels(self.data)
+
+    def time_create_layer(self, n):
+        """Time to create layer."""
+        layer = Labels(self.data)
+
+    def time_set_view_slice(self, n):
+        """Time to set view slice."""
+        self.layer._set_view_slice()
+
+    def time_update_thumbnail(self, n):
+        """Time to update thumbnail."""
+        self.layer._update_thumbnail()
+
+    def time_get_value(self, n):
+        """Time to get current value."""
+        self.layer.get_value()
+
+    def time_save_history(self, n):
+        """Time to save history."""
+        self.layer._save_history()
+
+    def time_raw_to_displayed(self, n):
+        """Time to convert raw to displayed."""
+        self.layer._raw_to_displayed(self.layer._data_raw)
+
+    def time_paint(self, n):
+        """Time to paint."""
+        self.layer.paint(self.layer.coordinates, self.layer.selected_label)
+
+    def time_fill(self, n):
+        """Time to fill."""
+        self.layer.fill(
+            self.layer.coordinates,
+            self.layer._value,
+            self.layer.selected_label,
+        )
+
+    def mem_layer(self, n):
+        """Memory used by layer."""
+        return self.layer
+
+    def mem_data(self, n):
+        """Memory used by raw data."""
+        return self.data
+
+
+class Labels3DSuite:
+    """Benchmarks for the Labels layer with 3D data."""
+
+    params = [2 ** i for i in range(4, 11)]
+
+    def setup(self, n):
+        np.random.seed(0)
+        self.data = np.random.randint(20, size=(n, n, n))
+        self.layer = Labels(self.data)
+
+    def time_create_layer(self, n):
+        """Time to create layer."""
+        layer = Labels(self.data)
+
+    def time_set_view_slice(self, n):
+        """Time to set view slice."""
+        self.layer._set_view_slice()
+
+    def time_update_thumbnail(self, n):
+        """Time to update thumbnail."""
+        self.layer._update_thumbnail()
+
+    def time_get_value(self, n):
+        """Time to get current value."""
+        self.layer.get_value()
+
+    def time_save_history(self, n):
+        """Time to save history."""
+        self.layer._save_history()
+
+    def time_raw_to_displayed(self, n):
+        """Time to convert raw to displayed."""
+        self.layer._raw_to_displayed(self.layer._data_raw)
+
+    def time_paint(self, n):
+        """Time to paint."""
+        self.layer.paint(self.layer.coordinates, self.layer.selected_label)
+
+    def time_fill(self, n):
+        """Time to fill."""
+        self.layer.fill(
+            self.layer.coordinates,
+            self.layer._value,
+            self.layer.selected_label,
+        )
+
+    def mem_layer(self, n):
+        """Memory used by layer."""
+        return self.layer
+
+    def mem_data(self, n):
+        """Memory used by raw data."""
+        return self.data

--- a/benchmarks/benchmark_points_layer.py
+++ b/benchmarks/benchmark_points_layer.py
@@ -3,22 +3,22 @@
 # or the napari documentation on benchmarking
 # https://github.com/napari/napari/blob/master/BENCHMARKS.md
 import numpy as np
-from napari.layers import Image
+from napari.layers import Points
 
 
-class Image2DSuite:
-    """Benchmarks for the Image layer with 2D data."""
+class Points2DSuite:
+    """Benchmarks for the Points layer with 2D data"""
 
-    params = [2 ** i for i in range(4, 13)]
+    params = [2 ** i for i in range(4, 18, 2)]
 
     def setup(self, n):
         np.random.seed(0)
-        self.data = np.random.random((n, n))
-        self.layer = Image(self.data)
+        self.data = np.random.random((n, 2))
+        self.layer = Points(self.data)
 
     def time_create_layer(self, n):
-        """Time to create an image layer."""
-        layer = Image(self.data)
+        """Time to create layer."""
+        layer = Points(self.data)
 
     def time_set_view_slice(self, n):
         """Time to set view slice."""
@@ -41,19 +41,19 @@ class Image2DSuite:
         return self.data
 
 
-class Image3DSuite:
-    """Benchmarks for the Image layer with 3D data."""
+class Points3DSuite:
+    """Benchmarks for the Points layer with 3D data."""
 
-    params = [2 ** i for i in range(4, 11)]
+    params = [2 ** i for i in range(4, 18, 2)]
 
     def setup(self, n):
         np.random.seed(0)
-        self.data = np.random.random((n, n, n))
-        self.layer = Image(self.data)
+        self.data = np.random.random((n, 3))
+        self.layer = Points(self.data)
 
     def time_create_layer(self, n):
-        """Time to create an image layer."""
-        layer = Image(self.data)
+        """Time to create layer."""
+        layer = Points(self.data)
 
     def time_set_view_slice(self, n):
         """Time to set view slice."""
@@ -69,7 +69,7 @@ class Image3DSuite:
 
     def mem_layer(self, n):
         """Memory used by layer."""
-        return Image(self.data)
+        return self.layer
 
     def mem_data(self, n):
         """Memory used by raw data."""

--- a/benchmarks/benchmark_shapes_layer.py
+++ b/benchmarks/benchmark_shapes_layer.py
@@ -3,22 +3,22 @@
 # or the napari documentation on benchmarking
 # https://github.com/napari/napari/blob/master/BENCHMARKS.md
 import numpy as np
-from napari.layers import Image
+from napari.layers import Shapes
 
 
-class Image2DSuite:
-    """Benchmarks for the Image layer with 2D data."""
+class Shapes2DSuite:
+    """Benchmarks for the Shapes layer with 2D data"""
 
-    params = [2 ** i for i in range(4, 13)]
+    params = [2 ** i for i in range(4, 9)]
 
     def setup(self, n):
         np.random.seed(0)
-        self.data = np.random.random((n, n))
-        self.layer = Image(self.data)
+        self.data = [50 * np.random.random((6, 2)) for i in range(n)]
+        self.layer = Shapes(self.data, shape_type='polygon')
 
     def time_create_layer(self, n):
         """Time to create an image layer."""
-        layer = Image(self.data)
+        layer = Shapes(self.data, shape_type='polygon')
 
     def time_set_view_slice(self, n):
         """Time to set view slice."""
@@ -41,19 +41,19 @@ class Image2DSuite:
         return self.data
 
 
-class Image3DSuite:
-    """Benchmarks for the Image layer with 3D data."""
+class Shapes3DSuite:
+    """Benchmarks for the Shapes layer with 3D data."""
 
-    params = [2 ** i for i in range(4, 11)]
+    params = [2 ** i for i in range(4, 9)]
 
     def setup(self, n):
         np.random.seed(0)
-        self.data = np.random.random((n, n, n))
-        self.layer = Image(self.data)
+        self.data = [50 * np.random.random((6, 3)) for i in range(n)]
+        self.layer = Shapes(self.data, shape_type='polygon')
 
     def time_create_layer(self, n):
-        """Time to create an image layer."""
-        layer = Image(self.data)
+        """Time to create a layer."""
+        layer = Shapes(self.data, shape_type='polygon')
 
     def time_set_view_slice(self, n):
         """Time to set view slice."""
@@ -69,7 +69,7 @@ class Image3DSuite:
 
     def mem_layer(self, n):
         """Memory used by layer."""
-        return Image(self.data)
+        return self.layer
 
     def mem_data(self, n):
         """Memory used by raw data."""

--- a/benchmarks/benchmark_surface_layer.py
+++ b/benchmarks/benchmark_surface_layer.py
@@ -3,22 +3,26 @@
 # or the napari documentation on benchmarking
 # https://github.com/napari/napari/blob/master/BENCHMARKS.md
 import numpy as np
-from napari.layers import Image
+from napari.layers import Surface
 
 
-class Image2DSuite:
-    """Benchmarks for the Image layer with 2D data."""
+class Surface2DSuite:
+    """Benchmarks for the Surface layer with 2D data"""
 
-    params = [2 ** i for i in range(4, 13)]
+    params = [2 ** i for i in range(4, 18, 2)]
 
     def setup(self, n):
         np.random.seed(0)
-        self.data = np.random.random((n, n))
-        self.layer = Image(self.data)
+        self.data = (
+            np.random.random((n, 2)),
+            np.random.randint(n, size=(n, 3)),
+            np.random.random(n),
+        )
+        self.layer = Surface(self.data)
 
     def time_create_layer(self, n):
         """Time to create an image layer."""
-        layer = Image(self.data)
+        layer = Surface(self.data)
 
     def time_set_view_slice(self, n):
         """Time to set view slice."""
@@ -41,19 +45,23 @@ class Image2DSuite:
         return self.data
 
 
-class Image3DSuite:
-    """Benchmarks for the Image layer with 3D data."""
+class Surface3DSuite:
+    """Benchmarks for the Surface layer with 3D data."""
 
-    params = [2 ** i for i in range(4, 11)]
+    params = [2 ** i for i in range(4, 18, 2)]
 
     def setup(self, n):
         np.random.seed(0)
-        self.data = np.random.random((n, n, n))
-        self.layer = Image(self.data)
+        self.data = (
+            np.random.random((n, 3)),
+            np.random.randint(n, size=(n, 3)),
+            np.random.random(n),
+        )
+        self.layer = Surface(self.data)
 
     def time_create_layer(self, n):
-        """Time to create an image layer."""
-        layer = Image(self.data)
+        """Time to create a layer."""
+        layer = Surface(self.data)
 
     def time_set_view_slice(self, n):
         """Time to set view slice."""
@@ -69,7 +77,7 @@ class Image3DSuite:
 
     def mem_layer(self, n):
         """Memory used by layer."""
-        return Image(self.data)
+        return self.layer
 
     def mem_data(self, n):
         """Memory used by raw data."""

--- a/benchmarks/benchmark_vectors_layer.py
+++ b/benchmarks/benchmark_vectors_layer.py
@@ -3,22 +3,22 @@
 # or the napari documentation on benchmarking
 # https://github.com/napari/napari/blob/master/BENCHMARKS.md
 import numpy as np
-from napari.layers import Image
+from napari.layers import Vectors
 
 
-class Image2DSuite:
-    """Benchmarks for the Image layer with 2D data."""
+class Vectors2DSuite:
+    """Benchmarks for the Vectors layer with 2D data"""
 
-    params = [2 ** i for i in range(4, 13)]
+    params = [2 ** i for i in range(4, 18, 2)]
 
     def setup(self, n):
         np.random.seed(0)
-        self.data = np.random.random((n, n))
-        self.layer = Image(self.data)
+        self.data = np.random.random((n, 2, 2))
+        self.layer = Vectors(self.data)
 
     def time_create_layer(self, n):
         """Time to create an image layer."""
-        layer = Image(self.data)
+        layer = Vectors(self.data)
 
     def time_set_view_slice(self, n):
         """Time to set view slice."""
@@ -31,6 +31,14 @@ class Image2DSuite:
     def time_get_value(self, n):
         """Time to get current value."""
         self.layer.get_value()
+
+    def time_width(self, n):
+        """Time to update width."""
+        self.layer.width = 2
+
+    def time_length(self, n):
+        """Time to update length."""
+        self.layer.length = 2
 
     def mem_layer(self, n):
         """Memory used by layer."""
@@ -41,19 +49,19 @@ class Image2DSuite:
         return self.data
 
 
-class Image3DSuite:
-    """Benchmarks for the Image layer with 3D data."""
+class Vectors3DSuite:
+    """Benchmarks for the Vectors layer with 3D data."""
 
-    params = [2 ** i for i in range(4, 11)]
+    params = [2 ** i for i in range(4, 18, 2)]
 
     def setup(self, n):
         np.random.seed(0)
-        self.data = np.random.random((n, n, n))
-        self.layer = Image(self.data)
+        self.data = np.random.random((n, 2, 3))
+        self.layer = Vectors(self.data)
 
     def time_create_layer(self, n):
-        """Time to create an image layer."""
-        layer = Image(self.data)
+        """Time to create a layer."""
+        layer = Vectors(self.data)
 
     def time_set_view_slice(self, n):
         """Time to set view slice."""
@@ -67,9 +75,17 @@ class Image3DSuite:
         """Time to get current value."""
         self.layer.get_value()
 
+    def time_width(self, n):
+        """Time to update width."""
+        self.layer.width = 2
+
+    def time_length(self, n):
+        """Time to update length."""
+        self.layer.length = 2
+
     def mem_layer(self, n):
         """Memory used by layer."""
-        return Image(self.data)
+        return self.layer
 
     def mem_data(self, n):
         """Memory used by raw data."""


### PR DESCRIPTION
# Description
Building on #476 this PR adds basic benchmarks for all our layer model files. They are certainly not comprehensive, but the immediately expose 2 major (already known) problems

1) for the labels layer the `raw_to_displayed` conversion is very! slow (see #569) - this can maybe be fixed with the approach in #204 

2) for shapes, points, vectors our thumbnail generation code is super slow

The status bar update (get_value) code doesn't seem to be quite as bad but can almost certainly be sped up in places too.

We'll need to follow up with testing of the vispy code that actually does the display of these layers, right now this is just the model code, not including the view code. That followup can come in a later PR.

We also need to figure out a good way to start looking at / viewing these benchmarks

Here are the results of some of the newly added benchmarks:
```
[ 91.67%] ··· benchmark_points_layer.Points2DSuite.time_set_view_slice                                                                                                                                    ok
[ 91.67%] ··· ======== ============
               param1
              -------- ------------
                 16     2.04±0.6ms
                 64     4.53±0.2ms
                256      16.9±2ms
                1024    76.6±40ms
                4096     213±8ms
               16384     871±9ms
               65536    3.53±0.09s
              ======== ============

[100.00%] ··· benchmark_points_layer.Points2DSuite.time_update_thumbnail                                                                                                                                  ok
[100.00%] ··· ======== =============
               param1
              -------- -------------
                 16     1.34±0.04ms
                 64      4.02±0.2ms
                256      13.9±0.6ms
                1024      56.9±2ms
                4096      221±5ms
               16384      850±20ms
               65536     3.50±0.04s
              ======== =============

[ 91.67%] ··· benchmark_shapes_layer.Shapes2DSuite.time_set_view_slice                                                                                                                                    ok
[ 91.67%] ··· ======== ============
               param1
              -------- ------------
                 16     10.4±0.3ms
                 32      22.1±2ms
                 64     40.7±0.7ms
                128      80.4±2ms
                256      171±10ms
              ======== ============

[100.00%] ··· benchmark_shapes_layer.Shapes2DSuite.time_update_thumbnail                                                                                                                                  ok
[100.00%] ··· ======== ============
               param1
              -------- ------------
                 16      9.98±1ms
                 32     19.1±0.8ms
                 64      40.8±2ms
                128      80.0±3ms
                256      165±3ms
              ======== ============



[ 80.00%] ··· benchmark_labels_layer.Labels2DSuite.time_paint                                                                                                                                             ok
[ 80.00%] ··· ======== =============
               param1
              -------- -------------
                 16     1.06±0.03ms
                 32     1.12±0.05ms
                 64     1.38±0.02ms
                128     2.14±0.07ms
                256      4.97±0.5ms
                512      15.9±0.5ms
                1024     63.2±0.9ms
                2048      272±9ms
                4096      1.63±0s
              ======== =============

[ 85.00%] ··· benchmark_labels_layer.Labels2DSuite.time_raw_to_displayed                                                                                                                                  ok
[ 85.00%] ··· ======== =============
               param1
              -------- -------------
                 16       36.2±2μs
                 32       60.4±1μs
                 64       156±30μs
                128       492±7μs
                256     1.76±0.02ms
                512      6.90±0.6ms
                1024      29.0±4ms
                2048      126±1ms
                4096      764±2ms
              ======== =============

[ 90.00%] ··· benchmark_labels_layer.Labels2DSuite.time_save_history                                                                                                                                      ok
[ 90.00%] ··· ======== =============
               param1
              -------- -------------
                 16      5.65±0.2μs
                 32      6.40±0.2μs
                 64      8.43±0.3μs
                128      29.2±0.6μs
                256       138±4μs
                512     1.04±0.05ms
                1024    3.77±0.07ms
                2048     5.23±0.2ms
                4096      98.2±8ms
              ======== =============

[ 95.00%] ··· benchmark_labels_layer.Labels2DSuite.time_set_view_slice                                                                                                                                    ok
[ 95.00%] ··· ======== =============
               param1
              -------- -------------
                 16       922±20μs
                 32      1.07±0.2ms
                 64      1.38±0.4ms
                128      1.98±0.2ms
                256     4.52±0.03ms
                512      14.4±0.3ms
                1024      58.5±3ms
                2048      252±3ms
                4096     1.57±0.02s
              ======== =============
```