### PR TITLE
Minor updates to custom mouse functionality examples

### DIFF
--- a/examples/custom_mouse_functions.py
+++ b/examples/custom_mouse_functions.py
@@ -16,7 +16,7 @@ with napari.gui_qt():
     labeled = ndi.label(blobs)[0]
     labels_layer = viewer.add_labels(labeled, name='blob ID')
 
-    @viewer.mouse_press_callbacks.append
+    @viewer.mouse_drag_callbacks.append
     def get_event(viewer, event):
         print(event)
 

--- a/examples/mouse_drag_callback.py
+++ b/examples/mouse_drag_callback.py
@@ -13,7 +13,9 @@ def profile_lines(image, shape_layer):
     profile_data = []
     for line in shape_layer.data:
         profile_data.append(
-            measure.profile_line(image, line[0], line[1]).mean()
+            measure.profile_line(
+                image, line[0], line[1], mode='reflect'
+            ).mean()
         )
     msg = ('profile means: ['
             + ', '.join([f'{d:.2f}' for d in profile_data])


### PR DESCRIPTION
# Description

Our examples were using outdated mouse callback machinery. Additionally, one gets deprecation warnings from scikit-image.

See https://forum.image.sc/t/how-to-get-the-coordinates-of-the-mouse-when-it-is-clicked-over-an-image-labels-layer/42175/2 for more.

Incidentally, I wonder whether we should just provide `mouse_press_callbacks` as a synonym for `mouse_drag_callbacks`. I don't find it very intuitive to write a drag callback for a button press...
