### PR TITLE
Qt/Vispy connection & lambda refactor

### DIFF
--- a/napari/_qt/layers/qt_base_layer.py
+++ b/napari/_qt/layers/qt_base_layer.py
@@ -29,7 +29,7 @@ class QtLayerControls(QFrame):
         self._on_opacity_change(None)
 
         blend_comboBox = QComboBox()
-        blend_comboBox.addItems([str(mode) for mode in Blending])
+        blend_comboBox.addItems(Blending.keys())
         index = blend_comboBox.findText(
             self.layer.blending, Qt.MatchFixedString
         )

--- a/napari/_qt/layers/qt_base_layer.py
+++ b/napari/_qt/layers/qt_base_layer.py
@@ -26,7 +26,7 @@ class QtLayerControls(QFrame):
         sld.setSingleStep(1)
         sld.valueChanged.connect(self.changeOpacity)
         self.opacitySlider = sld
-        self._on_opacity_change(None)
+        self._on_opacity_change()
 
         blend_comboBox = QComboBox()
         blend_comboBox.addItems(Blending.keys())
@@ -44,11 +44,11 @@ class QtLayerControls(QFrame):
     def changeBlending(self, text):
         self.layer.blending = text
 
-    def _on_opacity_change(self, event):
+    def _on_opacity_change(self, event=None):
         with self.layer.events.opacity.blocker():
             self.opacitySlider.setValue(self.layer.opacity * 100)
 
-    def _on_blending_change(self, event):
+    def _on_blending_change(self, event=None):
         with self.layer.events.blending.blocker():
             index = self.blendComboBox.findText(
                 self.layer.blending, Qt.MatchFixedString

--- a/napari/_qt/layers/qt_base_layer.py
+++ b/napari/_qt/layers/qt_base_layer.py
@@ -24,22 +24,17 @@ class QtLayerControls(QFrame):
         sld.setMinimum(0)
         sld.setMaximum(100)
         sld.setSingleStep(1)
-        sld.valueChanged[int].connect(
-            lambda value=sld: self.changeOpacity(value)
-        )
+        sld.valueChanged.connect(self.changeOpacity)
         self.opacitySlider = sld
         self._on_opacity_change(None)
 
         blend_comboBox = QComboBox()
-        for blend in Blending:
-            blend_comboBox.addItem(str(blend))
+        blend_comboBox.addItems([str(mode) for mode in Blending])
         index = blend_comboBox.findText(
             self.layer.blending, Qt.MatchFixedString
         )
         blend_comboBox.setCurrentIndex(index)
-        blend_comboBox.activated[str].connect(
-            lambda text=blend_comboBox: self.changeBlending(text)
-        )
+        blend_comboBox.activated[str].connect(self.changeBlending)
         self.blendComboBox = blend_comboBox
 
     def changeOpacity(self, value):

--- a/napari/_qt/layers/qt_image_base_layer.py
+++ b/napari/_qt/layers/qt_image_base_layer.py
@@ -51,7 +51,7 @@ class QtBaseImageControls(QtLayerControls):
         self.colorbarLabel.setObjectName('colorbar')
         self.colorbarLabel.setToolTip('Colorbar')
 
-        self._on_colormap_change(None)
+        self._on_colormap_change()
 
     def changeColor(self, text):
         self.layer.colormap = text
@@ -94,7 +94,7 @@ class QtBaseImageControls(QtLayerControls):
                 self.clim_pop.slider.setValues(clims)
                 self.clim_pop._on_values_change(clims)
 
-    def _on_colormap_change(self, event):
+    def _on_colormap_change(self, event=None):
         name = self.layer.colormap[0]
         if name not in self.colormapComboBox._allitems:
             self.colormapComboBox._allitems.add(name)

--- a/napari/_qt/layers/qt_image_base_layer.py
+++ b/napari/_qt/layers/qt_image_base_layer.py
@@ -21,19 +21,15 @@ class QtBaseImageControls(QtLayerControls):
         self.layer.events.contrast_limits.connect(self._on_clims_change)
 
         comboBox = QComboBox()
-        for cmap in self.layer.colormaps:
-            comboBox.addItem(cmap)
+        comboBox.addItems(self.layer.colormaps)
         comboBox._allitems = set(self.layer.colormaps)
-        comboBox.activated[str].connect(
-            lambda text=comboBox: self.changeColor(text)
-        )
+        comboBox.activated[str].connect(self.changeColor)
         self.colormapComboBox = comboBox
 
         # Create contrast_limits slider
         self.contrastLimitsSlider = QHRangeSlider(
             self.layer.contrast_limits, self.layer.contrast_limits_range
         )
-
         self.contrastLimitsSlider.mousePressEvent = self._clim_mousepress
         set_clim = partial(setattr, self.layer, 'contrast_limits')
         set_climrange = partial(setattr, self.layer, 'contrast_limits_range')
@@ -47,7 +43,7 @@ class QtBaseImageControls(QtLayerControls):
         sld.setMaximum(200)
         sld.setSingleStep(2)
         sld.setValue(100)
-        sld.valueChanged[int].connect(self.gamma_slider_changed)
+        sld.valueChanged.connect(self.gamma_slider_changed)
         self.gammaSlider = sld
         self.gamma_slider_update()
 

--- a/napari/_qt/layers/qt_image_layer.py
+++ b/napari/_qt/layers/qt_image_layer.py
@@ -15,7 +15,7 @@ class QtImageControls(QtBaseImageControls):
         self.layer.dims.events.ndisplay.connect(self._on_ndisplay_change)
 
         interp_comboBox = QComboBox()
-        interp_comboBox.addItems([str(i) for i in Interpolation])
+        interp_comboBox.addItems(Interpolation.keys())
         index = interp_comboBox.findText(
             self.layer.interpolation, Qt.MatchFixedString
         )
@@ -25,7 +25,7 @@ class QtImageControls(QtBaseImageControls):
         self.interpLabel = QLabel('interpolation:')
 
         renderComboBox = QComboBox()
-        renderComboBox.addItems([str(r) for r in Rendering])
+        renderComboBox.addItems(Rendering.keys())
         index = renderComboBox.findText(
             self.layer.rendering, Qt.MatchFixedString
         )

--- a/napari/_qt/layers/qt_image_layer.py
+++ b/napari/_qt/layers/qt_image_layer.py
@@ -15,28 +15,22 @@ class QtImageControls(QtBaseImageControls):
         self.layer.dims.events.ndisplay.connect(self._on_ndisplay_change)
 
         interp_comboBox = QComboBox()
-        for interp in Interpolation:
-            interp_comboBox.addItem(str(interp))
+        interp_comboBox.addItems([str(i) for i in Interpolation])
         index = interp_comboBox.findText(
             self.layer.interpolation, Qt.MatchFixedString
         )
         interp_comboBox.setCurrentIndex(index)
-        interp_comboBox.activated[str].connect(
-            lambda text=interp_comboBox: self.changeInterpolation(text)
-        )
+        interp_comboBox.activated[str].connect(self.changeInterpolation)
         self.interpComboBox = interp_comboBox
         self.interpLabel = QLabel('interpolation:')
 
         renderComboBox = QComboBox()
-        for render in Rendering:
-            renderComboBox.addItem(str(render))
+        renderComboBox.addItems([str(r) for r in Rendering])
         index = renderComboBox.findText(
             self.layer.rendering, Qt.MatchFixedString
         )
         renderComboBox.setCurrentIndex(index)
-        renderComboBox.activated[str].connect(
-            lambda text=renderComboBox: self.changeRendering(text)
-        )
+        renderComboBox.activated[str].connect(self.changeRendering)
         self.renderComboBox = renderComboBox
         self.renderLabel = QLabel('rendering:')
 
@@ -46,9 +40,7 @@ class QtImageControls(QtBaseImageControls):
         sld.setMaximum(100)
         sld.setSingleStep(1)
         sld.setValue(self.layer.iso_threshold * 100)
-        sld.valueChanged[int].connect(
-            lambda value=sld: self.changeIsoThreshold(value)
-        )
+        sld.valueChanged.connect(self.changeIsoThreshold)
         self.isoThresholdSlider = sld
         self.isoThresholdLabel = QLabel('iso threshold:')
 
@@ -58,9 +50,7 @@ class QtImageControls(QtBaseImageControls):
         sld.setMaximum(200)
         sld.setSingleStep(1)
         sld.setValue(self.layer.attenuation * 100)
-        sld.valueChanged[int].connect(
-            lambda value=sld: self.changeAttenuation(value)
-        )
+        sld.valueChanged.connect(self.changeAttenuation)
         self.attenuationSlider = sld
         self.attenuationLabel = QLabel('attenuation:')
         self._on_ndisplay_change(None)

--- a/napari/_qt/layers/qt_image_layer.py
+++ b/napari/_qt/layers/qt_image_layer.py
@@ -53,7 +53,7 @@ class QtImageControls(QtBaseImageControls):
         sld.valueChanged.connect(self.changeAttenuation)
         self.attenuationSlider = sld
         self.attenuationLabel = QLabel('attenuation:')
-        self._on_ndisplay_change(None)
+        self._on_ndisplay_change()
 
         # grid_layout created in QtLayerControls
         # addWidget(widget, row, column, [row_span, column_span])
@@ -135,7 +135,7 @@ class QtImageControls(QtBaseImageControls):
             self.attenuationSlider.hide()
             self.attenuationLabel.hide()
 
-    def _on_ndisplay_change(self, event):
+    def _on_ndisplay_change(self, event=None):
         if self.layer.dims.ndisplay == 2:
             self.isoThresholdSlider.hide()
             self.isoThresholdLabel.hide()

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -127,7 +127,7 @@ class QtLabelsControls(QtLayerControls):
         elif mode == Mode.FILL:
             self.fill_button.setChecked(True)
         else:
-            raise ValueError("Mode not recongnized")
+            raise ValueError("Mode not recognized")
 
     def changeColor(self):
         self.layer.new_colormap()

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -1,7 +1,6 @@
 from qtpy.QtGui import QPainter, QColor
 from qtpy.QtWidgets import (
     QButtonGroup,
-    QRadioButton,
     QWidget,
     QPushButton,
     QSlider,
@@ -15,6 +14,7 @@ from qtpy.QtCore import Qt
 import numpy as np
 from .qt_base_layer import QtLayerControls
 from ...layers.labels._constants import Mode
+from ..qt_mode_radio import QtModeRadio
 
 
 class QtLabelsControls(QtLayerControls):
@@ -64,23 +64,22 @@ class QtLabelsControls(QtLayerControls):
         self.ndimCheckBox = ndim_cb
         self._on_n_dim_change(None)
 
-        self.panzoom_button = QtModeButton(
-            layer, 'zoom', Mode.PAN_ZOOM, 'Pan/zoom mode'
+        self.panzoom_button = QtModeRadio(
+            layer, 'zoom', Mode.PAN_ZOOM, 'Pan/zoom mode', checked=True
         )
-        self.pick_button = QtModeButton(
+        self.pick_button = QtModeRadio(
             layer, 'picker', Mode.PICKER, 'Pick mode'
         )
-        self.paint_button = QtModeButton(
+        self.paint_button = QtModeRadio(
             layer, 'paint', Mode.PAINT, 'Paint mode'
         )
-        self.fill_button = QtModeButton(layer, 'fill', Mode.FILL, 'Fill mode')
+        self.fill_button = QtModeRadio(layer, 'fill', Mode.FILL, 'Fill mode')
 
         self.button_group = QButtonGroup(self)
         self.button_group.addButton(self.panzoom_button)
         self.button_group.addButton(self.paint_button)
         self.button_group.addButton(self.pick_button)
         self.button_group.addButton(self.fill_button)
-        self.panzoom_button.setChecked(True)
         self._on_editable_change(None)
 
         button_row = QHBoxLayout()
@@ -174,24 +173,6 @@ class QtLabelsControls(QtLayerControls):
         self.pick_button.setEnabled(self.layer.editable)
         self.paint_button.setEnabled(self.layer.editable)
         self.fill_button.setEnabled(self.layer.editable)
-
-
-class QtModeButton(QRadioButton):
-    def __init__(self, layer, button_name, mode, tool_tip):
-        super().__init__()
-
-        self.mode = mode
-        self.layer = layer
-        self.setToolTip(tool_tip)
-        self.setChecked(False)
-        self.setProperty('mode', button_name)
-        self.toggled.connect(lambda state=self: self._set_mode(state))
-        self.setFixedWidth(28)
-
-    def _set_mode(self, bool):
-        with self.layer.events.mode.blocker(self._set_mode):
-            if bool:
-                self.layer.mode = self.mode
 
 
 class QtColorBox(QWidget):

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -65,16 +65,20 @@ class QtLabelsControls(QtLayerControls):
         self._on_n_dim_change()
 
         self.panzoom_button = QtModeRadioButton(
-            layer, 'zoom', Mode.PAN_ZOOM, 'Pan/zoom mode', checked=True
+            layer,
+            'zoom',
+            Mode.PAN_ZOOM,
+            tool_tip='Pan/zoom mode',
+            checked=True,
         )
         self.pick_button = QtModeRadioButton(
-            layer, 'picker', Mode.PICKER, 'Pick mode'
+            layer, 'picker', Mode.PICKER, tool_tip='Pick mode'
         )
         self.paint_button = QtModeRadioButton(
-            layer, 'paint', Mode.PAINT, 'Paint mode'
+            layer, 'paint', Mode.PAINT, tool_tip='Paint mode'
         )
         self.fill_button = QtModeRadioButton(
-            layer, 'fill', Mode.FILL, 'Fill mode'
+            layer, 'fill', Mode.FILL, tool_tip='Fill mode'
         )
 
         self.button_group = QButtonGroup(self)

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -65,20 +65,16 @@ class QtLabelsControls(QtLayerControls):
         self._on_n_dim_change()
 
         self.panzoom_button = QtModeRadioButton(
-            layer,
-            'zoom',
-            Mode.PAN_ZOOM,
-            tool_tip='Pan/zoom mode',
-            checked=True,
+            layer, 'zoom', Mode.PAN_ZOOM, tooltip='Pan/zoom mode', checked=True
         )
         self.pick_button = QtModeRadioButton(
-            layer, 'picker', Mode.PICKER, tool_tip='Pick mode'
+            layer, 'picker', Mode.PICKER, tooltip='Pick mode'
         )
         self.paint_button = QtModeRadioButton(
-            layer, 'paint', Mode.PAINT, tool_tip='Paint mode'
+            layer, 'paint', Mode.PAINT, tooltip='Paint mode'
         )
         self.fill_button = QtModeRadioButton(
-            layer, 'fill', Mode.FILL, tool_tip='Fill mode'
+            layer, 'fill', Mode.FILL, tooltip='Fill mode'
         )
 
         self.button_group = QButtonGroup(self)

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -48,23 +48,19 @@ class QtLabelsControls(QtLayerControls):
         sld.setMinimum(1)
         sld.setMaximum(40)
         sld.setSingleStep(1)
-        sld.valueChanged[int].connect(lambda value=sld: self.changeSize(value))
+        sld.valueChanged.connect(self.changeSize)
         self.brushSizeSlider = sld
         self._on_brush_size_change(None)
 
         contig_cb = QCheckBox()
         contig_cb.setToolTip('contiguous editing')
-        contig_cb.stateChanged.connect(
-            lambda state=contig_cb: self.change_contig(state)
-        )
+        contig_cb.stateChanged.connect(self.change_contig)
         self.contigCheckBox = contig_cb
         self._on_contig_change(None)
 
         ndim_cb = QCheckBox()
         ndim_cb.setToolTip('n-dimensional editing')
-        ndim_cb.stateChanged.connect(
-            lambda state=ndim_cb: self.change_ndim(state)
-        )
+        ndim_cb.stateChanged.connect(self.change_ndim)
         self.ndimCheckBox = ndim_cb
         self._on_n_dim_change(None)
 

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -41,7 +41,7 @@ class QtLabelsControls(QtLayerControls):
         self.selectionSpinBox.setMinimum(0)
         self.selectionSpinBox.setMaximum(2147483647)
         self.selectionSpinBox.valueChanged.connect(self.changeSelection)
-        self._on_selection_change(None)
+        self._on_selection_change()
 
         sld = QSlider(Qt.Horizontal)
         sld.setFocusPolicy(Qt.NoFocus)
@@ -50,19 +50,19 @@ class QtLabelsControls(QtLayerControls):
         sld.setSingleStep(1)
         sld.valueChanged.connect(self.changeSize)
         self.brushSizeSlider = sld
-        self._on_brush_size_change(None)
+        self._on_brush_size_change()
 
         contig_cb = QCheckBox()
         contig_cb.setToolTip('contiguous editing')
         contig_cb.stateChanged.connect(self.change_contig)
         self.contigCheckBox = contig_cb
-        self._on_contig_change(None)
+        self._on_contig_change()
 
         ndim_cb = QCheckBox()
         ndim_cb.setToolTip('n-dimensional editing')
         ndim_cb.stateChanged.connect(self.change_ndim)
         self.ndimCheckBox = ndim_cb
-        self._on_n_dim_change(None)
+        self._on_n_dim_change()
 
         self.panzoom_button = QtModeRadioButton(
             layer, 'zoom', Mode.PAN_ZOOM, 'Pan/zoom mode', checked=True
@@ -82,7 +82,7 @@ class QtLabelsControls(QtLayerControls):
         self.button_group.addButton(self.paint_button)
         self.button_group.addButton(self.pick_button)
         self.button_group.addButton(self.fill_button)
-        self._on_editable_change(None)
+        self._on_editable_change()
 
         button_row = QHBoxLayout()
         button_row.addWidget(self.pick_button)
@@ -152,26 +152,26 @@ class QtLabelsControls(QtLayerControls):
         else:
             self.layer.n_dimensional = False
 
-    def _on_selection_change(self, event):
+    def _on_selection_change(self, event=None):
         with self.layer.events.selected_label.blocker():
             value = self.layer.selected_label
             self.selectionSpinBox.setValue(int(value))
 
-    def _on_brush_size_change(self, event):
+    def _on_brush_size_change(self, event=None):
         with self.layer.events.brush_size.blocker():
             value = self.layer.brush_size
             value = np.clip(int(value), 1, 40)
             self.brushSizeSlider.setValue(value)
 
-    def _on_n_dim_change(self, event):
+    def _on_n_dim_change(self, event=None):
         with self.layer.events.n_dimensional.blocker():
             self.ndimCheckBox.setChecked(self.layer.n_dimensional)
 
-    def _on_contig_change(self, event):
+    def _on_contig_change(self, event=None):
         with self.layer.events.contiguous.blocker():
             self.contigCheckBox.setChecked(self.layer.contiguous)
 
-    def _on_editable_change(self, event):
+    def _on_editable_change(self, event=None):
         self.pick_button.setEnabled(self.layer.editable)
         self.paint_button.setEnabled(self.layer.editable)
         self.fill_button.setEnabled(self.layer.editable)

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -14,7 +14,7 @@ from qtpy.QtCore import Qt
 import numpy as np
 from .qt_base_layer import QtLayerControls
 from ...layers.labels._constants import Mode
-from ..qt_mode_radio import QtModeRadio
+from ..qt_mode_buttons import QtModeRadioButton
 
 
 class QtLabelsControls(QtLayerControls):
@@ -64,16 +64,18 @@ class QtLabelsControls(QtLayerControls):
         self.ndimCheckBox = ndim_cb
         self._on_n_dim_change(None)
 
-        self.panzoom_button = QtModeRadio(
+        self.panzoom_button = QtModeRadioButton(
             layer, 'zoom', Mode.PAN_ZOOM, 'Pan/zoom mode', checked=True
         )
-        self.pick_button = QtModeRadio(
+        self.pick_button = QtModeRadioButton(
             layer, 'picker', Mode.PICKER, 'Pick mode'
         )
-        self.paint_button = QtModeRadio(
+        self.paint_button = QtModeRadioButton(
             layer, 'paint', Mode.PAINT, 'Paint mode'
         )
-        self.fill_button = QtModeRadio(layer, 'fill', Mode.FILL, 'Fill mode')
+        self.fill_button = QtModeRadioButton(
+            layer, 'fill', Mode.FILL, 'Fill mode'
+        )
 
         self.button_group = QButtonGroup(self)
         self.button_group.addButton(self.panzoom_button)

--- a/napari/_qt/layers/qt_points_layer.py
+++ b/napari/_qt/layers/qt_points_layer.py
@@ -5,7 +5,6 @@ from qtpy.QtWidgets import (
     QSlider,
     QCheckBox,
     QButtonGroup,
-    QRadioButton,
     QPushButton,
     QFrame,
     QHBoxLayout,
@@ -13,6 +12,7 @@ from qtpy.QtWidgets import (
 from vispy.color import Color
 from .qt_base_layer import QtLayerControls
 from ...layers.points._constants import Mode, Symbol
+from ..qt_mode_radio import QtModeRadio
 
 
 class QtPointsControls(QtLayerControls):
@@ -70,14 +70,14 @@ class QtPointsControls(QtLayerControls):
         ndim_cb.stateChanged.connect(self.change_ndim)
         self.ndimCheckBox = ndim_cb
 
-        self.select_button = ModeButton(
-            'QtSelectButton', layer, 'Select points', Mode.SELECT
+        self.select_button = QtModeRadio(
+            layer, 'select_points', Mode.SELECT, 'Select points'
         )
-        self.addition_button = ModeButton(
-            'QtAdditionButton', layer, 'Add points', Mode.ADD
+        self.addition_button = QtModeRadio(
+            layer, 'add_points', Mode.ADD, 'Add points'
         )
-        self.panzoom_button = ModeButton(
-            'QtPanZoomButton', layer, 'Pan/zoom', Mode.PAN_ZOOM, checked=True
+        self.panzoom_button = QtModeRadio(
+            layer, 'pan_zoom', Mode.PAN_ZOOM, 'Pan/zoom', checked=True
         )
         self.delete_button = QtDeletePointsButton(layer)
 
@@ -187,24 +187,6 @@ class QtPointsControls(QtLayerControls):
         self.select_button.setEnabled(self.layer.editable)
         self.addition_button.setEnabled(self.layer.editable)
         self.delete_button.setEnabled(self.layer.editable)
-
-
-class ModeButton(QRadioButton):
-    def __init__(self, name, layer, tooltip, mode, checked=False):
-        super().__init__()
-
-        self.setObjectName(name)
-        self.layer = layer
-        self.setToolTip(tooltip)
-        self._mode = mode
-        self.setChecked(checked)
-        self.toggled.connect(self._set_mode)
-        self.setFixedWidth(28)
-
-    def _set_mode(self, bool):
-        with self.layer.events.mode.blocker():
-            if bool:
-                self.layer.mode = self._mode
 
 
 class QtDeletePointsButton(QPushButton):

--- a/napari/_qt/layers/qt_points_layer.py
+++ b/napari/_qt/layers/qt_points_layer.py
@@ -82,7 +82,7 @@ class QtPointsControls(QtLayerControls):
             layer,
             'delete_shape',
             self.layer.remove_selected,
-            'Delete selected points',
+            tool_tip='Delete selected points',
         )
 
         self.button_group = QButtonGroup(self)

--- a/napari/_qt/layers/qt_points_layer.py
+++ b/napari/_qt/layers/qt_points_layer.py
@@ -70,19 +70,19 @@ class QtPointsControls(QtLayerControls):
         self.ndimCheckBox = ndim_cb
 
         self.select_button = QtModeRadioButton(
-            layer, 'select_points', Mode.SELECT, tool_tip='Select points'
+            layer, 'select_points', Mode.SELECT, tooltip='Select points'
         )
         self.addition_button = QtModeRadioButton(
-            layer, 'add_points', Mode.ADD, tool_tip='Add points'
+            layer, 'add_points', Mode.ADD, tooltip='Add points'
         )
         self.panzoom_button = QtModeRadioButton(
-            layer, 'pan_zoom', Mode.PAN_ZOOM, tool_tip='Pan/zoom', checked=True
+            layer, 'pan_zoom', Mode.PAN_ZOOM, tooltip='Pan/zoom', checked=True
         )
         self.delete_button = QtModePushButton(
             layer,
             'delete_shape',
-            self.layer.remove_selected,
-            tool_tip='Delete selected points',
+            slot=self.layer.remove_selected,
+            tooltip='Delete selected points',
         )
 
         self.button_group = QButtonGroup(self)

--- a/napari/_qt/layers/qt_points_layer.py
+++ b/napari/_qt/layers/qt_points_layer.py
@@ -70,13 +70,13 @@ class QtPointsControls(QtLayerControls):
         self.ndimCheckBox = ndim_cb
 
         self.select_button = QtModeRadioButton(
-            layer, 'select_points', Mode.SELECT, 'Select points'
+            layer, 'select_points', Mode.SELECT, tool_tip='Select points'
         )
         self.addition_button = QtModeRadioButton(
-            layer, 'add_points', Mode.ADD, 'Add points'
+            layer, 'add_points', Mode.ADD, tool_tip='Add points'
         )
         self.panzoom_button = QtModeRadioButton(
-            layer, 'pan_zoom', Mode.PAN_ZOOM, 'Pan/zoom', checked=True
+            layer, 'pan_zoom', Mode.PAN_ZOOM, tool_tip='Pan/zoom', checked=True
         )
         self.delete_button = QtModePushButton(
             layer,

--- a/napari/_qt/layers/qt_points_layer.py
+++ b/napari/_qt/layers/qt_points_layer.py
@@ -5,14 +5,13 @@ from qtpy.QtWidgets import (
     QSlider,
     QCheckBox,
     QButtonGroup,
-    QPushButton,
     QFrame,
     QHBoxLayout,
 )
 from vispy.color import Color
 from .qt_base_layer import QtLayerControls
 from ...layers.points._constants import Mode, Symbol
-from ..qt_mode_radio import QtModeRadio
+from ..qt_mode_buttons import QtModeRadioButton, QtModePushButton
 
 
 class QtPointsControls(QtLayerControls):
@@ -70,16 +69,21 @@ class QtPointsControls(QtLayerControls):
         ndim_cb.stateChanged.connect(self.change_ndim)
         self.ndimCheckBox = ndim_cb
 
-        self.select_button = QtModeRadio(
+        self.select_button = QtModeRadioButton(
             layer, 'select_points', Mode.SELECT, 'Select points'
         )
-        self.addition_button = QtModeRadio(
+        self.addition_button = QtModeRadioButton(
             layer, 'add_points', Mode.ADD, 'Add points'
         )
-        self.panzoom_button = QtModeRadio(
+        self.panzoom_button = QtModeRadioButton(
             layer, 'pan_zoom', Mode.PAN_ZOOM, 'Pan/zoom', checked=True
         )
-        self.delete_button = QtDeletePointsButton(layer)
+        self.delete_button = QtModePushButton(
+            layer,
+            'delete_shape',
+            'Delete selected points',
+            self.layer.remove_selected,
+        )
 
         self.button_group = QButtonGroup(self)
         self.button_group.addButton(self.select_button)
@@ -187,14 +191,3 @@ class QtPointsControls(QtLayerControls):
         self.select_button.setEnabled(self.layer.editable)
         self.addition_button.setEnabled(self.layer.editable)
         self.delete_button.setEnabled(self.layer.editable)
-
-
-class QtDeletePointsButton(QPushButton):
-    def __init__(self, layer):
-        super().__init__()
-
-        self.layer = layer
-        self.setFixedWidth(28)
-        self.setFixedHeight(28)
-        self.setToolTip('Delete selected points')
-        self.clicked.connect(self.layer.remove_selected)

--- a/napari/_qt/layers/qt_points_layer.py
+++ b/napari/_qt/layers/qt_points_layer.py
@@ -43,7 +43,7 @@ class QtPointsControls(QtLayerControls):
         self.faceColorSwatch = QFrame()
         self.faceColorSwatch.setObjectName('swatch')
         self.faceColorSwatch.setToolTip('Face color swatch')
-        self._on_face_color_change(None)
+        self._on_face_color_change()
 
         edge_comboBox = QComboBox()
         edge_comboBox.addItems(self.layer._colors)
@@ -52,7 +52,7 @@ class QtPointsControls(QtLayerControls):
         self.edgeColorSwatch = QFrame()
         self.edgeColorSwatch.setObjectName('swatch')
         self.edgeColorSwatch.setToolTip('Edge color swatch')
-        self._on_edge_color_change(None)
+        self._on_edge_color_change()
 
         symbol_comboBox = QComboBox()
         symbol_comboBox.addItems([str(s) for s in Symbol])
@@ -164,12 +164,12 @@ class QtPointsControls(QtLayerControls):
             )
             self.symbolComboBox.setCurrentIndex(index)
 
-    def _on_size_change(self, event):
+    def _on_size_change(self, event=None):
         with self.layer.events.size.blocker():
             value = self.layer.current_size
             self.sizeSlider.setValue(int(value))
 
-    def _on_edge_color_change(self, event):
+    def _on_edge_color_change(self, event=None):
         with self.layer.events.edge_color.blocker():
             index = self.edgeComboBox.findText(
                 self.layer.current_edge_color, Qt.MatchFixedString
@@ -178,7 +178,7 @@ class QtPointsControls(QtLayerControls):
         color = Color(self.layer.current_edge_color).hex
         self.edgeColorSwatch.setStyleSheet("background-color: " + color)
 
-    def _on_face_color_change(self, event):
+    def _on_face_color_change(self, event=None):
         with self.layer.events.face_color.blocker():
             index = self.faceComboBox.findText(
                 self.layer.current_face_color, Qt.MatchFixedString
@@ -187,7 +187,7 @@ class QtPointsControls(QtLayerControls):
         color = Color(self.layer.current_face_color).hex
         self.faceColorSwatch.setStyleSheet("background-color: " + color)
 
-    def _on_editable_change(self, event):
+    def _on_editable_change(self, event=None):
         self.select_button.setEnabled(self.layer.editable)
         self.addition_button.setEnabled(self.layer.editable)
         self.delete_button.setEnabled(self.layer.editable)

--- a/napari/_qt/layers/qt_points_layer.py
+++ b/napari/_qt/layers/qt_points_layer.py
@@ -133,7 +133,7 @@ class QtPointsControls(QtLayerControls):
         elif mode == Mode.PAN_ZOOM:
             self.panzoom_button.setChecked(True)
         else:
-            raise ValueError("Mode not recongnized")
+            raise ValueError("Mode not recognized")
 
     def changeFaceColor(self, text):
         self.layer.current_face_color = text

--- a/napari/_qt/layers/qt_points_layer.py
+++ b/napari/_qt/layers/qt_points_layer.py
@@ -81,8 +81,8 @@ class QtPointsControls(QtLayerControls):
         self.delete_button = QtModePushButton(
             layer,
             'delete_shape',
-            'Delete selected points',
             self.layer.remove_selected,
+            'Delete selected points',
         )
 
         self.button_group = QButtonGroup(self)

--- a/napari/_qt/layers/qt_points_layer.py
+++ b/napari/_qt/layers/qt_points_layer.py
@@ -64,8 +64,7 @@ class QtPointsControls(QtLayerControls):
         self._on_edge_color_change(None)
 
         symbol_comboBox = QComboBox()
-        for s in Symbol:
-            symbol_comboBox.addItem(str(s))
+        symbol_comboBox.addItems([str(s) for s in Symbol])
         index = symbol_comboBox.findText(
             self.layer.symbol, Qt.MatchFixedString
         )

--- a/napari/_qt/layers/qt_shapes_layer.py
+++ b/napari/_qt/layers/qt_shapes_layer.py
@@ -37,36 +37,26 @@ class QtShapesControls(QtLayerControls):
                 value = np.asarray(value)
             value = value.mean()
         sld.setValue(int(value))
-        sld.valueChanged[int].connect(
-            lambda value=sld: self.changeWidth(value)
-        )
+        sld.valueChanged.connect(self.changeWidth)
         self.widthSlider = sld
 
         face_comboBox = QComboBox()
-        colors = self.layer._colors
-        for c in colors:
-            face_comboBox.addItem(c)
-        face_comboBox.activated[str].connect(
-            lambda text=face_comboBox: self.changeFaceColor(text)
-        )
+        face_comboBox.addItems(self.layer._colors)
+        face_comboBox.activated[str].connect(self.changeFaceColor)
         self.faceComboBox = face_comboBox
         self.faceColorSwatch = QFrame()
         self.faceColorSwatch.setObjectName('swatch')
         self.faceColorSwatch.setToolTip('Face color swatch')
-        self._on_face_color_change(None)
+        self._on_face_color_change()
 
         edge_comboBox = QComboBox()
-        colors = self.layer._colors
-        for c in colors:
-            edge_comboBox.addItem(c)
-        edge_comboBox.activated[str].connect(
-            lambda text=edge_comboBox: self.changeEdgeColor(text)
-        )
+        edge_comboBox.addItems(self.layer._colors)
+        edge_comboBox.activated[str].connect(self.changeEdgeColor)
         self.edgeComboBox = edge_comboBox
         self.edgeColorSwatch = QFrame()
         self.edgeColorSwatch.setObjectName('swatch')
         self.edgeColorSwatch.setToolTip('Edge color swatch')
-        self._on_edge_color_change(None)
+        self._on_edge_color_change()
 
         self.select_button = QtModeRadio(
             layer, 'select', Mode.SELECT, 'Select shapes'
@@ -155,29 +145,23 @@ class QtShapesControls(QtLayerControls):
         self.layer.status = str(self.layer.mode)
 
     def set_mode(self, event):
-        mode = event.mode
-        if mode == Mode.SELECT:
-            self.select_button.setChecked(True)
-        elif mode == Mode.DIRECT:
-            self.direct_button.setChecked(True)
-        elif mode == Mode.PAN_ZOOM:
-            self.panzoom_button.setChecked(True)
-        elif mode == Mode.ADD_RECTANGLE:
-            self.rectangle_button.setChecked(True)
-        elif mode == Mode.ADD_ELLIPSE:
-            self.ellipse_button.setChecked(True)
-        elif mode == Mode.ADD_LINE:
-            self.line_button.setChecked(True)
-        elif mode == Mode.ADD_PATH:
-            self.path_button.setChecked(True)
-        elif mode == Mode.ADD_POLYGON:
-            self.polygon_button.setChecked(True)
-        elif mode == Mode.VERTEX_INSERT:
-            self.vertex_insert_button.setChecked(True)
-        elif mode == Mode.VERTEX_REMOVE:
-            self.vertex_remove_button.setChecked(True)
+        mode_buttons = {
+            Mode.SELECT: self.select_button,
+            Mode.DIRECT: self.direct_button,
+            Mode.PAN_ZOOM: self.panzoom_button,
+            Mode.ADD_RECTANGLE: self.rectangle_button,
+            Mode.ADD_ELLIPSE: self.ellipse_button,
+            Mode.ADD_LINE: self.line_button,
+            Mode.ADD_PATH: self.path_button,
+            Mode.ADD_POLYGON: self.polygon_button,
+            Mode.VERTEX_INSERT: self.vertex_insert_button,
+            Mode.VERTEX_REMOVE: self.vertex_remove_button,
+        }
+
+        if event.mode in mode_buttons:
+            mode_buttons[event.mode].setChecked(True)
         else:
-            raise ValueError("Mode not recongnized")
+            raise ValueError(f"Mode '{event.mode}'not recongnized")
 
     def changeFaceColor(self, text):
         self.layer.current_face_color = text
@@ -192,13 +176,13 @@ class QtShapesControls(QtLayerControls):
         with self.layer.events.blocker(self._on_opacity_change):
             self.layer.current_opacity = value / 100
 
-    def _on_edge_width_change(self, event):
+    def _on_edge_width_change(self, event=None):
         with self.layer.events.edge_width.blocker():
             value = self.layer.current_edge_width
             value = np.clip(int(2 * value), 0, 40)
             self.widthSlider.setValue(value)
 
-    def _on_edge_color_change(self, event):
+    def _on_edge_color_change(self, event=None):
         with self.layer.events.edge_color.blocker():
             index = self.edgeComboBox.findText(
                 self.layer.current_edge_color, Qt.MatchFixedString
@@ -207,7 +191,7 @@ class QtShapesControls(QtLayerControls):
         color = Color(self.layer.current_edge_color).hex
         self.edgeColorSwatch.setStyleSheet("background-color: " + color)
 
-    def _on_face_color_change(self, event):
+    def _on_face_color_change(self, event=None):
         with self.layer.events.face_color.blocker():
             index = self.faceComboBox.findText(
                 self.layer.current_face_color, Qt.MatchFixedString
@@ -216,11 +200,11 @@ class QtShapesControls(QtLayerControls):
         color = Color(self.layer.current_face_color).hex
         self.faceColorSwatch.setStyleSheet("background-color: " + color)
 
-    def _on_opacity_change(self, event):
+    def _on_opacity_change(self, event=None):
         with self.layer.events.opacity.blocker():
             self.opacitySlider.setValue(self.layer.current_opacity * 100)
 
-    def _on_editable_change(self, event):
+    def _on_editable_change(self, event=None):
         self.select_button.setEnabled(self.layer.editable)
         self.direct_button.setEnabled(self.layer.editable)
         self.rectangle_button.setEnabled(self.layer.editable)

--- a/napari/_qt/layers/qt_shapes_layer.py
+++ b/napari/_qt/layers/qt_shapes_layer.py
@@ -89,16 +89,16 @@ class QtShapesControls(QtLayerControls):
         )
 
         self.move_front_button = QtModePushButton(
-            layer, 'move_front', 'Move to front', self.layer.move_to_front
+            layer, 'move_front', self.layer.move_to_front, 'Move to front'
         )
         self.move_back_button = QtModePushButton(
-            layer, 'move_back', 'Move to back', self.layer.move_to_back
+            layer, 'move_back', self.layer.move_to_back, 'Move to back'
         )
         self.delete_button = QtModePushButton(
             layer,
             'delete_shape',
-            'Delete selected shapes',
             self.layer.remove_selected,
+            'Delete selected shapes',
         )
 
         self.button_group = QButtonGroup(self)

--- a/napari/_qt/layers/qt_shapes_layer.py
+++ b/napari/_qt/layers/qt_shapes_layer.py
@@ -58,47 +58,59 @@ class QtShapesControls(QtLayerControls):
         self._on_edge_color_change()
 
         self.select_button = QtModeRadioButton(
-            layer, 'select', Mode.SELECT, 'Select shapes'
+            layer, 'select', Mode.SELECT, tool_tip='Select shapes'
         )
         self.direct_button = QtModeRadioButton(
-            layer, 'direct', Mode.DIRECT, 'Select vertices'
+            layer, 'direct', Mode.DIRECT, tool_tip='Select vertices'
         )
         self.panzoom_button = QtModeRadioButton(
-            layer, 'zoom', Mode.PAN_ZOOM, 'Pan/zoom', checked=True
+            layer, 'zoom', Mode.PAN_ZOOM, tool_tip='Pan/zoom', checked=True
         )
         self.rectangle_button = QtModeRadioButton(
-            layer, 'rectangle', Mode.ADD_RECTANGLE, 'Add rectangles'
+            layer, 'rectangle', Mode.ADD_RECTANGLE, tool_tip='Add rectangles'
         )
         self.ellipse_button = QtModeRadioButton(
-            layer, 'ellipse', Mode.ADD_ELLIPSE, 'Add ellipses'
+            layer, 'ellipse', Mode.ADD_ELLIPSE, tool_tip='Add ellipses'
         )
         self.line_button = QtModeRadioButton(
-            layer, 'line', Mode.ADD_LINE, 'Add lines'
+            layer, 'line', Mode.ADD_LINE, tool_tip='Add lines'
         )
         self.path_button = QtModeRadioButton(
-            layer, 'path', Mode.ADD_PATH, 'Add paths'
+            layer, 'path', Mode.ADD_PATH, tool_tip='Add paths'
         )
         self.polygon_button = QtModeRadioButton(
-            layer, 'polygon', Mode.ADD_POLYGON, 'Add polygons'
+            layer, 'polygon', Mode.ADD_POLYGON, tool_tip='Add polygons'
         )
         self.vertex_insert_button = QtModeRadioButton(
-            layer, 'vertex_insert', Mode.VERTEX_INSERT, 'Insert vertex'
+            layer,
+            'vertex_insert',
+            Mode.VERTEX_INSERT,
+            tool_tip='Insert vertex',
         )
         self.vertex_remove_button = QtModeRadioButton(
-            layer, 'vertex_remove', Mode.VERTEX_REMOVE, 'Remove vertex'
+            layer,
+            'vertex_remove',
+            Mode.VERTEX_REMOVE,
+            tool_tip='Remove vertex',
         )
 
         self.move_front_button = QtModePushButton(
-            layer, 'move_front', self.layer.move_to_front, 'Move to front'
+            layer,
+            'move_front',
+            self.layer.move_to_front,
+            tool_tip='Move to front',
         )
         self.move_back_button = QtModePushButton(
-            layer, 'move_back', self.layer.move_to_back, 'Move to back'
+            layer,
+            'move_back',
+            self.layer.move_to_back,
+            tool_tip='Move to back',
         )
         self.delete_button = QtModePushButton(
             layer,
             'delete_shape',
             self.layer.remove_selected,
-            'Delete selected shapes',
+            tool_tip='Delete selected shapes',
         )
 
         self.button_group = QButtonGroup(self)

--- a/napari/_qt/layers/qt_shapes_layer.py
+++ b/napari/_qt/layers/qt_shapes_layer.py
@@ -3,7 +3,6 @@ import numpy as np
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QButtonGroup,
-    QRadioButton,
     QPushButton,
     QLabel,
     QComboBox,
@@ -14,6 +13,7 @@ from qtpy.QtWidgets import (
 from vispy.color import Color
 from .qt_base_layer import QtLayerControls
 from ...layers.shapes._constants import Mode
+from ..qt_mode_radio import QtModeRadio
 
 
 class QtShapesControls(QtLayerControls):
@@ -68,41 +68,40 @@ class QtShapesControls(QtLayerControls):
         self.edgeColorSwatch.setToolTip('Edge color swatch')
         self._on_edge_color_change(None)
 
-        self.select_button = QtModeButton(
+        self.select_button = QtModeRadio(
             layer, 'select', Mode.SELECT, 'Select shapes'
         )
-        self.direct_button = QtModeButton(
+        self.direct_button = QtModeRadio(
             layer, 'direct', Mode.DIRECT, 'Select vertices'
         )
-        self.panzoom_button = QtModeButton(
-            layer, 'zoom', Mode.PAN_ZOOM, 'Pan/zoom'
+        self.panzoom_button = QtModeRadio(
+            layer, 'zoom', Mode.PAN_ZOOM, 'Pan/zoom', checked=True
         )
-        self.rectangle_button = QtModeButton(
+        self.rectangle_button = QtModeRadio(
             layer, 'rectangle', Mode.ADD_RECTANGLE, 'Add rectangles'
         )
-        self.ellipse_button = QtModeButton(
+        self.ellipse_button = QtModeRadio(
             layer, 'ellipse', Mode.ADD_ELLIPSE, 'Add ellipses'
         )
-        self.line_button = QtModeButton(
+        self.line_button = QtModeRadio(
             layer, 'line', Mode.ADD_LINE, 'Add lines'
         )
-        self.path_button = QtModeButton(
+        self.path_button = QtModeRadio(
             layer, 'path', Mode.ADD_PATH, 'Add paths'
         )
-        self.polygon_button = QtModeButton(
+        self.polygon_button = QtModeRadio(
             layer, 'polygon', Mode.ADD_POLYGON, 'Add polygons'
         )
-        self.vertex_insert_button = QtModeButton(
+        self.vertex_insert_button = QtModeRadio(
             layer, 'vertex_insert', Mode.VERTEX_INSERT, 'Insert vertex'
         )
-        self.vertex_remove_button = QtModeButton(
+        self.vertex_remove_button = QtModeRadio(
             layer, 'vertex_remove', Mode.VERTEX_REMOVE, 'Remove vertex'
         )
 
         self.move_front_button = QtMoveFrontButton(layer)
         self.move_back_button = QtMoveBackButton(layer)
         self.delete_button = QtDeleteShapeButton(layer)
-        self.panzoom_button.setChecked(True)
 
         self.button_group = QButtonGroup(self)
         self.button_group.addButton(self.select_button)
@@ -234,24 +233,6 @@ class QtShapesControls(QtLayerControls):
         self.delete_button.setEnabled(self.layer.editable)
         self.move_back_button.setEnabled(self.layer.editable)
         self.move_front_button.setEnabled(self.layer.editable)
-
-
-class QtModeButton(QRadioButton):
-    def __init__(self, layer, button_name, mode, tool_tip):
-        super().__init__()
-
-        self.mode = mode
-        self.layer = layer
-        self.setToolTip(tool_tip)
-        self.setChecked(False)
-        self.setProperty('mode', button_name)
-        self.toggled.connect(lambda state=self: self._set_mode(state))
-        self.setFixedWidth(28)
-
-    def _set_mode(self, bool):
-        with self.layer.events.mode.blocker(self._set_mode):
-            if bool:
-                self.layer.mode = self.mode
 
 
 class QtDeleteShapeButton(QPushButton):

--- a/napari/_qt/layers/qt_shapes_layer.py
+++ b/napari/_qt/layers/qt_shapes_layer.py
@@ -169,7 +169,7 @@ class QtShapesControls(QtLayerControls):
         if event.mode in mode_buttons:
             mode_buttons[event.mode].setChecked(True)
         else:
-            raise ValueError(f"Mode '{event.mode}'not recongnized")
+            raise ValueError(f"Mode '{event.mode}'not recognized")
 
     def changeFaceColor(self, text):
         self.layer.current_face_color = text

--- a/napari/_qt/layers/qt_shapes_layer.py
+++ b/napari/_qt/layers/qt_shapes_layer.py
@@ -58,59 +58,53 @@ class QtShapesControls(QtLayerControls):
         self._on_edge_color_change()
 
         self.select_button = QtModeRadioButton(
-            layer, 'select', Mode.SELECT, tool_tip='Select shapes'
+            layer, 'select', Mode.SELECT, tooltip='Select shapes'
         )
         self.direct_button = QtModeRadioButton(
-            layer, 'direct', Mode.DIRECT, tool_tip='Select vertices'
+            layer, 'direct', Mode.DIRECT, tooltip='Select vertices'
         )
         self.panzoom_button = QtModeRadioButton(
-            layer, 'zoom', Mode.PAN_ZOOM, tool_tip='Pan/zoom', checked=True
+            layer, 'zoom', Mode.PAN_ZOOM, tooltip='Pan/zoom', checked=True
         )
         self.rectangle_button = QtModeRadioButton(
-            layer, 'rectangle', Mode.ADD_RECTANGLE, tool_tip='Add rectangles'
+            layer, 'rectangle', Mode.ADD_RECTANGLE, tooltip='Add rectangles'
         )
         self.ellipse_button = QtModeRadioButton(
-            layer, 'ellipse', Mode.ADD_ELLIPSE, tool_tip='Add ellipses'
+            layer, 'ellipse', Mode.ADD_ELLIPSE, tooltip='Add ellipses'
         )
         self.line_button = QtModeRadioButton(
-            layer, 'line', Mode.ADD_LINE, tool_tip='Add lines'
+            layer, 'line', Mode.ADD_LINE, tooltip='Add lines'
         )
         self.path_button = QtModeRadioButton(
-            layer, 'path', Mode.ADD_PATH, tool_tip='Add paths'
+            layer, 'path', Mode.ADD_PATH, tooltip='Add paths'
         )
         self.polygon_button = QtModeRadioButton(
-            layer, 'polygon', Mode.ADD_POLYGON, tool_tip='Add polygons'
+            layer, 'polygon', Mode.ADD_POLYGON, tooltip='Add polygons'
         )
         self.vertex_insert_button = QtModeRadioButton(
-            layer,
-            'vertex_insert',
-            Mode.VERTEX_INSERT,
-            tool_tip='Insert vertex',
+            layer, 'vertex_insert', Mode.VERTEX_INSERT, tooltip='Insert vertex'
         )
         self.vertex_remove_button = QtModeRadioButton(
-            layer,
-            'vertex_remove',
-            Mode.VERTEX_REMOVE,
-            tool_tip='Remove vertex',
+            layer, 'vertex_remove', Mode.VERTEX_REMOVE, tooltip='Remove vertex'
         )
 
         self.move_front_button = QtModePushButton(
             layer,
             'move_front',
-            self.layer.move_to_front,
-            tool_tip='Move to front',
+            slot=self.layer.move_to_front,
+            tooltip='Move to front',
         )
         self.move_back_button = QtModePushButton(
             layer,
             'move_back',
-            self.layer.move_to_back,
-            tool_tip='Move to back',
+            slot=self.layer.move_to_back,
+            tooltip='Move to back',
         )
         self.delete_button = QtModePushButton(
             layer,
             'delete_shape',
-            self.layer.remove_selected,
-            tool_tip='Delete selected shapes',
+            slot=self.layer.remove_selected,
+            tooltip='Delete selected shapes',
         )
 
         self.button_group = QButtonGroup(self)

--- a/napari/_qt/layers/qt_shapes_layer.py
+++ b/napari/_qt/layers/qt_shapes_layer.py
@@ -3,7 +3,6 @@ import numpy as np
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QButtonGroup,
-    QPushButton,
     QLabel,
     QComboBox,
     QSlider,
@@ -13,7 +12,7 @@ from qtpy.QtWidgets import (
 from vispy.color import Color
 from .qt_base_layer import QtLayerControls
 from ...layers.shapes._constants import Mode
-from ..qt_mode_radio import QtModeRadio
+from ..qt_mode_buttons import QtModeRadioButton, QtModePushButton
 
 
 class QtShapesControls(QtLayerControls):
@@ -58,40 +57,49 @@ class QtShapesControls(QtLayerControls):
         self.edgeColorSwatch.setToolTip('Edge color swatch')
         self._on_edge_color_change()
 
-        self.select_button = QtModeRadio(
+        self.select_button = QtModeRadioButton(
             layer, 'select', Mode.SELECT, 'Select shapes'
         )
-        self.direct_button = QtModeRadio(
+        self.direct_button = QtModeRadioButton(
             layer, 'direct', Mode.DIRECT, 'Select vertices'
         )
-        self.panzoom_button = QtModeRadio(
+        self.panzoom_button = QtModeRadioButton(
             layer, 'zoom', Mode.PAN_ZOOM, 'Pan/zoom', checked=True
         )
-        self.rectangle_button = QtModeRadio(
+        self.rectangle_button = QtModeRadioButton(
             layer, 'rectangle', Mode.ADD_RECTANGLE, 'Add rectangles'
         )
-        self.ellipse_button = QtModeRadio(
+        self.ellipse_button = QtModeRadioButton(
             layer, 'ellipse', Mode.ADD_ELLIPSE, 'Add ellipses'
         )
-        self.line_button = QtModeRadio(
+        self.line_button = QtModeRadioButton(
             layer, 'line', Mode.ADD_LINE, 'Add lines'
         )
-        self.path_button = QtModeRadio(
+        self.path_button = QtModeRadioButton(
             layer, 'path', Mode.ADD_PATH, 'Add paths'
         )
-        self.polygon_button = QtModeRadio(
+        self.polygon_button = QtModeRadioButton(
             layer, 'polygon', Mode.ADD_POLYGON, 'Add polygons'
         )
-        self.vertex_insert_button = QtModeRadio(
+        self.vertex_insert_button = QtModeRadioButton(
             layer, 'vertex_insert', Mode.VERTEX_INSERT, 'Insert vertex'
         )
-        self.vertex_remove_button = QtModeRadio(
+        self.vertex_remove_button = QtModeRadioButton(
             layer, 'vertex_remove', Mode.VERTEX_REMOVE, 'Remove vertex'
         )
 
-        self.move_front_button = QtMoveFrontButton(layer)
-        self.move_back_button = QtMoveBackButton(layer)
-        self.delete_button = QtDeleteShapeButton(layer)
+        self.move_front_button = QtModePushButton(
+            layer, 'move_front', 'Move to front', self.layer.move_to_front
+        )
+        self.move_back_button = QtModePushButton(
+            layer, 'move_back', 'Move to back', self.layer.move_to_back
+        )
+        self.delete_button = QtModePushButton(
+            layer,
+            'delete_shape',
+            'Delete selected shapes',
+            self.layer.remove_selected,
+        )
 
         self.button_group = QButtonGroup(self)
         self.button_group.addButton(self.select_button)
@@ -217,36 +225,3 @@ class QtShapesControls(QtLayerControls):
         self.delete_button.setEnabled(self.layer.editable)
         self.move_back_button.setEnabled(self.layer.editable)
         self.move_front_button.setEnabled(self.layer.editable)
-
-
-class QtDeleteShapeButton(QPushButton):
-    def __init__(self, layer):
-        super().__init__()
-
-        self.layer = layer
-        self.setFixedWidth(28)
-        self.setFixedHeight(28)
-        self.setToolTip('Delete selected shapes')
-        self.clicked.connect(self.layer.remove_selected)
-
-
-class QtMoveBackButton(QPushButton):
-    def __init__(self, layer):
-        super().__init__()
-
-        self.layer = layer
-        self.setFixedWidth(28)
-        self.setFixedHeight(28)
-        self.setToolTip('Move to back')
-        self.clicked.connect(self.layer.move_to_back)
-
-
-class QtMoveFrontButton(QPushButton):
-    def __init__(self, layer):
-        super().__init__()
-
-        self.layer = layer
-        self.setFixedWidth(28)
-        self.setFixedHeight(28)
-        self.setToolTip('Move to front')
-        self.clicked.connect(self.layer.move_to_front)

--- a/napari/_qt/layers/qt_vectors_layer.py
+++ b/napari/_qt/layers/qt_vectors_layer.py
@@ -14,9 +14,7 @@ class QtVectorsControls(QtLayerControls):
 
         # vector color adjustment and widget
         edge_comboBox = QComboBox()
-        colors = self.layer._colors
-        for c in colors:
-            edge_comboBox.addItem(c)
+        edge_comboBox.addItems(self.layer._colors)
         edge_comboBox.activated[str].connect(
             lambda text=edge_comboBox: self.change_edge_color(text)
         )

--- a/napari/_qt/layers/qt_vectors_layer.py
+++ b/napari/_qt/layers/qt_vectors_layer.py
@@ -15,30 +15,26 @@ class QtVectorsControls(QtLayerControls):
         # vector color adjustment and widget
         edge_comboBox = QComboBox()
         edge_comboBox.addItems(self.layer._colors)
-        edge_comboBox.activated[str].connect(
-            lambda text=edge_comboBox: self.change_edge_color(text)
-        )
+        edge_comboBox.activated[str].connect(self.change_edge_color)
         self.edgeComboBox = edge_comboBox
         self.edgeColorSwatch = QFrame()
         self.edgeColorSwatch.setObjectName('swatch')
         self.edgeColorSwatch.setToolTip('Edge color swatch')
-        self._on_edge_color_change(None)
+        self._on_edge_color_change()
 
         # line width in pixels
         self.widthSpinBox = QDoubleSpinBox()
         self.widthSpinBox.setKeyboardTracking(False)
         self.widthSpinBox.setSingleStep(0.1)
         self.widthSpinBox.setMinimum(0.1)
-        value = self.layer.edge_width
-        self.widthSpinBox.setValue(value)
+        self.widthSpinBox.setValue(self.layer.edge_width)
         self.widthSpinBox.valueChanged.connect(self.change_width)
 
         # line length
         self.lengthSpinBox = QDoubleSpinBox()
         self.lengthSpinBox.setKeyboardTracking(False)
         self.lengthSpinBox.setSingleStep(0.1)
-        value = self.layer.length
-        self.lengthSpinBox.setValue(value)
+        self.lengthSpinBox.setValue(self.layer.length)
         self.lengthSpinBox.setMinimum(0.1)
         self.lengthSpinBox.valueChanged.connect(self.change_length)
 
@@ -62,9 +58,6 @@ class QtVectorsControls(QtLayerControls):
     def change_edge_color(self, text):
         self.layer.edge_color = text
 
-    def change_connector_type(self, text):
-        self.layer.connector = text
-
     def change_width(self, value):
         self.layer.edge_width = value
         self.widthSpinBox.clearFocus()
@@ -75,15 +68,15 @@ class QtVectorsControls(QtLayerControls):
         self.lengthSpinBox.clearFocus()
         self.setFocus()
 
-    def _on_len_change(self, event):
+    def _on_len_change(self, event=None):
         with self.layer.events.length.blocker():
             self.lengthSpinBox.setValue(self.layer.length)
 
-    def _on_width_change(self, event):
+    def _on_width_change(self, event=None):
         with self.layer.events.edge_width.blocker():
             self.widthSpinBox.setValue(self.layer.edge_width)
 
-    def _on_edge_color_change(self, event):
+    def _on_edge_color_change(self, event=None):
         with self.layer.events.edge_color.blocker():
             index = self.edgeComboBox.findText(
                 self.layer.edge_color, Qt.MatchFixedString

--- a/napari/_qt/layers/tests/test_qt_image_base_layer_.py
+++ b/napari/_qt/layers/tests/test_qt_image_base_layer_.py
@@ -54,14 +54,16 @@ def test_range_popup_clim_buttons(qtbot, layer):
 
     # pressing the reset button returns the clims to the default values
     reset_button = qtctrl.clim_pop.findChild(QPushButton, "reset_clims_button")
-    qtbot.mouseClick(reset_button, Qt.LeftButton)
+    reset_button.click()
+    qtbot.wait(20)
     assert tuple(qtctrl.contrastLimitsSlider.values()) == original_clims
 
     rangebtn = qtctrl.clim_pop.findChild(QPushButton, "full_clim_range_button")
     # the data we created above was uint16 for Image, and float for Surface
     # Surface will not have a "full range button"
     if np.issubdtype(layer.dtype, np.integer):
-        qtbot.mouseClick(rangebtn, Qt.LeftButton)
+        rangebtn.click()
+        qtbot.wait(20)
         assert tuple(layer.contrast_limits_range) == (0, 2 ** 16 - 1)
         assert tuple(qtctrl.contrastLimitsSlider.range()) == (0, 2 ** 16 - 1)
     else:

--- a/napari/_qt/qt_about_keybindings.py
+++ b/napari/_qt/qt_about_keybindings.py
@@ -50,11 +50,8 @@ class QtAboutKeybindings(QDialog):
 
         # layer type selection
         self.layerTypeComboBox = QComboBox()
-        for name in self.keybindings_strs:
-            self.layerTypeComboBox.addItem(name)
-        self.layerTypeComboBox.activated[str].connect(
-            lambda text=self.layerTypeComboBox: self.change_layer_type(text)
-        )
+        self.layerTypeComboBox.addItems(list(self.keybindings_strs))
+        self.layerTypeComboBox.activated[str].connect(self.change_layer_type)
         self.layerTypeComboBox.setCurrentText(self.ALL_ACTIVE_KEYBINDINGS)
         # self.change_layer_type(current_layer)
         layer_type_layout = QHBoxLayout()

--- a/napari/_qt/qt_about_keybindings.py
+++ b/napari/_qt/qt_about_keybindings.py
@@ -64,12 +64,12 @@ class QtAboutKeybindings(QDialog):
 
         self.viewer.events.active_layer.connect(self.update_active_layer)
         self.viewer.events.palette.connect(self.update_active_layer)
-        self.update_active_layer(None)
+        self.update_active_layer()
 
     def change_layer_type(self, text):
         self.textEditBox.setHtml(self.keybindings_strs[text])
 
-    def update_active_layer(self, event):
+    def update_active_layer(self, event=None):
         col = self.viewer.palette['secondary']
         text = ''
         # Add class and instance viewer keybindings

--- a/napari/_qt/qt_dims.py
+++ b/napari/_qt/qt_dims.py
@@ -316,7 +316,7 @@ class QtDims(QWidget):
         # doing manual check here to avoid issue in StringEnum
         # see https://github.com/napari/napari/issues/754
         if loop_mode is not None:
-            _modes = [str(mode) for mode in LoopMode]
+            _modes = LoopMode.keys()
             if loop_mode not in _modes:
                 raise ValueError(
                     f'loop_mode must be one of {_modes}.  Got: {loop_mode}'

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -337,7 +337,7 @@ class QtLayerWidget(QFrame):
         cb.setToolTip('Layer visibility')
         cb.setChecked(self.layer.visible)
         cb.setProperty('mode', 'visibility')
-        cb.stateChanged.connect(lambda state=cb: self.changeVisible(state))
+        cb.stateChanged.connect(self.changeVisible)
         self.visibleCheckBox = cb
         self.layout.addWidget(cb)
 

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -46,7 +46,7 @@ class QtLayerList(QScrollArea):
 
         self.layers.events.added.connect(self._add)
         self.layers.events.removed.connect(self._remove)
-        self.layers.events.reordered.connect(lambda e: self._reorder())
+        self.layers.events.reordered.connect(self._reorder)
 
         self.drag_start_position = np.zeros(2)
         self.drag_name = None
@@ -74,7 +74,7 @@ class QtLayerList(QScrollArea):
         self.vbox_layout.removeWidget(divider)
         divider.deleteLater()
 
-    def _reorder(self):
+    def _reorder(self, event=None):
         """Reorders list of layer widgets by looping through all
         widgets in list sequentially removing them and inserting
         them into the correct place in final list.

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -388,16 +388,16 @@ class QtLayerWidget(QFrame):
     def mouseMoveEvent(self, event):
         event.ignore()
 
-    def _on_layer_name_change(self, event):
+    def _on_layer_name_change(self, event=None):
         with self.layer.events.name.blocker():
             self.nameTextBox.setText(self.layer.name)
             self.nameTextBox.home(False)
 
-    def _on_visible_change(self, event):
+    def _on_visible_change(self, event=None):
         with self.layer.events.visible.blocker():
             self.visibleCheckBox.setChecked(self.layer.visible)
 
-    def _on_thumbnail_change(self, event):
+    def _on_thumbnail_change(self, event=None):
         thumbnail = self.layer.thumbnail
         # Note that QImage expects the image width followed by height
         image = QImage(

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -329,7 +329,7 @@ class QtLayerWidget(QFrame):
         tb.setObjectName('thumbmnail')
         tb.setToolTip('Layer thumbmnail')
         self.thumbnailLabel = tb
-        self._on_thumbnail_change(None)
+        self._on_thumbnail_change()
         self.layout.addWidget(tb)
 
         cb = QCheckBox(self)

--- a/napari/_qt/qt_mode_buttons.py
+++ b/napari/_qt/qt_mode_buttons.py
@@ -2,16 +2,19 @@ from qtpy.QtWidgets import QRadioButton, QPushButton
 
 
 class QtModeRadioButton(QRadioButton):
-    def __init__(self, layer, button_name, mode, tool_tip, checked=False):
+    def __init__(
+        self, layer, button_name, mode=None, tool_tip=None, checked=False
+    ):
         super().__init__()
 
-        self.mode = mode
         self.layer = layer
-        self.setToolTip(tool_tip)
+        self.setToolTip(tool_tip or button_name)
         self.setChecked(checked)
         self.setProperty('mode', button_name)
-        self.toggled.connect(self._set_mode)
         self.setFixedWidth(28)
+        self.mode = mode
+        if mode is not None:
+            self.toggled.connect(self._set_mode)
 
     def _set_mode(self, bool):
         with self.layer.events.mode.blocker(self._set_mode):
@@ -20,12 +23,12 @@ class QtModeRadioButton(QRadioButton):
 
 
 class QtModePushButton(QPushButton):
-    def __init__(self, layer, button_name, tool_tip, slot=None):
+    def __init__(self, layer, button_name, tool_tip=None, slot=None):
         super().__init__()
 
         self.layer = layer
         self.setProperty('mode', button_name)
-        self.setToolTip(tool_tip)
+        self.setToolTip(tool_tip or button_name)
         self.setFixedWidth(28)
         self.setFixedHeight(28)
         if slot is not None:

--- a/napari/_qt/qt_mode_buttons.py
+++ b/napari/_qt/qt_mode_buttons.py
@@ -1,7 +1,7 @@
-from qtpy.QtWidgets import QRadioButton
+from qtpy.QtWidgets import QRadioButton, QPushButton
 
 
-class QtModeRadio(QRadioButton):
+class QtModeRadioButton(QRadioButton):
     def __init__(self, layer, button_name, mode, tool_tip, checked=False):
         super().__init__()
 
@@ -17,3 +17,16 @@ class QtModeRadio(QRadioButton):
         with self.layer.events.mode.blocker(self._set_mode):
             if bool:
                 self.layer.mode = self.mode
+
+
+class QtModePushButton(QPushButton):
+    def __init__(self, layer, button_name, tool_tip, slot=None):
+        super().__init__()
+
+        self.layer = layer
+        self.setProperty('mode', button_name)
+        self.setToolTip(tool_tip)
+        self.setFixedWidth(28)
+        self.setFixedHeight(28)
+        if slot is not None:
+            self.clicked.connect(slot)

--- a/napari/_qt/qt_mode_buttons.py
+++ b/napari/_qt/qt_mode_buttons.py
@@ -40,7 +40,7 @@ class QtModeRadioButton(QRadioButton):
 
 
 class QtModePushButton(QPushButton):
-    def __init__(self, layer, button_name, slot=None, tool_tip=None):
+    def __init__(self, layer, button_name, slot=None, *, tool_tip=None):
         """Creates a radio button that can trigger a specific action.
 
         Parameters

--- a/napari/_qt/qt_mode_buttons.py
+++ b/napari/_qt/qt_mode_buttons.py
@@ -10,7 +10,7 @@ class QtModeRadioButton(QRadioButton):
         self.setToolTip(tool_tip)
         self.setChecked(checked)
         self.setProperty('mode', button_name)
-        self.toggled.connect(lambda state=self: self._set_mode(state))
+        self.toggled.connect(self._set_mode)
         self.setFixedWidth(28)
 
     def _set_mode(self, bool):

--- a/napari/_qt/qt_mode_buttons.py
+++ b/napari/_qt/qt_mode_buttons.py
@@ -5,6 +5,23 @@ class QtModeRadioButton(QRadioButton):
     def __init__(
         self, layer, button_name, mode=None, tool_tip=None, checked=False
     ):
+        """Creates a radio button that can enable a specific layer mode.
+
+        Parameters
+        ----------
+        layer : Layer
+            The layer instance that this button controls.
+        button_name : str
+            Name for the button.  This is mostly used to identify the button
+            in stylesheets (e.g. to add a custom icon)
+        mode : Enum, optional
+            The mode to enable when this button is clicked.
+        tool_tip : str, optional
+            A tooltip to display when hovering the mouse on this button.
+        checked : bool, optional
+            Whether the button is activate, by default False.
+            One button in a QButtonGroup should be initially checked.
+        """
         super().__init__()
 
         self.layer = layer
@@ -23,7 +40,21 @@ class QtModeRadioButton(QRadioButton):
 
 
 class QtModePushButton(QPushButton):
-    def __init__(self, layer, button_name, tool_tip=None, slot=None):
+    def __init__(self, layer, button_name, slot=None, tool_tip=None):
+        """Creates a radio button that can trigger a specific action.
+
+        Parameters
+        ----------
+        layer : Layer
+            The layer instance that this button controls.
+        button_name : str
+            Name for the button.  This is mostly used to identify the button
+            in stylesheets (e.g. to add a custom icon)
+        slot : callable, optional
+            The function to call when this button is clicked.
+        tool_tip : str, optional
+            A tooltip to display when hovering the mouse on this button.
+        """
         super().__init__()
 
         self.layer = layer

--- a/napari/_qt/qt_mode_buttons.py
+++ b/napari/_qt/qt_mode_buttons.py
@@ -3,7 +3,7 @@ from qtpy.QtWidgets import QRadioButton, QPushButton
 
 class QtModeRadioButton(QRadioButton):
     def __init__(
-        self, layer, button_name, mode, *, tool_tip=None, checked=False
+        self, layer, button_name, mode, *, tooltip=None, checked=False
     ):
         """Creates a radio button that can enable a specific layer mode.
 
@@ -14,10 +14,11 @@ class QtModeRadioButton(QRadioButton):
         button_name : str
             Name for the button.  This is mostly used to identify the button
             in stylesheets (e.g. to add a custom icon)
-        mode : Enum, optional
+        mode : Enum
             The mode to enable when this button is clicked.
-        tool_tip : str, optional
-            A tooltip to display when hovering the mouse on this button.
+        tooltip : str, optional
+            A tooltip to display when hovering the mouse on this button,
+            by default it will be set to `button_name`.
         checked : bool, optional
             Whether the button is activate, by default False.
             One button in a QButtonGroup should be initially checked.
@@ -25,7 +26,7 @@ class QtModeRadioButton(QRadioButton):
         super().__init__()
 
         self.layer = layer
-        self.setToolTip(tool_tip or button_name)
+        self.setToolTip(tooltip or button_name)
         self.setChecked(checked)
         self.setProperty('mode', button_name)
         self.setFixedWidth(28)
@@ -40,7 +41,7 @@ class QtModeRadioButton(QRadioButton):
 
 
 class QtModePushButton(QPushButton):
-    def __init__(self, layer, button_name, slot=None, *, tool_tip=None):
+    def __init__(self, layer, button_name, *, slot=None, tooltip=None):
         """Creates a radio button that can trigger a specific action.
 
         Parameters
@@ -52,14 +53,14 @@ class QtModePushButton(QPushButton):
             in stylesheets (e.g. to add a custom icon)
         slot : callable, optional
             The function to call when this button is clicked.
-        tool_tip : str, optional
+        tooltip : str, optional
             A tooltip to display when hovering the mouse on this button.
         """
         super().__init__()
 
         self.layer = layer
         self.setProperty('mode', button_name)
-        self.setToolTip(tool_tip or button_name)
+        self.setToolTip(tooltip or button_name)
         self.setFixedWidth(28)
         self.setFixedHeight(28)
         if slot is not None:

--- a/napari/_qt/qt_mode_buttons.py
+++ b/napari/_qt/qt_mode_buttons.py
@@ -3,7 +3,7 @@ from qtpy.QtWidgets import QRadioButton, QPushButton
 
 class QtModeRadioButton(QRadioButton):
     def __init__(
-        self, layer, button_name, mode=None, tool_tip=None, checked=False
+        self, layer, button_name, mode, *, tool_tip=None, checked=False
     ):
         """Creates a radio button that can enable a specific layer mode.
 

--- a/napari/_qt/qt_mode_radio.py
+++ b/napari/_qt/qt_mode_radio.py
@@ -1,0 +1,19 @@
+from qtpy.QtWidgets import QRadioButton
+
+
+class QtModeRadio(QRadioButton):
+    def __init__(self, layer, button_name, mode, tool_tip, checked=False):
+        super().__init__()
+
+        self.mode = mode
+        self.layer = layer
+        self.setToolTip(tool_tip)
+        self.setChecked(checked)
+        self.setProperty('mode', button_name)
+        self.toggled.connect(lambda state=self: self._set_mode(state))
+        self.setFixedWidth(28)
+
+    def _set_mode(self, bool):
+        with self.layer.events.mode.blocker(self._set_mode):
+            if bool:
+                self.layer.mode = self.mode

--- a/napari/_qt/qt_viewer_buttons.py
+++ b/napari/_qt/qt_viewer_buttons.py
@@ -11,20 +11,20 @@ class QtLayerButtons(QFrame):
         self.deleteButton = QtDeleteButton(self.viewer)
         self.newPointsButton = QtViewerPushButton(
             self.viewer,
-            'New points layer',
             'new_points',
+            'New points layer',
             lambda: self.viewer.add_points(data=None),
         )
         self.newShapesButton = QtViewerPushButton(
             self.viewer,
-            'New shapes layer',
             'new_shapes',
+            'New shapes layer',
             lambda: self.viewer.add_shapes(data=None),
         )
         self.newLabelsButton = QtViewerPushButton(
             self.viewer,
-            'New labels layer',
             'new_labels',
+            'New labels layer',
             lambda: self.viewer._new_labels(),
         )
 
@@ -44,23 +44,23 @@ class QtViewerButtons(QFrame):
 
         self.viewer = viewer
         self.consoleButton = QtViewerPushButton(
-            self.viewer, 'Open IPython terminal', 'console'
+            self.viewer, 'console', 'Open IPython terminal'
         )
         self.consoleButton.setProperty('expanded', False)
         self.rollDimsButton = QtViewerPushButton(
             self.viewer,
-            'Roll dimensions order for display',
             'roll',
+            'Roll dimensions order for display',
             lambda: self.viewer.dims._roll(),
         )
         self.transposeDimsButton = QtViewerPushButton(
             self.viewer,
-            'Transpose displayed dimensions',
             'transpose',
+            'Transpose displayed dimensions',
             lambda: self.viewer.dims._transpose(),
         )
         self.resetViewButton = QtViewerPushButton(
-            self.viewer, 'Reset view', 'home', lambda: self.viewer.reset_view()
+            self.viewer, 'home', 'Reset view', lambda: self.viewer.reset_view()
         )
         self.gridViewButton = QtGridViewButton(self.viewer)
         self.ndisplayButton = QtNDisplayButton(self.viewer)
@@ -107,11 +107,11 @@ class QtDeleteButton(QPushButton):
 
 
 class QtViewerPushButton(QPushButton):
-    def __init__(self, viewer, tooltip, button_name, slot=None):
+    def __init__(self, viewer, button_name, tooltip=None, slot=None):
         super().__init__()
 
         self.viewer = viewer
-        self.setToolTip(tooltip)
+        self.setToolTip(tooltip or button_name)
         self.setProperty('mode', button_name)
         if slot is not None:
             self.clicked.connect(slot)

--- a/napari/_qt/qt_viewer_buttons.py
+++ b/napari/_qt/qt_viewer_buttons.py
@@ -125,7 +125,7 @@ class QtGridViewButton(QCheckBox):
         self.setToolTip('Toggle grid view view')
         self.viewer.events.grid.connect(self._on_grid_change)
         self.stateChanged.connect(self.change_grid)
-        self._on_grid_change(None)
+        self._on_grid_change()
 
     def change_grid(self, state):
         if state == Qt.Checked:
@@ -133,7 +133,7 @@ class QtGridViewButton(QCheckBox):
         else:
             self.viewer.grid_view()
 
-    def _on_grid_change(self, event):
+    def _on_grid_change(self, event=None):
         with self.viewer.events.grid.blocker():
             self.setChecked(np.all(self.viewer.grid_size == (1, 1)))
 
@@ -147,9 +147,7 @@ class QtNDisplayButton(QCheckBox):
         self.viewer.dims.events.ndisplay.connect(self._on_ndisplay_change)
 
         self.setChecked(self.viewer.dims.ndisplay == 3)
-        self.stateChanged.connect(
-            lambda state=self: self.change_ndisplay(state)
-        )
+        self.stateChanged.connect(self.change_ndisplay)
 
     def change_ndisplay(self, state):
         if state == Qt.Checked:
@@ -157,6 +155,6 @@ class QtNDisplayButton(QCheckBox):
         else:
             self.viewer.dims.ndisplay = 2
 
-    def _on_ndisplay_change(self, event):
+    def _on_ndisplay_change(self, event=None):
         with self.viewer.dims.events.ndisplay.blocker():
             self.setChecked(self.viewer.dims.ndisplay == 3)

--- a/napari/_qt/qt_viewer_buttons.py
+++ b/napari/_qt/qt_viewer_buttons.py
@@ -9,9 +9,24 @@ class QtLayerButtons(QFrame):
 
         self.viewer = viewer
         self.deleteButton = QtDeleteButton(self.viewer)
-        self.newPointsButton = QtNewPointsButton(self.viewer)
-        self.newShapesButton = QtNewShapesButton(self.viewer)
-        self.newLabelsButton = QtNewLabelsButton(self.viewer)
+        self.newPointsButton = QtViewerPushButton(
+            self.viewer,
+            'New points layer',
+            'new_points',
+            lambda: self.viewer.add_points(data=None),
+        )
+        self.newShapesButton = QtViewerPushButton(
+            self.viewer,
+            'New shapes layer',
+            'new_shapes',
+            lambda: self.viewer.add_shapes(data=None),
+        )
+        self.newLabelsButton = QtViewerPushButton(
+            self.viewer,
+            'New labels layer',
+            'new_labels',
+            lambda: self.viewer._new_labels(),
+        )
 
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
@@ -28,12 +43,27 @@ class QtViewerButtons(QFrame):
         super().__init__()
 
         self.viewer = viewer
-        self.consoleButton = QtConsoleButton(self.viewer)
-        self.ndisplayButton = QtNDisplayButton(self.viewer)
-        self.rollDimsButton = QtRollDimsButton(self.viewer)
-        self.transposeDimsButton = QtTransposeDimsButton(self.viewer)
+        self.consoleButton = QtViewerPushButton(
+            self.viewer, 'Open IPython terminal', 'console'
+        )
+        self.consoleButton.setProperty('expanded', False)
+        self.rollDimsButton = QtViewerPushButton(
+            self.viewer,
+            'Roll dimensions order for display',
+            'roll',
+            lambda: self.viewer.dims._roll(),
+        )
+        self.transposeDimsButton = QtViewerPushButton(
+            self.viewer,
+            'Transpose displayed dimensions',
+            'transpose',
+            lambda: self.viewer.dims._transpose(),
+        )
+        self.resetViewButton = QtViewerPushButton(
+            self.viewer, 'Reset view', 'home', lambda: self.viewer.reset_view()
+        )
         self.gridViewButton = QtGridViewButton(self.viewer)
-        self.resetViewButton = QtResetViewButton(self.viewer)
+        self.ndisplayButton = QtNDisplayButton(self.viewer)
 
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
@@ -76,67 +106,15 @@ class QtDeleteButton(QPushButton):
             self.viewer.layers.remove_selected()
 
 
-class QtNewPointsButton(QPushButton):
-    def __init__(self, viewer):
+class QtViewerPushButton(QPushButton):
+    def __init__(self, viewer, tooltip, button_name, slot=None):
         super().__init__()
 
         self.viewer = viewer
-        self.setToolTip('New points layer')
-        self.clicked.connect(lambda: self.viewer.add_points())
-
-
-class QtNewShapesButton(QPushButton):
-    def __init__(self, viewer):
-        super().__init__()
-
-        self.viewer = viewer
-        self.setToolTip('New shapes layer')
-        self.clicked.connect(lambda: self.viewer.add_shapes())
-
-
-class QtNewLabelsButton(QPushButton):
-    def __init__(self, viewer):
-        super().__init__()
-
-        self.viewer = viewer
-        self.setToolTip('New labels layer')
-        self.clicked.connect(lambda: self.viewer._new_labels())
-
-
-class QtResetViewButton(QPushButton):
-    def __init__(self, viewer):
-        super().__init__()
-
-        self.viewer = viewer
-        self.setToolTip('Reset view')
-        self.clicked.connect(lambda: self.viewer.reset_view())
-
-
-class QtRollDimsButton(QPushButton):
-    def __init__(self, viewer):
-        super().__init__()
-
-        self.viewer = viewer
-        self.setToolTip('Roll dimensions order for display')
-        self.clicked.connect(lambda: self.viewer.dims._roll())
-
-
-class QtTransposeDimsButton(QPushButton):
-    def __init__(self, viewer):
-        super().__init__()
-
-        self.viewer = viewer
-        self.setToolTip('Transpose displayed dimensions')
-        self.clicked.connect(lambda: self.viewer.dims._transpose())
-
-
-class QtConsoleButton(QPushButton):
-    def __init__(self, viewer):
-        super().__init__()
-
-        self.viewer = viewer
-        self.setToolTip('Open IPython terminal')
-        self.setProperty('expanded', False)
+        self.setToolTip(tooltip)
+        self.setProperty('mode', button_name)
+        if slot is not None:
+            self.clicked.connect(slot)
 
 
 class QtGridViewButton(QCheckBox):
@@ -146,7 +124,7 @@ class QtGridViewButton(QCheckBox):
         self.viewer = viewer
         self.setToolTip('Toggle grid view view')
         self.viewer.events.grid.connect(self._on_grid_change)
-        self.stateChanged.connect(lambda state=self: self.change_grid(state))
+        self.stateChanged.connect(self.change_grid)
         self._on_grid_change(None)
 
     def change_grid(self, state):

--- a/napari/_qt/tests/test_qt_buttons.py
+++ b/napari/_qt/tests/test_qt_buttons.py
@@ -10,7 +10,7 @@ def test_radio_button(qtbot):
     layer = Points()
     assert layer.mode != Mode.ADD
 
-    btn = QtModeRadioButton(layer, 'test_button', Mode.ADD, 'tooltip')
+    btn = QtModeRadioButton(layer, 'test_button', Mode.ADD, tool_tip='tooltip')
     assert btn.property('mode') == 'test_button'
     assert btn.toolTip() == 'tooltip'
 
@@ -25,7 +25,9 @@ def test_push_button(qtbot):
     def set_test_prop():
         layer.test_prop = True
 
-    btn = QtModePushButton(layer, 'test_button', set_test_prop, 'tooltip')
+    btn = QtModePushButton(
+        layer, 'test_button', set_test_prop, tool_tip='tooltip'
+    )
     assert btn.property('mode') == 'test_button'
     assert btn.toolTip() == 'tooltip'
 

--- a/napari/_qt/tests/test_qt_buttons.py
+++ b/napari/_qt/tests/test_qt_buttons.py
@@ -10,7 +10,7 @@ def test_radio_button(qtbot):
     layer = Points()
     assert layer.mode != Mode.ADD
 
-    btn = QtModeRadioButton(layer, 'test_button', Mode.ADD, tool_tip='tooltip')
+    btn = QtModeRadioButton(layer, 'test_button', Mode.ADD, tooltip='tooltip')
     assert btn.property('mode') == 'test_button'
     assert btn.toolTip() == 'tooltip'
 
@@ -26,7 +26,7 @@ def test_push_button(qtbot):
         layer.test_prop = True
 
     btn = QtModePushButton(
-        layer, 'test_button', set_test_prop, tool_tip='tooltip'
+        layer, 'test_button', slot=set_test_prop, tooltip='tooltip'
     )
     assert btn.property('mode') == 'test_button'
     assert btn.toolTip() == 'tooltip'

--- a/napari/_qt/tests/test_qt_buttons.py
+++ b/napari/_qt/tests/test_qt_buttons.py
@@ -15,6 +15,7 @@ def test_radio_button(qtbot):
     assert btn.toolTip() == 'tooltip'
 
     qtbot.mouseClick(btn, Qt.LeftButton)
+    qtbot.wait(50)
     assert layer.mode == 'add'
 
 
@@ -32,4 +33,5 @@ def test_push_button(qtbot):
     assert btn.toolTip() == 'tooltip'
 
     qtbot.mouseClick(btn, Qt.LeftButton)
+    qtbot.wait(50)
     assert layer.test_prop

--- a/napari/_qt/tests/test_qt_buttons.py
+++ b/napari/_qt/tests/test_qt_buttons.py
@@ -1,0 +1,33 @@
+from qtpy.QtCore import Qt
+
+from napari._qt.qt_mode_buttons import QtModePushButton, QtModeRadioButton
+from napari.layers import Points
+from napari.layers.points._constants import Mode
+
+
+def test_radio_button(qtbot):
+    """Make sure the QtModeRadioButton works to change layer modes"""
+    layer = Points()
+    assert layer.mode != Mode.ADD
+
+    btn = QtModeRadioButton(layer, 'test_button', Mode.ADD, 'tooltip')
+    assert btn.property('mode') == 'test_button'
+    assert btn.toolTip() == 'tooltip'
+
+    qtbot.mouseClick(btn, Qt.LeftButton)
+    assert layer.mode == 'add'
+
+
+def test_push_button(qtbot):
+    """Make sure the QtModePushButton works with callbacks"""
+    layer = Points()
+
+    def set_test_prop():
+        layer.test_prop = True
+
+    btn = QtModePushButton(layer, 'test_button', set_test_prop, 'tooltip')
+    assert btn.property('mode') == 'test_button'
+    assert btn.toolTip() == 'tooltip'
+
+    qtbot.mouseClick(btn, Qt.LeftButton)
+    assert layer.test_prop

--- a/napari/_qt/tests/test_qt_buttons.py
+++ b/napari/_qt/tests/test_qt_buttons.py
@@ -14,7 +14,7 @@ def test_radio_button(qtbot):
     assert btn.property('mode') == 'test_button'
     assert btn.toolTip() == 'tooltip'
 
-    qtbot.mouseClick(btn, Qt.LeftButton)
+    btn.click()
     qtbot.wait(50)
     assert layer.mode == 'add'
 
@@ -32,6 +32,6 @@ def test_push_button(qtbot):
     assert btn.property('mode') == 'test_button'
     assert btn.toolTip() == 'tooltip'
 
-    qtbot.mouseClick(btn, Qt.LeftButton)
+    btn.click()
     qtbot.wait(50)
     assert layer.test_prop

--- a/napari/_qt/tests/test_qt_buttons.py
+++ b/napari/_qt/tests/test_qt_buttons.py
@@ -1,5 +1,3 @@
-from qtpy.QtCore import Qt
-
 from napari._qt.qt_mode_buttons import QtModePushButton, QtModeRadioButton
 from napari.layers import Points
 from napari.layers.points._constants import Mode

--- a/napari/_qt/tests/test_qt_dims.py
+++ b/napari/_qt/tests/test_qt_dims.py
@@ -210,7 +210,7 @@ def test_slider_press_updates_last_used(qtbot):
         assert view.last_used == i
 
 
-@pytest.skipif(
+@pytest.mark.skipif(
     os.environ.get('CI') and platform() == 'win32', 'not working in windows VM'
 )
 def test_play_button(qtbot):

--- a/napari/_qt/tests/test_qt_dims.py
+++ b/napari/_qt/tests/test_qt_dims.py
@@ -211,7 +211,7 @@ def test_slider_press_updates_last_used(qtbot):
 
 
 @pytest.mark.skipif(
-    os.environ.get('CI') and platform() == 'win32', 'not working in windows VM'
+    os.environ.get('CI') and platform == 'win32', 'not working in windows VM'
 )
 def test_play_button(qtbot):
     """test that the play button and its popup dialog work"""

--- a/napari/_qt/tests/test_qt_dims.py
+++ b/napari/_qt/tests/test_qt_dims.py
@@ -1,10 +1,13 @@
-import numpy as np
+import os
+from sys import platform
 
-from napari.components import Dims
-from napari._qt.qt_dims import QtDims
+import numpy as np
+import pytest
 from qtpy.QtCore import Qt
+
+from napari._qt.qt_dims import QtDims
 from napari._qt.qt_viewer import QtViewer
-from napari.components import ViewerModel
+from napari.components import Dims, ViewerModel
 
 
 def test_creating_view(qtbot):
@@ -207,6 +210,7 @@ def test_slider_press_updates_last_used(qtbot):
         assert view.last_used == i
 
 
+@pytest.skipif(os.environ.get('CI') and platform() == 'win32', 'not working in windows VM')
 def test_play_button(qtbot):
     """test that the play button and its popup dialog work"""
     ndim = 3
@@ -218,7 +222,8 @@ def test_play_button(qtbot):
     qtbot.wait(200)
     assert view.is_playing
     with qtbot.waitSignal(view._animation_thread.finished, timeout=7000):
-        qtbot.mouseClick(button, Qt.LeftButton)
+        button.click()
+
     qtbot.wait(200)
     assert not view.is_playing
 

--- a/napari/_qt/tests/test_qt_dims.py
+++ b/napari/_qt/tests/test_qt_dims.py
@@ -225,7 +225,7 @@ def test_play_button(qtbot):
     qtbot.wait(200)
     assert view.is_playing
     with qtbot.waitSignal(view._animation_thread.finished, timeout=7000):
-        button.click()
+        qtbot.mouseClick(button, Qt.LeftButton)
 
     qtbot.wait(200)
     assert not view.is_playing

--- a/napari/_qt/tests/test_qt_dims.py
+++ b/napari/_qt/tests/test_qt_dims.py
@@ -211,7 +211,8 @@ def test_slider_press_updates_last_used(qtbot):
 
 
 @pytest.mark.skipif(
-    os.environ.get('CI') and platform == 'win32', 'not working in windows VM'
+    os.environ.get('CI') and platform == 'win32',
+    reason='not working in windows VM',
 )
 def test_play_button(qtbot):
     """test that the play button and its popup dialog work"""

--- a/napari/_qt/tests/test_qt_dims.py
+++ b/napari/_qt/tests/test_qt_dims.py
@@ -210,7 +210,9 @@ def test_slider_press_updates_last_used(qtbot):
         assert view.last_used == i
 
 
-@pytest.skipif(os.environ.get('CI') and platform() == 'win32', 'not working in windows VM')
+@pytest.skipif(
+    os.environ.get('CI') and platform() == 'win32', 'not working in windows VM'
+)
 def test_play_button(qtbot):
     """test that the play button and its popup dialog work"""
     ndim = 3

--- a/napari/_qt/tests/test_qt_play.py
+++ b/napari/_qt/tests/test_qt_play.py
@@ -148,7 +148,7 @@ def test_play_api(qtbot, view):
     view.dims._frame = 0
 
     def increment(e):
-        view.dims._frame = e.value  # this is provided by the axis event
+        view.dims._frame += 1
         # if we don't "enable play" again, view.dims won't request a new frame
         view.dims._play_ready = True
 

--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -54,17 +54,12 @@ class VispyBaseLayer(ABC):
         self.camera = None
 
         self.layer.events.refresh.connect(lambda e: self.node.update())
-        self.layer.events.set_data.connect(lambda e: self._on_data_change())
-
-        self.layer.events.visible.connect(lambda e: self._on_visible_change())
-        self.layer.events.opacity.connect(lambda e: self._on_opacity_change())
-        self.layer.events.blending.connect(
-            lambda e: self._on_blending_change()
-        )
-        self.layer.events.scale.connect(lambda e: self._on_scale_change())
-        self.layer.events.translate.connect(
-            lambda e: self._on_translate_change()
-        )
+        self.layer.events.set_data.connect(self._on_data_change)
+        self.layer.events.visible.connect(self._on_visible_change)
+        self.layer.events.opacity.connect(self._on_opacity_change)
+        self.layer.events.blending.connect(self._on_blending_change)
+        self.layer.events.scale.connect(self._on_scale_change)
+        self.layer.events.translate.connect(self._on_translate_change)
 
     @property
     def _master_transform(self):
@@ -118,26 +113,26 @@ class VispyBaseLayer(ABC):
         return scale_factor
 
     @abstractmethod
-    def _on_data_change(self):
+    def _on_data_change(self, event=None):
         raise NotImplementedError()
 
-    def _on_visible_change(self):
+    def _on_visible_change(self, event=None):
         self.node.visible = self.layer.visible
 
-    def _on_opacity_change(self):
+    def _on_opacity_change(self, event=None):
         self.node.opacity = self.layer.opacity
 
-    def _on_blending_change(self):
+    def _on_blending_change(self, event=None):
         self.node.set_gl_state(self.layer.blending)
         self.node.update()
 
-    def _on_scale_change(self):
+    def _on_scale_change(self, event=None):
         self.scale = [
             self.layer.scale[d] for d in self.layer.dims.displayed[::-1]
         ]
         self.layer.position = self._transform_position(self._position)
 
-    def _on_translate_change(self):
+    def _on_translate_change(self, event=None):
         self.translate = [
             self.layer.translate[d] + self.layer.translate_grid[d]
             for d in self.layer.dims.displayed[::-1]

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -22,25 +22,15 @@ class VispyImageLayer(VispyBaseLayer):
         node = ImageNode(None, method='auto')
         super().__init__(layer, node)
 
-        self.layer.events.rendering.connect(
-            lambda e: self._on_rendering_change()
-        )
-        self.layer.events.interpolation.connect(
-            lambda e: self._on_interpolation_change()
-        )
-        self.layer.events.colormap.connect(
-            lambda e: self._on_colormap_change()
-        )
+        self.layer.events.rendering.connect(self._on_rendering_change)
+        self.layer.events.interpolation.connect(self._on_interpolation_change)
+        self.layer.events.colormap.connect(self._on_colormap_change)
         self.layer.events.contrast_limits.connect(
-            lambda e: self._on_contrast_limits_change()
+            self._on_contrast_limits_change
         )
-        self.layer.events.gamma.connect(lambda e: self._on_gamma_change())
-        self.layer.events.iso_threshold.connect(
-            lambda e: self._on_threshold_change()
-        )
-        self.layer.events.attenuation.connect(
-            lambda e: self._on_threshold_change()
-        )
+        self.layer.events.gamma.connect(self._on_gamma_change)
+        self.layer.events.iso_threshold.connect(self._on_threshold_change)
+        self.layer.events.attenuation.connect(self._on_threshold_change)
 
         self._on_display_change()
         self._on_data_change()
@@ -105,7 +95,7 @@ class VispyImageLayer(VispyBaseLayer):
                 self.node.set_data(data, clim=self.layer.contrast_limits)
         self.node.update()
 
-    def _on_interpolation_change(self):
+    def _on_interpolation_change(self, event=None):
         if self.layer.dims.ndisplay == 3 and isinstance(self.layer, Labels):
             self.node.interpolation = 'nearest'
         elif self.layer.dims.ndisplay == 3 and isinstance(self.layer, Image):
@@ -113,12 +103,12 @@ class VispyImageLayer(VispyBaseLayer):
         else:
             self.node.interpolation = self.layer.interpolation
 
-    def _on_rendering_change(self):
+    def _on_rendering_change(self, event=None):
         if self.layer.dims.ndisplay == 3:
             self.node.method = self.layer.rendering
             self._on_threshold_change()
 
-    def _on_colormap_change(self):
+    def _on_colormap_change(self, event=None):
         cmap = self.layer.colormap[1]
         if self.layer.gamma != 1:
             # when gamma!=1, we instantiate a new colormap
@@ -132,16 +122,16 @@ class VispyImageLayer(VispyBaseLayer):
             )
         self.node.cmap = cmap
 
-    def _on_contrast_limits_change(self):
+    def _on_contrast_limits_change(self, event=None):
         if self.layer.dims.ndisplay == 2:
             self.node.clim = self.layer.contrast_limits
         else:
             self._on_data_change()
 
-    def _on_gamma_change(self):
+    def _on_gamma_change(self, event=None):
         self._on_colormap_change()
 
-    def _on_threshold_change(self):
+    def _on_threshold_change(self, event=None):
         if self.layer.dims.ndisplay == 2:
             return
         rendering = self.layer.rendering
@@ -251,7 +241,7 @@ class VispyImageLayer(VispyBaseLayer):
             else:
                 self.layer.top_left = self.find_top_left()
 
-    def reset(self):
+    def reset(self, event=None):
         self._reset_base()
         self._on_interpolation_change()
         self._on_colormap_change()

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -59,7 +59,7 @@ class VispyImageLayer(VispyBaseLayer):
         self.node.parent = parent
         self.reset()
 
-    def _on_data_change(self):
+    def _on_data_change(self, event=None):
         data = self.layer._data_view
         dtype = np.dtype(data.dtype)
         if dtype not in texture_dtypes:
@@ -152,7 +152,7 @@ class VispyImageLayer(VispyBaseLayer):
         elif rendering == Rendering.ATTENUATED_MIP:
             self.node.threshold = float(self.layer.attenuation)
 
-    def _on_scale_change(self):
+    def _on_scale_change(self, event=None):
         self.scale = [
             self.layer.scale[d] * self.layer._scale_view[d]
             for d in self.layer.dims.displayed[::-1]
@@ -161,7 +161,7 @@ class VispyImageLayer(VispyBaseLayer):
             self.layer.top_left = self.find_top_left()
         self.layer.position = self._transform_position(self._position)
 
-    def _on_translate_change(self):
+    def _on_translate_change(self, event=None):
         self.translate = [
             self.layer.translate[d]
             + self.layer._translate_view[d]

--- a/napari/_vispy/vispy_points_layer.py
+++ b/napari/_vispy/vispy_points_layer.py
@@ -18,14 +18,11 @@ class VispyPointsLayer(VispyBaseLayer):
 
         super().__init__(layer, node)
 
-        self.layer.events.symbol.connect(lambda e: self._on_data_change())
-        self.layer.events.edge_width.connect(lambda e: self._on_data_change())
-        self.layer.events.edge_color.connect(lambda e: self._on_data_change())
-        self.layer.events.face_color.connect(lambda e: self._on_data_change())
-        self.layer.events.highlight.connect(
-            lambda e: self._on_highlight_change()
-        )
-
+        self.layer.events.symbol.connect(self._on_data_change)
+        self.layer.events.edge_width.connect(self._on_data_change)
+        self.layer.events.edge_color.connect(self._on_data_change)
+        self.layer.events.face_color.connect(self._on_data_change)
+        self.layer.events.highlight.connect(self._on_highlight_change)
         self._on_display_change()
         self._on_data_change()
 
@@ -90,7 +87,7 @@ class VispyPointsLayer(VispyBaseLayer):
         )
         self.node.update()
 
-    def _on_highlight_change(self):
+    def _on_highlight_change(self, event=None):
         if self.layer.dims.ndisplay == 3:
             return
 

--- a/napari/_vispy/vispy_points_layer.py
+++ b/napari/_vispy/vispy_points_layer.py
@@ -41,7 +41,7 @@ class VispyPointsLayer(VispyBaseLayer):
         self.node.parent = parent
         self._reset_base()
 
-    def _on_data_change(self):
+    def _on_data_change(self, event=None):
         # Check if ndisplay has changed current node type needs updating
         if (
             self.layer.dims.ndisplay == 3

--- a/napari/_vispy/vispy_shapes_layer.py
+++ b/napari/_vispy/vispy_shapes_layer.py
@@ -15,13 +15,11 @@ class VispyShapesLayer(VispyBaseLayer):
 
         super().__init__(layer, node)
 
-        self.layer.events.edge_width.connect(lambda e: self._on_data_change())
-        self.layer.events.edge_color.connect(lambda e: self._on_data_change())
-        self.layer.events.face_color.connect(lambda e: self._on_data_change())
-        self.layer.events.opacity.connect(lambda e: self._on_data_change())
-        self.layer.events.highlight.connect(
-            lambda e: self._on_highlight_change()
-        )
+        self.layer.events.edge_width.connect(self._on_data_change)
+        self.layer.events.edge_color.connect(self._on_data_change)
+        self.layer.events.face_color.connect(self._on_data_change)
+        self.layer.events.opacity.connect(self._on_data_change)
+        self.layer.events.highlight.connect(self._on_highlight_change)
 
         self._reset_base()
         self._on_data_change()
@@ -50,7 +48,7 @@ class VispyShapesLayer(VispyBaseLayer):
         )
         self.node.update()
 
-    def _on_highlight_change(self):
+    def _on_highlight_change(self, event=None):
         # Compute the vertices and faces of any shape outlines
         vertices, faces = self.layer._outline_shapes()
 

--- a/napari/_vispy/vispy_shapes_layer.py
+++ b/napari/_vispy/vispy_shapes_layer.py
@@ -27,7 +27,7 @@ class VispyShapesLayer(VispyBaseLayer):
         self._on_data_change()
         self._on_highlight_change()
 
-    def _on_data_change(self):
+    def _on_data_change(self, event=None):
         faces = self.layer._data_view._mesh.displayed_triangles
         colors = self.layer._data_view._mesh.displayed_triangles_colors
         vertices = self.layer._data_view._mesh.vertices
@@ -101,5 +101,5 @@ class VispyShapesLayer(VispyBaseLayer):
             pos=pos, color=edge_color, width=width
         )
 
-    def _on_opacity_change(self):
+    def _on_opacity_change(self, event=None):
         pass

--- a/napari/_vispy/vispy_surface_layer.py
+++ b/napari/_vispy/vispy_surface_layer.py
@@ -28,7 +28,7 @@ class VispySurfaceLayer(VispyBaseLayer):
         self.reset()
         self._on_data_change()
 
-    def _on_data_change(self):
+    def _on_data_change(self, event=None):
         if len(self.layer._data_view) == 0 or len(self.layer._view_faces) == 0:
             vertices = None
             faces = None

--- a/napari/_vispy/vispy_surface_layer.py
+++ b/napari/_vispy/vispy_surface_layer.py
@@ -17,13 +17,11 @@ class VispySurfaceLayer(VispyBaseLayer):
 
         super().__init__(layer, node)
 
-        self.layer.events.colormap.connect(
-            lambda e: self._on_colormap_change()
-        )
+        self.layer.events.colormap.connect(self._on_colormap_change)
         self.layer.events.contrast_limits.connect(
-            lambda e: self._on_contrast_limits_change()
+            self._on_contrast_limits_change
         )
-        self.layer.events.gamma.connect(lambda e: self._on_gamma_change())
+        self.layer.events.gamma.connect(self._on_gamma_change)
 
         self.reset()
         self._on_data_change()
@@ -50,7 +48,7 @@ class VispySurfaceLayer(VispyBaseLayer):
         )
         self.node.update()
 
-    def _on_colormap_change(self):
+    def _on_colormap_change(self, event=None):
         cmap = self.layer.colormap[1]
         if self.layer.gamma != 1:
             # when gamma!=1, we instantiate a new colormap with 256 control
@@ -62,13 +60,13 @@ class VispySurfaceLayer(VispyBaseLayer):
             )
         self.node.cmap = cmap
 
-    def _on_contrast_limits_change(self):
+    def _on_contrast_limits_change(self, event=None):
         self.node.clim = self.layer.contrast_limits
 
-    def _on_gamma_change(self):
+    def _on_gamma_change(self, event=None):
         self._on_colormap_change()
 
-    def reset(self):
+    def reset(self, event=None):
         self._reset_base()
         self._on_colormap_change()
         self._on_contrast_limits_change()

--- a/napari/_vispy/vispy_vectors_layer.py
+++ b/napari/_vispy/vispy_vectors_layer.py
@@ -13,7 +13,7 @@ class VispyVectorsLayer(VispyBaseLayer):
         self._reset_base()
         self._on_data_change()
 
-    def _on_data_change(self):
+    def _on_data_change(self, event=None):
         if (
             len(self.layer._view_vertices) == 0
             or len(self.layer._view_faces) == 0

--- a/napari/_vispy/vispy_vectors_layer.py
+++ b/napari/_vispy/vispy_vectors_layer.py
@@ -8,8 +8,7 @@ class VispyVectorsLayer(VispyBaseLayer):
         node = Mesh()
         super().__init__(layer, node)
 
-        self.layer.events.edge_color.connect(lambda e: self._on_data_change())
-
+        self.layer.events.edge_color.connect(self._on_data_change)
         self._reset_base()
         self._on_data_change()
 

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -8,7 +8,7 @@ def _add(event):
     layers = event.source
     layer = event.item
     layer.name = layers._coerce_name(layer.name, layer)
-    layer.events.name.connect(lambda e: layers._update_name(e))
+    layer.events.name.connect(layers._update_name)
     layers.unselect_all(ignore=layer)
 
 

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -8,7 +8,7 @@ def _add(event):
     layers = event.source
     layer = event.item
     layer.name = layers._coerce_name(layer.name, layer)
-    layer.events.name.connect(layers._update_name)
+    layer.events.name.connect(lambda e: layers._update_name(e))
     layers.unselect_all(ignore=layer)
 
 

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -84,18 +84,18 @@ class ViewerModel(KeymapMixin):
         self._palette = None
         self.theme = 'dark'
 
-        self.dims.events.camera.connect(lambda e: self.reset_view())
-        self.dims.events.ndisplay.connect(lambda e: self._update_layers())
-        self.dims.events.order.connect(lambda e: self._update_layers())
-        self.dims.events.axis.connect(lambda e: self._update_layers())
+        self.dims.events.camera.connect(self.reset_view)
+        self.dims.events.ndisplay.connect(self._update_layers)
+        self.dims.events.order.connect(self._update_layers)
+        self.dims.events.axis.connect(self._update_layers)
         self.layers.events.added.connect(self._on_layers_change)
         self.layers.events.removed.connect(self._on_layers_change)
         self.layers.events.added.connect(self._update_active_layer)
         self.layers.events.removed.connect(self._update_active_layer)
         self.layers.events.reordered.connect(self._update_active_layer)
-        self.layers.events.added.connect(lambda e: self._update_grid())
-        self.layers.events.removed.connect(lambda e: self._update_grid())
-        self.layers.events.reordered.connect(lambda e: self._update_grid())
+        self.layers.events.added.connect(self._update_grid)
+        self.layers.events.removed.connect(self._update_grid)
+        self.layers.events.reordered.connect(self._update_grid)
 
         # Hold callbacks for when mouse moves with nothing pressed
         self.mouse_move_callbacks = []
@@ -267,7 +267,7 @@ class ViewerModel(KeymapMixin):
 
         return size, corner
 
-    def reset_view(self):
+    def reset_view(self, event=None):
         """Resets the camera's view using `event.rect` a 4-tuple of the x, y
         corner position followed by width and height of the camera
         """
@@ -1010,7 +1010,7 @@ class ViewerModel(KeymapMixin):
         empty_labels = np.zeros(dims, dtype=int)
         self.add_labels(empty_labels)
 
-    def _update_layers(self, layers=None):
+    def _update_layers(self, event=None, layers=None):
         """Updates the contained layers.
 
         Parameters
@@ -1199,7 +1199,7 @@ class ViewerModel(KeymapMixin):
         """
         self.grid_view(n_row=1, n_column=1, stride=1)
 
-    def _update_grid(self):
+    def _update_grid(self, event=None):
         """Update grid with current grid values.
         """
         self.grid_view(

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -176,10 +176,10 @@ class Layer(KeymapMixin, ABC):
 
         self.events.data.connect(lambda e: self._set_editable())
         self.dims.events.ndisplay.connect(lambda e: self._set_editable())
-        self.dims.events.order.connect(lambda e: self.refresh())
-        self.dims.events.ndisplay.connect(lambda e: self._update_dims())
-        self.dims.events.order.connect(lambda e: self._update_dims())
-        self.dims.events.axis.connect(lambda e: self.refresh())
+        self.dims.events.order.connect(self.refresh)
+        self.dims.events.ndisplay.connect(self._update_dims)
+        self.dims.events.order.connect(self._update_dims)
+        self.dims.events.axis.connect(self.refresh)
 
         self.mouse_move_callbacks = []
         self.mouse_drag_callbacks = []
@@ -330,7 +330,7 @@ class Layer(KeymapMixin, ABC):
         self._position = position
         self._update_coordinates()
 
-    def _update_dims(self):
+    def _update_dims(self, event=None):
         """Updates dims model, which is useful after data has been changed."""
         ndim = self._get_ndim()
         ndisplay = self.dims.ndisplay
@@ -593,7 +593,7 @@ class Layer(KeymapMixin, ABC):
         """
         pass
 
-    def refresh(self):
+    def refresh(self, event=None):
         """Refresh all layer data based on current view slice.
         """
         if self.visible:

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -177,9 +177,9 @@ class Labels(Image):
         self._update_dims()
         self._set_editable()
 
-        self.dims.events.ndisplay.connect(lambda e: self._reset_history())
-        self.dims.events.order.connect(lambda e: self._reset_history())
-        self.dims.events.axis.connect(lambda e: self._reset_history())
+        self.dims.events.ndisplay.connect(self._reset_history)
+        self.dims.events.order.connect(self._reset_history)
+        self.dims.events.axis.connect(self._reset_history)
 
     @property
     def contiguous(self):
@@ -383,7 +383,7 @@ class Labels(Image):
             col = self.colormap[1][val].rgba[0]
         return col
 
-    def _reset_history(self):
+    def _reset_history(self, event=None):
         self._undo_history = deque()
         self._redo_history = deque()
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -330,7 +330,7 @@ class Labels(Image):
             self.interactive = False
             self.help = 'hold <space> to pan/zoom, click to fill a label'
         else:
-            raise ValueError("Mode not recongnized")
+            raise ValueError("Mode not recognized")
 
         self.status = str(mode)
         self._mode = mode
@@ -550,7 +550,7 @@ class Labels(Image):
             # Fill clicked on region with new label
             self.fill(self.coordinates, self._value, self.selected_label)
         else:
-            raise ValueError("Mode not recongnized")
+            raise ValueError("Mode not recognized")
 
     def on_mouse_move(self, event):
         """Called whenever mouse moves over canvas.

--- a/napari/layers/shapes/shape_models/shape.py
+++ b/napari/layers/shapes/shape_models/shape.py
@@ -75,10 +75,10 @@ class Shape(ABC):
     ----------
     _edge_color_name : str
         Name of edge color or six digit hex code representing edge color if not
-        recongnized
+        recognized
     _face_color_name : str
         Name of edge color or six digit hex code representing face color if not
-        recongnized
+        recognized
     _closed : bool
         Bool if shape edge is a closed path or not
     _box : np.ndarray

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -574,7 +574,7 @@ class Shapes(Layer):
                 'hold <space> to pan/zoom, ' 'press <esc> to finish drawing'
             )
         else:
-            raise ValueError("Mode not recongnized")
+            raise ValueError("Mode not recognized")
 
         self.status = str(mode)
         self._mode = mode
@@ -1648,7 +1648,7 @@ class Shapes(Layer):
                         self._selected_box = self.interaction_box(shapes)
                 self.refresh()
         else:
-            raise ValueError("Mode not recongnized")
+            raise ValueError("Mode not recognized")
 
     def on_mouse_move(self, event):
         """Called whenever mouse moves over canvas.
@@ -1700,7 +1700,7 @@ class Shapes(Layer):
         elif self._mode in [Mode.VERTEX_INSERT, Mode.VERTEX_REMOVE]:
             self._set_highlight()
         else:
-            raise ValueError("Mode not recongnized")
+            raise ValueError("Mode not recognized")
 
     def on_mouse_release(self, event):
         """Called whenever mouse released in canvas.
@@ -1767,4 +1767,4 @@ class Shapes(Layer):
         ):
             pass
         else:
-            raise ValueError("Mode not recongnized")
+            raise ValueError("Mode not recognized")

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -295,9 +295,9 @@ class Shapes(Layer):
         self._status = self.mode
         self._help = 'enter a selection mode to edit shape properties'
 
-        self.events.deselect.connect(lambda x: self._finish_drawing())
-        self.events.face_color.connect(lambda e: self._update_thumbnail())
-        self.events.edge_color.connect(lambda e: self._update_thumbnail())
+        self.events.deselect.connect(self._finish_drawing)
+        self.events.face_color.connect(self._update_thumbnail)
+        self.events.edge_color.connect(self._update_thumbnail)
 
         self.add(
             data,
@@ -925,7 +925,7 @@ class Shapes(Layer):
         self._drag_box_stored = copy(self._drag_box)
         self.events.highlight()
 
-    def _finish_drawing(self):
+    def _finish_drawing(self, event=None):
         """Reset properties used in shape drawing."""
         index = copy(self._moving_value[0])
         self._is_moving = False
@@ -954,7 +954,7 @@ class Shapes(Layer):
         self._is_creating = False
         self._update_dims()
 
-    def _update_thumbnail(self):
+    def _update_thumbnail(self, event=None):
         """Update thumbnail with current points and colors."""
         # calculate min vals for the vertices and pad with 0.5
         # the offset is needed to ensure that the top left corner of the shapes

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -766,112 +766,109 @@ QtResetViewButton {
    border-radius: 3px;
 }
 
-QtModeRadio {
+QtModeRadioButton {
   background-color: {{ foreground }};
   border-radius: 3px;
 }
 
-QtModeRadio:disabled {
+QtModeRadioButton:disabled {
   background-color: {{ background }};
 }
 
-QtModeRadio::indicator {
+QtModeRadioButton::indicator {
   subcontrol-position:
   center center;
   subcontrol-origin: content;
   width: 28px; height: 28px;
 }
 
-QtModeRadio::indicator:checked {
+QtModeRadioButton::indicator:checked {
   background-color: {{ highlight }};
   border-radius: 3px;
 }
 
-QtModeRadio::indicator:unchecked:hover {
+QtModeRadioButton::indicator:unchecked:hover {
   background-color: {{ primary }};
   border-radius: 3px;
 }
 
-QtModeRadio[mode="zoom"]::indicator {
+QtModeRadioButton[mode="zoom"]::indicator {
   image: url(":/icons/{{ folder }}/zoom.svg");
 }
 
-QtModeRadio[mode="select"]::indicator {
+QtModeRadioButton[mode="select"]::indicator {
   image: url(":/icons/{{ folder }}/select.svg");
 }
 
-QtModeRadio[mode="direct"]::indicator {
+QtModeRadioButton[mode="direct"]::indicator {
   image: url(":/icons/{{ folder }}/direct.svg");
 }
 
-QtModeRadio[mode="rectangle"]::indicator {
+QtModeRadioButton[mode="rectangle"]::indicator {
   image: url(":/icons/{{ folder }}/rectangle.svg");
 }
 
-QtModeRadio[mode="ellipse"]::indicator {
+QtModeRadioButton[mode="ellipse"]::indicator {
   image: url(":/icons/{{ folder }}/ellipse.svg");
   color: red;
 }
 
-QtModeRadio[mode="line"]::indicator {
+QtModeRadioButton[mode="line"]::indicator {
   image: url(":/icons/{{ folder }}/line.svg");
 }
 
-QtModeRadio[mode="path"]::indicator {
+QtModeRadioButton[mode="path"]::indicator {
   image: url(":/icons/{{ folder }}/path.svg");
 }
 
-QtModeRadio[mode="polygon"]::indicator {
+QtModeRadioButton[mode="polygon"]::indicator {
   image: url(":/icons/{{ folder }}/polygon.svg");
 }
 
-QtModeRadio[mode="vertex_insert"]::indicator {
+QtModeRadioButton[mode="vertex_insert"]::indicator {
   image: url(":/icons/{{ folder }}/vertex_insert.svg");
 }
 
-QtModeRadio[mode="vertex_remove"]::indicator {
+QtModeRadioButton[mode="vertex_remove"]::indicator {
   image: url(":/icons/{{ folder }}/vertex_remove.svg");
 }
 
-QtModeRadio[mode="paint"]::indicator {
+QtModeRadioButton[mode="paint"]::indicator {
   image: url(":/icons/{{ folder }}/paint.svg");
 }
 
-QtModeRadio[mode="fill"]::indicator {
+QtModeRadioButton[mode="fill"]::indicator {
   image: url(":/icons/{{ folder }}/fill.svg");
 }
 
-QtModeRadio[mode="picker"]::indicator {
+QtModeRadioButton[mode="picker"]::indicator {
   image: url(":/icons/{{ folder }}/picker.svg");
 }
 
-QtModeRadio[mode="pan_zoom"]::indicator {
+QtModeRadioButton[mode="pan_zoom"]::indicator {
     image: url(":/icons/{{ folder }}/zoom.svg");
 }
 
-QtModeRadio[mode="select_points"]::indicator {
+QtModeRadioButton[mode="select_points"]::indicator {
     image: url(":/icons/{{ folder }}/select.svg");
 }
 
-QtModeRadio[mode="add_points"]::indicator {
+QtModeRadioButton[mode="add_points"]::indicator {
     image: url(":/icons/{{ folder }}/add.svg");
 }
 
-QtMoveBackButton {
+QtModePushButton[mode="move_back"] {
    image: url(":/icons/{{ folder }}/move_back.svg");
 }
 
-QtMoveFrontButton {
+QtModePushButton[mode="move_front"] {
    image: url(":/icons/{{ folder }}/move_front.svg");
 }
 
-QtDeleteShapeButton {
+QtModePushButton[mode="delete_shape"] {
    image: url(":/icons/{{ folder }}/delete_shape.svg");
 }
 
-QtDeletePointsButton {
-   image: url(":/icons/{{ folder }}/delete_shape.svg");
-}
 
 QtCopyToClipboardButton {
    background-color: {{ background }};

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -614,18 +614,6 @@ QRadioButton::indicator:checked {
     border-radius: 3px;
 }
 
-#QtPanZoomButton::indicator {
-    image: url(":/icons/{{ folder }}/zoom.svg");
-}
-
-#QtSelectButton::indicator {
-    image: url(":/icons/{{ folder }}/select.svg");
-}
-
-#QtAdditionButton::indicator {
-    image: url(":/icons/{{ folder }}/add.svg");
-}
-
 QtLayerButtons {
   min-width: 242px;
   max-width: 242px;
@@ -778,83 +766,95 @@ QtResetViewButton {
    border-radius: 3px;
 }
 
-QtModeButton {
+QtModeRadio {
   background-color: {{ foreground }};
   border-radius: 3px;
 }
 
-QtModeButton:disabled {
+QtModeRadio:disabled {
   background-color: {{ background }};
 }
 
-QtModeButton::indicator {
+QtModeRadio::indicator {
   subcontrol-position:
   center center;
   subcontrol-origin: content;
   width: 28px; height: 28px;
 }
 
-QtModeButton::indicator:checked {
+QtModeRadio::indicator:checked {
   background-color: {{ highlight }};
   border-radius: 3px;
 }
 
-QtModeButton::indicator:unchecked:hover {
+QtModeRadio::indicator:unchecked:hover {
   background-color: {{ primary }};
   border-radius: 3px;
 }
 
-QtModeButton[mode="zoom"]::indicator {
+QtModeRadio[mode="zoom"]::indicator {
   image: url(":/icons/{{ folder }}/zoom.svg");
 }
 
-QtModeButton[mode="select"]::indicator {
+QtModeRadio[mode="select"]::indicator {
   image: url(":/icons/{{ folder }}/select.svg");
 }
 
-QtModeButton[mode="direct"]::indicator {
+QtModeRadio[mode="direct"]::indicator {
   image: url(":/icons/{{ folder }}/direct.svg");
 }
 
-QtModeButton[mode="rectangle"]::indicator {
+QtModeRadio[mode="rectangle"]::indicator {
   image: url(":/icons/{{ folder }}/rectangle.svg");
 }
 
-QtModeButton[mode="ellipse"]::indicator {
+QtModeRadio[mode="ellipse"]::indicator {
   image: url(":/icons/{{ folder }}/ellipse.svg");
   color: red;
 }
 
-QtModeButton[mode="line"]::indicator {
+QtModeRadio[mode="line"]::indicator {
   image: url(":/icons/{{ folder }}/line.svg");
 }
 
-QtModeButton[mode="path"]::indicator {
+QtModeRadio[mode="path"]::indicator {
   image: url(":/icons/{{ folder }}/path.svg");
 }
 
-QtModeButton[mode="polygon"]::indicator {
+QtModeRadio[mode="polygon"]::indicator {
   image: url(":/icons/{{ folder }}/polygon.svg");
 }
 
-QtModeButton[mode="vertex_insert"]::indicator {
+QtModeRadio[mode="vertex_insert"]::indicator {
   image: url(":/icons/{{ folder }}/vertex_insert.svg");
 }
 
-QtModeButton[mode="vertex_remove"]::indicator {
+QtModeRadio[mode="vertex_remove"]::indicator {
   image: url(":/icons/{{ folder }}/vertex_remove.svg");
 }
 
-QtModeButton[mode="paint"]::indicator {
+QtModeRadio[mode="paint"]::indicator {
   image: url(":/icons/{{ folder }}/paint.svg");
 }
 
-QtModeButton[mode="fill"]::indicator {
+QtModeRadio[mode="fill"]::indicator {
   image: url(":/icons/{{ folder }}/fill.svg");
 }
 
-QtModeButton[mode="picker"]::indicator {
+QtModeRadio[mode="picker"]::indicator {
   image: url(":/icons/{{ folder }}/picker.svg");
+}
+
+QtModeRadio[mode="pan_zoom"]::indicator {
+    image: url(":/icons/{{ folder }}/zoom.svg");
+}
+
+QtModeRadio[mode="select_points"]::indicator {
+    image: url(":/icons/{{ folder }}/select.svg");
+}
+
+QtModeRadio[mode="add_points"]::indicator {
+    image: url(":/icons/{{ folder }}/add.svg");
 }
 
 QtMoveBackButton {

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -647,36 +647,39 @@ QtDeleteButton {
    max-height : 28px;
 }
 
-QtNewPointsButton {
-   image: url(":/icons/{{ folder }}/new_points.svg");
+QtViewerPushButton{
    min-width : 28px;
    max-width : 28px;
    min-height : 28px;
    max-height : 28px;
 }
 
-QtNewShapesButton {
-   image: url(":/icons/{{ folder }}/new_shapes.svg");
-   min-width : 28px;
-   max-width : 28px;
-   min-height : 28px;
-   max-height : 28px;
+QtViewerPushButton[mode="new_points"] {
+  image: url(":/icons/{{ folder }}/new_points.svg");
 }
 
-QtNewLabelsButton {
-   image: url(":/icons/{{ folder }}/new_labels.svg");
-   min-width : 28px;
-   max-width : 28px;
-   min-height : 28px;
-   max-height : 28px;
+QtViewerPushButton[mode="new_shapes"] {
+  image: url(":/icons/{{ folder }}/new_shapes.svg");
 }
 
-QtConsoleButton {
-  min-width : 28px;
-  max-width : 28px;
-  min-height : 28px;
-  max-height : 28px;
+QtViewerPushButton[mode="new_labels"] {
+  image: url(":/icons/{{ folder }}/new_labels.svg");
+}
+
+QtViewerPushButton[mode="console"] {
   image: url(":/icons/{{ folder }}/console.svg");
+}
+
+QtViewerPushButton[mode="roll"] {
+  image: url(":/icons/{{ folder }}/roll.svg");
+}
+
+QtViewerPushButton[mode="transpose"] {
+  image: url(":/icons/{{ folder }}/transpose.svg");
+}
+
+QtViewerPushButton[mode="home"] {
+  image: url(":/icons/{{ folder }}/home.svg");
 }
 
 QtNDisplayButton {
@@ -737,33 +740,6 @@ QtGridViewButton::indicator:checked {
 
 QtGridViewButton::indicator:hover {
   background-color: {{ primary }};
-}
-
-QtRollDimsButton {
-   image: url(":/icons/{{ folder }}/roll.svg");
-   min-width : 28px;
-   max-width : 28px;
-   min-height : 28px;
-   max-height : 28px;
-   border-radius: 3px;
-}
-
-QtTransposeDimsButton {
-   image: url(":/icons/{{ folder }}/transpose.svg");
-   min-width : 28px;
-   max-width : 28px;
-   min-height : 28px;
-   max-height : 28px;
-   border-radius: 3px;
-}
-
-QtResetViewButton {
-   image: url(":/icons/{{ folder }}/home.svg");
-   min-width : 28px;
-   max-width : 28px;
-   min-height : 28px;
-   max-height : 28px;
-   border-radius: 3px;
 }
 
 QtModeRadioButton {

--- a/napari/resources/stylesheet.qss
+++ b/napari/resources/stylesheet.qss
@@ -614,15 +614,15 @@ QRadioButton::indicator:checked {
     border-radius: 3px;
 }
 
-QtPanZoomButton::indicator {
+#QtPanZoomButton::indicator {
     image: url(":/icons/{{ folder }}/zoom.svg");
 }
 
-QtSelectButton::indicator {
+#QtSelectButton::indicator {
     image: url(":/icons/{{ folder }}/select.svg");
 }
 
-QtAdditionButton::indicator {
+#QtAdditionButton::indicator {
     image: url(":/icons/{{ folder }}/add.svg");
 }
 

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -93,6 +93,9 @@ class StringEnumMeta(EnumMeta):
             start=start,
         )
 
+    def keys(self):
+        return list(map(str, self))
+
 
 class StringEnum(Enum, metaclass=StringEnumMeta):
     def _generate_next_value_(name, start, count, last_values):


### PR DESCRIPTION
# Description
Following up on the discussion in https://github.com/napari/napari/pull/846#discussion_r364016783, this PR is a broad sweep through the codebase cleaning up and standardizing our usage of connections (both in Qt and vispy), and lambda functions.    Here were the rules I followed:

- if there is a class method that is more or less designed to be a vispy event handler or a qt slot, even if the method doesn't use the event object, we should add `event=None` to the method signature so that we don't have to catch the event and discard it with a lambda every time it is connected:

  ```python
  self.events.something.connect(lambda x: self._on_something())
  
  #becomes
  self.events.something.connect(self._on_something)
  ...
  def _on_something(self, event=None):
      handle_something()
  ```

- `connect(lambda val: self.doSomething(val))` is the same as `connect(self.doSomething)` and has been changed where appropriate

- defaults in lambda parameters are used in a lot of places throughout the code, but often the defaults don't have the same type as the eventual signal.  So it wasn't clear to me why they were being provided.  Removing them seems to have no effect either on tests or functionality, but let me know if I'm missing something:
  ```python
  sld.valueChanged.connect(lambda value=sld: self.changeSize(value))

  # sld is never an integer, right? ... it becomes
  sld.valueChanged.connect(self.changeSize)
  ```

- the syntax `widget.signal[type].connect` is used for [overloaded signals](https://wiki.qt.io/Qt_for_Python_Signals_and_Slots), and it is unnecessary unless the signal you are handling is overloaded _and_ you want the non default signature.  For instance: 
  ```python
  # this is unnecessary because Qslider.valueChanged always returns an int
  QSlider.valueChanged[int].connect()
  # this is necessary because QCombBox.activated is overloaded, 
  # and the default is an int
  QComboBox.activated[str].connect()

I made a couple additional Qt refactors:

- Juan's `QtModeButton` was being used in some places but other places had lots of duplicated classes.  I used his button class everyone and removed the duplicates.  But I renamed it to `QtModeRadioButton` because I also added a `QtModePushButton` that serves a similar code-reduction purpose.
- wherever there was a `for` loop using `addItem` to a combobox, I turned it into `addItems`
- I added a `keys()` method to our `StringEnum` because we often just want to get the list of options for a combo box.

i think a lot of the code is much easier to follow now.  Hope you agree and hope it isn't a pain to merge into any open PRs.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Refactor

# References
https://wiki.qt.io/Qt_for_Python_Signals_and_Slots

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change
