### PR TITLE
Add installed plugins to sys_info()

### DIFF
--- a/napari/_qt/_tests/test_qt_plugin_list.py
+++ b/napari/_qt/_tests/test_qt_plugin_list.py
@@ -1,0 +1,24 @@
+from qtpy.QtCore import QTimer
+import os
+
+
+def test_qt_plugin_list(viewer_factory):
+    """Make sure the plugin list viewer works and has the test plugins."""
+    view, viewer = viewer_factory()
+
+    from napari.plugins import _tests
+    from napari.plugins import plugin_manager
+
+    fixture_path = os.path.join(os.path.dirname(_tests.__file__), 'fixtures')
+    plugin_manager.discover(fixture_path)
+
+    def handle_dialog():
+        assert hasattr(viewer.window, '_plugin_list')
+        table = viewer.window._plugin_list.table
+        assert table.rowCount() > 0
+        plugins = {table.item(i, 0).text() for i in range(table.rowCount())}
+        assert 'working' in plugins
+        viewer.window._plugin_list.close()
+
+    QTimer.singleShot(100, handle_dialog)
+    viewer.window._show_plugin_list()

--- a/napari/_qt/_tests/test_qt_plugin_report.py
+++ b/napari/_qt/_tests/test_qt_plugin_report.py
@@ -11,7 +11,7 @@ def test_error_reporter(qtbot):
     qtbot.addWidget(report)
 
     # the null option plus the one we created
-    assert report.plugin_combo.count() == 2
+    assert report.plugin_combo.count() >= 2
 
     # the message should appear somewhere in the text area
     report.set_plugin('plugin_name')

--- a/napari/_qt/qt_about.py
+++ b/napari/_qt/qt_about.py
@@ -60,7 +60,7 @@ class QtAbout(QDialog):
         self.infoTextBox.setText(sys_info(as_html=True))
         self.infoTextBox.setMinimumSize(
             self.infoTextBox.document().size().width() + 19,
-            self.infoTextBox.document().size().height() + 10,
+            min(self.infoTextBox.document().size().height() + 10, 500),
         )
 
         self.layout.addWidget(QLabel('<b>citation information:</b>'))

--- a/napari/_qt/qt_dict_table.py
+++ b/napari/_qt/qt_dict_table.py
@@ -1,0 +1,76 @@
+from qtpy.QtWidgets import QTableWidget, QTableWidgetItem
+from qtpy.QtCore import Slot, QSize
+from typing import List, Dict, Optional
+import re
+import webbrowser
+
+email_pattern = re.compile(r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$")
+url_pattern = re.compile(
+    r"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}"
+    r"\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)"
+)
+
+
+class QtDictTable(QTableWidget):
+    def __init__(
+        self,
+        parent=None,
+        source=None,
+        *,
+        headers=None,
+        min_section_width=None,
+        max_section_width=480,
+    ):
+        super().__init__(parent=parent)
+        if min_section_width:
+            self.horizontalHeader().setMinimumSectionSize(min_section_width)
+        self.horizontalHeader().setMaximumSectionSize(max_section_width)
+        self.horizontalHeader().setStretchLastSection(True)
+        if source:
+            self.set_data(source, headers)
+        self.cellDoubleClicked.connect(self._on_double_click)
+        self.setMouseTracking(True)
+
+    def set_data(
+        self, data: List[Dict[str, str]], headers: Optional[List[str]] = None
+    ):
+        nrows = len(data)
+        _headers = sorted(set().union(*data))
+        if headers:
+            for h in headers:
+                if h not in _headers:
+                    raise ValueError(
+                        f"Argument 'headers' got item {h}, which was "
+                        "not found in any of the items in 'data'"
+                    )
+            _headers = headers
+        self.setRowCount(nrows)
+        self.setColumnCount(len(_headers))
+        for row, elem in enumerate(data):
+            for key, value in elem.items():
+                if key not in _headers:
+                    continue
+                col = _headers.index(key)
+                self.setItem(row, col, QTableWidgetItem(value))
+
+        self.setHorizontalHeaderLabels(_headers)
+        self.resize_to_fit()
+
+    @Slot(int, int)
+    def _on_double_click(self, row, col):
+        item = self.item(row, col)
+        text = item.text().strip()
+        if email_pattern.match(text):
+            webbrowser.open(f'mailto:{text}', new=1)
+            return
+        if url_pattern.match(text):
+            webbrowser.open(text, new=1)
+
+    def resize_to_fit(self):
+        self.resizeColumnsToContents()
+        self.resize(self.sizeHint())
+
+    def sizeHint(self):
+        width = sum(map(self.columnWidth, range(self.columnCount()))) + 25
+        height = self.rowHeight(0) * (self.rowCount() + 1)
+        return QSize(width, height)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -226,9 +226,16 @@ class Window:
         title = QLabel("Installed Plugins")
         title.setObjectName("h2")
         layout.addWidget(title)
-        table = QtDictTable(
+        # get metadata for successfully registered plugins
+        data = [
+            v
+            for k, v in plugin_manager._plugin_meta.items()
+            if k in plugin_manager._name2plugin
+        ]
+        # create a table for it
+        dialog.table = QtDictTable(
             self._qt_window,
-            list(plugin_manager._plugin_meta.values()),
+            data,
             headers=[
                 'plugin',
                 'package',
@@ -239,11 +246,13 @@ class Window:
             ],
             min_section_width=60,
         )
-        table.horizontalHeader().setObjectName('pluginTableHeader')
-        table.verticalHeader().setObjectName('pluginTableHeader')
-        table.setGridStyle(Qt.NoPen)
-        layout.addWidget(table)
+        dialog.table.horizontalHeader().setObjectName('pluginTableHeader')
+        dialog.table.verticalHeader().setObjectName('pluginTableHeader')
+        dialog.table.setGridStyle(Qt.NoPen)
+        layout.addWidget(dialog.table)
         dialog.setLayout(layout)
+        dialog.setAttribute(Qt.WA_DeleteOnClose)
+        self._plugin_list = dialog
         dialog.exec_()
 
     def _show_plugin_sorter(self):

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -9,7 +9,7 @@ from skimage.io import imsave
 
 from .qt_about import QtAbout
 from .qt_plugin_report import QtPluginErrReporter
-from .qt_plugin_list import QtPluginSorter
+from .qt_plugin_sorter import QtPluginSorter
 from .qt_viewer_dock_widget import QtViewerDockWidget
 from ..resources import get_stylesheet
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -228,7 +228,7 @@ class Window:
         layout.addWidget(title)
         table = QtDictTable(
             self._qt_window,
-            plugin_manager._plugin_meta.values(),
+            list(plugin_manager._plugin_meta.values()),
             headers=[
                 'plugin',
                 'package',

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -224,6 +224,7 @@ class Window:
         dialog.setMaximumHeight(800)
         dialog.setMaximumWidth(1280)
         layout = QVBoxLayout()
+        # maybe someday add a search bar here?
         title = QLabel("Installed Plugins")
         title.setObjectName("h2")
         layout.addWidget(title)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -216,6 +216,7 @@ class Window:
         self.plugins_menu.addAction(report_plugin_action)
 
     def _show_plugin_list(self):
+        """Show dialog with a table of installed plugins and metadata."""
         from ..plugins import plugin_manager
 
         dialog = QDialog(self._qt_window)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -219,6 +219,8 @@ class Window:
         from ..plugins import plugin_manager
 
         dialog = QDialog(self._qt_window)
+        dialog.setMaximumHeight(800)
+        dialog.setMaximumWidth(1280)
         layout = QVBoxLayout()
         title = QLabel("Installed Plugins")
         title.setObjectName("h2")

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -18,6 +18,7 @@ from ..resources import get_stylesheet
 # these module-level imports have to come after `app.use_app(API)`
 # see discussion on #638
 from qtpy.QtWidgets import (  # noqa: E402
+    QAbstractItemView,
     QApplication,
     QMainWindow,
     QWidget,
@@ -246,9 +247,12 @@ class Window:
             ],
             min_section_width=60,
         )
-        dialog.table.horizontalHeader().setObjectName('pluginTableHeader')
-        dialog.table.verticalHeader().setObjectName('pluginTableHeader')
+        dialog.table.setObjectName("pluginTable")
+        dialog.table.horizontalHeader().setObjectName("pluginTableHeader")
+        dialog.table.verticalHeader().setObjectName("pluginTableHeader")
         dialog.table.setGridStyle(Qt.NoPen)
+        # prevent editing of table
+        dialog.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         layout.addWidget(dialog.table)
         dialog.setLayout(layout)
         dialog.setAttribute(Qt.WA_DeleteOnClose)

--- a/napari/_qt/qt_plugin_report.py
+++ b/napari/_qt/qt_plugin_report.py
@@ -133,7 +133,12 @@ class QtPluginErrReporter(QDialog):
             name of a plugin that has created an error this session.
         """
         if plugin not in PLUGIN_ERRORS:
-            raise ValueError("No errors reported for plugin '{plugin}'")
+            if plugin == self.NULL_OPTION:
+                self.plugin_meta.setText('')
+                self.text_area.setHtml('')
+                return
+            else:
+                raise ValueError(f"No errors reported for plugin '{plugin}'")
         self.plugin_combo.setCurrentText(plugin)
         self.github_button.hide()
         self.clipboard_button.hide()

--- a/napari/_qt/qt_plugin_sorter.py
+++ b/napari/_qt/qt_plugin_sorter.py
@@ -96,7 +96,7 @@ class QtHookImplementationListWidget(QListWidget):
     """A ListWidget to display & sort the call order of a hook implementation.
 
     This class will usually be instantiated by a
-    :class:`~napari._qt.qt_plugin_list.QtPluginSorter`.  Each item in the list
+    :class:`~napari._qt.qt_plugin_sorter.QtPluginSorter`.  Each item in the list
     will be rendered as a :class:`ImplementationListItem`.
 
     Parameters

--- a/napari/plugins/_tests/test_manager.py
+++ b/napari/plugins/_tests/test_manager.py
@@ -50,7 +50,11 @@ def test_iter_plugins():
     sys.path.append(fixture_path)
 
     # Search by entry_point group only
-    assert set(manager.iter_plugin_modules(group='napari.plugin')).issuperset(
+    _hits = set(
+        item[:2] for item in manager.iter_plugin_modules(group='napari.plugin')
+    )
+
+    assert _hits.issuperset(
         {
             ('unimportable', 'unimportable_plugin'),
             ('invalid', 'invalid_plugin'),
@@ -59,7 +63,11 @@ def test_iter_plugins():
     )
 
     # Search by name_convention only
-    assert set(manager.iter_plugin_modules(prefix='napari_')).issuperset(
+    _hits = set(
+        item[:2] for item in manager.iter_plugin_modules(prefix='napari_')
+    )
+
+    assert _hits.issuperset(
         {
             ('napari_bad_plugin', 'napari_bad_plugin'),
             ('napari_invalid_plugin', 'napari_invalid_plugin'),
@@ -71,9 +79,14 @@ def test_iter_plugins():
     # Search by BOTH name_convention and entry_point...
     # note that the plugin name for plugin "working" is taken from the
     # entry_point, and not from the module name...
-    assert set(
-        manager.iter_plugin_modules(prefix='napari', group='napari.plugin')
-    ).issuperset(
+    _hits = set(
+        item[:2]
+        for item in manager.iter_plugin_modules(
+            prefix='napari', group='napari.plugin'
+        )
+    )
+
+    assert _hits.issuperset(
         {
             ('unimportable', 'unimportable_plugin'),
             ('invalid', 'invalid_plugin'),

--- a/napari/plugins/exceptions.py
+++ b/napari/plugins/exceptions.py
@@ -127,7 +127,7 @@ def format_exceptions(plugin_name: str, as_html: bool = False):
     if package_meta:
         msg.extend(
             [
-                f'{"plugin name": >16}: {package_meta["name"]}',
+                f'{"package package": >16}: {package_meta["package"]}',
                 f'{"version": >16}: {package_meta["version"]}',
                 f'{"module": >16}: {err0.plugin_module}',
             ]
@@ -267,7 +267,7 @@ def fetch_module_metadata(dist: Union[Distribution, str]) -> Dict[str, str]:
         except importlib_metadata.PackageNotFoundError:
             return {}
     return {
-        'name': meta.get('Name', ''),
+        'package': meta.get('Name', ''),
         'version': meta.get('Version', ''),
         'summary': meta.get('Summary', ''),
         'url': meta.get('Home-page') or meta.get('Download-Url', ''),

--- a/napari/plugins/exceptions.py
+++ b/napari/plugins/exceptions.py
@@ -127,7 +127,7 @@ def format_exceptions(plugin_name: str, as_html: bool = False):
     if package_meta:
         msg.extend(
             [
-                f'{"package package": >16}: {package_meta["package"]}',
+                f'{"plugin package": >16}: {package_meta["package"]}',
                 f'{"version": >16}: {package_meta["version"]}',
                 f'{"module": >16}: {err0.plugin_module}',
             ]

--- a/napari/plugins/exceptions.py
+++ b/napari/plugins/exceptions.py
@@ -249,14 +249,15 @@ def fetch_module_metadata(dist: Union[Distribution, str]) -> Dict[str, str]:
 
     Parameters
     ----------
-    distname : str
-        Name of a distribution.  Note: this must match the *name* of the
-        package in the METADATA file... not the name of the module.
+    distname : str or Distribution
+        Distribution object or name of a distribution.  If a string, it must
+        match the *name* of the package in the METADATA file... not the name of
+        the module.
 
     Returns
     -------
-    package_info : dict or None
-        A dict with keys 'name', 'version', 'email', and 'url'.
+    package_info : dict
+        A dict with metadata about the package
         Returns None of the distname cannot be found.
     """
     if isinstance(dist, Distribution):

--- a/napari/plugins/manager.py
+++ b/napari/plugins/manager.py
@@ -450,7 +450,7 @@ def iter_plugin_modules(
     Yields
     -------
     plugin_info : tuple
-        (plugin_name, module_name)
+        (plugin_name, module_name, metadata)
     """
     seen_modules = set()
     if group and not os.environ.get("NAPARI_DISABLE_ENTRYPOINT_PLUGINS"):

--- a/napari/plugins/manager.py
+++ b/napari/plugins/manager.py
@@ -327,6 +327,7 @@ class PluginManager(pluggy.PluginManager):
             a PluginValidationError.)
         """
         if meta:
+            meta.update({'plugin': plugin_name})
             self._plugin_meta[plugin_name] = meta
         try:
             mod = importlib.import_module(module_name)

--- a/napari/plugins/manager.py
+++ b/napari/plugins/manager.py
@@ -1,16 +1,20 @@
 import importlib
 import os
 import pkgutil
-import re
 import sys
 from logging import getLogger
-from typing import Generator, Optional, Tuple, Union, List
+from typing import Generator, Optional, Tuple, Union, List, Dict
 
 import pluggy
 from pluggy.hooks import HookImpl
 
 from . import _builtins, hook_specifications
-from .exceptions import PluginError, PluginImportError, PluginRegistrationError
+from .exceptions import (
+    PluginError,
+    PluginImportError,
+    PluginRegistrationError,
+    fetch_module_metadata,
+)
 
 logger = getLogger(__name__)
 
@@ -218,6 +222,10 @@ class PluginManager(pluggy.PluginManager):
             will simply search the current sys.path.  by default True
         """
         super().__init__(project_name)
+        # a dict to store package metadata for each plugin, will be populated
+        # during self._register_module
+        # possible keys for this dict will be set by fetch_module_metadata()
+        self._plugin_meta: Dict[str, Dict[str, str]] = dict()
 
         # project_name might not be napari if running tests
         if project_name == 'napari':
@@ -269,13 +277,13 @@ class PluginManager(pluggy.PluginManager):
             sys.path.insert(0, path)
 
         count = 0
-        for plugin_name, module_name in iter_plugin_modules(
+        for plugin_name, module_name, meta in iter_plugin_modules(
             prefix=self.PLUGIN_PREFIX, group=self.PLUGIN_ENTRYPOINT
         ):
             if self.get_plugin(plugin_name) or self.is_blocked(plugin_name):
                 continue
             try:
-                self._register_module(plugin_name, module_name)
+                self._register_module(plugin_name, module_name, meta)
                 count += 1
             except PluginError as exc:
                 logger.error(exc.format_with_contact_info())
@@ -296,7 +304,9 @@ class PluginManager(pluggy.PluginManager):
 
         return count
 
-    def _register_module(self, plugin_name: str, module_name: str):
+    def _register_module(
+        self, plugin_name: str, module_name: str, meta: Optional[dict] = None
+    ):
         """Try to register `module_name` as a plugin named `plugin_name`.
 
         Parameters
@@ -305,6 +315,8 @@ class PluginManager(pluggy.PluginManager):
             The name given to the plugin in the plugin manager.
         module_name : str
             The importable module name
+        meta : dict, optional
+            Metadata to be associated with ``plugin_name``.
 
         Raises
         ------
@@ -314,6 +326,8 @@ class PluginManager(pluggy.PluginManager):
             If an error is raised when trying to register the plugin (such as
             a PluginValidationError.)
         """
+        if meta:
+            self._plugin_meta[plugin_name] = meta
         try:
             mod = importlib.import_module(module_name)
         except Exception as exc:
@@ -329,13 +343,17 @@ class PluginManager(pluggy.PluginManager):
 
 def entry_points_for(
     group: str,
-) -> Generator[importlib_metadata.EntryPoint, None, None]:
+) -> Generator[
+    Tuple[importlib_metadata.Distribution, importlib_metadata.EntryPoint],
+    None,
+    None,
+]:
     """Yield all entry_points matching "group", from any distribution.
 
     Distribution here refers more specifically to the information in the
     dist-info folder that usually accompanies an installed package.  If a
     package in the environment does *not* have a ``dist-info/entry_points.txt``
-    file, then in will not be discovered by this function.
+    file, then it will not be discovered by this function.
 
     Note: a single package may provide multiple entrypoints for a given group.
 
@@ -346,20 +364,22 @@ def entry_points_for(
 
     Yields
     -------
-    Generator[importlib_metadata.EntryPoint, None, None]
-        [description]
+    tuples
+        (Distribution, EntryPoint) objects for each matching EntryPoint
+        that matches the provided ``group`` string.
 
     Example
     -------
     >>> list(entry_points_for('napari.plugin'))
-    [EntryPoint(name='napari-reg', value='napari_reg', group='napari.plugin'),
-     EntryPoint(name='myplug', value='another.module', group='napari.plugin')]
-
+    [(<importlib.metadata.PathDistribution at 0x124f0fe80>,
+      EntryPoint(name='napari-reg',value='napari_reg',group='napari.plugin')),
+     (<importlib.metadata.PathDistribution at 0x1041485b0>,
+      EntryPoint(name='myplug',value='another.module',group='napari.plugin'))]
     """
     for dist in importlib_metadata.distributions():
         for ep in dist.entry_points:
             if ep.group == group:
-                yield ep
+                yield dist, ep
 
 
 def modules_starting_with(prefix: str) -> Generator[str, None, None]:
@@ -381,18 +401,9 @@ def modules_starting_with(prefix: str) -> Generator[str, None, None]:
             yield name
 
 
-# regex to parse importlib_metadata.EntryPoint.value strings
-# entry point format:  "name = module.with.periods:attr [extras]"
-entry_point_pattern = re.compile(
-    r'(?P<module>[\w.]+)\s*'
-    r'(:\s*(?P<attr>[\w.]+))?\s*'
-    r'(?P<extras>\[.*\])?\s*$'
-)
-
-
 def iter_plugin_modules(
     prefix: Optional[str] = None, group: Optional[str] = None
-) -> Generator[Tuple[str, str], None, None]:
+) -> Generator[Tuple[str, str, dict], None, None]:
     """Discover plugins using naming convention and/or entry points.
 
     This function makes sure that packages that *both* follow the naming
@@ -442,12 +453,12 @@ def iter_plugin_modules(
     """
     seen_modules = set()
     if group and not os.environ.get("NAPARI_DISABLE_ENTRYPOINT_PLUGINS"):
-        for ep in entry_points_for(group):
-            match = entry_point_pattern.match(ep.value)
+        for dist, ep in entry_points_for(group):
+            match = ep.pattern.match(ep.value)
             if match:
                 module = match.group('module')
                 seen_modules.add(module.split(".")[0])
-                yield ep.name, module
+                yield ep.name, module, fetch_module_metadata(dist)
     if prefix and not os.environ.get("NAPARI_DISABLE_NAMEPREFIX_PLUGINS"):
         for module in modules_starting_with(prefix):
             if module not in seen_modules:
@@ -455,4 +466,4 @@ def iter_plugin_modules(
                     name = importlib_metadata.metadata(module).get('Name')
                 except Exception:
                     name = None
-                yield name or module, module
+                yield name or module, module, fetch_module_metadata(module)

--- a/napari/resources/styles/02_custom.qss
+++ b/napari/resources/styles/02_custom.qss
@@ -425,3 +425,17 @@ QtHookImplListWidget {
 #pluginInfo {
   color: text;
 }
+
+#pluginTableHeader::section {
+    background-color: {{ background }};
+    border: none;
+    font-weight: bold;
+    font-size: 12px;
+    text-align: left;
+    qproperty-alignment: left;
+}
+
+#pluginTableHeader::section:horizontal {
+  border-right: 1px solid {{ foreground }};
+}
+

--- a/napari/resources/styles/02_custom.qss
+++ b/napari/resources/styles/02_custom.qss
@@ -426,6 +426,13 @@ QtHookImplListWidget {
   color: text;
 }
 
+/* ------------ Plugin Info ------------ */
+
+#pluginTable::item {
+  background: {{ background }};
+  padding-top: 2px;
+}
+
 #pluginTableHeader::section {
     background-color: {{ background }};
     border: none;
@@ -436,6 +443,10 @@ QtHookImplListWidget {
 }
 
 #pluginTableHeader::section:horizontal {
-  border-right: 1px solid {{ foreground }};
+  border-left: 1px solid {{ foreground }};
 }
 
+QTableCornerButton::section{
+  background: {{ background }};
+  border: 1px solid {{ background }};
+}

--- a/napari/utils/_tests/test_info.py
+++ b/napari/utils/_tests/test_info.py
@@ -6,6 +6,7 @@ def test_sys_info():
     assert isinstance(str_info, str)
     assert '<br>' not in str_info
     assert '<b>' not in str_info
+    assert "Plugins" in str_info
 
     html_info = sys_info(as_html=True)
     assert isinstance(html_info, str)

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -65,17 +65,13 @@ def sys_info(as_html=False):
         text += f'<br>{sys_info_text}'
 
     plugins = []
-    for plugin in plugin_manager.get_plugins():
-        name = plugin_manager.get_name(plugin)
-        if name == 'builtins':
+    for plugin_name in plugin_manager._name2plugin:
+        if plugin_name == 'builtins':
             continue
-        # look for __version__ attr in the plugin module
-        version = getattr(plugin, '__version__', '')
-        if not version and '.' in plugin.__name__:
-            # if no version is found, look in the base module
-            root = sys.modules[plugin.__name__.split('.')[0]]
-            version = getattr(root, '__version__', '')
-        plugins.append(f'  - {name}' + (f': {version}' if version else ''))
+        meta = plugin_manager._plugin_meta.get(plugin_name, {})
+        version = meta.get('version')
+        version_string = f": {version}" if version else ""
+        plugins.append(f"  - {plugin_name}{version_string}")
     text += '<br><br><b>Plugins</b>:'
     text += ("<br>" + "<br>".join(sorted(plugins))) if plugins else '  None'
 


### PR DESCRIPTION
# Description
This PR adds a list of currently installed plugins (and versions) to `napari.utils.info.sys_info()` so that they appear in the "napari info" dialog... and when using `napari --info` on the command line.  Looks like this:
```
napari: 0.2.12+35.g5924b456.dirty
Platform: macOS-10.13.6-x86_64-i386-64bit
Python: 3.8.2 | packaged by conda-forge | (default, Mar  5 2020, 16:54:44)  [Clang 9.0.1 ]
Qt: 5.14.1
PySide2: 5.14.1
NumPy: 1.18.1
SciPy: 1.4.1
scikit-image: 0.16.2
Dask: 2.10.1
VisPy: 0.6.5.dev83+g8c52a317

GL version:  2.1 NVIDIA-10.33.0 387.10.10.15.15.108
MAX_TEXTURE_SIZE: 16384

Plugins:
  - aicsimageio: 0.1.0
  - aicsimageio_delayed: 0.1.0
  - dv_reader: 0.2.3
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
- [x] added line to test
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
