### PR TITLE
improve labels painting speed

### DIFF
--- a/benchmarks/benchmark_qt_viewer_labels.py
+++ b/benchmarks/benchmark_qt_viewer_labels.py
@@ -5,6 +5,7 @@
 import numpy as np
 import napari
 from qtpy.QtWidgets import QApplication
+import collections
 
 
 class QtViewerSingleLabels:
@@ -16,6 +17,12 @@ class QtViewerSingleLabels:
         self.data = np.random.randint(10, size=(512, 512))
         self.viewer = napari.view_labels(self.data)
         self.layer = self.viewer.layers[0]
+        self.layer.brush_size = 10
+        self.layer.mode = 'paint'
+        self.layer.selected_label = 3
+        self.layer._last_cursor_coord = (511, 511)
+        Event = collections.namedtuple('Event', 'is_dragging')
+        self.event = Event(is_dragging=True)
 
     def teardown(self):
         self.viewer.window.close()
@@ -47,3 +54,7 @@ class QtViewerSingleLabels:
             self.layer._value,
             self.layer.selected_label,
         )
+
+    def time_on_mouse_move(self):
+        """Time to drag paint on mouse move."""
+        self.layer.on_mouse_move(self.event)

--- a/benchmarks/benchmark_qt_viewer_labels.py
+++ b/benchmarks/benchmark_qt_viewer_labels.py
@@ -1,0 +1,49 @@
+# See "Writing benchmarks" in the asv docs for more information.
+# https://asv.readthedocs.io/en/latest/writing_benchmarks.html
+# or the napari documentation on benchmarking
+# https://github.com/napari/napari/blob/master/BENCHMARKS.md
+import numpy as np
+import napari
+from qtpy.QtWidgets import QApplication
+
+
+class QtViewerSingleLabels:
+    """Benchmarks for editing a single labels layer in the viewer."""
+
+    def setup(self):
+        _ = QApplication.instance() or QApplication([])
+        np.random.seed(0)
+        self.data = np.random.randint(10, size=(512, 512))
+        self.viewer = napari.view_labels(self.data)
+        self.layer = self.viewer.layers[0]
+
+    def teardown(self):
+        self.viewer.window.close()
+
+    def time_set_view_slice(self):
+        """Time to set view slice."""
+        self.layer._set_view_slice()
+
+    def time_update_thumbnail(self):
+        """Time to update thumbnail."""
+        self.layer._update_thumbnail()
+
+    def time_get_value(self):
+        """Time to get current value."""
+        self.layer.get_value()
+
+    def time_raw_to_displayed(self):
+        """Time to convert raw to displayed."""
+        self.layer._raw_to_displayed(self.layer._data_raw)
+
+    def time_paint(self):
+        """Time to paint."""
+        self.layer.paint(self.layer.coordinates, self.layer.selected_label)
+
+    def time_fill(self):
+        """Time to fill."""
+        self.layer.fill(
+            self.layer.coordinates,
+            self.layer._value,
+            self.layer.selected_label,
+        )

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -139,13 +139,13 @@ The airspeed velocity tool also supports code profiling using [`cProfile`](https
 To profile the `time_create_viewer` benchmark in napari you can run
 
 ```
-asv profile benchmark_qt_viewer.QtViewerSuite.time_create_viewer -g snakeviz
+asv profile benchmark_qt_viewer.QtViewerSuite.time_create_viewer -g snakeviz --python=same
 ```
 
 or
 
 ```
-asv profile "benchmark_image_layer.Image2DSuite.time_create_layer(.*)" -g snakeviz
+asv profile "benchmark_image_layer.Image2DSuite.time_create_layer(.*)" -g snakeviz --python=same
 ```
 to profile a parametrized benchmark.
 
@@ -154,3 +154,4 @@ which you can pip install with
 ```
 pip install snakeviz
 ```
+and we use `--python=same` to profile against our current python environment.

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -549,7 +549,6 @@ class Labels(Image):
                 interp_coord = interpolate_coordinates(
                     self._last_cursor_coord, self.coordinates, self.brush_size
                 )
-            self._save_history()
             with self.events.set_data.blocker():
                 for c in interp_coord:
                     self.paint(c, new_label, refresh=False)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -545,7 +545,6 @@ class Labels(Image):
             Vispy event
         """
         if self._mode == Mode.PAINT and event.is_dragging:
-            new_label = self.selected_label
             if self._last_cursor_coord is None:
                 interp_coord = [self.coordinates]
             else:
@@ -553,7 +552,7 @@ class Labels(Image):
                     self._last_cursor_coord, self.coordinates, self.brush_size
                 )
             for c in interp_coord:
-                self.paint(c, new_label, refresh=False)
+                self.paint(c, self.selected_label, refresh=False)
             self._set_view_slice()
             self._last_cursor_coord = copy(self.coordinates)
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -459,6 +459,9 @@ class Labels(Image):
             Position of mouse cursor in image coordinates.
         new_label : int
             Value of the new label to be filled in.
+        refresh : bool
+            Whether to refresh view slice or not. Set to False to batch paint
+            calls.
         """
         if refresh is True:
             self._save_history()
@@ -549,9 +552,8 @@ class Labels(Image):
                 interp_coord = interpolate_coordinates(
                     self._last_cursor_coord, self.coordinates, self.brush_size
                 )
-            with self.events.set_data.blocker():
-                for c in interp_coord:
-                    self.paint(c, new_label, refresh=False)
+            for c in interp_coord:
+                self.paint(c, new_label, refresh=False)
             self._set_view_slice()
             self._last_cursor_coord = copy(self.coordinates)
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -448,7 +448,7 @@ class Labels(Image):
 
         self._set_view_slice()
 
-    def paint(self, coord, new_label):
+    def paint(self, coord, new_label, refresh=True):
         """Paint over existing labels with a new label, using the selected
         brush shape and size, either only on the visible slice or in all
         n dimensions.
@@ -460,7 +460,8 @@ class Labels(Image):
         new_label : int
             Value of the new label to be filled in.
         """
-        self._save_history()
+        if refresh is True:
+            self._save_history()
 
         if self.n_dimensional or self.ndim == 2:
             slice_coord = tuple(
@@ -504,7 +505,8 @@ class Labels(Image):
         # update the labels image
         self.data[slice_coord] = new_label
 
-        self._set_view_slice()
+        if refresh is True:
+            self._set_view_slice()
 
     def on_mouse_press(self, event):
         """Called whenever mouse pressed in canvas.
@@ -547,9 +549,10 @@ class Labels(Image):
                 interp_coord = interpolate_coordinates(
                     self._last_cursor_coord, self.coordinates, self.brush_size
                 )
+            self._save_history()
             with self.events.set_data.blocker():
                 for c in interp_coord:
-                    self.paint(c, new_label)
+                    self.paint(c, new_label, refresh=False)
             self._set_view_slice()
             self._last_cursor_coord = copy(self.coordinates)
 

--- a/napari/layers/labels/tests/test_labels.py
+++ b/napari/layers/labels/tests/test_labels.py
@@ -2,6 +2,7 @@ import numpy as np
 from xml.etree.ElementTree import Element
 from vispy.color import Colormap
 from napari.layers import Labels
+import collections
 
 
 def test_random_labels():
@@ -365,3 +366,21 @@ def test_xml_list():
     assert type(xml) == list
     assert len(xml) == 1
     assert type(xml[0]) == Element
+
+
+def test_mouse_move():
+    """Test painting labels with different brush sizes."""
+    np.random.seed(0)
+    data = np.random.randint(20, size=(20, 20))
+    layer = Labels(data)
+    layer.brush_size = 10
+    layer.mode = 'paint'
+    layer.selected_label = 3
+    layer._last_cursor_coord = (0, 0)
+    layer.coordinates = (19, 19)
+    Event = collections.namedtuple('Event', 'is_dragging')
+    event = Event(is_dragging=True)
+    layer.on_mouse_move(event)
+
+    assert np.unique(layer.data[:5, :5]) == 3
+    assert np.unique(layer.data[-5:, -5:]) == 3


### PR DESCRIPTION
# Description
This PR begins to address https://github.com/napari/napari/issues/569 by improving the labels painting speed - it does this by removing unnecessary calls to `_set_view_slice`. Fixes like #204 will improve this further, but this is already a large improvement, try it out when painting on a `(2048, 2048)` image, it goes from unusable, to not very good ;-) `(1024, 1024)` is now not too bad.
Note that this PR doesn't affect the speed of one individual `Paint` call, it just bundles the refreshing of many paint calls. It also adds a dedicated benchmark for the individual `Paint` call
 