### PR TITLE
Fix attenuation setting

### DIFF
--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -1,0 +1,43 @@
+import numpy as np
+import os
+import sys
+import pytest
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith('win') or not os.getenv("CI"),
+    reason='Screenshot tests are not supported on napari windows CI.',
+)
+def test_changing_image_colormap(make_test_viewer):
+    """Test changing colormap changes rendering."""
+    viewer = make_test_viewer(show=True)
+
+    viewer.dims.ndisplay = 3
+
+    data = np.zeros((100, 10, 10))
+    data[-1] = 1
+
+    viewer.add_image(data, contrast_limits=[0, 1])
+    viewer.layers[0].rendering = 'mip'
+
+    # Check the max intensity projection value
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    # Note right now this value is approximately half of the expected value
+    # given contrast limits and max data value. It looks like some attenuation
+    # is happening even in mip mode.
+    assert screenshot[center + (0,)] < 150 and screenshot[center + (0,)] > 120
+
+    viewer.layers[0].rendering = 'attenuated_mip'
+    viewer.layers[0].attenuation = 0.02
+
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    # Check that rendering has been attenuated
+    assert screenshot[center + (0,)] < 60
+
+    viewer.layers[0].attenuation = 2.0
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    # Check that rendering has not been attenuated
+    assert screenshot[center + (0,)] > 200

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -10,34 +10,22 @@ import pytest
 )
 def test_changing_image_colormap(make_test_viewer):
     """Test changing colormap changes rendering."""
-    viewer = make_test_viewer(show=True)
-
-    viewer.dims.ndisplay = 3
-
     data = np.zeros((100, 10, 10))
     data[-1] = 1
 
+    viewer = make_test_viewer(show=True)
+    viewer.dims.ndisplay = 3
     viewer.add_image(data, contrast_limits=[0, 1])
-    viewer.layers[0].rendering = 'mip'
-
-    # Check the max intensity projection value
-    screenshot = viewer.screenshot(canvas_only=True)
-    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
-    # Note right now this value is approximately half of the expected value
-    # given contrast limits and max data value. It looks like some attenuation
-    # is happening even in mip mode.
-    assert screenshot[center + (0,)] < 150 and screenshot[center + (0,)] > 120
-
     viewer.layers[0].rendering = 'attenuated_mip'
-    viewer.layers[0].attenuation = 0.02
-
-    screenshot = viewer.screenshot(canvas_only=True)
-    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
-    # Check that rendering has been attenuated
-    assert screenshot[center + (0,)] < 60
 
     viewer.layers[0].attenuation = 2.0
     screenshot = viewer.screenshot(canvas_only=True)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that rendering has not been attenuated
     assert screenshot[center + (0,)] > 200
+
+    viewer.layers[0].attenuation = 0.02
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    # Check that rendering has been attenuated
+    assert screenshot[center + (0,)] < 60

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -138,6 +138,11 @@ class VispyImageLayer(VispyBaseLayer):
         elif rendering == Rendering.ATTENUATED_MIP:
             self.node.threshold = float(self.layer.attenuation)
 
+        # Fix for #1399, should be fixed in the VisPy threshold setter
+        if 'u_threshold' not in self.node.shared_program:
+            self.node.shared_program['u_threshold'] = self.node._threshold
+            self.node.update()
+
     def reset(self, event=None):
         self._reset_base()
         self._on_interpolation_change()


### PR DESCRIPTION
# Description
Fix first call to attenuation setting not triggering actual vispy update, closes #1399. Note this supersedes #1403 (which was based with on post EVH style).

This is ready for community testing cc @AdvancedImagingUTSW

I will add a unit test in the meantime.

I might also address the default value for attenuation as mentioned in #1392 (see https://github.com/napari/napari/pull/1403#pullrequestreview-445256923)

It might be nice to know from @AdvancedImagingUTSW what range of values you normally use for the attenuation parameter and what you think a good default might be.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
