### PR TITLE
Open up Pillow again after 7.1.*

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,7 +1,7 @@
 dask[array]>=2.1.0
 fsspec>=0.3.3
 imageio>=2.5.0
-Pillow<=7.0.0  # not a direct dependency; remove once fixed
+Pillow!=7.1.*  # not a direct dependency, but 7.1.0 and 7.1.1 broke imageio
 ipykernel>=5.1.1
 numpy>=1.10.0
 qtpy>=1.7.0


### PR DESCRIPTION
# Description
@jni mentioned that he [prefers blocking specific versions](https://github.com/napari/napari/pull/1108#issuecomment-608979036), and the Pillow issues are going to be fixed in version ≥7.2.0 (fixed in https://github.com/python-pillow/Pillow/pull/4528), so this PR just restricts Pillow to != 7.1.*


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] dependencies

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
I ran our test suite and some examples on Pillow 7.2.0.dev and everything works
