### PR TITLE
Fix np.pad() usage

### DIFF
--- a/napari/_vispy/vispy_shapes_layer.py
+++ b/napari/_vispy/vispy_shapes_layer.py
@@ -44,7 +44,7 @@ class VispyShapesLayer(VispyBaseLayer):
             colors = np.array([[0, 0, 0, 0]])
 
         if self.layer.dims.ndisplay == 3 and self.layer.dims.ndim == 2:
-            vertices = np.pad(vertices, ((0, 0), (0, 1)))
+            vertices = np.pad(vertices, ((0, 0), (0, 1)), mode='constant')
 
         self.node._subvisuals[0].set_data(
             vertices=vertices, faces=faces, face_colors=colors

--- a/napari/_vispy/vispy_vectors_layer.py
+++ b/napari/_vispy/vispy_vectors_layer.py
@@ -25,7 +25,7 @@ class VispyVectorsLayer(VispyBaseLayer):
             faces = self.layer._view_faces
 
         if self.layer.dims.ndisplay == 3 and self.layer.dims.ndim == 2:
-            vertices = np.pad(vertices, ((0, 0), (0, 1)))
+            vertices = np.pad(vertices, ((0, 0), (0, 1)), mode='constant')
 
         self.node.set_data(
             vertices=vertices, faces=faces, color=self.layer.edge_color


### PR DESCRIPTION
# Description
As discussed in #645, this PR adds the `mode='constant'` keyword argument to `numpy.pad()` to maintain compatibility with `numpy < 1.17`.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
This PR closes #645 

# How has this been tested?
- [x] ran the tests in `/napari/tests

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
