### PR TITLE
Fix small plugin error report bug

### DIFF
--- a/napari/_qt/qt_plugin_report.py
+++ b/napari/_qt/qt_plugin_report.py
@@ -17,7 +17,7 @@ from qtpy.QtWidgets import (
 )
 
 from ..plugins.exceptions import format_exceptions
-from napari_plugin_engine import PluginManager
+from napari_plugin_engine import PluginManager, standard_metadata
 
 
 class QtPluginErrReporter(QDialog):
@@ -158,11 +158,7 @@ class QtPluginErrReporter(QDialog):
 
         # set metadata and outbound links/buttons
         err0 = self.plugin_manager.get_errors(plugin)[0]
-        meta = (
-            self.plugin_manager.get_standard_metadata(err0.plugin)
-            if err0.plugin
-            else None
-        )
+        meta = standard_metadata(err0.plugin) if err0.plugin else None
         meta_text = ''
         if not meta:
             self.plugin_meta.setText(meta_text)


### PR DESCRIPTION
# Description
this fixes a tiny bug in the Qt plugin error reporter when getting metadata for a plugin that was not successfully imported at runtime.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# How has this been tested?
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
