### PR TITLE
drop ndim keyword from labels

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -673,7 +673,6 @@ class ViewerModel(KeymapMixin):
         is_pyramid=None,
         num_colors=50,
         seed=0.5,
-        n_dimensional=False,
         name=None,
         metadata=None,
         scale=None,
@@ -702,8 +701,6 @@ class ViewerModel(KeymapMixin):
             Number of unique colors to use in colormap.
         seed : float
             Seed for colormap random generator.
-        n_dimensional : bool
-            If `True`, paint and fill edit labels across all dimensions.
         name : str
             Name of the layer.
         metadata : dict
@@ -741,7 +738,6 @@ class ViewerModel(KeymapMixin):
             is_pyramid=is_pyramid,
             num_colors=num_colors,
             seed=seed,
-            n_dimensional=n_dimensional,
             name=name,
             metadata=metadata,
             scale=scale,

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -33,8 +33,6 @@ class Labels(Image):
         Number of unique colors to use in colormap.
     seed : float
         Seed for colormap random generator.
-    n_dimensional : bool
-        If `True`, paint and fill edit labels across all dimensions.
     name : str
         Name of the layer.
     metadata : dict
@@ -120,7 +118,6 @@ class Labels(Image):
         is_pyramid=None,
         num_colors=50,
         seed=0.5,
-        n_dimensional=False,
         name=None,
         metadata=None,
         scale=None,
@@ -160,7 +157,7 @@ class Labels(Image):
         )
 
         self._data_raw = np.zeros((1,) * self.dims.ndisplay)
-        self._n_dimensional = n_dimensional
+        self._n_dimensional = False
         self._contiguous = True
         self._brush_size = 10
         self._last_cursor_coord = None

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -241,7 +241,6 @@ def view_labels(
     is_pyramid=None,
     num_colors=50,
     seed=0.5,
-    n_dimensional=False,
     name=None,
     metadata=None,
     scale=None,
@@ -274,8 +273,6 @@ def view_labels(
         Number of unique colors to use in colormap.
     seed : float
         Seed for colormap random generator.
-    n_dimensional : bool
-        If `True`, paint and fill edit labels across all dimensions.
     name : str
         Name of the layer.
     metadata : dict
@@ -319,7 +316,6 @@ def view_labels(
         is_pyramid=is_pyramid,
         num_colors=num_colors,
         seed=seed,
-        n_dimensional=n_dimensional,
         name=name,
         metadata=metadata,
         scale=scale,


### PR DESCRIPTION
# Description
This PR drops the `n_dimensional` keyword from the `Labels` layer. It will actually be basically backwards compatible because the `n_dimensional` keyword doesn't actually affect any of the processing or rendering, it just sets the value of a checkbox in the Qt which affects how new data gets added with the paintbrush and fill bucket. I don't this parameters like this should not be settable as keyword args and other similar parameters are not. I am fine merging this and still keeping the version change as a "minor release" when that time comes

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

