### PR TITLE
Add ability to run napari script with/without gui_qt from CLI

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -170,7 +170,9 @@ def main():
                 'single positional argument may be provided'
             )
 
-        with gui_qt(startup_logo=False) as app:
+        with gui_qt(startup_logo=True) as app:
+            if hasattr(app, '_splash_widget'):
+                app._splash_widget.close()
             runpy.run_path(args.paths[0])
             if getattr(app, '_existed', False):
                 sys.exit()

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -172,7 +172,7 @@ def main():
 
         with gui_qt(startup_logo=False) as app:
             runpy.run_path(args.paths[0])
-            if getattr(app, 'existed', False):
+            if getattr(app, '_existed', False):
                 sys.exit()
     else:
         with gui_qt(startup_logo=True):

--- a/napari/_qt/event_loop.py
+++ b/napari/_qt/event_loop.py
@@ -62,6 +62,7 @@ def gui_qt(*, startup_logo=False):
             )
             splash_widget = QSplashScreen(pm)
             splash_widget.show()
+            app._splash_widget = splash_widget
     else:
         app._existed = True
     yield app

--- a/napari/_qt/event_loop.py
+++ b/napari/_qt/event_loop.py
@@ -62,6 +62,8 @@ def gui_qt(*, startup_logo=False):
             )
             splash_widget = QSplashScreen(pm)
             splash_widget.show()
+    else:
+        app.existed = True
     yield app
     # if the application already existed before this function was called,
     # there's no need to start it again.  By avoiding unnecessary calls to

--- a/napari/_qt/event_loop.py
+++ b/napari/_qt/event_loop.py
@@ -63,7 +63,7 @@ def gui_qt(*, startup_logo=False):
             splash_widget = QSplashScreen(pm)
             splash_widget.show()
     else:
-        app.existed = True
+        app._existed = True
     yield app
     # if the application already existed before this function was called,
     # there's no need to start it again.  By avoiding unnecessary calls to

--- a/napari/_tests/test_cli.py
+++ b/napari/_tests/test_cli.py
@@ -61,3 +61,21 @@ def test_cli_raises(monkeypatch):
         with pytest.raises(SystemExit) as e:
             __main__.main()
         assert str(e.value) == 'error: argument --gamma expected one argument'
+
+
+def test_cli_runscript(monkeypatch, tmp_path):
+    """Test that running napari script.py runs a script"""
+    script = tmp_path / 'test.py'
+    script.write_text('1/0')  # raise error so we can assert it ran
+
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ['napari', str(script)])
+        with pytest.raises(ZeroDivisionError):
+            __main__.main()
+
+    script.write_text('import napari; v = napari.Viewer(show=False)')
+
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ['napari', str(script)])
+        with pytest.raises(SystemExit):
+            __main__.main()


### PR DESCRIPTION
# Description
as discussed in https://github.com/napari/tutorials/issues/70 and #1333, this PR adds the ability to run a python script inside of a napari/qt event loop (regardless of whether the script contains `napari.gui_qt()`), by using `napari path/to/script.py` on the command line.

If any of the positional arguments end in .py and more than a single positional argument is used, the program exits and prints an error.

closes #1333 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
