### PR TITLE
Fix ranger slide position

### DIFF
--- a/napari/_qt/qt_modal.py
+++ b/napari/_qt/qt_modal.py
@@ -119,6 +119,8 @@ class QtPopup(QDialog):
         elif isinstance(position, (tuple, list)):
             assert len(position) == 4, '`position` argument must have length 4'
             left, top, width, height = position
+        else:
+            raise ValueError(f"Wrong type of position {position}")
 
         # necessary for transparent round corners
         self.resize(self.sizeHint())

--- a/napari/_qt/qt_modal.py
+++ b/napari/_qt/qt_modal.py
@@ -127,9 +127,20 @@ class QtPopup(QDialog):
         # make sure the popup is completely on the screen
         # In Qt ≥5.10 we can use screenAt to know which monitor the mouse is on
 
-        screen_geometry: QRect = QGuiApplication.screenAt(
-            QCursor.pos()
-        ).geometry()
+        if hasattr(QGuiApplication, "screenAt"):
+            screen_geometry: QRect = QGuiApplication.screenAt(
+                QCursor.pos()
+            ).geometry()
+        else:
+            from qtpy.QtWidgets import QDesktopWidget
+
+            window = self.parent().window() if self.parent() else None
+            screen_num = (
+                QDesktopWidget.screenNumber(window)
+                if window is not None
+                else 0
+            )
+            screen_geometry = QGuiApplication.screens()[screen_num].geometry()
 
         left = max(
             min(screen_geometry.right() - width, left), screen_geometry.left()

--- a/napari/_qt/qt_modal.py
+++ b/napari/_qt/qt_modal.py
@@ -135,12 +135,7 @@ class QtPopup(QDialog):
             # This widget is deprecated since Qt 5.11
             from qtpy.QtWidgets import QDesktopWidget
 
-            window = self.parent().window() if self.parent() else None
-            screen_num = (
-                QDesktopWidget.screenNumber(window)
-                if window is not None
-                else 0
-            )
+            screen_num = QDesktopWidget().screenNumber(QCursor.pos())
             screen_geometry = QGuiApplication.screens()[screen_num].geometry()
 
         left = max(

--- a/napari/_qt/qt_modal.py
+++ b/napari/_qt/qt_modal.py
@@ -132,6 +132,7 @@ class QtPopup(QDialog):
                 QCursor.pos()
             ).geometry()
         else:
+            # This widget is deprecated since Qt 5.11
             from qtpy.QtWidgets import QDesktopWidget
 
             window = self.parent().window() if self.parent() else None

--- a/napari/_qt/qt_modal.py
+++ b/napari/_qt/qt_modal.py
@@ -1,4 +1,4 @@
-from qtpy.QtCore import QPoint, Qt
+from qtpy.QtCore import QPoint, Qt, QRect
 from qtpy.QtGui import QCursor, QGuiApplication
 from qtpy.QtWidgets import QDialog, QFrame, QVBoxLayout
 
@@ -126,13 +126,17 @@ class QtPopup(QDialog):
         self.resize(self.sizeHint())
         # make sure the popup is completely on the screen
         # In Qt ≥5.10 we can use screenAt to know which monitor the mouse is on
-        if hasattr(QGuiApplication, 'screenAt'):
-            screen_size = QGuiApplication.screenAt(QCursor.pos()).size()
-        else:
-            # otherwise we just use the size of the first monitor
-            screen_size = QGuiApplication.screens()[0].size()
-        left = max(min(screen_size.width() - width, left), 0)
-        top = max(min(screen_size.height() - height, top), 0)
+
+        screen_geometry: QRect = QGuiApplication.screenAt(
+            QCursor.pos()
+        ).geometry()
+
+        left = max(
+            min(screen_geometry.right() - width, left), screen_geometry.left()
+        )
+        top = max(
+            min(screen_geometry.bottom() - height, top), screen_geometry.top()
+        )
         self.setGeometry(left, top, width, height)
         self.show()
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
This is bugfix for range slider outside main screen. 

Additional i add else clause to silence "variable may be referenced before assignment" and got better error message if wrong type argument is passed. 

Code for Qt below 5.10 was removed. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
Fixes  #1337
# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] looks good outside main screen

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
