### PR TITLE
Fix add points

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -300,6 +300,9 @@ def test_properties():
     layer = Points(data, properties=copy(properties))
     assert layer.properties == properties
 
+    current_prop = {'point_type': np.array(['B'])}
+    assert layer.current_properties == current_prop
+
     # test removing points
     layer.selected_data = [0, 1]
     layer.remove_selected()
@@ -344,13 +347,13 @@ def test_adding_annotations():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {'point_type': np.array(['A', 'B'] * int((shape[0] / 2)))}
+    properties = {'point_type': np.array(['A', 'B'] * int((shape[0] / 2)))}
     layer = Points(data)
     assert layer.properties == {}
 
     # add properties
-    layer.properties = copy(annotations)
-    assert layer.properties == annotations
+    layer.properties = copy(properties)
+    assert layer.properties == properties
 
     # change properties
     new_annotations = {
@@ -358,6 +361,20 @@ def test_adding_annotations():
     }
     layer.properties = copy(new_annotations)
     assert layer.properties == new_annotations
+
+
+def test_add_points_with_properties():
+    # test adding points initialized with properties
+    shape = (10, 2)
+    np.random.seed(0)
+    data = 20 * np.random.random(shape)
+    properties = {'point_type': np.array(['A', 'B'] * int((shape[0] / 2)))}
+    layer = Points(data, properties=copy(properties))
+
+    coord = [18, 18]
+    layer.add(coord)
+    new_prop = {'point_type': np.append(properties['point_type'], 'B')}
+    np.testing.assert_equal(layer.properties, new_prop)
 
 
 def test_annotations_errors():

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1034,11 +1034,8 @@ class Points(Layer):
             k: np.unique(v[index], axis=0) for k, v in self.properties.items()
         }
         n_unique_properties = np.array([len(v) for v in properties.values()])
-        self.current_properties = {}
-        # only include the properties that common across all selected points
-        for n, prop in zip(n_unique_properties, properties):
-            if n == 1:
-                self.current_properties[prop] = properties[prop]
+        if np.all(n_unique_properties == 1):
+            self.current_properties = properties
 
     def interaction_box(self, index):
         """Create the interaction box around a list of points in view.

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -336,7 +336,7 @@ class Points(Layer):
         self._current_face_color = self.face_color[-1]
         self.size = size
         self.current_properties = {
-            k: v[-1] for k, v in self.properties.items()
+            k: np.asarray([v[-1]]) for k, v in self.properties.items()
         }
 
         # Trigger generation of view slice and thumbnail


### PR DESCRIPTION
# Description
This PR fixes the point added bug described in #930. Points were unable to be added without selecting a point first due to an bug in how `Points.current_properties` was initialized. I have fixed the issue and added a test.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
This PR addresses the point adding bug described in #930.

# How has this been tested?
- [ ] added a test for adding a point with properties and no points selected
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
