### PR TITLE
RFC: Refactor proposal! Adding a controllers to napari 

### DIFF
--- a/napari/_controllers/__init__.py
+++ b/napari/_controllers/__init__.py
@@ -1,0 +1,6 @@
+from ..layers import Image
+from .image_controller import ImageController
+
+layer_to_controller = {
+    Image: ImageController,
+}

--- a/napari/_controllers/_base.py
+++ b/napari/_controllers/_base.py
@@ -1,0 +1,30 @@
+from napari._qt.layers.qt_image_base_layer import QtBaseImageControls
+from napari._vispy.vispy_base_layer import VispyBaseLayer
+from napari.layers import Layer
+
+
+class ControllerBase:
+    """
+    Base layer controller class responsible for the interactions between vispy, qt and the data
+    """
+
+    def __init__(
+        self,
+        layer: Layer,
+        qt_controls: QtBaseImageControls,
+        vispy_layer: VispyBaseLayer,
+    ):
+        """
+        Parameters
+        ----------
+        layer: Layer
+            The data layer
+        qt_controls: QtBaseImageControls
+            The qt_controls attached to the layer
+        vispy_layer: VispyBaseLayer
+            The vispy rendering of the layer
+        """
+
+        self.layer = layer
+        self.qt_controls = qt_controls
+        self.vispy_layer = vispy_layer

--- a/napari/_controllers/image_controller.py
+++ b/napari/_controllers/image_controller.py
@@ -1,0 +1,35 @@
+from ._base import ControllerBase
+
+from ..layers.image.image import Image
+from .._qt.layers.qt_image_layer import QtImageControls
+from .._vispy.vispy_image_layer import VispyImageLayer
+
+
+class ImageController(ControllerBase):
+    def __init__(
+        self,
+        layer: Image,
+        qt_controls: QtImageControls,
+        vispy_layer: VispyImageLayer,
+    ):
+        super().__init__(layer, qt_controls, vispy_layer)
+
+        # connect to specific image layer events
+        self.layer.events.interpolation.connect(self.on_interpolation_change)
+
+        # connect to qt events
+        self.qt_controls.events.interpolation.connect(
+            self.on_interpolation_change
+        )
+
+    def on_interpolation_change(self, event=None):
+        """
+        Process changes when the interpolation attribute is changed from any interface
+        """
+        value = event.interpolation
+        # update layer
+        self.layer._set_interpolation(value)
+        # update qt
+        self.qt_controls.set_interpolation(value)
+        # update vispy
+        self.vispy_layer.set_interpolation(value)

--- a/napari/_qt/layers/qt_image_base_layer.py
+++ b/napari/_qt/layers/qt_image_base_layer.py
@@ -6,6 +6,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtGui import QImage, QPixmap
 from qtpy.QtWidgets import QComboBox, QLabel, QSlider, QPushButton
 
+from ...utils.event import EmitterGroup
 from ..qt_range_slider import QHRangeSlider
 from ..qt_range_slider_popup import QRangeSliderPopup
 from ..utils import qt_signals_blocked
@@ -15,6 +16,9 @@ from .qt_base_layer import QtLayerControls
 class QtBaseImageControls(QtLayerControls):
     def __init__(self, layer):
         super().__init__(layer)
+
+        # initialize qt events
+        self.events = EmitterGroup()
 
         self.layer.events.colormap.connect(self._on_colormap_change)
         self.layer.events.gamma.connect(self.gamma_slider_update)

--- a/napari/_qt/qt_controls.py
+++ b/napari/_qt/qt_controls.py
@@ -14,7 +14,6 @@ class QtControls(QStackedWidget):
         self.addWidget(self.empty_widget)
         self._display(None)
 
-        self.viewer.layers.events.added.connect(self._add)
         self.viewer.layers.events.removed.connect(self._remove)
         self.viewer.events.active_layer.connect(self._display)
 
@@ -49,6 +48,7 @@ class QtControls(QStackedWidget):
         controls = create_qt_controls(layer)
         self.addWidget(controls)
         self.widgets[layer] = controls
+        return controls
 
     def _remove(self, event):
         """Remove the controls target layer from the list of control widgets.

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -32,6 +32,9 @@ from .qt_viewer_dock_widget import QtViewerDockWidget
 from .qt_about_keybindings import QtAboutKeybindings
 from .._vispy import create_vispy_visual
 
+from .._controllers import layer_to_controller
+from .layers import create_qt_controls
+
 
 class QtViewer(QSplitter):
     """Qt view for the napari Viewer model.
@@ -136,6 +139,9 @@ class QtViewer(QSplitter):
         # This dictionary holds the corresponding vispy visual for each layer
         self.layer_to_visual = {}
 
+        # This dict holds coresponding controllers for each layer
+        self.layer_controllers = {}
+
         if self.console.shell is not None:
             self.viewerButtons.consoleButton.clicked.connect(
                 lambda: self.toggle_console()
@@ -218,7 +224,6 @@ class QtViewer(QSplitter):
 
     def _add_layer(self, event):
         """When a layer is added, set its parent and order.
-
         Parameters
         ----------
         event : qtpy.QtCore.QEvent
@@ -226,11 +231,24 @@ class QtViewer(QSplitter):
         """
         layers = event.source
         layer = event.item
+
+        # make vispy layer
         vispy_layer = create_vispy_visual(layer)
         vispy_layer.camera = self.view.camera
         vispy_layer.node.parent = self.view.scene
         vispy_layer.order = len(layers)
         self.layer_to_visual[layer] = vispy_layer
+
+        # make qt_controls
+        controls = create_qt_controls(layer)
+        self.controls.addWidget(controls)
+        self.controls.widgets[layer] = controls
+
+        # make event controller
+        layer_controller = layer_to_controller[type(layer)](
+            layer=layer, qt_controls=controls, vispy_layer=vispy_layer
+        )
+        self.layer_controllers[layer] = layer_controller
 
     def _remove_layer(self, event):
         """When a layer is removed, remove its parent.
@@ -244,7 +262,9 @@ class QtViewer(QSplitter):
         vispy_layer = self.layer_to_visual[layer]
         vispy_layer.node.transforms = ChainTransform()
         vispy_layer.node.parent = None
+        # TODO evnetualy delete the layer to visual stuff. Should be in controller
         del self.layer_to_visual[layer]
+        del self.layer_controllers[layer]
 
     def _reorder_layers(self, event):
         """When the list is reordered, propagate changes to draw order.

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -23,7 +23,6 @@ class VispyImageLayer(VispyBaseLayer):
         super().__init__(layer, node)
 
         self.layer.events.rendering.connect(self._on_rendering_change)
-        self.layer.events.interpolation.connect(self._on_interpolation_change)
         self.layer.events.colormap.connect(self._on_colormap_change)
         self.layer.events.contrast_limits.connect(
             self._on_contrast_limits_change
@@ -95,13 +94,13 @@ class VispyImageLayer(VispyBaseLayer):
                 self.node.set_data(data, clim=self.layer.contrast_limits)
         self.node.update()
 
-    def _on_interpolation_change(self, event=None):
+    def set_interpolation(self, interpolation):
         if self.layer.dims.ndisplay == 3 and isinstance(self.layer, Labels):
             self.node.interpolation = 'nearest'
         elif self.layer.dims.ndisplay == 3 and isinstance(self.layer, Image):
             self.node.interpolation = 'linear'
         else:
-            self.node.interpolation = self.layer.interpolation
+            self.node.interpolation = interpolation
 
     def _on_rendering_change(self, event=None):
         if self.layer.dims.ndisplay == 3:
@@ -243,7 +242,6 @@ class VispyImageLayer(VispyBaseLayer):
 
     def reset(self, event=None):
         self._reset_base()
-        self._on_interpolation_change()
         self._on_colormap_change()
         self._on_rendering_change()
         if self.layer.dims.ndisplay == 2:

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -213,7 +213,7 @@ class Image(IntensityVisualizationMixin, Layer):
         self._contrast_limits = tuple(self.contrast_limits_range)
         self.colormap = colormap
         self.contrast_limits = self._contrast_limits
-        self.interpolation = interpolation
+        self._set_interpolation(interpolation)
         self.rendering = rendering
 
         # Trigger generation of view slice and thumbnail
@@ -335,10 +335,12 @@ class Image(IntensityVisualizationMixin, Layer):
 
     @interpolation.setter
     def interpolation(self, interpolation):
+        self.events.interpolation(interpolation=interpolation)
+
+    def _set_interpolation(self, interpolation):
         if isinstance(interpolation, str):
             interpolation = Interpolation(interpolation)
         self._interpolation = interpolation
-        self.events.interpolation()
 
     @property
     def rendering(self):


### PR DESCRIPTION
The current flow of data in napari is through the use of events emitted. A user can modify a layer through the gui or directly in a jupyter notebook or ipython terminal. 

The following  diagram charts the flow of calls when a user modifies the interpolation attribute of an image in the second scenario. 

![napari_data_flow_1](https://user-images.githubusercontent.com/6810854/75410292-49092780-58d0-11ea-90ca-3416697e0fc5.png)

This system works alright but when a user modifies the interpolation attribute through the gui dropdown menu the flow is a bit more complicated, see below:

![napari_data_flow_2](https://user-images.githubusercontent.com/6810854/75410301-4f979f00-58d0-11ea-9487-9032fd2dd593.png)

The current architecture:

- makes it hard to debug, and track everything that happens when changes are made
- causes repeat calls of methods 
- forces the qt, vispy connection through qt_viewer

This proposal adds a controllers to the codebase that are the central place to process data updates. A layer's controller has access to all three components (data, qt, and vispy). When changes are made the controller is the only component that receives events, it then updates the layer, qt_controls, and vispy_layer. See modified architecture below:

![proposal_napari_data_flow](https://user-images.githubusercontent.com/6810854/75410307-57efda00-58d0-11ea-8b03-56986338c79f.png)

This simplifies the codebase by:

-  Only having one method to track down that shows everything that happens on a user change of any kind
- Neither the vispy layer or qt  controls will need to connect to events, they will only be responsible for updating themselves. 
- When something goes wrong the error message will be much easier to parse 
- There won't be any need to ever suppress events, or risk of causing an endless update loop
- eventually qt_viewer will not need to keep track of each layer's vispy mapping and can just call the controllers instead. 


The code in this PR is just a small example I made for feedback. I added everything needed for napari to process image interpolation changes from either the layer level or gui level through the new image_controller. The whole refactor would be significant but I think it would be really helpful longterm for readability and debugging. Also from a plugin standpoint we could add hooks to the controller methods and not have to worry about updating anything else. 

Looking for all the feedback, likes, dislikes, and concerns!! 



NOTE: The tests and build will definitely be broken since this is just a partial refactor meant as an example