### PR TITLE
Fix adding points with new properties 

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -834,6 +834,19 @@ def test_color_cycle(attribute, color_cycle):
     # refresh colors
     layer.refresh_colors(update_color_mapping=True)
 
+    # test adding a point with a new property value
+    layer.selected_data = {}
+    current_properties = layer.current_properties
+    current_properties['point_type'] = np.array(['new'])
+    layer.current_properties = current_properties
+    layer.add([10, 10])
+    color_cycle_map = getattr(layer, f'{attribute}_color_cycle_map')
+
+    assert 'new' in color_cycle_map
+    np.testing.assert_allclose(
+        color_cycle_map['new'], np.squeeze(transform_color(color_cycle[0]))
+    )
+
 
 @pytest.mark.parametrize("attribute", ['edge', 'face'])
 def test_add_color_cycle_to_empty_layer(attribute):

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1016,7 +1016,7 @@ class Points(Layer):
                 if update_color_mapping:
                     color_cycle = getattr(self, f'_{attribute}_color_cycle')
                     color_cycle_map = {
-                        k: transform_color(c)
+                        k: np.squeeze(transform_color(c))
                         for k, c in zip(
                             np.unique(color_properties), color_cycle
                         )

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -510,9 +510,10 @@ class Points(Layer):
             color_cycle_keys = [*color_cycle_map]
             if color_property_value not in color_cycle_keys:
                 color_cycle = getattr(self, f'_{attribute}_color_cycle')
-                color_cycle_map[color_property_value] = transform_color(
-                    next(color_cycle)
+                color_cycle_map[color_property_value] = np.squeeze(
+                    transform_color(next(color_cycle))
                 )
+
                 setattr(self, f'{attribute}_color_cycle_map', color_cycle_map)
 
             new_colors = np.tile(

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -411,7 +411,7 @@ class Points(Layer):
             color_property = getattr(self, f'_{attribute}_color_property')
             prop_value = self._property_choices[color_property][0]
             color_cycle_map = getattr(self, f'{attribute}_color_cycle_map')
-            color_cycle_map[prop_value] = curr_color
+            color_cycle_map[prop_value] = np.squeeze(curr_color)
             setattr(self, f'{attribute}_color_cycle_map', color_cycle_map)
 
         elif color_mode == ColorMode.COLORMAP:


### PR DESCRIPTION
# Description
This PR fixes a big where adding points with a previously-unused property value when setting the face or edge color by a color cycle on a property caused an error. The error due to the color being added to the color cycle color map with the wrong shape.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References


# How has this been tested?
- [x] I added a test for adding a point with a new property and using a color cycle for face/edge color
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
