### PR TITLE
show splash screen

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -50,7 +50,7 @@ def main():
         'only a single image is given.',
     )
     args = parser.parse_args()
-    with gui_qt():
+    with gui_qt(startup_logo=True):
         v = Viewer()
         if len(args.images) > 0:
             images = io.magic_imread(

--- a/napari/_qt/event_loop.py
+++ b/napari/_qt/event_loop.py
@@ -7,12 +7,12 @@ from qtpy.QtWidgets import QApplication, QSplashScreen
 
 
 @contextmanager
-def gui_qt(splash_screen=True):
+def gui_qt(*, startup_logo=False):
     """Start a Qt event loop in which to run the application.
 
     Parameters
     ----------
-    splash_screen : bool
+    startup_logo : bool
         Show a splash screen with the napari logo during startup.
 
     Notes
@@ -23,11 +23,11 @@ def gui_qt(splash_screen=True):
     ``ipython --gui=qt``.
     """
     app = QApplication.instance() or QApplication(sys.argv)
-    if splash_screen:
+    if startup_logo:
         logopath = join(dirname(__file__), '..', 'resources', 'logo.png')
         splash_widget = QSplashScreen(QPixmap(logopath).scaled(400, 400))
         splash_widget.show()
     yield
-    if splash_screen:
+    if startup_logo:
         splash_widget.close()
     app.exec_()

--- a/napari/_qt/event_loop.py
+++ b/napari/_qt/event_loop.py
@@ -1,7 +1,9 @@
 import sys
 from contextlib import contextmanager
+from os.path import dirname, join
 
-from qtpy.QtWidgets import QApplication
+from qtpy.QtGui import QPixmap
+from qtpy.QtWidgets import QApplication, QSplashScreen
 
 
 @contextmanager
@@ -16,5 +18,9 @@ def gui_qt():
     ``ipython --gui=qt``.
     """
     app = QApplication.instance() or QApplication(sys.argv)
+    logopath = join(dirname(__file__), '..', 'resources', 'logo.png')
+    splash_screen = QSplashScreen(QPixmap(logopath).scaled(400, 400))
+    splash_screen.show()
     yield
+    splash_screen.close()
     app.exec_()

--- a/napari/_qt/event_loop.py
+++ b/napari/_qt/event_loop.py
@@ -7,8 +7,13 @@ from qtpy.QtWidgets import QApplication, QSplashScreen
 
 
 @contextmanager
-def gui_qt():
+def gui_qt(splash_screen=True):
     """Start a Qt event loop in which to run the application.
+
+    Parameters
+    ----------
+    splash_screen : bool
+        Show a splash screen with the napari logo during startup.
 
     Notes
     -----
@@ -18,9 +23,11 @@ def gui_qt():
     ``ipython --gui=qt``.
     """
     app = QApplication.instance() or QApplication(sys.argv)
-    logopath = join(dirname(__file__), '..', 'resources', 'logo.png')
-    splash_screen = QSplashScreen(QPixmap(logopath).scaled(400, 400))
-    splash_screen.show()
+    if splash_screen:
+        logopath = join(dirname(__file__), '..', 'resources', 'logo.png')
+        splash_widget = QSplashScreen(QPixmap(logopath).scaled(400, 400))
+        splash_widget.show()
     yield
-    splash_screen.close()
+    if splash_screen:
+        splash_widget.close()
     app.exec_()

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,7 +1,7 @@
 from os.path import dirname, join
 
-from qtpy.QtGui import QIcon, QPixmap
-from qtpy.QtWidgets import QApplication, QSplashScreen
+from qtpy.QtGui import QIcon
+from qtpy.QtWidgets import QApplication
 
 from napari._qt.qt_update_ui import QtUpdateUI
 
@@ -50,8 +50,6 @@ class Viewer(ViewerModel):
             raise RuntimeError(message)
 
         logopath = join(dirname(__file__), 'resources', 'logo.png')
-        splash_screen = QSplashScreen(QPixmap(logopath).scaled(400, 400))
-        splash_screen.show()
         app.setWindowIcon(QIcon(logopath))
 
         super().__init__(
@@ -61,7 +59,6 @@ class Viewer(ViewerModel):
             axis_labels=axis_labels,
         )
         qt_viewer = QtViewer(self)
-        splash_screen.finish(qt_viewer)
         self.window = Window(qt_viewer)
         self.update_console = self.window.qt_viewer.console.push
 

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,7 +1,7 @@
 from os.path import dirname, join
 
-from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QApplication
+from qtpy.QtGui import QIcon, QPixmap
+from qtpy.QtWidgets import QApplication, QSplashScreen
 
 from napari._qt.qt_update_ui import QtUpdateUI
 
@@ -50,6 +50,8 @@ class Viewer(ViewerModel):
             raise RuntimeError(message)
 
         logopath = join(dirname(__file__), 'resources', 'logo.png')
+        splash_screen = QSplashScreen(QPixmap(logopath).scaled(400, 400))
+        splash_screen.show()
         app.setWindowIcon(QIcon(logopath))
 
         super().__init__(
@@ -59,6 +61,7 @@ class Viewer(ViewerModel):
             axis_labels=axis_labels,
         )
         qt_viewer = QtViewer(self)
+        splash_screen.finish(qt_viewer)
         self.window = Window(qt_viewer)
         self.update_console = self.window.qt_viewer.console.push
 


### PR DESCRIPTION
# Description
This PR closes #567 by showing the napari logo during startup on a `QSplashScreen`. It's fairly unobtrusive and I kinda like it. The splash screen only appears when launching from script / command line - and not from IPython or jupyter (not 100% sure why but that is the observed behaviour, and seems to be what @jni and @tlambert03 want).

We can also add a message to the splash screen using `showMessage` but not sure if we need that yet.

Here is launching from a script with splash screen:
![splash_screen_script](https://user-images.githubusercontent.com/6531703/69895313-f5436e00-12e1-11ea-8423-1a5275ce5e6b.gif)

Here is launching from IPython, no splash screen:
![splash_screen_ipython](https://user-images.githubusercontent.com/6531703/69895321-feccd600-12e1-11ea-8e07-2071d3535823.gif)

What do people think about this? @AhmetCanSolak @royerloic? 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

