### PR TITLE
Have layer tooltip display the layer name: add self.layer.name to layer tooltip

### DIFF
--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -511,6 +511,7 @@ class QtLayerWidget(QFrame):
         textbox = QLineEdit(self)
         textbox.setText(layer.name)
         textbox.home(False)
+        # Chris Wood changed from 'Layer Name' 2020/05/22
         textbox.setToolTip(self.layer.name)
         textbox.setAcceptDrops(False)
         textbox.setEnabled(True)
@@ -557,6 +558,8 @@ class QtLayerWidget(QFrame):
     def changeText(self):
         """Update layer name attribute using layer name textbox contents."""
         self.layer.name = self.nameTextBox.text()
+        # set tool tip to layer name, Chris Wood 20202/05/22"""
+        self.nameTextBox.setToolTip(self.layer.name)
         self.nameTextBox.clearFocus()
         self.setFocus()
 

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -511,7 +511,7 @@ class QtLayerWidget(QFrame):
         textbox = QLineEdit(self)
         textbox.setText(layer.name)
         textbox.home(False)
-        textbox.setToolTip('Layer name')
+        textbox.setToolTip(self.layer.name)
         textbox.setAcceptDrops(False)
         textbox.setEnabled(True)
         textbox.editingFinished.connect(self.changeText)

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -511,7 +511,6 @@ class QtLayerWidget(QFrame):
         textbox = QLineEdit(self)
         textbox.setText(layer.name)
         textbox.home(False)
-        # Chris Wood changed from 'Layer Name' 2020/05/22
         textbox.setToolTip(self.layer.name)
         textbox.setAcceptDrops(False)
         textbox.setEnabled(True)
@@ -558,7 +557,6 @@ class QtLayerWidget(QFrame):
     def changeText(self):
         """Update layer name attribute using layer name textbox contents."""
         self.layer.name = self.nameTextBox.text()
-        # set tool tip to layer name, Chris Wood 20202/05/22"""
         self.nameTextBox.setToolTip(self.layer.name)
         self.nameTextBox.clearFocus()
         self.setFocus()


### PR DESCRIPTION
# Description
When hovering over a layer in the layer list, the tooltip just displays "Layer Name"

I changed the static string 'Layer Name' to self.layer.name in qt_layerlist.py, and also set the tool tip after a name change in QtLayerWidget.changeText().

## Type of change
- [ ] Bug-fix (non-breaking change which fixes an issue)

# References
I couldn't find an open issue for this.

# How has this been tested?
Checked to see if the changes worked on another workstation after pushing and pulling.

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
