### PR TITLE
remove pytest-timeout

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,6 +2,7 @@ pytest
 pytest-faulthandler
 pytest-qt
 pytest-ordering
+pytest-timeout<1.4.0
 pandas
 xarray
 fsspec

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,7 +2,6 @@ pytest
 pytest-faulthandler
 pytest-qt
 pytest-ordering
-pytest-timeout
 pandas
 xarray
 fsspec


### PR DESCRIPTION
hah, sorry... I just realized I actually pushed this PR 😜 ... was just looking for it in my fork and couldn't find it.  Anyway, I think that pinning pytest-timeout to <1.4.0 might fix our windows tests.  Let's see how this test does.  I don't have an explanation at this point, but I could repeat the windows failures in github actions, and they seemed to be linked to pytest-timeout (which updated 3 days ago)