### PR TITLE
relax play_api

### DIFF
--- a/napari/_qt/tests/test_qt_play.py
+++ b/napari/_qt/tests/test_qt_play.py
@@ -167,7 +167,7 @@ def test_play_api(qtbot, view):
     with qtbot.waitSignal(view.dims._animation_thread.finished, timeout=7000):
         view.dims.stop()
     A = view.dims._frame
-    assert A > 3
+    assert A >= 3
 
     # make sure the stop button actually worked
     qtbot.wait(150)


### PR DESCRIPTION
# Description
Another test relaxation for `test_play_api`.  There was a failure in osx py3.7 [here](https://cirrus-ci.com/task/4870346624204800).  This is a different test than I relaxed before, so hopefully this will be the last of them.
