### PR TITLE
Add headless mode

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -158,3 +158,13 @@ def test_update(qtbot):
 
     # Close the viewer
     viewer.window.close()
+
+
+@pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)
+def test_add_layer_headless(qtbot, layer_class, data, ndim):
+    viewer = Viewer(headless=True)
+    assert viewer.window is None
+    assert viewer.screenshot() is None
+
+    _ = add_layer_by_type(viewer, layer_class, data, visible=True)
+    check_viewer_functioning(viewer, None, data, ndim)

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -91,11 +91,12 @@ def check_viewer_functioning(viewer, view=None, data=None, ndim=2):
     viewer.dims.ndisplay = 2
     assert np.all(viewer.layers[0].data == data)
     assert len(viewer.layers) == 1
-    assert view.layers.vbox_layout.count() == 2 * len(viewer.layers) + 2
-
     assert viewer.dims.ndim == ndim
-    assert view.dims.nsliders == viewer.dims.ndim
-    assert np.sum(view.dims._displayed_sliders) == ndim - 2
+
+    if view is not None:
+        assert view.layers.vbox_layout.count() == 2 * len(viewer.layers) + 2
+        assert view.dims.nsliders == viewer.dims.ndim
+        assert np.sum(view.dims._displayed_sliders) == ndim - 2
 
     # Switch to 3D rendering mode and back to 2D rendering mode
     viewer.dims.ndisplay = 3

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -27,6 +27,7 @@ def view_image(
     order=None,
     axis_labels=None,
     show=True,
+    headless=True,
 ):
     """Create a viewer and add an image layer.
 
@@ -108,7 +109,9 @@ def view_image(
     axis_labels : list of str
         Dimension names.
     show : bool, optional
-        Whether to show the viewer after instantiation. by default True.
+        Whether to show the viewer after instantiation, by default True.
+    headless : bool, optional
+        In headless mode no graphical user interface is created.
 
     Returns
     -------
@@ -121,6 +124,7 @@ def view_image(
         order=order,
         axis_labels=axis_labels,
         show=show,
+        headless=headless,
     )
     viewer.add_image(
         data=data,
@@ -174,6 +178,7 @@ def view_points(
     order=None,
     axis_labels=None,
     show=True,
+    headless=True,
 ):
     """Create a viewer and add a points layer.
 
@@ -250,7 +255,9 @@ def view_points(
     axis_labels : list of str
         Dimension names.
     show : bool, optional
-        Whether to show the viewer after instantiation. by default True.
+        Whether to show the viewer after instantiation, by default True.
+    headless : bool, optional
+        In headless mode no graphical user interface is created.
 
     Returns
     -------
@@ -268,6 +275,7 @@ def view_points(
         order=order,
         axis_labels=axis_labels,
         show=show,
+        headless=headless,
     )
     viewer.add_points(
         data=data,
@@ -314,6 +322,7 @@ def view_labels(
     order=None,
     axis_labels=None,
     show=True,
+    headless=True,
 ):
     """Create a viewer and add a labels (or segmentation) layer.
 
@@ -364,7 +373,9 @@ def view_labels(
     axis_labels : list of str
         Dimension names.
     show : bool, optional
-        Whether to show the viewer after instantiation. by default True.
+        Whether to show the viewer after instantiation, by default True.
+    headless : bool, optional
+        In headless mode no graphical user interface is created.
 
     Returns
     -------
@@ -377,6 +388,7 @@ def view_labels(
         order=order,
         axis_labels=axis_labels,
         show=show,
+        headless=headless,
     )
     viewer.add_labels(
         data=data,
@@ -415,6 +427,7 @@ def view_shapes(
     order=None,
     axis_labels=None,
     show=True,
+    headless=True,
 ):
     """Create a viewer and add a shapes layer.
 
@@ -480,7 +493,9 @@ def view_shapes(
     axis_labels : list of str
         Dimension names.
     show : bool, optional
-        Whether to show the viewer after instantiation. by default True.
+        Whether to show the viewer after instantiation, by default True.
+    headless : bool, optional
+        In headless mode no graphical user interface is created.
 
     Returns
     -------
@@ -493,6 +508,7 @@ def view_shapes(
         order=order,
         axis_labels=axis_labels,
         show=show,
+        headless=headless,
     )
     viewer.add_shapes(
         data=data,
@@ -530,6 +546,7 @@ def view_surface(
     order=None,
     axis_labels=None,
     show=True,
+    headless=True,
 ):
     """Create a viewer and add a surface layer.
 
@@ -581,7 +598,9 @@ def view_surface(
     axis_labels : list of str
         Dimension names.
     show : bool, optional
-        Whether to show the viewer after instantiation. by default True.
+        Whether to show the viewer after instantiation, by default True.
+    headless : bool, optional
+        In headless mode no graphical user interface is created.
 
     Returns
     -------
@@ -594,6 +613,7 @@ def view_surface(
         order=order,
         axis_labels=axis_labels,
         show=show,
+        headless=headless,
     )
     viewer.add_surface(
         data,
@@ -629,6 +649,7 @@ def view_vectors(
     order=None,
     axis_labels=None,
     show=True,
+    headless=True,
 ):
     """Create a viewer and add a vectors layer.
 
@@ -673,7 +694,9 @@ def view_vectors(
     axis_labels : list of str
         Dimension names.
     show : bool, optional
-        Whether to show the viewer after instantiation. by default True.
+        Whether to show the viewer after instantiation, by default True.
+    headless : bool, optional
+        In headless mode no graphical user interface is created.
 
     Returns
     -------
@@ -686,6 +709,7 @@ def view_vectors(
         order=order,
         axis_labels=axis_labels,
         show=show,
+        headless=headless,
     )
     viewer.add_vectors(
         data,


### PR DESCRIPTION
# Description
This PR follows on discussion in https://github.com/napari/napari/pull/1006#discussion_r386058302 by adding an explicit `headless` mode. It has an implementation that follows the `is_remote` option in #654, which will be superseded by this.

We might want to think about how to improve our testing so that the main viewer in headless mode undergoes more stringent testing, but there is at least some testing for now.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

