### PR TITLE
Standardize usage of cmaps and add cmap tests

### DIFF
--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -533,8 +533,8 @@ class Image(Layer):
             color_range = high - low
             if color_range != 0:
                 downsampled = (downsampled - low) / color_range
-            colormapped = self.colormap[1].map(downsampled)
-            colormapped = colormapped.reshape(downsampled.shape + (4,))
+            color_array = self.colormap[1][downsampled.ravel()]
+            colormapped = color_array.rgba.reshape(downsampled.shape + (4,))
             colormapped[..., 3] *= self.opacity
         self.thumbnail = colormapped
 
@@ -584,8 +584,8 @@ class Image(Layer):
         color_range = self.contrast_limits[1] - self.contrast_limits[0]
         if color_range != 0:
             image = image / color_range
-        mapped_image = (self.colormap[1].map(image) * 255).astype('uint8')
-        mapped_image = mapped_image.reshape(list(self._data_view.shape) + [4])
+        mapped_image = self.colormap[1][image.ravel()]
+        mapped_image = mapped_image.RGBA.reshape(image.shape + (4,))
         image_str = imwrite('<bytes>', mapped_image, format='png')
         image_str = "data:image/png;base64," + str(b64encode(image_str))[2:-1]
         props = {'xlink:href': image_str}

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -368,7 +368,7 @@ class Labels(Image):
             col = None
         else:
             val = self._raw_to_displayed(np.array([label]))
-            col = self.colormap[1].map(val)[0]
+            col = self.colormap[1][val].rgba[0]
         return col
 
     def _reset_history(self):

--- a/napari/util/colormaps/colorbars.py
+++ b/napari/util/colormaps/colorbars.py
@@ -29,10 +29,9 @@ def make_colorbar(cmap, size=(12, 28), horizontal=True):
         input = np.linspace(0, 1, size[0])
         bar = np.tile(np.expand_dims(input, 1), size[1])
 
-    cbar = cmap.map(bar.reshape(-1)).reshape(tuple(size) + (4,))
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        cbar = img_as_ubyte(cbar)
+    # cmap.__getitem__ returns a vispy.color.ColorArray
+    color_array = cmap[bar.ravel()]
+    # the ColorArray.RGBA method returns a normalized uint8 array
+    cbar = color_array.RGBA.reshape(bar.shape + (4,))
 
     return cbar

--- a/napari/util/colormaps/colormaps.py
+++ b/napari/util/colormaps/colormaps.py
@@ -254,7 +254,7 @@ class TransFire(BaseColormap):
 
     def map(self, t):
         if isinstance(t, np.ndarray):
-            return np.dstack(
+            return np.hstack(
                 [np.power(t, 0.5), t, t * t, np.maximum(0, t * 1.05 - 0.05)]
             ).astype(np.float32)
         else:
@@ -273,7 +273,7 @@ class TransGrays(BaseColormap):
 
     def map(self, t):
         if isinstance(t, np.ndarray):
-            return np.dstack([t, t, t, t * 0.5]).astype(np.float32)
+            return np.hstack([t, t, t, t * 0.5]).astype(np.float32)
         else:
             return np.array([t, t, t, t * 0.5], dtype=np.float32)
 

--- a/napari/util/tests/test_colormaps.py
+++ b/napari/util/tests/test_colormaps.py
@@ -1,0 +1,25 @@
+import pytest
+import numpy as np
+
+from ..colormaps import AVAILABLE_COLORMAPS
+from vispy.color.color_array import ColorArray
+
+
+@pytest.mark.parametrize("name", list(AVAILABLE_COLORMAPS.keys()))
+def test_colormap(name):
+    cmap = AVAILABLE_COLORMAPS[name]
+
+    # colormaps should accept a scalar with the __getitem__ method and return a ColorArray
+    assert isinstance(cmap[0.5], ColorArray)
+
+    # colormaps should accept a 1D array with the __getitem__ method and return a ColorArray
+    assert isinstance(cmap[np.linspace(0, 1, 256) ** 0.5], ColorArray)
+
+    # colormap.map() is a lower level API
+    # it akes a (N, 1) vector of values in [0, 1], and returns a rgba array of size (N, 4).
+    # as per the vispy documentation: This function doesn't need to implement argument
+    # checking on `item`. It can always assume that `item` is a (N, 1) array of values
+    # between 0 and 1.
+    # http://vispy.org/color.html
+    q = np.random.rand(10, 10)
+    assert cmap.map(q.reshape(-1, 1)).shape == (q.size, 4)


### PR DESCRIPTION
# Description
In adding the gamma slider (PR #610), I realized that a couple of the colormaps didn't behave like the others (#611).  After some digging, I found a number of places in napari in which colormaps were being used in a way that was inconsistent with the `vispy.colors.Colormap` API described at: http://vispy.org/color.html . This PR adds tests to make sure all `AVAILABLE_COLORMAPS` abide by the vispy API, and corrects a few places in the code where the `cmap.map()` method was being called directly in a way that led to different results depending on the cmap being used.

It's easy to write tests that assert existing cmaps follow the API, but it's hard to make sure they get used this way in the code... So just to summarize the API (for later reference), `vispy.color.Colormap`s should be used in one of two ways:

1. `cmap.__getitem__(item)` (i.e. `cmap[item]`)

   This is the preferred API (from vispy: "Users are expected to use a colormap with ``__getitem__()`` rather than ``map()`` (which implements a lower-level API)."  This API expects `item` to be either a scalar value, or a 1D numpy array (it does not handle 2D+ arrays).  It returns a `vispy.color.ColorArray` which has a few convenient methods such as `rgba()` or `RGBA()` that return normalized data in various dtypes that can then be reshaped as desired.  An example usage of this API (as in `make_colorbar`)
   ```python
   color_array = cmap[image.ravel()]
   # the ColorArray.RGBA method returns a normalized uint8 array
   cbar = color_array.RGBA.reshape(image.shape + (4,))
   ```
2. `cmap.map(item)`

   This is the lower-level API. Data provided to `map()` **MUST** be of shape `(N, 1)`, not `(N,)`, with values of [0,1]. (this was the issue that cause the inconsistent behavior).  So, for example:
this is ok: `cmap.map(image2d.reshape(-1, 1))`
but this is not: `cmap.map(image2d.reshape(-1))`
any new custom `cmaps` implementing a `map()` method must return an rgba array of size `(N, 4)`

This PR will be necessary for the gamma PR #610 to work consistently across cmaps.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
http://vispy.org/color.html [& [source](https://github.com/vispy/vispy/blob/876a0d37116f5b29c7b190c8e67cbf9247c45f04/vispy/color/colormap.py#L256-L293)]

# How has this been tested?
- [x] added tests to make sure that all available colormaps adhere to the vispy API assumptions
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
