### PR TITLE
Add chains of transforms

### DIFF
--- a/napari/_vispy/_tests/test_vispy_big_images.py
+++ b/napari/_vispy/_tests/test_vispy_big_images.py
@@ -11,8 +11,8 @@ def test_big_2D_image(viewer_factory):
     visual = view.layer_to_visual[layer]
     assert visual.node is not None
     if visual.MAX_TEXTURE_SIZE_2D is not None:
-        ds = np.ceil(np.divide(shape, visual.MAX_TEXTURE_SIZE_2D)).astype(int)
-        assert np.all(layer._transforms['view2data'].scale == ds)
+        s = np.ceil(np.divide(shape, visual.MAX_TEXTURE_SIZE_2D)).astype(int)
+        assert np.all(layer._transforms['view2data'].scale == s)
 
 
 def test_big_3D_image(viewer_factory):
@@ -25,5 +25,5 @@ def test_big_3D_image(viewer_factory):
     visual = view.layer_to_visual[layer]
     assert visual.node is not None
     if visual.MAX_TEXTURE_SIZE_3D is not None:
-        ds = np.ceil(np.divide(shape, visual.MAX_TEXTURE_SIZE_3D)).astype(int)
-        assert np.all(layer._transforms['view2data'].scale == ds)
+        s = np.ceil(np.divide(shape, visual.MAX_TEXTURE_SIZE_3D)).astype(int)
+        assert np.all(layer._transforms['view2data'].scale == s)

--- a/napari/_vispy/_tests/test_vispy_big_images.py
+++ b/napari/_vispy/_tests/test_vispy_big_images.py
@@ -12,7 +12,7 @@ def test_big_2D_image(viewer_factory):
     assert visual.node is not None
     if visual.MAX_TEXTURE_SIZE_2D is not None:
         ds = np.ceil(np.divide(shape, visual.MAX_TEXTURE_SIZE_2D)).astype(int)
-        assert np.all(layer._transform_view.scale == ds)
+        assert np.all(layer._transforms['view2data'].scale == ds)
 
 
 def test_big_3D_image(viewer_factory):
@@ -26,4 +26,4 @@ def test_big_3D_image(viewer_factory):
     assert visual.node is not None
     if visual.MAX_TEXTURE_SIZE_3D is not None:
         ds = np.ceil(np.divide(shape, visual.MAX_TEXTURE_SIZE_3D)).astype(int)
-        assert np.all(layer._transform_view.scale == ds)
+        assert np.all(layer._transforms['view2data'].scale == ds)

--- a/napari/_vispy/_tests/test_vispy_big_images.py
+++ b/napari/_vispy/_tests/test_vispy_big_images.py
@@ -12,7 +12,7 @@ def test_big_2D_image(viewer_factory):
     assert visual.node is not None
     if visual.MAX_TEXTURE_SIZE_2D is not None:
         s = np.ceil(np.divide(shape, visual.MAX_TEXTURE_SIZE_2D)).astype(int)
-        assert np.all(layer._transforms['view2data'].scale == s)
+        assert np.all(layer._transforms['tile2data'].scale == s)
 
 
 def test_big_3D_image(viewer_factory):
@@ -26,4 +26,4 @@ def test_big_3D_image(viewer_factory):
     assert visual.node is not None
     if visual.MAX_TEXTURE_SIZE_3D is not None:
         s = np.ceil(np.divide(shape, visual.MAX_TEXTURE_SIZE_3D)).astype(int)
-        assert np.all(layer._transforms['view2data'].scale == s)
+        assert np.all(layer._transforms['tile2data'].scale == s)

--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -128,11 +128,9 @@ class VispyBaseLayer(ABC):
         self.node.update()
 
     def _on_scale_change(self, event=None):
-        scale = (
-            self.layer._transform_view.compose(self.layer._transform)
-            .set_slice(self.layer.dims.displayed)
-            .scale
-        )
+        scale = self.layer._transforms.composite.set_slice(
+            self.layer.dims.displayed
+        ).scale
         # convert NumPy axis ordering to VisPy axis ordering
         self.scale = scale[::-1]
         if self.layer.is_pyramid:
@@ -140,13 +138,9 @@ class VispyBaseLayer(ABC):
         self.layer.position = self._transform_position(self._position)
 
     def _on_translate_change(self, event=None):
-        translate = (
-            self.layer._transform_grid.compose(
-                self.layer._transform_view.compose(self.layer._transform)
-            )
-            .set_slice(self.layer.dims.displayed)
-            .translate
-        )
+        translate = self.layer._transforms.composite.set_slice(
+            self.layer.dims.displayed
+        ).translate
         # convert NumPy axis ordering to VisPy axis ordering
         self.translate = translate[::-1]
         self.layer.position = self._transform_position(self._position)

--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -128,7 +128,7 @@ class VispyBaseLayer(ABC):
         self.node.update()
 
     def _on_scale_change(self, event=None):
-        scale = self.layer._transforms.composite.set_slice(
+        scale = self.layer._transforms.simplified.set_slice(
             self.layer.dims.displayed
         ).scale
         # convert NumPy axis ordering to VisPy axis ordering
@@ -138,7 +138,7 @@ class VispyBaseLayer(ABC):
         self.layer.position = self._transform_position(self._position)
 
     def _on_translate_change(self, event=None):
-        translate = self.layer._transforms.composite.set_slice(
+        translate = self.layer._transforms.simplified.set_slice(
             self.layer.dims.displayed
         ).translate
         # convert NumPy axis ordering to VisPy axis ordering

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -266,7 +266,7 @@ class VispyImageLayer(VispyBaseLayer):
             scale = np.ones(self.layer.ndim)
             for i, d in enumerate(self.layer.dims.displayed):
                 scale[d] = downsample[i]
-            self.layer._transforms['view2data'].scale = scale
+            self.layer._transforms['tile2data'].scale = scale
             self._on_scale_change()
             slices = tuple(slice(None, None, ds) for ds in downsample)
             data = data[slices]

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -266,7 +266,7 @@ class VispyImageLayer(VispyBaseLayer):
             scale = np.ones(self.layer.ndim)
             for i, d in enumerate(self.layer.dims.displayed):
                 scale[d] = downsample[i]
-            self.layer._transform_view.scale = scale
+            self.layer._transforms['view2data'].scale = scale
             self._on_scale_change()
             slices = tuple(slice(None, None, ds) for ds in downsample)
             data = data[slices]

--- a/napari/layers/_tests/test_transform_chain.py
+++ b/napari/layers/_tests/test_transform_chain.py
@@ -15,13 +15,13 @@ def test_transform_chain():
     npt.assert_allclose(new_coord_1, new_coord_2)
 
 
-def test_transform_chain_composite():
+def test_transform_chain_simplified():
     coord = [10, 13]
     transform_a = ScaleTranslate(scale=[2, 3], translate=[8, -5])
     transform_b = ScaleTranslate(scale=[0.3, 1.4], translate=[-2.2, 3])
 
     transform_chain = TransformChain([transform_a, transform_b])
-    transform_c = transform_chain.composite
+    transform_c = transform_chain.simplified
 
     new_coord_1 = transform_c(coord)
     new_coord_2 = transform_chain(coord)
@@ -58,7 +58,7 @@ def test_transform_chain_slice():
     npt.assert_allclose(new_coord_1, new_coord_2)
 
 
-def test_transform_chain_pad():
+def test_transform_chain_expanded():
     coord = [10, 3, 13]
     transform_a = ScaleTranslate(scale=[2, 1, 3], translate=[8, 0, -5])
     transform_b = ScaleTranslate(scale=[0.3, 1, 1.4], translate=[-2.2, 0, 3])
@@ -67,8 +67,8 @@ def test_transform_chain_pad():
 
     transform_chain_a = TransformChain([transform_a, transform_b])
     transform_chain_b = TransformChain([transform_c, transform_d])
-    transform_chain_padded = transform_chain_b.set_pad([1])
+    transform_chain_expandded = transform_chain_b.expand_dims([1])
 
     new_coord_2 = transform_chain_a(coord)
-    new_coord_1 = transform_chain_padded(coord)
+    new_coord_1 = transform_chain_expandded(coord)
     npt.assert_allclose(new_coord_1, new_coord_2)

--- a/napari/layers/_tests/test_transform_chain.py
+++ b/napari/layers/_tests/test_transform_chain.py
@@ -1,0 +1,74 @@
+import numpy.testing as npt
+from napari.layers.transforms import ScaleTranslate, TransformChain
+
+
+def test_transform_chain():
+    coord = [10, 13]
+    transform_a = ScaleTranslate(scale=[2, 3], translate=[8, -5])
+    transform_b = ScaleTranslate(scale=[0.3, 1.4], translate=[-2.2, 3])
+    transform_c = transform_b.compose(transform_a)
+
+    transform_chain = TransformChain([transform_a, transform_b])
+
+    new_coord_1 = transform_c(coord)
+    new_coord_2 = transform_chain(coord)
+    npt.assert_allclose(new_coord_1, new_coord_2)
+
+
+def test_transform_chain_composite():
+    coord = [10, 13]
+    transform_a = ScaleTranslate(scale=[2, 3], translate=[8, -5])
+    transform_b = ScaleTranslate(scale=[0.3, 1.4], translate=[-2.2, 3])
+
+    transform_chain = TransformChain([transform_a, transform_b])
+    transform_c = transform_chain.composite
+
+    new_coord_1 = transform_c(coord)
+    new_coord_2 = transform_chain(coord)
+    npt.assert_allclose(new_coord_1, new_coord_2)
+
+
+def test_transform_chain_inverse():
+    coord = [10, 13]
+    transform_a = ScaleTranslate(scale=[2, 3], translate=[8, -5])
+    transform_b = ScaleTranslate(scale=[0.3, 1.4], translate=[-2.2, 3])
+
+    transform_chain = TransformChain([transform_a, transform_b])
+    transform_chain_inverse = transform_chain.inverse
+
+    new_coord = transform_chain(coord)
+    orig_coord = transform_chain_inverse(new_coord)
+    npt.assert_allclose(coord, orig_coord)
+
+
+def test_transform_chain_slice():
+    coord = [10, 13]
+    transform_a = ScaleTranslate(scale=[2, 3, 3], translate=[8, 2, -5])
+    transform_b = ScaleTranslate(scale=[0.3, 1, 1.4], translate=[-2.2, 4, 3])
+    transform_c = ScaleTranslate(scale=[2, 3], translate=[8, -5])
+    transform_d = ScaleTranslate(scale=[0.3, 1.4], translate=[-2.2, 3])
+
+    transform_chain_a = TransformChain([transform_a, transform_b])
+    transform_chain_b = TransformChain([transform_c, transform_d])
+
+    transform_chain_sliced = transform_chain_a.set_slice([0, 2])
+
+    new_coord_1 = transform_chain_sliced(coord)
+    new_coord_2 = transform_chain_b(coord)
+    npt.assert_allclose(new_coord_1, new_coord_2)
+
+
+def test_transform_chain_pad():
+    coord = [10, 3, 13]
+    transform_a = ScaleTranslate(scale=[2, 1, 3], translate=[8, 0, -5])
+    transform_b = ScaleTranslate(scale=[0.3, 1, 1.4], translate=[-2.2, 0, 3])
+    transform_c = ScaleTranslate(scale=[2, 3], translate=[8, -5])
+    transform_d = ScaleTranslate(scale=[0.3, 1.4], translate=[-2.2, 3])
+
+    transform_chain_a = TransformChain([transform_a, transform_b])
+    transform_chain_b = TransformChain([transform_c, transform_d])
+    transform_chain_padded = transform_chain_b.set_pad([1])
+
+    new_coord_2 = transform_chain_a(coord)
+    new_coord_1 = transform_chain_padded(coord)
+    npt.assert_allclose(new_coord_1, new_coord_2)

--- a/napari/layers/_tests/test_transforms.py
+++ b/napari/layers/_tests/test_transforms.py
@@ -45,7 +45,7 @@ def test_scale_translate_slice():
     assert transform_b.set_slice([0, 2]).name == 'st'
 
 
-def test_scale_translate_pad():
+def test_scale_translate_expand_dims():
     transform_a = ScaleTranslate(scale=[2, 3], translate=[8, -5], name='st')
     transform_b = ScaleTranslate(scale=[2, 1, 3], translate=[8, 0, -5])
     npt.assert_allclose(transform_a.expand_dims([1]).scale, transform_b.scale)

--- a/napari/layers/_tests/test_transforms.py
+++ b/napari/layers/_tests/test_transforms.py
@@ -4,9 +4,10 @@ from napari.layers.transforms import ScaleTranslate
 
 def test_scale_translate():
     coord = [10, 13]
-    transform = ScaleTranslate(scale=[2, 3], translate=[8, -5])
+    transform = ScaleTranslate(scale=[2, 3], translate=[8, -5], name='st')
     new_coord = transform(coord)
     target_coord = [2 * 10 + 8, 3 * 13 - 5]
+    assert transform.name == 'st'
     npt.assert_allclose(new_coord, target_coord)
 
 
@@ -34,20 +35,24 @@ def test_scale_translate_compose():
 
 def test_scale_translate_slice():
     transform_a = ScaleTranslate(scale=[2, 3], translate=[8, -5])
-    transform_b = ScaleTranslate(scale=[2, 1, 3], translate=[8, 3, -5])
+    transform_b = ScaleTranslate(
+        scale=[2, 1, 3], translate=[8, 3, -5], name='st'
+    )
     npt.assert_allclose(transform_b.set_slice([0, 2]).scale, transform_a.scale)
     npt.assert_allclose(
         transform_b.set_slice([0, 2]).translate, transform_a.translate
     )
+    assert transform_b.set_slice([0, 2]).name == 'st'
 
 
 def test_scale_translate_pad():
-    transform_a = ScaleTranslate(scale=[2, 3], translate=[8, -5])
+    transform_a = ScaleTranslate(scale=[2, 3], translate=[8, -5], name='st')
     transform_b = ScaleTranslate(scale=[2, 1, 3], translate=[8, 0, -5])
     npt.assert_allclose(transform_a.set_pad([1]).scale, transform_b.scale)
     npt.assert_allclose(
         transform_a.set_pad([1]).translate, transform_b.translate
     )
+    assert transform_a.set_pad([1]).name == 'st'
 
 
 def test_scale_translate_identity_default():

--- a/napari/layers/_tests/test_transforms.py
+++ b/napari/layers/_tests/test_transforms.py
@@ -48,11 +48,11 @@ def test_scale_translate_slice():
 def test_scale_translate_pad():
     transform_a = ScaleTranslate(scale=[2, 3], translate=[8, -5], name='st')
     transform_b = ScaleTranslate(scale=[2, 1, 3], translate=[8, 0, -5])
-    npt.assert_allclose(transform_a.set_pad([1]).scale, transform_b.scale)
+    npt.assert_allclose(transform_a.expand_dims([1]).scale, transform_b.scale)
     npt.assert_allclose(
-        transform_a.set_pad([1]).translate, transform_b.translate
+        transform_a.expand_dims([1]).translate, transform_b.translate
     )
-    assert transform_a.set_pad([1]).name == 'st'
+    assert transform_a.expand_dims([1]).name == 'st'
 
 
 def test_scale_translate_identity_default():

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -147,13 +147,12 @@ class Layer(KeymapMixin, ABC):
 
         # Create a transform chain consisting of three transforms:
         # 1. `tile2data`: An initial transform only needed displaying tiles
-        #   of an image. It maps pixels of tile into the pixels of the tile
-        #   into the coordinate space of the full resolution data and can
-        #   usually be represented by a scale factor and a translation. A
-        #   common use case is viewing part of lower resolution level of an
-        #   image pyramid, another is using a downsampled version of an image
-        #   when the full image size is larger than the maximum allowed texture
-        #   size of your graphics card.
+        #   of an image. It maps pixels of the tile into the coordinate space
+        #   of the full resolution data and can usually be represented by a
+        #   scale factor and a translation. A common use case is viewing part
+        #   of lower resolution level of an image pyramid, another is using a
+        #   downsampled version of an image when the full image size is larger
+        #   than the maximum allowed texture size of your graphics card.
         # 2. `data2world`: The main transform mapping data to a world-like
         #   coordinate.
         # 3. `world2grid`: An additional transform mapping world-coordinates

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -14,7 +14,7 @@ from ...utils.keybindings import KeymapMixin
 from ...utils.misc import ROOT_DIR
 from ...utils.naming import magic_name
 from ...utils.status_messages import status_format, format_float
-from ..transforms import ScaleTranslate
+from ..transforms import ScaleTranslate, TransformChain
 
 
 class Layer(KeymapMixin, ABC):
@@ -145,21 +145,30 @@ class Layer(KeymapMixin, ABC):
         if translate is None:
             translate = [0] * ndim
 
-        # Create main transform mapping data to a world-like coordinate
-        self._transform = ScaleTranslate(scale, translate)
-        # Create additional transform mapping viewed data to data coordinate
-        # This is useful for cases where the displayed data is not the base
-        # data given by the user. In such cases, we need to transform the
-        # coordinates from the displayed data space to the original input data
-        # space. One example of such a situation is viewing a lower resolution
-        # level of an input pyramid, where _transform contains the transform
-        # only from the base level to world coordinates, another is when an
-        # image is larger than the maximum allowed texture size and has been
-        # downsampled
-        self._transform_view = ScaleTranslate(np.ones(ndim), np.zeros(ndim))
-        # Create additional transform mapping world-coordinates into a grid
-        # for looking at layers side-by-side
-        self._transform_grid = ScaleTranslate(np.ones(ndim), np.zeros(ndim))
+        # Create a transform chain consisting of three transforms:
+        # - An initial transform mapping viewed data to the data coordinates
+        #   This is useful for cases where the displayed data is not the base
+        #   data given by the user. In such cases, we need to transform the
+        #   coordinates from the displayed data space to the original input data
+        #   space. One example of such a situation is viewing a lower resolution
+        #   level of an input pyramid, where _transform contains the transform
+        #   only from the base level to world coordinates, another is when an
+        #   image is larger than the maximum allowed texture size and has been
+        #   downsampled
+        # - A main transform mapping data to a world-like coordinate
+        # - An additional transform mapping world-coordinates into a grid
+        #   for looking at layers side-by-side
+        self._transforms = TransformChain(
+            [
+                ScaleTranslate(
+                    np.ones(ndim), np.zeros(ndim), name='view2data'
+                ),
+                ScaleTranslate(scale, translate, name='data2world'),
+                ScaleTranslate(
+                    np.ones(ndim), np.zeros(ndim), name='world2grid'
+                ),
+            ]
+        )
 
         self.coordinates = (0,) * ndim
         self._position = (0,) * self.dims.ndisplay
@@ -305,35 +314,35 @@ class Layer(KeymapMixin, ABC):
     @property
     def scale(self):
         """list: Anisotropy factors to scale the layer by."""
-        return self._transform.scale
+        return self._transforms['data2world'].scale
 
     @scale.setter
     def scale(self, scale):
-        self._transform.scale = np.array(scale)
+        self._transforms['data2world'].scale = np.array(scale)
         self._update_dims()
         self.events.scale()
 
     @property
     def translate(self):
         """list: Factors to shift the layer by."""
-        return self._transform.translate
+        return self._transforms['data2world'].translate
 
     @translate.setter
     def translate(self, translate):
-        self._transform.translate = np.array(translate)
+        self._transforms['data2world'].translate = np.array(translate)
         self._update_dims()
         self.events.translate()
 
     @property
     def translate_grid(self):
         """list: Factors to shift the layer by."""
-        return self._transform_grid.translate
+        return self._transforms['world2grid'].translate
 
     @translate_grid.setter
     def translate_grid(self, translate_grid):
         if np.all(self.translate_grid == translate_grid):
             return
-        self._transform_grid.translate = np.array(translate_grid)
+        self._transforms['world2grid'].translate = np.array(translate_grid)
         self.events.translate()
 
     @property
@@ -366,14 +375,10 @@ class Layer(KeymapMixin, ABC):
         old_ndim = self.dims.ndim
         if old_ndim > ndim:
             keep_axes = range(old_ndim - ndim, old_ndim)
-            self._transform = self._transform.set_slice(keep_axes)
-            self._transform_view = self._transform_view.set_slice(keep_axes)
-            self._transform_grid = self._transform_grid.set_slice(keep_axes)
+            self._transforms = self._transforms.set_slice(keep_axes)
         elif old_ndim < ndim:
             new_axes = range(ndim - old_ndim)
-            self._transform = self._transform.set_pad(new_axes)
-            self._transform_view = self._transform_view.set_pad(new_axes)
-            self._transform_grid = self._transform_grid.set_pad(new_axes)
+            self._transforms = self._transforms.set_pad(new_axes)
 
         self.dims.ndim = ndim
 
@@ -623,9 +628,7 @@ class Layer(KeymapMixin, ABC):
         msg : string
             String containing a message that can be used as a status update.
         """
-        coordinates = self._transform_view.compose(self._transform)(
-            self.coordinates
-        )
+        coordinates = self._transforms.composite(self.coordinates)
         full_coord = np.round(coordinates).astype(int)
 
         msg = f'{self.name} {full_coord}'

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -146,18 +146,18 @@ class Layer(KeymapMixin, ABC):
             translate = [0] * ndim
 
         # Create a transform chain consisting of three transforms:
-        # - An initial transform mapping viewed data to the data coordinates
-        #   This is useful for cases where the displayed data is not the base
-        #   data given by the user. In such cases, we need to transform the
-        #   coordinates from the displayed data space to the original input data
-        #   space. One example of such a situation is viewing a lower resolution
-        #   level of an input pyramid, where _transform contains the transform
-        #   only from the base level to world coordinates, another is when an
-        #   image is larger than the maximum allowed texture size and has been
-        #   downsampled
-        # - A main transform mapping data to a world-like coordinate
-        # - An additional transform mapping world-coordinates into a grid
-        #   for looking at layers side-by-side
+        # 1. `view2data`: An initial transform mapping the actually viewed data
+        #   to the data coordinates. This is useful for cases where the
+        #   displayed data is not the base data given by the user. In such
+        #   cases, we need to  transform the coordinates from the displayed
+        #   data space to the original input data space. One example of such a
+        #   situation is viewing a lower resolution level of an input pyramid,
+        #   another is when an image is larger than the maximum allowed texture
+        #   size and has been downsampled so it can be viewed.
+        # 2. `data2world`: The main transform mapping data to a world-like
+        #   coordinate.
+        # 3. `world2grid`: An additional transform mapping world-coordinates
+        #   into a grid for looking at layers side-by-side.
         self._transforms = TransformChain(
             [
                 ScaleTranslate(
@@ -313,7 +313,7 @@ class Layer(KeymapMixin, ABC):
 
     @property
     def scale(self):
-        """list: Anisotropy factors to scale the layer by."""
+        """list: Anisotropy factors to scale data into world coordinates."""
         return self._transforms['data2world'].scale
 
     @scale.setter
@@ -324,7 +324,7 @@ class Layer(KeymapMixin, ABC):
 
     @property
     def translate(self):
-        """list: Factors to shift the layer by."""
+        """list: Factors to shift the layer by in units of world coordinates."""
         return self._transforms['data2world'].translate
 
     @translate.setter

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -454,8 +454,8 @@ class Image(IntensityVisualizationMixin, Layer):
                         self._top_left[d] + self._max_tile_shape,
                         1,
                     )
-                # Note that top left marks the ocation of top left canvas
-                # pixel in image
+                # Note that top left marks the location of top left canvas
+                # pixel in data coordinates
                 self._transforms['tile2data'].translate = (
                     self._top_left
                     * self._transforms['data2world'].scale

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -445,7 +445,7 @@ class Image(IntensityVisualizationMixin, Layer):
             scale = np.ones(self.ndim)
             for d in self.dims.displayed:
                 scale[d] = self.level_downsamples[self.data_level][d]
-            self._transforms['view2data'].scale = scale
+            self._transforms['tile2data'].scale = scale
 
             if np.any(disp_shape > self._max_tile_shape):
                 for d in self.dims.displayed:
@@ -454,13 +454,15 @@ class Image(IntensityVisualizationMixin, Layer):
                         self._top_left[d] + self._max_tile_shape,
                         1,
                     )
-                self._transforms['view2data'].translate = (
+                # Note that top left marks the ocation of top left canvas
+                # pixel in image
+                self._transforms['tile2data'].translate = (
                     self._top_left
-                    * self.scale
-                    * self._transforms['view2data'].scale
+                    * self._transforms['data2world'].scale
+                    * self._transforms['tile2data'].scale
                 )
             else:
-                self._transforms['view2data'].translate = [0] * self.ndim
+                self._transforms['tile2data'].translate = [0] * self.ndim
 
             image = np.asarray(
                 self._data_pyramid[level][tuple(indices)]
@@ -485,7 +487,7 @@ class Image(IntensityVisualizationMixin, Layer):
                     self._data_pyramid[-1][tuple(indices)]
                 ).transpose(order)
         else:
-            self._transforms['view2data'].scale = np.ones(self.dims.ndim)
+            self._transforms['tile2data'].scale = np.ones(self.dims.ndim)
             image = np.asarray(self.data[self.dims.indices]).transpose(order)
             thumbnail = image
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -445,7 +445,7 @@ class Image(IntensityVisualizationMixin, Layer):
             scale = np.ones(self.ndim)
             for d in self.dims.displayed:
                 scale[d] = self.level_downsamples[self.data_level][d]
-            self._transform_view.scale = scale
+            self._transforms['view2data'].scale = scale
 
             if np.any(disp_shape > self._max_tile_shape):
                 for d in self.dims.displayed:
@@ -454,11 +454,13 @@ class Image(IntensityVisualizationMixin, Layer):
                         self._top_left[d] + self._max_tile_shape,
                         1,
                     )
-                self._transform_view.translate = (
-                    self._top_left * self.scale * self._transform_view.scale
+                self._transforms['view2data'].translate = (
+                    self._top_left
+                    * self.scale
+                    * self._transforms['view2data'].scale
                 )
             else:
-                self._transform_view.translate = [0] * self.ndim
+                self._transforms['view2data'].translate = [0] * self.ndim
 
             image = np.asarray(
                 self._data_pyramid[level][tuple(indices)]
@@ -483,7 +485,7 @@ class Image(IntensityVisualizationMixin, Layer):
                     self._data_pyramid[-1][tuple(indices)]
                 ).transpose(order)
         else:
-            self._transform_view.scale = np.ones(self.dims.ndim)
+            self._transforms['view2data'].scale = np.ones(self.dims.ndim)
             image = np.asarray(self.data[self.dims.indices]).transpose(order)
             thumbnail = image
 

--- a/napari/layers/transforms.py
+++ b/napari/layers/transforms.py
@@ -37,7 +37,7 @@ class Transform:
             raise ValueError('Inverse function was not provided.')
 
     def compose(self, transform: 'Transform') -> 'Transform':
-        """Return the composite of this transform and the proivded one."""
+        """Return the composite of this transform and the provided one."""
         raise ValueError('Transform composition rule not provided')
 
     def set_slice(self, axes: Sequence[int]) -> 'Transform':
@@ -55,15 +55,15 @@ class Transform:
         """
         raise NotImplementedError('Cannot subset arbitrary transforms.')
 
-    def set_pad(self, axes: Sequence[int]) -> 'Transform':
+    def expand_dims(self, axes: Sequence[int]) -> 'Transform':
         """Return a transform with added axes for non-visible dimensions.
 
         Parameters
         ----------
         axes : Sequence[int]
-            Location of axes to pad the current transform with. Passing a list
-            allows padding to occur at specific locations and for set_pad to
-            be like an inverse to the set_slice method.
+            Location of axes to expand the current transform with. Passing a
+            list allows expanion to occur at specific locations and for
+            expand_dims to be like an inverse to the set_slice method.
 
         Returns
         -------
@@ -93,8 +93,8 @@ class TransformChain(ListModel, Transform):
         return TransformChain([tf.inverse for tf in self[::-1]])
 
     @property
-    def composite(self) -> 'Transform':
-        """Return a composite of the transform chain."""
+    def simplified(self) -> 'Transform':
+        """Return the composite of the transforms inside the transform chain."""
         if len(self) == 0:
             return None
         if len(self) == 1:
@@ -117,22 +117,22 @@ class TransformChain(ListModel, Transform):
         """
         return TransformChain([tf.set_slice(axes) for tf in self])
 
-    def set_pad(self, axes: Sequence[int]) -> 'Transform':
+    def expand_dims(self, axes: Sequence[int]) -> 'Transform':
         """Return a transform chain with added axes for non-visible dimensions.
 
         Parameters
         ----------
         axes : Sequence[int]
-            Location of axes to pad the current transform chain with. Passing a
-            list allows padding to occur at specific locations and for set_pad
-            to be like an inverse to the set_slice method.
+            Location of axes to expand the current transform with. Passing a
+            list allows expanion to occur at specific locations and for
+            expand_dims to be like an inverse to the set_slice method.
 
         Returns
         -------
         TransformChain
             Resulting transform chain.
         """
-        return TransformChain([tf.set_pad(axes) for tf in self])
+        return TransformChain([tf.expand_dims(axes) for tf in self])
 
 
 class ScaleTranslate(Transform):
@@ -178,7 +178,7 @@ class ScaleTranslate(Transform):
         return ScaleTranslate(1 / self.scale, -1 / self.scale * self.translate)
 
     def compose(self, transform: 'ScaleTranslate') -> 'ScaleTranslate':
-        """Return the composite of this transform and the proivded one."""
+        """Return the composite of this transform and the provided one."""
         scale = self.scale * transform.scale
         translate = self.translate + self.scale * transform.translate
         return ScaleTranslate(scale, translate)
@@ -200,15 +200,15 @@ class ScaleTranslate(Transform):
             self.scale[axes], self.translate[axes], name=self.name
         )
 
-    def set_pad(self, axes: Sequence[int]) -> 'ScaleTranslate':
+    def expand_dims(self, axes: Sequence[int]) -> 'ScaleTranslate':
         """Return a transform with added axes for non-visible dimensions.
 
         Parameters
         ----------
         axes : Sequence[int]
-            Location of axes to pad the current transform with. Passing a list
-            allows padding to occur at specific locations and for set_pad to
-            be like an inverse to the set_slice method.
+            Location of axes to expand the current transform with. Passing a
+            list allows expanion to occur at specific locations and for
+            expand_dims to be like an inverse to the set_slice method.
 
         Returns
         -------

--- a/napari/layers/transforms.py
+++ b/napari/layers/transforms.py
@@ -1,6 +1,7 @@
 import toolz as tz
 from typing import Sequence
 import numpy as np
+from ..utils.list import ListModel
 
 
 class Transform:
@@ -27,6 +28,17 @@ class Transform:
     def __call__(self, coords):
         """Transform input coordinates to output."""
         return self.func(coords)
+
+    @property
+    def inverse(self) -> 'Transform':
+        if self._inverse_func is not None:
+            return Transform(self._inverse_func, self.func)
+        else:
+            raise ValueError('Inverse function was not provided.')
+
+    def compose(self, transform: 'Transform') -> 'Transform':
+        """Return the composite of this transform and the proivded one."""
+        raise ValueError('Transform composition rule not provided')
 
     def set_slice(self, axes: Sequence[int]) -> 'Transform':
         """Return a transform subset to the visible dimensions.
@@ -60,12 +72,67 @@ class Transform:
         """
         raise NotImplementedError('Cannot subset arbitrary transforms.')
 
+
+class TransformChain(ListModel, Transform):
+    def __init__(self, transforms=[]):
+        super().__init__(
+            basetype=Transform,
+            iterable=transforms,
+            lookup={str: lambda q, e: q == e.name},
+        )
+
+    def __call__(self, coords):
+        return tz.pipe(coords, *self)
+
+    def __newlike__(self, iterable):
+        return ListModel(self._basetype, iterable, self._lookup)
+
     @property
-    def inverse(self) -> 'Transform':
-        if self._inverse_func is not None:
-            return Transform(self._inverse_func, self.func)
+    def inverse(self) -> 'TransformChain':
+        """Return the inverse transform chain."""
+        return TransformChain([tf.inverse for tf in self[::-1]])
+
+    @property
+    def composite(self) -> 'Transform':
+        """Return a composite of the transform chain."""
+        if len(self) == 0:
+            return None
+        if len(self) == 1:
+            return self[0]
         else:
-            raise ValueError('Inverse function was not provided.')
+            return tz.pipe(self[0], *[tf.compose for tf in self[1:]])
+
+    def set_slice(self, axes: Sequence[int]) -> 'TransformChain':
+        """Return a transform chain subset to the visible dimensions.
+
+        Parameters
+        ----------
+        axes : Sequence[int]
+            Axes to subset the current transform chain with.
+
+        Returns
+        -------
+        TransformChain
+            Resulting transform chain.
+        """
+        return TransformChain([tf.set_slice(axes) for tf in self])
+
+    def set_pad(self, axes: Sequence[int]) -> 'Transform':
+        """Return a transform chain with added axes for non-visible dimensions.
+
+        Parameters
+        ----------
+        axes : Sequence[int]
+            Location of axes to pad the current transform chain with. Passing a
+            list allows padding to occur at specific locations and for set_pad
+            to be like an inverse to the set_slice method.
+
+        Returns
+        -------
+        TransformChain
+            Resulting transform chain.
+        """
+        return TransformChain([tf.set_pad(axes) for tf in self])
 
 
 class ScaleTranslate(Transform):
@@ -110,6 +177,12 @@ class ScaleTranslate(Transform):
         """Return the inverse transform."""
         return ScaleTranslate(1 / self.scale, -1 / self.scale * self.translate)
 
+    def compose(self, transform: 'ScaleTranslate') -> 'ScaleTranslate':
+        """Return the composite of this transform and the proivded one."""
+        scale = self.scale * transform.scale
+        translate = self.translate + self.scale * transform.translate
+        return ScaleTranslate(scale, translate)
+
     def set_slice(self, axes: Sequence[int]) -> 'ScaleTranslate':
         """Return a transform subset to the visible dimensions.
 
@@ -146,10 +219,4 @@ class ScaleTranslate(Transform):
         scale[not_axes] = self.scale
         translate = np.zeros(n)
         translate[not_axes] = self.translate
-        return ScaleTranslate(scale, translate)
-
-    def compose(self, transform: 'ScaleTranslate') -> 'ScaleTranslate':
-        """Return the composite of this transform and the proivded one."""
-        scale = self.scale * transform.scale
-        translate = self.translate + self.scale * transform.translate
         return ScaleTranslate(scale, translate)

--- a/napari/layers/transforms.py
+++ b/napari/layers/transforms.py
@@ -196,7 +196,9 @@ class ScaleTranslate(Transform):
         Transform
             Resulting transform.
         """
-        return ScaleTranslate(self.scale[axes], self.translate[axes])
+        return ScaleTranslate(
+            self.scale[axes], self.translate[axes], name=self.name
+        )
 
     def set_pad(self, axes: Sequence[int]) -> 'ScaleTranslate':
         """Return a transform with added axes for non-visible dimensions.
@@ -219,4 +221,4 @@ class ScaleTranslate(Transform):
         scale[not_axes] = self.scale
         translate = np.zeros(n)
         translate[not_axes] = self.translate
-        return ScaleTranslate(scale, translate)
+        return ScaleTranslate(scale, translate, name=self.name)


### PR DESCRIPTION
# Description
This PR follows on from #1018 and #885 and the work of @jni and @GenevieveBuckley by adding support for a `ChainTransform` (first described in #885) and consolidating our current 3 types of transform - view2data, data2world, and world2grid inside it.

This PR is not designed to change any functionality, but makes it easier to chain our transforms together. We still have to think about what does it look like when a user wants to provide many transforms of mixed types etc as described in #1016, this PR is only a small step in that direction.

The next step after this will be to introduce the concept of a world coordinate system that our dims sliders obey too. 

Would love your feedback @GenevieveBuckley @jni and others

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Refactor (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] adds `napari/layers/_tests/test_transform_chain.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
