### PR TITLE
document qt not qt5

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For more information see our [installation tutorial](https://napari.github.io/na
 
 ## simple example
 
-From inside an IPython shell (started with `ipython --gui=qt`) or jupyter notebook (after running a cell with magic command `%gui qt5`) you can open up an interactive viewer by calling
+From inside an IPython shell (started with `ipython --gui=qt`) or jupyter notebook (after running a cell with magic command `%gui qt`) you can open up an interactive viewer by calling
 
 ```python
 from skimage import data


### PR DESCRIPTION
# Description
This PR closes #478 by correcting our docs to use `%gui qt` and not `%gui qt5` (which is PyQt5) specific. We also need to update our tutorials page