### PR TITLE
fix docs url

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -252,7 +252,7 @@ push_docs_task:
     - git config --global user.email "cirrus@cirrus-ci.org"
     - git config --global user.name "Cirrus Bot"
     - git rm -rq .
-    - cp -r ../docs/build/html/ .
+    - cp -r ../docs/build/html/* .
     - touch .nojekyll
     - git add .
     - if [[ -z $(git status --untracked-files=no --porcelain) ]]; then exit 0; fi  # repo is clean 


### PR DESCRIPTION
fixes #959 

can a linux user please verify that the following commands yield the same output?

```
# in napari repo root
git clone https://github.com/napari/docs doc_repo
cd doc_repo
git rm -rf .
cp -r ../docs/build/html/* .
ls
```

output:

```
_images          api              objects.inv      releases.html
_modules         api.html         plugins.html     search.html
_sources         genindex.html    py-modindex.html searchindex.js
_static          index.html       release
```