### PR TITLE
Skip bundle test when setup.cfg is missing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include LICENSE
 recursive-include napari _tests/*.py
-exclude napari/_tests/test_bundle.py
 recursive-include napari/resources *.png *.jpeg *.jpg *.svg *.qss
 exclude napari/resources/_qt_resources*.py
 include napari/utils/colormaps/matplotlib_cmaps.txt

--- a/docs/release/release_0_3_7.md
+++ b/docs/release/release_0_3_7.md
@@ -25,7 +25,7 @@ datasets, such as those backed by remote data or by dask computation. To opt
 into this, set the NAPARI_ASYNC environment variable to anything other than
 "0". 3D rendering and multiscale are currently not supported. If you encounter
 an issue please check the [async label](https://github.com/napari/napari/labels/async)
-on the repository to see if your issue is known. 
+on the repository to see if your issue is known.
 
 Scrolling through n-dimensional datasets has become a bit more convenient:
 scroll to zoom, as always, but hold Ctrl (Cmd on Mac) while scrolling to move
@@ -90,14 +90,16 @@ for the full list! Thank you to everyone who contributed to this release!
 - Add fingerprint script to pip caching (#1553)
 - Add Shapes benchmarks for interactions (#1563)
 - Exclude test_bundle.py from distribution (#1604)
+- Skip bundle test when setup.cfg is missing (#1608)
 
-## 10 authors added to this release (alphabetical)
+## 11 authors added to this release (alphabetical)
 
 - [Dan Allan](https://github.com/napari/napari/commits?author=danielballan) - @danielballan
 - [Draga Doncila Pop](https://github.com/napari/napari/commits?author=DragaDoncila) - @DragaDoncila
 - [Grzegorz Bokota](https://github.com/napari/napari/commits?author=Czaki) - @Czaki
 - [Hector](https://github.com/napari/napari/commits?author=hectormz) - @hectormz
 - [Jordão Bragantini](https://github.com/napari/napari/commits?author=JoOkuma) - @JoOkuma
+- [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) - @jni
 - [Kevin Yamauchi](https://github.com/napari/napari/commits?author=kevinyamauchi) - @kevinyamauchi
 - [Nicholas Sofroniew](https://github.com/napari/napari/commits?author=sofroniewn) - @sofroniewn
 - [Philip Winston](https://github.com/napari/napari/commits?author=pwinston) - @pwinston

--- a/napari/_tests/test_bundle.py
+++ b/napari/_tests/test_bundle.py
@@ -7,17 +7,24 @@ be run in development environments.
 import configparser
 from pathlib import Path
 
+import pytest
 import tomlkit
 
 import napari
 
+root_dir = Path(napari.__file__).parent.parent
+setup_file = root_dir / 'setup.cfg'
 
+
+@pytest.mark.skipif(
+    not setup_file.is_file(),
+    reason='Bundle not tested in source or wheel distributions',
+)
 def test_bundle_requirements():
     """Test that briefcase requirements are superset of setup.cfg requirements.
     """
     parser = configparser.ConfigParser()
-    root_dir = Path(napari.__file__).parent.parent
-    parser.read(root_dir / 'setup.cfg')
+    parser.read(setup_file)
     requirements = parser.get("options", "install_requires").splitlines()
     requirements = {r.split('#')[0].strip() for r in requirements if r}
 

--- a/napari/_tests/test_bundle.py
+++ b/napari/_tests/test_bundle.py
@@ -1,9 +1,3 @@
-"""
-NOTE:
-
-This file is NOT included in the distribution.  Tests included here will only
-be run in development environments.
-"""
 import configparser
 from pathlib import Path
 


### PR DESCRIPTION
# Description

Bundle tests were failing in `pytest --pyargs napari` with wheel builds. This skips the test is the necessary files are not present. See the [Zulip extended discussion](https://napari.zulipchat.com/#narrow/stream/215289-release/topic/0.2E3.2E7/near/208840108) for reference.
