### PR TITLE
Adjust welcome colors of text

### DIFF
--- a/napari/_vispy/vispy_welcome_visual.py
+++ b/napari/_vispy/vispy_welcome_visual.py
@@ -63,6 +63,8 @@ class VispyWelcomeVisual:
             background_color = np.divide(
                 str_to_rgb(darken(self._viewer.palette['background'], 70)), 255
             )
+            # Note this unsual scaling is done to preserve color balance on
+            # rendering by VisPy, which appears to be off when opacity < 1
             text_color = np.multiply(foreground_color, [0.2, 0.45, 0.7])
         else:
             foreground_color = np.divide(
@@ -89,6 +91,8 @@ class VispyWelcomeVisual:
 
         self._logo = new_logo
         self.node.set_data(self._logo)
+        # Having opacity < 1 improves blending but throws color balance
+        # off which needs to be adjusted if desired
         self.text_node.color = list(text_color) + [0.7]
 
     def _on_visible_change(self, event):

--- a/napari/_vispy/vispy_welcome_visual.py
+++ b/napari/_vispy/vispy_welcome_visual.py
@@ -65,7 +65,7 @@ class VispyWelcomeVisual:
             )
             # Note this unsual scaling is done to preserve color balance on
             # rendering by VisPy, which appears to be off when opacity < 1
-            text_color = np.multiply(foreground_color, [0.2, 0.45, 0.7])
+            text_color = np.multiply(foreground_color, [0.4, 0.65, 0.9])
         else:
             foreground_color = np.divide(
                 str_to_rgb(lighten(self._viewer.palette['foreground'], 30)),

--- a/napari/_vispy/vispy_welcome_visual.py
+++ b/napari/_vispy/vispy_welcome_visual.py
@@ -32,7 +32,9 @@ class VispyWelcomeVisual:
         self.node.cmap = 'gray'
         self.node.transform = STTransform()
 
-        self.text_node = Text(pos=[0, 0], parent=parent, bold=True)
+        self.text_node = Text(
+            pos=[0, 0], parent=parent, method='gpu', bold=False
+        )
         self.text_node.order = order
         self.text_node.transform = STTransform()
         self.text_node.anchors = ('center', 'center')
@@ -61,9 +63,7 @@ class VispyWelcomeVisual:
             background_color = np.divide(
                 str_to_rgb(darken(self._viewer.palette['background'], 70)), 255
             )
-            text_color = np.divide(
-                str_to_rgb(darken(self._viewer.palette['foreground'], 50)), 255
-            )
+            text_color = np.multiply(foreground_color, [0.2, 0.45, 0.7])
         else:
             foreground_color = np.divide(
                 str_to_rgb(lighten(self._viewer.palette['foreground'], 30)),
@@ -74,7 +74,7 @@ class VispyWelcomeVisual:
                 255,
             )
             text_color = np.divide(
-                str_to_rgb(darken(self._viewer.palette['background'], 40)), 255
+                str_to_rgb(darken(self._viewer.palette['background'], 60)), 255
             )
 
         new_logo = np.zeros(self._logo_raw.shape)

--- a/napari/_vispy/vispy_welcome_visual.py
+++ b/napari/_vispy/vispy_welcome_visual.py
@@ -35,13 +35,15 @@ class VispyWelcomeVisual:
         self.text_node = Text(
             pos=[0, 0], parent=parent, method='gpu', bold=False
         )
+        # self.text_node.blending = 'additive'
         self.text_node.order = order
         self.text_node.transform = STTransform()
-        self.text_node.anchors = ('center', 'center')
+        self.text_node.anchors = ('left', 'center')
         self.text_node.text = (
-            'drag and drop file(s) here\n'
-            'use the File Open menu\n'
-            'call a viewer.add_* method'
+            'to add data:\n'
+            '   - drag and drop file(s) here\n'
+            '   - select File > Open from the menu\n'
+            '   - call a viewer.add_* method'
         )
         self.text_node.color = np.divide(
             str_to_rgb(darken(self._viewer.palette['foreground'], 30)), 255
@@ -123,7 +125,7 @@ class VispyWelcomeVisual:
 
         self.text_node.font_size = center[1] / 24
         self.text_node.transform.translate = [
-            center[0],
+            center[0] - center[1] / 2.4,
             1.45 * center[1],
             0,
             0,


### PR DESCRIPTION
# Description
This PR follows on from #1721 by fine tuning some of the colors of the text on the welcome visual. Manual inspection of the colors with photoshop shows that the color balance for vispy text is off then rendering text with opacity < 1. It looks like the blending is not happening correctly. We need opacity < 1 though as otherwise there are very strong alias like artifacts at the edge of the text.

I've fine tuned things to improve the color for our default theme. This is clearly a temporary solution, but better than before. I also made the font no longer bold, and made the rendering use the gpu as quality is supposedly higher but that didn't actually improve anything. cc @jni @alisterburt 

Before:
<img width="1200" alt="Screen Shot 2020-10-26 at 9 04 01 AM" src="https://user-images.githubusercontent.com/6531703/97197535-ffc4ec80-176a-11eb-882e-8e1ecec59f5f.png">

After:
<img width="1200" alt="Screen Shot 2020-10-26 at 9 02 25 AM" src="https://user-images.githubusercontent.com/6531703/97197555-05bacd80-176b-11eb-9fdd-8bb3f6203720.png">

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
