### PR TITLE
Fix adding single shape duplicating properties

### DIFF
--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -1286,3 +1286,41 @@ def test_to_labels_3D():
     labels = layer.to_labels(labels_shape=labels_shape)
     assert np.all(labels.shape == labels_shape)
     assert np.all(np.unique(labels) == [0, 1, 2, 3])
+
+
+def test_add_single_shape_consistent_properties():
+    """Test adding a single shape ensures correct number of added properties"""
+    data = [
+        np.array([[100, 200], [200, 300]]),
+        np.array([[300, 400], [400, 500]]),
+    ]
+    properties = {'index': [1, 2]}
+    layer = Shapes(
+        np.array(data), shape_type='rectangle', properties=properties
+    )
+
+    layer.add(np.array([[500, 600], [700, 800]]))
+    assert len(layer.properties['index']) == 3
+    assert layer.properties['index'][2] == 2
+
+
+def test_add_shapes_consistent_properties():
+    """Test adding multiple shapes ensures correct number of added properties"""
+    data = [
+        np.array([[100, 200], [200, 300]]),
+        np.array([[300, 400], [400, 500]]),
+    ]
+    properties = {'index': [1, 2]}
+    layer = Shapes(
+        np.array(data), shape_type='rectangle', properties=properties
+    )
+
+    layer.add(
+        [
+            np.array([[500, 600], [700, 800]]),
+            np.array([[700, 800], [800, 900]]),
+        ]
+    )
+    assert len(layer.properties['index']) == 4
+    assert layer.properties['index'][2] == 2
+    assert layer.properties['index'][3] == 2

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1365,10 +1365,11 @@ class Shapes(Layer):
         if edge_width is None:
             edge_width = self.current_edge_width
 
-        n_new_shapes = len(data)
         if np.array(data[0]).ndim == 1:
             # If a single array for a shape
             n_new_shapes = 1
+        else:
+            n_new_shapes = len(data)
 
         if edge_color is None:
             edge_color = self._get_new_shape_color(

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1366,6 +1366,9 @@ class Shapes(Layer):
             edge_width = self.current_edge_width
 
         n_new_shapes = len(data)
+        if np.array(data[0]).ndim == 1:
+            # If a single array for a shape
+            n_new_shapes = 1
 
         if edge_color is None:
             edge_color = self._get_new_shape_color(


### PR DESCRIPTION
# Description

When adding a single shape, more than one property is added to the shapes layer. We expect only one property to be added when adding a single shape.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References

closes #1414 

# How has this been tested?
- [x] added two tests, and they pass

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
