### PR TITLE
fix for data array overwriting during 3D rendering

### DIFF
--- a/napari/_qt/tests/test_qt_viewer.py
+++ b/napari/_qt/tests/test_qt_viewer.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from napari.components import ViewerModel
 from napari._qt.qt_viewer import QtViewer
@@ -287,3 +288,31 @@ def test_screenshot(qtbot):
     # Take screenshot
     screenshot = view.screenshot()
     assert screenshot.ndim == 3
+
+
+@pytest.mark.parametrize(
+    "dtype", ['int8', 'uint8', 'int16', 'uint16', 'float32']
+)
+def test_qt_viewer_data_integrity(qtbot, dtype):
+    """Test that the viewer doesn't change the underlying array."""
+
+    image = np.random.rand(10, 32, 32)
+    image *= 200 if dtype.endswith('8') else 2 ** 14
+    image = image.astype(dtype)
+    imean = image.mean()
+
+    viewer = ViewerModel()
+    view = QtViewer(viewer)
+    qtbot.addWidget(view)
+
+    viewer.add_image(image.copy())
+    datamean = viewer.layers[0].data.mean()
+    assert datamean == imean
+    # toggle dimensions
+    viewer.dims.ndisplay = 3
+    datamean = viewer.layers[0].data.mean()
+    assert datamean == imean
+    # back to 2D
+    viewer.dims.ndisplay = 2
+    datamean = viewer.layers[0].data.mean()
+    assert datamean == imean

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -71,6 +71,8 @@ class VispyImageLayer(VispyBaseLayer):
             self.node._need_colortransform_update = True
             self.node.set_data(data)
         else:
+            if dtype == 'float32':
+                data = data.copy()
             self.node.set_data(data, clim=self.layer.contrast_limits)
         self.node.update()
 


### PR DESCRIPTION
a fix for #575 and #612, and a test.
explanation [here](https://github.com/napari/napari/issues/575#issuecomment-544753893)

This does not solve the repeated calls to `VispyImageLayer._on_data_change`, but prevents the diminishing data problem.