### PR TITLE
Fix world coordinates origin in 3D

### DIFF
--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -127,9 +127,11 @@ class VispyBaseLayer(ABC):
         affine_matrix[: matrix.shape[0], : matrix.shape[1]] = matrix
         affine_matrix[-1, : len(translate)] = translate
 
-        if self._array_like:
+        if self._array_like and self.layer.dims.ndisplay == 2:
             # Perform pixel offset to shift origin from top left corner
-            # of pixel to center of pixel
+            # of pixel to center of pixel.
+            # Note this offset is only required for array like data in
+            # 2D.
             offset_matrix = (
                 self.layer._transforms['data2world']
                 .set_slice(self.layer.dims.displayed)


### PR DESCRIPTION
# Description
This closes #1739 by only applying the pixel scale offset when doing 2D rendering. Evidently vispy uses a top left corner pixel origin for 2D data and a center pixel origin for 3D data. This change now takes that into account, as seen in the gif below (see issue for example of broken gif):

![world_coordinates_volume_fix](https://user-images.githubusercontent.com/6531703/96400905-da424c80-1186-11eb-8f37-661d5b850832.gif)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
