### PR TITLE
fix menubar raise on mac by running with framework python

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -195,8 +195,8 @@ def _run():
 def _run_pythonw(python_path):
     """Execute this script again through pythonw.
 
-    This can be used to ensures we're using a framework
-    build of Python on macOS which fixes menubar issues.
+    This can be used to ensure we're using a framework
+    build of Python on macOS, which fixes frozen menubar issues.
 
     Parameters
     ----------

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -239,16 +239,14 @@ def main():
             _run_pythonw(python_path)
         else:
             msg = (
-                'pythonw executable not found. '
-                'The menubar might only become '
-                'functional on the macOS after '
-                'focus is toggled in and out of '
-                'napari. To fix this problem, '
-                'please install python.app via conda, '
-                'which can be done with '
-                '`conda install -c conda-forge python.app`.'
+                'pythonw executable not found.\n'
+                'To unfreeze the menubar on macOS, '
+                'click away from napari to another app, '
+                'then reactivate napari. To avoid this problem, '
+                'please install python.app in conda using:\n'
+                'conda install -c conda-forge python.app'
             )
-            raise warnings.warn(msg)
+            warnings.warn(msg)
     _run()
 
 


### PR DESCRIPTION
# Description
Following the incredibly helpful and detailed example of @cbrnr https://github.com/napari/napari/issues/380#issuecomment-659656775 I have now fixed the menubar issue on mac when launching napari from the CLI with `napari`, see #380.

Note that the issue is not fixed when running `python examples/add_image.py` as the needed code doesn't get called.

I'm not an expert in this stuff and we might want to make some adjustments to the code that @cbrnr to meet all of napari's use cases, but it's pretty huge to get this working!!

Feedback, review, and testing from @ziyangczi @tlambert03 @jni welcome and thanks again to @cbrnr - truly incredible to have this bug fixed.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
