### PR TITLE
Add support for deprecate signal in EmitterGroup

### DIFF
--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -60,6 +60,7 @@ class Dims:
             order=None,
             range=None,
             camera=None,
+            deprecated={"axis": "current_step"},
         )
         self._range = []
         self._current_step = []

--- a/napari/utils/events/_tests/test_evented_list.py
+++ b/napari/utils/events/_tests/test_evented_list.py
@@ -366,3 +366,17 @@ def test_evented_list_subclass():
     assert hasattr(lst, 'events')
     assert 'boom' in lst.events.emitters
     assert lst == [1, 2]
+
+
+def test_event_group_depr(capsys):
+    events = EmitterGroup(b=None, deprecated={"a": "b"})
+    assert events.b == events.a
+    captured = capsys.readouterr()
+    assert captured.err == "emitter a is deprecated, b provided instead\n"
+    with pytest.raises(AttributeError):
+        events.c.connect()
+    assert events["b"] == events["a"]
+    captured = capsys.readouterr()
+    assert captured.err == "emitter a is deprecated, b provided instead\n"
+    with pytest.raises(KeyError):
+        events["c"].connect()

--- a/napari/utils/events/_tests/test_evented_list.py
+++ b/napari/utils/events/_tests/test_evented_list.py
@@ -368,15 +368,13 @@ def test_evented_list_subclass():
     assert lst == [1, 2]
 
 
-def test_event_group_depr(capsys):
+def test_event_group_depr():
     events = EmitterGroup(b=None, deprecated={"a": "b"})
-    assert events.b == events.a
-    captured = capsys.readouterr()
-    assert captured.err == "emitter a is deprecated, b provided instead\n"
+    with pytest.warns(FutureWarning):
+        assert events.b == events.a
     with pytest.raises(AttributeError):
         events.c.connect()
-    assert events["b"] == events["a"]
-    captured = capsys.readouterr()
-    assert captured.err == "emitter a is deprecated, b provided instead\n"
+    with pytest.warns(FutureWarning):
+        assert events["b"] == events["a"]
     with pytest.raises(KeyError):
         events["c"].connect()

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -53,8 +53,8 @@ For more information see http://github.com/vispy/vispy/wiki/API_Events
 from __future__ import division
 
 import inspect
-import sys
 import traceback
+import warnings
 import weakref
 from collections import OrderedDict
 from typing import Any
@@ -689,10 +689,10 @@ class EmitterGroup(EventEmitter):
     # mypy fix for dynamic attribute access
     def __getattr__(self, name: str) -> Any:
         if name in self._deprecated:
-            print(
+            warnings.warn(
                 f"emitter {name} is deprecated, {self._deprecated[name]} provided instead",
-                file=sys.stderr,
-            )
+                category=FutureWarning,
+            ),
             return object.__getattribute__(self, self._deprecated[name])
         return object.__getattribute__(self, name)
 
@@ -703,10 +703,10 @@ class EmitterGroup(EventEmitter):
         EmitterGroup.
         """
         if name in self._deprecated:
-            print(
+            warnings.warn(
                 f"emitter {name} is deprecated, {self._deprecated[name]} provided instead",
-                file=sys.stderr,
-            )
+                category=FutureWarning,
+            ),
             return self._emitters[self._deprecated[name]]
         return self._emitters[name]
 

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -667,6 +667,8 @@ class EmitterGroup(EventEmitter):
         <vispy.event.EventEmitter.connect>`.
         This provides a simple mechanism for automatically connecting a large
         group of emitters to default callbacks.
+    deprecated: dict
+        dict with mapping old emitter name to new emitter name
     emitters : keyword arguments
         See the :func:`add <vispy.event.EmitterGroup.add>` method.
     """

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -53,6 +53,7 @@ For more information see http://github.com/vispy/vispy/wiki/API_Events
 from __future__ import division
 
 import inspect
+import sys
 import traceback
 import weakref
 from collections import OrderedDict
@@ -670,10 +671,13 @@ class EmitterGroup(EventEmitter):
         See the :func:`add <vispy.event.EmitterGroup.add>` method.
     """
 
-    def __init__(self, source=None, auto_connect=True, **emitters):
+    def __init__(
+        self, source=None, auto_connect=True, deprecated=None, **emitters
+    ):
         EventEmitter.__init__(self, source)
 
         self.auto_connect = auto_connect
+        self._deprecated = {} if deprecated is None else deprecated
         self.auto_connect_format = "on_%s"
         self._emitters = OrderedDict()
         # whether the sub-emitters have been connected to the group:
@@ -682,6 +686,12 @@ class EmitterGroup(EventEmitter):
 
     # mypy fix for dynamic attribute access
     def __getattr__(self, name: str) -> Any:
+        if name in self._deprecated:
+            print(
+                f"emitter {name} is deprecated, {self._deprecated[name]} provided instead",
+                file=sys.stderr,
+            )
+            return object.__getattribute__(self, self._deprecated[name])
         return object.__getattribute__(self, name)
 
     def __getitem__(self, name):
@@ -690,6 +700,12 @@ class EmitterGroup(EventEmitter):
         Note that emitters may also be retrieved as an attribute of the
         EmitterGroup.
         """
+        if name in self._deprecated:
+            print(
+                f"emitter {name} is deprecated, {self._deprecated[name]} provided instead",
+                file=sys.stderr,
+            )
+            return self._emitters[self._deprecated[name]]
         return self._emitters[name]
 
     def __setitem__(self, name, emitter):


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
This PR  allow to provide alias for changed/removed signal in emitter group to not break external scripts without warnings. 


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [X] example: the test suite for my feature covers cases x, y, and z
- [X] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
