### PR TITLE
only assert that config returns to original value

### DIFF
--- a/docs/release/release_0_3_0.md
+++ b/docs/release/release_0_3_0.md
@@ -278,6 +278,7 @@ with napari.gui_qt():
 - Update napari-svg to 0.1.1 (#1182)
 - Update manifest.in for plugin code removal (#1187)
 - Fix pip-missing-reqs step (#1189)
+- Only assert that dask config returns to original value in test (#1202)
 
 
 ## 13 authors added to this release (alphabetical)


### PR DESCRIPTION
# Description
fix for dask test on release candidate.  Changing test to just assert that the config returns to what it was before we touched it, and not what it's supposed to be to begin with.  Also skipping the two call-counting tests if dask version isn't high enough.  (Note, the cache tests should still pass on earlier versions of dask).