### PR TITLE
Fix label styles in contrast limit popup 

### DIFF
--- a/napari/_qt/qt_range_slider_popup.py
+++ b/napari/_qt/qt_range_slider_popup.py
@@ -72,7 +72,7 @@ class LabelEdit(QLineEdit):
     def update_position(self):
         """Update slider position."""
         x = self.get_pos() - self.width() / 2
-        y = self.slider.handle_radius + 6
+        y = self.slider.handle_radius + 12
         self.move(QPoint(x, -y) + self.slider.pos())
 
     def mouseDoubleClickEvent(self, event):

--- a/napari/resources/styles/02_custom.qss
+++ b/napari/resources/styles/02_custom.qss
@@ -371,6 +371,7 @@ QtDimSliderWidget > QLineEdit {
 #slice_label {
   font-size: 11pt;
   color: {{ secondary }};
+  background: transparent;
 }
 
 #slice_label_sep{


### PR DESCRIPTION
# Description
The labels in range slider popups (like the contrast limits popup) needed a tiny tweak after #1017.
