### PR TITLE
exclude test_bundle from distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 recursive-include napari _tests/*.py
+exclude napari/_tests/test_bundle.py
 recursive-include napari/resources *.png *.jpeg *.jpg *.svg *.qss
 exclude napari/resources/_qt_resources*.py
 include napari/utils/colormaps/matplotlib_cmaps.txt

--- a/docs/release/release_0_3_7.md
+++ b/docs/release/release_0_3_7.md
@@ -89,6 +89,7 @@ for the full list! Thank you to everyone who contributed to this release!
 - Revert "CI cache reset" (#1551)
 - Add fingerprint script to pip caching (#1553)
 - Add Shapes benchmarks for interactions (#1563)
+- Exclude test_bundle.py from distribution (#1604)
 
 ## 10 authors added to this release (alphabetical)
 

--- a/napari/_tests/test_bundle.py
+++ b/napari/_tests/test_bundle.py
@@ -1,3 +1,9 @@
+"""
+NOTE:
+
+This file is NOT included in the distribution.  Tests included here will only
+be run in development environments.
+"""
 import configparser
 from pathlib import Path
 


### PR DESCRIPTION
# Description
`pytest --pyargs napari` was failing because `test_bundle.py` needs files that we do not distribute.  This PR just removes `test_bundl.py` from the distribution, since it doesn't make sense to include it.

