### PR TITLE
Speed up points selection and selection display

### DIFF
--- a/docs/release/release_0_3_8.md
+++ b/docs/release/release_0_3_8.md
@@ -19,7 +19,7 @@ and (#1643). This will also be our last release supporting Python3.6.
 ## Improvements
 - Async-2.5: Vispy Changes (#1607)
 - Increase screenshot performance (#1615)
-
+- Speed up points selection and selection display (#1648)
 
 ## Bug Fixes
 - Remove silence overwritte during screenshot (#1567)
@@ -45,6 +45,7 @@ and (#1643). This will also be our last release supporting Python3.6.
 - [Grzegorz Bokota](https://github.com/napari/napari/commits?author=Czaki) - @Czaki
 - [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) - @jni
 - [Kira Evans](https://github.com/napari/napari/commits?author=kne42) - @kne42
+- [Matthias Wagner](https://github.com/napari/napari/commits?author=matthias-us) - @matthias-us
 - [Philip Winston](https://github.com/napari/napari/commits?author=pwinston) - @pwinston
 - [Talley Lambert](https://github.com/napari/napari/commits?author=tlambert03) - @tlambert03
 - [Ziyang Liu](https://github.com/napari/napari/commits?author=ziyangczi) - @ziyangczi

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1175,12 +1175,11 @@ class Points(Layer):
     @selected_data.setter
     def selected_data(self, selected_data):
         self._selected_data = set(selected_data)
-        selected = []
-        for c in self._selected_data:
-            if c in self._indices_view:
-                ind = list(self._indices_view).index(c)
-                selected.append(ind)
-        self._selected_view = selected
+        _, _, self._selected_view = np.intersect1d(
+            np.array(list(self._selected_data)),
+            self._indices_view,
+            return_indices=True,
+        )
 
         # Update properties based on selected points
         if len(self._selected_data) == 0:
@@ -1479,12 +1478,11 @@ class Points(Layer):
         self._view_size_scale = scale
         self._indices_view = indices
         # get the selected points that are in view
-        selected = []
-        for c in self.selected_data:
-            if c in self._indices_view:
-                ind = list(self._indices_view).index(c)
-                selected.append(ind)
-        self._selected_view = selected
+        _, _, self._selected_view = np.intersect1d(
+            np.array(list(self._selected_data)),
+            self._indices_view,
+            return_indices=True,
+        )
         with self.events.highlight.blocker():
             self._set_highlight(force=True)
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1175,10 +1175,12 @@ class Points(Layer):
     @selected_data.setter
     def selected_data(self, selected_data):
         self._selected_data = set(selected_data)
-        _, _, self._selected_view = np.intersect1d(
-            np.array(list(self._selected_data)),
-            self._indices_view,
-            return_indices=True,
+        self._selected_view = list(
+            np.intersect1d(
+                np.array(list(self._selected_data)),
+                self._indices_view,
+                return_indices=True,
+            )[2]
         )
 
         # Update properties based on selected points
@@ -1478,10 +1480,12 @@ class Points(Layer):
         self._view_size_scale = scale
         self._indices_view = indices
         # get the selected points that are in view
-        _, _, self._selected_view = np.intersect1d(
-            np.array(list(self._selected_data)),
-            self._indices_view,
-            return_indices=True,
+        self._selected_view = list(
+            np.intersect1d(
+                np.array(list(self._selected_data)),
+                self._indices_view,
+                return_indices=True,
+            )[2]
         )
         with self.events.highlight.blocker():
             self._set_highlight(force=True)


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
Refactored point selection and selection display code, specifically where selected points are compared against points in currently viewed slice. For large numbers of points in layer (50K+), this brings the time to complete a selection from ~5msec/point to <0.5µsec/point (~25sec --> ~2.5msec) for a 5K-point selection.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] ran in made-up test cases (100K points, 5+ slices) with GUI selection
- [x] ran in case where points are selected both in GUI and programatically

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
