### PR TITLE
gui_qt: Ipython command is "%gui qt"

### DIFF
--- a/napari/_qt/event_loop.py
+++ b/napari/_qt/event_loop.py
@@ -12,7 +12,7 @@ def gui_qt():
     Notes
     -----
     This context manager is not needed if running napari within an interactive
-    IPython session. In this case, use the %gui=qt magic command, or start
+    IPython session. In this case, use the ``%gui qt`` magic command, or start
     IPython with the Qt GUI event loop enabled by default by using
     ``ipython --gui=qt``.
     """


### PR DESCRIPTION
# Description
Fixes the doc message in `gui_qt()`: `%gui=qt` is incorrect
```
In [4]: %gui=qt
UsageError: Line magic function `%gui=qt` not found.

In [5]: %gui qt

```

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References

# How has this been tested?
- [x] Manual testing in IPython:
```
%Python 3.6.7 | packaged by conda-forge | (default, Jul  2 2019, 02:07:37)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.9.0 -- An enhanced Interactive Python. Type '?' for help.
```
```
In [5]: %gui qt

In [6]: viewer = napari.Viewer()

In [7]: viewer
Out[7]: <napari.viewer.Viewer at 0x1252f82e8>
```

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
