### PR TITLE
clean up info box

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Contributions are encouraged! Please read our [contributing guide](./docs/CONTRI
 
 If you find `napari` useful please cite this repository using its DOI as follows:
 
-> napari team (2019). napari: a multi-dimensional image viewer for python. [doi:10.5281/zenodo.3555620](https://zenodo.org/record/3555620)
+> napari contributors (2019). napari: a multi-dimensional image viewer for python. [doi:10.5281/zenodo.3555620](https://zenodo.org/record/3555620)
 
 Note this DOI will resolve to all versions of napari. To cite a specific version please find the
 DOI of that version on our [zenodo page](https://zenodo.org/record/3555620).

--- a/napari/_qt/qt_about.py
+++ b/napari/_qt/qt_about.py
@@ -1,82 +1,83 @@
+import sys
+import platform
 import skimage
 import vispy
 import scipy
 import numpy
+import dask
 
-from qtpy import QtCore
+from qtpy import QtCore, API_NAME, PYSIDE_VERSION, PYQT_VERSION
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QWidget, QVBoxLayout, QLabel, QDialog, QFrame
+from qtpy.QtWidgets import QVBoxLayout, QTextEdit, QDialog, QLabel
 
 import napari
 
 
-class QtAbout(QWidget):
-    def __init__(self, parent):
-        super(QtAbout, self).__init__(parent)
+class QtAbout(QDialog):
+    def __init__(self):
+        super().__init__()
 
         self.layout = QVBoxLayout()
 
         # Description
         title_label = QLabel(
-            "<b>napari</b>: a fast n-dimensional image viewer"
+            "<b>napari: a multi-dimensional image viewer for python</b>"
         )
         title_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self.layout.addWidget(title_label)
 
-        # Horizontal Line Break
-        self.hline_break1 = QFrame()
-        self.hline_break1.setFrameShape(QFrame.HLine)
-        self.hline_break1.setFrameShadow(QFrame.Sunken)
-        self.layout.addWidget(self.hline_break1)
+        # Add information
+        self.infoTextBox = QTextEdit()
+        self.infoTextBox.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.infoTextBox.setLineWrapMode(QTextEdit.NoWrap)
+        self.layout.addWidget(self.infoTextBox, 1)
 
-        # Versions
-        versions_label = QLabel(
-            "napari, "
-            + napari.__version__
-            + "\n"
-            + "Qt, "
-            + QtCore.__version__
-            + "\n"
-            + "NumPy, "
-            + numpy.__version__
-            + "\n"
-            + "SciPy, "
-            + scipy.__version__
-            + "\n"
-            + "VisPy, "
-            + vispy.__version__
-            + "\n"
-            + "scikit-image, "
-            + skimage.__version__
-            + "\n"
+        if API_NAME == 'PySide2':
+            API_VERSION = PYSIDE_VERSION
+        elif API_NAME == 'PyQt5':
+            API_VERSION = PYQT_VERSION
+        else:
+            API_VERSION = ''
+        sys_version = sys.version.replace('\n', ' ')
+
+        versions = (
+            f"<b>napari</b>: {napari.__version__} <br>"
+            f"<b>Platform</b>: {platform.platform()} <br>"
+            f"<b>Python</b>: {sys_version} <br>"
+            f"<b>{API_NAME}</b>: {API_VERSION} <br>"
+            f"<b>Qt</b>: {QtCore.__version__} <br>"
+            f"<b>VisPy</b>: {vispy.__version__} <br>"
+            f"<b>NumPy</b>: {numpy.__version__} <br>"
+            f"<b>SciPy</b>: {scipy.__version__} <br>"
+            f"<b>scikit-image</b>: {skimage.__version__} <br>"
+            f"<b>Dask</b>: {dask.__version__} <br>"
         )
-        versions_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        self.layout.addWidget(versions_label)
 
-        # Horizontal Line Break
-        self.hline_break1 = QFrame()
-        self.hline_break1.setFrameShape(QFrame.HLine)
-        self.hline_break1.setFrameShadow(QFrame.Sunken)
-        self.layout.addWidget(self.hline_break1)
-
-        sys_info_lines = "\n".join(
-            [
-                vispy.sys_info().split("\n")[index]
-                for index in [0, 1, 3, -4, -3]
-            ]
+        sys_info_text = "<br>".join(
+            [vispy.sys_info().split("\n")[index] for index in [-4, -3]]
         )
-        sys_info_label = QLabel(sys_info_lines)
-        sys_info_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        self.layout.addWidget(sys_info_label)
+
+        text = f'{versions} <br> {sys_info_text} <br>'
+        self.infoTextBox.setText(text)
+
+        self.layout.addWidget(QLabel('<b>citation information:</b>'))
+
+        citation_text = (
+            'napari contributors (2019). napari: a '
+            'multi-dimensional image viewer for python. '
+            'doi:10.5281/zenodo.3555620'
+        )
+        self.citationTextBox = QTextEdit(citation_text)
+        self.citationTextBox.setFixedHeight(64)
+        self.layout.addWidget(self.citationTextBox)
 
         self.setLayout(self.layout)
 
     @staticmethod
     def showAbout(qt_viewer):
-        d = QDialog()
+        d = QtAbout()
         d.setObjectName('QtAbout')
         d.setStyleSheet(qt_viewer.styleSheet())
-        QtAbout(d)
         d.setWindowTitle('About')
         d.setWindowModality(Qt.ApplicationModal)
         d.exec_()

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -163,6 +163,7 @@ class Window:
         self.help_menu = self.main_menu.addMenu('&Help')
 
         about_action = QAction("napari info", self._qt_window)
+        about_action.setShortcut("Ctrl+/")
         about_action.setStatusTip('About napari')
         about_action.triggered.connect(
             lambda e: QtAbout.showAbout(self.qt_viewer)
@@ -170,7 +171,7 @@ class Window:
         self.help_menu.addAction(about_action)
 
         keybidings_action = QAction("keybindings", self._qt_window)
-        keybidings_action.setShortcut("Ctrl+/")
+        keybidings_action.setShortcut("Ctrl+Alt+/")
         keybidings_action.setStatusTip('About keybindings')
         keybidings_action.triggered.connect(
             lambda e: QtAboutKeybindings.showAbout(self.qt_viewer)

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -67,14 +67,15 @@ QDialog#QtAboutKeybindings {
 }
 
 QDialog#QtAbout {
-  min-width: 580px;
-  max-width: 580px;
-  min-height: 300px;
-  max-height: 300px;
+  min-width: 620px;
+  max-width: 620px;
+  min-height: 320px;
+  max-height: 320px;
 }
 
 QtAbout > QLabel {
-   qproperty-alignment: AlignLeft;
+  background-color: {{ background }};
+  qproperty-alignment: AlignLeft;
 }
 
 QtActiveKeybindings > QLabel {


### PR DESCRIPTION
# Description
This PR continues in the vein of #749 by cleaning up some of the info dialog box and adding citation information to it. It also changes our citation from `team` -> `contributors` which was proposed in #655 and liked by @jni - will be nice to get this in sooner though.

Here is the new look - not this dialog is not dockable as i think that doesn't make sense in this context:

![image](https://user-images.githubusercontent.com/6531703/69919461-d81db500-1431-11ea-9e07-c4aa3b74fd22.png)
