### PR TITLE
pin conda in CI tests to 4.8.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,7 +50,7 @@ linux_task:
     - bash install.sh -b -p $HOME/conda
     # https://github.com/napari/napari/pull/594#issuecomment-542475164
     - conda install --yes -c conda-forge setuptools
-    - conda update -y -n base conda
+    - conda install -y -n base conda=4.8.3
     - conda install -y python=$PY_VER
 
   # https://github.com/cirruslabs/cirrus-ci-docs/issues/97
@@ -110,7 +110,7 @@ mac_task:
     - bash install.sh -b -p $HOME/conda
     # https://github.com/napari/napari/pull/594#issuecomment-542475164
     - conda install --yes -c conda-forge setuptools
-    - conda update -y -n base conda
+    - conda install -y -n base conda=4.8.3
     - conda install -y python=$PY_VER
 
   pip_cache:
@@ -174,7 +174,7 @@ win_task:
     - choco install -y miniconda3 --params="'/D:%ANACONDA_LOCATION%'"
     # https://github.com/napari/napari/pull/594#issuecomment-542475164
     - conda install --yes -c conda-forge setuptools
-    - conda update -y -n base conda
+    - conda install -y -n base conda=4.8.3
     - conda install -y python=%PY_VER%
 
   pip_cache:


### PR DESCRIPTION
# Description
let's see if this lets us test again... there's very little need to be on the bleeding edge conda for our CI, and we can unpin later