### PR TITLE
do not raise viewer in IPython with pre-existing event loop

### DIFF
--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -27,6 +27,28 @@ def running_as_bundled_app() -> bool:
     return importlib_metadata.metadata("napari").get("App-ID") is not None
 
 
+def in_jupyter() -> bool:
+    """Return true if we're running in jupyter notebook/lab or qtconsole."""
+    try:
+        from IPython import get_ipython
+
+        return get_ipython().__class__.__name__ == 'ZMQInteractiveShell'
+    except Exception:
+        pass
+    return False
+
+
+def in_ipython() -> bool:
+    """Return true if we're running in an IPython interactive shell."""
+    try:
+        from IPython import get_ipython
+
+        return get_ipython().__class__.__name__ == 'TerminalInteractiveShell'
+    except Exception:
+        pass
+    return False
+
+
 def str_to_rgb(arg):
     """Convert an rgb string 'rgb(x,y,z)' to a list of ints [x,y,z].
     """


### PR DESCRIPTION
# Description
fixes #1594
The viewer will no longer be automatically brought to the front when creating a viewer in an IPython session that already has a `%gui qt` event loop running.  It will, however, always be brought to the front in a jupyter lab/notebook environment... and it will also be brought to front in an IPython environment that is _not_ already running an event loop, when using `gui_qt` (since there's not much you can do in that blocked context manager in IPython until you close the viewer anyway).
In all cases, the window can be brought to front by using the newly added `viewer.window.activate()`

@jni let me know if this works for you

## Type of change
- [x] New feature (non-breaking change which adds functionality)


# References
#721, #732, #735, #795, #1594 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] manually in jupyter lab, ipython, regular scripts.  Not sure how to test for running in, for instance, a jupyter environment besides simply mocking the test that I use, which feels pretty useless.

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
