### PR TITLE
Basic remote control of napari

### DIFF
--- a/examples/remote_access.py
+++ b/examples/remote_access.py
@@ -1,0 +1,26 @@
+"""
+Example of making calls to the viewer from a separate script or process
+using a ZMQ server started with the --remote-port flag.
+
+Run this example after having started napari on localhost with:
+   napari --remote-port 7341
+"""
+
+from napari.remote import Client
+
+client = Client()
+print(
+    f"Started client to napari remote server on {client.host} with port {client.port}"
+)
+
+version = client.request('version')
+print(f"napari version: {version}")
+
+print("Adding image to napari")
+client.request(
+    'add_image',
+    path=r'https://github.com/napari/napari/raw/master/napari/resources/logo.png',
+)
+
+print("Getting data from layer 0")
+data = client.request('get_data', layer=0)

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -49,9 +49,15 @@ def main():
         'dask if all the images fit in RAM. This option does nothing if '
         'only a single image is given.',
     )
+    parser.add_argument(
+        '-p',
+        '--remote-port',
+        help='Start a ZMQSserver listening on specified port for remote procedure calls.',
+        default=None,
+    )
     args = parser.parse_args()
     with gui_qt(startup_logo=True):
-        v = Viewer()
+        v = Viewer(port=args.remote_port)
         if len(args.images) > 0:
             images = io.magic_imread(
                 args.images, use_dask=args.use_dask, stack=not args.layers

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -12,6 +12,10 @@ from ..utils.keybindings import KeymapMixin
 from ..utils.theme import palettes
 from ..utils.misc import ensure_iterable, is_iterable
 from ..utils import io
+from .._version import get_versions
+
+__version__ = get_versions()['version']
+del get_versions
 
 
 class ViewerModel(KeymapMixin):
@@ -49,6 +53,8 @@ class ViewerModel(KeymapMixin):
         self, title='napari', ndisplay=2, order=None, axis_labels=None
     ):
         super().__init__()
+
+        self.version = __version__
 
         self.events = EmitterGroup(
             source=self,

--- a/napari/remote.py
+++ b/napari/remote.py
@@ -1,0 +1,85 @@
+import weakref
+import zprocess
+from qtutils import inmain_decorator
+
+
+class RemoteServer(zprocess.ZMQServer):
+    def __init__(self, parent, *args, **kwargs):
+        self.parent = weakref.ref(parent)
+        super().__init__(*args, **kwargs)
+
+    @inmain_decorator()
+    def handler(self, msg):
+        """Description.
+
+        Arguments:
+            msg {[type]} -- [description]
+
+        Returns:
+            [type] -- [description]
+        """
+        if isinstance(msg, (tuple, list)) and len(msg) == 3:
+            name, args, kwargs = msg
+            # Is there an explicit handler for the request?
+            if hasattr(self, 'handle_' + name):
+                return getattr(self, 'handle_' + name)(*args, **kwargs)
+            # Run the parent method if it exists
+            if hasattr(self.parent(), name):
+                fn = getattr(self.parent(), name)
+                if callable(fn):
+                    # This is a callable method, so call it
+                    fn(*args, **kwargs)
+                    return True
+                else:
+                    # This is an attribute/property, so return it
+                    return fn
+        elif msg == 'hello':
+            return 'hello'
+        return "error: request not supported."
+
+    def handle_close(self):
+        """Close the napari window (equivalent to Ctrl+W)."""
+        self.parent().window.close()
+        return True
+
+    def handle_hello(self):
+        """Simple req/rep confirmation."""
+        return "hello"
+
+    def handle_get_data(self, layer=0):
+        """Get image data from the specified layer."""
+        return self.parent().layers[layer].data
+
+
+class Client(zprocess.ZMQClient):
+    """A zprocess.ZMQClient for communicating with napari."""
+
+    def __init__(self, host='localhost', port=7341, timeout=5):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        super().__init__()
+
+    def request(self, name, *args, **kwargs):
+        """Call a method of napari.viewer.Viewer remotely or get
+        an instance attribute/property. If `name` is a method, args
+        and kwargs are passed.
+        """
+        return self.get(
+            port=self.port,
+            host=self.host,
+            data=[name, args, kwargs],
+            timeout=self.timeout,
+        )
+
+    def say_hello(self):
+        """Ping the napari server for a response."""
+        return self.request('hello')
+
+    def get_version(self):
+        """Return the version of napari the server is running in."""
+        return self.request('version')
+
+    def reset_view(self):
+        """Reset the view (equivalent to Ctrl+R)."""
+        return self.request('reset_view')

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -8,6 +8,7 @@ from napari._qt.qt_update_ui import QtUpdateUI
 from ._qt.qt_main_window import Window
 from ._qt.qt_viewer import QtViewer
 from .components import ViewerModel
+from .remote import RemoteServer
 
 
 class Viewer(ViewerModel):
@@ -25,10 +26,18 @@ class Viewer(ViewerModel):
         ndisplay is 2 or 3.
     axis_labels : list of str
         Dimension names.
+    port : int
+        Port of `zprocess.ZMQServer` used to listen for remote calls to
+        methods of the viewer.
     """
 
     def __init__(
-        self, title='napari', ndisplay=2, order=None, axis_labels=None
+        self,
+        title='napari',
+        ndisplay=2,
+        order=None,
+        axis_labels=None,
+        port=None,
     ):
         # instance() returns the singleton instance if it exists, or None
         app = QApplication.instance()
@@ -61,6 +70,12 @@ class Viewer(ViewerModel):
         qt_viewer = QtViewer(self)
         self.window = Window(qt_viewer)
         self.update_console = self.window.qt_viewer.console.push
+        if port:
+            self.remote = RemoteServer(
+                self, port=int(port), allow_insecure=True
+            )
+        else:
+            self.remote = None
 
     def screenshot(self, with_viewer=False):
         """Take currently displayed screen and convert to an image array.

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -16,3 +16,5 @@ PyOpenGL>=3.1.0
 PySide2>=5.12.3
 wrapt>=1.11.1
 numpydoc>=0.9.1
+qtutils>=2.3.2
+zprocess>=2.18.0


### PR DESCRIPTION
# Description
Provides access to methods and attributes of viewer using ZeroMQ.

This might be useful where you want to programmatically add images/layers/shapes from a separate process rather than via the napari console or the interactive session that napari was launched with. This will allow existing software to interface with napari in a way that doesn't require you to launch napari from that software (or vice versa) or on the same host.

Start napari with a ZMQ server using:
`napari --remote-port 7341`

Then, from a separate process, you can call:
```python
In [1]: from napari.remote import Client

In [2]: client = Client()

In [3]: client.request('version')
Out[3]: '0.2.7rc1+0.g04b5ae5.dirty'

In [4]: client.request('title')
Out[4]: 'napari'

In [5]: client.request('status')
Out[5]: 'Ready'

In [6]: client.request('add_image', path=r'https://github.com/napari/napari/raw/master/napari/resources/logo.png')
Out[6]: True

In[7]: data = client.request('get_data', layer=0)
Out[7]:
array([[[255, 255, 255,   0],
        [255, 255, 255,   0],
        [255, 255, 255,   0],
        ...,
        [255, 255, 255,   0],
        [255, 255, 255,   0],
        [255, 255, 255,   0]]], dtype=uint8)

In [8]: client.reset_view()
Out[8]: True
```
Requests are handled in the main thread and the Qt lock is acquired using the `inmain_decorator` of the [qtutils package](https://qtutils.readthedocs.io/).

In this proof-of-concept, methods of the `napari.viewer.Viewer` singleton are accessed via `client.request('method_name', *args, **kwargs)`. The `get_data`, `close`, and `hello`  requests are handled separately, with [their own methods](https://github.com/rpanderson/napari/blob/remote-access/napari/remote.py#L40) of the server (prefixed by `handle_`).

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## TODO
- Document and support the use of a shared secret file for use with [zprocess](https://github.com/chrisjbillington/zprocess) security mechanisms.
