### PR TITLE
DOC: try to apply black to example inside docstrings.

### DIFF
--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -757,7 +757,7 @@ class AddLayersMixin:
         edge_width : float
             Width for all vectors in pixels.
         length : float
-             Multiplicative factor on projections for length of all vectors.
+            Multiplicative factor on projections for length of all vectors.
         edge_color : str
             Color of all of the vectors.
         edge_color_cycle : np.ndarray, list
@@ -982,8 +982,8 @@ class AddLayersMixin:
         >>> viewer = napari.Viewer()
         >>> data = (
         ...     np.random.random((10, 2)) * 20,
-        ...     {'face_color': 'blue'},
-        ...     'points',
+        ...     {"face_color": "blue"},
+        ...     "points",
         ... )
         >>> viewer._add_layer_from_data(*data)
 
@@ -1164,15 +1164,15 @@ def prune_kwargs(kwargs: Dict[str, Any], layer_type: str) -> Dict[str, Any]:
     Examples
     --------
     >>> test_kwargs = {
-            'scale': (0.75, 1),
-            'blending': 'additive',
-            'num_colors': 10,
-        }
-    >>> prune_kwargs(test_kwargs, 'image')
+    ...     "scale": (0.75, 1),
+    ...     "blending": "additive",
+    ...     "num_colors": 10,
+    ... }
+    >>> prune_kwargs(test_kwargs, "image")
     {'scale': (0.75, 1), 'blending': 'additive'}
 
     >>> # only labels has the ``num_colors`` argument
-    >>> prune_kwargs(test_kwargs, 'labels')
+    >>> prune_kwargs(test_kwargs, "labels")
     {'scale': (0.75, 1), 'blending': 'additive', 'num_colors': 10}
     """
     add_method = getattr(AddLayersMixin, 'add_' + layer_type, None)


### PR DESCRIPTION
This might be a bit controversial to apply on all docstrings' examples,
so, so far I ran it only a chosen file, and have to think about how to
make docstring on which to not apply black; this is mostly problematic
on example for two things:

 - One the code width black is ~100 ish, but is not aware those
   docstring are themselves indented by 4 to 8 spaces, +4 because of `>>>`
   prompts.
 - It does reformat carefully bayed out arrays.

Note that I also manually fixed one example to prepend continuations
prompt with `... ` instead of 4 spaces.

---

Your feedback on whether black in docstring is desirable (or not) and whether it should be configurable on a per file/function basis and how is appreciated.


