### PR TITLE
fix initialization of tracks color_by

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_tracks_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_tracks_layer.py
@@ -10,23 +10,26 @@ _PROPERTIES = {'speed': [50, 30], 'time': [0, 1]}
 
 def test_tracks_controls_color_by(qtbot):
     """Check updating of the color_by combobox."""
-    layer = Tracks(_TRACKS, properties=_PROPERTIES, color_by='speed')
+    inital_color_by = 'time'
+    layer = Tracks(_TRACKS, properties=_PROPERTIES, color_by=inital_color_by)
     qtctrl = QtTracksControls(layer)
     qtbot.addWidget(qtctrl)
 
     # verify the color_by argument is initialized correctly
-    assert layer.color_by == 'speed'
-    assert qtctrl.color_by_combobox.currentText() == 'speed'
+    assert layer.color_by == inital_color_by
+    assert qtctrl.color_by_combobox.currentText() == inital_color_by
 
     # update color_by from the layer model
-    layer.color_by = 'time'
-    assert layer.color_by == 'time'
-    assert qtctrl.color_by_combobox.currentText() == 'time'
+    layer_update_color_by = 'speed'
+    layer.color_by = layer_update_color_by
+    assert layer.color_by == layer_update_color_by
+    assert qtctrl.color_by_combobox.currentText() == layer_update_color_by
 
     # update color_by from the qt controls
+    qt_update_color_by = 'track_id'
     speed_index = qtctrl.color_by_combobox.findText(
-        'speed', Qt.MatchFixedString
+        qt_update_color_by, Qt.MatchFixedString
     )
     qtctrl.color_by_combobox.setCurrentIndex(speed_index)
-    assert layer.color_by == 'speed'
-    assert qtctrl.color_by_combobox.currentText() == 'speed'
+    assert layer.color_by == qt_update_color_by
+    assert qtctrl.color_by_combobox.currentText() == qt_update_color_by

--- a/napari/_qt/layer_controls/_tests/test_qt_tracks_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_tracks_layer.py
@@ -1,0 +1,32 @@
+import numpy as np
+from qtpy.QtCore import Qt
+
+from napari._qt.layer_controls.qt_tracks_controls import QtTracksControls
+from napari.layers import Tracks
+
+_TRACKS = np.zeros((2, 4))
+_PROPERTIES = {'speed': [50, 30], 'time': [0, 1]}
+
+
+def test_tracks_controls_color_by(qtbot):
+    """Check updating of the color_by combobox."""
+    layer = Tracks(_TRACKS, properties=_PROPERTIES, color_by='speed')
+    qtctrl = QtTracksControls(layer)
+    qtbot.addWidget(qtctrl)
+
+    # verify the color_by argument is initialized correctly
+    assert layer.color_by == 'speed'
+    assert qtctrl.color_by_combobox.currentText() == 'speed'
+
+    # update color_by from the layer model
+    layer.color_by = 'time'
+    assert layer.color_by == 'time'
+    assert qtctrl.color_by_combobox.currentText() == 'time'
+
+    # update color_by from the qt controls
+    speed_index = qtctrl.color_by_combobox.findText(
+        'speed', Qt.MatchFixedString
+    )
+    qtctrl.color_by_combobox.setCurrentIndex(speed_index)
+    assert layer.color_by == 'speed'
+    assert qtctrl.color_by_combobox.currentText() == 'speed'

--- a/napari/_qt/layer_controls/qt_tracks_controls.py
+++ b/napari/_qt/layer_controls/qt_tracks_controls.py
@@ -42,7 +42,7 @@ class QtTracksControls(QtLayerControls):
         self.color_by_combobox.addItems(self.layer.properties_to_color_by)
 
         self.colormap_combobox = QComboBox()
-        self.colormap_combobox.addItems(AVAILABLE_COLORMAPS.keys())
+        self.colormap_combobox.addItems(list(AVAILABLE_COLORMAPS.keys()))
 
         # slider for track tail length
         self.tail_length_slider = QSlider(Qt.Horizontal)

--- a/napari/_qt/layer_controls/qt_tracks_controls.py
+++ b/napari/_qt/layer_controls/qt_tracks_controls.py
@@ -40,6 +40,7 @@ class QtTracksControls(QtLayerControls):
         # keys
         self.color_by_combobox = QComboBox()
         self.color_by_combobox.addItems(self.layer.properties_to_color_by)
+
         self.colormap_combobox = QComboBox()
         self.colormap_combobox.addItems(AVAILABLE_COLORMAPS.keys())
 
@@ -99,7 +100,6 @@ class QtTracksControls(QtLayerControls):
 
         self._on_tail_length_change()
         self._on_tail_width_change()
-        self._on_properties_change()
         self._on_colormap_change()
         self._on_color_by_change()
 


### PR DESCRIPTION
# Description
This PR fixes the handling of the `color_by` argument when initializing a `Tracks` layer (see #1722)

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #1722 

# How has this been tested?
- [x] all tests pass with my change
- [x] added a test for the qt controls that fails on master and passes with this patch

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
