### PR TITLE
add PyGithub to dev dependencies

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,6 +7,8 @@ it will include generating release notes, documentation, etc.
 This is mainly meant for the core developers who will actually be performing the release.
 They will need to have a [PyPI](https://pypi.org) account with upload permissions to the `napari` package.
 
+You will also need the additional `release` dependencies in `requirements/release.txt` to complete the release process.
+
 ## determining the version
 
 The version of `napari` is automatically determined by [`versioneer`](https://github.com/warner/python-versioneer)
@@ -84,11 +86,6 @@ $ python setup.py sdist bdist_wheel
 Make sure to check that all necessary ones are listed before beginning the release process.
 
 ## uploading the release candidate to PyPI
-
-You'll need `twine` installed for this step:
-```bash
-$ pip install twine
-```
 
 Upload the release candidate with:
 ```bash

--- a/docs/release/release_0_2_7.rst
+++ b/docs/release/release_0_2_7.rst
@@ -54,6 +54,7 @@ Bugfixes
 - Bumpy vispy dependency to 0.6.4 (#807)
 - Set threshold for codecov failure (#806)
 - Rename util to utils in MANIFEST.in (#811)
+- Add `requirements/release.txt` with release dependencies (#809)
 
 API Changes
 ***********

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,3 +1,4 @@
 pre-commit>=1.16.1
 black>=19.3b0
 flake8==3.7.9
+PyGithub>=1.44.1

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,4 +1,5 @@
 pre-commit>=1.16.1
 black>=19.3b0
 flake8==3.7.9
+twine>=3.1.1
 PyGithub>=1.44.1

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,5 +1,3 @@
 pre-commit>=1.16.1
 black>=19.3b0
 flake8==3.7.9
-twine>=3.1.1
-PyGithub>=1.44.1

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -1,0 +1,2 @@
+PyGithub>=1.44.1
+twine>=3.1.1


### PR DESCRIPTION
This PR adds PyGithub to our dev dependencies as it is needed to generate release notes