### PR TITLE
Pre-sort tracks data by ID and time

### DIFF
--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -57,6 +57,15 @@ def test_track_layer_data():
     assert np.all(layer.data == data)
 
 
+def test_track_layer_data_flipped():
+    """Test data flipped."""
+    data = np.zeros((100, 4))
+    data[:, 1] = np.arange(100)
+    data = np.flip(data, axis=0)
+    layer = Tracks(data)
+    assert np.all(layer.data == np.flip(data, axis=0))
+
+
 properties_dict = {'time': np.arange(100)}
 properties_df = pd.DataFrame(properties_dict)
 

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -168,9 +168,10 @@ class Tracks(Layer):
         self.display_tail = True
         self.display_graph = True
 
-        # set the data, properties and graph
+        # order track vertices according to ID and time
         indices = np.lexsort((data[:, 1], data[:, 0]))
         data = data[indices]
+        # set the data, properties and graph
         self.data = data
         self.properties = properties
         self.graph = graph or {}

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -169,6 +169,8 @@ class Tracks(Layer):
         self.display_graph = True
 
         # set the data, properties and graph
+        indices = np.lexsort((data[:, 1], data[:, 0]))
+        data = data[indices]
         self.data = data
         self.properties = properties
         self.graph = graph or {}


### PR DESCRIPTION
# Description
Currently, inputted tracks vertices must be sorted according to track ID, then time (i.e., in ascending order columns 0 then 1 of the input array). If the data is not sorted, an error is returned. This PR resolves this by pre-sorting the data.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
This change was discussed by @jni in https://github.com/napari/napari/issues/1662#issuecomment-703180933 and https://github.com/napari/napari/pull/1361#discussion_r497459001.

# How has this been tested?

- [x] Added test for unsorted data
- [x] Track layer tests pass

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
