### PR TITLE
rename mark to avoid warning on pytest ordering package

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -52,7 +52,7 @@ def test_viewer(viewer_factory):
     # Window.close() method.
 
 
-@pytest.mark.first  # provided by pytest-ordering
+@pytest.mark.run(order=1)  # provided by pytest-ordering
 def test_no_qt_loop():
     """Test informative error raised when no Qt event loop exists.
 


### PR DESCRIPTION
# Description
Fixed a warning during pytest due to mark not registered

## Type of change
<!-- Please delete options that are not relevant. -->
- Bug-fix (non-breaking change which fixes an issue)

# References
https://github.com/napari/napari/issues/1243

# How has this been tested?
- [X] all tests pass with my change

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
