### PR TITLE
Fix points color cycle refresh

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -598,6 +598,29 @@ def test_edge_color_cycle():
     )
 
 
+def test_adding_value_edge_color_cycle():
+    shape = (10, 2)
+    np.random.seed(0)
+    data = 20 * np.random.random(shape)
+    annotations = {'point_type': np.array(['A', 'B'] * int((shape[0] / 2)))}
+    color_cycle = ['red', 'blue']
+    layer = Points(
+        data,
+        properties=annotations,
+        edge_color='point_type',
+        edge_color_cycle=color_cycle,
+    )
+
+    # make point 0 point_type C
+    point_types = layer.properties['point_type']
+    point_types[0] = 'C'
+    layer.properties['point_type'] = point_types
+    layer.refresh_colors(update_color_mapping=False)
+
+    edge_color_map_keys = [*layer.edge_color_cycle_map]
+    assert 'C' in edge_color_map_keys
+
+
 def test_edge_color_colormap():
     # create Points using with face_color colormap
     shape = (10, 2)
@@ -768,6 +791,29 @@ def test_face_color_cycle():
             (face_color_array[1], face_color_array[3:], transform_color('red'))
         ),
     )
+
+
+def test_adding_value_face_color_cycle():
+    shape = (10, 2)
+    np.random.seed(0)
+    data = 20 * np.random.random(shape)
+    annotations = {'point_type': np.array(['A', 'B'] * int((shape[0] / 2)))}
+    color_cycle = ['red', 'blue']
+    layer = Points(
+        data,
+        properties=annotations,
+        face_color='point_type',
+        face_color_cycle=color_cycle,
+    )
+
+    # make point 0 point_type C
+    point_types = layer.properties['point_type']
+    point_types[0] = 'C'
+    layer.properties['point_type'] = point_types
+    layer.refresh_colors(update_color_mapping=False)
+
+    face_color_map_keys = [*layer.face_color_cycle_map]
+    assert 'C' in face_color_map_keys
 
 
 def test_face_color_colormap():

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -804,7 +804,7 @@ def test_adding_value_face_color_cycle():
     and then calling Points.refresh_colors() performs the update and adds the
     new value to the face_color_cycle_map.
 
-    See: https://github.com/napari/napari/pull/1034
+    See: https://github.com/napari/napari/issues/988
     """
     shape = (10, 2)
     np.random.seed(0)

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -599,6 +599,12 @@ def test_edge_color_cycle():
 
 
 def test_adding_value_edge_color_cycle():
+    """ Test that adding values to properties used to set an edge color cycle
+    and then calling Points.refresh_colors() performs the update and adds the
+    new value to the edge_color_cycle_map.
+
+    See: https://github.com/napari/napari/pull/1034
+    """
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
@@ -794,6 +800,12 @@ def test_face_color_cycle():
 
 
 def test_adding_value_face_color_cycle():
+    """ Test that adding values to properties used to set an face color cycle
+    and then calling Points.refresh_colors() performs the update and adds the
+    new value to the face_color_cycle_map.
+
+    See: https://github.com/napari/napari/pull/1034
+    """
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -603,7 +603,7 @@ def test_adding_value_edge_color_cycle():
     and then calling Points.refresh_colors() performs the update and adds the
     new value to the edge_color_cycle_map.
 
-    See: https://github.com/napari/napari/pull/1034
+    See: https://github.com/napari/napari/issues/988
     """
     shape = (10, 2)
     np.random.seed(0)

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -321,6 +321,7 @@ class Points(Layer):
             if edge_color_cycle is None:
                 edge_color_cycle = DEFAULT_COLOR_CYCLE
             self.edge_color_cycle = edge_color_cycle
+            self.edge_color_cycle_map = {}
             self.edge_colormap = edge_colormap
             self._edge_contrast_limits = edge_contrast_limits
 
@@ -329,6 +330,7 @@ class Points(Layer):
             if face_color_cycle is None:
                 face_color_cycle = DEFAULT_COLOR_CYCLE
             self.face_color_cycle = face_color_cycle
+            self.face_color_cycle_map = {}
             self.face_colormap = face_colormap
             self._face_contrast_limits = face_contrast_limits
 
@@ -621,7 +623,7 @@ class Points(Layer):
             default="white",
         )
         if self._edge_color_mode == ColorMode.CYCLE:
-            self.refresh_colors()
+            self.refresh_colors(update_color_mapping=True)
 
     @property
     def edge_colormap(self):
@@ -762,7 +764,7 @@ class Points(Layer):
             default="white",
         )
         if self._face_color_mode == ColorMode.CYCLE:
-            self.refresh_colors()
+            self.refresh_colors(update_color_mapping=True)
 
     @property
     def face_colormap(self):
@@ -861,7 +863,7 @@ class Points(Layer):
             self._face_color_mode = face_color_mode
             self.refresh_colors()
 
-    def refresh_colors(self, update_color_mapping: bool = True):
+    def refresh_colors(self, update_color_mapping: bool = False):
         """Calculate and update face and edge colors if using a cycle or color map
 
         Parameters
@@ -917,7 +919,7 @@ class Points(Layer):
                 face_color_properties = self.properties[
                     self._face_color_property
                 ]
-                if update_color_mapping:
+                if update_color_mapping or self.face_contrast_limits is None:
                     face_colors, contrast_limits = map_property(
                         prop=face_color_properties,
                         colormap=self.face_colormap[1],
@@ -969,7 +971,7 @@ class Points(Layer):
                 edge_color_properties = self.properties[
                     self._edge_color_property
                 ]
-                if update_color_mapping:
+                if update_color_mapping or self.edge_contrast_limits is None:
                     edge_colors, contrast_limits = map_property(
                         prop=edge_color_properties,
                         colormap=self.edge_colormap[1],

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -888,6 +888,21 @@ class Points(Layer):
                             self.face_color_cycle,
                         )
                     }
+
+                else:
+                    # add properties if they are not in the colormap and update_color_mapping==False
+                    face_color_cycle_keys = [*self.face_color_cycle_map]
+                    props_in_map = np.in1d(
+                        face_color_properties, face_color_cycle_keys
+                    )
+                    if not np.all(props_in_map):
+                        props_to_add = np.unique(
+                            face_color_properties[np.logical_not(props_in_map)]
+                        )
+                        for prop in props_to_add:
+                            self.face_color_cycle_map[prop] = next(
+                                self.face_color_cycle
+                            )
                 face_colors = np.array(
                     [
                         self.face_color_cycle_map[x]
@@ -927,6 +942,20 @@ class Points(Layer):
                             self.edge_color_cycle,
                         )
                     }
+                else:
+                    # add properties if they are not in the colormap and update_color_mapping==False
+                    edge_color_cycle_keys = [*self.edge_color_cycle_map]
+                    props_in_map = np.in1d(
+                        edge_color_properties, edge_color_cycle_keys
+                    )
+                    if not np.all(props_in_map):
+                        props_to_add = np.unique(
+                            edge_color_properties[np.logical_not(props_in_map)]
+                        )
+                        for prop in props_to_add:
+                            self.edge_color_cycle_map[prop] = next(
+                                self.edge_color_cycle
+                            )
                 edge_colors = np.array(
                     [
                         self.edge_color_cycle_map[x]

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -890,7 +890,8 @@ class Points(Layer):
                     }
 
                 else:
-                    # add properties if they are not in the colormap and update_color_mapping==False
+                    # add properties if they are not in the colormap
+                    # and update_color_mapping==False
                     face_color_cycle_keys = [*self.face_color_cycle_map]
                     props_in_map = np.in1d(
                         face_color_properties, face_color_cycle_keys
@@ -943,7 +944,8 @@ class Points(Layer):
                         )
                     }
                 else:
-                    # add properties if they are not in the colormap and update_color_mapping==False
+                    # add properties if they are not in the colormap
+                    # and update_color_mapping==False
                     edge_color_cycle_keys = [*self.edge_color_cycle_map]
                     props_in_map = np.in1d(
                         edge_color_properties, edge_color_cycle_keys


### PR DESCRIPTION
# Description
This PR fixes a bug where adding values to properties used to set an edge/face color cycle and then calling refresh caused a `KeyError` (described in #988). The bug is fixed by adding any property values not in the color cycle map when refreshing the edge/face colors.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Fixes #988 

# How has this been tested?
- [x] added tests to verify property values can be added when refreshing color cycle properties
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
