### PR TITLE
fix edge color select bug

### DIFF
--- a/napari/_qt/layers/_tests/test_qt_shapes_layer.py
+++ b/napari/_qt/layers/_tests/test_qt_shapes_layer.py
@@ -1,0 +1,35 @@
+import numpy as np
+from napari._qt.layers.qt_shapes_layer import QtShapesControls
+from napari.layers import Shapes
+from napari.utils.colormaps.standardize_color import transform_color
+
+
+_SHAPES = np.random.random((10, 4, 2))
+
+
+def test_shape_controls_face_color(qtbot):
+    """Check updating of face color updates QtShapesControls."""
+    layer = Shapes(_SHAPES)
+    qtctrl = QtShapesControls(layer)
+    qtbot.addWidget(qtctrl)
+    target_color = transform_color(layer.current_face_color)[0]
+    np.testing.assert_almost_equal(qtctrl.faceColorEdit.color, target_color)
+
+    # Update current face color
+    layer.current_face_color = 'red'
+    target_color = transform_color(layer.current_face_color)[0]
+    np.testing.assert_almost_equal(qtctrl.faceColorEdit.color, target_color)
+
+
+def test_shape_controls_edge_color(qtbot):
+    """Check updating of edge color updates QtShapesControls."""
+    layer = Shapes(_SHAPES)
+    qtctrl = QtShapesControls(layer)
+    qtbot.addWidget(qtctrl)
+    target_color = transform_color(layer.current_edge_color)[0]
+    np.testing.assert_almost_equal(qtctrl.edgeColorEdit.color, target_color)
+
+    # Update current edge color
+    layer.current_edge_color = 'red'
+    target_color = transform_color(layer.current_edge_color)[0]
+    np.testing.assert_almost_equal(qtctrl.edgeColorEdit.color, target_color)

--- a/napari/_qt/layers/qt_shapes_layer.py
+++ b/napari/_qt/layers/qt_shapes_layer.py
@@ -294,18 +294,6 @@ class QtShapesControls(QtLayerControls):
         """
         self.layer.current_edge_width = float(value) / 2
 
-    def changeOpacity(self, value):
-        """Change opacity value of shapes on the layer model.
-
-        Parameters
-        ----------
-        value : float
-            Opacity value for shapes.
-            Input range 0 - 100 (transparent to fully opaque).
-        """
-        with self.layer.events.blocker(self._on_opacity_change):
-            self.layer.opacity = value / 100
-
     def _on_edge_width_change(self, event=None):
         """Receive layer model edge line width change event and update slider.
 
@@ -340,17 +328,6 @@ class QtShapesControls(QtLayerControls):
         """
         with qt_signals_blocked(self.faceColorEdit):
             self.faceColorEdit.setColor(self.layer.current_face_color)
-
-    def _on_opacity_change(self, event=None):
-        """Receive layer model opacity change event and update opacity slider.
-
-        Parameters
-        ----------
-        event : qtpy.QtCore.QEvent, optional.
-            Event from the Qt context, by default None.
-        """
-        with self.layer.events.opacity.blocker():
-            self.opacitySlider.setValue(self.layer.opacity * 100)
 
     def _on_editable_change(self, event=None):
         """Receive layer model editable change event & enable/disable buttons.

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -565,7 +565,7 @@ class Shapes(Layer):
             for i in self.selected_data:
                 self._data_view.update_edge_color(i, self._current_edge_color)
         self.events.edge_color()
-        self.events.current_face_color()
+        self.events.current_edge_color()
 
     @property
     def current_face_color(self):


### PR DESCRIPTION
# Description
Closes #1461 - was a type `events.current_face_color()` instead of `events.current_edge_color`.

We should add a test though. I'll give that a go. In general we should get better about testing our qt updates. Fine though to get there gradually, but at some point we might want to do a comprehensive sweep.

cc @kevinyamauchi 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
