### PR TITLE
Update Pillow dependency pin

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -2,7 +2,7 @@ napari-plugins>=0.1.0
 dask[array]>=2.1.0
 fsspec>=0.3.3
 imageio>=2.5.0
-Pillow!=7.1.*  # not a direct dependency, but 7.1.0 and 7.1.1 broke imageio
+Pillow!=7.1.0,!=7.1.1  # not a direct dependency, but 7.1.0 and 7.1.1 broke imageio
 ipykernel>=5.1.1
 numpy>=1.10.0
 qtpy>=1.7.0


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

As Pillow is an indirect dependency, remove the pin added in https://github.com/napari/napari/pull/1146.

https://github.com/python-pillow/Pillow/pull/4528 was released in Pillow 7.1.2 yesterday: https://pillow.readthedocs.io/en/stable/releasenotes/7.1.2.html

Alternatively, you could keep the pin with:

`Pillow!=7.1.0,!=7.1.1`

or

`Pillow>=7.1.2`

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [n/a] I have added tests that prove my fix is effective or that my feature works
