### PR TITLE
Fix add_points_with_properties example

### DIFF
--- a/examples/add_points_with_properties.py
+++ b/examples/add_points_with_properties.py
@@ -46,7 +46,7 @@ with napari.gui_qt():
         selected_points = list(points_layer.selected_data)
         if len(selected_points) > 0:
             good_point = points_layer.properties['good_point']
-            good_point[selected_points] = ~good_point[selected_points]
+            good_point[list(selected_points)] = ~good_point[list(selected_points)]
             points_layer.properties['good_point'] = good_point
 
             # we need to manually refresh since we did not use the Points.properties setter


### PR DESCRIPTION
# Description
This PR fixes the points with properties example. The point toggling in `add_points_with_properties.py` was broken by #1033 when `Points.selected_data` became a set.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References


# How has this been tested?
- [x] tested the example
- [x] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
