### PR TITLE
add error raise in Viewer._add_layer_from_data

### DIFF
--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -865,5 +865,7 @@ class AddLayersMixin:
                     "_add_layer_from_data received an unexpected keyword "
                     f"argument ({bad_key}) for layer type {layer_type}"
                 ) from exc
+            else:
+                raise exc
 
         return layer


### PR DESCRIPTION
# Description
2-liner here... in `Viewer._add_layer_from_data`, I added a try/except to provide a more useful error message in one certain case, but forgot to re-raise the exception otherwise (so if the `add_method` fails with a different `TypeError`, it passes).