### PR TITLE
Fix TransformChain.__init__()

### DIFF
--- a/napari/utils/transforms/_tests/test_transform_chain.py
+++ b/napari/utils/transforms/_tests/test_transform_chain.py
@@ -79,3 +79,11 @@ def test_transform_chain_expanded(Transform):
     new_coord_2 = transform_chain_a(coord)
     new_coord_1 = transform_chain_expandded(coord)
     npt.assert_allclose(new_coord_1, new_coord_2)
+
+
+def test_base_transform_init_is_called():
+    # TransformChain() was not calling Transform.__init__() at one point.
+    # So below would fail with AttributeError: 'TransformChain' object has
+    # no attribute 'name'.
+    chain = TransformChain()
+    assert chain.name is None

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -88,6 +88,10 @@ class TransformChain(ListModel, Transform):
             iterable=transforms,
             lookup={str: lambda q, e: q == e.name},
         )
+        # The above super().__init__() will not call Transform.__init__().
+        # For that to work every __init__() called using super() needs to
+        # in turn call super().__init__(). So we call it explicitly here.
+        Transform.__init__(self)
 
     def __call__(self, coords):
         return tz.pipe(coords, *self)


### PR DESCRIPTION
# Description
This PR makes `TransformChain.__init__()` call `Transform.__init__()`. The PR adds a test that shows this was not happening before. The test now passes.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
* [Understanding Python MRO - Class search path](https://makina-corpus.com/blog/metier/2014/python-tutorial-understanding-python-mro-class-search-path)
* [Composition over inheritance](https://en.wikipedia.org/wiki/Composition_over_inheritance)

# Comments

I would strongly recommend avoiding multiple inheritance from two or more concrete base classes.  Doing so plunges you into Python's Method Resolution Order (MRO) rules which are complicated, to say the least. Inheriting from Abstract Base Classes (interfaces) is far less dangerous. 

In this case calling `super().__init__` starts Python on a walk through the inheritance graph looking for `__init__` methods. Probably because some of the `__init__` methods we call using `super()` do not in turn call `super().__init__` the search ends without calling `Transform.__init__()`. So we were left with an uninitialized base class.

I'm not aware of any bug this was causing, but it was clearly unintended behavior. Multiple inheritance of concrete base classes create puzzles that are hard to solve even with extensive inspection of the code. I had to use the debugger and insert prints to figure out what was happening. It took a while.

Even expert developers find these situations confusing. Multiple inheritence raises the bar on the skill level required to understand napari's code base, so I think avoiding it when possible is a good idea. Generally there are other designs that meet all the same requirements.

# How has this been tested?
- [x] Added unit test that shows issue and then fixes it.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
