### PR TITLE
Drop Python 3.6

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,9 +28,6 @@ linux_task:
   
   matrix:
     env:
-      PY_VER: "3.6"
-      PYTEST_FLAGS: ""
-    env:
       PY_VER: "3.7"
       PYTEST_FLAGS: ""
     env:
@@ -113,7 +110,6 @@ mac_task:
     - only_if: $CIRRUS_PR == ""
       env:
         matrix:
-          PY_VER: "3.6"
           PY_VER: "3.7"
           PY_VER: "3.8"
     # is a pull request, only run python 3.8
@@ -164,7 +160,6 @@ win_task:
     - only_if: $CIRRUS_PR == ""
       env:
         matrix:
-          PY_VER: "3.6"
           PY_VER: "3.7"
           PY_VER: "3.8"
     # is a pull request, only run python 3.8

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ We're working on [tutorials](https://napari.org/tutorials/), but you can also qu
 ### from pip, with "batteries included"
 
 napari can be installed on most macOS, Linux, and Windows systems with
-Python 3.6, 3.7 and 3.8 using pip:
+Python 3.7 and 3.8 using pip:
 
 ```sh
 pip install napari[all]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,7 +33,7 @@ installation
 ------------
 
 napari can be installed on most macOS, Linux, and Windows systems with
-Python 3.6, 3.7 and 3.8 using pip:
+Python 3.7 and 3.8 using pip:
 
 .. code-block:: console
 

--- a/napari/_qt/dialogs/_tests/test_qt_plugin_list.py
+++ b/napari/_qt/dialogs/_tests/test_qt_plugin_list.py
@@ -28,7 +28,7 @@ def entrypoint_plugin(tmp_path):
         "Version: 1.2.3\n"
         "Author-Email: example@example.com\n"
         "Home-Page: https://www.example.com\n"
-        "Requires-Python: >=3.6\n"
+        "Requires-Python: >=3.7\n"
     )
     return tmp_path
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Programming Language :: C
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Topic :: Scientific/Engineering
@@ -35,7 +34,7 @@ classifiers =
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 install_requires =
     appdirs>=1.4.4


### PR DESCRIPTION
# Description
This PR drops Python 3.6 by removing it from all our CI frameworks. It will pave the way for merging #1475.

I imagine @jni that we might be able to change some imports / remove some dependencies that were providing back-ported features, is that right? If so can you take over this PR and make those changes in them too, thanks!!


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
