### PR TITLE
Viewer view_* func signature parity

### DIFF
--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -116,7 +116,11 @@ def view_image(
         The newly-created viewer.
     """
     viewer = Viewer(
-        title=title, ndisplay=ndisplay, order=order, axis_labels=axis_labels
+        title=title,
+        ndisplay=ndisplay,
+        order=order,
+        axis_labels=axis_labels,
+        show=show,
     )
     viewer.add_image(
         data=data,
@@ -259,7 +263,11 @@ def view_points(
     http://api.vispy.org/en/latest/visuals.html#vispy.visuals.MarkersVisual
     """
     viewer = Viewer(
-        title=title, ndisplay=ndisplay, order=order, axis_labels=axis_labels
+        title=title,
+        ndisplay=ndisplay,
+        order=order,
+        axis_labels=axis_labels,
+        show=show,
     )
     viewer.add_points(
         data=data,
@@ -364,7 +372,11 @@ def view_labels(
         The newly-created viewer.
     """
     viewer = Viewer(
-        title=title, ndisplay=ndisplay, order=order, axis_labels=axis_labels
+        title=title,
+        ndisplay=ndisplay,
+        order=order,
+        axis_labels=axis_labels,
+        show=show,
     )
     viewer.add_labels(
         data=data,
@@ -476,7 +488,11 @@ def view_shapes(
         The newly-created viewer.
     """
     viewer = Viewer(
-        title=title, ndisplay=ndisplay, order=order, axis_labels=axis_labels
+        title=title,
+        ndisplay=ndisplay,
+        order=order,
+        axis_labels=axis_labels,
+        show=show,
     )
     viewer.add_shapes(
         data=data,
@@ -573,7 +589,11 @@ def view_surface(
         The newly-created viewer.
     """
     viewer = Viewer(
-        title=title, ndisplay=ndisplay, order=order, axis_labels=axis_labels
+        title=title,
+        ndisplay=ndisplay,
+        order=order,
+        axis_labels=axis_labels,
+        show=show,
     )
     viewer.add_surface(
         data,
@@ -661,7 +681,11 @@ def view_vectors(
         The newly-created viewer.
     """
     viewer = Viewer(
-        title=title, ndisplay=ndisplay, order=order, axis_labels=axis_labels
+        title=title,
+        ndisplay=ndisplay,
+        order=order,
+        axis_labels=axis_labels,
+        show=show,
     )
     viewer.add_vectors(
         data,

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -26,6 +26,7 @@ def view_image(
     ndisplay=2,
     order=None,
     axis_labels=None,
+    show=True,
 ):
     """Create a viewer and add an image layer.
 
@@ -106,6 +107,8 @@ def view_image(
         ndisplay is 2 or 3.
     axis_labels : list of str
         Dimension names.
+    show : bool, optional
+        Whether to show the viewer after instantiation. by default True.
 
     Returns
     -------
@@ -166,6 +169,7 @@ def view_points(
     ndisplay=2,
     order=None,
     axis_labels=None,
+    show=True,
 ):
     """Create a viewer and add a points layer.
 
@@ -231,6 +235,18 @@ def view_points(
         {'opaque', 'translucent', and 'additive'}.
     visible : bool
         Whether the layer visual is currently being displayed.
+    title : string
+        The title of the viewer window.
+    ndisplay : {2, 3}
+        Number of displayed dimensions.
+    order : tuple of int
+        Order in which dimensions are displayed where the last two or last
+        three dimensions correspond to row x column or plane x row x column if
+        ndisplay is 2 or 3.
+    axis_labels : list of str
+        Dimension names.
+    show : bool, optional
+        Whether to show the viewer after instantiation. by default True.
 
     Returns
     -------
@@ -284,11 +300,12 @@ def view_labels(
     opacity=0.7,
     blending='translucent',
     visible=True,
+    path=None,
     title='napari',
     ndisplay=2,
     order=None,
     axis_labels=None,
-    path=None,
+    show=True,
 ):
     """Create a viewer and add a labels (or segmentation) layer.
 
@@ -338,6 +355,8 @@ def view_labels(
         ndisplay is 2 or 3.
     axis_labels : list of str
         Dimension names.
+    show : bool, optional
+        Whether to show the viewer after instantiation. by default True.
 
     Returns
     -------
@@ -383,6 +402,7 @@ def view_shapes(
     ndisplay=2,
     order=None,
     axis_labels=None,
+    show=True,
 ):
     """Create a viewer and add a shapes layer.
 
@@ -447,6 +467,8 @@ def view_shapes(
         ndisplay is 2 or 3.
     axis_labels : list of str
         Dimension names.
+    show : bool, optional
+        Whether to show the viewer after instantiation. by default True.
 
     Returns
     -------
@@ -491,6 +513,7 @@ def view_surface(
     ndisplay=2,
     order=None,
     axis_labels=None,
+    show=True,
 ):
     """Create a viewer and add a surface layer.
 
@@ -541,6 +564,8 @@ def view_surface(
         ndisplay is 2 or 3.
     axis_labels : list of str
         Dimension names.
+    show : bool, optional
+        Whether to show the viewer after instantiation. by default True.
 
     Returns
     -------
@@ -583,6 +608,7 @@ def view_vectors(
     ndisplay=2,
     order=None,
     axis_labels=None,
+    show=True,
 ):
     """Create a viewer and add a vectors layer.
 
@@ -626,6 +652,8 @@ def view_vectors(
         ndisplay is 2 or 3.
     axis_labels : list of str
         Dimension names.
+    show : bool, optional
+        Whether to show the viewer after instantiation. by default True.
 
     Returns
     -------


### PR DESCRIPTION
# Description
as discussed https://github.com/napari/napari/pull/961#issuecomment-586725447
this PR adds the `Viewer(show=)` argument introduced in #961 to all of the `view_*` methods to keep their signatures consistent.


## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality

