### PR TITLE
Toggle image/ volume nodes on ndisplay change

### DIFF
--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -18,8 +18,9 @@ texture_dtypes = [
 
 class VispyImageLayer(VispyBaseLayer):
     def __init__(self, layer):
-        node = ImageNode(None, method='auto')
-        super().__init__(layer, node)
+        self._image_node = ImageNode(None, method='auto')
+        self._volume_node = VolumeNode(np.zeros((1, 1, 1)), clim=[0, 1])
+        super().__init__(layer, self._image_node)
 
         self.layer.events.rendering.connect(self._on_rendering_change)
         self.layer.events.interpolation.connect(self._on_interpolation_change)
@@ -39,11 +40,13 @@ class VispyImageLayer(VispyBaseLayer):
         self.node.parent = None
 
         if self.layer.dims.ndisplay == 2:
-            self.node = ImageNode(data, method='auto')
+            self.node = self._image_node
+            self.node.set_data(data)
         else:
             if data is None:
                 data = np.zeros((1, 1, 1))
-            self.node = VolumeNode(data, clim=self.layer.contrast_limits)
+            self.node = self._volume_node
+            self.node.set_data(data, clim=self.layer.contrast_limits)
 
         self.node.parent = parent
         self.reset()

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -40,13 +40,13 @@ class VispyImageLayer(VispyBaseLayer):
         self.node.parent = None
 
         if self.layer.dims.ndisplay == 2:
+            self._image_node.set_data(data)
             self.node = self._image_node
-            self.node.set_data(data)
         else:
             if data is None:
                 data = np.zeros((1, 1, 1))
+            self._volume_node.set_data(data, clim=self.layer.contrast_limits)
             self.node = self._volume_node
-            self.node.set_data(data, clim=self.layer.contrast_limits)
 
         self.node.parent = parent
         self.reset()


### PR DESCRIPTION
# Description
This PR supersedes #1404 to hopefully fix the same windows bugs it was fixing by no longer creating/ destroying vispy visuals just toggling between them when ndisplay changes.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
- closes #1404 

# How has this been tested?
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
