### PR TITLE
compatibility with numpy 1.18

### DIFF
--- a/napari/layers/labels/labels_utils.py
+++ b/napari/layers/labels/labels_utils.py
@@ -24,7 +24,7 @@ def interpolate_coordinates(old_coord, new_coord, brush_size):
         max(abs(np.array(new_coord) - np.array(old_coord))) / brush_size * 4
     )
     coords = [
-        np.linspace(old_coord[i], new_coord[i], num=num_step + 1)
+        np.linspace(old_coord[i], new_coord[i], num=int(num_step + 1))
         for i in range(len(new_coord))
     ]
     coords = np.stack(coords).T


### PR DESCRIPTION
# Description
Fixes #826 caused by an expired deprecation in numpy:
> np.linspace parameter num must be an integer. Deprecated in NumPy 1.12.

https://numpy.org/devdocs/release/1.18.0-notes.html

sorry that I missed this is #800.  somehow I thought it was due to code outside of napari... will take another look at our deprecations and follow up with additional PRs if any are found.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
https://numpy.org/devdocs/release/1.18.0-notes.html

# How has this been tested?
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
