### PR TITLE
Fix warning that filenames might not be set

### DIFF
--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -390,6 +390,7 @@ class AddLayersMixin:
 
         # glean layer names from filename. These will be used as *fallback*
         # names, if the plugin does not return a name kwarg in their meta dict.
+        filenames = []
         if isinstance(path_or_paths, str):
             filenames = itertools.repeat(path_or_paths)
         elif is_sequence(path_or_paths):


### PR DESCRIPTION
# Description
I see this warning in VSCode not sure why CI does not flag it.

It's saying it cannot guarantee that filenames will be assigned to anything. Even though presumably in our usage it is always set. The one-line fix here is totally harmless and fixes the warning.

## Type of change
- [x] Fix warning

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
