### PR TITLE
Don't look for release notes in pre-releases

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -30,12 +30,16 @@ jobs:
         id: release_notes
         run: |
           TAG="${GITHUB_REF/refs\/tags\/v/}"  # clean tag
-          VER="${TAG/rc*/}"  # remove pre-release identifier
-          RELEASE_NOTES="$(cat docs/release/release_${VER//./_}.md)"
-          # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
-          RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"
-          RELEASE_NOTES="${RELEASE_NOTES//$'\n'/'%0A'}"
-          RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}"
+          if [[ "$TAG" != *"rc"* ]]; then
+            VER="${TAG/rc*/}"  # remove pre-release identifier
+            RELEASE_NOTES="$(cat docs/release/release_${VER//./_}.md)"
+            # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
+            RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"
+            RELEASE_NOTES="${RELEASE_NOTES//$'\n'/'%0A'}"
+            RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}"
+          else
+            RELEASE_NOTES="pre-release $TAG"
+          fi
           # https://help.github.com/en/actions/reference/workflow-commands-for-github-actions
           echo "::set-env name=tag::$TAG"
           echo "::set-output name=contents::$RELEASE_NOTES"


### PR DESCRIPTION
# Description
This makes release notes optional for pre-releases (tagged with `rc`).  Pre-release versions will simply have "pre-release $TAG" for their notes in the github release.  Builds for versions without rc in the tag will still crash if release notes are missing