### PR TITLE
Change array to np.ndarray in type information

### DIFF
--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -92,7 +92,7 @@ class AddLayersMixin:
 
         Parameters
         ----------
-        data : array or list of array
+        data : np.ndarray or list of np.ndarray
             Image data. Can be N dimensional. If the last dimension has length
             3 or 4 can be interpreted as RGB or RGBA if rgb is `True`. If a
             list and arrays are decreasing in shape then the data is treated as
@@ -299,9 +299,9 @@ class AddLayersMixin:
 
         Parameters
         ----------
-        data : array (N, D)
+        data : np.ndarray (N, D)
             Coordinates for N points in D dimensions.
-        properties : dict {str: array (N,)}, DataFrame
+        properties : dict {str: np.ndarray (N,)}, DataFrame
             Properties for each point. Each property should be an array of length N,
             where N is the number of points.
         symbol : str
@@ -432,8 +432,8 @@ class AddLayersMixin:
 
         Parameters
         ----------
-        data : array or list of array
-            Labels data as an array or multiscale.
+        data : np.ndarray or list of np.ndarray
+            Labels data as an array or pyramid.
         num_colors : int
             Number of unique colors to use in colormap.
         seed : float
@@ -679,13 +679,13 @@ class AddLayersMixin:
 
         Parameters
         ----------
-        data : (N, 2, D) or (N1, N2, ..., ND, D) array
+        data : (N, 2, D) or (N1, N2, ..., ND, D) np.ndarray
             An (N, 2, D) array is interpreted as "coordinate-like" data and a
             list of N vectors with start point and projections of the vector in
             D dimensions. An (N1, N2, ..., ND, D) array is interpreted as
             "image-like" data where there is a length D vector of the
             projections at each pixel.
-        properties : dict {str: array (N,)}, DataFrame
+        properties : dict {str: np.ndarray (N,)}, DataFrame
             Properties for each vector. Each property should be an array of length N,
             where N is the number of vectors.
         edge_width : float

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -4,8 +4,7 @@ from abc import ABC, abstractmethod
 import os
 from functools import lru_cache
 from logging import getLogger
-from typing import Any, Dict, List, Optional, Sequence, Union, TypeVar
-from ..utils.colormaps import ensure_colormap_tuple
+from typing import Any, Dict, List, Optional, Set, Sequence, Union, TypeVar
 
 import numpy as np
 

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -9,6 +9,7 @@ from ..utils.colormaps import ensure_colormap_tuple
 
 import numpy as np
 
+from napari.layers.utils.array_interface import ArrayInterface
 from . import Dims
 from .. import layers
 from ..layers.image._image_utils import guess_labels, guess_multiscale
@@ -25,10 +26,6 @@ from ..utils.misc import (
 logger = getLogger(__name__)
 
 LayerType = TypeVar("LayerType", bound=layers.Layer)
-
-
-class ArrayInterface(ABC):
-    pass
 
 
 class AddLayersMixin(ABC):
@@ -82,7 +79,7 @@ class AddLayersMixin(ABC):
 
     def add_image(
         self,
-        data=None,
+        data: Union[ArrayInterface, List[ArrayInterface]],
         *,
         channel_axis=None,
         rgb=None,
@@ -106,7 +103,7 @@ class AddLayersMixin(ABC):
 
         Parameters
         ----------
-        data : np.ndarray or list of np.ndarray
+        data : ArrayInterface or list of ArrayInterface
             Image data. Can be N dimensional. If the last dimension has length
             3 or 4 can be interpreted as RGB or RGBA if rgb is `True`. If a
             list and arrays are decreasing in shape then the data is treated as

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -29,8 +29,6 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
 
     Attributes
     ----------
-    window : Window
-        Parent window.
     layers : LayerList
         List of contained layers.
     dims : Dimensions
@@ -167,10 +165,10 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         return self._help
 
     @help.setter
-    def help(self, help):
-        if help == self.help:
+    def help(self, help_text):
+        if help_text == self.help:
             return
-        self._help = help
+        self._help = help_text
         self.events.help(text=self._help)
 
     @property
@@ -417,9 +415,9 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
 
         min_shape = []
         max_shape = []
-        for min, max, step in self._calc_layers_ranges():
-            min_shape.append(min)
-            max_shape.append(max)
+        for min_val, max_val, step in self._calc_layers_ranges():
+            min_shape.append(min_val)
+            max_shape.append(max_val)
         if len(min_shape) == 0:
             min_shape = [0] * self.dims.ndim
             max_shape = [1] * self.dims.ndim
@@ -522,8 +520,6 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
             Layer that is to be moved.
         position : 2-tuple of int
             New position of layer in grid.
-        size : 2-tuple of int
-            Size of the grid that is being used.
         """
         scene_size, corner = self._scene_shape()
         translate_2d = np.multiply(scene_size[-2:], position)

--- a/napari/layers/image/_image_utils.py
+++ b/napari/layers/image/_image_utils.py
@@ -8,7 +8,7 @@ def guess_rgb(shape):
 
     Parameters
     ----------
-    shape : list of int
+    shape : list of int or tuple of int
         Shape of the data that should be checked.
 
     Returns
@@ -32,7 +32,7 @@ def guess_multiscale(data):
 
     Parameters
     ----------
-    data : array or list of array
+    data : np.ndarray or list of np.ndarray
         Data that should be checked.
 
     Returns

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -1,6 +1,9 @@
 import types
 import warnings
+from typing import Union, List
+
 import numpy as np
+from napari.layers.utils.array_interface import ArrayInterface
 from scipy import ndimage as ndi
 
 from ...utils.colormaps import AVAILABLE_COLORMAPS
@@ -19,7 +22,7 @@ class Image(IntensityVisualizationMixin, Layer):
 
     Parameters
     ----------
-    data : np.ndarray or list of np.ndarray
+    data : napari.layers.utils.array_interface.ArrayInterface or list of napari.layers.utils.array_interface.ArrayInterface
         Image data. Can be N dimensional. If the last dimension has length
         3 or 4 can be interpreted as RGB or RGBA if rgb is `True`. If a
         list and arrays are decreasing in shape then the data is treated as
@@ -131,7 +134,7 @@ class Image(IntensityVisualizationMixin, Layer):
 
     def __init__(
         self,
-        data,
+        data: Union[ArrayInterface, List[ArrayInterface]],
         *,
         rgb=None,
         colormap='gray',

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -19,7 +19,7 @@ class Image(IntensityVisualizationMixin, Layer):
 
     Parameters
     ----------
-    data : array or list of array
+    data : np.ndarray or list of np.ndarray
         Image data. Can be N dimensional. If the last dimension has length
         3 or 4 can be interpreted as RGB or RGBA if rgb is `True`. If a
         list and arrays are decreasing in shape then the data is treated as
@@ -76,7 +76,7 @@ class Image(IntensityVisualizationMixin, Layer):
 
     Attributes
     ----------
-    data : array or list of array
+    data : np.ndarray or list of np.ndarray
         Image data. Can be N dimensional. If the last dimension has length
         3 or 4 can be interpreted as RGB or RGBA if rgb is `True`. If a list
         and arrays are decreaing in shape then the data is treated as a
@@ -119,7 +119,7 @@ class Image(IntensityVisualizationMixin, Layer):
 
     Extended Summary
     ----------
-    _data_view : array (N, M), (N, M, 3), or (N, M, 4)
+    _data_view : np.ndarray (N, M), (N, M, 3), or (N, M, 4)
         Image data for the currently viewed slice. Must be 2D image data, but
         can be multidimensional for RGB or RGBA images if multidimensional is
         `True`.
@@ -434,7 +434,7 @@ class Image(IntensityVisualizationMixin, Layer):
 
         Parameters
         -------
-        raw : array
+        raw : np.ndarray
             Raw array.
 
         Returns

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -20,8 +20,8 @@ class Labels(Image):
 
     Parameters
     ----------
-    data : array or list of array
-        Labels data as an array or multiscale.
+    data : np.ndarray or list of np.ndarray
+        Labels data as an array or pyramid.
     num_colors : int
         Number of unique colors to use in colormap.
     seed : float
@@ -51,7 +51,7 @@ class Labels(Image):
 
     Attributes
     ----------
-    data : array
+    data : np.ndarray
         Integer valued label data. Can be N dimensional. Every pixel contains
         an integer ID corresponding to the region it belongs to. The label 0 is
         rendered as transparent.
@@ -98,7 +98,7 @@ class Labels(Image):
 
     Extended Summary
     ----------
-    _data_raw : array (N, M)
+    _data_raw : np.ndarray (N, M)
         2D labels data for the currently viewed slice.
     _selected_color : 4-tuple or None
         RGBA tuple of the color of the selected label, or None if the
@@ -378,7 +378,7 @@ class Labels(Image):
 
         Parameters
         -------
-        raw : array or int
+        raw : np.ndarray or int
             Raw integer input image.
 
         Returns

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -44,9 +44,9 @@ class Points(Layer):
 
     Parameters
     ----------
-    data : array (N, D)
+    data : np.ndarray (N, D)
         Coordinates for N points in D dimensions.
-    properties : dict {str: array (N,)}, DataFrame
+    properties : dict {str: np.ndarray (N,)}, DataFrame
         Properties for each point. Each property should be an array of length N,
         where N is the number of points.
     symbol : str
@@ -107,14 +107,14 @@ class Points(Layer):
 
     Attributes
     ----------
-    data : array (N, D)
+    data : np.ndarray (N, D)
         Coordinates for N points in D dimensions.
-    properties : dict {str: array (N,)}
+    properties : dict {str: np.ndarray (N,)}
         Annotations for each point. Each property should be an array of length N,
         where N is the number of points.
     symbol : str
         Symbol used for all point markers.
-    size : array (N, D)
+    size : np.ndarray (N, D)
         Array of sizes for each point in each dimension. Must have the same
         shape as the layer `data`.
     edge_width : float
@@ -187,19 +187,19 @@ class Points(Layer):
 
     Extended Summary
     ----------
-    _property_choices : dict {str: array (N,)}
+    _property_choices : dict {str: np.ndarray (N,)}
         Possible values for the properties in Points.properties.
         If properties is not provided, it will be {} (empty dictionary).
-    _view_data : array (M, 2)
+    _view_data : np.ndarray (M, 2)
         2D coordinates of points in the currently viewed slice.
-    _view_size : array (M, )
+    _view_size : np.ndarray (M, )
         Size of the point markers in the currently viewed slice.
-    _indices_view : array (M, )
+    _indices_view : np.ndarray (M, )
         Integer indices of the points in the currently viewed slice.
     _selected_view :
         Integer indices of selected points in the currently viewed slice within
         the `_view_data` array.
-    _selected_box : array (4, 2) or None
+    _selected_box : np.ndarray (4, 2) or None
         Four corners of any box either around currently selected points or
         being created during a drag action. Starting in the top left and
         going clockwise.

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -854,9 +854,9 @@ def path_to_mask(mask_shape, vertices):
 
     Parameters
     ----------
-    mask_shape : array (2,)
+    mask_shape : np.ndarray (2,)
         Shape of mask to be generated.
-    vertices : array (N, 2)
+    vertices : np.ndarray (N, 2)
         Vertices of the path.
 
     Returns

--- a/napari/layers/utils/array_interface.py
+++ b/napari/layers/utils/array_interface.py
@@ -10,12 +10,20 @@ else:
 
 
 class ArrayInterface(Protocol):
-    shape: Tuple[int] = (0,)
-    dtype: type = np.uint8
-    ndim: int = 1
-
     def __getitem__(self, item) -> Union['ArrayInterface', int, float, bool]:
         ...
 
     def __len__(self) -> int:
         ...
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return (0,)
+
+    @property
+    def dtype(self) -> type:
+        return np.uint8
+
+    @property
+    def ndim(self) -> int:
+        return 0

--- a/napari/layers/utils/array_interface.py
+++ b/napari/layers/utils/array_interface.py
@@ -1,0 +1,21 @@
+import sys
+from typing import Tuple, Union
+
+import numpy as np
+
+if sys.version_info.minor < 8:
+    from typing_extensions import Protocol
+else:
+    from typing import Protocol
+
+
+class ArrayInterface(Protocol):
+    shape: Tuple[int] = (0,)
+    dtype: type = np.uint8
+    ndim: int = 1
+
+    def __getitem__(self, item) -> Union['ArrayInterface', int, float, bool]:
+        ...
+
+    def __len__(self) -> int:
+        ...

--- a/napari/layers/utils/array_interface.py
+++ b/napari/layers/utils/array_interface.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Tuple, Union
+from typing import Tuple, Union, Type
 
 import numpy as np
 
@@ -9,21 +9,37 @@ else:
     from typing import Protocol
 
 
-class ArrayInterface(Protocol):
-    def __getitem__(self, item) -> Union['ArrayInterface', int, float, bool]:
+class SupportsShape(Protocol):
+    shape: Tuple[int, ...]
+
+
+class Is2D(Protocol):
+    shape: Tuple[int, int]
+
+
+class SupportsLen(Protocol):
+    def __len__(self, item) -> int:
         ...
 
-    def __len__(self) -> int:
-        ...
 
-    @property
-    def shape(self) -> Tuple[int, ...]:
-        return (0,)
+class HasDtype(Protocol):
+    dtype: Type[np.uint8]
 
-    @property
-    def dtype(self) -> type:
-        return np.uint8
 
+class HasNdim(Protocol):
     @property
     def ndim(self) -> int:
         return 0
+
+
+class BaseArrayInterface(SupportsLen, HasDtype, HasNdim, Protocol):
+    def __getitem__(self, item) -> Union['ArrayInterface', int, float, bool]:
+        ...
+
+
+class ArrayInterface(BaseArrayInterface, SupportsShape, Protocol):
+    ...
+
+
+class Array2DInterface(BaseArrayInterface, Is2D):
+    ...

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -1,15 +1,16 @@
 from typing import Dict, Union, Tuple
 
 import numpy as np
+from napari.layers.utils.array_interface import ArrayInterface
 from vispy.color import Colormap
 
 
-def calc_data_range(data):
+def calc_data_range(data: ArrayInterface):
     """Calculate range of data values. If all values are equal return [0, 1].
 
     Parameters
     -------
-    data : array
+    data : ArrayInterface
         Data to calculate range of values over.
 
     Returns
@@ -189,7 +190,7 @@ def map_property(
     if contrast_limits is None:
         contrast_limits = (prop.min(), prop.max())
     normalized_properties = np.interp(prop, contrast_limits, (0, 1))
-    mapped_properties = colormap.map(normalized_properties)
+    mapped_properties = np.array(colormap.map(normalized_properties))
 
     return mapped_properties, contrast_limits
 
@@ -221,7 +222,7 @@ def compute_multiscale_level(
         Level of the multiscale to be viewing.
     """
     # Scale shape by downsample factors
-    scaled_shape = requested_shape / downsample_factors
+    scaled_shape = np.array(requested_shape) / np.array(downsample_factors)
 
     # Find the highest resolution level allowed
     locations = np.argwhere(np.all(scaled_shape > shape_threshold, axis=1))

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -30,13 +30,13 @@ class Vectors(Layer):
 
     Parameters
     ----------
-    data : (N, 2, D) or (N1, N2, ..., ND, D) array
+    data : (N, 2, D) or (N1, N2, ..., ND, D) np.ndarray
         An (N, 2, D) array is interpreted as "coordinate-like" data and a
         list of N vectors with start point and projections of the vector in
         D dimensions. An (N1, N2, ..., ND, D) array is interpreted as
         "image-like" data where there is a length D vector of the
         projections at each pixel.
-    properties : dict {str: array (N,)}, DataFrame
+    properties : dict {str: np.ndarray (N,)}, DataFrame
         Properties for each vector. Each property should be an array of length N,
         where N is the number of vectors.
     edge_width : float
@@ -77,7 +77,7 @@ class Vectors(Layer):
     ----------
     data : (N, 2, D) array
         The start point and projections of N vectors in D dimensions.
-    properties : dict {str: array (N,)}, DataFrame
+    properties : dict {str: np.ndarray (N,)}, DataFrame
         Properties for each vector. Each property should be an array of length N,
         where N is the number of vectors.
     edge_width : float
@@ -112,7 +112,7 @@ class Vectors(Layer):
     _view_faces : (2M, 3) or (4M, 3) np.ndarray
         indices of the _mesh_vertices that form the faces of the M in view vectors.
         Shape is (2M, 2) for 2D and (4M, 2) for 3D.
-    _property_choices : dict {str: array (N,)}
+    _property_choices : dict {str: np.ndarray (N,)}
         Possible values for the properties in Vectors.properties.
         If properties is not provided, it will be {} (empty dictionary).
     _mesh_vertices : (4N, 2) array
@@ -247,7 +247,7 @@ class Vectors(Layer):
 
     @property
     def properties(self) -> Dict[str, np.ndarray]:
-        """dict {str: array (N,)}, DataFrame: Annotations for each point"""
+        """dict {str: np.ndarray (N,)}, DataFrame: Annotations for each point"""
         return self._properties
 
     @properties.setter

--- a/napari/plugins/_builtins.py
+++ b/napari/plugins/_builtins.py
@@ -68,7 +68,7 @@ def napari_write_image(path: str, data: Any, meta: dict) -> Optional[str]:
     ----------
     path : str
         Path to file, directory, or resource (like a URL).
-    data : array or list of array
+    data : np.ndarray or list of np.ndarray
         Image data. Can be N dimensional. If meta['rgb'] is ``True`` then the
         data should be interpreted as RGB or RGBA. If ``meta['multiscale']`` is
         ``True``, then the data should be interpreted as a multiscale image.
@@ -126,7 +126,7 @@ def napari_write_points(path: str, data: Any, meta: dict) -> Optional[str]:
     ----------
     path : str
         Path to file, directory, or resource (like a URL).
-    data : array (N, D)
+    data : np.ndarray (N, D)
         Coordinates for N points in D dimensions.
     meta : dict
         Points metadata.

--- a/napari/plugins/hook_specifications.py
+++ b/napari/plugins/hook_specifications.py
@@ -166,7 +166,7 @@ def napari_write_image(path: str, data: Any, meta: dict) -> Optional[str]:
     ----------
     path : str
         Path to file, directory, or resource (like a URL).
-    data : array or list of array
+    data : np.ndarray or list of np.ndarray
         Image data. Can be N dimensional. If meta['rgb'] is ``True`` then the
         data should be interpreted as RGB or RGBA. If meta['multiscale'] is
         True, then the data should be interpreted as a multiscale image.
@@ -194,7 +194,7 @@ def napari_write_labels(path: str, data: Any, meta: dict) -> Optional[str]:
     ----------
     path : str
         Path to file, directory, or resource (like a URL).
-    data : array or list of array
+    data : np.ndarray or list of np.ndarray
         Integer valued label data. Can be N dimensional. Every pixel contains
         an integer ID corresponding to the region it belongs to. The label 0 is
         rendered as transparent. If a list and arrays are decreasing in shape
@@ -223,7 +223,7 @@ def napari_write_points(path: str, data: Any, meta: dict) -> Optional[str]:
     ----------
     path : str
         Path to file, directory, or resource (like a URL).
-    data : array (N, D)
+    data : np.ndarray (N, D)
         Coordinates for N points in D dimensions.
     meta : dict
         Points metadata.

--- a/napari/utils/colormaps/colormaps.py
+++ b/napari/utils/colormaps/colormaps.py
@@ -50,7 +50,7 @@ def _validate_rgb(colors, *, tolerance=0.0):
 
     Parameters
     ----------
-    colors : array of float, shape (N, 3)
+    colors : np.ndarray of float, shape (N, 3)
         Input colors in RGB space.
 
     Other Parameters
@@ -61,7 +61,7 @@ def _validate_rgb(colors, *, tolerance=0.0):
 
     Returns
     -------
-    filtered_colors : array of float, shape (M, 3), M <= N
+    filtered_colors : np.ndarray of float, shape (M, 3), M <= N
         The subset of colors that are in valid RGB space.
 
     Examples
@@ -87,7 +87,7 @@ def _low_discrepancy_image(image, seed=0.5, margin=1 / 256):
 
     Parameters
     ----------
-    labels : array of int
+    labels : np.ndarray of int
         A set of labels or label image.
     seed : float
         The seed from which to start the quasirandom sequence.
@@ -98,7 +98,7 @@ def _low_discrepancy_image(image, seed=0.5, margin=1 / 256):
 
     Returns
     -------
-    image_out : array of float
+    image_out : np.ndarray of float
         The set of ``labels`` remapped to [0, 1] quasirandomly.
 
     """
@@ -125,7 +125,7 @@ def _low_discrepancy(dim, n, seed=0.5):
 
     Returns
     -------
-    pts : array of float, shape (n, dim)
+    pts : np.ndarray of float, shape (n, dim)
         The sampled points.
 
     References
@@ -160,7 +160,7 @@ def _color_random(n, *, colorspace='lab', tolerance=0.0, seed=0.5):
 
     Returns
     -------
-    rgb : array of float, shape (n, 3)
+    rgb : np.ndarray of float, shape (n, 3)
         RGB colors chosen uniformly at random from given colorspace.
     """
     factor = 6  # about 1/5 of random LUV tuples are inside the space

--- a/napari/utils/event.py
+++ b/napari/utils/event.py
@@ -689,6 +689,12 @@ class EmitterGroup(EventEmitter):
         """
         self.add(**{name: emitter})
 
+    def __getattr__(self, item):
+        """To hide warning about unresolved references for dynamic fields"""
+        if item in self._emitters:
+            return self._emitters[item]
+        raise AttributeError
+
     def add(self, auto_connect=None, **kwargs):
         """ Add one or more EventEmitter instances to this emitter group.
         Each keyword argument may be specified as either an EventEmitter

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -31,7 +31,7 @@ def view_image(
 
     Parameters
     ----------
-    data : array or list of array
+    data : np.ndarray or list of np.ndarray
         Image data. Can be N dimensional. If the last dimension has length
         3 or 4 can be interpreted as RGB or RGBA if rgb is `True`. If a
         list and arrays are decreasing in shape then the data is treated as
@@ -243,9 +243,9 @@ def view_points(
 
     Parameters
     ----------
-    data : array (N, D)
+    data : np.ndarray (N, D)
         Coordinates for N points in D dimensions.
-    properties : dict {str: array (N,)}, DataFrame
+    properties : dict {str: np.ndarray (N,)}, DataFrame
         Properties for each point. Each property should be an array of length N,
         where N is the number of points.
     symbol : str
@@ -395,7 +395,7 @@ def view_labels(
 
     Parameters
     ----------
-    data : array or list of array
+    data : np.ndarray or list of np.ndarray
         Labels data as an array or multiscale.
     num_colors : int
         Number of unique colors to use in colormap.
@@ -707,13 +707,13 @@ def view_vectors(
 
     Parameters
     ----------
-    data : (N, 2, D) or (N1, N2, ..., ND, D) array
+    data : (N, 2, D) or (N1, N2, ..., ND, D) np.ndarray
         An (N, 2, D) array is interpreted as "coordinate-like" data and a
         list of N vectors with start point and projections of the vector in
         D dimensions. An (N1, N2, ..., ND, D) array is interpreted as
         "image-like" data where there is a length D vector of the
         projections at each pixel.
-    properties : dict {str: array (N,)}, DataFrame
+    properties : dict {str: np.ndarray (N,)}, DataFrame
         Properties for each vector. Each property should be an array of length N,
         where N is the number of vectors.
     edge_width : float

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -20,4 +20,5 @@ napari-svg>=0.1.2
 tifffile>=2020.2.16
 toolz>=0.10.0
 importlib-metadata>=1.5.0 ; python_version < '3.8'
+typing-extensions>=3.7.4.2 ; python_version < '3.8'
 # Qt version is managed from setup.py to install PySide2 when no Qt libraries are found


### PR DESCRIPTION
# Description
Some of IDE like PyCharm read types from docstring and use it in type hints/warnings

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Update docstring
- [x] add ArrayInterface protocol 

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
https://www.jetbrains.com/help/pycharm/type-hinting-in-product.html#

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality

