### PR TITLE
remove scipy.stats import

### DIFF
--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -69,13 +69,5 @@ from .utils import sys_info, _magicgui
 # register napari object types with magicgui if it is installed
 _magicgui.register_types_with_magicgui()
 
-
-# this unused import is here to fix a very strange bug.
-# there is some mysterious magical goodness in scipy stats that needs
-# to be imported early.
-# see: https://github.com/napari/napari/issues/925
-from scipy import stats  # noqa: F401
-
 del _magicgui
-del stats
 del _viewer_key_bindings


### PR DESCRIPTION
# Description
closes #925 

Just tried to repeat the bug that I described in #925 and I wasn't able to, even without this mysterious import (on py 3.7 with qt5, etc... as described there).  So I think whatever that was has been solved.  We've changed a number of things about widget cleanup, console creation, etc... so I'm not terribly surprised! 