### PR TITLE
doc: Fix top-level links referenced in README.md and published on napari.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,20 +121,20 @@ For more details on how to use `napari` checkout our [tutorials](https://napari.
 
 ## mission, values, and roadmap
 
-For more information about our plans for `napari` you can read our [mission and values statement](./docs/source/developers/MISSION_AND_VALUES.md), which includes more details on our vision for supporting a plugin ecosystem around napari. We also have
-a [roadmap](./docs/source/developers/ROADMAP_0_3.md) that captures current development priorities within the project.
+For more information about our plans for `napari` you can read our [mission and values statement](https://napari.org/docs/dev/developers/MISSION_AND_VALUES.html), which includes more details on our vision for supporting a plugin ecosystem around napari. We also have
+a [roadmap](https://napari.org/docs/dev/developers/ROADMAP_0_3.html) that captures current development priorities within the project.
 
 ## contributing
 
-Contributions are encouraged! Please read our [contributing guide](./docs/source/developers/CONTRIBUTING.md) to get started. Given that we're in an early stage, you may want to reach out on our [Github Issues](https://github.com/napari/napari/issues) before jumping in.
+Contributions are encouraged! Please read our [contributing guide](https://napari.org/docs/dev/developers/CONTRIBUTING.html) to get started. Given that we're in an early stage, you may want to reach out on our [Github Issues](https://github.com/napari/napari/issues) before jumping in.
 
 ## code of conduct
 
-`napari` has a [Code of Conduct](./docs/source/developers/CODE_OF_CONDUCT.md) that should be honored by everyone who participates in the `napari` community.
+`napari` has a [Code of Conduct](https://napari.org/docs/dev/developers/CODE_OF_CONDUCT.html) that should be honored by everyone who participates in the `napari` community.
 
 ## governance
 
-You can learn more about how the `napari` project is organized and managed from our [governance model](./docs/source/developers/GOVERNANCE.md), which includes information about, and ways to contact, the [@napari/steering-council](https://github.com/orgs/napari/teams/steering-council) and [@napari/core-devs](https://github.com/orgs/napari/teams/core-devs).
+You can learn more about how the `napari` project is organized and managed from our [governance model](https://napari.org/docs/dev/developers/GOVERNANCE.html), which includes information about, and ways to contact, the [@napari/steering-council](https://github.com/orgs/napari/teams/steering-council) and [@napari/core-devs](https://github.com/orgs/napari/teams/core-devs).
 
 ## citing napari
 


### PR DESCRIPTION
# Description

This commit fixes links to mission and values, governance, and related pages
by implementing changes suggested in #1702.

This fix is similar to ba72fc2f3 (Fix 404 links in documentation and
remove warnings in docs build)

Background: Following commit ce154d62e (Build docs action (#1638)), documentation
is built and published to a dedicated documentation repository (https://github.com/napari/docs)
associated with URL https://napari.org/docs. This takes precedence over
the publication of the top-level README.md as GitHub pages associated with
https://napari.org. This commit addresses this problem by directly linking
to page published at https://napari.org/docs

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
<!--
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
-->

# References

<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

closes #1702

<!-- Please describe the tests that you ran to verify your changes. -->

# How has this been tested?

Links referenced in README.md have been manually verified.

## Final checklist:

- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works