### PR TITLE
avoid pillow 7.1.0

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,7 @@
 dask[array]>=2.1.0
 fsspec>=0.3.3
 imageio>=2.5.0
+Pillow!=7.1.0  # not a direct dependency; remove once fixed
 ipykernel>=5.1.1
 numpy>=1.10.0
 qtpy>=1.7.0


### PR DESCRIPTION
# Description
Fixes #1098.  this pins Pillow to `!=7.1.0`.  Looks like there's an issue for it https://github.com/python-pillow/Pillow/issues/4509, so hopefully will be fixed in the next release.
