### PR TITLE
Allow add_path() to accept any layer-specific kwarg and rename to open_path()

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -329,7 +329,7 @@ class QtViewer(QSplitter):
             directory=self._last_visited_dir,  # home dir by default
         )
         if (filenames != []) and (filenames is not None):
-            self.viewer.add_path(filenames)
+            self.viewer.open_path(filenames)
 
     def _open_images_as_stack(self):
         """Add image files as a stack, from the menubar."""
@@ -339,7 +339,7 @@ class QtViewer(QSplitter):
             directory=self._last_visited_dir,  # home dir by default
         )
         if (filenames != []) and (filenames is not None):
-            self.viewer.add_path(filenames, stack=True)
+            self.viewer.open_path(filenames, stack=True)
 
     def _open_folder(self):
         """Add a folder of files from the menubar."""
@@ -349,7 +349,7 @@ class QtViewer(QSplitter):
             directory=self._last_visited_dir,  # home dir by default
         )
         if folder not in {'', None}:
-            self.viewer.add_path([folder])
+            self.viewer.open_path([folder])
 
     def _on_interactive(self, event):
         """Link interactive attributes of view and viewer.
@@ -595,7 +595,7 @@ class QtViewer(QSplitter):
                 filenames.append(url.toLocalFile())
             else:
                 filenames.append(url.toString())
-        self.viewer.add_path(filenames, stack=bool(shift_down))
+        self.viewer.open_path(filenames, stack=bool(shift_down))
 
     def closeEvent(self, event):
         """Clear pool of worker threads and close.

--- a/napari/components/_tests/test_add_layers.py
+++ b/napari/components/_tests/test_add_layers.py
@@ -1,0 +1,71 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from napari._tests.utils import layer_test_data
+from napari.components.viewer_model import ViewerModel
+
+img = np.random.rand(10, 10)
+layer_data = [(lay[1], {}, lay[0].__name__.lower()) for lay in layer_test_data]
+
+plugin_returns = [
+    ([(img, {'name': 'foo'})], {'name': 'bar'}),
+    ([(img, {'blending': 'additive'}), (img,)], {'blending': 'translucent'}),
+]
+
+
+@pytest.mark.parametrize("layer_datum", layer_data)
+def test_add_layers_with_plugins(layer_datum):
+    """Test that add_layers_with_plugins adds the expected layer types."""
+    with patch(
+        "napari.components.add_layers_mixin.read_data_with_plugins",
+        MagicMock(return_value=[layer_datum]),
+    ):
+        v = ViewerModel()
+        v._add_layers_with_plugins('mock_path')
+        layertypes = [l.__class__.__name__.lower() for l in v.layers]
+        assert layertypes == [layer_datum[2]]
+
+
+@patch(
+    "napari.components.add_layers_mixin.read_data_with_plugins",
+    MagicMock(return_value=None),
+)
+def test_plugin_returns_nothing():
+    """Test that a plugin to returning nothing adds nothing to the Viewer."""
+    v = ViewerModel()
+    v._add_layers_with_plugins('mock_path')
+    assert not v.layers
+
+
+@patch(
+    "napari.components.add_layers_mixin.read_data_with_plugins",
+    MagicMock(return_value=[(img,)]),
+)
+def test_open_path():
+    """Test that a plugin to returning nothing adds nothing to the Viewer."""
+    v = ViewerModel()
+    assert len(v.layers) == 0
+    v.open_path('mock_path')
+    assert len(v.layers) == 1
+
+    v.open_path('mock_path', stack=True)
+    assert len(v.layers) == 2
+
+
+@pytest.mark.parametrize("layer_data, kwargs", plugin_returns)
+def test_add_layers_with_plugins_and_kwargs(layer_data, kwargs):
+    """Test that _add_layers_with_plugins kwargs override plugin kwargs.
+
+    see also: napari.components._test.test_prune_kwargs
+    """
+    with patch(
+        "napari.components.add_layers_mixin.read_data_with_plugins",
+        MagicMock(return_value=layer_data),
+    ):
+        v = ViewerModel()
+        v._add_layers_with_plugins('mock_path', kwargs=kwargs)
+        for layer in v.layers:
+            for key, val in kwargs.items():
+                assert getattr(layer, key) == val

--- a/napari/components/_tests/test_prune_kwargs.py
+++ b/napari/components/_tests/test_prune_kwargs.py
@@ -72,7 +72,6 @@ EXPECTATIONS = [
         {'blending': 'translucent', 'scale': (0.75, 1), 'name': 'name'},
     ),
     ('layer', {}),
-    ('path', {}),
 ]
 
 ids = [i[0] for i in EXPECTATIONS]

--- a/napari/components/_tests/test_prune_kwargs.py
+++ b/napari/components/_tests/test_prune_kwargs.py
@@ -1,0 +1,87 @@
+import pytest
+from napari.components.add_layers_mixin import prune_kwargs
+
+TEST_KWARGS = {
+    'scale': (0.75, 1),
+    'vectors_scale': (1, 1, 1),
+    'image_blending': 'additive',
+    'points_blending': 'translucent',
+    'num_colors': 10,
+    'edge_color': 'red',
+    'z_index': 20,
+    'edge_width': 2,
+    'shapes_edge_width': 10,
+    'face_color': 'white',
+    'is_pyramid': False,
+    'name': 'name',
+    'image_name': 'image',
+    'points_name': 'points',
+    'extra_kwarg': 'never_included',
+}
+
+EXPECTATIONS = [
+    (
+        'image',
+        {
+            'scale': (0.75, 1),
+            'blending': 'additive',
+            'is_pyramid': False,
+            'name': 'image',
+        },
+    ),
+    (
+        'labels',
+        {
+            'scale': (0.75, 1),
+            'num_colors': 10,
+            'is_pyramid': False,
+            'name': 'name',
+        },
+    ),
+    (
+        'points',
+        {
+            'scale': (0.75, 1),
+            'blending': 'translucent',
+            'edge_color': 'red',
+            'edge_width': 2,
+            'face_color': 'white',
+            'name': 'points',
+        },
+    ),
+    (
+        'shapes',
+        {
+            'scale': (0.75, 1),
+            'edge_color': 'red',
+            'z_index': 20,
+            'edge_width': 10,
+            'face_color': 'white',
+            'name': 'name',
+        },
+    ),
+    (
+        'vectors',
+        {
+            'scale': (1, 1, 1),
+            'edge_color': 'red',
+            'edge_width': 2,
+            'name': 'name',
+        },
+    ),
+    ('surface', {'scale': (0.75, 1), 'name': 'name'}),
+    ('layer', {}),
+    ('path', {}),
+]
+
+ids = [i[0] for i in EXPECTATIONS]
+
+
+@pytest.mark.parametrize('label_type, expectation', EXPECTATIONS, ids=ids)
+def test_prune_kwargs(label_type, expectation):
+    assert prune_kwargs(TEST_KWARGS, label_type) == expectation
+
+
+def test_prune_kwargs_raises():
+    with pytest.raises(ValueError):
+        prune_kwargs({}, 'nonexistent_layer_type')

--- a/napari/components/_tests/test_prune_kwargs.py
+++ b/napari/components/_tests/test_prune_kwargs.py
@@ -3,19 +3,14 @@ from napari.components.add_layers_mixin import prune_kwargs
 
 TEST_KWARGS = {
     'scale': (0.75, 1),
-    'vectors_scale': (1, 1, 1),
-    'image_blending': 'additive',
-    'points_blending': 'translucent',
+    'blending': 'translucent',
     'num_colors': 10,
     'edge_color': 'red',
     'z_index': 20,
     'edge_width': 2,
-    'shapes_edge_width': 10,
     'face_color': 'white',
     'is_pyramid': False,
     'name': 'name',
-    'image_name': 'image',
-    'points_name': 'points',
     'extra_kwarg': 'never_included',
 }
 
@@ -24,9 +19,9 @@ EXPECTATIONS = [
         'image',
         {
             'scale': (0.75, 1),
-            'blending': 'additive',
+            'blending': 'translucent',
             'is_pyramid': False,
-            'name': 'image',
+            'name': 'name',
         },
     ),
     (
@@ -36,6 +31,7 @@ EXPECTATIONS = [
             'num_colors': 10,
             'is_pyramid': False,
             'name': 'name',
+            'blending': 'translucent',
         },
     ),
     (
@@ -46,7 +42,7 @@ EXPECTATIONS = [
             'edge_color': 'red',
             'edge_width': 2,
             'face_color': 'white',
-            'name': 'points',
+            'name': 'name',
         },
     ),
     (
@@ -55,21 +51,26 @@ EXPECTATIONS = [
             'scale': (0.75, 1),
             'edge_color': 'red',
             'z_index': 20,
-            'edge_width': 10,
+            'edge_width': 2,
             'face_color': 'white',
             'name': 'name',
+            'blending': 'translucent',
         },
     ),
     (
         'vectors',
         {
-            'scale': (1, 1, 1),
+            'scale': (0.75, 1),
             'edge_color': 'red',
             'edge_width': 2,
             'name': 'name',
+            'blending': 'translucent',
         },
     ),
-    ('surface', {'scale': (0.75, 1), 'name': 'name'}),
+    (
+        'surface',
+        {'blending': 'translucent', 'scale': (0.75, 1), 'name': 'name'},
+    ),
     ('layer', {}),
     ('path', {}),
 ]

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -794,9 +794,16 @@ class AddLayersMixin:
         # add each layer to the viewer
         added: List[layers.Layer] = []  # for layers that get added
         for data in layer_data:
-            if kwargs and len(data) > 1:
-                assert isinstance(data[1], dict), '2nd item should be a dict'
-                data[1].update(kwargs)  # or should we update kwargs instead?
+            # if user provided kwargs, use to override the plugin meta dict
+            if kwargs:
+                if len(data) == 1:
+                    data = (data[0], kwargs)
+                elif len(data) > 1:
+                    assert isinstance(
+                        data[1], dict
+                    ), '2nd item should be a dict'
+                    # or should we update kwargs instead?
+                    data[1].update(kwargs)
             new = self._add_layer_from_data(*data)
             # some add_* methods return a List[Layer] others just a Layer
             # we want to always return a list

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -822,10 +822,6 @@ class AddLayersMixin:
                 if len(data) == 1:
                     data = (data[0], valid_kwargs)
                 elif len(data) > 1:
-                    assert isinstance(
-                        data[1], dict
-                    ), '2nd item should be a dict'
-                    # or should we update kwargs instead?
                     data[1].update(valid_kwargs)
             # actually add the layer
             new = self._add_layer_from_data(*data)

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -711,10 +711,10 @@ class AddLayersMixin:
         self.add_layer(layer)
         return layer
 
-    def add_path(
+    def open_path(
         self, path: Union[str, Sequence[str]], stack: bool = False, **kwargs
     ) -> List[layers.Layer]:
-        """Add a path or list of paths to the viewer.
+        """Open a path or list of paths with plugins, and add layers to viewer.
 
         A list of paths will be handed one-by-one to the napari_get_reader hook
         if stack is False, otherwise the full list is passed to each plugin
@@ -762,7 +762,7 @@ class AddLayersMixin:
     ) -> List[layers.Layer]:
         """Load a path or a list of paths into the viewer using plugins.
 
-        This function is mostly called from self.add_path, where the ``stack``
+        This function is mostly called from self.open_path, where the ``stack``
         argument determines whether a list of strings is handed to plugins one
         at a time, or en-masse.
 

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -47,10 +47,7 @@ def test_empty_points_with_properties_list():
 
     See: https://github.com/napari/napari/pull/1069
     """
-    properties = {
-        'label': ['label1', 'label2'],
-        'cont_prop': [0],
-    }
+    properties = {'label': ['label1', 'label2'], 'cont_prop': [0]}
     pts = Points(properties=properties)
     current_props = {k: np.asarray(v[0]) for k, v in properties.items()}
     np.testing.assert_equal(pts.current_properties, current_props)

--- a/napari/plugins/_tests/test_reader_plugins.py
+++ b/napari/plugins/_tests/test_reader_plugins.py
@@ -58,7 +58,7 @@ def test_builtin_reader_plugin(viewer_factory):
         assert np.allclose(data, layer_data[0][0])
 
         view, viewer = viewer_factory()
-        viewer.add_path(tmp.name)
+        viewer.open_path(tmp.name)
 
         assert np.allclose(viewer.layers[0].data, data)
 
@@ -78,11 +78,11 @@ def test_builtin_reader_plugin_stacks(viewer_factory):
         tmps.append(tmp)
 
     _, viewer = viewer_factory()
-    # add_path should take both strings and Path object, so we make one of the
+    # open_path should take both strings and Path object, so we make one of the
     # pathnames a Path object
     names = [tmp.name for tmp in tmps]
     names[0] = Path(names[0])
-    viewer.add_path(names, stack=True)
+    viewer.open_path(names, stack=True)
     assert np.allclose(viewer.layers[0].data, data)
     for tmp in tmps:
         tmp.close()

--- a/napari/plugins/hook_specifications.py
+++ b/napari/plugins/hook_specifications.py
@@ -51,8 +51,8 @@ def napari_get_reader(path: Union[str, List[str]]) -> Optional[ReaderFunction]:
     This is the primary "**reader plugin**" function.  It accepts a path or
     list of paths, and returns a list of data to be added to the ``Viewer``.
 
-    The main place this hook is used is in :func:`Viewer.add_path()
-    <napari.components.add_layers_mixin.AddLayersMixin.add_path>`, via the
+    The main place this hook is used is in :func:`Viewer.open_path()
+    <napari.components.add_layers_mixin.AddLayersMixin.open_path>`, via the
     :func:`~napari.plugins.io.read_data_with_plugins` function.
 
     It will also be called on ``File -> Open...`` or when a user drops a file

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -197,7 +197,7 @@ def view_path(
         axis_labels=axis_labels,
         show=show,
     )
-    viewer.add_path(path=path, stack=stack, **kwargs)
+    viewer.open_path(path=path, stack=stack, **kwargs)
     return viewer
 
 

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -155,6 +155,7 @@ def view_path(
     order=None,
     axis_labels=None,
     show=True,
+    **kwargs,
 ):
     """Create a viewer and add a layer whose type will be determined by path.
 
@@ -180,6 +181,9 @@ def view_path(
         Dimension names. by default None
     show : bool, optional
         Whether to show the viewer after instantiation. by default True.
+    **kwargs
+        All other keyword arguments will be passed on to the respective
+        ``add_layer`` method.
 
     Returns
     -------
@@ -193,7 +197,7 @@ def view_path(
         axis_labels=axis_labels,
         show=show,
     )
-    viewer.add_path(path=path, stack=stack)
+    viewer.add_path(path=path, stack=stack, **kwargs)
     return viewer
 
 


### PR DESCRIPTION
# Description
This would close #1107 (allowing `Viewer.add_path` to accept kwargs like the other `add_*` methods) and would solve the conversation started in https://github.com/napari/napari/pull/937#issuecomment-581190625, in which we discussed deprecating the `path=` argument to specific `viewer.add_*` methods (while maintaining the option for layer-specific kwargs).  Actual deprecation warnings could be added here, or in a follow-=up PR.

Basic idea is to pass any received `kwargs` through to `_add_layers_with_plugins`, where they are used to overwrite the corresponding keys in the `meta` dict returned from plugins.  A new `prune_kwargs(kwargs, layer_type)` function ensures that the appropriate kwargs are passed to the `add_*` methods.

After this PR:
```python
viewer.add_path('mybundle.zip', image_name=['dapi', 'fitc'], points_name='spots', scale=(0.5, 1)) 
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change
- [x] test added for `prune_kwargs` function

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
