### PR TITLE
Add docstrings to qt_layerlist.py

### DIFF
--- a/napari/_qt/layers/qt_image_base_layer.py
+++ b/napari/_qt/layers/qt_image_base_layer.py
@@ -129,7 +129,7 @@ def create_range_popup(layer, attr, parent=None):
 
     Parameters
     ----------
-    layer : napari.Layer
+    layer : napari.layers.Layer
         probably an instance of Image or Surface layer
     attr : str
         the attribute to control with the slider.
@@ -187,7 +187,8 @@ def create_clim_reset_buttons(layer):
 
     Parameters
     ----------
-    layer : Image or Surface Layer
+    layer : napari.layers.Layer
+        Image or Surface Layer
 
     Returns
     -------

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -117,6 +117,18 @@ class QtLabelsControls(QtLayerControls):
         self.layer.status = str(self.layer.mode)
 
     def _on_mode_change(self, event):
+        """Update ticks in checkbox widgets when label layer mode is changed.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+
+        Raises
+        ------
+        ValueError
+            Raise error if event.mode is not PAN_ZOOM, PICKER, PAINT, or FILL
+        """
         mode = event.mode
         if mode == Mode.PAN_ZOOM:
             self.panzoom_button.setChecked(True)
@@ -130,40 +142,90 @@ class QtLabelsControls(QtLayerControls):
             raise ValueError("Mode not recognized")
 
     def changeColor(self):
+        """Change colormap of the label layer."""
         self.layer.new_colormap()
 
     def changeSelection(self, value):
+        """Change currently selected label.
+
+        Parameters
+        ----------
+        value : int
+            Index of label to select.
+        """
         self.layer.selected_label = value
         self.selectionSpinBox.clearFocus()
         self.setFocus()
 
     def changeSize(self, value):
+        """Change paint brush size.
+
+        Parameters
+        ----------
+        value : float
+            Size of the paint brush.
+        """
         self.layer.brush_size = value
 
     def change_contig(self, state):
+        """Toggle contiguous state of label layer.
+
+        Parameters
+        ----------
+        state : QCheckBox
+            Checkbox indicating if labels are contiguous.
+        """
         if state == Qt.Checked:
             self.layer.contiguous = True
         else:
             self.layer.contiguous = False
 
     def change_ndim(self, state):
+        """Toggle n-dimensional state of label layer.
+
+        Parameters
+        ----------
+        state : QCheckBox
+            Checkbox indicating if label layer is n-dimensional.
+        """
         if state == Qt.Checked:
             self.layer.n_dimensional = True
         else:
             self.layer.n_dimensional = False
 
     def _on_selection_change(self, event=None):
+        """Switch currently selected selected label.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent, optional.
+            Event from the Qt context.
+        """
         with self.layer.events.selected_label.blocker():
             value = self.layer.selected_label
             self.selectionSpinBox.setValue(int(value))
 
     def _on_brush_size_change(self, event=None):
+        """Update brush size for the label layer.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent, optional.
+            Event from the Qt context.
+        """
         with self.layer.events.brush_size.blocker():
             value = self.layer.brush_size
             value = np.clip(int(value), 1, 40)
             self.brushSizeSlider.setValue(value)
 
     def _on_n_dim_change(self, event=None):
+        """Toggle n-dimensional state.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent, optional.
+            Event from the Qt context.
+        """
         with self.layer.events.n_dimensional.blocker():
             self.ndimCheckBox.setChecked(self.layer.n_dimensional)
 

--- a/napari/_qt/qt_console.py
+++ b/napari/_qt/qt_console.py
@@ -44,7 +44,7 @@ if sys.platform.startswith("win") and sys.version_info >= (3, 8):
 
 
 class QtConsole(RichJupyterWidget):
-    """Qt view for console.
+    """Qt view for the console, an integrated iPython terminal in napari.
 
     Parameters
     ----------

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -415,7 +415,7 @@ class QtLayerList(QScrollArea):
 
 
 class QtDivider(QFrame):
-    """QtDivider class
+    """Qt divider used to separate Qt widgets visually.
 
     Attributes
     ----------
@@ -448,7 +448,7 @@ class QtDivider(QFrame):
 
 
 class QtLayerWidget(QFrame):
-    """QtLayerWidget class
+    """Qt view for Layer model.
 
     Attributes
     ----------

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -114,7 +114,7 @@ class QtLayerList(QScrollArea):
         """Reorder list of layer widgets.
 
         Loops through all widgets in list, sequentially removing them
-        and inserting them into the correct place in final list.
+        and inserting them into the correct place in the final list.
 
         Parameters
         ----------

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -182,7 +182,8 @@ class QtLayerList(QScrollArea):
 
         Parameters
         ----------
-        layer : napari.components.LayerList
+        layer : napari.layers.Layer
+            An instance of a napari layer.
 
         """
         total = len(self.layers)
@@ -452,8 +453,8 @@ class QtLayerWidget(QFrame):
 
     Attributes
     ----------
-    layer : [type]
-        [description]
+    layer : napari.layers.Layer
+        An instance of a napari layer.
     layout : QVBoxLayout
         Layout of the widget.
     nameTextBox : QLineEdit

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -17,6 +17,30 @@ import numpy as np
 
 
 class QtLayerList(QScrollArea):
+    """QtLayerList class
+
+    Parameters
+    ----------
+    layers : napari.components.LayerList
+        Layer widget list class instance.
+
+    Attributes
+    ----------
+    centers : list
+        List of layer widgets center coordinates.
+    drag_name : str
+        Name attribute of the dragged layer.
+    drag_start_position : Two element array
+        Mouse coordinates at the beginning of the mouse drag event.
+    dragTimer : QTimer
+        Timer for autoscrolling layers list up/down when dragging a layer
+        near the end of the displayed area.
+    layers : napari.components.LayerList
+        Layer widget list class instance.
+    vbox_layout : QVBoxLayout
+        Layout of the layer list widgets.
+    """
+
     def __init__(self, layers):
         super().__init__()
 
@@ -52,7 +76,13 @@ class QtLayerList(QScrollArea):
         self.drag_name = None
 
     def _add(self, event):
-        """Insert widget for layer `event.item` at index `event.index`."""
+        """Insert widget for layer `event.item` at index `event.index`.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         layer = event.item
         total = len(self.layers)
         index = 2 * (total - event.index) - 1
@@ -62,7 +92,13 @@ class QtLayerList(QScrollArea):
         layer.events.select.connect(self._scroll_on_select)
 
     def _remove(self, event):
-        """Remove widget for layer at index `event.index`."""
+        """Remove widget for layer at index `event.index`.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         layer_index = event.index
         total = len(self.layers)
         # Find property widget and divider for layer to be removed
@@ -75,9 +111,15 @@ class QtLayerList(QScrollArea):
         divider.deleteLater()
 
     def _reorder(self, event=None):
-        """Reorders list of layer widgets by looping through all
-        widgets in list sequentially removing them and inserting
-        them into the correct place in final list.
+        """Reorders list of layer widgets.
+
+        Loops through all widgets in list, sequentially removing them
+        and inserting them into the correct place in final list.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent, optional
+            Event from the Qt context.
         """
         total = len(self.layers)
 
@@ -125,12 +167,24 @@ class QtLayerList(QScrollArea):
             self.verticalScrollBar().setValue(new_value)
 
     def _scroll_on_select(self, event):
-        """Scroll to ensure that the currently selected layer is visible."""
+        """Scroll to ensure that the currently selected layer is visible.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         layer = event.source
         self._ensure_visible(layer)
 
     def _ensure_visible(self, layer):
-        """Ensure layer widget for at particular layer is visible."""
+        """Ensure layer widget for at particular layer is visible.
+
+        Parameters
+        ----------
+        layer : napari.components.LayerList
+
+        """
         total = len(self.layers)
         layer_index = self.layers.index(layer)
         # Find property widget and divider for layer to be removed
@@ -139,15 +193,37 @@ class QtLayerList(QScrollArea):
         self.ensureWidgetVisible(widget)
 
     def keyPressEvent(self, event):
+        """Ignores key press event.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         event.ignore()
 
     def keyReleaseEvent(self, event):
+        """Ignores key relase event.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         event.ignore()
 
     def mousePressEvent(self, event):
-        # Check if mouse press happens on a layer properties widget or
-        # a child of such a widget. If not, the press has happended on the
-        # Layers Widget itself and should be ignored.
+        """Register mouse click if it happens on a layer widget.
+
+        Checks if mouse press happens on a layer properties widget or
+        a child of such a widget. If not, the press has happended on the
+        Layers Widget itself and should be ignored.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         widget = self.childAt(event.pos())
         layer = (
             getattr(widget, 'layer', None)
@@ -164,6 +240,19 @@ class QtLayerList(QScrollArea):
             self.drag_name = None
 
     def mouseReleaseEvent(self, event):
+        """Select layer using mouse click.
+
+        Key modifiers:
+        Shift - If the Shift button is pressed, select all layers in between
+            currently selected one and the clicked one.
+        Control - If the Control button is pressed, mouse click will
+            toggle selected state of the layer.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         if self.drag_name is None:
             # Unselect all the layers if not dragging a layer
             self.layers.unselect_all()
@@ -192,6 +281,13 @@ class QtLayerList(QScrollArea):
             layer.selected = True
 
     def mouseMoveEvent(self, event):
+        """Drag and drop layer with mouse movement.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         position = np.array([event.pos().x(), event.pos().y()])
         distance = np.linalg.norm(position - self.drag_start_position)
         if (
@@ -211,13 +307,26 @@ class QtLayerList(QScrollArea):
             self._ensure_visible(layer)
 
     def dragLeaveEvent(self, event):
-        """Unselects layer dividers."""
+        """Unselects layer dividers.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         event.ignore()
         self.dragTimer.stop()
         for i in range(0, self.vbox_layout.count(), 2):
             self.vbox_layout.itemAt(i).widget().setSelected(False)
 
     def dragEnterEvent(self, event):
+        """Update divider position before dragging layer widget to new position
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         if event.source() == self:
             event.accept()
             divs = []
@@ -231,8 +340,15 @@ class QtLayerList(QScrollArea):
             event.ignore()
 
     def dragMoveEvent(self, event):
-        """Set the appropriate layers list divider to be highlighted when
+        """Highlight appriate divider when dragging layer to new position.
+
+        Sets the appropriate layers list divider to be highlighted when
         dragging a layer to a new position in the layers list.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
         """
         max_height = self.frameGeometry().height()
         if (
@@ -273,6 +389,13 @@ class QtLayerList(QScrollArea):
                 self.vbox_layout.itemAt(i).widget().setSelected(False)
 
     def dropEvent(self, event):
+        """Drop dragged layer widget into new position in the list of layers.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         if self.dragTimer.isActive():
             self.dragTimer.stop()
 
@@ -292,6 +415,16 @@ class QtLayerList(QScrollArea):
 
 
 class QtDivider(QFrame):
+    """QtDivider class
+
+    Attributes
+    ----------
+    layout : QVBoxLayout
+        Layout of the widget.
+    selected : bool
+        Whether the QtDivider is currently selected.
+    """
+
     def __init__(self):
         super().__init__()
         self.setSelected(False)
@@ -300,6 +433,12 @@ class QtDivider(QFrame):
         self.setLayout(self.layout)
 
     def setSelected(self, selected):
+        """Toggle boolean 'selected' attribute of QTDivider instance.
+
+        Parameters
+        ----------
+        selected : bool
+        """
         if selected:
             self.setProperty('selected', True)
             self.style().polish(self)
@@ -309,6 +448,24 @@ class QtDivider(QFrame):
 
 
 class QtLayerWidget(QFrame):
+    """QtLayerWidget class
+
+    Attributes
+    ----------
+    layer : [type]
+        [description]
+    layout : QVBoxLayout
+        Layout of the widget.
+    nameTextBox : QLineEdit
+        Textbox for layer name.
+    thumbnailLabel : QLabel
+        Label of layer thumbnail.
+    typeLabel : QLabel
+        Label of layer type.
+    visibleCheckBox : QCheckBox
+        Checkbox to toggle layer visibility.
+    """
+
     def __init__(self, layer):
         super().__init__()
 
@@ -363,41 +520,96 @@ class QtLayerWidget(QFrame):
         self.setSelected(self.layer.selected)
 
     def setSelected(self, state):
+        """Select layer widget.
+
+        Parameters
+        ----------
+        state : bool
+        """
         self.setProperty('selected', state)
         self.nameTextBox.setEnabled(state)
         self.style().unpolish(self)
         self.style().polish(self)
 
     def changeVisible(self, state):
+        """Toggle visibility of the layer.
+
+        Parameters
+        ----------
+        state : bool
+        """
         if state == Qt.Checked:
             self.layer.visible = True
         else:
             self.layer.visible = False
 
     def changeText(self):
+        """Update layer name attribute using layer name textbox contents."""
         self.layer.name = self.nameTextBox.text()
         self.nameTextBox.clearFocus()
         self.setFocus()
 
     def mouseReleaseEvent(self, event):
+        """Ignores mouse release event.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         event.ignore()
 
     def mousePressEvent(self, event):
+        """Ignores mouse press event.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         event.ignore()
 
     def mouseMoveEvent(self, event):
+        """Ignores mouse move event.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         event.ignore()
 
     def _on_layer_name_change(self, event=None):
+        """Update text displaying name of layer.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent, optional
+            Event from the Qt context.
+        """
         with self.layer.events.name.blocker():
             self.nameTextBox.setText(self.layer.name)
             self.nameTextBox.home(False)
 
     def _on_visible_change(self, event=None):
+        """Toggle visibility of the layer.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent, optional
+            Event from the Qt context.
+        """
         with self.layer.events.visible.blocker():
             self.visibleCheckBox.setChecked(self.layer.visible)
 
     def _on_thumbnail_change(self, event=None):
+        """Update thumbnail image on the layer widget.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent, optional
+            Event from the Qt context.
+        """
         thumbnail = self.layer.thumbnail
         # Note that QImage expects the image width followed by height
         image = QImage(

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -22,7 +22,7 @@ class QtLayerList(QScrollArea):
     Parameters
     ----------
     layers : napari.components.LayerList
-        Layer widget list class instance.
+        The layer list to track and display.
 
     Attributes
     ----------
@@ -30,15 +30,15 @@ class QtLayerList(QScrollArea):
         List of layer widgets center coordinates.
     drag_name : str
         Name attribute of the dragged layer.
-    drag_start_position : Two element array
+    drag_start_position : array, shape (2,)
         Mouse coordinates at the beginning of the mouse drag event.
     dragTimer : QTimer
         Timer for autoscrolling layers list up/down when dragging a layer
         near the end of the displayed area.
     layers : napari.components.LayerList
-        Layer widget list class instance.
+        The layer list to track and display.
     vbox_layout : QVBoxLayout
-        Layout of the layer list widgets.
+        The layout instance in which the layouts appear.
     """
 
     def __init__(self, layers):

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -111,7 +111,7 @@ class QtLayerList(QScrollArea):
         divider.deleteLater()
 
     def _reorder(self, event=None):
-        """Reorders list of layer widgets.
+        """Reorder list of layer widgets.
 
         Loops through all widgets in list, sequentially removing them
         and inserting them into the correct place in final list.

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -203,7 +203,7 @@ class QtLayerList(QScrollArea):
         event.ignore()
 
     def keyReleaseEvent(self, event):
-        """Ignores key relase event.
+        """Ignore key relase event.
 
         Parameters
         ----------

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -193,7 +193,7 @@ class QtLayerList(QScrollArea):
         self.ensureWidgetVisible(widget)
 
     def keyPressEvent(self, event):
-        """Ignores key press event.
+        """Ignore a key press event.
 
         Parameters
         ----------

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -17,7 +17,7 @@ import numpy as np
 
 
 class QtLayerList(QScrollArea):
-    """QtLayerList class
+    """Widget storing a list of all the layers present in the current window.
 
     Parameters
     ----------

--- a/napari/_qt/qt_mode_buttons.py
+++ b/napari/_qt/qt_mode_buttons.py
@@ -9,7 +9,7 @@ class QtModeRadioButton(QRadioButton):
 
         Parameters
         ----------
-        layer : Layer
+        layer : napari.layers.Layer
             The layer instance that this button controls.
         button_name : str
             Name for the button.  This is mostly used to identify the button
@@ -46,7 +46,7 @@ class QtModePushButton(QPushButton):
 
         Parameters
         ----------
-        layer : Layer
+        layer : napari.layers.Layer
             The layer instance that this button controls.
         button_name : str
             Name for the button.  This is mostly used to identify the button

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -33,6 +33,47 @@ from .._vispy import create_vispy_visual
 
 
 class QtViewer(QSplitter):
+    """QtViewer class
+
+    Parameters
+    ----------
+    viewer : napari.components.ViewerModel
+        Napari viewer containing the rendered scene, layers, and controls.
+
+    Attributes
+    ----------
+    canvas : vispy.scene.SceneCanvas
+        Canvas for rendering the current view.
+    console : QtConsole
+        iPython console terminal integrated into the napari GUI.
+    controls : QtControls
+        Qt view for GUI controls.
+    dims : napari.qt_dims.QtDims
+        Dimension sliders; Qt View for Dims model.
+    dockConsole : QtViewerDockWidget
+        QWidget wrapped in a QDockWidget with forwarded viewer events.
+    aboutKeybindings : QtAboutKeybindings
+        Key bindings for the 'About' Qt dialog.
+    dockLayerControls : QtViewerDockWidget
+        QWidget wrapped in a QDockWidget with forwarded viewer events.
+    dockLayerList : QtViewerDockWidget
+        QWidget wrapped in a QDockWidget with forwarded viewer events.
+    layerButtons : QtLayerButtons
+        Button controls for napari layers.
+    layers : QtLayerList
+        Qt view for LayerList controls.
+    layer_to_visual : dict
+        Dictionary mapping napari layers with their corresponding vispy_layers.
+    pool : qtpy.QtCore.QThreadPool
+        Pool of worker threads.
+    view : vispy scene widget
+        View displayed by vispy canvas. Adds a vispy ViewBox as a child widget.
+    viewer : napari.components.ViewerModel
+        Napari viewer containing the rendered scene, layers, and controls.
+    viewerButtons : QtViewerButtons
+        Button controls for the napari viewer.
+    """
+
     with open(os.path.join(resources_dir, 'stylesheet.qss'), 'r') as f:
         raw_stylesheet = f.read()
 
@@ -162,14 +203,26 @@ class QtViewer(QSplitter):
         self.setAcceptDrops(True)
 
     def _constrain_width(self, event):
-        # allow the layer controls to be wider, only if floated
+        """Allow the layer controls to be wider, only if floated.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         if self.dockLayerControls.isFloating():
             self.controls.setMaximumWidth(700)
         else:
             self.controls.setMaximumWidth(220)
 
     def _add_layer(self, event):
-        """When a layer is added, set its parent and order."""
+        """When a layer is added, set its parent and order.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         layers = event.source
         layer = event.item
         vispy_layer = create_vispy_visual(layer)
@@ -179,7 +232,13 @@ class QtViewer(QSplitter):
         self.layer_to_visual[layer] = vispy_layer
 
     def _remove_layer(self, event):
-        """When a layer is removed, remove its parent."""
+        """When a layer is removed, remove its parent.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         layer = event.item
         vispy_layer = self.layer_to_visual[layer]
         vispy_layer.node.transforms = ChainTransform()
@@ -187,7 +246,13 @@ class QtViewer(QSplitter):
         del self.layer_to_visual[layer]
 
     def _reorder_layers(self, event):
-        """When the list is reordered, propagate changes to draw order."""
+        """When the list is reordered, propagate changes to draw order.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         for i, layer in enumerate(self.viewer.layers):
             vispy_layer = self.layer_to_visual[layer]
             vispy_layer.order = i
@@ -195,6 +260,7 @@ class QtViewer(QSplitter):
         self.canvas.update()
 
     def _update_camera(self):
+        """Update the viewer camera."""
         if self.viewer.dims.ndisplay == 3:
             # Set a 3D camera
             if not isinstance(self.view.camera, ArcballCamera):
@@ -264,9 +330,23 @@ class QtViewer(QSplitter):
             self._last_visited_dir = os.path.dirname(filenames[0])
 
     def _on_interactive(self, event):
+        """Link interactive attributes of view and viewer.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         self.view.interactive = self.viewer.interactive
 
     def _on_cursor(self, event):
+        """Set the appearance of the mouse cursor.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         cursor = self.viewer.cursor
         size = self.viewer.cursor_size
         if cursor == 'square':
@@ -283,6 +363,13 @@ class QtViewer(QSplitter):
         self.canvas.native.setCursor(q_cursor)
 
     def _on_reset_view(self, event):
+        """Reset view of the rendered scene.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         if isinstance(self.view.camera, ArcballCamera):
             quat = self.view.camera._quaternion.create_from_axis_angle(
                 *event.quaternion
@@ -295,6 +382,14 @@ class QtViewer(QSplitter):
             self.view.camera.rect = event.rect
 
     def _update_palette(self, palette):
+        """Update the napari GUI theme.
+
+        Parameters
+        ----------
+        palette : dict of str: str
+            Color palette with which to style the viewer.
+            Property of napari.components.viewer_model.ViewerModel
+        """
         # template and apply the primary stylesheet
         themed_stylesheet = template(self.raw_stylesheet, **palette)
         self.console.style_sheet = themed_stylesheet
@@ -325,6 +420,11 @@ class QtViewer(QSplitter):
 
     def on_mouse_press(self, event):
         """Called whenever mouse pressed in canvas.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
         """
         if event.pos is None:
             return
@@ -340,6 +440,11 @@ class QtViewer(QSplitter):
 
     def on_mouse_move(self, event):
         """Called whenever mouse moves over canvas.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
         """
         if event.pos is None:
             return
@@ -354,6 +459,11 @@ class QtViewer(QSplitter):
 
     def on_mouse_release(self, event):
         """Called whenever mouse released in canvas.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
         """
         mouse_release_callbacks(self.viewer, event)
 
@@ -365,6 +475,11 @@ class QtViewer(QSplitter):
 
     def on_key_press(self, event):
         """Called whenever key pressed in canvas.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
         """
         if (
             event.native is not None
@@ -399,6 +514,11 @@ class QtViewer(QSplitter):
 
     def on_key_release(self, event):
         """Called whenever key released in canvas.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
         """
         try:
             next(self._key_release_generators[event.key])
@@ -407,26 +527,58 @@ class QtViewer(QSplitter):
 
     def on_draw(self, event):
         """Called whenever drawn in canvas. Called for all layers, not just top
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
         """
         for visual in self.layer_to_visual.values():
             visual.on_draw(event)
 
     def keyPressEvent(self, event):
+        """Called whenever a key is pressed.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         self.canvas._backend._keyEvent(self.canvas.events.key_press, event)
         event.accept()
 
     def keyReleaseEvent(self, event):
+        """Called whenever a key is released.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         self.canvas._backend._keyEvent(self.canvas.events.key_release, event)
         event.accept()
 
     def dragEnterEvent(self, event):
+        """Ignore event if not dragging & dropping a file or URL to open.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         if event.mimeData().hasUrls():
             event.accept()
         else:
             event.ignore()
 
     def dropEvent(self, event):
-        """Add local files and web URLS with drag and drop."""
+        """Add local files and web URLS with drag and drop.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         filenames = []
         for url in event.mimeData().urls():
             if url.isLocalFile():
@@ -436,21 +588,36 @@ class QtViewer(QSplitter):
         self._add_files(filenames)
 
     def closeEvent(self, event):
+        """Clear pool of worker threads and close.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         if self.pool.activeThreadCount() > 0:
             self.pool.clear()
         event.accept()
 
     def shutdown(self):
+        """Shutdown and close viewer.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         self.pool.clear()
         self.canvas.close()
         self.console.shutdown()
 
 
 def viewbox_key_event(event):
-    """ViewBox key event handler
+    """ViewBox key event handler.
+
     Parameters
     ----------
-    event : instance of Event
-        The event.
+    event : qtpy.QtCore.QEvent
+        Event from the Qt context.
     """
     return

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -33,7 +33,7 @@ from .._vispy import create_vispy_visual
 
 
 class QtViewer(QSplitter):
-    """QtViewer class
+    """Qt view for the napari Viewer model.
 
     Parameters
     ----------

--- a/napari/_qt/qt_viewer_buttons.py
+++ b/napari/_qt/qt_viewer_buttons.py
@@ -14,7 +14,7 @@ class QtLayerButtons(QFrame):
     Attributes
     ----------
     deleteButton : QtDeleteButton
-        Button to delete layer.
+        Button to delete selected layers.
     newLabelsButton : QtViewerPushButton
         Button to add new Label layer.
     newPointsButton : QtViewerPushButton
@@ -78,7 +78,7 @@ class QtViewerButtons(QFrame):
     resetViewButton : QtViewerPushButton
         Button resetting the view of the rendered scene.
     gridViewButton : QtGridViewButton
-        Button to toggle grid view of layers.
+        Button to toggle grid view mode of layers on and off.
     ndisplayButton : QtNDisplayButton
         Button to toggle number of displayed dimensions.
     viewer : napari.components.ViewerModel
@@ -124,6 +124,21 @@ class QtViewerButtons(QFrame):
 
 
 class QtDeleteButton(QPushButton):
+    """Delete button to remove selected layers.
+
+    Parameters
+    ----------
+    viewer : napari.components.ViewerModel
+        Napari viewer containing the rendered scene, layers, and controls.
+
+    Attributes
+    ----------
+    hover : bool
+        Hover is true while mouse cursor is on the button widget.
+    viewer : napari.components.ViewerModel
+        Napari viewer containing the rendered scene, layers, and controls.
+    """
+
     def __init__(self, viewer):
         super().__init__()
 
@@ -133,16 +148,37 @@ class QtDeleteButton(QPushButton):
         self.clicked.connect(lambda: self.viewer.layers.remove_selected())
 
     def dragEnterEvent(self, event):
+        """The cursor enters the widget during a drag and drop operation.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         event.accept()
         self.hover = True
         self.update()
 
     def dragLeaveEvent(self, event):
+        """The cursor leaves the widget during a drag and drop operation.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         event.ignore()
         self.hover = False
         self.update()
 
     def dropEvent(self, event):
+        """The drag and drop mouse event is completed.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         event.accept()
         layer_name = event.mimeData().text()
         layer = self.viewer.layers[layer_name]
@@ -153,6 +189,19 @@ class QtDeleteButton(QPushButton):
 
 
 class QtViewerPushButton(QPushButton):
+    """Push button.
+
+    Parameters
+    ----------
+    viewer : napari.components.ViewerModel
+        Napari viewer containing the rendered scene, layers, and controls.
+
+    Attributes
+    ----------
+    viewer : napari.components.ViewerModel
+        Napari viewer containing the rendered scene, layers, and controls.
+    """
+
     def __init__(self, viewer, button_name, tooltip=None, slot=None):
         super().__init__()
 
@@ -164,6 +213,19 @@ class QtViewerPushButton(QPushButton):
 
 
 class QtGridViewButton(QCheckBox):
+    """Button to toggle grid view mode of layers on and off.
+
+    Parameters
+    ----------
+    viewer : napari.components.ViewerModel
+        Napari viewer containing the rendered scene, layers, and controls.
+
+    Attributes
+    ----------
+    viewer : napari.components.ViewerModel
+        Napari viewer containing the rendered scene, layers, and controls.
+    """
+
     def __init__(self, viewer):
         super().__init__()
 
@@ -174,17 +236,39 @@ class QtGridViewButton(QCheckBox):
         self._on_grid_change()
 
     def change_grid(self, state):
+        """Toggle between grid view mode and (the ordinary) stack view mode.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         if state == Qt.Checked:
             self.viewer.stack_view()
         else:
             self.viewer.grid_view()
 
     def _on_grid_change(self, event=None):
+        """Update grid layout size.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
         with self.viewer.events.grid.blocker():
             self.setChecked(np.all(self.viewer.grid_size == (1, 1)))
 
 
 class QtNDisplayButton(QCheckBox):
+    """Button to toggle number of displayed dimensions.
+
+    Parameters
+    ----------
+    viewer : napari.components.ViewerModel
+        Napari viewer containing the rendered scene, layers, and controls.
+    """
+
     def __init__(self, viewer):
         super().__init__()
 
@@ -196,11 +280,25 @@ class QtNDisplayButton(QCheckBox):
         self.stateChanged.connect(self.change_ndisplay)
 
     def change_ndisplay(self, state):
+        """Toggle between 2D and 3D display.
+
+        Parameters
+        ----------
+        state : bool
+            If state is True the display view is 3D, if False display is 2D.
+        """
         if state == Qt.Checked:
             self.viewer.dims.ndisplay = 3
         else:
             self.viewer.dims.ndisplay = 2
 
     def _on_ndisplay_change(self, event=None):
+        """Update number of displayed dimensions, while blocking events.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent, optional
+            Event from the Qt context.
+        """
         with self.viewer.dims.events.ndisplay.blocker():
             self.setChecked(self.viewer.dims.ndisplay == 3)

--- a/napari/_qt/qt_viewer_buttons.py
+++ b/napari/_qt/qt_viewer_buttons.py
@@ -4,6 +4,27 @@ import numpy as np
 
 
 class QtLayerButtons(QFrame):
+    """Button controls for napari layers.
+
+    Parameters
+    ----------
+    viewer : napari.components.ViewerModel
+        Napari viewer containing the rendered scene, layers, and controls.
+
+    Attributes
+    ----------
+    deleteButton : QtDeleteButton
+        Button to delete layer.
+    newLabelsButton : QtViewerPushButton
+        Button to add new Label layer.
+    newPointsButton : QtViewerPushButton
+        Button to add new Points layer.
+    newShapesButton : QtViewerPushButton
+        Button to add new Shapes layer.
+    viewer : napari.components.ViewerModel
+        Napari viewer containing the rendered scene, layers, and controls.
+    """
+
     def __init__(self, viewer):
         super().__init__()
 
@@ -39,6 +60,31 @@ class QtLayerButtons(QFrame):
 
 
 class QtViewerButtons(QFrame):
+    """Button controls for the napari viewer.
+
+    Parameters
+    ----------
+    viewer : napari.components.ViewerModel
+        Napari viewer containing the rendered scene, layers, and controls.
+
+    Attributes
+    ----------
+    consoleButton : QtViewerPushButton
+        Button to open iPython console within napari.
+    rollDimsButton : QtViewerPushButton
+        Button to roll orientation of spatial dimensions in the napari viewer.
+    transposeDimsButton : QtViewerPushButton
+        Button to transpose dimensions in the napari viewer.
+    resetViewButton : QtViewerPushButton
+        Button resetting the view of the rendered scene.
+    gridViewButton : QtGridViewButton
+        Button to toggle grid view of layers.
+    ndisplayButton : QtNDisplayButton
+        Button to toggle number of displayed dimensions.
+    viewer : napari.components.ViewerModel
+        Napari viewer containing the rendered scene, layers, and controls.
+    """
+
     def __init__(self, viewer):
         super().__init__()
 
@@ -122,7 +168,7 @@ class QtGridViewButton(QCheckBox):
         super().__init__()
 
         self.viewer = viewer
-        self.setToolTip('Toggle grid view view')
+        self.setToolTip('Toggle grid view')
         self.viewer.events.grid.connect(self._on_grid_change)
         self.stateChanged.connect(self.change_grid)
         self._on_grid_change()

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -25,7 +25,7 @@ class AddLayersMixin:
 
         Parameters
         ----------
-        layer : Layer
+        layer : napari.layers.Layer
             Layer to add.
         """
         layer.events.select.connect(self._update_active_layer)

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -41,7 +41,7 @@ class LayerList(ListModel):
         ----------
         name : str
             Original name.
-        layer : Layer, optional
+        layer : napari.layers.Layer, optional
             Layer for which name is generated.
 
         Returns


### PR DESCRIPTION
# Description
@jni suggests in https://github.com/napari/napari/issues/945 we need better docstrings for the Qt classes:
> I was looking through our Qt classes to try to provide some guidance in [napari/tutorials#52](https://github.com/napari/tutorials/issues/52), but found it hard to understand exactly what each Qt class is doing, because almost none of them have class docstrings, and many methods have no docstring or a one-liner rather than a complete docstring. See e.g. https://github.com/napari/napari/blob/master/napari/_qt/qt_layerlist.py#L19

This PR chips away at that problem a bit.

Note: it's entirely possible I've made some mistakes trying to decipher thing. Let me know if that's happened, since those are likely to be the places we need the most clarification. We might need to be especially careful about docstrings for things with similar names in both the napari models and qt widgets (stuff like "layer" might be super ambiguous). 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] documentation update

# References
Reference https://github.com/napari/napari/issues/945

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
N/A, docstring only changes

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
