### PR TITLE
DOC: autoreformat of more docstrings.

### DIFF
--- a/napari/_qt/_tests/test_qt_layerlist.py
+++ b/napari/_qt/_tests/test_qt_layerlist.py
@@ -19,7 +19,7 @@ def check_layout_layers(layout, layers):
         LayersList to compare to
 
     Returns
-    ----------
+    -------
     match : bool
         Boolean if layout matches layers
     """
@@ -42,7 +42,7 @@ def check_layout_dividers(layout, nlayers):
         Number of layers that should be present
 
     Returns
-    ----------
+    -------
     match : bool
         Boolean if layout contains dividers in the right places
     """

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -308,10 +308,8 @@ class QtLabelsControls(QtLayerControls):
         Parameters
         ----------
         new_mode : str
-
-        AUTO (default) allows color to be set via a hash function with a seed.
-
-        DIRECT allows color of each label to be set directly by a color dictionary.
+            AUTO (default) allows color to be set via a hash function with a seed.
+            DIRECT allows color of each label to be set directly by a color dictionary.
         """
         self.layer.color_mode = new_mode
 

--- a/napari/_qt/qt_about.py
+++ b/napari/_qt/qt_about.py
@@ -78,8 +78,8 @@ class QtAbout(QDialog):
     def showAbout(qt_viewer):
         """Display the 'About napari' dialog box.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         qt_viewer : QtViewer
             QtViewer instance that the `About napari` dialog box belongs to.
         """

--- a/napari/_qt/qt_dims_slider.py
+++ b/napari/_qt/qt_dims_slider.py
@@ -234,8 +234,8 @@ class QtDimSliderWidget(QWidget):
     def fps(self, value):
         """Frames per second for animation.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         value : float
             Frames per second for animation.
         """
@@ -267,8 +267,8 @@ class QtDimSliderWidget(QWidget):
     def loop_mode(self, value):
         """Loop mode for animation.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         value : napari._qt._constants.LoopMode
             Loop mode for animation.
             Available options for the loop mode string enumeration are:
@@ -298,8 +298,8 @@ class QtDimSliderWidget(QWidget):
     def frame_range(self, value):
         """Frame range for animation, as (minimum_frame, maximum_frame).
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         value : tuple(int, int)
             Frame range as tuple/list with range (minimum_frame, maximum_frame)
         """
@@ -427,8 +427,8 @@ class QtCustomDoubleSpinBox(QDoubleSpinBox):
     def textFromValue(self, value):
         """This removes the decimal places if the float is an integer.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         value : float
             The value of this custom double spin box.
         """

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -388,8 +388,8 @@ class Window:
 
         Parameters
         ----------
-            widget : QWidget | str
-                If widget == 'all', all docked widgets will be removed.
+        widget : QWidget | str
+            If widget == 'all', all docked widgets will be removed.
         """
         if widget == 'all':
             for dw in self._qt_window.findChildren(QDockWidget):

--- a/napari/_qt/qt_range_slider_popup.py
+++ b/napari/_qt/qt_range_slider_popup.py
@@ -169,8 +169,8 @@ class QRangeSliderPopup(QtPopup):
     def _numformat(self, number):
         """Format float value to a specific number of decimal places.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         number : float
             Number value formatted to a specific number of decimal places.
         """

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -336,8 +336,8 @@ class QtViewer(QSplitter):
     def screenshot(self, path=None):
         """Take currently displayed screen and convert to an image array.
 
-        Parmeters
-        ---------
+        Parameters
+        ----------
         path : str
             Filename for saving screenshot image.
 

--- a/napari/_qt/threading.py
+++ b/napari/_qt/threading.py
@@ -129,7 +129,6 @@ class WorkerBase(QRunnable):
 
         Examples
         --------
-
         .. code-block:: python
 
             class MyWorker(WorkerBase):

--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -169,7 +169,7 @@ class VispyBaseLayer(ABC):
         """Transform cursor position from canvas space (x, y) into image space.
 
         Parameters
-        -------
+        ----------
         position : 2-tuple
             Cursor position in canvase (x, y).
 
@@ -201,7 +201,7 @@ class VispyBaseLayer(ABC):
         depends on the current pan and zoom position.
 
         Returns
-        ----------
+        -------
         corner_pixels : array
             Coordinates of top left and bottom right canvas pixel in the data.
         """

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -757,7 +757,7 @@ class AddLayersMixin:
         edge_width : float
             Width for all vectors in pixels.
         length : float
-             Multiplicative factor on projections for length of all vectors.
+            Multiplicative factor on projections for length of all vectors.
         edge_color : str
             Color of all of the vectors.
         edge_color_cycle : np.ndarray, list

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -250,7 +250,7 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         """Get shape of currently viewed dimensions.
 
         Returns
-        ----------
+        -------
         centroid : list
             List of center coordinates of scene, length 2 or 3 if displayed
             view is 2D or 3D.

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -42,8 +42,8 @@ def pytest_addoption(parser):
     placement of this conftest.py file, you must specify the napari folder (in
     the pytest command) to use this flag.
 
-    Example
-    -------
+    Examples
+    --------
     $ pytest napari --show-viewer
     """
     parser.addoption(

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -704,7 +704,7 @@ class Layer(KeymapProvider, ABC):
         """Generate a status message based on the coordinates and value
 
         Returns
-        ----------
+        -------
         msg : string
             String containing a message that can be used as a status update.
         """

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -621,7 +621,7 @@ class Image(IntensityVisualizationMixin, Layer):
         and set of indices.
 
         Returns
-        ----------
+        -------
         value : tuple
             Value of the data at the coord.
         """

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -530,7 +530,7 @@ class Labels(Image):
         pixel.
 
         Parameters
-        -------
+        ----------
         raw : array or int
             Raw integer input image.
 

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -13,15 +13,15 @@ from napari.utils.colormaps.standardize_color import transform_color
 def _make_cycled_properties(values, length):
     """Helper function to make property values
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     values :
         The values to be cycled.
     length : int
         The length of the resulting property array
 
-    Returns:
-    --------
+    Returns
+    -------
     cycled_properties : np.ndarray
         The property array comprising the cycled values.
     """

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -386,8 +386,8 @@ class Points(Layer):
     ):
         """Initialize current_{edge,face}_color when starting with empty layer.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         color : (N, 4) array or str
             The value for setting edge or face_color
         attribute : str in {'edge', 'face'}
@@ -487,7 +487,7 @@ class Points(Layer):
     def _add_point_color(self, adding: int, attribute: str):
         """Add the edge or face colors for new points.
 
-        Parameters:
+        Parameters
         ----------
         adding : int
             the number of points that were added
@@ -702,7 +702,6 @@ class Points(Layer):
     def edge_color_cycle(self) -> np.ndarray:
         """Union[list, np.ndarray] :  Color cycle for edge_color.
         Can be a list of colors defined by name, RGB or RGBA
-
         """
         return self._edge_color_cycle_values
 
@@ -1191,7 +1190,7 @@ class Points(Layer):
             List of points around which to construct the interaction box.
 
         Returns
-        ----------
+        -------
         box : np.ndarray
             4x2 array of corners of the interaction box in clockwise order
             starting in the upper-left corner.
@@ -1292,10 +1291,10 @@ class Points(Layer):
     def _view_size(self) -> np.ndarray:
         """Get the sizes of the points in view
 
-       Returns
-       -------
-       view_size : (N x D) np.ndarray
-           Array of sizes for the N points in view
+        Returns
+        -------
+        view_size : (N x D) np.ndarray
+            Array of sizes for the N points in view
         """
         if len(self._indices_view) > 0:
             # Get the point sizes and scale for ndim display
@@ -1357,7 +1356,7 @@ class Points(Layer):
             Indices to slice with.
 
         Returns
-        ----------
+        -------
         slice_indices : list
             Indices of points in the currently viewed slice.
         scale : float, (N, ) array
@@ -1392,7 +1391,7 @@ class Points(Layer):
         """Determine if points at current coordinates.
 
         Returns
-        ----------
+        -------
         selection : int or None
             Index of point that is at the current coordinate if any.
         """

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -658,7 +658,7 @@ class ShapeList:
             list of int
 
         Returns
-        ----------
+        -------
         centers :np.ndarray
             Nx2 array of centers of outline
         offsets :np.ndarray
@@ -718,7 +718,7 @@ class ShapeList:
             aligned box.
 
         Returns
-        ----------
+        -------
         shapes : list
             List of shapes that are inside the box.
         """
@@ -740,7 +740,7 @@ class ShapeList:
             Image coordinates to check if any shapes are at.
 
         Returns
-        ----------
+        -------
         shape : int | None
             Index of shape if any that is at the coordinates. Returns `None`
             if no shape is found.
@@ -774,7 +774,7 @@ class ShapeList:
             zoom_factor. Used for putting negative coordinates into the mask.
 
         Returns
-        ----------
+        -------
         masks : (N, M, P) np.ndarray
             Array where there is one binary mask of shape MxP for each of
             N shapes
@@ -810,7 +810,7 @@ class ShapeList:
             zoom_factor. Used for putting negative coordinates into the mask.
 
         Returns
-        ----------
+        -------
         labels : np.ndarray
             MxP integer array where each value is either 0 for background or an
             integer up to N for points inside the corresponding shape.
@@ -848,7 +848,7 @@ class ShapeList:
             zoom_factor. Used for putting negative coordinates into the mask.
 
         Returns
-        ----------
+        -------
         colors : (N, M, 4) array
             rgba array where each value is either 0 for background or the rgba
             value of the shape for points inside the corresponding shape.

--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -373,7 +373,7 @@ class Shape(ABC):
             zoom_factor. Used for putting negative coordinates into the mask.
 
         Returns
-        ----------
+        -------
         mask : np.ndarray
             Boolean array with `True` for points inside the shape
         """

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -158,7 +158,7 @@ def lines_intersect(p1, q1, p2, q2):
     """Determines if line segment p1q1 intersects line segment p2q2
 
     Parameters
-    -------
+    ----------
     p1 : (2,) array
         Array of first point of first line segment
     q1 : (2,) array
@@ -208,7 +208,7 @@ def on_segment(p, q, r):
     """Checks if q is on the segment from p to r
 
     Parameters
-    -------
+    ----------
     p : (2,) array
         Array of first point of segment
     q : (2,) array
@@ -238,7 +238,7 @@ def orientation(p, q, r):
     """Determines oritentation of ordered triplet (p, q, r)
 
     Parameters
-    -------
+    ----------
     p : (2,) array
         Array of first point of triplet
     q : (2,) array
@@ -262,7 +262,7 @@ def is_collinear(points):
     """Determines if a list of 2D points are collinear.
 
     Parameters
-    -------
+    ----------
     points : (N, 2) array
         Points to be tested for collinearity
 

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -13,15 +13,15 @@ from napari.utils.colormaps.standardize_color import transform_color
 def _make_cycled_properties(values, length):
     """Helper function to make property values
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     values :
         The values to be cycled.
     length : int
         The length of the resulting property array
 
-    Returns:
-    --------
+    Returns
+    -------
     cycled_properties : np.ndarray
         The property array comprising the cycled values.
     """

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -435,8 +435,8 @@ class Shapes(Layer):
     ):
         """Initialize current_{edge,face}_color when starting with empty layer.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         color : (N, 4) array or str
             The value for setting edge or face_color
         attribute : str in {'edge', 'face'}
@@ -1099,7 +1099,7 @@ class Shapes(Layer):
     def _get_new_shape_color(self, adding: int, attribute: str):
         """Get the color for the shape(s) to be added.
 
-        Parameters:
+        Parameters
         ----------
         adding : int
             the number of shapes that were added
@@ -1108,8 +1108,8 @@ class Shapes(Layer):
             The name of the attribute to set the color of.
             Should be 'edge' for edge_color_mode or 'face' for face_color_mode.
 
-        Returns:
-        --------
+        Returns
+        -------
         new_colors : (N, 4) array
             (Nx4) RGBA array of colors for the N new shapes
         """
@@ -1651,7 +1651,7 @@ class Shapes(Layer):
             construct the interaction box
 
         Returns
-        ----------
+        -------
         box : np.ndarray
             10x2 array of vertices of the interaction box. The first 8 points
             are the corners and midpoints of the box in clockwise order
@@ -1691,7 +1691,7 @@ class Shapes(Layer):
         """Find outlines of any selected or hovered shapes.
 
         Returns
-        ----------
+        -------
         vertices : None | np.ndarray
             Nx2 array of any vertices of outline or None
         triangles : None | np.ndarray
@@ -1727,7 +1727,7 @@ class Shapes(Layer):
         """Compute location of highlight vertices and box for rendering.
 
         Returns
-        ----------
+        -------
         vertices : np.ndarray
             Nx2 array of any vertices to be rendered as Markers
         face_color : str
@@ -1980,12 +1980,12 @@ class Shapes(Layer):
         """Expand shape from 2D to the full data dims.
 
         Parameters
-        --------
+        ----------
         data : array
             2D data array of shape to be expanded.
 
         Returns
-        --------
+        -------
         data_full : array
             Full D dimensional data array of the shape.
         """
@@ -2007,7 +2007,7 @@ class Shapes(Layer):
         Getting value is not supported yet for 3D meshes
 
         Returns
-        ----------
+        -------
         shape : int | None
             Index of shape if any that is at the coordinates. Returns `None`
             if no shape is found.
@@ -2331,7 +2331,7 @@ class Shapes(Layer):
             takes the max of all the vertiecs
 
         Returns
-        ----------
+        -------
         masks : np.ndarray
             Array where there is one binary mask for each shape
         """
@@ -2353,7 +2353,7 @@ class Shapes(Layer):
             specified, takes the max of all the vertiecs
 
         Returns
-        ----------
+        -------
         labels : np.ndarray
             Integer array where each value is either 0 for background or an
             integer up to N for points inside the shape at the index value - 1.

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -308,7 +308,7 @@ class Surface(IntensityVisualizationMixin, Layer):
         and set of indices.
 
         Returns
-        ----------
+        -------
         value : int, None
             Value of the data at the coord.
         """

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -8,7 +8,7 @@ def calc_data_range(data):
     """Calculate range of data values. If all values are equal return [0, 1].
 
     Parameters
-    -------
+    ----------
     data : array
         Data to calculate range of values over.
 

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -706,7 +706,7 @@ class Vectors(Layer):
         and set of indices.
 
         Returns
-        ----------
+        -------
         value : int, None
             Value of the data at the coord.
         """

--- a/napari/resources/__init__.py
+++ b/napari/resources/__init__.py
@@ -65,6 +65,7 @@ def import_resources(version: str = '', overwrite: bool = False) -> str:
         Version string, by default the resources will be written to a file that
         encodes the current napari version, as well as Qt backend and version:
         ``_qt_resources_{napari.__version__}_{API}_{QT_VERSION}.py``
+
     overwrite : bool, optional
         Whether to recompile and overwrite the resources.
         Resources will be rebuilt if any of the following are True:

--- a/napari/utils/colormaps/standardize_color.py
+++ b/napari/utils/colormaps/standardize_color.py
@@ -43,19 +43,19 @@ def transform_color(colors: Any) -> np.ndarray:
     calling this function.
 
     Parameters
-    --------
+    ----------
     colors : string and array-like.
         The color(s) to interpret and convert
 
     Returns
-    ------
+    -------
     colors : np.ndarray
         An instance of np.ndarray with a data type of float32, 4 columns in
         RGBA order and N rows, with N being the number of colors. The array
         will always be 2D even if a single color is passed.
 
     Raises
-    -----
+    ------
     ValueError, AttributeError, KeyError
         invalid inputs
     """
@@ -70,13 +70,13 @@ def _handle_str(color: str) -> np.ndarray:
     The function uses an LRU cache to enhance performance.
 
     Parameters
-    --------
+    ----------
     color : str
         A single string as an input color. Can be a color name or a
         hex representation of a color, with either 6 or 8 hex digits.
 
     Returns
-    ------
+    -------
     colorarray : np.ndarray
         1x4 array
 
@@ -105,13 +105,13 @@ def _handle_list_like(colors: Sequence) -> np.ndarray:
     Generators should first visit _handle_generator before arriving as input.
 
     Parameters
-    --------
+    ----------
     colors : Sequence
         A list-like container of colors. The colors inside should be homogeneuous
         in their representation.
 
     Returns
-    ------
+    -------
     color_array : np.ndarray
         Nx4 numpy array, with N being the length of ``colors``.
     """
@@ -242,12 +242,12 @@ def _convert_array_to_correct_format(colors: np.ndarray) -> np.ndarray:
     data type of float32.
 
     Parameters
-    --------
+    ----------
     colors : np.ndarray
         Input color array, perhaps un-normalized and without the alpha channel.
 
     Returns
-    ------
+    -------
     colors : np.ndarray
         Nx4, float32 color array with values in the range [0, 1]
     """
@@ -274,12 +274,12 @@ def _handle_str_list_like(colors: Sequence) -> np.ndarray:
     format.
 
     Parameters
-    ---------
+    ----------
     colors : list-like
         A sequence of string colors
 
     Returns
-    ------
+    -------
     color_array : np.ndarray
         Nx4, float32 color array
     """
@@ -296,12 +296,12 @@ def _handle_none(color) -> np.ndarray:
     """Converts color given as None to black.
 
     Parameters
-    --------
+    ----------
     color : NoneType
         None value given as a color
 
     Returns
-    ------
+    -------
     arr : np.ndarray
         1x4 numpy array of float32 zeros
 
@@ -351,7 +351,7 @@ def _create_hex_to_name_dict():
     'official' name.
 
     Returns
-    -----
+    -------
     hex_to_rgb : dict
         Mapping from hexadecimal RGB ('#ff0000') to name ('red').
     """
@@ -369,7 +369,7 @@ def get_color_namelist():
     function is no longer necessary.
 
     Returns
-    ------
+    -------
     color_dict : list
         A list of all valid vispy color names plus "transparent".
     """

--- a/napari/utils/event.py
+++ b/napari/utils/event.py
@@ -585,8 +585,8 @@ class EventEmitter(object):
     def blocker(self, callback=None):
         """Return an EventBlocker to be used in 'with' statements
 
-           Notes
-           -----
+        Notes
+        -----
            For example, one could do::
 
                with emitter.blocker():

--- a/napari/utils/interactions.py
+++ b/napari/utils/interactions.py
@@ -85,7 +85,7 @@ def mouse_move_callbacks(obj, event):
             print('goodbye world ;(')
 
     Parameters
-    ---------
+    ----------
     obj : ViewerModel or Layer
         Layer or Viewer object to run callbacks on
     event : Event
@@ -131,7 +131,7 @@ def mouse_release_callbacks(obj, event):
             print('goodbye world ;(')
 
     Parameters
-    ---------
+    ----------
     obj : ViewerModel or Layer
         Layer or Viewer object to run callbacks on
     event : Event

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -144,7 +144,7 @@ def magic_imread(filenames, *, use_dask=None, stack=True):
     The files are assumed to all have the same shape.
 
     Parameters
-    -------
+    ----------
     filenames : list
         List of filenames or directories to be opened.
         A list of `pathlib.Path` objects and a single filename or `Path` object
@@ -246,7 +246,7 @@ def read_zarr_dataset(path):
     """Read a zarr dataset, including an array or a group of arrays.
 
     Parameters
-    --------
+    ----------
     path : str
         Path to directory ending in '.zarr'. Path can contain either an array
         or a group of arrays in the case of multiscale data.

--- a/napari/utils/perf/_utils.py
+++ b/napari/utils/perf/_utils.py
@@ -26,8 +26,8 @@ if USE_PERFMON:
         category : str, optional
             Category for this timer.
 
-        Example
-        -------
+        Examples
+        --------
         with perf_timer("draw"):
             draw_stuff()
         """
@@ -47,8 +47,8 @@ if USE_PERFMON:
         func
             The function we are wrapping.
 
-        Example
-        -------
+        Examples
+        --------
         @perf_func
         def draw(self):
             draw_stuff()
@@ -72,8 +72,8 @@ if USE_PERFMON:
         timer_name : str
             The name to give this timer.
 
-        Example
-        -------
+        Examples
+        --------
         @perf_func_name("important draw")
         def draw(self):
             draw_stuff()


### PR DESCRIPTION
Unlike previous PR this is

1) more conservative on whitespace at start and end of docstrings,
2) does visit the full ast, and hence also fix methods.

There are a couple of manual changes where vélin had issues, and used a
custom fork of numpydoc to handle the typoes instead of failing.