### PR TITLE
Allow last added point to be deleted with backspace keybinding

### DIFF
--- a/napari/_viewer_key_bindings.py
+++ b/napari/_viewer_key_bindings.py
@@ -75,6 +75,7 @@ def focus_axes_down(viewer):
 
 
 @Viewer.bind_key('Control-Backspace')
+@Viewer.bind_key('Control-Delete')
 def remove_selected(viewer):
     """Remove selected layers."""
     viewer.layers.remove_selected()
@@ -87,6 +88,7 @@ def select_all(viewer):
 
 
 @Viewer.bind_key('Control-Shift-Backspace')
+@Viewer.bind_key('Control-Shift-Delete')
 def remove_all_layers(viewer):
     """Remove all layers."""
     viewer.layers.select_all()

--- a/napari/layers/points/_points_key_bindings.py
+++ b/napari/layers/points/_points_key_bindings.py
@@ -60,6 +60,7 @@ def select_all(layer):
 
 
 @Points.bind_key('Backspace')
+@Points.bind_key('Delete')
 def delete_selected(layer):
     """Delet all selected points."""
     if layer._mode in (Mode.SELECT, Mode.ADD):

--- a/napari/layers/points/_points_key_bindings.py
+++ b/napari/layers/points/_points_key_bindings.py
@@ -62,5 +62,5 @@ def select_all(layer):
 @Points.bind_key('Backspace')
 def delete_selected(layer):
     """Delet all selected points."""
-    if layer._mode == Mode.SELECT:
+    if layer._mode in (Mode.SELECT, Mode.ADD):
         layer.remove_selected()

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -262,6 +262,10 @@ def test_adding_points():
     assert len(layer.data) == 13
     assert np.all(layer.data[11:, :] == coords)
 
+    # test that the last added points can be deleted
+    layer.remove_selected()
+    np.testing.assert_equal(layer.data, np.vstack((data, coord)))
+
 
 def test_adding_points_to_empty():
     """Test adding Points data to empty."""


### PR DESCRIPTION
# Description
This PR adds the ability to delete the last added point with backspace keybinding when in the point adding mode.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
This PR closes #1161 .

# How has this been tested?
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
