### PR TITLE
Abstract the construction of view/viewermodel

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,2 +1,5 @@
 # pytest ignores these
 collect_ignore = ['setup.py', 'napari_gui']
+pytest_plugins = [
+    'napari._tests.infra.viewer',
+]

--- a/napari/_qt/_tests/test_qt_dims.py
+++ b/napari/_qt/_tests/test_qt_dims.py
@@ -6,8 +6,7 @@ import pytest
 from qtpy.QtCore import Qt
 
 from napari._qt.qt_dims import QtDims
-from napari._qt.qt_viewer import QtViewer
-from napari.components import Dims, ViewerModel
+from napari.components import Dims
 
 
 def test_creating_view(qtbot):
@@ -294,10 +293,8 @@ def test_play_button(qtbot):
     assert button.popup.isVisible()
 
 
-def test_slice_labels(qtbot):
-    viewer = ViewerModel()
-    view = QtViewer(viewer)
-    qtbot.addWidget(view)
+def test_slice_labels(viewermodel_factory):
+    view, viewer = viewermodel_factory()
     np.random.seed(0)
     data = np.random.random((20, 10, 10))
     viewer.add_image(data)

--- a/napari/_qt/_tests/test_qt_play.py
+++ b/napari/_qt/_tests/test_qt_play.py
@@ -3,9 +3,6 @@ from contextlib import contextmanager
 import numpy as np
 import pytest
 
-from napari._qt.qt_viewer import QtViewer
-from napari.components import ViewerModel
-
 from ...components import Dims
 from ..qt_dims import QtDims
 from ..qt_dims_slider import AnimationWorker
@@ -99,19 +96,14 @@ def test_animation_thread_once(qtbot):
 
 
 @pytest.fixture()
-def view(qtbot):
+def view(viewermodel_factory):
     """basic viewer with data that we will use a few times"""
-    viewer = ViewerModel()
-    view = QtViewer(viewer)
-    qtbot.addWidget(view)
+    view, viewer = viewermodel_factory()
 
     np.random.seed(0)
     data = np.random.random((10, 10, 15))
     viewer.add_image(data)
 
-    yield view  # Adding teardown code for fixture
-    print("shutting down QtViewer")
-    view.shutdown()
     return view
 
 

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from napari.components import ViewerModel
-from napari._qt.qt_viewer import QtViewer
 from napari._tests.utils import (
     add_layer_by_type,
     check_viewer_functioning,
@@ -10,11 +8,9 @@ from napari._tests.utils import (
 )
 
 
-def test_qt_viewer(qtbot):
+def test_qt_viewer(viewermodel_factory):
     """Test instantiating viewer."""
-    viewer = ViewerModel()
-    view = QtViewer(viewer)
-    qtbot.addWidget(view)
+    view, viewer = viewermodel_factory()
 
     assert viewer.title == 'napari'
     assert view.viewer == viewer
@@ -25,26 +21,20 @@ def test_qt_viewer(qtbot):
     assert viewer.dims.ndim == 2
     assert view.dims.nsliders == viewer.dims.ndim
     assert np.sum(view.dims._displayed_sliders) == 0
-    view.shutdown()
 
 
 @pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)
-def test_add_layer(qtbot, layer_class, data, ndim):
-    viewer = ViewerModel(ndisplay=ndim)
-    view = QtViewer(viewer)
-    qtbot.addWidget(view)
+def test_add_layer(viewermodel_factory, layer_class, data, ndim):
+    view, viewer = viewermodel_factory(ndisplay=ndim)
 
     add_layer_by_type(viewer, layer_class, data)
     check_viewer_functioning(viewer, view, data, ndim)
-    view.shutdown()
 
 
-def test_new_labels(qtbot):
+def test_new_labels(viewermodel_factory):
     """Test adding new labels layer."""
     # Add labels to empty viewer
-    viewer = ViewerModel()
-    view = QtViewer(viewer)
-    qtbot.addWidget(view)
+    view, viewer = viewermodel_factory()
 
     viewer._new_labels()
     assert np.max(viewer.layers[0].data) == 0
@@ -56,9 +46,7 @@ def test_new_labels(qtbot):
     assert np.sum(view.dims._displayed_sliders) == 0
 
     # Add labels with image already present
-    viewer = ViewerModel()
-    view = QtViewer(viewer)
-    qtbot.addWidget(view)
+    view, viewer = viewermodel_factory()
 
     np.random.seed(0)
     data = np.random.random((10, 15))
@@ -71,15 +59,12 @@ def test_new_labels(qtbot):
     assert viewer.dims.ndim == 2
     assert view.dims.nsliders == viewer.dims.ndim
     assert np.sum(view.dims._displayed_sliders) == 0
-    view.shutdown()
 
 
-def test_new_points(qtbot):
+def test_new_points(viewermodel_factory):
     """Test adding new points layer."""
     # Add labels to empty viewer
-    viewer = ViewerModel()
-    view = QtViewer(viewer)
-    qtbot.addWidget(view)
+    view, viewer = viewermodel_factory()
 
     viewer.add_points()
     assert len(viewer.layers[0].data) == 0
@@ -91,9 +76,7 @@ def test_new_points(qtbot):
     assert np.sum(view.dims._displayed_sliders) == 0
 
     # Add points with image already present
-    viewer = ViewerModel()
-    view = QtViewer(viewer)
-    qtbot.addWidget(view)
+    view, viewer = viewermodel_factory()
 
     np.random.seed(0)
     data = np.random.random((10, 15))
@@ -106,15 +89,12 @@ def test_new_points(qtbot):
     assert viewer.dims.ndim == 2
     assert view.dims.nsliders == viewer.dims.ndim
     assert np.sum(view.dims._displayed_sliders) == 0
-    view.shutdown()
 
 
-def test_new_shapes(qtbot):
+def test_new_shapes_empty_viewer(viewermodel_factory):
     """Test adding new shapes layer."""
     # Add labels to empty viewer
-    viewer = ViewerModel()
-    view = QtViewer(viewer)
-    qtbot.addWidget(view)
+    view, viewer = viewermodel_factory()
 
     viewer.add_shapes()
     assert len(viewer.layers[0].data) == 0
@@ -126,9 +106,7 @@ def test_new_shapes(qtbot):
     assert np.sum(view.dims._displayed_sliders) == 0
 
     # Add points with image already present
-    viewer = ViewerModel()
-    view = QtViewer(viewer)
-    qtbot.addWidget(view)
+    view, viewer = viewermodel_factory()
 
     np.random.seed(0)
     data = np.random.random((10, 15))
@@ -144,11 +122,9 @@ def test_new_shapes(qtbot):
     view.shutdown()
 
 
-def test_screenshot(qtbot):
+def test_screenshot(viewermodel_factory):
     "Test taking a screenshot"
-    viewer = ViewerModel()
-    view = QtViewer(viewer)
-    qtbot.addWidget(view)
+    view, viewer = viewermodel_factory()
 
     np.random.seed(0)
     # Add image
@@ -180,7 +156,7 @@ def test_screenshot(qtbot):
 @pytest.mark.parametrize(
     "dtype", ['int8', 'uint8', 'int16', 'uint16', 'float32']
 )
-def test_qt_viewer_data_integrity(qtbot, dtype):
+def test_qt_viewer_data_integrity(viewermodel_factory, dtype):
     """Test that the viewer doesn't change the underlying array."""
 
     image = np.random.rand(10, 32, 32)
@@ -188,9 +164,7 @@ def test_qt_viewer_data_integrity(qtbot, dtype):
     image = image.astype(dtype)
     imean = image.mean()
 
-    viewer = ViewerModel()
-    view = QtViewer(viewer)
-    qtbot.addWidget(view)
+    view, viewer = viewermodel_factory()
 
     viewer.add_image(image.copy())
     datamean = viewer.layers[0].data.mean()
@@ -203,4 +177,3 @@ def test_qt_viewer_data_integrity(qtbot, dtype):
     viewer.dims.ndisplay = 2
     datamean = viewer.layers[0].data.mean()
     assert datamean == imean
-    view.shutdown()

--- a/napari/_qt/qt_console.py
+++ b/napari/_qt/qt_console.py
@@ -131,5 +131,5 @@ class QtConsole(RichJupyterWidget):
     def shutdown(self):
         if self.kernel_client is not None:
             self.kernel_client.stop_channels()
-        if self.kernel_manager is not None:
+        if self.kernel_manager is not None and self.kernel_manager.has_kernel:
             self.kernel_manager.shutdown_kernel()

--- a/napari/_tests/infra/viewer.py
+++ b/napari/_tests/infra/viewer.py
@@ -1,0 +1,24 @@
+from typing import List
+
+import pytest
+
+from napari._qt.qt_viewer import QtViewer
+from napari.components import ViewerModel
+
+
+@pytest.fixture(scope="function")
+def viewermodel_factory(qtbot):
+    views: List[QtViewer] = []
+
+    def actual_factory(*model_args, **model_kwargs):
+        viewer = ViewerModel(*model_args, **model_kwargs)
+        view = QtViewer(viewer)
+        views.append(view)
+        qtbot.add_widget(view)
+
+        return view, viewer
+
+    yield actual_factory
+
+    for view in views:
+        view.shutdown()


### PR DESCRIPTION
# Description
This ensures that we properly clean up QtViewers.

Some views were not being cleaned up properly, and thus exposed a bug where qtconsoles shared a kernel.  see the change on `napari/_qt/qt_console.py`

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
