### PR TITLE
make window public

### DIFF
--- a/napari/qt/__init__.py
+++ b/napari/qt/__init__.py
@@ -1,3 +1,4 @@
+from .._qt.qt_main_window import Window
 from .._qt.qt_viewer import QtViewer
 from .._qt.qt_viewer_buttons import QtNDisplayButton, QtViewerButtons
 from .threading import create_worker, thread_worker
@@ -8,4 +9,5 @@ __all__ = (
     'QtViewer',
     'QtViewerButtons',
     'thread_worker',
+    'Window',
 )


### PR DESCRIPTION
# Description
as per https://github.com/napari/napari/pull/1122#issuecomment-635058811, adds `qt_main_window.Window` to the public qt module, so it appears in the docs