### PR TITLE
brighter active layer

### DIFF
--- a/napari/resources/build_icons.py
+++ b/napari/resources/build_icons.py
@@ -50,7 +50,7 @@ def themify_icons(
 
     color_lookup = color_lookup or {
         'visibility': 'text',
-        'visibility_off': 'highlight',
+        'visibility_off': 'secondary',
         'menu': 'highlight',
         'drop_down': 'secondary',
         'plus': 'secondary',

--- a/napari/resources/styles/02_custom.qss
+++ b/napari/resources/styles/02_custom.qss
@@ -184,7 +184,8 @@ QtLayerWidget > QLineEdit:disabled {
 }
 
 QtLayerWidget > QLineEdit:focus {
-  background-color: {{ primary }};
+  background-color: {{ darken(current, 20) }};
+  selection-background-color: {{ lighten(current, 20) }};
 }
 
 QtLayerWidget QCheckBox::indicator {

--- a/napari/resources/styles/02_custom.qss
+++ b/napari/resources/styles/02_custom.qss
@@ -147,7 +147,6 @@ QtDivider[selected=false] {
 
 QtLayerWidget {
   padding: 0px;
-  border: 1px solid {{ background }};
   background-color: {{ foreground }};
   border-radius: 2px;
   min-height: 32px;
@@ -157,8 +156,7 @@ QtLayerWidget {
 }
 
 QtLayerWidget[selected="true"] {
-  border: 1px solid {{ secondary }};
-  background-color: {{ highlight }};
+  background-color: {{ current }};
 }
 
 

--- a/napari/resources/styles/02_custom.qss
+++ b/napari/resources/styles/02_custom.qss
@@ -156,17 +156,63 @@ QtLayerWidget {
   max-width: 228px;
 }
 
-QtLayerWidget QCheckBox::indicator:hover {
-  background-color: {{ foreground }};
-}
-
 QtLayerWidget[selected="true"] {
   border: 1px solid {{ secondary }};
+  background-color: {{ highlight }};
 }
 
+
 QtLayerWidget > QLabel {
+  background-color: transparent;
   padding: 0px;
   qproperty-alignment: AlignCenter;
+}
+
+
+/* The name of the layer*/
+QtLayerWidget > QLineEdit {
+  background-color: transparent;
+  border: none;
+  border-radius: 2px;
+  padding: 2px;
+  font-size: 14px;
+  qproperty-alignment: right;
+}
+
+QtLayerWidget > QLineEdit:disabled {
+  background-color: transparent;
+  border-color: transparent;
+  border-radius: 3px;
+}
+
+QtLayerWidget > QLineEdit:focus {
+  background-color: {{ primary }};
+}
+
+QtLayerWidget QCheckBox::indicator {
+  background-color: transparent;
+}
+
+QtLayerWidget QCheckBox::indicator:hover {
+  background-color:  transparent;
+}
+
+QtLayerWidget > QCheckBox#visibility {
+  spacing: 0px;
+  margin: 0px 0px 0px 4px;
+}
+
+QtLayerWidget > QCheckBox#visibility::indicator{
+  width: 18px;
+  height: 18px;
+}
+
+QtLayerWidget > QCheckBox#visibility::indicator:unchecked {
+  image: url(":/themes/{{ folder }}/visibility_off.svg");
+}
+
+QtLayerWidget > QCheckBox#visibility::indicator:checked {
+  image: url(":/themes/{{ folder }}/visibility.svg");
 }
 
 
@@ -204,46 +250,6 @@ QLabel#Surface {
 
 QLabel#Vectors {
   image: url(":/themes/{{ folder }}/new_vectors.svg");
-}
-
-/* The name of the layer*/
-QtLayerWidget > QLineEdit {
-  background-color: {{ foreground }};
-  border: 1px solid {{ foreground }};
-  border-radius: 2px;
-  padding: 2px;
-  font-size: 14px;
-  qproperty-alignment: right;
-}
-
-QtLayerWidget > QLineEdit:focus {
-  border-color: {{ secondary }};
-  background-color: {{ darken(foreground, 20) }};
-}
-
-QtLayerWidget > QLineEdit:disabled {
-  background-color: {{ foreground }};
-  border-color: {{ foreground }};
-  border-radius: 3px;
-}
-
-QtLayerWidget > QCheckBox#visibility {
-  background-color: none;
-  spacing: 0px;
-  margin: 0px 0px 0px 4px;
-}
-
-QtLayerWidget > QCheckBox#visibility::indicator{
-  width: 18px;
-  height: 18px;
-}
-
-QtLayerWidget > QCheckBox#visibility::indicator:unchecked {
-  image: url(":/themes/{{ folder }}/visibility_off.svg");
-}
-
-QtLayerWidget > QCheckBox#visibility::indicator:checked {
-  image: url(":/themes/{{ folder }}/visibility.svg");
 }
 
 

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -38,7 +38,7 @@ palettes = {
         'text': 'rgb(59, 58, 57)',
         'icon': 'rgb(107, 105, 103)',
         'warning': 'rgb(255, 18, 31)',
-        'current': 'rgb(148, 240, 253)',
+        'current': 'rgb(253, 240, 148)',
         'syntax_style': 'default',
         'console': 'rgb(255, 255, 255)',
         'canvas': 'white',


### PR DESCRIPTION
# Description
as per #1283, makes the active layer pop out more (adds shading in addition to a brighter border)
<img width="239" alt="Screen Shot 2020-05-25 at 2 51 47 PM" src="https://user-images.githubusercontent.com/1609449/82838332-e6f19b80-9e99-11ea-8513-2c4132430dc7.png">


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New style


## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
