### PR TITLE
generalize keybindings

### DIFF
--- a/napari/_qt/qt_about_keybindings.py
+++ b/napari/_qt/qt_about_keybindings.py
@@ -121,16 +121,8 @@ class QtAboutKeybindings(QDialog):
             Event from the Qt context, by default None.
         """
         col = self.viewer.palette['secondary']
-        text = ''
         # Add class and instance viewer keybindings
-        text += get_keybindings_summary(self.viewer.class_keymap, col=col)
-        text += get_keybindings_summary(self.viewer.keymap, col=col)
-
-        layer = self.viewer.active_layer
-        if layer is not None:
-            # Add class and instance layer keybindings for the active layer
-            text += get_keybindings_summary(layer.class_keymap, col=col)
-            text += get_keybindings_summary(layer.keymap, col=col)
+        text = get_keybindings_summary(self.viewer.active_keymap, col=col)
 
         # Update layer speficic keybindings if all active are displayed
         self.keybindings_strs[self.ALL_ACTIVE_KEYBINDINGS] = text

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -1,4 +1,3 @@
-import os.path
 from pathlib import Path
 
 from qtpy import QtGui

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -10,14 +10,14 @@ from ._constants import Blending
 
 from ...components import Dims
 from ...utils.event import EmitterGroup, Event
-from ...utils.keybindings import KeymapMixin
+from ...utils.keybindings import KeymapProvider
 from ...utils.misc import ROOT_DIR
 from ...utils.naming import magic_name
 from ...utils.status_messages import status_format, format_float
 from ..transforms import ScaleTranslate
 
 
-class Layer(KeymapMixin, ABC):
+class Layer(KeymapProvider, ABC):
     """Base layer class.
 
     Parameters

--- a/napari/utils/keybindings.py
+++ b/napari/utils/keybindings.py
@@ -368,14 +368,15 @@ class KeymapHandler:
     @property
     def active_keymap(self):
         """dict: Active keymap, created by resolving the keymap chain."""
-        keymaps = self.keymap_chain.maps
+        active_keymap = self.keymap_chain
+        keymaps = active_keymap.maps
 
         for i, keymap in enumerate(keymaps):
-            if Ellipsis in keymap:  # catch-all
+            if Ellipsis in keymap:  # catch-all key
+                # trim all keymaps after catch-all
+                active_keymap = ChainMap(*keymaps[: i + 1])
                 break
-        keymaps = keymaps[: i + 1]  # trim maps after a catch-all
 
-        active_keymap = ChainMap(*keymaps)
         active_keymap_final = {
             k: func
             for k, func in active_keymap.items()
@@ -397,7 +398,7 @@ class KeymapHandler:
         if key_combo in keymap:
             func = keymap[key_combo]
         elif Ellipsis in keymap:  # catch-all
-            func = keymap[Ellipsis]
+            func = keymap[...]
         else:
             return  # no keybinding found
 


### PR DESCRIPTION
# Description
Improve keybindings via the following changes:
- move keybinding pressing & releasing logic to a new `KeymapHandler` class
- make `ViewerModel` inherit from `KeymapHandler`
- add property to auto-compute currently active keybindings
- any class inheriting from `KeymapProvider` can prepend itself to a `KeymapHandler`'s `keymap_providers` to active its keymap
- delete `InheritedKeymap` and instead use a keymap lookup chain (**breaking change**)
- passing `...` as the function to `bind_key` will serve as a blocker to ignore this keybinding provided by any keymap further down the lookup chain
- passing `None` as the function to `bind_key` only unbinds from that keymap (**breaking change**); to achieve the previous functionality, pass `...` instead
- passing `...` as the key combination to `bind_key` behaves as a wildcard, and therefore causes any keymap further down the lookup chain to be ignored

### Examples of the new `...` usage
#### press any key to exit
```python
Mode.bind_key(..., Mode.exit)
```

#### blocking mode
```python
Mode.bind_key(..., ...)  # ignore all "inherited" keybindings
Mode.bind_key('Left', Mode.left)
Mode.bind_key('Right', Mode.right)
```

#### re-map
```python
Mode.bind_key('Control-S', Mode.save)
...
mode.bind_key('Control-S', ...)  # block binding "inherited" from class
mode.bind_key('S', Mode.save)    # re-map to 'S'
```

This is meant to make it easier for plugin developers and modes, such as the movie mode in #780, to set keybindings. It also adds useful functionality in allowing primary modes to overwrite all "inherited" keybindings thanks to the `...` wildcard.

I'm sure, as always, that the way I explained things probably doesn't make sense so please give suggestions on how to better explain this in the docs :)

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# References
closes #785 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change