### PR TITLE
resize axis labels on show

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -409,6 +409,8 @@ class Window:
         """Resize, show, and bring forward the window."""
         self._qt_window.resize(self._qt_window.layout().sizeHint())
         self._qt_window.show()
+        # Resize axis labels now that window is shown
+        self.qt_viewer.dims._resize_axis_labels()
 
         # We want to call Window._qt_window.raise_() in every case *except*
         # when instantiating a viewer within a gui_qt() context for the


### PR DESCRIPTION
# Description
This PR will close #1114 - thought not sure if there is a nicer way to do it @tlambert03? I couldn't get calling the resize to work before the window is shown 

To reproduce I was using
```python
data = np.random.random((20, 100, 200))
viewer = napari.view_image(data, axis_labels=['a very long label', 'y', 'x'])
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
