### PR TITLE
Reduce code duplication in Points

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -469,7 +469,7 @@ def test_adding_properties(attribute):
     assert isinstance(layer.properties['point_type'], np.ndarray)
 
     # removing a property that was the _edge_color_property should give a warning
-    setattr(layer, '_%s_color_property' % attribute, 'vector_type')
+    setattr(layer, f'_{attribute}_color_property', 'vector_type')
     properties_2 = {
         'not_vector_type': np.array(['A', 'B'] * int(shape[0] / 2))
     }
@@ -649,9 +649,9 @@ def test_switch_color_mode(attribute):
     properties = {'point_type': np.array([0, 1.5] * int((shape[0] / 2)))}
     initial_color = [1, 0, 0, 1]
     color_cycle = ['red', 'blue']
-    color_kwarg = '%s_color' % attribute
-    colormap_kwarg = '%s_colormap' % attribute
-    color_cycle_kwarg = '%s_color_cycle' % attribute
+    color_kwarg = f'{attribute}_color'
+    colormap_kwarg = f'{attribute}_colormap'
+    color_cycle_kwarg = f'{attribute}_color_cycle'
     args = {
         color_kwarg: initial_color,
         colormap_kwarg: 'gray',
@@ -659,36 +659,36 @@ def test_switch_color_mode(attribute):
     }
     layer = Points(data, properties=properties, **args,)
 
-    layer_color_mode = getattr(layer, '%s_color_mode' % attribute)
-    layer_color = getattr(layer, '%s_color' % attribute)
+    layer_color_mode = getattr(layer, f'{attribute}_color_mode')
+    layer_color = getattr(layer, f'{attribute}_color')
     assert layer_color_mode == 'direct'
     np.testing.assert_allclose(
         layer_color, np.repeat([initial_color], shape[0], axis=0)
     )
 
     # there should not be an edge_color_property
-    color_property = getattr(layer, '_%s_color_property' % attribute)
+    color_property = getattr(layer, f'_{attribute}_color_property')
     assert color_property == ''
 
     # transitioning to colormap should raise a warning
     # because there isn't an edge color property yet and
     # the first property in Vectors.properties is being automatically selected
     with pytest.warns(UserWarning):
-        setattr(layer, '%s_color_mode' % attribute, 'colormap')
-    color_property = getattr(layer, '_%s_color_property' % attribute)
+        setattr(layer, f'{attribute}_color_mode', 'colormap')
+    color_property = getattr(layer, f'_{attribute}_color_property')
     assert color_property == next(iter(properties))
-    layer_color = getattr(layer, '%s_color' % attribute)
+    layer_color = getattr(layer, f'{attribute}_color')
     np.testing.assert_allclose(layer_color[-1], [1, 1, 1, 1])
 
     # switch to color cycle
-    setattr(layer, '%s_color_mode' % attribute, 'cycle')
-    color = getattr(layer, '%s_color' % attribute)
+    setattr(layer, f'{attribute}_color_mode', 'cycle')
+    color = getattr(layer, f'{attribute}_color')
     layer_color = transform_color(color_cycle * int((shape[0] / 2)))
     np.testing.assert_allclose(color, layer_color)
 
     # switch back to direct, edge_colors shouldn't change
-    setattr(layer, '%s_color_mode' % attribute, 'direct')
-    new_edge_color = getattr(layer, '%s_color' % attribute)
+    setattr(layer, f'{attribute}_color_mode', 'direct')
+    new_edge_color = getattr(layer, f'{attribute}_color')
     np.testing.assert_allclose(new_edge_color, color)
 
 
@@ -701,7 +701,7 @@ def test_colormap_without_properties(attribute):
     layer = Points(data)
 
     with pytest.raises(ValueError):
-        setattr(layer, '%s_color_mode' % attribute, 'colormap')
+        setattr(layer, f'{attribute}_color_mode', 'colormap')
 
 
 @pytest.mark.parametrize("attribute", ['edge', 'face'])
@@ -714,7 +714,7 @@ def test_colormap_with_categorical_properties(attribute):
     layer = Points(data, properties=properties)
 
     with pytest.raises(TypeError):
-        setattr(layer, '%s_color_mode' % attribute, 'colormap')
+        setattr(layer, f'{attribute}_color_mode', 'colormap')
 
 
 @pytest.mark.parametrize("attribute", ['edge', 'face'])
@@ -724,13 +724,13 @@ def test_add_colormap(attribute):
     np.random.seed(0)
     data = 20 * np.random.random(shape)
     annotations = {'point_type': np.array([0, 1.5] * int((shape[0] / 2)))}
-    color_kwarg = '%s_color' % attribute
-    colormap_kwarg = '%s_colormap' % attribute
+    color_kwarg = f'{attribute}_color'
+    colormap_kwarg = f'{attribute}_colormap'
     args = {color_kwarg: 'point_type', colormap_kwarg: 'viridis'}
     layer = Points(data, properties=annotations, **args,)
 
-    setattr(layer, '%s_colormap' % attribute, get_colormap('gray'))
-    layer_colormap = getattr(layer, '%s_colormap' % attribute)
+    setattr(layer, f'{attribute}_colormap', get_colormap('gray'))
+    layer_colormap = getattr(layer, f'{attribute}_colormap')
     assert layer_colormap[0] == 'unknown_colormap'
 
 

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1,4 +1,5 @@
 from copy import copy
+from itertools import cycle, islice
 from xml.etree.ElementTree import Element
 
 import numpy as np
@@ -8,6 +9,13 @@ from vispy.color import get_colormap
 
 from napari.layers import Points
 from napari.utils.colormaps.standardize_color import transform_color
+
+
+def _make_categorical_properties(categories, count):
+    categorical_properties = np.array(
+        list(islice(cycle(categories), 0, count))
+    )
+    return categorical_properties
 
 
 def test_empty_points():
@@ -454,7 +462,9 @@ def test_adding_properties(attribute):
     layer = Points(data)
 
     # add properties
-    properties = {'point_type': np.array(['A', 'B'] * int(shape[0] / 2))}
+    properties = {
+        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
+    }
     layer.properties = properties
     np.testing.assert_equal(layer.properties, properties)
 
@@ -464,16 +474,18 @@ def test_adding_properties(attribute):
     np.testing.assert_equal(layer.properties, properties)
 
     # add properties as a dictionary with list values
-    properties_list = {'point_type': ['A', 'B'] * int(shape[0] / 2)}
+    properties_list = {
+        'point_type': list(_make_categorical_properties(['A', 'B'], shape[0]))
+    }
     layer.properties = properties_list
     assert isinstance(layer.properties['point_type'], np.ndarray)
 
     # removing a property that was the _edge_color_property should give a warning
     setattr(layer, f'_{attribute}_color_property', 'vector_type')
     properties_2 = {
-        'not_vector_type': np.array(['A', 'B'] * int(shape[0] / 2))
+        'not_vector_type': _make_categorical_properties(['A', 'B'], shape[0])
     }
-    with pytest.warns(UserWarning):
+    with pytest.warns(RuntimeWarning):
         layer.properties = properties_2
 
 
@@ -482,7 +494,9 @@ def test_properties_dataframe():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {'point_type': np.array(['A', 'B'] * int(shape[0] / 2))}
+    properties = {
+        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
+    }
     properties_df = pd.DataFrame(properties)
     properties_df = properties_df.astype(properties['point_type'].dtype)
     layer = Points(data, properties=properties_df)
@@ -494,7 +508,9 @@ def test_properties_list():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {'point_type': ['A', 'B'] * int(shape[0] / 2)}
+    properties = {
+        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
+    }
     layer = Points(data, properties=properties)
     np.testing.assert_equal(layer.properties, properties)
 
@@ -506,7 +522,9 @@ def test_adding_annotations():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {'point_type': np.array(['A', 'B'] * int((shape[0] / 2)))}
+    properties = {
+        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
+    }
     layer = Points(data)
     assert layer.properties == {}
 
@@ -516,7 +534,7 @@ def test_adding_annotations():
 
     # change properties
     new_annotations = {
-        'other_type': np.array(['C', 'D'] * int((shape[0] / 2)))
+        'other_type': _make_categorical_properties(['C', 'D'], shape[0])
     }
     layer.properties = copy(new_annotations)
     assert layer.properties == new_annotations
@@ -527,7 +545,9 @@ def test_add_points_with_properties():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {'point_type': np.array(['A', 'B'] * int((shape[0] / 2)))}
+    properties = {
+        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
+    }
     layer = Points(data, properties=copy(properties))
 
     coord = [18, 18]
@@ -541,7 +561,9 @@ def test_add_points_with_properties_as_list():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {'point_type': ['A', 'B'] * int((shape[0] / 2))}
+    properties = {
+        'point_type': list(_make_categorical_properties(['A', 'B'], shape[0]))
+    }
     layer = Points(data, properties=copy(properties))
 
     coord = [18, 18]
@@ -555,7 +577,9 @@ def test_updating_points_properties():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {'point_type': np.array(['A', 'B'] * int((shape[0] / 2)))}
+    properties = {
+        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
+    }
     layer = Points(data, properties=copy(properties))
 
     layer.mode = 'select'
@@ -582,7 +606,9 @@ def test_is_color_mapped():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {'point_type': np.array(['A', 'B'] * int((shape[0] / 2)))}
+    annotations = {
+        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
+    }
     layer = Points(data, properties=annotations)
 
     # giving the name of an annotation should return True
@@ -646,7 +672,9 @@ def test_switch_color_mode(attribute):
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {'point_type': np.array([0, 1.5] * int((shape[0] / 2)))}
+    properties = {
+        'point_type': _make_categorical_properties([0, 1.5], shape[0])
+    }
     initial_color = [1, 0, 0, 1]
     color_cycle = ['red', 'blue']
     color_kwarg = f'{attribute}_color'
@@ -710,7 +738,9 @@ def test_colormap_with_categorical_properties(attribute):
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {'point_type': np.array(['A', 'B'] * int((shape[0] / 2)))}
+    properties = {
+        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
+    }
     layer = Points(data, properties=properties)
 
     with pytest.raises(TypeError):
@@ -723,7 +753,9 @@ def test_add_colormap(attribute):
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {'point_type': np.array([0, 1.5] * int((shape[0] / 2)))}
+    annotations = {
+        'point_type': _make_categorical_properties([0, 1.5], shape[0])
+    }
     color_kwarg = f'{attribute}_color'
     colormap_kwarg = f'{attribute}_colormap'
     args = {color_kwarg: 'point_type', colormap_kwarg: 'viridis'}
@@ -809,7 +841,9 @@ def test_edge_color_cycle():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {'point_type': np.array(['A', 'B'] * int((shape[0] / 2)))}
+    annotations = {
+        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
+    }
     color_cycle = ['red', 'blue']
     layer = Points(
         data,
@@ -902,7 +936,9 @@ def test_adding_value_edge_color_cycle():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {'point_type': np.array(['A', 'B'] * int((shape[0] / 2)))}
+    annotations = {
+        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
+    }
     color_cycle = ['red', 'blue']
     layer = Points(
         data,
@@ -926,7 +962,9 @@ def test_edge_color_colormap():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {'point_type': np.array([0, 1.5] * int((shape[0] / 2)))}
+    annotations = {
+        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
+    }
     layer = Points(
         data,
         properties=annotations,
@@ -1053,7 +1091,9 @@ def test_face_color_cycle():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {'point_type': np.array(['A', 'B'] * int((shape[0] / 2)))}
+    annotations = {
+        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
+    }
     color_cycle = ['red', 'blue']
     layer = Points(
         data,
@@ -1145,7 +1185,9 @@ def test_adding_value_face_color_cycle():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {'point_type': np.array(['A', 'B'] * int((shape[0] / 2)))}
+    annotations = {
+        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
+    }
     color_cycle = ['red', 'blue']
     layer = Points(
         data,
@@ -1169,7 +1211,9 @@ def test_face_color_colormap():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {'point_type': np.array([0, 1.5] * int((shape[0] / 2)))}
+    annotations = {
+        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
+    }
     layer = Points(
         data,
         properties=annotations,

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -672,7 +672,13 @@ def test_switch_color_mode(attribute):
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {'point_type': _make_cycled_properties([0, 1.5], shape[0])}
+    # create a continuous property with a known value in the last element
+    continuous_prop = np.random.random((shape[0],))
+    continuous_prop[-1] = 1
+    properties = {
+        'point_truthiness': continuous_prop,
+        'point_type': _make_cycled_properties(['A', 'B'], shape[0]),
+    }
     initial_color = [1, 0, 0, 1]
     color_cycle = ['red', 'blue']
     color_kwarg = f'{attribute}_color'
@@ -698,7 +704,7 @@ def test_switch_color_mode(attribute):
 
     # transitioning to colormap should raise a warning
     # because there isn't an edge color property yet and
-    # the first property in Vectors.properties is being automatically selected
+    # the first property in points.properties is being automatically selected
     with pytest.warns(UserWarning):
         setattr(layer, f'{attribute}_color_mode', 'colormap')
     color_property = getattr(layer, f'_{attribute}_color_property')
@@ -708,6 +714,7 @@ def test_switch_color_mode(attribute):
 
     # switch to color cycle
     setattr(layer, f'{attribute}_color_mode', 'cycle')
+    setattr(layer, f'{attribute}_color', 'point_type')
     color = getattr(layer, f'{attribute}_color')
     layer_color = transform_color(color_cycle * int((shape[0] / 2)))
     np.testing.assert_allclose(color, layer_color)

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -447,6 +447,7 @@ def test_properties():
 
 @pytest.mark.parametrize("attribute", ['edge', 'face'])
 def test_adding_properties(attribute):
+    """Test adding properties to an existing layer"""
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
@@ -456,6 +457,16 @@ def test_adding_properties(attribute):
     properties = {'point_type': np.array(['A', 'B'] * int(shape[0] / 2))}
     layer.properties = properties
     np.testing.assert_equal(layer.properties, properties)
+
+    # add properties as a dataframe
+    properties_df = pd.DataFrame(properties)
+    layer.properties = properties_df
+    np.testing.assert_equal(layer.properties, properties)
+
+    # add properties as a dictionary with list values
+    properties_list = {'point_type': ['A', 'B'] * int(shape[0] / 2)}
+    layer.properties = properties_list
+    assert isinstance(layer.properties['point_type'], np.ndarray)
 
     # removing a property that was the _edge_color_property should give a warning
     setattr(layer, '_%s_color_property' % attribute, 'vector_type')
@@ -679,6 +690,31 @@ def test_switch_color_mode(attribute):
     setattr(layer, '%s_color_mode' % attribute, 'direct')
     new_edge_color = getattr(layer, '%s_color' % attribute)
     np.testing.assert_allclose(new_edge_color, color)
+
+
+@pytest.mark.parametrize("attribute", ['edge', 'face'])
+def test_colormap_without_properties(attribute):
+    """Setting the colormode to colormap should raise an exception"""
+    shape = (10, 2)
+    np.random.seed(0)
+    data = 20 * np.random.random(shape)
+    layer = Points(data)
+
+    with pytest.raises(ValueError):
+        setattr(layer, '%s_color_mode' % attribute, 'colormap')
+
+
+@pytest.mark.parametrize("attribute", ['edge', 'face'])
+def test_colormap_with_categorical_properties(attribute):
+    """Setting the colormode to colormap should raise an exception"""
+    shape = (10, 2)
+    np.random.seed(0)
+    data = 20 * np.random.random(shape)
+    properties = {'point_type': np.array(['A', 'B'] * int((shape[0] / 2)))}
+    layer = Points(data, properties=properties)
+
+    with pytest.raises(TypeError):
+        setattr(layer, '%s_color_mode' % attribute, 'colormap')
 
 
 @pytest.mark.parametrize("attribute", ['edge', 'face'])

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -11,11 +11,23 @@ from napari.layers import Points
 from napari.utils.colormaps.standardize_color import transform_color
 
 
-def _make_categorical_properties(categories, count):
-    categorical_properties = np.array(
-        list(islice(cycle(categories), 0, count))
-    )
-    return categorical_properties
+def _make_cycled_properties(values, length):
+    """Helper function to make property values
+
+    Parameters:
+    -----------
+    values :
+        The values to be cycled.
+    length : int
+        The length of the resulting property array
+
+    Returns:
+    --------
+    cycled_properties : np.ndarray
+        The property array comprising the cycled values.
+    """
+    cycled_properties = np.array(list(islice(cycle(values), 0, length)))
+    return cycled_properties
 
 
 def test_empty_points():
@@ -462,9 +474,7 @@ def test_adding_properties(attribute):
     layer = Points(data)
 
     # add properties
-    properties = {
-        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
-    }
+    properties = {'point_type': _make_cycled_properties(['A', 'B'], shape[0])}
     layer.properties = properties
     np.testing.assert_equal(layer.properties, properties)
 
@@ -475,7 +485,7 @@ def test_adding_properties(attribute):
 
     # add properties as a dictionary with list values
     properties_list = {
-        'point_type': list(_make_categorical_properties(['A', 'B'], shape[0]))
+        'point_type': list(_make_cycled_properties(['A', 'B'], shape[0]))
     }
     layer.properties = properties_list
     assert isinstance(layer.properties['point_type'], np.ndarray)
@@ -483,7 +493,7 @@ def test_adding_properties(attribute):
     # removing a property that was the _edge_color_property should give a warning
     setattr(layer, f'_{attribute}_color_property', 'vector_type')
     properties_2 = {
-        'not_vector_type': _make_categorical_properties(['A', 'B'], shape[0])
+        'not_vector_type': _make_cycled_properties(['A', 'B'], shape[0])
     }
     with pytest.warns(RuntimeWarning):
         layer.properties = properties_2
@@ -494,9 +504,7 @@ def test_properties_dataframe():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {
-        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
-    }
+    properties = {'point_type': _make_cycled_properties(['A', 'B'], shape[0])}
     properties_df = pd.DataFrame(properties)
     properties_df = properties_df.astype(properties['point_type'].dtype)
     layer = Points(data, properties=properties_df)
@@ -508,9 +516,7 @@ def test_properties_list():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {
-        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
-    }
+    properties = {'point_type': _make_cycled_properties(['A', 'B'], shape[0])}
     layer = Points(data, properties=properties)
     np.testing.assert_equal(layer.properties, properties)
 
@@ -522,9 +528,7 @@ def test_adding_annotations():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {
-        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
-    }
+    properties = {'point_type': _make_cycled_properties(['A', 'B'], shape[0])}
     layer = Points(data)
     assert layer.properties == {}
 
@@ -534,7 +538,7 @@ def test_adding_annotations():
 
     # change properties
     new_annotations = {
-        'other_type': _make_categorical_properties(['C', 'D'], shape[0])
+        'other_type': _make_cycled_properties(['C', 'D'], shape[0])
     }
     layer.properties = copy(new_annotations)
     assert layer.properties == new_annotations
@@ -545,9 +549,7 @@ def test_add_points_with_properties():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {
-        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
-    }
+    properties = {'point_type': _make_cycled_properties(['A', 'B'], shape[0])}
     layer = Points(data, properties=copy(properties))
 
     coord = [18, 18]
@@ -562,7 +564,7 @@ def test_add_points_with_properties_as_list():
     np.random.seed(0)
     data = 20 * np.random.random(shape)
     properties = {
-        'point_type': list(_make_categorical_properties(['A', 'B'], shape[0]))
+        'point_type': list(_make_cycled_properties(['A', 'B'], shape[0]))
     }
     layer = Points(data, properties=copy(properties))
 
@@ -577,9 +579,7 @@ def test_updating_points_properties():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {
-        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
-    }
+    properties = {'point_type': _make_cycled_properties(['A', 'B'], shape[0])}
     layer = Points(data, properties=copy(properties))
 
     layer.mode = 'select'
@@ -606,9 +606,7 @@ def test_is_color_mapped():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {
-        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
-    }
+    annotations = {'point_type': _make_cycled_properties(['A', 'B'], shape[0])}
     layer = Points(data, properties=annotations)
 
     # giving the name of an annotation should return True
@@ -672,9 +670,7 @@ def test_switch_color_mode(attribute):
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {
-        'point_type': _make_categorical_properties([0, 1.5], shape[0])
-    }
+    properties = {'point_type': _make_cycled_properties([0, 1.5], shape[0])}
     initial_color = [1, 0, 0, 1]
     color_cycle = ['red', 'blue']
     color_kwarg = f'{attribute}_color'
@@ -738,9 +734,7 @@ def test_colormap_with_categorical_properties(attribute):
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {
-        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
-    }
+    properties = {'point_type': _make_cycled_properties(['A', 'B'], shape[0])}
     layer = Points(data, properties=properties)
 
     with pytest.raises(TypeError):
@@ -753,9 +747,7 @@ def test_add_colormap(attribute):
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {
-        'point_type': _make_categorical_properties([0, 1.5], shape[0])
-    }
+    annotations = {'point_type': _make_cycled_properties([0, 1.5], shape[0])}
     color_kwarg = f'{attribute}_color'
     colormap_kwarg = f'{attribute}_colormap'
     args = {color_kwarg: 'point_type', colormap_kwarg: 'viridis'}
@@ -841,9 +833,7 @@ def test_edge_color_cycle():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {
-        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
-    }
+    annotations = {'point_type': _make_cycled_properties(['A', 'B'], shape[0])}
     color_cycle = ['red', 'blue']
     layer = Points(
         data,
@@ -936,9 +926,7 @@ def test_adding_value_edge_color_cycle():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {
-        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
-    }
+    annotations = {'point_type': _make_cycled_properties(['A', 'B'], shape[0])}
     color_cycle = ['red', 'blue']
     layer = Points(
         data,
@@ -962,9 +950,7 @@ def test_edge_color_colormap():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {
-        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
-    }
+    annotations = {'point_type': _make_cycled_properties([0, 1.5], shape[0])}
     layer = Points(
         data,
         properties=annotations,
@@ -1091,9 +1077,7 @@ def test_face_color_cycle():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {
-        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
-    }
+    annotations = {'point_type': _make_cycled_properties(['A', 'B'], shape[0])}
     color_cycle = ['red', 'blue']
     layer = Points(
         data,
@@ -1185,9 +1169,7 @@ def test_adding_value_face_color_cycle():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {
-        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
-    }
+    annotations = {'point_type': _make_cycled_properties(['A', 'B'], shape[0])}
     color_cycle = ['red', 'blue']
     layer = Points(
         data,
@@ -1211,9 +1193,7 @@ def test_face_color_colormap():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    annotations = {
-        'point_type': _make_categorical_properties(['A', 'B'], shape[0])
-    }
+    annotations = {'point_type': _make_cycled_properties([0, 1.5], shape[0])}
     layer = Points(
         data,
         properties=annotations,

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -516,7 +516,9 @@ def test_properties_list():
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {'point_type': _make_cycled_properties(['A', 'B'], shape[0])}
+    properties = {
+        'point_type': list(_make_cycled_properties(['A', 'B'], shape[0]))
+    }
     layer = Points(data, properties=properties)
     np.testing.assert_equal(layer.properties, properties)
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -392,37 +392,37 @@ class Points(Layer):
             The name of the attribute to set the color of.
             Should be 'edge' for edge_color or 'face' for face_color.
         """
-        color_mode = getattr(self, '_%s_color_mode' % attribute)
+        color_mode = getattr(self, f'_{attribute}_color_mode')
         if color_mode == ColorMode.DIRECT:
             curr_color = transform_color_with_defaults(
                 num_entries=1,
                 colors=color,
-                elem_name='%s_color' % attribute,
+                elem_name=f'{attribute}_color',
                 default="white",
             )
 
         elif color_mode == ColorMode.CYCLE:
-            color_cycle = getattr(self, '%s_color_cycle' % attribute)
+            color_cycle = getattr(self, f'{attribute}_color_cycle')
             curr_color = transform_color(next(color_cycle))
 
             # add the new color cycle mapping
-            color_property = getattr(self, '_%s_color_property' % attribute)
+            color_property = getattr(self, f'_{attribute}_color_property')
             prop_value = self._property_choices[color_property][0]
-            color_cycle_map = getattr(self, '%s_color_cycle_map' % attribute)
+            color_cycle_map = getattr(self, f'{attribute}_color_cycle_map')
             color_cycle_map[prop_value] = curr_color
-            setattr(self, '%s_color_cycle_map' % attribute, color_cycle_map)
+            setattr(self, f'{attribute}_color_cycle_map', color_cycle_map)
 
         elif color_mode == ColorMode.COLORMAP:
-            color_property = getattr(self, '_%s_color_property' % attribute)
+            color_property = getattr(self, f'_{attribute}_color_property')
             prop_value = self._property_choices[color_property][0]
-            colormap = getattr(self, '%s_colormap' % attribute)
-            contrast_limits = getattr(self, '_%s_contrast_limits' % attribute)
+            colormap = getattr(self, f'{attribute}_colormap')
+            contrast_limits = getattr(self, f'_{attribute}_contrast_limits')
             curr_color, _ = map_property(
                 prop=prop_value,
                 colormap=colormap[1],
                 contrast_limits=contrast_limits,
             )
-        setattr(self, '_current_%s_color' % attribute, curr_color)
+        setattr(self, f'_current_{attribute}_color', curr_color)
 
     @property
     def data(self) -> np.ndarray:
@@ -494,33 +494,31 @@ class Points(Layer):
             The name of the attribute to set the color of.
             Should be 'edge' for edge_colo_moder or 'face' for face_color_mode.
         """
-        color_mode = getattr(self, '_%s_color_mode' % attribute)
+        color_mode = getattr(self, f'_{attribute}_color_mode')
         if color_mode == ColorMode.DIRECT:
-            current_face_color = getattr(self, '_current_%s_color' % attribute)
+            current_face_color = getattr(self, f'_current_{attribute}_color')
             new_colors = np.tile(current_face_color, (adding, 1))
         elif color_mode == ColorMode.CYCLE:
-            property_name = getattr(self, '_%s_color_property' % attribute)
+            property_name = getattr(self, f'_{attribute}_color_property')
             color_property_value = self.current_properties[property_name][0]
 
             # check if the new color property is in the cycle map
             # and add it if it is not
-            color_cycle_map = getattr(self, '%s_color_cycle_map' % attribute)
+            color_cycle_map = getattr(self, f'{attribute}_color_cycle_map')
             color_cycle_keys = [*color_cycle_map]
             if color_property_value not in color_cycle_keys:
-                color_cycle = getattr(self, '%s_color_cycle' % attribute)
+                color_cycle = getattr(self, f'{attribute}_color_cycle')
                 color_cycle_map[color_property_value] = next(color_cycle)
-                setattr(
-                    self, '%s_color_cycle_map' % attribute, color_cycle_map
-                )
+                setattr(self, f'{attribute}_color_cycle_map', color_cycle_map)
 
             new_colors = np.tile(
                 color_cycle_map[color_property_value], (adding, 1),
             )
         elif color_mode == ColorMode.COLORMAP:
-            property_name = getattr(self, '_%s_color_property' % attribute)
+            property_name = getattr(self, f'_{attribute}_color_property')
             color_property_value = self.current_properties[property_name][0]
-            colormap = getattr(self, '%s_colormap' % attribute)
-            contrast_limits = getattr(self, '_%s_contrast_limits' % attribute)
+            colormap = getattr(self, f'{attribute}_colormap')
+            contrast_limits = getattr(self, f'_{attribute}_contrast_limits')
 
             fc, _ = map_property(
                 prop=color_property_value,
@@ -528,8 +526,8 @@ class Points(Layer):
                 contrast_limits=contrast_limits,
             )
             new_colors = np.tile(fc, (adding, 1))
-        colors = getattr(self, '%s_color' % attribute)
-        setattr(self, '_%s_color' % attribute, np.vstack((colors, new_colors)))
+        colors = getattr(self, f'{attribute}_color')
+        setattr(self, f'_{attribute}_color', np.vstack((colors, new_colors)))
 
     @property
     def properties(self):
@@ -891,35 +889,34 @@ class Points(Layer):
         color_mode = ColorMode(color_mode)
 
         if color_mode == ColorMode.DIRECT:
-            setattr(self, '_%s_color_mode' % attribute, color_mode)
+            setattr(self, f'_{attribute}_color_mode', color_mode)
         elif color_mode in (ColorMode.CYCLE, ColorMode.COLORMAP):
-            color_property = getattr(self, '_%s_color_property' % attribute)
+            color_property = getattr(self, f'_{attribute}_color_property')
             if color_property == '':
                 if self.properties:
+                    new_color_property = next(iter(self.properties))
                     setattr(
                         self,
-                        '_%s_color_property' % attribute,
-                        next(iter(self.properties)),
+                        f'_{attribute}_color_property',
+                        new_color_property,
                     )
                     warnings.warn(
-                        '_%s_color_property was not set, setting to: %s'
-                        % (attribute, self._face_color_property)
+                        '_{attribute}_color_property was not set, setting to: {new_color_property}'
                     )
                 else:
                     raise ValueError(
-                        'There must be a valid Points.properties to use %s'
-                        % color_mode
+                        'There must be a valid Points.properties to use {color_mode}'
                     )
 
             # ColorMode.COLORMAP can only be applied to numeric properties
-            color_property = getattr(self, '_%s_color_property' % attribute)
+            color_property = getattr(self, f'_{attribute}_color_property')
             if (color_mode == ColorMode.COLORMAP) and not issubclass(
                 self.properties[color_property].dtype.type, np.number,
             ):
                 raise TypeError(
                     'selected property must be numeric to use ColorMode.COLORMAP'
                 )
-            setattr(self, '_%s_color_mode' % attribute, color_mode)
+            setattr(self, f'_{attribute}_color_mode', color_mode)
             self.refresh_colors()
 
     def _set_color(self, color: ColorType, attribute: str):
@@ -937,10 +934,10 @@ class Points(Layer):
         # otherwise, assume it is the name of a color
         if self._is_color_mapped(color):
             if guess_continuous(self.properties[color]):
-                setattr(self, '_%s_color_mode' % attribute, ColorMode.COLORMAP)
+                setattr(self, f'_{attribute}_color_mode', ColorMode.COLORMAP)
             else:
-                setattr(self, '_%s_color_mode' % attribute, ColorMode.CYCLE)
-            setattr(self, '_%s_color_property' % attribute, color)
+                setattr(self, f'_{attribute}_color_mode', ColorMode.CYCLE)
+            setattr(self, f'_{attribute}_color_property', color)
             self.refresh_colors()
 
         else:
@@ -953,10 +950,10 @@ class Points(Layer):
             colors = normalize_and_broadcast_colors(
                 len(self.data), transformed_color
             )
-            setattr(self, '_%s_color' % attribute, colors)
-            setattr(self, '_%s_color_mode' % attribute, ColorMode.DIRECT)
+            setattr(self, f'_{attribute}_color', colors)
+            setattr(self, f'_{attribute}_color_mode', ColorMode.DIRECT)
 
-            color_event = getattr(self.events, '%s_color' % attribute)
+            color_event = getattr(self.events, f'{attribute}_color')
             color_event()
 
     def refresh_colors(self, update_color_mapping: bool = False):
@@ -995,14 +992,12 @@ class Points(Layer):
             Default value is False.
         """
         if self._update_properties:
-            color_mode = getattr(self, '_%s_color_mode' % attribute)
+            color_mode = getattr(self, f'_{attribute}_color_mode')
             if color_mode == ColorMode.CYCLE:
-                color_property = getattr(
-                    self, '_%s_color_property' % attribute
-                )
+                color_property = getattr(self, f'_{attribute}_color_property')
                 color_properties = self.properties[color_property]
                 if update_color_mapping:
-                    color_cycle = getattr(self, '%s_color_cycle' % attribute)
+                    color_cycle = getattr(self, f'{attribute}_color_cycle')
                     color_cycle_map = {
                         k: c
                         for k, c in zip(
@@ -1010,14 +1005,14 @@ class Points(Layer):
                         )
                     }
                     setattr(
-                        self, '%s_color_cycle_map' % attribute, color_cycle_map
+                        self, f'{attribute}_color_cycle_map', color_cycle_map
                     )
 
                 else:
                     # add properties if they are not in the colormap
                     # and update_color_mapping==False
                     color_cycle_map = getattr(
-                        self, '%s_color_cycle_map' % attribute
+                        self, f'{attribute}_color_cycle_map'
                     )
                     color_cycle_keys = [*color_cycle_map]
                     props_in_map = np.in1d(color_properties, color_cycle_keys)
@@ -1025,14 +1020,12 @@ class Points(Layer):
                         props_to_add = np.unique(
                             color_properties[np.logical_not(props_in_map)]
                         )
-                        color_cycle = getattr(
-                            self, '%s_color_cycle' % attribute
-                        )
+                        color_cycle = getattr(self, f'{attribute}_color_cycle')
                         for prop in props_to_add:
                             color_cycle_map[prop] = next(color_cycle)
                         setattr(
                             self,
-                            '%s_color_cycle_map' % attribute,
+                            f'{attribute}_color_cycle_map',
                             color_cycle_map,
                         )
                 colors = np.array(
@@ -1040,18 +1033,16 @@ class Points(Layer):
                 )
                 if len(colors) == 0:
                     colors = np.empty((0, 4))
-                setattr(self, '_%s_color' % attribute, colors)
+                setattr(self, f'_{attribute}_color', colors)
 
             elif color_mode == ColorMode.COLORMAP:
-                color_property = getattr(
-                    self, '_%s_color_property' % attribute
-                )
+                color_property = getattr(self, f'_{attribute}_color_property')
                 color_properties = self.properties[color_property]
                 if len(color_properties) > 0:
                     contrast_limits = getattr(
-                        self, '%s_contrast_limits' % attribute
+                        self, f'{attribute}_contrast_limits'
                     )
-                    colormap = getattr(self, '%s_colormap' % attribute)
+                    colormap = getattr(self, f'{attribute}_colormap')
                     if update_color_mapping or contrast_limits is None:
 
                         colors, contrast_limits = map_property(
@@ -1059,7 +1050,7 @@ class Points(Layer):
                         )
                         setattr(
                             self,
-                            '%s_contrast_limits' % attribute,
+                            f'{attribute}_contrast_limits',
                             contrast_limits,
                         )
                     else:
@@ -1071,9 +1062,9 @@ class Points(Layer):
                         )
                 else:
                     colors = np.empty((0, 4))
-                setattr(self, '_%s_color' % attribute, colors)
+                setattr(self, f'_{attribute}_color', colors)
 
-            color_event = getattr(self.events, '%s_color' % attribute)
+            color_event = getattr(self.events, f'{attribute}_color')
             color_event()
 
     def _is_color_mapped(self, color):

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -900,7 +900,7 @@ class Points(Layer):
     ):
         """ Set the face_color_mode or edge_color_mode property
 
-        Paramters:
+        Parameters
         ----------
         color_mode : str, ColorMode
             The value for setting edge or face_color_mode. If color_mode is a string,
@@ -947,7 +947,7 @@ class Points(Layer):
     def _set_color(self, color: ColorType, attribute: str):
         """ Set the face_color or edge_color property
 
-        Paramters:
+        Parameters
         ----------
         color : (N, 4) array or str
             The value for setting edge or face_color

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -483,7 +483,7 @@ class Points(Layer):
         self.events.data()
 
     def _add_point_color(self, adding: int, attribute: str):
-        """Add the edge or face colors for new points
+        """Add the edge or face colors for new points.
 
         Parameters:
         ----------

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -382,14 +382,13 @@ class Points(Layer):
     def _initialize_current_color_for_empty_layer(
         self, color: ColorType, attribute: str
     ):
-        """Initialize the current_edge_color or current_face_color
-        property for the case when you are starting with an empty layer
+        """Initialize current_{edge,face}_color when starting with empty layer.
 
         Parameters:
         -----------
         color : (N, 4) array or str
             The value for setting edge or face_color
-        attribute : str
+        attribute : str in {'edge', 'face'}
             The name of the attribute to set the color of.
             Should be 'edge' for edge_color or 'face' for face_color.
         """
@@ -491,7 +490,7 @@ class Points(Layer):
         adding : int
             the number of points that were added
             (and thus the number of color entries to add)
-        attribute : str
+        attribute : str in {'edge', 'face'}
             The name of the attribute to set the color of.
             Should be 'edge' for edge_colo_moder or 'face' for face_color_mode.
         """

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -778,7 +778,7 @@ class Points(Layer):
 
     @edge_color_mode.setter
     def edge_color_mode(self, edge_color_mode: Union[str, ColorMode]):
-        self._set_color(edge_color_mode, 'edge')
+        self._set_color_mode(edge_color_mode, 'edge')
 
     @property
     def face_color(self):

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -886,7 +886,7 @@ class Points(Layer):
         color_mode : str, ColorMode
             The value for setting edge or face_color_mode. If color_mode is a string,
             it should be one of: 'direct', 'cycle', or 'colormap'
-        attribute : str
+        attribute : str in {'edge', 'face'}
             The name of the attribute to set the color of.
             Should be 'edge' for edge_colo_moder or 'face' for face_color_mode.
         """
@@ -930,7 +930,7 @@ class Points(Layer):
         ----------
         color : (N, 4) array or str
             The value for setting edge or face_color
-        attribute : str
+        attribute : str in {'edge', 'face'}
             The name of the attribute to set the color of.
             Should be 'edge' for edge_color or 'face' for face_color.
         """
@@ -983,7 +983,7 @@ class Points(Layer):
 
         Parameters
         ----------
-        attribute : str
+        attribute : str  in {'edge', 'face'}
             The name of the attribute to set the color of.
             Should be 'edge' for edge_color or 'face' for face_color.
         update_color_mapping : bool

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -543,13 +543,17 @@ class Points(Layer):
             self._face_color_property not in self._properties
         ):
             self._face_color_property = ''
-            warnings.warn('property used for face_color dropped')
+            warnings.warn(
+                'property used for face_color dropped', RuntimeWarning
+            )
 
         if self._edge_color_property and (
             self._edge_color_property not in self._properties
         ):
             self._edge_color_property = ''
-            warnings.warn('property used for edge_color dropped')
+            warnings.warn(
+                'property used for edge_color dropped', RuntimeWarning
+            )
 
     @property
     def current_properties(self):

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -920,7 +920,7 @@ class Points(Layer):
                 raise TypeError(
                     'selected property must be numeric to use ColorMode.COLORMAP'
                 )
-            setattr(self, '_%s_color_mode', color_mode)
+            setattr(self, '_%s_color_mode' % attribute, color_mode)
             self.refresh_colors()
 
     def _set_color(self, color: ColorType, attribute: str):


### PR DESCRIPTION
# Description
This PR aims to reduce some of the code duplication in the Points layer that was introduced when adding properties and allowing colors to be mapped to properties. The general approach is to write general functions that can be used for both edge_color and face_color properties using `setattr` and `getattr`.

I also added some tests to increase coverage on the Points model (closes #1136).


## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References


# How has this been tested?
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
