### PR TITLE
Only block in gui_qt or quit QApp when necessary

### DIFF
--- a/napari/_qt/event_loop.py
+++ b/napari/_qt/event_loop.py
@@ -22,17 +22,20 @@ def gui_qt(*, startup_logo=False):
     IPython with the Qt GUI event loop enabled by default by using
     ``ipython --gui=qt``.
     """
+    had_app = True
     app = QApplication.instance()
     if not app:
+        had_app = False
         # if this is the first time the Qt app is being instantiated, we set
         # the name, so that we know whether to raise_ in Window.show()
         app = QApplication(sys.argv)
         app.setApplicationName('napari')
-    if startup_logo:
-        logopath = join(dirname(__file__), '..', 'resources', 'logo.png')
-        splash_widget = QSplashScreen(QPixmap(logopath).scaled(400, 400))
-        splash_widget.show()
-    yield
-    if startup_logo:
-        splash_widget.close()
-    app.exec_()
+        if startup_logo:
+            logopath = join(dirname(__file__), '..', 'resources', 'logo.png')
+            splash_widget = QSplashScreen(QPixmap(logopath).scaled(400, 400))
+            splash_widget.show()
+    yield app
+    if not had_app:
+        if startup_logo:
+            splash_widget.close()
+        app.exec_()

--- a/napari/_qt/event_loop.py
+++ b/napari/_qt/event_loop.py
@@ -34,9 +34,9 @@ def gui_qt(*, startup_logo=False):
             splash_widget = QSplashScreen(QPixmap(logopath).scaled(400, 400))
             splash_widget.show()
     yield app
-    # the application already existed before this function was called, there's
-    # no need to start it again.  By avoiding unnecessary calls to app.exec_
-    # we avoid blocking.
+    # if the application already existed before this function was called,
+    # there's no need to start it again.  By avoiding unnecessary calls to
+    # ``app.exec_``, we avoid blocking.
     if app.applicationName() == 'napari':
         if splash_widget and startup_logo:
             splash_widget.close()

--- a/napari/_qt/event_loop.py
+++ b/napari/_qt/event_loop.py
@@ -22,10 +22,9 @@ def gui_qt(*, startup_logo=False):
     IPython with the Qt GUI event loop enabled by default by using
     ``ipython --gui=qt``.
     """
-    had_app = True
+    splash_widget = None
     app = QApplication.instance()
     if not app:
-        had_app = False
         # if this is the first time the Qt app is being instantiated, we set
         # the name, so that we know whether to raise_ in Window.show()
         app = QApplication(sys.argv)
@@ -35,7 +34,10 @@ def gui_qt(*, startup_logo=False):
             splash_widget = QSplashScreen(QPixmap(logopath).scaled(400, 400))
             splash_widget.show()
     yield app
-    if not had_app:
-        if startup_logo:
+    # the application already existed before this function was called, there's
+    # no need to start it again.  By avoiding unnecessary calls to app.exec_
+    # we avoid blocking.
+    if app.applicationName() == 'napari':
+        if splash_widget and startup_logo:
             splash_widget.close()
         app.exec_()


### PR DESCRIPTION
# Description
This PR solves two issues that have bothered me for a long time!


### Problem `#1`

sometimes `gui_qt` blocks unnecessarily (for instance, if a qt event loop has already been started by IPython, then our context manager actually doesn't need to block at all).  Fixing this allows you to quickly load any of our examples in IPython, keeping all of the variables in scope.

```python
> ipython

In [1]: %gui qt

# in the current master, this command would block
# (unnecessarily, since we already have an event loop provided by IPython,
# AND you can't use the console in napari since it was started from IPython)
In [2]: %run examples/add_points_with_properties.py

# after this PR, you can keep working with all of the variables
# that were declared in the file/example.
In [3]: viewer
Out[3]: <napari.viewer.Viewer at 0x13ce1adf0>

In [4]: points_layer
Out[4]: <Points layer 'Points' at 0x143c54940>
```

### Problem `#2`

If you already have an event loop running (via IPython or otherwise) if you QUIT the application (rather than closing the main window) you actually can't create another window without restarting the app (which usually just means restarting the IPython session).

```python
> ipython

In [1]: %gui qt

In [2]: import napari

In [3]: v = napari.Viewer()
# if you close this viewer window using the close button on the main window
# or using command-W (on mac) ... then it's fine.

# but if you QUIT the program (command-Q or File -> Exit), then there is
# no more event loop and this command just hangs ...
In [4]: v = napari.Viewer()

# until you actually create a new event loop
In [5]: from qtpy.QtWidgets import QApplication

In [6]: QApplication.exec_()  # now it shows up.
```

after this PR, the second instantiation on line 4 would show the Viewer.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
