### PR TITLE
Specify viewer.open(plugins='builtins') for all tests

### DIFF
--- a/napari/components/_tests/test_viewer_image_io.py
+++ b/napari/components/_tests/test_viewer_image_io.py
@@ -112,7 +112,7 @@ def test_add_zarr():
     with TemporaryDirectory(suffix='.zarr') as fout:
         z = zarr.open(fout, 'a', shape=image.shape)
         z[:] = image
-        viewer.open([fout])
+        viewer.open([fout], plugin='builtins')
         assert len(viewer.layers) == 1
         # Note: due to lazy loading, the next line needs to happen within
         # the context manager. Alternatively, we could convert to NumPy here.
@@ -133,7 +133,7 @@ def test_zarr_multiscale():
             shape = 20 // 2 ** i
             z = root.create_dataset(str(i), shape=(shape,) * 2)
             z[:] = multiscale[i]
-        viewer.open(fout, multiscale=True)
+        viewer.open(fout, multiscale=True, plugin='builtins')
         assert len(viewer.layers) == 1
         assert len(multiscale) == len(viewer.layers[0].data)
         # Note: due to lazy loading, the next line needs to happen within

--- a/napari/components/_tests/test_viewer_image_io.py
+++ b/napari/components/_tests/test_viewer_image_io.py
@@ -52,7 +52,7 @@ def single_tiff():
 def test_add_single_png_defaults(single_png):
     image_files = single_png
     viewer = ViewerModel()
-    viewer.open(image_files)
+    viewer.open(image_files, plugin='builtins')
     assert len(viewer.layers) == 1
     assert viewer.dims.ndim == 2
     assert isinstance(viewer.layers[0].data, np.ndarray)
@@ -75,7 +75,7 @@ def test_add_multi_png_defaults(two_pngs):
 def test_add_tiff(single_tiff):
     image_files = single_tiff
     viewer = ViewerModel()
-    viewer.open(image_files)
+    viewer.open(image_files, plugin='builtins')
     assert len(viewer.layers) == 1
     assert viewer.dims.ndim == 3
     assert isinstance(viewer.layers[0].data, np.ndarray)
@@ -97,7 +97,7 @@ def test_add_many_tiffs(single_tiff):
 def test_add_single_filename(single_tiff):
     image_files = single_tiff[0]
     viewer = ViewerModel()
-    viewer.open(image_files)
+    viewer.open(image_files, plugin='builtins')
     assert len(viewer.layers) == 1
     assert viewer.dims.ndim == 3
     assert isinstance(viewer.layers[0].data, np.ndarray)
@@ -145,7 +145,7 @@ def test_zarr_multiscale():
 def test_add_multichannel_rgb(rgb_png):
     image_files = rgb_png
     viewer = ViewerModel()
-    viewer.open(image_files, channel_axis=2)
+    viewer.open(image_files, channel_axis=2, plugin='builtins')
     assert len(viewer.layers) == 3
     assert viewer.dims.ndim == 2
     assert isinstance(viewer.layers[0].data, np.ndarray)
@@ -155,7 +155,7 @@ def test_add_multichannel_rgb(rgb_png):
 def test_add_multichannel_tiff(single_tiff):
     image_files = single_tiff
     viewer = ViewerModel()
-    viewer.open(image_files, channel_axis=0)
+    viewer.open(image_files, channel_axis=0, plugin='builtins')
     assert len(viewer.layers) == 2
     assert viewer.dims.ndim == 2
     assert isinstance(viewer.layers[0].data, np.ndarray)

--- a/napari/components/_tests/test_viewer_labels_io.py
+++ b/napari/components/_tests/test_viewer_labels_io.py
@@ -15,7 +15,7 @@ def test_open_labels(suffix):
     labeled = ndi.label(blobs)[0].astype(np.uint8)
     with temporary_file(suffix) as fout:
         imwrite(fout, labeled, format=suffix)
-        viewer.open(fout, layer_type='labels')
+        viewer.open(fout, layer_type='labels', plugin='builtins')
         assert len(viewer.layers) == 1
         assert np.all(labeled == viewer.layers[0].data)
         assert isinstance(viewer.layers[0], Labels)

--- a/napari/plugins/_tests/test_reader_plugins.py
+++ b/napari/plugins/_tests/test_reader_plugins.py
@@ -10,9 +10,6 @@ from napari.plugins.io import read_data_with_plugins
 
 def test_builtin_reader_plugin(viewer_factory):
     """Test the builtin reader plugin reads a temporary file."""
-    from napari.plugins import plugin_manager
-
-    plugin_manager.hooks.napari_get_reader.bring_to_front(['builtins'])
 
     with NamedTemporaryFile(suffix='.tif', delete=False) as tmp:
         data = np.random.rand(20, 20)
@@ -26,17 +23,13 @@ def test_builtin_reader_plugin(viewer_factory):
         assert np.allclose(data, layer_data[0][0])
 
         view, viewer = viewer_factory()
-        viewer.open(tmp.name)
+        viewer.open(tmp.name, plugin='builtins')
 
         assert np.allclose(viewer.layers[0].data, data)
 
 
 def test_builtin_reader_plugin_csv(viewer_factory, tmpdir):
     """Test the builtin reader plugin reads a temporary file."""
-    from napari.plugins import plugin_manager
-
-    plugin_manager.hooks.napari_get_reader.bring_to_front(['builtins'])
-
     tmp = os.path.join(tmpdir, 'test.csv')
     column_names = ['index', 'axis-0', 'axis-1']
     table = np.random.random((5, 3))
@@ -52,17 +45,13 @@ def test_builtin_reader_plugin_csv(viewer_factory, tmpdir):
     assert np.allclose(data, layer_data[0][0])
 
     view, viewer = viewer_factory()
-    viewer.open(tmp)
+    viewer.open(tmp, plugin='builtins')
 
     assert np.allclose(viewer.layers[0].data, data)
 
 
 def test_builtin_reader_plugin_stacks(viewer_factory):
     """Test the builtin reader plugin reads multiple files as a stack."""
-    from napari.plugins import plugin_manager
-
-    plugin_manager.hooks.napari_get_reader.bring_to_front(['builtins'])
-
     data = np.random.rand(5, 20, 20)
     tmps = []
     for plane in data:
@@ -76,7 +65,7 @@ def test_builtin_reader_plugin_stacks(viewer_factory):
     # pathnames a Path object
     names = [tmp.name for tmp in tmps]
     names[0] = Path(names[0])
-    viewer.open(names, stack=True)
+    viewer.open(names, stack=True, plugin='builtins')
     assert np.allclose(viewer.layers[0].data, data)
     for tmp in tmps:
         tmp.close()


### PR DESCRIPTION
# Description
Just saw some zarr tests failing locally that weren't failing on CI, and narrowed it down to different behavior between our `magic_imread` and the `ome_zarr` plugin, which I had recently installed in my env.  So this PR changes all of the `viewer.open()` calls in our tests to specify `plugin='builtins'` (which is the assumption in our tests anyway).  

as a sidenote: I haven't really looked into why they are behaving differently, but I think it has to do with stacking behavior in our function?  (their plugin added 20 layers and ours added 1).  This sort of thing is inevitable, but just wanted to point it out so people can start thinking about how/whether to eventually address that sort of issue where two plugins handle a similar file quite differently.  

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] this makes tests more predictable regardless of environment.
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
