### PR TITLE
Pin pillow at <= 7.0.0

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,7 +1,7 @@
 dask[array]>=2.1.0
 fsspec>=0.3.3
 imageio>=2.5.0
-Pillow!=7.1.0  # not a direct dependency; remove once fixed
+Pillow<=7.0.0  # not a direct dependency; remove once fixed
 ipykernel>=5.1.1
 numpy>=1.10.0
 qtpy>=1.7.0


### PR DESCRIPTION
# Description
#1098 was fixed in Pillow 7.1.1, but it looks like there's still an issue that is affecting us too: https://github.com/python-pillow/Pillow/issues/4518.
Given the imminent release, it seems like a safer bet to pin pillow at 7.0.0 rather than just avoiding specific versions.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] dependency
