### PR TITLE
Handle non-existant properties keys for color_by in Tracks layer

### DIFF
--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -75,7 +75,7 @@ def test_track_layer_colorby_nonexistant():
     """Test error handling for non-existant properties with color_by"""
     data = np.zeros((100, 4))
     data[:, 1] = np.arange(100)
-    non_existant_property = '42'
+    non_existant_property = 'not_a_valid_key'
     assert non_existant_property not in properties_dict.keys()
     with pytest.raises(ValueError):
         layer = Tracks(

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -56,7 +56,6 @@ def test_track_layer_data():
     layer = Tracks(data)
     assert np.all(layer.data == data)
 
-
 properties_dict = {'time': np.arange(100)}
 properties_df = pd.DataFrame(properties_dict)
 
@@ -83,6 +82,23 @@ def test_track_layer_colorby_nonexistant():
                     properties=properties_dict,
                     color_by=non_existant_property
                     )
+
+def test_track_layer_properties_changed_colorby():
+    """Test behaviour when changes to properties invalidate current color_by"""
+    properties_dict_1 = {'time': np.arange(100), 'prop1': np.arange(100)}
+    properties_dict_2 = {'time': np.arange(100), 'prop2': np.arange(100)}
+    data = np.zeros((100, 4))
+    data[:, 1] = np.arange(100)
+    layer = Tracks(
+                    data, 
+                    properties=properties_dict_1,
+                    color_by='prop1'
+                    )
+    # test warning is raised
+    with pytest.warns(UserWarning):
+        layer.properties = properties_dict_2
+    # test default fallback
+    assert layer.color_by == 'track_id'
 
 
 def test_track_layer_graph():

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -56,6 +56,7 @@ def test_track_layer_data():
     layer = Tracks(data)
     assert np.all(layer.data == data)
 
+
 properties_dict = {'time': np.arange(100)}
 properties_df = pd.DataFrame(properties_dict)
 
@@ -69,6 +70,7 @@ def test_track_layer_properties(properties):
     for k, v in properties.items():
         np.testing.assert_equal(layer.properties[k], v)
 
+
 @pytest.mark.filterwarnings("ignore:.*track_id.*:UserWarning")
 def test_track_layer_colorby_nonexistant():
     """Test error handling for non-existant properties with color_by"""
@@ -78,10 +80,9 @@ def test_track_layer_colorby_nonexistant():
     assert non_existant_property not in properties_dict.keys()
     with pytest.raises(ValueError):
         layer = Tracks(
-                    data, 
-                    properties=properties_dict,
-                    color_by=non_existant_property
-                    )
+            data, properties=properties_dict, color_by=non_existant_property
+        )
+
 
 @pytest.mark.filterwarnings("ignore:.*track_id.*:UserWarning")
 def test_track_layer_properties_changed_colorby():
@@ -90,11 +91,7 @@ def test_track_layer_properties_changed_colorby():
     properties_dict_2 = {'time': np.arange(100), 'prop2': np.arange(100)}
     data = np.zeros((100, 4))
     data[:, 1] = np.arange(100)
-    layer = Tracks(
-                    data, 
-                    properties=properties_dict_1,
-                    color_by='prop1'
-                    )
+    layer = Tracks(data, properties=properties_dict_1, color_by='prop1')
     # test warning is raised
     with pytest.warns(UserWarning):
         layer.properties = properties_dict_2

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -70,6 +70,19 @@ def test_track_layer_properties(properties):
     for k, v in properties.items():
         np.testing.assert_equal(layer.properties[k], v)
 
+def test_track_layer_colorby_nonexistant():
+    """Test error handling for non-existant properties with color_by"""
+    data = np.zeros((100, 4))
+    data[:, 1] = np.arange(100)
+    non_existant_property = '42'
+    assert non_existant_property not in properties_dict.keys()
+    with pytest.raises(ValueError):
+        layer = Tracks(
+                    data, 
+                    properties=properties_dict(),
+                    color_by=non_existant_property
+                    )
+
 
 def test_track_layer_graph():
     """Test track layer graph."""

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -69,7 +69,7 @@ def test_track_layer_properties(properties):
     for k, v in properties.items():
         np.testing.assert_equal(layer.properties[k], v)
 
-
+@pytest.mark.filterwarnings("ignore:.*track_id.*:UserWarning")
 def test_track_layer_colorby_nonexistant():
     """Test error handling for non-existant properties with color_by"""
     data = np.zeros((100, 4))
@@ -83,6 +83,7 @@ def test_track_layer_colorby_nonexistant():
                     color_by=non_existant_property
                     )
 
+@pytest.mark.filterwarnings("ignore:.*track_id.*:UserWarning")
 def test_track_layer_properties_changed_colorby():
     """Test behaviour when changes to properties invalidate current color_by"""
     properties_dict_1 = {'time': np.arange(100), 'prop1': np.arange(100)}

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -80,7 +80,7 @@ def test_track_layer_colorby_nonexistant():
     with pytest.raises(ValueError):
         layer = Tracks(
                     data, 
-                    properties=properties_dict(),
+                    properties=properties_dict,
                     color_by=non_existant_property
                     )
 

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -70,6 +70,7 @@ def test_track_layer_properties(properties):
     for k, v in properties.items():
         np.testing.assert_equal(layer.properties[k], v)
 
+
 def test_track_layer_colorby_nonexistant():
     """Test error handling for non-existant properties with color_by"""
     data = np.zeros((100, 4))

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -79,7 +79,7 @@ def test_track_layer_colorby_nonexistant():
     non_existant_property = 'not_a_valid_key'
     assert non_existant_property not in properties_dict.keys()
     with pytest.raises(ValueError):
-        layer = Tracks(
+        Tracks(
             data, properties=properties_dict, color_by=non_existant_property
         )
 

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -351,8 +351,8 @@ class Tracks(Layer):
 
             warn(
                 (f"Previous color_by key {self._color_by} not present in"
-                " new properties. Falling back to track_id")
-                UserWarning,
+                " new properties. Falling back to track_id"),
+                UserWarning
             )
             self._color_by = 'track_id'
         self._manager.properties = properties

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -3,6 +3,7 @@
 # from napari.utils.colormaps import AVAILABLE_COLORMAPS
 
 from typing import Dict, List, Union
+from warnings import warn
 
 import numpy as np
 
@@ -347,8 +348,6 @@ class Tracks(Layer):
     def properties(self, properties: Dict[str, np.ndarray]):
         """ set track properties """
         if self._color_by not in [*properties.keys(), 'track_id']:
-            from warnings import warn
-
             warn(
                 (
                     f"Previous color_by key {self._color_by} not present in"

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -348,7 +348,8 @@ class Tracks(Layer):
         """ set track properties """
         if self._color_by not in properties.keys():
             from warnings import warn
-            warn("existing color_by key not present in new properties", UserWarning)
+            warn(f"Previous color_by key {self._color_by} not present in new properties.Falling back to track_id", UserWarning)
+            self._color_by='track_id'
         self._manager.properties = properties
         self.events.properties()
         self.events.color_by()

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -346,7 +346,7 @@ class Tracks(Layer):
     @properties.setter
     def properties(self, properties: Dict[str, np.ndarray]):
         """ set track properties """
-        if self._color_by not in properties.keys():
+        if self._color_by not in [*properties.keys(), 'track_id']:
             from warnings import warn
             warn(f"Previous color_by key {self._color_by} not present in new properties.Falling back to track_id", UserWarning)
             self._color_by='track_id'

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -346,6 +346,9 @@ class Tracks(Layer):
     @properties.setter
     def properties(self, properties: Dict[str, np.ndarray]):
         """ set track properties """
+        if self._color_by not in properties.keys():
+            from warnings import warn
+            warn("existing color_by key not present in new properties", UserWarning)
         self._manager.properties = properties
         self.events.properties()
         self.events.color_by()

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -423,7 +423,7 @@ class Tracks(Layer):
     def color_by(self, color_by: str):
         """ set the property to color vertices by """
         if color_by not in self.properties_to_color_by:
-            raise ValueError(f"{color_by} is not a valid property key")
+            raise ValueError(f'{color_by} is not a valid property key')
         self._color_by = color_by
         self._recolor_tracks()
         self.events.color_by()

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -14,7 +14,7 @@ from ._track_utils import TrackManager
 
 
 class Tracks(Layer):
-    """ Tracks layer.
+    """Tracks layer.
 
     Parameters
     ----------
@@ -303,8 +303,8 @@ class Tracks(Layer):
 
     @property
     def use_fade(self) -> bool:
-        """ toggle whether we fade the tail of the track, depending on whether
-        the time dimension is displayed """
+        """toggle whether we fade the tail of the track, depending on whether
+        the time dimension is displayed"""
         return 0 in self.dims.not_displayed
 
     @property
@@ -348,8 +348,13 @@ class Tracks(Layer):
         """ set track properties """
         if self._color_by not in [*properties.keys(), 'track_id']:
             from warnings import warn
-            warn(f"Previous color_by key {self._color_by} not present in new properties.Falling back to track_id", UserWarning)
-            self._color_by='track_id'
+
+            warn(
+                (f"Previous color_by key {self._color_by} not present in"
+                " new properties. Falling back to track_id")
+                UserWarning,
+            )
+            self._color_by = 'track_id'
         self._manager.properties = properties
         self.events.properties()
         self.events.color_by()
@@ -486,8 +491,8 @@ class Tracks(Layer):
 
     @property
     def track_colors(self) -> np.ndarray:
-        """ return the vertex colors according to the currently selected
-        property """
+        """return the vertex colors according to the currently selected
+        property"""
         return self._track_colors
 
     @property

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -423,7 +423,7 @@ class Tracks(Layer):
     def color_by(self, color_by: str):
         """ set the property to color vertices by """
         if color_by not in self.properties_to_color_by:
-            return
+            raise ValueError(f"{color_by} is not a valid property key")
         self._color_by = color_by
         self._recolor_tracks()
         self.events.color_by()

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -350,9 +350,11 @@ class Tracks(Layer):
             from warnings import warn
 
             warn(
-                (f"Previous color_by key {self._color_by} not present in"
-                " new properties. Falling back to track_id"),
-                UserWarning
+                (
+                    f"Previous color_by key {self._color_by} not present in"
+                    " new properties. Falling back to track_id"
+                ),
+                UserWarning,
             )
             self._color_by = 'track_id'
         self._manager.properties = properties


### PR DESCRIPTION
# Description

Addresses #1733 

1. Specifying a non-existing property as `color_by` argument when creating a Track now triggers a ValueError.
1. When the `color_by` key becomes obsolete when the `properties` are updated `color_by` will fall back to `track_id` and a `UserWarning` is issued.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Fixes #1733

# How has this been tested?

See added tests.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
