### PR TITLE
Fix flipped transform

### DIFF
--- a/napari/components/_tests/test_layers_list.py
+++ b/napari/components/_tests/test_layers_list.py
@@ -578,6 +578,22 @@ def test_world_extent_mixed_ndim():
     np.testing.assert_allclose(layers._step_size, (4, 6, 2))
 
 
+def test_world_extent_mixed_flipped():
+    """Test world extent after adding data with a flip."""
+    # Flipped data results in a negative scale value which should be
+    # made positive when taking into consideration for the step size
+    # calculation
+    np.random.seed(0)
+    layers = LayerList()
+
+    layer = Image(
+        np.random.random((15, 15)), affine=[[0, 1, 0], [1, 0, 0], [0, 0, 1]]
+    )
+    layers.append(layer)
+    np.testing.assert_allclose(layer.scale, (1, -1))
+    np.testing.assert_allclose(layers._step_size, (1, 1))
+
+
 def test_ndim():
     """Test world extent after adding layers."""
     np.random.seed(0)

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -248,7 +248,7 @@ class LayerList(ListModel):
         if len(self) == 0:
             return np.ones(self.ndim)
         else:
-            scales = [layer.scale[::-1] for layer in self]
+            scales = [abs(layer.scale[::-1]) for layer in self]
             full_scales = list(
                 np.array(
                     list(itertools.zip_longest(*scales, fillvalue=np.nan))


### PR DESCRIPTION
# Description
Closes #1756, problem was a missing `abs` now that scales could be negative to indicate flipped transforms introduced in #1616. Broadcasting actually worked perfectly. I've fixed and added a test

<img width="1200" alt="Screen Shot 2020-10-22 at 9 30 30 AM" src="https://user-images.githubusercontent.com/6531703/96902364-4653d780-1449-11eb-94bf-4d67fcf359da.png">


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

