### PR TITLE
Simplify viewer and make headless mode easier

### DIFF
--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -1,5 +1,6 @@
 from ..resources import import_resources
 from .event_loop import gui_qt
+from .qt_main_window import Window
 from .widgets.qt_range_slider import QHRangeSlider, QVRangeSlider
 
 import_resources()

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -94,9 +94,7 @@ class Window:
 
         if perf_config:
             if perf_config.trace_qt_events:
-                from ._qt.tracing.qt_event_tracing import (
-                    convert_app_for_tracing,
-                )
+                from .tracing.qt_event_tracing import convert_app_for_tracing
 
                 # For tracing Qt events we need a special QApplication. If
                 # using `gui_qt` we already have the special one, and no

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -236,12 +236,15 @@ class QtViewer(QSplitter):
         self.viewer.cursor.events.size.connect(self._on_cursor)
         self.viewer.events.palette.connect(self._update_palette)
         self.viewer.layers.events.reordered.connect(self._reorder_layers)
-        self.viewer.layers.events.added.connect(self._add_layer)
+        self.viewer.layers.events.added.connect(self._on_add_layer_change)
         self.viewer.layers.events.removed.connect(self._remove_layer)
         # stop any animations whenever the layers change
         self.viewer.events.layers_change.connect(lambda x: self.dims.stop())
 
         self.setAcceptDrops(True)
+
+        for layer in self.viewer.layers:
+            self._add_layer(layer)
 
     def _create_performance_dock_widget(self):
         """Create the dock widget that shows performance metrics.
@@ -302,7 +305,7 @@ class QtViewer(QSplitter):
         else:
             self.controls.setMaximumWidth(220)
 
-    def _add_layer(self, event):
+    def _on_add_layer_change(self, event):
         """When a layer is added, set its parent and order.
 
         Parameters
@@ -310,13 +313,22 @@ class QtViewer(QSplitter):
         event : napari.utils.event.Event
             The napari event that triggered this method.
         """
-        layers = event.source
         layer = event.item
+        self._add_layer(layer)
+
+    def _add_layer(self, layer):
+        """When a layer is added, set its parent and order.
+
+        Parameters
+        ----------
+        layer : napari.layers.Layer
+            Layer to be added.
+        """
         vispy_layer = create_vispy_visual(layer)
         self.viewer.camera.events.center.connect(vispy_layer._on_camera_move)
 
         vispy_layer.node.parent = self.view.scene
-        vispy_layer.order = len(layers) - 1
+        vispy_layer.order = len(self.viewer.layers) - 1
         self.layer_to_visual[layer] = vispy_layer
 
     def _remove_layer(self, event):

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 import numpy as np
 import pytest
@@ -116,44 +115,6 @@ def test_screenshot(make_test_viewer):
     # Take screenshot with the viewer included
     screenshot = viewer.screenshot(canvas_only=False)
     assert screenshot.ndim == 3
-
-
-def test_update(make_test_viewer):
-    data = np.random.random((512, 512))
-    viewer = make_test_viewer()
-    layer = viewer.add_image(data)
-
-    def layer_update(*, update_period, num_updates):
-        # number of times to update
-
-        for k in range(num_updates):
-            time.sleep(update_period)
-
-            dat = np.random.random((512, 512))
-            layer.data = dat
-
-            assert layer.data.all() == dat.all()
-            # if you're looking at this as an example,
-            # it would be best to put a yield statement here...
-            # but we're testing how it handles not having a yield statement
-
-    # NOTE: The closure approach used here has the potential to throw an error:
-    # "RuntimeError: Internal C++ object () already deleted."
-    # if an enclosed object (like the layer here) is deleted in the main thread
-    # and then subsequently called in the other thread.
-    # Previously this error would have been invisible (raised only in the other
-    # thread). But because this can make debugging hard, the new
-    # `create_worker` approach reraises thread errors in the main thread by
-    # default.  To make this test pass, we now need to explicitly use
-    # `_ignore_errors=True`, because the `layer.data = dat` line will throw an
-    # error when called after the main thread is closed.
-    with pytest.warns(DeprecationWarning):
-        viewer.update(
-            layer_update,
-            update_period=0.01,
-            num_updates=100,
-            _ignore_errors=True,
-        )
 
 
 def test_changing_theme(make_test_viewer):

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -109,6 +109,10 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         self._mouse_drag_gen = {}
         self._mouse_wheel_gen = {}
 
+    def __str__(self):
+        """Simple string representation"""
+        return f'napari.Viewer: {self.title}'
+
     @property
     def palette(self):
         """dict of str: str : Color palette with which to style the viewer.

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,17 +1,6 @@
-import platform
-import sys
-from os.path import dirname, join
-
-from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QApplication
-
-from . import __version__
-from ._qt.qt_main_window import Window
-from ._qt.qt_viewer import QtViewer
-from ._qt.qthreading import create_worker, wait_for_workers_to_quit
+from ._qt import Window
 from .components import ViewerModel
 from .utils import config
-from .utils.perf import perf_config
 
 
 class Viewer(ViewerModel):
@@ -33,10 +22,6 @@ class Viewer(ViewerModel):
         Whether to show the viewer after instantiation. by default True.
     """
 
-    # set _napari_app_id to False to avoid overwriting dock icon on windows
-    # set _napari_app_id to custom string to prevent grouping different base viewer
-    _napari_app_id = 'napari.napari.viewer.' + str(__version__)
-
     def __init__(
         self,
         *,
@@ -46,67 +31,13 @@ class Viewer(ViewerModel):
         axis_labels=None,
         show=True,
     ):
-        # instance() returns the singleton instance if it exists, or None
-        app = QApplication.instance()
-        # if None, raise a RuntimeError with the appropriate message
-        if app is None:
-            message = (
-                "napari requires a Qt event loop to run. To create one, "
-                "try one of the following: \n"
-                "  - use the `napari.gui_qt()` context manager. See "
-                "https://github.com/napari/napari/tree/master/examples for"
-                " usage examples.\n"
-                "  - In IPython or a local Jupyter instance, use the "
-                "`%gui qt` magic command.\n"
-                "  - Launch IPython with the option `--gui=qt`.\n"
-                "  - (recommended) in your IPython configuration file, add"
-                " or uncomment the line `c.TerminalIPythonApp.gui = 'qt'`."
-                " Then, restart IPython."
-            )
-            raise RuntimeError(message)
-
-        if perf_config:
-            if perf_config.trace_qt_events:
-                from ._qt.tracing.qt_event_tracing import (
-                    convert_app_for_tracing,
-                )
-
-                # For tracing Qt events we need a special QApplication. If
-                # using `gui_qt` we already have the special one, and no
-                # conversion is done here. However when running inside
-                # IPython or Jupyter this is where we switch out the
-                # QApplication.
-                app = convert_app_for_tracing(app)
-
-            # Will patch based on config file.
-            perf_config.patch_callables()
-
-        if (
-            platform.system() == "Windows"
-            and not getattr(sys, 'frozen', False)
-            and self._napari_app_id
-        ):
-            import ctypes
-
-            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
-                self._napari_app_id
-            )
-
-        logopath = join(dirname(__file__), 'resources', 'logo.png')
-        app.setWindowIcon(QIcon(logopath))
-
-        # see docstring of `wait_for_workers_to_quit` for caveats on killing
-        # workers at shutdown.
-        app.aboutToQuit.connect(wait_for_workers_to_quit)
-
         super().__init__(
             title=title,
             ndisplay=ndisplay,
             order=order,
             axis_labels=axis_labels,
         )
-        qt_viewer = QtViewer(self)
-        self.window = Window(qt_viewer, show=show)
+        self.window = Window(self, show=show)
 
     def update_console(self, variables):
         """Update console's namespace with desired variables.
@@ -150,16 +81,6 @@ class Viewer(ViewerModel):
             image = self.window.screenshot(path=path)
         return image
 
-    def update(self, func, *args, **kwargs):
-        import warnings
-
-        warnings.warn(
-            "Viewer.update() is deprecated, use "
-            "create_worker(func, *args, **kwargs) instead",
-            DeprecationWarning,
-        )
-        return create_worker(func, *args, **kwargs, _start_thread=True)
-
     def show(self):
         """Resize, show, and raise the viewer window."""
         self.window.show()
@@ -175,7 +96,3 @@ class Viewer(ViewerModel):
             # https://github.com/napari/napari/issues/1500
             for layer in self.layers:
                 chunk_loader.on_layer_deleted(layer)
-
-    def __str__(self):
-        """Simple string representation"""
-        return f'napari.Viewer: {self.title}'


### PR DESCRIPTION
# Description
This PR is a mostly backwards compatible simplification to our `Viewer` that makes working with napari headless much easier.

The actual API of our instantiated objects doesn't change, but I did change `Window` to now take a `ViewerModel` rather than `QtViewer` (so you can run `Window(viewer)` instead of `Window(QtViewer(viewer))` which is much nicer.

The `Viewer` file has now become much simpler, all the checking of the Qt application, logo setting etc happens inside `Window` which is where it is required. I've left window as public on `Viewer`, so this is unrelated #1799.

The true power of this PR though, is that you can now do much more with the ViewerModel headless and then look at it in a window much later.

For example the following is now possible

```python
# Cell 1
import numpy as np
from napari.components import ViewerModel as Viewer
viewer = Viewer()
viewer.add_image(np.random.random((20, 20)), colormap='red')
viewer.add_points(20*np.random.random((12, 2)), face_color=[0, .2, .5], size=1)
viewer.dims.ndisplay=3

# Cell 2
%gui qt

# Cell 3
from napari._qt import Window
window = Window(viewer)
```
And then you can see the viewer model!!!

You don't end up in an identical place as if you had just done
```python
from napari import Viewer
viewer = Viewer()
viewer.add_image(np.random.random((20, 20)), colormap='red')
viewer.add_points(20*np.random.random((12, 2)), face_color=[0, .2, .5], size=1)
viewer.dims.ndisplay=3
```
As in the first approach you are missing the `viewer.window` property, the methods that get added in `Viewer`, and the keybindings which get added in the main init.

I'd like to continue to move these together, but that might require some more significant changes and so want to do it gradually.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Refactor
