### PR TITLE
Allow add_points() to be called without an argument to create empty points layer

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,6 +33,7 @@ task:
       conda_script:
         - curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > install.sh
         - bash install.sh -b -p $HOME/conda
+        - conda install --yes -c conda-forge setuptools  # https://github.com/napari/napari/pull/594#issuecomment-542475164
         - conda update -yn base conda
         - conda install -y python=$PY_VER
         - rm install.sh
@@ -63,6 +64,7 @@ task:
         - ps: rm opengl.ps1
       conda_script:
         - choco install -y miniconda3 --params="'/D:%ANACONDA_LOCATION%'"
+        - conda install --yes -c conda-forge setuptools  # https://github.com/napari/napari/pull/594#issuecomment-542475164
         - conda update -yn base conda
         - conda install -y python=%PY_VER%
         - pip install setuptools-scm
@@ -75,6 +77,7 @@ task:
       conda_script:
         - curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > install.sh
         - bash install.sh -b -p $HOME/conda
+        - conda install --yes -c conda-forge setuptools  # https://github.com/napari/napari/pull/594#issuecomment-542475164
         - conda update -yn base conda
         - conda install -y python=$PY_VER
         - rm install.sh

--- a/napari/_qt/qt_viewer_buttons.py
+++ b/napari/_qt/qt_viewer_buttons.py
@@ -82,7 +82,7 @@ class QtNewPointsButton(QPushButton):
 
         self.viewer = viewer
         self.setToolTip('New points layer')
-        self.clicked.connect(lambda: self.viewer._new_points())
+        self.clicked.connect(lambda: self.viewer.add_points())
 
 
 class QtNewShapesButton(QPushButton):
@@ -91,7 +91,7 @@ class QtNewShapesButton(QPushButton):
 
         self.viewer = viewer
         self.setToolTip('New shapes layer')
-        self.clicked.connect(lambda: self.viewer._new_shapes())
+        self.clicked.connect(lambda: self.viewer.add_shapes())
 
 
 class QtNewLabelsButton(QPushButton):

--- a/napari/_qt/tests/test_qt_viewer.py
+++ b/napari/_qt/tests/test_qt_viewer.py
@@ -196,7 +196,7 @@ def test_new_points(qtbot):
     view = QtViewer(viewer)
     qtbot.addWidget(view)
 
-    viewer._new_points()
+    viewer.add_points()
     assert len(viewer.layers[0].data) == 0
     assert len(viewer.layers) == 1
     assert view.layers.vbox_layout.count() == 2 * len(viewer.layers) + 2
@@ -213,7 +213,7 @@ def test_new_points(qtbot):
     np.random.seed(0)
     data = np.random.random((10, 15))
     viewer.add_image(data)
-    viewer._new_points()
+    viewer.add_points()
     assert len(viewer.layers[1].data) == 0
     assert len(viewer.layers) == 2
     assert view.layers.vbox_layout.count() == 2 * len(viewer.layers) + 2
@@ -230,7 +230,7 @@ def test_new_shapes(qtbot):
     view = QtViewer(viewer)
     qtbot.addWidget(view)
 
-    viewer._new_shapes()
+    viewer.add_shapes()
     assert len(viewer.layers[0].data) == 0
     assert len(viewer.layers) == 1
     assert view.layers.vbox_layout.count() == 2 * len(viewer.layers) + 2
@@ -247,7 +247,7 @@ def test_new_shapes(qtbot):
     np.random.seed(0)
     data = np.random.random((10, 15))
     viewer.add_image(data)
-    viewer._new_shapes()
+    viewer.add_shapes()
     assert len(viewer.layers[1].data) == 0
     assert len(viewer.layers) == 2
     assert view.layers.vbox_layout.count() == 2 * len(viewer.layers) + 2

--- a/napari/components/tests/test_viewer_model.py
+++ b/napari/components/tests/test_viewer_model.py
@@ -88,6 +88,14 @@ def test_add_empty_points_on_top_of_image():
     assert pts.data.shape == (1, 3)
 
 
+def test_add_empty_shapes_layer():
+    viewer = ViewerModel()
+    image = np.random.random((8, 64, 64))
+    image_layer = viewer.add_image(image)
+    shp = viewer.add_shapes()
+    assert shp.dims.ndim == 3
+
+
 def test_add_vectors():
     """Test adding vectors."""
     viewer = ViewerModel()

--- a/napari/components/tests/test_viewer_model.py
+++ b/napari/components/tests/test_viewer_model.py
@@ -175,7 +175,7 @@ def test_new_points():
     """Test adding new points layer."""
     # Add labels to empty viewer
     viewer = ViewerModel()
-    viewer._new_points()
+    viewer.add_points()
     assert len(viewer.layers) == 1
     assert len(viewer.layers[0].data) == 0
     assert viewer.dims.ndim == 2
@@ -185,7 +185,7 @@ def test_new_points():
     np.random.seed(0)
     data = np.random.random((10, 15))
     viewer.add_image(data)
-    viewer._new_points()
+    viewer.add_points()
     assert len(viewer.layers) == 2
     assert len(viewer.layers[1].data) == 0
     assert viewer.dims.ndim == 2
@@ -195,7 +195,7 @@ def test_new_shapes():
     """Test adding new shapes layer."""
     # Add labels to empty viewer
     viewer = ViewerModel()
-    viewer._new_shapes()
+    viewer.add_shapes()
     assert len(viewer.layers) == 1
     assert len(viewer.layers[0].data) == 0
     assert viewer.dims.ndim == 2
@@ -205,7 +205,7 @@ def test_new_shapes():
     np.random.seed(0)
     data = np.random.random((10, 15))
     viewer.add_image(data)
-    viewer._new_shapes()
+    viewer.add_shapes()
     assert len(viewer.layers) == 2
     assert len(viewer.layers[1].data) == 0
     assert viewer.dims.ndim == 2

--- a/napari/components/tests/test_viewer_model.py
+++ b/napari/components/tests/test_viewer_model.py
@@ -70,6 +70,24 @@ def test_add_points():
     assert viewer.dims.ndim == 2
 
 
+def test_add_empty_points_to_empty_viewer():
+    viewer = ViewerModel()
+    pts = viewer.add_points(name='empty points')
+    assert pts.dims.ndim == 2
+    pts.add([1000.0, 27.0])
+    assert pts.data.shape == (1, 2)
+
+
+def test_add_empty_points_on_top_of_image():
+    viewer = ViewerModel()
+    image = np.random.random((8, 64, 64))
+    image_layer = viewer.add_image(image)
+    pts = viewer.add_points()
+    assert pts.dims.ndim == 3
+    pts.add([5.0, 32.0, 61.0])
+    assert pts.data.shape == (1, 3)
+
+
 def test_add_vectors():
     """Test adding vectors."""
     viewer = ViewerModel()

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -648,7 +648,7 @@ class ViewerModel(KeymapMixin):
             data = np.empty([0, ndim])
 
         layer = layers.Points(
-            data,
+            data=data,
             symbol=symbol,
             size=size,
             edge_width=edge_width,
@@ -823,7 +823,7 @@ class ViewerModel(KeymapMixin):
             data = np.empty((0, 0, ndim))
 
         layer = layers.Shapes(
-            data,
+            data=data,
             shape_type=shape_type,
             edge_width=edge_width,
             edge_color=edge_color,

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -980,12 +980,6 @@ class ViewerModel(KeymapMixin):
         self.add_layer(layer)
         return layer
 
-    def _new_points(self):
-        self.add_points()
-
-    def _new_shapes(self):
-        self.add_shapes()
-
     def _new_labels(self):
         if self.dims.ndim == 0:
             dims = (512, 512)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -577,7 +577,7 @@ class ViewerModel(KeymapMixin):
 
     def add_points(
         self,
-        data,
+        data=None,
         *,
         symbol='o',
         size=10,
@@ -643,6 +643,10 @@ class ViewerModel(KeymapMixin):
         See vispy's marker visual docs for more details:
         http://api.vispy.org/en/latest/visuals.html#vispy.visuals.MarkersVisual
         """
+        if data is None:
+            ndim = max(self.dims.ndim, 2)
+            data = np.empty([0, ndim])
+
         layer = layers.Points(
             data,
             symbol=symbol,
@@ -740,7 +744,7 @@ class ViewerModel(KeymapMixin):
 
     def add_shapes(
         self,
-        data,
+        data=None,
         *,
         shape_type='rectangle',
         edge_width=1,
@@ -814,6 +818,10 @@ class ViewerModel(KeymapMixin):
         layer : :class:`napari.layers.Shapes`
             The newly-created shapes layer.
         """
+        if data is None:
+            ndim = max(self.dims.ndim, 2)
+            data = np.empty((0, 0, ndim))
+
         layer = layers.Shapes(
             data,
             shape_type=shape_type,
@@ -973,18 +981,10 @@ class ViewerModel(KeymapMixin):
         return layer
 
     def _new_points(self):
-        if self.dims.ndim == 0:
-            ndim = 2
-        else:
-            ndim = self.dims.ndim
-        self.add_points(np.empty((0, ndim)))
+        self.add_points()
 
     def _new_shapes(self):
-        if self.dims.ndim == 0:
-            ndim = 2
-        else:
-            ndim = self.dims.ndim
-        layer = self.add_shapes(np.empty((0, 0, ndim)))
+        self.add_shapes()
 
     def _new_labels(self):
         if self.dims.ndim == 0:

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -118,7 +118,7 @@ class Points(Layer):
 
     def __init__(
         self,
-        data,
+        data=None,
         *,
         symbol='o',
         size=10,
@@ -134,7 +134,8 @@ class Points(Layer):
         blending='translucent',
         visible=True,
     ):
-
+        if data is None:
+            data = np.empty([0, 2])
         ndim = data.shape[1]
         super().__init__(
             ndim,

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -135,7 +135,7 @@ class Points(Layer):
         visible=True,
     ):
         if data is None:
-            data = np.empty([0, 2])
+            data = np.empty((0, 2))
         ndim = data.shape[1]
         super().__init__(
             ndim,

--- a/napari/layers/points/tests/test_points.py
+++ b/napari/layers/points/tests/test_points.py
@@ -4,6 +4,11 @@ from xml.etree.ElementTree import Element
 from napari.layers import Points
 
 
+def test_empty_points():
+    pts = Points()
+    assert pts.data.shape == (0, 2)
+
+
 def test_random_points():
     """Test instantiating Points layer with random 2D data."""
     shape = (10, 2)

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -193,7 +193,7 @@ class Shapes(Layer):
 
     def __init__(
         self,
-        data,
+        data=None,
         *,
         shape_type='rectangle',
         edge_width=1,
@@ -208,7 +208,8 @@ class Shapes(Layer):
         blending='translucent',
         visible=True,
     ):
-
+        if data is None:
+            data = np.empty((0, 0, 2))
         if np.array(data).ndim == 3:
             ndim = np.array(data).shape[2]
         elif len(data) == 0:

--- a/napari/layers/shapes/tests/test_shapes.py
+++ b/napari/layers/shapes/tests/test_shapes.py
@@ -1,7 +1,11 @@
 import numpy as np
-from copy import copy
 from xml.etree.ElementTree import Element
 from napari.layers import Shapes
+
+
+def test_empty_shapes():
+    shp = Shapes()
+    assert shp.dims.ndim == 2
 
 
 def test_rectangles():

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -202,7 +202,7 @@ def view_multichannel(
 
 
 def view_points(
-    data,
+    data=None,
     *,
     symbol='o',
     size=10,
@@ -281,7 +281,7 @@ def view_points(
     """
     viewer = Viewer(title=title, ndisplay=ndisplay, order=order)
     viewer.add_points(
-        data,
+        data=data,
         symbol=symbol,
         size=size,
         edge_width=edge_width,
@@ -387,7 +387,7 @@ def view_labels(
 
 
 def view_shapes(
-    data,
+    data=None,
     *,
     shape_type='rectangle',
     edge_width=1,
@@ -474,7 +474,7 @@ def view_shapes(
     """
     viewer = Viewer(title=title, ndisplay=ndisplay, order=order)
     viewer.add_shapes(
-        data,
+        data=data,
         shape_type=shape_type,
         edge_width=edge_width,
         edge_color=edge_color,


### PR DESCRIPTION
# Description
Similarly for add_shapes(). This allows easier annotation of volumes when working in an interactive IPython session.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: the test suite for my feature covers all new code paths
- [x] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
