### PR TITLE
Fix 0.3.6 release notes to indicate reversions.

### DIFF
--- a/docs/release/release_0_3_6.md
+++ b/docs/release/release_0_3_6.md
@@ -36,12 +36,12 @@ room at https://napari.zulipchat.com!
 
 ## Improvements
 - Add ability to run napari script with/without gui_qt from CLI (#1373)
-- Event handler refactor for image layer (#1376)
+- Event handler refactor for image layer  "reverted by (#1416)" (#1376)
 - Add ndim as a keyword argument to shapes to support creating empty layers (#1379)
 - Add helpful error on multichannel IndexError (#1381)
-- Use qlistwidget for QtLayerList (#1391)
-- Event handler surface layer (#1396)
-- Revert event handler for now (#1416)
+- Use qlistwidget for QtLayerList "reverted by (#1416)" (#1391)
+- Event handler surface layer  "reverted by (#1416)" (#1396)
+- Revert "event handler refactors (#1376), (#1391), (#1396)" (#1416)
 - Move contrast limits and gamma to the shader by vendoring vispy code (#1456)
 - Reduce attenuation default and range (#1460)
 


### PR DESCRIPTION
# Description
Docs PR that updates 0.3.6 release notes to indicate reversions. As pointed out by @justinelarsen the current release notes might be confusing to someone coming new as they don't clearly indicate what PRs were reverted. This update fixes that.