### PR TITLE
fixes warning for python 3.8

### DIFF
--- a/napari/_qt/layers/qt_image_base_layer.py
+++ b/napari/_qt/layers/qt_image_base_layer.py
@@ -187,7 +187,7 @@ class QtBaseImageControls(QtLayerControls):
             Event from the Qt context, by default None.
         """
         with qt_signals_blocked(self.gammaSlider):
-            self.gammaSlider.setValue(self.layer.gamma * 100)
+            self.gammaSlider.setValue(int(self.layer.gamma * 100))
 
     def mouseMoveEvent(self, event):
         self.layer.status = self.layer._contrast_limits_msg

--- a/napari/_qt/layers/qt_image_layer.py
+++ b/napari/_qt/layers/qt_image_layer.py
@@ -69,7 +69,7 @@ class QtImageControls(QtBaseImageControls):
         sld.setMinimum(0)
         sld.setMaximum(100)
         sld.setSingleStep(1)
-        sld.setValue(self.layer.iso_threshold * 100)
+        sld.setValue(int(self.layer.iso_threshold * 100))
         sld.valueChanged.connect(self.changeIsoThreshold)
         self.isoThresholdSlider = sld
         self.isoThresholdLabel = QLabel('iso threshold:')
@@ -79,7 +79,7 @@ class QtImageControls(QtBaseImageControls):
         sld.setMinimum(0)
         sld.setMaximum(200)
         sld.setSingleStep(1)
-        sld.setValue(self.layer.attenuation * 100)
+        sld.setValue(int(self.layer.attenuation * 100))
         sld.valueChanged.connect(self.changeAttenuation)
         self.attenuationSlider = sld
         self.attenuationLabel = QLabel('attenuation:')

--- a/napari/_qt/qt_dims.py
+++ b/napari/_qt/qt_dims.py
@@ -272,7 +272,7 @@ class QtDims(QWidget):
         self.layout().removeWidget(slider_widget)
         slider_widget.deleteLater()
         nsliders = np.sum(self._displayed_sliders)
-        self.setMinimumHeight(nsliders * self.SLIDERHEIGHT)
+        self.setMinimumHeight(int(nsliders * self.SLIDERHEIGHT))
         self.last_used = None
 
     def focus_up(self):

--- a/napari/_qt/qt_dims_slider.py
+++ b/napari/_qt/qt_dims_slider.py
@@ -124,10 +124,10 @@ class QtDimSliderWidget(QWidget):
 
         slider = ModifiedScrollBar(Qt.Horizontal)
         slider.setFocusPolicy(Qt.NoFocus)
-        slider.setMinimum(_range[0])
-        slider.setMaximum(_range[1])
-        slider.setSingleStep(_range[2])
-        slider.setPageStep(_range[2])
+        slider.setMinimum(int(_range[0]))
+        slider.setMaximum(int(_range[1]))
+        slider.setSingleStep(int(_range[2]))
+        slider.setPageStep(int(_range[2]))
         slider.setValue(point)
 
         # Listener to be used for sending events back to model:
@@ -198,10 +198,10 @@ class QtDimSliderWidget(QWidget):
                     displayed_sliders[self.axis] = True
                     self.last_used = self.axis
                     self.show()
-                self.slider.setMinimum(_range[0])
-                self.slider.setMaximum(_range[1])
-                self.slider.setSingleStep(_range[2])
-                self.slider.setPageStep(_range[2])
+                self.slider.setMinimum(int(_range[0]))
+                self.slider.setMaximum(int(_range[1]))
+                self.slider.setSingleStep(int(_range[2]))
+                self.slider.setPageStep(int(_range[2]))
                 maxi = self.dims.max_indices[self.axis]
                 self.totslice_label.setText(str(int(maxi)))
                 self.totslice_label.setAlignment(Qt.AlignLeft)
@@ -214,7 +214,7 @@ class QtDimSliderWidget(QWidget):
         """Update dimension slider."""
         mode = self.dims.mode[self.axis]
         if mode == DimsMode.POINT:
-            self.slider.setValue(self.dims.point[self.axis])
+            self.slider.setValue(int(self.dims.point[self.axis]))
             self._update_slice_labels()
 
     def _update_slice_labels(self):

--- a/napari/_qt/qt_viewer_buttons.py
+++ b/napari/_qt/qt_viewer_buttons.py
@@ -261,7 +261,7 @@ class QtGridViewButton(QCheckBox):
             Event from the Qt context.
         """
         with self.viewer.events.grid.blocker():
-            self.setChecked(np.all(self.viewer.grid_size == (1, 1)))
+            self.setChecked(bool(np.all(self.viewer.grid_size == (1, 1))))
 
 
 class QtNDisplayButton(QCheckBox):


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
Fix warning which makes fail my test for python 3.8 

https://github.com/4DNucleome/PartSeg/runs/735659437

like: 
```
   /home/runner/work/PartSeg/PartSeg/.tox/py38-PyQt5/lib/python3.8/site-packages/napari/_qt/layers/qt_image_base_layer.py:190: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
    self.gammaSlider.setValue(self.layer.gamma * 100)
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

Add explicit type conversion 

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality

