### PR TITLE
Warn when nothing saved

### DIFF
--- a/napari/plugins/_tests/test_save_layers.py
+++ b/napari/plugins/_tests/test_save_layers.py
@@ -1,4 +1,7 @@
 import os
+
+import pytest
+
 from napari.plugins.io import save_layers
 
 
@@ -18,6 +21,15 @@ def test_save_layer_single_named_plugin(tmpdir, layer_data_and_types):
 
         # Check file now exists
         assert os.path.isfile(path)
+
+
+# the layer_data_and_types fixture is defined in napari/conftest.py
+def test_save_layer_no_results(tmpdir):
+    """Test no layers is not an error, and warns on no results."""
+
+    with pytest.warns(UserWarning):
+        result = save_layers('no_layers', [], plugin='builtins')
+        assert result == []
 
 
 # the layer_data_and_types fixture is defined in napari/conftest.py

--- a/napari/plugins/io.py
+++ b/napari/plugins/io.py
@@ -141,6 +141,8 @@ def save_layers(
             path, layers[0], plugin_name=plugin
         )
         written = [written] if written else []
+    else:
+        written = []
 
     if not written:
         # if written is empty, it means no plugin could write the
@@ -148,7 +150,7 @@ def save_layers(
         # we just want to provide some useful feedback
         warnings.warn(
             'No data written! There may be no plugins '
-            f'capable of writing these layers to {path}.'
+            f'capable of writing these {len(layers)} layers to {path}.'
         )
 
     return written

--- a/napari/plugins/io.py
+++ b/napari/plugins/io.py
@@ -1,3 +1,4 @@
+import warnings
 from logging import getLogger
 from typing import List, Optional, Sequence, Union
 
@@ -132,15 +133,25 @@ def save_layers(
         File paths of any files that were written.
     """
     if len(layers) > 1:
-        return _write_multiple_layers_with_plugins(
+        written = _write_multiple_layers_with_plugins(
             path, layers, plugin_name=plugin
         )
-    if len(layers) == 1:
+    elif len(layers) == 1:
         written = _write_single_layer_with_plugins(
             path, layers[0], plugin_name=plugin
         )
-        return [written] if written else []
-    return []
+        written = [written] if written else []
+
+    if not written:
+        # if written is empty, it means no plugin could write the
+        # path/layers combination
+        # we just want to provide some useful feedback
+        warnings.warn(
+            'No data written! There may be no plugins '
+            f'capable of writing these layers to {path}.'
+        )
+
+    return written
 
 
 def _write_multiple_layers_with_plugins(
@@ -216,9 +227,7 @@ def _write_multiple_layers_with_plugins(
     try:
         return writer_function(abspath_or_url(path), layer_data)
     except Exception as exc:
-        raise PluginCallError(
-            implementation, cause=exc, manager=plugin_manager
-        )
+        raise PluginCallError(implementation, cause=exc)
 
 
 def _write_single_layer_with_plugins(


### PR DESCRIPTION
# Description
This adds a warning if `save_layers` is called but nothing is written.  Could make it an exception instead if you prefer.  (Also fixing a `PluginCallError()` signature)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)



# How has this been tested?
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
