### PR TITLE
async-1: Stub ChunkLoader

### DIFF
--- a/napari/components/chunk/__init__.py
+++ b/napari/components/chunk/__init__.py
@@ -1,0 +1,6 @@
+"""Synchronous and Asynchronous Chunk Loading.
+"""
+import os
+
+from ._loader import chunk_loader
+from ._request import ChunkKey, ChunkRequest

--- a/napari/components/chunk/__init__.py
+++ b/napari/components/chunk/__init__.py
@@ -1,4 +1,4 @@
-"""Synchronous and Asynchronous Chunk Loading.
+"""Stub Async Loading: sync only so far.
 """
 import os
 

--- a/napari/components/chunk/_loader.py
+++ b/napari/components/chunk/_loader.py
@@ -1,6 +1,4 @@
-"""Stub ChunkLoader for future async loading.
-
-Right now it's 100% synchronous only.
+"""Stub ChunkLoader: sync only so far.
 """
 from typing import Dict
 

--- a/napari/components/chunk/_loader.py
+++ b/napari/components/chunk/_loader.py
@@ -2,6 +2,7 @@
 """
 from typing import Dict
 
+from ...layers.base.base import Layer
 from ...types import ArrayLike
 from ._request import ChunkKey, ChunkRequest
 
@@ -10,11 +11,20 @@ class ChunkLoader:
     """Stub for future ChunkLoader that can do async loads."""
 
     def create_request(
-        self, layer, key: ChunkKey, chunks: Dict[str, ArrayLike]
+        self, layer: Layer, key: ChunkKey, chunks: Dict[str, ArrayLike]
     ) -> ChunkRequest:
         """Create a ChunkRequest for submission to load_chunk.
 
         This is a stub and will make more sense in the next version.
+
+        Parameters
+        ----------
+        layer : Layer
+            We are loading a chunk for this layer.
+        key : ChunkKey
+            This should identify the chunk uniquely.
+        chunks : Dict[str, ArrayLike]
+            The arrays we should load.
         """
         # Return the new request.
         return ChunkRequest(key, chunks)
@@ -25,12 +35,12 @@ class ChunkLoader:
         Parameters
         ----------
         request : ChunkRequest
-            Contains the array to load from and related info.
+            The request that contains the arrays we need to load.
 
         Returns
         -------
         ChunkRequest
-            The loaded request.
+            The request which contains the loaded arrays.
         """
 
         request.load_chunks()

--- a/napari/components/chunk/_loader.py
+++ b/napari/components/chunk/_loader.py
@@ -21,6 +21,7 @@ class ChunkLoader:
         ----------
         layer : Layer
             We are loading a chunk for this layer.
+            Unused right now: will be used is next version.
         key : ChunkKey
             This should identify the chunk uniquely.
         chunks : Dict[str, ArrayLike]
@@ -43,9 +44,9 @@ class ChunkLoader:
             The request which contains the loaded arrays.
         """
 
-        request.load_chunks()
+        request.load_chunks()  # Load all chunks synchronously.
         return request
 
 
-# Global instance
+# Global Singleton instance
 chunk_loader = ChunkLoader()

--- a/napari/components/chunk/_loader.py
+++ b/napari/components/chunk/_loader.py
@@ -1,0 +1,43 @@
+"""Stub ChunkLoader for future async loading.
+
+Right now it's 100% synchronous only.
+"""
+from typing import Dict
+
+from ...types import ArrayLike
+from ._request import ChunkKey, ChunkRequest
+
+
+class ChunkLoader:
+    """Stub for future ChunkLoader that can do async loads."""
+
+    def create_request(
+        self, layer, key: ChunkKey, chunks: Dict[str, ArrayLike]
+    ) -> ChunkRequest:
+        """Create a ChunkRequest for submission to load_chunk.
+
+        This is a stub and will make more sense in the next version.
+        """
+        # Return the new request.
+        return ChunkRequest(key, chunks)
+
+    def load_chunk(self, request: ChunkRequest) -> ChunkRequest:
+        """Stub in the future will do async loads.
+
+        Parameters
+        ----------
+        request : ChunkRequest
+            Contains the array to load from and related info.
+
+        Returns
+        -------
+        ChunkRequest
+            The loaded request.
+        """
+
+        request.load_chunks()
+        return request
+
+
+# Global instance
+chunk_loader = ChunkLoader()

--- a/napari/components/chunk/_request.py
+++ b/napari/components/chunk/_request.py
@@ -1,7 +1,7 @@
 """ChunkRequest is passed to ChunkLoader.load_chunks().
 """
 import logging
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 import numpy as np
 
@@ -30,13 +30,13 @@ class ChunkKey:
         The id of the layer making the request.
     data_level : int
         The level in the data (for multi-scale).
-    indices : Indices
+    indices : Tuple[Optional[slice], ...]
         The indices of the slice.
     key : Tuple
         The combined key, all the identifies together.
     """
 
-    def __init__(self, layer: Layer, indices):
+    def __init__(self, layer: Layer, indices: Tuple[Optional[slice], ...]):
         self.layer_id = id(layer)
         self.data_level = layer._data_level
 

--- a/napari/components/chunk/_request.py
+++ b/napari/components/chunk/_request.py
@@ -11,7 +11,7 @@ from ...types import ArrayLike, Dict
 LOGGER = logging.getLogger("napari.async")
 
 # We convert slices to tuple for hashing.
-SliceTuple = Tuple[int, int, int]
+SliceTuple = Tuple[Optional[int], Optional[int], Optional[int]]
 
 
 class ChunkKey:
@@ -33,7 +33,7 @@ class ChunkKey:
     indices : Tuple[Optional[slice], ...]
         The indices of the slice.
     key : Tuple
-        The combined key, all the identifies together.
+        The combined key, all the identifiers together.
     """
 
     def __init__(self, layer: Layer, indices: Tuple[Optional[slice], ...]):
@@ -119,16 +119,6 @@ class ChunkRequest:
             # No thumbnail_source so return the image instead. For single-scale
             # we use the image as the thumbnail_source.
             return self.chunks.get('image')
-
-    def is_compatible(self, layer: Layer) -> bool:
-        """Return True if the given data is compatible with this request.
-
-        Parameters
-        ----------
-        layer : Layer
-            Compare this data to the data_id in the request.
-        """
-        return True  # Stub for now, will grow in the next version.
 
 
 def _index_to_tuple(index: Union[int, slice]) -> Union[int, SliceTuple]:

--- a/napari/components/chunk/_request.py
+++ b/napari/components/chunk/_request.py
@@ -1,0 +1,164 @@
+"""ChunkRequest is used to ask the ChunkLoader to load chunks.
+"""
+import logging
+from typing import List, Tuple, Union
+
+import numpy as np
+
+from ...types import ArrayLike, Dict
+
+LOGGER = logging.getLogger("ChunkLoader")
+
+# We convert slices to tuple for hashing.
+SliceTuple = Tuple[int, int, int]
+
+LayerData = Union[ArrayLike, List[ArrayLike]]
+
+
+class ChunkKey:
+    """The key which a ChunkRequest will load.
+
+    Parameters
+    ----------
+    layer : Layer
+        The layer to load data for.
+    indices : ?
+        The indices to load from the layer
+    """
+
+    def __init__(self, layer, indices):
+        self.layer_id = id(layer)
+        self.data_level = layer._data_level
+
+        # Slice objects are not hashable, so turn them into tuples.
+        self.indices = tuple(_index_to_tuple(x) for x in indices)
+
+        # All together as one tuple for easy comparison.
+        self.key = (self.layer_id, self.data_level, self.indices)
+
+    def __str__(self):
+        return (
+            f"layer_id={self.layer_id} data_id={self.data_id} "
+            f"data_level={self.data_level} indices={self.indices}"
+        )
+
+    def __eq__(self, other):
+        return self.key == other.key
+
+
+class ChunkRequest:
+    """A request asking the ChunkLoader to load one or more arrays.
+
+    Parameters
+    ----------
+    layer_id : int
+        Python id() for the Layer requesting the chunk.
+    data_id : int
+        Python id() for the Layer._data requesting the chunk.
+    indices
+        The tuple of slices index into the data.
+    array : ArrayLike
+        Load the data from this array.
+
+    Attributes
+    ----------
+    layer_ref : weakref
+        Reference to the layer that submitted the request.
+    data_id : int
+        Python id() of the data in the layer.
+    load_seconds : float
+        Delay for this long during the load portion.
+    """
+
+    def __init__(self, key: ChunkKey, chunks: Dict[str, ArrayLike]):
+        # Make sure chunks is str->array as expected.
+        for chunk_key, array in chunks.items():
+            assert isinstance(chunk_key, str)
+            assert array is not None
+
+        self.key = key
+        self.chunks = chunks
+
+        # No delay by default, ChunkLoader.load_chunk() will set this if desired.
+        self.load_seconds = 0
+
+    @property
+    def num_chunks(self) -> int:
+        """Return the number of chunks in this request."""
+        return len(self.chunks)
+
+    @property
+    def num_bytes(self) -> int:
+        """Return the number of bytes that were loaded."""
+        return sum(array.nbytes for array in self.chunks.values())
+
+    @property
+    def in_memory(self) -> bool:
+        """True if all chunks are ndarrays."""
+        for array in self.chunks.values():
+            if not isinstance(array, np.ndarray):
+                return False
+        return True
+
+    def load_chunks(self):
+        """Load all of our chunks now in this thread."""
+        for key, array in self.chunks.items():
+            loaded_array = np.asarray(array)
+            self.chunks[key] = loaded_array
+
+    def transpose_chunks(self, order):
+        """Transpose all our chunks.
+
+        Parameters
+        ----------
+        order
+            Transpose the chunks with this order.
+        """
+        for key, array in self.chunks.items():
+            self.chunks[key] = array.transpose(order)
+
+    @property
+    def image(self):
+        """The image chunk if we have one or None.
+        """
+        return self.chunks.get('image')
+
+    @property
+    def thumbnail_source(self):
+        """The chunk to use as the thumbnail_source or None.
+        """
+        try:
+            return self.chunks['thumbnail_source']
+        except KeyError:
+            # For single-scale we use the image as the thumbnail_source.
+            return self.chunks.get('image')
+
+    def is_compatible(self, layer) -> bool:
+        """Return True if the given data is compatible with this request.
+
+        Parameters
+        ----------
+        data : LayerData
+            Compare this data to the data_id in the request.
+        """
+        return True  # stub for now
+
+
+def _index_to_tuple(index: Union[int, slice]) -> Union[int, SliceTuple]:
+    """Get hashable object for the given index.
+
+    Slice is not hashable so we convert slices to tuples.
+
+    Parameters
+    ----------
+    index
+        Integer index or a slice.
+
+    Returns
+    -------
+    Union[int, SliceTuple]
+        Hashable object that can be used for the index.
+    """
+    if isinstance(index, slice):
+        return (index.start, index.stop, index.step)
+    return index

--- a/napari/components/chunk/_request.py
+++ b/napari/components/chunk/_request.py
@@ -1,7 +1,7 @@
 """ChunkRequest is passed to ChunkLoader.load_chunks().
 """
 import logging
-from typing import List, Tuple, Union
+from typing import Tuple, Union
 
 import numpy as np
 
@@ -12,9 +12,6 @@ LOGGER = logging.getLogger("napari.async")
 
 # We convert slices to tuple for hashing.
 SliceTuple = Tuple[int, int, int]
-
-# The type of Layer.data
-LayerData = Union[ArrayLike, List[ArrayLike]]
 
 
 class ChunkKey:
@@ -123,12 +120,12 @@ class ChunkRequest:
             # we use the image as the thumbnail_source.
             return self.chunks.get('image')
 
-    def is_compatible(self, layer: LayerData) -> bool:
+    def is_compatible(self, layer: Layer) -> bool:
         """Return True if the given data is compatible with this request.
 
         Parameters
         ----------
-        data : LayerData
+        layer : Layer
             Compare this data to the data_id in the request.
         """
         return True  # Stub for now, will grow in the next version.

--- a/napari/components/chunk/_request.py
+++ b/napari/components/chunk/_request.py
@@ -7,11 +7,12 @@ import numpy as np
 
 from ...types import ArrayLike, Dict
 
-LOGGER = logging.getLogger("ChunkLoader")
+LOGGER = logging.getLogger("napari.async")
 
 # We convert slices to tuple for hashing.
 SliceTuple = Tuple[int, int, int]
 
+# The type of Layer.data
 LayerData = Union[ArrayLike, List[ArrayLike]]
 
 
@@ -51,23 +52,19 @@ class ChunkRequest:
 
     Parameters
     ----------
-    layer_id : int
-        Python id() for the Layer requesting the chunk.
-    data_id : int
-        Python id() for the Layer._data requesting the chunk.
-    indices
-        The tuple of slices index into the data.
-    array : ArrayLike
-        Load the data from this array.
+    key : ChunkKey
+        The key of the request.
+    chunks : Dict[str, ArrayLike]
+        The chunk arrays we need to load.
 
     Attributes
     ----------
-    layer_ref : weakref
-        Reference to the layer that submitted the request.
-    data_id : int
-        Python id() of the data in the layer.
+    key : ChunkKey
+        The key of the request.
+    chunks : Dict[str, ArrayLike]
+        The chunk arrays we need to load.
     load_seconds : float
-        Delay for this long during the load portion.
+        Delay for this long during the load portion, for testing.
     """
 
     def __init__(self, key: ChunkKey, chunks: Dict[str, ArrayLike]):
@@ -115,7 +112,7 @@ class ChunkRequest:
             # For single-scale we use the image as the thumbnail_source.
             return self.chunks.get('image')
 
-    def is_compatible(self, layer) -> bool:
+    def is_compatible(self, layer: LayerData) -> bool:
         """Return True if the given data is compatible with this request.
 
         Parameters

--- a/napari/components/chunk/_request.py
+++ b/napari/components/chunk/_request.py
@@ -82,24 +82,6 @@ class ChunkRequest:
         # No delay by default, ChunkLoader.load_chunk() will set this if desired.
         self.load_seconds = 0
 
-    @property
-    def num_chunks(self) -> int:
-        """Return the number of chunks in this request."""
-        return len(self.chunks)
-
-    @property
-    def num_bytes(self) -> int:
-        """Return the number of bytes that were loaded."""
-        return sum(array.nbytes for array in self.chunks.values())
-
-    @property
-    def in_memory(self) -> bool:
-        """True if all chunks are ndarrays."""
-        for array in self.chunks.values():
-            if not isinstance(array, np.ndarray):
-                return False
-        return True
-
     def load_chunks(self):
         """Load all of our chunks now in this thread."""
         for key, array in self.chunks.items():

--- a/napari/components/chunk/_request.py
+++ b/napari/components/chunk/_request.py
@@ -5,6 +5,7 @@ from typing import List, Tuple, Union
 
 import numpy as np
 
+from ...layers.base.base import Layer
 from ...types import ArrayLike, Dict
 
 LOGGER = logging.getLogger("napari.async")
@@ -27,7 +28,7 @@ class ChunkKey:
         The indices to load from the layer
     """
 
-    def __init__(self, layer, indices):
+    def __init__(self, layer: Layer, indices):
         self.layer_id = id(layer)
         self.data_level = layer._data_level
 

--- a/napari/components/chunk/_tests/test_chunk.py
+++ b/napari/components/chunk/_tests/test_chunk.py
@@ -59,5 +59,8 @@ def test_loader():
 
     assert np.all(request.image.data == request.chunks['image'].data)
 
+    # Since we didn't ask for a thumbnail_source it should be the image.
+    assert np.all(request.thumbnail_source.data[:] == request.image.data[:])
+
     with pytest.raises(KeyError):
-        request.chunks['this_array_does_not_exist']
+        request.chunks['missing_chunk_name']

--- a/napari/components/chunk/_tests/test_chunk.py
+++ b/napari/components/chunk/_tests/test_chunk.py
@@ -9,7 +9,7 @@ from .. import ChunkKey, chunk_loader
 
 def _create_layer() -> Image:
     """Return a small random Image layer."""
-    data = np.random.random((16, 16))
+    data = np.random.random((32, 16))
     return Image(data)
 
 
@@ -53,8 +53,11 @@ def test_loader():
     layer = _create_layer()
     key = ChunkKey(layer, (0, 0))
 
+    shape = (64, 32)
+    transpose_shape = (32, 64)
+
     # Just load one array.
-    data = np.random.random((64, 64))
+    data = np.random.random(shape)
     chunks = {'image': data}
 
     # Give data2 different data.
@@ -62,6 +65,9 @@ def test_loader():
 
     # Create the ChunkRequest.
     request = chunk_loader.create_request(layer, key, chunks)
+
+    # Should be compatible with the layer we made it from!
+    assert request.is_compatible(layer)
 
     # Load the ChunkRequest.
     request = chunk_loader.load_chunk(request)
@@ -79,3 +85,7 @@ def test_loader():
     # KeyError for chunks that do not exist.
     with pytest.raises(KeyError):
         request.chunks['missing_chunk_name']
+
+    # Test transpose_chunks()
+    request.transpose_chunks((1, 0))
+    assert request.image.shape == transpose_shape

--- a/napari/components/chunk/_tests/test_chunk.py
+++ b/napari/components/chunk/_tests/test_chunk.py
@@ -73,14 +73,14 @@ def test_loader():
     request = chunk_loader.load_chunk(request)
 
     # Data should only match data not data2.
-    assert np.all(data[:] == request.image.data[:])
-    assert not np.all(data2[:] == request.image.data[:])
+    assert np.all(data == request.image.data)
+    assert not np.all(data2 == request.image.data)
 
     # request.image is just short-hand for request.chunks['image']
     assert np.all(request.image.data == request.chunks['image'].data)
 
     # Since we didn't ask for a thumbnail_source it should be the image.
-    assert np.all(request.thumbnail_source.data[:] == request.image.data[:])
+    assert np.all(request.thumbnail_source.data == request.image.data)
 
     # KeyError for chunks that do not exist.
     with pytest.raises(KeyError):

--- a/napari/components/chunk/_tests/test_chunk.py
+++ b/napari/components/chunk/_tests/test_chunk.py
@@ -8,7 +8,7 @@ from .. import ChunkKey, chunk_loader
 
 
 def _create_layer() -> Image:
-    """Return a random Image layer."""
+    """Return a small random Image layer."""
     data = np.random.random((16, 16))
     return Image(data)
 
@@ -19,23 +19,28 @@ def test_chunk_key():
     layer1 = _create_layer()
     layer2 = _create_layer()
 
+    # key1 and key2 should be identical.
     key1 = ChunkKey(layer1, (0, 0))
     key2 = ChunkKey(layer1, (0, 0))
     assert key1 == key2
     assert key1.key == key2.key
 
+    # Check key1 attributes.
     assert key1.layer_id == id(layer1)
     assert key1.data_level == layer1.data_level
 
+    # key3 is for a different layer.
     key3 = ChunkKey(layer2, (0, 0))
     assert key1 != key3
     assert key2 != key3
 
+    # key4 has different indices.
     key4 = ChunkKey(layer2, (0, 1))
     assert key1 != key4
     assert key2 != key4
     assert key3 != key4
 
+    # key5 matches key4.
     key5 = ChunkKey(layer2, (0, 1))
     assert key1 != key5
     assert key2 != key5
@@ -47,20 +52,30 @@ def test_loader():
     """Test ChunkRequest and the ChunkLoader."""
     layer = _create_layer()
     key = ChunkKey(layer, (0, 0))
-    data = np.random.random((64, 64))
 
+    # Just load one array.
+    data = np.random.random((64, 64))
+    chunks = {'image': data}
+
+    # Give data2 different data.
     data2 = data * 2
 
-    request = chunk_loader.create_request(layer, key, {'image': data})
+    # Create the ChunkRequest.
+    request = chunk_loader.create_request(layer, key, chunks)
 
+    # Load the ChunkRequest.
     request = chunk_loader.load_chunk(request)
+
+    # Data should only match data not data2.
     assert np.all(data[:] == request.image.data[:])
     assert not np.all(data2[:] == request.image.data[:])
 
+    # request.image is just short-hand for request.chunks['image']
     assert np.all(request.image.data == request.chunks['image'].data)
 
     # Since we didn't ask for a thumbnail_source it should be the image.
     assert np.all(request.thumbnail_source.data[:] == request.image.data[:])
 
+    # KeyError for chunks that do not exist.
     with pytest.raises(KeyError):
         request.chunks['missing_chunk_name']

--- a/napari/components/chunk/_tests/test_chunk.py
+++ b/napari/components/chunk/_tests/test_chunk.py
@@ -1,0 +1,36 @@
+"""Tests for components.chunk."""
+
+import numpy as np
+
+from ....layers.image import Image
+from .. import ChunkKey
+
+
+def test_chunk_key():
+
+    data = np.random.random((512, 512))
+    layer1 = Image(data)
+    layer2 = Image(data)
+
+    key1 = ChunkKey(layer1, (0, 0))
+    key2 = ChunkKey(layer1, (0, 0))
+    assert key1 == key2
+    assert key1.key == key2.key
+
+    assert key1.layer_id == id(layer1)
+    assert key1.data_level == layer1.data_level
+
+    key3 = ChunkKey(layer2, (0, 0))
+    assert key1 != key3
+    assert key2 != key3
+
+    key4 = ChunkKey(layer2, (0, 1))
+    assert key1 != key4
+    assert key2 != key4
+    assert key3 != key4
+
+    key5 = ChunkKey(layer2, (0, 1))
+    assert key1 != key5
+    assert key2 != key5
+    assert key3 != key5
+    assert key4 == key5

--- a/napari/components/chunk/_tests/test_chunk.py
+++ b/napari/components/chunk/_tests/test_chunk.py
@@ -3,8 +3,8 @@
 import numpy as np
 import pytest
 
-from ....layers.image import Image
-from .. import ChunkKey, chunk_loader
+from napari.components.chunk import ChunkKey, chunk_loader
+from napari.layers.image import Image
 
 
 def _create_layer() -> Image:
@@ -67,7 +67,7 @@ def test_loader():
     request = chunk_loader.create_request(layer, key, chunks)
 
     # Should be compatible with the layer we made it from!
-    assert request.is_compatible(layer)
+    # assert request.is_compatible(layer)
 
     # Load the ChunkRequest.
     request = chunk_loader.load_chunk(request)

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -249,11 +249,11 @@ class Layer(KeymapProvider, ABC):
         return self._name
 
     @property
-    def loaded(self):
-        """Has layer been fully loaded into memory.
+    def loaded(self) -> bool:
+        """Return True if this layer is fully loaded in memory.
 
-        By default layers are always loaded, but derived classes that load
-        data asynchronously can override this method to report load status.
+        This base class says that layers are permanently in the loaded state.
+        Derived classes that do asynchronous loading can override this.
         """
         return True
 

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -214,6 +214,7 @@ class Layer(KeymapProvider, ABC):
             cursor=Event,
             cursor_size=Event,
             editable=Event,
+            loaded=Event,
         )
         self.name = name
 
@@ -246,6 +247,15 @@ class Layer(KeymapProvider, ABC):
     def name(self):
         """str: Unique name of the layer."""
         return self._name
+
+    @property
+    def loaded(self):
+        """Has layer been fully loaded into memory.
+
+        By default layers are always loaded, but derived classes that load
+        data asynchronously can override this method to report load status.
+        """
+        return True
 
     @name.setter
     def name(self, name):

--- a/napari/layers/image/_image_slice.py
+++ b/napari/layers/image/_image_slice.py
@@ -1,54 +1,125 @@
+"""ImageSlice class.
+"""
+import logging
 from typing import Optional
 
+import numpy as np
+
+from ...components.chunk import ChunkKey, ChunkRequest, chunk_loader
 from ...types import ArrayLike, ImageConverter
 from ._image_view import ImageView
+
+LOGGER = logging.getLogger('ChunkLoader')
 
 
 class ImageSlice:
     """The slice of the image that we are currently viewing.
 
-    Right now this just holds the image and its thumbnail, however future async
-    and multiscale-async changes will likely grow this class a lot.
+    Holds the image and its thumbnail and has load_chunk() and chunk_loaded() methods.
 
     Parameters
     ----------
     view_image : ArrayLike
-        The default image for the time and its thumbail.
-    image_converter : ImageConverter, optional
+        The initial image used as the image and the thumbnail source.
+    image_converter : ImageConverter
         ImageView uses this to convert from raw to viewable.
+    rgb : bool
+        Is the image in RGB or RGBA format.
 
     Attributes
     ----------
     image : ImageView
         The main image for this slice.
-
     thumbnail : ImageView
-        The smaller thumbnail image for this slice.
-
-    Examples
-    --------
-    Create with some default image:
-
-    >> image_slice = ImageSlice(default_image)
-
-    Set raw image or thumbnail, viewable is computed.:
-
-    >> image_slice.image = raw_image
-    >> image_slice.thumbnail = raw_thumbnail
-
-    Access viewable images:
-
-    >> draw_image(image_slice.image.view)
-    >> draw_thumbnail(image_slice.thumbnail.view)
+        The source image used to compute the smaller thumbnail image.
+    rgb : bool
+        Is the image in RGB or RGBA format.
+    current_key
+        The ChunkKey we are currently showing or which is loading.
+    loaded : bool
+        Has the data for this slice been loaded yet.
     """
 
     def __init__(
         self,
         view_image: ArrayLike,
-        image_converter: Optional[ImageConverter] = None,
+        image_converter: ImageConverter,
+        rgb: bool = False,
     ):
-        """
-        Create an ImageSlice with some default viewable image.
-        """
+        LOGGER.info("ImageSlice.__init__")
         self.image: ImageView = ImageView(view_image, image_converter)
         self.thumbnail: ImageView = ImageView(view_image, image_converter)
+        self.rgb = rgb
+
+        # We're showing nothing to start.
+        self.current_key: Optional[ChunkKey] = None
+
+        # With async there can be a gap between when the ImageSlice is
+        # created and the data is actually loaded.
+        self.loaded = False
+
+    def set_raw_images(self, image: ArrayLike, thumbnail: ArrayLike) -> None:
+        """Set the image and its thumbnail.
+
+        If floating point / grayscale then clip to [0..1].
+
+        Parameters
+        ----------
+        image : ArrayLike
+            Set this as the main image.
+        thumbnail : ArrayLike
+            Set this as the thumbnail.
+        """
+        if self.rgb and image.dtype.kind == 'f':
+            image = np.clip(image, 0, 1)
+            thumbnail = np.clip(thumbnail, 0, 1)
+        self.image.raw = image
+        self.thumbnail.raw = thumbnail
+        self.loaded = True
+
+    def load_chunk(self, request: ChunkRequest) -> Optional[ChunkRequest]:
+        """Load the requested chunk asynchronously.
+
+        Parameters
+        ----------
+        request : ChunkRequest
+            Load this chunk sync or async.
+        """
+        LOGGER.info("ImageSlice.load_chunk: %s", request.key)
+
+        # Now "showing" this slice, even if it hasn't loaded yet.
+        self.current_key = request.key
+        self.loaded = False
+
+        # This will return a satisfied request in ChunkLoader is doing
+        # syncrhonous loading or the chunk was in the cache. If it returns
+        # None that means a request was queued and it will be loaded in a
+        # worker thread or process.
+        return chunk_loader.load_chunk(request)
+
+    def chunk_loaded(self, request: ChunkRequest) -> bool:
+        """Chunk was loaded, show this new data.
+
+        Parameters
+        ----------
+        request : ChunkRequest
+            The chunk request that was loaded in a worker thread or process.
+
+        Return
+        ------
+        bool
+            False if the chunk was for the wrong slice and was not used.
+        """
+        # Is this the chunk we last requested?
+        if not self.current_key == request.key:
+            # Probably we are scrolling through slices and we are no longer
+            # showing this slice, so drop it. It should have been added
+            # to the cache so the load was not totally wasted.
+            LOGGER.info("ImageSlice.chunk_loaded: reject %s", request.key)
+            return False
+
+        LOGGER.info("ImageSlice.chunk_loaded: accept %s", request.key)
+
+        # Display the newly loaded data.
+        self.set_raw_images(request.image, request.thumbnail_source)
+        return True

--- a/napari/layers/image/_image_slice.py
+++ b/napari/layers/image/_image_slice.py
@@ -44,7 +44,7 @@ class ImageSlice:
         image_converter: ImageConverter,
         rgb: bool = False,
     ):
-        LOGGER.info("ImageSlice.__init__")
+        LOGGER.debug("ImageSlice.__init__")
         self.image: ImageView = ImageView(image, image_converter)
         self.thumbnail: ImageView = ImageView(image, image_converter)
         self.rgb = rgb
@@ -85,7 +85,7 @@ class ImageSlice:
         request : ChunkRequest
             Load this chunk sync or async.
         """
-        LOGGER.info("ImageSlice.load_chunk: %s", request.key)
+        LOGGER.debug("ImageSlice.load_chunk: %s", request.key)
 
         # Now "showing" this slice, even if it hasn't loaded yet.
         self.current_key = request.key
@@ -115,10 +115,10 @@ class ImageSlice:
             # Probably we are scrolling through slices and we are no longer
             # showing this slice, so drop it. It should have been added
             # to the cache so the load was not totally wasted.
-            LOGGER.info("ImageSlice.chunk_loaded: reject %s", request.key)
+            LOGGER.debug("ImageSlice.chunk_loaded: reject %s", request.key)
             return False
 
-        LOGGER.info("ImageSlice.chunk_loaded: accept %s", request.key)
+        LOGGER.debug("ImageSlice.chunk_loaded: accept %s", request.key)
 
         # Display the newly loaded data.
         self.set_raw_images(request.image, request.thumbnail_source)

--- a/napari/layers/image/_image_slice.py
+++ b/napari/layers/image/_image_slice.py
@@ -91,8 +91,8 @@ class ImageSlice:
         self.current_key = request.key
         self.loaded = False
 
-        # This will return a satisfied request in ChunkLoader is doing
-        # syncrhonous loading or the chunk was in the cache. If it returns
+        # This will return a satisfied request if ChunkLoader is doing
+        # synchronous loading or the chunk was in the cache. If it returns
         # None that means a request was queued and it will be loaded in a
         # worker thread or process.
         return chunk_loader.load_chunk(request)

--- a/napari/layers/image/_image_slice.py
+++ b/napari/layers/image/_image_slice.py
@@ -97,7 +97,7 @@ class ImageSlice:
         # worker thread or process.
         return chunk_loader.load_chunk(request)
 
-    def chunk_loaded(self, request: ChunkRequest) -> bool:
+    def on_chunk_loaded(self, request: ChunkRequest) -> bool:
         """Chunk was loaded, show this new data.
 
         Parameters

--- a/napari/layers/image/_image_slice.py
+++ b/napari/layers/image/_image_slice.py
@@ -1,12 +1,12 @@
 """ImageSlice class.
 """
 import logging
-from typing import Optional
+from typing import Callable, Optional
 
 import numpy as np
 
 from ...components.chunk import ChunkKey, ChunkRequest, chunk_loader
-from ...types import ArrayLike, ImageConverter
+from ...types import ArrayLike
 from ._image_view import ImageView
 
 LOGGER = logging.getLogger("napari.async")
@@ -19,7 +19,7 @@ class ImageSlice:
     ----------
     image : ArrayLike
         The initial image used as the image and the thumbnail source.
-    image_converter : ImageConverter
+    image_converter : Callable[[ArrayLike], ArrayLike]
         ImageView uses this to convert from raw to viewable.
     rgb : bool
         True if the image is RGB format. Otherwise its RGBA.
@@ -41,7 +41,7 @@ class ImageSlice:
     def __init__(
         self,
         image: ArrayLike,
-        image_converter: ImageConverter,
+        image_converter: Callable[[ArrayLike], ArrayLike],
         rgb: bool = False,
     ):
         LOGGER.debug("ImageSlice.__init__")

--- a/napari/layers/image/_image_utils.py
+++ b/napari/layers/image/_image_utils.py
@@ -1,3 +1,5 @@
+"""guess_rgb, guess_multiscale, guess_labels.
+"""
 import numpy as np
 
 

--- a/napari/layers/image/_image_view.py
+++ b/napari/layers/image/_image_view.py
@@ -1,47 +1,33 @@
-from typing import Optional
-
+"""ImageView class.
+"""
 from ...types import ArrayLike, ImageConverter
 
 
 class ImageView:
     """A raw image and a viewable version of it.
 
-    A very simple class that groups together two related images, the raw one and
-    the viewable one. Its primary purpose right now is just making sure the
-    viewable image is updated when the raw one is changed. And just to group
-    them together and provide convenient access.
+    Small class that groups together two related images, the raw one and
+    the viewable one. The image_converter passed in is either
+    Image._raw_to_displayed or Labels._raw_to_displayed. The Image one does
+    nothing but the Labels ones does colormapping.
 
     Parameters
     ----------
     view_image : ArrayLike
         Default viewable image, raw is set to the same thing.
-    image_converter : Optional[ImageConverter]
-        If given this is used to convert images from raw to viewable.
+    image_converter : ImageConverter
+        Used to convert images from raw to viewable.
 
     Attributes
     ----------
-    _raw : ArrayLike
+    view : ArrayLike
         The raw image.
 
-    _view : ArrayLike
-        The viewable image, derived from raw.
-
-    Examples
-    --------
-    Create ImageView with initial default:
-
-    >> image = ImageView(view_image)
-
-    Update ImageView's raw image, it will compute the new viable one:
-
-    >> image.raw = raw_image
+    image_convert : ImageConvert
+        Converts from raw to viewable.
     """
 
-    def __init__(
-        self,
-        view_image: ArrayLike,
-        image_converter: Optional[ImageConverter] = None,
-    ):
+    def __init__(self, view_image: ArrayLike, image_converter: ImageConverter):
         """Create an ImageView with some default image.
         """
         self.view = view_image
@@ -54,7 +40,7 @@ class ImageView:
 
     @view.setter
     def view(self, view_image: ArrayLike):
-        """Set the viewed and draw images.
+        """Set the viewed and raw image.
 
         Parameters
         ----------
@@ -81,7 +67,4 @@ class ImageView:
         self._raw = raw_image
 
         # Update the view image based on this new raw image.
-        has_converter = self.image_converter is not None
-        self._view = (
-            self.image_converter(raw_image) if has_converter else raw_image
-        )
+        self._view = self.image_converter(raw_image)

--- a/napari/layers/image/_image_view.py
+++ b/napari/layers/image/_image_view.py
@@ -1,6 +1,6 @@
 """ImageView class.
 """
-from ...types import ArrayLike, ImageConverter
+from ...types import ArrayLike, Callable
 
 
 class ImageView:
@@ -15,7 +15,7 @@ class ImageView:
     ----------
     view_image : ArrayLike
         Default viewable image, raw is set to the same thing.
-    image_converter : ImageConverter
+    image_converter : Callable[[ArrayLike], ArrayLike]
         Used to convert images from raw to viewable.
 
     Attributes
@@ -27,7 +27,11 @@ class ImageView:
         Converts from raw to viewable.
     """
 
-    def __init__(self, view_image: ArrayLike, image_converter: ImageConverter):
+    def __init__(
+        self,
+        view_image: ArrayLike,
+        image_converter: Callable[[ArrayLike], ArrayLike],
+    ):
         """Create an ImageView with some default image.
         """
         self.view = view_image

--- a/napari/layers/image/_tests/test_image_slice.py
+++ b/napari/layers/image/_tests/test_image_slice.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from napari.layers.image._image_slice import ImageSlice
+
+
+def _converter(array):
+    return array * 2
+
+
+def test_image_slice():
+    image1 = np.random.random((32, 16))
+    image2 = np.random.random((32, 16))
+
+    # Create a slice and check it was created as expected.
+    image_slice = ImageSlice(image1, _converter)
+    assert image_slice.rgb is False
+    assert id(image_slice.image.view) == id(image1)
+    assert id(image_slice.image.raw) == id(image1)
+
+    # Update the slice and see the conversion happened.
+    image_slice.image.raw = image2
+    assert id(image_slice.image.raw) == id(image2)
+    assert np.all(image_slice.image.view == image2 * 2)

--- a/napari/layers/image/_tests/test_image_slice.py
+++ b/napari/layers/image/_tests/test_image_slice.py
@@ -21,3 +21,12 @@ def test_image_slice():
     image_slice.image.raw = image2
     assert id(image_slice.image.raw) == id(image2)
     assert np.all(image_slice.image.view == image2 * 2)
+
+    # Test ImageSlice.set_raw_images().
+    image3 = np.random.random((32, 16))
+    image4 = np.random.random((32, 16))
+    image_slice.set_raw_images(image3, image4)
+    assert id(image_slice.image.raw) == id(image3)
+    assert id(image_slice.thumbnail.raw) == id(image4)
+    assert np.all(image_slice.image.view == image3 * 2)
+    assert np.all(image_slice.thumbnail.view == image4 * 2)

--- a/napari/layers/image/_tests/test_image_slice.py
+++ b/napari/layers/image/_tests/test_image_slice.py
@@ -8,6 +8,7 @@ def _converter(array):
 
 
 def test_image_slice():
+    """Test ImageSlice and ImageView."""
     image1 = np.random.random((32, 16))
     image2 = np.random.random((32, 16))
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -628,12 +628,9 @@ class Image(IntensityVisualizationMixin, Layer):
         # Chunks get transposed after load.
         request.transpose_chunks(self._get_order())
 
-        # The main image chunk.
-        image = request.chunks['image']
-
         # The shape of the array after we loaded it was "wrong" in that it
         # didn't match the rgb flag that the user specified (or we inferred?).
-        if self.rgb != guess_rgb(image.shape):
+        if self.rgb != guess_rgb(request.image.shape):
             raise ValueError(
                 "Loaded chunk was the wrong shape, was rgb set correctly?"
             )

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -620,11 +620,6 @@ class Image(IntensityVisualizationMixin, Layer):
         sync : bool
             If True the chunk was loaded synchronously.
         """
-        # Confirm this chunk is for us. We shouldn't be receiving any chunks
-        # that are not for us, but this takes no time so lets be sure.
-        if not request.is_compatible(self):
-            return  # Request was not for us, drop it.
-
         # Chunks get transposed after load.
         request.transpose_chunks(self._get_order())
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -20,7 +20,7 @@ from ._image_utils import guess_multiscale, guess_rgb
 
 # Mixin must come before Layer
 class Image(IntensityVisualizationMixin, Layer):
-    """Image layer with async loading.
+    """Image layer.
 
     Parameters
     ----------

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -580,9 +580,9 @@ class Image(IntensityVisualizationMixin, Layer):
         2) We are in synchronous mode, or
         3) The arrays were found in the ChunkCache.
 
-        If the load is synchronous we immediately call our chunk_loaded()
+        If the load is synchronous we immediately call our on_chunk_loaded()
         method so that we use the new data right away. If the load is
-        asynchronous then sometime later our chunk_loaded() method will be
+        asynchronous then sometime later our on_chunk_loaded() method will be
         called with the loaded data.
         """
         # We always load the image.
@@ -604,9 +604,11 @@ class Image(IntensityVisualizationMixin, Layer):
             self.events.loaded()
         else:
             # The load was sync, it's done, so use the chunk now.
-            self.chunk_loaded(satisfied_request, sync=True)
+            self.on_chunk_loaded(satisfied_request, sync=True)
 
-    def chunk_loaded(self, request: ChunkRequest, sync: bool = False) -> None:
+    def on_chunk_loaded(
+        self, request: ChunkRequest, sync: bool = False
+    ) -> None:
         """The given ChunkRequest was satisfied, we can use the data now.
 
         This routine is called synchronously from _load_async() above, or
@@ -631,7 +633,7 @@ class Image(IntensityVisualizationMixin, Layer):
             )
 
         # Pass the loaded data to the slice.
-        if not self._slice.chunk_loaded(request):
+        if not self._slice.on_chunk_loaded(request):
             # Slice rejected it, was it for the wrong indices?
             return
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -1,9 +1,12 @@
+"""Image class.
+"""
 import types
 import warnings
 
 import numpy as np
 from scipy import ndimage as ndi
 
+from ...components.chunk import ChunkKey, ChunkRequest, chunk_loader
 from ...utils.colormaps import AVAILABLE_COLORMAPS
 from ...utils.events import Event
 from ...utils.status_messages import format_float
@@ -17,7 +20,7 @@ from ._image_utils import guess_multiscale, guess_rgb
 
 # Mixin must come before Layer
 class Image(IntensityVisualizationMixin, Layer):
-    """Image layer.
+    """Image layer with async loading.
 
     Parameters
     ----------
@@ -120,7 +123,7 @@ class Image(IntensityVisualizationMixin, Layer):
         Attenuation rate for attenuated maximum intensity projection.
 
     Extended Summary
-    ----------
+    ----------------
     _data_view : array (N, M), (N, M, 3), or (N, M, 4)
         Image data for the currently viewed slice. Must be 2D image data, but
         can be multidimensional for RGB or RGBA images if multidimensional is
@@ -218,7 +221,7 @@ class Image(IntensityVisualizationMixin, Layer):
 
         # Initialize the current slice to an empty image.
         self._slice = ImageSlice(
-            self._get_empty_image(), self._raw_to_displayed
+            self._get_empty_image(), self._raw_to_displayed, self.rgb
         )
 
         # Set contrast_limits and colormaps
@@ -437,6 +440,15 @@ class Image(IntensityVisualizationMixin, Layer):
         self._rendering = Rendering(rendering)
         self.events.rendering()
 
+    @property
+    def loaded(self):
+        """Has the data for this layer been loaded yet.
+
+        With asynchronous loading the layer might exist but its data
+        for the current slice has not been loaded.
+        """
+        return self._slice.loaded
+
     def _get_state(self):
         """Get dictionary of layer state.
 
@@ -483,7 +495,6 @@ class Image(IntensityVisualizationMixin, Layer):
     def _set_view_slice(self):
         """Set the view given the indices to slice with."""
         not_disp = self.dims.not_displayed
-        order = self._get_order()
 
         if self.multiscale:
             # If 3d redering just show lowest level of multiscale
@@ -526,9 +537,8 @@ class Image(IntensityVisualizationMixin, Layer):
                     * self._transforms['tile2data'].scale
                 )
 
-            image = np.transpose(
-                np.asarray(self.data[level][tuple(indices)]), order
-            )
+            image = self.data[level][tuple(indices)]
+            image_indices = indices
 
             # Slice thumbnail
             indices = np.array(self.dims.indices)
@@ -546,27 +556,115 @@ class Image(IntensityVisualizationMixin, Layer):
             )
             indices[not_disp] = downsampled_indices
 
-            thumbnail_source = np.asarray(
-                self.data[self._thumbnail_level][tuple(indices)]
-            ).transpose(order)
+            thumbnail_source = self.data[self._thumbnail_level][tuple(indices)]
         else:
             self._transforms['tile2data'].scale = np.ones(self.dims.ndim)
-            image = np.asarray(self.data[self.dims.indices]).transpose(order)
-            thumbnail_source = image
+            image_indices = self.dims.indices
+            image = self.data[image_indices]
 
-        if self.rgb and image.dtype.kind == 'f':
-            self._slice.image.raw = np.clip(image, 0, 1)
-            self._slice.thumbnail.raw = np.clip(thumbnail_source, 0, 1)
+            # For single-scale we don't request a separate thumbnail_source
+            # from the ChunkLoader because in ImageSlice.chunk_loaded we
+            # call request.thumbnail_source() and it knows to just use the
+            # image itself is there is no explicit thumbnail_source.
+            thumbnail_source = None
+
+        # Load our images, might be sync or async.
+        key = ChunkKey(self, image_indices)
+        self._load_images(key, image, thumbnail_source)
+
+    def _load_images(self, key: ChunkKey, image, thumbnail_source=None):
+        """Load the image and maybe thumbnail source.
+
+        The load will happen synchronously if any of these are true:
+        1) The arrays are already ndarrays, or
+        2) We are in synchronous mode, or
+        3) The arrays were found in the ChunkCache.
+
+        If the load is synchronous we immediately call our chunk_loaded()
+        method so that we use the new data right away. If the load is
+        asynchronous then sometime later our chunk_loaded() method will be
+        called with the loaded data.
+        """
+        # We always load the image.
+        chunks = {'image': image}
+
+        # Optionally also load the thumbnail_source.
+        if thumbnail_source is not None:
+            chunks['thumbnail_source'] = thumbnail_source
+
+        # Create the ChunkRequest for the chunks we are going to load.
+        request = chunk_loader.create_request(self, key, chunks)
+
+        # Load the chunk(s), the load could happen sync or async.
+        satisfied_request = self._slice.load_chunk(request)
+
+        if satisfied_request is None:
+            # The load is going to be async, announce that a load is
+            # underway, that we are no longer in the loaded state.
+            self.events.loaded()
         else:
-            self._slice.image.raw = image
-            self._slice.thumbnail.raw = thumbnail_source
+            # The load was sync, it's done, so use the chunk now.
+            self.chunk_loaded(satisfied_request, sync=True)
 
+    def chunk_loaded(self, request: ChunkRequest, sync: bool = False) -> None:
+        """The given ChunkRequest was satisfied, we can use the data now.
+
+        This routine is called synchronously from _load_async() above, or
+        it is called asynchronously sometime later when the ChunkLoader
+        finishes loading the data in a worker thread or process.
+
+        Parameters
+        ----------
+        request : ChunkRequest
+            The request that was satisfied/loaded.
+        sync : bool
+            If True the chunk was loaded synchronously.
+        """
+        # Confirm this chunk is for us. We shouldn't be receiving any chunks
+        # that are not for us, but this takes no time so lets be sure.
+        if not request.is_compatible(self):
+            return  # Request was not for us, drop it.
+
+        # Chunks get transposed after load.
+        request.transpose_chunks(self._get_order())
+
+        # The main image chunk.
+        image = request.chunks['image']
+
+        # The shape of the array after we loaded it was "wrong" in that it
+        # didn't match the rgb flag that the user specified (or we inferred?).
+        if self.rgb != guess_rgb(image.shape):
+            raise ValueError(
+                "Loaded chunk was the wrong shape, was rgb set correctly?"
+            )
+
+        # Pass the loaded data to the slice.
+        if not self._slice.chunk_loaded(request):
+            # Slice rejected it, was it for the wrong indices?
+            return
+
+        # Notify the world.
         if self.multiscale:
             self.events.scale()
             self.events.translate()
 
+        # Announcing we are in the loaded state will make our node visible
+        # if it was invisible during the load.
+        self.events.loaded()
+
+        if not sync:
+            # If this specific load itself was async we need a full refresh.
+            # Note: even in async mode, some loads are sync, such as cache hits
+            # and loads of ndarray data.
+            self.refresh()
+
     def _update_thumbnail(self):
         """Update thumbnail with current image data and colormap."""
+        if not self._slice.loaded:
+            # ASYNC_TODO: Do not compute the thumbnail until we are loaded.
+            # Is there a nicer way to prevent this from getting called?
+            return
+
         image = self._slice.thumbnail.view
         if self.dims.ndisplay == 3 and self.dims.ndim > 2:
             image = np.max(image, axis=0)

--- a/napari/types.py
+++ b/napari/types.py
@@ -34,9 +34,6 @@ ExcInfo = Union[
     Tuple[None, None, None],
 ]
 
-# Converts a raw image to a displayable one.
-ImageConverter = Callable[[ArrayLike], ArrayLike]
-
 
 def image_reader_to_layerdata_reader(
     func: Callable[[PathLike], ArrayLike]


### PR DESCRIPTION
# Description
* Image changes and stub `ChunkLoader`
* See more async PRs: [The Napari Rendering GitHub Project](https://github.com/users/pwinston/projects/1)

# Details
* Adds `napari.components.chunk` module with stub `ChunkLoader`, `ChunkKey` and `
ChunkRequest`
* `ChunkLoader` is a stub that always loads **synchronously**.
* Add `Layer.loaded` property and `loaded` event
    * By default layers are permanently in the loaded state
* Adds `Image._load_images()` and `Image.chunk_loaded()` methods.
* Small `ImageView` change.
* New `ImageSlice.load_chunk()` and `ImageSlice.chunk_loaded()` methods.
* It loads **synchronously** 100% of the time.
