### PR TITLE
allow all animation thread tests to be +/- 1 frame

### DIFF
--- a/napari/_qt/tests/test_qt_play.py
+++ b/napari/_qt/tests/test_qt_play.py
@@ -90,12 +90,13 @@ def test_animation_thread_variants(qtbot, nframes, fps, mode, rng, result):
         current = thread.go()
     if rng:
         nrange = rng[1] - rng[0] + 1
-        assert current == rng[0] + result(nframes, nrange)
+        expected = rng[0] + result(nframes, nrange)
+        assert expected - 1 <= current <= expected + 1
     else:
         expected = result(nframes, thread.nz)
         # assert current == expected
         # relaxing for CI OSX tests
-        assert expected <= current <= expected + 1
+        assert expected - 1 <= current <= expected + 1
 
 
 def test_animation_thread_once(qtbot):


### PR DESCRIPTION
# Description
I had hoped that my revised `play_axis` tests in #607 would allow slightly stricter testing on the animation function.  But another failure [leaked through](https://cirrus-ci.com/task/6145843798736896?command=test#L452), so this PR relaxes the expectations to +/- 1 frame.  That should be enough, I but can relax more in the future if need be.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Test-fix (non-breaking change which fixes an issue)
