### PR TITLE
bracketed numbers for autoincrementing

### DIFF
--- a/napari/components/tests/test_layers_list.py
+++ b/napari/components/tests/test_layers_list.py
@@ -111,13 +111,13 @@ def test_naming():
     layers.append(layer_a)
     layers.append(layer_b)
 
-    assert [l.name for l in layers] == ['img', 'img 1']
+    assert [l.name for l in layers] == ['img', 'img [1]']
 
     layer_b.name = 'chg'
     assert [l.name for l in layers] == ['img', 'chg']
 
     layer_a.name = 'chg'
-    assert [l.name for l in layers] == ['chg 1', 'chg']
+    assert [l.name for l in layers] == ['chg [1]', 'chg']
 
 
 def test_selection():

--- a/napari/components/tests/test_multichannel.py
+++ b/napari/components/tests/test_multichannel.py
@@ -40,9 +40,7 @@ def test_names():
 
     viewer = ViewerModel()
     name = 'example'
-    names = [name] + [
-        name + ' ' + str(i + 1) for i in range(data.shape[-1] - 1)
-    ]
+    names = [name] + [name + f' [{i + 1}]' for i in range(data.shape[-1] - 1)]
     viewer.add_multichannel(data, name=name)
     assert len(viewer.layers) == data.shape[-1]
     for i in range(data.shape[-1]):

--- a/napari/util/naming.py
+++ b/napari/util/naming.py
@@ -7,7 +7,9 @@ from .misc import formatdoc
 sep = ' '
 start = 1
 
-numbered_patt = re.compile(r'(?<!\d)(?:\d+|)$')
+# Match integer between square brackets at end of string if after space
+# or at beginning of string or just match end of string
+numbered_patt = re.compile(r'((?<=\A\[)|(?<=\s\[))(?:\d+|)(?=\]$)|$')
 
 
 def _inc_name_count_sub(match):
@@ -16,7 +18,7 @@ def _inc_name_count_sub(match):
     try:
         count = int(count)
     except ValueError:  # not an int
-        count = f'{sep}{start}'
+        count = f'{sep}[{start}]'
     else:
         count = f'{count + 1}'
 
@@ -27,7 +29,7 @@ def _inc_name_count_sub(match):
 def inc_name_count(name):
     """Increase a name's count matching `{numbered_patt}` by ``1``.
 
-    If the name is not already numbered, append '{sep}{start}'.
+    If the name is not already numbered, append '{sep}[{start}]'.
 
     Parameters
     ----------
@@ -39,4 +41,4 @@ def inc_name_count(name):
     incremented_name : str
         Numbered name incremented by ``1``.
     """
-    return numbered_patt.sub(_inc_name_count_sub, name)
+    return numbered_patt.sub(_inc_name_count_sub, name, count=1)

--- a/napari/util/tests/test_naming.py
+++ b/napari/util/tests/test_naming.py
@@ -1,35 +1,35 @@
 from ..naming import numbered_patt, inc_name_count, sep, start
 
 
-def test_re_base_num():
-    assert numbered_patt.search('layer 12').group(0) == '12'
-
-
-def test_re_base_empty():
+def test_re_base_brackets():
+    assert numbered_patt.search('layer [12]').group(0) == '12'
+    assert numbered_patt.search('layer [e]').group(0) == ''
+    assert numbered_patt.search('layer 12]').group(0) == ''
+    assert numbered_patt.search('layer [12').group(0) == ''
+    assert numbered_patt.search('layer[12]').group(0) == ''
+    assert numbered_patt.search('layer 12').group(0) == ''
+    assert numbered_patt.search('layer12').group(0) == ''
     assert numbered_patt.search('layer').group(0) == ''
 
 
-def test_re_other_digs():
-    assert numbered_patt.search('layer3 123').group(0) == '123'
+def test_re_other_brackets():
+    assert numbered_patt.search('layer [3] [123]').group(0) == '123'
 
 
-def test_re_no_space():
-    assert numbered_patt.search('layer7').group(0) == '7'
-
-
-def test_re_first_dig():
-    assert numbered_patt.search('42').group(0) == '42'
+def test_re_first_bracket():
+    assert numbered_patt.search(' [42]').group(0) == '42'
+    assert numbered_patt.search('[42]').group(0) == '42'
 
 
 def test_re_sub_base_num():
-    assert numbered_patt.sub('8', 'layer 7') == 'layer 8'
+    assert numbered_patt.sub('8', 'layer [7]', count=1) == 'layer [8]'
 
 
 def test_re_sub_base_empty():
-    assert numbered_patt.sub(' 3', 'layer') == 'layer 3'
+    assert numbered_patt.sub(' [3]', 'layer', count=1) == 'layer [3]'
 
 
 def test_inc_name_count():
-    assert inc_name_count('layer 7') == 'layer 8'
-    assert inc_name_count('layer') == f'layer{sep}{start}'
-    assert inc_name_count('41') == '42'
+    assert inc_name_count('layer [7]') == 'layer [8]'
+    assert inc_name_count('layer') == f'layer{sep}[{start}]'
+    assert inc_name_count('[41]') == '[42]'


### PR DESCRIPTION
# Description
This PR closes #586 by switching to bracketed numbers for our auto incrementing - i.e. `layer [1]`, `layer [2]`. See screenshot:

<img width="1200" alt="autoincrement" src="https://user-images.githubusercontent.com/6531703/66729003-37067b00-ee40-11e9-8ba1-e91ed239230e.png">

It should match the behavior discussed in the issue, and there are tests for various edge cases

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
