### PR TITLE
Fix broken links in CODE_OF_CONDUCT.md

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ If your report involves any members of the committee, or if they feel they have 
 
 
 ## Incident reporting resolution & Code of Conduct enforcement
-*This section summarizes the most important points, more details can be found in [napari Code of Conduct - How to follow up on a report.](https://github.com/napari/napari/blob/master/REPORT_HANDLING_MANUAL.md)*
+*This section summarizes the most important points, more details can be found in [napari Code of Conduct - How to follow up on a report.](https://github.com/napari/napari/blob/master/docs/REPORT_HANDLING_MANUAL.md)*
 
 We will investigate and respond to all complaints. The napari Code of Conduct Committee will protect the identity of the reporter, and treat the content of complaints as confidential (unless the reporter agrees otherwise).
 
@@ -75,7 +75,7 @@ In cases not involving clear severe and obvious breaches of this code of conduct
 
 3. mediation (if feedback didn’t help, and only if both reporter and reportee agree to this)
 
-4. enforcement via transparent decision (see [Resolutions](https://github.com/napari/napari/blob/master/REPORT_HANDLING_MANUAL.md#resolutions)) by the Code of Conduct Committee
+4. enforcement via transparent decision (see [Resolutions](https://github.com/napari/napari/blob/master/docs/REPORT_HANDLING_MANUAL.md#resolutions)) by the Code of Conduct Committee
 
 The committee will respond to any report as soon as possible, and at most within 72 hours.
 

--- a/docs/CORE_DEV_GUIDE.md
+++ b/docs/CORE_DEV_GUIDE.md
@@ -25,7 +25,7 @@ other contributors' pull requests.  Much like nuclear launch keys, it
 is a shared power: you must merge *only after* another core has
 approved the pull request, *and* after you yourself have carefully
 reviewed it.  (See [Reviewing](#reviewing) and especially
-[Merge Only Changes You Understand](#Merge Only Changes You Understand) below.)
+[Merge Only Changes You Understand](#merge-only-changes-you-understand) below.)
 It should also be considered best practice to leave a reasonable (24hr) time window
 after approval before merge to ensure that other core developers have a reasonable
 chance to weigh in.
@@ -99,7 +99,7 @@ For any major new features, accompanying changes should be made to our
 illustrates the new feature, but explains it.
 
 5. **Implementations and algorithms:** You should understand the code being modified
-or added before approving it.  (See [Merge Only Changes You Understand](#Merge Only Changes You Understand)
+or added before approving it.  (See [Merge Only Changes You Understand](#merge-only-changes-you-understand)
 below.) Implementations should do what they claim and be simple, readable, and efficient
 in that order.
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
This PR fixes two broken links to other markdown files. Some relative links in the developer docs stopped working after the files were moved into `docs/`.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] This change is a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] I made the changes, then clicked on the new links.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
