### PR TITLE
CLI accepts --plugin or any add_* kwargs

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -105,7 +105,7 @@ def main():
     )
 
     args, unknown = parser.parse_known_args()
-    kwargs = validate_unknown_args(unknown)
+    kwargs = validate_unknown_args(unknown) if unknown else {}
 
     # parse -v flags and set the appropriate logging level
     levels = [logging.WARNING, logging.INFO, logging.DEBUG]

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -54,7 +54,7 @@ def validate_unknown_args(unknown: List[str]) -> Dict[str, Any]:
             continue
         if "=" in arg:
             sys.exit(f"error: '=' in argument {arg}. (Use space instead)")
-        key = arg[2:].replace("-", "_")
+        key = arg.lstrip('-').replace("-", "_")
         if key not in valid:
             sys.exit(f"error: unrecognized arguments: {arg}")
         try:

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -2,10 +2,16 @@
 napari command line viewer.
 """
 import argparse
+import logging
 import sys
+from ast import literal_eval
+from typing import Any, Dict, List
 
 from . import __version__, gui_qt, view_path
 from .utils import citation_text, sys_info
+
+# prevent unrelated INFO logs when doing "napari --info"
+logging.basicConfig(level=logging.WARNING)
 
 
 class InfoAction(argparse.Action):
@@ -20,14 +26,70 @@ class CitationAction(argparse.Action):
         sys.exit()
 
 
+def get_valid_kwargs():
+    """Get a set of valid argument names for add_* methods."""
+    from .components.add_layers_mixin import AddLayersMixin
+    import inspect
+
+    valid = set()
+    for meth in dir(AddLayersMixin):
+        if not meth.startswith('add_'):
+            continue
+        params = inspect.signature(getattr(AddLayersMixin, meth)).parameters
+        valid.update(set(params) - {'self', 'kwargs'})
+    return valid
+
+
+def validate_unknown_args(unknown: List[str]) -> Dict[str, Any]:
+    """Convert a list of strings into a dict of valid kwargs for add_* methods.
+
+    Will exit program if any of the arguments are unrecognized, or are
+    malformed.  Converts string to python type using literal_eval.
+
+    Parameters
+    ----------
+    unknown : List[str]
+        a list of strings gathered as "unknown" arguments in argparse.
+
+    Returns
+    -------
+    kwargs : Dict[str, Any]
+        {key: val} dict suitable for the viewer.add_* methods where ``val``
+        is a ``literal_eval`` result, or string.
+    """
+    out: Dict[str, Any] = dict()
+    valid = get_valid_kwargs()
+    for i, arg in enumerate(unknown):
+        if not arg.startswith("--"):
+            continue
+        if "=" in arg:
+            sys.exit(f"error: '=' in argument {arg}. (Use space instead)")
+        if arg[2:] not in valid:
+            sys.exit(f"error: unrecognized arguments: {arg}")
+        try:
+            next_arg = unknown[i + 1]
+            if next_arg.startswith("--"):
+                raise IndexError()
+        except IndexError:
+            sys.exit(f"error: argument {arg} expected one argument")
+            get_valid_kwargs
+        try:
+            val = literal_eval(next_arg)
+        except Exception:
+            val = next_arg
+        out[arg[2:]] = val
+    return out
+
+
 def main():
     parser = argparse.ArgumentParser(usage=__doc__)
     parser.add_argument('images', nargs='*', help='Images to view.')
+    parser.add_argument('-v', '--verbose', action='count', default=0)
     parser.add_argument(
-        '-v',
-        '--version',
-        action='version',
-        version=f'napari version {__version__}',
+        '--version', action='version', version=f'napari version {__version__}',
+    )
+    parser.add_argument(
+        '--plugin', help='specify plugin name when opening a file',
     )
     parser.add_argument(
         '--info',
@@ -60,9 +122,31 @@ def main():
         action='store_false',
         help='interpret all dimensions in the image as spatial',
     )
-    args = parser.parse_args()
+
+    args, unknown = parser.parse_known_args()
+    kwargs = validate_unknown_args(unknown)
+
+    levels = [logging.WARNING, logging.INFO, logging.DEBUG]
+    level = levels[min(2, args.verbose)]  # prevent index error
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt='%H:%M:%S',
+    )
+
+    if args.plugin:
+        if not args.images:
+            sys.exit(
+                "error: The '--plugin' argument is only valid "
+                "when providing a file name"
+            )
+        # I *think* that Qt is looking in sys.argv for a flag `--plugins`,
+        # which emits "WARNING: No such plugin for spec 'builtins'"
+        # so remove --plugin from sys.argv to prevent that warningz
+        sys.argv.remove('--plugin')
+
     with gui_qt(startup_logo=True):
-        view_path(args.images, stack=args.stack)
+        view_path(args.images, stack=args.stack, plugin=args.plugin, **kwargs)
 
 
 if __name__ == '__main__':

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -10,18 +10,19 @@ from typing import Any, Dict, List
 from . import __version__, gui_qt, view_path
 from .utils import citation_text, sys_info
 
-# prevent unrelated INFO logs when doing "napari --info"
-logging.basicConfig(level=logging.WARNING)
-
 
 class InfoAction(argparse.Action):
     def __call__(self, *args, **kwargs):
+        # prevent unrelated INFO logs when doing "napari --info"
+        logging.basicConfig(level=logging.WARNING)
         print(sys_info())
         sys.exit()
 
 
 class CitationAction(argparse.Action):
     def __call__(self, *args, **kwargs):
+        # prevent unrelated INFO logs when doing "napari --citation"
+        logging.basicConfig(level=logging.WARNING)
         print(citation_text)
         sys.exit()
 
@@ -126,6 +127,7 @@ def main():
     args, unknown = parser.parse_known_args()
     kwargs = validate_unknown_args(unknown)
 
+    # parse -v flags and set the appropriate logging level
     levels = [logging.WARNING, logging.INFO, logging.DEBUG]
     level = levels[min(2, args.verbose)]  # prevent index error
     logging.basicConfig(
@@ -135,6 +137,7 @@ def main():
     )
 
     if args.plugin:
+        # make sure plugin is only used when files are specified
         if not args.images:
             sys.exit(
                 "error: The '--plugin' argument is only valid "

--- a/napari/_tests/test_cli.py
+++ b/napari/_tests/test_cli.py
@@ -1,0 +1,63 @@
+from napari import __main__
+import sys
+import pytest
+from contextlib import contextmanager
+
+
+def test_cli_works(monkeypatch, capsys):
+    """Test the cli runs and shows help"""
+    monkeypatch.setattr(sys, 'argv', ['napari', '-h'])
+    with pytest.raises(SystemExit):
+        __main__.main()
+    assert 'napari command line viewer.' in str(capsys.readouterr())
+
+
+def test_cli_shows_plugins(monkeypatch, capsys):
+    """Test the cli --info runs and shows plugins"""
+    monkeypatch.setattr(sys, 'argv', ['napari', '--info'])
+    with pytest.raises(SystemExit):
+        __main__.main()
+    assert 'svg' in str(capsys.readouterr())
+
+
+def test_cli_parses_unknowns(monkeypatch):
+    """test that we can parse layer keyword arg variants"""
+
+    def assert_kwargs(*args, **kwargs):
+        assert args == (["file"],)
+        assert kwargs['contrast_limits'] == (0, 1)
+
+    @contextmanager
+    def gui_qt(**kwargs):
+        yield
+
+    # testing all the variants of literal_evals
+    monkeypatch.setattr(__main__, 'view_path', assert_kwargs)
+    monkeypatch.setattr(__main__, 'gui_qt', gui_qt)
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ['n', 'file', '--contrast-limits', '(0, 1)'])
+        __main__.main()
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ['n', 'file', '--contrast-limits', '(0,1)'])
+        __main__.main()
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ['n', 'file', '--contrast-limits=(0, 1)'])
+        __main__.main()
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ['n', 'file', '--contrast-limits=(0,1)'])
+        __main__.main()
+
+
+def test_cli_raises(monkeypatch):
+    """test that unknown kwargs raise the correct errors."""
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ['napari', 'path/to/file', '--nonsense'])
+        with pytest.raises(SystemExit) as e:
+            __main__.main()
+        assert str(e.value) == 'error: unrecognized arguments: --nonsense'
+
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ['napari', 'path/to/file', '--gamma'])
+        with pytest.raises(SystemExit) as e:
+            __main__.main()
+        assert str(e.value) == 'error: argument --gamma expected one argument'

--- a/napari/components/_tests/test_prune_kwargs.py
+++ b/napari/components/_tests/test_prune_kwargs.py
@@ -71,7 +71,6 @@ EXPECTATIONS = [
         'surface',
         {'blending': 'translucent', 'scale': (0.75, 1), 'name': 'name'},
     ),
-    ('layer', {}),
 ]
 
 ids = [i[0] for i in EXPECTATIONS]

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -1,8 +1,9 @@
+import inspect
 import itertools
 from functools import lru_cache
 from logging import getLogger
 from os import fspath
-from typing import Any, Dict, List, Optional, Sequence, Union, Set
+from typing import Any, Dict, List, Optional, Sequence, Set, Union
 
 import numpy as np
 
@@ -958,8 +959,7 @@ class AddLayersMixin:
 
 @lru_cache(maxsize=1)
 def valid_add_kwargs() -> Dict[str, Set[str]]:
-    import inspect
-
+    """Return a dict where keys are layer types & values are valid kwargs."""
     valid = dict()
     for meth in dir(AddLayersMixin):
         if not meth.startswith('add_') or meth[4:] == 'layer':

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -145,6 +145,8 @@ def view_path(
     path,
     *,
     stack=False,
+    plugin=None,
+    layer_type=None,
     title='napari',
     ndisplay=2,
     order=None,
@@ -164,6 +166,16 @@ def view_path(
         plugins to know how to handle a list of paths.  If ``stack`` is
         ``False``, then the ``path`` list is broken up and passed to plugin
         readers one by one.  by default False.
+    plugin : str, optional
+        Name of a plugin to use.  If provided, will force ``path`` to be
+        read with the specified ``plugin``.  If the requested plugin cannot
+        read ``path``, an execption will be raised.
+    layer_type : str, optional
+        If provided, will force data read from ``path`` to be passed to the
+        corresponding ``add_<layer_type>`` method (along with any
+        additional) ``kwargs`` provided to this function.  This *may*
+        result in exceptions if the data returned from the path is not
+        compatible with the layer_type.
     title : string, optional
         The title of the viewer window. by default 'napari'
     ndisplay : {2, 3}, optional
@@ -192,7 +204,9 @@ def view_path(
         axis_labels=axis_labels,
         show=show,
     )
-    viewer.open(path=path, stack=stack, **kwargs)
+    viewer.open(
+        path=path, stack=stack, plugin=plugin, layer_type=layer_type, **kwargs
+    )
     return viewer
 
 


### PR DESCRIPTION
# Description
This adds some features to the command line program:

- accept `--plugin` argument that uses a specific plugin to open a file.  An error will be thrown if this argument is used without specifying a file to open.
- add `-v`, `-vv`, verbosity flags that change the logging level from `WARNING` (default) to `INFO` (with `-v`) or `DEBUG` (with `-vv`)
- added the ability to pass "unrecognized" arguments to the command line, that will be parsed, validated, and passed to `viewer.open()`.  If any of the arguments are not valid for at least one of the `viewer.add_*` methods, the program quits and warns (so we don't lose the "unrecognized arguments" error.  Values are parsed with `literal_eval`.

All together, allows stuff like this:

```
napari -vv path/to/file.tif --plugin builtins --gamma 0.6 --contrast_limits '(0, 700)' --name confocal
```
while preserving helpful errors like this:

```bash
# should be "--plugin" not "--plugins"
napari path/to/file.tif --plugins builtins
error: unrecognized arguments: --plugins
```

and combined with #1219  ... will generally make testing reader plugin easier.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
