### PR TITLE
Bump numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires = [
   "IPython>=7.7.0",
   "napari-plugin-engine>=0.1.5",
   "napari-svg>=0.1.3",
-  "numpy>=1.10.0",
+  "numpy>=1.17.0",
   "numpydoc>=0.9.2",
   "Pillow!=7.1.0,!=7.1.1",
   "psutil>=5.0",

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     IPython>=7.7.0
     napari-plugin-engine>=0.1.5
     napari-svg>=0.1.3
-    numpy>=1.10.0
+    numpy>=1.17.0
     numpydoc>=0.9.2
     Pillow!=7.1.0,!=7.1.1  # not a direct dependency, but 7.1.0 and 7.1.1 broke imageio
     psutil>=5.0


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

Bump numpy version 1.17 because nan parameters of nan_to_num is introduced in this version. 
Bug introduced in #1360

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

https://numpy.org/doc/stable/reference/generated/numpy.nan_to_num.html

https://github.com/napari/napari/blob/ea0fc9ca29d730808b1a66a8710679ee0fbe7ab5/napari/components/layerlist.py#L230-L231

https://travis-ci.com/github/4DNucleome/PartSeg/jobs/380612109 line 663
# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality

