### PR TITLE
Display slice info on right of slider

### DIFF
--- a/napari/_qt/qt_dims.py
+++ b/napari/_qt/qt_dims.py
@@ -6,7 +6,6 @@ from qtpy.QtGui import QFont, QFontMetrics
 from qtpy.QtWidgets import QLineEdit, QSizePolicy, QVBoxLayout, QWidget
 
 from ..components.dims import Dims
-from ..components.dims_constants import DimsMode
 from .qt_dims_slider import QtDimSliderWidget
 from ._constants import LoopMode
 
@@ -111,11 +110,7 @@ class QtDims(QWidget):
         if axis >= len(self.slider_widgets):
             return
 
-        slider = self.slider_widgets[axis].slider
-
-        mode = self.dims.mode[axis]
-        if mode == DimsMode.POINT:
-            slider.setValue(self.dims.point[axis])
+        self.slider_widgets[axis]._update_slider()
         self.last_used = axis
 
     def _update_range(self, axis: int):
@@ -198,7 +193,7 @@ class QtDims(QWidget):
         for slider_num in range(self.nsliders, number_of_sliders):
             dim_axis = number_of_sliders - slider_num - 1
             slider_widget = QtDimSliderWidget(self, dim_axis)
-            slider_widget.label_changed.connect(self._resize_labels)
+            slider_widget.axis_label_changed.connect(self._resize_labels)
             slider_widget.play_button.play_requested.connect(self.play)
             self.layout().addWidget(slider_widget)
             self.slider_widgets.insert(0, slider_widget)

--- a/napari/_qt/qt_dims.py
+++ b/napari/_qt/qt_dims.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 from qtpy.QtGui import QFont, QFontMetrics
-from qtpy.QtWidgets import QLineEdit, QSizePolicy, QVBoxLayout, QWidget, QLabel
+from qtpy.QtWidgets import QLineEdit, QSizePolicy, QVBoxLayout, QWidget
 
 from ..components.dims import Dims
 from .qt_dims_slider import QtDimSliderWidget
@@ -194,12 +194,12 @@ class QtDims(QWidget):
             if not self._displayed_sliders[axis]:
                 continue
             _range = self.dims.range[axis]
-            longest = str(_range[1] - _range[2] // _range[2]) * 2 + ' / '
+            longest = str(_range[1] - _range[2] // _range[2])
             length = fm.width(longest)
             if length > width:
                 width = length
-        for labl in self.findChildren(QLabel, 'slice_label'):
-            labl.setMinimumWidth(width + 4)
+        for labl in self.findChildren(QWidget, 'slice_label'):
+            labl.setFixedWidth(width + 6)
 
     def _create_sliders(self, number_of_sliders: int):
         """Creates sliders to match new number of dimensions.

--- a/napari/_qt/qt_dims.py
+++ b/napari/_qt/qt_dims.py
@@ -187,17 +187,15 @@ class QtDims(QWidget):
         right aligned.  The width is determined by the number of digits in the
         largest dimensions, plus a little padding.
         """
-        fm = QFontMetrics(QFont("", 0))
-
         width = 0
-        for axis, slider in enumerate(self.slider_widgets):
-            if not self._displayed_sliders[axis]:
-                continue
-            _range = self.dims.range[axis]
-            longest = str(_range[1] - _range[2] // _range[2])
-            length = fm.width(longest)
-            if length > width:
-                width = length
+        for ax, maxi in enumerate(self.dims.max_indices):
+            if self._displayed_sliders[ax]:
+                length = len(str(int(maxi)))
+                if length > width:
+                    width = length
+        # gui width of a string of length `width`
+        fm = QFontMetrics(QFont("", 0))
+        width = fm.width("8" * width)
         for labl in self.findChildren(QWidget, 'slice_label'):
             labl.setFixedWidth(width + 6)
 

--- a/napari/_qt/qt_dims_slider.py
+++ b/napari/_qt/qt_dims_slider.py
@@ -3,7 +3,6 @@ from typing import Optional, Tuple
 import numpy as np
 from qtpy.QtCore import Qt, QTimer, Signal, Slot, QObject
 from qtpy.QtWidgets import QApplication
-from qtpy.QtGui import QFont, QFontMetrics
 from qtpy.QtWidgets import (
     QComboBox,
     QHBoxLayout,
@@ -46,7 +45,7 @@ class QtDimSliderWidget(QWidget):
         self.slider = None
         self.play_button = None
         self.slice_label = QLabel(self)
-        self.slice_label.setObjectName('sliceLabel')
+        self.slice_label.setObjectName('slice_label')
 
         self._fps = 10
         self._minframe = None
@@ -169,9 +168,6 @@ class QtDimSliderWidget(QWidget):
                 self.slider.setMaximum(_range[1])
                 self.slider.setSingleStep(_range[2])
                 self.slider.setPageStep(_range[2])
-                fm = QFontMetrics(QFont("", 0))
-                longest = str(_range[1] // _range[2]) * 2 + '   /   '
-                self.slice_label.setFixedWidth(fm.width(longest))
                 self._update_slice_labels()
         else:
             displayed_sliders[self.axis] = False

--- a/napari/_qt/qt_dims_slider.py
+++ b/napari/_qt/qt_dims_slider.py
@@ -47,6 +47,7 @@ class QtDimSliderWidget(QWidget):
         self.slider = None
         self.play_button = None
         self.curslice_label = QLineEdit(self)
+        self.curslice_label.setToolTip(f'Current slice for axis {axis}')
         self.curslice_label.setValidator(QIntValidator(0, 999999))
 
         def change_slice():
@@ -64,6 +65,7 @@ class QtDimSliderWidget(QWidget):
 
         self.curslice_label.editingFinished.connect(change_slice)
         self.totslice_label = QLabel(self)
+        self.totslice_label.setToolTip(f'Total slices for axis {axis}')
         self.curslice_label.setObjectName('slice_label')
         self.totslice_label.setObjectName('slice_label')
         sep = QFrame(self)

--- a/napari/_qt/tests/test_qt_dims.py
+++ b/napari/_qt/tests/test_qt_dims.py
@@ -185,9 +185,9 @@ def test_update_dims_labels(qtbot):
     view = QtDims(Dims(ndim))
     qtbot.addWidget(view)
     view.dims.axis_labels = list('TZYX')
-    assert [w.label.text() for w in view.slider_widgets] == list('TZYX')
+    assert [w.axis_label.text() for w in view.slider_widgets] == list('TZYX')
 
-    first_label = view.slider_widgets[0].label
+    first_label = view.slider_widgets[0].axis_label
     assert first_label.text() == view.dims.axis_labels[0]
     first_label.setText('napari')
     # first_label.editingFinished.emit()

--- a/napari/_qt/tests/test_qt_dims.py
+++ b/napari/_qt/tests/test_qt_dims.py
@@ -3,6 +3,8 @@ import numpy as np
 from napari.components import Dims
 from napari._qt.qt_dims import QtDims
 from qtpy.QtCore import Qt
+from napari._qt.qt_viewer import QtViewer
+from napari.components import ViewerModel
 
 
 def test_creating_view(qtbot):
@@ -223,3 +225,25 @@ def test_play_button(qtbot):
     assert not button.popup.isVisible()
     qtbot.mouseClick(button, Qt.RightButton)
     assert button.popup.isVisible()
+
+
+def test_slice_labels(qtbot):
+    viewer = ViewerModel()
+    view = QtViewer(viewer)
+    qtbot.addWidget(view)
+    np.random.seed(0)
+    data = np.random.random((20, 10, 10))
+    viewer.add_image(data)
+
+    # make sure the totslice_label is showing the correct number
+    assert int(view.dims.slider_widgets[0].totslice_label.text()) == 19
+
+    # make sure setting the dims.point updates the slice label
+    label_edit = view.dims.slider_widgets[0].curslice_label
+    viewer.dims.set_point(0, 15)
+    assert int(label_edit.text()) == 15
+
+    # make sure setting the current slice label updates the model
+    label_edit.setText(str(8))
+    label_edit.editingFinished.emit()
+    assert viewer.dims.point[0] == 8

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -122,6 +122,12 @@ class Dims:
         return copy(self._range)
 
     @property
+    def max_indices(self):
+        """Maximum index for each dimension (in data space).
+        """
+        return [((ma - st) // st) for mi, ma, st in self._range]
+
+    @property
     def point(self):
         """List of int: value of each dimension if in POINT mode."""
         return copy(self._point)

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -1156,6 +1156,18 @@ QtPlayButton[playing=True] {
 #slice_label {
   background-color: {{ background }};
   color: {{ secondary }};
-  padding-top: 3px;
+  padding: 0;
+  margin: 0;
+  margin-top: 0px;
   font-size: 11pt;
+  max-height: 12px;
+  min-height: 12px;
+  border: 0px;
+  padding-left: 1px;
+}
+
+
+#slice_label_sep{
+  background-color: {{ background }};
+  border: 1px solid {{ foreground }};
 }

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -1169,5 +1169,5 @@ QtPlayButton[playing=True] {
 
 #slice_label_sep{
   background-color: {{ background }};
-  border: 1px solid {{ foreground }};
+  border: 1px solid {{ primary }};
 }

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -1166,7 +1166,6 @@ QtPlayButton[playing=True] {
   padding-left: 1px;
 }
 
-
 #slice_label_sep{
   background-color: {{ background }};
   border: 1px solid {{ primary }};

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -1153,10 +1153,9 @@ QtPlayButton[playing=True] {
    border-radius: 3px;
 }
 
-#curSliceLabel, #totSliceLabel {
+#sliceLabel {
   background-color: {{ background }};
   color: {{ secondary }};
   padding-top: 3.5px;
-  padding-right: 0px;
   font-size: 12pt;
 }

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -1152,3 +1152,11 @@ QtPlayButton[playing=True] {
    background-color: {{ foreground }};
    border-radius: 3px;
 }
+
+#curSliceLabel, #totSliceLabel {
+  background-color: {{ background }};
+  color: {{ secondary }};
+  padding-top: 3.5px;
+  padding-right: 0px;
+  font-size: 12pt;
+}

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -1153,9 +1153,9 @@ QtPlayButton[playing=True] {
    border-radius: 3px;
 }
 
-#sliceLabel {
+#slice_label {
   background-color: {{ background }};
   color: {{ secondary }};
-  padding-top: 3.5px;
-  font-size: 12pt;
+  padding-top: 3px;
+  font-size: 11pt;
 }


### PR DESCRIPTION
# Description
This would close #456 by displaying `current / total` slice info on the right of each dims slider

![Untitled](https://user-images.githubusercontent.com/1609449/70138672-0816c380-1691-11ea-979d-5247c58be3b0.gif)

still want to tighten up some styles... but just wanted to make sure this was what everyone was generally picturing.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] need to add tests
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
