### PR TITLE
Segfault with two test passes

### DIFF
--- a/napari/components/_tests/test_multichannel.py
+++ b/napari/components/_tests/test_multichannel.py
@@ -1,9 +1,12 @@
-import numpy as np
+import copy
+
 import dask.array as da
+import numpy as np
+import pytest
+
 from napari.components import ViewerModel
 from napari.utils.colormaps import colormaps, ensure_colormap_tuple
 from napari.utils.misc import ensure_sequence_of_iterables, ensure_iterable
-import pytest
 
 base_colormaps = colormaps.CYMRGB
 two_colormaps = colormaps.MAGENTA_GREEN
@@ -87,6 +90,8 @@ def test_multichannel(shape, kwargs):
     viewer = ViewerModel()
     np.random.seed(0)
     data = np.random.random(shape or (15, 10, 5))
+    # Copy because we pop, in case multiple test passes
+    kwargs = copy.deepcopy(kwargs)
     channel_axis = kwargs.pop('channel_axis', -1)
     viewer.add_image(data, channel_axis=channel_axis, **kwargs)
 

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -291,3 +291,8 @@ def irregular_images():
 @pytest.fixture
 def single_tiff():
     return [image_fetcher.fetch('data/multipage.tif')]
+
+
+@pytest.fixture(params=[0, 1], scope="session", autouse=True)
+def two_passes(request):
+    pass

--- a/napari/utils/_tests/colors_data.py
+++ b/napari/utils/_tests/colors_data.py
@@ -72,18 +72,23 @@ single_colors_as_array = [
     np.zeros((1, 4), dtype=np.float32),
 ]
 
+
+# Use lambda as factory to produce a generator, otherwise the first pass of
+# the test would consume it.
 two_color_options = [
     ['red', 'red'],
     ('green', 'red'),
     ['green', '#ff0000'],
     ['green', 'g'],
-    ('r' for r in range(2)),
+    lambda: ('r' for r in range(2)),
     ['r', 'r'],
     np.array(['r', 'r']),
     np.array([[1, 1, 1, 1], [0, GREENV, 0, 1]]),
     (None, 'green'),
     [GREENARR[0, :3], REDARR[0, :3]],
 ]
+
+
 # Some of the options below are commented out. When the bugs with
 # vispy described above are resolved, we can uncomment the lines
 # below as well.

--- a/napari/utils/_tests/test_color_to_array.py
+++ b/napari/utils/_tests/test_color_to_array.py
@@ -41,7 +41,9 @@ def test_warns_but_parses():
     "colors, true_colors", zip(two_color_options, two_colors_as_array)
 )
 def test_twod_points(colors, true_colors):
-    np.testing.assert_array_equal(true_colors, transform_color(colors))
+    # If callable it's a factory for our value.
+    expanded = colors() if callable(colors) else colors
+    np.testing.assert_array_equal(true_colors, transform_color(expanded))
 
 
 @pytest.mark.parametrize("color", invalid_colors)


### PR DESCRIPTION
# Description
This PR is for debugging. Do not merge. It shows something we want to do for #1354 that is causing a segfault there, and it causes a segfault here. So this PR is master plus just these 3 lines:

```
@pytest.fixture(params=[0, 1], scope="session", autouse=True)
def two_passes(request):
    pass
```

That means run all the tests twice and it causes a segfault.

# segfault

It segfaults in various places, one is in `pytestqt` where it calls `app.processEvents()`:
https://github.com/pytest-dev/pytest-qt/blob/master/src/pytestqt/plugin.py#L194-L200

Where _process_events() is called by pytest_runtest_call:
https://github.com/pytest-dev/pytest-qt/blob/master/src/pytestqt/plugin.py#L194-L200

Stack is:
```
  File "/Users/pbw/miniconda3/envs/new-base/lib/python3.8/site-packages/pytestqt/plugin.py", line 197 in _process_events
  File "/Users/pbw/miniconda3/envs/new-base/lib/python3.8/site-packages/pytestqt/plugin.py", line 166 in pytest_runtest_call
  File "/Users/pbw/miniconda3/envs/new-base/lib/python3.8/site-packages/pluggy/callers.py", line 203 in _multicall
  File "/Users/pbw/miniconda3/envs/new-base/lib/python3.8/site-packages/pluggy/manager.py", line 84 in <lambda>
  File "/Users/pbw/miniconda3/envs/new-base/lib/python3.8/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/Users/pbw/miniconda3/envs/new-base/lib/python3.8/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/Users/pbw/miniconda3/envs/new-base/lib/python3.8/site-packages/_pytest/runner.py", line 217 in <lambda>
```