### PR TITLE
Add test for theme changing

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -152,12 +152,21 @@ def test_update(make_test_viewer):
 
 
 def test_changing_theme(make_test_viewer):
-    """Test instantiating viewer."""
+    """Test changing the theme updates the full window."""
     viewer = make_test_viewer()
     assert viewer.palette['folder'] == 'dark'
 
+    screenshot_dark = viewer.screenshot(canvas_only=False)
+
     viewer.theme = 'light'
     assert viewer.palette['folder'] == 'light'
+
+    screenshot_light = viewer.screenshot(canvas_only=False)
+    equal = (screenshot_dark == screenshot_light)[..., :3]
+    np.count_nonzero(equal)
+
+    # (less than 1 in 100,000 pixels are the same)
+    assert (np.count_nonzero(equal) / equal.size) < 1e-5, "Themes are similar!"
 
     with pytest.raises(ValueError):
         viewer.theme = 'nonexistent_theme'

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -163,7 +163,6 @@ def test_changing_theme(make_test_viewer):
 
     screenshot_light = viewer.screenshot(canvas_only=False)
     equal = (screenshot_dark == screenshot_light)[..., :3]
-    np.count_nonzero(equal)
 
     # (less than 1 in 100,000 pixels are the same)
     assert (np.count_nonzero(equal) / equal.size) < 1e-5, "Themes are similar!"

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -164,8 +164,8 @@ def test_changing_theme(make_test_viewer):
     screenshot_light = viewer.screenshot(canvas_only=False)
     equal = (screenshot_dark == screenshot_light)[..., :3]
 
-    # (less than 1 in 100,000 pixels are the same)
-    assert (np.count_nonzero(equal) / equal.size) < 1e-5, "Themes are similar!"
+    # (less than 1 in 10,000 pixels are the same)
+    assert (np.count_nonzero(equal) / equal.size) < 1e-4, "Themes are similar!"
 
     with pytest.raises(ValueError):
         viewer.theme = 'nonexistent_theme'

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -163,10 +163,10 @@ def test_changing_theme(make_test_viewer):
     assert viewer.palette['folder'] == 'light'
 
     screenshot_light = viewer.screenshot(canvas_only=False)
-    equal = (screenshot_dark == screenshot_light)[..., :3]
+    equal = (screenshot_dark == screenshot_light).min(-1)
 
     # more than 99.5% of the pixels have changed
-    assert (np.count_nonzero(equal) / equal.size) < 5e-3, "Themes are similar!"
+    assert (np.count_nonzero(equal) / equal.size) < 0.05, "Themes too similar"
 
     with pytest.raises(ValueError):
         viewer.theme = 'nonexistent_theme'

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -154,6 +154,7 @@ def test_update(make_test_viewer):
 def test_changing_theme(make_test_viewer):
     """Test changing the theme updates the full window."""
     viewer = make_test_viewer()
+    viewer.add_points(data=None)
     assert viewer.palette['folder'] == 'dark'
 
     screenshot_dark = viewer.screenshot(canvas_only=False)
@@ -164,8 +165,8 @@ def test_changing_theme(make_test_viewer):
     screenshot_light = viewer.screenshot(canvas_only=False)
     equal = (screenshot_dark == screenshot_light)[..., :3]
 
-    # (less than 1 in 10,000 pixels are the same)
-    assert (np.count_nonzero(equal) / equal.size) < 1e-4, "Themes are similar!"
+    # more than 99.5% of the pixels have changed
+    assert (np.count_nonzero(equal) / equal.size) < 5e-3, "Themes are similar!"
 
     with pytest.raises(ValueError):
         viewer.theme = 'nonexistent_theme'


### PR DESCRIPTION
# Description
closes #669 and adds a test to make sure that >99.5% of the pixels in a screenshot have changed when switching between dark and light themes. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Test

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] takes two screenshots and looks for the ratio of non-equal pixels between dark/light themes


## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
