### PR TITLE
improve slider step precision based on data range

### DIFF
--- a/napari/_qt/layers/qt_image_base_layer.py
+++ b/napari/_qt/layers/qt_image_base_layer.py
@@ -161,7 +161,11 @@ def create_range_popup(layer, attr, parent=None):
         precision=(
             0
             if is_integer_type
-            # scale precision with the log of the data range
+            # scale precision with the log of the data range order of magnitude
+            # eg.   0 - 1   (0 order of mag)  -> 3 decimal places
+            #       0 - 10  (1 order of mag)  -> 2 decimals
+            #       0 - 100 (2 orders of mag) -> 1 decimal
+            #       ≥ 3 orders of mag -> no decimals
             else int(max(3 - np.log10(max(d_range[1] - d_range[0], 0.01)), 0))
         ),
         parent=parent,

--- a/napari/_qt/layers/qt_image_base_layer.py
+++ b/napari/_qt/layers/qt_image_base_layer.py
@@ -153,11 +153,17 @@ def create_range_popup(layer, attr, parent=None):
         )
     is_integer_type = np.issubdtype(layer.dtype, np.integer)
 
+    d_range = getattr(layer, range_attr)
     popup = QRangeSliderPopup(
         initial_values=getattr(layer, attr),
-        data_range=getattr(layer, range_attr),
+        data_range=d_range,
         collapsible=False,
-        precision=(0 if is_integer_type else 2),
+        precision=(
+            0
+            if is_integer_type
+            # scale precision with the log of the data range
+            else int(max(3 - np.log10(max(d_range[1] - d_range[0], 0.01)), 0))
+        ),
         parent=parent,
     )
 

--- a/napari/_qt/qt_range_slider.py
+++ b/napari/_qt/qt_range_slider.py
@@ -77,7 +77,13 @@ class QRangeSlider(QWidget):
 
         self.setRange((0, 100) if data_range is None else data_range)
         self.setValues((20, 80) if initial_values is None else initial_values)
-        self.setStep(0.01 if step_size is None else step_size)
+        if step_size is None:
+            # pick an appropriate slider step size based on the data range
+            if data_range is not None:
+                step_size = (data_range[1] - data_range[0]) / 1000
+            else:
+                step_size = 0.001
+        self.setStep(step_size)
         if not parent:
             if 'HRange' in self.__class__.__name__:
                 self.setGeometry(200, 200, 200, 20)


### PR DESCRIPTION
# Description
this fixes #882 by guessing an appropriate slider step size (and number of decimal places for the popup clims control) based on the current contrast_limits_range. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas