### PR TITLE
Add keybinding to toggle selected layer visibility

### DIFF
--- a/napari/_viewer_key_bindings.py
+++ b/napari/_viewer_key_bindings.py
@@ -142,7 +142,7 @@ def play(viewer):
         viewer.window.qt_viewer.dims.play(axis)
 
 
-@Viewer.bind_key('Control-H')
+@Viewer.bind_key('V')
 def toggle_selected_visibility(viewer):
     """Toggle visibility of selected layers"""
     viewer.layers.toggle_selected_visibility()

--- a/napari/_viewer_key_bindings.py
+++ b/napari/_viewer_key_bindings.py
@@ -140,3 +140,9 @@ def play(viewer):
     else:
         axis = viewer.window.qt_viewer.dims.last_used or 0
         viewer.window.qt_viewer.dims.play(axis)
+
+
+@Viewer.bind_key('Control-H')
+def toggle_selected_visibility(viewer):
+    """Toggle visibility of selected layers"""
+    viewer.layers.toggle_selected_visibility()

--- a/napari/components/_tests/test_layers_list.py
+++ b/napari/components/_tests/test_layers_list.py
@@ -393,3 +393,34 @@ def test_move_selected():
         False,
         False,
     ]
+
+
+def test_toggle_visibility():
+    """
+    Test toggling layer visibility
+    """
+    layers = LayerList()
+    layer_a = Image(np.random.random((10, 10)))
+    layer_b = Image(np.random.random((15, 15)))
+    layer_c = Image(np.random.random((15, 15)))
+    layer_d = Image(np.random.random((15, 15)))
+    layers.append(layer_a)
+    layers.append(layer_b)
+    layers.append(layer_c)
+    layers.append(layer_d)
+
+    layers[0].visible = False
+    layers[1].visible = True
+    layers[2].visible = False
+    layers[3].visible = True
+
+    layers.select_all()
+    layers[0].selected = False
+
+    layers.toggle_selected_visibility()
+
+    assert [l.visible for l in layers] == [False, False, True, False]
+
+    layers.toggle_selected_visibility()
+
+    assert [l.visible for l in layers] == [False, True, False, True]

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -176,6 +176,6 @@ class LayerList(ListModel):
 
     def toggle_selected_visibility(self):
         """Toggle visibility of selected layers"""
-        for i in range(len(self)):
-            if self[i].selected:
-                self[i].visible = not self[i].visible
+        for layer in self:
+            if layer.selected:
+                layer.visible = not layer.visible

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -173,3 +173,9 @@ class LayerList(ListModel):
                 self[selected[0] - 1].selected = True
         elif len(self) > 0:
             self[0].selected = True
+
+    def toggle_selected_visibility(self):
+        """Toggle visibility of selected layers"""
+        for i in range(len(self)):
+            if self[i].selected:
+                self[i].visible = not self[i].visible


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
This adds a function to toggle selected layer visibility along with a key binding (`Ctl+H`)

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] New feature (non-breaking change which adds functionality)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #1139 " -->
This PR (partially) closes #1139

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [X] Added test to select some of layers with heterogeneous visibility and toggle the visibility back and forth

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
