### PR TITLE
fix multichannel implicit multiscale

### DIFF
--- a/napari/components/_tests/test_multichannel.py
+++ b/napari/components/_tests/test_multichannel.py
@@ -147,6 +147,28 @@ def test_multichannel_multiscale():
         assert viewer.layers[i].colormap[0] == base_colormaps[i]
 
 
+def test_multichannel_implicit_multiscale():
+    """Test adding multichannel implicit multiscale."""
+    viewer = ViewerModel()
+    np.random.seed(0)
+    shapes = [(40, 20, 4), (20, 10, 4), (10, 5, 4)]
+    np.random.seed(0)
+    data = [np.random.random(s) for s in shapes]
+    viewer.add_image(data, channel_axis=-1)
+    assert len(viewer.layers) == data[0].shape[-1]
+    for i in range(data[0].shape[-1]):
+        assert np.all(
+            [
+                np.all(l_d == d)
+                for l_d, d in zip(
+                    viewer.layers[i].data,
+                    [data[j].take(i, axis=-1) for j in range(len(data))],
+                )
+            ]
+        )
+        assert viewer.layers[i].colormap[0] == base_colormaps[i]
+
+
 def test_multichannel_dask_array():
     """Test adding multichannel dask array."""
     viewer = ViewerModel()

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -8,6 +8,7 @@ from ..utils.colormaps import ensure_colormap_tuple
 import numpy as np
 
 from .. import layers
+from ..layers.image._image_utils import guess_multiscale
 from ..plugins.io import read_data_with_plugins
 from ..utils import colormaps
 from ..utils.misc import (
@@ -226,6 +227,9 @@ class AddLayersMixin:
 
             return self.add_layer(layers.Image(data, **kwargs))
         else:
+            # Determine if data is a multiscale
+            if multiscale is None:
+                multiscale = guess_multiscale(data)
             n_channels = (data[0] if multiscale else data).shape[channel_axis]
             kwargs['blending'] = kwargs['blending'] or 'additive'
 


### PR DESCRIPTION
# Description
This PR closes #1117 by fixing the implicit multiscale with a multichannel by using the `guess_multiscale` function if none is provided.

Given the usage of `guess_multiscale` here we might want to move it out of the `image` layer utils into our more general utils, we could also rename it `guess_image_multiscale` to be more explicit.

A test has been added.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)