### PR TITLE
Fix zoom of scale bar and axes visuals on launch

### DIFF
--- a/docs/release/release_0_4_0.md
+++ b/docs/release/release_0_4_0.md
@@ -112,6 +112,7 @@ We thank the many contributors who have made this release possible!
 - Adjust welcome colors of text (#1780)
 - Fix gray to grays for vispy (#1784)
 - Fix welcome text contrast (#1788)
+- Fix zoom of scale bar and axes visuals on launch (#1791)
 
 ## API Changes and Deprecations
 - Make layer dims private (#1581)

--- a/napari/_vispy/vispy_axes_visual.py
+++ b/napari/_vispy/vispy_axes_visual.py
@@ -66,6 +66,7 @@ class VispyAxesVisual:
         self._axes = axes
         self._dims = dims
         self._camera = camera
+        self._scale = 1
 
         # note order is z, y, x
         self._default_data = np.array(
@@ -127,11 +128,10 @@ class VispyAxesVisual:
         self._on_visible_change(None)
         self._on_data_change(None)
 
-        self._scale = 1
-
     def _on_visible_change(self, event):
         """Change visibiliy of axes."""
         self.node.visible = self._axes.visible
+        self._on_zoom_change(None)
 
     def _on_data_change(self, event):
         """Change style of axes."""

--- a/napari/_vispy/vispy_scale_bar_visual.py
+++ b/napari/_vispy/vispy_scale_bar_visual.py
@@ -115,6 +115,7 @@ class VispyScaleBarVisual:
         """Change visibiliy of scale bar."""
         self.node.visible = self._scale_bar.visible
         self.text_node.visible = self._scale_bar.visible
+        self._on_zoom_change(None)
 
     def _on_position_change(self, event):
         """Change position of scale bar."""

--- a/napari/_vispy/vispy_welcome_visual.py
+++ b/napari/_vispy/vispy_welcome_visual.py
@@ -29,13 +29,12 @@ class VispyWelcomeVisual:
         self.node = ImageNode(parent=parent)
         self.node.order = order
 
-        self.node.cmap = 'gray'
+        self.node.cmap = 'grays'
         self.node.transform = STTransform()
 
         self.text_node = Text(
             pos=[0, 0], parent=parent, method='gpu', bold=False
         )
-        # self.text_node.blending = 'additive'
         self.text_node.order = order
         self.text_node.transform = STTransform()
         self.text_node.anchors = ('left', 'center')


### PR DESCRIPTION
# Description
This PR closes #1789 by fixing the zoom of scale bar and axes visuals on launch. We don't update the zoom when visible is False so when toggling visibility the `_on_zoom_change` method needs to be called to update the zoom.

Thanks @jni for identifying that fix and thanks @kevinyamauchi for the initial report

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

