### PR TITLE
add new performance doc in new "explanations" directory

### DIFF
--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -20,6 +20,8 @@ application can feel clunky or frustrating if not designed well.
 
 ## Objective Performance
 
+How to keep napari objectively fast:
+
 **Focus On Real Use Cases**
 
 * Focus on cases that matter to lots of people.
@@ -69,25 +71,25 @@ Napari should strive to have these properties:
 
 **Interruptible**
 * Modeless operations are best. They can interrupted by simply performing some
-  other action. For example is imagery is loading in the background, you can
+  other action. For example if imagery is loading in the background you can
   interrupt it just by navigating to somewhere else.
 * Modal operations that disable the UI should have a cancel button when possible
   unless they are very short.
 * The user should never feel “trapped”.
 
 **Progressive**
-* Show intermediate results as they become available, instead of showing nothing
+* Show intermediate results as they become available instead of showing nothing
   until the full result is ready.
 * Sometimes progressive results are better even if they slow things down a bit,
   which is not necessarily intuitive.
 
 **Informative**
 * Clearly show what controls are enabled or disabled.
-* If progressive display is not possible, show progress bars.
-* Show an busy animation as the last resort, never look totally locked up.
+* If progressive display is not possible, show a progress bar.
+* Show a busy animation as the last resort, never look totally locked up.
 * Show time estimates for super long operations.
 * Let power users see timings, bandwidth, FPS, etc.
-* Revealing internal state lets users appreciate why its taking time.
+* Revealing internal state that explains why it's taking time is helpful.
 
 ## Performance Is Never Done
 
@@ -99,24 +101,24 @@ Performance is never "done" for several reasons:
   before merging to master.
 * New features should be tested on a variety of data types and sizes, including the largest data sets that are supported.
 * The new feature should scale to large datasets, or the performance limitations of the feature should be well documented.
-* It can be hard to impossible to "add performance in later" so the best time to
-  make changes is when the feature is being added.
+* It can be hard to impossible to "add performance in later". The best time to
+  ensure the new feature performs well is when the feature is first added.
 
 **Regressions** 
 
-* New features can slow down existing features.
+* We must be on guard for new features slowing down existing features.
 * New versions of dependencies can slow things down.
 * New hardware generally helps performance but not always.
 
 **Scope Changes**
 
-* New types of users adopt napari and have new use cases.
-* Existing users change their usage over time, e.g more remote viewing.
-* New file formats are invented or become more common.
-* New data types or sizes become more common.
+* As new types of users adopt napari they will have new use cases.
+* Existing users will change their usage over time, e.g more remote viewing.
+* New file formats will be invented or become more common.
+* New data types or sizes will become more common.
 
 ## Conclusion
 
 Achieving and maintaining performance requires an extreme amount of effort
-and diligence, but the payoff is felt in every minute of usage. Delighted
-and productive users are happy users.
+and diligence, but the payoff is felt in every minute of usage and it 
+will result is delighted an productive users.

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -44,7 +44,8 @@ How to keep napari objectively fast:
   *  *it seemed slow* → *it ran at 10Hz*.
   *  *it took a long time* → *it took 2 minutes and 30 seconds*.
 * Teaches users how different hardware impacts performance.
-  * For example HDD vs. SSD vs. network file systems.
+  * For example seek times with SSD are radically faster than HDD.
+  * Also helps notice the impact of local vs. networked file systems.
 
 **Performance System Tests**
 * Create automatic tests that time specific operations in specific known datasets.

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -43,8 +43,8 @@ application can feel clunky or frustrating if not designed well.
 
 **Performance Unit Tests**
 * Time one small operation to monitor for regressions.
-* Interesting to see how different hardware performs.
 * Napari has some of these today as "benchmarks".
+* Interesting to see how different hardware performs as time goes on.
 
 **Run All Tests Every Merge**
 * Save results to a database or somewhere.
@@ -61,11 +61,11 @@ Napari should strive to have these properties:
   * The full operation happens right away.
   * The interface clearly indicates the input was received and the operation was
     started.
-* The UI should never seem dead, the user should never be left wondering if
-  napari has crashed.
 * For click or keypress events the **ideal response is 100ms**.
 * For drag events or animations the **ideal refresh is 60Hz** which is 16.7ms per
   frame.
+* The UI should never seem dead, the user should never be left wondering if
+  napari has crashed.
 
 **Interruptible**
 * Modeless operations are best. They can interrupted by simply performing some
@@ -87,6 +87,7 @@ Napari should strive to have these properties:
 * Show an busy animation as the last resort, never look totally locked up.
 * Show time estimates for super long operations.
 * Let power users see timings, bandwidth, FPS, etc.
+* Revealing internal state lets users appreciate why its taking time.
 
 ## Performance Is Never Done
 
@@ -94,11 +95,12 @@ Performance is never "done" for several reasons:
 
 **New Features**
 
-* New features should be evaluated on their objective subjective and performance before merging to master.
+* The objective and subjective performance of new features should be scrutinized
+  before merging to master.
 * New features should be tested on a variety of data types and sizes, including the largest data sets that are supported.
-* Test widely for regressions since new features can easily slow down existing features.
 * The new feature should scale to large datasets, or the performance limitations of the feature should be well documented.
-* It can be hard to impossible to "add performance in later".
+* It can be hard to impossible to "add performance in later" so the best time to
+  make changes is when the feature is being added.
 
 **Regressions** 
 
@@ -116,5 +118,5 @@ Performance is never "done" for several reasons:
 ## Conclusion
 
 Achieving and maintaining performance requires an extreme amount of effort
-and diligence, but the payoff is felt in every minute usage, if users are
-delighted and able to productively do their work.
+and diligence, but the payoff is felt in every minute of usage. Delighted
+and productive users are happy users.

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -55,7 +55,6 @@ How to keep napari objectively fast:
 * Time one small operation to monitor for regressions.
 * Napari has some of these today as "benchmarks".
 * Interesting to see how different hardware performs as time goes on.
-* We 
 
 **Run All Tests Every Merge**
 * Save results to a database maybe using [ASV](https://asv.readthedocs.io/en/stable/index.html).

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -55,9 +55,10 @@ How to keep napari objectively fast:
 * Time one small operation to monitor for regressions.
 * Napari has some of these today as "benchmarks".
 * Interesting to see how different hardware performs as time goes on.
+* We 
 
 **Run All Tests Every Merge**
-* Save results to a database or somewhere.
+* Save results to a database maybe using [ASV](https://asv.readthedocs.io/en/stable/index.html).
 * Catch a regression right when it happens and not weeks or
   months later.
 * See how new features run on large datasets no one tested.

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -35,8 +35,8 @@ How to keep napari objectively fast:
 * If not always visible, power users and developers should be able to toggle them on.
 * This gives people an ambient awareness of how long things take.
 * Allows users to report concrete performance numbers:
-  *  *it seemed slow* &#8594; *it ran at 10Hz*.
-  *  *it took a long time* &#8594; *it took 2 minutes and 30 seconds*.
+  *  *it seemed slow* → *it ran at 10Hz*.
+  *  *it took a long time* → *it took 2 minutes and 30 seconds*.
 * Teaches users how different hardware impacts performance.
 
 **Performance System Tests**

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -33,8 +33,8 @@ application can feel clunky or frustrating if not designed well.
 * If not always visible, power users and developers should be able to toggle them on.
 * This gives people an ambient awareness of how long things take.
 * Allows users to report concrete performance numbers:
-  *  *it seemed slow* becomes *it ran at 10Hz*.
-  *  *it took a long time* becomes *it took 2 minutes and 30 seconds*.
+  *  *it seemed slow* &#8594; *it ran at 10Hz*.
+  *  *it took a long time* &#8594; *it took 2 minutes and 30 seconds*.
 * Teaches users how different hardware impacts performance.
 
 **Performance System Tests**

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -44,6 +44,7 @@ How to keep napari objectively fast:
   *  *it seemed slow* → *it ran at 10Hz*.
   *  *it took a long time* → *it took 2 minutes and 30 seconds*.
 * Teaches users how different hardware impacts performance.
+  * For example HDD vs. SSD vs. network file systems.
 
 **Performance System Tests**
 * Create automatic tests that time specific operations in specific known datasets.

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -27,8 +27,8 @@ How to keep napari objectively fast:
 * Focus on cases that matter to lots of people.
 * It’s easy to waste time optimizing things no one cares about or no one will
   notice.
-* If a dataset is unreasonable or out of scope or fringe, don’t waste time
-  trying to make it run fast.
+* If a dataset is unreasonable or out of scope or fringe, don’t spend too
+  many resources trying to make it run fast.
 
 **Always Be Timing**
 * Build timers into the software that always run.

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -1,0 +1,117 @@
+# Napari Performance
+
+Performance is a core feature of napari. Performance is a concern for every
+feature that napari implements. Without adequate performance users will migrate
+to other visualization tools, even if napari has impressive functionality.
+
+## Types of Performance
+
+There are two main types of performance:
+
+**Objective Performance**
+* How long operations take when timed with a stopwatch.
+* Most (but not all) times will vary based on the data.
+
+**Subjective Performance**
+* The user’s experience as it relates to performance.
+* Is the user’s experience pleasant or frustrating?
+
+Both types of performance are important. No amount of slickness can make up for
+an application that is fundamentally too slow. And even a relatively fast
+application can feel clunky or frustrating if not designed well.
+
+## Objective Performance
+
+**Focus On Real Use Cases**
+
+* It’s easy to waste time optimizing things no one cares about or no one will
+  notice.
+* Focus on cases that matter to lots of people.
+* If a dataset is unreasonable or out of scope or very fringe, don’t waste time
+  trying to make it run fast.
+
+**Always Be Timing**
+* Build timers into the software that always run.
+* They do not necessarily have to be visible, but power users and developers
+  should be able to see them.
+* This gives people an “ambient awareness” of how long things take. Users will
+  often load data no developer has seen, useful to know how slow it is.
+* Allows users to report concrete performance numbers instead of “it seemed
+  slow” they’ll say “it ran at 10Hz.”. Instead of “it took a long time” they can
+  see “it took 4 minutes and 30 seconds”
+* Teaches users to be aware how different hardware impacts performance.
+
+**Performance System Tests**
+* Create automatic tests that time specific operations in specific known datasets.
+* Time many different operations on a nice selection of different datasets.
+
+**Performance Unit Tests** (benchmarks)
+* Create automatic tests that time one small operation to monitor for
+  regressions. Like a single matrix operation.
+* Interesting to see how different hardware performs.
+* Napari has some of these today.
+
+**Run All Tests Often**
+* Saver results to a database or somewhere.
+* It’s useful to catch a regression right when it happens and not weeks or
+  months later.
+* It’s important for developers to see how new features run on large datasets
+  they might not have tested.
+
+## Subjective Performance
+
+Subjective performance is an ongoing battle. Napari should strive to have these properties:
+
+**Responsive**
+* The full operation happens or the interface clearly indicates the input was
+  received and the operation was started.
+* The UI should never seem dead, the user should never be left wondering if
+  napari has crashed.
+* For click or keypress events the ideal response is 100ms.
+* For drag events or animations the ideal refresh is 60Hz which is 16.7ms per
+  frame.
+
+**Interruptible**
+* Modeless operations can be interrupted by simply performing some other action.
+  If imagery is loading in the background, you can interrupt it just by
+  navigating to somewhere else.
+* Modal operations that disable the UI should have a cancel button when possible
+  unless they are very short.
+* The user should never feel “trapped”.
+
+**Progressive**
+* Show intermediate results as they become available, instead of showing nothing
+  until the full result is ready.
+* Sometimes progressive results are better even if they slow things down a bit,
+  which is not necessarily intuitive.
+
+**Informative**
+* Clearly show what controls are enabled or disabled.
+* If progressive display is not possible, show progress bars.
+* Show time estimates for super long operations.
+* Show a “busy” animation as the last resort, never look totally locked up.
+* Let power users see timings, bandwidth, FPS, etc.
+
+## Performance Is Never Done
+
+Performance is never "done" for several reasons:
+
+**New Features**
+
+* Every new feature must be evaluated for performance.
+* Often new features work great on small datasets, but fall apart on large ones
+  that the developer never tested.
+
+**Regressions** 
+
+* New features can slow down existing features.
+* New versions of dependencies can slow things down.
+* New hardware generally helps performance but not always.
+
+**Scope Changes**
+
+* New types of users adopt napari and have new needs.
+* Existing users change their usage over time, e.g more network/remote viewing.
+* New file formats are invented or become more common.
+* New data types or sizes become more common.
+

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -1,8 +1,14 @@
 # Napari Performance
 
-Performance is a core feature of napari. Performance is a concern for every
-feature that napari implements. Without adequate performance users will migrate
-to other visualization tools, even if napari has impressive functionality.
+With offline analysis tools performance dictates how long the user has to wait
+for a result, however with an interactive tool like napari performance is even
+more critical. Therefore performance is a core feature of napari. 
+
+Inadequate performance will leave the user frustrated and discouraged and they
+will migrate to other tools or simply give up on interactive exploration all
+together. In contrast excellent performance will create a joyful experience that
+encourages longer and more intensive exploration of data yielding better
+scientific results.
 
 There are two main types of performance:
 

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -115,3 +115,15 @@ Performance is never "done" for several reasons:
 * New file formats are invented or become more common.
 * New data types or sizes become more common.
 
+## New Features
+
+1. New features should be evaluated on their objective and subjective
+   performance.
+1. New features should be tested on a variety of data types and sizes, including
+   the largest data sets that are supported.
+1. It's easy to create features that do not "scale" well to large datasets.
+   Either the feature should scale well, or the limitations of the feature
+   should be well documented. It can be hard to impossible to "add performance
+   in later".
+1. Existing features should be tested both automatically and manually for
+   performance. Well meaning new features can slow down existing features.

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -8,11 +8,12 @@ There are two main types of performance:
 
 **Objective Performance**
 * How long operations take when timed with a stopwatch.
-* Most (but not all) times will vary based on the data.
+* Most times will vary based on the data being viewed.
 
 **Subjective Performance**
 * The user’s experience as it relates to performance.
 * Is the user’s experience pleasant or frustrating?
+* Does napari "seem fast"?
 
 Both types of performance are important. No amount of slickness can make up for
 an application that is fundamentally too slow. And even a relatively fast
@@ -58,13 +59,13 @@ Napari should strive to have these properties:
 
 **Responsive**
 * Two cases:
-  * The full operation happens right away 
+  * The full operation happens right away.
   * The interface clearly indicates the input was received and the operation was
     started.
 * The UI should never seem dead, the user should never be left wondering if
   napari has crashed.
-* For click or keypress events the ideal response is 100ms.
-* For drag events or animations the ideal refresh is 60Hz which is 16.7ms per
+* For click or keypress events the **ideal response is 100ms**.
+* For drag events or animations the **ideal refresh is 60Hz** which is 16.7ms per
   frame.
 
 **Interruptible**
@@ -105,7 +106,7 @@ Performance is never "done" for several reasons:
 
 **Scope Changes**
 
-* New types of users adopt napari and have new needs.
+* New types of users adopt napari and have new use cases.
 * Existing users change their usage over time, e.g more remote viewing.
 * New file formats are invented or become more common.
 * New data types or sizes become more common.
@@ -114,6 +115,12 @@ Performance is never "done" for several reasons:
 
 * New features should be evaluated on their objective subjective and performance before merging to master.
 * New features should be tested on a variety of data types and sizes, including the largest data sets that are supported.
-* Test for regressions since new features can easily slow down existing features.
-* The feature should scale to large datasets, or the performance limitations of the feature should be well documented.
+* Test widely for regressions since new features can easily slow down existing features.
+* The new feature should scale to large datasets, or the performance limitations of the feature should be well documented.
 * It can be hard to impossible to "add performance in later".
+
+## Conclusion
+
+Achieving and maintaining performance requires an extreme amount of effort
+and diligence, but the payoff is felt in every minute usage, if users are
+delighted and able to productively do their work.

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -121,12 +121,12 @@ Performance is never "done" for several reasons:
 **Scope Changes**
 
 * As new types of users adopt napari they will have new use cases.
-* Existing users will change their usage over time, e.g. more remote viewing.
+* Existing users will change their usage over time such as more remote viewing.
 * New file formats will be invented or become more common.
 * New data types or sizes will become more common.
 
 ## Conclusion
 
 Achieving and maintaining performance requires an extreme amount of effort and
-diligence, but the payoff is felt in every minute of usage. The end result is
-delighted and productive users.
+diligence, but the payoff will be felt in every minute of usage. The end result
+is delighted and productive users.

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -4,8 +4,6 @@ Performance is a core feature of napari. Performance is a concern for every
 feature that napari implements. Without adequate performance users will migrate
 to other visualization tools, even if napari has impressive functionality.
 
-## Types of Performance
-
 There are two main types of performance:
 
 **Objective Performance**
@@ -27,44 +25,40 @@ application can feel clunky or frustrating if not designed well.
 * It’s easy to waste time optimizing things no one cares about or no one will
   notice.
 * Focus on cases that matter to lots of people.
-* If a dataset is unreasonable or out of scope or very fringe, don’t waste time
+* If a dataset is unreasonable or out of scope or fringe, don’t waste time
   trying to make it run fast.
 
 **Always Be Timing**
 * Build timers into the software that always run.
-* They do not necessarily have to be visible, but power users and developers
+* At least power users and developers
   should be able to see them.
-* This gives people an “ambient awareness” of how long things take. Users will
-  often load data no developer has seen, useful to know how slow it is.
-* Allows users to report concrete performance numbers instead of “it seemed
-  slow” they’ll say “it ran at 10Hz.”. Instead of “it took a long time” they can
-  see “it took 4 minutes and 30 seconds”
-* Teaches users to be aware how different hardware impacts performance.
+* This gives people an “ambient awareness” of how long things take.
+* Allows users to report concrete performance numbers.
+  *  From “it seemed slow” to “it ran at 10Hz”.
+  *  From “it took a long time” to “it took 2 minutes and 30 seconds”.
+* Teaches users how different hardware impacts performance.
 
 **Performance System Tests**
 * Create automatic tests that time specific operations in specific known datasets.
 * Time many different operations on a nice selection of different datasets.
 
-**Performance Unit Tests** (benchmarks)
-* Create automatic tests that time one small operation to monitor for
-  regressions. Like a single matrix operation.
+**Performance Unit Tests**
+* Time one small operation to monitor for regressions.
 * Interesting to see how different hardware performs.
-* Napari has some of these today.
+* Napari has some of these today as "benchmarks".
 
-**Run All Tests Often**
-* Saver results to a database or somewhere.
-* It’s useful to catch a regression right when it happens and not weeks or
+**Run All Tests Every Merge**
+* Save results to a database or somewhere.
+* Catch a regression right when it happens and not weeks or
   months later.
-* It’s important for developers to see how new features run on large datasets
-  they might not have tested.
+* See how new features run on large datasets no one tested.
 
 ## Subjective Performance
 
-Subjective performance is an ongoing battle. Napari should strive to have these properties:
+Napari should strive to have these properties:
 
 **Responsive**
-* The full operation happens or the interface clearly indicates the input was
-  received and the operation was started.
+* The full operation happens right away or the interface clearly indicates the input was received and the operation was started.
 * The UI should never seem dead, the user should never be left wondering if
   napari has crashed.
 * For click or keypress events the ideal response is 100ms.
@@ -99,8 +93,7 @@ Performance is never "done" for several reasons:
 **New Features**
 
 * Every new feature must be evaluated for performance.
-* Often new features work great on small datasets, but fall apart on large ones
-  that the developer never tested.
+* Often new features work great on small datasets, but fall apart on large ones that the developer never tested.
 
 **Regressions** 
 
@@ -111,19 +104,15 @@ Performance is never "done" for several reasons:
 **Scope Changes**
 
 * New types of users adopt napari and have new needs.
-* Existing users change their usage over time, e.g more network/remote viewing.
+* Existing users change their usage over time, e.g more remote viewing.
 * New file formats are invented or become more common.
 * New data types or sizes become more common.
 
-## New Features
+## News Features
 
-1. New features should be evaluated on their objective and subjective
-   performance.
-1. New features should be tested on a variety of data types and sizes, including
-   the largest data sets that are supported.
-1. It's easy to create features that do not "scale" well to large datasets.
-   Either the feature should scale well, or the limitations of the feature
-   should be well documented. It can be hard to impossible to "add performance
-   in later".
-1. Existing features should be tested both automatically and manually for
-   performance. Well meaning new features can slow down existing features.
+* New features should be evaluated on their objective and subjective and performance before merging to master.
+* New features should be tested on a variety of data types and sizes, including the largest data sets that are supported.
+* New features can easily slow down existing features.
+* It's easy to create features that do not scale well to large datasets. Either the feature should scale, or the performance limitations of the feature should be well documented.
+* It can be hard to impossible to "add performance in later".
+

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -12,8 +12,7 @@ There are two main types of performance:
 
 **Subjective Performance**
 * The user’s experience as it relates to performance.
-* Is the user’s experience pleasant or frustrating?
-* Does napari "seem fast"?
+* Is the user’s experience pleasant or frustrating? Does napari "seem fast"?
 
 Both types of performance are important. No amount of slickness can make up for
 an application that is fundamentally too slow. And even a relatively fast
@@ -33,9 +32,9 @@ application can feel clunky or frustrating if not designed well.
 * Build timers into the software that always run.
 * If not always visible, power users and developers should be able to toggle them on.
 * This gives people an ambient awareness of how long things take.
-* Allows users to report concrete performance numbers.
-  *  “it seemed slow” becomes “it ran at 10Hz”.
-  *  “it took a long time” becomes “it took 2 minutes and 30 seconds”.
+* Allows users to report concrete performance numbers:
+  *  *it seemed slow* becomes *it ran at 10Hz*.
+  *  *it took a long time* becomes *it took 2 minutes and 30 seconds*.
 * Teaches users how different hardware impacts performance.
 
 **Performance System Tests**
@@ -69,9 +68,9 @@ Napari should strive to have these properties:
   frame.
 
 **Interruptible**
-* Modeless operations can be interrupted by simply performing some other action.
-  If imagery is loading in the background, you can interrupt it just by
-  navigating to somewhere else.
+* Modeless operations are best. They can interrupted by simply performing some
+  other action. For example is imagery is loading in the background, you can
+  interrupt it just by navigating to somewhere else.
 * Modal operations that disable the UI should have a cancel button when possible
   unless they are very short.
 * The user should never feel “trapped”.
@@ -85,8 +84,8 @@ Napari should strive to have these properties:
 **Informative**
 * Clearly show what controls are enabled or disabled.
 * If progressive display is not possible, show progress bars.
-* Show time estimates for super long operations.
 * Show an busy animation as the last resort, never look totally locked up.
+* Show time estimates for super long operations.
 * Let power users see timings, bandwidth, FPS, etc.
 
 ## Performance Is Never Done
@@ -95,8 +94,11 @@ Performance is never "done" for several reasons:
 
 **New Features**
 
-* Every new feature must be evaluated for performance.
-* Often new features work great on small datasets, but fall apart on large ones that the developer never tested.
+* New features should be evaluated on their objective subjective and performance before merging to master.
+* New features should be tested on a variety of data types and sizes, including the largest data sets that are supported.
+* Test widely for regressions since new features can easily slow down existing features.
+* The new feature should scale to large datasets, or the performance limitations of the feature should be well documented.
+* It can be hard to impossible to "add performance in later".
 
 **Regressions** 
 
@@ -110,14 +112,6 @@ Performance is never "done" for several reasons:
 * Existing users change their usage over time, e.g more remote viewing.
 * New file formats are invented or become more common.
 * New data types or sizes become more common.
-
-## New Features
-
-* New features should be evaluated on their objective subjective and performance before merging to master.
-* New features should be tested on a variety of data types and sizes, including the largest data sets that are supported.
-* Test widely for regressions since new features can easily slow down existing features.
-* The new feature should scale to large datasets, or the performance limitations of the feature should be well documented.
-* It can be hard to impossible to "add performance in later".
 
 ## Conclusion
 

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -5,9 +5,9 @@ for a result, however with an interactive tool like napari performance is even
 more critical. Therefore performance is a core feature of napari. 
 
 Inadequate performance will leave the user frustrated and discouraged and they
-will migrate to other tools or simply give up on interactive exploration all
-together. In contrast excellent performance will create a joyful experience that
-encourages longer and more intensive exploration of data yielding better
+will migrate to other tools or simply give up on interactive exploration of
+their data all together. In contrast excellent performance will create a joyful
+experience that encourages longer and more intensive exploration yielding better
 scientific results.
 
 There are two main types of performance:
@@ -45,7 +45,7 @@ How to keep napari objectively fast:
   *  *it took a long time* → *it took 2 minutes and 30 seconds*.
 * Teaches users how different hardware impacts performance.
   * For example seek times with SSD are radically faster than HDD.
-  * Also helps notice the impact of local vs. networked file systems.
+  * Become familiar with the impact of local vs. networked file systems.
 
 **Performance System Tests**
 * Create automatic tests that time specific operations in specific known datasets.

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -22,20 +22,19 @@ application can feel clunky or frustrating if not designed well.
 
 **Focus On Real Use Cases**
 
+* Focus on cases that matter to lots of people.
 * It’s easy to waste time optimizing things no one cares about or no one will
   notice.
-* Focus on cases that matter to lots of people.
 * If a dataset is unreasonable or out of scope or fringe, don’t waste time
   trying to make it run fast.
 
 **Always Be Timing**
 * Build timers into the software that always run.
-* At least power users and developers
-  should be able to see them.
-* This gives people an “ambient awareness” of how long things take.
+* If not always visible, power users and developers should be able to toggle them on.
+* This gives people an ambient awareness of how long things take.
 * Allows users to report concrete performance numbers.
-  *  From “it seemed slow” to “it ran at 10Hz”.
-  *  From “it took a long time” to “it took 2 minutes and 30 seconds”.
+  *  “it seemed slow” becomes “it ran at 10Hz”.
+  *  “it took a long time” becomes “it took 2 minutes and 30 seconds”.
 * Teaches users how different hardware impacts performance.
 
 **Performance System Tests**
@@ -58,7 +57,10 @@ application can feel clunky or frustrating if not designed well.
 Napari should strive to have these properties:
 
 **Responsive**
-* The full operation happens right away or the interface clearly indicates the input was received and the operation was started.
+* Two cases:
+  * The full operation happens right away 
+  * The interface clearly indicates the input was received and the operation was
+    started.
 * The UI should never seem dead, the user should never be left wondering if
   napari has crashed.
 * For click or keypress events the ideal response is 100ms.
@@ -83,7 +85,7 @@ Napari should strive to have these properties:
 * Clearly show what controls are enabled or disabled.
 * If progressive display is not possible, show progress bars.
 * Show time estimates for super long operations.
-* Show a “busy” animation as the last resort, never look totally locked up.
+* Show an busy animation as the last resort, never look totally locked up.
 * Let power users see timings, bandwidth, FPS, etc.
 
 ## Performance Is Never Done
@@ -108,11 +110,10 @@ Performance is never "done" for several reasons:
 * New file formats are invented or become more common.
 * New data types or sizes become more common.
 
-## News Features
+## New Features
 
-* New features should be evaluated on their objective and subjective and performance before merging to master.
+* New features should be evaluated on their objective subjective and performance before merging to master.
 * New features should be tested on a variety of data types and sizes, including the largest data sets that are supported.
-* New features can easily slow down existing features.
-* It's easy to create features that do not scale well to large datasets. Either the feature should scale, or the performance limitations of the feature should be well documented.
+* Test for regressions since new features can easily slow down existing features.
+* The feature should scale to large datasets, or the performance limitations of the feature should be well documented.
 * It can be hard to impossible to "add performance in later".
-

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -113,12 +113,12 @@ Performance is never "done" for several reasons:
 **Scope Changes**
 
 * As new types of users adopt napari they will have new use cases.
-* Existing users will change their usage over time, e.g more remote viewing.
+* Existing users will change their usage over time, e.g. more remote viewing.
 * New file formats will be invented or become more common.
 * New data types or sizes will become more common.
 
 ## Conclusion
 
-Achieving and maintaining performance requires an extreme amount of effort
-and diligence, but the payoff is felt in every minute of usage and it 
-will result is delighted an productive users.
+Achieving and maintaining performance requires an extreme amount of effort and
+diligence, but the payoff is felt in every minute of usage. The end result is
+delighted and productive users.

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -67,7 +67,7 @@ How to keep napari objectively fast:
 Napari should strive to have these properties:
 
 **Responsive**
-* Two cases:
+* React to input one of two ways:
   * The full operation happens right away.
   * The interface clearly indicates the input was received and the operation was
     started.


### PR DESCRIPTION
## Description
Adds new file: `docs/explanations/performance.md`. It contains findings from my first week of reading about napari performance related issues and discussing performance with a number of people. It also contains some pretty generic background/philosophy about performance in general.

## Type of change
Documentation only change.

## Explanations
I created a new `docs/explanations` directory for this based on this comment  by @sofroniewn:
https://github.com/napari/napari/issues/764#issuecomment-605077118

The "4 types of documentation" idea is from this divio page:
https://documentation.divio.com/