### PR TITLE
MAINT: Increase retry action timeout from 10 to 30 mins

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Make Bundle
         uses: nick-invision/retry@v1
         with:
-          timeout_minutes: 10
+          timeout_minutes: 30
           max_attempts: 3
           command: python -m bundle
       - name: Upload Artifact


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
This PR increases the retry action timeout from 10 to 30 minutes.

Ten minutes seemed fine when I tested how long the app bundling took on my branch, but it's clearly not enough when I look at the logs for the latest napari release. I'm increasing the timeout length to give the retry action a chance to work.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Maintenance

# References

Related: https://github.com/napari/napari/issues/1611

