### PR TITLE
exit context before return on _repr_png

### DIFF
--- a/napari/utils/notebook_display.py
+++ b/napari/utils/notebook_display.py
@@ -73,4 +73,5 @@ class NotebookScreenshot:
         with BytesIO() as file_obj:
             imsave(file_obj, self.image, format='png')
             file_obj.seek(0)
-            return file_obj.read()
+            png = file_obj.read()
+        return png


### PR DESCRIPTION
# Description
lets try this fix for the notebook tests... exiting the context before returning.

I also think something funny is going on with cirrus today.  i tried to test this on my branch and after an hour, it still was hanging.
