### PR TITLE
Don't calc_data_range on uint8 data

### DIFF
--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -268,7 +268,14 @@ def calc_data_range(data):
     -------
     values : list of float
         Range of values.
+
+    Notes
+    -----
+    If the data type is uint8, no calculation is performed, and 0-255 is
+    returned.
     """
+    if data.dtype == np.uint8:
+        return [0, 255]
     if np.prod(data.shape) > 1e6:
         # If data is very large take the average of the top, bottom, and
         # middle slices

--- a/napari/util/tests/test_misc.py
+++ b/napari/util/tests/test_misc.py
@@ -1,4 +1,6 @@
+import time
 import numpy as np
+import dask.array as da
 from skimage.transform import pyramid_gaussian
 from napari.util.misc import (
     is_rgb,
@@ -64,6 +66,25 @@ def test_calc_data_range():
     data[0, 0, 1] = 2
     clim = calc_data_range(data)
     assert np.all(clim == [0, 2])
+
+
+def test_calc_data_fast_uint8():
+    data = da.random.randint(
+        0,
+        100,
+        size=(100_000, 1000, 1000),
+        chunks=(1, 1000, 1000),
+        dtype=np.uint8,
+    )
+    assert calc_data_range(data) == [0, 255]
+
+
+def test_calc_data_range_fast_big():
+    data = da.random.random(size=(100_000, 1000, 1000), chunks=(1, 1000, 1000))
+    t0 = time.time()
+    _ = calc_data_range(data)
+    t1 = time.time()
+    assert t1 - t0 < 1
 
 
 def test_is_pyramid():

--- a/napari/util/tests/test_misc.py
+++ b/napari/util/tests/test_misc.py
@@ -84,7 +84,7 @@ def test_calc_data_range_fast_big():
     t0 = time.time()
     _ = calc_data_range(data)
     t1 = time.time()
-    assert t1 - t0 < 1
+    assert t1 - t0 < 2
 
 
 def test_is_pyramid():


### PR DESCRIPTION
# Description
We've had a few issues with `calc_data_range` being too brittle. In some cases, for example with bad chunking, even on lazy arrays it is too slow (see e.g. [this image.sc post](https://forum.image.sc/t/napari-issues-it-works-but-no-gpu-and-the-gui-is-all-squashed/31411), while, in other cases, e.g. #624, sampling a few planes does not result in correct estimation of the min and max.

Doing the right thing in all cases is tricky, but for uint8 images (both of the above cases), I think that 0-255 is a sufficiently narrow range that we can just set it to that.

As a bonus I've added a test to ensure that we don't instantiate big dask arrays when using calc_data_range. 

The one case where I see this failing is if someone has a uint8 image with values 0 and 1, when you will have an image that is completely black. I think this is less critical and should be solved in a future PR.