### PR TITLE
[WIP] Add repr_png method to Viewer

### DIFF
--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,7 +1,9 @@
+from io import BytesIO
 from os.path import dirname, join
 
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QApplication
+from skimage import io
 
 from napari._qt.qt_update_ui import QtUpdateUI
 
@@ -82,6 +84,14 @@ class Viewer(ViewerModel):
         else:
             image = self.window.qt_viewer.screenshot()
         return image
+
+    def _repr_png_(self):
+        """PNG representation of the viewer object for IPython."""
+        image = self.screenshot(with_viewer=True)
+        file_obj = BytesIO()
+        io.imsave(file_obj, image, format='png', check_contrast=False)
+        file_obj.seek(0)
+        return file_obj.read()
 
     def update(self, func, *args, **kwargs):
         t = QtUpdateUI(func, *args, **kwargs)


### PR DESCRIPTION
I was getting kind of annoyed that notebooks would only display
"napari.Viewer object at <0xGIBBERISH>" at the end of cells
calling napari. This instead makes a png and displays it.

The disadvantage is that users might be confused and think that
this is the interactive napari viewer. But, on the whole, I think
it's a pretty cool way to save notebook state!

![napari-repr](https://user-images.githubusercontent.com/492549/70031720-7ebc9f80-1571-11ea-9a93-abdb7b2ffc3a.png)
