### PR TITLE
patch py3.8 on windows

### DIFF
--- a/napari/_qt/qt_console.py
+++ b/napari/_qt/qt_console.py
@@ -1,11 +1,33 @@
-from qtconsole.rich_jupyter_widget import RichJupyterWidget
-from qtconsole.inprocess import QtInProcessKernelManager
-from qtconsole.client import QtKernelClient
-from IPython import get_ipython
-from IPython.terminal.interactiveshell import TerminalInteractiveShell
+import sys
+
+from ipykernel.connect import get_connection_file
 from ipykernel.inprocess.ipkernel import InProcessInteractiveShell
 from ipykernel.zmqshell import ZMQInteractiveShell
-from ipykernel.connect import get_connection_file
+from IPython import get_ipython
+from IPython.terminal.interactiveshell import TerminalInteractiveShell
+from qtconsole.client import QtKernelClient
+from qtconsole.inprocess import QtInProcessKernelManager
+from qtconsole.rich_jupyter_widget import RichJupyterWidget
+
+# FIXME: if/when tornado supports the defaults in asyncio,
+# remove and bump tornado requirement for py38
+# borrowed from ipykernel:
+# https://github.com/ipython/ipykernel/blob/7b2727d827a95d2059c9d9d9354899feabb642ee/ipykernel/kernelapp.py#L521-L535
+if sys.platform.startswith("win") and sys.version_info >= (3, 8):
+    import asyncio
+    try:
+        from asyncio import (
+            WindowsProactorEventLoopPolicy,
+            WindowsSelectorEventLoopPolicy,
+        )
+    except ImportError:
+        pass
+        # not affected
+    else:
+        if type(asyncio.get_event_loop_policy()) is WindowsProactorEventLoopPolicy:
+            # WindowsProactorEventLoopPolicy is not compatible with tornado 6
+            # fallback to the pre-3.8 default of Selector
+            asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
 
 
 class QtConsole(RichJupyterWidget):

--- a/napari/_qt/qt_console.py
+++ b/napari/_qt/qt_console.py
@@ -24,6 +24,7 @@ borrowed from ipykernel:  https://github.com/ipython/ipykernel/pull/456
 """
 if sys.platform.startswith("win") and sys.version_info >= (3, 8):
     import asyncio
+
     try:
         from asyncio import (
             WindowsProactorEventLoopPolicy,
@@ -33,7 +34,10 @@ if sys.platform.startswith("win") and sys.version_info >= (3, 8):
         pass
         # not affected
     else:
-        if type(asyncio.get_event_loop_policy()) is WindowsProactorEventLoopPolicy:
+        if (
+            type(asyncio.get_event_loop_policy())
+            is WindowsProactorEventLoopPolicy
+        ):
             # WindowsProactorEventLoopPolicy is not compatible with tornado 6
             # fallback to the pre-3.8 default of Selector
             asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())

--- a/napari/_qt/qt_console.py
+++ b/napari/_qt/qt_console.py
@@ -9,10 +9,19 @@ from qtconsole.client import QtKernelClient
 from qtconsole.inprocess import QtInProcessKernelManager
 from qtconsole.rich_jupyter_widget import RichJupyterWidget
 
-# FIXME: if/when tornado supports the defaults in asyncio,
-# remove and bump tornado requirement for py38
-# borrowed from ipykernel:
-# https://github.com/ipython/ipykernel/blob/7b2727d827a95d2059c9d9d9354899feabb642ee/ipykernel/kernelapp.py#L521-L535
+"""
+set default asyncio policy to be compatible with tornado
+
+Tornado 6 (at least) is not compatible with the default
+asyncio implementation on Windows
+
+Pick the older SelectorEventLoopPolicy on Windows
+if the known-incompatible default policy is in use.
+
+FIXME: if/when tornado supports the defaults in asyncio,
+remove and bump tornado requirement for py38
+borrowed from ipykernel:  https://github.com/ipython/ipykernel/pull/456
+"""
 if sys.platform.startswith("win") and sys.version_info >= (3, 8):
     import asyncio
     try:


### PR DESCRIPTION
# Description
napari is broken on python 3.8 on windows, because a change in `asyncio` in python 3.8 poses a [problem for tornado](https://github.com/tornadoweb/tornado/issues/2608), which `ipykernel` in turn depends on, which our console mechanism in-turn depends on.

as of v5.1.4 ipykernel has fixed this for instances of their `IPKernelApp`.  but the patch doesn't seem to be triggered in the way we access the kernel (maybe lower down... haven't looked too far into it).
I borrowed their fix from [here](https://github.com/ipython/ipykernel/blob/7b2727d827a95d2059c9d9d9354899feabb642ee/ipykernel/kernelapp.py#L506-L535) and added it to `qt_console`, it fixes napari and tests on windows py 3.8.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
https://github.com/tornadoweb/tornado/issues/2608
https://github.com/ipython/ipykernel/pull/456

# How has this been tested?
- [x] example: all tests pass with my change
