### PR TITLE
Fix URL parsing scheme for view_path

### DIFF
--- a/napari/utils/_tests/test_misc.py
+++ b/napari/utils/_tests/test_misc.py
@@ -179,6 +179,7 @@ def test_abspath_or_url():
     assert abspath_or_url('https://something') == 'https://something'
     assert abspath_or_url('http://something') == 'http://something'
     assert abspath_or_url('ftp://something') == 'ftp://something'
+    assert abspath_or_url('s3://something') == 's3://something'
     assert abspath_or_url('file://something') == 'file://something'
     assert abspath_or_url(('a', '~')) == (abspath('a'), expanduser('~'))
     assert abspath_or_url(['a', '~']) == [abspath('a'), expanduser('~')]

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -4,10 +4,10 @@ import collections.abc
 import inspect
 import itertools
 import re
-
 from enum import Enum, EnumMeta
 from os import PathLike, fspath, path
 from typing import Optional, Sequence, Type, TypeVar
+from urllib.parse import urlparse
 
 import numpy as np
 
@@ -221,6 +221,9 @@ def abspath_or_url(relpath: T) -> T:
 
     if isinstance(relpath, (str, PathLike)):
         relpath = fspath(relpath)
+        urlp = urlparse(relpath)
+        if urlp.scheme and urlp.netloc:
+            return relpath
         if relpath.startswith(('http:', 'https:', 'ftp:', 'file:')):
             return relpath
         return path.abspath(path.expanduser(relpath))

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -224,8 +224,6 @@ def abspath_or_url(relpath: T) -> T:
         urlp = urlparse(relpath)
         if urlp.scheme and urlp.netloc:
             return relpath
-        if relpath.startswith(('http:', 'https:', 'ftp:', 'file:')):
-            return relpath
         return path.abspath(path.expanduser(relpath))
 
     raise TypeError("Argument must be a string, PathLike, or sequence thereof")


### PR DESCRIPTION
# Description
small bugfix to fix URL mangling when using `view_path` with a non "http/ftp" URL scheme (like `s3://`):
```
napari s3://tjl-data/neuro.zarr
No such file: '/Users/talley/dev/forks/napari/s3:/tjl-data/neuro.zarripy'
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] added new test for s3
- [ ] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
