### PR TITLE
support multichannel dask array

### DIFF
--- a/napari/components/tests/test_multichannel.py
+++ b/napari/components/tests/test_multichannel.py
@@ -1,4 +1,5 @@
 import numpy as np
+import dask.array as da
 from napari.components import ViewerModel
 from napari.util import colormaps
 
@@ -174,3 +175,15 @@ def test_rgb_images():
     for i in range(data.shape[-1]):
         assert viewer.layers[i].rgb is True
         assert viewer.layers[i]._data_view.ndim == 3
+
+
+def test_dask_array():
+    """Test adding multichannel dask array."""
+    viewer = ViewerModel()
+    np.random.seed(0)
+    data = da.random.random((2, 10, 10, 5))
+    viewer.add_image(data, channel_axis=0)
+    assert len(viewer.layers) == data.shape[0]
+    for i in range(data.shape[0]):
+        assert viewer.layers[i].data.shape == data.shape[1:]
+        assert isinstance(viewer.layers[i].data, da.Array)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -545,11 +545,11 @@ class ViewerModel(KeymapMixin):
             for i, cmap, clims, _gamma, name in zipped_args:
                 if is_pyramid:
                     image = [
-                        data[j].take(i, axis=channel_axis)
+                        np.take(data[j], i, axis=channel_axis)
                         for j in range(len(data))
                     ]
                 else:
-                    image = data.take(i, axis=channel_axis)
+                    image = np.take(data, i, axis=channel_axis)
                 layer = layers.Image(
                     image,
                     rgb=rgb,


### PR DESCRIPTION
# Description
This PR closes #700 by switching to `np.take` calls, which still return dask arrays. It also adds a test to check dask arrays are supported. More generally we should probably add tests for dask arrays to more places in the code base, but that can come in followup PRs.

@tlambert03 can you confirm this works for you / isn't actually triggering compute on the dask array but doing lazy indexing.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] add test to `test_multichannel.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
