### PR TITLE
Rich jupyter display for napari screenshots

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -98,28 +98,13 @@ def test_screenshot(viewer_factory):
     data = 20 * np.random.random((10, 4, 2))
     viewer.add_shapes(data)
 
-    # Take screenshot
-    screenshot = viewer.screenshot()
+    # Take screenshot of the image canvas only
+    screenshot = viewer.screenshot(canvas_only=True)
     assert screenshot.ndim == 3
 
     # Take screenshot with the viewer included
-    screenshot = viewer.screenshot(with_viewer=True)
+    screenshot = viewer.screenshot(canvas_only=False)
     assert screenshot.ndim == 3
-
-
-def test_nbscreenshot(viewer_factory):
-    """Test taking a screenshot."""
-    view, viewer = viewer_factory()
-
-    np.random.seed(0)
-    data = np.random.random((10, 15))
-    viewer.add_image(data)
-
-    rich_display_object = viewer.nbscreenshot()
-    assert hasattr(rich_display_object, '_repr_png_')
-    # Trigger method that would run in jupyter notebook cell automatically
-    rich_display_object._repr_png_()
-    assert rich_display_object.image is not None
 
 
 def test_update(viewer_factory):

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -107,6 +107,21 @@ def test_screenshot(viewer_factory):
     assert screenshot.ndim == 3
 
 
+def test_nbscreenshot(viewer_factory):
+    """Test taking a screenshot."""
+    view, viewer = viewer_factory()
+
+    np.random.seed(0)
+    data = np.random.random((10, 15))
+    viewer.add_image(data)
+
+    rich_display_object = viewer.nbscreenshot()
+    assert hasattr(rich_display_object, '_repr_png_')
+    # Trigger method that would run in jupyter notebook cell automatically
+    rich_display_object._repr_png_()
+    assert rich_display_object.image is not None
+
+
 def test_update(viewer_factory):
     data = np.random.random((512, 512))
     view, viewer = viewer_factory()

--- a/napari/_vispy/_tests/test_vispy_multiscale.py
+++ b/napari/_vispy/_tests/test_vispy_multiscale.py
@@ -73,7 +73,7 @@ def test_multiscale_screenshot(viewer_factory):
     # Set canvas size to target amount
     view.view.canvas.size = (800, 600)
 
-    screenshot = viewer.screenshot()
+    screenshot = viewer.screenshot(canvas_only=True)
     center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)
     target_center = np.array([255, 255, 255, 255], dtype='uint8')
     target_edge = np.array([0, 0, 0, 255], dtype='uint8')
@@ -110,7 +110,7 @@ def test_multiscale_screenshot_zoomed(viewer_factory):
     # Check that current level is bottom level of multiscale
     assert viewer.layers[0].data_level == 0
 
-    screenshot = viewer.screenshot()
+    screenshot = viewer.screenshot(canvas_only=True)
     center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)
     target_center = np.array([255, 255, 255, 255], dtype='uint8')
     screen_offset = 3  # Offset is needed as our screenshots have black borders
@@ -142,7 +142,7 @@ def test_image_screenshot_zoomed(viewer_factory):
     view.view.camera.rect = [1000, 1000, 200, 150]
     list(view.layer_to_visual.values())[0].on_draw(None)
 
-    screenshot = viewer.screenshot()
+    screenshot = viewer.screenshot(canvas_only=True)
     center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)
     target_center = np.array([255, 255, 255, 255], dtype='uint8')
     screen_offset = 3  # Offset is needed as our screenshots have black borders

--- a/napari/utils/__init__.py
+++ b/napari/utils/__init__.py
@@ -1,5 +1,6 @@
 from .info import sys_info, citation_text
 from .dask_utils import resize_dask_cache
+from .notebook_display import nbscreenshot
 
 #: dask.cache.Cache, optional : A dask cache for opportunistic caching
 #: use :func:`~.resize_dask_cache` to actually register and resize.

--- a/napari/utils/_tests/test_notebook_display.py
+++ b/napari/utils/_tests/test_notebook_display.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from napari.utils.notebook_display import nbscreenshot
+
+
+def test_nbscreenshot(viewer_factory):
+    """Test taking a screenshot."""
+    view, viewer = viewer_factory()
+
+    np.random.seed(0)
+    data = np.random.random((10, 15))
+    viewer.add_image(data)
+
+    rich_display_object = nbscreenshot(viewer)
+    assert hasattr(rich_display_object, '_repr_png_')
+    # Trigger method that would run in jupyter notebook cell automatically
+    rich_display_object._repr_png_()
+    assert rich_display_object.image is not None

--- a/napari/utils/_tests/test_notebook_display.py
+++ b/napari/utils/_tests/test_notebook_display.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from napari.utils.notebook_display import nbscreenshot
+from napari.utils import nbscreenshot
 
 
 def test_nbscreenshot(viewer_factory):

--- a/napari/utils/notebook_display.py
+++ b/napari/utils/notebook_display.py
@@ -3,11 +3,13 @@ from io import BytesIO
 __all__ = ['nbscreenshot']
 
 
-def nbscreenshot(viewer, canvas_only=False):
+def nbscreenshot(viewer, *, canvas_only=False):
     """Display napari screenshot in the jupyter notebook.
 
     Parameters
     ----------
+    viewer : napari.Viewer
+        The napari viewer.
     with_viewer : bool, optional
         If True includes the napari viewer frame in the screenshot,
         otherwise just includes the canvas. By default, True.
@@ -42,7 +44,7 @@ class NotebookScreenshot:
     ```
     """
 
-    def __init__(self, viewer, canvas_only=False):
+    def __init__(self, viewer, *, canvas_only=False):
         """Initalize screenshot object.
 
         Parameters

--- a/napari/utils/notebook_display.py
+++ b/napari/utils/notebook_display.py
@@ -1,7 +1,5 @@
 from io import BytesIO
 
-import imageio
-
 
 class NotebookScreenshot:
     """Display napari screenshot in the jupyter notebook.
@@ -36,6 +34,8 @@ class NotebookScreenshot:
             If True includes the napari viewer frame in the screenshot,
             otherwise just includes the canvas. By default, True.
         """
+        import imageio
+        
         self.viewer = viewer
         self.with_viewer = with_viewer
         self.image = None

--- a/napari/utils/notebook_display.py
+++ b/napari/utils/notebook_display.py
@@ -1,5 +1,24 @@
 from io import BytesIO
 
+__all__ = ['nbscreenshot']
+
+
+def nbscreenshot(viewer, canvas_only=False):
+    """Display napari screenshot in the jupyter notebook.
+
+    Parameters
+    ----------
+    with_viewer : bool, optional
+        If True includes the napari viewer frame in the screenshot,
+        otherwise just includes the canvas. By default, True.
+
+    Returns
+    -------
+    napari.utils.notebook_display.NotebookScreenshot
+        Napari screenshot rendered as rich display in the jupyter notebook.
+    """
+    return NotebookScreenshot(viewer, canvas_only=canvas_only)
+
 
 class NotebookScreenshot:
     """Display napari screenshot in the jupyter notebook.
@@ -23,19 +42,20 @@ class NotebookScreenshot:
     ```
     """
 
-    def __init__(self, viewer, with_viewer=True):
+    def __init__(self, viewer, canvas_only=False):
         """Initalize screenshot object.
 
         Parameters
         ----------
         viewer : napari.Viewer
             The napari viewer
-        with_viewer : bool, optional
-            If True includes the napari viewer frame in the screenshot,
-            otherwise just includes the canvas. By default, True.
+        canvas_only : bool, optional
+            If False include the napari viewer frame in the screenshot,
+            and if True then take screenshot of just the image display canvas.
+            By default, False.
         """
         self.viewer = viewer
-        self.with_viewer = with_viewer
+        self.canvas_only = canvas_only
         self.image = None
 
     def _repr_png_(self):
@@ -47,7 +67,7 @@ class NotebookScreenshot:
         """
         from imageio import imsave
 
-        self.image = self.viewer.screenshot(with_viewer=self.with_viewer)
+        self.image = self.viewer.screenshot(canvas_only=self.canvas_only)
         file_obj = BytesIO()
         imsave(file_obj, self.image, format='png')
         file_obj.seek(0)

--- a/napari/utils/notebook_display.py
+++ b/napari/utils/notebook_display.py
@@ -6,6 +6,11 @@ import imageio
 class NotebookScreenshot:
     """Display napari screenshot in the jupyter notebook.
 
+    Functions returning an object with a _repr_png_() method
+    will displayed as a rich image in the jupyter notebook.
+
+    https://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html
+
     Examples
     --------
     ```
@@ -13,7 +18,10 @@ class NotebookScreenshot:
     from skimage.data import chelsea
 
     viewer = napari.view_image(chelsea(), name='chelsea-the-cat')
-    nbscreenshot(viewer)
+    viewer.nbscreenshot()
+
+    # screenshot just the canvas without the napari viewer framing it
+    viewer.nbscreenshot(with_viewer=False)
     ```
     """
 
@@ -30,6 +38,7 @@ class NotebookScreenshot:
         """
         self.viewer = viewer
         self.with_viewer = with_viewer
+        self.image = None
 
     def _repr_png_(self):
         """PNG representation of the viewer object for IPython.
@@ -38,8 +47,8 @@ class NotebookScreenshot:
         -------
         In memory binary stream containing PNG screenshot image.
         """
-        image = self.viewer.screenshot(with_viewer=self.with_viewer)
+        self.image = self.viewer.screenshot(with_viewer=self.with_viewer)
         file_obj = BytesIO()
-        imageio.imsave(file_obj, image, format='png')
+        imageio.imsave(file_obj, self.image, format='png')
         file_obj.seek(0)
         return file_obj.read()

--- a/napari/utils/notebook_display.py
+++ b/napari/utils/notebook_display.py
@@ -1,0 +1,45 @@
+from io import BytesIO
+
+import imageio
+
+
+class NotebookScreenshot:
+    """Display napari screenshot in the jupyter notebook.
+
+    Examples
+    --------
+    ```
+    import napari
+    from skimage.data import chelsea
+
+    viewer = napari.view_image(chelsea(), name='chelsea-the-cat')
+    nbscreenshot(viewer)
+    ```
+    """
+
+    def __init__(self, viewer, with_viewer=True):
+        """Initalize screenshot object.
+
+        Parameters
+        ----------
+        viewer : napari.Viewer
+            The napari viewer
+        with_viewer : bool, optional
+            If True includes the napari viewer frame in the screenshot,
+            otherwise just includes the canvas. By default, True.
+        """
+        self.viewer = viewer
+        self.with_viewer = with_viewer
+
+    def _repr_png_(self):
+        """PNG representation of the viewer object for IPython.
+
+        Returns
+        -------
+        In memory binary stream containing PNG screenshot image.
+        """
+        image = self.viewer.screenshot(with_viewer=self.with_viewer)
+        file_obj = BytesIO()
+        imageio.imsave(file_obj, image, format='png')
+        file_obj.seek(0)
+        return file_obj.read()

--- a/napari/utils/notebook_display.py
+++ b/napari/utils/notebook_display.py
@@ -33,7 +33,7 @@ class NotebookScreenshot:
         with_viewer : bool, optional
             If True includes the napari viewer frame in the screenshot,
             otherwise just includes the canvas. By default, True.
-        """        
+        """
         self.viewer = viewer
         self.with_viewer = with_viewer
         self.image = None

--- a/napari/utils/notebook_display.py
+++ b/napari/utils/notebook_display.py
@@ -33,9 +33,7 @@ class NotebookScreenshot:
         with_viewer : bool, optional
             If True includes the napari viewer frame in the screenshot,
             otherwise just includes the canvas. By default, True.
-        """
-        import imageio
-        
+        """        
         self.viewer = viewer
         self.with_viewer = with_viewer
         self.image = None
@@ -47,8 +45,10 @@ class NotebookScreenshot:
         -------
         In memory binary stream containing PNG screenshot image.
         """
+        from imageio import imsave
+
         self.image = self.viewer.screenshot(with_viewer=self.with_viewer)
         file_obj = BytesIO()
-        imageio.imsave(file_obj, self.image, format='png')
+        imsave(file_obj, self.image, format='png')
         file_obj.seek(0)
         return file_obj.read()

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -10,7 +10,6 @@ from ._qt.qt_main_window import Window
 from ._qt.qt_viewer import QtViewer
 from .components import ViewerModel
 from . import __version__
-from .utils.notebook_display import NotebookScreenshot
 
 
 class Viewer(ViewerModel):
@@ -104,16 +103,17 @@ class Viewer(ViewerModel):
         else:
             self.window.qt_viewer.console.push(variables)
 
-    def screenshot(self, path=None, *, with_viewer=False):
+    def screenshot(self, path=None, *, canvas_only=False):
         """Take currently displayed screen and convert to an image array.
 
         Parameters
         ----------
         path : str
             Filename for saving screenshot image.
-        with_viewer : bool
-            If True includes the napari viewer, otherwise just includes the
-            canvas.
+        canvas_only : bool
+            If False include the napari viewer frame in the screenshot,
+            and if True then take screenshot of just the image display canvas.
+            By default, False.
 
         Returns
         -------
@@ -121,27 +121,11 @@ class Viewer(ViewerModel):
             Numpy array of type ubyte and shape (h, w, 4). Index [0, 0] is the
             upper-left corner of the rendered region.
         """
-        if with_viewer:
-            image = self.window.screenshot(path=path)
-        else:
+        if canvas_only:
             image = self.window.qt_viewer.screenshot(path=path)
+        else:
+            image = self.window.screenshot(path=path)
         return image
-
-    def nbscreenshot(self, with_viewer=True):
-        """Display napari screenshot in the jupyter notebook.
-
-        Parameters
-        ----------
-        with_viewer : bool, optional
-            If True includes the napari viewer frame in the screenshot,
-            otherwise just includes the canvas. By default, True.
-
-        Returns
-        -------
-        napari.utils.notebook_display.NotebookScreenshot
-            Napari screenshot rendered as rich display in the jupyter notebook.
-        """
-        return NotebookScreenshot(self, with_viewer=with_viewer)
 
     def update(self, func, *args, **kwargs):
         t = QtUpdateUI(func, *args, **kwargs)

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -10,6 +10,7 @@ from ._qt.qt_main_window import Window
 from ._qt.qt_viewer import QtViewer
 from .components import ViewerModel
 from . import __version__
+from .utils.notebook_display import NotebookScreenshot
 
 
 class Viewer(ViewerModel):
@@ -125,6 +126,22 @@ class Viewer(ViewerModel):
         else:
             image = self.window.qt_viewer.screenshot(path=path)
         return image
+
+    def nbscreenshot(self, with_viewer=True):
+        """Display napari screenshot in the jupyter notebook.
+
+        Parameters
+        ----------
+        with_viewer : bool, optional
+            If True includes the napari viewer frame in the screenshot,
+            otherwise just includes the canvas. By default, True.
+
+        Returns
+        -------
+        napari.utils.notebook_display.NotebookScreenshot
+            Napari screenshot rendered as rich display in the jupyter notebook.
+        """
+        return NotebookScreenshot(self, with_viewer=with_viewer)
 
     def update(self, func, *args, **kwargs):
         t = QtUpdateUI(func, *args, **kwargs)

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -103,7 +103,7 @@ class Viewer(ViewerModel):
         else:
             self.window.qt_viewer.console.push(variables)
 
-    def screenshot(self, path=None, *, canvas_only=False):
+    def screenshot(self, path=None, *, canvas_only=True):
         """Take currently displayed screen and convert to an image array.
 
         Parameters
@@ -111,9 +111,9 @@ class Viewer(ViewerModel):
         path : str
             Filename for saving screenshot image.
         canvas_only : bool
-            If False include the napari viewer frame in the screenshot,
-            and if True then take screenshot of just the image display canvas.
-            By default, False.
+            If True, screenshot shows only the image display canvas, and
+            if False include the napari viewer frame in the screenshot,
+            By default, True.
 
         Returns
         -------


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
This PR implements a new viewer method `nbscreenshot()`, which provides rich image display of the napari screenshots in jupyter notebooks.

[See example output of the new functionality in the notebook gist here](https://gist.github.com/GenevieveBuckley/97b49f9ac3e02422f98abe3c412ee2a0)

Based on Juan's approach in [#756](https://github.com/napari/napari/pull/756) (one difference to note is that this PR removes the `scikit-image` dependency in favour of `imageio`).

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
Closes https://github.com/napari/napari/issues/1267

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] test covering new functionality
- [x] all existing tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
