### PR TITLE
Allow just backspace to delete a layer

### DIFF
--- a/napari/_viewer_key_bindings.py
+++ b/napari/_viewer_key_bindings.py
@@ -74,6 +74,7 @@ def focus_axes_down(viewer):
     viewer.window.qt_viewer.dims.focus_down()
 
 
+@Viewer.bind_key('Backspace')
 @Viewer.bind_key('Control-Backspace')
 @Viewer.bind_key('Control-Delete')
 def remove_selected(viewer):


### PR DESCRIPTION
# Description

I often find that I want to delete a layer with just backspace. Since that key is not used for anything else, it might as well be used here?

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
