### PR TITLE
Use correct pyqt version in tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -79,8 +79,8 @@ linux_task:
     - codecov
 
   test_pyqt5_script:
-    - pip uninstall -y pyside2
-    - pip install pyqt5
+    - python -m pip uninstall -y pyside2
+    - python -m pip install -e .[pyqt5]
     - pytest -v
 
 


### PR DESCRIPTION
# Description
small fix to make sure we're testing the pinned version of pyqt5 on cirrus.
see fail in https://github.com/napari/napari/runs/734105957