### PR TITLE
fix resources/build_icons:build_resources_qrc

### DIFF
--- a/napari/resources/build_icons.py
+++ b/napari/resources/build_icons.py
@@ -109,16 +109,15 @@ def build_resources_qrc(
         2-tuple of (path-to-qrc.res, path-to-theme-directory).
     """
     qrc_path = os.path.join(dest_dir, 'res.qrc')
+    theme_dir = os.path.join(dest_dir, 'themes')
     if os.path.exists(qrc_path) and (not overwrite):
-        return qrc_path
+        return qrc_path, theme_dir
 
     qrc_string = """
     <!DOCTYPE RCC>
     <RCC version="1.0">
     <qresource>
     """
-
-    theme_dir = os.path.join(dest_dir, 'themes')
     for filename in themify_icons(theme_dir):
         qrc_string += f'\n    <file>themes/{filename}</file>'
 


### PR DESCRIPTION
# Description
If qrc_path exist and there is no forced overwritten function returns single string, not tuple

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
During try of run napari test on my computer I found this bug

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
