### PR TITLE
Adding shutdown method to QtViewer that closes all resources

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -418,6 +418,11 @@ class QtViewer(QSplitter):
             self.pool.clear()
         event.accept()
 
+    def shutdown(self):
+        self.pool.clear()
+        self.canvas.close()
+        self.console.shutdown()
+
 
 def viewbox_key_event(event):
     """ViewBox key event handler

--- a/napari/_qt/tests/test_qt_play.py
+++ b/napari/_qt/tests/test_qt_play.py
@@ -118,6 +118,10 @@ def view(qtbot):
     np.random.seed(0)
     data = np.random.random((10, 10, 15))
     viewer.add_image(data)
+
+    yield view  # Adding teardown code for fixture
+    print("shutting down QtViewer")
+    view.shutdown()
     return view
 
 

--- a/napari/_qt/tests/test_qt_viewer.py
+++ b/napari/_qt/tests/test_qt_viewer.py
@@ -20,6 +20,7 @@ def test_qt_viewer(qtbot):
     assert viewer.dims.ndim == 2
     assert view.dims.nsliders == viewer.dims.ndim
     assert np.sum(view.dims._displayed_sliders) == 0
+    view.shutdown()
 
 
 def test_add_image(qtbot):
@@ -39,6 +40,7 @@ def test_add_image(qtbot):
     assert viewer.dims.ndim == 2
     assert view.dims.nsliders == viewer.dims.ndim
     assert np.sum(view.dims._displayed_sliders) == 0
+    view.shutdown()
 
 
 def test_add_volume(qtbot):
@@ -58,6 +60,7 @@ def test_add_volume(qtbot):
     assert viewer.dims.ndim == 3
     assert view.dims.nsliders == viewer.dims.ndim
     assert np.sum(view.dims._displayed_sliders) == 0
+    view.shutdown()
 
 
 def test_add_pyramid(qtbot):
@@ -78,6 +81,7 @@ def test_add_pyramid(qtbot):
     assert viewer.dims.ndim == 2
     assert view.dims.nsliders == viewer.dims.ndim
     assert np.sum(view.dims._displayed_sliders) == 0
+    view.shutdown()
 
 
 def test_add_labels(qtbot):
@@ -97,6 +101,7 @@ def test_add_labels(qtbot):
     assert viewer.dims.ndim == 2
     assert view.dims.nsliders == viewer.dims.ndim
     assert np.sum(view.dims._displayed_sliders) == 0
+    view.shutdown()
 
 
 def test_add_points(qtbot):
@@ -116,6 +121,7 @@ def test_add_points(qtbot):
     assert viewer.dims.ndim == 2
     assert view.dims.nsliders == viewer.dims.ndim
     assert np.sum(view.dims._displayed_sliders) == 0
+    view.shutdown()
 
 
 def test_add_vectors(qtbot):
@@ -135,6 +141,7 @@ def test_add_vectors(qtbot):
     assert viewer.dims.ndim == 2
     assert view.dims.nsliders == viewer.dims.ndim
     assert np.sum(view.dims._displayed_sliders) == 0
+    view.shutdown()
 
 
 def test_add_shapes(qtbot):
@@ -154,6 +161,7 @@ def test_add_shapes(qtbot):
     assert viewer.dims.ndim == 2
     assert view.dims.nsliders == viewer.dims.ndim
     assert np.sum(view.dims._displayed_sliders) == 0
+    view.shutdown()
 
 
 def test_new_labels(qtbot):
@@ -188,6 +196,7 @@ def test_new_labels(qtbot):
     assert viewer.dims.ndim == 2
     assert view.dims.nsliders == viewer.dims.ndim
     assert np.sum(view.dims._displayed_sliders) == 0
+    view.shutdown()
 
 
 def test_new_points(qtbot):
@@ -222,6 +231,7 @@ def test_new_points(qtbot):
     assert viewer.dims.ndim == 2
     assert view.dims.nsliders == viewer.dims.ndim
     assert np.sum(view.dims._displayed_sliders) == 0
+    view.shutdown()
 
 
 def test_new_shapes(qtbot):
@@ -256,6 +266,7 @@ def test_new_shapes(qtbot):
     assert viewer.dims.ndim == 2
     assert view.dims.nsliders == viewer.dims.ndim
     assert np.sum(view.dims._displayed_sliders) == 0
+    view.shutdown()
 
 
 def test_screenshot(qtbot):
@@ -288,6 +299,7 @@ def test_screenshot(qtbot):
     # Take screenshot
     screenshot = view.screenshot()
     assert screenshot.ndim == 3
+    view.shutdown()
 
 
 @pytest.mark.parametrize(
@@ -316,3 +328,4 @@ def test_qt_viewer_data_integrity(qtbot, dtype):
     viewer.dims.ndisplay = 2
     datamean = viewer.layers[0].data.mean()
     assert datamean == imean
+    view.shutdown()


### PR DESCRIPTION
# Description
Adds a shutdown method to the QtViewer class that closes all resources. Specifically not shutting down the console was causing the "Too many open files" kernal crash in #723. The new shutdown method should be used in any future tests that instantiate a QtViewer. Should be merged before #723 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
