### PR TITLE
add show param to Viewer

### DIFF
--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -14,20 +14,27 @@ class Viewer(ViewerModel):
 
     Parameters
     ----------
-    title : string
-        The title of the viewer window.
-    ndisplay : {2, 3}
-        Number of displayed dimensions.
-    order : tuple of int
+    title : string, optional
+        The title of the viewer window. by default 'napari'.
+    ndisplay : {2, 3}, optional
+        Number of displayed dimensions.  by default 2.
+    order : tuple of int, optional
         Order in which dimensions are displayed where the last two or last
         three dimensions correspond to row x column or plane x row x column if
         ndisplay is 2 or 3.
-    axis_labels : list of str
-        Dimension names.
+    axis_labels : list of str, optional
+        Dimension names. by default they are labeled with sequential numbers
+    show : bool, optional
+        Whether to show the viewer after instantiation. by default True.
     """
 
     def __init__(
-        self, title='napari', ndisplay=2, order=None, axis_labels=None
+        self,
+        title='napari',
+        ndisplay=2,
+        order=None,
+        axis_labels=None,
+        show=True,
     ):
         # instance() returns the singleton instance if it exists, or None
         app = QApplication.instance()
@@ -58,7 +65,7 @@ class Viewer(ViewerModel):
             axis_labels=axis_labels,
         )
         qt_viewer = QtViewer(self)
-        self.window = Window(qt_viewer)
+        self.window = Window(qt_viewer, show=show)
         self.update_console = self.window.qt_viewer.console.push
 
     def screenshot(self, with_viewer=False):

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -17,11 +17,11 @@ class Viewer(ViewerModel):
     title : string, optional
         The title of the viewer window. by default 'napari'.
     ndisplay : {2, 3}, optional
-        Number of displayed dimensions.  by default 2.
+        Number of displayed dimensions. by default 2.
     order : tuple of int, optional
         Order in which dimensions are displayed where the last two or last
         three dimensions correspond to row x column or plane x row x column if
-        ndisplay is 2 or 3.
+        ndisplay is 2 or 3. by default None
     axis_labels : list of str, optional
         Dimension names. by default they are labeled with sequential numbers
     show : bool, optional

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -93,3 +93,7 @@ class Viewer(ViewerModel):
         t = QtUpdateUI(func, *args, **kwargs)
         self.window.qt_viewer.pool.start(t)
         return self.window.qt_viewer.pool  # returns threadpool object
+
+    def show(self):
+        """Resize, show, and raise the viewer window."""
+        self.window.show()


### PR DESCRIPTION
# Description
anyone mind if we add a `show` argument to the `Viewer` to pass to `Window`?  (to allow `napari.Viewer(show=False)`).  I actually just had a case where I wished it was there (wanted to add layers and stuff but didn't actually want the gui up yet).  I'm not adding a show method to `Viewer` in this PR, so to show later would be `viewer.window.show()`

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)


# How has this been tested?
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
