### PR TITLE
viewer.watch_path method to auto-concatenate data from a monitored folder

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -3,7 +3,6 @@ import numpy as np
 from ..utils.event import EmitterGroup, Event
 from ..utils.key_bindings import KeymapHandler, KeymapProvider
 from ..utils.theme import palettes
-from ..utils.watch_path import watch_path as _watch_path
 from ._viewer_mouse_bindings import dims_scroll
 from .add_layers_mixin import AddLayersMixin
 from .dims import Dims
@@ -494,6 +493,3 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         translate = [0] * layer.ndim
         translate[-2:] = translate_2d
         layer.translate_grid = translate
-
-    def watch_path(self, path, *, plugin=None, channel_parser=None):
-        _watch_path(self, path, plugin=plugin, channel_parser=channel_parser)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -3,6 +3,7 @@ import numpy as np
 from ..utils.event import EmitterGroup, Event
 from ..utils.key_bindings import KeymapHandler, KeymapProvider
 from ..utils.theme import palettes
+from ..utils.watch_path import watch_path as _watch_path
 from ._viewer_mouse_bindings import dims_scroll
 from .add_layers_mixin import AddLayersMixin
 from .dims import Dims
@@ -493,3 +494,6 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         translate = [0] * layer.ndim
         translate[-2:] = translate_2d
         layer.translate_grid = translate
+
+    def watch_path(self, path, *, plugin=None, channel_parser=None):
+        _watch_path(self, path, plugin=plugin, channel_parser=channel_parser)

--- a/napari/utils/watch_path.py
+++ b/napari/utils/watch_path.py
@@ -1,0 +1,134 @@
+import os
+import re
+import time
+from typing import Callable, Dict, Generator, List, Optional, Tuple
+
+import numpy as np
+
+from napari._qt.qthreading import thread_worker
+from napari.plugins.io import read_data_with_plugins
+from napari.types import FullLayerData
+
+
+@thread_worker
+def path_watcher(path, interval=0.1) -> Generator[Optional[str], None, None]:
+    # does not recurse
+    files_last = set(os.listdir(path))
+    while True:
+        files_new = set(os.listdir(path))
+        diff = files_new - files_last
+        if diff:
+            for p in diff:
+                print('watcher yielding', p)
+                yield os.path.join(path, p)
+        else:
+            yield None
+        files_last = files_new
+        time.sleep(interval)
+
+
+@thread_worker
+def path_reader(
+    plugin=None,
+) -> Generator[Optional[Tuple[str, List[FullLayerData]]], Optional[str], None]:
+    from napari.components.add_layers_mixin import _normalize_layer_data
+
+    path = None
+    data = None
+    while True:
+        if path:
+            data = read_data_with_plugins(path, plugin=plugin)
+            data = (path, [_normalize_layer_data(d) for d in data])
+        path = yield data
+        data = None
+        time.sleep(0.1)
+
+
+def regex_parser(pattern) -> Callable[[str], Tuple[int, ...]]:
+    _parser = re.compile(pattern)
+
+    def parser(path: str) -> Tuple[int, ...]:
+        match = _parser.match(path)
+        return tuple(int(x) for x in match.groups()) if match else ()
+
+    return parser
+
+
+class Stacker:
+    COLORS = ['green', 'magenta', 'blue']  # whatever...
+
+    def __init__(
+        self, viewer, channel_parser: Callable[[str], Tuple[int, ...]] = None
+    ):
+        self.viewer = viewer
+        self.shapes: Dict[Tuple, List[Tuple]] = {}
+        self.channel_parser = channel_parser
+
+    def __call__(self, layer_data: Optional[Tuple[str, List[FullLayerData]]]):
+        if not layer_data:
+            return
+        path, _layer_data = layer_data
+        _ch = self.channel_parser(path) if self.channel_parser else ()
+
+        assert (_ch == ()) or len(_ch) == 1, 'one channel per image for now'
+        assert len(_layer_data) == 1, 'one channel per image for now'
+
+        _ld = _layer_data[0]
+
+        if _ch not in self.shapes:
+            try:
+                self.shapes[_ch] = [d[0].shape for d in _layer_data]
+            except AttributeError:
+                raise TypeError(
+                    "Stacker only handles numpy-like arrays, "
+                    f"got layer data: {_layer_data}"
+                )
+            _ld[1].setdefault('metadata', {})
+            _ld[1]['metadata']['channel'] = _ch
+            self.viewer._add_layer_from_data(*_ld)
+            if len(self.shapes) == 2:
+                # we added a second channel
+                for n, i in enumerate(self.shapes):
+                    layer = next(
+                        lay
+                        for lay in self.viewer.layers
+                        if lay.metadata.get('channel') == i
+                    )
+                    layer.colormap = self.COLORS[n]
+                    layer.blending = 'additive'
+            if len(self.shapes) > 2:
+                next(
+                    lay
+                    for lay in self.viewer.layers
+                    if lay.metadata.get('channel') == _ch
+                ).colormap = self.COLORS[len(self.shapes)]
+                layer.blending = 'additive'
+        else:
+            img = _ld[0]
+            shps = self.shapes[_ch]
+            layer = next(
+                lay
+                for lay in self.viewer.layers
+                if lay.metadata.get('channel') == _ch
+            )
+            # FIXME: only works for single channel per image
+            if layer.data.shape == shps[0]:
+                # this is the second image in the timelapse
+                layer.data = np.stack((layer.data, img), axis=0)
+            else:
+                layer.data = np.concatenate(
+                    (layer.data, img[np.newaxis, :, :]), axis=0
+                )
+
+        self.viewer.dims.set_point(0, self.viewer.dims.max_indices[0])
+
+
+# example channel_parser = regex_parser(r'.*ch(\d{1}).*')
+def watch_path(viewer, path, *, plugin=None, channel_parser=None):
+    watcher = path_watcher('/Users/talley/Desktop/watch/')
+    reader = path_reader(plugin)
+    stacker = Stacker(viewer, channel_parser)
+    watcher.yielded.connect(reader.send)
+    reader.yielded.connect(stacker)
+    reader.start()
+    watcher.start()


### PR DESCRIPTION
# Description
Got inspired thinking about [this zulip thread](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/live.20data), and wrote up a proposal for a `viewer.watch_path` method.  This PR would allow the following:

```python
import napari
from napari.utils.watch_path import regex_parser

with napari.gui_qt():
    viewer = napari.Viewer()
    channel_parser=regex_parser(r'.*ch(\d{1}).*'),
    viewer.watch_path('some/path', plugin=None, channel_parser=channel_parser)
```

and then everytime a new image appears in `'some/path'`, it will be appended to the corresponding channel (where channels are gleaned from the pathname using the `channel_parser`, a function that takes a string and returns a list of channel names).  The slider will also keep up, showing the most recent dataset. 

This works fine with multiple channels across multiple files, but it does assume that a given channel will have the same shape across all timepoints.  Probably a lot of edge cases to consider, but curious what you think of the API.


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
