### PR TITLE
Update github issues templates with links to image.sc and zulip 

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+# Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: true  # default
+contact_links:
+- name: 🤷💻 napari forum
+  url: https://forum.image.sc/tag/napari
+  about: |
+    Please ask general "how do I ... ?" questions over at image.sc
+- name: '💬 napari @ zulip'
+  url: https://napari.zulipchat.com/
+  about: Chat with devs

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,6 +1,6 @@
 ---
 name: "\U0001F4DA Documentation"
-about: Report an issue
+about: Report an issue with napari documentation
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,9 +1,0 @@
----
-name: "❓Questions/Help/Support"
-about: Do you need support? We have resources.
-
----
-
-## ❓ Questions and Help
-
-### Please note that this issue tracker is not a help form and this issue will be closed.


### PR DESCRIPTION
# Description
small update to our issues templates.  I was inspired by the [pip issues](https://github.com/pypa/pip/issues/new/choose), which adds a couple nice linkouts.  So i removed the questions template and instead link to image.sc, and also add a zulip link
