### PR TITLE
Fix scaled painting

### DIFF
--- a/napari/layers/labels/_tests/test_labels_mouse_bindings.py
+++ b/napari/layers/labels/_tests/test_labels_mouse_bindings.py
@@ -33,6 +33,7 @@ def test_paint(Event, brush_shape, expected_sum):
     data = np.ones((20, 20))
     layer = Labels(data)
     layer.brush_size = 10
+    assert layer.cursor_size == 10
     layer.brush_shape = brush_shape
     layer.mode = 'paint'
     layer.selected_label = 3
@@ -43,6 +44,43 @@ def test_paint(Event, brush_shape, expected_sum):
     mouse_press_callbacks(layer, event)
 
     layer.position = (19, 19)
+
+    # Simulate drag
+    event = ReadOnlyWrapper(Event(type='mouse_move', is_dragging=True))
+    mouse_move_callbacks(layer, event)
+
+    # Simulate release
+    event = ReadOnlyWrapper(Event(type='mouse_release', is_dragging=False))
+    mouse_release_callbacks(layer, event)
+
+    # Painting goes from (0, 0) to (19, 19) with a brush size of 10, changing
+    # all pixels along that path, but none outside it.
+    assert np.unique(layer.data[:8, :8]) == 3
+    assert np.unique(layer.data[-8:, -8:]) == 3
+    assert np.unique(layer.data[:5, -5:]) == 1
+    assert np.unique(layer.data[-5:, :5]) == 1
+    assert np.sum(layer.data == 3) == expected_sum
+
+
+@pytest.mark.parametrize(
+    "brush_shape, expected_sum", [("circle", 244), ("square", 274)]
+)
+def test_paint_scale(Event, brush_shape, expected_sum):
+    """Test painting labels with circle/square brush when scaled."""
+    data = np.ones((20, 20))
+    layer = Labels(data, scale=(2, 2))
+    layer.brush_size = 10
+    assert layer.cursor_size == 20
+    layer.brush_shape = brush_shape
+    layer.mode = 'paint'
+    layer.selected_label = 3
+    layer.position = (0, 0)
+
+    # Simulate click
+    event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
+    mouse_press_callbacks(layer, event)
+
+    layer.position = (39, 39)
 
     # Simulate drag
     event = ReadOnlyWrapper(Event(type='mouse_move', is_dragging=True))

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -512,6 +512,8 @@ class Labels(Image):
             self.help = 'hold <space> to pan/zoom, click to pick a label'
             self.mouse_drag_callbacks.append(pick)
         elif mode == Mode.PAINT:
+            # Note we have to reset the brush size to tigger an event
+            # This will be fixed in an upcomming PR
             self.brush_size = self.brush_size
             self.cursor = self.brush_shape
             self.interactive = False
@@ -529,6 +531,8 @@ class Labels(Image):
             self.help = 'hold <space> to pan/zoom, click to fill a label'
             self.mouse_drag_callbacks.append(draw)
         elif mode == Mode.ERASE:
+            # Note we have to reset the brush size to tigger an event
+            # This will be fixed in an upcomming PR
             self.brush_size = self.brush_size
             self.cursor = self.brush_shape
             self.interactive = False

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -273,7 +273,12 @@ class Labels(Image):
     @brush_size.setter
     def brush_size(self, brush_size):
         self._brush_size = int(brush_size)
-        self.cursor_size = self._brush_size / self.scale_factor
+        data2world_scale = np.mean(
+            [self.scale[d] for d in self._dims.displayed]
+        )
+        self.cursor_size = (
+            self._brush_size / self.scale_factor * data2world_scale
+        )
         self.status = format_float(self.brush_size)
         self.events.brush_size()
 
@@ -507,7 +512,7 @@ class Labels(Image):
             self.help = 'hold <space> to pan/zoom, click to pick a label'
             self.mouse_drag_callbacks.append(pick)
         elif mode == Mode.PAINT:
-            self.cursor_size = self.brush_size / self.scale_factor
+            self.brush_size = self.brush_size
             self.cursor = self.brush_shape
             self.interactive = False
             self.help = (
@@ -524,7 +529,7 @@ class Labels(Image):
             self.help = 'hold <space> to pan/zoom, click to fill a label'
             self.mouse_drag_callbacks.append(draw)
         elif mode == Mode.ERASE:
-            self.cursor_size = self.brush_size / self.scale_factor
+            self.brush_size = self.brush_size
             self.cursor = self.brush_shape
             self.interactive = False
             self.help = 'hold <space> to pan/zoom, drag to erase a label'


### PR DESCRIPTION
# Description
This will close #1508 by fixing the size of the cursor when painting on scaled labels layers. It's independent of #1763 where we are adding a cursor model, but we might want to revisit after #1763 merges, or I might want to update #1763 after this merges to reduce some of the complexity / make things more clear.

You can see the original problem with the following example

```python
with napari.gui_qt():
    image = np.random.random((5, 128, 128))
    labels = np.zeros((5, 128, 128))
    scale = [1, 0.16, 0.16]
    viewer = napari.view_image(image, name='Raw', rgb=False, scale=scale) 
    label_layer = viewer.add_labels(labels, name='Label', scale=scale)
```

where the cursor size is too big relative to what actually gets painted:

![scaled_painting_master](https://user-images.githubusercontent.com/6531703/97095603-52d95b00-1616-11eb-9b5e-af85329660bb.gif)

you can see after this PR this has been fixed:

![scaled_painting_PR](https://user-images.githubusercontent.com/6531703/97095604-61c00d80-1616-11eb-8dec-9ae0e79a4f43.gif)

I've added a fairly crude test too.

Would be great to hear from @kapoorlab if this fixes what let them to report #1508 too. Thanks!!

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
