### PR TITLE
Fix scale bar length in 3D

### DIFF
--- a/examples/scale_bar.py
+++ b/examples/scale_bar.py
@@ -1,0 +1,12 @@
+"""
+Display a 3D volume and the scale bar
+"""
+import numpy as np
+import napari
+
+
+with napari.gui_qt():
+    np.random.seed(0)
+    viewer = napari.Viewer()
+    viewer.add_image(np.random.random((5, 5, 5)), colormap='red', opacity=0.8)
+    viewer.scale_bar.visible = True


### PR DESCRIPTION
# Description
This PR fixes the scale bar in 3D by removing a magic number and getting the correct scaling from the vispy camera matrix.
This closes #1735.

I also added a small example `examples/scale_bar.py` that can be used to verify the accuracy of the scale bar length in both 2D and 3D, see the gif below. This is ready for review.

![scale_bar_position2](https://user-images.githubusercontent.com/6531703/96355778-88bc9380-109a-11eb-8839-81dc40045a86.gif)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
Closes #1735
# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added `examples/scale_bar.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
