### PR TITLE
Add ndim as a keyword argument to shapes to support creating empty layers

### DIFF
--- a/napari/_tests/test_viewer_layer_parity.py
+++ b/napari/_tests/test_viewer_layer_parity.py
@@ -150,11 +150,8 @@ def test_signature(layer):
     )
     autogen = str(autogen)[1:-1]  # remove parentheses
 
-    try:
-        assert args == autogen
-    except AssertionError as e:
-        msg = (
-            'arguments improperly passed from convenience '
-            f'method to layer {name}'
-        )
-        raise SyntaxError(msg) from e
+    msg = (
+        'arguments improperly passed from convenience '
+        f'method to layer {name}'
+    )
+    assert args == autogen, msg

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -496,6 +496,7 @@ class AddLayersMixin:
     def add_shapes(
         self,
         data=None,
+        ndim=None,
         *,
         properties=None,
         shape_type='rectangle',
@@ -525,6 +526,9 @@ class AddLayersMixin:
             List of shape data, where each element is an (N, D) array of the
             N vertices of a shape in D dimensions. Can be an 3-dimensional
             array if each shape has the same number of vertices.
+        ndim : int
+            Number of dimensions for shapes. When data is not None, ndim must be D.
+            An empty shapes layer can be instantiated with arbitrary ndim.
         properties : dict {str: array (N,)}, DataFrame
             Properties for each shape. Each property should be an array of
             length N, where N is the number of shapes.
@@ -602,7 +606,8 @@ class AddLayersMixin:
             The newly-created shapes layer.
         """
         if data is None:
-            ndim = max(self.dims.ndim, 2)
+            if ndim is None:
+                ndim = max(self.dims.ndim, 2)
             data = np.empty((0, 0, ndim))
 
         layer = layers.Shapes(

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -496,8 +496,8 @@ class AddLayersMixin:
     def add_shapes(
         self,
         data=None,
-        ndim=None,
         *,
+        ndim=None,
         properties=None,
         shape_type='rectangle',
         edge_width=1,
@@ -612,6 +612,7 @@ class AddLayersMixin:
 
         layer = layers.Shapes(
             data=data,
+            ndim=ndim,
             properties=properties,
             shape_type=shape_type,
             edge_width=edge_width,

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -976,3 +976,30 @@ def points_in_poly(points, vertices):
     # if the number of crossings is odd then the point is inside the polygon
 
     return inside
+
+
+def get_shape_ndim(data):
+    """Checks whether data is a list of the same type of shape, one shape, or
+    a list of different shapes and returns the dimensionality of the shape/s.
+
+    Parameters
+    ----------
+    data : (N, ) list of array
+        List of shape data, where each element is an (N, D) array of the
+        N vertices of a shape in D dimensions.
+
+    Returns
+    ----------
+    ndim : int
+        Dimensionality of the shape/s in data
+    """
+    # list of all the same shapes
+    if np.array(data).ndim == 3:
+        ndim = np.array(data).shape[2]
+    # just one shape
+    elif np.array(data[0]).ndim == 1:
+        ndim = np.array(data).shape[1]
+    # list of different shapes
+    else:
+        ndim = np.array(data[0]).shape[1]
+    return ndim

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -262,8 +262,8 @@ class Shapes(Layer):
     def __init__(
         self,
         data=None,
-        ndim=None,
         *,
+        ndim=None,
         properties=None,
         shape_type='rectangle',
         edge_width=1,

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -37,7 +37,7 @@ from ._shapes_constants import (
     ColorMode,
 )
 from ._shape_list import ShapeList
-from ._shapes_utils import create_box
+from ._shapes_utils import create_box, get_shape_ndim
 from ._shapes_models import Rectangle, Ellipse, Polygon
 from ._shapes_mouse_bindings import (
     highlight,
@@ -63,6 +63,9 @@ class Shapes(Layer):
         List of shape data, where each element is an (N, D) array of the
         N vertices of a shape in D dimensions. Can be an 3-dimensional
         array if each shape has the same number of vertices.
+    ndim : int
+        Number of dimensions for shapes. When data is not None, ndim must be D.
+        An empty shapes layer can be instantiated with arbitrary ndim.
     properties : dict {str: array (N,)}, DataFrame
         Properties for each shape. Each property should be an array of length N,
         where N is the number of shapes.
@@ -259,6 +262,7 @@ class Shapes(Layer):
     def __init__(
         self,
         data=None,
+        ndim=None,
         *,
         properties=None,
         shape_type='rectangle',
@@ -281,15 +285,14 @@ class Shapes(Layer):
         visible=True,
     ):
         if data is None:
-            data = np.empty((0, 0, 2))
-        if np.array(data).ndim == 3:
-            ndim = np.array(data).shape[2]
-        elif len(data) == 0:
-            ndim = 2
-        elif np.array(data[0]).ndim == 1:
-            ndim = np.array(data).shape[1]
+            if ndim is None:
+                ndim = 2
+            data = np.empty((0, 0, ndim))
         else:
-            ndim = np.array(data[0]).shape[1]
+            data_ndim = get_shape_ndim(data)
+            if ndim is not None and ndim != data_ndim:
+                raise ValueError("Shape dimensions must be equal to ndim")
+            ndim = data_ndim
 
         super().__init__(
             data,

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -296,7 +296,7 @@ class Shapes(Layer):
 
         super().__init__(
             data,
-            ndim,
+            ndim=ndim,
             name=name,
             metadata=metadata,
             scale=scale,
@@ -1176,6 +1176,7 @@ class Shapes(Layer):
         state = self._get_base_state()
         state.update(
             {
+                'ndim': self.ndim,
                 'properties': self.properties,
                 'shape_type': self.shape_type,
                 'opacity': self.opacity,

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -478,6 +478,7 @@ def view_labels(
 def view_shapes(
     data=None,
     *,
+    ndim=None,
     properties=None,
     shape_type='rectangle',
     edge_width=1,
@@ -511,6 +512,9 @@ def view_shapes(
         List of shape data, where each element is an (N, D) array of the
         N vertices of a shape in D dimensions. Can be an 3-dimensional
         array if each shape has the same number of vertices.
+    ndim : int
+        Number of dimensions for shapes. When data is not None, ndim must be D.
+        An empty shapes layer can be instantiated with arbitrary ndim.
     properties : dict {str: array (N,)}, DataFrame
         Properties for each shape. Each property should be an array of length N,
         where N is the number of shapes.
@@ -608,6 +612,7 @@ def view_shapes(
     )
     viewer.add_shapes(
         data=data,
+        ndim=ndim,
         properties=properties,
         shape_type=shape_type,
         edge_width=edge_width,


### PR DESCRIPTION
# Description
- Add ndim keyword arg
- Move inferring ndim from data (from constructor to shapes utils)

Fixes issue #1257.

Currently it fails the serialization test. Not entirely sure why but I think it's expecting ndim to be a property, but it's simply a parameter.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
