### PR TITLE
Changed class evaluation from `type` to `isinstance`

### DIFF
--- a/napari/_qt/layers/utils.py
+++ b/napari/_qt/layers/utils.py
@@ -36,4 +36,4 @@ def create_qt_controls(layer):
         if isinstance(layer, layer_type):
             return controls(layer)
 
-    raise ValueError
+    raise TypeError(f'Could not find QtControls for layer of type {type(layer)}')

--- a/napari/_qt/layers/utils.py
+++ b/napari/_qt/layers/utils.py
@@ -7,16 +7,6 @@ from .qt_surface_layer import QtSurfaceControls
 from .qt_vectors_layer import QtVectorsControls
 
 
-layer_to_controls = {
-    Image: QtImageControls,
-    Labels: QtLabelsControls,
-    Points: QtPointsControls,
-    Shapes: QtShapesControls,
-    Surface: QtSurfaceControls,
-    Vectors: QtVectorsControls,
-}
-
-
 def create_qt_controls(layer):
     """
     Create a qt controls widget for a layer based on its layer type.
@@ -31,6 +21,20 @@ def create_qt_controls(layer):
     controls : napari.layers.base.QtLayerControls
         Qt controls widget
     """
-    controls = layer_to_controls[type(layer)](layer)
+    if isinstance(layer, Labels):
+        controls = QtLabelsControls(layer)
+    elif isinstance(layer, Image):
+        # must be after Labels layer
+        controls = QtImageControls(layer)
+    elif isinstance(layer, Points):
+        controls = QtPointsControls(layer)
+    elif isinstance(layer, Shapes):
+        controls = QtShapesControls(layer)
+    elif isinstance(layer, Surface):
+        controls = QtSurfaceControls(layer)
+    elif isinstance(layer, Vectors):
+        controls = QtVectorsControls(layer)
+    else:
+        raise ValueError
 
     return controls

--- a/napari/_qt/layers/utils.py
+++ b/napari/_qt/layers/utils.py
@@ -36,4 +36,6 @@ def create_qt_controls(layer):
         if isinstance(layer, layer_type):
             return controls(layer)
 
-    raise TypeError(f'Could not find QtControls for layer of type {type(layer)}')
+    raise TypeError(
+        f'Could not find QtControls for layer of type {type(layer)}'
+    )

--- a/napari/_qt/layers/utils.py
+++ b/napari/_qt/layers/utils.py
@@ -7,6 +7,16 @@ from .qt_surface_layer import QtSurfaceControls
 from .qt_vectors_layer import QtVectorsControls
 
 
+layer_to_controls = {
+    Labels: QtLabelsControls,
+    Image: QtImageControls,  # must be after Labels layer
+    Points: QtPointsControls,
+    Shapes: QtShapesControls,
+    Surface: QtSurfaceControls,
+    Vectors: QtVectorsControls,
+}
+
+
 def create_qt_controls(layer):
     """
     Create a qt controls widget for a layer based on its layer type.
@@ -21,20 +31,9 @@ def create_qt_controls(layer):
     controls : napari.layers.base.QtLayerControls
         Qt controls widget
     """
-    if isinstance(layer, Labels):
-        controls = QtLabelsControls(layer)
-    elif isinstance(layer, Image):
-        # must be after Labels layer
-        controls = QtImageControls(layer)
-    elif isinstance(layer, Points):
-        controls = QtPointsControls(layer)
-    elif isinstance(layer, Shapes):
-        controls = QtShapesControls(layer)
-    elif isinstance(layer, Surface):
-        controls = QtSurfaceControls(layer)
-    elif isinstance(layer, Vectors):
-        controls = QtVectorsControls(layer)
-    else:
-        raise ValueError
 
-    return controls
+    for layer_type, controls in layer_to_controls.items():
+        if isinstance(layer, layer_type):
+            return controls(layer)
+
+    raise ValueError

--- a/napari/_vispy/utils.py
+++ b/napari/_vispy/utils.py
@@ -1,4 +1,4 @@
-from ..layers import Image, Labels, Points, Shapes, Surface, Vectors
+from ..layers import Image, Points, Shapes, Surface, Vectors
 from .vispy_image_layer import VispyImageLayer
 from .vispy_points_layer import VispyPointsLayer
 from .vispy_shapes_layer import VispyShapesLayer
@@ -8,7 +8,6 @@ from .vispy_surface_layer import VispySurfaceLayer
 
 layer_to_visual = {
     Image: VispyImageLayer,
-    Labels: VispyImageLayer,
     Points: VispyPointsLayer,
     Shapes: VispyShapesLayer,
     Surface: VispySurfaceLayer,

--- a/napari/_vispy/utils.py
+++ b/napari/_vispy/utils.py
@@ -29,6 +29,8 @@ def create_vispy_visual(layer):
     visual : vispy.scene.visuals.VisualNode
         Vispy visual node
     """
-    visual = layer_to_visual[type(layer)](layer)
+    for layer_type, visual in layer_to_visual.items():
+        if isinstance(layer, layer_type):
+            return visual(layer)
 
-    return visual
+    raise ValueError

--- a/napari/_vispy/utils.py
+++ b/napari/_vispy/utils.py
@@ -32,4 +32,6 @@ def create_vispy_visual(layer):
         if isinstance(layer, layer_type):
             return visual(layer)
 
-    raise TypeError(f'Could not find VispyLayer for layer of type {type(layer)}')
+    raise TypeError(
+        f'Could not find VispyLayer for layer of type {type(layer)}'
+    )

--- a/napari/_vispy/utils.py
+++ b/napari/_vispy/utils.py
@@ -32,4 +32,4 @@ def create_vispy_visual(layer):
         if isinstance(layer, layer_type):
             return visual(layer)
 
-    raise ValueError
+    raise TypeError(f'Could not find VispyLayer for layer of type {type(layer)}')


### PR DESCRIPTION
# Description
This PR closes issue #1176.
It changes the `create_qt_controls` and `create_vispy_visual` to evaluate the layer's class with `isinstance` and not `type`.

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# References
Issue #1176 and [image.sc forum post](https://forum.image.sc/t/is-it-possible-to-constrain-regions-where-it-is-possible-to-insert-points/41286/4).

# How has this been tested?
- [X] Using the standard `pytest` command as described [here](https://github.com/napari/napari/blob/master/docs/source/developers/TESTING.md).

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Comments

The `create_qt_controls` need to respect a certain ordering because `Labels` inherits `Image` and they have different `QtControls`. The sequence is of if and else is not very elegant but I think it is less error-prone than using a list in place of the dictionary.
