### PR TITLE
Add Shapes benchmarks for interactions

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -14,7 +14,7 @@
     "repo": ".",
 
     // Install using default qt install
-    "install_command": ["in-dir={env_dir} python -mpip install {conf_dir}[all]"],
+    "install_command": ["in-dir={env_dir} python -m pip install {conf_dir}[all]"],
 
     // List of branches to benchmark
     "branches": ["master"],

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -13,6 +13,9 @@
     // project being benchmarked
     "repo": ".",
 
+    // Install using default qt install
+    "install_command": ["in-dir={env_dir} python -mpip install {conf_dir}[all]"],
+
     // List of branches to benchmark
     "branches": ["master"],
 

--- a/napari/benchmarks/benchmark_shapes_layer.py
+++ b/napari/benchmarks/benchmark_shapes_layer.py
@@ -2,9 +2,21 @@
 # https://asv.readthedocs.io/en/latest/writing_benchmarks.html
 # or the napari documentation on benchmarking
 # https://github.com/napari/napari/blob/master/docs/BENCHMARKS.md
+import collections
+
 import numpy as np
 
 from napari.layers import Shapes
+from napari.utils.interactions import (
+    ReadOnlyWrapper,
+    mouse_move_callbacks,
+    mouse_press_callbacks,
+    mouse_release_callbacks,
+)
+
+Event = collections.namedtuple(
+    'Event', field_names=['type', 'is_dragging', 'modifiers']
+)
 
 
 class Shapes2DSuite:
@@ -83,3 +95,66 @@ class Shapes3DSuite:
     def mem_data(self, n):
         """Memory used by raw data."""
         return self.data
+
+
+class ShapesInteractionSuite:
+    """Benchmarks for interacting with the Shapes layer with 2D data"""
+
+    params = [2 ** i for i in range(4, 9)]
+
+    def setup(self, n):
+        np.random.seed(0)
+        self.data = [50 * np.random.random((6, 2)) for i in range(n)]
+        self.layer = Shapes(self.data, shape_type='polygon')
+        self.layer.mode = 'select'
+
+        # create events
+        self.click_event = ReadOnlyWrapper(
+            Event(type='mouse_press', is_dragging=False, modifiers=[])
+        )
+        self.release_event = ReadOnlyWrapper(
+            Event(type='mouse_release', is_dragging=False, modifiers=[])
+        )
+        self.drag_event = ReadOnlyWrapper(
+            Event(type='mouse_move', is_dragging=True, modifiers=[])
+        )
+
+        # initialize the position and select a shape
+        self.layer.position = tuple(np.mean(self.layer.data[0], axis=0))
+
+        # Simulate click
+        mouse_press_callbacks(self.layer, self.click_event)
+
+        # Simulate release
+        mouse_release_callbacks(self.layer, self.release_event)
+
+    def time_drag_shape(self, n):
+        """Time to process 5 shape drag events"""
+        # Simulate click
+        mouse_press_callbacks(self.layer, self.click_event)
+
+        # start drag event
+        mouse_move_callbacks(self.layer, self.drag_event)
+
+        # simulate 5 drag events
+        for _ in range(5):
+            self.layer.position = tuple(np.add(self.layer.position, [10, 5]))
+            # Simulate move, click, and release
+            mouse_move_callbacks(self.layer, self.drag_event)
+
+        # Simulate release
+        mouse_release_callbacks(self.layer, self.release_event)
+
+    time_drag_shape.param_names = ['n_shapes']
+
+    def time_select_shape(self, n):
+        """Time to process shape selection events"""
+        self.layer.position = tuple(np.mean(self.layer.data[1], axis=0))
+
+        # Simulate click
+        mouse_press_callbacks(self.layer, self.click_event)
+
+        # Simulate release
+        mouse_release_callbacks(self.layer, self.release_event)
+
+    time_select_shape.param_names = ['n_shapes']


### PR DESCRIPTION
# Description
As discussed in #1562 , I have added a small benchmarking suite for two Shapes layer interactions we observed to be a bit slow (selecting shapes and dragging shapes). This PR adds:

- A benchmark for selecting a shape by simulating a click event
- A benchmark for dragging a shape (makes 5 drag event calls) by simulating a click and drag
- Updates the installation in the `asv.conf.json` to include the new qt installation flag (`[all]`)

The `ShapesInteractionSuite` results currently are:

```bash

(napari-dev) ➜  napari git:(add-shapes-benchmarks) ✗ asv dev -b ShapesInteractionSuite
· Discovering benchmarks
· Running 2 total benchmarks (1 commits * 1 environments * 2 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_yamauc0000_miniconda3_envs_napari-dev_bin_python
[ 25.00%] ··· ...mark_shapes_layer.ShapesInteractionSuite.time_drag_shape                 ok
[ 25.00%] ··· ========== ==========
               n_shapes
              ---------- ----------
                  16      94.4±0ms
                  32      196±0ms
                  64      370±0ms
                 128      832±0ms
                 256      1.61±0s
              ========== ==========

[ 50.00%] ··· ...rk_shapes_layer.ShapesInteractionSuite.time_select_shape                 ok
[ 50.00%] ··· ========== ==========
               n_shapes
              ---------- ----------
                  16      54.7±0ms
                  32      112±0ms
                  64      401±0ms
                 128      812±0ms
                 256      1.02±0s
              ========== ==========
```

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


# References
This PR arises from discussion in #1562 

# How has this been tested?
- [x] I ran `asv dev -b ShapesInteractionSuite` to test the suite from my environment
- [x] I ran `asv continuous master -b ShapesInteractionSuite` to test the build
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
