### PR TITLE
check if PyQt5 is installed and then not install PySide2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -69,7 +69,7 @@ linux_task:
   install_script:
     - python -m pip install --retries 3 --upgrade pip
     - pip install --retries 3 -r requirements.txt
-    - python setup.py develop
+    - python -m pip install -e .
 
   check_script:
     - conda list
@@ -123,7 +123,7 @@ mac_task:
   install_script:
     - python -m pip install --retries 3 --upgrade pip
     - pip install --retries 3 -r requirements.txt
-    - python setup.py develop
+    - python -m pip install -e .
 
   check_script:
     - conda list
@@ -187,7 +187,7 @@ win_task:
   install_script:
     - python -m pip install --retries 3 --upgrade pip
     - pip install --retries 3 -r requirements.txt
-    - python setup.py develop
+    - python -m pip install -e .
 
   check_script:
     - conda list

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -220,6 +220,7 @@ codecov_task:
   install_script: |
     python -m pip install --retries 3 --upgrade pip
     pip install -r requirements.txt
+    pip install -e .
     pip install pytest-cov codecov
 
   coverage_script: |

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -15,4 +15,4 @@ PyOpenGL>=3.1.0
 wrapt>=1.11.1
 numpydoc>=0.9.2
 pluggy>=0.13.0
-# Qt version is managed form setup.py to allow Pyside2 installation omit whem PyQt5 is installed
+# Qt version is managed from setup.py to install PySide2 when no Qt libraries are found

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -12,7 +12,7 @@ vispy>=0.6.4
 IPython>=7.7.0
 backcall>=0.1.0
 PyOpenGL>=3.1.0
-PySide2>=5.12.3
 wrapt>=1.11.1
 numpydoc>=0.9.2
 pluggy>=0.13.0
+# Qt version is managed form setup.py to allow Pyside2 installation omit whem PyQt5 is installed

--- a/setup.py
+++ b/setup.py
@@ -54,12 +54,19 @@ if sys.version_info < (MIN_PY_MAJOR_VER, MIN_PY_MINOR_VER):
     )
     sys.exit(1)
 
+try:
+    import PyQt5  # noqa: F401
+
+    pyqt = True
+except ImportError:
+    pyqt = False
+
 requirements = []
 with open(osp.join('requirements', 'default.txt')) as f:
     for line in f:
         splitted = line.split("#")
         stripped = splitted[0].strip()
-        if len(stripped) > 0:
+        if len(stripped) > 0 and not (pyqt and stripped.startswith("PySide2")):
             requirements.append(stripped)
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,8 @@ if sys.version_info < (MIN_PY_MAJOR_VER, MIN_PY_MINOR_VER):
     )
     sys.exit(1)
 
+QT_MIN_VERSION = "5.12.3"
+
 try:
     import PyQt5  # noqa: F401
 
@@ -61,13 +63,26 @@ try:
 except ImportError:
     pyqt = False
 
+try:
+    import PySide2  # noqa: F401
+
+    pyside = True
+except ImportError:
+    pyside = False
+
 requirements = []
 with open(osp.join('requirements', 'default.txt')) as f:
     for line in f:
         splitted = line.split("#")
         stripped = splitted[0].strip()
-        if len(stripped) > 0 and not (pyqt and stripped.startswith("PySide2")):
+        if len(stripped) > 0:
             requirements.append(stripped)
+
+if pyqt:
+    requirements.append("PyQt5>=" + QT_MIN_VERSION)
+if pyside or not (pyqt or pyside):
+    requirements.append("PySide2>=" + QT_MIN_VERSION)
+
 
 setup(
     name=DISTNAME,


### PR DESCRIPTION
# Description
If someone have installed PyQt5 then installing PySide2 next to may create problem with chosing Qt implementation. 

## Type of change
Filter Pyside2 from requirements if PyQt5 is installed 
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] run `python setup.py sdist` then on new interpeter (ex. virtualenv) `pip install -U pip; pip install PyQt5; pip install dist/napari*tar.gz` 
I do not know why, but when try to install from repository it still install PySide2 

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

Other option is to move PySide2 requirements from requirements/default.txt to setup.py and add it under condition.