### PR TITLE
in bindings logic, check if generator, not generator function

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -395,7 +395,7 @@ class QtViewer(QSplitter):
         func = parent.keymap[comb]
         gen = func(parent)
 
-        if inspect.isgeneratorfunction(func):
+        if inspect.isgenerator(gen):
             try:
                 next(gen)
             except StopIteration:  # only one statement

--- a/napari/utils/interactions.py
+++ b/napari/utils/interactions.py
@@ -49,7 +49,7 @@ def mouse_press_callbacks(obj, event):
         # exectute function to run press event code
         gen = mouse_drag_func(obj, event)
         # if function returns a generator then try to iterate it
-        if inspect.isgeneratorfunction(mouse_drag_func):
+        if inspect.isgenerator(gen):
             try:
                 next(gen)
                 # now store iterated genenerator


### PR DESCRIPTION
# Description
Change usages of `inspect.isgeneratorfunction` to `inspect.isgenerator` in the logic of mouse and key bindings.

This makes it significantly easier to use helper functions when writing bindings:
```python
def foo_helper(bar):
    print(bar)
    yield
    print(bar)


def foo_42():
    return foo_helper(42)


>>> inspect.isgeneratorfunction(foo_helper)
True
>>> inspect.isgeneratorfunction(foo_42)
False

>>> inspect.isgenerator(foo_helper(42))
True
>>> inspect.isgenerator(foo_42())
True
```