### PR TITLE
New perfmon doc

### DIFF
--- a/docs/source/events/index.rst
+++ b/docs/source/events/index.rst
@@ -6,6 +6,7 @@ Events and Threading
 
    event_loop
    threading
+   perfmon
 
 If you'd like to start customizing the behavior of napari, it pays to
 familiarize yourself with the concept of an Event Loop. For an introduction to
@@ -16,3 +17,7 @@ If you use napari to view and interact with the results of long-running
 computations, and would like to avoid having the viewer become unresponsive
 while you wait for a computation to finish, you may benefit from reading about
 :ref:`multithreading-in-napari`.
+
+Performance is a core feature of napari, and napari contains tools to help
+you monitor performance and diagnose and fix performance problems, see
+:ref:`perfmon`.

--- a/docs/source/events/index.rst
+++ b/docs/source/events/index.rst
@@ -1,5 +1,5 @@
-Events and Threading
-====================
+Guides
+======
 
 .. toctree::
    :maxdepth: 1
@@ -18,6 +18,5 @@ computations, and would like to avoid having the viewer become unresponsive
 while you wait for a computation to finish, you may benefit from reading about
 :ref:`multithreading-in-napari`.
 
-Performance is a core feature of napari, and napari contains tools to help
-you monitor performance and diagnose and fix performance problems, see
-:ref:`perfmon`.
+Performance is a core feature of napari. To learn how to monitor
+performance and diagnose and fix performance problems, see :ref:`perfmon`.

--- a/docs/source/events/perfmon.rst
+++ b/docs/source/events/perfmon.rst
@@ -277,4 +277,4 @@ prints", things you add while investigating a problem, but you do not leave
 them in the code permanently.
 
 You can save JSON files so that you can compare how things looked 
-before and after you changes.
+before and after your changes.

--- a/docs/source/events/perfmon.rst
+++ b/docs/source/events/perfmon.rst
@@ -1,11 +1,10 @@
 .. _perfmon:
 
-Performance Monitoring
-======================
+Performance Monitoring ======================
 
 Performance is a core feature of napari. In order to help you monitor
-performance and diagnose or fix performance issues, napari includes
-:mod:`~napari.utils.perf`. The module has several features:
+performance and diagnose or fix performance issues, napari includes the
+:mod:`~napari.utils.perf` module which has several features:
 
 1. It can time Qt Events and other functions or methods.
 
@@ -14,6 +13,27 @@ duration is over some configurable threshold.
 
 3. It can produce JSON trace files that can be visualized and interactively
 explored using Chrome's tracing GUI.
+
+Monitoring vs. Profiling
+------------------------
+
+Performance Monitoring and Profiling are similar, they are both are ways to
+objectively time the duration of code. Some differences between the two
+tend to be:
+
+1. Monitoring is generally done by the application itself, it does not
+require an external tool. Profiling often requires running a separate tool.
+
+2. Monitoring is generally lighter weight than profiling. In some cases
+profiling can slow an application down so much that it cannot be used
+interactively.
+
+3. Monitoring usually focuses on timing important or expensive functions,
+while profiling often times every function no matter how tiny.
+
+This document focuses only on performance monitoring, but you are encouraged
+to profile Napari and share your findings.
+
 
 Enabling perfmon
 ----------------
@@ -26,17 +46,12 @@ Setting the environment variable to 1 enables perfmon in a mode that can
 only time Qt Events. In order to time other functions and methods, you need
 to use the configuration file.
 
-Configuration File
-------------------
-
-.. code-block:: JSON
+Configuration File ------------------ .. code-block:: python
     {
-        "trace_qt_events": true,
-        "trace_file_on_start": "/path/to/latest.json",
-        "trace_callables": [
+        "trace_qt_events": true, "trace_file_on_start":
+        "/path/to/latest.json", "trace_callables": [
             "chunk_loader"
-        ],
-        "callable_lists": {
+        ], "callable_lists": {
             "chunk_loader": [
                 "napari.components.chunk._loader.ChunkLoader.load_chunk",
                 "napari.components.chunk._loader.ChunkLoader._done"
@@ -44,12 +59,12 @@ Configuration File
         }
     }
 
-Config options
---------------
+Config options --------------
 
-`trace_qt_events` if true perfmon times the duration of all Qt Events. This is
-on by default if `NAPARI_PERFMON=1`. The only reason to turn it off would be
-if the overhead is noticeable, or if you just wanted less clutter in your trace files.
+`trace_qt_events` if true perfmon times the duration of all Qt Events. This
+is on by default if `NAPARI_PERFMON=1`. The only reason to turn it off
+would be if the overhead is noticeable, or if you just wanted less clutter
+in your trace files.
 
 `trace_file_on_start` if set then napari will start recording a trace file
 as soon as it starts. In many cases this is much more convenient than using
@@ -68,8 +83,7 @@ interested in. The reason to not just trace everything is tracing has some
 performance overhead of its own, and tracing too many things will clutter
 the trace file.
 
-Trace File
------------
+Trace File -----------
 
 A performance trace is a JSON file that is viewable using Chrome's tracing
 GUI. The GUI is a development tool that's built-in to Chrome. You can

--- a/docs/source/events/perfmon.rst
+++ b/docs/source/events/perfmon.rst
@@ -1,12 +1,14 @@
 .. _perfmon:
 
-Performance Monitoring ======================
+Performance Monitoring
+======================
 
 Performance is a core feature of napari. In order to help you monitor
 performance and diagnose or fix performance issues, napari includes the
 :mod:`~napari.utils.perf` module which has several features:
 
-1. It can time Qt Events and other functions or methods.
+1. It can time Qt Events and any function or method you specify in the
+config file.
 
 2. It can display a dockable performance widget that will list events whose
 duration is over some configurable threshold.
@@ -18,40 +20,44 @@ Monitoring vs. Profiling
 ------------------------
 
 Performance Monitoring and Profiling are similar, they are both are ways to
-objectively time the duration of code. Some differences between the two
-tend to be:
+time the duration of code execution. This document focuses only on
+performance monitoring, but profiling can also be a productive tool. Some
+differences between the two:
 
 1. Monitoring is generally done by the application itself, it does not
-require an external tool. Profiling often requires running a separate tool.
+require an external tool. Profiling often requires running the application
+using a separate tool.
 
 2. Monitoring is generally lighter weight than profiling. In some cases
 profiling can slow an application down so much that it cannot be used
 interactively.
 
-3. Monitoring usually focuses on timing important or expensive functions,
-while profiling often times every function no matter how tiny.
-
-This document focuses only on performance monitoring, but you are encouraged
-to profile Napari and share your findings.
+3. Monitoring usually focuses on timing specific sets of important or
+expensive functions, while by profiling by default will time every function
+no matter how tiny.
 
 
 Enabling perfmon
 ----------------
 
-To enable perfmonance monitoring set the environment variable
-`NAPARI_PERFMON=1`, or is set to the path of a configuration file such as
+To enable performance monitoring, set the environment variable
+`NAPARI_PERFMON=1`, or set it to the path of a configuration file such as
 `NAPARI_PERFMON=~/.perfmon.json`.
 
 Setting the environment variable to 1 enables perfmon in a mode that can
-only time Qt Events. In order to time other functions and methods, you need
+only time Qt Events. In order to time other functions and methods you need
 to use the configuration file.
 
-Configuration File ------------------ .. code-block:: python
+Configuration File ------------------
+
+.. code-block:: python
     {
-        "trace_qt_events": true, "trace_file_on_start":
-        "/path/to/latest.json", "trace_callables": [
+        "trace_qt_events": true,
+        "trace_file_on_start": "/path/to/latest.json",
+        "trace_callables": [
             "chunk_loader"
-        ], "callable_lists": {
+        ],
+        "callable_lists": {
             "chunk_loader": [
                 "napari.components.chunk._loader.ChunkLoader.load_chunk",
                 "napari.components.chunk._loader.ChunkLoader._done"
@@ -59,7 +65,8 @@ Configuration File ------------------ .. code-block:: python
         }
     }
 
-Config options --------------
+Config options
+--------------
 
 `trace_qt_events` if true perfmon times the duration of all Qt Events. This
 is on by default if `NAPARI_PERFMON=1`. The only reason to turn it off
@@ -83,7 +90,8 @@ interested in. The reason to not just trace everything is tracing has some
 performance overhead of its own, and tracing too many things will clutter
 the trace file.
 
-Trace File -----------
+Trace File
+-----------
 
 A performance trace is a JSON file that is viewable using Chrome's tracing
 GUI. The GUI is a development tool that's built-in to Chrome. You can
@@ -95,7 +103,3 @@ Google "Trace Event Format" for the Google Doc which specifies the trace
 file format. The format is well-documented, but the document does not
 generally explain how a given feature actually looks in the Chrome Tracing
 GUI.
-
-
-
-

--- a/docs/source/events/perfmon.rst
+++ b/docs/source/events/perfmon.rst
@@ -5,50 +5,48 @@ Performance Monitoring
 
 Performance is a core feature of napari. In order to help you monitor
 performance and diagnose or fix performance issues, napari includes the
-:mod:`~napari.utils.perf` module which has several features:
+`napari.utils.`:mod:`~napari.utils.perf` module which has several features:
 
-1. It can time Qt Events and any function or method you specify in the
-config file.
+1. Times Qt Events 
 
-2. It can display a dockable performance widget that will list events whose
-duration is over some configurable threshold.
+2. Times any function or method you specify in the config file.
 
-3. It can produce JSON trace files that can be visualized and interactively
-explored using Chrome's tracing GUI.
+3. Displays a dockable "performance widget" that lists "long running" timers.
+
+4. Produces JSON trace files that can be visualized using Chrome's built-in
+tracing GUI.
 
 Monitoring vs. Profiling
 ------------------------
 
-Performance Monitoring and Profiling are similar, they are both are ways to
-time the duration of code execution. This document focuses only on
-performance monitoring, but profiling can also be a productive tool. Some
-differences between the two:
+Profiling is similar to monitoring. Although generally profiling involves
+using an external tool which times every function and method. Instead
+monitoring tends to be built-in to the application. And with monitoring you
+usually only time a small set of functions and methods.
 
-1. Monitoring is generally done by the application itself, it does not
-require an external tool. Profiling often requires running the application
-using a separate tool.
+Profiling sometimes slows an application down to the point where you cannot
+use it normally. While the intent of monitoring is that you can monitor 
+while still using the application normally.
 
-2. Monitoring is generally lighter weight than profiling. In some cases
-profiling can slow an application down so much that it cannot be used
-interactively.
-
-3. Monitoring usually focuses on timing specific sets of important or
-expensive functions, while by profiling by default will time every function
-no matter how tiny.
+This document discusses napari's Performance Monitoring features. Profiling
+napari might also be a good approach to try, but it is not discussed here.
 
 
 Enabling perfmon
 ----------------
 
-To enable performance monitoring, set the environment variable
-`NAPARI_PERFMON=1`, or set it to the path of a configuration file such as
-`NAPARI_PERFMON=~/.perfmon.json`.
+There are two ways to enable performance monitoring.
 
-Setting the environment variable to 1 enables perfmon in a mode that can
-only time Qt Events. In order to time other functions and methods you need
-to use the configuration file.
+1. Set the environment variable `NAPARI_PERFMON=1`. This will time
+Qt events, show the dockable widget, and reveal the **Performance Trace**
+menu items on the **Debug** menu.
 
-Configuration File ------------------
+2. Set that same environment variable to point to a JSON config file such as
+`NAPARI_PERFMON=~/.perfmon-config.json`. This gives you additional options
+describe below.
+
+Configuration File
+------------------
 
 .. code-block:: python
     {

--- a/docs/source/events/perfmon.rst
+++ b/docs/source/events/perfmon.rst
@@ -5,7 +5,9 @@ Performance Monitoring
 
 If napari is not performing well, you can use the
 :mod:`napari.utils.perf<napari.utils.perf>` to help
-diagnose the problem. The module can do several things:
+diagnose the problem.
+
+The module can do several things:
 
 1. Time Qt Events 
 
@@ -13,21 +15,20 @@ diagnose the problem. The module can do several things:
 
 3. Write JSON trace files viewable with `chrome://tracing`.
 
-4. Time any function or method you specify in the config file.
+4. Time any function that you specify in the config file.
 
 Monitoring vs. Profiling
 ------------------------
 
-Profiling is similar to performance monitoring. Profiling usually
-involves running an external tool to acquire timing data on
-every function and method in the program. Sometimes this will
-cause the program to run so slowly it's hard to use the program
-interactively.
+Profiling is similar to performance monitoring. Profiling usually involves
+running an external tool to acquire timing data on every function in the
+program. Sometimes this will cause the program to run so slowly it's hard
+to use the program interactively.
 
 Performance monitoring does not require running a separate tool to collect
 the timing information. Although we do use Chrome to view the trace files.
-If you don't time too many functions and and methods, the program can run
-at close to full speed.
+If you don't time too many functions the napari can run at close to full
+speed.
 
 This document discusses napari's Performance Monitoring features. Profiling
 napari might be useful as well, but it is not discussed here.
@@ -96,8 +97,8 @@ Specify which `callable_lists` you want to trace. You can have many
 `callable_lists`
 ~~~~~~~~~~~~~~~~
 
-These lists can be referenced by the `callable_lists` option. For example
-you might want one list for "rendering" and another for "painting".
+These lists can be referenced by the `callable_lists` option. You might
+want multiple lists so they can be enabled separately.
 
 Trace File
 -----------
@@ -165,7 +166,7 @@ Now run napari's `add_labels` example like this:
     NAPARI_PERFMON=/tmp/perfmon.json python examples/add_labels.py
 
 Use the paint tool to draw on the labels layer. Notice in the
-**performance** widget it prints some events took over 100ms. It says both
+**performance** widget it says some events took over 100ms. It says both
 events took over 100ms, but really one probably called the other one, the
 call hierarchy is not shown:
 
@@ -179,10 +180,8 @@ View Trace in Chrome
 Run Chrome and go to the URL `chrome://tracing`. Drag and drop
 `/temp/latest.json` into the Chrome window. You can navigate multiple ways,
 but one easy way is use the `AD` keys to move left and right, and use `WS`
-keys to zoom in or out.
-
-Locate one of the slow `MouseMove` events and click on it. In the lower
-pane the `Wall Duration` field says it took over 100ms:
+keys to zoom in or out. Locate one of the slow `MouseMove` events and click
+on it. In the lower pane the `Wall Duration` field says it took over 100ms:
 
 .. image:: https://user-images.githubusercontent.com/4163446/94200256-1fc17180-fe88-11ea-9935-bef4f818407d.png
 
@@ -217,16 +216,20 @@ command.
 View the new Trace File
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Drop `/tmp/latest.json` into Chrome again. After clicking on the event
-press the `m` key to show the duration of that event on the timeline,
-below it says the event took 106.597ms:
+Drop `/tmp/latest.json` into Chrome again. Now we can see that
+`MouseButtonPress` calls
+:meth:`Labels.paint<napari.layer.labels.Label.paint>` and that
+:meth:`Labels.paint<napari.layer.labels.Label.paint>` is really responsible
+for most of the time. After clicking on the event press the `m` key, that
+will highlight the event duration with arrows and print the duration right
+on the timeline, in this case it says the even took  106.597ms:
 
 .. image:: https://user-images.githubusercontent.com/4163446/94201049-66fc3200-fe89-11ea-9720-6a7ff3c7361a.png
 
-We added the timer for :meth:`Labels.paint<napari.layer.labels.Label.paint>` and now we see that `MouseButtonPress`
-takes is slow because :meth:`Labels.paint<napari.layer.labels.Label.paint>` is slow. When
-investigating a real problem we might have to add quite a few timers. We can save 
-the `callable_list` for future use.
+When investigating a real problem we might have to add quite a few timers. If
+add timers that are called hundreds of times that might slow things down
+or clutter the trace file. In general we want to trace important and interesting
+functions. If we create a large `callable_list` we can save it for future use.
 
 Advanced
 ~~~~~~~~
@@ -237,8 +240,7 @@ what you care about will yield the best performance and lead to trace files
 that are easier to understand.
 
 Use the :func:`perf_timer<napari.utils.perf.perf_timer>` context object to
-time a single block of code, if you don't want to time an entire function
-or method.
+time a single block of code, if you don't want to time an entire function.
 
 Use :func:`add_instant_event<napari.utils.perf.add_instant_event>` and
 :func:`add_counter_event<napari.utils.perf.add_counter_event>` to annotate

--- a/docs/source/events/perfmon.rst
+++ b/docs/source/events/perfmon.rst
@@ -1,0 +1,87 @@
+.. _perfmon:
+
+Performance Monitoring
+======================
+
+Performance is a core feature of napari. In order to help you monitor
+performance and diagnose or fix performance issues, napari includes
+:mod:`~napari.utils.perf`. The module has several features:
+
+1. It can time Qt Events and other functions or methods.
+
+2. It can display a dockable performance widget that will list events whose
+duration is over some configurable threshold.
+
+3. It can produce JSON trace files that can be visualized and interactively
+explored using Chrome's tracing GUI.
+
+Enabling perfmon
+----------------
+
+To enable perfmonance monitoring set the environment variable
+`NAPARI_PERFMON=1`, or is set to the path of a configuration file such as
+`NAPARI_PERFMON=~/.perfmon.json`.
+
+Setting the environment variable to 1 enables perfmon in a mode that can
+only time Qt Events. In order to time other functions and methods, you need
+to use the configuration file.
+
+Configuration File
+------------------
+
+.. code-block:: JSON
+    {
+        "trace_qt_events": true,
+        "trace_file_on_start": "/path/to/latest.json",
+        "trace_callables": [
+            "chunk_loader"
+        ],
+        "callable_lists": {
+            "chunk_loader": [
+                "napari.components.chunk._loader.ChunkLoader.load_chunk",
+                "napari.components.chunk._loader.ChunkLoader._done"
+            ]
+        }
+    }
+
+Config options
+--------------
+
+`trace_qt_events` if true perfmon times the duration of all Qt Events. This is
+on by default if `NAPARI_PERFMON=1`. The only reason to turn it off would be
+if the overhead is noticeable, or if you just wanted less clutter in your trace files.
+
+`trace_file_on_start` if set then napari will start recording a trace file
+as soon as it starts. In many cases this is much more convenient than using
+the Debug Menu. Simply run napari, do what you want to test, and exit. Be
+sure to exist with the Quit option. The trace file is only written on exit,
+because otherwise writing the file would alter the timing of things.
+
+`trace_callables` is how you trace function and methods. Tracing Qt Events
+is a great start, but often you will need to add many functions and methods
+during the investigation of a performance issue.
+
+`callable_lists` let you define lists of callables that you can toggle on
+with the `trace_callables` setting. The idea is you can have a number of
+pre-defined sets of callables, and then toggle on just the ones you are
+interested in. The reason to not just trace everything is tracing has some
+performance overhead of its own, and tracing too many things will clutter
+the trace file.
+
+Trace File
+-----------
+
+A performance trace is a JSON file that is viewable using Chrome's tracing
+GUI. The GUI is a development tool that's built-in to Chrome. You can
+access the GUI by going to the special URL `chrome://tracing` in Chrome.
+You can also those same files using the Speedscope website at
+https://www.speedscope.app/.
+
+Google "Trace Event Format" for the Google Doc which specifies the trace
+file format. The format is well-documented, but the document does not
+generally explain how a given feature actually looks in the Chrome Tracing
+GUI.
+
+
+
+

--- a/docs/source/events/perfmon.rst
+++ b/docs/source/events/perfmon.rst
@@ -83,7 +83,7 @@ your trace file to be less cluttered.
 ~~~~~~~~~~~~~~~~~~~~~
 
 If a path is given, napari will start tracing immediately on start. In many
-cases this is much more convenient than using the Debug Menu. Be sure to
+cases this is much more convenient than using the **Debug** Menu. Be sure to
 exit napari using the **Quit** command. The trace file will be written on
 exit.
 
@@ -103,14 +103,13 @@ Trace File
 -----------
 
 The trace file that napari produces is viewable in Chrome. Go to the
-special URL `chrome://tracing` in Chrome. Use the **Load** button inside
-the Chrome window, or just drag-n-drop your JSON trace file into the Chrome
-window.
+special URL `chrome://tracing`. Use the **Load** button inside the Chrome
+window, or just drag-n-drop your JSON trace file into the Chrome window.
+You can also view trace files using the `Speedscope website
+<https://www.speedscope.app/>`__. It is similar to `chrome://tracing` but
+has some different features.
 
-You can also view trace files using the `Speedscope website<https://www.speedscope.app/>`_. It is similar to `chrome://tracing` but has
-some different features.
-
-The trace file format is specified in the `Trace File Format<https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview>`_
+The trace file format is specified in the `Trace File Format <https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview>`__
 Google Doc. The format is well-documented, but there are no pictures so
 it's not always clear how a given feature actually looks in the Chrome
 Tracing GUI.
@@ -118,12 +117,13 @@ Tracing GUI.
 Example Investigation
 ---------------------
 
-This is an example showing how you might use the perfmon module.
+This is an example showing how you might use the
+:mod:`napari.utils.perf<napari.utils.perf>` module.
 
 Add a Sleep
 ~~~~~~~~~~~
 
-To simulate a performance problem in napari  add a `sleep()` call to the
+To simulate a performance problem in napari, add a `sleep()` call to the
 :meth:`Labels.paint<napari.layer.labels.Label.paint>` method, this 
 will make the method take at least 100ms:
 
@@ -192,15 +192,19 @@ the lower pane the `Wall Duration` field says it took over 100ms:
 
 .. image:: https://user-images.githubusercontent.com/4163446/94200256-1fc17180-fe88-11ea-9935-bef4f818407d.png
 
-So we've found an event that's slow. But what about `MouseButtonPress` or `MouseMove`
-is running slow?
+So we can see that some events are running slow. The next questions is
+why are `MouseButtonPress` or `MouseMove` is running slow? To answer this
+question we can add more timers. In this case we know the answer, but often
+you will have to guess or experiment. You might add some timers and then
+find out they actually runs fast, so you can remove them.
 
 Add Paint Method
 ~~~~~~~~~~~~~~~~
 
-Add :meth:`Labels.paint<napari.layer.labels.Label.paint>` to the trace.
-Create a new list of callables called `labels` which will trace the paint
-method:
+To add the :meth:`Labels.paint<napari.layer.labels.Label.paint>` method to
+the trace, create a new list of callables named `labels` and put the
+:meth:`Labels.paint<napari.layer.labels.Label.paint>` method into 
+that list.
 
 .. code-block:: json
 
@@ -271,3 +275,6 @@ Calls to `perf_timer`, `add_instant_event` and `add_counter_event` should
 be removed before merging code into master. Think of them like "debug
 prints", things you add while investigating a problem, but you do not leave
 them in the code permanently.
+
+You can save JSON files so that you can compare how things looked 
+before and after you changes.

--- a/docs/source/events/perfmon.rst
+++ b/docs/source/events/perfmon.rst
@@ -3,55 +3,60 @@
 Performance Monitoring
 ======================
 
-Performance is a core feature of napari. In order to help you monitor
-performance and diagnose or fix performance issues, napari includes the
-`napari.utils.`:mod:`~napari.utils.perf` module which has several features:
+If napari is not performing well, you can use the
+:mod:`napari.utils.perf<napari.utils.perf>` to help
+diagnose the problem. The module can do several things:
 
-1. Times Qt Events 
+1. Time Qt Events 
 
-2. Times any function or method you specify in the config file.
+2. Display a dockable **performance** widget.
 
-3. Displays a dockable "performance widget" that lists "long running" timers.
+3. Write JSON trace files viewable with `chrome://tracing`.
 
-4. Produces JSON trace files that can be visualized using Chrome's built-in
-tracing GUI.
+4. Time any function or method you specify in the config file.
 
 Monitoring vs. Profiling
 ------------------------
 
-Profiling is similar to monitoring. Although generally profiling involves
-using an external tool which times every function and method. Instead
-monitoring tends to be built-in to the application. And with monitoring you
-usually only time a small set of functions and methods.
+Profiling is similar to performance monitoring. Profiling usually
+involves running an external tool to acquire timing data on
+every function and method in the program. Sometimes this will
+cause the program to run so slowly it's hard to use the program
+interactively.
 
-Profiling sometimes slows an application down to the point where you cannot
-use it normally. While the intent of monitoring is that you can monitor 
-while still using the application normally.
+Performance monitoring does not require running a separate tool to collect
+the timing information. Although we do use Chrome to view the trace files.
+If you don't time too many functions and and methods, the program can run
+at close to full speed.
 
 This document discusses napari's Performance Monitoring features. Profiling
-napari might also be a good approach to try, but it is not discussed here.
+napari might be useful as well, but it is not discussed here.
 
 
 Enabling perfmon
 ----------------
 
-There are two ways to enable performance monitoring.
+There are two ways to enable performance monitoring. Set the environment
+variable `NAPARI_PERFMON=1` or set `NAPARI_PERFMON` to the path of 
+a JSON configuration file, for example `NAPARI_PERFMON=/tmp/perfmon.json`.
 
-1. Set the environment variable `NAPARI_PERFMON=1`. This will time
-Qt events, show the dockable widget, and reveal the **Performance Trace**
-menu items on the **Debug** menu.
+Setting `NAPARI_PERFMON=1` does three things:
 
-2. Set that same environment variable to point to a JSON config file such as
-`NAPARI_PERFMON=~/.perfmon-config.json`. This gives you additional options
-describe below.
+1. Time Qt Events
+2. Show the dockable **performance** widget.
+3. Reveal the **Debug** menu which you can use to create a trace file.
 
-Configuration File
-------------------
 
-.. code-block:: python
+Configuration File Format
+-------------------------
+
+Example configuration file:
+
+.. code-block:: json
+
     {
         "trace_qt_events": true,
-        "trace_file_on_start": "/path/to/latest.json",
+        "trace_file_on_start": "/tmp/latest.json",
         "trace_callables": [
             "chunk_loader"
         ],
@@ -63,41 +68,180 @@ Configuration File
         }
     }
 
-Config options
---------------
 
-`trace_qt_events` if true perfmon times the duration of all Qt Events. This
-is on by default if `NAPARI_PERFMON=1`. The only reason to turn it off
-would be if the overhead is noticeable, or if you just wanted less clutter
-in your trace files.
+Configuration Options
+---------------------
 
-`trace_file_on_start` if set then napari will start recording a trace file
-as soon as it starts. In many cases this is much more convenient than using
-the Debug Menu. Simply run napari, do what you want to test, and exit. Be
-sure to exist with the Quit option. The trace file is only written on exit,
-because otherwise writing the file would alter the timing of things.
+`trace_qt_events` 
+~~~~~~~~~~~~~~~~~
 
-`trace_callables` is how you trace function and methods. Tracing Qt Events
-is a great start, but often you will need to add many functions and methods
-during the investigation of a performance issue.
+If true perfmon will time the duration of all Qt Events. You might
+want to turn this off if the overhead is noticeable, or if you want
+your trace file to be less cluttered.
 
-`callable_lists` let you define lists of callables that you can toggle on
-with the `trace_callables` setting. The idea is you can have a number of
-pre-defined sets of callables, and then toggle on just the ones you are
-interested in. The reason to not just trace everything is tracing has some
-performance overhead of its own, and tracing too many things will clutter
-the trace file.
+`trace_file_on_start`
+~~~~~~~~~~~~~~~~~~~~~
+
+If a path is given, napari will start tracing immediately on start. In many
+cases this is much more convenient than using the Debug Menu. Be sure to
+exit napari using the **Quit** command. The trace file will be written on
+exit.
+
+`trace_callables`
+~~~~~~~~~~~~~~~~~
+
+Specify which `callable_lists` you want to trace. You can have many
+`callable_lists` defined, but this setting says which should be traced.
+
+`callable_lists`
+~~~~~~~~~~~~~~~~
+
+These lists can be referenced by the `callable_lists` option. For example
+you might want one list for "rendering" and another for "painting".
 
 Trace File
 -----------
 
-A performance trace is a JSON file that is viewable using Chrome's tracing
-GUI. The GUI is a development tool that's built-in to Chrome. You can
-access the GUI by going to the special URL `chrome://tracing` in Chrome.
-You can also those same files using the Speedscope website at
-https://www.speedscope.app/.
+The trace file that napari produces is viewable in Chrome. Go to the
+special URL `chrome://tracing` in Chrome. Use the **Load** button inside
+the Chrome window, or just drag-n-drop your JSON trace file into the Chrome
+window.
 
-Google "Trace Event Format" for the Google Doc which specifies the trace
-file format. The format is well-documented, but the document does not
-generally explain how a given feature actually looks in the Chrome Tracing
-GUI.
+You can also view trace files using the Speedscope website at
+https://www.speedscope.app/. It is similar to `chrome://tracing` but has
+some different features.
+
+The trace file format is specifed in the [Trace File Format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview)
+Google Doc. The format is well-documented, but there are no pictures so
+it's not always clear how a given feature actually looks in the Chrome
+Tracing GUI.
+
+Example Investigation
+---------------------
+
+Add a Sleep
+~~~~~~~~~~~
+
+To simulate part of napari running slow, add a `sleep()` call to the
+:meth:`Labels.paint<napari.layer.labels.Label.paint>` method, this 
+will make the method take at least 100ms:
+
+.. code-block:: python
+   :emphasize-lines: 2-3
+
+    def paint(self, coord, new_label, refresh=True):
+        import time
+        time.sleep(0.1)
+
+        if refresh is True:
+            self._save_history()
+
+
+Create a Perfmon Config File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create a minimal perfmon config file `/tmp/perfmon.json` like this:
+
+.. code-block:: json
+
+    {
+        "trace_qt_events": true,
+        "trace_file_on_start": "/tmp/latest.json",
+        "trace_callables": []
+    }
+
+This will write `/tmp/latest.json` every time we run napari and then exit
+with the **Quit** commmand. This is often easier than manually start a trace
+using the **Debug** menu. 
+
+
+Run napari
+~~~~~~~~~~
+
+Now run napari's `add_labels` example like this:
+
+.. code-block:: shell
+
+    NAPARI_PERFMON=/tmp/perfmon.json python examples/add_labels.py
+
+Use the paint tool to draw on the labels layer. Notice in the
+**performance** widget it prints some events took over 100ms. It says both
+events took over 100ms, but really one probably called the other one, the
+call hierarchy is not shown:
+
+.. image:: https://user-images.githubusercontent.com/4163446/94198620-898c4c00-fe85-11ea-8769-83f52c0a1aad.png
+
+Exit napari using the **Quit** command so that it writes the trace file on exit.
+
+View Trace in Chrome
+~~~~~~~~~~~~~~~~~~~~
+
+Run Chrome and go to the URL `chrome://tracing`. Drag and drop
+`/temp/latest.json` into the Chrome window. You can navigate multiple ways,
+but one easy way is use the `AD` keys to move left and right, and use `WS`
+keys to zoom in or out.
+
+Locate one of the slow `MouseMove` events and click on it. In the lower
+pane the `Wall Duration` field says it took over 100ms:
+
+.. image:: https://user-images.githubusercontent.com/4163446/94200256-1fc17180-fe88-11ea-9935-bef4f818407d.png
+
+Add Paint Method
+~~~~~~~~~~~~~~~~
+
+The `MouseMove` event was slow, but why was it slow? Add :meth:`Labels.paint<napari.layer.labels.Label.paint>` to
+the trace. Create a new list of callables called `labels` which will trace
+the paint method:
+
+.. code-block:: json
+
+    {
+        "trace_qt_events": true,
+        "trace_file_on_start": "/tmp/latest.json",
+        "trace_callables": [
+            "labels"
+        ],
+        "callable_lists": {
+            "labels": [
+                "napari.layers.labels.Labels.paint"
+            ]
+        }
+    }
+
+Create the new Trace File
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Run `add_labels` as before, use the paint tool, exit with the **Quit**
+command.
+
+View the new Trace File
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Drop `/tmp/latest.json` into Chrome again. After clicking on the event
+press the `m` key to show the duration of that event on the timeline,
+below it says the event took 106.597ms:
+
+.. image:: https://user-images.githubusercontent.com/4163446/94201049-66fc3200-fe89-11ea-9720-6a7ff3c7361a.png
+
+We added the timer for :meth:`Labels.paint<napari.layer.labels.Label.paint>` and now we see that `MouseButtonPress`
+takes is slow because :meth:`Labels.paint<napari.layer.labels.Label.paint>` is slow. When
+investigating a real problem we might have to add quite a few timers. We can save 
+the `callable_list` for future use.
+
+Advanced
+~~~~~~~~
+
+Create multiple `callable_lists` and toggle them on or off depending on
+what you are investigating. The perfmon overhead is low, but tracing only
+what you care about will yield the best performance and lead to trace files
+that are easier to understand.
+
+Use the :func:`perf_timer<napari.utils.perf.perf_timer>` context object to
+time a single block of code, if you don't want to time an entire function
+or method.
+
+Use :func:`add_instant_event<napari.utils.perf.add_instant_event>` and
+:func:`add_counter_event<napari.utils.perf.add_counter_event>` to annotate
+your trace file with additional information beyond just timing events. These
+commands should be removed before merging code into master, they are for
+temporary use only.


### PR DESCRIPTION
# Description
* Added a new guide for the `napari.utils.perf` module.
* Renamed heading from **Events and Threading** to **Guides** since there are now 3 docs in that folder.
* Images are hyperlinks to the GitHub hosted images in the PR. A trick to avoid putting binaries into the repo. Maybe we will come up with a better image hosting approach later. GitHub could disable this out from under us someday.

Guide is just an invented name, I'm open to other suggestions. New website might change this.

## Type of change
- [x] New documentation
