### PR TITLE
Fix LayerList and ListModel type checking

### DIFF
--- a/napari/components/_tests/test_layers_list.py
+++ b/napari/components/_tests/test_layers_list.py
@@ -1,6 +1,7 @@
 from napari.components import LayerList
 from napari.layers import Image
 import numpy as np
+import pytest
 
 
 def test_empty_layers_list():
@@ -26,6 +27,10 @@ def test_adding_layer():
     layers = LayerList()
     layer = Image(np.random.random((10, 10)))
     layers.append(layer)
+
+    # LayerList should err if you add anything other than a layer
+    with pytest.raises(TypeError):
+        layers.append('something')
 
     assert len(layers) == 1
 

--- a/napari/utils/list/_model.py
+++ b/napari/utils/list/_model.py
@@ -56,7 +56,7 @@ class ListModel(MultiIndexList, TypedList):
         self.events.added(item=obj, index=self.__locitem__(index))
 
     def append(self, obj):
-        super(TypedList, self).append(obj)
+        TypedList.append(self, obj)
         self.events.added(item=obj, index=len(self) - 1)
 
     def pop(self, key):


### PR DESCRIPTION
# Description
fixes #1086 and adds a test.
LayerList and ListModel were not inheriting the `TypedList.append` method

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] new test added 
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
