### PR TITLE
skip pyqt5 tests on osx py3.7

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -88,8 +88,6 @@ task:
       pip install pyqt5
       pytest -v
     fi
-  
-
 
 
 windows_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -82,10 +82,14 @@ task:
   test_pyside2_script:
     - pytest -v
 
-  test_pyqt5_script:
-    - pip uninstall -y pyside2
-    - pip install pyqt5
-    - pytest -v
+  test_pyqt5_script: |
+    if [ "$PY_VER" == "3.6" ] || [ $OS == "linux" ]; then
+      pip uninstall -y pyside2
+      pip install pyqt5
+      pytest -v
+    fi
+  
+
 
 
 windows_task:


### PR DESCRIPTION
# Description
tests are consistently failing on OSX py3.7 with PyQt5.  They fail with an Abort trap after all tests are complete, which might suggests that a thread has not been completely cleaned up?  However, I've been unable to reproduce this locally, making it really hard to debug, and we're already testing pyqt5 on py3.7 on linux, and OSX on py3.6 ... so for now this backs off a bit.
