### PR TITLE
Use evented dataclass for TextManager

### DIFF
--- a/napari/_vispy/vispy_points_layer.py
+++ b/napari/_vispy/vispy_points_layer.py
@@ -24,9 +24,8 @@ class VispyPointsLayer(VispyBaseLayer):
         self.layer.events.edge_width.connect(self._on_data_change)
         self.layer.events.edge_color.connect(self._on_data_change)
         self.layer.events.face_color.connect(self._on_data_change)
-        self.layer.text._connect_update_events(
-            self._on_text_change, self._on_blending_change
-        )
+        self.layer.text.events.connect(self._on_text_change)
+        self.layer.text.events.blending.connect(self._on_blending_change)
         self.layer.events.highlight.connect(self._on_highlight_change)
         self._on_data_change()
 

--- a/napari/_vispy/vispy_shapes_layer.py
+++ b/napari/_vispy/vispy_shapes_layer.py
@@ -19,9 +19,8 @@ class VispyShapesLayer(VispyBaseLayer):
         self.layer.events.edge_width.connect(self._on_data_change)
         self.layer.events.edge_color.connect(self._on_data_change)
         self.layer.events.face_color.connect(self._on_data_change)
-        self.layer.text._connect_update_events(
-            self._on_text_change, self._on_blending_change
-        )
+        self.layer.text.events.connect(self._on_text_change)
+        self.layer.text.events.blending.connect(self._on_blending_change)
         self.layer.events.highlight.connect(self._on_highlight_change)
 
         self._reset_base()

--- a/napari/layers/utils/_tests/test_text.py
+++ b/napari/layers/utils/_tests/test_text.py
@@ -115,6 +115,6 @@ def test_blending_modes():
     assert text_manager.blending == 'additive'
 
     # set to opaque, which is not allowed
-    with pytest.warns(RuntimeWarning):
+    with pytest.warns(UserWarning):
         text_manager.blending = 'opaque'
         assert text_manager.blending == 'translucent'

--- a/napari/layers/utils/text.py
+++ b/napari/layers/utils/text.py
@@ -1,30 +1,32 @@
-from typing import Tuple, Union
 import warnings
+from dataclasses import field
+from typing import Dict, Tuple, Union
 
 import numpy as np
 
-from ..base._base_constants import Blending
-from ._text_constants import TextMode, Anchor
-from ._text_utils import (
-    format_text_properties,
-    get_text_anchors,
-)
 from ...utils.colormaps.standardize_color import transform_color
-from ...utils.event import EmitterGroup, Event
+from ...utils.dataclass import dataclass
+from ..base._base_constants import Blending
+from ._text_constants import Anchor, TextMode
+from ._text_utils import format_text_properties, get_text_anchors
 
 
+@dataclass(events=True, properties=True)
 class TextManager:
     """Manages properties related to text displayed in conjunction with the layer.
 
     Parameters
     ----------
     text : array or str
-        the strings to be displayed
+        The strings to be displayed
+    n_text : int
+        The length of data being annotated.
     rotation : float
         Angle of the text elements around the anchor point. Default value is 0.
     anchor : str
         The location of the text origin relative to the bounding box.
-        Should be 'center', 'upper_left', 'upper_right', 'lower_left', or 'lower_right'
+        Should be 'center', 'upper_left', 'upper_right', 'lower_left', or
+        'lower_right'
     translation : np.ndarray
         Offset from the anchor point.
     color : array or str
@@ -39,73 +41,67 @@ class TextManager:
         The default value is 'translucent'
     visible : bool
         Set to true of the text should be displayed.
-
-    Attributes
-    ----------
-    text : array
-        the strings to be displayed
-    rotation : float
-        Angle of the text elements around the anchor point. Default value is 0.
-    anchor : str
-        The location of the text origin relative to the bounding box.
-        Should be 'center', 'upper_left', 'upper_right', 'lower_left', or 'lower_right'.
-    translation : np.ndarray
-        Offset from the anchor point.
-    color : array
-        Font color for the text
-    size : float
-        Font size of the text. Default value is 12.
-    The blending mode that determines how RGB and
-        alpha values of the layer visual get mixed. Allowed values are
-        {'opaque', 'translucent', and 'additive'}. Note that 'opaque` blending
-        is not recommended, as colors the bounding box surrounding the text.
-    visible : bool
-        Set to true of the text should be displayed.
     """
 
-    def __init__(
-        self,
-        text,
-        n_text,
-        properties={},
-        rotation=0,
-        translation=0,
-        anchor='center',
-        color='cyan',
-        size=12,
-        blending='translucent',
-        visible=True,
-    ):
+    text: Union[np.ndarray, str]
+    n_text: int
+    properties: Dict[str, np.ndarray] = field(default_factory=dict)
+    rotation: float = 0.0
+    translation: np.ndarray = np.asarray(0)
+    anchor: Anchor = Anchor.CENTER
+    color: Union[np.ndarray, str] = 'cyan'
+    size: float = 12.0
+    blending: Blending = Blending.TRANSLUCENT
+    visible: bool = True
 
-        self.events = EmitterGroup(
-            source=self,
-            auto_connect=True,
-            text=Event,
-            rotation=Event,
-            translation=Event,
-            anchor=Event,
-            color=Event,
-            size=Event,
-            blending=Event,
-            visible=Event,
-        )
-
-        self.events.block_all()
-        self._rotation = rotation
-        self._anchor = Anchor(anchor)
-        self._translation = translation
-        self._color = transform_color(color)[0]
-        self._size = size
-        self._blending = self._check_blending_mode(blending)
-        self._visible = visible
-
-        self._set_text(text, n_text, properties)
-        self.events.unblock_all()
+    def __post_init__(self):
+        # private attributes not in dataclass
+        self._text_format_string: str = ''
+        self._values = None
+        self._mode: TextMode = TextMode.NONE
+        self.anchor = Anchor(self.anchor)
+        self.blending = Blending(self.blending)
+        with self.events.text.blocker():
+            self._set_text(self.text, self.n_text, self.properties)
 
     @property
     def values(self):
         """np.ndarray: the text values to be displayed"""
         return self._values
+
+    @property
+    def mode(self) -> str:
+        """str: The current text setting mode."""
+        return str(self._mode)
+
+    # Things that need to modify the value on set
+
+    def _on_translation_set(self, translation):
+        if not isinstance(translation, np.ndarray):
+            self.translation = np.asarray(translation)
+            return True
+
+    def _on_color_set(self, color):
+        if color != self.color:
+            self.color = transform_color(color)[0]
+        return True
+
+    def _on_blending_set(self, blending):
+        if Blending(blending) == Blending.OPAQUE:
+            warnings.warn(
+                'opaque blending mode is not allowed for text. '
+                'setting to translucent.'
+            )
+            self.blending = Blending.TRANSLUCENT
+            return True
+
+    # Things that need to modify the value on get
+
+    def _on_blending_get(self, blending):
+        return str(blending)
+
+    def _on_anchor_get(self, anchor):
+        return str(anchor)
 
     def _set_text(
         self, text: Union[None, str], n_text: int, properties: dict = {}
@@ -121,110 +117,7 @@ class TextManager:
             self._text_format_string = text
             self._values = formatted_text
             self._mode = text_mode
-        self.events.text()
-
-    @property
-    def anchor(self) -> str:
-        """str: The location of the text origin relative to the bounding box.
-        Should be 'center', 'upper_left', 'upper_right', 'lower_left', or 'lower_right
-        '"""
-        return str(self._anchor)
-
-    @anchor.setter
-    def anchor(self, anchor):
-        self._anchor = Anchor(anchor)
-        self.events.anchor()
-
-    @property
-    def rotation(self) -> float:
-        """float: angle of the text elements around the anchor point."""
-        return self._rotation
-
-    @rotation.setter
-    def rotation(self, rotation):
-        self._rotation = rotation
-        self.events.rotation()
-
-    @property
-    def translation(self) -> np.ndarray:
-        """np.ndarray: offset from the anchor point"""
-        return self._translation
-
-    @translation.setter
-    def translation(self, translation):
-        self._translation = np.asarray(translation)
-        self.events.translation()
-
-    @property
-    def color(self) -> np.ndarray:
-        """np.ndarray: Font color for the text"""
-        return self._color
-
-    @color.setter
-    def color(self, color):
-        self._color = transform_color(color)[0]
-        self.events.color()
-
-    @property
-    def size(self) -> float:
-        """float: Font size of the text."""
-        return self._size
-
-    @size.setter
-    def size(self, size):
-        self._size = size
-        self.events.size()
-
-    @property
-    def blending(self) -> str:
-        """Blending mode: Determines how RGB and alpha values get mixed.
-
-            Blending.TRANSLUCENT
-                Allows for multiple layers to be blended with different opacity
-                and corresponds to depth_test=True, cull_face=False,
-                blend=True, blend_func=('src_alpha', 'one_minus_src_alpha').
-            Blending.ADDITIVE
-                Allows for multiple layers to be blended together with
-                different colors and opacity. Useful for creating overlays. It
-                corresponds to depth_test=False, cull_face=False, blend=True,
-                blend_func=('src_alpha', 'one').
-        """
-        return str(self._blending)
-
-    @blending.setter
-    def blending(self, blending):
-
-        self._blending = self._check_blending_mode(blending)
-        self.events.blending()
-
-    def _check_blending_mode(self, blending):
-        blending_mode = Blending(blending)
-
-        # the opaque blending mode is not allowed for text
-        # see: https://github.com/napari/napari/pull/600#issuecomment-554142225
-        if blending_mode == Blending.OPAQUE:
-            blending_mode = Blending.TRANSLUCENT
-            warnings.warn(
-                'opaque blending mode is not allowed for text. setting to translucent.',
-                category=RuntimeWarning,
-            )
-
-        return blending_mode
-
-    @property
-    def visible(self) -> bool:
-        """bool: Set to true of the text should be displayed."""
-        return self._visible
-
-    @visible.setter
-    def visible(self, visible):
-        self._visible = visible
-        self.events.visible()
-
-    @property
-    def mode(self) -> str:
-        """str: The current text setting mode."""
-        return str(self._mode)
+        self.events.text(value=self.text)
 
     def refresh_text(self, properties: dict):
         """Refresh all of the current text elements using updated properties values
@@ -325,62 +218,3 @@ class TextManager:
             text = np.array([''])
 
         return text
-
-    def _get_state(self):
-
-        state = {
-            'text': self.values,
-            'rotation': self.rotation,
-            'color': self.color,
-            'translation': self.translation,
-            'size': self.size,
-            'visible': self.visible,
-        }
-
-        return state
-
-    def _connect_update_events(
-        self, text_update_function, blending_update_function
-    ):
-        """Function to connect all property update events to the update callback.
-
-        This is typically used in the vispy view file.
-        """
-        # connect the function for updating the text node
-        self.events.text.connect(text_update_function)
-        self.events.rotation.connect(text_update_function)
-        self.events.translation.connect(text_update_function)
-        self.events.anchor.connect(text_update_function)
-        self.events.color.connect(text_update_function)
-        self.events.size.connect(text_update_function)
-        self.events.visible.connect(text_update_function)
-
-        # connect the function for updating the text node blending
-        self.events.blending.connect(blending_update_function)
-
-    def __eq__(self, other):
-        """Method to test equivalence
-
-        called by: text_manager_1 == text_manager_2
-        """
-        if isinstance(other, TextManager):
-            my_state = self._get_state()
-            other_state = other._get_state()
-            equal = np.all(
-                [
-                    np.all(value == other_state[key])
-                    for key, value in my_state.items()
-                ]
-            )
-
-        else:
-            equal = False
-
-        return equal
-
-    def __ne__(self, other):
-        """Method to test not equal
-
-        called by: text_manager_1 != text_manager_2
-        """
-        return not (self.__eq__(other))

--- a/napari/layers/utils/text.py
+++ b/napari/layers/utils/text.py
@@ -1,14 +1,17 @@
+from typing import Tuple, Union, Dict
 import warnings
-from dataclasses import field
-from typing import Dict, Tuple, Union
 
 import numpy as np
 
+from ..base._base_constants import Blending
+from ._text_constants import TextMode, Anchor
+from ._text_utils import (
+    format_text_properties,
+    get_text_anchors,
+)
 from ...utils.colormaps.standardize_color import transform_color
 from ...utils.dataclass import dataclass
-from ..base._base_constants import Blending
-from ._text_constants import Anchor, TextMode
-from ._text_utils import format_text_properties, get_text_anchors
+from dataclasses import field
 
 
 @dataclass(events=True, properties=True)
@@ -18,15 +21,14 @@ class TextManager:
     Parameters
     ----------
     text : array or str
-        The strings to be displayed
+        the strings to be displayed
     n_text : int
         The length of data being annotated.
     rotation : float
         Angle of the text elements around the anchor point. Default value is 0.
     anchor : str
         The location of the text origin relative to the bounding box.
-        Should be 'center', 'upper_left', 'upper_right', 'lower_left', or
-        'lower_right'
+        Should be 'center', 'upper_left', 'upper_right', 'lower_left', or 'lower_right'
     translation : np.ndarray
         Offset from the anchor point.
     color : array or str
@@ -117,7 +119,7 @@ class TextManager:
             self._text_format_string = text
             self._values = formatted_text
             self._mode = text_mode
-        self.events.text(value=self.text)
+        self.events.text()
 
     def refresh_text(self, properties: dict):
         """Refresh all of the current text elements using updated properties values

--- a/napari/layers/utils/text.py
+++ b/napari/layers/utils/text.py
@@ -9,9 +9,8 @@ from ._text_utils import (
 )
 from ...utils.colormaps.standardize_color import transform_color
 from ...utils.colormaps.vendored.colors import to_hex
-from ...utils.dataclass import dataclass
+from ...utils.dataclass import dataclass, Property
 from dataclasses import InitVar
-from typing_extensions import Annotated
 
 
 # https://github.com/napari/napari/issues/1491
@@ -68,13 +67,11 @@ class TextManager:
     properties: InitVar[Dict[str, np.ndarray]] = None
 
     rotation: float = 0.0
-    translation: Annotated[np.ndarray, None, np.asarray] = np.asarray(0)
-    anchor: Annotated[Anchor, str, Anchor] = Anchor.CENTER
-    color: Annotated[
-        Union[np.ndarray, str], to_hex, transform_1_color
-    ] = 'cyan'
+    translation: Property[np.ndarray, None, np.asarray] = np.asarray(0)
+    anchor: Property[Anchor, str, Anchor] = Anchor.CENTER
+    color: Property[Union[np.ndarray, str], to_hex, transform_1_color] = 'cyan'
     size: float = 12.0
-    blending: Annotated[Blending, str, no_opaque] = Blending.TRANSLUCENT
+    blending: Property[Blending, str, no_opaque] = Blending.TRANSLUCENT
     visible: bool = True
     values: Optional[np.ndarray] = None
     mode: TextMode = TextMode.NONE

--- a/napari/layers/utils/text.py
+++ b/napari/layers/utils/text.py
@@ -12,6 +12,7 @@ from ._text_utils import (
 from ...utils.colormaps.standardize_color import transform_color
 from ...utils.dataclass import dataclass
 from dataclasses import field
+from typing_extensions import Annotated
 
 
 @dataclass(events=True, properties=True)
@@ -50,10 +51,10 @@ class TextManager:
     properties: Dict[str, np.ndarray] = field(default_factory=dict)
     rotation: float = 0.0
     translation: np.ndarray = np.asarray(0)
-    anchor: Anchor = Anchor.CENTER
+    anchor: Annotated[Anchor, str] = Anchor.CENTER
     color: Union[np.ndarray, str] = 'cyan'
     size: float = 12.0
-    blending: Blending = Blending.TRANSLUCENT
+    blending: Annotated[Blending, str] = Blending.TRANSLUCENT
     visible: bool = True
 
     def __post_init__(self):
@@ -96,14 +97,6 @@ class TextManager:
             )
             self.blending = Blending.TRANSLUCENT
             return True
-
-    # Things that need to modify the value on get
-
-    def _on_blending_get(self, blending):
-        return str(blending)
-
-    def _on_anchor_get(self, anchor):
-        return str(anchor)
 
     def _set_text(
         self, text: Union[None, str], n_text: int, properties: dict = {}

--- a/napari/utils/_tests/test_dataclass.py
+++ b/napari/utils/_tests/test_dataclass.py
@@ -35,6 +35,8 @@ def test_dataclass_with_properties(props, events):
         c: List[int] = field(default_factory=list)
 
         def _on_b_set(self, value):
+            # NB: if you want to set value again, you must check that it is
+            # actually different from ``value``!
             if value != 'bossy':
                 self.b = 'bossy'
 
@@ -89,3 +91,5 @@ def test_dataclass_with_properties(props, events):
         m.c = [1, 2]
         assert m.c == [1, 2]
         m.events.c.assert_not_called()
+    else:
+        assert not hasattr(m, 'events')

--- a/napari/utils/_tests/test_dataclass.py
+++ b/napari/utils/_tests/test_dataclass.py
@@ -93,3 +93,14 @@ def test_dataclass_with_properties(props, events):
         m.events.c.assert_not_called()
     else:
         assert not hasattr(m, 'events')
+
+
+def test_dataclass_missing_vars_raises():
+    @dataclass(properties=True)
+    class M:
+        a: int
+
+    with pytest.raises(TypeError):
+        _ = M()  # missing `a`
+    assert M(1).a == 1
+    assert M(a=1).a == 1

--- a/napari/utils/_tests/test_dataclass.py
+++ b/napari/utils/_tests/test_dataclass.py
@@ -131,3 +131,22 @@ def test_dataclass_missing_vars_raises():
     assert not hasattr(m, 'f')
     assert not hasattr(M, 'f')
     assert 'f' in M.__annotations__
+
+
+def test_dataclass_coerces_types():
+    from napari.layers.utils._text_constants import Anchor
+    from napari.layers.base._base_constants import Blending
+    from typing_extensions import Annotated
+    from napari.utils.dataclass import dataclass
+
+    @dataclass(properties=True)
+    class M:
+        x: int = 2
+        anchor: Annotated[Anchor, str, Anchor] = Anchor.UPPER_LEFT
+        blending: Blending = Blending.OPAQUE
+
+    m = M()
+    m.anchor = 'center'
+    assert isinstance(m._anchor, Anchor)
+    assert isinstance(m.anchor, str)
+    assert isinstance(m.blending, Blending)

--- a/napari/utils/_tests/test_dataclass.py
+++ b/napari/utils/_tests/test_dataclass.py
@@ -1,0 +1,62 @@
+from dataclasses import asdict, field
+from typing import List
+from unittest.mock import Mock
+
+import pytest
+
+from napari.utils.dataclass import dataclass
+from napari.utils.event import EmitterGroup
+
+
+@pytest.mark.parametrize("props, events", [(1, 1), (0, 1), (0, 0), (1, 0)])
+def test_dataclass_with_properties(props, events):
+    @dataclass(properties=props, events=events)
+    class M:
+        """Just a test.
+
+        Parameters
+        ----------
+        a : int
+            Description of parameter `a`.
+        b : str, optional
+            Description of parameter `b`. by default 'hi'
+        c : list, optional
+            Description of parameter `c`. by default empty.
+        """
+
+        a: int
+        b: str = 'hi'
+        c: List[int] = field(default_factory=list)
+
+    # currently, properties will only be added to the class during post_init
+    m = M(a=1)
+    # basic functionality
+    assert m.a == 1
+    assert m.b == 'hi'
+    assert m.c == []
+    m.a = 7
+    m.c.append(9)
+    # nice function
+    assert asdict(m) == {'a': 7, 'b': 'hi', 'c': [9]}
+
+    assert isinstance(m.a, int)
+    assert isinstance(m.b, str)
+    if props:
+        assert isinstance(M.a, property)
+        assert isinstance(M.b, property)
+        assert M.a.__doc__ == "Description of parameter `a`."
+        assert M.b.__doc__ == "Description of parameter `b`. by default 'hi'"
+        assert M.c.__doc__ == "Description of parameter `c`. by default empty."
+    else:
+        assert not hasattr(M, 'a')
+
+    if events:
+        assert isinstance(m.events, EmitterGroup)
+        assert 'a' in m.events
+        assert 'b' in m.events
+        m.events.b = Mock(m.events.b)
+        m.events.a = Mock(m.events.a)
+        m.a = 4
+        m.events.a.assert_called_with(value=4)
+        m.b = 'howdie'
+        m.events.b.assert_called_with(value='howdie')

--- a/napari/utils/_tests/test_dataclass.py
+++ b/napari/utils/_tests/test_dataclass.py
@@ -135,13 +135,14 @@ def test_dataclass_coerces_types():
     from napari.layers.utils._text_constants import Anchor
     from napari.layers.base._base_constants import Blending
     from typing_extensions import Annotated
-    from napari.utils.dataclass import dataclass
+    from napari.utils.dataclass import dataclass, Property
 
     @dataclass(properties=True)
     class M:
         x: int = 2
         anchor: Annotated[Anchor, str, Anchor] = Anchor.UPPER_LEFT
-        blending: Blending = Blending.OPAQUE
+        # Property is an alias for Annotated, that provides stricter checking
+        blending: Property[Blending, None, Blending] = Blending.OPAQUE
 
     m = M()
     m.anchor = 'center'

--- a/napari/utils/_tests/test_dataclass.py
+++ b/napari/utils/_tests/test_dataclass.py
@@ -1,10 +1,13 @@
 from dataclasses import asdict, field
-from typing import List, ClassVar
+from typing import ClassVar, List
 from unittest.mock import Mock
 
 import pytest
+from typing_extensions import Annotated
 
-from napari.utils.dataclass import dataclass
+from napari.layers.base._base_constants import Blending
+from napari.layers.utils._text_constants import Anchor
+from napari.utils.dataclass import Property, dataclass
 from napari.utils.event import EmitterGroup
 
 
@@ -12,8 +15,8 @@ from napari.utils.event import EmitterGroup
 def test_dataclass_with_properties(props, events):
     """Test that the @dataclass decorator works.
 
-    The parameters test all combinations of props and events to make sure they
-    work alone as well as together.
+    This test is a bit long... but parameters test all combinations of props
+    and events to make sure they work alone as well as together.
     """
 
     @dataclass(properties=props, events=events)
@@ -85,6 +88,10 @@ def test_dataclass_with_properties(props, events):
         # setting an attribute should, by default, emit an event with the value
         m.a = 4
         m.events.a.assert_called_with(value=4)
+        # and event should only be emitted when the value has changed.
+        m.events.a.reset_mock()
+        m.a = 4
+        m.events.a.assert_not_called()
 
         # test that our _on_b_set override worked, and emitted the right event
         m.b = 'howdie'
@@ -132,16 +139,11 @@ def test_dataclass_missing_vars_raises():
 
 
 def test_dataclass_coerces_types():
-    from napari.layers.utils._text_constants import Anchor
-    from napari.layers.base._base_constants import Blending
-    from typing_extensions import Annotated
-    from napari.utils.dataclass import dataclass, Property
-
     @dataclass(properties=True)
     class M:
         x: int = 2
         anchor: Annotated[Anchor, str, Anchor] = Anchor.UPPER_LEFT
-        # Property is an alias for Annotated, that provides stricter checking
+        # Property is an alias for Annotated, and provides stricter checking
         blending: Property[Blending, None, Blending] = Blending.OPAQUE
 
     m = M()
@@ -149,3 +151,29 @@ def test_dataclass_coerces_types():
     assert isinstance(m._anchor, Anchor)
     assert isinstance(m.anchor, str)
     assert isinstance(m.blending, Blending)
+
+
+def test_Property_validation():
+    with pytest.raises(TypeError):
+        _ = Property[int]
+    with pytest.raises(TypeError):
+        _ = Property(int, None)
+    with pytest.raises(TypeError):
+        _ = Property(int, 1)
+    with pytest.raises(TypeError):
+        _ = Property(int, int, None)
+
+
+def test_exception_resets_value():
+    @dataclass(events=True)
+    class M:
+        x: int = 2
+
+        def _on_x_set(self, val):
+            raise ValueError('no can do')
+
+    m = M()
+    with pytest.raises(ValueError) as exc:
+        m.x = 5
+    assert 'Error in M._on_x_set (value not set): no can do' in str(exc)
+    assert m.x == 2

--- a/napari/utils/dataclass.py
+++ b/napari/utils/dataclass.py
@@ -115,7 +115,7 @@ def dataclass(
     unsafe_hash : bool, optional
         If true, a __hash__() method function is added, by default False
     frozen : bool, optional
-        If true, fields may not be assigned to after instance creation., by
+        If true, fields may not be assigned to after instance creation, by
         default False
     events : bool, optional
         If true, an ``EmmitterGroup`` instance is added as attribute "events".

--- a/napari/utils/dataclass.py
+++ b/napari/utils/dataclass.py
@@ -125,7 +125,7 @@ def dataclass(
         If true, field attributes will be converted to property descriptors.
         If the class has a class docstring in numpydocs format, docs for each
         property will be taken from the ``Parameters`` section for the
-        corresponding parameter. by default False
+        corresponding parameter, by default False
 
     Returns
     -------

--- a/napari/utils/dataclass.py
+++ b/napari/utils/dataclass.py
@@ -1,4 +1,4 @@
-import dataclasses as _dataclasses
+import dataclasses as _dataclasses  # builtin private for ease of tab complete
 from typing import Any, Callable, Type, TypeVar
 
 import toolz as tz
@@ -10,13 +10,32 @@ T = TypeVar("T")
 
 
 def make_post_init(
-    orig_post_init: Callable[..., None] = None, events=False, properties=False,
+    cls: Type[T], events=False, properties=False
 ) -> Callable[..., None]:
-    def _event_post_init(self, *initvars) -> None:
+    """Return a new __post_init__ method wrapper with events & properties.
+
+    Parameters
+    ----------
+    cls : type
+        The class being decorated as a dataclass
+    events : bool, optional
+        Whether to add an `EmitterGroup` to the class, by default False
+    properties : bool, optional
+        Whether to convert the dataclass fields to properties, by default False
+
+    Returns
+    -------
+    Callable[..., None]
+        A modified __post_init__ method that wraps the original.
+    """
+
+    orig_post_init: Callable[..., None] = getattr(cls, '__post_init__', None)
+
+    def _event_post_init(self: T, *initvars) -> None:
         emitter_group = EmitterGroup(
             source=self,
             auto_connect=False,
-            **{name: None for name in self.__dataclass_fields__},
+            **{n: None for n in getattr(self, '__dataclass_fields__', {})},
         )
         object.__setattr__(self, 'events', emitter_group)
         if orig_post_init is not None:
@@ -31,6 +50,37 @@ def make_post_init(
 
 
 def setattr_with_events(self: T, name: str, value: Any) -> None:
+    """Modified __setattr__ method that emits an event when set.
+
+    Events will *only* be emitted if the ``name`` of the attribute being set
+    is one of the dataclass fields (i.e. ``name in self.__annotations__``),
+    and the dataclass ``__post_init__` method has already been called.
+
+    Also looks for and calls an optional ``_on_name_set()`` method afterwards.
+
+    Order of operations:
+        1. Call the original ``__setattr__`` function to set the value
+        2. Look for an ``_on_name_set`` method on the object
+            a. If present, call it with the current value
+            b. That method can do anything (including changing the value, or
+               emitting its own events if necessary).  If changing the value,
+               it should check to make sure that it is different than the
+               current value before setting, or a ``RecursionError`` may occur.
+            c. If that method returns ``True``. Return *without* emitting
+               an event.
+        3. If ``_on_name_set`` has not returned ``True``, then emit an event
+           from the EventEmitter with the corresponding ``name`` in the.
+           e.g. ``self.events.<name>(value=value)``.
+
+    Parameters
+    ----------
+    self : T
+        An instance of the decorated dataclass of Type[T]
+    name : str
+        The name of the attribute being set.
+    value : Any
+        The new value for the attribute.
+    """
     object.__setattr__(self, name, value)
     if name in self.__annotations__ and getattr(
         self, '_is_initialized', False
@@ -41,12 +91,15 @@ def setattr_with_events(self: T, name: str, value: Any) -> None:
             # the method can return True, if it wants to handle its own events
             if setter_method(getattr(self, name)):
                 return
-        # otherwise, we emit this event
+        # otherwise, we emit the event
         if name in self.events:  # type: ignore # (needs SupportsEvents)
+            # use gettattr again in case `_on_name_set` has modified it
             getattr(self.events, name)(value=getattr(self, name))  # type: ignore
 
 
 def make_getter(name):
+    """Make an fget function for creating a property descriptor."""
+
     def fget(self):
         return getattr(self, name)
 
@@ -54,13 +107,33 @@ def make_getter(name):
 
 
 def make_setter(name):
+    """Make an fset function for creating a property descriptor."""
+
     def fset(self, value):
         setattr(self, name, value)
 
     return fset
 
 
-def convert_fields_to_properties(obj):
+def convert_fields_to_properties(obj: T):
+    """Convert all fields in a dataclass instance to property descriptors.
+
+    Note: this modifies class Type[T] (the class that was decorated with
+    ``@dataclass``) *after* instantiation of the class.  In other words, for a
+    given field `f` on class `C`, `C.f` will *not* be a property descriptor
+    until *after* C has been instantiated: `c = C()`.  (And reminder: property
+    descriptors are class attributes).
+
+    The reason for this is that dataclasses can have "default factory"
+    functions that create default values for fields only during instantiation,
+    and we don't want to have to recreate that logic here, (but we do need to
+    know what the value of the field is).
+
+    Parameters
+    ----------
+    obj : T
+        An instance of class ``Type[T]`` that has been deorated as a dataclass.
+    """
     from numpydoc.docscrape import ClassDoc
 
     cls = obj.__class__
@@ -142,15 +215,19 @@ def dataclass(
     if properties and frozen:
         raise ValueError("`properties=True` cannot be used with `frozen=True`")
     if events or properties:
-        orig_post_init = getattr(cls, '__post_init__', None)
-        post_init = make_post_init(orig_post_init, events, properties)
+        # create a modified __post_init__ method that will create the
+        # EmitterGroup, and convert fields to properties (if requested)
+        post_init = make_post_init(cls, events, properties)
         setattr(cls, '__post_init__', post_init)
 
-    _cls = _dataclasses._process_class(  # type: ignore
+    # if neither events or properties are True, this function is exactly like
+    # the builtin `dataclasses.dataclass`
+    _cls = _dataclasses._process_class(
         cls, init, repr, eq, order, unsafe_hash, frozen
     )
 
     if events:
-        setattr(_cls, '_is_initialized', False)
+        setattr(_cls, '_is_initialized', False)  # made true in __post_init__
+        # modify __setattr__ with version that emits an event when setting
         _cls.__setattr__ = setattr_with_events
     return _cls

--- a/napari/utils/dataclass.py
+++ b/napari/utils/dataclass.py
@@ -1,0 +1,157 @@
+import dataclasses as _dataclasses
+from typing import Any, Callable, Type, TypeVar
+
+import toolz as tz
+
+from .event import EmitterGroup
+
+WHEN_SET = "_on_{name}_set"
+T = TypeVar("T")
+
+
+def make_post_init(
+    orig_post_init: Callable[..., None] = None, events=False, properties=False,
+) -> Callable[..., None]:
+    def _event_post_init(self, *initvars) -> None:
+        emitter_group = EmitterGroup(
+            source=self,
+            auto_connect=False,
+            **{name: None for name in self.__dataclass_fields__},
+        )
+        object.__setattr__(self, 'events', emitter_group)
+        if orig_post_init is not None:
+            orig_post_init(self, *initvars)
+        if properties:
+            # This should happen after initialization to handle default
+            # factories in dataclasses
+            convert_fields_to_properties(self)
+        object.__setattr__(self, '_is_initialized', True)
+
+    return _event_post_init
+
+
+def setattr_with_events(self: T, name: str, value: Any) -> None:
+    object.__setattr__(self, name, value)
+    if name in self.__annotations__ and getattr(
+        self, '_is_initialized', False
+    ):
+        # if custom set method `_on_<name>_set` exists, call it
+        setter_method = getattr(self, WHEN_SET.format(name=name), None)
+        if callable(setter_method):
+            # the method can return True, if it wants to handle its own events
+            if setter_method(getattr(self, name)):
+                return
+        # otherwise, we emit this event
+        if name in self.events:  # type: ignore # (needs SupportsEvents)
+            getattr(self.events, name)(value=getattr(self, name))  # type: ignore
+
+
+def make_getter(name):
+    def fget(self):
+        return getattr(self, name)
+
+    return fget
+
+
+def make_setter(name):
+    def fset(self, value):
+        setattr(self, name, value)
+
+    return fset
+
+
+def convert_fields_to_properties(obj):
+    from numpydoc.docscrape import ClassDoc
+
+    cls = obj.__class__
+    cls_doc = ClassDoc(cls)
+    params = {p.name: p for p in cls_doc["Parameters"]}
+    for field in _dataclasses.fields(cls):
+
+        private_name = f"_{field.name}"
+        setattr(obj, private_name, getattr(obj, field.name))
+        fget = make_getter(private_name)
+        fset = make_setter(private_name)
+        doc = None
+        if field.name in params:
+            param = params[field.name]
+            doc = "\n".join(param.desc)
+            # TODO: could compare param.type to field.type here for consistency
+
+        prop = property(fget=fget, fset=fset, fdel=None, doc=doc)
+        setattr(cls, field.name, prop)
+
+
+@tz.curry
+def dataclass(
+    cls: Type[T],
+    /,  # noqa need to update flake8 in precommit
+    *,
+    init: bool = True,
+    repr: bool = True,
+    eq: bool = True,
+    order: bool = False,
+    unsafe_hash: bool = False,
+    frozen: bool = False,
+    events: bool = False,
+    properties: bool = False,
+) -> Type[T]:
+    """Enhanced dataclass decorator with events and property descriptors.
+
+    Examines PEP 526 __annotations__ to determine fields.  Fields are defined
+    as class attributes with a type annotation.
+
+    Parameters
+    ----------
+    cls : Type[T]
+        [description]
+    init : bool, optional
+        If  true, an __init__() method is added to the class, by default True
+    repr : bool, optional
+        If true, a __repr__() method is added, by default True
+    eq : bool, optional
+        [description], by default True
+    order : bool, optional
+        If true, rich comparison dunder methods are added, by default False
+    unsafe_hash : bool, optional
+        If true, a __hash__() method function is added, by default False
+    frozen : bool, optional
+        If true, fields may not be assigned to after instance creation., by
+        default False
+    events : bool, optional
+        If true, an ``EmmitterGroup`` instance is added as attribute "events".
+        Events will be emitted each time one of the dataclass fields are
+        altered. by default False
+    properties : bool, optional
+        If true, field attributes will be converted to property descriptors.
+        If the class has a class docstring in numpydocs format, docs for each
+        property will be taken from the ``Parameters`` section for the
+        corresponding parameter. by default False
+
+    Returns
+    -------
+    decorated class
+        Returns the same class as was passed in, with dunder methods
+        added based on the fields defined in the class.
+
+    Raises
+    ------
+    ValueError
+        If both ``properties`` and ``frozen`` are True
+    """
+
+    if properties and frozen:
+        raise ValueError("`properties=True` cannot be used with `frozen=True`")
+    if events or properties:
+        orig_post_init = getattr(cls, '__post_init__', None)
+        post_init = make_post_init(orig_post_init, events, properties)
+        setattr(cls, '__post_init__', post_init)
+
+    _cls = _dataclasses._process_class(  # type: ignore
+        cls, init, repr, eq, order, unsafe_hash, frozen
+    )
+
+    if events:
+        setattr(_cls, '_is_initialized', False)
+        _cls.__setattr__ = setattr_with_events
+    return _cls

--- a/napari/utils/dataclass.py
+++ b/napari/utils/dataclass.py
@@ -120,7 +120,7 @@ def dataclass(
     events : bool, optional
         If true, an ``EmmitterGroup`` instance is added as attribute "events".
         Events will be emitted each time one of the dataclass fields are
-        altered. by default False
+        altered, by default False
     properties : bool, optional
         If true, field attributes will be converted to property descriptors.
         If the class has a class docstring in numpydocs format, docs for each

--- a/napari/utils/dataclass.py
+++ b/napari/utils/dataclass.py
@@ -96,8 +96,6 @@ def make_post_init(
             # This should happen after initialization to allow default
             # factories to be handled by the dataclass
             convert_fields_to_properties(self)
-        # release self.__setattr__ to emit events.
-        object.__setattr__(self, '_is_initialized', True)
 
         if events:
             # modify __setattr__ with version that emits an event when setting

--- a/napari/utils/dataclass.py
+++ b/napari/utils/dataclass.py
@@ -1,48 +1,31 @@
-import dataclasses as _pydcls
+import dataclasses as _dc
 import typing
-from enum import EnumMeta
-from typing import Any, Callable, ClassVar, Optional, Set, Type, TypeVar
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    NamedTuple,
+    Optional,
+    Set,
+    Type,
+    TypeVar,
+    cast,
+)
 
 import toolz as tz
-from typing_extensions import get_type_hints
+from typing_extensions import Annotated, get_args, get_origin, get_type_hints
+
 
 from .event import EmitterGroup
 
 ON_SET = "_on_{name}_set"
 ON_GET = "_on_{name}_get"
-T = TypeVar("T")
-
-
-def coerce(value: Any, type_: Optional[Type]):
-    """Attempt to coerce value to a particular type.
-
-    Parameters
-    ----------
-    value : Any
-        The value being coerced
-    type_ : Type
-        The output type
-
-    Returns
-    -------
-    value : Any
-        possibly coerced value
-    """
-    if not type_ or isinstance(value, property):
-        return value
-    if isinstance(type_, EnumMeta):
-        return type_(value)
-    try:
-        # convert simple types
-        if type_.__module__ == 'builtins':
-            value = type_(value)
-    except Exception:
-        pass
-    return value
+C = TypeVar("C")
 
 
 @tz.curry
-def set_with_events(self: T, name: str, value: Any, fields: Set[str]) -> None:
+def set_with_events(self: C, name: str, value: Any, fields: Set[str]) -> None:
     """Modified __setattr__ method that emits an event when set.
 
     Events will *only* be emitted if the ``name`` of the attribute being set
@@ -67,8 +50,8 @@ def set_with_events(self: T, name: str, value: Any, fields: Set[str]) -> None:
 
     Parameters
     ----------
-    self : T
-        An instance of the decorated dataclass of Type[T]
+    self : C
+        An instance of the decorated dataclass of Type[C]
     name : str
         The name of the attribute being set.
     value : Any
@@ -76,9 +59,8 @@ def set_with_events(self: T, name: str, value: Any, fields: Set[str]) -> None:
     fields : set of str
         Only emit events for field names in this set.
     """
-    _value = coerce(value, get_type_hints(self).get(name))
     # first call the original
-    object.__setattr__(self, name, _value)
+    object.__setattr__(self, name, value)
     if name in fields:
         # if custom set method `_on_<name>_set` exists, call it
         setter_method = getattr(self, ON_SET.format(name=name), None)
@@ -92,32 +74,7 @@ def set_with_events(self: T, name: str, value: Any, fields: Set[str]) -> None:
             getattr(self.events, name)(value=getattr(self, name))  # type: ignore
 
 
-def getattr_with_conversion(self: T, name: str) -> Any:
-    """Modified __getattr__ method that allows class override.
-    Parameters
-    ----------
-    self : T
-        An instance of the decorated dataclass of Type[T]
-    name : str
-        The name of the attribute being retrieved.
-
-    Returns
-    -------
-    value : Any
-        The value being retrieved
-    """
-    val = object.__getattribute__(self, name)
-    name = name.lstrip("_")
-    hint = get_type_hints(self, include_extras=True).get(name)
-    if hasattr(hint, '__metadata__') and hint.__metadata__:
-        val = coerce(val, hint.__metadata__[0])
-    getter_method = getattr(self, ON_GET.format(name=name), None)
-    if callable(getter_method):
-        return getter_method(val)
-    return val
-
-
-def add_events_to_class(cls: Type[T]) -> Callable[..., None]:
+def add_events_to_class(cls: Type[C]) -> None:
     """Return a new __post_init__ method wrapper with events.
 
     Parameters
@@ -147,16 +104,107 @@ def add_events_to_class(cls: Type[T]) -> Callable[..., None]:
         if orig_post_init is not None:
             orig_post_init(self, *initvars)
         # modify __setattr__ with version that emits an event when setting
-        setter = set_with_events(fields={f.name for f in _pydcls.fields(cls)})
+        setter = set_with_events(fields={f.name for f in _dc.fields(cls)})
         setattr(cls, '__setattr__', setter)
 
     setattr(cls, '__post_init__', evented_post_init)
 
 
-def convert_fields_to_properties(cls: Type[T]):
+def getattr_with_conversion(self: C, name: str) -> Any:
+    """Modified __getattr__ method that allows class override.
+    Parameters
+    ----------
+    self : T
+        An instance of the decorated dataclass of Type[C]
+    name : str
+        The name of the attribute being retrieved.
+
+    Returns
+    -------
+    value : Any
+        The value being retrieved
+    """
+
+
+# make the actual getter/setter functions that the property will use
+@tz.curry
+def prop_getter(priv_name: str, fcoerce: Callable, obj) -> Any:
+    # val = object.__getattribute__(obj, name)
+    value = fcoerce(getattr(obj, priv_name))
+    pub_name = priv_name.lstrip("_")
+    getter_method = getattr(obj, ON_GET.format(name=pub_name), None)
+    if callable(getter_method):
+        return getter_method(value)
+    return value
+
+
+@tz.curry
+def prop_setter(
+    priv_name: str, default: Any, fcoerce: Callable, obj, value
+) -> None:
+    # during __init__, the dataclass will try to set the instance
+    # attribute to the property itself!  So we intervene and set it
+    # to the default value from the dataclass declaration
+    pub_name = priv_name.lstrip("_")
+    if type(value) is property:
+        value = default
+        # dataclasses may define attributes as field(...)
+        # so we need to get the default value from the field
+        if isinstance(default, _dc.Field):
+            default = cast(_dc.Field, default)
+            # there will only ever be default_factory OR default
+            # otherwise an exception will have been raised earlier.
+            if default.default_factory is not _dc.MISSING:
+                value = default.default_factory()
+            elif default.default is not _dc.MISSING:
+                value = default.default
+        # If the value is still missing, then it means that the user
+        # failed to provide a required positional argument when
+        # instantiating the dataclass.
+        if value is _dc.MISSING:
+            raise TypeError(
+                "__init__() missing required "
+                f"positional argument: '{pub_name}'"
+            )
+    setattr(obj, priv_name, fcoerce(value))
+
+
+T = TypeVar("T")
+
+
+class TypeGetSet(NamedTuple):
+    type: Type[T]
+    fget: Optional[Callable[[T], Any]]
+    fset: Optional[Callable[[Any], T]]
+
+
+@tz.curry
+def try_coerce(func, name, value):
+    if func is not None:
+        try:
+            return func(value)
+        except Exception as e:
+            raise TypeError(f"Failed to coerce value {value} in {name}: {e}")
+    return value
+
+
+def parse_annotated_types(cls: Type):
+    out: Dict[str, TypeGetSet] = {}
+    for name, typ in get_type_hints(cls, include_extras=True).items():
+        d = [typ, None, None]
+        if get_origin(typ) is Annotated:
+            args = get_args(typ)
+            d[: len(args)] = args
+        d[1] = try_coerce(d[1], name)
+        d[2] = try_coerce(d[2], name)
+        out[name] = TypeGetSet(*d)
+    return out
+
+
+def convert_fields_to_properties(cls: Type[C]):
     """Convert all fields in a dataclass instance to property descriptors.
 
-    Note: this modifies class Type[T] (the class that was decorated with
+    Note: this modifies class Type[C] (the class that was decorated with
     ``@dataclass``) *after* instantiation of the class.  In other words, for a
     given field `f` on class `C`, `C.f` will *not* be a property descriptor
     until *after* C has been instantiated: `c = C()`.  (And reminder: property
@@ -170,7 +218,7 @@ def convert_fields_to_properties(cls: Type[T]):
     Parameters
     ----------
     obj : T
-        An instance of class ``Type[T]`` that has been deorated as a dataclass.
+        An instance of class ``Type[C]`` that has been deorated as a dataclass.
     """
     from numpydoc.docscrape import ClassDoc
 
@@ -178,50 +226,23 @@ def convert_fields_to_properties(cls: Type[T]):
     cls_doc = ClassDoc(cls)
     params = {p.name: p for p in cls_doc["Parameters"]}
 
+    coerce_funcs = parse_annotated_types(cls)
     # loop through annotated members of the glass
     for name, type_ in list(cls.__dict__.get('__annotations__', {}).items()):
         # ClassVar types are exempt from dataclasses and @properties
         # https://docs.python.org/3/library/dataclasses.html#class-variables
-        if _pydcls._is_classvar(type_, typing):
+        if _dc._is_classvar(type_, typing):
             continue
         private_name = f"_{name}"
         # store the original value for the property
-        default = getattr(cls, name, _pydcls.MISSING)
+        default = getattr(cls, name, _dc.MISSING)
 
         # add the private_name as a ClassVar annotation on the original class
         # (annotations of type ClassVar are ignored by the dataclass)
         cls.__annotations__[private_name] = ClassVar[type_]
 
-        # make the actual getter/setter functions that the property will use
-        def fget(self, key=private_name):
-            return getattr_with_conversion(self, key)
-
-        def fset(self, value, key=private_name, default=default):
-            # during __init__, the dataclass will try to set the instance
-            # attribute to the property itself!  So we intervene and set it
-            # to the default value from the dataclass declaration
-            if type(value) is property:
-                value = default
-                # dataclasses may define attributes as field(...)
-                # so we need to get the default value from the field
-                if isinstance(default, _pydcls.Field):
-                    # there will only ever be default_factory OR default
-                    # otherwise an exception will have been raised earlier.
-                    if default.default_factory is not _pydcls.MISSING:
-                        value = default.default_factory()
-                    elif default.default is not _pydcls.MISSING:
-                        value = default.default
-                # If the value is still missing, then it means that the user
-                # failed to provide a required positional argument when
-                # instantiating the dataclass.
-                if value is _pydcls.MISSING:
-                    _name = key.lstrip("_")
-                    raise TypeError(
-                        "__init__() missing required "
-                        f"positional argument: '{_name}'"
-                    )
-            setattr(self, key, value)
-
+        fget = prop_getter(private_name, coerce_funcs.get(name).fget)
+        fset = prop_setter(private_name, default, coerce_funcs.get(name).fset)
         # bring the docstring from the class to the property
         doc = None
         if name in params:
@@ -238,7 +259,7 @@ def convert_fields_to_properties(cls: Type[T]):
 
 @tz.curry
 def dataclass(
-    cls: Type[T],
+    cls: Type[C],
     *,
     init: bool = True,
     repr: bool = True,
@@ -248,7 +269,7 @@ def dataclass(
     frozen: bool = False,
     events: bool = False,
     properties: bool = False,
-) -> Type[T]:
+) -> Type[C]:
     """Enhanced dataclass decorator with events and property descriptors.
 
     Examines PEP 526 __annotations__ to determine fields.  Fields are defined
@@ -257,7 +278,7 @@ def dataclass(
 
     Parameters
     ----------
-    cls : Type[T]
+    cls : Type[C]
         [description]
     init : bool, optional
         If  true, an __init__() method is added to the class, by default True
@@ -308,13 +329,11 @@ def dataclass(
 
     # if neither events or properties are True, this function is exactly like
     # the builtin `dataclasses.dataclass`
-    _cls = _pydcls._process_class(
-        cls, init, repr, eq, order, unsafe_hash, frozen
-    )
+    _cls = _dc._process_class(cls, init, repr, eq, order, unsafe_hash, frozen)
     setattr(_cls, '_get_state', _get_state)
     return _cls
 
 
 def _get_state(self):
     """Get dictionary of dataclass fiels."""
-    return _pydcls.asdict(self)
+    return _dc.asdict(self)

--- a/napari/utils/dataclass.py
+++ b/napari/utils/dataclass.py
@@ -85,7 +85,6 @@ def convert_fields_to_properties(obj):
 @tz.curry
 def dataclass(
     cls: Type[T],
-    /,  # noqa need to update flake8 in precommit
     *,
     init: bool = True,
     repr: bool = True,

--- a/napari/utils/dataclass.py
+++ b/napari/utils/dataclass.py
@@ -61,15 +61,21 @@ def set_with_events(self: C, name: str, value: Any, fields: Set[str]) -> None:
     """
     # first call the original
     object.__setattr__(self, name, value)
-    if name in fields:
+
+    if hasattr(self, 'events') and name in fields:
         # if custom set method `_on_<name>_set` exists, call it
         setter_method = getattr(self, ON_SET.format(name=name), None)
         if callable(setter_method):
             # the method can return True, if it wants to handle its own events
+            # TODO: if an exception is raised in the ON_SET method, we should
+            # undo any state changes.
             if setter_method(getattr(self, name)):
                 return
         # otherwise, we emit the event
-        if hasattr(self, 'events') and name in self.events:
+        # TODO: use np.all(old_val == new_val)
+        # TODO: don't emit an event if the value hasn't changed
+
+        if name in self.events:
             # use gettattr again in case `_on_name_set` has modified it
             getattr(self.events, name)(value=getattr(self, name))  # type: ignore
 
@@ -91,22 +97,26 @@ def add_events_to_class(cls: Type[C]) -> None:
     # get a handle to the original __post_init__ method if present
     orig_post_init: Callable[..., None] = getattr(cls, '__post_init__', None)
 
+    e_fields = {
+        _dc._get_field(cls, name, type_)
+        for name, type_ in cls.__dict__.get('__annotations__', {}).items()
+    }
+    e_fields = {
+        fld.name: None
+        for fld in e_fields
+        if fld._field_type is _dc._FIELD and fld.metadata.get("events", True)
+    }
+
     def evented_post_init(self: T, *initvars) -> None:
         # create an EmitterGroup with an EventEmitter for each field
-        # in the dataclass
-        emitter_group = EmitterGroup(
-            source=self,
-            auto_connect=False,
-            **{n: None for n in getattr(self, '__dataclass_fields__', {})},
-        )
-        object.__setattr__(self, 'events', emitter_group)
+        # in the dataclass, skip those with metadata={'events' = False}
+        self.events = EmitterGroup(source=self, auto_connect=False, **e_fields)
         # call original __post_init__
         if orig_post_init is not None:
             orig_post_init(self, *initvars)
-        # modify __setattr__ with version that emits an event when setting
-        setter = set_with_events(fields={f.name for f in _dc.fields(cls)})
-        setattr(cls, '__setattr__', setter)
 
+    # modify __setattr__ with version that emits an event when setting
+    setattr(cls, '__setattr__', set_with_events(fields=set(e_fields)))
     setattr(cls, '__post_init__', evented_post_init)
 
 
@@ -229,9 +239,9 @@ def convert_fields_to_properties(cls: Type[C]):
     coerce_funcs = parse_annotated_types(cls)
     # loop through annotated members of the glass
     for name, type_ in list(cls.__dict__.get('__annotations__', {}).items()):
-        # ClassVar types are exempt from dataclasses and @properties
+        # ClassVar and InitVar types are exempt from dataclasses and properties
         # https://docs.python.org/3/library/dataclasses.html#class-variables
-        if _dc._is_classvar(type_, typing):
+        if _dc._is_classvar(type_, typing) or _dc._is_initvar(type_, _dc):
             continue
         private_name = f"_{name}"
         # store the original value for the property
@@ -315,6 +325,12 @@ def dataclass(
         If both ``properties`` and ``frozen`` are True
     """
 
+    # TODO: currently, events must be process first here, otherwise
+    # metada={'events':False} does not work... but that should be fixed.
+    if events:
+        # create a modified __post_init__ method that creates an EmitterGroup
+        add_events_to_class(cls)
+
     if properties:
         if frozen:
             raise ValueError(
@@ -322,10 +338,6 @@ def dataclass(
             )
         # convert public dataclass fields to properties
         convert_fields_to_properties(cls)
-
-    if events:
-        # create a modified __post_init__ method that creates an EmitterGroup
-        add_events_to_class(cls)
 
     # if neither events or properties are True, this function is exactly like
     # the builtin `dataclasses.dataclass`

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -4,6 +4,7 @@ import collections.abc
 import inspect
 import itertools
 import re
+import builtins
 
 from enum import Enum, EnumMeta
 from os import PathLike, fspath, path
@@ -151,7 +152,7 @@ class StringEnumMeta(EnumMeta):
             else:
                 raise ValueError(
                     f'{cls} may only be called with a `str`'
-                    f' or an instance of {cls}'
+                    f' or an instance of {cls}. Got {builtins.type(value)}'
                 )
 
         # otherwise create new Enum class

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ install_requires =
     qtpy>=1.7.0
     scipy>=1.2.0
     tifffile>=2020.2.16
+    typing_extensions
     toolz>=0.10.0
     vispy>=0.6.4
     wrapt>=1.11.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ include_package_data = True
 install_requires =
     cachey>=0.2.1
     dask[array]>=2.1.0
+    dataclasses ; python_version < '3.7'
     imageio>=2.5.0
     importlib-metadata>=1.5.0 ; python_version < '3.8'
     ipykernel>=5.1.1


### PR DESCRIPTION
# Description
@sofroniewn [suggested](https://github.com/napari/napari/pull/1475#issuecomment-660506800) seeing how the evented dataclass from #1475  looks on the `TextManager` from #1374, and it was actually very encouraging!  I was nearly able to delete the entire class, without touching the tests! :) including all the `__eq__` and `_get_state`  methods which are nicely provided by [`dataclass.asdict`](https://docs.python.org/3/library/dataclasses.html#dataclasses.asdict). (most of the added stuff in this PR is just the unmerged dataclass file from #1475)

The main methods left over were cases where I needed to coerce the value type to something different on access (like converting an Enum back to a string), or on set (like making sure something is an ndarray).  It's nice having the `_on_name_get/set` fallback, but for setting things like Enums, I was even able to do the coercion in the dataclass logic using the type annotation, and that pattern could probably be reused for other simple types.  For declaring the "type on get", I can imagine using `Annotated` types, like:

```python
# coerces to Anchor when set, and coerces to str on get
anchor: Annotated[Anchor, str] = Anchor.CENTER
```


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
