### PR TITLE
make skimage data fixtures compatible with 0.17.0

### DIFF
--- a/napari/components/_tests/test_viewer_image_io.py
+++ b/napari/components/_tests/test_viewer_image_io.py
@@ -1,7 +1,5 @@
-import os
 import numpy as np
 from dask import array as da
-from skimage.data import data_dir
 from tempfile import TemporaryDirectory
 import pytest
 from napari.components import ViewerModel
@@ -15,38 +13,8 @@ except ImportError:
     zarr_available = False
 
 
-@pytest.fixture
-def two_pngs():
-    image_files = [
-        os.path.join(data_dir, fn) for fn in ['moon.png', 'camera.png']
-    ]
-    return image_files
-
-
-@pytest.fixture
-def rgb_png():
-    image_files = [os.path.join(data_dir, fn) for fn in ['astronaut.png']]
-    return image_files
-
-
-@pytest.fixture
-def single_png():
-    image_files = [os.path.join(data_dir, fn) for fn in ['camera.png']]
-    return image_files
-
-
-@pytest.fixture
-def irregular_images():
-    image_files = [
-        os.path.join(data_dir, fn) for fn in ['camera.png', 'coins.png']
-    ]
-    return image_files
-
-
-@pytest.fixture
-def single_tiff():
-    image_files = [os.path.join(data_dir, 'multipage.tif')]
-    return image_files
+# the following fixtures are defined in napari/conftest.py
+# single_png, two_pngs, irregular_images, single_tiff, rgb_png
 
 
 def test_add_single_png_defaults(single_png):

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -7,8 +7,8 @@ import pytest
 from qtpy.QtWidgets import QApplication
 
 from napari import Viewer
-from napari.layers import Image, Labels, Points, Shapes, Vectors
 from napari.components import LayerList
+from napari.layers import Image, Labels, Points, Shapes, Vectors
 from napari.plugins._builtins import (
     napari_write_image,
     napari_write_labels,
@@ -16,6 +16,23 @@ from napari.plugins._builtins import (
     napari_write_shapes,
 )
 from napari.utils import io
+
+try:
+    from skimage.data import image_fetcher
+except ImportError:
+    from skimage.data import data_dir
+    import os
+
+    class image_fetcher:
+        def fetch(data_name):
+            if data_name.startswith("data/"):
+                data_name = data_name[5:]
+            path = os.path.join(data_dir, data_name)
+            if not os.path.exists(path):
+                raise ValueError(
+                    f"Legacy skimage image_fetcher cannot find file: {path}"
+                )
+            return path
 
 
 def pytest_addoption(parser):
@@ -250,3 +267,28 @@ def layers():
         Vectors(np.random.rand(10, 2, 2)),
     ]
     return LayerList(list_of_layers)
+
+
+@pytest.fixture
+def two_pngs():
+    return [image_fetcher.fetch(f'data/{n}.png') for n in ('moon', 'camera')]
+
+
+@pytest.fixture
+def rgb_png():
+    return [image_fetcher.fetch('data/astronaut.png')]
+
+
+@pytest.fixture
+def single_png():
+    return [image_fetcher.fetch('data/camera.png')]
+
+
+@pytest.fixture
+def irregular_images():
+    return [image_fetcher.fetch(f'data/{n}.png') for n in ('camera', 'coins')]
+
+
+@pytest.fixture
+def single_tiff():
+    return [image_fetcher.fetch('data/multipage.tif')]

--- a/napari/utils/_tests/test_io.py
+++ b/napari/utils/_tests/test_io.py
@@ -3,7 +3,6 @@ import csv
 from pathlib import Path
 import numpy as np
 from dask import array as da
-from skimage.data import data_dir
 from tempfile import TemporaryDirectory
 from napari.utils import io
 import pytest
@@ -17,32 +16,8 @@ except ImportError:
     zarr_available = False
 
 
-@pytest.fixture
-def single_png():
-    image_files = [os.path.join(data_dir, fn) for fn in ['camera.png']]
-    return image_files
-
-
-@pytest.fixture
-def two_pngs():
-    image_files = [
-        os.path.join(data_dir, fn) for fn in ['moon.png', 'camera.png']
-    ]
-    return image_files
-
-
-@pytest.fixture
-def irregular_images():
-    image_files = [
-        os.path.join(data_dir, fn) for fn in ['camera.png', 'coins.png']
-    ]
-    return image_files
-
-
-@pytest.fixture
-def single_tiff():
-    image_files = [os.path.join(data_dir, 'multipage.tif')]
-    return image_files
+# the following fixtures are defined in napari/conftest.py
+# single_png, two_pngs, irregular_images, single_tiff
 
 
 def test_single_png_defaults(single_png):

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,4 +6,4 @@ pytest-ordering
 pytest-timeout
 xarray
 zarr
-scikit-image
+scikit-image==0.16.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,4 +6,4 @@ pytest-ordering
 pytest-timeout
 xarray
 zarr
-scikit-image==0.16.2
+scikit-image


### PR DESCRIPTION
# Description
With v0.17.0, scikit-image no longer bundles `multipage.tif`, which is causing our tests to break.
This fixes tests in a way that will continue to work for older versions of scikit-image.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
