### PR TITLE
Close the canvas used to retrieve maximum texture size.

### DIFF
--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -1,7 +1,8 @@
-from vispy.gloo import gl
-from vispy.app import Canvas
-from vispy.visuals.transforms import STTransform
 from abc import ABC, abstractmethod
+from functools import lru_cache
+from vispy.app import Canvas
+from vispy.gloo import gl
+from vispy.visuals.transforms import STTransform
 
 
 class VispyBaseLayer(ABC):
@@ -208,6 +209,7 @@ class VispyBaseLayer(ABC):
         self.layer.scale_factor = self.scale_factor
 
 
+@lru_cache()
 def get_max_texture_sizes():
     """Get maximum texture sizes for 2D and 3D rendering.
 
@@ -219,8 +221,11 @@ def get_max_texture_sizes():
         Max texture size allowed by the vispy canvas during 2D rendering.
     """
     # A canvas must be created to access gl values
-    _ = Canvas(show=False)
-    MAX_TEXTURE_SIZE_2D = gl.glGetParameter(gl.GL_MAX_TEXTURE_SIZE)
+    c = Canvas(show=False)
+    try:
+        MAX_TEXTURE_SIZE_2D = gl.glGetParameter(gl.GL_MAX_TEXTURE_SIZE)
+    finally:
+        c.close()
     if MAX_TEXTURE_SIZE_2D == ():
         MAX_TEXTURE_SIZE_2D = None
     # vispy doesn't expose GL_MAX_3D_TEXTURE_SIZE so hard coding


### PR DESCRIPTION
# Description
Canvases start up an OpenGL context, which is shared since Qt 5.4 (see `Qt::AA_ShareOpenGLContexts` under https://doc.qt.io/qt-5/qt.html#ApplicationAttribute-enum).  Unfortunately, once the canvas is out of scope, the context could potentially be deallocated.  Subsequent code that fires up another canvas (i.e., any visualization) could potentially use the reference to the context's memory, but that memory could have been repurposed for other objects.  I've seen this happen fairly reliably when I add code that allocates a fair amount of memory, triggering the python garbage collector.

This fixes the problem by closing the canvas.  Subsequent canvases will spin up their own context.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] Test plan: Adding a dask client to each qt app fixture seems to trigger the crash fairly reliably (like 8 out of 10 times) with just `napari/_qt/_tests/test_qt_viewer.py`.  After this change, it doesn't seem to crash.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
