### PR TITLE
Avoid numcodecs 0.6.4 for now

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,6 @@
 dask[array]>=2.1.0
 zarr>=2.3.0
+numcodecs!=0.6.4
 fsspec>=0.3.3
 imageio>=2.5.0
 ipykernel==5.1.1


### PR DESCRIPTION
It appears to not be trivial to compile numcodecs 0.6.4 on Mac or
Windows, which results in failed `pip install napari` for users. See
https://github.com/napari/napari/issues/665 for more details.