### PR TITLE
Fix potentially-confusing typo in comment.

### DIFF
--- a/napari/_qt/threading.py
+++ b/napari/_qt/threading.py
@@ -49,7 +49,7 @@ class WorkerBase(QRunnable):
     def __getattr__(self, name):
         """Pass through attr requests to signals to simplify connection API.
 
-        The goal is to enable ``worker.signal.connect`` instead of
+        The goal is to enable ``worker.yielded.connect`` instead of
         ``worker.signals.yielded.connect``. Because multiple inheritance of Qt
         classes is not well supported in PyQt, we have to use composition here
         (signals are provided by QObjects, and QRunnable is not a QObject). So


### PR DESCRIPTION
# Description
This fixes what I _believe_ is a typo in a comment. It's not so hard to figure out what is meant, but `__getattr__` magic can be confusing so I figure it might be worth patching.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Documentation fix