### PR TITLE
fix world origin

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -4,7 +4,7 @@ import time
 import numpy as np
 import pytest
 
-from napari import Viewer
+from napari import Viewer, layers
 from napari._tests.utils import (
     add_layer_by_type,
     check_view_transform_consistency,
@@ -180,6 +180,9 @@ def test_roll_traspose_update(make_test_viewer, layer_class, data, ndim):
     }
     for k, val in transf_dict.items():
         setattr(layer, k, val)
+
+    if layer_class in [layers.Image, layers.Labels]:
+        transf_dict['translate'] -= transf_dict['scale'] / 2
 
     # Check consistency:
     check_view_transform_consistency(layer, viewer, transf_dict)

--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -203,6 +203,8 @@ class VispyBaseLayer(ABC):
                     .set_slice(self.layer.dims.displayed)
                     .scale
                 )
+                if len(scale) < nd:
+                    scale = np.array(list(scale) + [1] * (nd - len(scale)))
                 mapped_position -= scale[::-1] / 2
             return tuple(mapped_position[::-1])
         else:

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -21,6 +21,7 @@ class VispyImageLayer(VispyBaseLayer):
         self._image_node = ImageNode(None, method='auto')
         self._volume_node = VolumeNode(np.zeros((1, 1, 1)), clim=[0, 1])
         super().__init__(layer, self._image_node)
+        self._array_like = True
 
         self.layer.events.rendering.connect(self._on_rendering_change)
         self.layer.events.interpolation.connect(self._on_interpolation_change)

--- a/napari/_vispy/vispy_points_layer.py
+++ b/napari/_vispy/vispy_points_layer.py
@@ -51,7 +51,7 @@ class VispyPointsLayer(VispyBaseLayer):
         set_data = self.node._subvisuals[0].set_data
 
         set_data(
-            data[:, ::-1] + 0.5,
+            data[:, ::-1],
             size=size,
             edge_width=self.layer.edge_width,
             symbol=self.layer.symbol,
@@ -79,7 +79,7 @@ class VispyPointsLayer(VispyBaseLayer):
             size = 0
 
         self.node._subvisuals[1].set_data(
-            data[:, ::-1] + 0.5,
+            data[:, ::-1],
             size=size,
             edge_width=self._highlight_width,
             symbol=self.layer.symbol,
@@ -101,9 +101,7 @@ class VispyPointsLayer(VispyBaseLayer):
                 width = self._highlight_width
 
             self.node._subvisuals[2].set_data(
-                pos=pos[:, ::-1] + 0.5,
-                color=self._highlight_color,
-                width=width,
+                pos=pos[:, ::-1], color=self._highlight_color, width=width,
             )
         else:
             self.node._subvisuals[2].set_data(

--- a/napari/_vispy/vispy_shapes_layer.py
+++ b/napari/_vispy/vispy_shapes_layer.py
@@ -37,7 +37,7 @@ class VispyShapesLayer(VispyBaseLayer):
         # Note that the indices of the vertices need to be resversed to
         # go from numpy style to xyz
         if vertices is not None:
-            vertices = vertices[:, ::-1] + 0.5
+            vertices = vertices[:, ::-1]
 
         if len(vertices) == 0 or len(faces) == 0:
             vertices = np.zeros((3, self.layer.dims.ndisplay))
@@ -64,8 +64,6 @@ class VispyShapesLayer(VispyBaseLayer):
         if vertices is None or len(vertices) == 0 or len(faces) == 0:
             vertices = np.zeros((3, self.layer.dims.ndisplay))
             faces = np.array([[0, 1, 2]])
-        else:
-            vertices = vertices + 0.5
 
         self.node._subvisuals[1].set_data(
             vertices=vertices, faces=faces, color=self.layer._highlight_color
@@ -85,7 +83,6 @@ class VispyShapesLayer(VispyBaseLayer):
             vertices = np.zeros((1, self.layer.dims.ndisplay))
             size = 0
         else:
-            vertices = vertices + 0.5
             size = self.layer._vertex_size
 
         self.node._subvisuals[3].set_data(
@@ -101,8 +98,6 @@ class VispyShapesLayer(VispyBaseLayer):
         if pos is None or len(pos) == 0:
             pos = np.zeros((1, self.layer.dims.ndisplay))
             width = 0
-        else:
-            pos = pos + 0.5
 
         self.node._subvisuals[2].set_data(
             pos=pos, color=edge_color, width=width

--- a/napari/_vispy/vispy_surface_layer.py
+++ b/napari/_vispy/vispy_surface_layer.py
@@ -34,7 +34,7 @@ class VispySurfaceLayer(VispyBaseLayer):
             vertex_values = np.array([0])
         else:
             # Offsetting so pixels now centered
-            vertices = self.layer._data_view[:, ::-1] + 0.5
+            vertices = self.layer._data_view[:, ::-1]
             faces = self.layer._view_faces
             vertex_values = self.layer._view_vertex_values
 

--- a/napari/_vispy/vispy_vectors_layer.py
+++ b/napari/_vispy/vispy_vectors_layer.py
@@ -22,7 +22,7 @@ class VispyVectorsLayer(VispyBaseLayer):
             faces = np.array([[0, 1, 2]])
             face_color = np.array([[0, 0, 0, 0]])
         else:
-            vertices = self.layer._view_vertices[:, ::-1] + 0.5
+            vertices = self.layer._view_vertices[:, ::-1]
             faces = self.layer._view_faces
             face_color = self.layer._view_face_color
 


### PR DESCRIPTION
# Description
This PR now adds a correct world based coordinate system that follows image-like axes conventions. The center of the [0, 0] pixel is not truely at [0, 0]. I think this is the way that @jni has been asking for a long time.

You can see this when looking at layers of different scales, for example

```python
with napari.gui_qt():
    viewer = napari.Viewer()
    viewer.add_image(np.random.random((11, 11)), colormap='red', opacity=.5, scale=(2, 2), name='half')
    viewer.add_image(np.random.random((21, 21)), colormap='blue', opacity=.5, name='full')
    viewer.add_points([[0, 0], [10, 10]], size=0.5, opacity=.5)
```

Currently on master yields:

<img width="1200" alt="Screen Shot 2020-09-29 at 4 59 23 PM" src="https://user-images.githubusercontent.com/6531703/94628616-48c17800-0275-11eb-955b-681c8769d31b.png">

where you can see the top left corners of the arrays are at the same location, but the points have been offset 0.5

Now on this PR:

<img width="1200" alt="Screen Shot 2020-09-29 at 4 59 46 PM" src="https://user-images.githubusercontent.com/6531703/94628630-51b24980-0275-11eb-8b38-d4dcb9420960.png">

Where now the center of the pixels of both arrays are overlapping and the point is in the correct place, which is what we want.

This also drops some of the strange `0.5` pixel offsets we needed before, instead introducing the concept of `_array_like` for a vispy visual. Depending on what merges first we'll want to update #1361 to reflect this too.

I have checked a bunch of the interactivity, cursor selection, painting etc. I want to add a cursor model in a PR after this and simplify some stuff, but that won't actually change the functionality, just make things simpler.

I can also add some tests for this before merge, but maybe want to hand it over to @jni @DragaDoncila @GenevieveBuckley @kevinyamauchi @d-v-b for playing with. Hopefully people like the new behavior!

Also note that this can merge before #1616 and then I can update #1616 so that it preserves this new world coordinate system.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
