### PR TITLE
fix deleting layers changing dims

### DIFF
--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -374,3 +374,18 @@ def test_add_layer_from_data_raises():
             {'rgb': True},  # vectors do not have an 'rgb' kwarg
             layer_type='vectors',
         )
+
+
+def test_add_delete_layers():
+    """Test adding and deleting layers with different dims."""
+    viewer = ViewerModel()
+    np.random.seed(0)
+    viewer.add_image(np.random.random((5, 5, 10, 15)))
+    assert len(viewer.layers) == 1
+    assert viewer.dims.ndim == 4
+    viewer.add_image(np.random.random((5, 6, 5, 10, 15)))
+    assert len(viewer.layers) == 2
+    assert viewer.dims.ndim == 5
+    viewer.layers.remove_selected()
+    assert len(viewer.layers) == 1
+    assert viewer.dims.ndim == 4

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -84,9 +84,9 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         self.dims.events.ndisplay.connect(self._update_layers)
         self.dims.events.order.connect(self._update_layers)
         self.dims.events.axis.connect(self._update_layers)
-        self.layers.events.changed.connect(self._on_layers_change)
         self.layers.events.changed.connect(self._update_active_layer)
         self.layers.events.changed.connect(self._update_grid)
+        self.layers.events.changed.connect(self._on_layers_change)
 
         self.keymap_providers = [self]
 


### PR DESCRIPTION
# Description
Closes #1323, where deleting layers which caused the overall dimensionality of the viewer to change caused an error. Dims needed to be updated before they were used. Test added.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
