### PR TITLE
Set threshold for codecov failure

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,12 @@
 ignore:
   - napari/_version.py
   - napari/resources
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%  # coverage can drop by up to 0.5% while still posting success
+    patch: off
+comment:
+  require_changes: true  # if true: only post the PR comment if coverage changes


### PR DESCRIPTION
# Description
As mentioned on zulip, I am slightly bothered by the red "X" next to PRs that are good in every way except a very slight drop in codecov.  I certainly don't want to encourage PRs lacking tests, but the status starts to be useless if you know there are relatively "nitpicky" things that might be causing it to show a failed status.  It'd be nice if the fail/success status were a direct predictor of whether the PR is ready (or close to ready) to merge or not.  

This would set a minimum threshold of a 0.5% loss in coverage in order for codecov to fail a build.  (We can of course, continue to manually evaluate whether there are sufficient tests as usual).  Certainly open to changing that number if anyone wants.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] CI change

# References
https://docs.codecov.io/docs/commit-status
