### PR TITLE
add Python 3.8 to PyPI tags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3 :: Only',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'Topic :: Scientific/Engineering',
     'Topic :: Scientific/Engineering :: Visualization',
     'Topic :: Scientific/Engineering :: Information Analysis',


### PR DESCRIPTION
add Python 3.8 to PyPI tags

I would exclude this from the release notes :)