### PR TITLE
Clean up setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,17 @@
 #!/usr/bin/env python
-"""Napari GUI
-
-GUI component of Napari.
+"""Napari viewer is a fast, interactive, multi-dimensional image viewer for
+Python. It's designed for browsing, annotating, and analyzing large
+multi-dimensional images. It's built on top of `Qt` (for the GUI), `vispy`
+(for performant GPU-based rendering), and the scientific Python stack
+(`numpy`, `scipy`).
 """
+
+import os.path as osp
+import sys
+from setuptools import find_packages, setup
+
+import versioneer
+
 
 import os.path as osp
 import sys
@@ -10,7 +19,9 @@ from setuptools import setup, find_packages
 
 import versioneer
 
-MIN_PY_VER = '3.6'
+MIN_PY_MAJOR_VER = 3
+MIN_PY_MINOR_VER = 6
+MIN_PY_VER = f"{MIN_PY_MAJOR_VER}.{MIN_PY_MINOR_VER}"
 DISTNAME = 'napari'
 DESCRIPTION = 'n-dimensional array viewer in Python.'
 LONG_DESCRIPTION = __doc__
@@ -40,52 +51,37 @@ CLASSIFIERS = [
     'Operating System :: MacOS',
 ]
 
-if sys.version_info < (3, 6):
+
+if sys.version_info < (MIN_PY_MAJOR_VER, MIN_PY_MINOR_VER):
     sys.stderr.write(
-        f'You are using Python '
-        + "{'.'.join(str(v) for v in sys.version_info[:3])}.\n\n"
-        + 'napari only supports Python 3.6 and above.\n\n'
-        + 'Please install Python 3.6 or later.\n'
+        f"You are using Python "
+        f"{'.'.join(str(v) for v in sys.version_info[:3])}.\n\n"
+        f"napari only supports Python {MIN_PY_VER} and above.\n\n"
+        f"Please install Python {MIN_PY_VER} or later.\n"
     )
     sys.exit(1)
 
-
-PACKAGES = [
-    package for package in find_packages() if not package.startswith('gui')
-]
-
-
+requirements = []
 with open(osp.join('requirements', 'default.txt')) as f:
-    requirements = [
-        line.strip() for line in f if line and not line.startswith('#')
-    ]
+    for line in f:
+        splitted = line.split("#")
+        stripped = splitted[0].strip()
+        if len(stripped) > 0:
+            requirements.append(splitted)
 
-
-INSTALL_REQUIRES = []
-REQUIRES = []
-
-for l in requirements:
-    sep = l.split(' #')
-    INSTALL_REQUIRES.append(sep[0].strip())
-    if len(sep) == 2:
-        REQUIRES.append(sep[1].strip())
-
-
-if __name__ == '__main__':
-    setup(
-        name=DISTNAME,
-        description=DESCRIPTION,
-        long_description=LONG_DESCRIPTION,
-        license=LICENSE,
-        download_url=DOWNLOAD_URL,
-        version=versioneer.get_version(),
-        cmdclass=versioneer.get_cmdclass(),
-        classifiers=CLASSIFIERS,
-        install_requires=INSTALL_REQUIRES,
-        requires=REQUIRES,
-        python_requires=f'>={MIN_PY_VER}',
-        packages=PACKAGES,
-        entry_points={'console_scripts': ['napari=napari.__main__:main']},
-        include_package_data=True,
-        zip_safe=False,  # the package can run out of an .egg file
-    )
+setup(
+    name=DISTNAME,
+    description=DESCRIPTION,
+    long_description=LONG_DESCRIPTION,
+    license=LICENSE,
+    download_url=DOWNLOAD_URL,
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
+    classifiers=CLASSIFIERS,
+    install_requires=requirements,
+    python_requires=f'>={MIN_PY_VER}',
+    packages=find_packages(),
+    entry_points={'console_scripts': ['napari=napari.__main__:main']},
+    include_package_data=True,
+    zip_safe=False,  # the package can run out of an .egg file
+)


### PR DESCRIPTION
# Description
1. napari-gui is gone.
2. collapse comment removal from requirements.txt into one place.
3. [setup()](https://packaging.python.org/guides/distributing-packages-using-setuptools/#setup-args) doesn't have a `requires` kwarg.
4. use [literal string concatenation](https://docs.python.org/3/reference/lexical_analysis.html#string-literal-concatenation).  IDEs know how to deal with literal string concatenation better.
5. move the block of string constants after the imports for PEP8 compliance.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
```
mkdir /tmp/i
cd /tmp/i
python3.6 venv .venv
pip install -e ~/imaging/napari
```

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
