### PR TITLE
Try different test for popup skipif mark

### DIFF
--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -1,4 +1,6 @@
 import collections
+import os
+import sys
 
 import numpy as np
 import pytest
@@ -10,16 +12,12 @@ from napari.utils.interactions import (
     mouse_release_callbacks,
 )
 
-# import os
-# import sys
-
-
 skip_on_win_ci = pytest.mark.skipif(
-    "sys.platform.startswith('win') and os.getenv('CI')",
+    sys.platform.startswith('win') and os.getenv('CI', '0') != '0',
     reason='Screenshot tests are not supported on windows CI.',
 )
 skip_local_popups = pytest.mark.skipif(
-    "not os.getenv('CI') and not os.getenv('NAPARI_POPUP_TESTS')=='1'",
+    not os.getenv('CI') and os.getenv('NAPARI_POPUP_TESTS', '0') == '0',
     reason='Tests requiring GUI windows are skipped locally by default.',
 )
 

--- a/napari/_vispy/_tests/test_vispy_multiscale.py
+++ b/napari/_vispy/_tests/test_vispy_multiscale.py
@@ -1,15 +1,15 @@
-# import os
-# import sys
+import os
+import sys
 
 import numpy as np
 import pytest
 
 skip_on_win_ci = pytest.mark.skipif(
-    "sys.platform.startswith('win') and os.getenv('CI')",
+    sys.platform.startswith('win') and os.getenv('CI'),
     reason='Screenshot tests are not supported on windows CI.',
 )
 skip_local_popups = pytest.mark.skipif(
-    "not os.getenv('CI') and not os.getenv('NAPARI_POPUP_TESTS')=='1'",
+    not os.getenv('CI') and os.getenv('NAPARI_POPUP_TESTS', '0') == '0',
     reason='Tests requiring GUI windows are skipped locally by default.',
 )
 

--- a/napari/_vispy/_tests/test_vispy_multiscale.py
+++ b/napari/_vispy/_tests/test_vispy_multiscale.py
@@ -1,11 +1,10 @@
 import os
-import sys
 
 import numpy as np
 import pytest
 
 skip_on_win_ci = pytest.mark.skipif(
-    sys.platform.startswith('win') and os.getenv('CI'),
+    "sys.platform.startswith('win') and os.getenv('CI')",
     reason='Screenshot tests are not supported on windows CI.',
 )
 skip_local_popups = pytest.mark.skipif(

--- a/napari/_vispy/_tests/test_vispy_multiscale.py
+++ b/napari/_vispy/_tests/test_vispy_multiscale.py
@@ -1,10 +1,11 @@
 import os
+import sys
 
 import numpy as np
 import pytest
 
 skip_on_win_ci = pytest.mark.skipif(
-    "sys.platform.startswith('win') and os.getenv('CI')",
+    sys.platform.startswith('win') and os.getenv('CI', '0') != '0',
     reason='Screenshot tests are not supported on windows CI.',
 )
 skip_local_popups = pytest.mark.skipif(


### PR DESCRIPTION
# Description

I am a bit unhappy that we had to use the deprecated string input to pytest.mark.skipif in #1807, so I'm opening this branch to experiment with a few options on the CI.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
