### PR TITLE
fix 4D ellipses

### DIFF
--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -153,6 +153,25 @@ def test_ellipses():
     assert np.all([s == 'ellipse' for s in layer.shape_type])
 
 
+def test_4D_ellispse():
+    """Test instantiating Shapes layer with 4D planar ellipse."""
+    # Test a single 4D ellipse
+    np.random.seed(0)
+    data = [
+        [
+            [3, 5, 108, 108],
+            [3, 5, 108, 148],
+            [3, 5, 148, 148],
+            [3, 5, 148, 108],
+        ]
+    ]
+    layer = Shapes(data, shape_type='ellipse')
+    assert layer.nshapes == len(data)
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data)])
+    assert layer.ndim == 4
+    assert np.all([s == 'ellipse' for s in layer.shape_type])
+
+
 def test_ellipses_roundtrip():
     """Test a full roundtrip with ellipss data."""
     shape = (10, 4, 2)

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -266,9 +266,9 @@ class Shapes(Layer):
             self._current_opacity = 0.7
 
         self._data_view = ShapeList(ndisplay=self.dims.ndisplay)
-        self._data_slice_keys = np.empty(
-            (0, 2, len(self.dims.not_displayed)), dtype=int
-        )
+        self._data_view.slice_key = np.array(self.dims.indices)[
+            list(self.dims.not_displayed)
+        ]
 
         self._value = (None, None)
         self._value_stored = (None, None)


### PR DESCRIPTION
# Description
This PR fixes the bug reported in https://forum.image.sc/t/adding-shapes-to-4d-data-in-napari/33600 on adding 4D ellipses and adds a test that would have previously failed. The problem was due to an incorrect initialization line.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)