### PR TITLE
Fix two remaining tests that try to show the viewer.

### DIFF
--- a/napari/_tests/test_napari.py
+++ b/napari/_tests/test_napari.py
@@ -23,7 +23,7 @@ def test_view_multichannel(qtbot):
     """Test adding image."""
     np.random.seed(0)
     data = np.random.random((15, 10, 5))
-    viewer = napari.view_image(data, channel_axis=-1)
+    viewer = napari.view_image(data, channel_axis=-1, show=False)
     assert len(viewer.layers) == data.shape[-1]
     for i in range(data.shape[-1]):
         assert np.all(viewer.layers[i].data == data.take(i, axis=-1))

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -84,7 +84,7 @@ def view_layer_type(layer_type, data):
     data :
         The layer data to view
     """
-    return layer2viewmethod[layer_type](data)
+    return layer2viewmethod[layer_type](data, show=False)
 
 
 def check_viewer_functioning(viewer, view=None, data=None, ndim=2):


### PR DESCRIPTION
# Description
this hides the GUI in two tests (testing the `napari.view_*` methods) that weren't caught in #1372.  

There is one remaining thing that is slightly annoying that I don't think we can do anything about:  If you tab away from the terminal right after starting `pytest`, then right at the moment when the first `qtbot` gets instantiated your current app will switch to the `python 3.x` app running the qt application.  (This is the same thing that happens when running the `%gui qt` magic in ipython ... so it's a general Qt thing, not testing specific).  You can just tab back and keep working, but just fyi...

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] refactor tests
