### PR TITLE
Improve Shapes layer performance

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -192,6 +192,7 @@ class Layer(KeymapProvider, ABC):
         self._thumbnail_shape = (32, 32, 4)
         self._thumbnail = np.zeros(self._thumbnail_shape, dtype=np.uint8)
         self._update_properties = True
+        self._allow_thumbnail_update = True
         self._name = ''
         self.events = EmitterGroup(
             source=self,
@@ -637,6 +638,12 @@ class Layer(KeymapProvider, ABC):
         self._update_properties = False
         yield
         self._update_properties = True
+
+    @contextmanager
+    def block_thumbnail_update(self):
+        self._allow_thumbnail_update = False
+        yield
+        self._allow_thumbnail_update = True
 
     def _set_highlight(self, force=False):
         """Render layer highlights when appropriate.

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -192,7 +192,6 @@ class Layer(KeymapProvider, ABC):
         self._thumbnail_shape = (32, 32, 4)
         self._thumbnail = np.zeros(self._thumbnail_shape, dtype=np.uint8)
         self._update_properties = True
-        self._allow_thumbnail_update = True
         self._name = ''
         self.events = EmitterGroup(
             source=self,
@@ -638,13 +637,6 @@ class Layer(KeymapProvider, ABC):
         self._update_properties = False
         yield
         self._update_properties = True
-
-    @contextmanager
-    def block_thumbnail_update(self):
-        """Use this context manager to block thumbnail updates"""
-        self._allow_thumbnail_update = False
-        yield
-        self._allow_thumbnail_update = True
 
     def _set_highlight(self, force=False):
         """Render layer highlights when appropriate.

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -641,6 +641,7 @@ class Layer(KeymapProvider, ABC):
 
     @contextmanager
     def block_thumbnail_update(self):
+        """Use this context manager to block thumbnail updates"""
         self._allow_thumbnail_update = False
         yield
         self._allow_thumbnail_update = True

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -217,7 +217,7 @@ class ShapeList:
         face_color=None,
         edge_color=None,
         shape_index=None,
-        reindex_z=True,
+        z_refresh=True,
     ):
         """Adds a single Shape object
 
@@ -230,8 +230,10 @@ class ShapeList:
             If int then edits the shape date at current index. To be used in
             conjunction with `remove` when renumber is `False`. If None, then
             appends a new shape to end of shapes list
-        reindex_z : bool
+        z_refresh : bool
             If set to true, the mesh elements are reindexed with the new z order.
+            When shape_index is provided, z_refresh will be overwritten to false,
+            as the z indices will not change.
             When adding a batch of shapes, set to false  and then call
             ShapesList._update_z_order() once at the end.
         """
@@ -239,10 +241,6 @@ class ShapeList:
             raise ValueError('shape must be subclass of Shape')
 
         if shape_index is None:
-            if reindex_z is True:
-                z_refresh = True
-            else:
-                z_refresh = False
             shape_index = len(self.shapes)
             self.shapes.append(shape)
             self._z_index = np.append(self._z_index, shape.z_index)

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -885,10 +885,7 @@ class ShapeList:
         z_order_in_view = z_order[z_order_in_view_mask]
 
         if max_shapes is not None and len(z_order_in_view) > max_shapes:
-            indices_to_use = np.random.randint(
-                0, len(z_order_in_view), max_shapes
-            )
-            z_order_in_view = z_order_in_view[indices_to_use]
+            z_order_in_view = z_order_in_view[0:max_shapes]
 
         for ind in z_order_in_view:
             mask = self.shapes[ind].to_mask(

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -211,7 +211,14 @@ class ShapeList:
         self.displayed_vertices = self._vertices[disp_vert]
         self.displayed_index = self._index[disp_vert]
 
-    def add(self, shape, face_color=None, edge_color=None, shape_index=None):
+    def add(
+        self,
+        shape,
+        face_color=None,
+        edge_color=None,
+        shape_index=None,
+        reindex_z=True,
+    ):
         """Adds a single Shape object
 
         Parameters
@@ -223,12 +230,19 @@ class ShapeList:
             If int then edits the shape date at current index. To be used in
             conjunction with `remove` when renumber is `False`. If None, then
             appends a new shape to end of shapes list
+        reindex_z : bool
+            If set to true, the mesh elements are reindexed with the new z order.
+            When adding a batch of shapes, set to false  and then call
+            ShapesList._update_z_order() once at the end.
         """
         if not issubclass(type(shape), Shape):
             raise ValueError('shape must be subclass of Shape')
 
         if shape_index is None:
-            z_refresh = True
+            if reindex_z is True:
+                z_refresh = True
+            else:
+                z_refresh = False
             shape_index = len(self.shapes)
             self.shapes.append(shape)
             self._z_index = np.append(self._z_index, shape.z_index)

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -884,6 +884,8 @@ class ShapeList:
         z_order_in_view_mask = np.isin(z_order, shapes_in_view)
         z_order_in_view = z_order[z_order_in_view_mask]
 
+        # If there are too many shapes to render responsively, just render
+        # the top max_shapes shapes
         if max_shapes is not None and len(z_order_in_view) > max_shapes:
             z_order_in_view = z_order_in_view[0:max_shapes]
 

--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -35,12 +35,17 @@ def select(layer, event):
         else:
             layer.selected_data = set()
     layer._set_highlight()
+    if len(layer.data) > layer._thumbnail_update_thresh:
+        update_thumbnail = False
+    else:
+        update_thumbnail = True
     yield
 
     # on move
     while event.type == 'mouse_move':
         # Drag any selected shapes
         layer._move(layer.displayed_coordinates)
+        update_thumbnail = True
         yield
 
     # on release
@@ -60,7 +65,9 @@ def select(layer, event):
     layer._fixed_vertex = None
     layer._moving_value = (None, None)
     layer._set_highlight()
-    layer._update_thumbnail()
+
+    if update_thumbnail:
+        layer._update_thumbnail()
 
 
 def add_line(layer, event):

--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -58,6 +58,8 @@ def select(layer, event):
     elif layer._is_selecting:
         layer.selected_data = layer._data_view.shapes_in_box(layer._drag_box)
         layer._is_selecting = False
+        if len(layer.data) > layer._thumbnail_update_thresh:
+            update_thumbnail = False
         layer._set_highlight()
     layer._is_moving = False
     layer._drag_start = None

--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -35,17 +35,19 @@ def select(layer, event):
         else:
             layer.selected_data = set()
     layer._set_highlight()
-    if len(layer.data) > layer._thumbnail_update_thresh:
-        update_thumbnail = False
-    else:
-        update_thumbnail = True
+
+    # we don't update the thumbnail unless a shape has been moved
+    update_thumbnail = False
     yield
 
     # on move
     while event.type == 'mouse_move':
         # Drag any selected shapes
         layer._move(layer.displayed_coordinates)
-        update_thumbnail = True
+
+        # if a shape is being moved, update the thumbnail
+        if layer._is_moving:
+            update_thumbnail = True
         yield
 
     # on release
@@ -58,9 +60,8 @@ def select(layer, event):
     elif layer._is_selecting:
         layer.selected_data = layer._data_view.shapes_in_box(layer._drag_box)
         layer._is_selecting = False
-        if len(layer.data) > layer._thumbnail_update_thresh:
-            update_thumbnail = False
         layer._set_highlight()
+
     layer._is_moving = False
     layer._drag_start = None
     layer._drag_box = None

--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -27,12 +27,8 @@ def select(layer, event):
         if shift and shape_under_cursor is not None:
             if shape_under_cursor in layer.selected_data:
                 layer.selected_data.remove(shape_under_cursor)
-                shapes = layer.selected_data
-                layer._selected_box = layer.interaction_box(shapes)
             else:
                 layer.selected_data.add(shape_under_cursor)
-                shapes = layer.selected_data
-                layer._selected_box = layer.interaction_box(shapes)
         elif shape_under_cursor is not None:
             if shape_under_cursor not in layer.selected_data:
                 layer.selected_data = {shape_under_cursor}

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1561,8 +1561,9 @@ class Shapes(Layer):
             edge_color=edge_color,
             face_color=face_color,
             z_index=z_index,
+            reindex_z=False,
         )
-
+        self._data_view._update_z_order()
         self.refresh_colors()
 
     def _add_shapes(
@@ -1574,6 +1575,7 @@ class Shapes(Layer):
         edge_color=None,
         face_color=None,
         z_index=None,
+        reindex_z=True,
     ):
         """Add shapes to the data view.
 
@@ -1673,7 +1675,9 @@ class Shapes(Layer):
                 )
 
                 # Add shape
-                self._data_view.add(shape, edge_color=ec, face_color=fc)
+                self._data_view.add(
+                    shape, edge_color=ec, face_color=fc, reindex_z=reindex_z
+                )
 
         self._display_order_stored = copy(self.dims.order)
         self._ndisplay_stored = copy(self.dims.ndisplay)

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -56,10 +56,6 @@ from ._shapes_utils import create_box, get_shape_ndim
 
 DEFAULT_COLOR_CYCLE = np.array([[1, 0, 1, 1], [0, 1, 0, 1]])
 
-# If there are more than this number of shapes, the thumnail won't update during
-# interactive events
-INTERACTIVE_THUMBNAIL_UPDATE_THRESHOLD = 100
-
 
 class Shapes(Layer):
     """Shapes layer.
@@ -284,6 +280,10 @@ class Shapes(Layer):
     _highlight_color = (0, 0.6, 1)
     _highlight_width = 1.5
 
+    # If more shapes are present then they are randomly subsampled
+    # in the thumbnail
+    _max_shapes_thumbnail = 100
+
     def __init__(
         self,
         data=None,
@@ -342,10 +342,6 @@ class Shapes(Layer):
             current_properties=Event,
             highlight=Event,
         )
-
-        # If there are more than this number of shapes, the thumnail won't update during
-        # interactive events
-        self._thumbnail_update_thresh = INTERACTIVE_THUMBNAIL_UPDATE_THRESHOLD
 
         # Flag set to false to block thumbnail refresh
         self._allow_thumbnail_update = True
@@ -2029,6 +2025,7 @@ class Shapes(Layer):
                 colors_shape=self._thumbnail_shape[:2],
                 zoom_factor=zoom_factor,
                 offset=offset[-2:],
+                max_shapes=self._max_shapes_thumbnail,
             )
 
             self.thumbnail = colormapped

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -55,6 +55,10 @@ from ._shapes_utils import create_box, get_shape_ndim
 
 DEFAULT_COLOR_CYCLE = np.array([[1, 0, 1, 1], [0, 1, 0, 1]])
 
+# If there are more than this number of shapes, the thumnail won't update during
+# interactive events
+INTERACTIVE_THUMBNAIL_UPDATE_THRESHOLD = 100
+
 
 class Shapes(Layer):
     """Shapes layer.
@@ -265,6 +269,9 @@ class Shapes(Layer):
         coordinates.
     _input_ndim : int
         Dimensions of shape data.
+    _thumbnail_update_thresh : int
+        If there are more than this number of shapes, the thumnail
+        won't update during interactive events
     """
 
     _colors = get_color_names()
@@ -331,6 +338,10 @@ class Shapes(Layer):
             current_properties=Event,
             highlight=Event,
         )
+
+        # If there are more than this number of shapes, the thumnail won't update during
+        # interactive events
+        self._thumbnail_update_thresh = INTERACTIVE_THUMBNAIL_UPDATE_THRESHOLD
 
         self._display_order_stored = []
         self._ndisplay_stored = self.dims.ndisplay
@@ -1370,7 +1381,7 @@ class Shapes(Layer):
 
         self.events.mode(mode=mode)
         # only update the thumbnail if there are < 100 shapes
-        if len(self.data) > 100:
+        if len(self.data) > self._thumbnail_update_thresh:
             with self.block_thumbnail_update():
                 if not (mode in draw_modes and old_mode in draw_modes):
                     # Shapes._finish_drawing() calls Shapes.refresh()

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1370,8 +1370,10 @@ class Shapes(Layer):
 
         self.events.mode(mode=mode)
         if not (mode in draw_modes and old_mode in draw_modes):
+            # Shapes._finish_drawing() calls Shapes.refresh()
             self._finish_drawing()
-        self.refresh()
+        else:
+            self.refresh()
 
     def _set_editable(self, editable=None):
         """Set editable mode based on layer properties."""

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -258,6 +258,9 @@ class Shapes(Layer):
         shapes when they are changed. Blocking this prevents circular loops
         when shapes are selected and the properties are changed based on that
         selection
+    _allow_thumnail_update : bool
+        Flag set to true to allow the thumbnail to be updated. Blocking the thumbnail
+        can be advantageous where responsiveness is critical.
     _clipboard : dict
         Dict of shape objects that are to be used during a copy and paste.
     _colors : list

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1554,17 +1554,18 @@ class Shapes(Layer):
                 face_color, attribute='face', n_shapes=n_shapes
             )
 
-        self._add_shapes(
-            data,
-            shape_type=shape_type,
-            edge_width=edge_width,
-            edge_color=edge_color,
-            face_color=face_color,
-            z_index=z_index,
-            reindex_z=False,
-        )
-        self._data_view._update_z_order()
-        self.refresh_colors()
+        with self.block_thumbnail_update():
+            self._add_shapes(
+                data,
+                shape_type=shape_type,
+                edge_width=edge_width,
+                edge_color=edge_color,
+                face_color=face_color,
+                z_index=z_index,
+                reindex_z=False,
+            )
+            self._data_view._update_z_order()
+            self.refresh_colors()
 
     def _add_shapes(
         self,
@@ -1974,7 +1975,7 @@ class Shapes(Layer):
         """Update thumbnail with current shapes and colors."""
 
         # don't update the thumbnail if dragging a shape
-        if self._is_moving is False:
+        if self._is_moving is False and self._allow_thumbnail_update is True:
             # calculate min vals for the vertices and pad with 0.5
             # the offset is needed to ensure that the top left corner of the shapes
             # corresponds to the top left corner of the thumbnail

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -266,7 +266,7 @@ class Shapes(Layer):
     _colors : list
         List of supported vispy color names.
     _vertex_size : float
-        Size of the vertices of the shapes and boudning box in Canvas
+        Size of the vertices of the shapes and bounding box in Canvas
         coordinates.
     _rotation_handle_length : float
         Length of the rotation handle of the boudning box in Canvas

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -605,7 +605,7 @@ class Shapes(Layer):
         if self._update_properties:
             for i in self.selected_data:
                 self._data_view.update_edge_color(i, self._current_edge_color)
-        self.events.edge_color()
+            self.events.edge_color()
         self.events.current_edge_color()
 
     @property
@@ -620,7 +620,7 @@ class Shapes(Layer):
         if self._update_properties:
             for i in self.selected_data:
                 self._data_view.update_face_color(i, self._current_face_color)
-        self.events.face_color()
+            self.events.face_color()
         self.events.current_face_color()
 
     @property

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1387,15 +1387,9 @@ class Shapes(Layer):
         ]
 
         self.events.mode(mode=mode)
-        # only update the thumbnail if there are < 100 shapes
-        if len(self.data) > self._thumbnail_update_thresh:
-            with self.block_thumbnail_update():
-                if not (mode in draw_modes and old_mode in draw_modes):
-                    # Shapes._finish_drawing() calls Shapes.refresh()
-                    self._finish_drawing()
-                else:
-                    self.refresh()
-        else:
+
+        # don't update thumbnail on mode changes
+        with self.block_thumbnail_update():
             if not (mode in draw_modes and old_mode in draw_modes):
                 # Shapes._finish_drawing() calls Shapes.refresh()
                 self._finish_drawing()

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1589,7 +1589,7 @@ class Shapes(Layer):
                 edge_color=edge_color,
                 face_color=face_color,
                 z_index=z_index,
-                reindex_z=False,
+                z_refresh=False,
             )
             self._data_view._update_z_order()
             self.refresh_colors()
@@ -1603,7 +1603,7 @@ class Shapes(Layer):
         edge_color=None,
         face_color=None,
         z_index=None,
-        reindex_z=True,
+        z_refresh=True,
     ):
         """Add shapes to the data view.
 
@@ -1642,6 +1642,12 @@ class Shapes(Layer):
             same length as the length of `data` and each element will be
             applied to each shape otherwise the same value will be used for all
             shapes.
+        z_refresh : bool
+            If set to true, the mesh elements are reindexed with the new z order.
+            When shape_index is provided, z_refresh will be overwritten to false,
+            as the z indices will not change.
+            When adding a batch of shapes, set to false  and then call
+            ShapesList._update_z_order() once at the end.
         """
         if edge_width is None:
             edge_width = self.current_edge_width
@@ -1704,7 +1710,7 @@ class Shapes(Layer):
 
                 # Add shape
                 self._data_view.add(
-                    shape, edge_color=ec, face_color=fc, reindex_z=reindex_z
+                    shape, edge_color=ec, face_color=fc, z_refresh=z_refresh
                 )
 
         self._display_order_stored = copy(self.dims.order)

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1,4 +1,5 @@
 import warnings
+from contextlib import contextmanager
 from copy import copy, deepcopy
 from itertools import cycle
 from typing import Dict, Optional, Tuple, Union
@@ -342,6 +343,9 @@ class Shapes(Layer):
         # If there are more than this number of shapes, the thumnail won't update during
         # interactive events
         self._thumbnail_update_thresh = INTERACTIVE_THUMBNAIL_UPDATE_THRESHOLD
+
+        # Flag set to false to block thumbnail refresh
+        self._allow_thumbnail_update = True
 
         self._display_order_stored = []
         self._ndisplay_stored = self.dims.ndisplay
@@ -1990,6 +1994,13 @@ class Shapes(Layer):
                 self._data_view.edit(index, data_full[:-1])
         self._is_creating = False
         self._update_dims()
+
+    @contextmanager
+    def block_thumbnail_update(self):
+        """Use this context manager to block thumbnail updates"""
+        self._allow_thumbnail_update = False
+        yield
+        self._allow_thumbnail_update = True
 
     def _update_thumbnail(self, event=None):
         """Update thumbnail with current shapes and colors."""

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1369,11 +1369,20 @@ class Shapes(Layer):
         ]
 
         self.events.mode(mode=mode)
-        if not (mode in draw_modes and old_mode in draw_modes):
-            # Shapes._finish_drawing() calls Shapes.refresh()
-            self._finish_drawing()
+        # only update the thumbnail if there are < 100 shapes
+        if len(self.data) > 100:
+            with self.block_thumbnail_update():
+                if not (mode in draw_modes and old_mode in draw_modes):
+                    # Shapes._finish_drawing() calls Shapes.refresh()
+                    self._finish_drawing()
+                else:
+                    self.refresh()
         else:
-            self.refresh()
+            if not (mode in draw_modes and old_mode in draw_modes):
+                # Shapes._finish_drawing() calls Shapes.refresh()
+                self._finish_drawing()
+            else:
+                self.refresh()
 
     def _set_editable(self, editable=None):
         """Set editable mode based on layer properties."""

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1966,26 +1966,31 @@ class Shapes(Layer):
 
     def _update_thumbnail(self, event=None):
         """Update thumbnail with current shapes and colors."""
-        # calculate min vals for the vertices and pad with 0.5
-        # the offset is needed to ensure that the top left corner of the shapes
-        # corresponds to the top left corner of the thumbnail
-        de = self._extent_data
-        offset = np.array([de[0, d] for d in self.dims.displayed]) + 0.5
-        # calculate range of values for the vertices and pad with 1
-        # padding ensures the entire shape can be represented in the thumbnail
-        # without getting clipped
-        shape = np.ceil(
-            [de[1, d] - de[0, d] + 1 for d in self.dims.displayed]
-        ).astype(int)
-        zoom_factor = np.divide(self._thumbnail_shape[:2], shape[-2:]).min()
 
-        colormapped = self._data_view.to_colors(
-            colors_shape=self._thumbnail_shape[:2],
-            zoom_factor=zoom_factor,
-            offset=offset[-2:],
-        )
+        # don't update the thumbnail if dragging a shape
+        if self._is_moving is False:
+            # calculate min vals for the vertices and pad with 0.5
+            # the offset is needed to ensure that the top left corner of the shapes
+            # corresponds to the top left corner of the thumbnail
+            de = self._extent_data
+            offset = np.array([de[0, d] for d in self.dims.displayed]) + 0.5
+            # calculate range of values for the vertices and pad with 1
+            # padding ensures the entire shape can be represented in the thumbnail
+            # without getting clipped
+            shape = np.ceil(
+                [de[1, d] - de[0, d] + 1 for d in self.dims.displayed]
+            ).astype(int)
+            zoom_factor = np.divide(
+                self._thumbnail_shape[:2], shape[-2:]
+            ).min()
 
-        self.thumbnail = colormapped
+            colormapped = self._data_view.to_colors(
+                colors_shape=self._thumbnail_shape[:2],
+                zoom_factor=zoom_factor,
+                offset=offset[-2:],
+            )
+
+            self.thumbnail = colormapped
 
     def remove_selected(self):
         """Remove any selected shapes."""


### PR DESCRIPTION
# Description
This PR implements some small changes to improve the responsiveness of the Shapes layer with a large number of shapes. In particular, based on the profiling we did in #1562 , I aimed to do the following:

- Reduce startup time
    - Delay re-indexing the mesh by z order until all shapes are added
    - Eliminate a redundant `Shapes._update_thumbnail()` call
- Decrease latency when switching interaction modes and selecting shapes
    - Eliminate a redundant `Shapes._update_thumbnail()` call
    - Do not call `Shapes._update_thumbnail()` when selecting shapes and there are more than 100 shapes
- Decrease latency during dragging
    - Delay updating the thumbnail until the drag is complete

### Profiling
I used the airspeed velocity benchmarks listed below (`/napari/benchmarks/benchmarks_shapes_layer.py`).

| Benchmark                                | n_shapes | Master [sec.] | PR [sec.]  | Change |
|------------------------------------------|----------|--------|------|--------|
| Shapes2DSuite.time_create_layer          | 256      | 1.93   | 1.25 | -35%   |
| ShapesInteractionSuite.time_select_shape | 256      | 0.79   | 0.01 | -99%   |
| ShapesInteractionSuite.time_drag_shape   | 256      | 1.23   | 0.18 | -85%   |

A couple of notes:
- `ShapesInteractionSuite.time_drag_shape` benchmark performs 5 drag events, the time per drag event is ~30 ms
- These only include the time for calculations performed on the model (i.e., they don't include the vispy draw time)
-  The layer creation is likely limited by the creation of each `Shape` object and the thumbnail generation.

### Demo
If you'd like to try it out, you can use the script below to generate a Shapes layer with 1000 shapes and compare between the PR and master. At least on my computer, this seems to be an improvement, but there are definitely more things we can do (e.g., speed up the calculation for selecting shapes with a bounding box)).

<details><summary>Demo script</summary>
<p>

```python
import numpy as np
import napari
from skimage import data

# make 3D image
blobs = data.binary_blobs(
    length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=0.1
).astype(float)


def make_square(lower_left_corner, width):
    upper_left_corner = lower_left_corner + [0, width]
    upper_right_corner = lower_left_corner + [width, width]
    lower_right_corner = lower_left_corner + [width, 0]

    return np.vstack((lower_left_corner, upper_left_corner, upper_right_corner, lower_right_corner))

# create random rectangles
n_shapes = 1000
np.random.seed(0)
corners = 100 * np.random.random((n_shapes, 2))
widths = 15 * np.random.random((n_shapes,))
squares = [make_square(llc, w) for llc, w in zip(corners, widths)]

base_cols = ['red', 'green', 'blue', 'white', 'yellow', 'magenta', 'cyan']
colors = np.random.choice(base_cols, size=n_shapes)

with napari.gui_qt():

    viewer = napari.view_image(blobs)

    shapes_layer = viewer.add_shapes(
        squares,
        shape_type='rectangle',
        face_color=colors,
        name='sliced',
    )
```

</p>
</details>

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References


# How has this been tested?
- [ ] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
