### PR TITLE
Calculate a minimum thumbnail side length so thumbnails are never zero width

### DIFF
--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -513,18 +513,21 @@ class Image(Layer):
         if dtype in [np.dtype(np.float16)]:
             image = image.astype(np.float32)
 
-        zoom_factor = np.divide(
+        raw_zoom_factor = np.divide(
             self._thumbnail_shape[:2], image.shape[:2]
         ).min()
+        new_shape = np.clip(
+            raw_zoom_factor * np.array(image.shape[:2]),
+            1,  # smallest side should be 1 pixel wide
+            self._thumbnail_shape[:2],
+        )
+        zoom_factor = tuple(new_shape / image.shape[:2])
         if self.rgb:
             # warning filter can be removed with scipy 1.4
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 downsampled = ndi.zoom(
-                    image,
-                    (zoom_factor, zoom_factor, 1),
-                    prefilter=False,
-                    order=0,
+                    image, zoom_factor + (1,), prefilter=False, order=0
                 )
             if image.shape[2] == 4:  # image is RGBA
                 colormapped = np.copy(downsampled)

--- a/napari/layers/image/tests/test_image.py
+++ b/napari/layers/image/tests/test_image.py
@@ -455,6 +455,22 @@ def test_thumbnail():
     assert layer.thumbnail.shape == layer._thumbnail_shape
 
 
+def test_narrow_thumbnail():
+    """Ensure that the thumbnail generation works for very narrow images.
+
+    See: https://github.com/napari/napari/issues/641 and
+    https://github.com/napari/napari/issues/489
+    """
+    image = np.random.random((1, 2048))
+    layer = Image(image)
+    layer._update_thumbnail()
+    thumbnail = layer.thumbnail[..., :3]  # ignore alpha channel
+    middle_row = thumbnail.shape[0] // 2
+    assert np.all(thumbnail[: middle_row - 1] == 0)
+    assert np.all(thumbnail[middle_row + 1 :] == 0)
+    assert np.mean(thumbnail[middle_row - 1 : middle_row + 1]) > 0
+
+
 def test_xml_list():
     """Test the xml generation."""
     np.random.seed(0)

--- a/napari/util/status_messages.py
+++ b/napari/util/status_messages.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 import numpy as np
 
 


### PR DESCRIPTION
# Description

Fixes #641 and the bad part of #489 

For images narrower than a 1/32 ratio, the narrow dimension would get squished to 0 and `ndi.zoom` would produce an array of size 0 along that axis, which would later error out when calling `np.max` on it. This addresses that issue by ensuring that the smallest side will always be 0. The result works pretty nicely:

![napari-singleton-axis](https://user-images.githubusercontent.com/492549/67766200-e421eb80-fa1b-11e9-8eec-e0b832c01fb3.png)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
