### PR TITLE
Add extent named tuple

### DIFF
--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -36,7 +36,7 @@ class QtLayerButtons(QFrame):
             'New points layer',
             lambda: self.viewer.add_points(
                 ndim=max(self.viewer.dims.ndim, 2),
-                scale=self.viewer.layers._step_size,
+                scale=self.viewer.layers.extent.step,
             ),
         )
 
@@ -46,7 +46,7 @@ class QtLayerButtons(QFrame):
             'New shapes layer',
             lambda: self.viewer.add_shapes(
                 ndim=max(self.viewer.dims.ndim, 2),
-                scale=self.viewer.layers._step_size,
+                scale=self.viewer.layers.extent.step,
             ),
         )
         self.newLabelsButton = QtViewerPushButton(

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -165,17 +165,17 @@ def check_layer_world_data_extent(layer, extent, scale, translate):
     translate : array, shape (D,)
         Translation to be applied to layer.
     """
-    np.testing.assert_almost_equal(layer._extent_data, extent)
-    np.testing.assert_almost_equal(layer._extent_world, extent)
+    np.testing.assert_almost_equal(layer.extent.data, extent)
+    np.testing.assert_almost_equal(layer.extent.world, extent)
 
     # Apply scale transformation
     layer.scale = scale
     scaled_extent = np.multiply(extent, scale)
-    np.testing.assert_almost_equal(layer._extent_data, extent)
-    np.testing.assert_almost_equal(layer._extent_world, scaled_extent)
+    np.testing.assert_almost_equal(layer.extent.data, extent)
+    np.testing.assert_almost_equal(layer.extent.world, scaled_extent)
 
     # Apply translation transformation
     layer.translate = translate
     translated_extent = np.add(scaled_extent, translate)
-    np.testing.assert_almost_equal(layer._extent_data, extent)
-    np.testing.assert_almost_equal(layer._extent_world, translated_extent)
+    np.testing.assert_almost_equal(layer.extent.data, extent)
+    np.testing.assert_almost_equal(layer.extent.world, translated_extent)

--- a/napari/components/_tests/test_layers_list.py
+++ b/napari/components/_tests/test_layers_list.py
@@ -534,31 +534,31 @@ def test_world_extent():
     layers = LayerList()
 
     # Empty data is taken to be 512 x 512
-    np.testing.assert_allclose(layers._extent_world[0], (0, 0))
-    np.testing.assert_allclose(layers._extent_world[1], (511, 511))
-    np.testing.assert_allclose(layers._step_size, (1, 1))
+    np.testing.assert_allclose(layers.extent.world[0], (0, 0))
+    np.testing.assert_allclose(layers.extent.world[1], (511, 511))
+    np.testing.assert_allclose(layers.extent.step, (1, 1))
 
     # Add one layer
     layer_a = Image(
         np.random.random((6, 10, 15)), scale=(3, 1, 1), translate=(10, 20, 5)
     )
     layers.append(layer_a)
-    np.testing.assert_allclose(layer_a._extent_world[0], (10, 20, 5))
-    np.testing.assert_allclose(layer_a._extent_world[1], (25, 29, 19))
-    np.testing.assert_allclose(layers._extent_world[0], (10, 20, 5))
-    np.testing.assert_allclose(layers._extent_world[1], (25, 29, 19))
-    np.testing.assert_allclose(layers._step_size, (3, 1, 1))
+    np.testing.assert_allclose(layer_a.extent.world[0], (10, 20, 5))
+    np.testing.assert_allclose(layer_a.extent.world[1], (25, 29, 19))
+    np.testing.assert_allclose(layers.extent.world[0], (10, 20, 5))
+    np.testing.assert_allclose(layers.extent.world[1], (25, 29, 19))
+    np.testing.assert_allclose(layers.extent.step, (3, 1, 1))
 
     # Add another layer
     layer_b = Image(
         np.random.random((8, 6, 15)), scale=(6, 2, 1), translate=(-5, -10, 10)
     )
     layers.append(layer_b)
-    np.testing.assert_allclose(layer_b._extent_world[0], (-5, -10, 10))
-    np.testing.assert_allclose(layer_b._extent_world[1], (37, 0, 24))
-    np.testing.assert_allclose(layers._extent_world[0], (-5, -10, 5))
-    np.testing.assert_allclose(layers._extent_world[1], (37, 29, 24))
-    np.testing.assert_allclose(layers._step_size, (3, 1, 1))
+    np.testing.assert_allclose(layer_b.extent.world[0], (-5, -10, 10))
+    np.testing.assert_allclose(layer_b.extent.world[1], (37, 0, 24))
+    np.testing.assert_allclose(layers.extent.world[0], (-5, -10, 5))
+    np.testing.assert_allclose(layers.extent.world[1], (37, 29, 24))
+    np.testing.assert_allclose(layers.extent.step, (3, 1, 1))
 
 
 def test_world_extent_mixed_ndim():
@@ -569,13 +569,13 @@ def test_world_extent_mixed_ndim():
     # Add 3D layer
     layer_a = Image(np.random.random((15, 15, 15)), scale=(4, 12, 2))
     layers.append(layer_a)
-    np.testing.assert_allclose(layers._extent_world[1], (56, 168, 28))
+    np.testing.assert_allclose(layers.extent.world[1], (56, 168, 28))
 
     # Add 2D layer
     layer_b = Image(np.random.random((10, 10)), scale=(6, 4))
     layers.append(layer_b)
-    np.testing.assert_allclose(layers._extent_world[1], (56, 168, 36))
-    np.testing.assert_allclose(layers._step_size, (4, 6, 2))
+    np.testing.assert_allclose(layers.extent.world[1], (56, 168, 36))
+    np.testing.assert_allclose(layers.extent.step, (4, 6, 2))
 
 
 def test_world_extent_mixed_flipped():
@@ -591,7 +591,7 @@ def test_world_extent_mixed_flipped():
     )
     layers.append(layer)
     np.testing.assert_allclose(layer.scale, (1, -1))
-    np.testing.assert_allclose(layers._step_size, (1, 1))
+    np.testing.assert_allclose(layers.extent.step, (1, 1))
 
 
 def test_ndim():

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -496,8 +496,8 @@ def test_sliced_world_extent():
     viewer.add_image(
         np.random.random((6, 10, 15)), scale=(3, 1, 1), translate=(10, 20, 5)
     )
-    np.testing.assert_allclose(viewer.layers._extent_world[0], (10, 20, 5))
-    np.testing.assert_allclose(viewer.layers._extent_world[1], (25, 29, 19))
+    np.testing.assert_allclose(viewer.layers.extent.world[0], (10, 20, 5))
+    np.testing.assert_allclose(viewer.layers.extent.world[1], (25, 29, 19))
     np.testing.assert_allclose(viewer._sliced_extent_world[0], (20, 5))
     np.testing.assert_allclose(viewer._sliced_extent_world[1], (29, 19))
 

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -1,5 +1,6 @@
 import itertools
 import warnings
+from collections import namedtuple
 from typing import List, Optional
 
 import numpy as np
@@ -7,6 +8,8 @@ import numpy as np
 from ..layers import Layer
 from ..utils.list import ListModel
 from ..utils.naming import inc_name_count
+
+Extent = namedtuple('Extent', 'data world step')
 
 
 def _add(event):
@@ -205,7 +208,7 @@ class LayerList(ListModel):
             min_v = [np.nan] * self.ndim
             max_v = [np.nan] * self.ndim
         else:
-            extrema = [layer._extent_world for layer in self]
+            extrema = [layer.extent.world for layer in self]
             mins = [e[0][::-1] for e in extrema]
             maxs = [e[1][::-1] for e in extrema]
 
@@ -248,7 +251,7 @@ class LayerList(ListModel):
         if len(self) == 0:
             return np.ones(self.ndim)
         else:
-            scales = [abs(layer.scale[::-1]) for layer in self]
+            scales = [layer.extent.step[::-1] for layer in self]
             full_scales = list(
                 np.array(
                     list(itertools.zip_longest(*scales, fillvalue=np.nan))
@@ -256,6 +259,13 @@ class LayerList(ListModel):
             )
             min_scales = np.nanmin(full_scales, axis=0)
             return min_scales[::-1]
+
+    @property
+    def extent(self) -> Extent:
+        """Extent of layers in data and world coordinates."""
+        return Extent(
+            data=None, world=self._extent_world, step=self._step_size
+        )
 
     @property
     def ndim(self) -> int:

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -278,7 +278,7 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
                 [np.zeros(self.dims.ndim), np.repeat(512, self.dims.ndim)]
             )
         else:
-            return self.layers._extent_world[:, self.dims.displayed]
+            return self.layers.extent.world[:, self.dims.displayed]
 
     def reset_view(self, event=None):
         """Reset the camera view."""
@@ -315,8 +315,8 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
 
     def _new_labels(self):
         """Create new labels layer filling full world coordinates space."""
-        extent = self.layers._extent_world
-        scale = self.layers._step_size
+        extent = self.layers.extent.world
+        scale = self.layers.extent.step
         scene_size = extent[1] - extent[0]
         corner = extent[0]
         shape = [
@@ -386,8 +386,8 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
             self.dims.ndim = 2
             self.dims.reset()
         else:
-            extent = self.layers._extent_world
-            ss = self.layers._step_size
+            extent = self.layers.extent.world
+            ss = self.layers.extent.step
             ndim = extent.shape[1]
             self.dims.ndim = ndim
             for i in range(ndim):

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -616,11 +616,11 @@ class Layer(KeymapProvider, ABC):
         """
         warnings.warn(
             (
-                "The shape parameter is deprecated and will be removed in version 0.4.1."
-                " Instead you should use the extent.data and extent.world parameters"
+                "The shape attribute is deprecated and will be removed in version 0.4.1."
+                " Instead you should use the extent.data and extent.world attributes"
                 " to get the extent of the data in data or world coordinates."
             ),
-            category=DeprecationWarning,
+            category=FutureWarning,
             stacklevel=2,
         )
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -495,8 +495,15 @@ class Image(IntensityVisualizationMixin, Layer):
         -------
         shape : tuple
         """
-        # To Do: Deprecate when full world coordinate refactor
-        # is complete
+        warnings.warn(
+            (
+                "The shape parameter is deprecated and will be removed in version 0.4.1."
+                " Instead you should use the extent.data and extent.world parameters"
+                " to get the extent of the data in data or world coordinates."
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
 
         extent = copy(self._extent_data)
         extent[1] = extent[1] + 1

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -497,11 +497,11 @@ class Image(IntensityVisualizationMixin, Layer):
         """
         warnings.warn(
             (
-                "The shape parameter is deprecated and will be removed in version 0.4.1."
-                " Instead you should use the extent.data and extent.world parameters"
+                "The shape attribute is deprecated and will be removed in version 0.4.1."
+                " Instead you should use the extent.data and extent.world attributes"
                 " to get the extent of the data in data or world coordinates."
             ),
-            category=DeprecationWarning,
+            category=FutureWarning,
             stacklevel=2,
         )
 


### PR DESCRIPTION
# Description
This PR closes #1697 by adding a namedtuple for data and world extent, so you can do `layer.extend.data`. I quite like how it's turned out where the named tuple is really a view into a private attribute. Curious what @jni and others think. I had considered creating an [extent object like this](https://gist.github.com/sofroniewn/c825924fd6a3feef8fbdbb1ff05d0979), but think the namedtuple approach is preferable.

I can add more doc strings if people want too.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Refactor (non-breaking change which fixes an issue)