### PR TITLE
Exclude `benchmarks` from the list of packages found

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.version_info < (3, 6):
 
 
 PACKAGES = [
-    package for package in find_packages() if not package.startswith('gui')
+    package for package in find_packages(exclude=['benchmarks']) if not package.startswith('gui')
 ]
 
 


### PR DESCRIPTION
# Description
The benchmarks directory was not meant to be packaged for distribution.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Fixes #910

# How has this been tested?
```
% python setup.py sdist
% mkdir /tmp/4
% cd /tmp/4
% pip install ~/imaging/napari/dist/napari-0+unknown.tar.gz
% python 
Python 3.7.5 (default, Oct 28 2019, 07:13:20) 
[Clang 11.0.0 (clang-1100.0.33.8)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import benchmarks
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'benchmarks'
>>> ^D
%
```

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
