### PR TITLE
make console loading lazy

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -34,7 +34,7 @@ def test_qt_viewer_with_console(viewer_factory):
     assert view.console is None
 
     # Test creation of console
-    view.toggle_console(None)
+    view.toggle_console_visibility(None)
     assert view.console is not None
     assert view.dockConsole.widget == view.console
 

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -18,6 +18,7 @@ def test_qt_viewer(viewer_factory):
 
     assert viewer.title == 'napari'
     assert view.viewer == viewer
+    assert view.console is None
 
     assert len(viewer.layers) == 0
     assert view.layers.vbox_layout.count() == 2
@@ -25,6 +26,17 @@ def test_qt_viewer(viewer_factory):
     assert viewer.dims.ndim == 2
     assert view.dims.nsliders == viewer.dims.ndim
     assert np.sum(view.dims._displayed_sliders) == 0
+
+
+def test_qt_viewer_with_console(viewer_factory):
+    """Test instantiating console from viewer."""
+    view, viewer = viewer_factory()
+    assert view.console is None
+
+    # Test creation of console
+    view.toggle_console(None)
+    assert view.console is not None
+    assert view.dockConsole.widget == view.console
 
 
 @pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -18,7 +18,8 @@ def test_qt_viewer(viewer_factory):
 
     assert viewer.title == 'napari'
     assert view.viewer == viewer
-    assert view.console is None
+    # Check no console is present before it is requested
+    assert view._console is None
 
     assert len(viewer.layers) == 0
     assert view.layers.vbox_layout.count() == 2
@@ -31,11 +32,21 @@ def test_qt_viewer(viewer_factory):
 def test_qt_viewer_with_console(viewer_factory):
     """Test instantiating console from viewer."""
     view, viewer = viewer_factory()
-    assert view.console is None
-
-    # Test creation of console
-    view.toggle_console_visibility(None)
+    # Check no console is present before it is requested
+    assert view._console is None
+    # Check console is created when requested
     assert view.console is not None
+    assert view.dockConsole.widget == view.console
+
+
+def test_qt_viewer_toggle_console(viewer_factory):
+    """Test instantiating console from viewer."""
+    view, viewer = viewer_factory()
+    # Check no console is present before it is requested
+    assert view._console is None
+    # Check console has been created when it is supposed to be shown
+    view.toggle_console_visibility(None)
+    assert view._console is not None
     assert view.dockConsole.widget == view.console
 
 

--- a/napari/_qt/qt_console.py
+++ b/napari/_qt/qt_console.py
@@ -141,7 +141,7 @@ class QtConsole(RichJupyterWidget):
         themed_stylesheet : str
             Stylesheet that has already been themed with the current pallete.
         """
-        # self.style_sheet = themed_stylesheet
+        self.style_sheet = themed_stylesheet
         self.syntax_style = palette['syntax_style']
         bracket_color = QColor(*str_to_rgb(palette['highlight']))
         self._bracket_matcher.format.setBackground(bracket_color)

--- a/napari/_qt/qt_console.py
+++ b/napari/_qt/qt_console.py
@@ -1,5 +1,6 @@
 import sys
 
+from qtpy.QtGui import QColor
 from ipykernel.connect import get_connection_file
 from ipykernel.inprocess.ipkernel import InProcessInteractiveShell
 from ipykernel.zmqshell import ZMQInteractiveShell
@@ -8,6 +9,7 @@ from IPython.terminal.interactiveshell import TerminalInteractiveShell
 from qtconsole.client import QtKernelClient
 from qtconsole.inprocess import QtInProcessKernelManager
 from qtconsole.rich_jupyter_widget import RichJupyterWidget
+from ..utils.misc import str_to_rgb
 
 """
 set default asyncio policy to be compatible with tornado
@@ -127,6 +129,22 @@ class QtConsole(RichJupyterWidget):
 
         # TODO: Try to get console from jupyter to run without a shift click
         # self.execute_on_complete_input = True
+
+    def _update_palette(self, palette, themed_stylesheet):
+        """Update the napari GUI theme.
+
+        Parameters
+        ----------
+        palette : dict of str: str
+            Color palette with which to style the viewer.
+            Property of napari.components.viewer_model.ViewerModel.
+        themed_stylesheet : str
+            Stylesheet that has already been themed with the current pallete.
+        """
+        self.style_sheet = themed_stylesheet
+        self.syntax_style = palette['syntax_style']
+        bracket_color = QColor(*str_to_rgb(palette['highlight']))
+        self._bracket_matcher.format.setBackground(bracket_color)
 
     def closeEvent(self, event):
         """Clean up the integrated console in napari."""

--- a/napari/_qt/qt_console.py
+++ b/napari/_qt/qt_console.py
@@ -141,7 +141,7 @@ class QtConsole(RichJupyterWidget):
         themed_stylesheet : str
             Stylesheet that has already been themed with the current pallete.
         """
-        self.style_sheet = themed_stylesheet
+        # self.style_sheet = themed_stylesheet
         self.syntax_style = palette['syntax_style']
         bracket_color = QColor(*str_to_rgb(palette['highlight']))
         self._bracket_matcher.format.setBackground(bracket_color)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -88,9 +88,7 @@ class Window:
 
         self._update_palette(qt_viewer.viewer.palette)
 
-        if self.qt_viewer.console.shell is not None:
-            self._add_viewer_dock_widget(self.qt_viewer.dockConsole)
-
+        self._add_viewer_dock_widget(self.qt_viewer.dockConsole)
         self._add_viewer_dock_widget(self.qt_viewer.dockLayerControls)
         self._add_viewer_dock_widget(self.qt_viewer.dockLayerList)
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -1,7 +1,6 @@
 import inspect
 from pathlib import Path
 
-from qtpy import QtGui
 from qtpy.QtCore import QCoreApplication, Qt, QSize
 from qtpy.QtWidgets import QWidget, QVBoxLayout, QFileDialog, QSplitter
 from qtpy.QtGui import QCursor, QGuiApplication
@@ -14,7 +13,6 @@ from .qt_dims import QtDims
 from .qt_layerlist import QtLayerList
 from ..resources import get_stylesheet
 from ..utils.theme import template
-from ..utils.misc import str_to_rgb
 from ..utils.interactions import (
     ReadOnlyWrapper,
     mouse_press_callbacks,
@@ -26,7 +24,6 @@ from ..utils.keybindings import components_to_key_combo
 from .utils import QImg2array, square_pixmap
 from .qt_controls import QtControls
 from .qt_viewer_buttons import QtLayerButtons, QtViewerButtons
-from .qt_console import QtConsole
 from .qt_viewer_dock_widget import QtViewerDockWidget
 from .qt_about_keybindings import QtAboutKeybindings
 from .._vispy import create_vispy_visual
@@ -91,7 +88,7 @@ class QtViewer(QSplitter):
         self.layers = QtLayerList(self.viewer.layers)
         self.layerButtons = QtLayerButtons(self.viewer)
         self.viewerButtons = QtViewerButtons(self.viewer)
-        self.console = QtConsole({'viewer': self.viewer})
+        self.console = None
 
         layerList = QWidget()
         layerList.setObjectName('layerList')
@@ -117,7 +114,7 @@ class QtViewer(QSplitter):
         )
         self.dockConsole = QtViewerDockWidget(
             self,
-            self.console,
+            QWidget(),
             name='console',
             area='bottom',
             allowed_areas=['top', 'bottom'],
@@ -130,13 +127,7 @@ class QtViewer(QSplitter):
 
         # This dictionary holds the corresponding vispy visual for each layer
         self.layer_to_visual = {}
-
-        if self.console.shell is not None:
-            self.viewerButtons.consoleButton.clicked.connect(
-                lambda: self.toggle_console()
-            )
-        else:
-            self.viewerButtons.consoleButton.setEnabled(False)
+        self.viewerButtons.consoleButton.clicked.connect(self.toggle_console)
 
         self.canvas = SceneCanvas(keys=None, vsync=True, parent=self)
         self.canvas.events.ignore_callback_errors = False
@@ -174,16 +165,14 @@ class QtViewer(QSplitter):
             'standard': QCursor(),
         }
 
-        self._update_palette(viewer.palette)
+        self._update_palette(None)
 
         self._key_release_generators = {}
 
         self.viewer.events.interactive.connect(self._on_interactive)
         self.viewer.events.cursor.connect(self._on_cursor)
         self.viewer.events.reset_view.connect(self._on_reset_view)
-        self.viewer.events.palette.connect(
-            lambda event: self._update_palette(event.palette)
-        )
+        self.viewer.events.palette.connect(self._update_palette)
         self.viewer.layers.events.reordered.connect(self._reorder_layers)
         self.viewer.layers.events.added.connect(self._add_layer)
         self.viewer.layers.events.removed.connect(self._remove_layer)
@@ -393,26 +382,31 @@ class QtViewer(QSplitter):
             # Assumes default camera has the same properties as PanZoomCamera
             self.view.camera.rect = event.rect
 
-    def _update_palette(self, palette):
-        """Update the napari GUI theme.
-
-        Parameters
-        ----------
-        palette : dict of str: str
-            Color palette with which to style the viewer.
-            Property of napari.components.viewer_model.ViewerModel
-        """
+    def _update_palette(self, event):
+        """Update the napari GUI theme."""
         # template and apply the primary stylesheet
-        themed_stylesheet = template(self.raw_stylesheet, **palette)
-        self.console.style_sheet = themed_stylesheet
-        self.console.syntax_style = palette['syntax_style']
-        bracket_color = QtGui.QColor(*str_to_rgb(palette['highlight']))
-        self.console._bracket_matcher.format.setBackground(bracket_color)
+        themed_stylesheet = template(
+            self.raw_stylesheet, **self.viewer.palette
+        )
+        if self.console is not None:
+            self.console._update_palette(
+                self.viewer.palette, themed_stylesheet
+            )
         self.setStyleSheet(themed_stylesheet)
-        self.canvas.bgcolor = palette['canvas']
+        self.canvas.bgcolor = self.viewer.palette['canvas']
 
-    def toggle_console(self):
-        """Toggle console visible and not visible."""
+    def toggle_console(self, event):
+        """Toggle console visible and not visible.
+
+        Imports the console the first time it is requested.
+        """
+        if self.console is None:
+            from .qt_console import QtConsole
+
+            self.console = QtConsole({'viewer': self.viewer})
+            self.dockConsole.widget = self.console
+            self._update_palette(None)
+
         viz = not self.dockConsole.isVisible()
         # modulate visibility at the dock widget level as console is docakable
         self.dockConsole.setVisible(viz)
@@ -621,7 +615,8 @@ class QtViewer(QSplitter):
         # not a problem)
         self.dims.stop()
         self.canvas.native.deleteLater()
-        self.console.close()
+        if self.console is not None:
+            self.console.close()
         self.dockConsole.deleteLater()
         if not self.pool.waitForDone(10000):
             raise TimeoutError("Timed out waiting for QtViewer.pool to finish")

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -406,7 +406,7 @@ class QtViewer(QSplitter):
         themed_stylesheet = template(
             self.raw_stylesheet, **self.viewer.palette
         )
-        if self.console is not None:
+        if self._console is not None:
             self.console._update_palette(
                 self.viewer.palette, themed_stylesheet
             )
@@ -418,6 +418,9 @@ class QtViewer(QSplitter):
 
         Imports the console the first time it is requested.
         """
+        # force instantiation of console if not already instantiated
+        _ = self.console
+
         viz = not self.dockConsole.isVisible()
         # modulate visibility at the dock widget level as console is docakable
         self.dockConsole.setVisible(viz)
@@ -626,7 +629,7 @@ class QtViewer(QSplitter):
         # not a problem)
         self.dims.stop()
         self.canvas.native.deleteLater()
-        if self.console is not None:
+        if self._console is not None:
             self.console.close()
         self.dockConsole.deleteLater()
         if not self.pool.waitForDone(10000):

--- a/napari/_qt/qt_viewer_dock_widget.py
+++ b/napari/_qt/qt_viewer_dock_widget.py
@@ -79,8 +79,7 @@ class QtViewerDockWidget(QDockWidget):
         self.setMinimumWidth(50)
         self.setObjectName(name)
 
-        self.setWidget(widget)
-        widget.setParent(self)
+        self.widget = widget
         self._features = self.features()
         self.dockLocationChanged.connect(self._set_title_orientation)
 
@@ -88,6 +87,17 @@ class QtViewerDockWidget(QDockWidget):
         self.title = QtCustomTitleBar(self)
         self.setTitleBarWidget(self.title)
         self.visibilityChanged.connect(self._on_visibility_changed)
+
+    @property
+    def widget(self):
+        """QWidget: widget that will be added as QDockWidget's main widget."""
+        return self._widget
+
+    @widget.setter
+    def widget(self, widget):
+        self.setWidget(widget)
+        widget.setParent(self)
+        self._widget = widget
 
     def setFeatures(self, features):
         super().setFeatures(features)

--- a/napari/_tests/test_advanced.py
+++ b/napari/_tests/test_advanced.py
@@ -155,13 +155,6 @@ def test_update_console(viewer_factory):
     """Test updating the console with local variables."""
     view, viewer = viewer_factory()
 
-    # Check no console is present befor it is called
-    assert view._console is None
-    # Call console
-    _ = view.console
-    # Check console has now been created
-    assert view._console is not None
-
     # Check viewer in console
     assert view.console.kernel_client is not None
     assert 'viewer' in view.console.shell.user_ns

--- a/napari/_tests/test_advanced.py
+++ b/napari/_tests/test_advanced.py
@@ -155,10 +155,12 @@ def test_update_console(viewer_factory):
     """Test updating the console with local variables."""
     view, viewer = viewer_factory()
 
-    # Create console
-    assert view.console is None
-    view.toggle_console(None)
-    assert view.console is not None
+    # Check no console is present befor it is called
+    assert view._console is None
+    # Call console
+    _ = view.console
+    # Check console has now been created
+    assert view._console is not None
 
     # Check viewer in console
     assert view.console.kernel_client is not None

--- a/napari/_tests/test_advanced.py
+++ b/napari/_tests/test_advanced.py
@@ -155,6 +155,11 @@ def test_update_console(viewer_factory):
     """Test updating the console with local variables."""
     view, viewer = viewer_factory()
 
+    # Create console
+    assert view.console is None
+    view.toggle_console(None)
+    assert view.console is not None
+
     # Check viewer in console
     assert view.console.kernel_client is not None
     assert 'viewer' in view.console.shell.user_ns

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -109,7 +109,7 @@ class ViewerModel(AddLayersMixin, KeymapMixin):
             return
 
         self._palette = palette
-        self.events.palette(palette=palette)
+        self.events.palette()
 
     @property
     def theme(self):

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -66,7 +66,24 @@ class Viewer(ViewerModel):
         )
         qt_viewer = QtViewer(self)
         self.window = Window(qt_viewer, show=show)
-        self.update_console = self.window.qt_viewer.console.push
+
+    def update_console(self, variables):
+        """Update console's namespace with desired variables.
+
+        Parameters
+        ----------
+        variables : dict, str or list/tuple of str
+            The variables to inject into the console's namespace.  If a dict, a
+            simple update is done.  If a str, the string is assumed to have
+            variable names separated by spaces.  A list/tuple of str can also
+            be used to give the variable names.  If just the variable names are
+            give (list/tuple/str) then the variable values looked up in the
+            callers frame.
+        """
+        if self.window.qt_viewer.console is None:
+            return
+        else:
+            self.window.qt_viewer.console.push(variables)
 
     def screenshot(self, path=None, *, with_viewer=False):
         """Take currently displayed screen and convert to an image array.


### PR DESCRIPTION
# Description
This PR will make console loading lazy - i.e. we won't load any console until it is requested by the user. This will have the nice effect of making unintended bugs from our console - such as #687 and #734 less painful to users (though we should maybe also fix them an alternative way), and it will also make load time ~30% faster - see https://github.com/napari/napari/issues/758#issuecomment-573787996.

This was one of the proposed console improvements in #787. There are more proposed in #787, but this seemed like a reasonable one to start with. Note that if you launch from ipython you'll get a button which then pops open a black space when clicked. We could disable that or present a message saying no console present with ipython. Curious what people recommend.

This is ready for review. Maybe @shanaxel42 @ttung @jni and @tlambert03 can take a look.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
Closes #758 - see https://github.com/napari/napari/issues/758#issuecomment-573787996

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: added an explicit test `test_qt_viewer_with_console` inside `napari/_qt/_tests/test_qt_viewer.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
