### PR TITLE
Bug fix for tracks layer properties as dataframe

### DIFF
--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -57,13 +57,18 @@ def test_track_layer_data():
     assert np.all(layer.data == data)
 
 
-def test_track_layer_properties():
+properties_dict = {'time': np.arange(100)}
+properties_df = pd.DataFrame(properties_dict)
+
+
+@pytest.mark.parametrize("properties", [{}, properties_dict, properties_df])
+def test_track_layer_properties(properties):
     """Test properties."""
     data = np.zeros((100, 4))
     data[:, 1] = np.arange(100)
-    properties = {'time': data[:, 1]}
     layer = Tracks(data, properties=properties)
-    assert layer.properties == properties
+    for k, v in properties.items():
+        np.testing.assert_equal(layer.properties[k], v)
 
 
 def test_track_layer_graph():

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -97,6 +97,10 @@ class Tracks(Layer):
             # convert data to a numpy array if it is not already one
             data = np.asarray(data)
 
+        # in absence of properties make the default an empty dict
+        if properties is None:
+            properties = {}
+
         # set the track data dimensions (remove ID from data)
         ndim = data.shape[1] - 1
 
@@ -144,7 +148,7 @@ class Tracks(Layer):
 
         # set the data, properties and graph
         self.data = data
-        self.properties = properties or {}
+        self.properties = properties
         self.graph = graph or {}
 
         self.color_by = color_by


### PR DESCRIPTION
# Description
Fixes error on adding `Tracks` layer using a DataFrame for properties

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #1706

# How has this been tested?

- [x] added new test for instantiating tracks layer with empty dictionary, properties dictionary and dataframe 
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
