### PR TITLE
fix docs version tag

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -245,7 +245,6 @@ push_docs_task:
 
   push_script:
     # adapted from https://github.com/scikit-image/scikit-image/blob/master/tools/travis/deploy_docs.sh
-    - git fetch --tags
     - VERSION=`python -c "from versioneer import get_version; print(get_version())"`
     - git clone --quiet https://${GH_REF} doc_repo
     - cd doc_repo

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -27,6 +27,7 @@ clean:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
+	git fetch --tags  # update tags so version info is correct
 	make buildapi
 	rm -rf source/release
 	cp -R release source/


### PR DESCRIPTION
update the git tags so that the version tag on the generated docs is correct

![Screen Shot 2020-02-10 at 2 25 40 PM](https://user-images.githubusercontent.com/29165011/74196066-54dac580-4c11-11ea-9af9-9185ebed9e0e.png)
