### PR TITLE
Unify _get_exent() return tuple formatting for all layer types

### DIFF
--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -609,7 +609,7 @@ class Points(Layer):
             maxs = np.max(self.data, axis=0)
             mins = np.min(self.data, axis=0)
 
-        return [(min, max, 1) for min, max in zip(mins, maxs)]
+        return [(min, max) for min, max in zip(mins, maxs)]
 
     @property
     def n_dimensional(self) -> bool:

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -354,7 +354,7 @@ class Shapes(Layer):
             maxs = np.max([np.max(d, axis=0) for d in self.data], axis=0)
             mins = np.min([np.min(d, axis=0) for d in self.data], axis=0)
 
-        return tuple((min, max, 1) for min, max in zip(mins, maxs))
+        return tuple((min, max) for min, max in zip(mins, maxs))
 
     @property
     def nshapes(self):

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -219,7 +219,7 @@ class Surface(IntensityVisualizationMixin, Layer):
             mins = [0] * (self.vertex_values.ndim - 1) + list(mins)
             maxs = list(self.vertex_values.shape[:-1]) + list(maxs)
 
-        return [(min, max, 1) for min, max in zip(mins, maxs)]
+        return [(min, max) for min, max in zip(mins, maxs)]
 
     def _get_state(self):
         """Get dictionary of layer state.

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -312,7 +312,7 @@ class Vectors(Layer):
             maxs = np.max(data, axis=(0, 1))
             mins = np.min(data, axis=(0, 1))
 
-        return [(min, max, 1) for min, max in zip(mins, maxs)]
+        return [(min, max) for min, max in zip(mins, maxs)]
 
     @property
     def edge_width(self) -> Union[int, float]:


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
As discussed in the meeting today, the _get_extent() method on our layers behaves differently for image/label layers vs points/shapes/surfaces/vectors. This PR unifies the formatting of the tuple returned by _get_extent().

We do this by removing a hardcoded "1" from the tuple returned by  points/shapes/surfaces/vector layers, since it's not actually being used anywhere in our codebase.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Refactor

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] All existing tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ N/A
- [ ] ~~I have made corresponding changes to the documentation~~ N/A
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ N/A
