### PR TITLE
viewer args to view_* methods

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -19,7 +19,7 @@ class ViewerModel(KeymapMixin):
     ----------
     title : string
         The title of the viewer window.
-    ndisplay : int
+    ndisplay : {2, 3}
         Number of displayed dimensions.
     order : tuple of int
         Order in which dimensions are displayed where the last two or last

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -20,6 +20,9 @@ def view_image(
     opacity=1,
     blending='translucent',
     visible=True,
+    title='napari',
+    ndisplay=2,
+    order=None,
 ):
     """Create a viewer and add an image layer.
 
@@ -70,13 +73,21 @@ def view_image(
         {'opaque', 'translucent', and 'additive'}.
     visible : bool
         Whether the layer visual is currently being displayed.
+    title : string
+        The title of the viewer window.
+    ndisplay : int
+        Number of displayed dimensions.
+    tuple of int
+        Order in which dimensions are displayed where the last two or last
+        three dimensions correspond to row x column or plane x row x column if
+        ndisplay is 2 or 3.
 
     Returns
     -------
     viewer : :class:`napari.Viewer`
         The newly-created viewer.
     """
-    viewer = Viewer()
+    viewer = Viewer(title=title, ndisplay=ndisplay, order=order)
     viewer.add_image(
         data,
         rgb=rgb,
@@ -111,6 +122,9 @@ def view_multichannel(
     opacity=1,
     blending='additive',
     visible=True,
+    title='napari',
+    ndisplay=2,
+    order=None,
 ):
     """Create a viewer and add images layers expanding along one axis.
 
@@ -153,13 +167,21 @@ def view_multichannel(
         {'opaque', 'translucent', and 'additive'}.
     visible : bool
         Whether the layer visual is currently being displayed.
+    title : string
+        The title of the viewer window.
+    ndisplay : int
+        Number of displayed dimensions.
+    tuple of int
+        Order in which dimensions are displayed where the last two or last
+        three dimensions correspond to row x column or plane x row x column if
+        ndisplay is 2 or 3.
 
     Returns
     -------
     viewer : :class:`napari.Viewer`
         The newly-created viewer.
     """
-    viewer = Viewer()
+    viewer = Viewer(title=title, ndisplay=ndisplay, order=order)
 
     viewer.add_multichannel(
         image,
@@ -195,6 +217,9 @@ def view_points(
     opacity=1,
     blending='translucent',
     visible=True,
+    title='napari',
+    ndisplay=2,
+    order=None,
 ):
     """Create a viewer and add a points layer.
 
@@ -235,6 +260,14 @@ def view_points(
         {'opaque', 'translucent', and 'additive'}.
     visible : bool
         Whether the layer visual is currently being displayed.
+    title : string
+        The title of the viewer window.
+    ndisplay : int
+        Number of displayed dimensions.
+    tuple of int
+        Order in which dimensions are displayed where the last two or last
+        three dimensions correspond to row x column or plane x row x column if
+        ndisplay is 2 or 3.
 
     Returns
     -------
@@ -246,7 +279,7 @@ def view_points(
     See vispy's marker visual docs for more details:
     http://api.vispy.org/en/latest/visuals.html#vispy.visuals.MarkersVisual
     """
-    viewer = Viewer()
+    viewer = Viewer(title=title, ndisplay=ndisplay, order=order)
     viewer.add_points(
         data,
         symbol=symbol,
@@ -280,6 +313,9 @@ def view_labels(
     opacity=0.7,
     blending='translucent',
     visible=True,
+    title='napari',
+    ndisplay=2,
+    order=None,
 ):
     """Create a viewer and add a labels (or segmentation) layer.
 
@@ -318,13 +354,21 @@ def view_labels(
         {'opaque', 'translucent', and 'additive'}.
     visible : bool
         Whether the layer visual is currently being displayed.
+    title : string
+        The title of the viewer window.
+    ndisplay : int
+        Number of displayed dimensions.
+    tuple of int
+        Order in which dimensions are displayed where the last two or last
+        three dimensions correspond to row x column or plane x row x column if
+        ndisplay is 2 or 3.
 
     Returns
     -------
     viewer : :class:`napari.Viewer`
         The newly-created viewer.
     """
-    viewer = Viewer()
+    viewer = Viewer(title=title, ndisplay=ndisplay, order=order)
     viewer.add_labels(
         data,
         is_pyramid=is_pyramid,
@@ -357,6 +401,9 @@ def view_shapes(
     opacity=0.7,
     blending='translucent',
     visible=True,
+    title='napari',
+    ndisplay=2,
+    order=None,
 ):
     """Create a viewer and add a shapes layer.
 
@@ -411,13 +458,21 @@ def view_shapes(
         {'opaque', 'translucent', and 'additive'}.
     visible : bool
         Whether the layer visual is currently being displayed.
+    title : string
+        The title of the viewer window.
+    ndisplay : int
+        Number of displayed dimensions.
+    tuple of int
+        Order in which dimensions are displayed where the last two or last
+        three dimensions correspond to row x column or plane x row x column if
+        ndisplay is 2 or 3.
 
     Returns
     -------
     viewer : :class:`napari.Viewer`
         The newly-created viewer.
     """
-    viewer = Viewer()
+    viewer = Viewer(title=title, ndisplay=ndisplay, order=order)
     viewer.add_shapes(
         data,
         shape_type=shape_type,
@@ -448,6 +503,9 @@ def view_surface(
     opacity=1,
     blending='translucent',
     visible=True,
+    title='napari',
+    ndisplay=2,
+    order=None,
 ):
     """Create a viewer and add a surface layer.
 
@@ -485,13 +543,21 @@ def view_surface(
         {'opaque', 'translucent', and 'additive'}.
     visible : bool
         Whether the layer visual is currently being displayed.
+    title : string
+        The title of the viewer window.
+    ndisplay : int
+        Number of displayed dimensions.
+    tuple of int
+        Order in which dimensions are displayed where the last two or last
+        three dimensions correspond to row x column or plane x row x column if
+        ndisplay is 2 or 3.
 
     Returns
     -------
     viewer : :class:`napari.Viewer`
         The newly-created viewer.
     """
-    viewer = Viewer()
+    viewer = Viewer(title=title, ndisplay=ndisplay, order=order)
     viewer.add_surface(
         data,
         colormap=colormap,
@@ -520,6 +586,9 @@ def view_vectors(
     opacity=0.7,
     blending='translucent',
     visible=True,
+    title='napari',
+    ndisplay=2,
+    order=None,
 ):
     """Create a viewer and add a vectors layer.
 
@@ -553,13 +622,21 @@ def view_vectors(
         {'opaque', 'translucent', and 'additive'}.
     visible : bool
         Whether the layer visual is currently being displayed.
-
+    title : string
+        The title of the viewer window.
+    ndisplay : int
+        Number of displayed dimensions.
+    tuple of int
+        Order in which dimensions are displayed where the last two or last
+        three dimensions correspond to row x column or plane x row x column if
+        ndisplay is 2 or 3.
+        
     Returns
     -------
     viewer : :class:`napari.Viewer`
         The newly-created viewer.
     """
-    viewer = Viewer()
+    viewer = Viewer(title=title, ndisplay=ndisplay, order=order)
     viewer.add_vectors(
         data,
         edge_width=edge_width,

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -75,7 +75,7 @@ def view_image(
         Whether the layer visual is currently being displayed.
     title : string
         The title of the viewer window.
-    ndisplay : int
+    ndisplay : {2, 3}
         Number of displayed dimensions.
     tuple of int
         Order in which dimensions are displayed where the last two or last
@@ -169,7 +169,7 @@ def view_multichannel(
         Whether the layer visual is currently being displayed.
     title : string
         The title of the viewer window.
-    ndisplay : int
+    ndisplay : {2, 3}
         Number of displayed dimensions.
     tuple of int
         Order in which dimensions are displayed where the last two or last
@@ -262,7 +262,7 @@ def view_points(
         Whether the layer visual is currently being displayed.
     title : string
         The title of the viewer window.
-    ndisplay : int
+    ndisplay : {2, 3}
         Number of displayed dimensions.
     tuple of int
         Order in which dimensions are displayed where the last two or last
@@ -356,7 +356,7 @@ def view_labels(
         Whether the layer visual is currently being displayed.
     title : string
         The title of the viewer window.
-    ndisplay : int
+    ndisplay : {2, 3}
         Number of displayed dimensions.
     tuple of int
         Order in which dimensions are displayed where the last two or last
@@ -460,7 +460,7 @@ def view_shapes(
         Whether the layer visual is currently being displayed.
     title : string
         The title of the viewer window.
-    ndisplay : int
+    ndisplay : {2, 3}
         Number of displayed dimensions.
     tuple of int
         Order in which dimensions are displayed where the last two or last
@@ -545,7 +545,7 @@ def view_surface(
         Whether the layer visual is currently being displayed.
     title : string
         The title of the viewer window.
-    ndisplay : int
+    ndisplay : {2, 3}
         Number of displayed dimensions.
     tuple of int
         Order in which dimensions are displayed where the last two or last
@@ -624,13 +624,13 @@ def view_vectors(
         Whether the layer visual is currently being displayed.
     title : string
         The title of the viewer window.
-    ndisplay : int
+    ndisplay : {2, 3}
         Number of displayed dimensions.
     tuple of int
         Order in which dimensions are displayed where the last two or last
         three dimensions correspond to row x column or plane x row x column if
         ndisplay is 2 or 3.
-        
+
     Returns
     -------
     viewer : :class:`napari.Viewer`

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -10,9 +10,9 @@ class Viewer(ViewerModel):
     ----------
     title : string
         The title of the viewer window.
-    ndisplay : int
+    ndisplay : {2, 3}
         Number of displayed dimensions.
-    tuple of int
+    order : tuple of int
         Order in which dimensions are displayed where the last two or last
         three dimensions correspond to row x column or plane x row x column if
         ndisplay is 2 or 3.


### PR DESCRIPTION
# Description
This PR closes #581 by making it possible to pass all keyword arguments that go to `napari.Viewer` to all of our `napari.view_*` methods.

For example, it is now possible to do
```python
import numpy as np
import napari


randoms = np.random.randint(0, 20, 1024*1024*5)
channels_first = randoms.reshape((5, 1024, 1024))
channels_last = randoms.reshape((1024, 1024, 5))

# example code for trying out napari functionality
with napari.gui_qt():
    viewer = napari.view_image(channels_last, rgb=False, name='channels_last', order=[2, 0, 1])
```

and observe the desired 1024x1024 slice immediately on display, rather than having to make a second function call.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have made corresponding changes to the documentation
