### PR TITLE
Refactor all tests to hide GUI

### DIFF
--- a/docs/source/developers/CONTRIBUTING.md
+++ b/docs/source/developers/CONTRIBUTING.md
@@ -109,6 +109,14 @@ pip install -r requirements/test.txt
 pytest
 ```
 
+There are a very small number of tests (<5) that require showing GUI elements, (such
+as testing screenshots). By default, these are only run during continuous integration.
+If you'd like to include them in local tests, set the environment variable "CI":
+
+```sh
+export CI=1
+```
+
 ## Writing Tests
 
 Writing tests for new code is a critical part of keeping napari maintainable as

--- a/napari/_qt/_tests/test_qt_dims.py
+++ b/napari/_qt/_tests/test_qt_dims.py
@@ -3,10 +3,11 @@ from sys import platform
 
 import numpy as np
 import pytest
-from qtpy.QtCore import Qt
-
 from napari._qt.qt_dims import QtDims
 from napari.components import Dims
+from qtpy.QtCore import Qt
+
+from unittest.mock import patch
 
 
 def test_creating_view(qtbot):
@@ -18,7 +19,6 @@ def test_creating_view(qtbot):
     view = QtDims(dims)
 
     qtbot.addWidget(view)
-    view.show()
 
     # Check that the dims model has been appended to the dims view
     assert view.dims == dims
@@ -29,7 +29,7 @@ def test_creating_view(qtbot):
     assert np.sum(view._displayed_sliders) == view.dims.ndim - 2
     assert np.all(
         [
-            s.isVisible() == d
+            s.isVisibleTo(view) == d
             for s, d in zip(view.slider_widgets, view._displayed_sliders)
         ]
     )
@@ -43,7 +43,6 @@ def test_changing_ndim(qtbot):
     view = QtDims(Dims(ndim))
 
     qtbot.addWidget(view)
-    view.show()
 
     # Check that adding dimensions adds sliders
     view.dims.ndim = 5
@@ -51,7 +50,7 @@ def test_changing_ndim(qtbot):
     assert np.sum(view._displayed_sliders) == view.dims.ndim - 2
     assert np.all(
         [
-            s.isVisible() == d
+            s.isVisibleTo(view) == d
             for s, d in zip(view.slider_widgets, view._displayed_sliders)
         ]
     )
@@ -62,7 +61,7 @@ def test_changing_ndim(qtbot):
     assert np.sum(view._displayed_sliders) == view.dims.ndim - 2
     assert np.all(
         [
-            s.isVisible() == d
+            s.isVisibleTo(view) == d
             for s, d in zip(view.slider_widgets, view._displayed_sliders)
         ]
     )
@@ -98,13 +97,12 @@ def test_changing_display(qtbot):
     ndim = 4
     view = QtDims(Dims(ndim))
     qtbot.addWidget(view)
-    view.show()
 
     assert view.nsliders == view.dims.ndim
     assert np.sum(view._displayed_sliders) == view.dims.ndim - 2
     assert np.all(
         [
-            s.isVisible() == d
+            s.isVisibleTo(view) == d
             for s, d in zip(view.slider_widgets, view._displayed_sliders)
         ]
     )
@@ -115,7 +113,7 @@ def test_changing_display(qtbot):
     assert np.sum(view._displayed_sliders) == view.dims.ndim - 3
     assert np.all(
         [
-            s.isVisible() == d
+            s.isVisibleTo(view) == d
             for s, d in zip(view.slider_widgets, view._displayed_sliders)
         ]
     )
@@ -181,7 +179,6 @@ def test_singleton_dims(qtbot):
     dims.set_range(0, (0, 1, 1))
     view = QtDims(dims)
     qtbot.addWidget(view)
-    view.show()
 
     # Check that the dims model has been appended to the dims view
     assert view.dims == dims
@@ -191,7 +188,7 @@ def test_singleton_dims(qtbot):
     assert np.sum(view._displayed_sliders) == 1
     assert np.all(
         [
-            s.isVisible() == d
+            s.isVisibleTo(view) == d
             for s, d in zip(view.slider_widgets, view._displayed_sliders)
         ]
     )
@@ -296,9 +293,9 @@ def test_play_button(qtbot):
     qtbot.wait(200)
     assert not view.is_playing
 
-    assert not button.popup.isVisible()
-    qtbot.mouseClick(button, Qt.RightButton)
-    assert button.popup.isVisible()
+    with patch.object(button.popup, 'show_above_mouse') as mock_popup:
+        qtbot.mouseClick(button, Qt.RightButton)
+        mock_popup.assert_called_once()
 
 
 def test_slice_labels(viewer_factory):

--- a/napari/_qt/_tests/test_qt_plugin_list.py
+++ b/napari/_qt/_tests/test_qt_plugin_list.py
@@ -1,6 +1,6 @@
-from qtpy.QtCore import QTimer
 import pytest
 from napari_plugin_engine.manager import temp_path_additions
+from napari._qt.qt_plugin_table import QtPluginTable
 
 
 GOOD_PLUGIN = """
@@ -42,16 +42,10 @@ def test_qt_plugin_list(
     with temp_path_additions(entrypoint_plugin):
         test_plugin_manager.discover(entry_point='app.plugin')
         assert 'a_plugin' in test_plugin_manager.plugins
-
-        def handle_dialog():
-            assert hasattr(viewer.window, '_plugin_list')
-            table = viewer.window._plugin_list.table
-            assert table.rowCount() > 0
-            plugins = {
-                table.item(i, 0).text() for i in range(table.rowCount())
-            }
-            assert 'a_plugin' in plugins
-            viewer.window._plugin_list.close()
-
-        QTimer.singleShot(100, handle_dialog)
-        viewer.window._show_plugin_list(test_plugin_manager)
+        dialog = QtPluginTable(None, test_plugin_manager)
+        assert dialog.table.rowCount() > 0
+        plugins = {
+            dialog.table.item(i, 0).text()
+            for i in range(dialog.table.rowCount())
+        }
+        assert 'a_plugin' in plugins

--- a/napari/_qt/_tests/test_qt_range_slider.py
+++ b/napari/_qt/_tests/test_qt_range_slider.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import os
 
 from qtpy.QtCore import QPoint, Qt
 from napari._qt.qt_range_slider import QHRangeSlider, QVRangeSlider
@@ -13,7 +14,6 @@ def test_range_slider(qtbot, orientation):
     diff = abs(np.diff(range_))
     step = 1
     sld = model(initial_values=initial, data_range=range_, step_size=step)
-    sld.show()
     assert np.all([sld.value_min, sld.value_max] == (initial / diff))
 
     # test clicking parts triggers the right slider.moving
@@ -36,6 +36,13 @@ def test_range_slider(qtbot, orientation):
         qtbot.mousePress(sld, Qt.LeftButton, pos=pos, delay=50)
         assert sld.moving == 'bar'
     else:
+        # for the vertical slider, somehow the required positions are changing
+        # when the slider is not visible.  So we only test the vertical slider
+        # on CI, to minimize GUI tests locally.
+        if not os.getenv("CI"):
+            return
+
+        sld.show()
         pos = sld.rangeSliderSize() * sld.value_min + sld.handle_radius
         pos = QPoint(sld.width() / 2, pos)
         qtbot.mousePress(sld, Qt.LeftButton, pos=pos, delay=50)

--- a/napari/_qt/layers/_tests/test_qt_image_base_layer_.py
+++ b/napari/_qt/layers/_tests/test_qt_image_base_layer_.py
@@ -1,16 +1,15 @@
-import os
-from sys import platform
+from unittest.mock import patch
 
 import numpy as np
 import pytest
-from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QPushButton
-
 from napari._qt.layers.qt_image_base_layer import (
+    QRangeSliderPopup,
     QtBaseImageControls,
     create_range_popup,
 )
 from napari.layers import Image, Surface
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QPushButton
 
 _IMAGE = np.arange(100).astype(np.uint16).reshape((10, 10))
 _SURF = (
@@ -32,16 +31,15 @@ def test_base_controls_creation(qtbot, layer):
     assert tuple(slider_clims) == original_clims
 
 
+@patch.object(QRangeSliderPopup, 'show')
 @pytest.mark.parametrize('layer', [Image(_IMAGE), Surface(_SURF)])
-def test_clim_right_click_shows_popup(qtbot, layer):
+def test_clim_right_click_shows_popup(mock_show, qtbot, layer):
     """Right clicking on the contrast limits slider should show a popup."""
     qtctrl = QtBaseImageControls(layer)
     qtbot.addWidget(qtctrl)
     qtbot.mousePress(qtctrl.contrastLimitsSlider, Qt.RightButton)
+    mock_show.assert_called_once()
     assert hasattr(qtctrl, 'clim_pop')
-    # virtualized tests on windows CI are failing on isVisible()
-    if not (os.environ.get('CI') and platform == 'win32'):
-        assert qtctrl.clim_pop.isVisible()
 
 
 @pytest.mark.parametrize('layer', [Image(_IMAGE), Surface(_SURF)])
@@ -54,8 +52,9 @@ def test_changing_model_updates_view(qtbot, layer):
     assert tuple(qtctrl.contrastLimitsSlider.values()) == new_clims
 
 
+@patch.object(QRangeSliderPopup, 'show')
 @pytest.mark.parametrize('layer', [Image(_IMAGE), Surface(_SURF)])
-def test_range_popup_clim_buttons(qtbot, layer):
+def test_range_popup_clim_buttons(mock_show, qtbot, layer):
     """The buttons in the clim_popup should adjust the contrast limits value"""
     qtctrl = QtBaseImageControls(layer)
     qtbot.addWidget(qtctrl)

--- a/napari/_qt/layers/qt_image_base_layer.py
+++ b/napari/_qt/layers/qt_image_base_layer.py
@@ -113,7 +113,8 @@ class QtBaseImageControls(QtLayerControls):
             self.clim_pop.layout.addWidget(reset)
             if fullrange is not None:
                 self.clim_pop.layout.addWidget(fullrange)
-            self.clim_pop.show_at('top', min_length=650)
+            self.clim_pop.move_to('top', min_length=650)
+            self.clim_pop.show()
         else:
             return QHRangeSlider.mousePressEvent(
                 self.contrastLimitsSlider, event

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -11,8 +11,9 @@ from .qt_viewer import QtViewer
 from .qt_about import QtAbout
 from .qt_plugin_report import QtPluginErrReporter
 from .qt_plugin_sorter import QtPluginSorter
+from .qt_plugin_table import QtPluginTable
 from .qt_debug_menu import DebugMenu
-from .qt_dict_table import QtDictTable
+
 from .qt_viewer_dock_widget import QtViewerDockWidget
 from ..resources import get_stylesheet
 from ..utils import perf
@@ -21,18 +22,15 @@ from ..utils import perf
 # these module-level imports have to come after `app.use_app(API)`
 # see discussion on #638
 from qtpy.QtWidgets import (  # noqa: E402
-    QAbstractItemView,
     QApplication,
     QMainWindow,
     QWidget,
     QHBoxLayout,
-    QDialog,
     QDockWidget,
     QLabel,
     QAction,
     QShortcut,
     QStatusBar,
-    QVBoxLayout,
     QFileDialog,
 )
 from qtpy.QtCore import Qt  # noqa: E402
@@ -286,46 +284,7 @@ class Window:
 
     def _show_plugin_list(self, plugin_manager=None):
         """Show dialog with a table of installed plugins and metadata."""
-        if not plugin_manager:
-            from ..plugins import plugin_manager
-
-        dialog = QDialog(self._qt_window)
-        dialog.setMaximumHeight(800)
-        dialog.setMaximumWidth(1280)
-        layout = QVBoxLayout()
-        # maybe someday add a search bar here?
-        title = QLabel("Installed Plugins")
-        title.setObjectName("h2")
-        layout.addWidget(title)
-        # get metadata for successfully registered plugins
-        plugin_manager.discover()
-        data = plugin_manager.list_plugin_metadata()
-        data = list(filter(lambda x: x['plugin_name'] != 'builtins', data))
-        # create a table for it
-        dialog.table = QtDictTable(
-            self._qt_window,
-            data,
-            headers=[
-                'plugin_name',
-                'package',
-                'version',
-                'url',
-                'author',
-                'license',
-            ],
-            min_section_width=60,
-        )
-        dialog.table.setObjectName("pluginTable")
-        dialog.table.horizontalHeader().setObjectName("pluginTableHeader")
-        dialog.table.verticalHeader().setObjectName("pluginTableHeader")
-        dialog.table.setGridStyle(Qt.NoPen)
-        # prevent editing of table
-        dialog.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
-        layout.addWidget(dialog.table)
-        dialog.setLayout(layout)
-        dialog.setAttribute(Qt.WA_DeleteOnClose)
-        self._plugin_list = dialog
-        dialog.exec_()
+        QtPluginTable(self._qt_window).exec_()
 
     def _show_plugin_sorter(self):
         """Show dialog that allows users to sort the call order of plugins."""

--- a/napari/_qt/qt_modal.py
+++ b/napari/_qt/qt_modal.py
@@ -59,8 +59,8 @@ class QtPopup(QDialog):
         self.move(pos)
         self.show()
 
-    def show_at(self, position='top', *, win_ratio=0.9, min_length=0):
-        """Show popup at a position relative to the QMainWindow.
+    def move_to(self, position='top', *, win_ratio=0.9, min_length=0):
+        """Move popup to a position relative to the QMainWindow.
 
         Parameters
         ----------
@@ -145,7 +145,6 @@ class QtPopup(QDialog):
             min(screen_geometry.bottom() - height, top), screen_geometry.top()
         )
         self.setGeometry(left, top, width, height)
-        self.show()
 
     def keyPressEvent(self, event):
         """Close window on return, else pass event through to super class.

--- a/napari/_qt/qt_plugin_table.py
+++ b/napari/_qt/qt_plugin_table.py
@@ -1,0 +1,45 @@
+from qtpy.QtWidgets import QDialog, QVBoxLayout, QLabel, QAbstractItemView
+from .qt_dict_table import QtDictTable
+from qtpy.QtCore import Qt
+
+
+class QtPluginTable(QDialog):
+    def __init__(self, parent, plugin_manager=None):
+        super().__init__(parent)
+        if not plugin_manager:
+            from ..plugins import plugin_manager
+
+        self.setMaximumHeight(800)
+        self.setMaximumWidth(1280)
+        layout = QVBoxLayout()
+        # maybe someday add a search bar here?
+        title = QLabel("Installed Plugins")
+        title.setObjectName("h2")
+        layout.addWidget(title)
+        # get metadata for successfully registered plugins
+        plugin_manager.discover()
+        data = plugin_manager.list_plugin_metadata()
+        data = list(filter(lambda x: x['plugin_name'] != 'builtins', data))
+        # create a table for it
+        self.table = QtDictTable(
+            parent,
+            data,
+            headers=[
+                'plugin_name',
+                'package',
+                'version',
+                'url',
+                'author',
+                'license',
+            ],
+            min_section_width=60,
+        )
+        self.table.setObjectName("pluginTable")
+        self.table.horizontalHeader().setObjectName("pluginTableHeader")
+        self.table.verticalHeader().setObjectName("pluginTableHeader")
+        self.table.setGridStyle(Qt.NoPen)
+        # prevent editing of table
+        self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        layout.addWidget(self.table)
+        self.setLayout(layout)
+        self.setAttribute(Qt.WA_DeleteOnClose)

--- a/napari/_qt/qt_range_slider.py
+++ b/napari/_qt/qt_range_slider.py
@@ -374,7 +374,7 @@ class QHRangeSlider(QRangeSlider):
         painter, w, h = QPainter(self), self.width(), self.height()
 
         half_width = self.slider_width / 2 - 1
-        halfdiff = h / 2 - half_width
+        halfdiff = int(h / 2 - half_width)
 
         # Background
         painter.setPen(self.background_color)
@@ -400,13 +400,13 @@ class QHRangeSlider(QRangeSlider):
         painter.setBrush(self.handle_color)
         painter.drawEllipse(
             self.display_min - self.handle_radius,
-            h / 2 - self.handle_radius + 1,
+            int(h / 2 - self.handle_radius + 1),
             self.handle_width - 1,
             self.handle_width - 1,
         )  # left
         painter.drawEllipse(
             self.display_max - self.handle_radius,
-            h / 2 - self.handle_radius + 1,
+            int(h / 2 - self.handle_radius + 1),
             self.handle_width - 1,
             self.handle_width - 1,
         )  # right
@@ -469,7 +469,7 @@ class QVRangeSlider(QRangeSlider):
         painter, w, h = QPainter(self), self.width(), self.height()
 
         half_width = self.slider_width / 2
-        halfdiff = w / 2 - half_width
+        halfdiff = int(w / 2 - half_width)
         # Background
         painter.setPen(self.background_color)
         painter.setBrush(self.background_color)
@@ -498,13 +498,13 @@ class QVRangeSlider(QRangeSlider):
         painter.setPen(self.handle_border_color)
         painter.setBrush(self.handle_color)
         painter.drawEllipse(
-            w / 2 - self.handle_radius,
+            int(w / 2 - self.handle_radius),
             h - self.display_min - self.handle_radius,
             self.handle_width,
             self.handle_width,
         )  # upper
         painter.drawEllipse(
-            w / 2 - self.handle_radius,
+            int(w / 2 - self.handle_radius),
             h - self.display_max - self.handle_radius,
             self.handle_width,
             self.handle_width,

--- a/napari/_qt/qt_range_slider_popup.py
+++ b/napari/_qt/qt_range_slider_popup.py
@@ -71,7 +71,7 @@ class LabelEdit(QLineEdit):
 
     def update_position(self):
         """Update slider position."""
-        x = self.get_pos() - self.width() / 2
+        x = self.get_pos() - self.width() // 2
         y = self.slider.handle_radius + 12
         self.move(QPoint(x, -y) + self.slider.pos())
 

--- a/napari/_tests/test_mouse_bindings.py
+++ b/napari/_tests/test_mouse_bindings.py
@@ -6,7 +6,7 @@ def test_viewer_mouse_bindings(viewer_factory):
     """Test adding mouse bindings to the viewer
     """
     np.random.seed(0)
-    view, viewer = viewer_factory(show=True)
+    view, viewer = viewer_factory()
 
     mock_press = Mock()
     mock_drag = Mock()
@@ -76,7 +76,7 @@ def test_layer_mouse_bindings(viewer_factory):
     """Test adding mouse bindings to a layer that is selected
     """
     np.random.seed(0)
-    view, viewer = viewer_factory(show=True)
+    view, viewer = viewer_factory()
 
     layer = viewer.add_image(np.random.random((10, 20)))
     layer.selected = True
@@ -148,7 +148,7 @@ def test_unselected_layer_mouse_bindings(viewer_factory):
     """Test adding mouse bindings to a layer that is not selected
     """
     np.random.seed(0)
-    view, viewer = viewer_factory(show=True)
+    view, viewer = viewer_factory()
 
     layer = viewer.add_image(np.random.random((10, 20)))
     layer.selected = False

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 import numpy as np
@@ -34,6 +35,10 @@ def test_viewer(viewer_factory):
 
     # Run all class key bindings
     for func in viewer.class_keymap.values():
+        # skip fullscreen test locally
+        if func.__name__ == 'toggle_fullscreen' and not os.getenv("CI"):
+            continue
+
         func(viewer)
         # the `play` keybinding calls QtDims.play_dim(), which then creates a
         # new QThread. we must then run the keybinding a second time, which

--- a/napari/_vispy/_tests/test_vispy_multiscale.py
+++ b/napari/_vispy/_tests/test_vispy_multiscale.py
@@ -1,11 +1,12 @@
 import numpy as np
+import os
 import sys
 import pytest
 
 
 def test_multiscale(viewer_factory):
     """Test rendering of multiscale data."""
-    view, viewer = viewer_factory(show=True)
+    view, viewer = viewer_factory()
 
     shapes = [(4000, 3000), (2000, 1500), (1000, 750), (500, 375)]
     np.random.seed(0)
@@ -43,7 +44,7 @@ def test_multiscale(viewer_factory):
 
 def test_3D_multiscale_image(viewer_factory):
     """Test rendering of 3D multiscale image uses lowest resolution."""
-    view, viewer = viewer_factory(show=True)
+    view, viewer = viewer_factory()
 
     data = [np.random.random((128,) * 3), np.random.random((64,) * 3)]
     viewer.add_image(data)
@@ -59,7 +60,7 @@ def test_3D_multiscale_image(viewer_factory):
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('win'),
+    sys.platform.startswith('win') or not os.getenv("CI"),
     reason='Screenshot tests are not supported on napari windows CI.',
 )
 def test_multiscale_screenshot(viewer_factory):
@@ -89,7 +90,7 @@ def test_multiscale_screenshot(viewer_factory):
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('win'),
+    sys.platform.startswith('win') or not os.getenv("CI"),
     reason='Screenshot tests are not supported on napari windows CI.',
 )
 def test_multiscale_screenshot_zoomed(viewer_factory):
@@ -125,7 +126,7 @@ def test_multiscale_screenshot_zoomed(viewer_factory):
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('win'),
+    sys.platform.startswith('win') or not os.getenv("CI"),
     reason='Screenshot tests are not supported on napari windows CI.',
 )
 def test_image_screenshot_zoomed(viewer_factory):


### PR DESCRIPTION
# Description
this is how I would propose we fix #1363
most of the tests that are showing gui elements don't need to be.  So rather than move tests or introduce new keywords and conventions into our tests to run or not run those tests, I propose we try to write tests that don't need to show anything.  In all but 2 cases (screenshot tests, and the full-screen keybinding test), I was able to remove the GUI without changing what the test is covering. 
couple strategies:
- use [`isVisibleTo(parent_widget)`](https://doc.qt.io/qt-5/qwidget.html#isVisibleTo) instead of `isVisible` which prevents the need to show the parent widget to test visibility.
- for `viewer_factory` always start without `show=True` ... if `show=True` is required, take a closer look at why.
- if we're just testing to see whether `show()` has been called.  mock the show method and `assert_called_once()` ... (we can trust Qt that `show()` actually works).
- if all else fails (as in the screenshot tests), we can add `if os.getenv('CI')` to restrict those tests to CI... or use `export CI` to "opt in" to testing them locally.

(sidenote: I think if we could figure out #1109, we could also hide the screenshot tests). and the  "full-screen keybinding" test is basically just calling a Qt method, so I feel fine relegating that one to CI as well since we don't need to test an external library.


 
## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Refactor tests


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass (locally at least) with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
