### PR TITLE
[WIP] support mixed 2D / 3D rendering

### DIFF
--- a/napari/_qt/qt_dims.py
+++ b/napari/_qt/qt_dims.py
@@ -61,6 +61,7 @@ class QtDims(QWidget):
         self.dims.events.range.connect(lambda ev: self._update_range(ev.axis))
         self.dims.events.ndisplay.connect(self._update_display)
         self.dims.events.order.connect(self._update_display)
+        self.dims.events.embedded.connect(self._update_display)
 
     @property
     def nsliders(self):
@@ -137,7 +138,7 @@ class QtDims(QWidget):
         """
         widgets = reversed(list(enumerate(self.slider_widgets)))
         for (axis, widget) in widgets:
-            if axis in self.dims.displayed:
+            if axis in self.dims.displayed and axis != self.dims.sliced:
                 # Displayed dimensions correspond to non displayed sliders
                 self._displayed_sliders[axis] = False
                 self.last_used = None

--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -138,10 +138,16 @@ class VispyBaseLayer(ABC):
         self.layer.position = self._transform_position(self._position)
 
     def _on_translate_change(self):
-        self.translate = [
-            self.layer.translate[d] + self.layer.translate_grid[d]
+        translate = [
+            self.layer.translate[d]
+            + self.layer._translate_view[d]
+            + self.layer.translate_grid[d]
             for d in self.layer.dims.displayed[::-1]
         ]
+        d = self.layer.dims.sliced
+        if d is not None and len(translate) == 2:
+            translate = translate + [self.layer._translate_view[d]]
+        self.translate = translate
         self.layer.position = self._transform_position(self._position)
 
     def _transform_position(self, position):

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -149,15 +149,6 @@ class VispyImageLayer(VispyBaseLayer):
             self.layer.top_left = self.find_top_left()
         self.layer.position = self._transform_position(self._position)
 
-    def _on_translate_change(self):
-        self.translate = [
-            self.layer.translate[d]
-            + self.layer._translate_view[d]
-            + self.layer.translate_grid[d]
-            for d in self.layer.dims.displayed[::-1]
-        ]
-        self.layer.position = self._transform_position(self._position)
-
     def compute_data_level(self, size):
         """Computed what level of the pyramid should be viewed given the
         current size of the requested field of view.

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -53,7 +53,15 @@ class Dims:
         Order of only displayed dimensions.
     """
 
-    def __init__(self, ndim=None, *, ndisplay=2, order=None, axis_labels=None):
+    def __init__(
+        self,
+        ndim=None,
+        *,
+        ndisplay=2,
+        order=None,
+        embedded=False,
+        axis_labels=None,
+    ):
         super().__init__()
 
         # Events:
@@ -64,6 +72,7 @@ class Dims:
             axis_labels=None,
             ndim=None,
             ndisplay=None,
+            embedded=None,
             order=None,
             range=None,
             camera=None,
@@ -76,6 +85,7 @@ class Dims:
         self._axis_labels = []
         self.clip = True
         self._ndisplay = 2 if ndisplay is None else ndisplay
+        self._embedded = embedded
 
         if ndim is None and order is None and axis_labels is None:
             ndim = self._ndisplay
@@ -297,6 +307,19 @@ class Dims:
         self.events.camera()
 
     @property
+    def embedded(self):
+        """Bool: Whether 2D display is embedded in 3D rendering."""
+        return self._embedded
+
+    @embedded.setter
+    def embedded(self, embedded):
+        if self._embedded == embedded:
+            return
+
+        self._embedded = embedded
+        self.events.embedded()
+
+    @property
     def displayed(self):
         """Tuple: Dimensions that are displayed."""
         return self.order[-self.ndisplay :]
@@ -305,6 +328,14 @@ class Dims:
     def not_displayed(self):
         """Tuple: Dimensions that are not displayed."""
         return self.order[: -self.ndisplay]
+
+    @property
+    def sliced(self):
+        """int: Dimension that is sliced if embedded."""
+        if self.embedded and self.ndim >= 3:
+            return self.order[-3]
+        else:
+            return None
 
     @property
     def displayed_order(self):

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -180,6 +180,7 @@ class Layer(KeymapMixin, ABC):
         self.dims.events.ndisplay.connect(lambda e: self._update_dims())
         self.dims.events.order.connect(lambda e: self._update_dims())
         self.dims.events.axis.connect(lambda e: self.refresh())
+        self.dims.events.axis.connect(lambda e: self._embedded_slicing())
 
         self.mouse_move_callbacks = []
         self.mouse_drag_callbacks = []
@@ -528,6 +529,16 @@ class Layer(KeymapMixin, ABC):
             return
         self.events.cursor_size(cursor_size=cursor_size)
         self._cursor_size = cursor_size
+
+    def _embedded_slicing(self):
+        """Translate embedded view based on slicing."""
+        if self.dims.sliced is None or self.dims.ndisplay == 3:
+            return
+        else:
+            self._translate_view[self.dims.sliced] = self.dims.point[
+                self.dims.sliced
+            ]
+            self.events.translate()
 
     @abstractmethod
     def _set_view_slice(self):


### PR DESCRIPTION
# Description
This PR will close #639 by supporting mixed 2D / 3D rendering for all layer types. I'm not quite sure about API yet, and I havn't added full documentation / tests, but I wanted to get this going to see what it is like. It'll also probably intersect with some of the work on physical coordinates - see #763, and also orthoviews, see #760, but I do like the functionality so far.

To make it work you must set the `viewer.dims.embedded = True`, this will pop up a third slider corresponding to the "embedded" or "sliced" dimension. You must then set the specific layer that is to be embedded to have `layer.dims.ndisplay=2` (while keeping the whole viewer in 3D rendering mode, i.e. `viewer.dims.ndisplday=3`).

Here are a couple gifs of the new functionality, note that the blending modes work really nicely here:  
![mixed_2D_3D_stent](https://user-images.githubusercontent.com/6531703/71606913-e0007000-2b29-11ea-9f2a-0e3311b347b7.gif)

and mixed surface + image rendering with some cryoET data

![mixed_2D_3D_cryoET](https://user-images.githubusercontent.com/6531703/71606980-79c81d00-2b2a-11ea-83ee-67b7f46bafc4.gif)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
