### PR TITLE
Fix osx py3.6 tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -113,7 +113,8 @@ mac_task:
 
   pip_cache:
     folder: $HOME/Library/Caches/pip
-    populate_script: 
+    populate_script:
+      - export MACOSX_DEPLOYMENT_TARGET=10.10
       - python -m pip install --retries 3 --upgrade pip
       - pip install -r requirements.txt
 


### PR DESCRIPTION
# Description
the cirrus auto-update of the OSX container to `catalina-xcode` is causing a [build failure during compilation of numcodecs](https://cirrus-ci.com/task/6660339609632768?command=pip#L387-L455) in the py3.6 environment on OS X.  This PR fixes that with `export MACOSX_DEPLOYMENT_TARGET=10.10`.

Note, OSX py3.6 tests only happen in the master branch, so the checks here will not show that it works for mac on 3.6, but you can see working tests in my fork here: 
https://cirrus-ci.com/build/4905459526139904
 
## Type of change
<!-- Please delete options that are not relevant. -->
- [x] CI-fix (non-breaking change which fixes an issue)

# References
https://github.com/cirruslabs/osx-images/issues/21
https://cirrus-ci.com/task/6660339609632768?command=pip#L387-L455
https://github.com/wesm/feather/issues/61
