### PR TITLE
close bytesIO in NotebookScreenshot._repr_png_

### DIFF
--- a/docs/release/release_0_3_2.md
+++ b/docs/release/release_0_3_2.md
@@ -33,6 +33,7 @@ https://github.com/napari/napari
 - Remove dupe import (#1263)
 - Fix missing docstring `create_dask_cache` (#1266)
 - Fix adding points with new properties  (#1274)
+- Close bytesIO in `NotebookScreenshot._repr_png_` (#1295)
 
 ## Build Tools
 - Add pooch to requirements/test.txt (#1249)

--- a/napari/utils/notebook_display.py
+++ b/napari/utils/notebook_display.py
@@ -70,7 +70,7 @@ class NotebookScreenshot:
         from imageio import imsave
 
         self.image = self.viewer.screenshot(canvas_only=self.canvas_only)
-        file_obj = BytesIO()
-        imsave(file_obj, self.image, format='png')
-        file_obj.seek(0)
-        return file_obj.read()
+        with BytesIO() as file_obj:
+            imsave(file_obj, self.image, format='png')
+            file_obj.seek(0)
+            return file_obj.read()


### PR DESCRIPTION
# Description
Not 100% sure, but this may help prevent the segfault that we saw in [this test](https://cirrus-ci.com/task/6681297080811520?command=test#L967)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
