### PR TITLE
Updating qt_console with better resource management. 

### DIFF
--- a/napari/_qt/qt_console.py
+++ b/napari/_qt/qt_console.py
@@ -50,12 +50,9 @@ class QtConsole(RichJupyterWidget):
             # If there is an existing running InProcessInteractiveShell
             # it is likely because multiple viewers have been launched from
             # the same process. In that case create a new kernel.
-            kernel_manager = QtInProcessKernelManager()
-            kernel_manager.start_kernel(show_banner=False)
-            kernel_manager.kernel.gui = 'qt'
-
+            # Connect existing kernel
+            kernel_manager = QtInProcessKernelManager(kernel=shell.kernel)
             kernel_client = kernel_manager.client()
-            kernel_client.start_channels()
 
             self.kernel_manager = kernel_manager
             self.kernel_client = kernel_client
@@ -87,7 +84,6 @@ class QtConsole(RichJupyterWidget):
             raise ValueError(
                 'ipython shell not recognized; ' f'got {type(shell)}'
             )
-
         # Add any user variables
         user_variables = user_variables or {}
         self.push(user_variables)
@@ -98,7 +94,5 @@ class QtConsole(RichJupyterWidget):
         # self.execute_on_complete_input = True
 
     def shutdown(self):
-        if self.kernel_client is not None:
-            self.kernel_client.stop_channels()
-        if self.kernel_manager is not None:
-            self.kernel_manager.shutdown_kernel()
+        self.kernel_client.stop_channels()
+        self.kernel_manager.shutdown_kernel()

--- a/napari/_qt/tests/test_qt_console.py
+++ b/napari/_qt/tests/test_qt_console.py
@@ -7,6 +7,7 @@ def test_console(qtbot):
     qtbot.addWidget(console)
 
     assert console.kernel_client is not None
+    console.shutdown()
 
 
 def test_console_user_variables(qtbot):
@@ -17,6 +18,7 @@ def test_console_user_variables(qtbot):
     assert console.kernel_client is not None
     assert 'var' in console.shell.user_ns
     assert console.shell.user_ns['var'] == 3
+    console.shutdown()
 
 
 def test_multiple_consoles(qtbot):
@@ -30,3 +32,5 @@ def test_multiple_consoles(qtbot):
     assert console_b.kernel_client is not None
     assert 'var_a' in console_a.shell.user_ns
     assert 'var_b' in console_a.shell.user_ns
+    console_a.shutdown()
+    console_b.shutdown()

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -3,7 +3,7 @@ zarr>=2.3.0
 numcodecs!=0.6.4
 fsspec>=0.3.3
 imageio>=2.5.0
-ipykernel==5.1.1
+ipykernel>=5.1.1
 numpy>=1.10.0
 qtpy>=1.7.0
 qtconsole>=4.5.1


### PR DESCRIPTION
# Description
So the issue with the existing code was that if a QtConsole was instantiated with an existing shell (InProcessInteractiveShell) self. kernel_manager and self. kernel_client were not getting properly set, meaning the shutdown code wasn't doing anything. This PR updates the QtConsole to create a QtInProcessKernelManager with an existing kernel if one exists and then sets both attributes. It also adds the shutdown() calls to the test_qt.py tests. Everything works with `ipykernel 5.1.3` so I also removed the pinned dependency.  

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
