### PR TITLE
Automatically set high DPI scaling in Qt

### DIFF
--- a/napari/_qt/event_loop.py
+++ b/napari/_qt/event_loop.py
@@ -2,6 +2,7 @@ import sys
 from contextlib import contextmanager
 from os.path import dirname, join
 
+from qtpy.QtCore import Qt
 from qtpy.QtGui import QPixmap
 from qtpy.QtWidgets import QApplication, QSplashScreen
 
@@ -25,6 +26,9 @@ def gui_qt(*, startup_logo=False):
     splash_widget = None
     app = QApplication.instance()
     if not app:
+        # automatically determine monitor DPI.
+        # Note: this MUST be set before the QApplication is instantiated
+        QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
         # if this is the first time the Qt app is being instantiated, we set
         # the name, so that we know whether to raise_ in Window.show()
         app = QApplication(sys.argv)


### PR DESCRIPTION
# Description
Fixes issue #367 (with slider bars not scaling correctly in high DPI screens)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
