### PR TITLE
Enable volume rendering interpolation control

### DIFF
--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -5,7 +5,6 @@ from vispy.color import Colormap
 import numpy as np
 from .vispy_base_layer import VispyBaseLayer
 from ..layers.image._image_constants import Rendering
-from ..layers import Image, Labels
 
 
 texture_dtypes = [
@@ -96,12 +95,7 @@ class VispyImageLayer(VispyBaseLayer):
         self.node.update()
 
     def _on_interpolation_change(self, event=None):
-        if self.layer.dims.ndisplay == 3 and isinstance(self.layer, Labels):
-            self.node.interpolation = 'nearest'
-        elif self.layer.dims.ndisplay == 3 and isinstance(self.layer, Image):
-            self.node.interpolation = 'linear'
-        else:
-            self.node.interpolation = self.layer.interpolation
+        self.node.interpolation = self.layer.interpolation
 
     def _on_rendering_change(self, event=None):
         if self.layer.dims.ndisplay == 3:

--- a/napari/layers/image/_image_constants.py
+++ b/napari/layers/image/_image_constants.py
@@ -29,13 +29,7 @@ class Interpolation(StringEnum):
 
 
 class Interpolation3D(StringEnum):
-    """INTERPOLATION: Vispy interpolation mode.
-
-    The spatial filters used for interpolation are from vispy's
-    spatial filters. The filters are built in the file below:
-
-    https://github.com/vispy/vispy/blob/master/vispy/glsl/build-spatial-filters.py
-    """
+    """INTERPOLATION: Vispy interpolation mode for volume rendering."""
 
     LINEAR = auto()
     NEAREST = auto()

--- a/napari/layers/image/_image_constants.py
+++ b/napari/layers/image/_image_constants.py
@@ -28,6 +28,19 @@ class Interpolation(StringEnum):
     SPLINE36 = auto()
 
 
+class Interpolation3D(StringEnum):
+    """INTERPOLATION: Vispy interpolation mode.
+
+    The spatial filters used for interpolation are from vispy's
+    spatial filters. The filters are built in the file below:
+
+    https://github.com/vispy/vispy/blob/master/vispy/glsl/build-spatial-filters.py
+    """
+
+    LINEAR = auto()
+    NEAREST = auto()
+
+
 class Rendering(StringEnum):
     """Rendering: Rendering mode for the layer.
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -12,7 +12,7 @@ from ...utils.status_messages import format_float
 from ..base import Layer
 from ..utils.layer_utils import calc_data_range
 from ..intensity_mixin import IntensityVisualizationMixin
-from ._image_constants import Interpolation, Rendering
+from ._image_constants import Interpolation, Interpolation3D, Rendering
 from ._image_utils import get_pyramid_and_rgb
 
 
@@ -213,6 +213,14 @@ class Image(IntensityVisualizationMixin, Layer):
         self._contrast_limits = tuple(self.contrast_limits_range)
         self.colormap = colormap
         self.contrast_limits = self._contrast_limits
+        self._interpolation = {
+            2: Interpolation.NEAREST,
+            3: (
+                Interpolation3D.NEAREST
+                if self.__class__.__name__ == 'Labels'
+                else Interpolation3D.LINEAR
+            ),
+        }
         self.interpolation = interpolation
         self.rendering = rendering
 
@@ -342,12 +350,19 @@ class Image(IntensityVisualizationMixin, Layer):
         str
             The current interpolation mode
         """
-        return str(self._interpolation)
+        return str(self._interpolation[self.dims.ndisplay])
 
     @interpolation.setter
     def interpolation(self, interpolation):
         """Set current interpolation mode."""
-        self._interpolation = Interpolation(interpolation)
+        if self.dims.ndisplay == 3:
+            self._interpolation[self.dims.ndisplay] = Interpolation3D(
+                interpolation
+            )
+        else:
+            self._interpolation[self.dims.ndisplay] = Interpolation(
+                interpolation
+            )
         self.events.interpolation()
 
     @property


### PR DESCRIPTION
# Description
This would close #1125 by exposing the 'nearest' interpolation option for volume visuals both on the model layer and in the Qt controls.  I changed the private `_interpolation` attribute to be a dict that stores the interpolation setting for both 2D and 3D rendering modes (so that it remembers settings when switching between `ndisplay`), but the external getter/setter API hasn't changed.

I haven't exposed the setting on the Labels Qt controls, since it looks so weird, but one can change it from the model (`labels_layer.interpolation = 'linear'`)

![Untitled](https://user-images.githubusercontent.com/1609449/78996226-25154480-7b12-11ea-9c39-67384a407df7.gif)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
