### PR TITLE
numpydoc 0_9_2

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -15,4 +15,4 @@ backcall>=0.1.0
 PyOpenGL>=3.1.0
 PySide2>=5.12.3
 wrapt>=1.11.1
-numpydoc>=0.9.1
+numpydoc>=0.9.2


### PR DESCRIPTION
# Description
Following up on our slow imports #758 this PR now bumps our numpydoc dependency to 0.9.2