### PR TITLE
Fix RangeSlider.rangeChange emit type bug

### DIFF
--- a/napari/_qt/layers/tests/test_qt_image_base_layer_.py
+++ b/napari/_qt/layers/tests/test_qt_image_base_layer_.py
@@ -63,6 +63,6 @@ def test_range_popup_clim_buttons(qtbot, layer):
     if np.issubdtype(layer.dtype, np.integer):
         qtbot.mouseClick(rangebtn, Qt.LeftButton)
         assert tuple(layer.contrast_limits_range) == (0, 2 ** 16 - 1)
-        assert tuple(qtctrl.contrastLimitsSlider.range) == (0, 2 ** 16 - 1)
+        assert tuple(qtctrl.contrastLimitsSlider.range()) == (0, 2 ** 16 - 1)
     else:
         assert rangebtn is None

--- a/napari/_qt/qt_range_slider.py
+++ b/napari/_qt/qt_range_slider.py
@@ -84,7 +84,6 @@ class QRangeSlider(QWidget):
             else:
                 self.setGeometry(200, 200, 20, 200)
 
-    @property
     def range(self):
         """Min and max possible values for the slider range. In data units"""
         return self.data_range_min, self.data_range_max
@@ -93,7 +92,7 @@ class QRangeSlider(QWidget):
         """Min and max possible values for the slider range. In data units."""
         validate_2_tuple(values)
         self.data_range_min, self.data_range_max = values
-        self.rangeChanged.emit(values)
+        self.rangeChanged.emit(self.range())
         self.updateDisplayPositions()
 
     def values(self):
@@ -257,11 +256,11 @@ class QRangeSlider(QWidget):
         self.update()
 
     def _data_to_slider_value(self, value):
-        rmin, rmax = self.range
+        rmin, rmax = self.range()
         return (value - rmin) / self.scale
 
     def _slider_to_data_value(self, value):
-        rmin, rmax = self.range
+        rmin, rmax = self.range()
         return rmin + value * self.scale
 
     @property

--- a/napari/_qt/qt_range_slider_popup.py
+++ b/napari/_qt/qt_range_slider_popup.py
@@ -103,7 +103,7 @@ class QRangeSliderPopup(QtPopup):
         self.curmax_label.setToolTip("current maximum contrast limit")
 
         # create range min/max labels (left & right of slider)
-        rmin, rmax = self.slider.range
+        rmin, rmax = self.slider.range()
         self.range_min_label = LabelEdit(self._numformat(rmin))
         self.range_max_label = LabelEdit(self._numformat(rmax))
         self.range_min_label.editingFinished.connect(self._range_label_changed)

--- a/napari/_qt/tests/test_qt_range_slider_popup.py
+++ b/napari/_qt/tests/test_qt_range_slider_popup.py
@@ -24,7 +24,7 @@ def test_range_slider_popup_labels(qtbot, popup):
     """make sure labels are correct"""
     assert float(popup.curmin_label.text()) == initial[0]
     assert float(popup.curmax_label.text()) == initial[1]
-    assert np.all(popup.slider.range == range_)
+    assert np.all(popup.slider.range() == range_)
 
 
 def test_range_slider_changes_labels(qtbot, popup):


### PR DESCRIPTION
# Description
This fixes the TypeError that Juan found and mentioned on zulip.  I'm also taking the opportunity to normalize the API within the class (I regret making `.range` a property when `.values()` is a method).  Since it's a QWidget, I'm making it a getter method rather than a prop.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
