### PR TITLE
Fix typo in perfmon patcher

### DIFF
--- a/napari/utils/perf/_patcher.py
+++ b/napari/utils/perf/_patcher.py
@@ -57,7 +57,7 @@ def _patch_attribute(
         # Assume attribute_str is <function>.
         class_str = None
         parent = module
-        parent_str = module.__name___
+        parent_str = module.__name__
         callable_str = attribute_str
 
     try:


### PR DESCRIPTION
# Description
This PR fixes a small typo in the perfmon patcher (`module.__name___` -> `module.__name__`).

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References

# How has this been tested?
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
