### PR TITLE
pyenv with PyQt5 in other enviroment workaround

### DIFF
--- a/napari/resources/build_icons.py
+++ b/napari/resources/build_icons.py
@@ -6,7 +6,7 @@ for styling svg elements using qss
 import os
 import re
 import shutil
-from subprocess import run
+from subprocess import check_call, CalledProcessError
 from typing import Dict, List, Tuple
 
 from ..utils.theme import palettes as _palettes
@@ -168,9 +168,9 @@ def build_pyqt_resources(out_path: str, overwrite: bool = False) -> str:
 
     # then convert it to a python file
     try:
-        run(['pyrcc5', '-o', out_path, qrc_path])
-    except FileNotFoundError:
-        run(['pyside2-rcc', '-o', out_path, qrc_path])
+        check_call(['pyrcc5', '-o', out_path, qrc_path])
+    except (FileNotFoundError, CalledProcessError):
+        check_call(['pyside2-rcc', '-o', out_path, qrc_path])
 
     # make sure we import from qtpy
     with open(out_path, "rt") as fin:


### PR DESCRIPTION
# Description
When using `pyenv` to manage python versions and have installed PyQt5 in any environment 
when user calls `prccc5` from environment which not contains this tool then got message like:

```
pyenv: pyrcc5: command not found

The `pyrcc5' command exists in these Python versions:
  3.6.9/envs/partseg3.6
  3.7.4/envs/partseg3.7
  partseg3.6
  partseg3.7
```

So I suggest to not only check existence of file but also return code and if fail then try ones from PySide2. 
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
can run without using PyQt5 tool to generate resources

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
