### PR TITLE
Fix StringEnum setting and errors

### DIFF
--- a/napari/util/misc.py
+++ b/napari/util/misc.py
@@ -1,6 +1,6 @@
 """Miscellaneous utility functions.
 """
-from enum import Enum
+from enum import Enum, EnumMeta
 import re
 import inspect
 import itertools
@@ -451,17 +451,47 @@ def interpolate_coordinates(old_coord, new_coord, brush_size):
     return coords
 
 
-class StringEnum(Enum):
+class StringEnumMeta(EnumMeta):
+    def __getitem__(self, item):
+        """ set the item name case to uppercase for name lookup
+        """
+        if isinstance(item, str):
+            item = item.upper()
+
+        return super().__getitem__(item)
+
+    def __call__(
+        cls,
+        value,
+        names=None,
+        *,
+        module=None,
+        qualname=None,
+        type=None,
+        start=1,
+    ):
+        """ set the item value case to lowercase for value lookup
+        """
+        # simple value lookup
+        if names is None:
+            value = value.lower()
+            return super().__call__(value)
+        # otherwise create new Enum class
+        return cls._create_(
+            value,
+            names,
+            module=module,
+            qualname=qualname,
+            type=type,
+            start=start,
+        )
+
+
+class StringEnum(Enum, metaclass=StringEnumMeta):
     def _generate_next_value_(name, start, count, last_values):
         """ autonaming function assigns each value its own name as a value
         """
         return name.lower()
-
-    def _missing_(self, value):
-        """ function called with provided value does not match any of the class
-           member values. This function tries again with an upper case string.
-        """
-        return self(value.lower())
 
     def __str__(self):
         """String representation: The string method returns the lowercase

--- a/napari/util/tests/test_misc.py
+++ b/napari/util/tests/test_misc.py
@@ -1,3 +1,5 @@
+from enum import auto
+
 import pytest
 import numpy as np
 import dask.array as da
@@ -11,6 +13,7 @@ from napari.util.misc import (
     fast_pyramid,
     trim_pyramid,
     calc_data_range,
+    StringEnum,
 )
 
 
@@ -326,3 +329,30 @@ def test_callsignature():
         str(callsignature(lambda a, b=42, *, c, d=5, **kwargs: None))
         == '(a, b=b, c=c, d=d, **kwargs)'
     )
+
+
+def test_string_enum():
+    # Make a test StringEnum
+    class TestEnum(StringEnum):
+        THING = auto()
+        OTHERTHING = auto()
+
+    # test setting by value, correct case
+    assert TestEnum('thing') == TestEnum.THING
+
+    # test setting by value mixed case
+    assert TestEnum('thInG') == TestEnum.THING
+
+    # test setting by name correct case
+    assert TestEnum['THING'] == TestEnum.THING
+
+    # test setting by name mixed case
+    assert TestEnum['tHiNg'] == TestEnum.THING
+
+    # Test setting by value with incorrect value
+    with pytest.raises(ValueError):
+        TestEnum('NotAThing')
+
+    # Test  setting by name with incorrect name
+    with pytest.raises(KeyError):
+        TestEnum['NotAThing']

--- a/napari/util/tests/test_misc.py
+++ b/napari/util/tests/test_misc.py
@@ -349,10 +349,16 @@ def test_string_enum():
     # test setting by name mixed case
     assert TestEnum['tHiNg'] == TestEnum.THING
 
-    # Test setting by value with incorrect value
+    # test setting by value with incorrect value
     with pytest.raises(ValueError):
         TestEnum('NotAThing')
 
-    # Test  setting by name with incorrect name
+    # test  setting by name with incorrect name
     with pytest.raises(KeyError):
         TestEnum['NotAThing']
+
+    # test creating a StringEnum with the functional API
+    animals = StringEnum('Animal', 'AARDVARK BUFFALO CAT DOG')
+    assert str(animals.AARDVARK) == 'aardvark'
+    assert animals('BUffALO') == animals.BUFFALO
+    assert animals['BUffALO'] == animals.BUFFALO


### PR DESCRIPTION
# Description
This PR aims to fix the `StringEnum`  issues raised by @tlambert03  in #754 :

- `StringEnum._missing_()` wasn't being called because `_missing_()` is a class method in `Enum`
- Attempting to set a `StringEnum` subclass to an improper value/name raises a deceptive exception

Towards this, I have done the following:
- removed `StringEnum._missing_()`
- Added a new metaclass (`StringEnumMeta`) that provides case-invariant lookup by item name or value.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
This PR aims to fix the issues identified by @tlambert03 in #754 .

# How has this been tested?
- [x] Tested setting options in `nD_image.py` example
- [x] Added tests for setting with mixed case strings in `/napari/util/tests/test_misc.py`
- [x] Added tests for raising proper error messages in `/napari/util/tests/test_misc.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
