### PR TITLE
Reduce the default dask cache size

### DIFF
--- a/napari/utils/dask_utils.py
+++ b/napari/utils/dask_utils.py
@@ -12,7 +12,7 @@ from .. import utils
 
 
 def create_dask_cache(
-    nbytes: Optional[int] = None, mem_fraction: float = 0.5
+    nbytes: Optional[int] = None, mem_fraction: float = 0.1
 ) -> Cache:
     """Create a dask cache at utils.dask_cache if one doesn't already exist.
 
@@ -26,7 +26,7 @@ def create_dask_cache(
         autodetermined using ``mem_fraction``.
     mem_fraction : float, optional
         The fraction (from 0 to 1) of total memory to use for the dask cache.
-        by default, 50% of total memory is used.
+        by default, 10% of total memory is used.
 
     Returns
     -------


### PR DESCRIPTION
# Description

It's not uncommon for me to have several long-running IPython sessions in which I test napari in a variety of scenarios, including with large dask arrays. This means I end up with multiple Python processes taking up 5GB+ RAM for no good reason. In general, I think it would be preferable to default to a modest cache size — I might even say 0, happy to discuss that option if people are happy — and let those users that need more, which I expect are in a minority, configure it for their purposes.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
