### PR TITLE
Make mouse drag attributes private in qt_layerlist

### DIFF
--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -28,13 +28,6 @@ class QtLayerList(QScrollArea):
     ----------
     centers : list
         List of layer widgets center coordinates.
-    drag_name : str
-        Name attribute of the dragged layer.
-    drag_start_position : array, shape (2,)
-        Mouse coordinates at the beginning of the mouse drag event.
-    dragTimer : QTimer
-        Timer for autoscrolling layers list up/down when dragging a layer
-        near the end of the displayed area.
     layers : napari.components.LayerList
         The layer list to track and display.
     vbox_layout : QVBoxLayout


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
This PR makes the QtLayerList class attributes related to mouse drag movements private, and uses `_snake_case` consistently for all of them:
* `drag_name` --> `_drag_name`
* `dragTimer` --> `_drag_timer`
* `drag_start_position` --> `_drag_start_position`

@jni suggested we make this change, while discussing the details of another pull request
https://github.com/napari/napari/pull/958#discussion_r376906435

> Not that this is a mistake in the PR, but are we sure we want this to be a public attribute? ditto for drag name and drag timer. The inconsistent naming is also a concern.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] This change requires a documentation update
This is an API change, but I don't think we need to change any docs - there's currently no docstrings for this yet (this is being addressed in https://github.com/napari/napari/pull/958)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
https://github.com/napari/napari/pull/958#discussion_r376906435

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality~~ NA
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~ NA
~~- [ ] I have made corresponding changes to the documentation~~ NA
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~ NA
