### PR TITLE
respect vispy max texture limits

### DIFF
--- a/napari/_vispy/tests/test_vispy_big_images.py
+++ b/napari/_vispy/tests/test_vispy_big_images.py
@@ -1,0 +1,43 @@
+import numpy as np
+from napari import Viewer
+
+
+def test_big_2D_image(qtbot):
+    """Test big 2D image with axis exceeding max texture size."""
+    viewer = Viewer()
+    view = viewer.window.qt_viewer
+    qtbot.addWidget(view)
+
+    shape = (20_000, 10)
+    data = np.random.random(shape)
+    layer = viewer.add_image(data, is_pyramid=False)
+    visual = view.layer_to_visual[layer]
+    assert visual.node is not None
+    if visual.MAX_TEXTURE_SIZE_2D is not None:
+        print(
+            'aasdfasdf', visual.MAX_TEXTURE_SIZE_2D, visual.MAX_TEXTURE_SIZE_3D
+        )
+        ds = np.ceil(np.divide(shape, visual.MAX_TEXTURE_SIZE_2D)).astype(int)
+        assert np.all(layer._scale_view == ds)
+
+    # Close the viewer
+    viewer.window.close()
+
+
+def test_big_3D_image(qtbot):
+    """Test big 3D image with axis exceeding max texture size."""
+    viewer = Viewer(ndisplay=3)
+    view = viewer.window.qt_viewer
+    qtbot.addWidget(view)
+
+    shape = (5, 10, 3_000)
+    data = np.random.random(shape)
+    layer = viewer.add_image(data, is_pyramid=False)
+    visual = view.layer_to_visual[layer]
+    assert visual.node is not None
+    if visual.MAX_TEXTURE_SIZE_3D is not None:
+        ds = np.ceil(np.divide(shape, visual.MAX_TEXTURE_SIZE_3D)).astype(int)
+        assert np.all(layer._scale_view == ds)
+
+    # Close the viewer
+    viewer.window.close()

--- a/napari/_vispy/tests/test_vispy_big_images.py
+++ b/napari/_vispy/tests/test_vispy_big_images.py
@@ -14,9 +14,6 @@ def test_big_2D_image(qtbot):
     visual = view.layer_to_visual[layer]
     assert visual.node is not None
     if visual.MAX_TEXTURE_SIZE_2D is not None:
-        print(
-            'aasdfasdf', visual.MAX_TEXTURE_SIZE_2D, visual.MAX_TEXTURE_SIZE_3D
-        )
         ds = np.ceil(np.divide(shape, visual.MAX_TEXTURE_SIZE_2D)).astype(int)
         assert np.all(layer._scale_view == ds)
 

--- a/napari/_vispy/util.py
+++ b/napari/_vispy/util.py
@@ -17,18 +17,17 @@ layer_to_visual = {
 
 
 def create_vispy_visual(layer):
-    """
-    Create vispy visual for a layer based on its layer type.
+    """Create vispy visual for a layer based on its layer type.
 
     Parameters
     ----------
-        layer : napari.layers._base_layer.Layer
-            Layer that needs its propetry widget created.
+    layer : napari.layers._base_layer.Layer
+        Layer that needs its propetry widget created.
 
     Returns
     ----------
-        visual : vispy.scene.visuals.VisualNode
-            Vispy visual node
+    visual : vispy.scene.visuals.VisualNode
+        Vispy visual node
     """
     visual = layer_to_visual[type(layer)](layer)
 

--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -1,3 +1,5 @@
+from vispy.gloo import gl
+from vispy.app import Canvas
 from vispy.visuals.transforms import STTransform
 from abc import ABC, abstractmethod
 
@@ -27,6 +29,10 @@ class VispyBaseLayer(ABC):
     scale_factor : float
         Conversion factor from canvas coordinates to image coordinates, which
         depends on the current zoom level.
+    MAX_TEXTURE_SIZE_2D : int
+        Max texture size allowed by the vispy canvas during 2D rendering.
+    MAX_TEXTURE_SIZE_3D : int
+        Max texture size allowed by the vispy canvas during 2D rendering.
 
     Extended Summary
     ----------
@@ -39,6 +45,11 @@ class VispyBaseLayer(ABC):
 
         self.layer = layer
         self.node = node
+
+        MAX_TEXTURE_SIZE_2D, MAX_TEXTURE_SIZE_3D = get_max_texture_sizes()
+        self.MAX_TEXTURE_SIZE_2D = MAX_TEXTURE_SIZE_2D
+        self.MAX_TEXTURE_SIZE_3D = MAX_TEXTURE_SIZE_3D
+
         self._position = (0,) * self.layer.dims.ndisplay
         self.camera = None
 
@@ -195,3 +206,26 @@ class VispyBaseLayer(ABC):
         """Called whenever the canvas is drawn.
         """
         self.layer.scale_factor = self.scale_factor
+
+
+def get_max_texture_sizes():
+    """Get maximum texture sizes for 2D and 3D rendering.
+    Returns
+    -------
+    MAX_TEXTURE_SIZE_2D : int or None
+        Max texture size allowed by the vispy canvas during 2D rendering.
+    MAX_TEXTURE_SIZE_3D : int or None
+        Max texture size allowed by the vispy canvas during 2D rendering.
+    """
+    # A canvas must be created to access gl values
+    _ = Canvas(show=False)
+    MAX_TEXTURE_SIZE_2D = gl.glGetParameter(gl.GL_MAX_TEXTURE_SIZE)
+    if MAX_TEXTURE_SIZE_2D == ():
+        MAX_TEXTURE_SIZE_2D = None
+    # vispy doesn't seem to expose this so hard coding for now ....
+    # MAX_TEXTURE_SIZE_3D = gl.glGetParameter(gl.GL_MAX_3D_TEXTURE_SIZE)
+    MAX_TEXTURE_SIZE_3D = 2048
+    if MAX_TEXTURE_SIZE_3D == ():
+        MAX_TEXTURE_SIZE_3D = None
+
+    return MAX_TEXTURE_SIZE_2D, MAX_TEXTURE_SIZE_3D

--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -210,6 +210,7 @@ class VispyBaseLayer(ABC):
 
 def get_max_texture_sizes():
     """Get maximum texture sizes for 2D and 3D rendering.
+
     Returns
     -------
     MAX_TEXTURE_SIZE_2D : int or None
@@ -222,8 +223,8 @@ def get_max_texture_sizes():
     MAX_TEXTURE_SIZE_2D = gl.glGetParameter(gl.GL_MAX_TEXTURE_SIZE)
     if MAX_TEXTURE_SIZE_2D == ():
         MAX_TEXTURE_SIZE_2D = None
-    # vispy doesn't seem to expose this so hard coding for now ....
     # MAX_TEXTURE_SIZE_3D = gl.glGetParameter(gl.GL_MAX_3D_TEXTURE_SIZE)
+    # vispy doesn't seem to expose GL_MAX_3D_TEXTURE_SIZE so hard coding
     MAX_TEXTURE_SIZE_3D = 2048
     if MAX_TEXTURE_SIZE_3D == ():
         MAX_TEXTURE_SIZE_3D = None

--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -223,10 +223,10 @@ def get_max_texture_sizes():
     MAX_TEXTURE_SIZE_2D = gl.glGetParameter(gl.GL_MAX_TEXTURE_SIZE)
     if MAX_TEXTURE_SIZE_2D == ():
         MAX_TEXTURE_SIZE_2D = None
+    # vispy doesn't expose GL_MAX_3D_TEXTURE_SIZE so hard coding
     # MAX_TEXTURE_SIZE_3D = gl.glGetParameter(gl.GL_MAX_3D_TEXTURE_SIZE)
-    # vispy doesn't seem to expose GL_MAX_3D_TEXTURE_SIZE so hard coding
+    # if MAX_TEXTURE_SIZE_3D == ():
+    #    MAX_TEXTURE_SIZE_3D = None
     MAX_TEXTURE_SIZE_3D = 2048
-    if MAX_TEXTURE_SIZE_3D == ():
-        MAX_TEXTURE_SIZE_3D = None
 
     return MAX_TEXTURE_SIZE_2D, MAX_TEXTURE_SIZE_3D

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -249,12 +249,14 @@ class VispyImageLayer(VispyBaseLayer):
 
     def downsample_texture(self, data, MAX_TEXTURE_SIZE):
         """Downsample data based on maximum allowed texture size.
+
         Parameters
         ----------
         data : array
             Data to be downsampled if needed.
         MAX_TEXTURE_SIZE : int
             Maximum allowed texture size.
+
         Returns
         -------
         data : array

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -1,3 +1,4 @@
+import warnings
 from vispy.scene.visuals import Image as ImageNode
 from vispy.scene.visuals import Volume as VolumeNode
 from vispy.color import Colormap
@@ -69,6 +70,18 @@ class VispyImageLayer(VispyBaseLayer):
 
         if self.layer.dims.ndisplay == 3 and self.layer.dims.ndim == 2:
             data = np.expand_dims(data, axis=0)
+
+        # Check if data exceeds MAX_TEXTURE_SIZE and downsample
+        if (
+            self.MAX_TEXTURE_SIZE_2D is not None
+            and self.layer.dims.ndisplay == 2
+        ):
+            data = self.downsample_texture(data, self.MAX_TEXTURE_SIZE_2D)
+        elif (
+            self.MAX_TEXTURE_SIZE_3D is not None
+            and self.layer.dims.ndisplay == 3
+        ):
+            data = self.downsample_texture(data, self.MAX_TEXTURE_SIZE_3D)
 
         # Check if ndisplay has changed current node type needs updating
         if (
@@ -233,3 +246,44 @@ class VispyImageLayer(VispyBaseLayer):
         self._on_rendering_change()
         if self.layer.dims.ndisplay == 2:
             self._on_contrast_limits_change()
+
+    def downsample_texture(self, data, MAX_TEXTURE_SIZE):
+        """Downsample data based on maximum allowed texture size.
+        Parameters
+        ----------
+        data : array
+            Data to be downsampled if needed.
+        MAX_TEXTURE_SIZE : int
+            Maximum allowed texture size.
+        Returns
+        -------
+        data : array
+            Data that now fits inside texture.
+        """
+        if np.any(np.greater(data.shape, MAX_TEXTURE_SIZE)):
+            if self.layer.is_pyramid:
+                raise ValueError(
+                    f"Shape of individual tiles in pyramid {data.shape} "
+                    f"cannot exceed GL_MAX_TEXTURE_SIZE "
+                    f"{MAX_TEXTURE_SIZE}. The max tile shape "
+                    f"`layer._max_tile_shape` {self.layer._max_tile_shape}"
+                    f" must be reduced. Rendering is currently in "
+                    f"{self.layer.dims.ndisplay}D mode."
+                )
+            warnings.warn(
+                f"data shape {data.shape} exceeds GL_MAX_TEXTURE_SIZE "
+                f"{MAX_TEXTURE_SIZE} in at least one axis and "
+                f"will be downsampled. Rendering is currently in "
+                f"{self.layer.dims.ndisplay}D mode."
+            )
+            downsample = np.ceil(
+                np.divide(data.shape, MAX_TEXTURE_SIZE)
+            ).astype(int)
+            scale = np.ones(self.layer.ndim)
+            for i, d in enumerate(self.layer.dims.displayed):
+                scale[d] = downsample[i]
+            self.layer._scale_view = scale
+            self._on_scale_change()
+            slices = tuple(slice(None, None, ds) for ds in downsample)
+            data = data[slices]
+        return data

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -495,6 +495,7 @@ class Image(Layer):
                     self._data_pyramid[-1][tuple(indices)]
                 ).transpose(order)
         else:
+            self._scale_view = np.ones(self.dims.ndim)
             image = np.asarray(self.data[self.dims.indices]).transpose(order)
             thumbnail = image
 


### PR DESCRIPTION
# Description
This PR contains parts of #737 that prevent vispy segmentation faults when the array sent over is too large by downsampling the array an emitting a warning that downsampling is happening. For 2D rendering it will read the max texture limit from your GPU, i havn't figured out how to read the value for 3D so have hard coded it to 2048, the value on my machine.

To test you can use
```python
img = np.random.random((20_000, 20_000))
napari.view_image(img, is_pyramid=False) 
```
note we need `is_pyramid=False` otherwise we will try and autogenerate a pyramid (something that maybe fixed in a future PR but is out of scope for this one)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] This PR adds two tests in `test_vispy_big_images.py` (one 2D one 3D) both of which currently fail on master

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
