### PR TITLE
Allow Tracks layer to accept data as a list or pandas DataFrame

### DIFF
--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 
 from napari.layers import Tracks
@@ -11,9 +12,14 @@ from napari.layers import Tracks
 
 data_array_2dt = np.zeros((1, 4))
 data_list_2dt = list(data_array_2dt)
+dataframe_2dt = pd.DataFrame(
+    data=data_array_2dt, columns=['track_id', 't', 'y', 'x']
+)
 
 
-@pytest.mark.parametrize("data", [data_array_2dt, data_list_2dt])
+@pytest.mark.parametrize(
+    "data", [data_array_2dt, data_list_2dt, dataframe_2dt]
+)
 def test_tracks_layer_2dt_ndim(data):
     """Test instantiating Tracks layer, check 2D+t dimensionality."""
     layer = Tracks(data)

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -28,9 +28,14 @@ def test_tracks_layer_2dt_ndim(data):
 
 data_array_3dt = np.zeros((1, 5))
 data_list_3dt = list(data_array_3dt)
+dataframe_3dt = pd.DataFrame(
+    data=data_array_3dt, columns=['track_id', 't', 'z', 'y', 'x']
+)
 
 
-@pytest.mark.parametrize("data", [data_array_3dt, data_list_3dt])
+@pytest.mark.parametrize(
+    "data", [data_array_3dt, data_list_3dt, dataframe_3dt]
+)
 def test_tracks_layer_3dt_ndim(data):
     """Test instantiating Tracks layer, check 3D+t dimensionality."""
     layer = Tracks(data)

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -9,16 +9,24 @@ from napari.layers import Tracks
 #     assert pts.data.shape == (0, 4)
 
 
-def test_tracks_layer_2dt_ndim():
+data_array_2dt = np.zeros((1, 4))
+data_list_2dt = list(data_array_2dt)
+
+
+@pytest.mark.parametrize("data", [data_array_2dt, data_list_2dt])
+def test_tracks_layer_2dt_ndim(data):
     """Test instantiating Tracks layer, check 2D+t dimensionality."""
-    data = np.zeros((1, 4))
     layer = Tracks(data)
     assert layer.ndim == 3
 
 
-def test_tracks_layer_3dt_ndim():
+data_array_3dt = np.zeros((1, 5))
+data_list_3dt = list(data_array_3dt)
+
+
+@pytest.mark.parametrize("data", [data_array_3dt, data_list_3dt])
+def test_tracks_layer_3dt_ndim(data):
     """Test instantiating Tracks layer, check 3D+t dimensionality."""
-    data = np.zeros((1, 5))
     layer = Tracks(data)
     assert layer.ndim == 4
 

--- a/napari/layers/tracks/_track_utils.py
+++ b/napari/layers/tracks/_track_utils.py
@@ -97,7 +97,7 @@ class TrackManager:
         return self._data
 
     @data.setter
-    def data(self, data: np.ndarray):
+    def data(self, data: Union[list, np.ndarray]):
         """ set the vertex data and build the vispy arrays for display """
 
         # convert data to a numpy array if it is not already one

--- a/napari/layers/tracks/_track_utils.py
+++ b/napari/layers/tracks/_track_utils.py
@@ -100,6 +100,9 @@ class TrackManager:
     def data(self, data: np.ndarray):
         """ set the vertex data and build the vispy arrays for display """
 
+        # convert data to a numpy array if it is not already one
+        data = np.asarray(data)
+
         # check check the formatting of the incoming track data
         self._data = self._validate_track_data(data)
 

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -93,6 +93,9 @@ class Tracks(Layer):
         # if not provided with any data, set up an empty layer in 2D+t
         if data is None:
             data = np.empty((0, 4))
+        else:
+            # convert data to a numpy array if it is not already one
+            data = np.asarray(data)
 
         # set the track data dimensions (remove ID from data)
         ndim = data.shape[1] - 1


### PR DESCRIPTION
# Description
This PR adds the ability to pass the data to the `Tracks` layer as a list or a pandas dataframe.

## Type of change
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# References


# How has this been tested?
- [x] I updated the tests to include list data
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
