### PR TITLE
rework dask cache

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -85,24 +85,25 @@ linux_task:
 mac_task:
   auto_cancellation: true
 
-  matrix:
-    # not a pull request: run full suite
-    - only_if: $CIRRUS_PR == ""
-      env:
-        matrix:
-          PY_VER: "3.6"
-          PY_VER: "3.7"
-          PY_VER: "3.8"
-    # is a pull request, only run python 3.8
-    - only_if: $CIRRUS_PR != ""
-      env:
-        PY_VER: "3.8"
+  # matrix:
+  #   # not a pull request: run full suite
+  #   - only_if: $CIRRUS_PR == ""
+  #     env:
+  #       matrix:
+  #         PY_VER: "3.6"
+  #         PY_VER: "3.7"
+  #         PY_VER: "3.8"
+  #   # is a pull request, only run python 3.8
+  #   - only_if: $CIRRUS_PR != ""
+  #     env:
+  #       PY_VER: "3.8"
 
   name: macos ${PY_VER}
   osx_instance:
     image: catalina-xcode
   env:
     PATH: $HOME/conda/bin:$PATH
+    PY_VER: "3.8"
   conda_script:
     - curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > install.sh
     - bash install.sh -b -p $HOME/conda
@@ -134,18 +135,18 @@ mac_task:
 win_task:
   auto_cancellation: true
 
-  matrix:
-    # not a pull request: run full suite
-    - only_if: $CIRRUS_PR == ""
-      env:
-        matrix:
-          PY_VER: "3.6"
-          PY_VER: "3.7"
-          PY_VER: "3.8"
-    # is a pull request, only run python 3.8
-    - only_if: $CIRRUS_PR != ""
-      env:
-        PY_VER: "3.8"
+  # matrix:
+  #   # not a pull request: run full suite
+  #   - only_if: $CIRRUS_PR == ""
+  #     env:
+  #       matrix:
+  #         PY_VER: "3.6"
+  #         PY_VER: "3.7"
+  #         PY_VER: "3.8"
+  #   # is a pull request, only run python 3.8
+  #   - only_if: $CIRRUS_PR != ""
+  #     env:
+  #       PY_VER: "3.8"
 
   name: windows ${PY_VER}
   windows_container:
@@ -160,6 +161,7 @@ win_task:
     # https://github.com/vispy/vispy/blob/v0.5.3/appveyor.yml#L44
     VISPY_GL_LIB: $CIRRUS_WORKING_DIR\opengl32.dll
     PYTHON_ARCH: 64
+    PY_VER: "3.8"
   
   system_script:
     # install OpenSSL

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -85,25 +85,24 @@ linux_task:
 mac_task:
   auto_cancellation: true
 
-  # matrix:
-  #   # not a pull request: run full suite
-  #   - only_if: $CIRRUS_PR == ""
-  #     env:
-  #       matrix:
-  #         PY_VER: "3.6"
-  #         PY_VER: "3.7"
-  #         PY_VER: "3.8"
-  #   # is a pull request, only run python 3.8
-  #   - only_if: $CIRRUS_PR != ""
-  #     env:
-  #       PY_VER: "3.8"
+  matrix:
+    # not a pull request: run full suite
+    - only_if: $CIRRUS_PR == ""
+      env:
+        matrix:
+          PY_VER: "3.6"
+          PY_VER: "3.7"
+          PY_VER: "3.8"
+    # is a pull request, only run python 3.8
+    - only_if: $CIRRUS_PR != ""
+      env:
+        PY_VER: "3.8"
 
   name: macos ${PY_VER}
   osx_instance:
     image: catalina-xcode
   env:
     PATH: $HOME/conda/bin:$PATH
-    PY_VER: "3.8"
   conda_script:
     - curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > install.sh
     - bash install.sh -b -p $HOME/conda
@@ -135,18 +134,18 @@ mac_task:
 win_task:
   auto_cancellation: true
 
-  # matrix:
-  #   # not a pull request: run full suite
-  #   - only_if: $CIRRUS_PR == ""
-  #     env:
-  #       matrix:
-  #         PY_VER: "3.6"
-  #         PY_VER: "3.7"
-  #         PY_VER: "3.8"
-  #   # is a pull request, only run python 3.8
-  #   - only_if: $CIRRUS_PR != ""
-  #     env:
-  #       PY_VER: "3.8"
+  matrix:
+    # not a pull request: run full suite
+    - only_if: $CIRRUS_PR == ""
+      env:
+        matrix:
+          PY_VER: "3.6"
+          PY_VER: "3.7"
+          PY_VER: "3.8"
+    # is a pull request, only run python 3.8
+    - only_if: $CIRRUS_PR != ""
+      env:
+        PY_VER: "3.8"
 
   name: windows ${PY_VER}
   windows_container:
@@ -161,7 +160,6 @@ win_task:
     # https://github.com/vispy/vispy/blob/v0.5.3/appveyor.yml#L44
     VISPY_GL_LIB: $CIRRUS_WORKING_DIR\opengl32.dll
     PYTHON_ARCH: 64
-    PY_VER: "3.8"
   
   system_script:
     # install OpenSSL

--- a/napari/layers/_tests/test_dask_layers.py
+++ b/napari/layers/_tests/test_dask_layers.py
@@ -48,6 +48,9 @@ def test_dask_array_creates_cache():
     layer2._set_view_slice = mock_set_view_slice2
     layer2.set_view_slice()
 
+    # clean up cache
+    utils.dask_cache = None
+
 
 def test_list_of_dask_arrays_creates_cache():
     """Test that adding a list of dask array also creates a dask cache."""
@@ -121,6 +124,7 @@ def test_dask_unoptimized_slicing(delayed_dask_stack, monkeypatch):
     # make sure we are not caching for this test, which also tests that we
     # can turn off caching
     utils.resize_dask_cache(0)
+    assert utils.dask_cache.cache.available_bytes == 0
 
     # mock the dask_configure function to return a no-op.
     def mock_dask_config(data):
@@ -157,3 +161,66 @@ def test_dask_unoptimized_slicing(delayed_dask_stack, monkeypatch):
     v.dims.set_point(0, 3)
     # all told, we have 2x as many calls as the optimized version above.
     assert delayed_dask_stack['calls'] == 8
+
+
+def test_dask_cache_resizing(delayed_dask_stack):
+    """Test that we can spin up, resize, and spin down the cache."""
+    # add dask stack to the viewer, making sure to pass multiscale and clims
+    utils.dask_cache = None
+
+    v = viewer.ViewerModel()
+    dask_stack = delayed_dask_stack['stack']
+
+    # adding a new stack should spin up a cache
+    v.add_image(dask_stack, multiscale=False, contrast_limits=(0, 1))
+    assert utils.dask_cache.cache.available_bytes > 0
+    # make sure the cache actually has been populated
+    assert len(utils.dask_cache.cache.heap.heap) > 0
+
+    # we can resize that cache back to 0 bytes
+    utils.resize_dask_cache(0)
+    assert utils.dask_cache.cache.available_bytes == 0
+
+    # adding a 2nd stack should not adjust the cache size once created
+    v.add_image(dask_stack, multiscale=False, contrast_limits=(0, 1))
+    assert utils.dask_cache.cache.available_bytes == 0
+    # and the cache will remain empty regardless of what we do
+    for i in range(3):
+        v.dims.set_point(1, i)
+    assert len(utils.dask_cache.cache.heap.heap) == 0
+
+    # but we can always spin it up again
+    utils.resize_dask_cache(1e4)
+    assert utils.dask_cache.cache.available_bytes == 1e4
+    # and adding a new image doesn't change the size
+    v.add_image(dask_stack, multiscale=False, contrast_limits=(0, 1))
+    assert utils.dask_cache.cache.available_bytes == 1e4
+    # but the cache heap is getting populated again
+    for i in range(3):
+        v.dims.set_point(0, i)
+    assert len(utils.dask_cache.cache.heap.heap) > 0
+
+    # however, if the dask_cache attribute is deleted entirely (or set to None)
+    # we will have no memory of it ever having been created.
+    # and adding a new stack will spin up a cache
+    del utils.dask_cache
+    v.add_image(dask_stack, multiscale=False, contrast_limits=(0, 1))
+    assert utils.dask_cache.cache.available_bytes > 0
+
+
+def test_prevent_dask_cache(delayed_dask_stack):
+    """Test that pre-emptively setting cache to zero keeps it off"""
+    # the del is not required, it just shows that prior state of the cache
+    # does not matter... calling resize_dask_cache(0) will permanently disable
+    del utils.dask_cache
+    utils.resize_dask_cache(0)
+
+    v = viewer.ViewerModel()
+    dask_stack = delayed_dask_stack['stack']
+    # adding a new stack will not increase the cache size
+    v.add_image(dask_stack, multiscale=False, contrast_limits=(0, 1))
+    assert utils.dask_cache.cache.available_bytes == 0
+    # and the cache will not be populated
+    for i in range(3):
+        v.dims.set_point(0, i)
+    assert len(utils.dask_cache.cache.heap.heap) == 0

--- a/napari/utils/__init__.py
+++ b/napari/utils/__init__.py
@@ -1,9 +1,6 @@
 from .info import sys_info, citation_text
 from .misc import resize_dask_cache
-from dask.cache import Cache
 
-#: dask.cache.Cache : A dask cache for opportunistic caching
+#: dask.cache.Cache, optional : A dask cache for opportunistic caching
 #: use :func:`~.resize_dask_cache` to actually register and resize.
-dask_cache = Cache(0)
-
-del Cache
+dask_cache = None

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -7,13 +7,15 @@ import re
 import warnings
 from contextlib import contextmanager
 from enum import Enum, EnumMeta
-from os import fspath, path, PathLike
-from typing import ContextManager, Optional, Type, TypeVar, Sequence
+from os import PathLike, fspath, path
+from typing import ContextManager, Optional, Sequence, Type, TypeVar
 
 import dask
 import dask.array as da
-import dask.cache
 import numpy as np
+from dask.cache import Cache
+
+from .. import utils
 
 ROOT_DIR = path.dirname(path.dirname(__file__))
 
@@ -313,8 +315,6 @@ def create_dask_cache(nbytes=None, mem_fraction=0.5):
         [description]
     """
     import psutil
-    from napari import utils
-    from dask.cache import Cache
 
     if nbytes is None:
         nbytes = psutil.virtual_memory().total * mem_fraction
@@ -328,10 +328,10 @@ def create_dask_cache(nbytes=None, mem_fraction=0.5):
 
 def resize_dask_cache(
     nbytes: Optional[int] = None, mem_fraction: float = None
-) -> dask.cache.Cache:
+) -> Cache:
     """Create or resize the dask cache used for opportunistic caching.
 
-    The cache object is an instance of a :class:`dask.cache.Cache`, (which
+    The cache object is an instance of a :class:`Cache`, (which
     wraps a :class:`cachey.Cache`), and is made available at
     :attr:`napari.utils.dask_cache`.
 
@@ -350,7 +350,7 @@ def resize_dask_cache(
 
     Returns
     -------
-    dask_cache : dask.cache.Cache
+    dask_cache : Cache
         An instance of a Dask Cache
 
     Example
@@ -366,8 +366,6 @@ def resize_dask_cache(
     >>> cache.cache.total_bytes   # currently used bytes
     """
 
-    from dask.cache import Cache
-    from napari import utils
     import psutil
 
     if nbytes is None and mem_fraction is not None:

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -292,8 +292,42 @@ def all_subclasses(cls: Type) -> set:
     )
 
 
+def create_dask_cache(nbytes=None, mem_fraction=0.5):
+    """Create a dask cache at utils.dask_cache if one doesn't already exist.
+
+    Parameters
+    ----------
+    nbytes : int, optional
+        The desired size of the cache, in bytes.  If ``None``, the cache size
+        will autodetermined as fraction of the total memory in the system,
+        using ``mem_fraction``.  If ``nbytes`` is 0, cache object will be
+        created, but not caching will occur. by default, cache size is
+        autodetermined using ``mem_fraction``.
+    mem_fraction : float, optional
+        The fraction (from 0 to 1) of total memory to use for the dask cache.
+        by default, 50% of total memory is used.
+
+    Returns
+    -------
+    [type]
+        [description]
+    """
+    import psutil
+    from napari import utils
+    from dask.cache import Cache
+
+    if nbytes is None:
+        nbytes = psutil.virtual_memory().total * mem_fraction
+    if not (
+        hasattr(utils, 'dask_cache') and isinstance(utils.dask_cache, Cache)
+    ):
+        utils.dask_cache = Cache(nbytes)
+        utils.dask_cache.register()
+    return utils.dask_cache
+
+
 def resize_dask_cache(
-    nbytes: Optional[int] = None, mem_fraction: float = 0.5
+    nbytes: Optional[int] = None, mem_fraction: float = None
 ) -> dask.cache.Cache:
     """Create or resize the dask cache used for opportunistic caching.
 
@@ -332,26 +366,31 @@ def resize_dask_cache(
     >>> cache.cache.total_bytes   # currently used bytes
     """
 
-    from napari.utils import dask_cache
+    from dask.cache import Cache
+    from napari import utils
     import psutil
 
-    if nbytes is None:
-        # availalble RAM
+    if nbytes is None and mem_fraction is not None:
         nbytes = psutil.virtual_memory().total * mem_fraction
 
-    if nbytes != dask_cache.cache.available_bytes:
-        dask_cache.cache.resize(nbytes)
-    if nbytes == 0:
-        # turn off caching
-        try:
-            dask_cache.unregister()
-        # if the cache is already unregistered, it raises a KeyError
-        except KeyError:
-            pass
-    else:
-        dask_cache.register()
+    # if we don't have a cache already, create one.  If neither nbytes nor
+    # mem_fraction was provided, it will use the default size as determined in
+    # create_cache.
+    if not (
+        hasattr(utils, 'dask_cache') and isinstance(utils.dask_cache, Cache)
+    ):
+        return create_dask_cache(nbytes)
+    else:  # we already have a cache
+        # if the cache has already been registered, then calling
+        # resize_dask_cache() without supplying either mem_fraction or nbytes
+        # is a no-op:
+        if (
+            nbytes is not None
+            and nbytes != utils.dask_cache.cache.available_bytes
+        ):
+            utils.dask_cache.cache.resize(nbytes)
 
-    return dask_cache
+    return utils.dask_cache
 
 
 def _is_dask_data(data) -> bool:
@@ -410,7 +449,7 @@ def configure_dask(data) -> ContextManager[dict]:
     ...    data[0, 2].compute()
     """
     if _is_dask_data(data):
-        resize_dask_cache()  # creates one if it doesn't exist
+        create_dask_cache()  # creates one if it doesn't exist
         dask_version = tuple(map(int, dask.__version__.split(".")))
         if dask_version < (2, 15, 0):
             warnings.warn(


### PR DESCRIPTION
# Description
This addresses #1205, by making sure that if a user has resized the dask cache manually, then it will not be changed.  And once a cache has been created, it can only be resized using `utils.resize_dask_cache`.  See the tests `test_dask_cache_resizing` and `test_prevent_dask_cache` for examples of what this is fixing.  Let's maybe leave #1205 open for input on tuning the default cache size (which this PR does not change)

Summary:
- `utils.resize_dask_cache(0)`, called _either_ before or after Layer creation will (permanently) disable the cache.
- cache can be resized up or down using `utils.resize_dask_cache(nbytes)` and it will stick.
- if someone actually deletes the `utils.dask_cache` attribute, we will lose the "memory" of the cache, and it will therefore get spun up again on the next Layer addition (but it won't break) ... so using the `resize_dask_cache` API is the way to go.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added a couple new well-commented tests that describe/test the use case
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
