### PR TITLE
Fix points thumbnail

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1051,14 +1051,14 @@ def test_thumbnail():
     assert layer.thumbnail.shape == layer._thumbnail_shape
 
     # test with n_points > _max_max_points_thumbnail in 2D
-    max_points = Points._max_points_thumbnail
-    bigger_data = np.random.randint(10, 100, (max_points * 2, 2))
+    max_points = Points._max_points_thumbnail * 2
+    bigger_data = np.random.randint(10, 100, (max_points, 2))
     big_layer = Points(bigger_data)
     big_layer._update_thumbnail()
     assert big_layer.thumbnail.shape == big_layer._thumbnail_shape
 
     # test with n_points > _max_max_points_thumbnail in 3D
-    bigger_data_3d = np.random.randint(10, 100, (max_points * 2, 3))
+    bigger_data_3d = np.random.randint(10, 100, (max_points, 3))
     bigger_layer_3d = Points(bigger_data_3d)
     bigger_layer_3d.dims.ndisplay = 3
     bigger_layer_3d._update_thumbnail()

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1050,6 +1050,20 @@ def test_thumbnail():
     layer._update_thumbnail()
     assert layer.thumbnail.shape == layer._thumbnail_shape
 
+    # test with n_points > _max_max_points_thumbnail in 2D
+    max_points = Points._max_points_thumbnail
+    bigger_data = np.random.randint(10, 100, (max_points * 2, 2))
+    big_layer = Points(bigger_data)
+    big_layer._update_thumbnail()
+    assert big_layer.thumbnail.shape == big_layer._thumbnail_shape
+
+    # test with n_points > _max_max_points_thumbnail in 3D
+    bigger_data_3d = np.random.randint(10, 100, (max_points * 2, 3))
+    bigger_layer_3d = Points(bigger_data_3d)
+    bigger_layer_3d.dims.ndisplay = 3
+    bigger_layer_3d._update_thumbnail()
+    assert bigger_layer_3d.thumbnail.shape == bigger_layer_3d._thumbnail_shape
+
 
 def test_xml_list():
     """Test the xml generation."""

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1050,14 +1050,20 @@ def test_thumbnail():
     layer._update_thumbnail()
     assert layer.thumbnail.shape == layer._thumbnail_shape
 
-    # test with n_points > _max_max_points_thumbnail in 2D
+
+def test_thumbnail_with_n_points_greater_than_max():
+    """Test thumbnail generation with n_points > _max_points_thumbnail
+
+    see: https://github.com/napari/napari/pull/934
+    """
+    # 2D
     max_points = Points._max_points_thumbnail * 2
     bigger_data = np.random.randint(10, 100, (max_points, 2))
     big_layer = Points(bigger_data)
     big_layer._update_thumbnail()
     assert big_layer.thumbnail.shape == big_layer._thumbnail_shape
 
-    # test with n_points > _max_max_points_thumbnail in 3D
+    # #3D
     bigger_data_3d = np.random.randint(10, 100, (max_points, 3))
     bigger_layer_3d = Points(bigger_data_3d)
     bigger_layer_3d.dims.ndisplay = 3

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1306,19 +1306,20 @@ class Points(Layer):
                 self._thumbnail_shape[:2], shape[-2:]
             ).min()
             if len(self._data_view) > self._max_points_thumbnail:
-                inds = np.random.randint(
+                thumbnail_indices = np.random.randint(
                     0, len(self._data_view), self._max_points_thumbnail
                 )
-                points = self._data_view[inds]
+                points = self._data_view[thumbnail_indices]
             else:
                 points = self._data_view
+                thumbnail_indices = self._indices_view
             coords = np.floor(
                 (points[:, -2:] - min_vals[-2:] + 0.5) * zoom_factor
             ).astype(int)
             coords = np.clip(
                 coords, 0, np.subtract(self._thumbnail_shape[:2], 1)
             )
-            colors = self.face_color[self._indices_view]
+            colors = self.face_color[thumbnail_indices]
             colormapped[coords[:, 0], coords[:, 1]] = colors
 
         colormapped[..., 3] *= self.opacity


### PR DESCRIPTION
# Description
This PR fixes the bug where points layer thumbnails with more points than `Points._max_points_thumbnail` caused a crash (flagged by @cudmore in #932).

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
This fixes #932 .

# How has this been tested?
- [x] added tests for more points than the limit
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
