### PR TITLE
Preserve tests from EVH revert

### DIFF
--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -109,7 +109,14 @@ def test_grid_mode(make_test_viewer):
     # check screenshot
     screenshot = viewer.screenshot(canvas_only=True)
     # sample 6 squares of the grid and check they have right colors
-    pos = [(3, 3), (3, 2), (3, 6 / 5), (5 / 3, 3), (5 / 3, 2), (5 / 3, 6 / 5)]
+    pos = [
+        (1 / 3, 1 / 3),
+        (1 / 3, 1 / 2),
+        (1 / 3, 2 / 3),
+        (1 / 2, 1 / 3),
+        (1 / 2, 1 / 2),
+        (1 / 2, 2 / 3),
+    ]
     # BGRMYC color order
     color = [
         [0, 0, 255, 255],
@@ -120,8 +127,9 @@ def test_grid_mode(make_test_viewer):
         [0, 255, 255, 255],
     ]
     for c, p in zip(color, pos):
-        coord = tuple(np.round(np.divide(screenshot.shape[:2], p)).astype(int))
-        print(coord, screenshot.shape)
+        coord = tuple(
+            np.round(np.multiply(screenshot.shape[:2], p)).astype(int)
+        )
         np.testing.assert_almost_equal(screenshot[coord], c)
 
     # reorder layers
@@ -130,7 +138,14 @@ def test_grid_mode(make_test_viewer):
     # check screenshot
     screenshot = viewer.screenshot(canvas_only=True)
     # sample 6 squares of the grid and check they have right colors
-    pos = [(3, 3), (3, 2), (3, 6 / 5), (5 / 3, 3), (5 / 3, 2), (5 / 3, 6 / 5)]
+    pos = [
+        (1 / 3, 1 / 3),
+        (1 / 3, 1 / 2),
+        (1 / 3, 2 / 3),
+        (1 / 2, 1 / 3),
+        (1 / 2, 1 / 2),
+        (1 / 2, 2 / 3),
+    ]
     # CGRMYB color order
     color = [
         [0, 255, 255, 255],
@@ -141,8 +156,9 @@ def test_grid_mode(make_test_viewer):
         [0, 0, 255, 255],
     ]
     for c, p in zip(color, pos):
-        coord = tuple(np.round(np.divide(screenshot.shape[:2], p)).astype(int))
-        print(coord, screenshot.shape)
+        coord = tuple(
+            np.round(np.multiply(screenshot.shape[:2], p)).astype(int)
+        )
         np.testing.assert_almost_equal(screenshot[coord], c)
 
     # retun to stack view

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -1,0 +1,159 @@
+import numpy as np
+import os
+import sys
+import pytest
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith('win') or not os.getenv("CI"),
+    reason='Screenshot tests are not supported on napari windows CI.',
+)
+def test_changing_image_colormap(make_test_viewer):
+    """Test changing colormap changes rendering."""
+    viewer = make_test_viewer(show=True)
+
+    data = np.ones((20, 20, 20))
+    layer = viewer.add_image(data, contrast_limits=[0, 1])
+
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    np.testing.assert_almost_equal(screenshot[center], [255, 255, 255, 255])
+
+    layer.colormap = 'red'
+    screenshot = viewer.screenshot(canvas_only=True)
+    np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
+
+    viewer.dims.ndisplay = 3
+    screenshot = viewer.screenshot(canvas_only=True)
+    np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
+
+    layer.colormap = 'blue'
+    screenshot = viewer.screenshot(canvas_only=True)
+    np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
+
+    viewer.dims.ndisplay = 2
+    screenshot = viewer.screenshot(canvas_only=True)
+    np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith('win') or not os.getenv("CI"),
+    reason='Screenshot tests are not supported on napari windows CI.',
+)
+def test_changing_image_gamma(make_test_viewer):
+    """Test changing gamma changes rendering."""
+    viewer = make_test_viewer(show=True)
+
+    data = np.ones((20, 20, 20))
+    layer = viewer.add_image(data, contrast_limits=[0, 2])
+
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    assert screenshot[center + (0,)] == 128
+
+    layer.gamma = 0.1
+    screenshot = viewer.screenshot(canvas_only=True)
+    assert screenshot[center + (0,)] > 230
+
+    viewer.dims.ndisplay = 3
+    screenshot = viewer.screenshot(canvas_only=True)
+    assert screenshot[center + (0,)] > 230
+
+    layer.gamma = 1.9
+    screenshot = viewer.screenshot(canvas_only=True)
+    assert screenshot[center + (0,)] < 80
+
+    viewer.dims.ndisplay = 2
+    screenshot = viewer.screenshot(canvas_only=True)
+    assert screenshot[center + (0,)] < 80
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith('win') or not os.getenv("CI"),
+    reason='Screenshot tests are not supported on napari windows CI.',
+)
+def test_grid_mode(make_test_viewer):
+    """Test changing gamma changes rendering."""
+    viewer = make_test_viewer(show=True)
+
+    # Add images
+    data = np.ones((6, 15, 15))
+    viewer.add_image(data, channel_axis=0, blending='translucent')
+
+    assert np.all(viewer.grid_size == (1, 1))
+    assert viewer.grid_stride == 1
+    translations = [layer.translate_grid for layer in viewer.layers]
+    expected_translations = np.zeros((6, 2))
+    np.testing.assert_allclose(translations, expected_translations)
+
+    # check screenshot
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
+
+    # enter grid view
+    viewer.grid_view()
+    assert np.all(viewer.grid_size == (3, 3))
+    assert viewer.grid_stride == 1
+    translations = [layer.translate_grid for layer in viewer.layers]
+    expected_translations = [
+        [0, 0],
+        [0, 15],
+        [0, 30],
+        [15, 0],
+        [15, 15],
+        [15, 30],
+    ]
+    np.testing.assert_allclose(translations, expected_translations[::-1])
+
+    # check screenshot
+    screenshot = viewer.screenshot(canvas_only=True)
+    # sample 6 squares of the grid and check they have right colors
+    pos = [(3, 3), (3, 2), (3, 6 / 5), (5 / 3, 3), (5 / 3, 2), (5 / 3, 6 / 5)]
+    # BGRMYC color order
+    color = [
+        [0, 0, 255, 255],
+        [0, 255, 0, 255],
+        [255, 0, 0, 255],
+        [255, 0, 255, 255],
+        [255, 255, 0, 255],
+        [0, 255, 255, 255],
+    ]
+    for c, p in zip(color, pos):
+        coord = tuple(np.round(np.divide(screenshot.shape[:2], p)).astype(int))
+        print(coord, screenshot.shape)
+        np.testing.assert_almost_equal(screenshot[coord], c)
+
+    # reorder layers
+    viewer.layers[0, 5] = viewer.layers[5, 0]
+
+    # check screenshot
+    screenshot = viewer.screenshot(canvas_only=True)
+    # sample 6 squares of the grid and check they have right colors
+    pos = [(3, 3), (3, 2), (3, 6 / 5), (5 / 3, 3), (5 / 3, 2), (5 / 3, 6 / 5)]
+    # CGRMYB color order
+    color = [
+        [0, 255, 255, 255],
+        [0, 255, 0, 255],
+        [255, 0, 0, 255],
+        [255, 0, 255, 255],
+        [255, 255, 0, 255],
+        [0, 0, 255, 255],
+    ]
+    for c, p in zip(color, pos):
+        coord = tuple(np.round(np.divide(screenshot.shape[:2], p)).astype(int))
+        print(coord, screenshot.shape)
+        np.testing.assert_almost_equal(screenshot[coord], c)
+
+    # retun to stack view
+    viewer.stack_view()
+    assert np.all(viewer.grid_size == (1, 1))
+    assert viewer.grid_stride == 1
+    translations = [layer.translate_grid for layer in viewer.layers]
+    expected_translations = np.zeros((6, 2))
+    np.testing.assert_allclose(translations, expected_translations)
+
+    # check screenshot
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    np.testing.assert_almost_equal(screenshot[center], [0, 255, 255, 255])

--- a/napari/_vispy/_tests/test_image_rendering.py
+++ b/napari/_vispy/_tests/test_image_rendering.py
@@ -35,39 +35,3 @@ def test_image_rendering(make_test_viewer):
     # Change rendering property
     layer.rendering = 'additive'
     assert layer.rendering == 'additive'
-
-
-def test_image_rendering_not_visible(make_test_viewer):
-    """Test 3D image with different rendering."""
-    viewer = make_test_viewer()
-
-    viewer.dims.ndisplay = 3
-
-    data = np.random.random((20, 20, 20))
-    layer = viewer.add_image(data, visible=False)
-
-    assert layer.rendering == 'mip'
-
-    # Change the interpolation property
-    layer.interpolation = 'linear'
-    assert layer.interpolation == 'linear'
-
-    # Change rendering property
-    layer.rendering = 'translucent'
-    assert layer.rendering == 'translucent'
-
-    # Change rendering property
-    layer.rendering = 'attenuated_mip'
-    assert layer.rendering == 'attenuated_mip'
-    layer.attenuation = 0.2
-    assert layer.attenuation == 0.2
-
-    # Change rendering property
-    layer.rendering = 'iso'
-    assert layer.rendering == 'iso'
-    layer.iso_threshold = 0.3
-    assert layer.iso_threshold == 0.3
-
-    # Change rendering property
-    layer.rendering = 'additive'
-    assert layer.rendering == 'additive'

--- a/napari/_vispy/_tests/test_image_rendering.py
+++ b/napari/_vispy/_tests/test_image_rendering.py
@@ -5,10 +5,52 @@ def test_image_rendering(make_test_viewer):
     """Test 3D image with different rendering."""
     viewer = make_test_viewer()
 
+    viewer.dims.ndisplay = 3
+
     data = np.random.random((20, 20, 20))
     layer = viewer.add_image(data)
 
     assert layer.rendering == 'mip'
+
+    # Change the interpolation property
+    layer.interpolation = 'linear'
+    assert layer.interpolation == 'linear'
+
+    # Change rendering property
+    layer.rendering = 'translucent'
+    assert layer.rendering == 'translucent'
+
+    # Change rendering property
+    layer.rendering = 'attenuated_mip'
+    assert layer.rendering == 'attenuated_mip'
+    layer.attenuation = 0.2
+    assert layer.attenuation == 0.2
+
+    # Change rendering property
+    layer.rendering = 'iso'
+    assert layer.rendering == 'iso'
+    layer.iso_threshold = 0.3
+    assert layer.iso_threshold == 0.3
+
+    # Change rendering property
+    layer.rendering = 'additive'
+    assert layer.rendering == 'additive'
+
+
+def test_image_rendering_not_visible(make_test_viewer):
+    """Test 3D image with different rendering."""
+    viewer = make_test_viewer()
+
+    viewer.dims.ndisplay = 3
+
+    data = np.random.random((20, 20, 20))
+    layer = viewer.add_image(data, visible=False)
+
+    assert layer.rendering == 'mip'
+
+    # Change the interpolation property
+    layer.interpolation = 'linear'
+    assert layer.interpolation == 'linear'
 
     # Change rendering property
     layer.rendering = 'translucent'

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -293,25 +293,51 @@ def test_grid():
     np.random.seed(0)
     # Add image
     for i in range(6):
-        data = np.random.random((10, 15))
+        data = np.random.random((15, 15))
         viewer.add_image(data)
     assert np.all(viewer.grid_size == (1, 1))
     assert viewer.grid_stride == 1
+    translations = [layer.translate_grid for layer in viewer.layers]
+    expected_translations = np.zeros((6, 2))
+    np.testing.assert_allclose(translations, expected_translations)
 
     # enter grid view
     viewer.grid_view()
     assert np.all(viewer.grid_size == (3, 3))
     assert viewer.grid_stride == 1
+    translations = [layer.translate_grid for layer in viewer.layers]
+    expected_translations = [
+        [0, 0],
+        [0, 15],
+        [0, 30],
+        [15, 0],
+        [15, 15],
+        [15, 30],
+    ]
+    np.testing.assert_allclose(translations, expected_translations[::-1])
 
     # retun to stack view
     viewer.stack_view()
     assert np.all(viewer.grid_size == (1, 1))
     assert viewer.grid_stride == 1
+    translations = [layer.translate_grid for layer in viewer.layers]
+    expected_translations = np.zeros((6, 2))
+    np.testing.assert_allclose(translations, expected_translations)
 
     # reenter grid view
     viewer.grid_view(n_column=2, n_row=3, stride=-2)
     assert np.all(viewer.grid_size == (3, 2))
     assert viewer.grid_stride == -2
+    translations = [layer.translate_grid for layer in viewer.layers]
+    expected_translations = [
+        [0, 0],
+        [0, 0],
+        [0, 15],
+        [0, 15],
+        [15, 0],
+        [15, 0],
+    ]
+    np.testing.assert_allclose(translations, expected_translations)
 
 
 def test_add_remove_layer_dims_change():
@@ -389,3 +415,33 @@ def test_add_delete_layers():
     viewer.layers.remove_selected()
     assert len(viewer.layers) == 1
     assert viewer.dims.ndim == 4
+
+
+def test_active_layer():
+    """Test active layer is correct as layer selections change."""
+    viewer = ViewerModel()
+    np.random.seed(0)
+    # Check no active layer present
+    assert viewer.active_layer is None
+
+    # Check added layer is active
+    viewer.add_image(np.random.random((5, 5, 10, 15)))
+    assert len(viewer.layers) == 1
+    assert viewer.active_layer == viewer.layers[0]
+
+    # Check newly added layer is active
+    viewer.add_image(np.random.random((5, 6, 5, 10, 15)))
+    assert len(viewer.layers) == 2
+    assert viewer.active_layer == viewer.layers[1]
+
+    # Check no active layer after unselecting all
+    viewer.layers.unselect_all()
+    assert viewer.active_layer is None
+
+    # Check selected layer is active
+    viewer.layers[0].selected = True
+    assert viewer.active_layer == viewer.layers[0]
+
+    # Check no layer is active if both layers are selected
+    viewer.layers[1].selected = True
+    assert viewer.active_layer is None

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -601,3 +601,12 @@ def test_image_translate(translate):
     np.random.seed(0)
     data = np.random.random((10, 15))
     Image(data, translate=translate)
+
+
+def test_grid_translate():
+    np.random.seed(0)
+    data = np.random.random((10, 15))
+    layer = Image(data)
+    translate = np.array([15, 15])
+    layer.translate_grid = translate
+    np.testing.assert_allclose(layer.translate_grid, translate)


### PR DESCRIPTION
# Description
This PR preserves tests added during the EVH refactor #1376 and follow-ups. Each of these tests was added when a bug from the EVH refactor was being fixed but also pass on master now. They will prevent further bugs slipping in during refactoring in the future.

See https://github.com/napari/napari/pull/1416#pullrequestreview-446098316 for more context.

I've actually moved in here now a few tests from #1404 which is unlikely to merge and from #1412 which we closed