### PR TITLE
Don't build wheels with releases

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -24,8 +24,7 @@ jobs:
           pip install -r requirements.txt
       - name: Build Distribution
         run: |
-          pip install wheel
-          python setup.py sdist bdist_wheel
+          python setup.py sdist
       - name: Find Release Notes
         id: release_notes
         run: |

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -34,7 +34,7 @@ jobs:
           # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
           RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"
           RELEASE_NOTES="${RELEASE_NOTES//$'\n'/'%0A'}"
-          RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}" 
+          RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}"
           # https://help.github.com/en/actions/reference/workflow-commands-for-github-actions
           echo "::set-env name=tag::$TAG"
           echo "::set-output name=contents::$RELEASE_NOTES"


### PR DESCRIPTION
# Description

Wheels break custom setup.py logic from #1059 to prevent installing PySide if PyQt5 is already present. Since napari is pure Python, this is not a big loss.

Closes #1212 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
