### PR TITLE
RFC: Refactor proposal! Adding event handlers to napari (TAKE 3) 

### DIFF
--- a/napari/_qt/layers/qt_base_layer.py
+++ b/napari/_qt/layers/qt_base_layer.py
@@ -1,10 +1,12 @@
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QSlider, QGridLayout, QFrame, QComboBox
 
+from ...layers.base._base_layer_interface import BaseLayerInterface
 from ...layers.base._base_constants import Blending
+from ...utils.event import Event, EmitterGroup
 
 
-class QtLayerControls(QFrame):
+class QtLayerControls(QFrame, BaseLayerInterface):
     """Superclass for all the other LayerControl classes.
 
     This class is never directly instantiated anywhere.
@@ -30,8 +32,14 @@ class QtLayerControls(QFrame):
         super().__init__()
 
         self.layer = layer
-        layer.events.blending.connect(self._on_blending_change)
-        layer.events.opacity.connect(self._on_opacity_change)
+
+        self.layer.event_handler.register_component_to_update(self)
+        self.events = EmitterGroup(
+            source=self,
+            blending=Event,
+            opacity=Event,
+            event_handler_callback=self.layer.event_handler.on_change,
+        )
         self.setObjectName('layer')
         self.setMouseTracking(True)
 
@@ -47,9 +55,13 @@ class QtLayerControls(QFrame):
         sld.setMinimum(0)
         sld.setMaximum(100)
         sld.setSingleStep(1)
-        sld.valueChanged.connect(self.changeOpacity)
+
+        self.emit_opacity_event = lambda value: self.events.opacity(
+            value=value / 100
+        )
+        sld.valueChanged.connect(self.emit_opacity_event)
         self.opacitySlider = sld
-        self._on_opacity_change()
+        self._on_opacity_change(self.layer.opacity)
 
         blend_comboBox = QComboBox(self)
         blend_comboBox.addItems(Blending.keys())
@@ -57,52 +69,26 @@ class QtLayerControls(QFrame):
             self.layer.blending, Qt.MatchFixedString
         )
         blend_comboBox.setCurrentIndex(index)
-        blend_comboBox.activated[str].connect(self.changeBlending)
+        blend_comboBox.activated[str].connect(self.events.blending)
         self.blendComboBox = blend_comboBox
 
-    def changeOpacity(self, value):
-        """Change opacity value on the layer model.
-
-        Parameters
-        ----------
-        value : float
-            Opacity value for shapes.
-            Input range 0 - 100 (transparent to fully opaque).
-        """
-        with self.layer.events.blocker(self._on_opacity_change):
-            self.layer.opacity = value / 100
-
-    def changeBlending(self, text):
-        """Change blending mode on the layer model.
-
-        Parameters
-        ----------
-        text : str
-            Name of blending mode, eg: 'translucent', 'additive', 'opaque'.
-        """
-        self.layer.blending = text
-
-    def _on_opacity_change(self, event=None):
+    def _on_opacity_change(self, value):
         """Receive layer model opacity change event and update opacity slider.
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
-            Event from the Qt context, by default None.
+        value : int
+            opacity value to change set the slider to.
         """
-        with self.layer.events.opacity.blocker():
-            self.opacitySlider.setValue(self.layer.opacity * 100)
+        self.opacitySlider.setValue(value * 100)
 
-    def _on_blending_change(self, event=None):
+    def _on_blending_change(self, value):
         """Receive layer model blending mode change event and update slider.
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
-            Event from the Qt context, by default None.
+        value : str
+           The value to set the blending element to
         """
-        with self.layer.events.blending.blocker():
-            index = self.blendComboBox.findText(
-                self.layer.blending, Qt.MatchFixedString
-            )
-            self.blendComboBox.setCurrentIndex(index)
+        index = self.blendComboBox.findText(value, Qt.MatchFixedString)
+        self.blendComboBox.setCurrentIndex(index)

--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -5,8 +5,10 @@ from vispy.app import Canvas
 from vispy.gloo import gl
 from vispy.visuals.transforms import STTransform
 
+from napari.layers.base._base_layer_interface import BaseLayerInterface
 
-class VispyBaseLayer(ABC):
+
+class VispyBaseLayer(ABC, BaseLayerInterface):
     """Base object for individual layer views
 
     Meant to be subclassed.
@@ -55,12 +57,6 @@ class VispyBaseLayer(ABC):
         self._position = (0,) * self.layer.dims.ndisplay
 
         self.layer.events.refresh.connect(lambda e: self.node.update())
-        self.layer.events.set_data.connect(self._on_data_change)
-        self.layer.events.visible.connect(self._on_visible_change)
-        self.layer.events.opacity.connect(self._on_opacity_change)
-        self.layer.events.blending.connect(self._on_blending_change)
-        self.layer.events.scale.connect(self._on_scale_change)
-        self.layer.events.translate.connect(self._on_translate_change)
 
     @property
     def _master_transform(self):

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -1,3 +1,4 @@
+from napari.layers.image.image_interface import ImageLayerInterface
 import warnings
 from vispy.scene.visuals import Image as ImageNode
 from .volume import Volume as VolumeNode
@@ -16,20 +17,10 @@ texture_dtypes = [
 ]
 
 
-class VispyImageLayer(VispyBaseLayer):
+class VispyImageLayer(VispyBaseLayer, ImageLayerInterface):
     def __init__(self, layer):
         node = ImageNode(None, method='auto')
         super().__init__(layer, node)
-
-        self.layer.events.rendering.connect(self._on_rendering_change)
-        self.layer.events.interpolation.connect(self._on_interpolation_change)
-        self.layer.events.colormap.connect(self._on_colormap_change)
-        self.layer.events.contrast_limits.connect(
-            self._on_contrast_limits_change
-        )
-        self.layer.events.gamma.connect(self._on_gamma_change)
-        self.layer.events.iso_threshold.connect(self._on_threshold_change)
-        self.layer.events.attenuation.connect(self._on_threshold_change)
 
         self._on_display_change()
         self._on_data_change()
@@ -98,16 +89,16 @@ class VispyImageLayer(VispyBaseLayer):
         self._on_translate_change()
         self.node.update()
 
-    def _on_interpolation_change(self, event=None):
-        self.node.interpolation = self.layer.interpolation
+    def _on_interpolation_change(self, interpolation):
+        self.node.interpolation = interpolation
 
-    def _on_rendering_change(self, event=None):
+    def _on_rendering_change(self, value):
         if self.layer.dims.ndisplay == 3:
-            self.node.method = self.layer.rendering
-            self._on_threshold_change()
+            self.node.method = value
+            self._on_iso_threshold_change(value=None)
 
-    def _on_colormap_change(self, event=None):
-        cmap = self.layer.colormap[1]
+    def _on_colormap_change(self, value=None):
+        cmap = value if value else self.layer.colormap[1]
         if self.layer.gamma != 1:
             # when gamma!=1, we instantiate a new colormap
             # with 256 control points from 0-1
@@ -120,31 +111,31 @@ class VispyImageLayer(VispyBaseLayer):
             )
         self.node.cmap = cmap
 
-    def _on_contrast_limits_change(self, event=None):
+    def _on_contrast_limits_change(self, contrast_limits):
         if self.layer.dims.ndisplay == 2:
-            self.node.clim = self.layer.contrast_limits
+            self.node.clim = contrast_limits
         else:
             self._on_data_change()
 
-    def _on_gamma_change(self, event=None):
-        self._on_colormap_change()
+    def _on_gamma_change(self, value):
+        self._on_colormap_change(value=None)
 
-    def _on_threshold_change(self, event=None):
+    def _on_iso_threshold_change(self, value):
+        value = value if value else self.layer.iso_threshold
         if self.layer.dims.ndisplay == 2:
             return
         rendering = Rendering(self.layer.rendering)
         if rendering == Rendering.ISO:
-            self.node.threshold = float(self.layer.iso_threshold)
+            self.node.threshold = float(value)
         elif rendering == Rendering.ATTENUATED_MIP:
             self.node.threshold = float(self.layer.attenuation)
 
     def reset(self, event=None):
         self._reset_base()
-        self._on_interpolation_change()
-        self._on_colormap_change()
-        self._on_rendering_change()
+        self._on_colormap_change(value=None)
+        self._on_rendering_change(value=None)
         if self.layer.dims.ndisplay == 2:
-            self._on_contrast_limits_change()
+            self._on_contrast_limits_change(self.layer.contrast_limits)
 
     def downsample_texture(self, data, MAX_TEXTURE_SIZE):
         """Downsample data based on maximum allowed texture size.

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -5,7 +5,7 @@ import numpy as np
 from .add_layers_mixin import AddLayersMixin
 from .dims import Dims
 from .layerlist import LayerList
-from ..utils.event import EmitterGroup, Event
+from ..utils.event import Event, EmitterGroup
 from ..utils.key_bindings import KeymapHandler, KeymapProvider
 from ..utils.theme import palettes
 
@@ -439,7 +439,7 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
 
     def _update_status(self, event):
         """Set the viewer status with the `event.status` string."""
-        self.status = event.status
+        self.status = event.value
 
     def _update_help(self, event):
         """Set the viewer help with the `event.help` string."""

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -443,19 +443,19 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
 
     def _update_help(self, event):
         """Set the viewer help with the `event.help` string."""
-        self.help = event.help
+        self.help = event.value
 
     def _update_interactive(self, event):
         """Set the viewer interactivity with the `event.interactive` bool."""
-        self.interactive = event.interactive
+        self.interactive = event.value
 
     def _update_cursor(self, event):
         """Set the viewer cursor with the `event.cursor` string."""
-        self.cursor = event.cursor
+        self.cursor = event.value
 
     def _update_cursor_size(self, event):
         """Set the viewer cursor_size with the `event.cursor_size` int."""
-        self.cursor_size = event.cursor_size
+        self.cursor_size = event.value
 
     def grid_view(self, n_row=None, n_column=None, stride=1):
         """Arrange the current layers is a 2D grid.

--- a/napari/layers/base/_base_layer_interface.py
+++ b/napari/layers/base/_base_layer_interface.py
@@ -80,7 +80,3 @@ class BaseLayerInterface(BaseInterface):
     @abstractmethod
     def _on_editable_change(self, value):
         ...
-
-    @abstractmethod
-    def _on_update_dims(self):
-        ...

--- a/napari/layers/base/_base_layer_interface.py
+++ b/napari/layers/base/_base_layer_interface.py
@@ -1,0 +1,86 @@
+from abc import abstractmethod
+
+from napari.utils.base_interface import BaseInterface
+
+
+class BaseLayerInterface(BaseInterface):
+    """
+    Empty implementation of BaseInterface. Defines a set of methods shared between the data layer visual
+    rendering and controls.
+    """
+
+    @abstractmethod
+    def _on_refresh_change(self):
+        ...
+
+    @abstractmethod
+    def _on_set_data_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_blending_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_opacity_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_visible_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_select_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_deselect_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_scale_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_translate_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_data_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_name_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_thumbnail_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_status_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_help_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_interactive_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_cursor_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_cursor_size_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_editable_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_update_dims(self):
+        ...

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -193,7 +193,7 @@ class Layer(KeymapProvider, ABC, BaseLayerInterface):
         self._thumbnail_shape = (32, 32, 4)
         self._thumbnail = np.zeros(self._thumbnail_shape, dtype=np.uint8)
         self._update_properties = True
-        self._name = name
+        self._on_name_change(name)
         self.event_handler = LayerEventHandler(component=self)
 
         self.events = EmitterGroup(
@@ -251,11 +251,10 @@ class Layer(KeymapProvider, ABC, BaseLayerInterface):
 
     @name.setter
     def name(self, name):
-        self.events.name(value=name)
+        if name != self.name:
+            self.events.name(value=name)
 
     def _on_name_change(self, name):
-        if name == self.name:
-            return
         if not name:
             name = self._basename()
         self._name = name

--- a/napari/layers/base/layer_event_handler.py
+++ b/napari/layers/base/layer_event_handler.py
@@ -1,0 +1,26 @@
+from ...utils.event_handler import EventHandler
+from napari.utils.base_interface import BaseInterface
+
+
+class LayerEventHandler(EventHandler):
+    """
+    Event handler for layer specific events. Receives change events made from the data/controls/
+    or visual interface and updates all associated components.
+
+    Ex. ImageLayer components = [qt_image.py, vispy_image.py, image.py]
+    """
+
+    def __init__(self, component: BaseInterface = None):
+        super().__init__(component)
+
+    def on_change(self, event=None):
+        """
+        Process changes made from any interface
+        """
+        name = event.type
+        value = event.value
+        print(f"event: {name}")
+        for component in self.components_to_update:
+            update_method_name = f"_on_{name}_change"
+            update_method = getattr(component, update_method_name)
+            update_method(value)

--- a/napari/layers/base/layer_event_handler.py
+++ b/napari/layers/base/layer_event_handler.py
@@ -1,5 +1,11 @@
+import logging
+
+
 from ...utils.event_handler import EventHandler
 from napari.utils.base_interface import BaseInterface
+
+
+logger = logging.getLogger(__name__)
 
 
 class LayerEventHandler(EventHandler):
@@ -18,8 +24,13 @@ class LayerEventHandler(EventHandler):
         Process changes made from any interface
         """
         name = event.type
-        value = event.value
-        print(f"event: {name}")
+        logger.debug(f"event: {name}")
+        try:  # until refactor on all layers is complete, not all events will have a value property
+            value = event.value
+        except AttributeError:
+            logger.debug(f"did not handle event {name}")
+            return
+
         for component in self.components_to_update:
             update_method_name = f"_on_{name}_change"
             update_method = getattr(component, update_method_name)

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -226,9 +226,6 @@ class Image(IntensityVisualizationMixin, Layer, ImageLayerInterface):
         self._data_thumbnail = self._data_view
 
         # Set contrast_limits and colormaps
-        self._on_gamma(gamma)
-        self._on_iso_threshold_change(iso_threshold)
-        self._on_attenuation_change(attenuation)
         if contrast_limits is None:
             self.contrast_limits_range = self._calc_data_range()
         else:
@@ -244,10 +241,13 @@ class Image(IntensityVisualizationMixin, Layer, ImageLayerInterface):
             ),
         }
 
-        self._on_colormap(colormap)
-        self._on_contrast_limits(self._contrast_limits)
+        self._on_colormap_change(colormap)
+        self._on_contrast_limits_change(self._contrast_limits)
         self._on_interpolation_change(interpolation)
         self._on_rendering_change(rendering)
+        self._on_gamma_change(gamma)
+        self._on_iso_threshold_change(iso_threshold)
+        self._on_attenuation_change(attenuation)
 
         # Trigger generation of view slice and thumbnail
         self._update_dims()

--- a/napari/layers/image/image_interface.py
+++ b/napari/layers/image/image_interface.py
@@ -1,0 +1,36 @@
+from abc import abstractmethod
+from ..base._base_layer_interface import BaseLayerInterface
+
+
+class ImageLayerInterface(BaseLayerInterface):
+    """
+    Defines the getters/setters editable across components for an ImageLayer
+    """
+
+    @abstractmethod
+    def _on_interpolation_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_contrast_limits_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_rendering_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_iso_threshold_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_attenuation_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_gamma_change(self, value):
+        ...
+
+    @abstractmethod
+    def _on_colormap_change(self, value):
+        ...

--- a/napari/layers/intensity_mixin.py
+++ b/napari/layers/intensity_mixin.py
@@ -74,7 +74,7 @@ class IntensityVisualizationMixin:
     def contrast_limits(self, contrast_limits):
         self.events.contrast_limits(value=contrast_limits)
 
-    def _on_contrast_limits(self, contrast_limits):
+    def _on_contrast_limits_change(self, contrast_limits):
         validate_2_tuple(contrast_limits)
         self._contrast_limits_msg = (
             format_float(contrast_limits[0])
@@ -127,7 +127,7 @@ class IntensityVisualizationMixin:
     def gamma(self, value):
         self.events.gamma(value=value)
 
-    def _on_gamma(self, value):
+    def _on_gamma_change(self, value):
         self.status = format_float(value)
         self._gamma = value
         self._update_thumbnail()

--- a/napari/layers/intensity_mixin.py
+++ b/napari/layers/intensity_mixin.py
@@ -51,12 +51,14 @@ class IntensityVisualizationMixin:
 
     @colormap.setter
     def colormap(self, colormap):
+        self.events.colormap(value=colormap)
+
+    def _on_colormap_change(self, colormap):
         name, cmap = ensure_colormap_tuple(colormap)
         self._colormap_name = name
         self._cmap = cmap
         self._colorbar = make_colorbar(self._cmap)
         self._update_thumbnail()
-        self.events.colormap()
 
     @property
     def colormaps(self):
@@ -70,6 +72,9 @@ class IntensityVisualizationMixin:
 
     @contrast_limits.setter
     def contrast_limits(self, contrast_limits):
+        self.events.contrast_limits(value=contrast_limits)
+
+    def _on_contrast_limits(self, contrast_limits):
         validate_2_tuple(contrast_limits)
         self._contrast_limits_msg = (
             format_float(contrast_limits[0])
@@ -84,7 +89,6 @@ class IntensityVisualizationMixin:
         newrange[1] = max(newrange[1], contrast_limits[1])
         self.contrast_limits_range = newrange
         self._update_thumbnail()
-        self.events.contrast_limits()
 
     @property
     def contrast_limits_range(self):
@@ -121,7 +125,9 @@ class IntensityVisualizationMixin:
 
     @gamma.setter
     def gamma(self, value):
+        self.events.gamma(value=value)
+
+    def _on_gamma(self, value):
         self.status = format_float(value)
         self._gamma = value
         self._update_thumbnail()
-        self.events.gamma()

--- a/napari/utils/base_interface.py
+++ b/napari/utils/base_interface.py
@@ -1,0 +1,4 @@
+class BaseInterface:
+    """
+    Base interface for updateble components
+    """

--- a/napari/utils/event_handler.py
+++ b/napari/utils/event_handler.py
@@ -1,0 +1,18 @@
+from abc import abstractmethod
+from typing import List
+
+from napari.utils.base_interface import BaseInterface
+
+
+class EventHandler:
+    def __init__(self, component=None):
+        self.components_to_update: List[BaseInterface] = [
+            component
+        ] if component else []
+
+    def register_component_to_update(self, component):
+        self.components_to_update.append(component)
+
+    @abstractmethod
+    def on_change(self, event=None):
+        ...


### PR DESCRIPTION
Alright! Thanks so much for all the feedback and help on these proposals everyone! I feel like we have moved in a cool direction that works for all. Given the discussion in #1020 and in the Napari sync, I iterated on the refactor proposal with a few changes: 

- UpdateContract is now an Interface (a more accurate description of what it is)
- Controller's are now EventHandlers
- The base data layer initializes the event handler so it does not have to be done outside of a viewer.add_layer() call. 
- The vispy and qt components register themselves with the layer's event handler rather then everything happening in qt_viewer. 

I dug into the `emitter_group` code a bit more and realized it could be utilized in this refactor. I added the ability to pass a single callback method to an emitter group that automatically get's hooked up to any event added to the group. This way we can pass `layer.event_handler.on_change` into the EmitterGroup's created in the base qt and vispy layers and everything "just works". 

For reference this is what the new event architecture would look like: 

![Refactor-take-3](https://user-images.githubusercontent.com/6810854/76366034-0e4aba80-62e6-11ea-81f0-27a368281851.png)


I wanted to give more of any idea of what this approach would look like so this PR refactors more of the code then just the `interpolation` attribute. The entire `base_layer, base_qt_layer, base_vispy_layer` and `image_layer, qt_image_layer, vispy_image_layer` have been reformatted. 

Check it out at let me know all the questions/comments/concerns! 

Also I am going to start referring to this refactor as an "Event Handler Refactor" instead of a "Controller Refactor"  : )




