### PR TITLE
Compute all min/max values in one pass with Dask

### DIFF
--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -37,7 +37,8 @@ def calc_data_range(data):
             [np.max(data[idx]) for idx in idxs],
             [np.min(data[idx]) for idx in idxs],
         ]
-        reduced_data = dask.compute(*reduced_data)  # compute everything in one go
+        # compute everything in one go
+        reduced_data = dask.compute(*reduced_data)
     else:
         reduced_data = data
 

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -1,5 +1,6 @@
 from typing import Dict, Tuple, Union
 
+import dask
 import numpy as np
 
 from ...utils.colormaps import Colormap
@@ -36,6 +37,7 @@ def calc_data_range(data):
             [np.max(data[idx]) for idx in idxs],
             [np.min(data[idx]) for idx in idxs],
         ]
+        reduced_data = dask.compute(*reduced_data)  # compute everything in one go
     else:
         reduced_data = data
 


### PR DESCRIPTION
# Description

Previously we would compute the min/max of every layer with independent
calls.  This could cause problems with Dask because we would reload the
same Dask array many times, which was inefficient, especially with the
distributed scheduler.

Now we compute all of these at once with a dask.compute call.  This adds
concurrency and also helps us take advantage of shared structure between
different layers.

The dask.compute call will pass through non-dask objects, so this
shouldn't have any effect in the numpy case.


## Type of change
- Performance enhancement

# How has this been tested?

I spot tested while running the following script

```python
import napari
from dask.distributed import Client
import dask.array as da

x = da.random.random((10000, 10000))

client = Client(processes=False)

with napari.gui_qt():
    viewer = napari.view_image(x + 1)
    viewer.add_image(x - 1)
```

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works