### PR TITLE
remove calls to QPoint.toTuple which is invalid in PyQt5

### DIFF
--- a/napari/_qt/qt_modal.py
+++ b/napari/_qt/qt_modal.py
@@ -69,7 +69,7 @@ class QtPopup(QDialog):
 
         # necessary for transparent round corners
         self.resize(self.sizeHint())
-        self.setGeometry(*xy.toTuple(), max(width, 20), max(height, 20))
+        self.setGeometry(xy.x(), xy.y(), max(width, 20), max(height, 20))
         self.show()
 
     def keyPressEvent(self, event):


### PR DESCRIPTION
# Description
Remove calls to `QPoint.toTuple` which is part of `PySide2`'s API but not `PyQt5`'s.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
fixes #865

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] the test suite passes for both `PyQt5` and `PySide2` installs
