### PR TITLE
Fix viewing properties for mutliscale labels layers

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -236,6 +236,41 @@ def test_properties():
     assert layer_message.endswith('Class 12')
 
 
+def test_multiscale_properties():
+    """Test adding labels with multiscale properties."""
+    np.random.seed(0)
+    data0 = np.random.randint(20, size=(10, 15))
+    data1 = data0[::2, ::2]
+    data = [data0, data1]
+
+    layer = Labels(data)
+    assert isinstance(layer.properties, dict)
+    assert len(layer.properties) == 0
+
+    properties = {'class': ['Background'] + [f'Class {i}' for i in range(20)]}
+    label_index = {i: i for i in range(len(properties['class']))}
+    layer = Labels(data, properties=properties)
+    assert isinstance(layer.properties, dict)
+    assert layer.properties == properties
+    assert layer._label_index == label_index
+
+    current_label = layer.get_value()
+    layer_message = layer.get_message()
+    assert layer_message.endswith(f'Class {current_label - 1}')
+
+    properties = {'class': ['Background']}
+    layer = Labels(data, properties=properties)
+    layer_message = layer.get_message()
+    assert layer_message.endswith("[No Properties]")
+
+    properties = {'class': ['Background', 'Class 12'], 'index': [0, 12]}
+    label_index = {0: 0, 12: 1}
+    layer = Labels(data, properties=properties)
+    layer_message = layer.get_message()
+    assert layer._label_index == label_index
+    assert layer_message.endswith('Class 12')
+
+
 def test_colormap():
     """Test colormap."""
     np.random.seed(0)

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -254,7 +254,7 @@ def test_multiscale_properties():
     assert layer.properties == properties
     assert layer._label_index == label_index
 
-    current_label = layer.get_value()
+    current_label = layer.get_value()[1]
     layer_message = layer.get_message()
     assert layer_message.endswith(f'Class {current_label - 1}')
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -742,8 +742,12 @@ class Labels(Image):
         if self._label_index and self._properties:
             # if the cursor is not outside the image or on the background
             if self._value is not None:
-                if self._value in self._label_index:
-                    idx = self._label_index[self._value]
+                if self.multiscale:
+                    value = self._value[1]
+                else:
+                    value = self._value
+                if value in self._label_index:
+                    idx = self._label_index[value]
                     for k, v in self._properties.items():
                         if k != 'index':
                             msg += f', {k}: {v[idx]}'


### PR DESCRIPTION
# Description
Change status message to check whether image is multiscale before grabbing the label value. Fixes #1397 .

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
Added test specifically for multiscale labels layer.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have added tests that prove my fix is effective or that my feature works
