### PR TITLE
make Qt component non private module

### DIFF
--- a/napari/qt/__init__.py
+++ b/napari/qt/__init__.py
@@ -1,0 +1,4 @@
+from .._qt.qt_viewer import QtViewer
+from .._qt.qt_viewer_buttons import QtViewerButtons, QtNDisplayButton
+
+__all__ = ('QtViewer', 'QtViewerButtons', 'QtNDisplayButton')


### PR DESCRIPTION
# Description
Move qt components to public module. Other software should not import from private modules, so ths changes simplify embedding napari viewer as widget, not as separate window.

This code still allow to import from `napar._qt` using custom Loader. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update (add qt modules documentation)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have made corresponding changes to the documentation

This PR still need changes in documentation which will be long. So I ask if this change is good for you?
