### PR TITLE
[WIP proposal] IO plugin

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -269,7 +269,8 @@ class QtViewer(QSplitter):
             for fname in filenames:
                 for check, read in plugin_manager.readers:
                     if check(fname):
-                        read(fname, self.viewer)
+                        data, meta = read(fname)
+                        self.viewer.add_image(data, **meta)
                         return
             self.viewer.add_image(path=filenames)
             self._last_visited_dir = os.path.dirname(filenames[0])

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -30,6 +30,7 @@ from .qt_console import QtConsole
 from .qt_viewer_dock_widget import QtViewerDockWidget
 from .qt_about_keybindings import QtAboutKeybindings
 from .._vispy import create_vispy_visual
+from ..plugins import plugin_manager
 
 
 class QtViewer(QSplitter):
@@ -260,6 +261,16 @@ class QtViewer(QSplitter):
             List of filenames to be opened
         """
         if len(filenames) > 0:
+            # FIXME: haven't decided how to handle lists of filenames yet in a
+            # way that also falls back gracefully to add_image(path=filenames)
+            # ALSO: need a GUI option (with persistence) to let the users
+            # change the order of reader plugins (because the first plugin
+            # to claim a path wins)
+            for fname in filenames:
+                for check, read in plugin_manager.readers:
+                    if check(fname):
+                        read(fname, self.viewer)
+                        return
             self.viewer.add_image(path=filenames)
             self._last_visited_dir = os.path.dirname(filenames[0])
 

--- a/napari/plugins.py
+++ b/napari/plugins.py
@@ -1,0 +1,127 @@
+import importlib
+import pkgutil
+import re
+
+import pkg_resources
+import requests
+
+"""
+This proposal for plugin discovery follows two of the recommendations here:
+https://packaging.python.org/guides/creating-and-discovering-plugins/
+
+1) Using naming convention:
+    plugins installed in the environment that follow a naming convention
+    (e.g. "napari_fancy_plugin"), can be discovered using `pkgutil`.
+    This also enables easy discovery on pypi
+
+2) Using package metadata:
+    plugins that declare a special key (e.g. "napari.plugins") in their
+    setup.py `entry_points` can be discovered using `pkg_resources`.
+    (this is used by pytest, for example)
+"""
+
+
+class PluginManager:
+    PREFIX = 'napari_'  # for discovery using naming convention
+    PLUGIN_ENTRY_POINT = "napari.plugins"  # for discovery using entry_points
+    IO_PLUGINS = "napari_io_"  # plugin subtype... this couple be an enum?
+    PYPI_SIMPLE_API_URL = 'https://pypi.org/simple/'
+
+    def __init__(self, discover=True):
+        self.plugins = {}
+        if discover:
+            self.discover_plugins()
+
+    @property
+    def readers(self):
+        """only plugins that declare themselves as io plugins.
+
+        the super basic API example I'm using here is that io plugins may
+        declare:
+            plugin.READERS : a list of 2-tuples (checker, reader)
+                `checker` is a function that returns True if it recognizes a
+                directory as something it can handle
+                `reader` is a function that accepts args (path, viewer) and
+                adds layers to the viewer given a path.
+            plugin.WRITERS : not implemented...
+
+        Yields
+        -------
+        tuple
+            (name, module) for all plugins
+        """
+        for name, module in self.plugins.items():
+            if name.startswith(self.IO_PLUGINS):
+                for item in getattr(module, 'READERS', []):
+                    yield item
+
+    def discover_plugins(self):
+        # using naming convention: http://bit.ly/pynaming-convention
+        # looks for all installed packages starting with self.PREFIX
+        # propsed convention for plugins is: napari_<plugin-name>
+        # coupld potentially have subclasses like napari_io_readerplugin
+        self.plugins.update(
+            {
+                name: importlib.import_module(name)
+                for finder, name, ispkg in pkgutil.iter_modules()
+                if name.startswith(self.PREFIX)
+            }
+        )
+
+        # using package metadata: http://bit.ly/pypackage-meta
+        # installed packages can register themselves for discovery by providing
+        # the `entry_points` argument in setup.py using self.PLUGIN_ENTRY_POINT
+        self.plugins.update(
+            {
+                entry.name: entry.load()
+                for entry in pkg_resources.iter_entry_points(
+                    self.PLUGIN_ENTRY_POINT
+                )
+            }
+        )
+
+    @property
+    def pypi_plugins(self):
+        # packages using naming convention: http://bit.ly/pynaming-convention
+        # can be autodiscovered on pypi using the SIMPLE API:
+        # https://www.python.org/dev/peps/pep-0503/
+        if not hasattr(self, '_pypi_plugins'):
+            response = requests.get(self.PYPI_SIMPLE_API_URL)
+            if response.status_code == 200:
+                pattern = f'<a href="/simple/(.+)">({self.PREFIX}.*)</a>'
+                self._pypi_plugins = {
+                    name: self.PYPI_SIMPLE_API_URL + url
+                    for url, name in re.findall(pattern, response.text)
+                }
+        return self._pypi_plugins
+
+    def fetch_plugin_versions(self, name):
+        """fetch versions for a plugin.
+
+        Parameters
+        ----------
+        name : str
+            name of the plugin
+
+        Returns
+        -------
+        tuple of versions availabe on pypi
+
+        Raises
+        ------
+        KeyError
+            if the plugin name is not found on pypi
+        """
+        if name not in self.pypi_plugins and not name.startswith(self.PREFIX):
+            # also search for plugin preceeded by self.PREFIX
+            name = f'{self.PREFIX}-{name}'
+        if name not in self.pypi_plugins:
+            raise KeyError(f'"{name}"" is not a recognized plugin name')
+
+        response = requests.get(self.pypi_plugins.get(name))
+        if response.status_code == 200:
+            versions = re.findall(f'>{name}-(.+).tar', response.text)
+            return tuple(set(versions))
+
+
+plugin_manager = PluginManager()

--- a/napari_io_lls/__init__.py
+++ b/napari_io_lls/__init__.py
@@ -29,16 +29,21 @@ def is_lls_folder(path):
 # two options here... the reader can either accept the viewer instance, and
 # call viewer.add_image (or even other layers) itself,
 # or it can return args and kwargs that would be passed to viewer.add_image
-# the first case is implemented here
-def read_lls_folder(directory, viewer):
-    """Take a directory and load images in the viewer
+# the second case is implemented here
+def read_lls_folder(directory):
+    """Take a directory and return image data and metadata
     
     Parameters
     ----------
     directory : str
         Path to directory
-    viewer : napari.Viewer
-        viewer instance
+    
+    Returns
+    -------
+    data : array
+        Image array data
+    meta : dict
+        Image metadata dictionary.
     """
     i = 0
     channels = []
@@ -73,8 +78,13 @@ def read_lls_folder(directory, viewer):
     stack = da.stack(channels)
     scale = [1] * stack.ndim
     scale[-3] = dz / dx
-    viewer.add_image(stack, channel_axis=0, rgb=False, scale=scale, name=waves)
-    viewer.dims.ndisplay = 3
+    meta = {
+        'channel_axis': 0,
+        'rgb': False,
+        'scale': scale,
+        'name': waves,
+    }
+    return stack, meta
 
 
 """

--- a/napari_io_lls/__init__.py
+++ b/napari_io_lls/__init__.py
@@ -78,12 +78,7 @@ def read_lls_folder(directory):
     stack = da.stack(channels)
     scale = [1] * stack.ndim
     scale[-3] = dz / dx
-    meta = {
-        'channel_axis': 0,
-        'rgb': False,
-        'scale': scale,
-        'name': waves,
-    }
+    meta = {'channel_axis': 0, 'rgb': False, 'scale': scale, 'name': waves}
     return stack, meta
 
 

--- a/napari_io_lls/__init__.py
+++ b/napari_io_lls/__init__.py
@@ -1,0 +1,94 @@
+import os
+import dask.array as da
+from dask import delayed
+from skimage.io import imread
+from skimage.external import tifffile as tf
+from glob import glob
+import re
+
+delayed_read = delayed(imread)
+
+
+def is_lls_folder(path):
+    """this should be a fast function that doesn't actually read any data.
+    It should simply return True if it is capable of handling the path."""
+    if not os.path.isdir(path):
+        return False
+    tiffs = 0
+    for fname in os.listdir(path):
+        # ignore all files but tifs
+        if not fname.endswith('.tif'):
+            continue
+        if not 'msecAbs' in fname and 'stack' in fname:
+            return False
+        else:
+            tiffs += 1
+    return tiffs > 0
+
+
+# two options here... the reader can either accept the viewer instance, and
+# call viewer.add_image (or even other layers) itself,
+# or it can return args and kwargs that would be passed to viewer.add_image
+# the first case is implemented here
+def read_lls_folder(directory, viewer):
+    """Take a directory and load images in the viewer
+    
+    Parameters
+    ----------
+    directory : str
+        Path to directory
+    viewer : napari.Viewer
+        viewer instance
+    """
+    i = 0
+    channels = []
+    waves = []
+    shape = None
+    dtype = None
+    while True:
+        ch_files = glob(os.path.join(directory, f'*ch{i}*.tif'))
+        if not ch_files:
+            break
+        if not (shape and dtype):
+            tif = tf.TiffFile(ch_files[0])
+            shape = tif.series[0].shape
+            dtype = tif.series[0].dtype
+            dx = tif.series[0][0].x_resolution or (1, 1)
+            dx = dx[1] / dx[0]
+            try:
+                dz = tif.series[0][0].imagej_tags.get('spacing', 1)
+            except AttributeError:
+                dz = 1
+        channels.append(
+            da.stack(
+                [
+                    da.from_delayed(delayed_read(fn), shape, dtype)
+                    for fn in ch_files
+                ]
+            )
+        )
+        waves.append(re.search('(\d+)nm_', ch_files[0]).groups()[0])
+        i += 1
+
+    stack = da.stack(channels)
+    scale = [1] * stack.ndim
+    scale[-3] = dz / dx
+    viewer.add_image(stack, channel_axis=0, rgb=False, scale=scale, name=waves)
+    viewer.dims.ndisplay = 3
+
+
+"""
+For a class-free, functional API, all IO plugins declare their functionality
+with two module level variables:
+    READERS : a list of 2-tuples (checker, reader)
+        `checker` is a function that returns True if it recognizes a
+            directory as something it can handle
+        `reader` is a function that accepts args (path, viewer) and
+            adds layers to the viewer given a path.
+    WRITERS : a list of writing functions
+        not implemented
+
+Alternatively, we could define a class-based API.
+"""
+READERS = [(is_lls_folder, read_lls_folder)]
+WRITERS = []


### PR DESCRIPTION
# Description
This PR implements a basic IO plugin architecture that enables users to control how a filepath dropped into the napari viewer is handled.  I see that there was once a [napari-io](https://github.com/napari/napari-io) repo and I suspect there has been plenty of discussion around io plugins, so forgive the late-entry and please take this PR simply as a working proposal very much open for criticism.

### Rationale

I see input plugins as very high priority, since there may be many potential users who simply want to view their images but don't necessarily know how to construct the appropriate numpy/dask array from their image (or other) files.  They should just be able to drag and drop their folders onto napari.  Also, there are many stereotyped microscopy image folder structures (like lattice data, or metamorph data, or basically any folder of tiffs with a naming convention), that could easily be made to look better in napari when dropping the folder on to the viewer.  

IO plugins may also be easier for us figure out than more "general" plugins as in #263, since their usage is  much more defined in some ways (e.g. take a filepath, and add it to the viewer)

### Design of this PR

this PR introduces a couple things:

- `napari.plugins.PluginManager`: this class finds all available napari plugins in the environment.  This differs slightly (but is not incompatible) with the `plug.crawl` discovery method that @jni started in #263, and is loosely based on the pytest plugin manager.  The goal here was to make plugins discoverable by simply being available in the environment.  `PluginManager. discover_plugins` has the main discovery logic and uses two discovery methods:
  - [naming convention](https://packaging.python.org/guides/creating-and-discovering-plugins/#using-naming-convention) - where a plugin is simply named something like `napari_myplugin` or a subclass like `napari_io_myplugin`
  - [package metadata](https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata) - where a package declares a special key (like "`napari.plugins`") in their `entry_points` in setup.py.  This is one way that [pytest does it](https://docs.pytest.org/en/latest/writing_plugins.html#making-your-plugin-installable-by-others).

  the plugin manager can also search pypi for packages following the naming convention (and something like github gists could also be added).  There are a couple notes there about plugin "subtypes" (e.g. IO plugins vs other plugins), but I haven't fleshed that out yet.  But for now, `PluginManager.readers` identifies and yields plugins that follow the IO plugin convention described below.

- `napari_io_lls` - this is an example package that gets discovered using the "naming convention" approach above (it would NOT be included in the final PR).  Note also: it's not a particularly "good" plugin, just an example of the API. It demonstrates a functional approach for an IO plugin module (could be easily switched to a class-based API).  The idea here is that all IO plugins declare their functionality with two module level `lists`:
  - `READERS` : a list of 2-tuples `(checker, reader)` where `checker` is a function that accepts a filepath and returns True if it recognizes it as something it can read, and `reader` is a function that accepts args `(filepath, viewer)` and adds layers to the `viewer` instance given a `filepath`.
  - `WRITERS` : not implemented yet... this is just focusing on getting images into napari for now.

- file-reader plugin functionality is added (for now) to the viewer in `QtViewer._add_files` as follows:  every filepath that is dropped onto the viewer is passed sequentially to each reader plugin discovered by `plugins_manager.readers` (an instance of `PluginManager`), and if the reader `checker` function returns `True`, the path is handled by the corresponding `reader` function.  Not implemented yet, but potentially important, would be a way for the user to re-order the reader plugins as desired (since the first one to "recognize" the folder wins).

If you'd like to try the `napari_io_lls` plugin, here's a [small example dataset](https://www.dropbox.com/s/d9lfdk9do0bfini/small_lls_example.zip?dl=0)