### PR TITLE
unpin qt, exclude 5.15.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,11 +69,11 @@ install_requires =
 
 [options.extras_require]
 pyside2 = 
-    PySide2>=5.12.3,<5.15.0
+    PySide2>=5.12.3,!=5.15.0
 pyside =  # alias for pyside2
     %(pyside2)s
 pyqt5 = 
-    PyQt5>=5.12.3,<5.15.0
+    PyQt5>=5.12.3,!=5.15.0
 pyqt =  # alias for pyqt5
     %(pyqt5)s
 qt =  # alias for pyqt5


### PR DESCRIPTION
# Description
unpins qt versions by just excluding 5.15.0 (which was a bug in Qt ... not our end)
closes #1312