### PR TITLE
Import scipy stats to prevent strange bug.

### DIFF
--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -52,3 +52,11 @@ from .utils import sys_info
 
 __version__ = get_versions()['version']
 del get_versions
+
+# this unused import is here to fix a very strange bug.
+# there is some mysterious magical goodness in scipy stats that needs
+# to be imported early.
+# see: https://github.com/napari/napari/issues/925
+from scipy import stats  # noqa: F401
+
+del stats

--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -52,11 +52,3 @@ from .utils import sys_info
 
 __version__ = get_versions()['version']
 del get_versions
-
-# this unused import is here to fix a very strange bug.
-# there is some mysterious magical goodness in scipy stats that needs
-# to be imported early.
-# see: https://github.com/napari/napari/issues/925
-from scipy import stats  # noqa: F401
-
-del stats

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -3,6 +3,14 @@ import numpy as np
 from napari import Viewer
 from napari.layers import Image, Labels, Points, Shapes, Vectors, Surface
 
+# this unused import is here to fix a very strange bug.
+# there is some mysterious magical goodness in scipy stats that needs
+# to be imported early.
+# see: https://github.com/napari/napari/issues/925
+from scipy import stats  # noqa: F401
+
+del stats
+
 """
 Used as pytest params for testing layer add and view functionality (Layer class, data, ndim)
 """

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -3,14 +3,6 @@ import numpy as np
 from napari import Viewer
 from napari.layers import Image, Labels, Points, Shapes, Vectors, Surface
 
-# this unused import is here to fix a very strange bug.
-# there is some mysterious magical goodness in scipy stats that needs
-# to be imported early.
-# see: https://github.com/napari/napari/issues/925
-from scipy import stats  # noqa: F401
-
-del stats
-
 """
 Used as pytest params for testing layer add and view functionality (Layer class, data, ndim)
 """


### PR DESCRIPTION
# Description
This PR fixes one of the strangest bugs i've seen (see #925 for details) ... and I still don't have a good explanation why.  Whatever the case may be, importing scipy.stats early prevents a bug that shows up (wait for it) .... only on py3.7, with pyqt5, using vispy >= 0.6.4, when pytest has been imported, when going from 2d -> 3d -> back to 2d, when a duplicate viewer has been instantiated with the same variable name as another.  (i know... 😭)

Seems relatively harmless to add for now until we learn more, since scipy.stats is almost certainly being imported eventually.

also worth mentioning.  the bug in our tests only started showing up in `test_napari/test_view` after [this](https://github.com/napari/napari/pull/923/files) seemingly innocuous commit.

edit: because pytest needs to be imported to see the bug I moved the import from `napari.__init__` to `napari._tests.utils`