### PR TITLE
DOC: minor doc reformatting.

### DIFF
--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -37,7 +37,7 @@ class VispyBaseLayer(ABC):
         Max texture size allowed by the vispy canvas during 2D rendering.
 
     Extended Summary
-    ----------
+    ----------------
     _master_transform : vispy.visuals.transforms.STTransform
         Transform positioning the layer visual inside the scenecanvas.
     """

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -1164,10 +1164,10 @@ def prune_kwargs(kwargs: Dict[str, Any], layer_type: str) -> Dict[str, Any]:
     Examples
     --------
     >>> test_kwargs = {
-            'scale': (0.75, 1),
-            'blending': 'additive',
-            'num_colors': 10,
-        }
+    ...     'scale': (0.75, 1),
+    ...     'blending': 'additive',
+    ...     'num_colors': 10,
+    ... }
     >>> prune_kwargs(test_kwargs, 'image')
     {'scale': (0.75, 1), 'blending': 'additive'}
 


### PR DESCRIPTION
Too short underline make numpydoc not see that as a header.

... as continuation prompt are necessay to non ambiguously detect conde
continuation.


