### PR TITLE
Remove 'in-depth' descriptor for tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 We're developing **napari** in the open! But the project is in an **alpha** stage, and there will still likely be **breaking changes** with each release. You can follow progress on this repository, test out new versions as we release them, and contribute ideas and code.
 
-We're working on [in-depth tutorials](https://napari.org/tutorials/), but you can also quickly get started by looking below.
+We're working on [tutorials](https://napari.org/tutorials/), but you can also quickly get started by looking below.
 
 ## installation
 
@@ -73,7 +73,7 @@ You can extend **napari** using custom shortcuts, key bindings, and mouse functi
 
 ## tutorials
 
-For more details on how to use `napari` checkout our [in-depth tutorials](https://napari.org/tutorials/). These are still a work in progress, but we'll be updating them regularly.
+For more details on how to use `napari` checkout our [tutorials](https://napari.org/tutorials/). These are still a work in progress, but we'll be updating them regularly.
 
 ## mission and values
 


### PR DESCRIPTION
# Description
Continues on the duplicate PR for fixing tutorial links in #948. (Apologies for missing #946 !) 

The "in-depth" descriptor is somewhat confusing for the tutorials. This PR changes instances of "in-depth tutorials" to "tutorials".

## Type of change
Documentation update.

# References
Discussion in #948 .