### PR TITLE
Monkeypatching dask to limit read events

### DIFF
--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -47,6 +47,7 @@ del app
 vispy_logger = logging.getLogger('vispy')
 vispy_logger.setLevel(logging.WARNING)
 
+from .utils import dask_monkeypatch  # must come before importing .viewer
 from .viewer import Viewer
 
 # Note that importing _viewer_key_bindings is needed as the Viewer gets

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -508,7 +508,15 @@ class Image(IntensityVisualizationMixin, Layer):
                 ).transpose(order)
         else:
             self._transforms['tile2data'].scale = np.ones(self.dims.ndim)
-            image = np.asarray(self.data[self.dims.indices]).transpose(order)
+
+            if self.dims.ndim > 2:
+                outer_idx = tuple(self.dims.indices[: self.dims.ndim - 3])
+                image = np.asarray(self.data[outer_idx])
+                image = image[tuple(self.dims.indices[-3:])]
+            else:
+                image = np.asarray(self.data[self.dims.indices])
+
+            image = image.transpose(order)
             thumbnail = image
 
         if self.rgb and image.dtype.kind == 'f':

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -508,15 +508,7 @@ class Image(IntensityVisualizationMixin, Layer):
                 ).transpose(order)
         else:
             self._transforms['tile2data'].scale = np.ones(self.dims.ndim)
-
-            if self.dims.ndim > 2:
-                outer_idx = tuple(self.dims.indices[: self.dims.ndim - 3])
-                image = np.asarray(self.data[outer_idx])
-                image = image[tuple(self.dims.indices[-3:])]
-            else:
-                image = np.asarray(self.data[self.dims.indices])
-
-            image = image.transpose(order)
+            image = np.asarray(self.data[self.dims.indices]).transpose(order)
             thumbnail = image
 
         if self.rgb and image.dtype.kind == 'f':

--- a/napari/utils/dask_monkeypatch.py
+++ b/napari/utils/dask_monkeypatch.py
@@ -1,0 +1,100 @@
+"""Patching dask.array.optimization.optimize
+
+without this patch everytime we index a single plane from a
+delayed dask array of 3D tiff stacks, it re-reads the whole file.
+Removing the call to dask.optimization.fuse fixes it.
+"""
+import sys
+
+import dask.array.optimization
+from dask.array.core import getter_inline
+from dask.blockwise import fuse_roots, optimize_blockwise
+from dask.core import flatten
+from dask.highlevelgraph import HighLevelGraph
+from dask.optimization import cull, inline_functions
+from dask.utils import ensure_dict
+
+
+def uncache(exclude):
+    """Remove package modules from cache except excluded ones.
+    On next import they will be reloaded.
+
+    Args:
+        exclude (iter<str>): Sequence of module paths.
+    """
+    pkgs = []
+    for mod in exclude:
+        pkg = mod.split('.', 1)[0]
+        pkgs.append(pkg)
+
+    to_uncache = []
+    for mod in sys.modules:
+        if mod in exclude:
+            continue
+
+        if mod in pkgs:
+            to_uncache.append(mod)
+            continue
+
+        for pkg in pkgs:
+            if mod.startswith(pkg + '.'):
+                to_uncache.append(mod)
+                break
+
+    for mod in to_uncache:
+        del sys.modules[mod]
+
+
+def optimize(
+    dsk,
+    keys,
+    fuse_keys=None,
+    fast_functions=None,
+    inline_functions_fast_functions=(getter_inline,),
+    rename_fused_keys=True,
+    **kwargs,
+):
+    """ Optimize dask for array computation
+
+    1.  Cull tasks not necessary to evaluate keys
+    2.  Remove full slicing, e.g. x[:]
+    3.  Inline fast functions like getitem and np.transpose
+    """
+    keys = list(flatten(keys))
+
+    # High level stage optimization
+    if isinstance(dsk, HighLevelGraph):
+        dsk = optimize_blockwise(dsk, keys=keys)
+        dsk = fuse_roots(dsk, keys=keys)
+
+    # Low level task optimizations
+    dsk = ensure_dict(dsk)
+    if fast_functions is not None:
+        inline_functions_fast_functions = fast_functions
+
+    dsk2, dependencies = cull(dsk, keys)
+    # this part causes the extra reads for 3D stacks
+    # hold = dask.array.optimization.hold_keys(dsk2, dependencies)
+    # dsk3, dependencies = fuse(
+    #     dsk2,
+    #     hold + keys + (fuse_keys or []),
+    #     dependencies,
+    #     rename_keys=rename_fused_keys,
+    # )
+    if inline_functions_fast_functions:
+        dsk4 = inline_functions(
+            dsk2,
+            keys,
+            dependencies=dependencies,
+            fast_functions=inline_functions_fast_functions,
+        )
+    else:
+        dsk4 = dsk2
+    dsk5 = dask.array.optimization.optimize_slices(dsk4)
+
+    return dsk5
+
+
+dask.array.optimization.optimize = optimize
+
+uncache(['dask.array.optimization'])


### PR DESCRIPTION
# Description
following the tips from @mrocklin in #718 this is mostly just a demonstration of how we could monkeypatch dask in order to prevent excess io with the way napari currently indexes nd data.  I'm not necessarily proposing we do this (it's a possibility I guess, but I'd of course like to hear from the dask folks whether this seems like a good short-term solution while we figure out whether this is an option that dask could support... or if there are hidden gotchas I'm missing here).

to test this, you can either make your own dask array of delayed array providers that "report" when they are called.  Or, you can use the llsfolder plugin I recently started making:  https://github.com/tlambert03/napari-llsfolder (follow instructions in the readme there to install the plugin, download sample data, and enable logging.DEBUG so you can watch the read/deskew tasks).

(there's probably a better way involving viewing the dask task graph too...)

