### PR TITLE
change image icon

### DIFF
--- a/napari/resources/icons/new_image.svg
+++ b/napari/resources/icons/new_image.svg
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 23.0.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!-- Generator: Adobe Illustrator 23.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
-<rect x="22.2" y="22.2" width="55.5" height="55.5"/>
+	 viewBox="0 0 440 440" style="enable-background:new 0 0 440 440;" xml:space="preserve">
+<path d="M373.1,344.4V273c-31-27.4-50.3-44.5-58-51.3c-7.5-6.6-18.1-6-24.9,1.4c-13.3,14.4-47,51.1-61.7,67.1
+	c-2.6,2.8-6.7,3-9.5,0.3c-7-6.8-17.4-16.9-22.9-22.3c-6.8-6.6-17-6.4-23.5,0.6c-10.4,11.1-36.3,38.8-77.9,83.1L373.1,344.4z"/>
+<path d="M358.4,77.8H81.6c-17,0-30.8,13.8-30.8,30.8v222.9c0,17,13.8,30.8,30.8,30.8h276.9c17,0,30.8-13.8,30.8-30.8V108.6
+	C389.2,91.6,375.5,77.8,358.4,77.8z M365.6,321.2c0,11.1-9,20.1-20.1,20.1H94.8c-11.1,0-20.1-9-20.1-20.1v-202
+	c0-11.1,9-20.1,20.1-20.1h250.7c11.1,0,20.1,9,20.1,20.1V321.2z"/>
+<circle cx="157.1" cy="164.2" r="30.4"/>
 </svg>

--- a/napari/resources/icons/square.svg
+++ b/napari/resources/icons/square.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
+<rect x="22.2" y="22.2" width="55.5" height="55.5"/>
+</svg>

--- a/napari/resources/styles/01_buttons.qss
+++ b/napari/resources/styles/01_buttons.qss
@@ -102,7 +102,7 @@ QtGridViewButton::indicator {
 }
 
 QtGridViewButton::indicator:unchecked {
-  image: url(":/themes/{{ folder }}/new_image.svg");
+  image: url(":/themes/{{ folder }}/square.svg");
 }
 
 QtGridViewButton::indicator:checked {
@@ -268,7 +268,7 @@ QtPlayButton[playing=True]:hover {
 }
 
 QtPlayButton[playing=True] {
-    image: url(":/themes/{{ folder }}/new_image.svg");
+    image: url(":/themes/{{ folder }}/square.svg");
     background-color: {{ warning }};
     height: 12px;
     width: 12px;


### PR DESCRIPTION
# Description
closes #1123 by changing the image layer icon to look like this:
![Untitled](https://user-images.githubusercontent.com/1609449/79006021-336d5b80-7b26-11ea-8e89-93e98e86df5c.png)


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
