### PR TITLE
fix set_fps type to float

### DIFF
--- a/napari/_qt/qt_dims_slider.py
+++ b/napari/_qt/qt_dims_slider.py
@@ -32,7 +32,7 @@ class QtDimSliderWidget(QWidget):
     """
 
     axis_label_changed = Signal(int, str)  # axis, label
-    fps_changed = Signal(int)
+    fps_changed = Signal(float)
     mode_changed = Signal(str)
     range_changed = Signal(tuple)
     play_started = Signal()
@@ -474,7 +474,7 @@ class AnimationWorker(QObject):
             self.advance()
         self.started.emit()
 
-    @Slot(int)
+    @Slot(float)
     def set_fps(self, fps):
         if fps == 0:
             return self.finish()

--- a/napari/_qt/qt_dims_slider.py
+++ b/napari/_qt/qt_dims_slider.py
@@ -32,7 +32,7 @@ class QtDimSliderWidget(QWidget):
     """
 
     axis_label_changed = Signal(int, str)  # axis, label
-    fps_changed = Signal(float)
+    fps_changed = Signal(int)
     mode_changed = Signal(str)
     range_changed = Signal(tuple)
     play_started = Signal()


### PR DESCRIPTION
# Description
fixes a small discrepancy between the signature of `set_fps` and the `fps_changed` emitter by ensuring that both are using the ~~`int`~~`float` data type (one was `float` and one was `int` previously)

this fixes compatibility with PyQt5 and consequently, allows napari to be run on Python 3.8 if PyQt5 is used as the backend (see #766 as to why PySide2 cannot be used)

the reason that this was only erroring with PyQt5 is because it checks that the emitters and callbacks share compatible signatures while PySide2 does not

~~@tlambert03 please verify that `int` is the correct data type to use for this emitter since I was just guessing as to which one to use~~

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change using both PySide2 on Python 3.7 and PyQt5 on Python 3.8
