### PR TITLE
Reduce code duplication: vispy _on_scale_change() & _on_translate_change()

### DIFF
--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -128,13 +128,18 @@ class VispyBaseLayer(ABC):
 
     def _on_scale_change(self, event=None):
         self.scale = [
-            self.layer.scale[d] for d in self.layer.dims.displayed[::-1]
+            self.layer.scale[d] * self.layer._scale_view[d]
+            for d in self.layer.dims.displayed[::-1]
         ]
+        if self.layer.is_pyramid:
+            self.layer.top_left = self.find_top_left()
         self.layer.position = self._transform_position(self._position)
 
     def _on_translate_change(self, event=None):
         self.translate = [
-            self.layer.translate[d] + self.layer.translate_grid[d]
+            self.layer.translate[d]
+            + self.layer._translate_view[d]
+            + self.layer.translate_grid[d]
             for d in self.layer.dims.displayed[::-1]
         ]
         self.layer.position = self._transform_position(self._position)

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -142,24 +142,6 @@ class VispyImageLayer(VispyBaseLayer):
         elif rendering == Rendering.ATTENUATED_MIP:
             self.node.threshold = float(self.layer.attenuation)
 
-    def _on_scale_change(self, event=None):
-        self.scale = [
-            self.layer.scale[d] * self.layer._scale_view[d]
-            for d in self.layer.dims.displayed[::-1]
-        ]
-        if self.layer.is_pyramid:
-            self.layer.top_left = self.find_top_left()
-        self.layer.position = self._transform_position(self._position)
-
-    def _on_translate_change(self, event=None):
-        self.translate = [
-            self.layer.translate[d]
-            + self.layer._translate_view[d]
-            + self.layer.translate_grid[d]
-            for d in self.layer.dims.displayed[::-1]
-        ]
-        self.layer.position = self._transform_position(self._position)
-
     def compute_data_level(self, size):
         """Computed what level of the pyramid should be viewed given the
         current size of the requested field of view.


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
This PR is a refactor to reduce code duplication.

Currently, `VispyImageLayer` overrides the base layer methods `_on_scale_change()` and `_on_translate_change()`. But there's no reason this can't live in `VispyBaseLayer` instead, and this simplifies things a bit.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Refactor

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
Original discussion with jni here: https://github.com/jni/napari/pull/6#discussion_r383197606

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
