### PR TITLE
enhance affine example to include scipy.ndimage

### DIFF
--- a/examples/affine_transforms.py
+++ b/examples/affine_transforms.py
@@ -3,6 +3,7 @@ Display an image and its corners before and after an affine transform
 """
 import numpy as np
 import napari
+import scipy.ndimage as ndi
 
 # Create a random image
 image = np.random.random((5, 5))
@@ -25,7 +26,14 @@ with napari.gui_qt():
     viewer.add_image(image, colormap='blue', opacity=.5, name='moving', affine=affine)
     viewer.add_points((corners_h @ affine.T)[:, :-1], size=0.5, opacity=.5, face_color=[0, 0, 0.8, 0.8], name='mv corners')
 
+    # Note how the transformed corner points remain at the corners of the transformed image
+
+    # Now add the a regridded version of the image transformed with scipy.ndimage.affine_transform
+    # Note that we have to use the inverse of the affine as scipy does ‘pull’ (or ‘backward’) resampling,
+    # transforming the output space to the input to locate data, but napari does ‘push’ (or ‘forward’) direction,
+    # transforming input to output.
+    scipy_affine = ndi.affine_transform(image, np.linalg.inv(affine), output_shape=(10, 25), order=5)
+    viewer.add_image(scipy_affine, colormap='green', opacity=.5, name='scipy')
+
     # Reset the view
     viewer.reset_view()
-
-    # Note how the transformed corner points remain at the corners of the transformed image


### PR DESCRIPTION
# Description
Following discussion with @GenevieveBuckley and @m-albert on dask-image affine transform PR at scipy japan - see https://github.com/dask/dask-image/pull/159#issuecomment-720192323 in particular. I've updated this napari affine example to include the result of transforming the image with `scipy.ndimage.affine_transform` - you can see how that example actually does the transform of the pixels. I also add a note about why you need the inverse of the affine too (you can read more about that in the scipy docs too) https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.affine_transform.html

Here in green is what the scipy transformed layer looks like, overlaid on the napari transformed layer in blue

<img width="1200" alt="Screen Shot 2020-11-01 at 5 58 14 PM" src="https://user-images.githubusercontent.com/6531703/97822986-6b77ef80-1c6c-11eb-9337-f887ed3c0995.png">

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
