### PR TITLE
support surface timeseries

### DIFF
--- a/examples/surface_timeseries.py
+++ b/examples/surface_timeseries.py
@@ -6,8 +6,9 @@ try:
     from nilearn import datasets
     from nilearn import surface
 except ImportError:
-    raise ImportError("""This example uses data and methods from nilearn but
-    nilearn installed. To install try 'pip install nilearn'.""")
+    raise ImportError(
+        "You must have nilearn installed to run this example."
+    )
 
 import numpy as np
 import napari
@@ -18,16 +19,19 @@ nki_dataset = datasets.fetch_surf_nki_enhanced(n_subjects=1)
 fsaverage = datasets.fetch_surf_fsaverage()
 
 # Load surface data and resting state time series from nilearn
-pial_left = surface.load_surf_data(fsaverage['pial_left'])
-sulc_left = surface.load_surf_data(fsaverage['sulc_left'])
-timeseries = surface.load_surf_data(nki_dataset['func_left'][0]).transpose((1, 0))
+brain_vertices, brain_faces = surface.load_surf_data(fsaverage['pial_left'])
+brain_vertex_depth = surface.load_surf_data(fsaverage['sulc_left'])
+timeseries = surface.load_surf_data(nki_dataset['func_left'][0])
+# nilearn provides data as n_vertices x n_timepoints, but napari requires the
+# vertices axis to be placed last to match NumPy broadcasting rules
+timeseries = timeseries.transpose((1, 0))
 
 with napari.gui_qt():
     # create an empty viewer
     viewer = napari.Viewer(ndisplay=3)
 
     # add the mri
-    viewer.add_surface((pial_left[0], pial_left[1], sulc_left), name='base')
-    viewer.add_surface((pial_left[0], pial_left[1], timeseries),
+    viewer.add_surface((brain_vertices, brain_faces, brain_vertex_depth), name='base')
+    viewer.add_surface((brain_vertices, brain_faces, timeseries),
                        colormap='turbo', opacity=0.9,
                        contrast_limits=[-1.5, 3.5], name='timeseries')

--- a/examples/surface_timeseries.py
+++ b/examples/surface_timeseries.py
@@ -1,0 +1,33 @@
+"""
+Display a surface timeseries using data from nilearn
+"""
+
+try:
+    from nilearn import datasets
+    from nilearn import surface
+except ImportError:
+    raise ImportError("""This example uses data and methods from nilearn but
+    nilearn installed. To install try 'pip install nilearn'.""")
+
+import numpy as np
+import napari
+
+
+# Fetch datasets - this will download dataset if datasets are not found
+nki_dataset = datasets.fetch_surf_nki_enhanced(n_subjects=1)
+fsaverage = datasets.fetch_surf_fsaverage()
+
+# Load surface data and resting state time series from nilearn
+pial_left = surface.load_surf_data(fsaverage['pial_left'])
+sulc_left = surface.load_surf_data(fsaverage['sulc_left'])
+timeseries = surface.load_surf_data(nki_dataset['func_left'][0]).transpose((1, 0))
+
+with napari.gui_qt():
+    # create an empty viewer
+    viewer = napari.Viewer(ndisplay=3)
+
+    # add the mri
+    viewer.add_surface((pial_left[0], pial_left[1], sulc_left), name='base')
+    viewer.add_surface((pial_left[0], pial_left[1], timeseries),
+                       colormap='turbo', opacity=0.9,
+                       contrast_limits=[-1.5, 3.5], name='timeseries')

--- a/napari/_vispy/vispy_surface_layer.py
+++ b/napari/_vispy/vispy_surface_layer.py
@@ -37,7 +37,7 @@ class VispySurfaceLayer(VispyBaseLayer):
             # Offseting so pixels now centered
             vertices = self.layer._data_view[:, ::-1] + 0.5
             faces = self.layer._view_faces
-            vertex_values = self.layer.vertex_values
+            vertex_values = self.layer._view_vertex_values
 
         if (
             vertices is not None

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -869,7 +869,7 @@ class ViewerModel(KeymapMixin):
         data : 3-tuple of array
             The first element of the tuple is an (N, D) array of vertices of
             mesh triangles. The second is an (M, 3) array of int of indices
-            of the mesh triangles. The third element is the (N, K0, ..., KL)
+            of the mesh triangles. The third element is the (K0, ..., KL, N)
             array of values used to color vertices where the additional L
             dimensions are used to color the same mesh with different values.
         colormap : str, vispy.Color.Colormap, tuple, dict

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -869,8 +869,9 @@ class ViewerModel(KeymapMixin):
         data : 3-tuple of array
             The first element of the tuple is an (N, D) array of vertices of
             mesh triangles. The second is an (M, 3) array of int of indices
-            of the mesh triangles. The third element is the (N, ) array of
-            values used to color vertices.
+            of the mesh triangles. The third element is the (N, K0, ..., KL)
+            array of values used to color vertices where the additional L
+            dimensions are used to color the same mesh with different values.
         colormap : str, vispy.Color.Colormap, tuple, dict
             Colormap to use for luminance images. If a string must be the name
             of a supported colormap from vispy or matplotlib. If a tuple the

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -315,7 +315,7 @@ class Surface(Layer):
         self._data_view = self.vertices[:, disp]
         if len(self.vertices) == 0:
             self._view_faces = np.zeros((0, 3))
-        elif self.ndim > self.dims.ndisplay:
+        elif self.vertices.shape[1] > self.dims.ndisplay:
             vertices = self.vertices[:, not_disp].astype('int')
             triangles = vertices[self.faces]
             matches = np.all(triangles == indices[not_disp], axis=(1, 2))

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -301,11 +301,17 @@ class Surface(Layer):
             values_indices = self.dims.indices[:-vertex_ndim]
             values = self.vertex_values[values_indices]
             if values.ndim > 1:
-                raise ValueError(
+                warnings.warn(
                     """Assigning multiple values per vertex after slicing is
                     not allowed. All dimensions corresponding to vertex_values
-                    must be non-displayed dimensions."""
+                    must be non-displayed dimensions. Data will not be
+                    visible."""
                 )
+                self._data_view = np.zeros((0, self.dims.ndisplay))
+                self._view_faces = np.zeros((0, 3))
+                self._view_vertex_values = []
+                return
+
             self._view_vertex_values = values
             # Determine which axes of the vertices data are being displayed
             # and not displayed, ignoring the additional dimensions

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -301,10 +301,11 @@ class Surface(Layer):
             values_indices = self.dims.indices[:-vertex_ndim]
             values = self.vertex_values[values_indices]
             if values.ndim > 1:
-                # If not all dimensions corresponding to the vertex_values
-                # are being sliced through, average over any remaining ones
-                # so that there is always only value per vertex.
-                values = values.mean(axis=tuple(range(0, values.ndim - 1)))
+                raise ValueError(
+                    """Assigning multiple values per vertex after slicing is
+                    not allowed. All dimensions corresponding to vertex_values
+                    must be non-displayed dimensions."""
+                )
             self._view_vertex_values = values
             # Determine which axes of the vertices data are being displayed
             # and not displayed, ignoring the additional dimensions

--- a/napari/layers/surface/tests/test_surface.py
+++ b/napari/layers/surface/tests/test_surface.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from napari.layers import Surface
 
 
@@ -72,6 +73,9 @@ def test_random_3D_timeseries_surface():
     layer.dims.ndisplay = 3
     assert layer._data_view.shape[1] == 3
     assert layer._view_vertex_values.ndim == 1
+
+    with pytest.raises(ValueError):
+        layer.dims.order = [3, 0, 1, 2]
 
 
 def test_random_3D_multitimeseries_surface():

--- a/napari/layers/surface/tests/test_surface.py
+++ b/napari/layers/surface/tests/test_surface.py
@@ -60,7 +60,7 @@ def test_random_3D_timeseries_surface():
     np.random.seed(0)
     vertices = np.random.random((10, 3))
     faces = np.random.randint(10, size=(6, 3))
-    values = np.random.random((10, 22))
+    values = np.random.random((22, 10))
     data = (vertices, faces, values)
     layer = Surface(data)
     assert layer.ndim == 4
@@ -79,7 +79,7 @@ def test_random_3D_multitimeseries_surface():
     np.random.seed(0)
     vertices = np.random.random((10, 3))
     faces = np.random.randint(10, size=(6, 3))
-    values = np.random.random((10, 22, 16))
+    values = np.random.random((16, 22, 10))
     data = (vertices, faces, values)
     layer = Surface(data)
     assert layer.ndim == 5

--- a/napari/layers/surface/tests/test_surface.py
+++ b/napari/layers/surface/tests/test_surface.py
@@ -73,6 +73,8 @@ def test_random_3D_timeseries_surface():
     assert layer._data_view.shape[1] == 3
     assert layer._view_vertex_values.ndim == 1
 
+    # If a values axis is made to be a displayed axis then no data should be
+    # shown
     layer.dims.order = [3, 0, 1, 2]
     assert len(layer._data_view) == 0
 

--- a/napari/layers/surface/tests/test_surface.py
+++ b/napari/layers/surface/tests/test_surface.py
@@ -10,11 +10,13 @@ def test_random_surface():
     values = np.random.random(10)
     data = (vertices, faces, values)
     layer = Surface(data)
+    assert layer.ndim == 2
     assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data)])
     assert np.all(layer.vertices == vertices)
     assert np.all(layer.faces == faces)
     assert np.all(layer.vertex_values == values)
     assert layer._data_view.shape[1] == 2
+    assert layer._view_vertex_values.ndim == 1
 
 
 def test_random_3D_surface():
@@ -25,11 +27,71 @@ def test_random_3D_surface():
     values = np.random.random(10)
     data = (vertices, faces, values)
     layer = Surface(data)
+    assert layer.ndim == 3
     assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data)])
     assert layer._data_view.shape[1] == 2
+    assert layer._view_vertex_values.ndim == 1
 
     layer.dims.ndisplay = 3
     assert layer._data_view.shape[1] == 3
+    assert layer._view_vertex_values.ndim == 1
+
+
+def test_random_4D_surface():
+    """Test instantiating Surface layer with random 4D data."""
+    np.random.seed(0)
+    vertices = np.random.random((10, 4))
+    faces = np.random.randint(10, size=(6, 3))
+    values = np.random.random(10)
+    data = (vertices, faces, values)
+    layer = Surface(data)
+    assert layer.ndim == 4
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data)])
+    assert layer._data_view.shape[1] == 2
+    assert layer._view_vertex_values.ndim == 1
+
+    layer.dims.ndisplay = 3
+    assert layer._data_view.shape[1] == 3
+    assert layer._view_vertex_values.ndim == 1
+
+
+def test_random_3D_timeseries_surface():
+    """Test instantiating Surface layer with random 3D timeseries data."""
+    np.random.seed(0)
+    vertices = np.random.random((10, 3))
+    faces = np.random.randint(10, size=(6, 3))
+    values = np.random.random((10, 22))
+    data = (vertices, faces, values)
+    layer = Surface(data)
+    assert layer.ndim == 4
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data)])
+    assert layer._data_view.shape[1] == 2
+    assert layer._view_vertex_values.ndim == 1
+    assert layer.shape[0] == 22
+
+    layer.dims.ndisplay = 3
+    assert layer._data_view.shape[1] == 3
+    assert layer._view_vertex_values.ndim == 1
+
+
+def test_random_3D_multitimeseries_surface():
+    """Test instantiating Surface layer with random 3D multitimeseries data."""
+    np.random.seed(0)
+    vertices = np.random.random((10, 3))
+    faces = np.random.randint(10, size=(6, 3))
+    values = np.random.random((10, 22, 16))
+    data = (vertices, faces, values)
+    layer = Surface(data)
+    assert layer.ndim == 5
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data)])
+    assert layer._data_view.shape[1] == 2
+    assert layer._view_vertex_values.ndim == 1
+    assert layer.shape[0] == 22
+    assert layer.shape[1] == 16
+
+    layer.dims.ndisplay = 3
+    assert layer._data_view.shape[1] == 3
+    assert layer._view_vertex_values.ndim == 1
 
 
 def test_visiblity():

--- a/napari/layers/surface/tests/test_surface.py
+++ b/napari/layers/surface/tests/test_surface.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from napari.layers import Surface
 
 
@@ -74,8 +73,8 @@ def test_random_3D_timeseries_surface():
     assert layer._data_view.shape[1] == 3
     assert layer._view_vertex_values.ndim == 1
 
-    with pytest.raises(ValueError):
-        layer.dims.order = [3, 0, 1, 2]
+    layer.dims.order = [3, 0, 1, 2]
+    assert len(layer._data_view) == 0
 
 
 def test_random_3D_multitimeseries_surface():

--- a/napari/layers/surface/tests/test_surface.py
+++ b/napari/layers/surface/tests/test_surface.py
@@ -86,8 +86,8 @@ def test_random_3D_multitimeseries_surface():
     assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data)])
     assert layer._data_view.shape[1] == 2
     assert layer._view_vertex_values.ndim == 1
-    assert layer.shape[0] == 22
-    assert layer.shape[1] == 16
+    assert layer.shape[0] == 16
+    assert layer.shape[1] == 22
 
     layer.dims.ndisplay = 3
     assert layer._data_view.shape[1] == 3

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -463,8 +463,9 @@ def view_surface(
     data : 3-tuple of array
         The first element of the tuple is an (N, D) array of vertices of
         mesh triangles. The second is an (M, 3) array of int of indices
-        of the mesh triangles. The third element is the (N, ) array of
-        values used to color vertices.
+        of the mesh triangles. The third element is the (N, K0, ..., KL)
+        array of values used to color vertices where the additional L
+        dimensions are used to color the same mesh with different values.
     colormap : str, vispy.Color.Colormap, tuple, dict
         Colormap to use for luminance images. If a string must be the name
         of a supported colormap from vispy or matplotlib. If a tuple the

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -463,7 +463,7 @@ def view_surface(
     data : 3-tuple of array
         The first element of the tuple is an (N, D) array of vertices of
         mesh triangles. The second is an (M, 3) array of int of indices
-        of the mesh triangles. The third element is the (N, K0, ..., KL)
+        of the mesh triangles. The third element is the (K0, ..., KL, N)
         array of values used to color vertices where the additional L
         dimensions are used to color the same mesh with different values.
     colormap : str, vispy.Color.Colormap, tuple, dict


### PR DESCRIPTION
# Description
This PR will close #829 by allowing timeseries values for surfaces (i.e. static surface, but values that vary in one (say time) or more dimensions. This code snippet will allow you to reproduce the example bellow

```python
# NKI resting state data from nilearn
from nilearn import datasets
from nilearn import surface
import napari
import numpy as np


nki_dataset = datasets.fetch_surf_nki_enhanced(n_subjects=1)

# Fsaverage5 surface template
fsaverage = datasets.fetch_surf_fsaverage()

# Load surface data and resting state time series from nilearn
pial_left = surface.load_surf_data(fsaverage['pial_left'])
sulc_left = surface.load_surf_data(fsaverage['sulc_left'])
timeseries = surface.load_surf_data(nki_dataset['func_left'][0])
timeseries = np.stack([timeseries, timeseries/2, timeseries/4, np.full(timeseries.shape, -1.5)], axis=2)
print(timeseries.shape)

with napari.gui_qt():
    # create an empty viewer
    viewer = napari.Viewer(ndisplay=3)

    # add the mri
    viewer.add_surface((pial_left[0], pial_left[1], sulc_left), name='base')
    viewer.add_surface((pial_left[0], pial_left[1], timeseries), colormap='red', opacity=0.9, name='timeseries')
```

![surface_timeseries](https://user-images.githubusercontent.com/6531703/71485965-aeee0b80-27c8-11ea-8490-b0cd70a6e9e0.gif)

Note some counterintuitive things may happen if you now try and "display" a timeseries like dimension, but it shouldn't crash. There might be some weird corner cases I havn't caught yet though.

Right now the change is backwards compatible with our current shapes API, this PR purely adds functionality. There was some discussion of changing the API in #829 which I am open too, but I think that can be separated from this PR, though I'm open to doing it here too!

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] tests added inside the surface layer tests

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
