### PR TITLE
Pull out layer visual transform code

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -545,7 +545,7 @@ class QtViewer(QSplitter):
         # Find corners of canvas in world coordinates
         top_left = self._map_canvas2world([0, 0])
         bottom_right = self._map_canvas2world(self.canvas.size)
-        return top_left, bottom_right
+        return np.array([top_left, bottom_right])
 
     def on_mouse_wheel(self, event):
         """Called whenever mouse wheel activated in canvas.
@@ -562,7 +562,7 @@ class QtViewer(QSplitter):
 
         layer = self.viewer.active_layer
         if layer is not None:
-            # update cursor position in world coordinates
+            # set cursor position in world coordinates
             layer.position = self._map_canvas2world(list(event.pos))
             mouse_wheel_callbacks(layer, event)
 
@@ -582,7 +582,7 @@ class QtViewer(QSplitter):
 
         layer = self.viewer.active_layer
         if layer is not None:
-            # update cursor position in world coordinates
+            # set cursor position in world coordinates
             layer.position = self._map_canvas2world(list(event.pos))
             mouse_press_callbacks(layer, event)
 
@@ -601,7 +601,7 @@ class QtViewer(QSplitter):
 
         layer = self.viewer.active_layer
         if layer is not None:
-            # update cursor position in world coordinates
+            # set cursor position in world coordinates
             layer.position = self._map_canvas2world(list(event.pos))
             mouse_move_callbacks(layer, event)
 
@@ -620,7 +620,7 @@ class QtViewer(QSplitter):
 
         layer = self.viewer.active_layer
         if layer is not None:
-            # update cursor position in world coordinates
+            # set cursor position in world coordinates
             layer.position = self._map_canvas2world(list(event.pos))
             mouse_release_callbacks(layer, event)
 
@@ -669,11 +669,14 @@ class QtViewer(QSplitter):
         the camera is moved and is connected in the `QtViewer`.
         """
         for layer in self.viewer.layers:
-            layer._update_draw(
-                scale_factors=self._canvas2world_scale,
-                corner_pixels=self._canvas_corners_in_world,
-                shape_threshold=self.canvas.size,
-            )
+            if layer.ndim <= self.viewer.dims.ndim:
+                layer._update_draw(
+                    scale_factors=self._canvas2world_scale[-layer.ndim :],
+                    corner_pixels=self._canvas_corners_in_world[
+                        :, -layer.ndim :
+                    ],
+                    shape_threshold=self.canvas.size,
+                )
 
     def keyPressEvent(self, event):
         """Called whenever a key is pressed.

--- a/napari/_vispy/_tests/test_vispy_multiscale.py
+++ b/napari/_vispy/_tests/test_vispy_multiscale.py
@@ -17,7 +17,7 @@ def test_multiscale(make_test_viewer):
 
     # Set canvas size to target amount
     viewer.window.qt_viewer.view.canvas.size = (800, 600)
-    list(viewer.window.qt_viewer.layer_to_visual.values())[0].on_draw(None)
+    viewer.window.qt_viewer.on_draw(None)
 
     # Check that current level is first large enough to fill the canvas with
     # a greater than one pixel depth
@@ -57,7 +57,7 @@ def test_3D_multiscale_image(make_test_viewer):
     assert viewer.layers[0].data_level == 1
 
     # Note that draw command must be explicitly triggered in our tests
-    list(viewer.window.qt_viewer.layer_to_visual.values())[0].on_draw(None)
+    viewer.window.qt_viewer.on_draw(None)
 
 
 @pytest.mark.skipif(
@@ -108,7 +108,7 @@ def test_multiscale_screenshot_zoomed(make_test_viewer):
 
     # Set zoom of camera to show highest resolution tile
     view.view.camera.rect = [1000, 1000, 200, 150]
-    list(view.layer_to_visual.values())[0].on_draw(None)
+    viewer.window.qt_viewer.on_draw(None)
 
     # Check that current level is bottom level of multiscale
     assert viewer.layers[0].data_level == 0
@@ -144,7 +144,7 @@ def test_image_screenshot_zoomed(make_test_viewer):
 
     # Set zoom of camera to show highest resolution tile
     view.view.camera.rect = [1000, 1000, 200, 150]
-    list(view.layer_to_visual.values())[0].on_draw(None)
+    viewer.window.qt_viewer.on_draw(None)
 
     screenshot = viewer.screenshot(canvas_only=True)
     center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)

--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -29,9 +29,6 @@ class VispyBaseLayer(ABC):
         Scale factors for the layer visual in the scenecanvas.
     translate : sequence of float
         Translation values for the layer visual in the scenecanvas.
-    scale_factor : float
-        Conversion factor from canvas coordinates to image coordinates, which
-        depends on the current zoom level.
     MAX_TEXTURE_SIZE_2D : int
         Max texture size allowed by the vispy canvas during 2D rendering.
     MAX_TEXTURE_SIZE_3D : int
@@ -53,8 +50,6 @@ class VispyBaseLayer(ABC):
         MAX_TEXTURE_SIZE_2D, MAX_TEXTURE_SIZE_3D = get_max_texture_sizes()
         self.MAX_TEXTURE_SIZE_2D = MAX_TEXTURE_SIZE_2D
         self.MAX_TEXTURE_SIZE_3D = MAX_TEXTURE_SIZE_3D
-
-        self._position = (0,) * self.layer.dims.ndisplay
 
         self.layer.events.refresh.connect(lambda e: self.node.update())
         self.layer.events.set_data.connect(self._on_data_change)
@@ -126,16 +121,6 @@ class VispyBaseLayer(ABC):
             return
         self._master_transform.translate = padded_translate
 
-    @property
-    def scale_factor(self):
-        """float: Conversion factor from canvas pixels to data coordinates.
-        """
-        if self.node.canvas is not None:
-            transform = self.node.canvas.scene.node_transform(self.node)
-            return transform.map([1, 1])[0] - transform.map([0, 0])[0]
-        else:
-            return 1
-
     @abstractmethod
     def _on_data_change(self, event=None):
         raise NotImplementedError()
@@ -156,8 +141,6 @@ class VispyBaseLayer(ABC):
         ).scale
         # convert NumPy axis ordering to VisPy axis ordering
         self.scale = scale[::-1]
-        self.layer.corner_pixels = self.coordinates_of_canvas_corners()
-        self.layer.position = self._transform_position(self._position)
 
     def _on_translate_change(self, event=None):
         translate = self.layer._transforms.simplified.set_slice(
@@ -173,42 +156,9 @@ class VispyBaseLayer(ABC):
             self.translate = translate[::-1] - scale[::-1] / 2
         else:
             self.translate = translate[::-1]
-        self.layer.corner_pixels = self.coordinates_of_canvas_corners()
-        self.layer.position = self._transform_position(self._position)
 
     def _on_loaded_change(self, event=None):
         self.node.visible = self.layer.visible and self.layer.loaded
-
-    def _transform_position(self, position):
-        """Transform cursor position from canvas space (x, y) into image space.
-
-        Parameters
-        ----------
-        position : 2-tuple
-            Cursor position in canvas (x, y).
-
-        Returns
-        -------
-        coords : tuple
-            Coordinates of cursor in image space for displayed dimensions only
-        """
-        nd = self.layer.dims.ndisplay
-        if self.node.canvas is not None:
-            transform = self.node.canvas.scene.node_transform(self.node)
-            # Map and offset position so that pixel center is at 0
-            mapped_position = transform.map(list(position))[:nd]
-            if self._array_like:
-                scale = (
-                    self.layer._transforms['data2world']
-                    .set_slice(self.layer.dims.displayed)
-                    .scale
-                )
-                if len(scale) < nd:
-                    scale = np.array(list(scale) + [1] * (nd - len(scale)))
-                mapped_position -= scale[::-1] / 2
-            return tuple(mapped_position[::-1])
-        else:
-            return (0,) * nd
 
     def _reset_base(self):
         self._on_visible_change()
@@ -216,58 +166,6 @@ class VispyBaseLayer(ABC):
         self._on_blending_change()
         self._on_scale_change()
         self._on_translate_change()
-
-    def coordinates_of_canvas_corners(self):
-        """Find location of the corners of canvas in data coordinates.
-
-        This method should only be used during 2D image viewing. The result
-        depends on the current pan and zoom position.
-
-        Returns
-        -------
-        corner_pixels : array
-            Coordinates of top left and bottom right canvas pixel in the data.
-        """
-        nd = self.layer.dims.ndisplay
-        # Find image coordinate of top left canvas pixel
-        if self.node.canvas is not None:
-            offset = self.translate[:nd] / self.scale[:nd]
-            tl_raw = np.floor(self._transform_position([0, 0]) + offset[::-1])
-            br_raw = np.ceil(
-                self._transform_position(self.node.canvas.size) + offset[::-1]
-            )
-        else:
-            tl_raw = [0] * nd
-            br_raw = [1] * nd
-
-        top_left = np.zeros(self.layer.ndim)
-        bottom_right = np.zeros(self.layer.ndim)
-        for d, tl, br in zip(self.layer.dims.displayed, tl_raw, br_raw):
-            top_left[d] = tl
-            bottom_right[d] = br
-
-        return np.array([top_left, bottom_right]).astype(int)
-
-    def on_draw(self, event):
-        """Called whenever the canvas is drawn.
-
-        This is triggered from vispy whenever new data is sent to the canvas or
-        the camera is moved and is connected in the `QtViewer`.
-        """
-        self.layer.scale_factor = self.scale_factor
-        old_corner_pixels = self.layer.corner_pixels
-        self.layer.corner_pixels = self.coordinates_of_canvas_corners()
-
-        # For 2D multiscale data determine if new data has been requested
-        if (
-            self.layer.multiscale
-            and self.layer.dims.ndisplay == 2
-            and self.node.canvas is not None
-        ):
-            self.layer._update_multiscale(
-                corner_pixels=old_corner_pixels,
-                shape_threshold=self.node.canvas.size,
-            )
 
 
 @lru_cache()

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -374,9 +374,10 @@ class Layer(KeymapProvider, ABC):
 
     @position.setter
     def position(self, position):
-        if self._position == position:
+        _position = position[-self.ndim :]
+        if self._position == _position:
             return
-        self._position = position
+        self._position = _position
         self._update_value_and_status()
 
     def _update_dims(self, event=None):
@@ -728,6 +729,7 @@ class Layer(KeymapProvider, ABC):
     @property
     def coordinates(self):
         """Cursor position in data coordinates."""
+        # Note we ignore the first transform which is tile2data
         return tuple(self._transforms[1:].simplified.inverse(self.position))
 
     def _update_value_and_status(self):
@@ -751,11 +753,11 @@ class Layer(KeymapProvider, ABC):
         shape_threshold : tuple
             Requested shape of field of view in data coordinates.
         """
-
+        # Note we ignore the first transform which is tile2data
         scale = np.divide(scale_factors, self._transforms[1:].simplified.scale)
-        self.scale_factor = np.linalg.norm(scale) / np.linalg.norm([1, 1])
-
         data_corners = self._transforms[1:].simplified.inverse(corner_pixels)
+
+        self.scale_factor = np.linalg.norm(scale) / np.linalg.norm([1, 1])
 
         # Round and clip data corners
         data_corners = np.array(

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -555,20 +555,15 @@ class Image(IntensityVisualizationMixin, Layer):
             self._transforms['tile2data'].scale = scale
 
             if self.dims.ndisplay == 2:
-                corner_pixels = np.clip(
-                    self.corner_pixels,
-                    0,
-                    np.subtract(self.level_shapes[self.data_level], 1),
-                )
-
                 for d in self.dims.displayed:
                     indices[d] = slice(
-                        corner_pixels[0, d], corner_pixels[1, d] + 1, 1
+                        self.corner_pixels[0, d],
+                        self.corner_pixels[1, d] + 1,
+                        1,
                     )
                 self._transforms['tile2data'].translate = (
-                    corner_pixels[0] * self._transforms['tile2data'].scale
+                    self.corner_pixels[0] * self._transforms['tile2data'].scale
                 )
-
             image = self.data[level][tuple(indices)]
             image_indices = indices
 

--- a/napari/layers/labels/_tests/test_labels_mouse_bindings.py
+++ b/napari/layers/labels/_tests/test_labels_mouse_bindings.py
@@ -36,13 +36,13 @@ def test_paint(Event, brush_shape, expected_sum):
     layer.brush_shape = brush_shape
     layer.mode = 'paint'
     layer.selected_label = 3
-    layer.coordinates = (0, 0)
+    layer.position = (0, 0)
 
     # Simulate click
     event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
     mouse_press_callbacks(layer, event)
 
-    layer.coordinates = (19, 19)
+    layer.position = (19, 19)
 
     # Simulate drag
     event = ReadOnlyWrapper(Event(type='mouse_move', is_dragging=True))
@@ -72,13 +72,13 @@ def test_erase(Event, brush_shape, expected_sum):
     layer.mode = 'erase'
     layer.brush_shape = brush_shape
     layer.selected_label = 3
-    layer.coordinates = (0, 0)
+    layer.position = (0, 0)
 
     # Simulate click
     event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
     mouse_press_callbacks(layer, event)
 
-    layer.coordinates = (19, 19)
+    layer.position = (19, 19)
 
     # Simulate drag
     event = ReadOnlyWrapper(Event(type='mouse_move', is_dragging=True))
@@ -106,14 +106,14 @@ def test_pick(Event):
     assert layer.selected_label == 1
 
     layer.mode = 'pick'
-    layer.coordinates = (0, 0)
+    layer.position = (0, 0)
 
     # Simulate click
     event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
     mouse_press_callbacks(layer, event)
     assert layer.selected_label == 2
 
-    layer.coordinates = (19, 19)
+    layer.position = (19, 19)
 
     # Simulate click
     event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
@@ -133,7 +133,7 @@ def test_fill(Event):
     assert np.unique(layer.data[-5:, :5]) == 1
 
     layer.mode = 'fill'
-    layer.coordinates = (0, 0)
+    layer.position = (0, 0)
     layer.selected_label = 4
 
     # Simulate click
@@ -144,7 +144,7 @@ def test_fill(Event):
     assert np.unique(layer.data[:5, -5:]) == 1
     assert np.unique(layer.data[-5:, :5]) == 1
 
-    layer.coordinates = (19, 19)
+    layer.position = (19, 19)
     layer.selected_label = 5
 
     # Simulate click
@@ -170,7 +170,7 @@ def test_fill_nD_plane(Event):
     assert np.unique(layer.data[0, 8:10, 8:10]) == 2
 
     layer.mode = 'fill'
-    layer.coordinates = (0, 0, 0)
+    layer.position = (0, 0, 0)
     layer.selected_label = 4
 
     # Simulate click
@@ -183,7 +183,7 @@ def test_fill_nD_plane(Event):
     assert np.unique(layer.data[-5:, :5, -5:]) == 1
     assert np.unique(layer.data[0, 8:10, 8:10]) == 2
 
-    layer.coordinates = (0, 19, 19)
+    layer.position = (0, 19, 19)
     layer.selected_label = 5
 
     # Simulate click
@@ -214,7 +214,7 @@ def test_fill_nD_all(Event):
 
     layer.n_dimensional = True
     layer.mode = 'fill'
-    layer.coordinates = (0, 0, 0)
+    layer.position = (0, 0, 0)
     layer.selected_label = 4
 
     # Simulate click
@@ -226,7 +226,7 @@ def test_fill_nD_all(Event):
     assert np.unique(layer.data[-5:, :5, -5:]) == 1
     assert np.unique(layer.data[0, 8:10, 8:10]) == 2
 
-    layer.coordinates = (0, 19, 19)
+    layer.position = (0, 19, 19)
     layer.selected_label = 5
 
     # Simulate click

--- a/napari/layers/labels/_tests/test_labels_mouse_bindings.py
+++ b/napari/layers/labels/_tests/test_labels_mouse_bindings.py
@@ -170,7 +170,7 @@ def test_fill_nD_plane(Event):
     assert np.unique(layer.data[0, 8:10, 8:10]) == 2
 
     layer.mode = 'fill'
-    layer.position = (0, 0)
+    layer.position = (0, 0, 0)
     layer.selected_label = 4
 
     # Simulate click
@@ -183,7 +183,7 @@ def test_fill_nD_plane(Event):
     assert np.unique(layer.data[-5:, :5, -5:]) == 1
     assert np.unique(layer.data[0, 8:10, 8:10]) == 2
 
-    layer.position = (19, 19)
+    layer.position = (0, 19, 19)
     layer.selected_label = 5
 
     # Simulate click
@@ -214,7 +214,7 @@ def test_fill_nD_all(Event):
 
     layer.n_dimensional = True
     layer.mode = 'fill'
-    layer.position = (0, 0)
+    layer.position = (0, 0, 0)
     layer.selected_label = 4
 
     # Simulate click
@@ -226,7 +226,7 @@ def test_fill_nD_all(Event):
     assert np.unique(layer.data[-5:, :5, -5:]) == 1
     assert np.unique(layer.data[0, 8:10, 8:10]) == 2
 
-    layer.position = (19, 19)
+    layer.position = (0, 19, 19)
     layer.selected_label = 5
 
     # Simulate click

--- a/napari/layers/labels/_tests/test_labels_mouse_bindings.py
+++ b/napari/layers/labels/_tests/test_labels_mouse_bindings.py
@@ -36,13 +36,13 @@ def test_paint(Event, brush_shape, expected_sum):
     layer.brush_shape = brush_shape
     layer.mode = 'paint'
     layer.selected_label = 3
-    layer.position = (0, 0)
+    layer.coordinates = (0, 0)
 
     # Simulate click
     event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
     mouse_press_callbacks(layer, event)
 
-    layer.position = (19, 19)
+    layer.coordinates = (19, 19)
 
     # Simulate drag
     event = ReadOnlyWrapper(Event(type='mouse_move', is_dragging=True))
@@ -72,13 +72,13 @@ def test_erase(Event, brush_shape, expected_sum):
     layer.mode = 'erase'
     layer.brush_shape = brush_shape
     layer.selected_label = 3
-    layer.position = (0, 0)
+    layer.coordinates = (0, 0)
 
     # Simulate click
     event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
     mouse_press_callbacks(layer, event)
 
-    layer.position = (19, 19)
+    layer.coordinates = (19, 19)
 
     # Simulate drag
     event = ReadOnlyWrapper(Event(type='mouse_move', is_dragging=True))
@@ -106,14 +106,14 @@ def test_pick(Event):
     assert layer.selected_label == 1
 
     layer.mode = 'pick'
-    layer.position = (0, 0)
+    layer.coordinates = (0, 0)
 
     # Simulate click
     event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
     mouse_press_callbacks(layer, event)
     assert layer.selected_label == 2
 
-    layer.position = (19, 19)
+    layer.coordinates = (19, 19)
 
     # Simulate click
     event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
@@ -133,7 +133,7 @@ def test_fill(Event):
     assert np.unique(layer.data[-5:, :5]) == 1
 
     layer.mode = 'fill'
-    layer.position = (0, 0)
+    layer.coordinates = (0, 0)
     layer.selected_label = 4
 
     # Simulate click
@@ -144,7 +144,7 @@ def test_fill(Event):
     assert np.unique(layer.data[:5, -5:]) == 1
     assert np.unique(layer.data[-5:, :5]) == 1
 
-    layer.position = (19, 19)
+    layer.coordinates = (19, 19)
     layer.selected_label = 5
 
     # Simulate click
@@ -170,7 +170,7 @@ def test_fill_nD_plane(Event):
     assert np.unique(layer.data[0, 8:10, 8:10]) == 2
 
     layer.mode = 'fill'
-    layer.position = (0, 0, 0)
+    layer.coordinates = (0, 0, 0)
     layer.selected_label = 4
 
     # Simulate click
@@ -183,7 +183,7 @@ def test_fill_nD_plane(Event):
     assert np.unique(layer.data[-5:, :5, -5:]) == 1
     assert np.unique(layer.data[0, 8:10, 8:10]) == 2
 
-    layer.position = (0, 19, 19)
+    layer.coordinates = (0, 19, 19)
     layer.selected_label = 5
 
     # Simulate click
@@ -214,7 +214,7 @@ def test_fill_nD_all(Event):
 
     layer.n_dimensional = True
     layer.mode = 'fill'
-    layer.position = (0, 0, 0)
+    layer.coordinates = (0, 0, 0)
     layer.selected_label = 4
 
     # Simulate click
@@ -226,7 +226,7 @@ def test_fill_nD_all(Event):
     assert np.unique(layer.data[-5:, :5, -5:]) == 1
     assert np.unique(layer.data[0, 8:10, 8:10]) == 2
 
-    layer.position = (0, 19, 19)
+    layer.coordinates = (0, 19, 19)
     layer.selected_label = 5
 
     # Simulate click

--- a/napari/layers/transforms.py
+++ b/napari/layers/transforms.py
@@ -87,7 +87,7 @@ class TransformChain(ListModel, Transform):
         return tz.pipe(coords, *self)
 
     def __newlike__(self, iterable):
-        return ListModel(self._basetype, iterable, self._lookup)
+        return TransformChain(iterable)
 
     @property
     def inverse(self) -> 'TransformChain':

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -234,3 +234,42 @@ def compute_multiscale_level(
     else:
         level = 0
     return level
+
+
+def compute_multiscale_level_and_corners(
+    corner_pixels, shape_threshold, downsample_factors
+):
+    """Computed desired level and corners of a multiscale view.
+
+    The level of the multiscale should be the lowest resolution such that
+    the requested shape is above the shape threshold. By passing a shape
+    threshold corresponding to the shape of the canvas on the screen this
+    ensures that we have at least one data pixel per screen pixel, but no
+    more than we need.
+
+    Parameters
+    ----------
+    corner_pixels : array (2, D)
+        Requested corner pixels at full resolution.
+    shape_threshold : tuple
+        Maximum size of a displayed tile in pixels.
+    downsample_factors : list of tuple
+        Downsampling factors for each level of the multiscale. Must be increasing
+        for each level of the multiscale.
+
+    Returns
+    -------
+    level : int
+        Level of the multiscale to be viewing.
+    corners : array (2, D)
+        Needed corner pixels at target resolution.
+    """
+    requested_shape = corner_pixels[1] - corner_pixels[0]
+    level = compute_multiscale_level(
+        requested_shape, shape_threshold, downsample_factors
+    )
+
+    corners = corner_pixels / downsample_factors[level]
+    corners = np.array([np.floor(corners[0]), np.ceil(corners[1])]).astype(int)
+
+    return level, corners


### PR DESCRIPTION
# Description
This PR will dramatically simply our visual transform code by no longer using transform on the individual layer visuals but instead using a single camera transform to get from canvas coordinates to world slice coordinates and then doing everything else with our new transform system.

This PR is still a WIP - multiscale isn't working yet - and it will need extensive testing before merge. Once this PR is in it will make things like adding a cursor model or camera model even easier too.

I might take this PR as an opportunity to fix #1667 too.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
