### PR TITLE
rename utils in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,5 @@ include LICENSE
 include versioneer.py
 include napari/_version.py
 recursive-include napari/resources *.png *.jpeg *.jpg *.svg stylesheet.qss res.qrc
-include napari/util/colormaps/matplotlib_cmaps.txt
+include napari/utils/colormaps/matplotlib_cmaps.txt
 include requirements/default.txt

--- a/docs/release/release_0_2_7.rst
+++ b/docs/release/release_0_2_7.rst
@@ -53,6 +53,7 @@ Bugfixes
 - Fix FPS spin box on Qt < 5.12 (#803)
 - Bumpy vispy dependency to 0.6.4 (#807)
 - Set threshold for codecov failure (#806)
+- Rename util to utils in MANIFEST.in (#811)
 
 API Changes
 ***********


### PR DESCRIPTION
This PR renames `util` -> `utils` in our `MANIFEST.ini` which is needed following #808 to make sure our releases contain the right files