### PR TITLE
Fix vertical aligment of QLabel in QtDimSliderWidget

### DIFF
--- a/napari/_qt/qt_dims_slider.py
+++ b/napari/_qt/qt_dims_slider.py
@@ -84,6 +84,7 @@ class QtDimSliderWidget(QWidget):
         layout.addWidget(self.totslice_label)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(2)
+        layout.setAlignment(Qt.AlignVCenter)
         self.setLayout(layout)
         self.dims.events.axis_labels.connect(self._pull_label)
 

--- a/napari/resources/styles/02_custom.qss
+++ b/napari/resources/styles/02_custom.qss
@@ -384,10 +384,6 @@ QtDimSliderWidget > QLineEdit {
   border: 1px solid {{ primary }};
 }
 
-QtDimSliderWidget > QLabel {
-  padding: 2px 0 0 1px;
-}
-
 
 /* ------------ Special Dialogs ------------ */
 

--- a/napari/resources/styles/02_custom.qss
+++ b/napari/resources/styles/02_custom.qss
@@ -385,7 +385,7 @@ QtDimSliderWidget > QLineEdit {
 }
 
 QtDimSliderWidget > QLabel {
-  padding: 4px 0 0 1px;
+  padding: 2px 0 0 1px;
 }
 
 


### PR DESCRIPTION

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
QtDim slider label which inform about number of layers is shifted down

![Zrzut ekranu z 2020-07-10 00-14-55](https://user-images.githubusercontent.com/3826210/87096418-0fafd380-c243-11ea-9303-d0b6bd9f69e7.png)

This PR fix this

![Zrzut ekranu z 2020-07-10 00-15-18](https://user-images.githubusercontent.com/3826210/87096421-12122d80-c243-11ea-8431-fbe26c7372cf.png)

Need to be tested on other systems. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
