### PR TITLE
support viewer annotation in magicgui

### DIFF
--- a/napari/utils/_magicgui.py
+++ b/napari/utils/_magicgui.py
@@ -9,8 +9,10 @@ end-user annotates one of their function arguments with a type hint using one
 of those custom classes, magicgui will know what to do with it.
 
 """
-from typing import Tuple, Type, Any
+from typing import Any, Tuple, Type
+
 from ..layers import Layer
+from ..viewer import Viewer
 
 try:
     from magicgui import register_type as _magictype
@@ -36,6 +38,18 @@ def register_types_with_magicgui():
 
     """
     _magictype(Layer, choices=get_layers, return_callback=show_layer_result)
+    _magictype(Viewer, choices=get_viewers)
+
+
+def get_viewers(gui, *args) -> Tuple[Viewer, ...]:
+    """Return the viewer that the magicwidget is in, or a list of all Viewers.
+    """
+    try:
+        return (gui.parent().qt_viewer.viewer,)
+    except AttributeError:
+        # until we maintain a list of instantiated viewers, this might be the
+        # only option
+        return tuple(v for v in globals().values() if isinstance(v, Viewer))
 
 
 def get_layers(gui, layer_type: Type[Layer]) -> Tuple[Layer, ...]:

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -138,3 +138,7 @@ class Viewer(ViewerModel):
     def close(self):
         """Close the viewer window."""
         self.window.close()
+
+    def __str__(self):
+        """Simple string representation"""
+        return f'napari.Viewer: {self.title}'


### PR DESCRIPTION
# Description
This registers `napari.Viewer` as a type that `magicgui` can handle, and results from discussion in https://github.com/hci-unihd/covid-if-annotations/issues/3.  If an argument is annotated as a `napari.Viewer`, then if the magicgui is docked in a viewer, it will return the current viewer, otherwise it returns a list of all global viewer instances (probably won't be used much).  It's slightly weird to show the viewer instance as the sole item in a dropdown, but combined with https://github.com/napari/magicgui/pull/17, it will make it easier to have a viewer object as a parameter in a magicgui function.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
