### PR TITLE
Fix fullscreen crash for test_viewer

### DIFF
--- a/napari/tests/test_viewer.py
+++ b/napari/tests/test_viewer.py
@@ -1,5 +1,10 @@
+import sys
+import time
+
 import numpy as np
 import pytest
+from qtpy.QtCore import QEventLoop
+from qtpy.QtWidgets import QApplication
 
 from napari import Viewer
 from napari.tests.utils import (
@@ -41,7 +46,17 @@ def test_viewer(qtbot):
         if func.__name__ == 'play':
             func(viewer)
 
-    # Close the viewer
+    if sys.platform == 'darwin':
+        # on some versions of Darwin, exiting while fullscreen seems to tickle
+        # some bug deep in NSWindow.  This forces the fullscreen keybinding
+        # test to complete its draw cycle, then pop back out of fullscreen.
+        start = time.time()
+        while time.time() < start + 1:
+            qapp = QApplication.instance()
+            qapp.processEvents(QEventLoop.ProcessEventsFlag.AllEvents, 0)
+
+        viewer.window._qt_window.showNormal()
+
     viewer.window.close()
 
 


### PR DESCRIPTION
# Description
On my mac 10.15.2 system, I consistently see a [crash](https://gist.github.com/ttung/90c04ae68e39a2e843c927fcd6f53b0a) in test_viewer.py.

It appears that exiting the app while fullscreen tickles some bug deep in NSWindow.  I suspect it has to do with restoring window state, but I have no proof.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] `pytest napari/tests/test_viewer.py` passes consistently on my laptop now!

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
