### PR TITLE
Further unify IO and use dask for multiple files

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -123,6 +123,7 @@ class Window:
 
         self.file_menu = self.main_menu.addMenu('&File')
         self.file_menu.addAction(open_images)
+        self.file_menu.addAction(open_folder)
 
     def _add_view_menu(self):
         toggle_visible = QAction('Toggle menubar visibility', self._qt_window)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -109,10 +109,18 @@ class Window:
             self._main_menu_shortcut.setEnabled(False)
 
     def _add_file_menu(self):
-        open_images = QAction('Open', self._qt_window)
+        open_images = QAction('Open image(s)...', self._qt_window)
         open_images.setShortcut('Ctrl+O')
         open_images.setStatusTip('Open image file(s)')
         open_images.triggered.connect(self.qt_viewer._open_images)
+
+        open_folder = QAction('Open Folder...', self._qt_window)
+        open_folder.setShortcut('Ctrl-Shift-O')
+        open_folder.setStatusTip(
+            'Open a folder of image file(s) or a zarr file'
+        )
+        open_folder.triggered.connect(self.qt_viewer._open_folder)
+
         self.file_menu = self.main_menu.addMenu('&File')
         self.file_menu.addAction(open_images)
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -212,12 +212,14 @@ class QtViewer(QSplitter):
 
     def _open_images(self):
         """Add image files from the menubar."""
-        filenames, _ = QFileDialog.getOpenFileNames(
-            parent=self,
-            caption='Select image(s)...',
-            directory=self._last_visited_dir,  # home dir by default
-        )
-        self._add_files(filenames)
+        open_dialog = QFileDialog()
+        open_dialog.setWindowTitle('Select file(s) or folder(s)')
+        open_dialog.setDirectory(self._last_visited_dir)
+        open_dialog.setProxyModel(None)
+
+        if open_dialog.exec_() == QFileDialog.Accepted:
+            filenames = open_dialog.selectedFiles()
+            self._add_files(filenames)
 
     def _add_files(self, filenames):
         """Add an image layer to the viewer.

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -384,7 +384,12 @@ class QtViewer(QSplitter):
 
     def dropEvent(self, event):
         """Add local files and web URLS with drag and drop."""
-        filenames = [url.toString() for url in event.mimeData().urls()]
+        filenames = []
+        for url in event.mimeData().urls():
+            if url.isLocalFile():
+                filenames.append(url.toLocalFile())
+            else:
+                filenames.append(url.toString())
         self._add_files(filenames)
 
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -220,6 +220,16 @@ class QtViewer(QSplitter):
         if filenames is not None:
             self._add_files(filenames)
 
+    def _open_folder(self):
+        """Add a folder of files from the menubar."""
+        folder = QFileDialog.getExistingDirectory(
+            parent=self,
+            caption='Select folder...',
+            directory=self._last_visited_dir,  # home dir by default
+        )
+        if folder is not None:
+            self._add_files([folder])
+
     def _add_files(self, filenames):
         """Add an image layer to the viewer.
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -373,15 +373,7 @@ class QtViewer(QSplitter):
 
     def dropEvent(self, event):
         """Add local files and web URLS with drag and drop."""
-        filenames = []
-        for url in event.mimeData().urls():
-            path = url.toString()
-            if os.path.isfile(path):
-                filenames.append(path)
-            elif os.path.isdir(path) and not path.endswith('.zarr'):
-                filenames = filenames + list(glob(os.path.join(path, '*')))
-            else:
-                filenames.append(path)
+        filenames = [url.toString() for url in event.mimeData().urls()]
         self._add_files(filenames)
 
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -212,13 +212,12 @@ class QtViewer(QSplitter):
 
     def _open_images(self):
         """Add image files from the menubar."""
-        open_dialog = QFileDialog()
-        open_dialog.setWindowTitle('Select file(s) or folder(s)')
-        open_dialog.setDirectory(self._last_visited_dir)
-        open_dialog.setProxyModel(None)
-
-        if open_dialog.exec_() == QFileDialog.Accepted:
-            filenames = open_dialog.selectedFiles()
+        filenames, _ = QFileDialog.getOpenFileNames(
+            parent=self,
+            caption='Select image(s)...',
+            directory=self._last_visited_dir,  # home dir by default
+        )
+        if filenames is not None:
             self._add_files(filenames)
 
     def _add_files(self, filenames):

--- a/napari/keybindings.py
+++ b/napari/keybindings.py
@@ -1,5 +1,4 @@
 import numpy as np
-from copy import copy
 from .viewer import Viewer
 
 

--- a/napari/util/io.py
+++ b/napari/util/io.py
@@ -9,7 +9,7 @@ from dask import delayed
 from dask import array as da
 
 
-def magic_read(filenames, *, use_dask=True, stack=True):
+def magic_read(filenames, *, use_dask=None, stack=True):
     """Dispatch the appropriate reader given some files.
 
     The files are assumed to all have the same shape.
@@ -20,6 +20,8 @@ def magic_read(filenames, *, use_dask=True, stack=True):
         List of filenames or directories to be opened
     use_dask : bool
         Whether to use dask to create a lazy array, rather than NumPy.
+        Default of None will resolve to True if filenames contains more than
+        one image, False otherwise.
     stack : bool
         Whether to stack the images in multiple files into a single array. If
         False, a list of arrays will be returned.
@@ -48,6 +50,9 @@ def magic_read(filenames, *, use_dask=True, stack=True):
             filenames_expanded.extend(dir_contents_files)
         else:
             filenames_expanded.append(filename)
+
+    if use_dask is None:
+        use_dask = len(filenames_expanded) > 1
 
     # then, read in images
     images = []

--- a/napari/util/io.py
+++ b/napari/util/io.py
@@ -33,6 +33,8 @@ def magic_read(filenames, *, use_dask=None, stack=True):
     """
     if len(filenames) == 0:
         return None
+    if isinstance(filenames, str):
+        filenames = [filenames]  # ensure list
 
     # replace folders with their contents
     filenames_expanded = []

--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -269,18 +269,19 @@ def calc_data_range(data):
     if np.prod(data.shape) > 1e6:
         # If data is very large take the average of the top, bottom, and
         # middle slices
-        top_plane_idx = np.zeros(data.ndim - 2).astype(int)
-        bottom_plane_idx = np.subtract(data.shape[:-2], 1).astype(int)
-        middle_plane_idx = np.round(np.divide(bottom_plane_idx, 2)).astype(int)
-        top_plane = np.asarray(data[tuple(top_plane_idx)])
-        bottom_plane = np.asarray(data[tuple(bottom_plane_idx)])
-        middle_plane = np.asarray(data[tuple(middle_plane_idx)])
-        reduced_data = np.array([top_plane, bottom_plane, middle_plane])
+        bottom_plane_idx = (0,) * (data.ndim - 2)
+        middle_plane_idx = tuple(s // 2 for s in data.shape[:-2])
+        top_plane_idx = tuple(s - 1 for s in data.shape[:-2])
+        idxs = [bottom_plane_idx, middle_plane_idx, top_plane_idx]
+        reduced_data = [
+            [np.max(data[idx]) for idx in idxs],
+            [np.min(data[idx]) for idx in idxs],
+        ]
     else:
         reduced_data = data
 
-    min_val = reduced_data.min()
-    max_val = reduced_data.max()
+    min_val = np.min(reduced_data)
+    max_val = np.max(reduced_data)
 
     if min_val == max_val:
         min_val = 0

--- a/napari/util/tests/test_io.py
+++ b/napari/util/tests/test_io.py
@@ -1,0 +1,57 @@
+import os
+import numpy as np
+from dask import array as da
+from skimage.data import data_dir
+from napari.util import io
+import pytest
+
+
+@pytest.fixture
+def two_pngs():
+    image_files = [
+        os.path.join(data_dir, fn) for fn in ['moon.png', 'camera.png']
+    ]
+    return image_files
+
+
+@pytest.fixture
+def irregular_images():
+    image_files = [
+        os.path.join(data_dir, fn) for fn in ['camera.png', 'coins.png']
+    ]
+    return image_files
+
+
+def test_multi_png_defaults(two_pngs):
+    image_files = two_pngs
+    images = io.magic_read(image_files)
+    assert type(images) == da.Array
+    assert images.shape == (2, 512, 512)
+
+
+def test_multi_png_no_dask(two_pngs):
+    image_files = two_pngs
+    images = io.magic_read(image_files, use_dask=False)
+    assert isinstance(images, np.ndarray)
+    assert images.shape == (2, 512, 512)
+
+
+def test_multi_png_no_stack(two_pngs):
+    image_files = two_pngs
+    images = io.magic_read(image_files, stack=False)
+    assert isinstance(images, list)
+    assert len(images) == 2
+    assert all(a.shape == (512, 512) for a in images)
+
+
+def test_irregular_images(irregular_images):
+    image_files = irregular_images
+    # Ideally, this would work "magically" with dask and irregular images,
+    # but there is no foolproof way to do this without reading in all the
+    # files. We need to be able to inspect the file shape without reading
+    # it in first, then we can automatically turn stacking off when shapes
+    # are irregular (and create proper dask arrays)
+    images = io.magic_read(image_files, use_dask=False, stack=False)
+    assert isinstance(images, list)
+    assert len(images) == 2
+    assert tuple(image.shape for image in images) == ((512, 512), (303, 384))

--- a/napari/util/tests/test_io.py
+++ b/napari/util/tests/test_io.py
@@ -22,6 +22,12 @@ def irregular_images():
     return image_files
 
 
+@pytest.fixture
+def single_tiff():
+    image_files = [os.path.join(data_dir, 'multipage.tif')]
+    return image_files
+
+
 def test_multi_png_defaults(two_pngs):
     image_files = two_pngs
     images = io.magic_read(image_files)
@@ -55,3 +61,19 @@ def test_irregular_images(irregular_images):
     assert isinstance(images, list)
     assert len(images) == 2
     assert tuple(image.shape for image in images) == ((512, 512), (303, 384))
+
+
+def test_tiff(single_tiff):
+    image_files = single_tiff
+    images = io.magic_read(image_files)
+    assert isinstance(images, np.ndarray)
+    assert images.shape == (2, 15, 10)
+    assert images.dtype == np.uint8
+
+
+def test_many_tiffs(single_tiff):
+    image_files = single_tiff * 3
+    images = io.magic_read(image_files)
+    assert isinstance(images, da.Array)
+    assert images.shape == (3, 2, 15, 10)
+    assert images.dtype == np.uint8

--- a/napari/util/tests/test_io.py
+++ b/napari/util/tests/test_io.py
@@ -88,6 +88,12 @@ def test_many_tiffs(single_tiff):
     assert images.dtype == np.uint8
 
 
+def test_single_filename(single_tiff):
+    image_files = single_tiff[0]
+    images = io.magic_read(image_files)
+    assert images.shape == (2, 15, 10)
+
+
 @pytest.mark.skipif(not zarr_available, reason='zarr not installed')
 def test_zarr(single_tiff):
     image_files = single_tiff * 3

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,6 @@
 dask[array]>=2.1.0
 zarr>=2.3.0
+fsspec>=0.3.3  # required for zarr write to local files
 imageio>=2.5.0
 ipykernel==5.1.1
 numpy>=1.10.0

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,5 @@
+dask[array]>=2.1.0
+zarr>=2.3.0
 imageio>=2.5.0
 ipykernel==5.1.1
 numpy>=1.10.0

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -10,5 +10,6 @@ scipy>=1.2.0
 scikit-image>=0.15.0
 vispy>=0.6.1
 IPython>=7.7.0
+backcall>=0.1.0  # required for qtconsole?
 PyOpenGL>=3.1.0
 PySide2>=5.12.3

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,6 @@
 dask[array]>=2.1.0
 zarr>=2.3.0
-fsspec>=0.3.3  # required for zarr write to local files
+fsspec>=0.3.3
 imageio>=2.5.0
 ipykernel==5.1.1
 numpy>=1.10.0
@@ -10,6 +10,6 @@ scipy>=1.2.0
 scikit-image>=0.15.0
 vispy>=0.6.1
 IPython>=7.7.0
-backcall>=0.1.0  # required for qtconsole?
+backcall>=0.1.0
 PyOpenGL>=3.1.0
 PySide2>=5.12.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,5 @@
-dask[array]
 numpydoc
 pytest
 pytest-faulthandler
 pytest-qt
 xarray
-zarr


### PR DESCRIPTION
# Description

This PR fixes dask usage behaviour when reading in folders of files. It also further unifies the behaviour of the file > open dialog, the command line file IO, and the drag and drop functionality.

This PR does not:
- allow lazy loading of single files e.g. multi-page tiffs.
- work correctly with mixed dtypes or mixed shapes if the user doesn't use `use_dask=False` (because we need to assume that all dtypes are the same, or read in all files in sequence to check the dtype).
- allow the user to set `use_dask` or `stack` options with `File > open` or drag and drop.

I haven't had time to test this but it could definitely have a first round of preliminary review to check the design.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
