### PR TITLE
Zenodo badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/napari.svg)](https://pypistats.org/packages/napari)
 [![Development Status](https://img.shields.io/pypi/status/napari.svg)](https://github.com/napari/napari)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
+[![DOI](https://zenodo.org/badge/144513571.svg)](https://zenodo.org/badge/latestdoi/144513571)
 
 **napari** is a fast, interactive, multi-dimensional image viewer for Python. It's designed for browsing, annotating, and analyzing large multi-dimensional images. It's built on top of `Qt` (for the GUI), `vispy` (for performant GPU-based rendering), and the scientific Python stack (`numpy`, `scipy`).
 
@@ -93,6 +94,12 @@ Contributions are encouraged! Please read our [contributing guide](./docs/CONTRI
 ## code of conduct
 
 `napari` has a [Code of Conduct](./docs/CODE_OF_CONDUCT.md) that should be honored by everyone who participates in the `napari` community.
+
+## citing napari
+
+If you find `napari` useful please cite this repository using its DOI as follows:
+
+napari team (2019). napari: a multi-dimensional image viewer for python. ![DOI](https://zenodo.org/badge/144513571.svg)
 
 ## help
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,10 @@ Contributions are encouraged! Please read our [contributing guide](./docs/CONTRI
 
 If you find `napari` useful please cite this repository using its DOI as follows:
 
-napari team (2019). napari: a multi-dimensional image viewer for python. ![DOI](https://zenodo.org/badge/144513571.svg)
+> napari team (2019). napari: a multi-dimensional image viewer for python. [doi:10.5281/zenodo.3555620](https://zenodo.org/record/3555620)
+
+Note this DOI will resolve to all versions of napari. To cite a specific version please find the
+DOI of that version on our [zenodo page](https://zenodo.org/record/3555620).
 
 ## help
 


### PR DESCRIPTION
# Description
This PR closed #711 and adds a zenodo badge and citation information. The DOI of the badge will always resolve to our latest release. Note that releases are different from tags, so we have a lot of control when we make them. (I unintentionally did turn `0.2.6rc2` into a release so we have a DOI for that, but I don't think it really matters and DOIs are hard to get rid of).

In the citation information I use the DOI that will always resolve to the latest `napari`, instead we could encourage people to use the DOI of their release, but I'm not sure there is much gained from that. Curious how others feel. We could also add the DOI / citation information to our drop-down menu (though there we probably need to use the global DOI otherwise we'd always be a DOI behind / have complex syncing problems).

You can see the zenodo reference here - https://zenodo.org/record/3555620. Turns out this is all auto generated and includes the release notes from our latest release, which I had manually copied and pasted in https://github.com/napari/napari/releases/tag/v0.2.6. It also autogenerated the author list based on # of contributions and names / github handles. I'm pretty sure I can go in and edit that manually if people want, though I do feel expectations around author lists are different for repos vs papers and we do plan to write a paper (at which point I think we need to ask people to cite both the paper and the repo??, we can deal with that later).

Curious for thoughts @jni @royerloic 