### PR TITLE
Update setup.cfg to add aliases for pyqt5 and pyside in extras_require

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,8 +70,14 @@ install_requires =
 [options.extras_require]
 pyside2 = 
     PySide2>=5.12.3,<5.15.0
+pyside =  # alias for pyside2
+    %(pyside2)s
 pyqt5 = 
     PyQt5>=5.12.3,<5.15.0
+pyqt =  # alias for pyqt5
+    %(pyqt5)s
+qt =  # alias for pyqt5
+    %(pyqt5)s
 # all will be the full "batteries included" extra.
 # though for now, it's just the GUI backend
 all =


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
This PR adds some aliases for the `extras_require` when installing napari. I sometimes find myself doing `pip install napari[pyqt]` which appears to install correctly, but because "pyqt" isn't an option for extras (should be "pyqt5" instead) I end up with no GUI backend installed.

It's not a big problem, just something that might be nice for convenience.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation **I haven't done this, but I think that might be confusing. This is really to catch typos/abbreviations when someone types the install command from memory.**
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
