### PR TITLE
rename attribute on QtViewerDockWidget

### DIFF
--- a/napari/_qt/qt_viewer_dock_widget.py
+++ b/napari/_qt/qt_viewer_dock_widget.py
@@ -21,6 +21,8 @@ class QtViewerDockWidget(QDockWidget):
 
     Parameters
     ----------
+    qt_viewer : QtViewer
+        The QtViewer instance that this dock widget will belong to.
     widget : QWidget
         `widget` that will be added as QDockWidget's main widget.
     name : str
@@ -38,7 +40,7 @@ class QtViewerDockWidget(QDockWidget):
 
     def __init__(
         self,
-        viewer,
+        qt_viewer,
         widget: QWidget,
         *,
         name: str = '',
@@ -46,7 +48,8 @@ class QtViewerDockWidget(QDockWidget):
         allowed_areas: Optional[List[str]] = None,
         shortcut=None,
     ):
-        self.viewer = viewer
+        self.qt_viewer = qt_viewer
+        self.viewer = qt_viewer.viewer  # convenience access to viewer model
         super().__init__(name)
         self.name = name
 
@@ -95,7 +98,7 @@ class QtViewerDockWidget(QDockWidget):
         # if you subclass QtViewerDockWidget and override the keyPressEvent
         # method, be sure to call super().keyPressEvent(event) at the end of
         # your method to pass uncaught key-combinations to the viewer.
-        return self.viewer.keyPressEvent(event)
+        return self.qt_viewer.keyPressEvent(event)
 
     def _set_title_orientation(self, area):
         if area in (Qt.LeftDockWidgetArea, Qt.RightDockWidgetArea):

--- a/napari/_qt/qt_viewer_dock_widget.py
+++ b/napari/_qt/qt_viewer_dock_widget.py
@@ -49,7 +49,6 @@ class QtViewerDockWidget(QDockWidget):
         shortcut=None,
     ):
         self.qt_viewer = qt_viewer
-        self.viewer = qt_viewer.viewer  # convenience access to viewer model
         super().__init__(name)
         self.name = name
 


### PR DESCRIPTION
# Description
very minor change:  I was just working with some dock widgets and wanted to get at the ancestor viewer model.  It was confusingly located at `QtViewerDockWidget.viewer.viewer` (where the middle viewer was the `QtViewer`).  This PR renames `QtViewerDockWidget.viewer` -> `QtViewerDockWidget.qt_viewer` to bring it in line with other usage (for instance, Window.qt_viewer), and adds a missing parameter to the docstring.

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
