### PR TITLE
fix dim change when no layers

### DIFF
--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -147,18 +147,7 @@ class Dims:
             return
         elif self.ndim < ndim:
             for i in range(self.ndim, ndim):
-                # Insert default values for the new axis at the beginning of
-                # the lists
-                # Range value is (min, max, step) for the entire slider
-                self._range.insert(0, (0, 2, 1))
-                # Point is the slider value if in point mode
-                self._point.insert(0, 0)
-                # Interval value is the (min, max) of the slider selction
-                # if in interval mode
-                self._interval.insert(0, (0, 1))
-                self._mode.insert(0, DimsMode.POINT)
-                self._order = [0] + list(np.add(self.order, 1))
-
+                self.set_initial_dims(0, insert=True)
             # Notify listeners that the number of dimensions have changed
             self.events.ndim()
 
@@ -232,6 +221,39 @@ class Dims:
         order = np.array(self.displayed)
         order[np.argsort(order)] = list(range(len(order)))
         return tuple(order)
+
+    def set_initial_dims(self, axis, insert=False):
+        """Initializes the dimensions values for a given axis (dimension)
+
+        Parameters
+        ----------
+        axis : int
+            Dimension index
+        insert : bool
+            Whether to insert the axis or not during initialization
+        """
+        if insert:
+            # Insert default values
+            # Range value is (min, max, step) for the entire slider
+            self._range.insert(axis, (0, 2, 1))
+            # Point is the slider value if in point mode
+            self._point.insert(axis, 0)
+            # Interval value is the (min, max) of the slider selction
+            # if in interval mode
+            self._interval.insert(axis, (0, 1))
+            self._mode.insert(axis, DimsMode.POINT)
+            cur_order = [o if o < axis else o + 1 for o in self.order]
+            self._order = [axis] + cur_order
+        else:
+            # Range value is (min, max, step) for the entire slider
+            self._range[axis] = (0, 2, 1)
+            # Point is the slider value if in point mode
+            self._point[axis] = 0
+            # Interval value is the (min, max) of the slider selction
+            # if in interval mode
+            self._interval[axis] = (0, 1)
+            self._mode[axis] = DimsMode.POINT
+            self._order[axis] = axis
 
     def set_range(self, axis: int, range: Sequence[Union[int, float]]):
         """Sets the range (min, max, step) for a given axis (dimension)

--- a/napari/components/tests/test_viewer_model.py
+++ b/napari/components/tests/test_viewer_model.py
@@ -292,3 +292,24 @@ def test_svg():
     # Generate svg
     svg = viewer.to_svg()
     assert type(svg) == str
+
+
+def test_add_remove_layer_dims_change():
+    """Test dims change appropriately when adding and removing layers."""
+    np.random.seed(0)
+    viewer = ViewerModel()
+
+    # Check ndim starts at 2
+    assert viewer.dims.ndim == 2
+
+    # Check ndim increase to 3 when 3D data added
+    data = np.random.random((10, 15, 20))
+    layer = viewer.add_image(data)
+    assert len(viewer.layers) == 1
+    assert np.all(viewer.layers[0].data == data)
+    assert viewer.dims.ndim == 3
+
+    # Remove layer and check ndim returns to 2
+    viewer.layers.remove(layer)
+    assert len(viewer.layers) == 0
+    assert viewer.dims.ndim == 2

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1065,10 +1065,16 @@ class ViewerModel(KeymapMixin):
             self.active_layer = active_layer
 
     def _on_layers_change(self, event):
-        layer_range = self._calc_layers_ranges()
-        self.dims.ndim = len(layer_range)
-        for i, r in enumerate(layer_range):
-            self.dims.set_range(i, r)
+        if len(self.layers) == 0:
+            self.dims.ndim = 2
+            for i in range(2):
+                self.dims.set_range(i, (0, 2, 1))
+                self.dims.set_point(i, 0)
+        else:
+            layer_range = self._calc_layers_ranges()
+            self.dims.ndim = len(layer_range)
+            for i, r in enumerate(layer_range):
+                self.dims.set_range(i, r)
 
     def _calc_layers_ranges(self):
         """Calculates the range along each axis from all present layers.

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1068,8 +1068,7 @@ class ViewerModel(KeymapMixin):
         if len(self.layers) == 0:
             self.dims.ndim = 2
             for i in range(2):
-                self.dims.set_range(i, (0, 2, 1))
-                self.dims.set_point(i, 0)
+                self.dims.set_initial_dims(i)
         else:
             layer_range = self._calc_layers_ranges()
             self.dims.ndim = len(layer_range)


### PR DESCRIPTION
# Description
This PR fixes a bug that prevented the dims model from reseting to its default values when no layers are present. It lead to weird / confusing behaviour where you could add a 4D image, get 2 dims sliders present, deleted the 4D image, still have the two sliders present, add a new 2D image and still have the two sliders present, which I think was quite strange.

Now when there are no layers present, the `ndim` will return to 2 and no sliders will be present.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] I've added a test for this inside the viewer model tests

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
