### PR TITLE
add attenuated MIP mode

### DIFF
--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -26,6 +26,16 @@ if StrictVersion(QtCore.__version__) < StrictVersion('5.12.3'):
     """
     warn(message=warn_message)
 
+from vispy import app
+import logging
+
+# set vispy application to the appropriate qt backend
+app.use_app(API_NAME)
+del app
+# set vispy logger to show warning and errors only
+vispy_logger = logging.getLogger('vispy')
+vispy_logger.setLevel(logging.WARNING)
+
 from .viewer import Viewer
 from . import keybindings
 from .view_layers import (

--- a/napari/_qt/layers/qt_base_layer.py
+++ b/napari/_qt/layers/qt_base_layer.py
@@ -28,7 +28,7 @@ class QtLayerControls(QFrame):
         sld.valueChanged[int].connect(
             lambda value=sld: self.changeOpacity(value)
         )
-        self.opacitySilder = sld
+        self.opacitySlider = sld
 
         blend_comboBox = QComboBox()
         for blend in Blending:
@@ -51,7 +51,7 @@ class QtLayerControls(QFrame):
 
     def _on_opacity_change(self, event):
         with self.layer.events.opacity.blocker():
-            self.opacitySilder.setValue(self.layer.opacity * 100)
+            self.opacitySlider.setValue(self.layer.opacity * 100)
 
     def _on_blending_change(self, event):
         with self.layer.events.blending.blocker():

--- a/napari/_qt/layers/qt_image_layer.py
+++ b/napari/_qt/layers/qt_image_layer.py
@@ -49,8 +49,8 @@ class QtImageControls(QtBaseImageControls):
         sld.valueChanged[int].connect(
             lambda value=sld: self.changeisoThreshold(value)
         )
-        self.isoThesholdSlider = sld
-        self.isoThesholdLabel = QLabel('iso threshold:')
+        self.isoThresholdSlider = sld
+        self.isoThresholdLabel = QLabel('iso threshold:')
 
         sld = QSlider(Qt.Horizontal)
         sld.setFocusPolicy(Qt.NoFocus)
@@ -73,8 +73,8 @@ class QtImageControls(QtBaseImageControls):
         self.grid_layout.addWidget(self.contrastLimitsSlider, 1, 1, 1, 2)
         self.grid_layout.addWidget(QLabel('gamma:'), 2, 0)
         self.grid_layout.addWidget(self.gammaSlider, 2, 1, 1, 2)
-        self.grid_layout.addWidget(self.isoThesholdLabel, 3, 0)
-        self.grid_layout.addWidget(self.isoThesholdSlider, 3, 1, 1, 2)
+        self.grid_layout.addWidget(self.isoThresholdLabel, 3, 0)
+        self.grid_layout.addWidget(self.isoThresholdSlider, 3, 1, 1, 2)
         self.grid_layout.addWidget(self.attenuationLabel, 3, 0)
         self.grid_layout.addWidget(self.attenuationSlider, 3, 1, 1, 2)
         self.grid_layout.addWidget(QLabel('colormap:'), 4, 0)
@@ -103,7 +103,7 @@ class QtImageControls(QtBaseImageControls):
 
     def _on_iso_threshold_change(self, event):
         with self.layer.events.iso_threshold.blocker():
-            self.isoThesholdSlider.setValue(self.layer.iso_threshold * 100)
+            self.isoThresholdSlider.setValue(self.layer.iso_threshold * 100)
 
     def changeAttenuation(self, value):
         with self.layer.events.blocker(self._on_attenuation_change):
@@ -133,11 +133,11 @@ class QtImageControls(QtBaseImageControls):
         if isinstance(rendering, str):
             rendering = Rendering(rendering)
         if rendering == Rendering.ISO:
-            self.isoThesholdSlider.show()
-            self.isoThesholdLabel.show()
+            self.isoThresholdSlider.show()
+            self.isoThresholdLabel.show()
         else:
-            self.isoThesholdSlider.hide()
-            self.isoThesholdLabel.hide()
+            self.isoThresholdSlider.hide()
+            self.isoThresholdLabel.hide()
         if rendering == Rendering.ATTENUATED_MIP:
             self.attenuationSlider.show()
             self.attenuationLabel.show()
@@ -147,8 +147,8 @@ class QtImageControls(QtBaseImageControls):
 
     def _on_ndisplay_change(self, event):
         if self.layer.dims.ndisplay == 2:
-            self.isoThesholdSlider.hide()
-            self.isoThesholdLabel.hide()
+            self.isoThresholdSlider.hide()
+            self.isoThresholdLabel.hide()
             self.attenuationSlider.hide()
             self.attenuationLabel.hide()
             self.renderComboBox.hide()

--- a/napari/_qt/layers/qt_image_layer.py
+++ b/napari/_qt/layers/qt_image_layer.py
@@ -47,7 +47,7 @@ class QtImageControls(QtBaseImageControls):
         sld.setSingleStep(1)
         sld.setValue(self.layer.iso_threshold * 100)
         sld.valueChanged[int].connect(
-            lambda value=sld: self.changeisoThreshold(value)
+            lambda value=sld: self.changeIsoThreshold(value)
         )
         self.isoThresholdSlider = sld
         self.isoThresholdLabel = QLabel('iso threshold:')
@@ -97,7 +97,7 @@ class QtImageControls(QtBaseImageControls):
         self.layer.rendering = text
         self._toggle_rendering_parameter_visbility()
 
-    def changeisoThreshold(self, value):
+    def changeIsoThreshold(self, value):
         with self.layer.events.blocker(self._on_iso_threshold_change):
             self.layer.iso_threshold = value / 100
 

--- a/napari/_qt/layers/qt_image_layer.py
+++ b/napari/_qt/layers/qt_image_layer.py
@@ -47,7 +47,7 @@ class QtImageControls(QtBaseImageControls):
         sld.setSingleStep(1)
         sld.setValue(self.layer.iso_threshold * 100)
         sld.valueChanged[int].connect(
-            lambda value=sld: self.changeIsoTheshold(value)
+            lambda value=sld: self.changeisoThreshold(value)
         )
         self.isoThesholdSlider = sld
         self.isoThesholdLabel = QLabel('iso threshold:')
@@ -97,7 +97,7 @@ class QtImageControls(QtBaseImageControls):
         self.layer.rendering = text
         self._toggle_rendering_parameter_visbility()
 
-    def changeIsoTheshold(self, value):
+    def changeisoThreshold(self, value):
         with self.layer.events.blocker(self._on_iso_threshold_change):
             self.layer.iso_threshold = value / 100
 

--- a/napari/_qt/layers/qt_image_layer.py
+++ b/napari/_qt/layers/qt_image_layer.py
@@ -109,7 +109,7 @@ class QtImageControls(QtBaseImageControls):
         rendering = self.layer.rendering
         if isinstance(rendering, str):
             rendering = Rendering(rendering)
-        if rendering == Rendering.ISO:
+        if rendering in [Rendering.ISO, Rendering.ATTENUATED_MIP]:
             self.isoThesholdSilder.show()
             self.isoThesholdLabel.show()
         else:

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -103,7 +103,7 @@ class QtLabelsControls(QtLayerControls):
         self.grid_layout.addWidget(self.selectionSpinBox, 1, 2)
         self.grid_layout.addWidget(QtColorBox(layer), 1, 1)
         self.grid_layout.addWidget(QLabel('opacity:'), 2, 0)
-        self.grid_layout.addWidget(self.opacitySilder, 2, 1, 1, 2)
+        self.grid_layout.addWidget(self.opacitySlider, 2, 1, 1, 2)
         self.grid_layout.addWidget(QLabel('brush size:'), 3, 0)
         self.grid_layout.addWidget(self.brushSizeSlider, 3, 1, 1, 2)
         self.grid_layout.addWidget(QLabel('blending:'), 4, 0)

--- a/napari/_qt/layers/qt_points_layer.py
+++ b/napari/_qt/layers/qt_points_layer.py
@@ -105,7 +105,7 @@ class QtPointsControls(QtLayerControls):
         # addWidget(widget, row, column, [row_span, column_span])
         self.grid_layout.addLayout(button_row, 0, 1, 1, 2)
         self.grid_layout.addWidget(QLabel('opacity:'), 1, 0)
-        self.grid_layout.addWidget(self.opacitySilder, 1, 1, 1, 2)
+        self.grid_layout.addWidget(self.opacitySlider, 1, 1, 1, 2)
         self.grid_layout.addWidget(QLabel('point size:'), 2, 0)
         self.grid_layout.addWidget(self.sizeSlider, 2, 1, 1, 2)
         self.grid_layout.addWidget(QLabel('blending:'), 3, 0)

--- a/napari/_qt/layers/qt_shapes_layer.py
+++ b/napari/_qt/layers/qt_shapes_layer.py
@@ -219,7 +219,7 @@ class QtShapesControls(QtLayerControls):
 
     def _on_opacity_change(self, event):
         with self.layer.events.opacity.blocker():
-            self.opacitySilder.setValue(self.layer.current_opacity * 100)
+            self.opacitySlider.setValue(self.layer.current_opacity * 100)
 
     def _on_editable_change(self, event):
         self.select_button.setEnabled(self.layer.editable)

--- a/napari/_qt/layers/qt_shapes_layer.py
+++ b/napari/_qt/layers/qt_shapes_layer.py
@@ -137,7 +137,7 @@ class QtShapesControls(QtLayerControls):
         # addWidget(widget, row, column, [row_span, column_span])
         self.grid_layout.addLayout(button_grid, 0, 0, 1, 3)
         self.grid_layout.addWidget(QLabel('opacity:'), 1, 0)
-        self.grid_layout.addWidget(self.opacitySilder, 1, 1, 1, 2)
+        self.grid_layout.addWidget(self.opacitySlider, 1, 1, 1, 2)
         self.grid_layout.addWidget(QLabel('edge width:'), 2, 0)
         self.grid_layout.addWidget(self.widthSlider, 2, 1, 1, 2)
         self.grid_layout.addWidget(QLabel('blending:'), 3, 0)

--- a/napari/_qt/layers/qt_surface_layer.py
+++ b/napari/_qt/layers/qt_surface_layer.py
@@ -9,7 +9,7 @@ class QtSurfaceControls(QtBaseImageControls):
         # grid_layout created in QtLayerControls
         # addWidget(widget, row, column, [row_span, column_span])
         self.grid_layout.addWidget(QLabel('opacity:'), 0, 0)
-        self.grid_layout.addWidget(self.opacitySilder, 0, 1, 1, 2)
+        self.grid_layout.addWidget(self.opacitySlider, 0, 1, 1, 2)
         self.grid_layout.addWidget(QLabel('contrast limits:'), 1, 0)
         self.grid_layout.addWidget(self.contrastLimitsSlider, 1, 1, 1, 2)
         self.grid_layout.addWidget(QLabel('gamma:'), 2, 0)

--- a/napari/_qt/layers/qt_vectors_layer.py
+++ b/napari/_qt/layers/qt_vectors_layer.py
@@ -47,7 +47,7 @@ class QtVectorsControls(QtLayerControls):
         # grid_layout created in QtLayerControls
         # addWidget(widget, row, column, [row_span, column_span])
         self.grid_layout.addWidget(QLabel('opacity:'), 0, 0)
-        self.grid_layout.addWidget(self.opacitySilder, 0, 1, 1, 2)
+        self.grid_layout.addWidget(self.opacitySlider, 0, 1, 1, 2)
         self.grid_layout.addWidget(QLabel('width:'), 1, 0)
         self.grid_layout.addWidget(self.widthSpinBox, 1, 1, 1, 2)
         self.grid_layout.addWidget(QLabel('length:'), 2, 0)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -5,15 +5,9 @@ wrap.
 # set vispy to use same backend as qtpy
 import os
 
-from qtpy import API_NAME
-from vispy import app
-
 from .qt_about import QtAbout
 from .qt_viewer_dock_widget import QtViewerDockWidget
 from ..resources import resources_dir
-
-app.use_app(API_NAME)
-del app
 
 # these "# noqa" comments are here to skip flake8 linting (E402),
 # these module-level imports have to come after `app.use_app(API)`

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -7,10 +7,8 @@ from qtpy.QtCore import QCoreApplication, Qt, QSize
 from qtpy.QtWidgets import QWidget, QVBoxLayout, QFileDialog, QSplitter
 from qtpy.QtGui import QCursor, QPixmap
 from qtpy.QtCore import QThreadPool
-from qtpy import API_NAME
 from vispy.scene import SceneCanvas, PanZoomCamera, ArcballCamera
 from vispy.visuals.transforms import ChainTransform
-from vispy.app import use_app
 
 from .qt_dims import QtDims
 from .qt_layerlist import QtLayerList
@@ -32,10 +30,6 @@ from .qt_console import QtConsole
 from .qt_viewer_dock_widget import QtViewerDockWidget
 from .qt_about_keybindings import QtAboutKeybindings
 from .._vispy import create_vispy_visual
-
-
-# set vispy application to the appropriate qt backend
-use_app(API_NAME)
 
 
 class QtViewer(QSplitter):

--- a/napari/_vispy/tests/test_image_rendering.py
+++ b/napari/_vispy/tests/test_image_rendering.py
@@ -1,0 +1,37 @@
+import numpy as np
+from napari import Viewer
+
+
+def test_image_rendering(qtbot):
+    """Test 3D image with different rendering."""
+    viewer = Viewer()
+    view = viewer.window.qt_viewer
+    qtbot.addWidget(view)
+
+    data = np.random.random((20, 20, 20))
+    layer = viewer.add_image(data)
+
+    assert layer.rendering == 'mip'
+
+    # Change rendering property
+    layer.rendering = 'translucent'
+    assert layer.rendering == 'translucent'
+
+    # Change rendering property
+    layer.rendering = 'attenuated_mip'
+    assert layer.rendering == 'attenuated_mip'
+    layer.attenuation = 0.2
+    assert layer.attenuation == 0.2
+
+    # Change rendering property
+    layer.rendering = 'iso'
+    assert layer.rendering == 'iso'
+    layer.iso_threshold = 0.3
+    assert layer.iso_threshold == 0.3
+
+    # Change rendering property
+    layer.rendering = 'additive'
+    assert layer.rendering == 'additive'
+
+    # Close the viewer
+    viewer.window.close()

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -4,7 +4,6 @@ from .volume import Volume as VolumeNode
 from vispy.color import Colormap
 import numpy as np
 from .vispy_base_layer import VispyBaseLayer
-from ..layers.image._constants import Rendering
 from ..layers import Image, Labels
 
 
@@ -139,12 +138,8 @@ class VispyImageLayer(VispyBaseLayer):
         self._on_colormap_change()
 
     def _on_iso_threshold_change(self):
-        rendering = self.layer.rendering
-        if isinstance(rendering, str):
-            rendering = Rendering(rendering)
-        if self.layer.dims.ndisplay == 3 and rendering == Rendering.ISO:
+        if self.layer.dims.ndisplay == 3:
             self.node.threshold = float(self.layer.iso_threshold)
-            self.node.shared_program['u_threshold'] = self.node.threshold
 
     def _on_scale_change(self):
         self.scale = [

--- a/napari/_vispy/volume.py
+++ b/napari/_vispy/volume.py
@@ -323,6 +323,7 @@ ATTENUATED_MIP_SNIPPETS = dict(
         float sumval = 0.0; // The sum of the encountered values
         float scaled = 0.0; // The scaled value
         int maxi = 0;  // Where the maximum value was encountered
+        vec3 maxloc = vec3(0.0);  // Location where the maximum value was encountered
         """,
     in_loop="""
         sumval = sumval + val;
@@ -330,9 +331,11 @@ ATTENUATED_MIP_SNIPPETS = dict(
         if( scaled > maxval ) {
             maxval = scaled;
             maxi = iter;
+            maxloc = loc;
         }
         """,
     after_loop="""
+        maxval = $sample(u_volumetex, maxloc).g;
         gl_FragColor = $cmap(maxval);
         """,
 )

--- a/napari/_vispy/volume.py
+++ b/napari/_vispy/volume.py
@@ -327,7 +327,7 @@ ATTENUATED_MIP_SNIPPETS = dict(
         """,
     in_loop="""
         sumval = sumval + val;
-        scaled = val * exp(-u_threshold * sumval / u_relative_step_size);
+        scaled = val * exp(-u_threshold * (sumval - 1) / u_relative_step_size);
         if( scaled > maxval ) {
             maxval = scaled;
             maxi = iter;
@@ -335,7 +335,6 @@ ATTENUATED_MIP_SNIPPETS = dict(
         }
         """,
     after_loop="""
-        maxval = $sample(u_volumetex, maxloc).g;
         gl_FragColor = $cmap(maxval);
         """,
 )

--- a/napari/_vispy/volume.py
+++ b/napari/_vispy/volume.py
@@ -395,7 +395,8 @@ class Volume(BaseVolume):
             if (hasattr(self.cmap, 'texture_lut'))
             else None
         )
-        self.shared_program['u_threshold'] = self.threshold
+        if 'u_threshold' in self.shared_program:
+            self.shared_program['u_threshold'] = self.threshold
         self.update()
 
     @property
@@ -407,7 +408,8 @@ class Volume(BaseVolume):
     @threshold.setter
     def threshold(self, value):
         self._threshold = float(value)
-        self.shared_program['u_threshold'] = self._threshold
+        if 'u_threshold' in self.shared_program:
+            self.shared_program['u_threshold'] = self._threshold
         self.update()
 
     @property

--- a/napari/_vispy/volume.py
+++ b/napari/_vispy/volume.py
@@ -317,11 +317,33 @@ ISO_SNIPPETS = dict(
 
 ISO_FRAG_SHADER = FRAG_SHADER.format(**ISO_SNIPPETS)
 
+ATTENUATED_MIP_SNIPPETS = dict(
+    before_loop="""
+        float maxval = -99999.0; // The maximum encountered value
+        float sumval = 0.0; // The sum of the encountered values
+        float scaled = 0.0; // The scaled value
+        int maxi = 0;  // Where the maximum value was encountered
+        """,
+    in_loop="""
+        sumval = sumval + val;
+        scaled = val * exp(-u_threshold * sumval / u_relative_step_size);
+        if( scaled > maxval ) {
+            maxval = scaled;
+            maxi = iter;
+        }
+        """,
+    after_loop="""
+        gl_FragColor = $cmap(maxval);
+        """,
+)
+ATTENUATED_MIP_FRAG_SHADER = FRAG_SHADER.format(**ATTENUATED_MIP_SNIPPETS)
+
 frag_dict = {
     'mip': MIP_FRAG_SHADER,
     'iso': ISO_FRAG_SHADER,
     'translucent': TRANSLUCENT_FRAG_SHADER,
     'additive': ADDITIVE_FRAG_SHADER,
+    'attenuated_mip': ATTENUATED_MIP_FRAG_SHADER,
 }
 
 
@@ -331,6 +353,7 @@ class Volume(BaseVolume):
 
     def __init__(self, *args, **kwargs):
         self._interpolation = 'linear'
+        self._threshold = 0
         super().__init__(*args, **kwargs)
 
     @property
@@ -361,10 +384,6 @@ class Volume(BaseVolume):
                 % (known_methods, method)
             )
         self._method = method
-        # Get rid of specific variables - they may become invalid
-        if 'u_threshold' in self.shared_program:
-            self.shared_program['u_threshold'] = None
-
         self.shared_program.frag = frag_dict[method]
         self.shared_program.frag['sampler_type'] = self._tex.glsl_sampler_type
         self.shared_program.frag['sample'] = self._tex.glsl_sample
@@ -374,6 +393,19 @@ class Volume(BaseVolume):
             if (hasattr(self.cmap, 'texture_lut'))
             else None
         )
+        self.shared_program['u_threshold'] = self.threshold
+        self.update()
+
+    @property
+    def threshold(self):
+        """ The threshold value to apply for the isosurface render method.
+        """
+        return self._threshold
+
+    @threshold.setter
+    def threshold(self, value):
+        self._threshold = float(value)
+        self.shared_program['u_threshold'] = self._threshold
         self.update()
 
     @property

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -402,6 +402,7 @@ class ViewerModel(KeymapMixin):
         interpolation='nearest',
         rendering='mip',
         iso_threshold=0.5,
+        attenuation=0.5,
         name=None,
         metadata=None,
         scale=None,
@@ -454,8 +455,13 @@ class ViewerModel(KeymapMixin):
         interpolation : str
             Interpolation mode used by vispy. Must be one of our supported
             modes.
+        rendering : str
+            Rendering mode used by vispy. Must be one of our supported
+            modes.
         iso_threshold : float
             Threshold for isosurface.
+        attenuation : float
+            Attenuation rate for attenuated maximum intensity projection.
         name : str
             Name of the layer.
         metadata : dict
@@ -503,6 +509,7 @@ class ViewerModel(KeymapMixin):
                 interpolation=interpolation,
                 rendering=rendering,
                 iso_threshold=iso_threshold,
+                attenuation=attenuation,
                 name=name,
                 metadata=metadata,
                 scale=scale,

--- a/napari/layers/image/_constants.py
+++ b/napari/layers/image/_constants.py
@@ -47,3 +47,4 @@ class Rendering(StringEnum):
     ADDITIVE = auto()
     ISO = auto()
     MIP = auto()
+    ATTENUATED_MIP = auto()

--- a/napari/layers/image/_constants.py
+++ b/napari/layers/image/_constants.py
@@ -36,6 +36,9 @@ class Rendering(StringEnum):
               the result is opaque.
             * mip: maxiumum intensity projection. Cast a ray and display the
               maximum value that was encountered.
+            * attenuated_mip: attenuated maxiumum intensity projection. Cast a
+              ray and attenuate values based on integral of encountered values,
+              display the maximum value that was encountered after attenuation.
             * additive: voxel colors are added along the view ray until
               the result is saturated.
             * iso: isosurface. Cast a ray until a certain threshold is

--- a/napari/layers/image/_constants.py
+++ b/napari/layers/image/_constants.py
@@ -39,6 +39,7 @@ class Rendering(StringEnum):
             * attenuated_mip: attenuated maxiumum intensity projection. Cast a
               ray and attenuate values based on integral of encountered values,
               display the maximum value that was encountered after attenuation.
+              This will make nearer objects appear more prominent.
             * additive: voxel colors are added along the view ray until
               the result is saturated.
             * iso: isosurface. Cast a ray until a certain threshold is

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -52,8 +52,13 @@ class Image(Layer):
     interpolation : str
         Interpolation mode used by vispy. Must be one of our supported
         modes.
+    rendering : str
+        Rendering mode used by vispy. Must be one of our supported
+        modes.
     iso_threshold : float
         Threshold for isosurface.
+    attenuation : float
+        Attenuation rate for attenuated maximum intensity projection.
     name : str
         Name of the layer.
     metadata : dict
@@ -104,10 +109,16 @@ class Image(Layer):
         rgb the contrast_limits_range is ignored.
     gamma : float
         Gamma correction for determining colormap linearity.
+    interpolation : str
+        Interpolation mode used by vispy. Must be one of our supported
+        modes.
+    rendering : str
+        Rendering mode used by vispy. Must be one of our supported
+        modes.
     iso_threshold : float
         Threshold for isosurface.
-    interpolation : str
-        Interpolation mode used by vispy. Must be one of our supported modes.
+    attenuation : float
+        Attenuation rate for attenuated maximum intensity projection.
 
     Extended Summary
     ----------
@@ -134,6 +145,7 @@ class Image(Layer):
         interpolation='nearest',
         rendering='mip',
         iso_threshold=0.5,
+        attenuation=0.5,
         name=None,
         metadata=None,
         scale=None,
@@ -167,6 +179,7 @@ class Image(Layer):
             interpolation=Event,
             rendering=Event,
             iso_threshold=Event,
+            attenuation=Event,
         )
 
         # Set data
@@ -193,6 +206,7 @@ class Image(Layer):
         # Set contrast_limits and colormaps
         self._gamma = gamma
         self._iso_threshold = iso_threshold
+        self._attenuation = attenuation
         self._colormap_name = ''
         self._contrast_limits_msg = ''
         if contrast_limits is None:
@@ -362,6 +376,18 @@ class Image(Layer):
         self.events.iso_threshold()
 
     @property
+    def attenuation(self):
+        """float: attenuation rate for attenuated_mip rendering."""
+        return self._attenuation
+
+    @attenuation.setter
+    def attenuation(self, value):
+        self.status = format_float(value)
+        self._attenuation = value
+        self._update_thumbnail()
+        self.events.attenuation()
+
+    @property
     def interpolation(self):
         """{
             'bessel', 'bicubic', 'bilinear', 'blackman', 'catrom', 'gaussian',
@@ -392,6 +418,9 @@ class Image(Layer):
             * iso: isosurface. Cast a ray until a certain threshold is
               encountered. At that location, lighning calculations are
               performed to give the visual appearance of a surface.
+            * attenuated_mip: attenuated maxiumum intensity projection. Cast a
+              ray and attenuate values based on integral of encountered values,
+              display the maximum value that was encountered after attenuation.
         """
         return str(self._rendering)
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -357,6 +357,7 @@ class Image(IntensityVisualizationMixin, Layer):
             * attenuated_mip: attenuated maxiumum intensity projection. Cast a
               ray and attenuate values based on integral of encountered values,
               display the maximum value that was encountered after attenuation.
+              This will make nearer objects appear more prominent.
         """
         return str(self._rendering)
 

--- a/napari/layers/image/tests/test_image.py
+++ b/napari/layers/image/tests/test_image.py
@@ -419,6 +419,30 @@ def test_gamma():
     assert layer.gamma == gamma
 
 
+def test_rendering():
+    """Test setting rendering."""
+    np.random.seed(0)
+    data = np.random.random((20, 10, 15))
+    layer = Image(data)
+    assert layer.rendering == 'mip'
+
+    # Change rendering property
+    layer.rendering = 'translucent'
+    assert layer.rendering == 'translucent'
+
+    # Change rendering property
+    layer.rendering = 'attenuated_mip'
+    assert layer.rendering == 'attenuated_mip'
+
+    # Change rendering property
+    layer.rendering = 'iso'
+    assert layer.rendering == 'iso'
+
+    # Change rendering property
+    layer.rendering = 'additive'
+    assert layer.rendering == 'additive'
+
+
 def test_iso_threshold():
     """Test setting iso_threshold."""
     np.random.seed(0)
@@ -434,6 +458,23 @@ def test_iso_threshold():
     # Set iso_threshold as keyword argument
     layer = Image(data, iso_threshold=iso_threshold)
     assert layer.iso_threshold == iso_threshold
+
+
+def test_attenuation():
+    """Test setting attenuation."""
+    np.random.seed(0)
+    data = np.random.random((10, 15))
+    layer = Image(data)
+    assert layer.attenuation == 0.5
+
+    # Change iso_threshold property
+    attenuation = 0.7
+    layer.attenuation = attenuation
+    assert layer.attenuation == attenuation
+
+    # Set attenuation as keyword argument
+    layer = Image(data, attenuation=attenuation)
+    assert layer.attenuation == attenuation
 
 
 def test_metadata():

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -13,6 +13,7 @@ def view_image(
     interpolation='nearest',
     rendering='mip',
     iso_threshold=0.5,
+    attenuation=0.5,
     name=None,
     metadata=None,
     scale=None,
@@ -69,8 +70,13 @@ def view_image(
     interpolation : str
         Interpolation mode used by vispy. Must be one of our supported
         modes.
+    rendering : str
+        Rendering mode used by vispy. Must be one of our supported
+        modes.
     iso_threshold : float
         Threshold for isosurface.
+    attenuation : float
+        Attenuation rate for attenuated maximum intensity projection.
     name : str
         Name of the layer.
     metadata : dict
@@ -120,6 +126,7 @@ def view_image(
         interpolation=interpolation,
         rendering=rendering,
         iso_threshold=iso_threshold,
+        attenuation=attenuation,
         name=name,
         metadata=metadata,
         scale=scale,

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -3,8 +3,7 @@ from os.path import dirname, join
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QApplication
 
-from napari._qt.qt_update_ui import QtUpdateUI
-
+from ._qt.qt_update_ui import QtUpdateUI
 from ._qt.qt_main_window import Window
 from ._qt.qt_viewer import QtViewer
 from .components import ViewerModel


### PR DESCRIPTION
# Description
This PR will close #843 by adding an attenuated maximum intensity projection mode, where the attenuation is controlled by a decay exponent. This PR still needs doc string edits, and right now I re-use the `iso_threshold` parameter. I should probably add a new parameter `attenuation_rate` (or something) to keep it clear whats going on. I'll do that shortly, but I wanted to let people see how it looks, which I think is quite nice :-)

![attenuated_mip](https://user-images.githubusercontent.com/6531703/71706444-be0d2480-2d99-11ea-9dd0-8b71d42967f1.gif)

I'm also getting
```bash
INFO: Not setting value for variable float u_threshold; uniform is not active.
INFO:vispy:Not setting value for variable float u_threshold; uniform is not active.
```
warning messages all over, that I would like to make disappear (problem is not new to this PR, but now there are many more of them)