### PR TITLE
allows Path in io.magic_imread, fixes #708

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -470,7 +470,8 @@ class ViewerModel(KeymapMixin):
         visible : bool
             Whether the layer visual is currently being displayed.
         path : str or list of str
-            Path or list of paths to image data.
+            Path or list of paths to image data. Paths can be passed as strings
+            or `pathlib.Path` instances.
 
         Returns
         -------

--- a/napari/util/io.py
+++ b/napari/util/io.py
@@ -20,7 +20,9 @@ def magic_imread(filenames, *, use_dask=None, stack=True):
     Parameters
     -------
     filenames : list
-        List of filenames or directories to be opened
+        List of filenames or directories to be opened.
+        A list of `pathlib.Path` objects and a single filename or `Path` object
+        are also accepted.
     use_dask : bool
         Whether to use dask to create a lazy array, rather than NumPy.
         Default of None will resolve to True if filenames contains more than

--- a/napari/util/io.py
+++ b/napari/util/io.py
@@ -1,5 +1,7 @@
 import os
+
 from glob import glob
+from pathlib import Path
 
 import numpy as np
 from skimage import io
@@ -32,6 +34,10 @@ def magic_imread(filenames, *, use_dask=None, stack=True):
     image : array-like
         Array or list of images
     """
+    # cast Path to string
+    if isinstance(filenames, Path):
+        filenames = filenames.as_posix()
+
     if len(filenames) == 0:
         return None
     if isinstance(filenames, str):

--- a/napari/util/tests/test_io.py
+++ b/napari/util/tests/test_io.py
@@ -1,4 +1,6 @@
 import os
+from pathlib import Path
+
 import numpy as np
 from dask import array as da
 from skimage.data import data_dir
@@ -45,6 +47,20 @@ def single_tiff():
 
 def test_single_png_defaults(single_png):
     image_files = single_png
+    images = io.magic_imread(image_files)
+    assert isinstance(images, np.ndarray)
+    assert images.shape == (512, 512)
+
+
+def test_single_png_single_file(single_png):
+    image_files = single_png[0]
+    images = io.magic_imread(image_files)
+    assert isinstance(images, np.ndarray)
+    assert images.shape == (512, 512)
+
+
+def test_single_png_pathlib(single_png):
+    image_files = Path(single_png[0])
     images = io.magic_imread(image_files)
     assert isinstance(images, np.ndarray)
     assert images.shape == (512, 512)

--- a/napari/util/tests/test_io.py
+++ b/napari/util/tests/test_io.py
@@ -73,6 +73,13 @@ def test_multi_png_defaults(two_pngs):
     assert images.shape == (2, 512, 512)
 
 
+def test_multi_png_pathlib(two_pngs):
+    image_files = [Path(png) for png in two_pngs]
+    images = io.magic_imread(image_files)
+    assert isinstance(images, da.Array)
+    assert images.shape == (2, 512, 512)
+
+
 def test_multi_png_no_dask(two_pngs):
     image_files = two_pngs
     images = io.magic_imread(image_files, use_dask=False)

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -85,7 +85,8 @@ def view_image(
     visible : bool
         Whether the layer visual is currently being displayed.
     path : str or list of str
-        Path or list of paths to image data.
+        Path or list of paths to image data. Paths can be passed as strings
+        or `pathlib.Path` instances.
     title : string
         The title of the viewer window.
     ndisplay : {2, 3}


### PR DESCRIPTION
# Description

Avoids io.magic_read to raise a `TypeError` when passed a `Path` object, casts `Path` objects to string.

## Type of change

- [ ] Bug-fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
closes #708 

# How has this been tested?
I added three tests in `util/tests/test_io.py` to test the input

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
> actually I'm not sure the documentation needs to be changed
- [X] I have added tests that prove my fix is effective or that my feature works
