### PR TITLE
Fix (minor) deprecations

### DIFF
--- a/napari/_qt/layers/qt_shapes_layer.py
+++ b/napari/_qt/layers/qt_shapes_layer.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 import numpy as np
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (

--- a/napari/_qt/qt_dims.py
+++ b/napari/_qt/qt_dims.py
@@ -172,7 +172,7 @@ class QtDims(QWidget):
         """
         fm = QFontMetrics(QFont("", 0))
         labels = self.findChildren(QLineEdit, 'axis_label')
-        newwidth = max([fm.width(lab.text()) for lab in labels])
+        newwidth = max([fm.boundingRect(lab.text()).width() for lab in labels])
 
         if any(self._displayed_sliders):
             # set maximum width to no more than 20% of slider width
@@ -195,7 +195,7 @@ class QtDims(QWidget):
                     width = length
         # gui width of a string of length `width`
         fm = QFontMetrics(QFont("", 0))
-        width = fm.width("8" * width)
+        width = fm.boundingRect("8" * width).width()
         for labl in self.findChildren(QWidget, 'slice_label'):
             labl.setFixedWidth(width + 6)
 

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -610,6 +610,7 @@ class Layer(KeymapMixin, ABC):
 
         value = self._value
 
+        # FIXME: deprecation warning... but logic unclear
         if value is not None and not np.all(value == (None, None)):
             msg += ': '
             if type(value) == tuple:

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -609,18 +609,15 @@ class Layer(KeymapMixin, ABC):
         msg = f'{self.name} {full_coord}'
 
         value = self._value
-
-        # FIXME: deprecation warning... but logic unclear
-        if value is not None and not np.all(value == (None, None)):
-            msg += ': '
-            if type(value) == tuple:
-                msg += status_format(value[0])
+        if value is not None:
+            if isinstance(value, tuple) and value != (None, None):
+                # it's a pyramid -> value == (data_level, value)
+                msg += f': {status_format(value[0])}'
                 if value[1] is not None:
-                    msg += ', '
-                    msg += status_format(value[1])
+                    msg += f', {status_format(value[1])}'
             else:
-                msg += status_format(value)
-
+                # it's either a grayscale or rgb image (scalar or list)
+                msg += f': {status_format(value)}'
         return msg
 
     def to_xml_list(self):

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -611,7 +611,7 @@ class Layer(KeymapMixin, ABC):
         value = self._value
         if value is not None:
             if isinstance(value, tuple) and value != (None, None):
-                # it's a pyramid -> value == (data_level, value)
+                # it's a pyramid -> value = (data_level, value)
                 msg += f': {status_format(value[0])}'
                 if value[1] is not None:
                     msg += f', {status_format(value[1])}'


### PR DESCRIPTION
# Description
this just fixes a couple deprecation warnings that show up in our tests.  perhaps most importantly `from collections import Iterable` will stop working in python3.8

@sofroniewn, the comparison in this line is deprecated ... but it wasn't immediately clear to me what the goal of the logic is:
https://github.com/napari/napari/blob/4096e71b7e1fa041a62f4ac2f6853fba60c93e52/napari/layers/base/base.py#L613
 
```
napari/layers/image/tests/test_image.py::test_negative_rgba_image
  /Users/talley/Dropbox (HMS)/Python/forks/napari/napari/layers/base/base.py:614
  DeprecationWarning: elementwise comparison failed; this will raise an error in the future.
    if value is not None and not np.all(value == (None, None)):
```

is it just making sure that, if `value` is an array, at least one value is not null?