### PR TITLE
Fix vispy volume colormap changing

### DIFF
--- a/napari/_tests/test_with_screenshots.py
+++ b/napari/_tests/test_with_screenshots.py
@@ -1,0 +1,68 @@
+import numpy as np
+import os
+import sys
+import pytest
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith('win') or not os.getenv("CI"),
+    reason='Screenshot tests are not supported on napari windows CI.',
+)
+def test_changing_image_colormap(make_test_viewer):
+    """Test changing colormap changes rendering."""
+    viewer = make_test_viewer(show=True)
+
+    data = np.ones((20, 20, 20))
+    layer = viewer.add_image(data, contrast_limits=[0, 1])
+
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    np.testing.assert_almost_equal(screenshot[center], [255, 255, 255, 255])
+
+    layer.colormap = 'red'
+    screenshot = viewer.screenshot(canvas_only=True)
+    np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
+
+    viewer.dims.ndisplay = 3
+    screenshot = viewer.screenshot(canvas_only=True)
+    np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
+
+    layer.colormap = 'blue'
+    screenshot = viewer.screenshot(canvas_only=True)
+    np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
+
+    viewer.dims.ndisplay = 2
+    screenshot = viewer.screenshot(canvas_only=True)
+    np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith('win') or not os.getenv("CI"),
+    reason='Screenshot tests are not supported on napari windows CI.',
+)
+def test_changing_image_gamma(make_test_viewer):
+    """Test changing gamma changes rendering."""
+    viewer = make_test_viewer(show=True)
+
+    data = np.ones((20, 20, 20))
+    layer = viewer.add_image(data, contrast_limits=[0, 2])
+
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    assert screenshot[center + (0,)] == 128
+
+    layer.gamma = 0.1
+    screenshot = viewer.screenshot(canvas_only=True)
+    assert screenshot[center + (0,)] > 230
+
+    viewer.dims.ndisplay = 3
+    screenshot = viewer.screenshot(canvas_only=True)
+    assert screenshot[center + (0,)] > 230
+
+    layer.gamma = 1.9
+    screenshot = viewer.screenshot(canvas_only=True)
+    assert screenshot[center + (0,)] < 80
+
+    viewer.dims.ndisplay = 2
+    screenshot = viewer.screenshot(canvas_only=True)
+    assert screenshot[center + (0,)] < 80

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -159,6 +159,13 @@ class VispyImageLayer(VispyBaseLayer):
             node_cmap = Colormap(cmap[np.linspace(0, 1, 256) ** self._gamma])
         else:
             node_cmap = cmap
+        # Following should be added to cmap setter in VisPy volume visual
+        if isinstance(self.node, VolumeNode):
+            self.node.view_program['texture2D_LUT'] = (
+                node_cmap.texture_lut()
+                if (hasattr(node_cmap, 'texture_lut'))
+                else None
+            )
         self.node.cmap = node_cmap
 
     def _on_contrast_limits_change(self, contrast_limits):
@@ -192,6 +199,11 @@ class VispyImageLayer(VispyBaseLayer):
         else:
             cmap = self._raw_cmap
         self._gamma = gamma
+        # Following should be added to cmap setter in VisPy volume visual
+        if isinstance(self.node, VolumeNode):
+            self.node.view_program['texture2D_LUT'] = (
+                cmap.texture_lut() if (hasattr(cmap, 'texture_lut')) else None
+            )
         self.node.cmap = cmap
 
     def _on_iso_threshold_change(self, iso_threshold):


### PR DESCRIPTION
# Description
This PR closes #1401 by reverting some code that was removed as part of #1376. I had thought the code was no longer needed due to the merge of https://github.com/vispy/vispy/pull/1712 in vispy, but in fact it is still needed, and the correct fix in vispy would be to insert this change into the cmap setter here https://github.com/liuyenting/vispy/blob/e9551f4880a7a6d8839be5f63b3a3552341ebfaf/vispy/visuals/volume.py#L513

