### PR TITLE
fix singleton dims display after toggle

### DIFF
--- a/napari/_qt/_tests/test_qt_dims.py
+++ b/napari/_qt/_tests/test_qt_dims.py
@@ -196,6 +196,18 @@ def test_singleton_dims(qtbot):
         ]
     )
 
+    # Change ndisplay to three
+    view.dims.ndisplay = 3
+
+    # Check no sliders now shown
+    assert np.sum(view._displayed_sliders) == 0
+
+    # Change ndisplay back to two
+    view.dims.ndisplay = 2
+
+    # Check only slider now shown
+    assert np.sum(view._displayed_sliders) == 1
+
 
 def test_order_when_changing_ndim(qtbot):
     """

--- a/napari/_qt/qt_dims.py
+++ b/napari/_qt/qt_dims.py
@@ -154,7 +154,8 @@ class QtDims(QWidget):
         """
         widgets = reversed(list(enumerate(self.slider_widgets)))
         for (axis, widget) in widgets:
-            if axis in self.dims.displayed:
+            _range = self.dims.range[axis][1] - self.dims.range[axis][2]
+            if axis in self.dims.displayed or _range == 0:
                 # Displayed dimensions correspond to non displayed sliders
                 self._displayed_sliders[axis] = False
                 self.last_used = None


### PR DESCRIPTION
# Description
This PR is a one liner fix to #1131 where singleton dims were being displayed after toggling to 3D then back to 2D


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)