### PR TITLE
Revert #784 console shutdown conditionals

### DIFF
--- a/napari/_qt/qt_console.py
+++ b/napari/_qt/qt_console.py
@@ -94,5 +94,7 @@ class QtConsole(RichJupyterWidget):
         # self.execute_on_complete_input = True
 
     def shutdown(self):
-        self.kernel_client.stop_channels()
-        self.kernel_manager.shutdown_kernel()
+        if self.kernel_client is not None:
+            self.kernel_client.stop_channels()
+        if self.kernel_manager is not None:
+            self.kernel_manager.shutdown_kernel()

--- a/napari/_qt/tests/test_qt_console.py
+++ b/napari/_qt/tests/test_qt_console.py
@@ -1,7 +1,9 @@
 from napari._qt.qt_console import QtConsole
+from IPython.terminal.interactiveshell import TerminalInteractiveShell
+from unittest import mock
 
 
-def test_console(qtbot):
+def test_console(qtbot, mocker):
     """Test creating the console."""
     console = QtConsole()
     qtbot.addWidget(console)
@@ -34,3 +36,18 @@ def test_multiple_consoles(qtbot):
     assert 'var_b' in console_a.shell.user_ns
     console_a.shutdown()
     console_b.shutdown()
+
+
+def test_ipython_console(qtbot, mocker):
+    """Test mock-creating a console from within ipython."""
+
+    def mock_get_ipython():
+        return TerminalInteractiveShell()
+
+    with mock.patch(
+        'napari._qt.qt_console.get_ipython', side_effect=mock_get_ipython
+    ):
+        console = QtConsole()
+        qtbot.addWidget(console)
+        assert console.kernel_client is None
+        console.shutdown()

--- a/napari/_qt/tests/test_qt_console.py
+++ b/napari/_qt/tests/test_qt_console.py
@@ -38,7 +38,7 @@ def test_multiple_consoles(qtbot):
     console_b.shutdown()
 
 
-def test_ipython_console(qtbot, mocker):
+def test_ipython_console(qtbot):
     """Test mock-creating a console from within ipython."""
 
     def mock_get_ipython():

--- a/napari/_qt/tests/test_qt_console.py
+++ b/napari/_qt/tests/test_qt_console.py
@@ -3,7 +3,7 @@ from IPython.terminal.interactiveshell import TerminalInteractiveShell
 from unittest import mock
 
 
-def test_console(qtbot, mocker):
+def test_console(qtbot):
     """Test creating the console."""
     console = QtConsole()
     qtbot.addWidget(console)


### PR DESCRIPTION
# Description
I left a comment on https://github.com/napari/napari/pull/784#discussion_r357945390, but since it's a closed PR, I'll just a new one so it doesn't get missed.  As stated there, I'm a bit confused why the conditionals were removed in the console shutdown method (even after reading the conversation there).  I'm getting exceptions now every time I close the napari window (in ipython).  If I'm missing something, we can just delete or modify this PR.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes a regression)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality