### PR TITLE
Fix 404 links in documentation and remove warnings in docs build

### DIFF
--- a/docs/source/developers/CONTRIBUTING.md
+++ b/docs/source/developers/CONTRIBUTING.md
@@ -39,12 +39,12 @@ pre-commit install
 ```
 
 Upon committing, your code will be formatted according to our [`black`
-configuration](../pyproject.toml), which includes the settings
+configuration](https://github.com/napari/napari/blob/master/pyproject.toml), which includes the settings
 `skip-string-normalization = true` and `max-line-length = 79`. To learn more,
 see [`black`'s documentation](https://black.readthedocs.io/en/stable/).
 
 Code will also be linted to enforce the stylistic and logistical rules specified
-in our [`flake8` configuration](../setup.cfg), which currently ignores
+in our [`flake8` configuration](https://github.com/napari/napari/blob/master/setup.cfg), which currently ignores
 [E203](https://lintlyci.github.io/Flake8Rules/rules/E203.html),
 [E501](https://lintlyci.github.io/Flake8Rules/rules/E501.html),
 [W503](https://lintlyci.github.io/Flake8Rules/rules/W503.html) and

--- a/docs/source/developers/RELEASE.md
+++ b/docs/source/developers/RELEASE.md
@@ -9,7 +9,7 @@ They will need to have a [PyPI](https://pypi.org) account with upload permission
 
 You will also need the additional `release` dependencies (`pip install -e .[release]`) to complete the release process.
 
-> [`MANIFEST.in`](../MANIFEST.in) determines which non-Python files are included.
+> [`MANIFEST.in`](https://github.com/napari/napari/blob/master/MANIFEST.in) determines which non-Python files are included.
 > Make sure to check that all necessary ones are listed before beginning the release process.
 
 The `napari/napari` repository must have a PyPI API token as a GitHub secret.

--- a/docs/source/events/event_loop.rst
+++ b/docs/source/events/event_loop.rst
@@ -13,7 +13,7 @@ At its core, an event loop is rather simple.  It amounts to something
 that looks like this (in pseudo-code):
 
 .. code-block:: python
-   
+
     event_queue = Queue()
 
     while True:  # infinite loop!
@@ -25,7 +25,7 @@ that looks like this (in pseudo-code):
                 process_event(event)
 
 Actions taken by the user add events to the queue ("button pressed",
-"slider moved", etc...), and the event loop handles them one at a time. 
+"slider moved", etc...), and the event loop handles them one at a time.
 
 The Qt Event Loop
 -----------------

--- a/docs/source/events/perfmon.rst
+++ b/docs/source/events/perfmon.rst
@@ -9,7 +9,7 @@ diagnose the problem.
 
 The module can do several things:
 
-1. Time Qt Events 
+1. Time Qt Events
 
 2. Display a dockable **performance** widget.
 
@@ -72,7 +72,7 @@ Example configuration file:
 Configuration Options
 ---------------------
 
-`trace_qt_events` 
+`trace_qt_events`
 ~~~~~~~~~~~~~~~~~
 
 If true perfmon will time the duration of all Qt Events. You might
@@ -154,7 +154,7 @@ Create a minimal perfmon config file `/tmp/perfmon.json` that looks like this:
 This will write `/tmp/latest.json` every time we run napari. This file is
 only written on exit, and you must exit with the **Quit** commmand. Using
 `trace_file_on_start` is often easier than manually starting a trace using
-the **Debug** menu. 
+the **Debug** menu.
 
 
 Run napari

--- a/docs/source/events/threading.rst
+++ b/docs/source/events/threading.rst
@@ -171,7 +171,7 @@ Generators for the Win!
         def my_generator():
             for i in range(10):
                 yield i
-        
+
 
 **Use a generator!** By writing our decorated function as a generator that
 ``yields`` results instead of a function that ``returns`` a single result at
@@ -261,7 +261,7 @@ button that aborts the worker when clicked:
 .. code-block:: python
    :linenos:
    :emphasize-lines: 19,29
-    
+
     import time
     import napari
     from qtpy.QtWidgets import QPushButton
@@ -334,7 +334,7 @@ hits "0":
 
     import napari
     import time
-    
+
     from napari.qt.threading import thread_worker
     from qtpy.QtWidgets import QLineEdit, QLabel, QWidget, QVBoxLayout
     from qtpy.QtGui import QDoubleValidator
@@ -460,7 +460,7 @@ depending on your function type. The following three examples are equivalent:
 .. code-block:: python
 
     from napari.qt.threading import FunctionWorker
-    
+
     def my_function(arg1, arg2=None):
        ...
 
@@ -490,11 +490,10 @@ keep in mind the following guidelines:
    <napari.qt.threading.WorkerBase.work>`.
 
 2. When implementing the :meth:`~napari.qt.threading.WorkerBase.work` method,
-it is 
-   important that you periodically check ``self.abort_requested`` in your
+   it is important that you periodically check ``self.abort_requested`` in your
    thread loop, and exit the thread accordingly, otherwise ``napari`` will not
    be able to gracefully exit a long-running thread.
-     
+
      .. code-block:: python
 
         def work(self):


### PR DESCRIPTION
# Description
Some links were pointing to a relative path, which lead to broken links.
The relative links were replaced by the full github url to the file.
This change removes 3 warnings from the docs build log.
![2020-10-03-004402_915x47_scrot](https://user-images.githubusercontent.com/3043706/94978038-d0c8ab80-051b-11eb-821d-8cc9ed54f6ed.png)

Also remove trailing whitespaces, add a newline at the end of
docs/source/events/event_loop.rst and fix indentation in threading.rst
(this one also removes a warning).
![2020-10-03-004413_632x18_scrot](https://user-images.githubusercontent.com/3043706/94978039-d2926f00-051b-11eb-82ab-1cdcab015401.png)

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)


# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
No associated issue.

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [X] the documentations builds fine (better, even!) 
- [X] the pytest test suite has been run and the results are the same than on `master`

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality

# Postscriptum
I was going to work on napari/docs#46 but came across these easy to fix warnings so this is my first pull request to this repo.

The dev env was installed with Pipenv, would you be willing to add Pipenv instructions to the dev docs? I believe the current `pip install` instruction is ill suited in a time where managing per-project dependencies is a must!
