### PR TITLE
Add github retry action to try and fix flaky app bundling for releases

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          cmd: python -m bundle
+          command: python -m bundle
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -51,19 +51,19 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          run: python -m bundle
+          cmd: python -m bundle
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
           name: napari-${{ env.version }}-${{ runner.os }}.zip
           path: napari-${{ env.version }}-${{ runner.os }}.zip
-      - name: Get Release
-        id: get_release
-        uses: bruceadams/get-release@v1.2.0
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: napari-${{ env.version }}-${{ runner.os }}.zip
-          asset_name: napari-${{ env.version }}-${{ runner.os }}.zip
-          asset_content_type: application/zip
+      # - name: Get Release
+      #   id: get_release
+      #   uses: bruceadams/get-release@v1.2.0
+      # - name: Upload Release Asset
+      #   uses: actions/upload-release-asset@v1
+      #   with:
+      #     upload_url: ${{ steps.get_release.outputs.upload_url }}
+      #     asset_path: napari-${{ env.version }}-${{ runner.os }}.zip
+      #     asset_name: napari-${{ env.version }}-${{ runner.os }}.zip
+      #     asset_content_type: application/zip

--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Make Bundle
         uses: nick-invision/retry@v1
         with:
-          timeout_minutes: 30
+          timeout_minutes: 10
           max_attempts: 3
           command: python -m bundle
       - name: Upload Artifact

--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -1,8 +1,8 @@
 on:
   push:
     # Sequence of patterns matched against refs/tags
-    # tags:
-    #   - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 name: Create App Bundle
 
@@ -57,13 +57,13 @@ jobs:
         with:
           name: napari-${{ env.version }}-${{ runner.os }}.zip
           path: napari-${{ env.version }}-${{ runner.os }}.zip
-      # - name: Get Release
-      #   id: get_release
-      #   uses: bruceadams/get-release@v1.2.0
-      # - name: Upload Release Asset
-      #   uses: actions/upload-release-asset@v1
-      #   with:
-      #     upload_url: ${{ steps.get_release.outputs.upload_url }}
-      #     asset_path: napari-${{ env.version }}-${{ runner.os }}.zip
-      #     asset_name: napari-${{ env.version }}-${{ runner.os }}.zip
-      #     asset_content_type: application/zip
+      - name: Get Release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.0
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: napari-${{ env.version }}-${{ runner.os }}.zip
+          asset_name: napari-${{ env.version }}-${{ runner.os }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -1,8 +1,8 @@
 on:
   push:
     # Sequence of patterns matched against refs/tags
-    tags:
-      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+    # tags:
+    #   - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 name: Create App Bundle
 

--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -37,7 +37,7 @@ jobs:
             -- :99 -screen 0 1920x1200x24 -ac +extension GLX
       - name: Install Dependencies
         run: |
-          python -m pip install --upgrade pip 
+          python -m pip install --upgrade pip
           python -m pip install briefcase==0.3.1 tomlkit wheel
           python -m pip install -e .[pyside2]
       - name: get tag
@@ -47,7 +47,11 @@ jobs:
           echo "::set-env name=version::$VER"
           echo $VER
       - name: Make Bundle
-        run: python -m bundle
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          run: python -m bundle
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:

--- a/docs/release/release_0_3_8.md
+++ b/docs/release/release_0_3_8.md
@@ -36,10 +36,12 @@ and (#1643). This will also be our last release supporting Python3.6.
 - Use pyside2-rcc if pyrcc5 fail (#1626)
 - Big update of rendering explanation doc (#1632)
 - Do not ship bundle.py in source distribution (#1633)
+- Add github retry action to try and fix flaky app bundling (#1649)
 
 
 ## 6 authors added to this release (alphabetical)
 
+- [Genevieve Buckley](https://github.com/napari/napari/commits?author=GenevieveBuckley) - @GenevieveBuckley
 - [Grzegorz Bokota](https://github.com/napari/napari/commits?author=Czaki) - @Czaki
 - [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) - @jni
 - [Kira Evans](https://github.com/napari/napari/commits?author=kne42) - @kne42


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

This is an attempt at a workaround for the flaky bundling on Mac https://github.com/napari/napari/issues/1611, using the github [retry action](https://github.com/marketplace/actions/retry-step).

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Maintenance

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
Resources used: Documentation page for https://github.com/marketplace/actions/retry-step
Related issue: https://github.com/napari/napari/issues/1611

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
I've tried this out in my own branch, and it seems to be working at least as well as the previous action
https://github.com/GenevieveBuckley/napari/actions/runs/269826043

It's a little tricky to force the bundling to be flaky or fail on demand, so we probably need to try this out in the wild to be completely sure if it'll solve our issue. One easy way to test this more thoroughly would be to add another release candidate tag (either now or when the next release rolls around).

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
