### PR TITLE
Reduce attenuation default and range

### DIFF
--- a/napari/_qt/layers/qt_image_layer.py
+++ b/napari/_qt/layers/qt_image_layer.py
@@ -77,9 +77,9 @@ class QtImageControls(QtBaseImageControls):
         sld = QSlider(Qt.Horizontal, parent=self)
         sld.setFocusPolicy(Qt.NoFocus)
         sld.setMinimum(0)
-        sld.setMaximum(200)
+        sld.setMaximum(100)
         sld.setSingleStep(1)
-        sld.setValue(int(self.layer.attenuation * 100))
+        sld.setValue(int(self.layer.attenuation * 200))
         sld.valueChanged.connect(self.changeAttenuation)
         self.attenuationSlider = sld
         self.attenuationLabel = QLabel('attenuation:')
@@ -185,7 +185,7 @@ class QtImageControls(QtBaseImageControls):
             Attenuation rate for attenuated maximum intensity projection.
         """
         with self.layer.events.blocker(self._on_attenuation_change):
-            self.layer.attenuation = value / 100
+            self.layer.attenuation = value / 200
 
     def _on_attenuation_change(self, event):
         """Receive layer model attenuation change event and update the slider.
@@ -196,7 +196,7 @@ class QtImageControls(QtBaseImageControls):
             Event from the Qt context.
         """
         with self.layer.events.attenuation.blocker():
-            self.attenuationSlider.setValue(self.layer.attenuation * 100)
+            self.attenuationSlider.setValue(self.layer.attenuation * 200)
 
     def _on_interpolation_change(self, event):
         """Receive layer interpolation change event and update dropdown menu.

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -189,7 +189,7 @@ def test_changing_image_attenuation(make_test_viewer):
     viewer.add_image(data, contrast_limits=[0, 1])
     viewer.layers[0].rendering = 'attenuated_mip'
 
-    viewer.layers[0].attenuation = 2.0
+    viewer.layers[0].attenuation = 0.5
     screenshot = viewer.screenshot(canvas_only=True)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that rendering has not been attenuated

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -193,7 +193,7 @@ def test_changing_image_attenuation(make_test_viewer):
     screenshot = viewer.screenshot(canvas_only=True)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that rendering has not been attenuated
-    assert screenshot[center + (0,)] > 200
+    assert screenshot[center + (0,)] > 80
 
     viewer.layers[0].attenuation = 0.02
     screenshot = viewer.screenshot(canvas_only=True)

--- a/napari/_vispy/_tests/test_image_rendering.py
+++ b/napari/_vispy/_tests/test_image_rendering.py
@@ -23,8 +23,8 @@ def test_image_rendering(make_test_viewer):
     # Change rendering property
     layer.rendering = 'attenuated_mip'
     assert layer.rendering == 'attenuated_mip'
-    layer.attenuation = 0.2
-    assert layer.attenuation == 0.2
+    layer.attenuation = 0.15
+    assert layer.attenuation == 0.15
 
     # Change rendering property
     layer.rendering = 'iso'

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -78,7 +78,7 @@ class AddLayersMixin:
         interpolation='nearest',
         rendering='mip',
         iso_threshold=0.5,
-        attenuation=0.5,
+        attenuation=0.25,
         name=None,
         metadata=None,
         scale=None,

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -78,7 +78,7 @@ class AddLayersMixin:
         interpolation='nearest',
         rendering='mip',
         iso_threshold=0.5,
-        attenuation=0.25,
+        attenuation=0.05,
         name=None,
         metadata=None,
         scale=None,

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -486,7 +486,7 @@ def test_attenuation():
     np.random.seed(0)
     data = np.random.random((10, 15))
     layer = Image(data)
-    assert layer.attenuation == 0.25
+    assert layer.attenuation == 0.05
 
     # Change attenuation property
     attenuation = 0.07

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -486,10 +486,10 @@ def test_attenuation():
     np.random.seed(0)
     data = np.random.random((10, 15))
     layer = Image(data)
-    assert layer.attenuation == 0.5
+    assert layer.attenuation == 0.25
 
-    # Change iso_threshold property
-    attenuation = 0.7
+    # Change attenuation property
+    attenuation = 0.07
     layer.attenuation = attenuation
     assert layer.attenuation == attenuation
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -141,7 +141,7 @@ class Image(IntensityVisualizationMixin, Layer):
         interpolation='nearest',
         rendering='mip',
         iso_threshold=0.5,
-        attenuation=0.5,
+        attenuation=0.25,
         name=None,
         metadata=None,
         scale=None,

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -141,7 +141,7 @@ class Image(IntensityVisualizationMixin, Layer):
         interpolation='nearest',
         rendering='mip',
         iso_threshold=0.5,
-        attenuation=0.25,
+        attenuation=0.05,
         name=None,
         metadata=None,
         scale=None,

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -12,7 +12,7 @@ def view_image(
     interpolation='nearest',
     rendering='mip',
     iso_threshold=0.5,
-    attenuation=0.25,
+    attenuation=0.05,
     name=None,
     metadata=None,
     scale=None,

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -12,7 +12,7 @@ def view_image(
     interpolation='nearest',
     rendering='mip',
     iso_threshold=0.5,
-    attenuation=0.5,
+    attenuation=0.25,
     name=None,
     metadata=None,
     scale=None,


### PR DESCRIPTION
# Description
Closes #1392 by reducing attenuation range from `(0, 2)` to `(0, 0.5)`. This is still bigger than a lot of values reported in #1392, which were `(0.02, 0.06)`, but one of the datasets I have still looks good out to `0.5`. @tlambert03 suggested something non-linear which we might want to try in the future, but for now I think this is an improvement on what we have, without being a major change.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
