### PR TITLE
Make signals public attribute of WorkerBase

### DIFF
--- a/napari/_qt/qthreading.py
+++ b/napari/_qt/qthreading.py
@@ -33,6 +33,11 @@ class WorkerBase(QRunnable):
     ----------
     SignalsClass : type, optional
         A QObject subclass that contains signals, by default WorkerBaseSignals
+
+    Attributes
+    ----------
+    signals: WorkerBaseSignals
+        signal emitter object. To allow identify which worker thread emitted signal.
     """
 
     #: A set of Workers.  Add to set using :meth:`WorkerBase.start`
@@ -249,7 +254,7 @@ class GeneratorWorker(WorkerBase):
         self,
         func: Callable,
         *args,
-        SignalsClass: Type[QObject] = GeneratorWorkerSignals,
+        SignalsClass: Type[WorkerBaseSignals] = GeneratorWorkerSignals,
         **kwargs,
     ):
         if not inspect.isgeneratorfunction(func):

--- a/napari/_qt/qthreading.py
+++ b/napari/_qt/qthreading.py
@@ -39,12 +39,15 @@ class WorkerBase(QRunnable):
     _worker_set: Set['WorkerBase'] = set()
 
     def __init__(
-        self, *args, SignalsClass: Type[QObject] = WorkerBaseSignals, **kwargs
+        self,
+        *args,
+        SignalsClass: Type[WorkerBaseSignals] = WorkerBaseSignals,
+        **kwargs,
     ) -> None:
         super().__init__()
         self._abort_requested = False
         self._running = False
-        self._signals = SignalsClass()
+        self.signals = SignalsClass()
 
     def __getattr__(self, name):
         """Pass through attr requests to signals to simplify connection API.
@@ -57,12 +60,12 @@ class WorkerBase(QRunnable):
         object.
         """
         # the Signal object is actually a class attribute
-        attr = getattr(self._signals.__class__, name, None)
+        attr = getattr(self.signals.__class__, name, None)
         if isinstance(attr, Signal):
             # but what we need to connect to is the instantiated signal
             # (which is of type `SignalInstance` in PySide and
             # `pyqtBoundSignal` in PyQt)
-            return getattr(self._signals, name)
+            return getattr(self.signals, name)
 
     def quit(self) -> None:
         """Send a request to abort the worker.


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

Make `signal` parameter of `WorkerBase` public to allow identify worker object with `self.sender()` without using private attribute.
It is important when keeping list of workers to be finished before close application. 


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have made corresponding changes to the documentation
