### PR TITLE
Add pyyaml dependency

### DIFF
--- a/docs/release/release_0_3_2.md
+++ b/docs/release/release_0_3_2.md
@@ -38,7 +38,7 @@ https://github.com/napari/napari
 - Add pooch to requirements/test.txt (#1249)
 - Prefer rcc binary at front of path (#1261)
 - Pin napari-svg to 0.1.2 (#1275)
-
+- Add PyYAML as dependency (#1291)
 
 ## 9 authors added to this release (alphabetical)
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -12,6 +12,7 @@ vispy>=0.6.4
 IPython>=7.7.0
 backcall>=0.1.0
 PyOpenGL>=3.1.0
+PyYAML>=5.1
 wrapt>=1.11.1
 psutil>=5.0
 numpydoc>=0.9.2


### PR DESCRIPTION
# Description
Adds pyyaml as a dependency. Needed because of dask `2.17` update - see https://github.com/dask/dask/pull/6198#issuecomment-629993387. Note choice was made to make requirement in #1183 