### PR TITLE
Raise informative warning when no Qt loop is detected

### DIFF
--- a/napari/tests/test_viewer.py
+++ b/napari/tests/test_viewer.py
@@ -1,6 +1,12 @@
 import numpy as np
+import pytest
 
 from napari import Viewer
+
+
+def test_no_qt_loop():
+    with pytest.raises(RuntimeError):
+        viewer = Viewer()
 
 
 def test_viewer(qtbot):

--- a/napari/tests/test_viewer.py
+++ b/napari/tests/test_viewer.py
@@ -4,6 +4,7 @@ import pytest
 from napari import Viewer
 
 
+@pytest.mark.first
 def test_no_qt_loop():
     with pytest.raises(RuntimeError):
         viewer = Viewer()

--- a/napari/tests/test_viewer.py
+++ b/napari/tests/test_viewer.py
@@ -4,12 +4,6 @@ import pytest
 from napari import Viewer
 
 
-@pytest.mark.first
-def test_no_qt_loop():
-    with pytest.raises(RuntimeError):
-        viewer = Viewer()
-
-
 def test_viewer(qtbot):
     """Test instantiating viewer."""
     viewer = Viewer()
@@ -38,6 +32,20 @@ def test_viewer(qtbot):
 
     # Close the viewer
     viewer.window.close()
+
+
+@pytest.mark.first  # provided by pytest-ordering
+def test_no_qt_loop():
+    """Test informative error raised when no Qt event loop exists.
+
+    Logically, this test should go at the top of the file. Howveer, that
+    resulted in tests passing when only this file was run, but failing when
+    other tests involving Qt-bot were run before this file. Putting this test
+    second provides a sanity check that pytest-ordering is correctly doing its
+    magic.
+    """
+    with pytest.raises(RuntimeError):
+        viewer = Viewer()
 
 
 def test_add_image(qtbot):

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 from qtpy.QtWidgets import QApplication
 from ._qt.qt_viewer import QtViewer
 from ._qt.qt_main_window import Window
@@ -22,19 +24,29 @@ class Viewer(ViewerModel):
     def __init__(self, title='napari', ndisplay=2, order=None):
         # instance() returns the singleton instance if it exists, or None
         app = QApplication.instance()
-        # if None, we create our own and we execute after creating our object
+        # if None, wait two seconds, as it may still be instantiating when
+        # using %gui qt inside IPython
         if app is None:
-            app = QApplication([])
-            self_execute = True
-        # otherwise, we don't execute and we delete our reference to app
-        else:
-            self_execute = False
-            # appears to be required to not conflict with IPython Qt loop
-            del app
+            sleep(2)
+            app = QApplication.instance()
+            # if still none, raise a RuntimeError with the appropriate message
+            if app is None:
+                message = (
+                    "napari requires a Qt event loop to run. To create one, "
+                    "try one of the following: \n"
+                    "  - use the `napari.gui_qt()` context manager. See "
+                    "https://github.com/napari/napari/tree/master/examples for"
+                    " usage examples.\n"
+                    "  - In IPython or a local Jupyter instance, use the "
+                    "`%gui qt` magic command.\n"
+                    "  - Launch IPython with the option `--gui=qt`.\n"
+                    "  - (recommended) in your IPython configuration file, add"
+                    " or uncomment the line `c.TerminalIPythonApp.gui = 'qt'`."
+                    " Then, restart IPython."
+                )
+                raise RuntimeError(message)
         super().__init__(title=title, ndisplay=ndisplay, order=order)
         qt_viewer = QtViewer(self)
         self.window = Window(qt_viewer)
         self.screenshot = self.window.qt_viewer.screenshot
         self.update_console = self.window.qt_viewer.console.push
-        if self_execute:
-            app.exec_()

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -24,27 +24,22 @@ class Viewer(ViewerModel):
     def __init__(self, title='napari', ndisplay=2, order=None):
         # instance() returns the singleton instance if it exists, or None
         app = QApplication.instance()
-        # if None, wait two seconds, as it may still be instantiating when
-        # using %gui qt inside IPython
+        # if None, raise a RuntimeError with the appropriate message
         if app is None:
-            sleep(2)
-            app = QApplication.instance()
-            # if still none, raise a RuntimeError with the appropriate message
-            if app is None:
-                message = (
-                    "napari requires a Qt event loop to run. To create one, "
-                    "try one of the following: \n"
-                    "  - use the `napari.gui_qt()` context manager. See "
-                    "https://github.com/napari/napari/tree/master/examples for"
-                    " usage examples.\n"
-                    "  - In IPython or a local Jupyter instance, use the "
-                    "`%gui qt` magic command.\n"
-                    "  - Launch IPython with the option `--gui=qt`.\n"
-                    "  - (recommended) in your IPython configuration file, add"
-                    " or uncomment the line `c.TerminalIPythonApp.gui = 'qt'`."
-                    " Then, restart IPython."
-                )
-                raise RuntimeError(message)
+            message = (
+                "napari requires a Qt event loop to run. To create one, "
+                "try one of the following: \n"
+                "  - use the `napari.gui_qt()` context manager. See "
+                "https://github.com/napari/napari/tree/master/examples for"
+                " usage examples.\n"
+                "  - In IPython or a local Jupyter instance, use the "
+                "`%gui qt` magic command.\n"
+                "  - Launch IPython with the option `--gui=qt`.\n"
+                "  - (recommended) in your IPython configuration file, add"
+                " or uncomment the line `c.TerminalIPythonApp.gui = 'qt'`."
+                " Then, restart IPython."
+            )
+            raise RuntimeError(message)
         super().__init__(title=title, ndisplay=ndisplay, order=order)
         qt_viewer = QtViewer(self)
         self.window = Window(qt_viewer)

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,3 +1,4 @@
+from qtpy.QtWidgets import QApplication
 from ._qt.qt_viewer import QtViewer
 from ._qt.qt_main_window import Window
 from .components import ViewerModel
@@ -19,8 +20,21 @@ class Viewer(ViewerModel):
     """
 
     def __init__(self, title='napari', ndisplay=2, order=None):
+        # instance() returns the singleton instance if it exists, or None
+        app = QApplication.instance()
+        # if None, we create our own and we execute after creating our object
+        if app is None:
+            app = QApplication([])
+            self_execute = True
+        # otherwise, we don't execute and we delete our reference to app
+        else:
+            self_execute = False
+            # appears to be required to not conflict with IPython Qt loop
+            del app
         super().__init__(title=title, ndisplay=ndisplay, order=order)
         qt_viewer = QtViewer(self)
         self.window = Window(qt_viewer)
         self.screenshot = self.window.qt_viewer.screenshot
         self.update_console = self.window.qt_viewer.console.push
+        if self_execute:
+            app.exec_()

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,5 @@
 pytest
 pytest-faulthandler
 pytest-qt
+pytest-ordering
 xarray


### PR DESCRIPTION
# Description

Currently, trying `napari.Viewer()` or `napari.view_*()` outside of a Qt loop raises a nasty error. (#634). In this PR, I try to detect whether there is a Qt loop active, and if there isn't, I make one. This results in blocking behaviour when there is no loop, ie `view_image()` will pause the console until the user is done with napari.

Problems:
- I'm not sure how to test it, since once it blocks there's nothing really for us to do. And we can't launch a QTimer before starting this since the whole point is to not have a QApplication running.
- Given this, this has not been as thoroughly tested as I would like!
- It all seems a bit clunky. However, my [other attempt](https://github.com/jni/napari/commit/716c460c463fd318cce5899560cd35a6839145b7) to improve `gui_qt` so that it can be called during viewer creation doesn't work, and ends up with an empty napari window in some circumstances.

Comments very welcome! But let's get this in ASAP! =)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
