### PR TITLE
Handle nested zarr path

### DIFF
--- a/napari/utils/_tests/test_io.py
+++ b/napari/utils/_tests/test_io.py
@@ -111,6 +111,13 @@ def test_single_filename(single_tiff):
     assert images.shape == (2, 15, 10)
 
 
+def test_guess_zarr_path():
+    assert io.guess_zarr_path('dataset.zarr')
+    assert io.guess_zarr_path('dataset.zarr/some/long/path')
+    assert not io.guess_zarr_path('data.tif')
+    assert not io.guess_zarr_path('no_zarr_suffix/data.png')
+
+
 @pytest.mark.skipif(not zarr_available, reason='zarr not installed')
 def test_zarr():
     image = np.random.random((10, 20, 20))

--- a/napari/utils/_tests/test_io.py
+++ b/napari/utils/_tests/test_io.py
@@ -124,6 +124,19 @@ def test_zarr():
 
 
 @pytest.mark.skipif(not zarr_available, reason='zarr not installed')
+def test_zarr_nested(tmp_path):
+    image = np.random.random((10, 20, 20))
+    image_name = 'my_image'
+    root_path = tmp_path / 'dataset.zarr'
+    grp = zarr.open(str(root_path), mode='a')
+    grp.create_dataset(image_name, data=image)
+    image_in = io.magic_imread([str(root_path / image_name)])
+    # Note: due to lazy loading, the next line needs to happen within
+    # the context manager. Alternatively, we could convert to NumPy here.
+    np.testing.assert_array_equal(image, image_in)
+
+
+@pytest.mark.skipif(not zarr_available, reason='zarr not installed')
 def test_zarr_multiscale():
     multiscale = [
         np.random.random((20, 20)),

--- a/napari/utils/_tests/test_io.py
+++ b/napari/utils/_tests/test_io.py
@@ -137,9 +137,8 @@ def test_zarr_nested(tmp_path):
     root_path = tmp_path / 'dataset.zarr'
     grp = zarr.open(str(root_path), mode='a')
     grp.create_dataset(image_name, data=image)
+
     image_in = io.magic_imread([str(root_path / image_name)])
-    # Note: due to lazy loading, the next line needs to happen within
-    # the context manager. Alternatively, we could convert to NumPy here.
     np.testing.assert_array_equal(image, image_in)
 
 

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -241,7 +241,7 @@ def magic_imread(filenames, *, use_dask=None, stack=True):
 
 
 def guess_zarr_path(path):
-    """Guess whether string path is for zarr hierarchy.
+    """Guess whether string path is part of a zarr hierarchy.
 
     Parameters
     ----------
@@ -252,6 +252,13 @@ def guess_zarr_path(path):
     -------
     bool
         Whether path is for zarr.
+
+    >>> guess_zarr_path('dataset.zarr')
+    True
+    >>> guess_zarr_path('dataset.zarr/path/to/array')
+    True
+    >>> guess_zarr_path('dataset.zarr/component.png')
+    True
     """
     return any(part.endswith(".zarr") for part in Path(path).parts)
 

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -174,9 +174,11 @@ def magic_imread(filenames, *, use_dask=None, stack=True):
     # replace folders with their contents
     filenames_expanded = []
     for filename in filenames:
-        ext = os.path.splitext(filename)[-1]
+        is_zarr_path = any(
+            part.endswith(".zarr") for part in Path(filename).parts
+        )
         # zarr files are folders, but should be read as 1 file
-        if os.path.isdir(filename) and not ext == '.zarr':
+        if os.path.isdir(filename) and not is_zarr_path:
             dir_contents = sorted(
                 glob(os.path.join(filename, '*.*')), key=_alphanumeric_key
             )
@@ -200,8 +202,10 @@ def magic_imread(filenames, *, use_dask=None, stack=True):
     images = []
     shape = None
     for filename in filenames_expanded:
-        ext = os.path.splitext(filename)[-1]
-        if ext == '.zarr':
+        is_zarr_path = any(
+            part.endswith(".zarr") for part in Path(filename).parts
+        )
+        if is_zarr_path:
             image, zarr_shape = read_zarr_dataset(filename)
             if shape is None:
                 shape = zarr_shape


### PR DESCRIPTION
# Description
Talking to @tlambert03 today, I thought this change would be pretty minimal to support more generic zarr IO in napari. It is a convention that the root directory of a zarr store ends with `.zarr`. However, arrays and groups can be nested at many levels deeper than the root. The previous `magic_imread` would only handle opening a root:

```bash
$ napari dataset.zarr # group or array
```

This PR keeps the previous behavior, but since all directories within a store are arrays or groups, the `magic_imread` now uses the same zarr logic on nested directory (group or array) which is requested in #1406. 

```bash
$ napari dataset.zarr/path/to/nested # group or array
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
This addresses some aspects of #1406, but it does not change _how_ napari loads zarr arrays and groups.

# How has this been tested?
I've added a test for a nested array.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
