### PR TITLE
Fix window raise & inactive menubar conflict

### DIFF
--- a/napari/_qt/event_loop.py
+++ b/napari/_qt/event_loop.py
@@ -22,7 +22,12 @@ def gui_qt(*, startup_logo=False):
     IPython with the Qt GUI event loop enabled by default by using
     ``ipython --gui=qt``.
     """
-    app = QApplication.instance() or QApplication(sys.argv)
+    app = QApplication.instance()
+    if not app:
+        # if this is the first time the Qt app is being instantiated, we set
+        # the name, so that we know whether to raise_ in Window.show()
+        app = QApplication(sys.argv)
+        app.setApplicationName('napari')
     if startup_logo:
         logopath = join(dirname(__file__), '..', 'resources', 'logo.png')
         splash_widget = QSplashScreen(QPixmap(logopath).scaled(400, 400))

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -274,16 +274,18 @@ class Window:
         """Resize, show, and bring forward the window."""
         self._qt_window.resize(self._qt_window.layout().sizeHint())
         self._qt_window.show()
-        # make sure window is not hidden, e.g. by browser window in Jupyter
-        # if the application was instantiated in gui_qt(), app_name will be
-        # "napari".  If it is the second time a _qt_window has been created,
-        # then isActiveWindow() will be True (otherwise false).
-        # this is the only combination that seems to fix #732
+
+        # We want to call Window._qt_window.raise_() in every case *except*
+        # when instantiating a viewer within a gui_qt() context for the
+        # _first_ time within the Qt app's lifecycle.
+        #
+        # `app_name` will be "napari" iff the application was instantiated in
+        # gui_qt(). isActiveWindow() will be True if it is the second time a
+        # _qt_window has been created. See #732
         app_name = QApplication.instance().applicationName()
-        if app_name == 'napari' and not self._qt_window.isActiveWindow():
-            return
-        self._qt_window.raise_()  # for MacOS
-        self._qt_window.activateWindow()  # for Windows
+        if app_name != 'napari' or self._qt_window.isActiveWindow():
+            self._qt_window.raise_()  # for macOS
+            self._qt_window.activateWindow()  # for Windows
 
     def _update_palette(self, palette):
         # set window styles which don't use the primary stylesheet

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -27,6 +27,7 @@ from qtpy.QtWidgets import (  # noqa: E402
     QAction,
     QShortcut,
     QStatusBar,
+    QApplication,
 )
 from qtpy.QtCore import Qt  # noqa: E402
 from qtpy.QtGui import QKeySequence  # noqa: E402
@@ -270,12 +271,19 @@ class Window:
         self._qt_window.resize(width, height)
 
     def show(self):
-        """Resize, show, and bring forward the window.
-        """
+        """Resize, show, and bring forward the window."""
         self._qt_window.resize(self._qt_window.layout().sizeHint())
         self._qt_window.show()
         # make sure window is not hidden, e.g. by browser window in Jupyter
-        self._qt_window.raise_()
+        # if the application was instantiated in gui_qt(), app_name will be
+        # "napari".  If it is the second time a _qt_window has been created,
+        # then isActiveWindow() will be True (otherwise false).
+        # this is the only combination that seems to fix #732
+        app_name = QApplication.instance().applicationName()
+        if app_name == 'napari' and not self._qt_window.isActiveWindow():
+            return
+        self._qt_window.raise_()  # for MacOS
+        self._qt_window.activateWindow()  # for Windows
 
     def _update_palette(self, palette):
         # set window styles which don't use the primary stylesheet


### PR DESCRIPTION
# Description
I think this should fix #732 (see also #721 and #553 ).  [This](https://github.com/napari/napari/issues/732#issuecomment-565765389) comment and [this](https://github.com/napari/napari/issues/732#issuecomment-565766439) comment detail some of the observations that led to this fix.  

The summary is that we want to call `Window._qt_window.raise_()` in pretty much every case _except_ when instantiating a viewer within a `gui_qt()` context manager for the first time within the Qt app's lifecycle.  It looks a bit strange but by naming any newly instantiated `QApplication`s within `gui_qt()` and checking whether `_qt_window.isActiveWindow()` during `Window.show()`... we seem to be able to figure out whether `raise_` should be called or not.

@sofroniewn, see if you can break it!

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas