### PR TITLE
Fix events docstring type

### DIFF
--- a/napari/_qt/layers/qt_base_layer.py
+++ b/napari/_qt/layers/qt_base_layer.py
@@ -87,7 +87,7 @@ class QtLayerControls(QFrame):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context, by default None.
         """
         with self.layer.events.opacity.blocker():
@@ -98,7 +98,7 @@ class QtLayerControls(QFrame):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context, by default None.
         """
         with self.layer.events.blending.blocker():

--- a/napari/_qt/layers/qt_base_layer.py
+++ b/napari/_qt/layers/qt_base_layer.py
@@ -87,8 +87,8 @@ class QtLayerControls(QFrame):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context, by default None.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method, by default None.
         """
         with self.layer.events.opacity.blocker():
             self.opacitySlider.setValue(self.layer.opacity * 100)
@@ -98,8 +98,8 @@ class QtLayerControls(QFrame):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context, by default None.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method, by default None.
         """
         with self.layer.events.blending.blocker():
             index = self.blendComboBox.findText(

--- a/napari/_qt/layers/qt_image_base_layer.py
+++ b/napari/_qt/layers/qt_image_base_layer.py
@@ -101,7 +101,7 @@ class QtBaseImageControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         if event.button() == Qt.RightButton:
@@ -125,7 +125,7 @@ class QtBaseImageControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context, by default None.
         """
         with qt_signals_blocked(self.contrastLimitsSlider):
@@ -149,7 +149,7 @@ class QtBaseImageControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context, by default None.
         """
         name = self.layer.colormap[0]
@@ -184,7 +184,7 @@ class QtBaseImageControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context, by default None.
         """
         with qt_signals_blocked(self.gammaSlider):

--- a/napari/_qt/layers/qt_image_base_layer.py
+++ b/napari/_qt/layers/qt_image_base_layer.py
@@ -102,7 +102,7 @@ class QtBaseImageControls(QtLayerControls):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         if event.button() == Qt.RightButton:
             self.clim_pop = create_range_popup(

--- a/napari/_qt/layers/qt_image_base_layer.py
+++ b/napari/_qt/layers/qt_image_base_layer.py
@@ -125,8 +125,8 @@ class QtBaseImageControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context, by default None.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method, by default None.
         """
         with qt_signals_blocked(self.contrastLimitsSlider):
             self.contrastLimitsSlider.setRange(
@@ -149,8 +149,8 @@ class QtBaseImageControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context, by default None.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method, by default None.
         """
         name = self.layer.colormap[0]
         if name not in self.colormapComboBox._allitems:
@@ -184,8 +184,8 @@ class QtBaseImageControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context, by default None.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method, by default None.
         """
         with qt_signals_blocked(self.gammaSlider):
             self.gammaSlider.setValue(int(self.layer.gamma * 100))

--- a/napari/_qt/layers/qt_image_layer.py
+++ b/napari/_qt/layers/qt_image_layer.py
@@ -260,7 +260,7 @@ class QtImageControls(QtBaseImageControls):
         Parameters
         ----------
         event : napari.utils.event.Event, optional
-            Event from the Qt context, default is None.
+            The napari event that triggered this method, default is None.
         """
         self._update_interpolation_combo()
         if self.layer.dims.ndisplay == 2:

--- a/napari/_qt/layers/qt_image_layer.py
+++ b/napari/_qt/layers/qt_image_layer.py
@@ -170,7 +170,7 @@ class QtImageControls(QtBaseImageControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         with self.layer.events.iso_threshold.blocker():
@@ -192,7 +192,7 @@ class QtImageControls(QtBaseImageControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         with self.layer.events.attenuation.blocker():
@@ -203,7 +203,7 @@ class QtImageControls(QtBaseImageControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         with self.layer.events.interpolation.blocker():
@@ -217,7 +217,7 @@ class QtImageControls(QtBaseImageControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         with self.layer.events.rendering.blocker():
@@ -259,7 +259,7 @@ class QtImageControls(QtBaseImageControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional
+        event : napari.utils.event.Event, optional
             Event from the Qt context, default is None.
         """
         self._update_interpolation_combo()

--- a/napari/_qt/layers/qt_image_layer.py
+++ b/napari/_qt/layers/qt_image_layer.py
@@ -171,7 +171,7 @@ class QtImageControls(QtBaseImageControls):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         with self.layer.events.iso_threshold.blocker():
             self.isoThresholdSlider.setValue(self.layer.iso_threshold * 100)
@@ -193,7 +193,7 @@ class QtImageControls(QtBaseImageControls):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         with self.layer.events.attenuation.blocker():
             self.attenuationSlider.setValue(self.layer.attenuation * 200)
@@ -204,7 +204,7 @@ class QtImageControls(QtBaseImageControls):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         with self.layer.events.interpolation.blocker():
             index = self.interpComboBox.findText(
@@ -218,7 +218,7 @@ class QtImageControls(QtBaseImageControls):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         with self.layer.events.rendering.blocker():
             index = self.renderComboBox.findText(

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -230,7 +230,7 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
 
         Raises
@@ -345,7 +345,7 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context.
         """
         with self.layer.events.selected_label.blocker():
@@ -357,7 +357,7 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context.
         """
         with self.layer.events.brush_size.blocker():
@@ -370,7 +370,7 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context.
         """
         with self.layer.events.n_dimensional.blocker():
@@ -381,7 +381,7 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context.
         """
         with self.layer.events.contiguous.blocker():
@@ -392,7 +392,7 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context.
         """
         with self.layer.events.preserve_labels.blocker():
@@ -403,7 +403,7 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context.
         """
         with self.layer.events.color_mode.blocker():
@@ -417,7 +417,7 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         with self.layer.events.brush_shape.blocker():
@@ -431,7 +431,7 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context.
         """
         disable_with_opacity(
@@ -466,7 +466,7 @@ class QtColorBox(QWidget):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         self.update()

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -345,8 +345,8 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method.
         """
         with self.layer.events.selected_label.blocker():
             value = self.layer.selected_label
@@ -357,8 +357,8 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method.
         """
         with self.layer.events.brush_size.blocker():
             value = self.layer.brush_size
@@ -370,8 +370,8 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method.
         """
         with self.layer.events.n_dimensional.blocker():
             self.ndimCheckBox.setChecked(self.layer.n_dimensional)
@@ -381,8 +381,8 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method.
         """
         with self.layer.events.contiguous.blocker():
             self.contigCheckBox.setChecked(self.layer.contiguous)
@@ -392,8 +392,8 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method.
         """
         with self.layer.events.preserve_labels.blocker():
             self.preserveLabelsCheckBox.setChecked(self.layer.preserve_labels)
@@ -403,8 +403,8 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method.
         """
         with self.layer.events.color_mode.blocker():
             index = self.colorModeComboBox.findText(
@@ -431,8 +431,8 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method.
         """
         disable_with_opacity(
             self,

--- a/napari/_qt/layers/qt_labels_layer.py
+++ b/napari/_qt/layers/qt_labels_layer.py
@@ -231,7 +231,7 @@ class QtLabelsControls(QtLayerControls):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
 
         Raises
         ------
@@ -418,7 +418,7 @@ class QtLabelsControls(QtLayerControls):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         with self.layer.events.brush_shape.blocker():
             index = self.brushShapeComboBox.findText(
@@ -467,7 +467,7 @@ class QtColorBox(QWidget):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         self.update()
 

--- a/napari/_qt/layers/qt_points_layer.py
+++ b/napari/_qt/layers/qt_points_layer.py
@@ -268,8 +268,8 @@ class QtPointsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method.
         """
         with self.layer.events.size.blocker():
             value = self.layer.current_size
@@ -302,8 +302,8 @@ class QtPointsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context, by default None.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method, by default None.
         """
         disable_with_opacity(
             self,

--- a/napari/_qt/layers/qt_points_layer.py
+++ b/napari/_qt/layers/qt_points_layer.py
@@ -188,7 +188,7 @@ class QtPointsControls(QtLayerControls):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
 
         Raises
         ------
@@ -244,7 +244,7 @@ class QtPointsControls(QtLayerControls):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         with self.layer.events.n_dimensional.blocker():
             self.ndimCheckBox.setChecked(self.layer.n_dimensional)
@@ -255,7 +255,7 @@ class QtPointsControls(QtLayerControls):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         with self.layer.events.symbol.blocker():
             index = self.symbolComboBox.findText(

--- a/napari/_qt/layers/qt_points_layer.py
+++ b/napari/_qt/layers/qt_points_layer.py
@@ -187,7 +187,7 @@ class QtPointsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
 
         Raises
@@ -243,7 +243,7 @@ class QtPointsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         with self.layer.events.n_dimensional.blocker():
@@ -254,7 +254,7 @@ class QtPointsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         with self.layer.events.symbol.blocker():
@@ -268,7 +268,7 @@ class QtPointsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context.
         """
         with self.layer.events.size.blocker():
@@ -302,7 +302,7 @@ class QtPointsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context, by default None.
         """
         disable_with_opacity(

--- a/napari/_qt/layers/qt_shapes_layer.py
+++ b/napari/_qt/layers/qt_shapes_layer.py
@@ -235,7 +235,7 @@ class QtShapesControls(QtLayerControls):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
 
         Raises
         ------

--- a/napari/_qt/layers/qt_shapes_layer.py
+++ b/napari/_qt/layers/qt_shapes_layer.py
@@ -234,7 +234,7 @@ class QtShapesControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
 
         Raises
@@ -299,7 +299,7 @@ class QtShapesControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context, by default None.
         """
         with self.layer.events.edge_width.blocker():
@@ -312,7 +312,7 @@ class QtShapesControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context, by default None.
         """
         with qt_signals_blocked(self.edgeColorEdit):
@@ -323,7 +323,7 @@ class QtShapesControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context, by default None.
         """
         with qt_signals_blocked(self.faceColorEdit):
@@ -334,7 +334,7 @@ class QtShapesControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context, by default None.
         """
         disable_with_opacity(

--- a/napari/_qt/layers/qt_shapes_layer.py
+++ b/napari/_qt/layers/qt_shapes_layer.py
@@ -299,8 +299,8 @@ class QtShapesControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context, by default None.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method, by default None.
         """
         with self.layer.events.edge_width.blocker():
             value = self.layer.current_edge_width
@@ -312,8 +312,8 @@ class QtShapesControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context, by default None.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method, by default None.
         """
         with qt_signals_blocked(self.edgeColorEdit):
             self.edgeColorEdit.setColor(self.layer.current_edge_color)
@@ -323,8 +323,8 @@ class QtShapesControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context, by default None.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method, by default None.
         """
         with qt_signals_blocked(self.faceColorEdit):
             self.faceColorEdit.setColor(self.layer.current_face_color)
@@ -334,8 +334,8 @@ class QtShapesControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context, by default None.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method, by default None.
         """
         disable_with_opacity(
             self,

--- a/napari/_qt/layers/qt_vectors_layer.py
+++ b/napari/_qt/layers/qt_vectors_layer.py
@@ -227,7 +227,7 @@ class QtVectorsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context, by default None.
         """
         with self.layer.events.length.blocker():
@@ -238,7 +238,7 @@ class QtVectorsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context, by default None.
         """
         with self.layer.events.edge_width.blocker():
@@ -249,7 +249,7 @@ class QtVectorsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context, by default None.
         """
         with qt_signals_blocked(self.color_mode_comboBox):
@@ -266,7 +266,7 @@ class QtVectorsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context, by default None.
         """
         if self.layer._edge_color_mode == ColorMode.DIRECT:

--- a/napari/_qt/layers/qt_vectors_layer.py
+++ b/napari/_qt/layers/qt_vectors_layer.py
@@ -227,8 +227,8 @@ class QtVectorsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context, by default None.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method, by default None.
         """
         with self.layer.events.length.blocker():
             self.lengthSpinBox.setValue(self.layer.length)
@@ -238,8 +238,8 @@ class QtVectorsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context, by default None.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method, by default None.
         """
         with self.layer.events.edge_width.blocker():
             self.widthSpinBox.setValue(self.layer.edge_width)
@@ -249,8 +249,8 @@ class QtVectorsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context, by default None.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method, by default None.
         """
         with qt_signals_blocked(self.color_mode_comboBox):
             mode = self.layer.edge_color_mode
@@ -266,8 +266,8 @@ class QtVectorsControls(QtLayerControls):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context, by default None.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method, by default None.
         """
         if self.layer._edge_color_mode == ColorMode.DIRECT:
             with qt_signals_blocked(self.edgeColorEdit):

--- a/napari/_qt/qt_about_key_bindings.py
+++ b/napari/_qt/qt_about_key_bindings.py
@@ -117,7 +117,7 @@ class QtAboutKeyBindings(QDialog):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional.
+        event : napari.utils.event.Event, optional.
             Event from the Qt context, by default None.
         """
         col = self.viewer.palette['secondary']

--- a/napari/_qt/qt_about_key_bindings.py
+++ b/napari/_qt/qt_about_key_bindings.py
@@ -117,8 +117,8 @@ class QtAboutKeyBindings(QDialog):
 
         Parameters
         ----------
-        event : napari.utils.event.Event, optional.
-            Event from the Qt context, by default None.
+        event : napari.utils.event.Event, optional
+            The napari event that triggered this method, by default None.
         """
         col = self.viewer.palette['secondary']
         # Add class and instance viewer key bindings

--- a/napari/_qt/qt_dims.py
+++ b/napari/_qt/qt_dims.py
@@ -149,7 +149,7 @@ class QtDims(QWidget):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional
+        event : napari.utils.event.Event, optional
             Event from the Qt context, by default None.
         """
         widgets = reversed(list(enumerate(self.slider_widgets)))
@@ -177,7 +177,7 @@ class QtDims(QWidget):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional
+        event : napari.utils.event.Event, optional
             Event from the Qt context, by default None.
         """
         self._trim_sliders(0)

--- a/napari/_qt/qt_dims.py
+++ b/napari/_qt/qt_dims.py
@@ -150,7 +150,7 @@ class QtDims(QWidget):
         Parameters
         ----------
         event : napari.utils.event.Event, optional
-            Event from the Qt context, by default None.
+            The napari event that triggered this method, by default None.
         """
         widgets = reversed(list(enumerate(self.slider_widgets)))
         for (axis, widget) in widgets:
@@ -178,7 +178,7 @@ class QtDims(QWidget):
         Parameters
         ----------
         event : napari.utils.event.Event, optional
-            Event from the Qt context, by default None.
+            The napari event that triggered this method, by default None.
         """
         self._trim_sliders(0)
         self._create_sliders(self.dims.ndim)

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -73,7 +73,7 @@ class QtLayerList(QScrollArea):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         layer = event.item
@@ -89,7 +89,7 @@ class QtLayerList(QScrollArea):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         layer_index = event.index
@@ -111,7 +111,7 @@ class QtLayerList(QScrollArea):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional
+        event : napari.utils.event.Event, optional
             Event from the Qt context.
         """
         total = len(self.layers)
@@ -164,7 +164,7 @@ class QtLayerList(QScrollArea):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         layer = event.source
@@ -608,7 +608,7 @@ class QtLayerWidget(QFrame):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional
+        event : napari.utils.event.Event, optional
             Event from the Qt context.
         """
         with self.layer.events.name.blocker():
@@ -620,7 +620,7 @@ class QtLayerWidget(QFrame):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional
+        event : napari.utils.event.Event, optional
             Event from the Qt context.
         """
         with self.layer.events.visible.blocker():
@@ -631,7 +631,7 @@ class QtLayerWidget(QFrame):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent, optional
+        event : napari.utils.event.Event, optional
             Event from the Qt context.
         """
         thumbnail = self.layer.thumbnail

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -74,7 +74,7 @@ class QtLayerList(QScrollArea):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         layer = event.item
         total = len(self.layers)
@@ -90,7 +90,7 @@ class QtLayerList(QScrollArea):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         layer_index = event.index
         total = len(self.layers)
@@ -165,7 +165,7 @@ class QtLayerList(QScrollArea):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         layer = event.source
         self._ensure_visible(layer)

--- a/napari/_qt/qt_layerlist.py
+++ b/napari/_qt/qt_layerlist.py
@@ -112,7 +112,7 @@ class QtLayerList(QScrollArea):
         Parameters
         ----------
         event : napari.utils.event.Event, optional
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         total = len(self.layers)
 
@@ -609,7 +609,7 @@ class QtLayerWidget(QFrame):
         Parameters
         ----------
         event : napari.utils.event.Event, optional
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         with self.layer.events.name.blocker():
             self.nameTextBox.setText(self.layer.name)
@@ -621,7 +621,7 @@ class QtLayerWidget(QFrame):
         Parameters
         ----------
         event : napari.utils.event.Event, optional
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         with self.layer.events.visible.blocker():
             self.visibleCheckBox.setChecked(self.layer.visible)
@@ -632,7 +632,7 @@ class QtLayerWidget(QFrame):
         Parameters
         ----------
         event : napari.utils.event.Event, optional
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         thumbnail = self.layer.thumbnail
         # Note that QImage expects the image width followed by height

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -451,7 +451,7 @@ class Window:
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         self._status_bar.showMessage(event.text)
 
@@ -461,7 +461,7 @@ class Window:
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         self._qt_window.setWindowTitle(event.text)
 
@@ -471,7 +471,7 @@ class Window:
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         self._help.setText(event.text)
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -450,7 +450,7 @@ class Window:
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         self._status_bar.showMessage(event.text)
@@ -460,7 +460,7 @@ class Window:
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         self._qt_window.setWindowTitle(event.text)
@@ -470,7 +470,7 @@ class Window:
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         self._help.setText(event.text)

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -679,6 +679,6 @@ def viewbox_key_event(event):
     Parameters
     ----------
     event : napari.utils.event.Event
-        Event from the Qt context.
+        The napari event that triggered this method.
     """
     return

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -229,7 +229,7 @@ class QtViewer(QSplitter):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         if self.dockLayerControls.isFloating():
             self.controls.setMaximumWidth(700)
@@ -242,7 +242,7 @@ class QtViewer(QSplitter):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         layers = event.source
         layer = event.item
@@ -258,7 +258,7 @@ class QtViewer(QSplitter):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         layer = event.item
         vispy_layer = self.layer_to_visual[layer]
@@ -273,7 +273,7 @@ class QtViewer(QSplitter):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         for i, layer in enumerate(self.viewer.layers):
             vispy_layer = self.layer_to_visual[layer]
@@ -406,7 +406,7 @@ class QtViewer(QSplitter):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         self.view.interactive = self.viewer.interactive
 
@@ -416,7 +416,7 @@ class QtViewer(QSplitter):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         cursor = self.viewer.cursor
         if cursor == 'square':
@@ -441,7 +441,7 @@ class QtViewer(QSplitter):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         if isinstance(self.view.camera, ArcballCamera):
             quat = self.view.camera._quaternion.create_from_axis_angle(
@@ -501,7 +501,7 @@ class QtViewer(QSplitter):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         if event.pos is None:
             return
@@ -523,7 +523,7 @@ class QtViewer(QSplitter):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         if event.pos is None:
             return
@@ -544,7 +544,7 @@ class QtViewer(QSplitter):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         if event.pos is None:
             return
@@ -565,7 +565,7 @@ class QtViewer(QSplitter):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         if (
             event.native is not None
@@ -586,7 +586,7 @@ class QtViewer(QSplitter):
         Parameters
         ----------
         event : napari.utils.event.Event
-            Event from the Qt context.
+            The napari event that triggered this method.
         """
         if event.key is None or (
             # on linux press down is treated as multiple press and release

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -228,7 +228,7 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         if self.dockLayerControls.isFloating():
@@ -241,7 +241,7 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         layers = event.source
@@ -257,7 +257,7 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         layer = event.item
@@ -272,7 +272,7 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         for i, layer in enumerate(self.viewer.layers):
@@ -405,7 +405,7 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         self.view.interactive = self.viewer.interactive
@@ -415,7 +415,7 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         cursor = self.viewer.cursor
@@ -440,7 +440,7 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         if isinstance(self.view.camera, ArcballCamera):
@@ -500,7 +500,7 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         if event.pos is None:
@@ -522,7 +522,7 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         if event.pos is None:
@@ -543,7 +543,7 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         if event.pos is None:
@@ -564,7 +564,7 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         if (
@@ -585,7 +585,7 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : napari.utils.event.Event
             Event from the Qt context.
         """
         if event.key is None or (
@@ -678,7 +678,7 @@ def viewbox_key_event(event):
 
     Parameters
     ----------
-    event : qtpy.QtCore.QEvent
+    event : napari.utils.event.Event
         Event from the Qt context.
     """
     return


### PR DESCRIPTION
# Description
small docs change to correct the event type in many of our callbacks that were incorrectly labeled as QEvents instead of our native/vispy `event.Event`.  As a quick heuristic, camel case methods in `QWidget` subclasses that have the word "event" in them (like `mouseMoveEvent()`) are likely reimplemented methods that _do_ take a `QEvent`... everything else is likely our own event object.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] docs update
