### PR TITLE
raise main window when showing

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -247,6 +247,8 @@ class Window:
         """
         self._qt_window.resize(self._qt_window.layout().sizeHint())
         self._qt_window.show()
+        # make sure window is not hidden, e.g. by browser window in Jupyter
+        self._qt_window.raise_()
 
     def _update_palette(self, palette):
         # set window styles which don't use the primary stylesheet


### PR DESCRIPTION
# Description
When using napari in, for example, a jupyter notebook.  Only the first call to `napari.view_image()` will raise the window above the browser.  In later calls, the window is opened in the background, but the user may not know it if their browser window is occluding the napari window (see gif).

This one-line PR adds a `_qt_window.raise_()` call to the `Window.show()` method to ensure that the window is visible when show() has been called

![Untitled](https://user-images.githubusercontent.com/1609449/69433988-b1ad9a80-0d0a-11ea-8f4d-be1e8d0aa1d3.gif)


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas