### PR TITLE
fix docs script

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,2 +1,2 @@
-Sphinx
+Sphinx<2.4.0  # 2.4.0 is bugged, see https://github.com/sphinx-doc/sphinx/issues/7126
 sphinx-rtd-theme


### PR DESCRIPTION
# Description
pin sphinx since v2.4.0 breaks the docs script

# References
see sphinx-doc/sphinx#7126

# How has this been tested?
tested locally