### PR TITLE
add option to disable overwrite of labels during painting

### DIFF
--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -107,7 +107,9 @@ class QtLabelsControls(QtLayerControls):
         self._on_n_dim_change()
 
         preserve_labels_cb = QCheckBox()
-        preserve_labels_cb.setToolTip('preserve existing labels while painting')
+        preserve_labels_cb.setToolTip(
+            'preserve existing labels while painting'
+        )
         preserve_labels_cb.stateChanged.connect(self.change_preserve_labels)
         self.preserveLabelsCheckBox = preserve_labels_cb
         self._on_preserve_labels_change()

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -107,7 +107,7 @@ class QtLabelsControls(QtLayerControls):
         self._on_n_dim_change()
 
         preserve_labels_cb = QCheckBox()
-        preserve_labels_cb.setToolTip('preserve_labels editing')
+        preserve_labels_cb.setToolTip('preserve existing labels while painting')
         preserve_labels_cb.stateChanged.connect(self.change_preserve_labels)
         self.preserveLabelsCheckBox = preserve_labels_cb
         self._on_preserve_labels_change()

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -66,6 +66,7 @@ class QtLabelsControls(QtLayerControls):
         self.layer.events.contiguous.connect(self._on_contig_change)
         self.layer.events.n_dimensional.connect(self._on_n_dim_change)
         self.layer.events.editable.connect(self._on_editable_change)
+        self.layer.events.overwrite.connect(self._on_overwrite_change)
 
         # shuffle colormap button
         self.colormapUpdate = QPushButton('shuffle colors')

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -66,7 +66,9 @@ class QtLabelsControls(QtLayerControls):
         self.layer.events.contiguous.connect(self._on_contig_change)
         self.layer.events.n_dimensional.connect(self._on_n_dim_change)
         self.layer.events.editable.connect(self._on_editable_change)
-        self.layer.events.overwrite.connect(self._on_overwrite_change)
+        self.layer.events.preserve_labels.connect(
+            self._on_preserve_labels_change
+        )
 
         # shuffle colormap button
         self.colormapUpdate = QPushButton('shuffle colors')
@@ -104,11 +106,11 @@ class QtLabelsControls(QtLayerControls):
         self.ndimCheckBox = ndim_cb
         self._on_n_dim_change()
 
-        overwrite_cb = QCheckBox()
-        overwrite_cb.setToolTip('overwrite editing')
-        overwrite_cb.stateChanged.connect(self.change_overwrite)
-        self.overwriteCheckBox = overwrite_cb
-        self._on_overwrite_change()
+        preserve_labels_cb = QCheckBox()
+        preserve_labels_cb.setToolTip('preserve_labels editing')
+        preserve_labels_cb.stateChanged.connect(self.change_preserve_labels)
+        self.preserveLabelsCheckBox = preserve_labels_cb
+        self._on_preserve_labels_change()
 
         self.panzoom_button = QtModeRadioButton(
             layer, 'zoom', Mode.PAN_ZOOM, tooltip='Pan/zoom mode', checked=True
@@ -159,8 +161,8 @@ class QtLabelsControls(QtLayerControls):
         self.grid_layout.addWidget(self.contigCheckBox, 5, 1)
         self.grid_layout.addWidget(QLabel('n-dim:'), 6, 0)
         self.grid_layout.addWidget(self.ndimCheckBox, 6, 1)
-        self.grid_layout.addWidget(QLabel('overwrite:'), 7, 0)
-        self.grid_layout.addWidget(self.overwriteCheckBox, 7, 1)
+        self.grid_layout.addWidget(QLabel('preserve_labels:'), 7, 0)
+        self.grid_layout.addWidget(self.preserveLabelsCheckBox, 7, 1)
         self.grid_layout.setRowStretch(8, 1)
         self.grid_layout.setColumnStretch(1, 1)
         self.grid_layout.setSpacing(4)
@@ -254,8 +256,8 @@ class QtLabelsControls(QtLayerControls):
         else:
             self.layer.n_dimensional = False
 
-    def change_overwrite(self, state):
-        """Toggle overwrite state of label layer.
+    def change_preserve_labels(self, state):
+        """Toggle preserve_labels state of label layer.
 
         Parameters
         ----------
@@ -263,9 +265,9 @@ class QtLabelsControls(QtLayerControls):
             Checkbox indicating if overwriting label is enabled.
         """
         if state == Qt.Checked:
-            self.layer.overwrite = True
+            self.layer.preserve_labels = True
         else:
-            self.layer.overwrite = False
+            self.layer.preserve_labels = False
 
     def _on_selection_change(self, event=None):
         """Receive layer model label selection change event and update spinbox.
@@ -314,16 +316,16 @@ class QtLabelsControls(QtLayerControls):
         with self.layer.events.contiguous.blocker():
             self.contigCheckBox.setChecked(self.layer.contiguous)
 
-    def _on_overwrite_change(self, event=None):
-        """Receive layer model overwrite change event and update the checkbox.
+    def _on_preserve_labels_change(self, event=None):
+        """Receive layer model preserve_labels change event and update the checkbox.
 
         Parameters
         ----------
         event : qtpy.QtCore.QEvent, optional.
             Event from the Qt context.
         """
-        with self.layer.events.overwrite.blocker():
-            self.overwriteCheckBox.setChecked(self.layer.overwrite)
+        with self.layer.events.preserve_labels.blocker():
+            self.preserveLabelsCheckBox.setChecked(self.layer.preserve_labels)
 
     def _on_editable_change(self, event=None):
         """Receive layer model editable change event & enable/disable buttons.

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -103,6 +103,12 @@ class QtLabelsControls(QtLayerControls):
         self.ndimCheckBox = ndim_cb
         self._on_n_dim_change()
 
+        overwrite_cb = QCheckBox()
+        overwrite_cb.setToolTip('overwrite editing')
+        overwrite_cb.stateChanged.connect(self.change_overwrite)
+        self.overwriteCheckBox = overwrite_cb
+        self._on_overwrite_change()
+
         self.panzoom_button = QtModeRadioButton(
             layer, 'zoom', Mode.PAN_ZOOM, tooltip='Pan/zoom mode', checked=True
         )
@@ -152,7 +158,9 @@ class QtLabelsControls(QtLayerControls):
         self.grid_layout.addWidget(self.contigCheckBox, 5, 1)
         self.grid_layout.addWidget(QLabel('n-dim:'), 6, 0)
         self.grid_layout.addWidget(self.ndimCheckBox, 6, 1)
-        self.grid_layout.setRowStretch(7, 1)
+        self.grid_layout.addWidget(QLabel('overwrite:'), 7, 0)
+        self.grid_layout.addWidget(self.overwriteCheckBox, 7, 1)
+        self.grid_layout.setRowStretch(8, 1)
         self.grid_layout.setColumnStretch(1, 1)
         self.grid_layout.setSpacing(4)
 
@@ -245,6 +253,19 @@ class QtLabelsControls(QtLayerControls):
         else:
             self.layer.n_dimensional = False
 
+    def change_overwrite(self, state):
+        """Toggle overwrite state of label layer.
+
+        Parameters
+        ----------
+        state : QCheckBox
+            Checkbox indicating if overwriting label is enabled.
+        """
+        if state == Qt.Checked:
+            self.layer.overwrite = True
+        else:
+            self.layer.overwrite = False
+
     def _on_selection_change(self, event=None):
         """Receive layer model label selection change event and update spinbox.
 
@@ -291,6 +312,17 @@ class QtLabelsControls(QtLayerControls):
         """
         with self.layer.events.contiguous.blocker():
             self.contigCheckBox.setChecked(self.layer.contiguous)
+
+    def _on_overwrite_change(self, event=None):
+        """Receive layer model overwrite change event and update the checkbox.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent, optional.
+            Event from the Qt context.
+        """
+        with self.layer.events.overwrite.blocker():
+            self.overwriteCheckBox.setChecked(self.layer.overwrite)
 
     def _on_editable_change(self, event=None):
         """Receive layer model editable change event & enable/disable buttons.

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -161,7 +161,7 @@ class QtLabelsControls(QtLayerControls):
         self.grid_layout.addWidget(self.contigCheckBox, 5, 1)
         self.grid_layout.addWidget(QLabel('n-dim:'), 6, 0)
         self.grid_layout.addWidget(self.ndimCheckBox, 6, 1)
-        self.grid_layout.addWidget(QLabel('preserve_labels:'), 7, 0)
+        self.grid_layout.addWidget(QLabel('preserve labels:'), 7, 0)
         self.grid_layout.addWidget(self.preserveLabelsCheckBox, 7, 1)
         self.grid_layout.setRowStretch(8, 1)
         self.grid_layout.setColumnStretch(1, 1)

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -78,7 +78,7 @@ def redo(layer):
 
 @Labels.bind_key('Shift')
 def preserve_labels(layer):
-    """toggle preserve label option when pressed"""
+    """Toggle preserve label option when pressed"""
     # on key press
     layer.preserve_labels = not layer.preserve_labels
 

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -77,8 +77,8 @@ def redo(layer):
 
 
 @Labels.bind_key('Shift')
-def overwrite(layer):
-    """Disallow overwrite of labeling when pressed"""
+def preserve_labels(layer):
+    """toggle preserve label option when pressed"""
     # on key press
     layer.preserve_labels = not layer.preserve_labels
 

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -80,9 +80,9 @@ def redo(layer):
 def overwrite(layer):
     """Disallow overwrite of labeling when pressed"""
     # on key press
-    layer.overwrite = False
+    layer.overwrite = not layer.overwrite
 
     yield
 
     # on key release
-    layer.overwrite = True
+    layer.overwrite = not layer.overwrite

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -80,9 +80,9 @@ def redo(layer):
 def overwrite(layer):
     """Disallow overwrite of labeling when pressed"""
     # on key press
-    layer.overwrite = not layer.overwrite
+    layer.preserve_labels = not layer.preserve_labels
 
     yield
 
     # on key release
-    layer.overwrite = not layer.overwrite
+    layer.preserve_labels = not layer.preserve_labels

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -74,3 +74,15 @@ def undo(layer):
 def redo(layer):
     """Redo any previously undone actions."""
     layer.redo()
+
+
+@Labels.bind_key('Shift')
+def overwrite(layer):
+    """Disallow overwrite of labeling when pressed"""
+    # on key press
+    layer.overwrite = False
+
+    yield
+
+    # on key release
+    layer.overwrite = True

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -312,12 +312,12 @@ def test_paint():
     assert np.unique(layer.data[5:10, 5:10]) == 2
 
 
-def test_paint_without_overwrite():
-    """Test painting labels without overwriting existing labels"""
+def test_paint_with_preserve_labels():
+    """Test painting labels while preserving existing labels"""
     data = np.zeros((15, 10))
     data[:3, :3] = 1
     layer = Labels(data)
-    layer.overwrite = False
+    layer.preserve_labels = True
     assert np.unique(layer.data[:3, :3]) == 1
 
     layer.brush_size = 9

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -312,6 +312,22 @@ def test_paint():
     assert np.unique(layer.data[5:10, 5:10]) == 2
 
 
+def test_paint_without_overwrite():
+    """Test painting labels without overwriting existing labels"""
+    data = np.zeros((15, 10))
+    data[:3, :3] = 1
+    layer = Labels(data)
+    layer.overwrite = False
+    assert np.unique(layer.data[:3, :3]) == 1
+
+    layer.brush_size = 9
+    layer.paint([0, 0], 2)
+
+    assert np.unique(layer.data[3:5, 0:5]) == 2
+    assert np.unique(layer.data[0:5, 3:5]) == 2
+    assert np.unique(layer.data[:3, :3]) == 1
+
+
 def test_fill():
     """Test filling labels with different brush sizes."""
     np.random.seed(0)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -146,7 +146,7 @@ class Labels(Image):
 
         self.events.add(
             mode=Event,
-            overwrite=Event,
+            preserve_labels=Event,
             n_dimensional=Event,
             contiguous=Event,
             brush_size=Event,
@@ -165,7 +165,7 @@ class Labels(Image):
         self._mode = Mode.PAN_ZOOM
         self._mode_history = self._mode
         self._status = self.mode
-        self._overwrite = True
+        self._preserve_labels = False
         self._help = 'enter paint or fill mode to edit labels'
 
         self._block_saving = False
@@ -328,7 +328,7 @@ class Labels(Image):
             self.cursor_size = self.brush_size / self.scale_factor
             self.cursor = 'square'
             self.interactive = False
-            self.help = 'hold <space> to pan/zoom, hold <shift> to toggle overwrite, drag to paint a label'
+            self.help = 'hold <space> to pan/zoom, hold <shift> to toggle preserve_labels, drag to paint a label'
             self.mouse_drag_callbacks.append(paint)
         elif mode == Mode.FILL:
             self.cursor = 'cross'
@@ -345,17 +345,18 @@ class Labels(Image):
         self.refresh()
 
     @property
-    def overwrite(self):
-        """
-        Defines if painting should overwrite existing labels, default to true to allow overwrite.
-        If set to false, painting would only be performed on the background label, and not on existing labels.
-        """
-        return self._overwrite
+    def preserve_labels(self):
+        """Defines if painting should preserve existing labels.
 
-    @overwrite.setter
-    def overwrite(self, overwrite: bool):
-        self._overwrite = overwrite
-        self.events.overwrite(overwrite=overwrite)
+        Default to false to allow paint on existing labels. When
+        set to true, existing labels will be replaced during painting.
+        """
+        return self._preserve_labels
+
+    @preserve_labels.setter
+    def preserve_labels(self, preserve_labels: bool):
+        self._preserve_labels = preserve_labels
+        self.events.preserve_labels(preserve_labels=preserve_labels)
 
     def _set_editable(self, editable=None):
         """Set editable mode based on layer properties."""
@@ -542,7 +543,7 @@ class Labels(Image):
 
         # update the labels image
 
-        if self._overwrite:
+        if not self._preserve_labels:
             self.data[slice_coord] = new_label
         else:
             keep_coords = self.data[slice_coord] == self._background_label

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -346,10 +346,13 @@ class Labels(Image):
 
     @property
     def overwrite(self):
-        return str(self._overwrite)
+        """
+        Defines if painting should overwrite existing labels, if set to true, painting should only be performed on the background label, and not on existing lables.
+        """
+        return self._overwrite
 
     @overwrite.setter
-    def overwrite(self, overwrite: Union[str, bool]):
+    def overwrite(self, overwrite: bool):
         self._overwrite = overwrite
         self.events.overwrite(overwrite=overwrite)
         self.refresh()

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -158,6 +158,7 @@ class Labels(Image):
         self._contiguous = True
         self._brush_size = 10
 
+        self._background_label = 0
         self._selected_label = 0
         self._selected_color = None
 
@@ -549,25 +550,42 @@ class Labels(Image):
     def paint_without_overwrite(
         self, array, slice_coord, new_label, dimension
     ):
+        """
+        Paint the label without overwriting existing label, which is equivalent to only painting on background label.
+
+        Parameters
+        ----------
+        array : data array to paint on
+        slice_coord : coordinates to paint
+        new_label: new label to paint with
+        dimension: dimension of the current painting progress
+        """
         if dimension == len(slice_coord) - 1:
-            for coord in self.read_dimension(slice_coord, dimension):
-                if array[coord] == 0:
+            for coord in self.list_coordinates(slice_coord[dimension]):
+                if array[coord] == self._background_label:
                     array[coord] = new_label
         else:
-            for coord in self.read_dimension(slice_coord, dimension):
+            for coord in self.list_coordinates(slice_coord[dimension]):
                 self.paint_without_overwrite(
                     array[coord], slice_coord, new_label, dimension + 1
                 )
 
     @staticmethod
-    def read_dimension(slice_coord, dimension):
-        if isinstance(slice_coord[dimension], slice):
+    def list_coordinates(slice_coord):
+        """
+        List out all coordinates in the given slice range.
+
+        Parameters
+        ----------
+        slice_coord : slice of coordinate to check and convert to list of all coordinates within the range
+
+        Returns
+        -------
+        list of all coordinates within the given coordinate range
+        """
+        if isinstance(slice_coord, slice):
             return list(
-                range(
-                    slice_coord[dimension].start,
-                    slice_coord[dimension].stop,
-                    slice_coord[dimension].step,
-                )
+                range(slice_coord.start, slice_coord.stop, slice_coord.step,)
             )
         else:
-            return (slice_coord[dimension],)
+            return (slice_coord,)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -543,7 +543,7 @@ class Labels(Image):
 
         # update the labels image
 
-        if not self._preserve_labels:
+        if not self.preserve_labels:
             self.data[slice_coord] = new_label
         else:
             keep_coords = self.data[slice_coord] == self._background_label

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -347,7 +347,8 @@ class Labels(Image):
     @property
     def overwrite(self):
         """
-        Defines if painting should overwrite existing labels, if set to true, painting should only be performed on the background label, and not on existing lables.
+        Defines if painting should overwrite existing labels, default to true to allow overwrite.
+        If set to false, painting would only be performed on the background label, and not on existing labels.
         """
         return self._overwrite
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1,4 +1,4 @@
-from collections import deque, Iterable
+from collections import deque
 from typing import Union
 
 import numpy as np
@@ -546,18 +546,28 @@ class Labels(Image):
         if refresh is True:
             self.refresh()
 
-    def paint_without_overwrite(self, array, slice_coord, new_label, dimension):
+    def paint_without_overwrite(
+        self, array, slice_coord, new_label, dimension
+    ):
         if dimension == len(slice_coord) - 1:
             for coord in self.read_dimension(slice_coord, dimension):
                 if array[coord] == 0:
                     array[coord] = new_label
         else:
             for coord in self.read_dimension(slice_coord, dimension):
-                self.paint_without_overwrite(array[coord], slice_coord, new_label, dimension + 1)
+                self.paint_without_overwrite(
+                    array[coord], slice_coord, new_label, dimension + 1
+                )
 
     @staticmethod
     def read_dimension(slice_coord, dimension):
         if isinstance(slice_coord[dimension], slice):
-            return list(range(slice_coord[dimension].start, slice_coord[dimension].stop, slice_coord[dimension].step))
+            return list(
+                range(
+                    slice_coord[dimension].start,
+                    slice_coord[dimension].stop,
+                    slice_coord[dimension].step,
+                )
+            )
         else:
-            return slice_coord[dimension],
+            return (slice_coord[dimension],)


### PR DESCRIPTION
# Description
Add toggling during painting of labels, to turn off overwriting of existing label https://github.com/napari/napari/issues/1142

when overwrite is disabled, existing labels(other than background label - 0) won't be replaced
## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
https://github.com/napari/napari/issues/1142 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [X] created test to verify paint with overwrite toggled off correctly mark only empty areas


## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
