### PR TITLE
Normalize paths handed to reader plugins

### DIFF
--- a/napari/plugins/io.py
+++ b/napari/plugins/io.py
@@ -60,6 +60,7 @@ def read_data_with_plugins(
         reader = hook_caller._call_plugin(plugin, path=path)
         return reader(path)
 
+    path = abspath_or_url(path)
     skip_impls: List[HookImplementation] = []
     while True:
         result = hook_caller.call_with_result_obj(
@@ -137,10 +138,10 @@ def save_layers(
             path, layers, plugin_name=plugin
         )
     elif len(layers) == 1:
-        written = _write_single_layer_with_plugins(
+        _written = _write_single_layer_with_plugins(
             path, layers[0], plugin_name=plugin
         )
-        written = [written] if written else []
+        written = [_written] if _written else []
     else:
         written = []
 

--- a/napari/utils/_tests/test_misc.py
+++ b/napari/utils/_tests/test_misc.py
@@ -1,5 +1,5 @@
 from enum import auto
-from os.path import expanduser, abspath
+from os.path import expanduser, abspath, sep
 from pathlib import Path
 
 import pytest
@@ -172,9 +172,10 @@ def test_string_enum():
 
 
 def test_abspath_or_url():
-    assert abspath_or_url('~/something') == expanduser('~/something')
+    relpath = "~" + sep + "something"
+    assert abspath_or_url(relpath) == expanduser(relpath)
     assert abspath_or_url('something') == abspath('something')
-    assert abspath_or_url('/something') == '/something'
+    assert abspath_or_url(sep + 'something') == abspath(sep + 'something')
     assert abspath_or_url('https://something') == 'https://something'
     assert abspath_or_url('http://something') == 'http://something'
     assert abspath_or_url('ftp://something') == 'ftp://something'

--- a/napari/utils/_tests/test_misc.py
+++ b/napari/utils/_tests/test_misc.py
@@ -1,5 +1,6 @@
 from enum import auto
 from os.path import expanduser, abspath
+from pathlib import Path
 
 import pytest
 
@@ -180,6 +181,8 @@ def test_abspath_or_url():
     assert abspath_or_url('file://something') == 'file://something'
     assert abspath_or_url(('a', '~')) == (abspath('a'), expanduser('~'))
     assert abspath_or_url(['a', '~']) == [abspath('a'), expanduser('~')]
+
+    assert abspath_or_url(('a', Path('~'))) == (abspath('a'), expanduser('~'))
 
     with pytest.raises(TypeError):
         abspath_or_url({'a', '~'})

--- a/napari/utils/_tests/test_misc.py
+++ b/napari/utils/_tests/test_misc.py
@@ -1,4 +1,5 @@
 from enum import auto
+from os.path import expanduser, abspath
 
 import pytest
 
@@ -7,6 +8,7 @@ from napari.utils.misc import (
     callsignature,
     ensure_sequence_of_iterables,
     ensure_iterable,
+    abspath_or_url,
 )
 
 ITERABLE = (0, 1, 2)
@@ -166,3 +168,18 @@ def test_string_enum():
     #  test setting by instance of a different StringEnum is an error
     with pytest.raises(ValueError):
         TestEnum(OtherEnum.SOMETHING)
+
+
+def test_abspath_or_url():
+    assert abspath_or_url('~/something') == expanduser('~/something')
+    assert abspath_or_url('something') == abspath('something')
+    assert abspath_or_url('/something') == '/something'
+    assert abspath_or_url('https://something') == 'https://something'
+    assert abspath_or_url('http://something') == 'http://something'
+    assert abspath_or_url('ftp://something') == 'ftp://something'
+    assert abspath_or_url('file://something') == 'file://something'
+    assert abspath_or_url(('a', '~')) == (abspath('a'), expanduser('~'))
+    assert abspath_or_url(['a', '~']) == [abspath('a'), expanduser('~')]
+
+    with pytest.raises(TypeError):
+        abspath_or_url({'a', '~'})

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -1,15 +1,15 @@
-import os
 import csv
+import os
 import re
-
 from glob import glob
 from pathlib import Path
-from typing import Union, List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
-
-from dask import delayed
 from dask import array as da
+from dask import delayed
+
+from ..utils.misc import abspath_or_url
 
 
 def imsave(filename: str, data: np.ndarray):
@@ -99,6 +99,7 @@ def imread(filename: str) -> np.ndarray:
     data : np.ndarray
         The image data.
     """
+    filename = abspath_or_url(filename)
     ext = os.path.splitext(filename)[1]
     if ext in [".tif", ".tiff", ".lsm"]:
         import tifffile

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -7,7 +7,7 @@ import re
 import warnings
 from contextlib import contextmanager
 from enum import Enum, EnumMeta
-from os import fspath, path
+from os import fspath, path, PathLike
 from typing import ContextManager, Optional, Type, TypeVar, Sequence
 
 import dask
@@ -216,13 +216,13 @@ def abspath_or_url(relpath: T) -> T:
     if isinstance(relpath, (tuple, list)):
         return type(relpath)(abspath_or_url(p) for p in relpath)
 
-    if isinstance(relpath, str):
+    if isinstance(relpath, (str, PathLike)):
         relpath = fspath(relpath)
         if relpath.startswith(('http:', 'https:', 'ftp:', 'file:')):
             return relpath
         return path.abspath(path.expanduser(relpath))
 
-    raise TypeError("Argument must be a string or sequence of strings")
+    raise TypeError("Argument must be a string, PathLike, or sequence thereof")
 
 
 class CallDefault(inspect.Parameter):


### PR DESCRIPTION
# Description
Just found that using `viewer.open_path("~/Desktop/my.tiff")` fails, in this case, because tifffile is not expecting a relative path with an un-expanded user directory.  This PR normalizes paths prior to handing to reader plugins (and also in our `imsave` function) by using the `abspath_or_url` function that was introduced for writer plugins.

Also let `abspath_or_url` accept a sequence of paths, and added more docs and tests for 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
