### PR TITLE
add main window option to screenshots

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -30,6 +30,7 @@ from qtpy.QtWidgets import (  # noqa: E402
 )
 from qtpy.QtGui import QKeySequence  # noqa: E402
 from qtpy.QtCore import Qt  # noqa: E402
+from .util import QImg2array  # noqa: E402
 from ..util.theme import template  # noqa: E402
 
 
@@ -279,6 +280,18 @@ class Window:
         """Update help message on status bar.
         """
         self._help.setText(event.text)
+
+    def screenshot(self):
+        """Take currently displayed viewer and convert to an image array.
+
+        Returns
+        -------
+        image : array
+            Numpy array of type ubyte and shape (h, w, 4). Index [0, 0] is the
+            upper-left corner of the rendered region.
+        """
+        img = self._qt_window.grab().toImage()
+        return QImg2array(img)
 
     def closeEvent(self, event):
         # Forward close event to the console to trigger proper shutdown

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -1,5 +1,4 @@
 import os.path
-import numpy as np
 import inspect
 from pathlib import Path
 
@@ -26,6 +25,7 @@ from ..util.misc import (
 )
 from ..util.keybindings import components_to_key_combo
 
+from .util import QImg2array
 from .qt_controls import QtControls
 from .qt_viewer_buttons import QtLayerButtons, QtViewerButtons
 from .qt_console import QtConsole
@@ -195,22 +195,7 @@ class QtViewer(QSplitter):
             upper-left corner of the rendered region.
         """
         img = self.canvas.native.grabFramebuffer()
-        b = img.constBits()
-        h, w, c = img.height(), img.width(), 4
-
-        # As vispy doesn't use qtpy we need to reconcile the differences
-        # between the `QImage` API for `PySide2` and `PyQt5` on how to convert
-        # a QImage to a numpy array.
-        if API_NAME == 'PySide2':
-            arr = np.array(b).reshape(h, w, c)
-        else:
-            b.setsize(h * w * c)
-            arr = np.frombuffer(b, np.uint8).reshape(h, w, c)
-
-        # Format of QImage is ARGB32_Premultiplied, but color channels are
-        # reversed.
-        arr = arr[:, :, [2, 1, 0, 3]]
-        return arr
+        return QImg2array(img)
 
     def _open_images(self):
         """Add image files from the menubar."""

--- a/napari/_qt/util.py
+++ b/napari/_qt/util.py
@@ -1,0 +1,34 @@
+import numpy as np
+from qtpy import API_NAME
+
+
+def QImg2array(img):
+    """Convert QImage to an array.
+
+    Parameters
+    ----------
+    img : qtpy.QtGui.QImage
+        QImage to be converted.
+
+    Returns
+    -------
+    arr : array
+        Numpy array of type ubyte and shape (h, w, 4). Index [0, 0] is the
+        upper-left corner of the rendered region.
+    """
+    b = img.constBits()
+    h, w, c = img.height(), img.width(), 4
+
+    # As vispy doesn't use qtpy we need to reconcile the differences
+    # between the `QImage` API for `PySide2` and `PyQt5` on how to convert
+    # a QImage to a numpy array.
+    if API_NAME == 'PySide2':
+        arr = np.array(b).reshape(h, w, c)
+    else:
+        b.setsize(h * w * c)
+        arr = np.frombuffer(b, np.uint8).reshape(h, w, c)
+
+    # Format of QImage is ARGB32_Premultiplied, but color channels are
+    # reversed.
+    arr = arr[:, :, [2, 1, 0, 3]]
+    return arr

--- a/napari/tests/test_viewer.py
+++ b/napari/tests/test_viewer.py
@@ -348,6 +348,10 @@ def test_screenshot(qtbot):
     screenshot = viewer.screenshot()
     assert screenshot.ndim == 3
 
+    # Take screenshot with the viewer included
+    screenshot = viewer.screenshot(with_viewer=True)
+    assert screenshot.ndim == 3
+
     # Close the viewer
     viewer.window.close()
 

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -52,8 +52,28 @@ class Viewer(ViewerModel):
         )
         qt_viewer = QtViewer(self)
         self.window = Window(qt_viewer)
-        self.screenshot = self.window.qt_viewer.screenshot
         self.update_console = self.window.qt_viewer.console.push
+
+    def screenshot(self, with_viewer=False):
+        """Take currently displayed screen and convert to an image array.
+
+        Parameters
+        ----------
+        with_viewer : bool
+            If True includes the napari viewer, otherwise just includes the
+            canvas.
+
+        Returns
+        -------
+        image : array
+            Numpy array of type ubyte and shape (h, w, 4). Index [0, 0] is the
+            upper-left corner of the rendered region.
+        """
+        if with_viewer:
+            image = self.window.screenshot()
+        else:
+            image = self.window.qt_viewer.screenshot()
+        return image
 
     def update(self, func, *args, **kwargs):
         t = QtUpdateUI(func, *args, **kwargs)


### PR DESCRIPTION
# Description
This PR adds a keyword arg `with_viewer` to our `viewer.screenshot` method that now allows you to capture the whole of napari main window when taking a screenshot. it could be useful for creating movies where you want to see the whole main window, or for us if we ever want to start doing pixel tests of screenshots as part of testing our UI.

This screenshot won't capture things like the cursor position etc. so there will still be a place for making gifs using things like LICEcap, but I thought this still might be useful.

Here's a screenshot of napari with a screenshot of napari inside it ;-)

<img width="1200" alt="Screen Shot 2019-11-22 at 11 45 46 AM" src="https://user-images.githubusercontent.com/6531703/69455938-538ab280-0d1e-11ea-89ac-c0d6f41f5749.png">

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added test in `test_viewer.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
