### PR TITLE
modify dims QScrollbar with scroll-to-click behavior

### DIFF
--- a/napari/_qt/qt_dims.py
+++ b/napari/_qt/qt_dims.py
@@ -1,11 +1,13 @@
+from typing import Optional, Tuple
+
 import numpy as np
 from qtpy.QtCore import QEventLoop, Qt, QThread, QTimer, Signal, Slot
-from qtpy.QtWidgets import QGridLayout, QScrollBar, QSizePolicy, QWidget
+from qtpy.QtWidgets import QGridLayout, QSizePolicy, QWidget
 
 from ..components.dims import Dims
 from ..components.dims_constants import DimsMode
 from ..util.event import Event
-from typing import Tuple, Optional
+from .qt_scrollbar import ModifiedScrollBar
 
 
 class QtDims(QWidget):
@@ -285,7 +287,7 @@ class QtDims(QWidget):
         range = (range[0], range[1] - range[2], range[2])
         point = self.dims.point[axis]
 
-        slider = QScrollBar(Qt.Horizontal)
+        slider = ModifiedScrollBar(Qt.Horizontal)
         slider.setFocusPolicy(Qt.NoFocus)
         slider.setMinimum(range[0])
         slider.setMaximum(range[1])

--- a/napari/_qt/qt_scrollbar.py
+++ b/napari/_qt/qt_scrollbar.py
@@ -1,0 +1,58 @@
+from qtpy.QtWidgets import QScrollBar, QStyleOptionSlider, QStyle
+from qtpy.QtCore import Qt
+
+
+# https://stackoverflow.com/questions/29710327/how-to-override-qscrollbar-onclick-default-behaviour
+class ModifiedScrollBar(QScrollBar):
+    """Modified QScrollBar that moves fully to the clicked position.
+
+    When the user clicks on the scroll bar background area (aka, the "page
+    control"), the default behavior of the QScrollBar is to move one "page"
+    towards the click (rather than all the way to the clicked position).
+    See: https://doc.qt.io/qt-5/qscrollbar.html
+    This scroll bar modifies the mousePressEvent to move the slider position
+    fully to the clicked position.
+    """
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            opt = QStyleOptionSlider()
+            self.initStyleOption(opt)
+            control = self.style().hitTestComplexControl(
+                QStyle.CC_ScrollBar, opt, event.pos(), self
+            )
+            if (
+                control == QStyle.SC_ScrollBarAddPage
+                or control == QStyle.SC_ScrollBarSubPage
+            ):
+                # scroll here
+                gr = self.style().subControlRect(
+                    QStyle.CC_ScrollBar, opt, QStyle.SC_ScrollBarGroove, self
+                )
+                sr = self.style().subControlRect(
+                    QStyle.CC_ScrollBar, opt, QStyle.SC_ScrollBarSlider, self
+                )
+                if self.orientation() == Qt.Horizontal:
+                    pos = event.pos().x()
+                    sliderLength = sr.width()
+                    sliderMin = gr.x()
+                    sliderMax = gr.right() - sliderLength + 1
+                    if self.layoutDirection() == Qt.RightToLeft:
+                        opt.upsideDown = not opt.upsideDown
+                else:
+                    pos = event.pos().y()
+                    sliderLength = sr.height()
+                    sliderMin = gr.y()
+                    sliderMax = gr.bottom() - sliderLength + 1
+                self.setValue(
+                    QStyle.sliderValueFromPosition(
+                        self.minimum(),
+                        self.maximum(),
+                        pos - sliderMin,
+                        sliderMax - sliderMin,
+                        opt.upsideDown,
+                    )
+                )
+                return
+
+        return super(ModifiedScrollBar, self).mousePressEvent(event)

--- a/napari/_qt/qt_scrollbar.py
+++ b/napari/_qt/qt_scrollbar.py
@@ -48,7 +48,7 @@ class ModifiedScrollBar(QScrollBar):
                     QStyle.sliderValueFromPosition(
                         self.minimum(),
                         self.maximum(),
-                        pos - sliderMin,
+                        pos - sliderMin - sliderLength // 2,
                         sliderMax - sliderMin,
                         opt.upsideDown,
                     )

--- a/napari/_qt/qt_scrollbar.py
+++ b/napari/_qt/qt_scrollbar.py
@@ -57,12 +57,10 @@ class ModifiedScrollBar(QScrollBar):
         if event.buttons() & Qt.LeftButton:
             # dragging with the mouse button down should move the slider
             self._move_to_mouse_position(event)
-            return
         return super().mouseMoveEvent(event)
 
     def mousePressEvent(self, event):
         if event.button() == Qt.LeftButton:
             # clicking the mouse button should move slider to the clicked point
             self._move_to_mouse_position(event)
-            return
         return super().mousePressEvent(event)

--- a/napari/_qt/qt_scrollbar.py
+++ b/napari/_qt/qt_scrollbar.py
@@ -14,45 +14,55 @@ class ModifiedScrollBar(QScrollBar):
     fully to the clicked position.
     """
 
+    def _move_to_mouse_position(self, event):
+        opt = QStyleOptionSlider()
+        self.initStyleOption(opt)
+        control = self.style().hitTestComplexControl(
+            QStyle.CC_ScrollBar, opt, event.pos(), self
+        )
+        if (
+            control == QStyle.SC_ScrollBarAddPage
+            or control == QStyle.SC_ScrollBarSubPage
+        ):
+            # scroll here
+            gr = self.style().subControlRect(
+                QStyle.CC_ScrollBar, opt, QStyle.SC_ScrollBarGroove, self
+            )
+            sr = self.style().subControlRect(
+                QStyle.CC_ScrollBar, opt, QStyle.SC_ScrollBarSlider, self
+            )
+            if self.orientation() == Qt.Horizontal:
+                pos = event.pos().x()
+                sliderLength = sr.width()
+                sliderMin = gr.x()
+                sliderMax = gr.right() - sliderLength + 1
+                if self.layoutDirection() == Qt.RightToLeft:
+                    opt.upsideDown = not opt.upsideDown
+            else:
+                pos = event.pos().y()
+                sliderLength = sr.height()
+                sliderMin = gr.y()
+                sliderMax = gr.bottom() - sliderLength + 1
+            self.setValue(
+                QStyle.sliderValueFromPosition(
+                    self.minimum(),
+                    self.maximum(),
+                    pos - sliderMin - sliderLength // 2,
+                    sliderMax - sliderMin,
+                    opt.upsideDown,
+                )
+            )
+
+    def mouseMoveEvent(self, event):
+        if event.buttons() & Qt.LeftButton:
+            # dragging with the mouse button down should move the slider
+            self._move_to_mouse_position(event)
+            return
+        return super().mouseMoveEvent(event)
+
     def mousePressEvent(self, event):
         if event.button() == Qt.LeftButton:
-            opt = QStyleOptionSlider()
-            self.initStyleOption(opt)
-            control = self.style().hitTestComplexControl(
-                QStyle.CC_ScrollBar, opt, event.pos(), self
-            )
-            if (
-                control == QStyle.SC_ScrollBarAddPage
-                or control == QStyle.SC_ScrollBarSubPage
-            ):
-                # scroll here
-                gr = self.style().subControlRect(
-                    QStyle.CC_ScrollBar, opt, QStyle.SC_ScrollBarGroove, self
-                )
-                sr = self.style().subControlRect(
-                    QStyle.CC_ScrollBar, opt, QStyle.SC_ScrollBarSlider, self
-                )
-                if self.orientation() == Qt.Horizontal:
-                    pos = event.pos().x()
-                    sliderLength = sr.width()
-                    sliderMin = gr.x()
-                    sliderMax = gr.right() - sliderLength + 1
-                    if self.layoutDirection() == Qt.RightToLeft:
-                        opt.upsideDown = not opt.upsideDown
-                else:
-                    pos = event.pos().y()
-                    sliderLength = sr.height()
-                    sliderMin = gr.y()
-                    sliderMax = gr.bottom() - sliderLength + 1
-                self.setValue(
-                    QStyle.sliderValueFromPosition(
-                        self.minimum(),
-                        self.maximum(),
-                        pos - sliderMin - sliderLength // 2,
-                        sliderMax - sliderMin,
-                        opt.upsideDown,
-                    )
-                )
-                return
-
-        return super(ModifiedScrollBar, self).mousePressEvent(event)
+            # clicking the mouse button should move slider to the clicked point
+            self._move_to_mouse_position(event)
+            return
+        return super().mousePressEvent(event)

--- a/napari/_qt/tests/test_qt_scrollbar.py
+++ b/napari/_qt/tests/test_qt_scrollbar.py
@@ -8,4 +8,4 @@ def test_modified_scrollbar_click(qtbot):
     assert w.value() == 0
     qtbot.mousePress(w, Qt.LeftButton, pos=QPoint(50, 5))
     # the normal QScrollBar would have moved to "10"
-    assert w.value() == 50
+    assert w.value() >= 40

--- a/napari/_qt/tests/test_qt_scrollbar.py
+++ b/napari/_qt/tests/test_qt_scrollbar.py
@@ -1,0 +1,11 @@
+from qtpy.QtCore import Qt, QPoint
+from ..qt_scrollbar import ModifiedScrollBar
+
+
+def test_modified_scrollbar_click(qtbot):
+    w = ModifiedScrollBar(Qt.Horizontal)
+    w.resize(100, 10)
+    assert w.value() == 0
+    qtbot.mousePress(w, Qt.LeftButton, pos=QPoint(50, 5))
+    # the normal QScrollBar would have moved to "10"
+    assert w.value() == 50


### PR DESCRIPTION
# Description
As discussed in #607, this PR changes the behavior of the dims QScrollbars such that when the user clicks on a position in the background area, the scrollbar moves all the way to the clicked position (rather than one "page" in the direction of the click).  The default behavior is [baked into Qt](https://doc.qt.io/qt-5/qscrollbar.html#details), so I borrowed an approach from [this (relatively old and not very popular) stack overflow post](https://stackoverflow.com/questions/29710327/how-to-override-qscrollbar-onclick-default-behaviour) to extract the position from the `mousePressEvent` event and convert it into a `slider.setValue`

![ezgif-3-954ab2da6bb0](https://user-images.githubusercontent.com/1609449/68494937-3b466e00-021d-11ea-9033-d25c53533c34.gif)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# References
https://doc.qt.io/qt-5/qscrollbar.html
https://stackoverflow.com/questions/29710327/how-to-override-qscrollbar-onclick-default-behaviour

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
