### PR TITLE
add helpful error on multichannel IndexError

### DIFF
--- a/napari/components/_tests/test_multichannel.py
+++ b/napari/components/_tests/test_multichannel.py
@@ -183,10 +183,24 @@ def test_multichannel_dask_array():
         assert isinstance(viewer.layers[i].data, da.Array)
 
 
-def test_multichannel_error_hint():
+def test_forgot_multichannel_error_hint():
+    """Test that a helpful error is raised when channel_axis is not used."""
     viewer = ViewerModel()
     np.random.seed(0)
     data = da.random.random((15, 10, 5))
     with pytest.raises(TypeError) as e:
         viewer.add_image(data, name=['a', 'b', 'c'])
     assert "did you mean to specify a 'channel_axis'" in str(e)
+
+
+def test_multichannel_index_error_hint():
+    """Test multichannel error when arg length != n_channels."""
+    viewer = ViewerModel()
+    np.random.seed(0)
+    data = da.random.random((5, 10, 5))
+    with pytest.raises(IndexError) as e:
+        viewer.add_image(data, channel_axis=0, name=['a', 'b'])
+    assert (
+        "Requested channel_axis (0) had length 5, but the "
+        "'name' argument only provided 2 values." in str(e)
+    )

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -265,7 +265,17 @@ class AddLayersMixin:
                     ]
                 else:
                     image = np.take(data, i, axis=channel_axis)
-                i_kwargs = {k: next(v) for k, v in kwargs.items()}
+                i_kwargs = {}
+                for key, val in kwargs.items():
+                    try:
+                        i_kwargs[key] = next(val)
+                    except StopIteration:
+                        raise IndexError(
+                            "Error adding multichannel image with data shape "
+                            f"{data.shape!r}. Requested channel_axis "
+                            f"({channel_axis}) had length {n_channels}, but "
+                            f"the '{key}' argument only provided {i} values. "
+                        )
                 layer = self.add_layer(layers.Image(image, **i_kwargs))
                 layer_list.append(layer)
             return layer_list

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -272,7 +272,7 @@ class AddLayersMixin:
                     except StopIteration:
                         raise IndexError(
                             "Error adding multichannel image with data shape "
-                            f"{data.shape!r}. Requested channel_axis "
+                            f"{data.shape!r}.\nRequested channel_axis "
                             f"({channel_axis}) had length {n_channels}, but "
                             f"the '{key}' argument only provided {i} values. "
                         )


### PR DESCRIPTION
# Description
@jacksonmaxfield reported a cryptic error in  https://forum.image.sc/t/what-would-cause-a-stopiteration-on-napari/39388
The `StopIteration` error is caused when `add_image` is used with a `channel_axis` that has a length greater than the length of the iterator for one of the keyword arguments used.  This PR catches that error and provides a more interpretable error message:
```pytb
IndexError: Error adding multichannel image with data shape (1, 4, 2, 614, 614).
Requested channel_axis (3) had length 614, but the 'name' argument only provided 2 values.
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added a test to catch the case when the length of the iterator doesn't match n_channels

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
