### PR TITLE
fix screen change glitch on pixel scale

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -69,7 +69,11 @@ class Window:
         self._qt_window = QMainWindow()
         self._qt_window.setAttribute(Qt.WA_DeleteOnClose)
         self._qt_window.setUnifiedTitleAndToolBarOnMac(True)
-        self._qt_window.windowHandle().screenChanged.connect(self.qt_viewer.canvas._backend.screen_changed)
+
+        # since we initialize canvas before window, we need to manually connect them again
+        self._qt_window.windowHandle().screenChanged.connect(
+            self.qt_viewer.canvas._backend.screen_changed
+        )
         self._qt_center = QWidget(self._qt_window)
 
         self._qt_window.setCentralWidget(self._qt_center)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -71,7 +71,7 @@ class Window:
         self._qt_window.setUnifiedTitleAndToolBarOnMac(True)
 
         # since we initialize canvas before window, we need to manually connect them again.
-        if hasattr(self.qt_viewer.canvas, "_backend"):
+        if hasattr(self._qt_window, "windowHandle"):
             self._qt_window.windowHandle().screenChanged.connect(
                 self.qt_viewer.canvas._backend.screen_changed
             )

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -70,7 +70,11 @@ class Window:
         self._qt_window.setAttribute(Qt.WA_DeleteOnClose)
         self._qt_window.setUnifiedTitleAndToolBarOnMac(True)
 
-        self._on_screen_change()
+        # since we initialize canvas before window, we need to manually connect them again.
+        if hasattr(self.qt_viewer.canvas, "_backend"):
+            self._qt_window.windowHandle().screenChanged.connect(
+                self.qt_viewer.canvas._backend.screen_changed
+            )
         self._qt_center = QWidget(self._qt_window)
 
         self._qt_window.setCentralWidget(self._qt_center)
@@ -118,18 +122,6 @@ class Window:
 
         if show:
             self.show()
-
-    def _on_screen_change(self):
-        """
-        since we initialize canvas before window, we need to manually connect them again.
-        """
-        try:
-            self._qt_window.windowHandle().screenChanged.connect(
-                self.qt_viewer.canvas._backend.screen_changed
-            )
-        except AttributeError:
-            # either not PyQt5 backend or no parent window available
-            pass
 
     def _add_menubar(self):
         """Add menubar to napari app."""

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -71,7 +71,7 @@ class Window:
         self._qt_window.setUnifiedTitleAndToolBarOnMac(True)
 
         # since we initialize canvas before window, we need to manually connect them again.
-        if hasattr(self._qt_window, "windowHandle"):
+        if self._qt_window.windowHandle() is not None:
             self._qt_window.windowHandle().screenChanged.connect(
                 self.qt_viewer.canvas._backend.screen_changed
             )

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -69,6 +69,7 @@ class Window:
         self._qt_window = QMainWindow()
         self._qt_window.setAttribute(Qt.WA_DeleteOnClose)
         self._qt_window.setUnifiedTitleAndToolBarOnMac(True)
+        self._qt_window.windowHandle().screenChanged.connect(self.qt_viewer.canvas._backend.screen_changed)
         self._qt_center = QWidget(self._qt_window)
 
         self._qt_window.setCentralWidget(self._qt_center)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -70,10 +70,7 @@ class Window:
         self._qt_window.setAttribute(Qt.WA_DeleteOnClose)
         self._qt_window.setUnifiedTitleAndToolBarOnMac(True)
 
-        # since we initialize canvas before window, we need to manually connect them again
-        self._qt_window.windowHandle().screenChanged.connect(
-            self.qt_viewer.canvas._backend.screen_changed
-        )
+        self._on_screen_change()
         self._qt_center = QWidget(self._qt_window)
 
         self._qt_window.setCentralWidget(self._qt_center)
@@ -121,6 +118,18 @@ class Window:
 
         if show:
             self.show()
+
+    def _on_screen_change(self):
+        """
+        since we initialize canvas before window, we need to manually connect them again.
+        """
+        try:
+            self._qt_window.windowHandle().screenChanged.connect(
+                self.qt_viewer.canvas._backend.screen_changed
+            )
+        except AttributeError:
+            # either not PyQt5 backend or no parent window available
+            pass
 
     def _add_menubar(self):
         """Add menubar to napari app."""


### PR DESCRIPTION
# Description
fixed screen change event connection, which was broken because we initialize viewer and canvas before the window
closes #566 

## Type of change
- Bug-fix (non-breaking change which fixes an issue)

# References
https://github.com/napari/napari/issues/566

# How has this been tested?
- manually tested screen change and verified the glitch is gone

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
