### PR TITLE
Longer spinbox

### DIFF
--- a/napari/resources/styles/00_base.qss
+++ b/napari/resources/styles/00_base.qss
@@ -148,7 +148,7 @@ QAbstractSpinBox {
   background-color: {{ foreground }};
   border: none;
   padding: 1px 10px;
-  min-width: 40px;
+  min-width: 70px;
   min-height: 18px;
   border-radius: 2px;
 }


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
With current width, on ubuntu it looks 
![image](https://user-images.githubusercontent.com/3826210/91321910-68b9d380-e7bf-11ea-84c8-3cd2feb9d32e.png)
instead of 
![image](https://user-images.githubusercontent.com/3826210/91321739-3c05bc00-e7bf-11ea-9706-a556d65d4e37.png)
So user cannot read value inside it. 

In Qt stylesheet is more important than object property so `setMinimumWidth` does not work 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] manually


## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

