### PR TITLE
Add nearest interpolation mode to volume rendering

### DIFF
--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -5,6 +5,8 @@ from vispy.color import Colormap
 import numpy as np
 from .vispy_base_layer import VispyBaseLayer
 from ..layers.image._constants import Rendering
+from ..layers import Image, Labels
+
 
 texture_dtypes = [
     np.dtype(np.int8),
@@ -101,7 +103,11 @@ class VispyImageLayer(VispyBaseLayer):
         self.node.update()
 
     def _on_interpolation_change(self):
-        if self.layer.dims.ndisplay == 2:
+        if self.layer.dims.ndisplay == 3 and isinstance(self.layer, Labels):
+            self.node.interpolation = 'nearest'
+        elif self.layer.dims.ndisplay == 3 and isinstance(self.layer, Image):
+            self.node.interpolation = 'linear'
+        else:
             self.node.interpolation = self.layer.interpolation
 
     def _on_rendering_change(self):

--- a/napari/_vispy/volume.py
+++ b/napari/_vispy/volume.py
@@ -381,13 +381,13 @@ class Volume(BaseVolume):
         return self._interpolation
 
     @interpolation.setter
-    def interpolation(self, i):
-        if i not in self._interpolation_names:
+    def interpolation(self, interp):
+        if interp not in self._interpolation_names:
             raise ValueError(
                 "interpolation must be one of %s"
                 % ', '.join(self._interpolation_names)
             )
-        if self._interpolation != i:
-            self._interpolation = i
+        if self._interpolation != interp:
+            self._interpolation = interp
             self._tex.interpolation = self._interpolation
             self.update()

--- a/napari/_vispy/volume.py
+++ b/napari/_vispy/volume.py
@@ -327,7 +327,10 @@ frag_dict = {
 
 # Custom volume class is needed for better 3D rendering
 class Volume(BaseVolume):
+    _interpolation_names = ['linear', 'nearest']
+
     def __init__(self, *args, **kwargs):
+        self._interpolation = 'linear'
         super().__init__(*args, **kwargs)
 
     @property
@@ -372,3 +375,19 @@ class Volume(BaseVolume):
             else None
         )
         self.update()
+
+    @property
+    def interpolation(self):
+        return self._interpolation
+
+    @interpolation.setter
+    def interpolation(self, i):
+        if i not in self._interpolation_names:
+            raise ValueError(
+                "interpolation must be one of %s"
+                % ', '.join(self._interpolation_names)
+            )
+        if self._interpolation != i:
+            self._interpolation = i
+            self._tex.interpolation = self._interpolation
+            self.update()

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -138,7 +138,7 @@ class Labels(Image):
             colormap=colormap,
             contrast_limits=[0.0, 1.0],
             interpolation='nearest',
-            rendering='mip',
+            rendering='translucent',
             name=name,
             metadata=metadata,
             scale=scale,


### PR DESCRIPTION
# Description
This PR follows on from #840 (which should be reviewed and merged first) and closes #574 by providing a `nearest` interpolation mode (in addition to default `linear` interpolation mode) for 3D volume rendering. Ultimately we may want to push these changes back to vispy, but for now as we are editing things frequently, I think it is fine to keep them here. Not that this improvement will be compatible with whatever colormap improvements come with #713 as it is only touching the interpolation code. Rendering of our image layers is also unchanged by this PR.

Here is what the labels layer now looks like:
![better_3D_labels](https://user-images.githubusercontent.com/6531703/71637154-f58c9d00-2bf0-11ea-95f4-57965afa17ab.gif)
which is much nicer!!




