### PR TITLE
Add layers.events.changed event

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -86,14 +86,9 @@ class ViewerModel(AddLayersMixin, KeymapMixin):
         self.dims.events.ndisplay.connect(self._update_layers)
         self.dims.events.order.connect(self._update_layers)
         self.dims.events.axis.connect(self._update_layers)
-        self.layers.events.added.connect(self._on_layers_change)
-        self.layers.events.removed.connect(self._on_layers_change)
-        self.layers.events.added.connect(self._update_active_layer)
-        self.layers.events.removed.connect(self._update_active_layer)
-        self.layers.events.reordered.connect(self._update_active_layer)
-        self.layers.events.added.connect(self._update_grid)
-        self.layers.events.removed.connect(self._update_grid)
-        self.layers.events.reordered.connect(self._update_grid)
+        self.layers.events.changed.connect(self._on_layers_change)
+        self.layers.events.changed.connect(self._update_active_layer)
+        self.layers.events.changed.connect(self._update_grid)
 
         # Hold callbacks for when mouse moves with nothing pressed
         self.mouse_move_callbacks = []

--- a/napari/utils/list/_model.py
+++ b/napari/utils/list/_model.py
@@ -32,6 +32,7 @@ class ListModel(MultiIndexList, TypedList):
             added=None,
             removed=None,
             reordered=None,
+            changed=None,
         )
 
     def __setitem__(self, query, values):
@@ -46,16 +47,20 @@ class ListModel(MultiIndexList, TypedList):
 
         super().__setitem__(indices, new_indices)
         self.events.reordered()
+        self.events.changed()
 
     def insert(self, index, obj):
         super().insert(index, obj)
         self.events.added(item=obj, index=self.__locitem__(index))
+        self.events.changed()
 
     def append(self, obj):
         super(TypedList, self).append(obj)
         self.events.added(item=obj, index=len(self) - 1)
+        self.events.changed()
 
     def pop(self, key):
         obj = super().pop(key)
         self.events.removed(item=obj, index=key)
+        self.events.changed()
         return obj

--- a/napari/utils/list/_model.py
+++ b/napari/utils/list/_model.py
@@ -34,6 +34,9 @@ class ListModel(MultiIndexList, TypedList):
             reordered=None,
             changed=None,
         )
+        self.events.added.connect(self.events.changed)
+        self.events.removed.connect(self.events.changed)
+        self.events.reordered.connect(self.events.changed)
 
     def __setitem__(self, query, values):
         indices = tuple(self.__prsitem__(query))
@@ -47,20 +50,16 @@ class ListModel(MultiIndexList, TypedList):
 
         super().__setitem__(indices, new_indices)
         self.events.reordered()
-        self.events.changed()
 
     def insert(self, index, obj):
         super().insert(index, obj)
         self.events.added(item=obj, index=self.__locitem__(index))
-        self.events.changed()
 
     def append(self, obj):
         super(TypedList, self).append(obj)
         self.events.added(item=obj, index=len(self) - 1)
-        self.events.changed()
 
     def pop(self, key):
         obj = super().pop(key)
         self.events.removed(item=obj, index=key)
-        self.events.changed()
         return obj


### PR DESCRIPTION
# Description
This PR adds a `changed` event to the List model.  

```python
viewer.layers.events.added.connect(callback)
viewer.layers.events.removed.connect(callback)
viewer.layers.events.reordered.connect(callback)

# becomes
viewer.layers.events.changed.connect(callback)
```

I found myself doing the former a number of times, and also found it here in `master`:
https://github.com/napari/napari/blob/b25ba4828ceef903d7532fb9568f8e0908be1a30/napari/components/viewer_model.py#L89-L96


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Refactor

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
