### PR TITLE
Add ensure_colormap utility function to standardize colormap getting/setting 

### DIFF
--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -3,6 +3,7 @@ import itertools
 from logging import getLogger
 from os import fspath
 from typing import Any, Dict, List, Optional, Sequence, Union
+from ..utils.colormaps import ensure_colormap_tuple
 
 import numpy as np
 
@@ -95,7 +96,7 @@ class AddLayersMixin:
             a multiscale image.
         channel_axis : int, optional
             Axis to expand image along.  If provided, each channel in the data
-            will be added as an individual image layer.  byIn channel_axis mode,
+            will be added as an individual image layer.  In channel_axis mode,
             all other parameters MAY be provided as lists, and the Nth value
             will be applied to the Nth channel in the data.  If a single value
             is provided, it will be broadcast to all Layers.
@@ -177,6 +178,16 @@ class AddLayersMixin:
         layer : :class:`napari.layers.Image` or list
             The newly-created image layer or list of image layers.
         """
+
+        if colormap is not None:
+            # standardize colormap argument(s) to strings, and make sure they
+            # are in AVAILABLE_COLORMAPS.  This will raise one of many various
+            # errors if the colormap argument is invalid.  See
+            # ensure_colormap_tuple for details
+            if isinstance(colormap, list):
+                colormap = [ensure_colormap_tuple(c)[0] for c in colormap]
+            else:
+                colormap, _ = ensure_colormap_tuple(colormap)
 
         # doing this here for IDE/console autocompletion in add_image function.
         kwargs = {

--- a/napari/layers/intensity_mixin.py
+++ b/napari/layers/intensity_mixin.py
@@ -1,14 +1,9 @@
-import warnings
-
 import numpy as np
-from vispy.color import Colormap
 
-from ..utils.colormaps import make_colorbar
+from ..utils.colormaps import ensure_colormap_tuple, make_colorbar
 from ..utils.event import Event
 from ..utils.status_messages import format_float
 from ..utils.validators import validate_n_seq
-from .utils.layer_utils import increment_unnamed_colormap
-
 
 validate_2_tuple = validate_n_seq(2)
 
@@ -56,25 +51,9 @@ class IntensityVisualizationMixin:
 
     @colormap.setter
     def colormap(self, colormap):
-        name = '[unnamed colormap]'
-        if isinstance(colormap, str):
-            name = colormap
-        elif isinstance(colormap, tuple):
-            name, cmap = colormap
-            self._colormaps[name] = cmap
-        elif isinstance(colormap, dict):
-            self._colormaps.update(colormap)
-            name = list(colormap)[0]  # first key in dict
-        elif isinstance(colormap, Colormap):
-            name = increment_unnamed_colormap(
-                name, list(self._colormaps.keys())
-            )
-            self._colormaps[name] = colormap
-        else:
-            warnings.warn(f'invalid value for colormap: {colormap}')
-            name = self._colormap_name
+        name, cmap = ensure_colormap_tuple(colormap)
         self._colormap_name = name
-        self._cmap = self._colormaps[name]
+        self._cmap = cmap
         self._colorbar = make_colorbar(self._cmap)
         self._update_thumbnail()
         self.events.colormap()

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -722,7 +722,7 @@ def test_add_colormap(attribute):
 
     setattr(layer, f'{attribute}_colormap', get_colormap('gray'))
     layer_colormap = getattr(layer, f'{attribute}_colormap')
-    assert layer_colormap[0] == 'unknown_colormap'
+    assert 'unnamed colormap' in layer_colormap[0]
 
 
 @pytest.mark.parametrize("attribute", ['edge', 'face'])

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -4,8 +4,10 @@ from itertools import cycle
 import warnings
 
 import numpy as np
-from vispy.color import get_colormap
 from vispy.color.colormap import Colormap
+
+from ...utils.colormaps import ensure_colormap_tuple
+from ...types import ValidColormapArg
 
 from ..base import Layer
 from ...utils.event import Event
@@ -721,12 +723,10 @@ class Points(Layer):
         return self._edge_colormap_name, self._edge_colormap
 
     @edge_colormap.setter
-    def edge_colormap(self, colormap: Union[str, Colormap]):
-        self._edge_colormap = get_colormap(colormap)
-        if isinstance(colormap, str):
-            self._edge_colormap_name = colormap
-        else:
-            self._edge_colormap_name = 'unknown_colormap'
+    def edge_colormap(self, colormap: ValidColormapArg):
+        name, cmap = ensure_colormap_tuple(colormap)
+        self._edge_colormap_name = name
+        self._edge_colormap = cmap
 
     @property
     def edge_contrast_limits(self) -> Tuple[float, float]:
@@ -811,12 +811,10 @@ class Points(Layer):
         return self._face_colormap_name, self._face_colormap
 
     @face_colormap.setter
-    def face_colormap(self, colormap: Union[str, Colormap]):
-        self._face_colormap = get_colormap(colormap)
-        if isinstance(colormap, str):
-            self._face_colormap_name = colormap
-        else:
-            self._face_colormap_name = 'unknown_colormap'
+    def face_colormap(self, colormap: ValidColormapArg):
+        name, cmap = ensure_colormap_tuple(colormap)
+        self._face_colormap_name = name
+        self._face_colormap = cmap
 
     @property
     def face_contrast_limits(self) -> Union[None, Tuple[float, float]]:

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -5,12 +5,10 @@ from dask import array as da
 
 from napari.layers.utils.layer_utils import (
     calc_data_range,
-    increment_unnamed_colormap,
-    segment_normal,
     dataframe_to_properties,
     guess_continuous,
+    segment_normal,
 )
-
 
 data_dask = da.random.random(
     size=(100_000, 1000, 1000), chunks=(1, 1000, 1000)
@@ -89,22 +87,6 @@ def test_segment_normal_3d():
 
     unit_norm = segment_normal(a, b, p)
     assert np.all(unit_norm == np.array([0, 0, -1]))
-
-
-def test_increment_unnamed_colormap():
-    # test that unnamed colormaps are incremented
-    names = [
-        '[unnamed colormap 0',
-        'existing_colormap',
-        'perceptually_uniform',
-        '[unnamed colormap 1]',
-    ]
-    name = '[unnamed colormap]'
-    assert increment_unnamed_colormap(name, names) == '[unnamed colormap 2]'
-
-    # test that named colormaps are not incremented
-    named_colormap = 'perfect_colormap'
-    assert increment_unnamed_colormap(named_colormap, names) == named_colormap
 
 
 def test_dataframe_to_properties():

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -4,27 +4,6 @@ import numpy as np
 from vispy.color import Colormap
 
 
-def increment_unnamed_colormap(name, names):
-    """Increment name for unnamed colormap.
-
-    Parameters
-    ----------
-    name : str
-        Name of colormap to be incremented.
-    names : List[str]
-        Names of existing colormaps.
-
-    Returns
-    -------
-    name : str
-        Name of colormap after incrementing.
-    """
-    if name == '[unnamed colormap]':
-        past_names = [n for n in names if n.startswith('[unnamed colormap')]
-        name = f'[unnamed colormap {len(past_names)}]'
-    return name
-
-
 def calc_data_range(data):
     """Calculate range of data values. If all values are equal return [0, 1].
 

--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -374,7 +374,7 @@ def test_edge_color_colormap():
 
     # test adding a colormap with a vispy Colormap object
     layer.edge_colormap = get_colormap('gray')
-    assert layer.edge_colormap[0] == 'unknown_colormap'
+    assert 'unnamed colormap' in layer.edge_colormap[0]
 
 
 def test_edge_color_map_non_numeric_property():

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -1,25 +1,27 @@
-from typing import Union, Dict, Tuple, List
 import warnings
+from copy import copy
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
-from copy import copy
+from vispy.color.colormap import Colormap
+
+from ...types import ValidColormapArg
+from ...utils.colormaps import ensure_colormap_tuple
+from ...utils.event import Event
+from ...utils.status_messages import format_float
 from ..base import Layer
-from ._vectors_constants import ColorMode, DEFAULT_COLOR_CYCLE
 from ..utils.color_transformations import (
-    transform_color_with_defaults,
-    transform_color_cycle,
     normalize_and_broadcast_colors,
+    transform_color_cycle,
+    transform_color_with_defaults,
 )
 from ..utils.layer_utils import (
     dataframe_to_properties,
     guess_continuous,
     map_property,
 )
-from ...utils.event import Event
-from ...utils.status_messages import format_float
-from ._vector_utils import vectors_to_coordinates, generate_vector_meshes
-from vispy.color import get_colormap
-from vispy.color.colormap import Colormap
+from ._vector_utils import generate_vector_meshes, vectors_to_coordinates
+from ._vectors_constants import DEFAULT_COLOR_CYCLE, ColorMode
 
 
 class Vectors(Layer):
@@ -569,12 +571,10 @@ class Vectors(Layer):
         return self._edge_colormap_name, self._edge_colormap
 
     @edge_colormap.setter
-    def edge_colormap(self, colormap: Union[str, Colormap]):
-        self._edge_colormap = get_colormap(colormap)
-        if isinstance(colormap, str):
-            self._edge_colormap_name = colormap
-        else:
-            self._edge_colormap_name = 'unknown_colormap'
+    def edge_colormap(self, colormap: ValidColormapArg):
+        name, cmap = ensure_colormap_tuple(colormap)
+        self._edge_colormap_name = name
+        self._edge_colormap = cmap
 
     @property
     def edge_contrast_limits(self) -> Tuple[float, float]:

--- a/napari/types.py
+++ b/napari/types.py
@@ -1,9 +1,10 @@
 from functools import wraps
-from typing import Any, Callable, Dict, List, Tuple, Union, Type
 from types import TracebackType
+from typing import Any, Callable, Dict, List, Tuple, Type, Union
 
-import numpy as np
 import dask.array as da
+import numpy as np
+import vispy.color
 
 try:
     import zarr
@@ -58,3 +59,11 @@ def image_reader_to_layerdata_reader(
         return [(result,)]
 
     return reader_function
+
+
+ValidColormapArg = Union[
+    str,
+    vispy.color.Colormap,
+    Tuple[str, vispy.color.Colormap],
+    Dict[str, vispy.color.Colormap],
+]

--- a/napari/utils/_tests/test_colormaps.py
+++ b/napari/utils/_tests/test_colormaps.py
@@ -1,7 +1,10 @@
 import pytest
 import numpy as np
 
-from ..colormaps.colormaps import AVAILABLE_COLORMAPS
+from ..colormaps.colormaps import (
+    AVAILABLE_COLORMAPS,
+    increment_unnamed_colormap,
+)
 from vispy.color.color_array import ColorArray
 
 
@@ -25,3 +28,18 @@ def test_colormap(name):
     # http://vispy.org/color.html
     q = np.random.rand(10, 10)
     assert cmap.map(q.reshape(-1, 1)).shape == (q.size, 4)
+
+
+def test_increment_unnamed_colormap():
+    # test that unnamed colormaps are incremented
+    names = [
+        '[unnamed colormap 0',
+        'existing_colormap',
+        'perceptually_uniform',
+        '[unnamed colormap 1]',
+    ]
+    assert increment_unnamed_colormap(names) == '[unnamed colormap 2]'
+
+    # test that named colormaps are not incremented
+    named_colormap = 'perfect_colormap'
+    assert increment_unnamed_colormap(names, named_colormap) == named_colormap

--- a/napari/utils/colormaps/__init__.py
+++ b/napari/utils/colormaps/__init__.py
@@ -1,6 +1,7 @@
 from .colormaps import (
     matplotlib_colormaps,
     simple_colormaps,
+    ensure_colormap_tuple,
     AVAILABLE_COLORMAPS,
     ALL_COLORMAPS,
     MAGENTA_GREEN,

--- a/napari/utils/colormaps/colormaps.py
+++ b/napari/utils/colormaps/colormaps.py
@@ -1,7 +1,11 @@
 import os
-from .vendored import colorconv, cm
+from typing import Tuple, List
+
 import numpy as np
-from vispy.color import get_colormap, get_colormaps, BaseColormap, Colormap
+from vispy.color import BaseColormap, Colormap, get_colormap, get_colormaps
+
+from ...types import ValidColormapArg
+from .vendored import cm, colorconv
 
 _matplotlib_list_file = os.path.join(
     os.path.dirname(__file__), 'matplotlib_cmaps.txt'
@@ -301,3 +305,108 @@ AVAILABLE_COLORMAPS = {k: v for k, v in sorted(ALL_COLORMAPS.items())}
 MAGENTA_GREEN = ['magenta', 'green']
 RGB = ['red', 'green', 'blue']
 CYMRGB = ['cyan', 'yellow', 'magenta', 'red', 'green', 'blue']
+
+
+def increment_unnamed_colormap(
+    existing: List[str], name: str = '[unnamed colormap]'
+) -> str:
+    """Increment name for unnamed colormap.
+
+    Parameters
+    ----------
+    existing : list of str
+        Names of existing colormaps.
+    name : str, optional
+        Name of colormap to be incremented. by default '[unnamed colormap]'
+
+    Returns
+    -------
+    name : str
+        Name of colormap after incrementing.
+    """
+    if name == '[unnamed colormap]':
+        past_names = [n for n in existing if n.startswith('[unnamed colormap')]
+        name = f'[unnamed colormap {len(past_names)}]'
+    return name
+
+
+def ensure_colormap_tuple(colormap: ValidColormapArg) -> Tuple[str, Colormap]:
+    """Accept any valid colormap arg, and return (name, Colormap), or raise.
+
+    Adds any new colormaps to AVAILABLE_COLORMAPS in the process.
+
+    Parameters
+    ----------
+    colormap : ValidColormapArg
+        colormap as str, Colormap, {name: Colormap} ``dict``, or
+        (name, Colormap) ``tuple``.
+
+    Returns
+    -------
+    Tuple[str, Colormap]
+        Normalized name and Colormap.
+
+    Raises
+    ------
+    KeyError
+        If a string is provided that is not in AVAILABLE_COLORMAPS
+    TypeError
+        If a tuple is provided and the first element is not a string or the
+        second element is not a Colormap.
+    TypeError
+        If a dict is provided and any of the values are not Colormap instances.
+    TypeError
+        If ``colormap`` is not a ``str``, ``dict``, ``tuple``, or ``Colormap``
+    """
+    if isinstance(colormap, str):
+        name = colormap
+        if name not in AVAILABLE_COLORMAPS:
+            cmap = vispy_or_mpl_colormap(name)  # raises KeyError if not found
+            AVAILABLE_COLORMAPS[name] = cmap
+    elif isinstance(colormap, BaseColormap):
+        # if a colormap instance is provided, make sure we don't already know
+        # about it before adding a new unnamed colormap
+        name = None
+        for key, val in AVAILABLE_COLORMAPS.items():
+            if colormap == val:
+                name = key
+                break
+        if not name:
+            name = increment_unnamed_colormap(AVAILABLE_COLORMAPS)
+        AVAILABLE_COLORMAPS[name] = colormap
+    elif isinstance(colormap, tuple):
+        if not (
+            len(colormap) > 1
+            and isinstance(colormap[1], BaseColormap)
+            and isinstance(colormap[0], str)
+        ):
+            raise TypeError(
+                "When providing a tuple as a colormap argument, the first "
+                "element must be a string and the second a Colormap instance"
+            )
+        name, cmap = colormap
+        AVAILABLE_COLORMAPS[name] = cmap
+    elif isinstance(colormap, dict):
+        if not all(isinstance(i, BaseColormap) for i in colormap.values()):
+            raise TypeError(
+                "When providing a dict as a colormap, "
+                "all values must be BaseColormap instances"
+            )
+        AVAILABLE_COLORMAPS.update(colormap)
+        if len(colormap) == 1:
+            name = list(colormap)[0]  # first key in dict
+        elif len(colormap) > 1:
+            import warnings
+
+            warnings.warn(
+                "only the first item in a colormap dict is used as an argument"
+            )
+        else:
+            raise ValueError("Received an empty dict as a colormap argument.")
+    else:
+        raise TypeError(
+            f'invalid type for colormap: {type(colormap)}. '
+            'Must be a {str, tuple, dict, vispy.colormap.Colormap}'
+        )
+
+    return name, AVAILABLE_COLORMAPS[name]


### PR DESCRIPTION
# Description
This PR fixes the issue raised by @will-moore in https://github.com/napari/napari/pull/1092#issuecomment-621148849.  I introduce a new utility function `napari.utils.colormaps.ensure_colormap_tuple` that accepts any of the valid colormap argument types (string, `Colormap` instance, tuple of `(string, Colormap)`, dict of `{string: Colormap}`) and returns a `(name, Colormap)` tuple that is _guaranteed_ to be available in `AVAILABLE_COLORMAPS`, otherwises it raises various Exceptions depending on the specifics of the argument (it will also look up strings in `vispy_or_mpl_colormap` before raising).  This simplifies fixing https://github.com/napari/napari/pull/1092#issuecomment-621148849 because it means we can always normalize any type of colormap arg to a string, that can be looked up elsewhere.

I also replaced all of our `@colormap.setter` methods to use this function, and added a lot of tests for all of the various combinations of types with and without `channel_axis`.

@kevinyamauchi: I changed the "unknown_colormap" literal in the points and vectors layers to match the `increment_unnamed_colormap` pattern used in `Image`, let me know if that breaks any of your stuff (i.e. if you need the literal string `unknown_colormap` somewhere).

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] refactor
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added tests
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
