### PR TITLE
Deprecation: Make main window private

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 import numpy as np
 import pytest
@@ -116,44 +115,6 @@ def test_screenshot(make_test_viewer):
     # Take screenshot with the viewer included
     screenshot = viewer.screenshot(canvas_only=False)
     assert screenshot.ndim == 3
-
-
-def test_update(make_test_viewer):
-    data = np.random.random((512, 512))
-    viewer = make_test_viewer()
-    layer = viewer.add_image(data)
-
-    def layer_update(*, update_period, num_updates):
-        # number of times to update
-
-        for k in range(num_updates):
-            time.sleep(update_period)
-
-            dat = np.random.random((512, 512))
-            layer.data = dat
-
-            assert layer.data.all() == dat.all()
-            # if you're looking at this as an example,
-            # it would be best to put a yield statement here...
-            # but we're testing how it handles not having a yield statement
-
-    # NOTE: The closure approach used here has the potential to throw an error:
-    # "RuntimeError: Internal C++ object () already deleted."
-    # if an enclosed object (like the layer here) is deleted in the main thread
-    # and then subsequently called in the other thread.
-    # Previously this error would have been invisible (raised only in the other
-    # thread). But because this can make debugging hard, the new
-    # `create_worker` approach reraises thread errors in the main thread by
-    # default.  To make this test pass, we now need to explicitly use
-    # `_ignore_errors=True`, because the `layer.data = dat` line will throw an
-    # error when called after the main thread is closed.
-    with pytest.warns(DeprecationWarning):
-        viewer.update(
-            layer_update,
-            update_period=0.01,
-            num_updates=100,
-            _ignore_errors=True,
-        )
 
 
 def test_changing_theme(make_test_viewer):

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -109,6 +109,10 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         self._mouse_drag_gen = {}
         self._mouse_wheel_gen = {}
 
+    def __str__(self):
+        """Simple string representation"""
+        return f'napari.Viewer: {self.title}'
+
     @property
     def palette(self):
         """dict of str: str : Color palette with which to style the viewer.

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -204,6 +204,28 @@ class Viewer(ViewerModel):
             shortcut=shortcut,
         )
 
+    def remove_dock_widget(self, widget):
+        """Removes specified dock widget.
+
+        Parameters
+        ----------
+        widget : QWidget | str
+            If widget == 'all', all docked widgets will be removed.
+        """
+        self._window.remove_dock_widget(widget)
+
+    def resize(self, width, height):
+        """Resize the window.
+
+        Parameters
+        ----------
+        width : int
+            Width in logical pixels.
+        height : int
+            Height in logical pixels.
+        """
+        self._window.resize(width, height)
+
     def show(self):
         """Resize, show, and raise the viewer window."""
         self._window.show()

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -219,7 +219,3 @@ class Viewer(ViewerModel):
             # https://github.com/napari/napari/issues/1500
             for layer in self.layers:
                 chunk_loader.on_layer_deleted(layer)
-
-    def __str__(self):
-        """Simple string representation"""
-        return f'napari.Viewer: {self.title}'

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -113,7 +113,7 @@ class Viewer(ViewerModel):
     def window(self):
         warnings.warn(
             (
-                "The viewer.window parameter is deprecated and will be removed in version 0.4.2."
+                "The viewer.window parameter is deprecated and will be removed in version 0.5.0."
                 " Instead you should use the viewer.add_dock_widget method to extend the GUI."
                 " Directly manipulation of the window is no longer supported."
             ),

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,14 +1,15 @@
 import platform
 import sys
+import warnings
 from os.path import dirname, join
 
 from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication, QWidget
 
 from . import __version__
 from ._qt.qt_main_window import Window
 from ._qt.qt_viewer import QtViewer
-from ._qt.qthreading import create_worker, wait_for_workers_to_quit
+from ._qt.qthreading import wait_for_workers_to_quit
 from .components import ViewerModel
 from .utils import config
 from .utils.perf import perf_config
@@ -106,7 +107,20 @@ class Viewer(ViewerModel):
             axis_labels=axis_labels,
         )
         qt_viewer = QtViewer(self)
-        self.window = Window(qt_viewer, show=show)
+        self._window = Window(qt_viewer, show=show)
+
+    @property
+    def window(self):
+        warnings.warn(
+            (
+                "The viewer.window parameter is deprecated and will be removed in version 0.4.2."
+                " Instead you should use the viewer.add_dock_widget method to extend the GUI."
+                " Directly manipulation of the window is no longer supported."
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._window
 
     def update_console(self, variables):
         """Update console's namespace with desired variables.
@@ -121,10 +135,10 @@ class Viewer(ViewerModel):
             give (list/tuple/str) then the variable values looked up in the
             callers frame.
         """
-        if self.window.qt_viewer.console is None:
+        if self._window.qt_viewer.console is None:
             return
         else:
-            self.window.qt_viewer.console.push(variables)
+            self._window.qt_viewer.console.push(variables)
 
     def screenshot(self, path=None, *, canvas_only=True):
         """Take currently displayed screen and convert to an image array.
@@ -145,28 +159,58 @@ class Viewer(ViewerModel):
             upper-left corner of the rendered region.
         """
         if canvas_only:
-            image = self.window.qt_viewer.screenshot(path=path)
+            image = self._window.qt_viewer.screenshot(path=path)
         else:
-            image = self.window.screenshot(path=path)
+            image = self._window.screenshot(path=path)
         return image
 
-    def update(self, func, *args, **kwargs):
-        import warnings
+    def add_dock_widget(
+        self,
+        widget: QWidget,
+        *,
+        name: str = '',
+        area: str = 'bottom',
+        allowed_areas=None,
+        shortcut=None,
+    ):
+        """Add a Dock Widget to the main window to extend the GUI functionality.
 
-        warnings.warn(
-            "Viewer.update() is deprecated, use "
-            "create_worker(func, *args, **kwargs) instead",
-            DeprecationWarning,
+        Parameters
+        ----------
+        widget : QWidget
+            `widget` will be added as QDockWidget's main widget.
+        name : str, optional
+            Name of dock widget to appear in window menu.
+        area : str
+            Side of the main window to which the new dock widget will be added.
+            Must be in {'left', 'right', 'top', 'bottom'}
+        allowed_areas : list[str], optional
+            Areas, relative to main window, that the widget is allowed dock.
+            Each item in list must be in {'left', 'right', 'top', 'bottom'}
+            By default, all areas are allowed.
+        shortcut : str, optional
+            Keyboard shortcut to appear in dropdown menu.
+
+        Returns
+        -------
+        dock_widget : QtViewerDockWidget
+            `dock_widget` that can pass viewer events.
+        """
+        return self._window.add_dock_widget(
+            widget=widget,
+            name=name,
+            area=area,
+            allowed_areas=allowed_areas,
+            shortcut=shortcut,
         )
-        return create_worker(func, *args, **kwargs, _start_thread=True)
 
     def show(self):
         """Resize, show, and raise the viewer window."""
-        self.window.show()
+        self._window.show()
 
     def close(self):
         """Close the viewer window."""
-        self.window.close()
+        self._window.close()
 
         if config.async_loading:
             from .components.experimental.chunk import chunk_loader


### PR DESCRIPTION
# Description
This PR makes the main window private and exposes `add_dock_widget` on the main viewer. I think we've had a lot of people getting value from the `add_dock_widget` method and so it make sense to expose that now on the Viewer directly. At the same time we've also clean up a lot of our internal models now (like camera, cursor, etc) that I don't think we need/ want users going into the main window anymore, which is still public at `viewer.window`.

I'm also thinking ahead to supporting a `provide_dock_widget` hookspec, as outlined in #1327, and having the `window` private but the `add_dock_widget` will make that much more natural.

I've added a deprecation warning so we can actually remove in `0.4.2`

I'm already working on #1327 so hopefully that will go out in `0.4.1` too, and the gain in functionality there will be well worth it.

Would be great to know from anyone whose been adding dock widgets/ manipulating the Qt window if they see any problems with this -  cc @Czaki @adamltyson @joshmoore @jni 

I also moved a string representation back to the viewer_model to keep the viewer file cleaner, and removed the deprecated update method - cc @AhmetCanSolak 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
