### PR TITLE
fix multiscale value update

### DIFF
--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -729,7 +729,9 @@ class Image(IntensityVisualizationMixin, Layer):
             Value of the data at the coord.
         """
         if self.multiscale:
-            coord = self._transforms[0].inverse(self.coordinates)
+            # for multiscale data map the coordinate from the data back to
+            # the tile
+            coord = self._transforms['tile2data'].inverse(self.coordinates)
         else:
             coord = self.coordinates
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -728,7 +728,12 @@ class Image(IntensityVisualizationMixin, Layer):
         value : tuple
             Value of the data at the coord.
         """
-        coord = np.round(self.coordinates).astype(int)
+        if self.multiscale:
+            coord = self._transforms[0].inverse(self.coordinates)
+        else:
+            coord = self.coordinates
+
+        coord = np.round(coord).astype(int)
         raw = self._slice.image.raw
         if self.rgb:
             shape = raw.shape[:-1]


### PR DESCRIPTION
# Description
There was a small bug following #1673 that fixes multiscale value update by mapping the coordinates back from the data to the tile.

Note @MaksHess that #1673 also closes #1557 and supersedes #1577. See this gif from the downsampled example in #1557 and note how the cursor value updates properly as the mouse moves into the bottom right corner. My apologies for taking over this @MaksHess and not helping you more with #1577, it just turned out to be easier to fix this all in one go!

![downsample_coords](https://user-images.githubusercontent.com/6531703/95021610-d8c14200-0626-11eb-9c05-c1b0a42c330c.gif)

We might want to add a couple tests before merging this PR. Once based on #1557 and one based on the multiscale value.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
