### PR TITLE
fix bracket highlighting

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -4,6 +4,7 @@ import numpy as np
 import inspect
 from pathlib import Path
 
+from qtpy import QtGui
 from qtpy.QtCore import QCoreApplication, Qt, QSize
 from qtpy.QtWidgets import (
     QWidget,
@@ -27,6 +28,7 @@ from ..resources import resources_dir
 from ..util.theme import template
 from ..util.misc import (
     is_rgb,
+    str_to_rgb,
     ReadOnlyWrapper,
     mouse_press_callbacks,
     mouse_move_callbacks,
@@ -290,6 +292,8 @@ class QtViewer(QSplitter):
         themed_stylesheet = template(self.raw_stylesheet, **palette)
         self.console.style_sheet = themed_stylesheet
         self.console.syntax_style = palette['syntax_style']
+        bracket_color = QtGui.QColor(*str_to_rgb(palette['highlight']))
+        self.console._bracket_matcher.format.setBackground(bracket_color)
         self.setStyleSheet(themed_stylesheet)
         self.canvas.bgcolor = palette['canvas']
 


### PR DESCRIPTION
# Description
This PR fixes some annoying bracket highlighting in the console that was using a default value and not being updated by our stylesheet. I think it is much more readable now:

OLD STYLE:
<img width="1200" alt="old_brackets" src="https://user-images.githubusercontent.com/6531703/67152088-c1fad180-f295-11e9-93fe-dedea92a3f6a.png">

NEW STYLE:
<img width="1200" alt="new_brackets" src="https://user-images.githubusercontent.com/6531703/67152091-c7f0b280-f295-11e9-9164-c7f472a3b4c2.png">

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
