### PR TITLE
Use another name for input arguments, instead of the python built-in "object"

### DIFF
--- a/napari/utils/list/_base.py
+++ b/napari/utils/list/_base.py
@@ -141,11 +141,11 @@ class List(list):
         for e in iterable:
             self.append(e)
 
-    def insert(self, index, object):
-        super().insert(self.__locitem__(index), object)
+    def insert(self, index, item):
+        super().insert(self.__locitem__(index), item)
 
     def pop(self, index):
         return super().pop(self.__locitem__(index))
 
-    def remove(self, object):
-        self.pop(self.__locitem__(object))
+    def remove(self, item):
+        self.pop(self.__locitem__(item))


### PR DESCRIPTION
# Description
The `insert()` and `remove()` methods in `napari.utils._base.List` have an input argument named "object". This was a little confusing to me at first, since`object` is a python built-in class.

I thought it might be clearer if the input argument was renamed `item`, what do other people think?

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
("Bug-fix" is putting it too strongly since it's debatable if this is even an issue, but this a non-breaking change so it was the closest option that kinda fit.)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
