### PR TITLE
Add blocked_signals context manager

### DIFF
--- a/napari/_qt/layers/qt_image_base_layer.py
+++ b/napari/_qt/layers/qt_image_base_layer.py
@@ -1,9 +1,10 @@
-from qtpy.QtWidgets import QSlider
-from .. import QHRangeSlider
-from .qt_base_layer import QtLayerControls
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QLabel, QComboBox
 from qtpy.QtGui import QImage, QPixmap
+from qtpy.QtWidgets import QComboBox, QLabel, QSlider
+
+from .. import QHRangeSlider
+from ..util import blocked_signals
+from .qt_base_layer import QtLayerControls
 
 
 class QtBaseImageControls(QtLayerControls):
@@ -86,17 +87,15 @@ class QtBaseImageControls(QtLayerControls):
         cmin, cmax = self.layer.contrast_limits
         slidermin = (cmin - valmin) / (valmax - valmin)
         slidermax = (cmax - valmin) / (valmax - valmin)
-        self.contrastLimitsSlider.blockSignals(True)
-        self.contrastLimitsSlider.setValues((slidermin, slidermax))
-        self.contrastLimitsSlider.blockSignals(False)
+        with blocked_signals(self.contrastLimitsSlider):
+            self.contrastLimitsSlider.setValues((slidermin, slidermax))
 
     def gamma_slider_changed(self, value):
         self.layer.gamma = value / 100
 
     def gamma_slider_update(self):
-        self.gammaSlider.blockSignals(True)
-        self.gammaSlider.setValue(self.layer.gamma * 100)
-        self.gammaSlider.blockSignals(False)
+        with blocked_signals(self.gammaSlider):
+            self.gammaSlider.setValue(self.layer.gamma * 100)
 
     def mouseMoveEvent(self, event):
         self.layer.status = self.layer._contrast_limits_msg

--- a/napari/_qt/layers/qt_image_base_layer.py
+++ b/napari/_qt/layers/qt_image_base_layer.py
@@ -3,7 +3,7 @@ from qtpy.QtGui import QImage, QPixmap
 from qtpy.QtWidgets import QComboBox, QLabel, QSlider
 
 from .. import QHRangeSlider
-from ..util import blocked_signals
+from ..util import qt_signals_blocked
 from .qt_base_layer import QtLayerControls
 
 
@@ -87,14 +87,14 @@ class QtBaseImageControls(QtLayerControls):
         cmin, cmax = self.layer.contrast_limits
         slidermin = (cmin - valmin) / (valmax - valmin)
         slidermax = (cmax - valmin) / (valmax - valmin)
-        with blocked_signals(self.contrastLimitsSlider):
+        with qt_signals_blocked(self.contrastLimitsSlider):
             self.contrastLimitsSlider.setValues((slidermin, slidermax))
 
     def gamma_slider_changed(self, value):
         self.layer.gamma = value / 100
 
     def gamma_slider_update(self):
-        with blocked_signals(self.gammaSlider):
+        with qt_signals_blocked(self.gammaSlider):
             self.gammaSlider.setValue(self.layer.gamma * 100)
 
     def mouseMoveEvent(self, event):

--- a/napari/_qt/qt_viewer_dock_widget.py
+++ b/napari/_qt/qt_viewer_dock_widget.py
@@ -13,6 +13,8 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from .util import blocked_signals
+
 
 class QtViewerDockWidget(QDockWidget):
     """Wrap a QWidget in a QDockWidget and forward viewer events
@@ -116,12 +118,13 @@ class QtViewerDockWidget(QDockWidget):
         return self.size().height() > self.size().width()
 
     def _on_visibility_changed(self):
-        self.blockSignals(True)
-        self.setTitleBarWidget(None)
-        if not self.isFloating():
-            self.title = QtCustomTitleBar(self, vertical=not self.is_vertical)
-            self.setTitleBarWidget(self.title)
-        self.blockSignals(False)
+        with blocked_signals(self):
+            self.setTitleBarWidget(None)
+            if not self.isFloating():
+                self.title = QtCustomTitleBar(
+                    self, vertical=not self.is_vertical
+                )
+                self.setTitleBarWidget(self.title)
 
 
 class QtCustomTitleBar(QLabel):

--- a/napari/_qt/qt_viewer_dock_widget.py
+++ b/napari/_qt/qt_viewer_dock_widget.py
@@ -13,7 +13,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from .util import blocked_signals
+from .util import qt_signals_blocked
 
 
 class QtViewerDockWidget(QDockWidget):
@@ -118,7 +118,7 @@ class QtViewerDockWidget(QDockWidget):
         return self.size().height() > self.size().width()
 
     def _on_visibility_changed(self):
-        with blocked_signals(self):
+        with qt_signals_blocked(self):
             self.setTitleBarWidget(None)
             if not self.isFloating():
                 self.title = QtCustomTitleBar(

--- a/napari/_qt/tests/test_qt_utils.py
+++ b/napari/_qt/tests/test_qt_utils.py
@@ -1,6 +1,6 @@
 from qtpy.QtCore import QObject, Signal
 
-from ..util import blocked_signals
+from ..util import qt_signals_blocked
 
 
 class Emitter(QObject):
@@ -24,6 +24,6 @@ def test_signal_blocker(qtbot):
         raise AssertionError('a signal was emitted')
 
     obj.test_signal.connect(err)
-    with blocked_signals(obj):
+    with qt_signals_blocked(obj):
         obj.go()
         qtbot.wait(750)

--- a/napari/_qt/tests/test_qt_utils.py
+++ b/napari/_qt/tests/test_qt_utils.py
@@ -1,0 +1,29 @@
+from qtpy.QtCore import QObject, Signal
+
+from ..util import blocked_signals
+
+
+class Emitter(QObject):
+    test_signal = Signal()
+
+    def go(self):
+        self.test_signal.emit()
+
+
+def test_signal_blocker(qtbot):
+    """make sure context manager signal blocker works"""
+
+    obj = Emitter()
+
+    # make sure signal works
+    with qtbot.waitSignal(obj.test_signal):
+        obj.go()
+
+    # make sure blocker works
+    def err():
+        raise AssertionError('a signal was emitted')
+
+    obj.test_signal.connect(err)
+    with blocked_signals(obj):
+        obj.go()
+        qtbot.wait(750)

--- a/napari/_qt/util.py
+++ b/napari/_qt/util.py
@@ -118,7 +118,7 @@ def new_worker_qthread(
 
 
 @contextmanager
-def blocked_signals(obj):
+def qt_signals_blocked(obj):
     """Context manager to temporarily block signals from `obj`"""
     obj.blockSignals(True)
     yield

--- a/napari/_qt/util.py
+++ b/napari/_qt/util.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 import numpy as np
 from qtpy import API_NAME
 from qtpy.QtCore import QObject, QThread
@@ -113,3 +115,11 @@ def new_worker_qthread(
     if start:
         thread.start()  # sometimes need to connect stuff before starting
     return worker, thread
+
+
+@contextmanager
+def blocked_signals(obj):
+    """Context manager to temporarily block signals from `obj`"""
+    obj.blockSignals(True)
+    yield
+    obj.blockSignals(False)


### PR DESCRIPTION
# Description
Tiny little PR here that adds a `blocked_signals` context manager.  There are a few places (and probably will be more) where we temporarily block qt signals using:
```python
obj.blockSignals(True)
# do something
obj.blockSignals(False)
```
this turns that into
```python 
with blocked_signals(obj):
    # do something
```

(also, it's in #675 and I'm trying to break that down into smaller bits)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
