### PR TITLE
fix FPS spin box on Qt < 5.12

### DIFF
--- a/napari/_qt/qt_dims_slider.py
+++ b/napari/_qt/qt_dims_slider.py
@@ -363,7 +363,9 @@ class QtPlayButton(QPushButton):
         fpsspin = QtCustomDoubleSpinBox(self.popup)
         fpsspin.setAlignment(Qt.AlignCenter)
         fpsspin.setValue(self.fps)
-        fpsspin.setStepType(QDoubleSpinBox.AdaptiveDecimalStepType)
+        if hasattr(fpsspin, 'setStepType'):
+            # this was introduced in Qt 5.12.  Totally optional, just nice.
+            fpsspin.setStepType(QDoubleSpinBox.AdaptiveDecimalStepType)
         fpsspin.setMaximum(500)
         fpsspin.setMinimum(0)
         self.popup.form_layout.insertRow(


### PR DESCRIPTION
# Description
fixes #802.  `QtCustomDoubleSpinBox.setStepType` was introduced in 5.12, so this maintains 5.9 compatibility (which I think we should try to do when possible)


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
