### PR TITLE
expose iso surface threshold

### DIFF
--- a/napari/_qt/layers/qt_image_layer.py
+++ b/napari/_qt/layers/qt_image_layer.py
@@ -11,6 +11,7 @@ class QtImageControls(QtBaseImageControls):
         self.layer.events.interpolation.connect(self._on_interpolation_change)
         self.layer.events.rendering.connect(self._on_rendering_change)
         self.layer.events.iso_threshold.connect(self._on_iso_threshold_change)
+        self.layer.dims.events.ndisplay.connect(self._on_ndisplay_change)
 
         interp_comboBox = QComboBox()
         for interp in Interpolation:
@@ -23,6 +24,7 @@ class QtImageControls(QtBaseImageControls):
             lambda text=interp_comboBox: self.changeInterpolation(text)
         )
         self.interpComboBox = interp_comboBox
+        self.interpLabel = QLabel('interpolation:')
 
         renderComboBox = QComboBox()
         for render in Rendering:
@@ -35,6 +37,7 @@ class QtImageControls(QtBaseImageControls):
             lambda text=renderComboBox: self.changeRendering(text)
         )
         self.renderComboBox = renderComboBox
+        self.renderLabel = QLabel('rendering:')
 
         sld = QSlider(Qt.Horizontal)
         sld.setFocusPolicy(Qt.NoFocus)
@@ -46,6 +49,7 @@ class QtImageControls(QtBaseImageControls):
             lambda value=sld: self.changeIsoTheshold(value)
         )
         self.isoThesholdSilder = sld
+        self.isoThesholdLabel = QLabel('iso threshold:')
 
         # grid_layout created in QtLayerControls
         # addWidget(widget, row, column, [row_span, column_span])
@@ -55,18 +59,18 @@ class QtImageControls(QtBaseImageControls):
         self.grid_layout.addWidget(self.contrastLimitsSlider, 1, 3, 1, 4)
         self.grid_layout.addWidget(QLabel('gamma:'), 2, 0, 1, 3)
         self.grid_layout.addWidget(self.gammaSlider, 2, 3, 1, 4)
-        self.grid_layout.addWidget(QLabel('iso threshold:'), 3, 0, 1, 3)
+        self.grid_layout.addWidget(self.isoThesholdLabel, 3, 0, 1, 3)
         self.grid_layout.addWidget(self.isoThesholdSilder, 3, 3, 1, 4)
         self.grid_layout.addWidget(QLabel('colormap:'), 4, 0, 1, 3)
         self.grid_layout.addWidget(self.colormapComboBox, 4, 3, 1, 3)
         self.grid_layout.addWidget(self.colorbarLabel, 4, 6)
         self.grid_layout.addWidget(QLabel('blending:'), 5, 0, 1, 3)
         self.grid_layout.addWidget(self.blendComboBox, 5, 3, 1, 4)
-        self.grid_layout.addWidget(QLabel('rendering:'), 6, 0, 1, 3)
+        self.grid_layout.addWidget(self.renderLabel, 6, 0, 1, 3)
         self.grid_layout.addWidget(self.renderComboBox, 6, 3, 1, 4)
-        self.grid_layout.addWidget(QLabel('interpolation:'), 7, 0, 1, 3)
+        self.grid_layout.addWidget(self.interpLabel, 7, 0, 1, 3)
         self.grid_layout.addWidget(self.interpComboBox, 7, 3, 1, 4)
-        self.grid_layout.setRowStretch(7, 1)
+        self.grid_layout.setRowStretch(8, 1)
         self.grid_layout.setVerticalSpacing(4)
 
     def changeInterpolation(self, text):
@@ -74,6 +78,7 @@ class QtImageControls(QtBaseImageControls):
 
     def changeRendering(self, text):
         self.layer.rendering = text
+        self._toggle_iso_threhold_visbility()
 
     def changeIsoTheshold(self, value):
         with self.layer.events.blocker(self._on_iso_threshold_change):
@@ -96,3 +101,30 @@ class QtImageControls(QtBaseImageControls):
                 self.layer.rendering, Qt.MatchFixedString
             )
             self.renderComboBox.setCurrentIndex(index)
+            self._toggle_iso_threhold_visbility()
+
+    def _toggle_iso_threhold_visbility(self):
+        rendering = self.layer.rendering
+        if isinstance(rendering, str):
+            rendering = Rendering(rendering)
+        if rendering == Rendering.ISO:
+            self.isoThesholdSilder.show()
+            self.isoThesholdLabel.show()
+        else:
+            self.isoThesholdSilder.hide()
+            self.isoThesholdLabel.hide()
+
+    def _on_ndisplay_change(self, event):
+        if self.layer.dims.ndisplay == 2:
+            self.isoThesholdSilder.hide()
+            self.isoThesholdLabel.hide()
+            self.renderComboBox.hide()
+            self.renderLabel.hide()
+            self.interpComboBox.show()
+            self.interpLabel.show()
+        else:
+            self.renderComboBox.show()
+            self.renderLabel.show()
+            self.interpComboBox.hide()
+            self.interpLabel.hide()
+            self._toggle_iso_threhold_visbility()

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -3,6 +3,7 @@ from vispy.scene.visuals import Volume as VolumeNode
 from vispy.color import Colormap
 import numpy as np
 from .vispy_base_layer import VispyBaseLayer
+from ..layers.image._constants import Rendering
 
 texture_dtypes = [
     np.dtype(np.int8),
@@ -119,7 +120,10 @@ class VispyImageLayer(VispyBaseLayer):
         self._on_colormap_change()
 
     def _on_iso_threshold_change(self):
-        if self.layer.dims.ndisplay == 3 and self.layer.rendering == 'iso':
+        rendering = self.layer.rendering
+        if isinstance(rendering, str):
+            rendering = Rendering(rendering)
+        if self.layer.dims.ndisplay == 3 and rendering == Rendering.ISO:
             self.node.threshold = float(self.layer.iso_threshold)
             self.node.shared_program['u_threshold'] = self.node.threshold
 

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -31,6 +31,9 @@ class VispyImageLayer(VispyBaseLayer):
             lambda e: self._on_contrast_limits_change()
         )
         self.layer.events.gamma.connect(lambda e: self._on_gamma_change())
+        self.layer.events.iso_threshold.connect(
+            lambda e: self._on_iso_threshold_change()
+        )
 
         self._on_display_change()
         self._on_data_change()
@@ -86,8 +89,9 @@ class VispyImageLayer(VispyBaseLayer):
             self.node.interpolation = self.layer.interpolation
 
     def _on_rendering_change(self):
-        if not self.layer.dims.ndisplay == 2:
+        if self.layer.dims.ndisplay == 3:
             self.node.method = self.layer.rendering
+            self._on_iso_threshold_change()
 
     def _on_colormap_change(self):
         cmap = self.layer.colormap[1]
@@ -111,6 +115,10 @@ class VispyImageLayer(VispyBaseLayer):
 
     def _on_gamma_change(self):
         self._on_colormap_change()
+
+    def _on_iso_threshold_change(self):
+        if self.layer.dims.ndisplay == 3 and self.layer.rendering == 'iso':
+            self.node.threshold = self.layer.iso_threshold
 
     def _on_scale_change(self):
         self.scale = [
@@ -216,5 +224,6 @@ class VispyImageLayer(VispyBaseLayer):
         self._on_interpolation_change()
         self._on_rendering_change()
         self._on_colormap_change()
+        self._on_iso_threshold_change()
         if self.layer.dims.ndisplay == 2:
             self._on_contrast_limits_change()

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -401,6 +401,7 @@ class ViewerModel(KeymapMixin):
         gamma=1,
         interpolation='nearest',
         rendering='mip',
+        iso_threshold=0.5,
         name=None,
         metadata=None,
         scale=None,
@@ -453,6 +454,8 @@ class ViewerModel(KeymapMixin):
         interpolation : str
             Interpolation mode used by vispy. Must be one of our supported
             modes.
+        iso_threshold : float
+            Threshold for isosurface.
         name : str
             Name of the layer.
         metadata : dict
@@ -499,6 +502,7 @@ class ViewerModel(KeymapMixin):
                 gamma=gamma,
                 interpolation=interpolation,
                 rendering=rendering,
+                iso_threshold=iso_threshold,
                 name=name,
                 metadata=metadata,
                 scale=scale,

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -55,6 +55,8 @@ class Image(Layer):
     interpolation : str
         Interpolation mode used by vispy. Must be one of our supported
         modes.
+    iso_threshold : float
+        Threshold for isosurface.
     name : str
         Name of the layer.
     metadata : dict
@@ -105,6 +107,8 @@ class Image(Layer):
         rgb the contrast_limits_range is ignored.
     gamma : float
         Gamma correction for determining colormap linearity.
+    iso_threshold : float
+        Threshold for isosurface.
     interpolation : str
         Interpolation mode used by vispy. Must be one of our supported modes.
 
@@ -132,6 +136,7 @@ class Image(Layer):
         gamma=1,
         interpolation='nearest',
         rendering='mip',
+        iso_threshold=0.5,
         name=None,
         metadata=None,
         scale=None,
@@ -164,6 +169,7 @@ class Image(Layer):
             colormap=Event,
             interpolation=Event,
             rendering=Event,
+            iso_threshold=Event,
         )
 
         # Set data
@@ -188,6 +194,7 @@ class Image(Layer):
 
         # Set contrast_limits and colormaps
         self._gamma = gamma
+        self._iso_threshold = iso_threshold
         self._colormap_name = ''
         self._contrast_limits_msg = ''
         if contrast_limits is None:
@@ -343,6 +350,18 @@ class Image(Layer):
         self._gamma = value
         self._update_thumbnail()
         self.events.gamma()
+
+    @property
+    def iso_threshold(self):
+        """float: threshold for isosurface."""
+        return self._iso_threshold
+
+    @iso_threshold.setter
+    def iso_threshold(self, value):
+        self.status = format_float(value)
+        self._iso_threshold = value
+        self._update_thumbnail()
+        self.events.iso_threshold()
 
     @property
     def interpolation(self):

--- a/napari/layers/image/tests/test_image.py
+++ b/napari/layers/image/tests/test_image.py
@@ -417,6 +417,23 @@ def test_gamma():
     assert layer.gamma == gamma
 
 
+def test_iso_threshold():
+    """Test setting iso_threshold."""
+    np.random.seed(0)
+    data = np.random.random((10, 15))
+    layer = Image(data)
+    assert layer.iso_threshold == 0.5
+
+    # Change iso_threshold property
+    iso_threshold = 0.7
+    layer.iso_threshold = iso_threshold
+    assert layer.iso_threshold == iso_threshold
+
+    # Set iso_threshold as keyword argument
+    layer = Image(data, iso_threshold=iso_threshold)
+    assert layer.iso_threshold == iso_threshold
+
+
 def test_metadata():
     """Test setting image metadata."""
     np.random.seed(0)

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -12,6 +12,7 @@ def view_image(
     gamma=1,
     interpolation='nearest',
     rendering='mip',
+    iso_threshold=0.5,
     name=None,
     metadata=None,
     scale=None,
@@ -68,6 +69,8 @@ def view_image(
     interpolation : str
         Interpolation mode used by vispy. Must be one of our supported
         modes.
+    iso_threshold : float
+        Threshold for isosurface.
     name : str
         Name of the layer.
     metadata : dict
@@ -116,6 +119,7 @@ def view_image(
         gamma=gamma,
         interpolation=interpolation,
         rendering=rendering,
+        iso_threshold=iso_threshold,
         name=name,
         metadata=metadata,
         scale=scale,


### PR DESCRIPTION
# Description
This PR exposes the iso surface threshold as a slider on image layers (it was previously hard coded to 0 making it not useful). It will close #572. 

The range of the iso surface threshold is always 0 to 1, with 0 rendering just the surface of the volume normally and 1 rendering nothing, I find it slightly counter-intuitive that moving the slider from left to right reduces what you see on the screen, but maybe it's just me and everyone else thinks its ok.

Right now I also get a vispy warning when first setting the iso surface threshold variable
```
INFO: Not setting value for variable float u_threshold; uniform is not active.
```
I should probably figure that out before we merge this.

Finally I don't love the colormap of the iso surface, it is hardcoded to max out on this slightly odd green. Maybe we can fix this before merging this PR.

Despite these caveats I think the PR is ready for review

![iso_surface2](https://user-images.githubusercontent.com/6531703/69171643-3309f080-0ab1-11ea-851e-33fadbd11abc.gif)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added tests to the image model

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
