### PR TITLE
Issue 716: allow using of custom color dict in labelling layer

### DIFF
--- a/examples/add_labels_with_properties.py
+++ b/examples/add_labels_with_properties.py
@@ -43,7 +43,12 @@ with napari.gui_qt():
         'size': ['none'] + list(coin_sizes),  # background is size: none
     }
 
+    color_dict = {1: 'white', 2: 'blue', 3: 'green', 4: 'red', 5: 'yellow'}
+
     # add the labels
     label_layer = viewer.add_labels(
-        label_image, name='segmentation', properties=label_properties
+        label_image,
+        name='segmentation',
+        properties=label_properties,
+        color_dict=color_dict,
     )

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -371,7 +371,7 @@ class QtLabelsControls(QtLayerControls):
             self.preserveLabelsCheckBox.setChecked(self.layer.preserve_labels)
 
     def _on_custom_color_check_box_change(self, event=None):
-        """Receive layer model preserve_labels event and update the checkbox.
+        """Receive layer model enable custom color event and update the checkbox.
 
         Parameters
         ----------

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -73,6 +73,9 @@ class QtLabelsControls(QtLayerControls):
         self.layer.events.preserve_labels.connect(
             self._on_preserve_labels_change
         )
+        self.layer.events.enable_custom_color_dict.connect(
+            self._on_custom_color_check_box_change
+        )
 
         # selection spinbox
         self.selectionSpinBox = QSpinBox()
@@ -158,7 +161,15 @@ class QtLabelsControls(QtLayerControls):
         button_row.setSpacing(4)
         button_row.setContentsMargins(0, 0, 0, 5)
 
+        self.customColorCheckBox = QCheckBox()
+        self.customColorCheckBox.setToolTip('enable custom color dict')
+        self.customColorCheckBox.stateChanged.connect(
+            self.change_enable_custom_color_dict
+        )
+        self._on_custom_color_check_box_change()
+
         color_layout = QHBoxLayout()
+        color_layout.addWidget(self.customColorCheckBox)
         color_layout.addWidget(QtColorBox(layer))
         color_layout.addWidget(self.selectionSpinBox)
 
@@ -288,6 +299,19 @@ class QtLabelsControls(QtLayerControls):
         else:
             self.layer.preserve_labels = False
 
+    def change_enable_custom_color_dict(self, state):
+        """Toggle enable custom color dict state of label layer.
+
+        Parameters
+        ----------
+        state : QCheckBox
+            Checkbox indicating if custom color dict is enabled in layer.
+        """
+        if state == Qt.Checked:
+            self.layer.enable_custom_color_dict = True
+        else:
+            self.layer.enable_custom_color_dict = False
+
     def _on_selection_change(self, event=None):
         """Receive layer model label selection change event and update spinbox.
 
@@ -345,6 +369,19 @@ class QtLabelsControls(QtLayerControls):
         """
         with self.layer.events.preserve_labels.blocker():
             self.preserveLabelsCheckBox.setChecked(self.layer.preserve_labels)
+
+    def _on_custom_color_check_box_change(self, event=None):
+        """Receive layer model preserve_labels event and update the checkbox.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent, optional.
+            Event from the Qt context.
+        """
+        with self.layer.events.enable_custom_color_dict.blocker():
+            self.customColorCheckBox.setChecked(
+                self.layer.enable_custom_color_dict
+            )
 
     def _on_editable_change(self, event=None):
         """Receive layer model editable change event & enable/disable buttons.

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -14,7 +14,7 @@ from qtpy.QtCore import Qt
 
 import numpy as np
 from .qt_base_layer import QtLayerControls
-from ...layers.labels._labels_constants import Mode, ColorMode
+from ...layers.labels._labels_constants import Mode, LabelColorMode
 from ..qt_mode_buttons import QtModeRadioButton, QtModePushButton
 from ..utils import disable_with_opacity
 
@@ -161,7 +161,7 @@ class QtLabelsControls(QtLayerControls):
         button_row.setContentsMargins(0, 0, 0, 5)
 
         color_mode_comboBox = QComboBox(self)
-        color_mode_comboBox.addItems(ColorMode.keys())
+        color_mode_comboBox.addItems(LabelColorMode.keys())
         index = color_mode_comboBox.findText(
             self.layer.color_mode, Qt.MatchFixedString
         )

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -415,6 +415,7 @@ class AddLayersMixin:
         blending='translucent',
         visible=True,
         multiscale=None,
+        color_dict=None,
     ) -> layers.Labels:
         """Add a labels (or segmentation) layer to the layers list.
 
@@ -484,6 +485,7 @@ class AddLayersMixin:
             blending=blending,
             visible=visible,
             multiscale=multiscale,
+            color_dict=color_dict,
         )
         self.add_layer(layer)
         return layer

--- a/napari/layers/_tests/test_serialize.py
+++ b/napari/layers/_tests/test_serialize.py
@@ -40,7 +40,7 @@ def test_attrs_arrays(Layer, data, ndim):
         elif isinstance(getattr(layer, prop), dict):
             assert np.all(
                 [
-                    np.all(value == getattr(layer, prop)[key])
+                    np.all(value == getattr(new_layer, prop)[key])
                     for key, value in getattr(layer, prop).items()
                 ]
             )

--- a/napari/layers/_tests/test_serialize.py
+++ b/napari/layers/_tests/test_serialize.py
@@ -37,5 +37,12 @@ def test_attrs_arrays(Layer, data, ndim):
                     )
                 ]
             )
+        elif isinstance(getattr(layer, prop), dict):
+            assert np.all(
+                [
+                    np.all(value == getattr(layer, prop)[key])
+                    for key, value in getattr(layer, prop).items()
+                ]
+            )
         else:
             assert np.all(getattr(layer, prop) == getattr(new_layer, prop))

--- a/napari/layers/labels/_labels_constants.py
+++ b/napari/layers/labels/_labels_constants.py
@@ -39,12 +39,12 @@ class LabelColorMode(StringEnum):
     """
     LabelColorMode: Labelling Color setting mode.
 
-    RANDOM (default) allows color to be set via a hash function with a seed.
+    AUTO (default) allows color to be set via a hash function with a seed.
 
     DIRECT allows color of each label to be set directly by a color dictionary.
     """
 
-    RANDOM = auto()
+    AUTO = auto()
     DIRECT = auto()
 
 

--- a/napari/layers/labels/_labels_constants.py
+++ b/napari/layers/labels/_labels_constants.py
@@ -35,4 +35,17 @@ class Mode(StringEnum):
     ERASE = auto()
 
 
+class ColorMode(StringEnum):
+    """
+    ColorMode: Color setting mode.
+
+    DIRECT (default mode) allows each color to be set arbitrarily
+
+    DICT allows color to be set via a color dictionary
+    """
+
+    DIRECT = auto()
+    DICT = auto()
+
+
 BACKSPACE = 'delete' if sys.platform == 'darwin' else 'backspace'

--- a/napari/layers/labels/_labels_constants.py
+++ b/napari/layers/labels/_labels_constants.py
@@ -35,17 +35,17 @@ class Mode(StringEnum):
     ERASE = auto()
 
 
-class ColorMode(StringEnum):
+class LabelColorMode(StringEnum):
     """
-    ColorMode: Color setting mode.
+    LabelColorMode: Labelling Color setting mode.
 
-    RANDOM (default mode) allows color to be set via a hash function with a seed.
+    RANDOM (default) allows color to be set via a hash function with a seed.
 
     DIRECT allows color of each label to be set directly by a color dictionary.
     """
 
+    RANDOM = auto()
     DIRECT = auto()
-    DICT = auto()
 
 
 BACKSPACE = 'delete' if sys.platform == 'darwin' else 'backspace'

--- a/napari/layers/labels/_labels_constants.py
+++ b/napari/layers/labels/_labels_constants.py
@@ -39,9 +39,9 @@ class ColorMode(StringEnum):
     """
     ColorMode: Color setting mode.
 
-    DIRECT (default mode) allows each color to be set arbitrarily
+    RANDOM (default mode) allows color to be set via a hash function with a seed.
 
-    DICT allows color to be set via a color dictionary
+    DIRECT allows color of each label to be set directly by a color dictionary.
     """
 
     DIRECT = auto()

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -263,7 +263,8 @@ def test_custom_color_dict():
     assert (layer.get_color(1) == np.array([1.0, 1.0, 1.0, 1.0])).all()
 
     # test disable custom color dict
-    layer.color_mode = 'random'
+    # should not initialize as white since we are using random.seed
+    layer.color_mode = 'auto'
     assert not (layer.get_color(1) == np.array([1.0, 1.0, 1.0, 1.0])).all()
 
 

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -263,7 +263,7 @@ def test_custom_color_dict():
     assert (layer.get_color(1) == np.array([1.0, 1.0, 1.0, 1.0])).all()
 
     # test disable custom color dict
-    layer.enable_custom_color_dict = False
+    layer.color_mode = 'direct'
     assert not (layer.get_color(1) == np.array([1.0, 1.0, 1.0, 1.0])).all()
 
 

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -251,6 +251,22 @@ def test_colormap():
     assert type(layer.colormap[1]) == Colormap
 
 
+def test_custom_color_dict():
+    """Test custom color dict."""
+    np.random.seed(0)
+    data = np.random.randint(20, size=(10, 15))
+    layer = Labels(data, color_dict={1: 'white'})
+
+    # test with custom color dict
+    assert type(layer.get_color(2)) == np.ndarray
+    assert type(layer.get_color(1)) == np.ndarray
+    assert (layer.get_color(1) == np.array([1.0, 1.0, 1.0, 1.0])).all()
+
+    # test disable custom color dict
+    layer.enable_custom_color_dict = False
+    assert not (layer.get_color(1) == np.array([1.0, 1.0, 1.0, 1.0])).all()
+
+
 def test_metadata():
     """Test setting labels metadata."""
     np.random.seed(0)
@@ -301,11 +317,9 @@ def test_selecting_label():
     data = np.random.randint(20, size=(10, 15))
     layer = Labels(data)
     assert layer.selected_label == 1
-    assert (layer._selected_color == layer.get_color(1)).all
 
     layer.selected_label = 1
     assert layer.selected_label == 1
-    assert len(layer._selected_color) == 4
 
 
 def test_label_color():

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -263,7 +263,7 @@ def test_custom_color_dict():
     assert (layer.get_color(1) == np.array([1.0, 1.0, 1.0, 1.0])).all()
 
     # test disable custom color dict
-    layer.color_mode = 'direct'
+    layer.color_mode = 'random'
     assert not (layer.get_color(1) == np.array([1.0, 1.0, 1.0, 1.0])).all()
 
 

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -317,9 +317,11 @@ def test_selecting_label():
     data = np.random.randint(20, size=(10, 15))
     layer = Labels(data)
     assert layer.selected_label == 1
+    assert (layer._selected_color == layer.get_color(1)).all
 
     layer.selected_label = 1
     assert layer.selected_label == 1
+    assert len(layer._selected_color) == 4
 
 
 def test_label_color():

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -3,7 +3,6 @@ from typing import Union, Dict
 
 import numpy as np
 from scipy import ndimage as ndi
-from vispy.color import Color, Colormap
 from ..image import Image
 from ...utils.colormaps import colormaps
 from ...utils.event import Event
@@ -140,7 +139,7 @@ class Labels(Image):
 
         self._seed = seed
         self._num_colors = num_colors
-        self.random_colormap = (
+        self._random_colormap = (
             'random',
             colormaps.label_colormap(self.num_colors),
         )
@@ -163,7 +162,7 @@ class Labels(Image):
         super().__init__(
             data,
             rgb=False,
-            colormap=self.random_colormap,
+            colormap=self._random_colormap,
             contrast_limits=[0.0, 1.0],
             interpolation='nearest',
             rendering='translucent',
@@ -367,23 +366,14 @@ class Labels(Image):
             return
 
         if enable_custom_color_dict:
-            self.custom_color = {0: 0.0}
-            colors = ['#000000'] + [
-                color_str for label, color_str in self.color_dict.items()
-            ]
-            self.custom_color_map = Colormap(colors)
-            self.colormap = self.custom_color_map
-
-            for label, color_str in self.color_dict.items():
-                color = Color(color_str)
-                for i in range(len(self.custom_color_map.colors)):
-                    if self.custom_color_map.colors[i] == color:
-                        self.custom_color[
-                            label
-                        ] = self.custom_color_map._controls[i]
+            custom_colormap, custom_color = colormaps.color_dict_to_colormap(
+                self.color_dict
+            )
+            self.colormap = custom_colormap
+            self.custom_color = custom_color
         else:
             self.custom_color = {}
-            self.colormap = self.random_colormap
+            self.colormap = self._random_colormap
 
         self._enable_custom_color_dict = enable_custom_color_dict
         self._selected_color = self.get_color(self.selected_label)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -331,6 +331,7 @@ class Labels(Image):
                 'properties': self._properties,
                 'seed': self.seed,
                 'data': self.data,
+                'color_dict': self.color_dict,
             }
         )
         return state

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -146,10 +146,6 @@ class Labels(Image):
             colormaps.label_colormap(self.num_colors),
         )
         self._color_mode = LabelColorMode.AUTO
-        self._color_dict = {
-            self._background_label: 'transparent',
-            None: 'black',
-        }
 
         if properties is None:
             self._properties = {}
@@ -360,7 +356,6 @@ class Labels(Image):
                 'seed': self.seed,
                 'data': self.data,
                 'color_dict': self.color_dict,
-                'color_mode': self.color_mode,
             }
         )
         return state
@@ -534,7 +529,7 @@ class Labels(Image):
         image : array
             Image mapped between 0 and 1 to be displayed.
         """
-        if self.color_mode == 'direct':
+        if self._color_mode == LabelColorMode.DIRECT:
             u, inv = np.unique(raw, return_inverse=True)
             image = np.array(
                 [
@@ -544,7 +539,7 @@ class Labels(Image):
                     for x in u
                 ]
             )[inv].reshape(raw.shape)
-        elif self.color_mode == 'auto':
+        elif self._color_mode == LabelColorMode.AUTO:
             image = np.where(
                 raw > 0, colormaps._low_discrepancy_image(raw, self._seed), 0
             )

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -366,13 +366,14 @@ class Labels(Image):
             return
 
         if enable_custom_color_dict:
-            custom_colormap, custom_color = colormaps.color_dict_to_colormap(
-                self.color_dict
-            )
+            (
+                custom_colormap,
+                label_color_index,
+            ) = colormaps.color_dict_to_colormap(self.color_dict)
             self.colormap = custom_colormap
-            self.custom_color = custom_color
+            self._label_color_index = label_color_index
         else:
-            self.custom_color = {}
+            self._label_color_index = {}
             self.colormap = self._random_colormap
 
         self._enable_custom_color_dict = enable_custom_color_dict
@@ -380,6 +381,7 @@ class Labels(Image):
         self.events.enable_custom_color_dict()
         self.events.colormap()
         self.events.selected_label()
+        self.refresh()
 
     @property
     def mode(self):
@@ -510,9 +512,9 @@ class Labels(Image):
             u, inv = np.unique(raw, return_inverse=True)
             image = np.array(
                 [
-                    self.custom_color[x]
-                    if x in self.custom_color
-                    else colormaps._low_discrepancy_image(x, self._seed)
+                    self._label_color_index[x]
+                    if x in self._label_color_index
+                    else self._label_color_index[None]
                     for x in u
                 ]
             )[inv].reshape(raw.shape)

--- a/napari/utils/colormaps/colormaps.py
+++ b/napari/utils/colormaps/colormaps.py
@@ -140,11 +140,8 @@ def color_dict_to_colormap(color_dict):
 
     colormap = Colormap(colors)
     label_color_index = {}
-    for label, color_str in color_dict.items():
-        color = Color(transform_color(color_str)[0])
-        for i in range(len(colormap.colors)):
-            if colormap.colors[i] == color:
-                label_color_index[label] = colormap._controls[i]
+    for i, (label, color_str) in enumerate(color_dict.items()):
+        label_color_index[label] = i / (len(colors) - 1)
     return colormap, label_color_index
 
 

--- a/napari/utils/colormaps/colormaps.py
+++ b/napari/utils/colormaps/colormaps.py
@@ -2,7 +2,13 @@ import os
 from typing import Tuple, List
 
 import numpy as np
-from vispy.color import BaseColormap, Colormap, get_colormap, get_colormaps
+from vispy.color import (
+    Color,
+    BaseColormap,
+    Colormap,
+    get_colormap,
+    get_colormaps,
+)
 
 from ...types import ValidColormapArg
 from .vendored import cm, colorconv
@@ -109,6 +115,31 @@ def _low_discrepancy_image(image, seed=0.5, margin=1 / 256):
         image_float - np.floor(image_float)
     )
     return image_out
+
+
+def color_dict_to_colormap(color_dict):
+    """
+    Generate a color map based on the given color dictionary
+    Parameters
+    ----------
+    color_dict : dict of label and color string matches
+
+    Returns
+    -------
+    colormap : Colormap with provided control colors
+    custom_color : dict of label to color control point within colormap
+    """
+    custom_color = {0: 0.0}
+    colors = ['#000000'] + [
+        color_str for label, color_str in color_dict.items()
+    ]
+    colormap = Colormap(colors)
+    for label, color_str in color_dict.items():
+        color = Color(color_str)
+        for i in range(len(colormap.colors)):
+            if colormap.colors[i] == color:
+                custom_color[label] = colormap._controls[i]
+    return colormap, custom_color
 
 
 def _low_discrepancy(dim, n, seed=0.5):

--- a/napari/utils/colormaps/colormaps.py
+++ b/napari/utils/colormaps/colormaps.py
@@ -119,6 +119,7 @@ def _low_discrepancy_image(image, seed=0.5, margin=1 / 256):
 def color_dict_to_colormap(colors):
     """
     Generate a color map based on the given color dictionary
+
     Parameters
     ----------
     colors : dict of int to array of float, shape (4)

--- a/napari/utils/colormaps/colormaps.py
+++ b/napari/utils/colormaps/colormaps.py
@@ -118,24 +118,21 @@ def _low_discrepancy_image(image, seed=0.5, margin=1 / 256):
     return image_out
 
 
-def color_dict_to_colormap(
-    color_dict, background_label=0, empty_color='black'
-):
+def color_dict_to_colormap(color_dict):
     """
     Generate a color map based on the given color dictionary
     Parameters
     ----------
-    color_dict : dict of label and color string matches
-    background_label : int of background label, default to 0
-    empty_color : str of color used as placeholder when color not present
+    color_dict : dict of int
+        Mapping between labels and color strings
 
     Returns
     -------
-    colormap : Colormap with provided control colors
-    label_color_index : dict of label to color control point within colormap
+    colormap : Colormap
+        Colormap constructed with provided control colors
+    label_color_index : dict of int
+        Mapping of Label to color control point within colormap
     """
-    color_dict[background_label] = 'transparent'
-    color_dict[None] = empty_color
     colors = [
         transform_color(color_str)[0]
         for label, color_str in color_dict.items()

--- a/napari/utils/colormaps/colormaps.py
+++ b/napari/utils/colormaps/colormaps.py
@@ -3,7 +3,6 @@ from typing import Tuple, List
 
 import numpy as np
 from vispy.color import (
-    Color,
     BaseColormap,
     Colormap,
     get_colormap,
@@ -12,7 +11,6 @@ from vispy.color import (
 
 from ...types import ValidColormapArg
 from .vendored import cm, colorconv
-from .standardize_color import transform_color
 
 _matplotlib_list_file = os.path.join(
     os.path.dirname(__file__), 'matplotlib_cmaps.txt'
@@ -118,13 +116,13 @@ def _low_discrepancy_image(image, seed=0.5, margin=1 / 256):
     return image_out
 
 
-def color_dict_to_colormap(color_dict):
+def color_dict_to_colormap(colors):
     """
     Generate a color map based on the given color dictionary
     Parameters
     ----------
-    color_dict : dict of int
-        Mapping between labels and color strings
+    colors : dict of int to array of float, shape (4)
+        Mapping between labels and color
 
     Returns
     -------
@@ -133,14 +131,10 @@ def color_dict_to_colormap(color_dict):
     label_color_index : dict of int
         Mapping of Label to color control point within colormap
     """
-    colors = [
-        transform_color(color_str)[0]
-        for label, color_str in color_dict.items()
-    ]
 
-    colormap = Colormap(colors)
+    colormap = Colormap([color for label, color in colors.items()])
     label_color_index = {}
-    for i, (label, color_str) in enumerate(color_dict.items()):
+    for i, (label, color) in enumerate(colors.items()):
         label_color_index[label] = i / (len(colors) - 1)
     return colormap, label_color_index
 


### PR DESCRIPTION
# Description
Add support for custom color dictionary and switching between a random colormap and custom colormap

## Type of change
- New feature (non-breaking change which adds functionality)

# References
https://github.com/napari/napari/issues/716

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- Added unit test to check get color behavior in both random and custom color map
- manually checked behavior when given no, one, and multiple color in dictionary

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
