### PR TITLE
DOC: update param names to match function signature.

### DIFF
--- a/napari/_qt/qt_debug_menu.py
+++ b/napari/_qt/qt_debug_menu.py
@@ -27,7 +27,7 @@ class DebugMenu:
 
         Parameters
         ----------
-        main_menu : qtpy.QtWidgets.QMainWindow.menuBar
+        main_window : qtpy.QtWidgets.QMainWindow.menuBar
             We add ourselves to this menu.
         """
         self.debug_menu = main_window.main_menu.addMenu('&Debug')
@@ -53,7 +53,7 @@ class PerformanceSubMenu:
 
         Parameters
         ----------
-        record : bool
+        recording : bool
             Are we currently recording a trace file.
         """
         self.start.setEnabled(not recording)

--- a/napari/_qt/qt_dims.py
+++ b/napari/_qt/qt_dims.py
@@ -263,7 +263,7 @@ class QtDims(QWidget):
 
         Parameters
         ----------
-        axis : int
+        index : int
             Index of slider to remove
         """
         # remove particular slider
@@ -310,14 +310,14 @@ class QtDims(QWidget):
 
         Parameters
         ----------
-        axis: int
+        axis : int
             Index of axis to play
-        fps: float
+        fps : float
             Frames per second for playback.  Negative values will play in
             reverse.  fps == 0 will stop the animation. The view is not
             guaranteed to keep up with the requested fps, and may drop frames
             at higher fps.
-        loop_mode: str
+        loop_mode : str
             Mode for animation playback.  Must be one of the following options:
                 "once": Animation will stop once movie reaches the
                     max frame (if fps > 0) or the first frame (if fps < 0).
@@ -325,7 +325,7 @@ class QtDims(QWidget):
                     after reaching the last frame, looping until stopped.
                 "back_and_forth":  Movie will loop back and forth until
                     stopped
-        frame_range: tuple | list
+        frame_range : tuple | list
             If specified, will constrain animation to loop [first, last] frames
 
         Raises

--- a/napari/_qt/qt_plugin_sorter.py
+++ b/napari/_qt/qt_plugin_sorter.py
@@ -137,7 +137,7 @@ class QtHookImplementationListWidget(QListWidget):
 
         Parameters
         ----------
-        hook : HookCaller, optional
+        hook_caller : HookCaller, optional
             A ``HookCaller`` for which to show implementations. by default None
             (i.e. no hooks shown)
         """

--- a/napari/_qt/qt_viewer_buttons.py
+++ b/napari/_qt/qt_viewer_buttons.py
@@ -244,7 +244,7 @@ class QtGridViewButton(QCheckBox):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        state : qtpy.QtCore.QEvent
             Event from the Qt context.
         """
         if state == Qt.Checked:

--- a/napari/_qt/qt_viewer_buttons.py
+++ b/napari/_qt/qt_viewer_buttons.py
@@ -244,8 +244,8 @@ class QtGridViewButton(QCheckBox):
 
         Parameters
         ----------
-        state : qtpy.QtCore.QEvent
-            Event from the Qt context.
+        state : qtpy.QtCore.Qt.CheckState
+            State of the checkbox.
         """
         if state == Qt.Checked:
             self.viewer.stack_view()

--- a/napari/_qt/threading.py
+++ b/napari/_qt/threading.py
@@ -566,7 +566,7 @@ def thread_worker(
 
     Parameters
     ----------
-    func : callable
+    function : callable
         Function to call in another thread.  For communication between threads
         may be a generator function.
     start_thread : bool, optional
@@ -694,7 +694,7 @@ def _new_worker_qthread(
     start_thread : bool
         If True, thread will be started immediately, otherwise, thread must
         be manually started with thread.start().
-    connections: dict, optional
+    connections : dict, optional
         Optional dictionary of {signal: function} to connect to the new worker.
         for instance:  connections = {'incremented': myfunc} will result in:
         worker.incremented.connect(myfunc)

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -67,7 +67,7 @@ def add_layer_by_type(viewer, layer_type, data, visible=True):
     ----------
     layer_type : LayerTypes
         Layer type to add
-    data :
+    data
         The layer data to view
     """
     return layer2addmethod[layer_type](viewer, data, visible=visible)
@@ -81,7 +81,7 @@ def view_layer_type(layer_type, data):
     ----------
     layer_type : LayerTypes
         Layer type to view
-    data :
+    data
         The layer data to view
     """
     return layer2viewmethod[layer_type](data, show=False)

--- a/napari/_vispy/vendored/volume.py
+++ b/napari/_vispy/vendored/volume.py
@@ -502,7 +502,7 @@ class VolumeVisual(Visual):
         self.freeze()
 
     def set_data(self, vol, clim=None, copy=True):
-        """ Set the volume data. 
+        """ Set the volume data.
 
         Parameters
         ----------
@@ -678,7 +678,7 @@ class VolumeVisual(Visual):
         """The interpolation method to use
 
         Current options are:
-        
+
             * linear: this method is appropriate for most volumes as it creates
               nice looking visuals.
             * nearest: this method is appropriate for volumes with discrete
@@ -703,7 +703,7 @@ class VolumeVisual(Visual):
         """The render method to use
 
         Current options are:
-        
+
             * translucent: voxel colors are blended along the view ray until
               the result is opaque.
             * mip: maxiumum intensity projection. Cast a ray and display the
@@ -712,7 +712,7 @@ class VolumeVisual(Visual):
               the result is saturated.
             * iso: isosurface. Cast a ray until a certain threshold is
               encountered. At that location, lighning calculations are
-              performed to give the visual appearance of a surface.  
+              performed to give the visual appearance of a surface.
         """
         return self._method
 
@@ -757,7 +757,7 @@ class VolumeVisual(Visual):
     @property
     def relative_step_size(self):
         """ The relative step size used during raycasting.
-        
+
         Larger values yield higher performance at reduced quality. If
         set > 2.0 the ray skips entire voxels. Recommended values are
         between 0.5 and 1.5. The amount of quality degredation depends
@@ -775,7 +775,7 @@ class VolumeVisual(Visual):
 
     def _create_vertex_data(self):
         """ Create and set positions and texture coords from the given shape
-        
+
         We have six faces with 1 quad (2 triangles) each, resulting in
         6*2*3 = 36 vertices in total.
         """

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -335,7 +335,7 @@ class Dims:
         ----------
         axis : int
             Dimension index.
-        range : tuple
+        _range : tuple
             Range specified as (min, max, step).
         """
         axis = self._assert_axis_in_bounds(axis)

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -277,18 +277,18 @@ class Layer(KeymapProvider, ABC):
     def blending(self):
         """Blending mode: Determines how RGB and alpha values get mixed.
 
-            Blending.OPAQUE
-                Allows for only the top layer to be visible and corresponds to
-                depth_test=True, cull_face=False, blend=False.
-            Blending.TRANSLUCENT
-                Allows for multiple layers to be blended with different opacity
-                and corresponds to depth_test=True, cull_face=False,
-                blend=True, blend_func=('src_alpha', 'one_minus_src_alpha').
-            Blending.ADDITIVE
-                Allows for multiple layers to be blended together with
-                different colors and opacity. Useful for creating overlays. It
-                corresponds to depth_test=False, cull_face=False, blend=True,
-                blend_func=('src_alpha', 'one').
+        Blending.OPAQUE
+            Allows for only the top layer to be visible and corresponds to
+            depth_test=True, cull_face=False, blend=False.
+        Blending.TRANSLUCENT
+            Allows for multiple layers to be blended with different opacity
+            and corresponds to depth_test=True, cull_face=False,
+            blend=True, blend_func=('src_alpha', 'one_minus_src_alpha').
+        Blending.ADDITIVE
+            Allows for multiple layers to be blended together with
+            different colors and opacity. Useful for creating overlays. It
+            corresponds to depth_test=False, cull_face=False, blend=True,
+            blend_func=('src_alpha', 'one').
         """
         return str(self._blending)
 

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -15,7 +15,7 @@ def _make_cycled_properties(values, length):
 
     Parameters
     ----------
-    values :
+    values
         The values to be cycled.
     length : int
         The length of the resulting property array

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -449,7 +449,7 @@ class ShapeList:
             Location in list of the shape to be changed.
         data : np.ndarray
             NxD array of vertices.
-        new_type: None | str | Shape
+        new_type : None | str | Shape
             If string , must be one of "{'line', 'rectangle', 'ellipse',
             'path', 'polygon'}".
         """
@@ -659,9 +659,9 @@ class ShapeList:
 
         Returns
         -------
-        centers :np.ndarray
+        centers : np.ndarray
             Nx2 array of centers of outline
-        offsets :np.ndarray
+        offsets : np.ndarray
             Nx2 array of offsets of outline
         triangles : np.ndarray
             Mx3 array of any indices of vertices for triangles of outline

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -15,7 +15,7 @@ def _make_cycled_properties(values, length):
 
     Parameters
     ----------
-    values :
+    values
         The values to be cycled.
     length : int
         The length of the resulting property array

--- a/napari/layers/utils/color_transformations.py
+++ b/napari/layers/utils/color_transformations.py
@@ -63,7 +63,7 @@ def transform_color_cycle(
 
     Parameters
     ----------
-    colors : ColorType, cycle
+    color_cycle : ColorType, cycle
         The desired colors for each of the data points
     elem_name : str
         Whether we're trying to set the face color or edge color of the layer
@@ -104,7 +104,7 @@ def normalize_and_broadcast_colors(
     ----------
     num_entries : int
         The number of data elements in the layer
-    color : ColorType
+    colors : ColorType
         The user's input after being normalized by transform_color_with_defaults
 
     Returns

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -182,7 +182,7 @@ def map_property(
         The property to be colormapped
     colormap : vispy.color.Colormap
         The vispy colormap object to apply to the property
-    contrast_limits: Union[None, Tuple[float, float]]
+    contrast_limits : Union[None, Tuple[float, float]]
         The contrast limits for applying the colormap to the property.
         If a 2-tuple is provided, it should be provided as (lower_bound, upper_bound).
         If None is provided, the contrast limits will be set to (property.min(), property.max()).

--- a/napari/plugins/io.py
+++ b/napari/plugins/io.py
@@ -221,7 +221,7 @@ def _write_multiple_layers_with_plugins(
         The path (file, directory, url) to write.
     layers : List of napari.layers.Layer
         List of napari layers to write.
-    plugin_name: str, optional
+    plugin_name : str, optional
         If provided, force the plugin manager to use the ``napari_get_writer``
         from the requested ``plugin_name``.  If none is available, or if it is
         incapable of handling the layers, this function will fail.

--- a/napari/resources/__init__.py
+++ b/napari/resources/__init__.py
@@ -20,7 +20,7 @@ def _try_touch_file(target) -> Optional[Path]:
     If the target already exists, it will not be touched.  If it does not
     exist, this function attempts to create it and delete it (i.e. testing
     permissions).  NOTE: all parent directories required to write the file will
-    be created, but NOT deleted.  
+    be created, but NOT deleted.
 
     If successful, the path is returned, if not, return None.
 

--- a/napari/utils/colormaps/colormaps.py
+++ b/napari/utils/colormaps/colormaps.py
@@ -92,7 +92,7 @@ def _low_discrepancy_image(image, seed=0.5, margin=1 / 256):
 
     Parameters
     ----------
-    labels : array of int
+    image : array of int
         A set of labels or label image.
     seed : float
         The seed from which to start the quasirandom sequence.

--- a/napari/utils/colormaps/vendored/cm.py
+++ b/napari/utils/colormaps/vendored/cm.py
@@ -189,7 +189,6 @@ class ScalarMappable(object):
     """
     def __init__(self, norm=None, cmap=None):
         r"""
-
         Parameters
         ----------
         norm : :class:`matplotlib.colors.Normalize` instance

--- a/napari/utils/colormaps/vendored/colors.py
+++ b/napari/utils/colormaps/vendored/colors.py
@@ -481,7 +481,7 @@ class Colormap(object):
 
     def set_under(self, color='k', alpha=None):
         """Set color to be used for low out-of-range values.
-           Requires norm.clip = False
+        Requires norm.clip = False
         """
         self._rgba_under = to_rgba(color, alpha)
         if self._isinit:
@@ -489,7 +489,7 @@ class Colormap(object):
 
     def set_over(self, color='k', alpha=None):
         """Set color to be used for high out-of-range values.
-           Requires norm.clip = False
+        Requires norm.clip = False
         """
         self._rgba_over = to_rgba(color, alpha)
         if self._isinit:
@@ -585,7 +585,6 @@ class LinearSegmentedColormap(Colormap):
             row i+1: x  y0  y1
 
         Hence y0 in the first row and y1 in the last row are never used.
-
 
         .. seealso::
 
@@ -1136,8 +1135,10 @@ class BoundaryNorm(Normalize):
         ----------
         boundaries : array-like
             Monotonically increasing sequence of boundaries
+
         ncolors : int
             Number of colors in the colormap to be used
+
         clip : bool, optional
             If clip is ``True``, out of range values are mapped to 0 if they
             are below ``boundaries[0]`` or mapped to ncolors - 1 if they are

--- a/napari/utils/event.py
+++ b/napari/utils/event.py
@@ -587,10 +587,10 @@ class EventEmitter(object):
 
         Notes
         -----
-           For example, one could do::
+        For example, one could do::
 
-               with emitter.blocker():
-                   pass  # ..do stuff; no events will be emitted..
+            with emitter.blocker():
+                pass  # ..do stuff; no events will be emitted..
         """
         return EventBlocker(self, callback)
 

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -245,14 +245,13 @@ def guess_zarr_path(path):
 
     Parameters
     ----------
-    path: str
+    path : str
         Path to a file or directory.
 
     Returns
     -------
     bool
         Whether path is for zarr.
-
     >>> guess_zarr_path('dataset.zarr')
     True
     >>> guess_zarr_path('dataset.zarr/path/to/array')

--- a/napari/utils/notebook_display.py
+++ b/napari/utils/notebook_display.py
@@ -10,7 +10,7 @@ def nbscreenshot(viewer, *, canvas_only=False):
     ----------
     viewer : napari.Viewer
         The napari viewer.
-    with_viewer : bool, optional
+    canvas_only : bool, optional
         If True includes the napari viewer frame in the screenshot,
         otherwise just includes the canvas. By default, True.
 


### PR DESCRIPTION
This attempt to match – in some non ambiguous case parameter names in
the docstring of functions to actually match the name in the signature.

This so far only works when there is a single misspelling and all the
other parameters are documented.

This also try respect a couple of other things with heuristics, to match
numpydocs:
  - Parameters with no type given should not have a ` : `
  - if there is a `:` without spaces assume it is still the type
  separator.
