### PR TITLE
Modify visibility changed slot to only update title if the object is visible

### DIFF
--- a/napari/_qt/qt_viewer_dock_widget.py
+++ b/napari/_qt/qt_viewer_dock_widget.py
@@ -117,7 +117,9 @@ class QtViewerDockWidget(QDockWidget):
                 )
         return self.size().height() > self.size().width()
 
-    def _on_visibility_changed(self):
+    def _on_visibility_changed(self, visible):
+        if not visible:
+            return
         with qt_signals_blocked(self):
             self.setTitleBarWidget(None)
             if not self.isFloating():


### PR DESCRIPTION
The visibilitychanged slot currently updates the title regardless of the visibility. We are seeing a crash when the viewer is shut down and a signal is sent to the visibilitychanged slot.  That executes some code which causes a segfault in the python process[1].  This PR changes the visibility changed slot to only update the title bar if the widget is visible.

[1]
```
  * frame #0: 0x0000000115cc96e4 QtWidgets`QWidgetPrivate::reparentFocusWidgets(QWidget*) + 356
    frame #1: 0x0000000115cb99cf QtWidgets`QWidget::setParent(QWidget*, QFlags<Qt::WindowType>) + 911
    frame #2: 0x0000000115cb82c0 QtWidgets`QWidgetPrivate::init(QWidget*, QFlags<Qt::WindowType>) + 688
    frame #3: 0x0000000115d73e5e QtWidgets`QFrame::QFrame(QFramePrivate&, QWidget*, QFlags<Qt::WindowType>) + 14
    frame #4: 0x0000000115dc3705 QtWidgets`QLabel::QLabel(QWidget*, QFlags<Qt::WindowType>) + 277
    frame #5: 0x0000000116503189 QtWidgets.abi3.so`Sbk_QLabel_Init(_object*, _object*, _object*) + 1497
    frame #6: 0x000000010015f84d Python`wrap_init + 12
    frame #7: 0x0000000100113e64 Python`_PyObject_FastCallDict + 143
    frame #8: 0x00000001001b17a2 Python`call_function + 439
    frame #9: 0x00000001001aa46b Python`_PyEval_EvalFrameDefault + 3078
    frame #10: 0x00000001001b1ee2 Python`_PyEval_EvalCodeWithName + 1638
    frame #11: 0x00000001001b281b Python`_PyFunction_FastCallDict + 447
    frame #12: 0x0000000100113e99 Python`_PyObject_FastCallDict + 196
    frame #13: 0x0000000100113fa3 Python`_PyObject_Call_Prepend + 131
    frame #14: 0x0000000100113d1e Python`PyObject_Call + 101
    frame #15: 0x000000010015f7d1 Python`slot_tp_init + 57
    frame #16: 0x000000010015c782 Python`type_call + 178
    frame #17: 0x0000000100113e64 Python`_PyObject_FastCallDict + 143
    frame #18: 0x00000001001141fa Python`_PyObject_FastCallKeywords + 97
    frame #19: 0x00000001001b17a2 Python`call_function + 439
    frame #20: 0x00000001001aa4fb Python`_PyEval_EvalFrameDefault + 3222
    frame #21: 0x00000001001b28e0 Python`_PyFunction_FastCall + 110
    frame #22: 0x0000000100113e99 Python`_PyObject_FastCallDict + 196
    frame #23: 0x0000000100113fa3 Python`_PyObject_Call_Prepend + 131
    frame #24: 0x0000000100113d1e Python`PyObject_Call + 101
    frame #25: 0x000000011126f146 libpyside2.abi3.5.14.dylib`PySide::SignalManager::callPythonMetaMethod(QMetaMethod const&, void**, _object*, bool) + 534
    frame #26: 0x000000011126eb77 libpyside2.abi3.5.14.dylib`PySide::SignalManager::qt_metacall(QObject*, QMetaObject::Call, int, void**) + 519
```

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
