### PR TITLE
Allow add_dock_widget to accept a list of widgets

### DIFF
--- a/docs/release/release_0_3_2.md
+++ b/docs/release/release_0_3_2.md
@@ -14,6 +14,7 @@ https://github.com/napari/napari
 ## New Features
 - General multithreading API and @thread_worker decorator (#1210)
 - Rich jupyter display for napari screenshots (#1269)
+- Allow add_dock_widget to accept a list of widgets (#1296)
 
 ## Improvements
 - Make Qt component non private module (#1122)

--- a/napari/_qt/_tests/test_qt_dock_widget.py
+++ b/napari/_qt/_tests/test_qt_dock_widget.py
@@ -1,0 +1,64 @@
+import pytest
+from qtpy.QtWidgets import QDockWidget, QHBoxLayout, QPushButton, QVBoxLayout
+
+
+def test_add_dock_widget(viewer_factory):
+    """Test basic add_dock_widget functionality"""
+    view, viewer = viewer_factory()
+    widg = QPushButton('button')
+    dwidg = viewer.window.add_dock_widget(widg, name='test')
+    assert not dwidg.is_vertical
+    assert viewer.window._qt_window.findChild(QDockWidget, 'test')
+    assert dwidg.widget == widg
+    dwidg._on_visibility_changed(True)  # smoke test
+
+    widg2 = QPushButton('button')
+    dwidg2 = viewer.window.add_dock_widget(widg2, name='test2', area='right')
+    assert dwidg2.is_vertical
+    assert viewer.window._qt_window.findChild(QDockWidget, 'test2')
+    assert dwidg2.widget == widg2
+    dwidg2._on_visibility_changed(True)  # smoke test
+
+    with pytest.raises(ValueError):
+        # 'under' is not a valid area
+        viewer.window.add_dock_widget(widg2, name='test2', area='under')
+
+    with pytest.raises(ValueError):
+        # 'under' is not a valid area
+        viewer.window.add_dock_widget(
+            widg2, name='test2', allowed_areas=['under']
+        )
+
+    with pytest.raises(TypeError):
+        # allowed_areas must be a list
+        viewer.window.add_dock_widget(
+            widg2, name='test2', allowed_areas='under'
+        )
+
+
+def test_add_dock_widget_from_list(viewer_factory):
+    """Test that we can add a list of widgets and they will be combined"""
+    view, viewer = viewer_factory()
+    widg = QPushButton('button')
+    widg2 = QPushButton('button')
+
+    dwidg = viewer.window.add_dock_widget(
+        [widg, widg2], name='test', area='right'
+    )
+    assert viewer.window._qt_window.findChild(QDockWidget, 'test')
+    assert isinstance(dwidg.widget.layout, QVBoxLayout)
+
+    dwidg = viewer.window.add_dock_widget(
+        [widg, widg2], name='test2', area='bottom'
+    )
+    assert viewer.window._qt_window.findChild(QDockWidget, 'test2')
+    assert isinstance(dwidg.widget.layout, QHBoxLayout)
+
+
+def test_add_dock_widget_raises(viewer_factory):
+    """Test that the widget passed must be a DockWidget."""
+    view, viewer = viewer_factory()
+    widg = object()
+
+    with pytest.raises(TypeError):
+        viewer.window.add_dock_widget(widg, name='test')

--- a/napari/_qt/qt_viewer_dock_widget.py
+++ b/napari/_qt/qt_viewer_dock_widget.py
@@ -13,7 +13,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from .utils import qt_signals_blocked
+from .utils import combine_widgets, qt_signals_blocked
 
 
 class QtViewerDockWidget(QDockWidget):
@@ -79,7 +79,9 @@ class QtViewerDockWidget(QDockWidget):
         self.setMinimumWidth(50)
         self.setObjectName(name)
 
-        self.widget = widget
+        self.widget = combine_widgets(
+            widget, vertical=area in {'left', 'right'}
+        )
         self._features = self.features()
         self.dockLocationChanged.connect(self._set_title_orientation)
 

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -1,10 +1,10 @@
 from contextlib import contextmanager
 from functools import lru_cache
-from typing import Sequence, Type, Union
+from typing import Sequence, Union
 
 import numpy as np
 from qtpy import API_NAME
-from qtpy.QtCore import QObject, QSize, Qt, QThread
+from qtpy.QtCore import QSize, Qt
 from qtpy.QtGui import QCursor, QDrag, QImage, QPainter, QPixmap
 from qtpy.QtWidgets import (
     QGraphicsOpacityEffect,
@@ -50,86 +50,6 @@ def QImg2array(img):
     # reversed.
     arr = arr[:, :, [2, 1, 0, 3]]
     return arr
-
-
-def new_worker_qthread(
-    Worker: Type[QObject], *args, start=False, connections=None, **kwargs
-):
-    """This is a convenience method to start a worker in a Qthread
-
-    It follows the pattern described here:
-    https://www.qt.io/blog/2010/06/17/youre-doing-it-wrong
-    and
-    https://doc.qt.io/qt-5/qthread.html#details
-
-    all *args, **kwargs will be passed to the Worker class on instantiation.
-
-    Parameters
-    ----------
-    Worker : QObject
-        QObject type that implements a work() method.  The Worker should also
-        emit a finished signal when the work is done.
-    start : bool
-        If True, worker will be started immediately, otherwise, you must
-        manually start the worker.
-    connections: dict, optional
-        Optional dictionary of {signal: function} to connect to the new worker.
-        for instance:  connections = {'incremented': myfunc} will result in:
-        worker.incremented.connect(myfunc)
-
-    Examples
-    --------
-    Create some QObject that has a long-running work method:
-
-    >>> class Worker(QObject):
-    ...
-    ...     finished = Signal()
-    ...     increment = Signal(int)
-    ...
-    ...     def __init__(self, argument):
-    ...         super().__init__()
-    ...         self.argument = argument
-    ...
-    ...     @Slot()
-    ...     def work(self):
-    ...         # some long running task...
-    ...         import time
-    ...         for i in range(10):
-    ...             time.sleep(1)
-    ...             self.increment.emit(i)
-    ...         self.finished.emit()
-    ...
-    >>> worker, thread = new_worker_qthread(
-    ...     Worker,
-    ...     'argument',
-    ...     start=True,
-    ...     connections={'increment': print},
-    ... )
-
-
-
-    >>> print([i for i in example_generator(4)])
-    [0, 1, 2, 3]
-
-    """
-
-    if not isinstance(connections, (dict, type(None))):
-        raise TypeError('connections parameter must be a dict')
-
-    thread = QThread()
-    worker = Worker(*args, **kwargs)
-    worker.moveToThread(thread)
-    thread.started.connect(worker.work)
-    worker.finished.connect(thread.quit)
-    worker.finished.connect(worker.deleteLater)
-    thread.finished.connect(thread.deleteLater)
-
-    if connections:
-        [getattr(worker, key).connect(val) for key, val in connections.items()]
-
-    if start:
-        thread.start()  # sometimes need to connect stuff before starting
-    return worker, thread
 
 
 @contextmanager

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -1,11 +1,20 @@
 from contextlib import contextmanager
 from functools import lru_cache
+from typing import Sequence, Type, Union
 
 import numpy as np
 from qtpy import API_NAME
-from qtpy.QtCore import QSize, Qt
+from qtpy.QtCore import QObject, QSize, Qt, QThread
 from qtpy.QtGui import QCursor, QDrag, QImage, QPainter, QPixmap
-from qtpy.QtWidgets import QGraphicsOpacityEffect, QListWidget
+from qtpy.QtWidgets import (
+    QGraphicsOpacityEffect,
+    QHBoxLayout,
+    QListWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..utils.misc import is_sequence
 
 
 def QImg2array(img):
@@ -41,6 +50,86 @@ def QImg2array(img):
     # reversed.
     arr = arr[:, :, [2, 1, 0, 3]]
     return arr
+
+
+def new_worker_qthread(
+    Worker: Type[QObject], *args, start=False, connections=None, **kwargs
+):
+    """This is a convenience method to start a worker in a Qthread
+
+    It follows the pattern described here:
+    https://www.qt.io/blog/2010/06/17/youre-doing-it-wrong
+    and
+    https://doc.qt.io/qt-5/qthread.html#details
+
+    all *args, **kwargs will be passed to the Worker class on instantiation.
+
+    Parameters
+    ----------
+    Worker : QObject
+        QObject type that implements a work() method.  The Worker should also
+        emit a finished signal when the work is done.
+    start : bool
+        If True, worker will be started immediately, otherwise, you must
+        manually start the worker.
+    connections: dict, optional
+        Optional dictionary of {signal: function} to connect to the new worker.
+        for instance:  connections = {'incremented': myfunc} will result in:
+        worker.incremented.connect(myfunc)
+
+    Examples
+    --------
+    Create some QObject that has a long-running work method:
+
+    >>> class Worker(QObject):
+    ...
+    ...     finished = Signal()
+    ...     increment = Signal(int)
+    ...
+    ...     def __init__(self, argument):
+    ...         super().__init__()
+    ...         self.argument = argument
+    ...
+    ...     @Slot()
+    ...     def work(self):
+    ...         # some long running task...
+    ...         import time
+    ...         for i in range(10):
+    ...             time.sleep(1)
+    ...             self.increment.emit(i)
+    ...         self.finished.emit()
+    ...
+    >>> worker, thread = new_worker_qthread(
+    ...     Worker,
+    ...     'argument',
+    ...     start=True,
+    ...     connections={'increment': print},
+    ... )
+
+
+
+    >>> print([i for i in example_generator(4)])
+    [0, 1, 2, 3]
+
+    """
+
+    if not isinstance(connections, (dict, type(None))):
+        raise TypeError('connections parameter must be a dict')
+
+    thread = QThread()
+    worker = Worker(*args, **kwargs)
+    worker.moveToThread(thread)
+    thread.started.connect(worker.work)
+    worker.finished.connect(thread.quit)
+    worker.finished.connect(worker.deleteLater)
+    thread.finished.connect(thread.deleteLater)
+
+    if connections:
+        [getattr(worker, key).connect(val) for key, val in connections.items()]
+
+    if start:
+        thread.start()  # sometimes need to connect stuff before starting
+    return worker, thread
 
 
 @contextmanager
@@ -115,3 +204,42 @@ def drag_with_pixmap(list_widget: QListWidget) -> QDrag:
     drag.setPixmap(pixmap)
     drag.setHotSpot(list_widget.viewport().mapFromGlobal(QCursor.pos()))
     return drag
+
+
+def combine_widgets(
+    widgets: Union[QWidget, Sequence[QWidget]], vertical: bool = False
+) -> QWidget:
+    """Combine a list of widgets into a single QWidget with Layout.
+
+    Parameters
+    ----------
+    widgets : QWidget or sequence of QWidget
+        A widget or a list of widgets to combine.
+    vertical : bool, optional
+        Whether the layout should be QVBoxLayout or not, by default
+        QHBoxLayout is used
+
+    Returns
+    -------
+    QWidget
+        If ``widgets`` is a sequence, returns combined QWidget with `.layout`
+        property, otherwise returns the original widget.
+
+    Raises
+    ------
+    TypeError
+        If ``widgets`` is neither a ``QWidget`` or a sequence of ``QWidgets``.
+    """
+    if isinstance(widgets, QWidget):
+        return widgets
+    elif is_sequence(widgets) and all(isinstance(i, QWidget) for i in widgets):
+        container = QWidget()
+        container.layout = QVBoxLayout() if vertical else QHBoxLayout()
+        container.setLayout(container.layout)
+        for widget in widgets:
+            container.layout.addWidget(widget)
+        if vertical:
+            container.layout.addStretch()
+        return container
+    else:
+        raise TypeError('"widget" must be a QWidget or a sequence of QWidgets')

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -12,6 +12,7 @@ from qtpy.QtWidgets import (
     QListWidget,
     QVBoxLayout,
     QWidget,
+    QSizePolicy,
 )
 
 from ..utils.misc import is_sequence
@@ -158,7 +159,12 @@ def combine_widgets(
         container.setLayout(container.layout)
         for widget in widgets:
             container.layout.addWidget(widget)
-        if vertical:
+        # if this is a vertical layout, and none of the widgets declare a size
+        # policy of "expanding", add our own stretch.
+        if vertical and not any(
+            w.sizePolicy().verticalPolicy() == QSizePolicy.Expanding
+            for w in widgets
+        ):
             container.layout.addStretch()
         return container
     else:


### PR DESCRIPTION
# Description
as discussed in https://github.com/hci-unihd/covid-if-annotations/issues/3, it would be nice for `add_dock_widget` to accept a list/tuple of widgets, and combine them into a single dock widget, rather than having to add multiple individual widgets.  This PR does that, using a QHBoxLayout if it's on the bottom or top, and QVBoxLayout if it's on the left or right.  Also adds "stretch" at the bottom of the layout if it's a vertical layout, so the widgets aren't so spread aprt.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] new tests add, some of which cover previous dock_widget functionality
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
