### PR TITLE
change autodevdoc script to use new git reference

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -172,7 +172,7 @@ push_docs_task:
   only_if: $CIRRUS_BRANCH == "master"
 
   env:
-    GH_REF: github.com/napari/napari.github.io
+    GH_REF: github.com/napari/docs
     GH_TOKEN: ENCRYPTED[bdbe1e34c8f2491f4c982798ed4bb5bfe61da8ecb1d7c5164bd97f6fccaa398818d2b788badd13651d8e1692cab10fec]
     CIRRUS_CLONE_DEPTH: 0  # unlimited depth allows versioneer to work properly
 


### PR DESCRIPTION
change autodevdoc script to push to `napari/docs` instead of `napari/napari.github.io`

see #764 