### PR TITLE
One more plugin error reporting  fix

### DIFF
--- a/napari/_qt/_tests/test_qt_plugin_report.py
+++ b/napari/_qt/_tests/test_qt_plugin_report.py
@@ -1,12 +1,16 @@
-from napari._qt import qt_plugin_report
-from qtpy.QtCore import Qt
-from qtpy.QtGui import QGuiApplication
-from napari_plugin_engine import PluginError
-import pytest
 import webbrowser
 
+import pytest
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QGuiApplication
 
+from napari._qt import qt_plugin_report
+from napari_plugin_engine import PluginError
+
+
+# qtbot fixture comes from pytest-qt
 # test_plugin_manager fixture is provided by napari_plugin_engine._testsupport
+# monkeypatch fixture is from pytest
 def test_error_reporter(qtbot, test_plugin_manager, monkeypatch):
     """test that QtPluginErrReporter shows any instantiated PluginErrors."""
 

--- a/napari/_qt/_tests/test_qt_plugin_report.py
+++ b/napari/_qt/_tests/test_qt_plugin_report.py
@@ -1,23 +1,53 @@
-from napari._qt.qt_plugin_report import QtPluginErrReporter
+from napari._qt import qt_plugin_report
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QGuiApplication
 from napari_plugin_engine import PluginError
 import pytest
+import webbrowser
 
 
 # test_plugin_manager fixture is provided by napari_plugin_engine._testsupport
-def test_error_reporter(qtbot, test_plugin_manager):
+def test_error_reporter(qtbot, test_plugin_manager, monkeypatch):
     """test that QtPluginErrReporter shows any instantiated PluginErrors."""
+
+    monkeypatch.setattr(
+        qt_plugin_report,
+        'standard_metadata',
+        lambda x: {'url': 'https://github.com/example/example'},
+    )
+
     error_message = 'my special error'
-    _ = PluginError(error_message, plugin_name='plugin_name')
-    report = QtPluginErrReporter(plugin_manager=test_plugin_manager)
-    qtbot.addWidget(report)
+    _ = PluginError(error_message, plugin_name='test_plugin', plugin="mock")
+    report_widget = qt_plugin_report.QtPluginErrReporter(
+        plugin_manager=test_plugin_manager
+    )
+    qtbot.addWidget(report_widget)
 
     # the null option plus the one we created
-    assert report.plugin_combo.count() >= 2
+    assert report_widget.plugin_combo.count() >= 2
 
     # the message should appear somewhere in the text area
-    report.set_plugin('plugin_name')
-    assert error_message in report.text_area.toPlainText()
+    report_widget.set_plugin('test_plugin')
+    assert error_message in report_widget.text_area.toPlainText()
+
+    # mock_webbrowser_open
+    def mock_webbrowser_open(url, new=0):
+        assert new == 2
+        assert "Errors for plugin 'test_plugin'" in url
+        assert "Traceback from napari" in url
+
+    monkeypatch.setattr(webbrowser, 'open', mock_webbrowser_open)
+
+    qtbot.mouseClick(report_widget.github_button, Qt.LeftButton)
+
+    # make sure we can copy traceback to clipboard
+    report_widget.copyToClipboard()
+    clipboard_text = QGuiApplication.clipboard().text()
+    assert "Errors for plugin 'test_plugin'" in clipboard_text
 
     # plugins without errors raise an error
     with pytest.raises(ValueError):
-        report.set_plugin('non_existent')
+        report_widget.set_plugin('non_existent')
+
+    report_widget.set_plugin(None)
+    assert not report_widget.text_area.toPlainText()

--- a/napari/_qt/qt_dict_table.py
+++ b/napari/_qt/qt_dict_table.py
@@ -1,5 +1,4 @@
 import re
-import webbrowser
 from typing import List, Optional
 
 from qtpy.QtCore import QSize, Slot
@@ -114,6 +113,8 @@ class QtDictTable(QTableWidget):
     @Slot(int, int)
     def _go_to_links(self, row, col):
         """if a cell is clicked and it contains an email or url, go to link."""
+        import webbrowser
+
         item = self.item(row, col)
         text = item.text().strip()
         if email_pattern.match(text):

--- a/napari/_qt/qt_plugin_report.py
+++ b/napari/_qt/qt_plugin_report.py
@@ -136,18 +136,6 @@ class QtPluginErrReporter(QDialog):
         plugin : str
             name of a plugin that has created an error this session.
         """
-        try:
-            self.github_button.clicked.disconnect()
-        except (RuntimeError, TypeError):
-            pass
-        if not self.plugin_manager.get_errors(plugin):
-            if not plugin or plugin == self.NULL_OPTION:
-                self.plugin_meta.setText('')
-                self.text_area.setHtml('')
-                return
-            else:
-                raise ValueError(f"No errors reported for plugin '{plugin}'")
-        self.plugin_combo.setCurrentText(plugin)
         self.github_button.hide()
         self.clipboard_button.hide()
         try:
@@ -156,6 +144,15 @@ class QtPluginErrReporter(QDialog):
         # PySide2 raises runtimeError, PyQt5 raises TypeError
         except (RuntimeError, TypeError):
             pass
+
+        if not plugin or (plugin == self.NULL_OPTION):
+            self.plugin_meta.setText('')
+            self.text_area.setHtml('')
+            return
+
+        if not self.plugin_manager.get_errors(plugin):
+            raise ValueError(f"No errors reported for plugin '{plugin}'")
+        self.plugin_combo.setCurrentText(plugin)
 
         err_string = format_exceptions(plugin, as_html=True)
         self.text_area.setHtml(err_string)

--- a/napari/_qt/qt_plugin_report.py
+++ b/napari/_qt/qt_plugin_report.py
@@ -138,7 +138,7 @@ class QtPluginErrReporter(QDialog):
         """
         try:
             self.github_button.clicked.disconnect()
-        except RuntimeError:
+        except (RuntimeError, TypeError):
             pass
         if not self.plugin_manager.get_errors(plugin):
             if not plugin or plugin == self.NULL_OPTION:

--- a/napari/_qt/qt_plugin_report.py
+++ b/napari/_qt/qt_plugin_report.py
@@ -1,6 +1,5 @@
 """Provides a QtPluginErrReporter that allows the user report plugin errors.
 """
-import webbrowser
 from typing import Optional
 
 from qtpy.QtCore import Qt
@@ -60,9 +59,11 @@ class QtPluginErrReporter(QDialog):
     ) -> None:
         super().__init__(parent)
         if not plugin_manager:
-            from ..plugins import plugin_manager
+            from ..plugins import plugin_manager as _pm
 
-        self.plugin_manager = plugin_manager
+            self.plugin_manager = _pm
+        else:
+            self.plugin_manager = plugin_manager
 
         self.setWindowTitle('Recorded Plugin Exceptions')
         self.setWindowModality(Qt.NonModal)
@@ -78,7 +79,7 @@ class QtPluginErrReporter(QDialog):
         # Create plugin dropdown menu
         self.plugin_combo = QComboBox()
         self.plugin_combo.addItem(self.NULL_OPTION)
-        bad_plugins = [e.plugin_name for e in plugin_manager.get_errors()]
+        bad_plugins = [e.plugin_name for e in self.plugin_manager.get_errors()]
         self.plugin_combo.addItems(list(sorted(set(bad_plugins))))
         self.plugin_combo.currentTextChanged.connect(self.set_plugin)
         self.plugin_combo.setCurrentText(self.NULL_OPTION)
@@ -135,8 +136,12 @@ class QtPluginErrReporter(QDialog):
         plugin : str
             name of a plugin that has created an error this session.
         """
+        try:
+            self.github_button.clicked.disconnect()
+        except RuntimeError:
+            pass
         if not self.plugin_manager.get_errors(plugin):
-            if plugin == self.NULL_OPTION:
+            if not plugin or plugin == self.NULL_OPTION:
                 self.plugin_meta.setText('')
                 self.text_area.setHtml('')
                 return
@@ -158,7 +163,7 @@ class QtPluginErrReporter(QDialog):
 
         # set metadata and outbound links/buttons
         err0 = self.plugin_manager.get_errors(plugin)[0]
-        meta = standard_metadata(err0.plugin) if err0.plugin else None
+        meta = standard_metadata(err0.plugin) if err0.plugin else {}
         meta_text = ''
         if not meta:
             self.plugin_meta.setText(meta_text)
@@ -167,24 +172,26 @@ class QtPluginErrReporter(QDialog):
         url = meta.get('url')
         if url:
             meta_text += (
-                '<span style="color:#999;">plugin home page:&nbsp;&nbsp;</span>'
-                f'<a href="{url}" style="color:#999">{url}</a>'
+                '<span style="color:#999;">plugin home page:&nbsp;&nbsp;'
+                f'</span><a href="{url}" style="color:#999">{url}</a>'
             )
+            if 'github.com' in url:
+
+                def onclick():
+                    import webbrowser
+
+                    err = format_exceptions(plugin, as_html=False)
+                    err = (
+                        "<!--Provide detail on the error here-->\n\n\n\n"
+                        "<details>\n<summary>Traceback from napari</summary>"
+                        f"\n\n```\n{err}\n```\n</details>"
+                    )
+                    url = f'{meta.get("url")}/issues/new?&body={err}'
+                    webbrowser.open(url, new=2)
+
+                self.github_button.clicked.connect(onclick)
+                self.github_button.show()
         self.plugin_meta.setText(meta_text)
-        if 'github.com' in meta.get('url', ''):
-
-            def onclick():
-                err = format_exceptions(plugin, as_html=False)
-                err = (
-                    "<!--Provide detail on the error here-->\n\n\n\n"
-                    "<details>\n<summary>Traceback from napari</summary>"
-                    f"\n\n```\n{err}\n```\n</details>"
-                )
-                url = f'{meta.get("url")}/issues/new?&body={err}'
-                webbrowser.open(url, new=2)
-
-            self.github_button.clicked.connect(onclick)
-            self.github_button.show()
 
     def copyToClipboard(self) -> None:
         """Copy current plugin traceback info to clipboard as plain text."""

--- a/napari/plugins/_tests/test_exceptions.py
+++ b/napari/plugins/_tests/test_exceptions.py
@@ -1,0 +1,28 @@
+from napari_plugin_engine import PluginError
+from napari.plugins import exceptions
+import sys
+import pytest
+
+
+@pytest.mark.parametrize('as_html', (True, False), ids=['as_html', 'as_text'])
+@pytest.mark.parametrize('cgitb', (True, False), ids=['cgitb', 'ipython'])
+def test_format_exceptions(cgitb, as_html, monkeypatch):
+    if cgitb:
+        monkeypatch.setitem(sys.modules, 'IPython.core.ultratb', None)
+    monkeypatch.setattr(
+        exceptions,
+        'standard_metadata',
+        lambda x: {'package': 'test-package', 'version': '0.1.0'},
+    )
+    _ = PluginError(
+        'some error',
+        plugin_name='test_plugin',
+        plugin="mock",
+        cause=ValueError("cause"),
+    )
+    formatted = exceptions.format_exceptions('test_plugin', as_html=as_html)
+    assert "some error" in formatted
+    assert "version: 0.1.0" in formatted
+    assert "plugin package: test-package" in formatted
+
+    assert exceptions.format_exceptions('nonexistent', as_html=as_html) == ''

--- a/napari/plugins/_tests/test_exceptions.py
+++ b/napari/plugins/_tests/test_exceptions.py
@@ -1,9 +1,12 @@
-from napari_plugin_engine import PluginError
-from napari.plugins import exceptions
 import sys
+
 import pytest
 
+from napari.plugins import exceptions
+from napari_plugin_engine import PluginError
 
+
+# monkeypatch fixture is from pytest
 @pytest.mark.parametrize('as_html', (True, False), ids=['as_html', 'as_text'])
 @pytest.mark.parametrize('cgitb', (True, False), ids=['cgitb', 'ipython'])
 def test_format_exceptions(cgitb, as_html, monkeypatch):

--- a/napari/plugins/exceptions.py
+++ b/napari/plugins/exceptions.py
@@ -52,7 +52,7 @@ def format_exceptions(plugin_name: str, as_html: bool = False):
                 [
                     f'{"plugin package": >16}: {package_meta["package"]}',
                     f'{"version": >16}: {package_meta["version"]}',
-                    f'{"module": >16}: {err0.plugin_module}',
+                    f'{"module": >16}: {err0.plugin}',
                 ]
             )
     msg.append('')


### PR DESCRIPTION
# Description
Caught one more lingering bug in the plugin error reporter since the move to `napari-plugin-engine`.  This PR fixes that one-liner [here](https://github.com/napari/napari/compare/master...tlambert03:error-reporter-fix?expand=1#diff-765ae9e85183a03498d33b5be8ff07cbR55), and adds more tests to ensure full coverage on all error reporting stuff.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
