### PR TITLE
Pin napari-svg to 0.1.2

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -16,7 +16,7 @@ wrapt>=1.11.1
 psutil>=5.0
 numpydoc>=0.9.2
 napari-plugin-engine>=0.1.5
-napari-svg>=0.1.2
+napari-svg==0.1.2
 tifffile>=2020.2.16
 toolz>=0.10.0
 importlib-metadata>=1.5.0 ; python_version < '3.8'


### PR DESCRIPTION
I would like to temporarily pin napari-svg to the current version. As discussed in #1248 , we need to update `napari-svg` to reflect the changes we are making to shapes (namely dropping per-shape opacity and moving the color data from the individual shape models). It seems like the best way to do this is to pin the version of `napari-svg` for now so we can update it and then test it in #1248. See [this comment](https://github.com/napari/napari/pull/1248#issuecomment-631286707) in #1248.