### PR TITLE
Do not ship bundle.py in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,4 @@ recursive-exclude docs *
 recursive-exclude examples *
 exclude napari/benchmarks/*
 recursive-exclude resources *
+exclude bundle.py


### PR DESCRIPTION
I noticed this when conda-forge started asking me to include tomlkit in our dependencies!

# Description
We don't need to include bundle.py in our source distribution, since it is an internal developer utility.
