### PR TITLE
Restore multiple command-line arguments

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -211,7 +211,7 @@ def _run_pythonw(python_path):
 
     # Append command line arguments.
     if len(sys.argv) > 1:
-        cmd.append(*sys.argv[1:])
+        cmd.extend(sys.argv[1:])
 
     result = subprocess.run(cmd, env=env, cwd=cwd)
     sys.exit(result.returncode)


### PR DESCRIPTION
`napari -vvv my.zarr` fails with

```
  File "/opt/napari/napari/__main__.py", line 214, in _run_pythonw
    cmd.append(*sys.argv[1:])
TypeError: append() takes exactly one argument (2 given)
```

see: #1554
