### PR TITLE
Fix points selection

### DIFF
--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -667,9 +667,10 @@ class Points(Layer):
                 ind = list(self._indices_view).index(c)
                 selected.append(ind)
         self._selected_view = selected
-        if len(selected) == 0:
-            self.selected_data
-        self._selected_box = self.interaction_box(self._selected_view)
+        if self.dims.ndisplay == 2:
+            self._selected_box = self.interaction_box(self._selected_view)
+        else:
+            self._selected_box = None
 
     def _set_highlight(self, force=False):
         """Render highlights of shapes including boundaries, vertices,

--- a/napari/layers/points/tests/test_points.py
+++ b/napari/layers/points/tests/test_points.py
@@ -105,8 +105,13 @@ def test_selecting_points():
     np.random.seed(0)
     data = 20 * np.random.random(shape)
     layer = Points(data)
+    layer.mode = 'select'
     layer.selected_data = [0, 1]
     assert layer.selected_data == [0, 1]
+
+    # test switching to 3D
+    layer.dims.ndisplay = 3
+    assert layer.selected_data == []
 
 
 def test_adding_points():


### PR DESCRIPTION
# Description
This PR fixes the `Points` layer bug where switching from 2D to 3D with a point selected causes a crash.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)expected)

# References
This addresses the bug described by @HagaiHargil in #901, but there are some nice feature suggestions in that issue we should follow up on.

# How has this been tested?
- [x] added a test in `test_points.py`
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
