### PR TITLE
Move contrast limits and gamma to the shader by vendoring vispy code

### DIFF
--- a/napari/_vispy/image.py
+++ b/napari/_vispy/image.py
@@ -1,0 +1,5 @@
+from .vendored import ImageVisual
+from vispy.scene.visuals import create_visual_node
+
+
+Image = create_visual_node(ImageVisual)

--- a/napari/_vispy/vendored/__init__.py
+++ b/napari/_vispy/vendored/__init__.py
@@ -1,0 +1,2 @@
+from .volume import VolumeVisual
+from .image import ImageVisual

--- a/napari/_vispy/vendored/image.py
+++ b/napari/_vispy/vendored/image.py
@@ -1,0 +1,564 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+
+from __future__ import division
+
+import numpy as np
+
+from vispy.gloo import Texture2D, VertexBuffer
+from vispy.color import get_colormap
+from vispy.visuals.shaders import Function, FunctionChain
+from vispy.visuals.transforms import NullTransform
+from vispy.visuals.visual import Visual
+from vispy.ext.six import string_types
+from vispy.io import load_spatial_filters
+
+VERT_SHADER = """
+uniform int method;  // 0=subdivide, 1=impostor
+attribute vec2 a_position;
+attribute vec2 a_texcoord;
+varying vec2 v_texcoord;
+
+void main() {
+    v_texcoord = a_texcoord;
+    gl_Position = $transform(vec4(a_position, 0., 1.));
+}
+"""
+
+FRAG_SHADER = """
+uniform vec2 image_size;
+uniform int method;  // 0=subdivide, 1=impostor
+uniform sampler2D u_texture;
+varying vec2 v_texcoord;
+
+vec4 map_local_to_tex(vec4 x) {
+    // Cast ray from 3D viewport to surface of image
+    // (if $transform does not affect z values, then this
+    // can be optimized as simply $transform.map(x) )
+    vec4 p1 = $transform(x);
+    vec4 p2 = $transform(x + vec4(0, 0, 0.5, 0));
+    p1 /= p1.w;
+    p2 /= p2.w;
+    vec4 d = p2 - p1;
+    float f = p2.z / d.z;
+    vec4 p3 = p2 - d * f;
+
+    // finally map local to texture coords
+    return vec4(p3.xy / image_size, 0, 1);
+}
+
+
+void main()
+{
+    vec2 texcoord;
+    if( method == 0 ) {
+        texcoord = v_texcoord;
+    }
+    else {
+        // vertex shader outputs clip coordinates;
+        // fragment shader maps to texture coordinates
+        texcoord = map_local_to_tex(vec4(v_texcoord, 0, 1)).xy;
+    }
+
+    gl_FragColor = $color_transform($get_data(texcoord));
+}
+"""  # noqa
+
+_interpolation_template = """
+    #include "misc/spatial-filters.frag"
+    vec4 texture_lookup_filtered(vec2 texcoord) {
+        if(texcoord.x < 0.0 || texcoord.x > 1.0 ||
+        texcoord.y < 0.0 || texcoord.y > 1.0) {
+            discard;
+        }
+        return %s($texture, $shape, texcoord);
+    }"""
+
+_texture_lookup = """
+    vec4 texture_lookup(vec2 texcoord) {
+        if(texcoord.x < 0.0 || texcoord.x > 1.0 ||
+        texcoord.y < 0.0 || texcoord.y > 1.0) {
+            discard;
+        }
+        return texture2D($texture, texcoord);
+    }"""
+
+_apply_clim_float = """
+    float apply_clim(float data) {
+        data = data - $clim.x;
+        data = data / ($clim.y - $clim.x);
+        return max(data, 0);
+    }"""
+_apply_clim = """
+    vec4 apply_clim(vec4 color) {
+        color.rgb = color.rgb - $clim.x;
+        color.rgb = color.rgb / ($clim.y - $clim.x);
+        return max(color, 0);
+    }
+"""
+
+_apply_gamma_float = """
+    float apply_gamma(float data) {
+        return pow(data, $gamma);
+    }"""
+_apply_gamma = """
+    vec4 apply_gamma(vec4 color) {
+        color.rgb = pow(color.rgb, vec3($gamma));
+        return color;
+    }
+"""
+
+_null_color_transform = 'vec4 pass(vec4 color) { return color; }'
+_c2l = 'float cmap(vec4 color) { return (color.r + color.g + color.b) / 3.; }'
+
+
+def _build_color_transform(data, clim, gamma, cmap):
+    if data.ndim == 2 or data.shape[2] == 1:
+        fclim = Function(_apply_clim_float)
+        fgamma = Function(_apply_gamma_float)
+        fun = FunctionChain(
+            None, [Function(_c2l), fclim, fgamma, Function(cmap.glsl_map)]
+        )
+    else:
+        fclim = Function(_apply_clim)
+        fgamma = Function(_apply_gamma)
+        fun = FunctionChain(
+            None, [Function(_null_color_transform), fclim, fgamma]
+        )
+    fclim['clim'] = clim
+    fgamma['gamma'] = gamma
+    return fun
+
+
+class ImageVisual(Visual):
+    """Visual subclass displaying an image.
+
+    Parameters
+    ----------
+    data : ndarray
+        ImageVisual data. Can be shape (M, N), (M, N, 3), or (M, N, 4).
+    method : str
+        Selects method of rendering image in case of non-linear transforms.
+        Each method produces similar results, but may trade efficiency
+        and accuracy. If the transform is linear, this parameter is ignored
+        and a single quad is drawn around the area of the image.
+
+            * 'auto': Automatically select 'impostor' if the image is drawn
+              with a nonlinear transform; otherwise select 'subdivide'.
+            * 'subdivide': ImageVisual is represented as a grid of triangles
+              with texture coordinates linearly mapped.
+            * 'impostor': ImageVisual is represented as a quad covering the
+              entire view, with texture coordinates determined by the
+              transform. This produces the best transformation results, but may
+              be slow.
+
+    grid: tuple (rows, cols)
+        If method='subdivide', this tuple determines the number of rows and
+        columns in the image grid.
+    cmap : str | ColorMap
+        Colormap to use for luminance images.
+    clim : str | tuple
+        Limits to use for the colormap. Can be 'auto' to auto-set bounds to
+        the min and max of the data.
+    gamma : float
+        Gamma to use during colormap lookup.  Final color will be cmap(val**gamma).
+        by default: 1.
+    interpolation : str
+        Selects method of image interpolation. Makes use of the two Texture2D
+        interpolation methods and the available interpolation methods defined
+        in vispy/gloo/glsl/misc/spatial_filters.frag
+
+            * 'nearest': Default, uses 'nearest' with Texture2D interpolation.
+            * 'bilinear': uses 'linear' with Texture2D interpolation.
+            * 'hanning', 'hamming', 'hermite', 'kaiser', 'quadric', 'bicubic',
+                'catrom', 'mitchell', 'spline16', 'spline36', 'gaussian',
+                'bessel', 'sinc', 'lanczos', 'blackman'
+
+    **kwargs : dict
+        Keyword arguments to pass to `Visual`.
+
+    Notes
+    -----
+    The colormap functionality through ``cmap`` and ``clim`` are only used
+    if the data are 2D.
+    """
+
+    def __init__(
+        self,
+        data=None,
+        method='auto',
+        grid=(1, 1),
+        cmap='viridis',
+        clim='auto',
+        gamma=1.0,
+        interpolation='nearest',
+        **kwargs,
+    ):
+        self._data = None
+        self._gamma = gamma
+
+        # load 'float packed rgba8' interpolation kernel
+        # to load float interpolation kernel use
+        # `load_spatial_filters(packed=False)`
+        kernel, self._interpolation_names = load_spatial_filters()
+
+        self._kerneltex = Texture2D(kernel, interpolation='nearest')
+        # The unpacking can be debugged by changing "spatial-filters.frag"
+        # to have the "unpack" function just return the .r component. That
+        # combined with using the below as the _kerneltex allows debugging
+        # of the pipeline
+        # self._kerneltex = Texture2D(kernel, interpolation='linear',
+        #                             internalformat='r32f')
+
+        # create interpolation shader functions for available
+        # interpolations
+        fun = [
+            Function(_interpolation_template % n)
+            for n in self._interpolation_names
+        ]
+        self._interpolation_names = [
+            n.lower() for n in self._interpolation_names
+        ]
+
+        self._interpolation_fun = dict(zip(self._interpolation_names, fun))
+        self._interpolation_names.sort()
+        self._interpolation_names = tuple(self._interpolation_names)
+
+        # overwrite "nearest" and "bilinear" spatial-filters
+        # with  "hardware" interpolation _data_lookup_fn
+        self._interpolation_fun['nearest'] = Function(_texture_lookup)
+        self._interpolation_fun['bilinear'] = Function(_texture_lookup)
+
+        if interpolation not in self._interpolation_names:
+            raise ValueError(
+                "interpolation must be one of %s"
+                % ', '.join(self._interpolation_names)
+            )
+
+        self._interpolation = interpolation
+
+        # check texture interpolation
+        if self._interpolation == 'bilinear':
+            texture_interpolation = 'linear'
+        else:
+            texture_interpolation = 'nearest'
+
+        self._method = method
+        self._grid = grid
+        self._texture_limits = None
+        self._need_texture_upload = True
+        self._need_vertex_update = True
+        self._need_colortransform_update = True
+        self._need_interpolation_update = True
+        self._texture = Texture2D(
+            np.zeros((1, 1, 4)), interpolation=texture_interpolation
+        )
+        self._subdiv_position = VertexBuffer()
+        self._subdiv_texcoord = VertexBuffer()
+
+        # impostor quad covers entire viewport
+        vertices = np.array(
+            [[-1, -1], [1, -1], [1, 1], [-1, -1], [1, 1], [-1, 1]],
+            dtype=np.float32,
+        )
+        self._impostor_coords = VertexBuffer(vertices)
+        self._null_tr = NullTransform()
+
+        self._init_view(self)
+        super(ImageVisual, self).__init__(vcode=VERT_SHADER, fcode=FRAG_SHADER)
+        self.set_gl_state('translucent', cull_face=False)
+        self._draw_mode = 'triangles'
+
+        # define _data_lookup_fn as None, will be setup in
+        # self._build_interpolation()
+        self._data_lookup_fn = None
+
+        self.clim = clim
+        self.cmap = cmap
+        if data is not None:
+            self.set_data(data)
+        self.freeze()
+
+    def set_data(self, image):
+        """Set the data
+
+        Parameters
+        ----------
+        image : array-like
+            The image data.
+        """
+        data = np.asarray(image)
+        if self._data is None or self._data.shape != data.shape:
+            self._need_vertex_update = True
+        self._data = data
+        self._need_texture_upload = True
+
+    def view(self):
+        v = Visual.view(self)
+        self._init_view(v)
+        return v
+
+    def _init_view(self, view):
+        # Store some extra variables per-view
+        view._need_method_update = True
+        view._method_used = None
+
+    @property
+    def clim(self):
+        return (
+            self._clim
+            if isinstance(self._clim, string_types)
+            else tuple(self._clim)
+        )
+
+    @clim.setter
+    def clim(self, clim):
+        if isinstance(clim, string_types):
+            if clim != 'auto':
+                raise ValueError('clim must be "auto" if a string')
+            self._need_texture_upload = True
+        else:
+            clim = np.array(clim, float)
+            if clim.shape != (2,):
+                raise ValueError('clim must have two elements')
+            if self._texture_limits is not None and (
+                (clim[0] < self._texture_limits[0])
+                or (clim[1] > self._texture_limits[1])
+            ):
+                self._need_texture_upload = True
+        self._clim = clim
+        if self._texture_limits is not None:
+            self.shared_program.frag['color_transform'][1][
+                'clim'
+            ] = self.clim_normalized
+        self.update()
+
+    @property
+    def clim_normalized(self):
+        """Normalize current clims between 0-1 based on last-used texture data range.
+        In _build_texture(), the data is normalized (on the CPU) to 0-1 using ``clim``.
+        During rendering, the frag shader will apply the final contrast adjustment based on
+        the current ``clim``.
+        """
+        range_min, range_max = self._texture_limits
+        clim_min, clim_max = self.clim
+        clim_min = (clim_min - range_min) / (range_max - range_min)
+        clim_max = (clim_max - range_min) / (range_max - range_min)
+        return clim_min, clim_max
+
+    @property
+    def cmap(self):
+        return self._cmap
+
+    @cmap.setter
+    def cmap(self, cmap):
+        self._cmap = get_colormap(cmap)
+        self._need_colortransform_update = True
+        self.update()
+
+    @property
+    def gamma(self):
+        """The gamma used when rendering the image."""
+        return self._gamma
+
+    @gamma.setter
+    def gamma(self, value):
+        """Set gamma used when rendering the image."""
+        if value <= 0:
+            raise ValueError("gamma must be > 0")
+        self._gamma = float(value)
+        self.shared_program.frag['color_transform'][2]['gamma'] = self._gamma
+        self.update()
+
+    @property
+    def method(self):
+        return self._method
+
+    @method.setter
+    def method(self, m):
+        if self._method != m:
+            self._method = m
+            self._need_vertex_update = True
+            self.update()
+
+    @property
+    def size(self):
+        return self._data.shape[:2][::-1]
+
+    @property
+    def interpolation(self):
+        return self._interpolation
+
+    @interpolation.setter
+    def interpolation(self, i):
+        if i not in self._interpolation_names:
+            raise ValueError(
+                "interpolation must be one of %s"
+                % ', '.join(self._interpolation_names)
+            )
+        if self._interpolation != i:
+            self._interpolation = i
+            self._need_interpolation_update = True
+            self.update()
+
+    @property
+    def interpolation_functions(self):
+        return self._interpolation_names
+
+    # The interpolation code could be transferred to a dedicated filter
+    # function in visuals/filters as discussed in #1051
+    def _build_interpolation(self):
+        """Rebuild the _data_lookup_fn using different interpolations within
+        the shader
+        """
+        interpolation = self._interpolation
+        self._data_lookup_fn = self._interpolation_fun[interpolation]
+        self.shared_program.frag['get_data'] = self._data_lookup_fn
+
+        # only 'bilinear' uses 'linear' texture interpolation
+        if interpolation == 'bilinear':
+            texture_interpolation = 'linear'
+        else:
+            # 'nearest' (and also 'bilinear') doesn't use spatial_filters.frag
+            # so u_kernel and shape setting is skipped
+            texture_interpolation = 'nearest'
+            if interpolation != 'nearest':
+                self.shared_program['u_kernel'] = self._kerneltex
+                self._data_lookup_fn['shape'] = self._data.shape[:2][::-1]
+
+        if self._texture.interpolation != texture_interpolation:
+            self._texture.interpolation = texture_interpolation
+
+        self._data_lookup_fn['texture'] = self._texture
+
+        self._need_interpolation_update = False
+
+    def _build_vertex_data(self):
+        """Rebuild the vertex buffers used for rendering the image when using
+        the subdivide method.
+        """
+        grid = self._grid
+        w = 1.0 / grid[1]
+        h = 1.0 / grid[0]
+
+        quad = np.array(
+            [[0, 0, 0], [w, 0, 0], [w, h, 0], [0, 0, 0], [w, h, 0], [0, h, 0]],
+            dtype=np.float32,
+        )
+        quads = np.empty((grid[1], grid[0], 6, 3), dtype=np.float32)
+        quads[:] = quad
+
+        mgrid = np.mgrid[0.0 : grid[1], 0.0 : grid[0]].transpose(1, 2, 0)
+        mgrid = mgrid[:, :, np.newaxis, :]
+        mgrid[..., 0] *= w
+        mgrid[..., 1] *= h
+
+        quads[..., :2] += mgrid
+        tex_coords = quads.reshape(grid[1] * grid[0] * 6, 3)
+        tex_coords = np.ascontiguousarray(tex_coords[:, :2])
+        vertices = tex_coords * self.size
+
+        self._subdiv_position.set_data(vertices.astype('float32'))
+        self._subdiv_texcoord.set_data(tex_coords.astype('float32'))
+        self._need_vertex_update = False
+
+    def _update_method(self, view):
+        """Decide which method to use for *view* and configure it accordingly.
+        """
+        method = self._method
+        if method == 'auto':
+            if view.transforms.get_transform().Linear:
+                method = 'subdivide'
+            else:
+                method = 'impostor'
+        view._method_used = method
+
+        if method == 'subdivide':
+            view.view_program['method'] = 0
+            view.view_program['a_position'] = self._subdiv_position
+            view.view_program['a_texcoord'] = self._subdiv_texcoord
+        elif method == 'impostor':
+            view.view_program['method'] = 1
+            view.view_program['a_position'] = self._impostor_coords
+            view.view_program['a_texcoord'] = self._impostor_coords
+        else:
+            raise ValueError("Unknown image draw method '%s'" % method)
+
+        self.shared_program['image_size'] = self.size
+        view._need_method_update = False
+        self._prepare_transforms(view)
+
+    def _build_texture(self):
+        data = self._data
+        if data.dtype == np.float64:
+            data = data.astype(np.float32)
+
+        if data.ndim == 2 or data.shape[2] == 1:
+            # deal with clim on CPU b/c of texture depth limits :(
+            # can eventually do this by simulating 32-bit float... maybe
+            clim = self._clim
+            if isinstance(clim, string_types) and clim == 'auto':
+                clim = np.min(data), np.max(data)
+            clim = np.asarray(clim, dtype=np.float32)
+            data = data - clim[0]  # not inplace so we don't modify orig data
+            if clim[1] - clim[0] > 0:
+                data /= clim[1] - clim[0]
+            else:
+                data[:] = 1 if data[0, 0] != 0 else 0
+            self._clim = np.array(clim)
+        else:
+            # assume that RGB data is already scaled (0, 1)
+            if isinstance(self._clim, string_types) and self._clim == 'auto':
+                self._clim = (0, 1)
+
+        self._texture_limits = np.array(self._clim)
+        self._texture.set_data(data)
+        self._need_texture_upload = False
+
+    def _compute_bounds(self, axis, view):
+        if axis > 1:
+            return (0, 0)
+        else:
+            return (0, self.size[axis])
+
+    def _prepare_transforms(self, view):
+        trs = view.transforms
+        prg = view.view_program
+        method = view._method_used
+        if method == 'subdivide':
+            prg.vert['transform'] = trs.get_transform()
+            prg.frag['transform'] = self._null_tr
+        else:
+            prg.vert['transform'] = self._null_tr
+            prg.frag['transform'] = trs.get_transform().inverse
+
+    def _prepare_draw(self, view):
+        if self._data is None:
+            return False
+
+        if self._need_interpolation_update:
+            self._build_interpolation()
+
+        if self._need_texture_upload:
+            self._build_texture()
+
+        if self._need_colortransform_update:
+            prg = view.view_program
+            self.shared_program.frag[
+                'color_transform'
+            ] = _build_color_transform(
+                self._data, self.clim_normalized, self.gamma, self.cmap
+            )
+            self._need_colortransform_update = False
+            prg['texture2D_LUT'] = (
+                self.cmap.texture_lut()
+                if (hasattr(self.cmap, 'texture_lut'))
+                else None
+            )
+
+        if self._need_vertex_update:
+            self._build_vertex_data()
+
+        if view._need_method_update:
+            self._update_method(view)

--- a/napari/_vispy/vendored/volume.py
+++ b/napari/_vispy/vendored/volume.py
@@ -1,0 +1,838 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+
+"""
+About this technique
+--------------------
+
+In Python, we define the six faces of a cuboid to draw, as well as
+texture cooridnates corresponding with the vertices of the cuboid. 
+The back faces of the cuboid are drawn (and front faces are culled)
+because only the back faces are visible when the camera is inside the 
+volume.
+
+In the vertex shader, we intersect the view ray with the near and far 
+clipping planes. In the fragment shader, we use these two points to
+compute the ray direction and then compute the position of the front
+cuboid surface (or near clipping plane) along the view ray.
+
+Next we calculate the number of steps to walk from the front surface
+to the back surface and iterate over these positions in a for-loop.
+At each iteration, the fragment color or other voxel information is 
+updated depending on the selected rendering method.
+
+It is important for the texture interpolation is 'linear' for most volumes,
+since with 'nearest' the result can look very ugly; however for volumes with
+discrete data 'nearest' is sometimes appropriate. The wrapping should be
+clamp_to_edge to avoid artifacts when the ray takes a small step outside the
+volume.
+
+The ray direction is established by mapping the vertex to the document
+coordinate frame, adjusting z to +/-1, and mapping the coordinate back.
+The ray is expressed in coordinates local to the volume (i.e. texture
+coordinates).
+
+"""
+
+from vispy.gloo import Texture3D, TextureEmulated3D, VertexBuffer, IndexBuffer
+from vispy.visuals import Visual
+from vispy.visuals.shaders import Function
+from vispy.color import get_colormap
+
+import numpy as np
+
+# todo: implement more render methods (port from visvis)
+# todo: allow anisotropic data
+# todo: what to do about lighting? ambi/diffuse/spec/shinynes on each visual?
+
+# Vertex shader
+VERT_SHADER = """
+attribute vec3 a_position;
+// attribute vec3 a_texcoord;
+uniform vec3 u_shape;
+
+// varying vec3 v_texcoord;
+varying vec3 v_position;
+varying vec4 v_nearpos;
+varying vec4 v_farpos;
+
+void main() {
+    // v_texcoord = a_texcoord;
+    v_position = a_position;
+    
+    // Project local vertex coordinate to camera position. Then do a step
+    // backward (in cam coords) and project back. Voila, we get our ray vector.
+    vec4 pos_in_cam = $viewtransformf(vec4(v_position, 1));
+
+    // intersection of ray and near clipping plane (z = -1 in clip coords)
+    pos_in_cam.z = -pos_in_cam.w;
+    v_nearpos = $viewtransformi(pos_in_cam);
+    
+    // intersection of ray and far clipping plane (z = +1 in clip coords)
+    pos_in_cam.z = pos_in_cam.w;
+    v_farpos = $viewtransformi(pos_in_cam);
+    
+    gl_Position = $transform(vec4(v_position, 1.0));
+}
+"""  # noqa
+
+# Fragment shader
+FRAG_SHADER = """
+// uniforms
+uniform $sampler_type u_volumetex;
+uniform vec3 u_shape;
+uniform vec2 clim;
+uniform float gamma;
+uniform float u_threshold;
+uniform float u_attenuation;
+uniform float u_relative_step_size;
+
+//varyings
+// varying vec3 v_texcoord;
+varying vec3 v_position;
+varying vec4 v_nearpos;
+varying vec4 v_farpos;
+
+// uniforms for lighting. Hard coded until we figure out how to do lights
+const vec4 u_ambient = vec4(0.2, 0.2, 0.2, 1.0);
+const vec4 u_diffuse = vec4(0.8, 0.2, 0.2, 1.0);
+const vec4 u_specular = vec4(1.0, 1.0, 1.0, 1.0);
+const float u_shininess = 40.0;
+
+//varying vec3 lightDirs[1];
+
+// global holding view direction in local coordinates
+vec3 view_ray;
+
+float rand(vec2 co)
+{{
+    // Create a pseudo-random number between 0 and 1.
+    // http://stackoverflow.com/questions/4200224
+    return fract(sin(dot(co.xy ,vec2(12.9898, 78.233))) * 43758.5453);
+}}
+
+float colorToVal(vec4 color1)
+{{
+    return color1.g; // todo: why did I have this abstraction in visvis?
+}}
+
+vec4 applyColormap(float data) {{
+    if (clim.x < clim.y) {{
+        data = clamp(data, clim.x, clim.y);
+    }} else {{
+        data = clamp(data, clim.y, clim.x);
+    }}
+
+    data = (data - clim.x) / (clim.y - clim.x);
+    return $cmap(pow(data, gamma));
+}}
+
+
+vec4 calculateColor(vec4 betterColor, vec3 loc, vec3 step)
+{{   
+    // Calculate color by incorporating lighting
+    vec4 color1;
+    vec4 color2;
+    
+    // View direction
+    vec3 V = normalize(view_ray);
+    
+    // calculate normal vector from gradient
+    vec3 N; // normal
+    color1 = $sample( u_volumetex, loc+vec3(-step[0],0.0,0.0) );
+    color2 = $sample( u_volumetex, loc+vec3(step[0],0.0,0.0) );
+    N[0] = colorToVal(color1) - colorToVal(color2);
+    betterColor = max(max(color1, color2),betterColor);
+    color1 = $sample( u_volumetex, loc+vec3(0.0,-step[1],0.0) );
+    color2 = $sample( u_volumetex, loc+vec3(0.0,step[1],0.0) );
+    N[1] = colorToVal(color1) - colorToVal(color2);
+    betterColor = max(max(color1, color2),betterColor);
+    color1 = $sample( u_volumetex, loc+vec3(0.0,0.0,-step[2]) );
+    color2 = $sample( u_volumetex, loc+vec3(0.0,0.0,step[2]) );
+    N[2] = colorToVal(color1) - colorToVal(color2);
+    betterColor = max(max(color1, color2),betterColor);
+    float gm = length(N); // gradient magnitude
+    N = normalize(N);
+    
+    // Flip normal so it points towards viewer
+    float Nselect = float(dot(N,V) > 0.0);
+    N = (2.0*Nselect - 1.0) * N;  // ==  Nselect * N - (1.0-Nselect)*N;
+    
+    // Get color of the texture (albeido)
+    color1 = betterColor;
+    color2 = color1;
+    // todo: parametrise color1_to_color2
+    
+    // Init colors
+    vec4 ambient_color = vec4(0.0, 0.0, 0.0, 0.0);
+    vec4 diffuse_color = vec4(0.0, 0.0, 0.0, 0.0);
+    vec4 specular_color = vec4(0.0, 0.0, 0.0, 0.0);
+    vec4 final_color;
+    
+    // todo: allow multiple light, define lights on viewvox or subscene
+    int nlights = 1; 
+    for (int i=0; i<nlights; i++)
+    {{ 
+        // Get light direction (make sure to prevent zero devision)
+        vec3 L = normalize(view_ray);  //lightDirs[i]; 
+        float lightEnabled = float( length(L) > 0.0 );
+        L = normalize(L+(1.0-lightEnabled));
+        
+        // Calculate lighting properties
+        float lambertTerm = clamp( dot(N,L), 0.0, 1.0 );
+        vec3 H = normalize(L+V); // Halfway vector
+        float specularTerm = pow( max(dot(H,N),0.0), u_shininess);
+        
+        // Calculate mask
+        float mask1 = lightEnabled;
+        
+        // Calculate colors
+        ambient_color +=  mask1 * u_ambient;  // * gl_LightSource[i].ambient;
+        diffuse_color +=  mask1 * lambertTerm;
+        specular_color += mask1 * specularTerm * u_specular;
+    }}
+    
+    // Calculate final color by componing different components
+    final_color = color2 * ( ambient_color + diffuse_color) + specular_color;
+    final_color.a = color2.a;
+    
+    // Done
+    return final_color;
+}}
+
+// for some reason, this has to be the last function in order for the
+// filters to be inserted in the correct place...
+
+void main() {{
+    vec3 farpos = v_farpos.xyz / v_farpos.w;
+    vec3 nearpos = v_nearpos.xyz / v_nearpos.w;
+
+    // Calculate unit vector pointing in the view direction through this
+    // fragment.
+    view_ray = normalize(farpos.xyz - nearpos.xyz);
+
+    // Compute the distance to the front surface or near clipping plane
+    float distance = dot(nearpos-v_position, view_ray);
+    distance = max(distance, min((-0.5 - v_position.x) / view_ray.x,
+                            (u_shape.x - 0.5 - v_position.x) / view_ray.x));
+    distance = max(distance, min((-0.5 - v_position.y) / view_ray.y,
+                            (u_shape.y - 0.5 - v_position.y) / view_ray.y));
+    distance = max(distance, min((-0.5 - v_position.z) / view_ray.z,
+                            (u_shape.z - 0.5 - v_position.z) / view_ray.z));
+
+    // Now we have the starting position on the front surface
+    vec3 front = v_position + view_ray * distance;
+
+    // Decide how many steps to take
+    int nsteps = int(-distance / u_relative_step_size + 0.5);
+    float f_nsteps = float(nsteps);
+    if( nsteps < 1 )
+        discard;
+
+    // Get starting location and step vector in texture coordinates
+    vec3 step = ((v_position - front) / u_shape) / f_nsteps;
+    vec3 start_loc = front / u_shape;
+
+    // For testing: show the number of steps. This helps to establish
+    // whether the rays are correctly oriented
+    //gl_FragColor = vec4(0.0, f_nsteps / 3.0 / u_shape.x, 1.0, 1.0);
+    //return;
+
+    {before_loop}
+
+    // This outer loop seems necessary on some systems for large
+    // datasets. Ugly, but it works ...
+    vec3 loc = start_loc;
+    int iter = 0;
+    while (iter < nsteps) {{
+        for (iter=iter; iter<nsteps; iter++)
+        {{
+            // Get sample color
+            vec4 color = $sample(u_volumetex, loc);
+            float val = color.g;
+
+            {in_loop}
+
+            // Advance location deeper into the volume
+            loc += step;
+        }}
+    }}
+
+    {after_loop}
+
+    /* Set depth value - from visvis TODO
+    int iter_depth = int(maxi);
+    // Calculate end position in world coordinates
+    vec4 position2 = vertexPosition;
+    position2.xyz += ray*shape*float(iter_depth);
+    // Project to device coordinates and set fragment depth
+    vec4 iproj = gl_ModelViewProjectionMatrix * position2;
+    iproj.z /= iproj.w;
+    gl_FragDepth = (iproj.z+1.0)/2.0;
+    */
+}}
+
+
+"""  # noqa
+
+
+MIP_SNIPPETS = dict(
+    before_loop="""
+        float maxval = -99999.0; // The maximum encountered value
+        int maxi = 0;  // Where the maximum value was encountered
+        """,
+    in_loop="""
+        if( val > maxval ) {
+            maxval = val;
+            maxi = iter;
+        }
+        """,
+    after_loop="""
+        // Refine search for max value
+        loc = start_loc + step * (float(maxi) - 0.5);
+        for (int i=0; i<10; i++) {
+            maxval = max(maxval, $sample(u_volumetex, loc).g);
+            loc += step * 0.1;
+        }
+        gl_FragColor = applyColormap(maxval);
+        """,
+)
+MIP_FRAG_SHADER = FRAG_SHADER.format(**MIP_SNIPPETS)
+
+
+TRANSLUCENT_SNIPPETS = dict(
+    before_loop="""
+        vec4 integrated_color = vec4(0., 0., 0., 0.);
+        """,
+    in_loop="""
+            color = applyColormap(val);
+            float a1 = integrated_color.a;
+            float a2 = color.a * (1 - a1);
+            float alpha = max(a1 + a2, 0.001);
+            
+            // Doesn't work.. GLSL optimizer bug?
+            //integrated_color = (integrated_color * a1 / alpha) + 
+            //                   (color * a2 / alpha); 
+            // This should be identical but does work correctly:
+            integrated_color *= a1 / alpha;
+            integrated_color += color * a2 / alpha;
+            
+            integrated_color.a = alpha;
+            
+            if( alpha > 0.99 ){
+                // stop integrating if the fragment becomes opaque
+                iter = nsteps;
+            }
+        
+        """,
+    after_loop="""
+        gl_FragColor = integrated_color;
+        """,
+)
+TRANSLUCENT_FRAG_SHADER = FRAG_SHADER.format(**TRANSLUCENT_SNIPPETS)
+
+
+ADDITIVE_SNIPPETS = dict(
+    before_loop="""
+        vec4 integrated_color = vec4(0., 0., 0., 0.);
+        """,
+    in_loop="""
+        color = applyColormap(val);
+        
+        integrated_color = 1.0 - (1.0 - integrated_color) * (1.0 - color);
+        """,
+    after_loop="""
+        gl_FragColor = integrated_color;
+        """,
+)
+ADDITIVE_FRAG_SHADER = FRAG_SHADER.format(**ADDITIVE_SNIPPETS)
+
+
+ISO_SNIPPETS = dict(
+    before_loop="""
+        vec4 color3 = vec4(0.0);  // final color
+        vec3 dstep = 1.5 / u_shape;  // step to sample derivative
+        gl_FragColor = vec4(0.0);
+    """,
+    in_loop="""
+        if (val > u_threshold-0.2) {
+            // Take the last interval in smaller steps
+            vec3 iloc = loc - step;
+            for (int i=0; i<10; i++) {
+                color = $sample(u_volumetex, iloc);
+                if (color.g > u_threshold) {
+                    color = calculateColor(color, iloc, dstep);
+                    gl_FragColor = applyColormap(color.g);
+                    iter = nsteps;
+                    break;
+                }
+                iloc += step * 0.1;
+            }
+        }
+        """,
+    after_loop="""
+        """,
+)
+
+ISO_FRAG_SHADER = FRAG_SHADER.format(**ISO_SNIPPETS)
+
+frag_dict = {
+    'mip': MIP_FRAG_SHADER,
+    'iso': ISO_FRAG_SHADER,
+    'translucent': TRANSLUCENT_FRAG_SHADER,
+    'additive': ADDITIVE_FRAG_SHADER,
+}
+
+
+class VolumeVisual(Visual):
+    """ Displays a 3D Volume
+    
+    Parameters
+    ----------
+    vol : ndarray
+        The volume to display. Must be ndim==3.
+    clim : tuple of two floats | None
+        The contrast limits. The values in the volume are mapped to
+        black and white corresponding to these values. Default maps
+        between min and max.
+    method : {'mip', 'translucent', 'additive', 'iso'}
+        The render method to use. See corresponding docs for details.
+        Default 'mip'.
+    threshold : float
+        The threshold to use for the isosurface render method. By default
+        the mean of the given volume is used.
+    relative_step_size : float
+        The relative step size to step through the volume. Default 0.8.
+        Increase to e.g. 1.5 to increase performance, at the cost of
+        quality.
+    cmap : str
+        Colormap to use.
+    gamma : float
+        Gamma to use during colormap lookup.  Final color will be cmap(val**gamma).
+        by default: 1.
+    clim_range_threshold : float
+        When changing the clims, if the new clim range is smaller than this fraction of the
+        last-used texture data range, then it will trigger a rescaling of the texture data.
+        For instance: if the texture data was last scaled from 0-1, and the clims are set to
+        0.4-0.5, then a texture rescale will be triggered if ``clim_range_threshold < 0.1``.
+        To prevent rescaling, set this value to 0.  To *always* rescale, set the value to
+        >= 1.  By default, 0.2
+    emulate_texture : bool
+        Use 2D textures to emulate a 3D texture. OpenGL ES 2.0 compatible,
+        but has lower performance on desktop platforms.
+    interpolation : {'linear', 'nearest'}
+        Selects method of image interpolation. 
+    """
+
+    _interpolation_names = ['linear', 'nearest']
+
+    def __init__(
+        self,
+        vol,
+        clim=None,
+        method='mip',
+        threshold=None,
+        relative_step_size=0.8,
+        cmap='grays',
+        gamma=1.0,
+        clim_range_threshold=0.2,
+        emulate_texture=False,
+        interpolation='linear',
+    ):
+
+        tex_cls = TextureEmulated3D if emulate_texture else Texture3D
+
+        # Storage of information of volume
+        self._vol_shape = ()
+        self._clim = None
+        self._texture_limits = None
+        self._gamma = gamma
+        self._need_vertex_update = True
+        self._clim_range_threshold = clim_range_threshold
+        # Set the colormap
+        self._cmap = get_colormap(cmap)
+
+        # Create gloo objects
+        self._vertices = VertexBuffer()
+        self._texcoord = VertexBuffer(
+            np.array(
+                [
+                    [0, 0, 0],
+                    [1, 0, 0],
+                    [0, 1, 0],
+                    [1, 1, 0],
+                    [0, 0, 1],
+                    [1, 0, 1],
+                    [0, 1, 1],
+                    [1, 1, 1],
+                ],
+                dtype=np.float32,
+            )
+        )
+
+        self._interpolation = interpolation
+        self._tex = tex_cls(
+            (10, 10, 10),
+            interpolation=self._interpolation,
+            wrapping='clamp_to_edge',
+        )
+
+        # Create program
+        Visual.__init__(self, vcode=VERT_SHADER, fcode="")
+        self.shared_program['u_volumetex'] = self._tex
+        self.shared_program['a_position'] = self._vertices
+        self.shared_program['a_texcoord'] = self._texcoord
+        self.shared_program['gamma'] = self._gamma
+        self._draw_mode = 'triangle_strip'
+        self._index_buffer = IndexBuffer()
+
+        # Only show back faces of cuboid. This is required because if we are
+        # inside the volume, then the front faces are outside of the clipping
+        # box and will not be drawn.
+        self.set_gl_state('translucent', cull_face=False)
+
+        # Set data
+        self.set_data(vol, clim)
+
+        # Set params
+        self.method = method
+        self.relative_step_size = relative_step_size
+        self.threshold = threshold if (threshold is not None) else vol.mean()
+        self.freeze()
+
+    def set_data(self, vol, clim=None, copy=True):
+        """ Set the volume data. 
+
+        Parameters
+        ----------
+        vol : ndarray
+            The 3D volume.
+        clim : tuple | None
+            Colormap limits to use. None will use the min and max values.
+        copy : bool | True
+            Whether to copy the input volume prior to applying clim normalization.
+        """
+        # Check volume
+        if not isinstance(vol, np.ndarray):
+            raise ValueError('Volume visual needs a numpy array.')
+        if not ((vol.ndim == 3) or (vol.ndim == 4 and vol.shape[-1] <= 4)):
+            raise ValueError('Volume visual needs a 3D image.')
+
+        # Handle clim
+        if clim is not None:
+            clim = np.array(clim, float)
+            if not (clim.ndim == 1 and clim.size == 2):
+                raise ValueError('clim must be a 2-element array-like')
+            self._clim = tuple(clim)
+        if self._clim is None:
+            self._clim = vol.min(), vol.max()
+
+        # store clims used to normalize _tex data for use in clim_normalized
+        self._texture_limits = self._clim
+        # store volume in case it needs to be renormalized by clim.setter
+        self._last_data = vol
+        self.shared_program['clim'] = self.clim_normalized
+
+        # Apply clim (copy data by default... see issue #1727)
+        vol = np.array(vol, dtype='float32', copy=copy)
+        if self._clim[1] == self._clim[0]:
+            if self._clim[0] != 0.0:
+                vol *= 1.0 / self._clim[0]
+        elif self._clim[0] > self._clim[1]:
+            vol *= -1
+            vol += self._clim[1]
+            vol /= self._clim[1] - self._clim[0]
+        else:
+            vol -= self._clim[0]
+            vol /= self._clim[1] - self._clim[0]
+
+        # Apply to texture
+        self._tex.set_data(vol)  # will be efficient if vol is same shape
+        self.shared_program['u_shape'] = (
+            vol.shape[2],
+            vol.shape[1],
+            vol.shape[0],
+        )
+
+        shape = vol.shape[:3]
+        if self._vol_shape != shape:
+            self._vol_shape = shape
+            self._need_vertex_update = True
+        self._vol_shape = shape
+
+        # Get some stats
+        self._kb_for_texture = np.prod(self._vol_shape) / 1024
+
+    def rescale_data(self):
+        """Force rescaling of data to the current contrast limits and texture upload.
+
+        Because Textures are currently 8-bits, and contrast adjustment is done during
+        rendering by scaling the values retrieved from the texture on the GPU (provided that
+        the new contrast limits settings are within the range of the clims used when the
+        last texture was uploaded), posterization may become visible if the contrast limits
+        become *too* small of a fraction of the clims used to normalize the texture.
+        This function is a convenience to "force" rescaling of the Texture data to the
+        current contrast limits range.
+        """
+        self.set_data(self._last_data, clim=self._clim)
+        self.update()
+
+    @property
+    def clim(self):
+        """The contrast limits that were applied to the volume data.
+
+        Volume display is mapped from black to white with these values.
+        Settable via set_data() as well as @clim.setter.
+        """
+        return self._clim
+
+    @property
+    def texture_is_inverted(self):
+        if self._texture_limits is not None:
+            return self._texture_limits[1] < self._texture_limits[0]
+
+    @clim.setter
+    def clim(self, value):
+        """Set contrast limits used when rendering the image.
+
+        ``value`` should be a 2-tuple of floats (min_clim, max_clim), where each value is
+        within the range set by self.clim. If the new value is outside of the (min, max)
+        range of the clims previously used to normalize the texture data, then data will
+        be renormalized using set_data.
+        """
+        clim = np.array(value, float)
+        if not (clim.ndim == 1 and clim.size == 2):
+            raise ValueError('clim must be a 2-element array-like')
+        self._clim = tuple(clim)
+        if self.texture_is_inverted:
+            if (clim[0] > self._texture_limits[0]) or (
+                clim[1] < self._texture_limits[1]
+            ):
+                self.rescale_data()
+                return
+        else:
+            if (clim[0] < self._texture_limits[0]) or (
+                clim[1] > self._texture_limits[1]
+            ):
+                self.rescale_data()
+                return
+        # if the clim range is too small of a percentage of the last-used texture range,
+        # posterization may be visible, so downscale the texture range.
+        range_ratio = np.subtract(*clim) / abs(
+            np.subtract(*self._texture_limits)
+        )
+        if np.abs(range_ratio) < self._clim_range_threshold:
+            self.rescale_data()
+        else:
+            #  new clims are within reasonable range of the texture data, just call shader
+            self.shared_program['clim'] = self.clim_normalized
+            self.update()
+
+    @property
+    def clim_normalized(self):
+        """Normalize current clims between 0-1 based on last-used texture data range.
+
+        In set_data(), the data is normalized (on the CPU) to 0-1 using ``clim``.
+        During rendering, the frag shader will apply the final contrast adjustment based on
+        the current ``clim``.
+        """
+        range_min, range_max = self._texture_limits
+        clim0, clim1 = self.clim
+        if self.texture_is_inverted:
+            tex_range = range_min - range_max
+            clim0 = (clim0 - range_max) / tex_range
+            clim1 = (clim1 - range_max) / tex_range
+        else:
+            tex_range = range_max - range_min
+            clim0 = (clim0 - range_min) / tex_range
+            clim1 = (clim1 - range_min) / tex_range
+        return clim0, clim1
+
+    @property
+    def gamma(self):
+        """The gamma used when rendering the image."""
+        return self._gamma
+
+    @gamma.setter
+    def gamma(self, value):
+        """Set gamma used when rendering the image."""
+        if value <= 0:
+            raise ValueError("gamma must be > 0")
+        self._gamma = float(value)
+        self.shared_program['gamma'] = self._gamma
+        self.update()
+
+    @property
+    def cmap(self):
+        return self._cmap
+
+    @cmap.setter
+    def cmap(self, cmap):
+        self._cmap = get_colormap(cmap)
+        self.shared_program.frag['cmap'] = Function(self._cmap.glsl_map)
+        self.update()
+
+    @property
+    def interpolation(self):
+        """The interpolation method to use
+
+        Current options are:
+        
+            * linear: this method is appropriate for most volumes as it creates
+              nice looking visuals.
+            * nearest: this method is appropriate for volumes with discrete
+              data where additional interpolation does not make sense.
+        """
+        return self._interpolation
+
+    @interpolation.setter
+    def interpolation(self, interp):
+        if interp not in self._interpolation_names:
+            raise ValueError(
+                "interpolation must be one of %s"
+                % ', '.join(self._interpolation_names)
+            )
+        if self._interpolation != interp:
+            self._interpolation = interp
+            self._tex.interpolation = self._interpolation
+            self.update()
+
+    @property
+    def method(self):
+        """The render method to use
+
+        Current options are:
+        
+            * translucent: voxel colors are blended along the view ray until
+              the result is opaque.
+            * mip: maxiumum intensity projection. Cast a ray and display the
+              maximum value that was encountered.
+            * additive: voxel colors are added along the view ray until
+              the result is saturated.
+            * iso: isosurface. Cast a ray until a certain threshold is
+              encountered. At that location, lighning calculations are
+              performed to give the visual appearance of a surface.  
+        """
+        return self._method
+
+    @method.setter
+    def method(self, method):
+        # Check and save
+        known_methods = list(frag_dict.keys())
+        if method not in known_methods:
+            raise ValueError(
+                'Volume render method should be in %r, not %r'
+                % (known_methods, method)
+            )
+        self._method = method
+        # Get rid of specific variables - they may become invalid
+        if 'u_threshold' in self.shared_program:
+            self.shared_program['u_threshold'] = None
+
+        self.shared_program.frag = frag_dict[method]
+        self.shared_program.frag['sampler_type'] = self._tex.glsl_sampler_type
+        self.shared_program.frag['sample'] = self._tex.glsl_sample
+        self.shared_program.frag['cmap'] = Function(self._cmap.glsl_map)
+        self.shared_program['texture2D_LUT'] = (
+            self.cmap.texture_lut()
+            if (hasattr(self.cmap, 'texture_lut'))
+            else None
+        )
+        self.update()
+
+    @property
+    def threshold(self):
+        """ The threshold value to apply for the isosurface render method.
+        """
+        return self._threshold
+
+    @threshold.setter
+    def threshold(self, value):
+        self._threshold = float(value)
+        if 'u_threshold' in self.shared_program:
+            self.shared_program['u_threshold'] = self._threshold
+        self.update()
+
+    @property
+    def relative_step_size(self):
+        """ The relative step size used during raycasting.
+        
+        Larger values yield higher performance at reduced quality. If
+        set > 2.0 the ray skips entire voxels. Recommended values are
+        between 0.5 and 1.5. The amount of quality degredation depends
+        on the render method.
+        """
+        return self._relative_step_size
+
+    @relative_step_size.setter
+    def relative_step_size(self, value):
+        value = float(value)
+        if value < 0.1:
+            raise ValueError('relative_step_size cannot be smaller than 0.1')
+        self._relative_step_size = value
+        self.shared_program['u_relative_step_size'] = value
+
+    def _create_vertex_data(self):
+        """ Create and set positions and texture coords from the given shape
+        
+        We have six faces with 1 quad (2 triangles) each, resulting in
+        6*2*3 = 36 vertices in total.
+        """
+        shape = self._vol_shape
+
+        # Get corner coordinates. The -0.5 offset is to center
+        # pixels/voxels. This works correctly for anisotropic data.
+        x0, x1 = -0.5, shape[2] - 0.5
+        y0, y1 = -0.5, shape[1] - 0.5
+        z0, z1 = -0.5, shape[0] - 0.5
+
+        pos = np.array(
+            [
+                [x0, y0, z0],
+                [x1, y0, z0],
+                [x0, y1, z0],
+                [x1, y1, z0],
+                [x0, y0, z1],
+                [x1, y0, z1],
+                [x0, y1, z1],
+                [x1, y1, z1],
+            ],
+            dtype=np.float32,
+        )
+
+        """
+          6-------7
+         /|      /|
+        4-------5 |
+        | |     | |
+        | 2-----|-3
+        |/      |/
+        0-------1
+        """
+
+        # Order is chosen such that normals face outward; front faces will be
+        # culled.
+        indices = np.array(
+            [2, 6, 0, 4, 5, 6, 7, 2, 3, 0, 1, 5, 3, 7], dtype=np.uint32
+        )
+
+        # Apply
+        self._vertices.set_data(pos)
+        self._index_buffer.set_data(indices)
+
+    def _compute_bounds(self, axis, view):
+        return 0, self._vol_shape[axis]
+
+    def _prepare_transforms(self, view):
+        trs = view.transforms
+        view.view_program.vert['transform'] = trs.get_transform()
+
+        view_tr_f = trs.get_transform('visual', 'document')
+        view_tr_i = view_tr_f.inverse
+        view.view_program.vert['viewtransformf'] = view_tr_f
+        view.view_program.vert['viewtransformi'] = view_tr_i
+
+    def _prepare_draw(self, view):
+        if self._need_vertex_update:
+            self._create_vertex_data()

--- a/napari/_vispy/vendored/volume.py
+++ b/napari/_vispy/vendored/volume.py
@@ -85,7 +85,7 @@ uniform vec3 u_shape;
 uniform vec2 clim;
 uniform float gamma;
 uniform float u_threshold;
-uniform float u_attenuation;
+uniform float u_attenuation; // todo add to vispy from napari
 uniform float u_relative_step_size;
 
 //varyings

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -1,10 +1,8 @@
 import warnings
-from vispy.scene.visuals import Image as ImageNode
+from .image import Image as ImageNode
 from .volume import Volume as VolumeNode
-from vispy.color import Colormap
 import numpy as np
 from .vispy_base_layer import VispyBaseLayer
-from ..layers.image._image_constants import Rendering
 
 
 texture_dtypes = [
@@ -29,8 +27,8 @@ class VispyImageLayer(VispyBaseLayer):
             self._on_contrast_limits_change
         )
         self.layer.events.gamma.connect(self._on_gamma_change)
-        self.layer.events.iso_threshold.connect(self._on_threshold_change)
-        self.layer.events.attenuation.connect(self._on_threshold_change)
+        self.layer.events.iso_threshold.connect(self._on_iso_threshold_change)
+        self.layer.events.attenuation.connect(self._on_attenuation_change)
 
         self._on_display_change()
         self._on_data_change()
@@ -40,14 +38,14 @@ class VispyImageLayer(VispyBaseLayer):
         self.node.parent = None
 
         if self.layer.dims.ndisplay == 2:
-            self._image_node.set_data(data)
             self.node = self._image_node
         else:
-            if data is None:
-                data = np.zeros((1, 1, 1))
-            self._volume_node.set_data(data, clim=self.layer.contrast_limits)
             self.node = self._volume_node
 
+        if data is None:
+            data = np.zeros((1,) * self.layer.dims.ndisplay)
+
+        self.node.set_data(data)
         self.node.parent = parent
         self.reset()
 
@@ -90,11 +88,7 @@ class VispyImageLayer(VispyBaseLayer):
         ):
             self._on_display_change(data)
         else:
-            if self.layer.dims.ndisplay == 2:
-                self.node._need_colortransform_update = True
-                self.node.set_data(data)
-            else:
-                self.node.set_data(data, clim=self.layer.contrast_limits)
+            self.node.set_data(data)
 
         # Call to update order of translation values with new dims:
         self._on_scale_change()
@@ -105,54 +99,36 @@ class VispyImageLayer(VispyBaseLayer):
         self.node.interpolation = self.layer.interpolation
 
     def _on_rendering_change(self, event=None):
-        if self.layer.dims.ndisplay == 3:
+        if isinstance(self.node, VolumeNode):
             self.node.method = self.layer.rendering
-            self._on_threshold_change()
+            self._on_attenuation_change()
+            self._on_iso_threshold_change()
 
     def _on_colormap_change(self, event=None):
-        cmap = self.layer.colormap[1]
-        if self.layer.gamma != 1:
-            # when gamma!=1, we instantiate a new colormap
-            # with 256 control points from 0-1
-            cmap = Colormap(cmap[np.linspace(0, 1, 256) ** self.layer.gamma])
-
-        # Below is fixed in #1712
-        if not self.layer.dims.ndisplay == 2:
-            self.node.view_program['texture2D_LUT'] = (
-                cmap.texture_lut() if (hasattr(cmap, 'texture_lut')) else None
-            )
-        self.node.cmap = cmap
+        self.node.cmap = self.layer.colormap[1]
 
     def _on_contrast_limits_change(self, event=None):
-        if self.layer.dims.ndisplay == 2:
-            self.node.clim = self.layer.contrast_limits
-        else:
-            self._on_data_change()
+        self.node.clim = self.layer.contrast_limits
 
     def _on_gamma_change(self, event=None):
-        self._on_colormap_change()
+        if len(self.node.shared_program.frag._set_items) > 0:
+            self.node.gamma = self.layer.gamma
 
-    def _on_threshold_change(self, event=None):
-        if self.layer.dims.ndisplay == 2:
-            return
-        rendering = Rendering(self.layer.rendering)
-        if rendering == Rendering.ISO:
-            self.node.threshold = float(self.layer.iso_threshold)
-        elif rendering == Rendering.ATTENUATED_MIP:
-            self.node.threshold = float(self.layer.attenuation)
+    def _on_iso_threshold_change(self, event=None):
+        if isinstance(self.node, VolumeNode):
+            self.node.threshold = self.layer.iso_threshold
 
-        # Fix for #1399, should be fixed in the VisPy threshold setter
-        if 'u_threshold' not in self.node.shared_program:
-            self.node.shared_program['u_threshold'] = self.node._threshold
-            self.node.update()
+    def _on_attenuation_change(self, event=None):
+        if isinstance(self.node, VolumeNode):
+            self.node.attenuation = self.layer.attenuation
 
     def reset(self, event=None):
         self._reset_base()
         self._on_interpolation_change()
         self._on_colormap_change()
+        self._on_contrast_limits_change()
+        self._on_gamma_change()
         self._on_rendering_change()
-        if self.layer.dims.ndisplay == 2:
-            self._on_contrast_limits_change()
 
     def downsample_texture(self, data, MAX_TEXTURE_SIZE):
         """Downsample data based on maximum allowed texture size.

--- a/napari/_vispy/volume.py
+++ b/napari/_vispy/volume.py
@@ -1,321 +1,12 @@
-from vispy.scene.visuals import Volume as BaseVolume
+from .vendored import VolumeVisual as BaseVolumeVisual
+from .vendored.volume import FRAG_SHADER, frag_dict
+from vispy.scene.visuals import create_visual_node
+from vispy.color import get_colormap
 from vispy.visuals.shaders import Function
 
-# Vertex shader
-VERT_SHADER = """
-attribute vec3 a_position;
-// attribute vec3 a_texcoord;
-uniform vec3 u_shape;
 
-// varying vec3 v_texcoord;
-varying vec3 v_position;
-varying vec4 v_nearpos;
-varying vec4 v_farpos;
+BaseVolume = create_visual_node(BaseVolumeVisual)
 
-void main() {
-    // v_texcoord = a_texcoord;
-    v_position = a_position;
-
-    // Project local vertex coordinate to camera position. Then do a step
-    // backward (in cam coords) and project back. Voila, we get our ray vector.
-    vec4 pos_in_cam = $viewtransformf(vec4(v_position, 1));
-
-    // intersection of ray and near clipping plane (z = -1 in clip coords)
-    pos_in_cam.z = -pos_in_cam.w;
-    v_nearpos = $viewtransformi(pos_in_cam);
-
-    // intersection of ray and far clipping plane (z = +1 in clip coords)
-    pos_in_cam.z = pos_in_cam.w;
-    v_farpos = $viewtransformi(pos_in_cam);
-
-    gl_Position = $transform(vec4(v_position, 1.0));
-}
-"""  # noqa
-
-# Fragment shader
-FRAG_SHADER = """
-// uniforms
-uniform $sampler_type u_volumetex;
-uniform vec3 u_shape;
-uniform float u_threshold;
-uniform float u_relative_step_size;
-
-//varyings
-// varying vec3 v_texcoord;
-varying vec3 v_position;
-varying vec4 v_nearpos;
-varying vec4 v_farpos;
-
-// uniforms for lighting. Hard coded until we figure out how to do lights
-const vec4 u_ambient = vec4(0.2, 0.2, 0.2, 1.0);
-const vec4 u_diffuse = vec4(0.8, 0.2, 0.2, 1.0);
-const vec4 u_specular = vec4(1.0, 1.0, 1.0, 1.0);
-const float u_shininess = 40.0;
-
-//varying vec3 lightDirs[1];
-
-// global holding view direction in local coordinates
-vec3 view_ray;
-
-float rand(vec2 co)
-{{
-    // Create a pseudo-random number between 0 and 1.
-    // http://stackoverflow.com/questions/4200224
-    return fract(sin(dot(co.xy ,vec2(12.9898, 78.233))) * 43758.5453);
-}}
-
-float colorToVal(vec4 color1)
-{{
-    return color1.g; // todo: why did I have this abstraction in visvis?
-}}
-
-vec4 calculateColor(vec4 betterColor, vec3 loc, vec3 step)
-{{
-    // Calculate color by incorporating lighting
-    vec4 color1;
-    vec4 color2;
-
-    // View direction
-    vec3 V = normalize(view_ray);
-
-    // calculate normal vector from gradient
-    vec3 N; // normal
-    color1 = $sample( u_volumetex, loc+vec3(-step[0],0.0,0.0) );
-    color2 = $sample( u_volumetex, loc+vec3(step[0],0.0,0.0) );
-    N[0] = colorToVal(color1) - colorToVal(color2);
-    betterColor = max(max(color1, color2),betterColor);
-    color1 = $sample( u_volumetex, loc+vec3(0.0,-step[1],0.0) );
-    color2 = $sample( u_volumetex, loc+vec3(0.0,step[1],0.0) );
-    N[1] = colorToVal(color1) - colorToVal(color2);
-    betterColor = max(max(color1, color2),betterColor);
-    color1 = $sample( u_volumetex, loc+vec3(0.0,0.0,-step[2]) );
-    color2 = $sample( u_volumetex, loc+vec3(0.0,0.0,step[2]) );
-    N[2] = colorToVal(color1) - colorToVal(color2);
-    betterColor = max(max(color1, color2),betterColor);
-    float gm = length(N); // gradient magnitude
-    N = normalize(N);
-
-    // Flip normal so it points towards viewer
-    float Nselect = float(dot(N,V) > 0.0);
-    N = (2.0*Nselect - 1.0) * N;  // ==  Nselect * N - (1.0-Nselect)*N;
-
-    // Get color of the texture (albeido)
-    color1 = betterColor;
-    color2 = color1;
-    // todo: parametrise color1_to_color2
-
-    // Init colors
-    vec4 ambient_color = vec4(0.0, 0.0, 0.0, 0.0);
-    vec4 diffuse_color = vec4(0.0, 0.0, 0.0, 0.0);
-    vec4 specular_color = vec4(0.0, 0.0, 0.0, 0.0);
-    vec4 final_color;
-
-    // todo: allow multiple light, define lights on viewvox or subscene
-    int nlights = 1;
-    for (int i=0; i<nlights; i++)
-    {{
-        // Get light direction (make sure to prevent zero division)
-        vec3 L = normalize(view_ray);  //lightDirs[i];
-        float lightEnabled = float( length(L) > 0.0 );
-        L = normalize(L+(1.0-lightEnabled));
-
-        // Calculate lighting properties
-        float lambertTerm = clamp( dot(N,L), 0.0, 1.0 );
-        vec3 H = normalize(L+V); // Halfway vector
-        float specularTerm = pow( max(dot(H,N),0.0), u_shininess);
-
-        // Calculate mask
-        float mask1 = lightEnabled;
-
-        // Calculate colors
-        ambient_color +=  mask1 * u_ambient; // * gl_LightSource[i].ambient;
-        diffuse_color +=  mask1 * lambertTerm;
-        specular_color += mask1 * specularTerm * u_specular;
-    }}
-
-    // Calculate final color by componing different components
-    final_color = color2 * ( ambient_color + diffuse_color) + specular_color;
-    final_color.a = color2.a;
-
-    // Done
-    return final_color;
-}}
-
-// for some reason, this has to be the last function in order for the
-// filters to be inserted in the correct place...
-
-void main() {{
-    vec3 farpos = v_farpos.xyz / v_farpos.w;
-    vec3 nearpos = v_nearpos.xyz / v_nearpos.w;
-
-    // Calculate unit vector pointing in the view direction through this
-    // fragment.
-    view_ray = normalize(farpos.xyz - nearpos.xyz);
-
-    // Compute the distance to the front surface or near clipping plane
-    float distance = dot(nearpos-v_position, view_ray);
-    distance = max(distance, min((-0.5 - v_position.x) / view_ray.x,
-                            (u_shape.x - 0.5 - v_position.x) / view_ray.x));
-    distance = max(distance, min((-0.5 - v_position.y) / view_ray.y,
-                            (u_shape.y - 0.5 - v_position.y) / view_ray.y));
-    distance = max(distance, min((-0.5 - v_position.z) / view_ray.z,
-                            (u_shape.z - 0.5 - v_position.z) / view_ray.z));
-
-    // Now we have the starting position on the front surface
-    vec3 front = v_position + view_ray * distance;
-
-    // Decide how many steps to take
-    int nsteps = int(-distance / u_relative_step_size + 0.5);
-    float f_nsteps = float(nsteps);
-    if( nsteps < 1 )
-        discard;
-
-    // Get starting location and step vector in texture coordinates
-    vec3 step = ((v_position - front) / u_shape) / f_nsteps;
-    vec3 start_loc = front / u_shape;
-
-    // For testing: show the number of steps. This helps to establish
-    // whether the rays are correctly oriented
-    //gl_FragColor = vec4(0.0, f_nsteps / 3.0 / u_shape.x, 1.0, 1.0);
-    //return;
-
-    {before_loop}
-
-    // This outer loop seems necessary on some systems for large
-    // datasets. Ugly, but it works ...
-    vec3 loc = start_loc;
-    int iter = 0;
-    while (iter < nsteps) {{
-        for (iter=iter; iter<nsteps; iter++)
-        {{
-            // Get sample color
-            vec4 color = $sample(u_volumetex, loc);
-            float val = color.g;
-
-            {in_loop}
-
-            // Advance location deeper into the volume
-            loc += step;
-        }}
-    }}
-
-    {after_loop}
-
-    /* Set depth value - from visvis TODO
-    int iter_depth = int(maxi);
-    // Calculate end position in world coordinates
-    vec4 position2 = vertexPosition;
-    position2.xyz += ray*shape*float(iter_depth);
-    // Project to device coordinates and set fragment depth
-    vec4 iproj = gl_ModelViewProjectionMatrix * position2;
-    iproj.z /= iproj.w;
-    gl_FragDepth = (iproj.z+1.0)/2.0;
-    */
-}}
-
-
-"""  # noqa
-
-
-MIP_SNIPPETS = dict(
-    before_loop="""
-        float maxval = -99999.0; // The maximum encountered value
-        int maxi = 0;  // Where the maximum value was encountered
-        """,
-    in_loop="""
-        if( val > maxval ) {
-            maxval = val;
-            maxi = iter;
-        }
-        """,
-    after_loop="""
-        // Refine search for max value
-        loc = start_loc + step * (float(maxi) - 0.5);
-        for (int i=0; i<10; i++) {
-            maxval = max(maxval, $sample(u_volumetex, loc).g);
-            loc += step * 0.1;
-        }
-        gl_FragColor = $cmap(maxval);
-        """,
-)
-MIP_FRAG_SHADER = FRAG_SHADER.format(**MIP_SNIPPETS)
-
-
-TRANSLUCENT_SNIPPETS = dict(
-    before_loop="""
-        vec4 integrated_color = vec4(0., 0., 0., 0.);
-        """,
-    in_loop="""
-            color = $cmap(val);
-            float a1 = integrated_color.a;
-            float a2 = color.a * (1 - a1);
-            float alpha = max(a1 + a2, 0.001);
-
-            // Doesn't work.. GLSL optimizer bug?
-            //integrated_color = (integrated_color * a1 / alpha) +
-            //                   (color * a2 / alpha);
-            // This should be identical but does work correctly:
-            integrated_color *= a1 / alpha;
-            integrated_color += color * a2 / alpha;
-
-            integrated_color.a = alpha;
-
-            if( alpha > 0.99 ){
-                // stop integrating if the fragment becomes opaque
-                iter = nsteps;
-            }
-
-        """,
-    after_loop="""
-        gl_FragColor = integrated_color;
-        """,
-)
-TRANSLUCENT_FRAG_SHADER = FRAG_SHADER.format(**TRANSLUCENT_SNIPPETS)
-
-
-ADDITIVE_SNIPPETS = dict(
-    before_loop="""
-        vec4 integrated_color = vec4(0., 0., 0., 0.);
-        """,
-    in_loop="""
-        color = $cmap(val);
-
-        integrated_color = 1.0 - (1.0 - integrated_color) * (1.0 - color);
-        """,
-    after_loop="""
-        gl_FragColor = integrated_color;
-        """,
-)
-ADDITIVE_FRAG_SHADER = FRAG_SHADER.format(**ADDITIVE_SNIPPETS)
-
-
-ISO_SNIPPETS = dict(
-    before_loop="""
-        vec4 color3 = vec4(0.0);  // final color
-        vec3 dstep = 1.5 / u_shape;  // step to sample derivative
-        gl_FragColor = vec4(0.0);
-    """,
-    in_loop="""
-        if (val > u_threshold-0.2) {
-            // Take the last interval in smaller steps
-            vec3 iloc = loc - step;
-            for (int i=0; i<10; i++) {
-                color = $sample(u_volumetex, iloc);
-                if (color.g > u_threshold) {
-                    color = calculateColor(color, iloc, dstep);
-                    gl_FragColor = $cmap(color.g);
-                    iter = nsteps;
-                    break;
-                }
-                iloc += step * 0.1;
-            }
-        }
-        """,
-    after_loop="""
-        """,
-)
-
-ISO_FRAG_SHADER = FRAG_SHADER.format(**ISO_SNIPPETS)
 
 ATTENUATED_MIP_SNIPPETS = dict(
     before_loop="""
@@ -327,7 +18,7 @@ ATTENUATED_MIP_SNIPPETS = dict(
         """,
     in_loop="""
         sumval = sumval + val;
-        scaled = val * exp(-u_threshold * (sumval - 1) / u_relative_step_size);
+        scaled = val * exp(-u_attenuation * (sumval - 1) / u_relative_step_size);
         if( scaled > maxval ) {
             maxval = scaled;
             maxi = iter;
@@ -335,95 +26,58 @@ ATTENUATED_MIP_SNIPPETS = dict(
         }
         """,
     after_loop="""
-        gl_FragColor = $cmap(maxval);
+        gl_FragColor = applyColormap(maxval);
         """,
 )
 ATTENUATED_MIP_FRAG_SHADER = FRAG_SHADER.format(**ATTENUATED_MIP_SNIPPETS)
 
-frag_dict = {
-    'mip': MIP_FRAG_SHADER,
-    'iso': ISO_FRAG_SHADER,
-    'translucent': TRANSLUCENT_FRAG_SHADER,
-    'additive': ADDITIVE_FRAG_SHADER,
-    'attenuated_mip': ATTENUATED_MIP_FRAG_SHADER,
-}
+frag_dict['attenuated_mip'] = ATTENUATED_MIP_FRAG_SHADER
 
 
 # Custom volume class is needed for better 3D rendering
 class Volume(BaseVolume):
-    _interpolation_names = ['linear', 'nearest']
-
     def __init__(self, *args, **kwargs):
-        self._interpolation = 'linear'
-        self._threshold = 0
+        self._attenuation = 1.0
         super().__init__(*args, **kwargs)
 
     @property
-    def method(self):
-        """The render method to use
+    def cmap(self):
+        return self._cmap
 
-        Current options are:
-
-            * translucent: voxel colors are blended along the view ray until
-              the result is opaque.
-            * mip: maximum intensity projection. Cast a ray and display the
-              maximum value that was encountered.
-            * additive: voxel colors are added along the view ray until
-              the result is saturated.
-            * iso: isosurface. Cast a ray until a certain threshold is
-              encountered. At that location, lighning calculations are
-              performed to give the visual appearance of a surface.
-        """
-        return self._method
-
-    @method.setter
-    def method(self, method):
-        # Check and save
-        known_methods = list(frag_dict.keys())
-        if method not in known_methods:
-            raise ValueError(
-                'Volume render method should be in %r, not %r'
-                % (known_methods, method)
-            )
-        self._method = method
-        self.shared_program.frag = frag_dict[method]
-        self.shared_program.frag['sampler_type'] = self._tex.glsl_sampler_type
-        self.shared_program.frag['sample'] = self._tex.glsl_sample
+    @cmap.setter
+    def cmap(self, cmap):
+        self._cmap = get_colormap(cmap)
         self.shared_program.frag['cmap'] = Function(self._cmap.glsl_map)
+        # Colormap change fix
         self.shared_program['texture2D_LUT'] = (
             self.cmap.texture_lut()
             if (hasattr(self.cmap, 'texture_lut'))
             else None
         )
-        if 'u_threshold' in self.shared_program:
-            self.shared_program['u_threshold'] = self.threshold
         self.update()
 
     @property
     def threshold(self):
-        """ The threshold value to apply for the isosurface render method.
+        """The threshold value to apply for the isosurface render method.
         """
         return self._threshold
 
     @threshold.setter
     def threshold(self, value):
+        # Fix for #1399, should be fixed in the VisPy threshold setter
         self._threshold = float(value)
-        if 'u_threshold' in self.shared_program:
-            self.shared_program['u_threshold'] = self._threshold
+        self.shared_program['u_threshold'] = self._threshold
         self.update()
 
     @property
-    def interpolation(self):
-        return self._interpolation
+    def attenuation(self):
+        """The attenuation value to apply for the attenuated mip render method.
+        """
+        return self._attenuation
 
-    @interpolation.setter
-    def interpolation(self, interp):
-        if interp not in self._interpolation_names:
-            raise ValueError(
-                "interpolation must be one of %s"
-                % ', '.join(self._interpolation_names)
-            )
-        if self._interpolation != interp:
-            self._interpolation = interp
-            self._tex.interpolation = self._interpolation
-            self.update()
+    @attenuation.setter
+    def attenuation(self, value):
+        # Fix for #1399, should be fixed in the VisPy threshold setter
+        self._attenuation = float(value)
+        self.shared_program['u_attenuation'] = self._attenuation
+        self.update()

--- a/napari/benchmarks/benchmark_qt_viewer_image.py
+++ b/napari/benchmarks/benchmark_qt_viewer_image.py
@@ -165,3 +165,57 @@ class QtViewerSingleInvisbleImageSuite:
     def time_ndisplay(self):
         """Time to enter 3D rendering."""
         self.viewer.dims.ndisplay = 3
+
+
+class QtImageRenderingSuite:
+    """Benchmarks for a single image layer in the viewer."""
+
+    params = [2 ** i for i in range(4, 13)]
+
+    def setup(self, n):
+        _ = QApplication.instance() or QApplication([])
+        np.random.seed(0)
+        self.data = np.random.random((n, n)) * 2 ** 12
+        self.viewer = napari.view_image(self.data, ndisplay=2)
+
+    def teardown(self, n):
+        self.viewer.close()
+
+    def time_change_contrast(self, n):
+        """Time to change contrast limits."""
+        self.viewer.layers[0].contrast_limits = (250, 3000)
+        self.viewer.layers[0].contrast_limits = (300, 2900)
+        self.viewer.layers[0].contrast_limits = (350, 2800)
+
+    def time_change_gamma(self, n):
+        """Time to change gamma."""
+        self.viewer.layers[0].gamma = 0.5
+        self.viewer.layers[0].gamma = 0.8
+        self.viewer.layers[0].gamma = 1.3
+
+
+class QtVolumeRenderingSuite:
+    """Benchmarks for a single image layer in the viewer."""
+
+    params = [2 ** i for i in range(4, 10)]
+
+    def setup(self, n):
+        _ = QApplication.instance() or QApplication([])
+        np.random.seed(0)
+        self.data = np.random.random((n, n, n)) * 2 ** 12
+        self.viewer = napari.view_image(self.data, ndisplay=3)
+
+    def teardown(self, n):
+        self.viewer.close()
+
+    def time_change_contrast(self, n):
+        """Time to change contrast limits."""
+        self.viewer.layers[0].contrast_limits = (250, 3000)
+        self.viewer.layers[0].contrast_limits = (300, 2900)
+        self.viewer.layers[0].contrast_limits = (350, 2800)
+
+    def time_change_gamma(self, n):
+        """Time to change gamma."""
+        self.viewer.layers[0].gamma = 0.5
+        self.viewer.layers[0].gamma = 0.8
+        self.viewer.layers[0].gamma = 1.3


### PR DESCRIPTION
# Description
This PR supersedes #1056 by porting @tlambert03 newly contributed vispy code from https://github.com/vispy/vispy/pull/1844 and https://github.com/vispy/vispy/pull/1842 for Image and Volume which have merged or are close to merge respectively at vispy but are not yet released.

The PR tries to keep the vendored code well isolated though an additional line  `uniform float u_attenuation;` is present in line 88 of `napari/_vispy/vendored/volume.py` as we have yet to contribute the attenuated max intensity projection shader back to vispy.

The most exciting thing about the PR are the performance improvements, and these are particularly impressive for the 3D case

### before this PR
```
(base) czirwc1macos2701:napari nsofroniew$ asv run -b QtImageRenderingSuite --python=same
· Discovering benchmarks
· Running 2 total benchmarks (1 commits * 1 environments * 2 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_nsofroniew_opt_anaconda3_bin_python
[ 25.00%] ··· Running (benchmark_qt_viewer_image.QtImageRenderingSuite.time_change_contrast--).
[ 50.00%] ··· Running (benchmark_qt_viewer_image.QtImageRenderingSuite.time_change_gamma--).
[ 75.00%] ··· benchmark_qt_viewer_image.QtImageRenderingSuite.time_change_contrast                                                                                                                        ok
[ 75.00%] ··· ======== =============
               param1
              -------- -------------
                 16      2.64±0.2ms
                 32      2.73±0.3ms
                 64      2.59±0.2ms
                128      2.64±0.2ms
                256     2.59±0.08ms
                512     2.40±0.07ms
                1024    2.46±0.06ms
                2048    2.42±0.07ms
                4096     2.64±0.4ms
              ======== =============

[100.00%] ··· benchmark_qt_viewer_image.QtImageRenderingSuite.time_change_gamma                                                                                                                           ok
[100.00%] ··· ======== ============
               param1
              -------- ------------
                 16     5.47±0.7ms
                 32     5.58±0.4ms
                 64     5.22±0.3ms
                128     5.21±0.3ms
                256     5.18±0.3ms
                512     5.37±0.4ms
                1024    5.35±0.4ms
                2048    5.36±0.4ms
                4096    5.22±0.3ms
              ======== ============

(base) czirwc1macos2701:napari nsofroniew$ asv run -b QtVolumeRenderingSuite --python=same
· Discovering benchmarks
· Running 2 total benchmarks (1 commits * 1 environments * 2 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_nsofroniew_opt_anaconda3_bin_python
[ 25.00%] ··· Running (benchmark_qt_viewer_image.QtVolumeRenderingSuite.time_change_contrast--).
[ 50.00%] ··· Running (benchmark_qt_viewer_image.QtVolumeRenderingSuite.time_change_gamma--).
[ 75.00%] ··· benchmark_qt_viewer_image.QtVolumeRenderingSuite.time_change_contrast                                                                                                                       ok
[ 75.00%] ··· ======== =============
               param1
              -------- -------------
                 16      7.72±0.1ms
                 32      7.99±0.1ms
                 64     11.4±0.08ms
                128      37.7±0.7ms
                256       251±4ms
                512      3.13±0.6s
              ======== =============

[100.00%] ··· benchmark_qt_viewer_image.QtVolumeRenderingSuite.time_change_gamma                                                                                                                          ok
[100.00%] ··· ======== =============
               param1
              -------- -------------
                 16     5.22±0.06ms
                 32      5.37±0.2ms
                 64     6.45±0.07ms
                128     17.0±0.08ms
                256       81.6±2ms
                512       551±4ms
              ======== =============
```

### after this PR
```
(base) czirwc1macos2701:napari nsofroniew$ asv run -b QtImageRenderingSuite --python=same
· Discovering benchmarks
· Running 2 total benchmarks (1 commits * 1 environments * 2 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_nsofroniew_opt_anaconda3_bin_python
[ 25.00%] ··· Running (benchmark_qt_viewer_image.QtImageRenderingSuite.time_change_contrast--).
[ 50.00%] ··· Running (benchmark_qt_viewer_image.QtImageRenderingSuite.time_change_gamma--).
[ 75.00%] ··· benchmark_qt_viewer_image.QtImageRenderingSuite.time_change_contrast                                                                                                                        ok
[ 75.00%] ··· ======== =============
               param1
              -------- -------------
                 16     2.32±0.02ms
                 32     2.37±0.05ms
                 64     2.37±0.03ms
                128     2.34±0.03ms
                256     2.41±0.04ms
                512     2.51±0.06ms
                1024    2.45±0.08ms
                2048    2.48±0.03ms
                4096     2.37±0.1ms
              ======== =============

[100.00%] ··· benchmark_qt_viewer_image.QtImageRenderingSuite.time_change_gamma                                                                                                                           ok
[100.00%] ··· ======== =============
               param1
              -------- -------------
                 16     2.06±0.02ms
                 32     2.08±0.05ms
                 64     2.06±0.05ms
                128     2.06±0.01ms
                256     2.06±0.02ms
                512     2.10±0.03ms
                1024    2.11±0.02ms
                2048    2.07±0.03ms
                4096    2.10±0.02ms
              ======== =============

(base) czirwc1macos2701:napari nsofroniew$ asv run -b QtVolumeRenderingSuite --python=same
· Discovering benchmarks
· Running 2 total benchmarks (1 commits * 1 environments * 2 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_nsofroniew_opt_anaconda3_bin_python
[ 25.00%] ··· Running (benchmark_qt_viewer_image.QtVolumeRenderingSuite.time_change_contrast--).
[ 50.00%] ··· Running (benchmark_qt_viewer_image.QtVolumeRenderingSuite.time_change_gamma--).
[ 75.00%] ··· benchmark_qt_viewer_image.QtVolumeRenderingSuite.time_change_contrast                                                                                                                       ok
[ 75.00%] ··· ======== =============
               param1
              -------- -------------
                 16     2.45±0.07ms
                 32     2.62±0.04ms
                 64     3.75±0.09ms
                128      13.9±0.6ms
                256      77.9±0.7ms
                512       582±9ms
              ======== =============

[100.00%] ··· benchmark_qt_viewer_image.QtVolumeRenderingSuite.time_change_gamma                                                                                                                          ok
[100.00%] ··· ======== =============
               param1
              -------- -------------
                 16     2.24±0.04ms
                 32     2.28±0.08ms
                 64      3.34±0.1ms
                128      13.3±0.6ms
                256       77.3±1ms
                512       571±4ms
              ======== =============
```

One question I have for @tlambert03 is if he wants to make better use of the `contrast_limits_range` parameter in this new system - I recall those values potentially being useful, and I'm not making use of them here. Feel free to update this PR directly if that is the case.

Otherwise this is ready for review, with all tests passing locally (and all tests unchanged). 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
