### PR TITLE
magic_name: Add test for an empty path_prefix that matches all paths

### DIFF
--- a/napari/utils/_tests/test_naming.py
+++ b/napari/utils/_tests/test_naming.py
@@ -116,3 +116,25 @@ def test_path_prefix():
 
     if walrus:
         assert eval_with_filename('foo(i:=33)', 'rye.py') == 'i'
+
+
+def test_empty_path_prefix():
+    """Test an empty path prefix that matches the entire stack"""
+    # Repeat tests with an empty path_prefix
+    mname = functools.partial(magic_name, path_prefix="")
+
+    def foo(x):
+        def bar(y):
+            return mname(y)
+
+        return bar(x)
+
+    # Test are all None because the path_prefix matches everything
+    # magic_name reads through until the end of the stack
+    assert eval_with_filename('foo(42)', 'hi.py') is None
+
+    r = 8  # noqa
+    assert eval_with_filename('foo(r)', 'bye.py') is None
+
+    if walrus:
+        assert eval_with_filename('foo(i:=33)', 'rye.py') is None


### PR DESCRIPTION
This also tests when magic_name reaches the end of the stackframes

# Description
This is a noop PR to see if this test fails in CI on the master branch

## Type of change
- [x] Adds a test for `magic_name`

# References
This tests for the issue in #1630 . The test should succeed when merged with #1635

# How has this been tested?
Running pytest locally for Python 3.8 indicates that the new fails on master

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
