### PR TITLE
fix toggle ndisplay z-order points

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -158,6 +158,39 @@ def test_new_shapes_empty_viewer(make_test_viewer):
     assert np.sum(view.dims._displayed_sliders) == 0
 
 
+def test_z_order_adding_removing_images(make_test_viewer):
+    """Test z order is correct after adding/ removing images."""
+    data = np.ones((10, 10))
+
+    viewer = make_test_viewer()
+    vis = viewer.window.qt_viewer.layer_to_visual
+    viewer.add_image(data, colormap='red', name='red')
+    viewer.add_image(data, colormap='green', name='green')
+    viewer.add_image(data, colormap='blue', name='blue')
+    order = [vis[x].order for x in viewer.layers]
+    np.testing.assert_almost_equal(order, list(range(len(viewer.layers))))
+
+    # Remove and re-add image
+    viewer.layers.remove('red')
+    order = [vis[x].order for x in viewer.layers]
+    np.testing.assert_almost_equal(order, list(range(len(viewer.layers))))
+    viewer.add_image(data, colormap='red', name='red')
+    order = [vis[x].order for x in viewer.layers]
+    np.testing.assert_almost_equal(order, list(range(len(viewer.layers))))
+
+    # Remove two other images
+    viewer.layers.remove('green')
+    viewer.layers.remove('blue')
+    order = [vis[x].order for x in viewer.layers]
+    np.testing.assert_almost_equal(order, list(range(len(viewer.layers))))
+
+    # Add two other layers back
+    viewer.add_image(data, colormap='green', name='green')
+    viewer.add_image(data, colormap='blue', name='blue')
+    order = [vis[x].order for x in viewer.layers]
+    np.testing.assert_almost_equal(order, list(range(len(viewer.layers))))
+
+
 def test_screenshot(make_test_viewer):
     "Test taking a screenshot"
     viewer = make_test_viewer()

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -266,6 +266,7 @@ class QtViewer(QSplitter):
         vispy_layer.node.transforms = ChainTransform()
         vispy_layer.node.parent = None
         del vispy_layer
+        self._reorder_layers(None)
 
     def _reorder_layers(self, event):
         """When the list is reordered, propagate changes to draw order.

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -248,7 +248,7 @@ class QtViewer(QSplitter):
         layer = event.item
         vispy_layer = create_vispy_visual(layer)
         vispy_layer.node.parent = self.view.scene
-        vispy_layer.order = len(layers)
+        vispy_layer.order = len(layers) - 1
         self.canvas.connect(vispy_layer.on_draw)
         self.layer_to_visual[layer] = vispy_layer
 

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -8,6 +8,114 @@ import pytest
     sys.platform.startswith('win') or not os.getenv("CI"),
     reason='Screenshot tests are not supported on napari windows CI.',
 )
+def test_z_order_images(make_test_viewer):
+    """Test changing order of images changes z order in display."""
+    data = np.ones((10, 10))
+
+    viewer = make_test_viewer(show=True)
+    viewer.add_image(data, colormap='red')
+    viewer.add_image(data, colormap='blue')
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    # Check that blue is visible
+    np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
+
+    viewer.layers[0, 1] = viewer.layers[1, 0]
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    # Check that red is now visible
+    np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith('win') or not os.getenv("CI"),
+    reason='Screenshot tests are not supported on napari windows CI.',
+)
+def test_z_order_image_points(make_test_viewer):
+    """Test changing order of image and points changes z order in display."""
+    data = np.ones((10, 10))
+
+    viewer = make_test_viewer(show=True)
+    viewer.add_image(data, colormap='red')
+    viewer.add_points([5, 5], face_color='blue', size=10)
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    # Check that blue is visible
+    np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
+
+    viewer.layers[0, 1] = viewer.layers[1, 0]
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    # Check that red is now visible
+    np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith('win') or not os.getenv("CI"),
+    reason='Screenshot tests are not supported on napari windows CI.',
+)
+def test_z_order_images_after_ndisplay(make_test_viewer):
+    """Test z order of images remanins constant after chaning ndisplay."""
+    data = np.ones((10, 10))
+
+    viewer = make_test_viewer(show=True)
+    viewer.add_image(data, colormap='red')
+    viewer.add_image(data, colormap='blue')
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    # Check that blue is visible
+    np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
+
+    # Switch to 3D rendering
+    viewer.dims.ndisplay = 3
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    # Check that blue is still visible
+    np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
+
+    # Switch back to 2D rendering
+    viewer.dims.ndisplay = 2
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    # Check that blue is still visible
+    np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith('win') or not os.getenv("CI"),
+    reason='Screenshot tests are not supported on napari windows CI.',
+)
+def test_z_order_image_points_after_ndisplay(make_test_viewer):
+    """Test z order of image and points remanins constant after chaning ndisplay."""
+    data = np.ones((10, 10))
+
+    viewer = make_test_viewer(show=True)
+    viewer.add_image(data, colormap='red')
+    viewer.add_points([5, 5], face_color='blue', size=10)
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    # Check that blue is visible
+    np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
+
+    # Switch to 3D rendering
+    viewer.dims.ndisplay = 3
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    # Check that blue is still visible
+    np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
+
+    # Switch back to 2D rendering
+    viewer.dims.ndisplay = 2
+    screenshot = viewer.screenshot(canvas_only=True)
+    center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
+    # Check that blue is still visible
+    np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith('win') or not os.getenv("CI"),
+    reason='Screenshot tests are not supported on napari windows CI.',
+)
 def test_changing_image_colormap(make_test_viewer):
     """Test changing colormap changes rendering."""
     viewer = make_test_viewer(show=True)

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -47,6 +47,7 @@ class VispyImageLayer(VispyBaseLayer):
 
         self.node.set_data(data)
         self.node.parent = parent
+        self.node.order = self.order
         self.reset()
 
     def _on_data_change(self, event=None):

--- a/napari/_vispy/vispy_points_layer.py
+++ b/napari/_vispy/vispy_points_layer.py
@@ -1,7 +1,6 @@
 import numpy as np
 from vispy.scene.visuals import Line, Compound
 from .markers import Markers
-from vispy.visuals.transforms import ChainTransform
 
 from .vispy_base_layer import VispyBaseLayer
 from ..utils.colormaps.standardize_color import transform_color
@@ -25,31 +24,9 @@ class VispyPointsLayer(VispyBaseLayer):
         self.layer.events.edge_color.connect(self._on_data_change)
         self.layer.events.face_color.connect(self._on_data_change)
         self.layer.events.highlight.connect(self._on_highlight_change)
-        self._on_display_change()
         self._on_data_change()
 
-    def _on_display_change(self):
-        parent = self.node.parent
-        self.node.transforms = ChainTransform()
-        self.node.parent = None
-
-        if self.layer.dims.ndisplay == 2:
-            self.node = Compound([Markers(), Markers(), Line()])
-        else:
-            self.node = Compound([Markers(), Markers()])
-        self.node.parent = parent
-        self._reset_base()
-
     def _on_data_change(self, event=None):
-        # Check if ndisplay has changed current node type needs updating
-        if (
-            self.layer.dims.ndisplay == 3 and len(self.node._subvisuals) != 2
-        ) or (
-            self.layer.dims.ndisplay == 2 and len(self.node._subvisuals) != 3
-        ):
-            self._on_display_change()
-            self._on_highlight_change()
-
         if len(self.layer._indices_view) > 0:
             edge_color = self.layer._view_edge_color
             face_color = self.layer._view_face_color
@@ -120,6 +97,10 @@ class VispyPointsLayer(VispyBaseLayer):
                 pos=pos[:, ::-1] + 0.5,
                 color=self._highlight_color,
                 width=width,
+            )
+        else:
+            self.node._subvisuals[2].set_data(
+                pos=np.zeros((1, self.layer.dims.ndisplay)), width=0,
             )
 
         self.node.update()


### PR DESCRIPTION
# Description
Closes #1462 by fixing z-ordering change when toggling ndisplay for images (bug introduced in #1445) and for points where we were previously using the node create destroy approach we wanted to move away from in #1445.

I will add two screenshots test for this - but I'm hoping we might have fixed our windows CI bug too! We'll see!!


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
