### PR TITLE
Napari "scale" keyword argument may accept array-like (numpy, dsak, xarray) input

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -130,7 +130,10 @@ class Layer(KeymapMixin, ABC):
         self.scale_factor = 1
 
         self.dims = Dims(ndim)
-        self._scale = scale or [1] * ndim
+        if scale is None:
+            self._scale = [1] * ndim
+        else:
+            self._scale = list(scale)
         self._translate = translate or [0] * ndim
         self._scale_view = np.ones(ndim)
         self._translate_view = np.zeros(ndim)

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -132,7 +132,7 @@ class Layer(KeymapMixin, ABC):
         self.dims = Dims(ndim)
         if scale is None:
             self._scale = [1] * ndim
-        else:
+        else:  # covers list and array-like inputs
             self._scale = list(scale)
         self._translate = translate or [0] * ndim
         self._scale_view = np.ones(ndim)

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -134,7 +134,10 @@ class Layer(KeymapMixin, ABC):
             self._scale = [1] * ndim
         else:  # covers list and array-like inputs
             self._scale = list(scale)
-        self._translate = translate or [0] * ndim
+        if translate is None:
+            self._translate = [0] * ndim
+        else:  # covers list and array-like inputs
+            self._translate = list(translate)
         self._scale_view = np.ones(ndim)
         self._translate_view = np.zeros(ndim)
         self._translate_grid = np.zeros(ndim)

--- a/napari/layers/image/tests/test_image.py
+++ b/napari/layers/image/tests/test_image.py
@@ -1,5 +1,7 @@
 import numpy as np
 from xml.etree.ElementTree import Element
+import dask.array as da
+import xarray as xr
 
 import pytest
 from vispy.color import Colormap
@@ -512,3 +514,39 @@ def test_out_of_range_no_contrast(dtype):
     data = np.full((10, 15), -3.2, dtype=dtype)
     layer = Image(data)
     layer._update_thumbnail()
+
+
+@pytest.mark.parametrize(
+    "scale",
+    [
+        (None),
+        ([1, 1]),
+        (np.array([1, 1])),
+        (da.from_array([1, 1], chunks=1)),
+        (da.from_array([1, 1], chunks=2)),
+        (xr.DataArray(np.array([1, 1]))),
+        (xr.DataArray(np.array([1, 1]), dims=('dimension_name'))),
+    ],
+)
+def test_image_scale(scale):
+    np.random.seed(0)
+    data = np.random.random((10, 15))
+    Image(data, scale=scale)
+
+
+@pytest.mark.parametrize(
+    "translate",
+    [
+        (None),
+        ([1, 1]),
+        (np.array([1, 1])),
+        (da.from_array([1, 1], chunks=1)),
+        (da.from_array([1, 1], chunks=2)),
+        (xr.DataArray(np.array([1, 1]))),
+        (xr.DataArray(np.array([1, 1]), dims=('dimension_name'))),
+    ],
+)
+def test_image_translate(translate):
+    np.random.seed(0)
+    data = np.random.random((10, 15))
+    Image(data, translate=translate)

--- a/napari/tests/test_numpy_like.py
+++ b/napari/tests/test_numpy_like.py
@@ -1,8 +1,10 @@
 import numpy as np
+import napari
 from napari import Viewer
 import dask.array as da
 import zarr
 import xarray as xr
+import pytest
 
 
 def test_dask_2D(qtbot):
@@ -129,3 +131,20 @@ def test_xarray_nD(qtbot):
 
     # Close the viewer
     viewer.window.close()
+
+
+@pytest.mark.parametrize("scale", [
+    (None),
+    ([1, 1]),
+    (np.array([1, 1])),
+    (da.from_array([1, 1], chunks=1)),
+    (da.from_array([1, 1], chunks=2)),
+    (xr.DataArray(np.array([1, 1]))),
+    (xr.DataArray(np.array([1, 1]), dims=('dimension_name'))),
+    ])
+def test_scale_arraytypes(qtbot, scale):
+    np.random.seed(0)
+    data = np.random.random((10, 15))
+    viewer = napari.view_image(data, scale=scale)
+    view = viewer.window.qt_viewer
+    qtbot.addWidget(view)

--- a/napari/tests/test_numpy_like.py
+++ b/napari/tests/test_numpy_like.py
@@ -1,10 +1,8 @@
 import numpy as np
-import napari
 from napari import Viewer
 import dask.array as da
 import zarr
 import xarray as xr
-import pytest
 
 
 def test_dask_2D(qtbot):
@@ -131,20 +129,3 @@ def test_xarray_nD(qtbot):
 
     # Close the viewer
     viewer.window.close()
-
-
-@pytest.mark.parametrize("scale", [
-    (None),
-    ([1, 1]),
-    (np.array([1, 1])),
-    (da.from_array([1, 1], chunks=1)),
-    (da.from_array([1, 1], chunks=2)),
-    (xr.DataArray(np.array([1, 1]))),
-    (xr.DataArray(np.array([1, 1]), dims=('dimension_name'))),
-    ])
-def test_scale_arraytypes(qtbot, scale):
-    np.random.seed(0)
-    data = np.random.random((10, 15))
-    viewer = napari.view_image(data, scale=scale)
-    view = viewer.window.qt_viewer
-    qtbot.addWidget(view)


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
This pull request addresses the bug report in issue https://github.com/napari/napari/issues/751.

The problem is if you pass an array-like object as the `scale` keyword argument to the napari image viewer (instead of the expected list or None type) an error results. This PR checks whether `scale` is None, and if not converts it to list type. Napari now handles `scale` input types of None, list, and array-like (eg: numpy array, dask array, and xarray).

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes https://github.com/napari/napari/issues/751

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] the test suite now has a new test covering cases with `scale` keyword argument types of:
* None
* list
* numpy array
* dask array
* xarray

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation <-- I don't think this needs a documentation update, my understanding is inputs like this are expected to work anyway. If I'm wrong, let me know and I'll add extra detail to the docs.
- [x] I have added tests that prove my fix is effective or that my feature works
