### PR TITLE
Fix miniconda download in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,7 +46,7 @@ linux_task:
     - apt-get install -y libgl1-mesa-glx xvfb libqt5x11extras5 herbstluftwm
 
   conda_script:
-    - curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > install.sh
+    - curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > install.sh
     - bash install.sh -b -p $HOME/conda
     # https://github.com/napari/napari/pull/594#issuecomment-542475164
     - conda install --yes -c conda-forge setuptools
@@ -105,7 +105,7 @@ mac_task:
   env:
     PATH: $HOME/conda/bin:$PATH
   conda_script:
-    - curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > install.sh
+    - curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > install.sh
     - bash install.sh -b -p $HOME/conda
     # https://github.com/napari/napari/pull/594#issuecomment-542475164
     - conda install --yes -c conda-forge setuptools


### PR DESCRIPTION
# Description
noticed that tests are failing in #1069, see: https://github.com/napari/napari/pull/1069/checks?check_run_id=570525381

I believe that something might have changed with redirects on on the miniconda side of things.  By default, `curl` does not follow redirects, so this PR adds `curl -L` to follow url redirects.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] test fix
