### PR TITLE
change screenshot hotkey and open menubar names

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -178,7 +178,7 @@ def test_screenshot(viewer_factory):
     assert screenshot.ndim == 3
 
 
-def test_save_screenshot(viewer_factory, tmpdir):
+def test_screenshot_dialog(viewer_factory, tmpdir):
     """Test save screenshot functionality."""
     view, viewer = viewer_factory()
 
@@ -208,7 +208,7 @@ def test_save_screenshot(viewer_factory, tmpdir):
     mock_return = (input_filepath, '')
     with mock.patch('napari._qt.qt_viewer.QFileDialog') as mocker:
         mocker.getSaveFileName.return_value = mock_return
-        view._save_screenshot()
+        view._screenshot_dialog()
     # Assert behaviour is correct
     expected_filepath = input_filepath + '.png'  # add default file extension
     assert os.path.exists(expected_filepath)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -142,52 +142,54 @@ class Window:
 
     def _add_file_menu(self):
         """Add 'File' menu to app menubar."""
-        open_images = QAction('Open file(s)...', self._qt_window)
+        open_images = QAction('Open File(s)...', self._qt_window)
         open_images.setShortcut('Ctrl+O')
         open_images.setStatusTip('Open file(s)')
-        open_images.triggered.connect(self.qt_viewer._open_files)
+        open_images.triggered.connect(self.qt_viewer._open_files_dialog)
 
-        open_stack = QAction('Open files as stack...', self._qt_window)
+        open_stack = QAction('Open Files as Stack...', self._qt_window)
         open_stack.setShortcut('Ctrl+Alt+O')
         open_stack.setStatusTip('Open files')
-        open_stack.triggered.connect(self.qt_viewer._open_files_as_stack)
+        open_stack.triggered.connect(
+            self.qt_viewer._open_files_dialog_as_stack_dialog
+        )
 
-        open_folder = QAction('Open folder...', self._qt_window)
+        open_folder = QAction('Open Folder...', self._qt_window)
         open_folder.setShortcut('Ctrl+Shift+O')
         open_folder.setStatusTip('Open a folder')
-        open_folder.triggered.connect(self.qt_viewer._open_folder)
+        open_folder.triggered.connect(self.qt_viewer._open_folder_dialog)
 
         save_selected_layers = QAction(
-            'Save selected layer(s)...', self._qt_window
+            'Save Selected Layer(s)...', self._qt_window
         )
         save_selected_layers.setShortcut('Ctrl+S')
         save_selected_layers.setStatusTip('Save selected layers')
         save_selected_layers.triggered.connect(
-            lambda: self.qt_viewer._save_layers(selected=True)
+            lambda: self.qt_viewer._save_layers_dialog(selected=True)
         )
 
-        save_all_layers = QAction('Save all layers...', self._qt_window)
+        save_all_layers = QAction('Save All Layers...', self._qt_window)
         save_all_layers.setShortcut('Ctrl+Shift+S')
         save_all_layers.setStatusTip('Save all layers')
         save_all_layers.triggered.connect(
-            lambda: self.qt_viewer._save_layers(selected=False)
+            lambda: self.qt_viewer._save_layers_dialog(selected=False)
         )
 
-        screenshot = QAction('Save screenshot...', self._qt_window)
+        screenshot = QAction('Save Screenshot...', self._qt_window)
         screenshot.setShortcut('Alt+S')
         screenshot.setStatusTip(
             'Save screenshot of current display, default .png'
         )
-        screenshot.triggered.connect(self.qt_viewer._save_screenshot)
+        screenshot.triggered.connect(self.qt_viewer._screenshot_dialog)
 
         screenshot_wv = QAction(
-            'Save screenshot with viewer...', self._qt_window
+            'Save Screenshot with Viewer...', self._qt_window
         )
         screenshot_wv.setShortcut('Alt+Shift+S')
         screenshot_wv.setStatusTip(
             'Save screenshot of current display with the viewer, default .png'
         )
-        screenshot_wv.triggered.connect(self._save_screenshot)
+        screenshot_wv.triggered.connect(self._screenshot_dialog)
 
         # OS X will rename this to Quit and put it in the app menu.
         exitAction = QAction('Exit', self._qt_window)
@@ -225,11 +227,11 @@ class Window:
 
     def _add_view_menu(self):
         """Add 'View' menu to app menubar."""
-        toggle_visible = QAction('Toggle menubar visibility', self._qt_window)
+        toggle_visible = QAction('Toggle Menubar Visibility', self._qt_window)
         toggle_visible.setShortcut('Ctrl+M')
         toggle_visible.setStatusTip('Hide Menubar')
         toggle_visible.triggered.connect(self._toggle_menubar_visible)
-        toggle_theme = QAction('Toggle theme', self._qt_window)
+        toggle_theme = QAction('Toggle Theme', self._qt_window)
         toggle_theme.setShortcut('Ctrl+Shift+T')
         toggle_theme.setStatusTip('Toggle theme')
         toggle_theme.triggered.connect(self.qt_viewer.viewer._toggle_theme)
@@ -239,7 +241,7 @@ class Window:
 
     def _add_window_menu(self):
         """Add 'Window' menu to app menubar."""
-        exit_action = QAction("Close window", self._qt_window)
+        exit_action = QAction("Close Window", self._qt_window)
         exit_action.setShortcut("Ctrl+W")
         exit_action.setStatusTip('Close napari window')
         exit_action.triggered.connect(self._qt_window.close)
@@ -251,18 +253,18 @@ class Window:
         self.plugins_menu = self.main_menu.addMenu('&Plugins')
 
         list_plugins_action = QAction(
-            "List installed plugins...", self._qt_window
+            "List Installed Plugins...", self._qt_window
         )
         list_plugins_action.setStatusTip('List installed plugins')
         list_plugins_action.triggered.connect(self._show_plugin_list)
         self.plugins_menu.addAction(list_plugins_action)
 
-        order_plugin_action = QAction("Plugin call order...", self._qt_window)
+        order_plugin_action = QAction("Plugin Call Order...", self._qt_window)
         order_plugin_action.setStatusTip('Change call order for plugins')
         order_plugin_action.triggered.connect(self._show_plugin_sorter)
         self.plugins_menu.addAction(order_plugin_action)
 
-        report_plugin_action = QAction("Plugin errors...", self._qt_window)
+        report_plugin_action = QAction("Plugin Errors...", self._qt_window)
         report_plugin_action.setStatusTip(
             'Review stack traces for plugin exceptions and notify developers'
         )
@@ -331,7 +333,7 @@ class Window:
         """Add 'Help' menu to app menubar."""
         self.help_menu = self.main_menu.addMenu('&Help')
 
-        about_action = QAction("napari info", self._qt_window)
+        about_action = QAction("napari Info", self._qt_window)
         about_action.setShortcut("Ctrl+/")
         about_action.setStatusTip('About napari')
         about_action.triggered.connect(
@@ -339,7 +341,7 @@ class Window:
         )
         self.help_menu.addAction(about_action)
 
-        about_key_bindings = QAction("Show key bindings", self._qt_window)
+        about_key_bindings = QAction("Show Key Bindings", self._qt_window)
         about_key_bindings.setShortcut("Ctrl+Alt+/")
         about_key_bindings.setShortcutContext(Qt.ApplicationShortcut)
         about_key_bindings.setStatusTip('key_bindings')
@@ -501,7 +503,7 @@ class Window:
         """
         self._help.setText(event.text)
 
-    def _save_screenshot(self):
+    def _screenshot_dialog(self):
         """Save screenshot of current display with viewer, default .png"""
         filename, _ = QFileDialog.getSaveFileName(
             parent=self.qt_viewer,
@@ -511,7 +513,7 @@ class Window:
             # jpg and jpeg not included as they don't support an alpha channel
         )
         if (filename != '') and (filename is not None):
-            # double check that an appropriate extension has been added as the filter
+            # double check that an appropriate extension has been added as the
             # filter option does not always add an extension on linux and windows
             # see https://bugreports.qt.io/browse/QTBUG-27186
             image_extensions = ('.bmp', '.gif', '.png', '.tif', '.tiff')

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -356,21 +356,21 @@ class QtViewer(QSplitter):
                 filename = filename + '.png'
             self.screenshot(path=filename)
 
-    def _open_images(self):
-        """Add image files from the menubar."""
+    def _open_files(self):
+        """Add files from the menubar."""
         filenames, _ = QFileDialog.getOpenFileNames(
             parent=self,
-            caption='Select image(s)...',
+            caption='Select file(s)...',
             directory=self._last_visited_dir,  # home dir by default
         )
         if (filenames != []) and (filenames is not None):
             self.viewer.open(filenames)
 
-    def _open_images_as_stack(self):
-        """Add image files as a stack, from the menubar."""
+    def _open_files_as_stack(self):
+        """Add files as a stack, from the menubar."""
         filenames, _ = QFileDialog.getOpenFileNames(
             parent=self,
-            caption='Select images...',
+            caption='Select files...',
             directory=self._last_visited_dir,  # home dir by default
         )
         if (filenames != []) and (filenames is not None):

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -290,7 +290,7 @@ class QtViewer(QSplitter):
                 self.view.camera.viewbox_key_event = viewbox_key_event
                 self.viewer.reset_view()
 
-    def _save_layers(self, selected=False):
+    def _save_layers_dialog(self, selected=False):
         """Save layers (all or selected) to disk, using ``LayerList.save()``.
 
         Parameters
@@ -338,7 +338,7 @@ class QtViewer(QSplitter):
             imsave(path, QImg2array(img))  # scikit-image imsave method
         return QImg2array(img)
 
-    def _save_screenshot(self):
+    def _screenshot_dialog(self):
         """Save screenshot of current display, default .png"""
         filename, _ = QFileDialog.getSaveFileName(
             parent=self,
@@ -348,7 +348,7 @@ class QtViewer(QSplitter):
             # jpg and jpeg not included as they don't support an alpha channel
         )
         if (filename != '') and (filename is not None):
-            # double check that an appropriate extension has been added as the filter
+            # double check that an appropriate extension has been added as the
             # filter option does not always add an extension on linux and windows
             # see https://bugreports.qt.io/browse/QTBUG-27186
             image_extensions = ('.bmp', '.gif', '.png', '.tif', '.tiff')
@@ -356,7 +356,7 @@ class QtViewer(QSplitter):
                 filename = filename + '.png'
             self.screenshot(path=filename)
 
-    def _open_files(self):
+    def _open_files_dialog(self):
         """Add files from the menubar."""
         filenames, _ = QFileDialog.getOpenFileNames(
             parent=self,
@@ -366,7 +366,7 @@ class QtViewer(QSplitter):
         if (filenames != []) and (filenames is not None):
             self.viewer.open(filenames)
 
-    def _open_files_as_stack(self):
+    def _open_files_dialog_as_stack_dialog(self):
         """Add files as a stack, from the menubar."""
         filenames, _ = QFileDialog.getOpenFileNames(
             parent=self,
@@ -376,7 +376,7 @@ class QtViewer(QSplitter):
         if (filenames != []) and (filenames is not None):
             self.viewer.open(filenames, stack=True)
 
-    def _open_folder(self):
+    def _open_folder_dialog(self):
         """Add a folder of files from the menubar."""
         folder = QFileDialog.getExistingDirectory(
             parent=self,


### PR DESCRIPTION
# Description
This PR changes the screenshot hotkey to `alt-S` and the screenshot with viewer hot-key to `alt-shift-S`.

It also renames the `Open image` to `Open file` in a couple places as now that we have support for reader plugins we can open more than images

