### PR TITLE
Fix grid size calculation

### DIFF
--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -256,7 +256,7 @@ def test_grid_mode(make_test_viewer):
 
     # enter grid view
     viewer.grid_view()
-    assert np.all(viewer.grid_size == (3, 3))
+    assert np.all(viewer.grid_size == (2, 3))
     assert viewer.grid_stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = [
@@ -276,9 +276,9 @@ def test_grid_mode(make_test_viewer):
         (1 / 3, 1 / 3),
         (1 / 3, 1 / 2),
         (1 / 3, 2 / 3),
-        (1 / 2, 1 / 3),
-        (1 / 2, 1 / 2),
-        (1 / 2, 2 / 3),
+        (2 / 3, 1 / 3),
+        (2 / 3, 1 / 2),
+        (2 / 3, 2 / 3),
     ]
     # BGRMYC color order
     color = [
@@ -300,15 +300,6 @@ def test_grid_mode(make_test_viewer):
 
     # check screenshot
     screenshot = viewer.screenshot(canvas_only=True)
-    # sample 6 squares of the grid and check they have right colors
-    pos = [
-        (1 / 3, 1 / 3),
-        (1 / 3, 1 / 2),
-        (1 / 3, 2 / 3),
-        (1 / 2, 1 / 3),
-        (1 / 2, 1 / 2),
-        (1 / 2, 2 / 3),
-    ]
     # CGRMYB color order
     color = [
         [0, 255, 255, 255],

--- a/napari/_viewer_key_bindings.py
+++ b/napari/_viewer_key_bindings.py
@@ -124,7 +124,7 @@ def reset_view(viewer):
 def toggle_grid(viewer):
     """Toggle grid mode."""
     if np.all(viewer.grid_size == (1, 1)):
-        viewer.grid_view()
+        viewer.grid_view(stride=viewer.grid_stride)
     else:
         viewer.stack_view()
 

--- a/napari/_viewer_key_bindings.py
+++ b/napari/_viewer_key_bindings.py
@@ -124,7 +124,7 @@ def reset_view(viewer):
 def toggle_grid(viewer):
     """Toggle grid mode."""
     if np.all(viewer.grid_size == (1, 1)):
-        viewer.grid_view(stride=viewer.grid_stride)
+        viewer.grid_view()
     else:
         viewer.stack_view()
 

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -339,7 +339,7 @@ def test_grid():
 
     # enter grid view
     viewer.grid_view()
-    assert np.all(viewer.grid_size == (3, 3))
+    assert np.all(viewer.grid_size == (2, 3))
     assert viewer.grid_stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = [

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -434,8 +434,8 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         """
         n_grid_squares = np.ceil(len(self.layers) / abs(stride)).astype(int)
         if n_row is None and n_column is None:
-            n_row = np.ceil(np.sqrt(n_grid_squares)).astype(int)
-            n_column = n_row
+            n_column = np.ceil(np.sqrt(n_grid_squares)).astype(int)
+            n_row = np.ceil(n_grid_squares / n_column).astype(int)
         elif n_row is None:
             n_row = np.ceil(n_grid_squares / n_column).astype(int)
         elif n_column is None:


### PR DESCRIPTION
# Description
This PR closes #1689 by updating the calculation for the grid size. See gif below of `example/nD_labels.py`

![grid_size](https://user-images.githubusercontent.com/6531703/96789610-5799d700-13aa-11eb-98b1-dea6f01025cb.gif)

I'm actually hoping that multicanvas support will be one of the very next things we work on after the `0.4.0` release and that we might actually drop grid mode after that is done, so I'd rather not do too much more here. At least the behavior @jni noted is improved.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
