### PR TITLE
lock briefcase version

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip 
-          python -m pip install briefcase tomlkit wheel
+          python -m pip install briefcase==0.3.1 tomlkit wheel
           python -m pip install -e .[pyside2]
       - name: get tag
         shell: bash


### PR DESCRIPTION
# Description
Fix ubuntu build failure by locking the briefcase version, this works for now but is certainly a bigger discussion of whether briefcase is the right call in longer-term if we can't use their up-to-date version release.

I tried to resolve the underlying issue, but no luck after quite a few days, the issue is quite deep in dependency linkings, and hard to debug in itself, and given that the Linux build doesn't work within docker mode for us, it is even harder to lock down the build environment.

## Type of change
- Bug-fix (non-breaking change which fixes an issue)

# References
https://github.com/napari/napari/pull/1289

# How has this been tested?
- all tests pass with my change: https://github.com/ziyangczi/napari/runs/1054182098?check_suite_focus=true

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
