### PR TITLE
Magic layer name guessing is always on

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1,4 +1,3 @@
-import os
 import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
@@ -133,7 +132,7 @@ class Layer(KeymapProvider, ABC):
     ):
         super().__init__()
 
-        if name is None and data is not None and os.getenv('MAGICNAME'):
+        if name is None and data is not None:
             name = magic_name(data, path_prefix=ROOT_DIR)
 
         self.metadata = metadata or {}


### PR DESCRIPTION
# Description
Following [this discussion](https://github.com/napari/napari/pull/1174#discussion_r416293635), we are turning on magic layer name guessing all the time.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
