### PR TITLE
async-13: Fix "render to black" problem

### DIFF
--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -58,7 +58,6 @@ class VispyBaseLayer(ABC):
         self.layer.events.blending.connect(self._on_blending_change)
         self.layer.events.scale.connect(self._on_scale_change)
         self.layer.events.translate.connect(self._on_translate_change)
-        self.layer.events.loaded.connect(self._on_loaded_change)
 
     @property
     def _master_transform(self):
@@ -156,9 +155,6 @@ class VispyBaseLayer(ABC):
             self.translate = translate[::-1] - scale[::-1] / 2
         else:
             self.translate = translate[::-1]
-
-    def _on_loaded_change(self, event=None):
-        self.node.visible = self.layer.visible
 
     def _reset_base(self):
         self._on_visible_change()

--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -126,7 +126,7 @@ class VispyBaseLayer(ABC):
         raise NotImplementedError()
 
     def _on_visible_change(self, event=None):
-        self.node.visible = self.layer.visible and self.layer.loaded
+        self.node.visible = self.layer.visible
 
     def _on_opacity_change(self, event=None):
         self.node.opacity = self.layer.opacity
@@ -158,7 +158,7 @@ class VispyBaseLayer(ABC):
             self.translate = translate[::-1]
 
     def _on_loaded_change(self, event=None):
-        self.node.visible = self.layer.visible and self.layer.loaded
+        self.node.visible = self.layer.visible
 
     def _reset_base(self):
         self._on_visible_change()


### PR DESCRIPTION
# Description

No longer render black while loading the next slice. Continue to render the "last" slice until the new one has loaded. This fixes the "render to black" problem that has been bugging us for a long time. Fixes it for time-series and multi-scale.

Making the node invisible must have been necessary back when we had an "update loop" or for some reason a long time ago. It's no longer need. This works fine.

# Experimental?

The change is not in "experimental," but `layer.loaded` is always true for non-async layers, so the change should have no effect.

## Type of change
- [x] Fix visuals with async

# How has this been tested?
- [x] Manual testing

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
