### PR TITLE
Fix black consistency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,32 +4,6 @@ repos:
     hooks:
     - id: black
       pass_filenames: true
-      args: [
-        '--target-version', 'py36',
-        '--target-version', 'py37',
-        '--target-version', 'py38',
-        '--skip-string-normalization',
-        '--line-length', '79',
-        '--exclude', '''
-        (
-          /(
-              \.eggs
-            | \.git
-            | \.hg
-            | \.mypy_cache
-            | \.tox
-            | \.venv
-            | _build
-            | buck-out
-            | build
-            | dist
-            | examples
-            | vendored
-          )/
-          | napari/resources/qt.py
-        )
-        '''
-      ]
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,35 @@
 repos:
 -   repo: https://github.com/python/black
-    rev: stable
+    rev: 19.10b0
     hooks:
     - id: black
-      # force black to run on whole repo & keep settings from pyproject.toml
-      pass_filenames: false
-      args: [.]
+      pass_filenames: true
+      args: [
+        '--target-version', 'py36',
+        '--target-version', 'py37',
+        '--target-version', 'py38',
+        '--skip-string-normalization',
+        '--line-length', '79',
+        '--exclude', '''
+        (
+          /(
+              \.eggs
+            | \.git
+            | \.hg
+            | \.mypy_cache
+            | \.tox
+            | \.venv
+            | _build
+            | buck-out
+            | build
+            | dist
+            | examples
+            | vendored
+          )/
+          | napari/resources/qt.py
+        )
+        '''
+      ]
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9
     hooks:

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -475,7 +475,7 @@ class Image(IntensityVisualizationMixin, Layer):
 
             for d in self.dims.displayed:
                 indices[d] = slice(
-                    corner_pixels[0, d], corner_pixels[1, d] + 1, 1,
+                    corner_pixels[0, d], corner_pixels[1, d] + 1, 1
                 )
             self._transforms['tile2data'].translate = (
                 corner_pixels[0]

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -686,7 +686,7 @@ def test_switch_color_mode(attribute):
         colormap_kwarg: 'gray',
         color_cycle_kwarg: color_cycle,
     }
-    layer = Points(data, properties=properties, **args,)
+    layer = Points(data, properties=properties, **args)
 
     layer_color_mode = getattr(layer, f'{attribute}_color_mode')
     layer_color = getattr(layer, f'{attribute}_color')
@@ -757,7 +757,7 @@ def test_add_colormap(attribute):
     color_kwarg = f'{attribute}_color'
     colormap_kwarg = f'{attribute}_colormap'
     args = {color_kwarg: 'point_type', colormap_kwarg: 'viridis'}
-    layer = Points(data, properties=annotations, **args,)
+    layer = Points(data, properties=annotations, **args)
 
     setattr(layer, f'{attribute}_colormap', get_colormap('gray'))
     layer_colormap = getattr(layer, f'{attribute}_colormap')

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -512,7 +512,7 @@ class Points(Layer):
                 setattr(self, f'{attribute}_color_cycle_map', color_cycle_map)
 
             new_colors = np.tile(
-                color_cycle_map[color_property_value], (adding, 1),
+                color_cycle_map[color_property_value], (adding, 1)
             )
         elif color_mode == ColorMode.COLORMAP:
             property_name = getattr(self, f'_{attribute}_color_property')
@@ -915,7 +915,7 @@ class Points(Layer):
             # ColorMode.COLORMAP can only be applied to numeric properties
             color_property = getattr(self, f'_{attribute}_color_property')
             if (color_mode == ColorMode.COLORMAP) and not issubclass(
-                self.properties[color_property].dtype.type, np.number,
+                self.properties[color_property].dtype.type, np.number
             ):
                 raise TypeError(
                     'selected property must be numeric to use ColorMode.COLORMAP'
@@ -1005,7 +1005,7 @@ class Points(Layer):
                     color_cycle_map = {
                         k: c
                         for k, c in zip(
-                            np.unique(color_properties), color_cycle,
+                            np.unique(color_properties), color_cycle
                         )
                     }
                     setattr(
@@ -1050,7 +1050,7 @@ class Points(Layer):
                     if update_color_mapping or contrast_limits is None:
 
                         colors, contrast_limits = map_property(
-                            prop=color_properties, colormap=colormap[1],
+                            prop=color_properties, colormap=colormap[1]
                         )
                         setattr(
                             self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py36', 'py37']
+target-version = ['py36', 'py37', 'py38']
 skip-string-normalization = true
 line-length = 79
 exclude = '''

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,5 +1,5 @@
 pre-commit>=1.16.1
-black>=19.3b0
+black==19.10b0
 flake8==3.7.9
 -r test.txt
 -r default.txt


### PR DESCRIPTION
# Description
We've noticed a couple cases recently where CI black let some trailing commas through, but my (and @jni's) local pre-commit was unhappy and tried to fix them.  This PR just does a couple things that I hope will prevent that:

- pins the version of black used in our `.pre-commit-config.yaml` and `requirements/development.txt`
- changes `pass_filenames: false` to `true` in `pre-commit-config`, which should make it only look at staged files.

note, I don't think it should be necessary for our CI to maintain consistency, but you may want to run `pip install -r requirements/development.txt` after merging this PR into your local environments.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] CI Bug-fix
