### PR TITLE
Test and display keybindings

### DIFF
--- a/napari/_qt/qt_about.py
+++ b/napari/_qt/qt_about.py
@@ -10,9 +10,9 @@ from qtpy.QtWidgets import QWidget, QVBoxLayout, QLabel, QDialog, QFrame
 import napari
 
 
-class AboutPage(QWidget):
+class QtAbout(QWidget):
     def __init__(self, parent):
-        super(AboutPage, self).__init__(parent)
+        super(QtAbout, self).__init__(parent)
 
         self.layout = QVBoxLayout()
 
@@ -72,11 +72,11 @@ class AboutPage(QWidget):
         self.setLayout(self.layout)
 
     @staticmethod
-    def showAbout():
+    def showAbout(qt_viewer):
         d = QDialog()
-        d.setGeometry(150, 150, 350, 400)
-        d.setFixedSize(600, 700)
-        AboutPage(d)
-        d.setWindowTitle("About")
+        d.setObjectName('QtAbout')
+        d.setStyleSheet(qt_viewer.styleSheet())
+        QtAbout(d)
+        d.setWindowTitle('About')
         d.setWindowModality(Qt.ApplicationModal)
         d.exec_()

--- a/napari/_qt/qt_about_keybindings.py
+++ b/napari/_qt/qt_about_keybindings.py
@@ -1,0 +1,82 @@
+from qtpy import QtCore
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
+    QTabWidget,
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QDialog,
+    QFrame,
+)
+import napari
+from ..util.misc import get_keybindings_summary
+
+
+class QtAboutKeybindings(QTabWidget):
+    def __init__(self, viewer, parent):
+        super(QtAboutKeybindings, self).__init__(parent)
+
+        self.viewer = viewer
+
+        self.addTab(QtActiveKeybindings(self.viewer), 'Currently active')
+        self.addTab(QtLayerKeybindings(napari.layers.Image), 'Image')
+        self.addTab(QtLayerKeybindings(napari.layers.Labels), 'Labels')
+        self.addTab(QtLayerKeybindings(napari.layers.Points), 'Labels')
+        self.addTab(QtLayerKeybindings(napari.layers.Shapes), 'Shapes')
+        self.addTab(QtLayerKeybindings(napari.layers.Surface), 'Surface')
+        self.addTab(QtLayerKeybindings(napari.layers.Vectors), 'Vectors')
+
+    @staticmethod
+    def showAbout(qt_viewer):
+        d = QDialog()
+        d.setObjectName('QtAboutKeybindings')
+        d.setStyleSheet(qt_viewer.styleSheet())
+        d.setGeometry(150, 150, 350, 400)
+        d.setFixedSize(600, 700)
+        QtAboutKeybindings(qt_viewer.viewer, d)
+        d.setWindowTitle('Keybindings')
+        d.setWindowModality(Qt.ApplicationModal)
+        d.exec_()
+
+
+class QtActiveKeybindings(QWidget):
+    def __init__(self, viewer):
+        super().__init__()
+
+        self.layout = QVBoxLayout()
+
+        keybindings_str = ''
+        # Add class and instance viewer keybindings
+        keybindings_str += get_keybindings_summary(viewer.class_keymap)
+        keybindings_str += get_keybindings_summary(viewer.keymap)
+
+        layer = viewer.active_layer
+        if layer is not None:
+            # Add class and instance layer keybindings for the active layer
+            keybindings_str += get_keybindings_summary(layer.class_keymap)
+            keybindings_str += get_keybindings_summary(layer.keymap)
+
+        active_label = QLabel(keybindings_str)
+        active_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        active_label.setAlignment(Qt.AlignLeft)
+        self.layout.addWidget(active_label)
+        self.setLayout(self.layout)
+
+
+class QtLayerKeybindings(QWidget):
+    def __init__(self, layer):
+        super().__init__()
+
+        self.layout = QVBoxLayout()
+
+        # Add class keybindings for the layer
+        if len(layer.class_keymap) == 0:
+            keybindings_str = 'No keybindings'
+        else:
+            keybindings_str = get_keybindings_summary(layer.class_keymap)
+
+        layer_label = QLabel(keybindings_str)
+        layer_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        layer_label.setAlignment(Qt.AlignLeft)
+        self.layout.addWidget(layer_label)
+        self.setLayout(self.layout)

--- a/napari/_qt/qt_about_keybindings.py
+++ b/napari/_qt/qt_about_keybindings.py
@@ -37,7 +37,7 @@ class QtAboutKeybindings(QTabWidget):
         qt_viewer._about_keybindings = QtAboutKeybindings(qt_viewer.viewer, d)
         d.show()
         d.setWindowModality(Qt.NonModal)
-        d.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
+        d.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         qt_viewer._about_keybindings_dialog = d
 
 
@@ -52,13 +52,18 @@ class QtActiveKeybindings(QScrollArea):
         self.active_label = QLabel()
         self.active_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self.active_label.setAlignment(Qt.AlignLeft)
+        self.active_label.setContentsMargins(10, 10, 10, 10)
         self.active_label.setSizePolicy(
-            QSizePolicy.MinimumExpanding, QSizePolicy.Fixed
+            QSizePolicy.Expanding, QSizePolicy.Expanding
         )
 
         self.update_text(None)
 
         scroll_widget = QWidget()
+        scroll_widget.setSizePolicy(
+            QSizePolicy.Expanding, QSizePolicy.Expanding
+        )
+        scroll_widget.setContentsMargins(10, 10, 10, 10)
         scroll_layout = QVBoxLayout()
         scroll_layout.addWidget(self.active_label)
         scroll_layout.addStretch(1)
@@ -95,6 +100,8 @@ class QtLayerKeybindings(QWidget):
 
         layer_label = QLabel(keybindings_str)
         layer_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        layer_label.setAlignment(Qt.AlignLeft)
+        # layer_label.setAlignment(Qt.AlignLeft)
+        layer_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.layout.addWidget(layer_label)
         self.setLayout(self.layout)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -144,6 +144,7 @@ class Window:
         self.help_menu.addAction(about_action)
 
         keybidings_action = QAction("keybindings", self._qt_window)
+        keybidings_action.setShortcut("Ctrl+/")
         keybidings_action.setStatusTip('About keybindings')
         keybidings_action.triggered.connect(
             lambda e: QtAboutKeybindings.showAbout(self.qt_viewer)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -6,7 +6,8 @@ wrap.
 from qtpy import API_NAME
 from vispy import app
 
-from napari._qt.qt_about import AboutPage
+from .qt_about import QtAbout
+from .qt_about_keybindings import QtAboutKeybindings
 
 app.use_app(API_NAME)
 del app
@@ -133,11 +134,21 @@ class Window:
         self.window_menu.addAction(exit_action)
 
     def _add_help_menu(self):
+        self.help_menu = self.main_menu.addMenu('&Help')
+
         about_action = QAction("napari info", self._qt_window)
         about_action.setStatusTip('About napari')
-        about_action.triggered.connect(AboutPage.showAbout)
-        self.help_menu = self.main_menu.addMenu('&Help')
+        about_action.triggered.connect(
+            lambda e: QtAbout.showAbout(self.qt_viewer)
+        )
         self.help_menu.addAction(about_action)
+
+        keybidings_action = QAction("keybindings", self._qt_window)
+        keybidings_action.setStatusTip('About keybindings')
+        keybidings_action.triggered.connect(
+            lambda e: QtAboutKeybindings.showAbout(self.qt_viewer)
+        )
+        self.help_menu.addAction(keybidings_action)
 
     def resize(self, width, height):
         """Resize the window.

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -314,7 +314,8 @@ class QtViewer(QSplitter):
         """Called whenever key pressed in canvas.
         """
         if (
-            event.native.isAutoRepeat()
+            not event.native is None
+            and event.native.isAutoRepeat()
             and event.key.name not in ['Up', 'Down', 'Left', 'Right']
         ) or event.key is None:
             # pass is no key is present or if key is held down, unless the

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1041,6 +1041,7 @@ class ViewerModel(KeymapMixin):
         """
         # iteration goes backwards to find top most selected layer if any
         # if multiple layers are selected sets the active layer to None
+
         active_layer = None
         for layer in self.layers:
             if active_layer is None and layer.selected:

--- a/napari/keybindings.py
+++ b/napari/keybindings.py
@@ -59,18 +59,83 @@ def increment_dims_right(viewer):
         viewer.dims.set_point(axis, new_point)
 
 
-Viewer.bind_key('Control-E', lambda v: v.dims._roll())
-Viewer.bind_key('Control-T', lambda v: v.dims._transpose())
-Viewer.bind_key('Alt-Up', lambda v: v.window.qt_viewer.dims.focus_up())
-Viewer.bind_key('Alt-Down', lambda v: v.window.qt_viewer.dims.focus_down())
-Viewer.bind_key('Control-Backspace', lambda v: v.layers.remove_selected())
-Viewer.bind_key('Control-A', lambda v: v.layers.select_all())
-Viewer.bind_key(
-    'Control-Shift-Backspace',
-    lambda v: (v.layers.select_all(), v.layers.remove_selected()),
-)
-Viewer.bind_key('Up', lambda v: v.layers.select_next())
-Viewer.bind_key('Down', lambda v: v.layers.select_previous())
-Viewer.bind_key('Shift-Up', lambda v: v.layers.select_next(shift=True))
-Viewer.bind_key('Shift-Down', lambda v: v.layers.select_previous(shift=True))
-Viewer.bind_key('Control-R', lambda v: v.reset_view())
+@Viewer.bind_key('Control-E')
+def roll_axes(viewer):
+    """Change order of the visible axes, e.g. [0, 1, 2] -> [2, 0, 1]."""
+    viewer.dims._roll()
+
+
+@Viewer.bind_key('Control-T')
+def transpose_axes(viewer):
+    """Transpose order of the last two visible axes, e.g. [0, 1] -> [1, 0]."""
+    viewer.dims._transpose()
+
+
+@Viewer.bind_key('Alt-Up')
+def focus_axes_up(viewer):
+    """Move focus of dimensions slider up."""
+    viewer.window.qt_viewer.dims.focus_up()
+
+
+@Viewer.bind_key('Alt-Down')
+def focus_axes_down(viewer):
+    """Move focus of dimensions slider down."""
+    viewer.window.qt_viewer.dims.focus_down()
+
+
+@Viewer.bind_key('Control-Backspace')
+def remove_selected(viewer):
+    """Remove selected layers."""
+    viewer.layers.remove_selected()
+
+
+@Viewer.bind_key('Control-A')
+def remove_selected(viewer):
+    """Selected all layers."""
+    viewer.layers.select_all()
+
+
+@Viewer.bind_key('Control-Shift-Backspace')
+def remove_all_layers(viewer):
+    """Remove all layers."""
+    viewer.layers.select_all()
+    viewer.layers.remove_selected()
+
+
+@Viewer.bind_key('Up')
+def select_layer_above(viewer):
+    """Select layer above."""
+    viewer.layers.select_next()
+
+
+@Viewer.bind_key('Down')
+def select_layer_below(viewer):
+    """Select layer below."""
+    viewer.layers.select_previous()
+
+
+@Viewer.bind_key('Shift-Up')
+def also_select_layer_above(viewer):
+    """Also select layer above."""
+    viewer.layers.select_next(shift=True)
+
+
+@Viewer.bind_key('Shift-Down')
+def also_select_layer_below(viewer):
+    """Also select layer below."""
+    viewer.layers.select_previous(shift=True)
+
+
+@Viewer.bind_key('Control-R')
+def reset_view(viewer):
+    """Reset view to original state."""
+    viewer.reset_view()
+
+
+@Viewer.bind_key('Control-G')
+def toggle_ndisplay(viewer):
+    """Toggle grid mode."""
+    if np.all(viewer.grid_size == (1, 1)):
+        viewer.grid_view()
+    else:
+        viewer.stack_view()

--- a/napari/keybindings.py
+++ b/napari/keybindings.py
@@ -5,6 +5,7 @@ from .viewer import Viewer
 
 @Viewer.bind_key('Control-F')
 def toggle_fullscreen(viewer):
+    """Toggle fullscreen mode."""
     if viewer.window._qt_window.isFullScreen():
         viewer.window._qt_window.showNormal()
     else:
@@ -13,6 +14,7 @@ def toggle_fullscreen(viewer):
 
 @Viewer.bind_key('Control-Shift-T')
 def toggle_theme(viewer):
+    """Toggle viewer theme."""
     theme_names = list(viewer.themes.keys())
     cur_theme = theme_names.index(viewer.theme)
     viewer.theme = theme_names[(cur_theme + 1) % len(theme_names)]
@@ -20,6 +22,7 @@ def toggle_theme(viewer):
 
 @Viewer.bind_key('Control-Y')
 def toggle_ndisplay(viewer):
+    """Toggle ndisplay."""
     if viewer.dims.ndisplay == 3:
         viewer.dims.ndisplay = 2
     else:
@@ -28,6 +31,7 @@ def toggle_ndisplay(viewer):
 
 @Viewer.bind_key('Left')
 def increment_dims_left(viewer):
+    """Increment dimensions slider to the left."""
     axis = viewer.window.qt_viewer.dims.last_used
     if axis is not None:
         cur_point = viewer.dims.point[axis]
@@ -42,6 +46,7 @@ def increment_dims_left(viewer):
 
 @Viewer.bind_key('Right')
 def increment_dims_right(viewer):
+    """Increment dimensions slider to the right."""
     axis = viewer.window.qt_viewer.dims.last_used
     if axis is not None:
         cur_point = viewer.dims.point[axis]

--- a/napari/layers/labels/keybindings.py
+++ b/napari/layers/labels/keybindings.py
@@ -4,6 +4,7 @@ from ._constants import Mode
 
 @Labels.bind_key('Space')
 def hold_to_pan_zoom(layer):
+    """Hold to pan and zoom in the viewer."""
     if layer._mode != Mode.PAN_ZOOM:
         # on key press
         prev_mode = layer.mode
@@ -17,43 +18,59 @@ def hold_to_pan_zoom(layer):
 
 @Labels.bind_key('P')
 def activate_paint_mode(layer):
+    """Activate the paintbrush."""
     layer.mode = Mode.PAINT
 
 
 @Labels.bind_key('F')
 def activate_fill_mode(layer):
+    """Activate the fill bucket."""
     layer.mode = Mode.FILL
 
 
 @Labels.bind_key('Z')
 def activate_pan_zoom_mode(layer):
+    """Activate pan and zoom mode."""
     layer.mode = Mode.PAN_ZOOM
 
 
 @Labels.bind_key('L')
 def activate_picker_mode(layer):
+    """Activate the label picker."""
     layer.mode = Mode.PICKER
 
 
 @Labels.bind_key('E')
 def erase(layer):
+    """Set the currently selected label to the background value, 0."""
     layer.selected_label = 0
 
 
 @Labels.bind_key('M')
 def new_label(layer):
+    """Set the currently selected label to the largest used label plus one."""
     layer.selected_label = layer.data.max() + 1
 
 
 @Labels.bind_key('D')
 def decrease_label_id(layer):
+    """Decrease the currently selected label by one."""
     layer.selected_label -= 1
 
 
 @Labels.bind_key('I')
 def increase_label_id(layer):
+    """Increase the currently selected label by one."""
     layer.selected_label += 1
 
 
-Labels.bind_key('Control-Z', Labels.undo)
-Labels.bind_key('Control-Shift-Z', Labels.redo)
+@Labels.bind_key('Control-Z')
+def undo(layer):
+    """Undo the last paint or fill action since the view slice has changed."""
+    layer.undo()
+
+
+@Labels.bind_key('Control-Shift-Z')
+def redo(layer):
+    """Redo any previously undone actions."""
+    layer.redo()

--- a/napari/layers/points/keybindings.py
+++ b/napari/layers/points/keybindings.py
@@ -4,6 +4,7 @@ from ._constants import Mode
 
 @Points.bind_key('Space')
 def hold_to_pan_zoom(layer):
+    """Hold to pan and zoom in the viewer."""
     if layer._mode != Mode.PAN_ZOOM:
         # on key press
         prev_mode = layer.mode
@@ -20,33 +21,39 @@ def hold_to_pan_zoom(layer):
 
 @Points.bind_key('P')
 def activate_add_mode(layer):
+    """Activate add points tool."""
     layer.mode = Mode.ADD
 
 
 @Points.bind_key('S')
 def activate_select_mode(layer):
+    """Activate select points tool."""
     layer.mode = Mode.SELECT
 
 
 @Points.bind_key('Z')
 def activate_pan_zoom_mode(layer):
+    """Activate pan and zoom mode."""
     layer.mode = Mode.PAN_ZOOM
 
 
 @Points.bind_key('Control-C')
 def copy(layer):
+    """Copy any selected points."""
     if layer._mode == Mode.SELECT:
         layer._copy_data()
 
 
 @Points.bind_key('Control-V')
 def paste(layer):
+    """Paste any copied points."""
     if layer._mode == Mode.SELECT:
         layer._paste_data()
 
 
 @Points.bind_key('A')
 def select_all(layer):
+    """Select all points in the current view slice."""
     if layer._mode == Mode.SELECT:
         layer.selected_data = layer._indices_view[: len(layer._data_view)]
         layer._set_highlight()
@@ -54,5 +61,6 @@ def select_all(layer):
 
 @Points.bind_key('Backspace')
 def delete_selected(layer):
+    """Delet all selected points."""
     if layer._mode == Mode.SELECT:
         layer.remove_selected()

--- a/napari/layers/shapes/keybindings.py
+++ b/napari/layers/shapes/keybindings.py
@@ -6,6 +6,7 @@ from ._constants import Mode, Box
 
 @Shapes.bind_key('Space')
 def hold_to_pan_zoom(layer):
+    """Hold to pan and zoom in the viewer."""
     if layer._mode != Mode.PAN_ZOOM:
         # on key press
         prev_mode = layer.mode
@@ -22,6 +23,7 @@ def hold_to_pan_zoom(layer):
 
 @Shapes.bind_key('Shift')
 def hold_to_lock_aspect_ratio(layer):
+    """Hold to lock aspect ratio when resizing a shape."""
     # on key press
     layer._fixed_aspect = True
     box = layer._selected_box
@@ -46,72 +48,93 @@ def hold_to_lock_aspect_ratio(layer):
 
 @Shapes.bind_key('R')
 def activate_add_rectangle_mode(layer):
+    """Activate add rectangle tool."""
     layer.mode = Mode.ADD_RECTANGLE
 
 
 @Shapes.bind_key('E')
 def activate_add_ellipse_mode(layer):
+    """Activate add ellipse tool."""
     layer.mode = Mode.ADD_ELLIPSE
 
 
 @Shapes.bind_key('L')
 def activate_add_line_mode(layer):
+    """Activate add line tool."""
     layer.mode = Mode.ADD_LINE
 
 
 @Shapes.bind_key('T')
 def activate_add_path_mode(layer):
+    """Activate add path tool."""
     layer.mode = Mode.ADD_PATH
 
 
 @Shapes.bind_key('P')
 def activate_add_polygon_mode(layer):
+    """Activate add polygon tool."""
     layer.mode = Mode.ADD_POLYGON
 
 
 @Shapes.bind_key('D')
 def activate_direct_mode(layer):
+    """Activate vertex selection tool."""
     layer.mode = Mode.DIRECT
 
 
 @Shapes.bind_key('S')
 def activate_select_mode(layer):
+    """Activate shape selection tool."""
     layer.mode = Mode.SELECT
 
 
 @Shapes.bind_key('Z')
 def activate_pan_zoom_mode(layer):
+    """Activate pan and zoom mode."""
     layer.mode = Mode.PAN_ZOOM
 
 
 @Shapes.bind_key('I')
 def activate_vertex_insert_mode(layer):
+    """Activate vertex insertion tool."""
     layer.mode = Mode.VERTEX_INSERT
 
 
 @Shapes.bind_key('X')
 def activate_vertex_remove_mode(layer):
+    """Activate vertex deletion tool."""
     layer.mode = Mode.VERTEX_REMOVE
 
 
 @Shapes.bind_key('Control-C')
 def copy(layer):
+    """Copy any selected shapes."""
     if layer._mode in (Mode.DIRECT, Mode.SELECT):
         layer._copy_data()
 
 
 @Shapes.bind_key('Control-V')
 def paste(layer):
+    """Paste any copied shapes."""
     if layer._mode in (Mode.DIRECT, Mode.SELECT):
         layer._paste_data()
 
 
 @Shapes.bind_key('A')
 def select_all(layer):
+    """Select all shapes in the current view slice."""
     if layer._mode in (Mode.DIRECT, Mode.SELECT):
         layer.selected_data = list(np.nonzero(self._data_view._displayed)[0])
         layer._set_highlight()
 
 
-Shapes.bind_key('Backspace', Shapes.remove_selected)
-Shapes.bind_key('Escape', Shapes._finish_drawing)
+@Shapes.bind_key('Backspace')
+def delete_selected(layer):
+    """Delete any selected shapes."""
+    layer.remove_selected()
+
+
+@Shapes.bind_key('Escape')
+def finish_drawing(layer):
+    """Finish any drawing, for example when using the path or polygon tool."""
+    layer._finish_drawing()

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -127,7 +127,7 @@ QtLayerList {
 
 QLabel {
    background-color: {{ foreground }};
-   qproperty-alignment: right;
+   qproperty-alignment: AlignLeft;
    padding-top: 1px;
    padding-bottom: 3px;
 }
@@ -135,8 +135,7 @@ QLabel {
 QDialog#QtAboutKeybindings {
   min-width: 530px;
   max-width: 530px;
-  min-height: 700px;
-  max-height: 700px;
+  min-height: 300px;
 }
 
 QDialog#QtAbout {
@@ -150,7 +149,7 @@ QtAbout > QLabel {
    qproperty-alignment: AlignLeft;
 }
 
-QtLayerKeybindings > QLabel {
+QtActiveKeybindings > QLabel {
    qproperty-alignment: AlignLeft;
 }
 

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -133,8 +133,8 @@ QLabel {
 }
 
 QDialog#QtAboutKeybindings {
-  min-width: 530px;
-  max-width: 530px;
+  min-width: 500px;
+  max-width: 500px;
   min-height: 300px;
 }
 
@@ -159,6 +159,10 @@ QtActiveKeybindings > QLabel {
 
 QTabBar::tab {
   background-color: {{ foreground }};
+  border: 2px solid {{ background }};
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  padding: 4px;
 }
 
 QTabBar::tab:selected {

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -146,7 +146,7 @@ QDialog#QtAbout {
   max-height: 300px;
 }
 
-QtAboutPage > QLabel {
+QtAbout > QLabel {
    qproperty-alignment: AlignLeft;
 }
 

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -125,12 +125,45 @@ QtLayerList {
     border: 0px;
 }
 
-
 QLabel {
    background-color: {{ foreground }};
    qproperty-alignment: right;
    padding-top: 1px;
    padding-bottom: 3px;
+}
+
+QDialog#QtAboutKeybindings {
+  min-width: 530px;
+  max-width: 530px;
+  min-height: 700px;
+  max-height: 700px;
+}
+
+QDialog#QtAbout {
+  min-width: 580px;
+  max-width: 580px;
+  min-height: 300px;
+  max-height: 300px;
+}
+
+QtAboutPage > QLabel {
+   qproperty-alignment: AlignLeft;
+}
+
+QtLayerKeybindings > QLabel {
+   qproperty-alignment: AlignLeft;
+}
+
+QtActiveKeybindings > QLabel {
+   qproperty-alignment: AlignLeft;
+}
+
+QTabBar::tab {
+  background-color: {{ foreground }};
+}
+
+QTabBar::tab:selected {
+  background-color: {{ highlight }};
 }
 
 QSplitter {

--- a/napari/tests/test_keybindings.py
+++ b/napari/tests/test_keybindings.py
@@ -1,0 +1,153 @@
+import numpy as np
+from unittest.mock import Mock
+from napari import Viewer
+from vispy import keys
+
+
+def test_viewer_keybindings(qtbot):
+    """Test adding keybindings to the viewer
+    """
+    np.random.seed(0)
+    viewer = Viewer()
+    view = viewer.window.qt_viewer
+    qtbot.addWidget(view)
+
+    mock_press = Mock()
+    mock_release = Mock()
+    mock_shift_press = Mock()
+    mock_shift_release = Mock()
+
+    @viewer.bind_key('F')
+    def key_callback(v):
+        assert viewer == v
+
+        # on press
+        mock_press.method()
+
+        yield
+
+        # on release
+        mock_release.method()
+
+    @viewer.bind_key('Shift-F')
+    def key_callback(v):
+        assert viewer == v
+
+        # on press
+        mock_shift_press.method()
+
+        yield
+
+        # on release
+        mock_shift_release.method()
+
+    # Simulate press only
+    view.canvas.events.key_press(key=keys.Key('F'))
+    mock_press.method.assert_called_once()
+    mock_press.reset_mock()
+    mock_release.method.assert_not_called()
+    mock_shift_press.method.assert_not_called()
+    mock_shift_release.method.assert_not_called()
+
+    # Simulate release only
+    view.canvas.events.key_release(key=keys.Key('F'))
+    mock_press.method.assert_not_called()
+    mock_release.method.assert_called_once()
+    mock_release.reset_mock()
+    mock_shift_press.method.assert_not_called()
+    mock_shift_release.method.assert_not_called()
+
+    # Simulate press only
+    view.canvas.events.key_press(key=keys.Key('F'), modifiers=[keys.SHIFT])
+    mock_press.method.assert_not_called()
+    mock_release.method.assert_not_called()
+    mock_shift_press.method.assert_called_once()
+    mock_shift_press.reset_mock()
+    mock_shift_release.method.assert_not_called()
+
+    # Simulate release only
+    view.canvas.events.key_release(key=keys.Key('F'), modifiers=[keys.SHIFT])
+    mock_press.method.assert_not_called()
+    mock_release.method.assert_not_called()
+    mock_shift_press.method.assert_not_called()
+    mock_shift_release.method.assert_called_once()
+    mock_shift_release.reset_mock()
+
+    # Close the viewer
+    viewer.window.close()
+
+
+def test_layer_keybindings(qtbot):
+    """Test adding keybindings to a layer
+    """
+    np.random.seed(0)
+    viewer = Viewer()
+    view = viewer.window.qt_viewer
+    qtbot.addWidget(view)
+
+    layer = viewer.add_image(np.random.random((10, 20)))
+    layer.selected = True
+
+    mock_press = Mock()
+    mock_release = Mock()
+    mock_shift_press = Mock()
+    mock_shift_release = Mock()
+
+    @layer.bind_key('F')
+    def key_callback(l):
+        assert layer == l
+
+        # on press
+        mock_press.method()
+
+        yield
+
+        # on release
+        mock_release.method()
+
+    @layer.bind_key('Shift-F')
+    def key_callback(l):
+        assert layer == l
+
+        # on press
+        mock_shift_press.method()
+
+        yield
+
+        # on release
+        mock_shift_release.method()
+
+    # Simulate press only
+    view.canvas.events.key_press(key=keys.Key('F'))
+    mock_press.method.assert_called_once()
+    mock_press.reset_mock()
+    mock_release.method.assert_not_called()
+    mock_shift_press.method.assert_not_called()
+    mock_shift_release.method.assert_not_called()
+
+    # Simulate release only
+    view.canvas.events.key_release(key=keys.Key('F'))
+    mock_press.method.assert_not_called()
+    mock_release.method.assert_called_once()
+    mock_release.reset_mock()
+    mock_shift_press.method.assert_not_called()
+    mock_shift_release.method.assert_not_called()
+
+    # Simulate press only
+    view.canvas.events.key_press(key=keys.Key('F'), modifiers=[keys.SHIFT])
+    mock_press.method.assert_not_called()
+    mock_release.method.assert_not_called()
+    mock_shift_press.method.assert_called_once()
+    mock_shift_press.reset_mock()
+    mock_shift_release.method.assert_not_called()
+
+    # Simulate release only
+    view.canvas.events.key_release(key=keys.Key('F'), modifiers=[keys.SHIFT])
+    mock_press.method.assert_not_called()
+    mock_release.method.assert_not_called()
+    mock_shift_press.method.assert_not_called()
+    mock_shift_release.method.assert_called_once()
+    mock_shift_release.reset_mock()
+
+    # Close the viewer
+    viewer.window.close()

--- a/napari/tests/test_viewer.py
+++ b/napari/tests/test_viewer.py
@@ -25,6 +25,10 @@ def test_viewer(qtbot):
     viewer.dims.ndisplay = 2
     assert viewer.dims.ndisplay == 2
 
+    # Run all class keybindings
+    for func in viewer.class_keymap.values():
+        func(viewer)
+
     # Close the viewer
     viewer.window.close()
 
@@ -37,7 +41,7 @@ def test_add_image(qtbot):
 
     np.random.seed(0)
     data = np.random.random((10, 15))
-    viewer.add_image(data)
+    layer = viewer.add_image(data)
     assert np.all(viewer.layers[0].data == data)
 
     assert len(viewer.layers) == 1
@@ -53,6 +57,10 @@ def test_add_image(qtbot):
     viewer.dims.ndisplay = 2
     assert viewer.dims.ndisplay == 2
 
+    # Run all class keybindings
+    for func in layer.class_keymap.values():
+        func(layer)
+
     # Close the viewer
     viewer.window.close()
 
@@ -65,7 +73,7 @@ def test_add_volume(qtbot):
 
     np.random.seed(0)
     data = np.random.random((10, 15, 20))
-    viewer.add_image(data)
+    layer = viewer.add_image(data)
     viewer.dims.ndisplay = 3
     assert np.all(viewer.layers[0].data == data)
 
@@ -82,6 +90,10 @@ def test_add_volume(qtbot):
     viewer.dims.ndisplay = 2
     assert viewer.dims.ndisplay == 2
 
+    # Run all class keybindings
+    for func in layer.class_keymap.values():
+        func(layer)
+
     # Close the viewer
     viewer.window.close()
 
@@ -95,7 +107,7 @@ def test_add_pyramid(qtbot):
     shapes = [(40, 20), (20, 10), (10, 5)]
     np.random.seed(0)
     data = [np.random.random(s) for s in shapes]
-    viewer.add_image(data, is_pyramid=True)
+    layer = viewer.add_image(data, is_pyramid=True)
     assert np.all(viewer.layers[0].data == data)
 
     assert len(viewer.layers) == 1
@@ -110,6 +122,10 @@ def test_add_pyramid(qtbot):
     assert viewer.dims.ndisplay == 3
     viewer.dims.ndisplay = 2
     assert viewer.dims.ndisplay == 2
+
+    # Run all class keybindings
+    for func in layer.class_keymap.values():
+        func(layer)
 
     # Close the viewer
     viewer.window.close()
@@ -123,7 +139,7 @@ def test_add_labels(qtbot):
 
     np.random.seed(0)
     data = np.random.randint(20, size=(10, 15))
-    viewer.add_labels(data)
+    layer = viewer.add_labels(data)
     assert np.all(viewer.layers[0].data == data)
 
     assert len(viewer.layers) == 1
@@ -138,6 +154,10 @@ def test_add_labels(qtbot):
     assert viewer.dims.ndisplay == 3
     viewer.dims.ndisplay = 2
     assert viewer.dims.ndisplay == 2
+
+    # Run all class keybindings
+    for func in layer.class_keymap.values():
+        func(layer)
 
     # Close the viewer
     viewer.window.close()
@@ -151,7 +171,7 @@ def test_add_points(qtbot):
 
     np.random.seed(0)
     data = 20 * np.random.random((10, 2))
-    viewer.add_points(data)
+    layer = viewer.add_points(data)
     assert np.all(viewer.layers[0].data == data)
 
     assert len(viewer.layers) == 1
@@ -166,6 +186,10 @@ def test_add_points(qtbot):
     assert viewer.dims.ndisplay == 3
     viewer.dims.ndisplay = 2
     assert viewer.dims.ndisplay == 2
+
+    # Run all class keybindings
+    for func in layer.class_keymap.values():
+        func(layer)
 
     # Close the viewer
     viewer.window.close()
@@ -179,7 +203,7 @@ def test_add_vectors(qtbot):
 
     np.random.seed(0)
     data = 20 * np.random.random((10, 2, 2))
-    viewer.add_vectors(data)
+    layer = viewer.add_vectors(data)
     assert np.all(viewer.layers[0].data == data)
 
     assert len(viewer.layers) == 1
@@ -194,6 +218,10 @@ def test_add_vectors(qtbot):
     assert viewer.dims.ndisplay == 3
     viewer.dims.ndisplay = 2
     assert viewer.dims.ndisplay == 2
+
+    # Run all class keybindings
+    for func in layer.class_keymap.values():
+        func(layer)
 
     # Close the viewer
     viewer.window.close()
@@ -207,7 +235,7 @@ def test_add_shapes(qtbot):
 
     np.random.seed(0)
     data = 20 * np.random.random((10, 4, 2))
-    viewer.add_shapes(data)
+    layer = viewer.add_shapes(data)
     assert np.all(viewer.layers[0].data == data)
 
     assert len(viewer.layers) == 1
@@ -222,6 +250,10 @@ def test_add_shapes(qtbot):
     assert viewer.dims.ndisplay == 3
     viewer.dims.ndisplay = 2
     assert viewer.dims.ndisplay == 2
+
+    # Run all class keybindings
+    for func in layer.class_keymap.values():
+        func(layer)
 
     # Close the viewer
     viewer.window.close()
@@ -238,7 +270,7 @@ def test_add_surface(qtbot):
     faces = np.random.randint(10, size=(6, 3))
     values = np.random.random(10)
     data = (vertices, faces, values)
-    viewer.add_surface(data)
+    layer = viewer.add_surface(data)
     assert np.all(
         [np.all(vd == d) for vd, d in zip(viewer.layers[0].data, data)]
     )
@@ -255,6 +287,10 @@ def test_add_surface(qtbot):
     assert viewer.dims.ndisplay == 3
     viewer.dims.ndisplay = 2
     assert viewer.dims.ndisplay == 2
+
+    # Run all class keybindings
+    for func in layer.class_keymap.values():
+        func(layer)
 
     # Close the viewer
     viewer.window.close()

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -6,6 +6,7 @@ import numpy as np
 import inspect
 import itertools
 from scipy import ndimage as ndi
+from numpydoc.docscrape import FunctionDoc
 
 
 def str_to_rgb(arg):
@@ -527,3 +528,34 @@ class CallSignature(inspect.Signature):
 
 
 callsignature = CallSignature.from_callable
+
+
+def get_keybindings_summary(keymap):
+    """Get summary of keybindings in keymap.
+
+    Parameters
+    ---------
+    keymap : dict
+        Dictionary of keybindings.
+
+    Returns
+    ---------
+    keybindings_str : str
+        String with summary of all keybindings and their functions.
+    """
+    keybindings_str = ''
+    for key in keymap:
+        func_str = key + ': ' + get_function_summary(keymap[key]) + '\n'
+        keybindings_str += func_str
+
+    return keybindings_str
+
+
+def get_function_summary(func):
+    """Get summary of doc string of function."""
+    doc = FunctionDoc(func)
+    summary = ''
+    summary += doc['Signature']
+    for s in doc['Summary']:
+        summary += '\n\t' + s
+    return summary

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -545,7 +545,7 @@ def get_keybindings_summary(keymap):
     """
     keybindings_str = ''
     for key in keymap:
-        func_str = key + ': ' + get_function_summary(keymap[key]) + '\n'
+        func_str = f'<b> {key}</b>: {get_function_summary(keymap[key])}<br>'
         keybindings_str += func_str
 
     return keybindings_str
@@ -557,5 +557,5 @@ def get_function_summary(func):
     summary = ''
     summary += doc['Signature']
     for s in doc['Summary']:
-        summary += '\n\t' + s
+        summary += '<br>&nbsp;&nbsp;&nbsp;&nbsp;' + s
     return summary


### PR DESCRIPTION
# Description
This PR follows on from #580 by adding the option to display all our keybindings in the pop-up from the help menu. It also adds more comprehensive tests for the keybindings themselves, including some tests similar to those in #544.

It also adjusts the stylings of both the `napari info` and `keybindings` pop-ups to use our style sheets.

The actual strings that are displayed for our keybindings clearly still need some work - particularly those associated with functions that don't have good doc strings or use a lambda

Finally I'm not quite so sure about the dialog box completely blocking the threads on the main viewer - say for keybindings it might be nice to have the keybindings box open and then be working with the viewer at the same time.

Here's what it looks like (note the actual menubar is cutoff from my gif!) - 
![keybindings_display](https://user-images.githubusercontent.com/6531703/66712035-99ca1a80-ed4b-11e9-9542-886e4e587b90.gif)

Curious to get feedback from @AhmetCanSolak, @jni, and @royerloic at this stage though 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added a custom keybindings test and tests of all our keybindings in our viewer / layers.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
