### PR TITLE
Reduce code duplication in points tests

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1011,12 +1011,6 @@ def test_size():
     layer.selected_data = {11}
     assert layer.current_size == 20
 
-    # Create new layer with new size data
-    layer = Points(data, size=15)
-    assert layer.current_size == 15
-    assert layer.size.shape == shape
-    assert np.unique(layer.size)[0] == 15
-
 
 def test_size_with_arrays():
     """Test setting size with arrays."""
@@ -1032,6 +1026,16 @@ def test_size_with_arrays():
     sizes = [5, 5]
     layer.size = sizes
     assert np.all(layer.size[0] == sizes)
+
+    # Test broadcasting of transposed sizes
+    sizes = np.random.randint(low=1, high=5, size=shape[::-1])
+    layer.size = sizes
+    np.testing.assert_equal(layer.size, sizes.T)
+
+    # Un-broadcastable array should raise an exception
+    bad_sizes = np.random.randint(low=1, high=5, size=(3, 8))
+    with pytest.raises(ValueError):
+        layer.size = bad_sizes
 
     # Create new layer with new size array data
     sizes = 5 * np.random.random(shape)

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -423,13 +423,17 @@ def test_symbol():
     assert layer.symbol == 'star'
 
 
-def test_properties():
+properties_array = {'point_type': _make_cycled_properties(['A', 'B'], 10)}
+properties_list = {'point_type': list(_make_cycled_properties(['A', 'B'], 10))}
+
+
+@pytest.mark.parametrize("properties", [properties_array, properties_list])
+def test_properties(properties):
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
-    properties = {'point_type': np.array(['A', 'B'] * int(shape[0] / 2))}
     layer = Points(data, properties=copy(properties))
-    assert layer.properties == properties
+    np.testing.assert_equal(layer.properties, properties)
 
     current_prop = {'point_type': np.array(['B'])}
     assert layer.current_properties == current_prop
@@ -447,7 +451,7 @@ def test_properties():
     assert len(selected_annotation) == 1
     assert selected_annotation[0] == 'A'
 
-    # test adding properties
+    # test adding points with properties
     layer.add([10, 10])
     add_annotations = np.concatenate((remove_properties, ['A']), axis=0)
     assert np.all(layer.properties['point_type'] == add_annotations)
@@ -487,7 +491,7 @@ def test_adding_properties(attribute):
     layer.properties = properties_list
     assert isinstance(layer.properties['point_type'], np.ndarray)
 
-    # removing a property that was the _edge_color_property should give a warning
+    # removing a property that was the _*_color_property should give a warning
     setattr(layer, f'_{attribute}_color_property', 'vector_type')
     properties_2 = {
         'not_vector_type': _make_cycled_properties(['A', 'B'], shape[0])
@@ -497,7 +501,7 @@ def test_adding_properties(attribute):
 
 
 def test_properties_dataframe():
-    """test if properties can be provided as a DataFrame"""
+    """Test if properties can be provided as a DataFrame"""
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
@@ -506,55 +510,6 @@ def test_properties_dataframe():
     properties_df = properties_df.astype(properties['point_type'].dtype)
     layer = Points(data, properties=properties_df)
     np.testing.assert_equal(layer.properties, properties)
-
-
-def test_properties_list():
-    """test if properties can be provided as a dict of lists"""
-    shape = (10, 2)
-    np.random.seed(0)
-    data = 20 * np.random.random(shape)
-    properties = {
-        'point_type': list(_make_cycled_properties(['A', 'B'], shape[0]))
-    }
-    layer = Points(data, properties=properties)
-    np.testing.assert_equal(layer.properties, properties)
-
-    # verify the lists were converted to numpy arrays
-    assert type(layer.properties['point_type']) == np.ndarray
-
-
-def test_adding_annotations():
-    shape = (10, 2)
-    np.random.seed(0)
-    data = 20 * np.random.random(shape)
-    properties = {'point_type': _make_cycled_properties(['A', 'B'], shape[0])}
-    layer = Points(data)
-    assert layer.properties == {}
-
-    # add properties
-    layer.properties = copy(properties)
-    assert layer.properties == properties
-
-    # change properties
-    new_annotations = {
-        'other_type': _make_cycled_properties(['C', 'D'], shape[0])
-    }
-    layer.properties = copy(new_annotations)
-    assert layer.properties == new_annotations
-
-
-def test_add_points_with_properties():
-    # test adding points initialized with properties
-    shape = (10, 2)
-    np.random.seed(0)
-    data = 20 * np.random.random(shape)
-    properties = {'point_type': _make_cycled_properties(['A', 'B'], shape[0])}
-    layer = Points(data, properties=copy(properties))
-
-    coord = [18, 18]
-    layer.add(coord)
-    new_prop = {'point_type': np.append(properties['point_type'], 'B')}
-    np.testing.assert_equal(layer.properties, new_prop)
 
 
 def test_add_points_with_properties_as_list():

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1186,8 +1186,6 @@ class Points(Layer):
         else:
             data = self._view_data[index]
             size = self._view_size[index]
-            if data.ndim == 1:
-                data = np.expand_dims(data, axis=0)
             data = points_to_squares(data, size)
             box = create_box(data)
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -508,7 +508,9 @@ class Points(Layer):
             color_cycle_keys = [*color_cycle_map]
             if color_property_value not in color_cycle_keys:
                 color_cycle = getattr(self, f'{attribute}_color_cycle')
-                color_cycle_map[color_property_value] = next(color_cycle)
+                color_cycle_map[color_property_value] = transform_color(
+                    next(color_cycle)
+                )
                 setattr(self, f'{attribute}_color_cycle_map', color_cycle_map)
 
             new_colors = np.tile(
@@ -1003,7 +1005,7 @@ class Points(Layer):
                 if update_color_mapping:
                     color_cycle = getattr(self, f'{attribute}_color_cycle')
                     color_cycle_map = {
-                        k: c
+                        k: transform_color(c)
                         for k, c in zip(
                             np.unique(color_properties), color_cycle,
                         )
@@ -1026,7 +1028,9 @@ class Points(Layer):
                         )
                         color_cycle = getattr(self, f'{attribute}_color_cycle')
                         for prop in props_to_add:
-                            color_cycle_map[prop] = next(color_cycle)
+                            color_cycle_map[prop] = np.squeeze(
+                                transform_color(next(color_cycle))
+                            )
                         setattr(
                             self,
                             f'{attribute}_color_cycle_map',


### PR DESCRIPTION
# Description
This PR reduces the code duplication between tests for `edge_color` and `face_color` in `Points`.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)


# References
This is a follow up to #1140 .

# How has this been tested?
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
