### PR TITLE
Fix #1631 by creating a new slice every time

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3.7
+    python: python3.8
 repos:
 -   repo: https://github.com/pycqa/isort
     rev: 5.3.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3.8
+    python: python3.7
 repos:
 -   repo: https://github.com/pycqa/isort
     rev: 5.3.2

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -1,8 +1,16 @@
+import collections
 import os
 import sys
 
 import numpy as np
 import pytest
+
+from napari.utils.interactions import (
+    ReadOnlyWrapper,
+    mouse_move_callbacks,
+    mouse_press_callbacks,
+    mouse_release_callbacks,
+)
 
 
 @pytest.mark.skipif(
@@ -355,3 +363,54 @@ def test_changing_image_attenuation(make_test_viewer):
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that rendering has been attenuated
     assert screenshot[center + (0,)] < 60
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith('win') or not os.getenv("CI"),
+    reason='Screenshot tests are not supported on napari windows CI.',
+)
+def test_labels_painting(make_test_viewer):
+    """Test painting labels updates image."""
+    data = np.zeros((100, 100))
+
+    viewer = make_test_viewer(show=True)
+    viewer.add_labels(data)
+    layer = viewer.layers[0]
+
+    screenshot = viewer.screenshot(canvas_only=True)
+
+    # Check that no painting has occurred
+    assert layer.data.max() == 0
+    assert screenshot[:, :, :2].max() == 0
+
+    # Enter paint mode
+    layer.position = (0, 0)
+    layer.mode = 'paint'
+    layer.selected_label = 3
+
+    # Simulate click
+    Event = collections.namedtuple(
+        'Event', field_names=['type', 'is_dragging']
+    )
+
+    # Simulate click
+    event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
+    mouse_press_callbacks(layer, event)
+
+    layer.position = (100, 100)
+
+    # Simulate drag
+    event = ReadOnlyWrapper(Event(type='mouse_move', is_dragging=True))
+    mouse_move_callbacks(layer, event)
+
+    # Simulate release
+    event = ReadOnlyWrapper(Event(type='mouse_release', is_dragging=False))
+    mouse_release_callbacks(layer, event)
+
+    event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
+    mouse_press_callbacks(layer, event)
+
+    screenshot = viewer.screenshot(canvas_only=True)
+    # Check that painting has now occurred
+    assert layer.data.max() > 0
+    assert screenshot[:, :, :2].max() > 0

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -219,11 +219,7 @@ class Image(IntensityVisualizationMixin, Layer):
             self._thumbnail_level = 0
         self.corner_pixels[1] = self.level_shapes[self._data_level]
 
-        # Initialize the current slice to an empty image.
-        self._slice = ImageSlice(
-            self._get_empty_image(), self._raw_to_displayed, self.rgb
-        )
-        self._empty = True
+        self._new_empty_slice()
 
         # Set contrast_limits and colormaps
         self._gamma = gamma
@@ -249,6 +245,14 @@ class Image(IntensityVisualizationMixin, Layer):
 
         # Trigger generation of view slice and thumbnail
         self._update_dims()
+
+    def _new_empty_slice(self):
+        """Initialize the current slice to an empty image.
+        """
+        self._slice = ImageSlice(
+            self._get_empty_image(), self._raw_to_displayed, self.rgb
+        )
+        self._empty = True
 
     def _get_empty_image(self):
         """Get empty image to use as the default before data is loaded.
@@ -495,6 +499,7 @@ class Image(IntensityVisualizationMixin, Layer):
 
     def _set_view_slice(self):
         """Set the view given the indices to slice with."""
+        self._new_empty_slice()
         not_disp = self.dims.not_displayed
 
         # Check if requested slice outside of data range
@@ -511,9 +516,6 @@ class Image(IntensityVisualizationMixin, Layer):
                 [extent[1, ax] - 1 for ax in not_disp],
             )
         ):
-            self._slice.image.raw = self._get_empty_image()
-            self._slice.thumbnail.raw = self._get_empty_image()
-            self._empty = True
             return
         self._empty = False
 


### PR DESCRIPTION
# Description
Fix #1631 by creating a new slice every time `_set_view_slice()` is called. So when the labels layer calls `refresh()` we refresh the slice and the painting is displayed correctly.

# Explanation
The idea that we needed to preserve a slice even when `_set_view_slice()` was based on async work that I think is moot now. It was based on an update-loop type of bug where `_set_view_slice()` was called redundantly.

With that fixed it's safe to just create an entire new slice. This will work even with the async branch. This is much cleaner anyway so `_set_view_slice()` means "create the slice" and not "update the slice".

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality