### PR TITLE
Lazy console fixes

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -86,7 +86,7 @@ class Window:
         self._qt_center.layout().addWidget(self.qt_viewer)
         self._qt_center.layout().setContentsMargins(4, 0, 4, 0)
 
-        self._update_palette(qt_viewer.viewer.palette)
+        self._update_palette()
 
         self._add_viewer_dock_widget(self.qt_viewer.dockConsole)
         self._add_viewer_dock_widget(self.qt_viewer.dockLayerControls)
@@ -95,9 +95,7 @@ class Window:
         self.qt_viewer.viewer.events.status.connect(self._status_changed)
         self.qt_viewer.viewer.events.help.connect(self._help_changed)
         self.qt_viewer.viewer.events.title.connect(self._title_changed)
-        self.qt_viewer.viewer.events.palette.connect(
-            lambda event: self._update_palette(event.palette)
-        )
+        self.qt_viewer.viewer.events.palette.connect(self._update_palette)
 
         if show:
             self.show()
@@ -313,16 +311,11 @@ class Window:
             self._qt_window.raise_()  # for macOS
             self._qt_window.activateWindow()  # for Windows
 
-    def _update_palette(self, palette):
-        """Update widget color palette.
-
-        Parameters
-        ----------
-        palette : qtpy.QtGui.QPalette
-            Color palette for each widget state (Active, Disabled, Inactive).
-        """
+    def _update_palette(self, event=None):
+        """Update widget color palette."""
         # set window styles which don't use the primary stylesheet
         # FIXME: this is a problem with the stylesheet not using properties
+        palette = self.qt_viewer.viewer.palette
         self._status_bar.setStyleSheet(
             template(
                 'QStatusBar { background: {{ background }}; '

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -171,7 +171,7 @@ class QtViewer(QSplitter):
             'standard': QCursor(),
         }
 
-        self._update_palette(None)
+        self._update_palette()
 
         self.viewer.events.interactive.connect(self._on_interactive)
         self.viewer.events.cursor.connect(self._on_cursor)
@@ -202,7 +202,7 @@ class QtViewer(QSplitter):
     def console(self, console):
         self._console = console
         self.dockConsole.widget = console
-        self._update_palette(None)
+        self._update_palette()
 
     def _constrain_width(self, event):
         """Allow the layer controls to be wider, only if floated.
@@ -402,7 +402,7 @@ class QtViewer(QSplitter):
             # Assumes default camera has the same properties as PanZoomCamera
             self.view.camera.rect = event.rect
 
-    def _update_palette(self, event):
+    def _update_palette(self, event=None):
         """Update the napari GUI theme."""
         # template and apply the primary stylesheet
         themed_stylesheet = template(
@@ -415,7 +415,7 @@ class QtViewer(QSplitter):
         self.setStyleSheet(themed_stylesheet)
         self.canvas.bgcolor = self.viewer.palette['canvas']
 
-    def toggle_console_visibility(self, event):
+    def toggle_console_visibility(self, event=None):
         """Toggle console visible and not visible.
 
         Imports the console the first time it is requested.

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -120,6 +120,11 @@ class QtViewer(QSplitter):
             shortcut='Ctrl+Shift+C',
         )
         self.dockConsole.setVisible(False)
+        # because the console is loaded lazily in the @getter, this line just
+        # gets (or creates) the console when the dock console is made visible.
+        self.dockConsole.visibilityChanged.connect(
+            lambda visible: self.console if visible else None
+        )
         self.dockLayerControls.visibilityChanged.connect(self._constrain_width)
         self.dockLayerList.setMaximumWidth(258)
         self.dockLayerList.setMinimumWidth(258)

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -125,3 +125,15 @@ def test_update(viewer_factory):
     viewer.update(layer_update, update_period=0.01, num_updates=100)
     # the previous time.sleep() that used to be here has been replaced with
     # QtViewer.pool.waitForDone() in the closeEvent of the QtViewer.
+
+
+def test_changing_theme(viewer_factory):
+    """Test instantiating viewer."""
+    view, viewer = viewer_factory()
+    assert viewer.palette['folder'] == 'dark'
+
+    viewer.theme = 'light'
+    assert viewer.palette['folder'] == 'light'
+
+    with pytest.raises(ValueError):
+        viewer.theme = 'nonexistent_theme'

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -111,7 +111,7 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
             return
 
         self._palette = palette
-        self.events.palette(palette=palette)
+        self.events.palette()
 
     @property
     def theme(self):

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -111,7 +111,7 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
             return
 
         self._palette = palette
-        self.events.palette()
+        self.events.palette(palette=palette)
 
     @property
     def theme(self):


### PR DESCRIPTION
# Description
This PR fixes #1073 by attaching a simple `self.console` "getter" to the `self.dockConsole.visibilityChanged` signal... and  fixes #1079 by re-adding the `palette=palette` to the `ViewerModel` `@palette.setter`.  @sofroniewn, is there anything I'm missing about why that was removed in #1055?  or was it removed because it appeared to be no longer necessary after the other changes in that PR?

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added a new test for changing theme
- [x] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
