### PR TITLE
Use mode='constant' in numpy.pad usage

### DIFF
--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -95,7 +95,9 @@ class VispyBaseLayer(ABC):
     def scale(self, scale):
         # Avoid useless update if nothing changed in the displayed dims
         # Note that the master_transform scale is always a 4-vector so pad
-        padded_scale = np.pad(scale, ((0, 4 - len(scale))), constant_values=1)
+        padded_scale = np.pad(
+            scale, ((0, 4 - len(scale))), constant_values=1, mode='constant'
+        )
         if self.scale is not None and np.all(self.scale == padded_scale):
             return
         self._master_transform.scale = padded_scale
@@ -110,7 +112,10 @@ class VispyBaseLayer(ABC):
         # Avoid useless update if nothing changed in the displayed dims
         # Note that the master_transform translate is always a 4-vector so pad
         padded_translate = np.pad(
-            translate, ((0, 4 - len(translate))), constant_values=1
+            translate,
+            ((0, 4 - len(translate))),
+            constant_values=1,
+            mode='constant',
         )
         if self.translate is not None and np.all(
             self.translate == padded_translate


### PR DESCRIPTION
# Description

A couple of changes snuck by that use `np.pad` without a `mode=` keyword argument, which is not valid in NumPy 1.16 and earlier. See #645. This adds the missing kwarg in those calls.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
