### PR TITLE
Sort tracks and track properties by ID then t

### DIFF
--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -61,6 +61,7 @@ def test_track_layer_data_flipped():
     """Test data flipped."""
     data = np.zeros((100, 4))
     data[:, 1] = np.arange(100)
+    data[:, 0] = np.arange(100)
     data = np.flip(data, axis=0)
     layer = Tracks(data)
     assert np.all(layer.data == np.flip(data, axis=0))
@@ -78,6 +79,18 @@ def test_track_layer_properties(properties):
     layer = Tracks(data, properties=properties)
     for k, v in properties.items():
         np.testing.assert_equal(layer.properties[k], v)
+
+
+@pytest.mark.parametrize("properties", [{}, properties_dict, properties_df])
+def test_track_layer_properties_filpped(properties):
+    """Test properties."""
+    data = np.zeros((100, 4))
+    data[:, 1] = np.arange(100)
+    data[:, 0] = np.arange(100)
+    data = np.flip(data, axis=0)
+    layer = Tracks(data, properties=properties)
+    for k, v in properties.items():
+        np.testing.assert_equal(layer.properties[k], np.flip(v))
 
 
 @pytest.mark.filterwarnings("ignore:.*track_id.*:UserWarning")

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -82,7 +82,7 @@ def test_track_layer_properties(properties):
 
 
 @pytest.mark.parametrize("properties", [{}, properties_dict, properties_df])
-def test_track_layer_properties_filpped(properties):
+def test_track_layer_properties_flipped(properties):
     """Test properties."""
     data = np.zeros((100, 4))
     data[:, 1] = np.arange(100)

--- a/napari/layers/tracks/_track_utils.py
+++ b/napari/layers/tracks/_track_utils.py
@@ -70,6 +70,7 @@ class TrackManager:
         # store the raw data here
         self._data = None
         self._properties = None
+        self._order = None
 
         # use a kdtree to help with fast lookup of the nearest track
         self._kdtree = None
@@ -102,6 +103,10 @@ class TrackManager:
 
         # convert data to a numpy array if it is not already one
         data = np.asarray(data)
+
+        # Sort data by ID then time
+        self._order = np.lexsort((data[:, 1], data[:, 0]))
+        data = data[self._order]
 
         # check check the formatting of the incoming track data
         self._data = self._validate_track_data(data)
@@ -144,11 +149,20 @@ class TrackManager:
     @properties.setter
     def properties(self, properties: Dict[str, np.ndarray]):
         """ set track properties """
+        # make copy so as not to mutate original 
+        properties = properties.copy()
+
         if not isinstance(properties, dict):
             properties, _ = dataframe_to_properties(properties)
 
         if 'track_id' not in properties:
             properties['track_id'] = self.track_ids
+
+        # order properties
+        for prop in properties.keys():
+            arr = np.array(properties[prop])
+            arr = arr[self._order]
+            properties[prop] = arr
 
         # check the formatting of incoming properties data
         self._properties = self._validate_track_properties(properties)

--- a/napari/layers/tracks/_track_utils.py
+++ b/napari/layers/tracks/_track_utils.py
@@ -149,7 +149,8 @@ class TrackManager:
     @properties.setter
     def properties(self, properties: Dict[str, np.ndarray]):
         """ set track properties """
-        # make copy so as not to mutate original 
+
+        # make copy so as not to mutate original
         properties = properties.copy()
 
         if not isinstance(properties, dict):
@@ -158,7 +159,7 @@ class TrackManager:
         if 'track_id' not in properties:
             properties['track_id'] = self.track_ids
 
-        # order properties
+        # order properties dict
         for prop in properties.keys():
             arr = np.array(properties[prop])
             arr = arr[self._order]

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -168,7 +168,6 @@ class Tracks(Layer):
         self.display_tail = True
         self.display_graph = True
 
-
         # set the data, properties and graph
         self.data = data
         self.properties = properties

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -168,9 +168,7 @@ class Tracks(Layer):
         self.display_tail = True
         self.display_graph = True
 
-        # order track vertices according to ID and time
-        indices = np.lexsort((data[:, 1], data[:, 0]))
-        data = data[indices]
+
         # set the data, properties and graph
         self.data = data
         self.properties = properties


### PR DESCRIPTION
# Description
This PR follows a previous PR, the intention of which was to allow track data to be inputted without being sorted prior (i.e., according to ID then t). Previously, I had neglected the properties data. This PR rectifies this issue by sorting both the tracks and properties data. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
This is a follow up to #1814
This change was discussed by @jni in https://github.com/napari/napari/issues/1662#issuecomment-703180933 and https://github.com/napari/napari/pull/1361#discussion_r497459001.

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] Added test to ensure properties are also sorted when inputting unsorted tracks data.
- [x] All tracks layer tests pass. 

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
