### PR TITLE
add fingerprint script to pip caching

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,7 +62,7 @@ linux_task:
     folder: ~/.cache/pip
     fingerprint_script:
       - echo $PYTHON_VERSION
-      - type requirements/test.txt
+      - cat requirements/test.txt
     populate_script: 
       - python -m pip install --retries 3 --upgrade pip
       - python -m pip install --retries 3 -r requirements/test.txt
@@ -120,7 +120,7 @@ mac_task:
     folder: $HOME/Library/Caches/pip
     fingerprint_script:
       - echo $PYTHON_VERSION
-      - type requirements/test.txt
+      - cat requirements/test.txt
     populate_script:
       - export MACOSX_DEPLOYMENT_TARGET=10.10
       - python -m pip install --retries 3 --upgrade pip

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -187,7 +187,7 @@ win_task:
     folder: $LOCALAPPDATA\pip\Cache
     fingerprint_script:
       - echo $PYTHON_VERSION
-      - type requirements/test.txt
+      - type requirements\test.txt
     populate_script: 
       - python -m pip install --retries 3 --upgrade pip
       - python -m pip install --retries 3 -r requirements/test.txt

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -181,7 +181,7 @@ win_task:
 
   pip_cache:
     folder: $LOCALAPPDATA\pip\Cache
-    fingerprint_script: echo $PYTHON_VERSION && cat requirements/test.txt
+    fingerprint_script: echo $PYTHON_VERSION && type requirements/test.txt
     populate_script: 
       - python -m pip install --retries 3 --upgrade pip
       - python -m pip install --retries 3 -r requirements/test.txt

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,7 +60,9 @@ linux_task:
 
   pip_cache:
     folder: ~/.cache/pip
-    fingerprint_script: echo $PYTHON_VERSION && cat requirements/test.txt
+    fingerprint_script:
+      - echo $PYTHON_VERSION
+      - type requirements/test.txt
     populate_script: 
       - python -m pip install --retries 3 --upgrade pip
       - python -m pip install --retries 3 -r requirements/test.txt
@@ -116,7 +118,9 @@ mac_task:
 
   pip_cache:
     folder: $HOME/Library/Caches/pip
-    fingerprint_script: echo $PYTHON_VERSION && cat requirements/test.txt
+    fingerprint_script:
+      - echo $PYTHON_VERSION
+      - type requirements/test.txt
     populate_script:
       - export MACOSX_DEPLOYMENT_TARGET=10.10
       - python -m pip install --retries 3 --upgrade pip
@@ -181,7 +185,9 @@ win_task:
 
   pip_cache:
     folder: $LOCALAPPDATA\pip\Cache
-    fingerprint_script: echo $PYTHON_VERSION && type requirements/test.txt
+    fingerprint_script:
+      - echo $PYTHON_VERSION
+      - type requirements/test.txt
     populate_script: 
       - python -m pip install --retries 3 --upgrade pip
       - python -m pip install --retries 3 -r requirements/test.txt

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,6 +60,7 @@ linux_task:
 
   pip_cache:
     folder: ~/.cache/pip
+    fingerprint_script: echo $PYTHON_VERSION && cat requirements/test.txt
     populate_script: 
       - python -m pip install --retries 3 --upgrade pip
       - python -m pip install --retries 3 -r requirements/test.txt
@@ -115,6 +116,7 @@ mac_task:
 
   pip_cache:
     folder: $HOME/Library/Caches/pip
+    fingerprint_script: echo $PYTHON_VERSION && cat requirements/test.txt
     populate_script:
       - export MACOSX_DEPLOYMENT_TARGET=10.10
       - python -m pip install --retries 3 --upgrade pip
@@ -179,6 +181,7 @@ win_task:
 
   pip_cache:
     folder: $LOCALAPPDATA\pip\Cache
+    fingerprint_script: echo $PYTHON_VERSION && cat requirements/test.txt
     populate_script: 
       - python -m pip install --retries 3 --upgrade pip
       - python -m pip install --retries 3 -r requirements/test.txt


### PR DESCRIPTION
# Description
Enforce fingerprint of pip caching, this is pretty much last resort to force cache update, I was reluctant to go this path because it could potentially lead to a refresh of all caches, but it is a more appropriate way of setting up ci to recognize caching opportunity. (According to cirrus ci doc: ```By default the task name is used as a fingerprint value.```)

## Type of change
- New feature (non-breaking change which adds functionality)

# References
https://github.com/napari/napari/issues/1527
https://cirrus-ci.org/guide/writing-tasks/#cache-instruction

# How has this been tested?
- all tests pass with my change

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
