### PR TITLE
better isosurface rendering with colormaps

### DIFF
--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -1,6 +1,6 @@
 import warnings
 from vispy.scene.visuals import Image as ImageNode
-from vispy.scene.visuals import Volume as VolumeNode
+from .volume import Volume as VolumeNode
 from vispy.color import Colormap
 import numpy as np
 from .vispy_base_layer import VispyBaseLayer

--- a/napari/_vispy/volume.py
+++ b/napari/_vispy/volume.py
@@ -47,7 +47,7 @@ varying vec4 v_nearpos;
 varying vec4 v_farpos;
 
 // uniforms for lighting. Hard coded until we figure out how to do lights
-const vec4 u_ambient = vec4(0.2, 0.4, 0.2, 1.0);
+const vec4 u_ambient = vec4(0.2, 0.2, 0.2, 1.0);
 const vec4 u_diffuse = vec4(0.8, 0.2, 0.2, 1.0);
 const vec4 u_specular = vec4(1.0, 1.0, 1.0, 1.0);
 const float u_shininess = 40.0;
@@ -300,10 +300,10 @@ ISO_SNIPPETS = dict(
             // Take the last interval in smaller steps
             vec3 iloc = loc - step;
             for (int i=0; i<10; i++) {
-                val = $sample(u_volumetex, iloc).g;
-                if (val > u_threshold) {
-                    color = $cmap(val);
-                    gl_FragColor = calculateColor(color, iloc, dstep);
+                color = $sample(u_volumetex, iloc);
+                if (color.g > u_threshold) {
+                    color = calculateColor(color, iloc, dstep);
+                    gl_FragColor = $cmap(color.g);
                     iter = nsteps;
                     break;
                 }

--- a/napari/_vispy/volume.py
+++ b/napari/_vispy/volume.py
@@ -1,0 +1,374 @@
+from vispy.scene.visuals import Volume as BaseVolume
+from vispy.visuals.shaders import Function
+
+# Vertex shader
+VERT_SHADER = """
+attribute vec3 a_position;
+// attribute vec3 a_texcoord;
+uniform vec3 u_shape;
+
+// varying vec3 v_texcoord;
+varying vec3 v_position;
+varying vec4 v_nearpos;
+varying vec4 v_farpos;
+
+void main() {
+    // v_texcoord = a_texcoord;
+    v_position = a_position;
+
+    // Project local vertex coordinate to camera position. Then do a step
+    // backward (in cam coords) and project back. Voila, we get our ray vector.
+    vec4 pos_in_cam = $viewtransformf(vec4(v_position, 1));
+
+    // intersection of ray and near clipping plane (z = -1 in clip coords)
+    pos_in_cam.z = -pos_in_cam.w;
+    v_nearpos = $viewtransformi(pos_in_cam);
+
+    // intersection of ray and far clipping plane (z = +1 in clip coords)
+    pos_in_cam.z = pos_in_cam.w;
+    v_farpos = $viewtransformi(pos_in_cam);
+
+    gl_Position = $transform(vec4(v_position, 1.0));
+}
+"""  # noqa
+
+# Fragment shader
+FRAG_SHADER = """
+// uniforms
+uniform $sampler_type u_volumetex;
+uniform vec3 u_shape;
+uniform float u_threshold;
+uniform float u_relative_step_size;
+
+//varyings
+// varying vec3 v_texcoord;
+varying vec3 v_position;
+varying vec4 v_nearpos;
+varying vec4 v_farpos;
+
+// uniforms for lighting. Hard coded until we figure out how to do lights
+const vec4 u_ambient = vec4(0.2, 0.4, 0.2, 1.0);
+const vec4 u_diffuse = vec4(0.8, 0.2, 0.2, 1.0);
+const vec4 u_specular = vec4(1.0, 1.0, 1.0, 1.0);
+const float u_shininess = 40.0;
+
+//varying vec3 lightDirs[1];
+
+// global holding view direction in local coordinates
+vec3 view_ray;
+
+float rand(vec2 co)
+{{
+    // Create a pseudo-random number between 0 and 1.
+    // http://stackoverflow.com/questions/4200224
+    return fract(sin(dot(co.xy ,vec2(12.9898, 78.233))) * 43758.5453);
+}}
+
+float colorToVal(vec4 color1)
+{{
+    return color1.g; // todo: why did I have this abstraction in visvis?
+}}
+
+vec4 calculateColor(vec4 betterColor, vec3 loc, vec3 step)
+{{
+    // Calculate color by incorporating lighting
+    vec4 color1;
+    vec4 color2;
+
+    // View direction
+    vec3 V = normalize(view_ray);
+
+    // calculate normal vector from gradient
+    vec3 N; // normal
+    color1 = $sample( u_volumetex, loc+vec3(-step[0],0.0,0.0) );
+    color2 = $sample( u_volumetex, loc+vec3(step[0],0.0,0.0) );
+    N[0] = colorToVal(color1) - colorToVal(color2);
+    betterColor = max(max(color1, color2),betterColor);
+    color1 = $sample( u_volumetex, loc+vec3(0.0,-step[1],0.0) );
+    color2 = $sample( u_volumetex, loc+vec3(0.0,step[1],0.0) );
+    N[1] = colorToVal(color1) - colorToVal(color2);
+    betterColor = max(max(color1, color2),betterColor);
+    color1 = $sample( u_volumetex, loc+vec3(0.0,0.0,-step[2]) );
+    color2 = $sample( u_volumetex, loc+vec3(0.0,0.0,step[2]) );
+    N[2] = colorToVal(color1) - colorToVal(color2);
+    betterColor = max(max(color1, color2),betterColor);
+    float gm = length(N); // gradient magnitude
+    N = normalize(N);
+
+    // Flip normal so it points towards viewer
+    float Nselect = float(dot(N,V) > 0.0);
+    N = (2.0*Nselect - 1.0) * N;  // ==  Nselect * N - (1.0-Nselect)*N;
+
+    // Get color of the texture (albeido)
+    color1 = betterColor;
+    color2 = color1;
+    // todo: parametrise color1_to_color2
+
+    // Init colors
+    vec4 ambient_color = vec4(0.0, 0.0, 0.0, 0.0);
+    vec4 diffuse_color = vec4(0.0, 0.0, 0.0, 0.0);
+    vec4 specular_color = vec4(0.0, 0.0, 0.0, 0.0);
+    vec4 final_color;
+
+    // todo: allow multiple light, define lights on viewvox or subscene
+    int nlights = 1;
+    for (int i=0; i<nlights; i++)
+    {{
+        // Get light direction (make sure to prevent zero devision)
+        vec3 L = normalize(view_ray);  //lightDirs[i];
+        float lightEnabled = float( length(L) > 0.0 );
+        L = normalize(L+(1.0-lightEnabled));
+
+        // Calculate lighting properties
+        float lambertTerm = clamp( dot(N,L), 0.0, 1.0 );
+        vec3 H = normalize(L+V); // Halfway vector
+        float specularTerm = pow( max(dot(H,N),0.0), u_shininess);
+
+        // Calculate mask
+        float mask1 = lightEnabled;
+
+        // Calculate colors
+        ambient_color +=  mask1 * u_ambient; // * gl_LightSource[i].ambient;
+        diffuse_color +=  mask1 * lambertTerm;
+        specular_color += mask1 * specularTerm * u_specular;
+    }}
+
+    // Calculate final color by componing different components
+    final_color = color2 * ( ambient_color + diffuse_color) + specular_color;
+    final_color.a = color2.a;
+
+    // Done
+    return final_color;
+}}
+
+// for some reason, this has to be the last function in order for the
+// filters to be inserted in the correct place...
+
+void main() {{
+    vec3 farpos = v_farpos.xyz / v_farpos.w;
+    vec3 nearpos = v_nearpos.xyz / v_nearpos.w;
+
+    // Calculate unit vector pointing in the view direction through this
+    // fragment.
+    view_ray = normalize(farpos.xyz - nearpos.xyz);
+
+    // Compute the distance to the front surface or near clipping plane
+    float distance = dot(nearpos-v_position, view_ray);
+    distance = max(distance, min((-0.5 - v_position.x) / view_ray.x,
+                            (u_shape.x - 0.5 - v_position.x) / view_ray.x));
+    distance = max(distance, min((-0.5 - v_position.y) / view_ray.y,
+                            (u_shape.y - 0.5 - v_position.y) / view_ray.y));
+    distance = max(distance, min((-0.5 - v_position.z) / view_ray.z,
+                            (u_shape.z - 0.5 - v_position.z) / view_ray.z));
+
+    // Now we have the starting position on the front surface
+    vec3 front = v_position + view_ray * distance;
+
+    // Decide how many steps to take
+    int nsteps = int(-distance / u_relative_step_size + 0.5);
+    float f_nsteps = float(nsteps);
+    if( nsteps < 1 )
+        discard;
+
+    // Get starting location and step vector in texture coordinates
+    vec3 step = ((v_position - front) / u_shape) / f_nsteps;
+    vec3 start_loc = front / u_shape;
+
+    // For testing: show the number of steps. This helps to establish
+    // whether the rays are correctly oriented
+    //gl_FragColor = vec4(0.0, f_nsteps / 3.0 / u_shape.x, 1.0, 1.0);
+    //return;
+
+    {before_loop}
+
+    // This outer loop seems necessary on some systems for large
+    // datasets. Ugly, but it works ...
+    vec3 loc = start_loc;
+    int iter = 0;
+    while (iter < nsteps) {{
+        for (iter=iter; iter<nsteps; iter++)
+        {{
+            // Get sample color
+            vec4 color = $sample(u_volumetex, loc);
+            float val = color.g;
+
+            {in_loop}
+
+            // Advance location deeper into the volume
+            loc += step;
+        }}
+    }}
+
+    {after_loop}
+
+    /* Set depth value - from visvis TODO
+    int iter_depth = int(maxi);
+    // Calculate end position in world coordinates
+    vec4 position2 = vertexPosition;
+    position2.xyz += ray*shape*float(iter_depth);
+    // Project to device coordinates and set fragment depth
+    vec4 iproj = gl_ModelViewProjectionMatrix * position2;
+    iproj.z /= iproj.w;
+    gl_FragDepth = (iproj.z+1.0)/2.0;
+    */
+}}
+
+
+"""  # noqa
+
+
+MIP_SNIPPETS = dict(
+    before_loop="""
+        float maxval = -99999.0; // The maximum encountered value
+        int maxi = 0;  // Where the maximum value was encountered
+        """,
+    in_loop="""
+        if( val > maxval ) {
+            maxval = val;
+            maxi = iter;
+        }
+        """,
+    after_loop="""
+        // Refine search for max value
+        loc = start_loc + step * (float(maxi) - 0.5);
+        for (int i=0; i<10; i++) {
+            maxval = max(maxval, $sample(u_volumetex, loc).g);
+            loc += step * 0.1;
+        }
+        gl_FragColor = $cmap(maxval);
+        """,
+)
+MIP_FRAG_SHADER = FRAG_SHADER.format(**MIP_SNIPPETS)
+
+
+TRANSLUCENT_SNIPPETS = dict(
+    before_loop="""
+        vec4 integrated_color = vec4(0., 0., 0., 0.);
+        """,
+    in_loop="""
+            color = $cmap(val);
+            float a1 = integrated_color.a;
+            float a2 = color.a * (1 - a1);
+            float alpha = max(a1 + a2, 0.001);
+
+            // Doesn't work.. GLSL optimizer bug?
+            //integrated_color = (integrated_color * a1 / alpha) +
+            //                   (color * a2 / alpha);
+            // This should be identical but does work correctly:
+            integrated_color *= a1 / alpha;
+            integrated_color += color * a2 / alpha;
+
+            integrated_color.a = alpha;
+
+            if( alpha > 0.99 ){
+                // stop integrating if the fragment becomes opaque
+                iter = nsteps;
+            }
+
+        """,
+    after_loop="""
+        gl_FragColor = integrated_color;
+        """,
+)
+TRANSLUCENT_FRAG_SHADER = FRAG_SHADER.format(**TRANSLUCENT_SNIPPETS)
+
+
+ADDITIVE_SNIPPETS = dict(
+    before_loop="""
+        vec4 integrated_color = vec4(0., 0., 0., 0.);
+        """,
+    in_loop="""
+        color = $cmap(val);
+
+        integrated_color = 1.0 - (1.0 - integrated_color) * (1.0 - color);
+        """,
+    after_loop="""
+        gl_FragColor = integrated_color;
+        """,
+)
+ADDITIVE_FRAG_SHADER = FRAG_SHADER.format(**ADDITIVE_SNIPPETS)
+
+
+ISO_SNIPPETS = dict(
+    before_loop="""
+        vec4 color3 = vec4(0.0);  // final color
+        vec3 dstep = 1.5 / u_shape;  // step to sample derivative
+        gl_FragColor = vec4(0.0);
+    """,
+    in_loop="""
+        if (val > u_threshold-0.2) {
+            // Take the last interval in smaller steps
+            vec3 iloc = loc - step;
+            for (int i=0; i<10; i++) {
+                val = $sample(u_volumetex, iloc).g;
+                if (val > u_threshold) {
+                    color = $cmap(val);
+                    gl_FragColor = calculateColor(color, iloc, dstep);
+                    iter = nsteps;
+                    break;
+                }
+                iloc += step * 0.1;
+            }
+        }
+        """,
+    after_loop="""
+        """,
+)
+
+ISO_FRAG_SHADER = FRAG_SHADER.format(**ISO_SNIPPETS)
+
+frag_dict = {
+    'mip': MIP_FRAG_SHADER,
+    'iso': ISO_FRAG_SHADER,
+    'translucent': TRANSLUCENT_FRAG_SHADER,
+    'additive': ADDITIVE_FRAG_SHADER,
+}
+
+
+# Custom volume class is needed for better 3D rendering
+class Volume(BaseVolume):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @property
+    def method(self):
+        """The render method to use
+
+        Current options are:
+
+            * translucent: voxel colors are blended along the view ray until
+              the result is opaque.
+            * mip: maxiumum intensity projection. Cast a ray and display the
+              maximum value that was encountered.
+            * additive: voxel colors are added along the view ray until
+              the result is saturated.
+            * iso: isosurface. Cast a ray until a certain threshold is
+              encountered. At that location, lighning calculations are
+              performed to give the visual appearance of a surface.
+        """
+        return self._method
+
+    @method.setter
+    def method(self, method):
+        # Check and save
+        known_methods = list(frag_dict.keys())
+        if method not in known_methods:
+            raise ValueError(
+                'Volume render method should be in %r, not %r'
+                % (known_methods, method)
+            )
+        self._method = method
+        # Get rid of specific variables - they may become invalid
+        if 'u_threshold' in self.shared_program:
+            self.shared_program['u_threshold'] = None
+
+        self.shared_program.frag = frag_dict[method]
+        self.shared_program.frag['sampler_type'] = self._tex.glsl_sampler_type
+        self.shared_program.frag['sample'] = self._tex.glsl_sample
+        self.shared_program.frag['cmap'] = Function(self._cmap.glsl_map)
+        self.shared_program['texture2D_LUT'] = (
+            self.cmap.texture_lut()
+            if (hasattr(self.cmap, 'texture_lut'))
+            else None
+        )
+        self.update()


### PR DESCRIPTION
# Description
This PR significantly improves our isosurface rendering by making it respect our colormaps and getting rid of the light green default. To do this I "vendored" the vispy volume shaders, which results in quite a bit of copied code, but which will give us significant flexibility as we continue to address issues like #574.

The changed lines are relatively minor
```bash
const vec4 u_ambient = vec4(0.2, 0.2, 0.2, 1.0);
```
 gets rid of the green, and 
```bash
                color = $sample(u_volumetex, iloc);
                if (color.g > u_threshold) {
                    color = calculateColor(color, iloc, dstep);
                    gl_FragColor = $cmap(color.g);
```
puts the colormap call in the right place

Here is a gif of the new performance, which I think is quite nice!!
![better_iso_surface](https://user-images.githubusercontent.com/6531703/71634662-c7986000-2bd2-11ea-9b16-d624f08c89f6.gif)

Ultimately we will probably want to push these changes to vispy, but I imagine we'll be making a bunch of them over the next chunk of time, so might make sense to wait till we're done.
