### PR TITLE
[WIP] Multislice projection

### DIFF
--- a/napari/_qt/widgets/qt_dims_slider.py
+++ b/napari/_qt/widgets/qt_dims_slider.py
@@ -121,6 +121,16 @@ class QtDimSliderWidget(QWidget):
         """
         self.dims.set_current_step(self.axis, value)
 
+    def _interval_values_changed(self, values):
+        """Interval slider changed to these new values
+        """
+        # Set step of dims to midpoints (rounding and clamping is done in dims.set_current_step)
+        slider_midpoint = sum(values) / len(values)
+        self.dims.set_current_step(self.axis, slider_midpoint)
+
+        # Set interval of dims
+        self.dims.set_interval(self.axis, values)
+
     def _create_range_slider_widget(self):
         """Creates a range slider widget for a given axis."""
         # Set the maximum values of the range slider to be one step less than
@@ -155,21 +165,22 @@ class QtDimSliderWidget(QWidget):
         slider.setRange(data_range)
 
         # Set steps
-        slider.setSingleStep(1)
-        slider.setPageStep(1)
+        #slider.setSingleStep(1) # QHRangeSlider doesn't have these methods
+        #slider.setPageStep(1)
 
         # Set min and max for slider handles
         slider.setValues(self.dims.interval[self.axis])
 
         # Listener to be used for sending events back to model:
-        slider.valuesChanged.connect(self._value_changed) # TODO: check whether this needs changing
+        slider.valuesChanged.connect(self._interval_values_changed) # TODO: check whether this needs changing
 
         def slider_focused_listener():
             self.dims.last_used = self.axis
 
         # linking focus listener to the last used:
-        slider.sliderPressed.connect(slider_focused_listener)
-        self.slider = slider
+        #slider.sliderPressed.connect(slider_focused_listener)
+
+        self.interval_slider = slider
 
     def _create_play_button_widget(self):
         """Creates the actual play button, which has the modal popup."""

--- a/napari/_qt/widgets/qt_dims_slider.py
+++ b/napari/_qt/widgets/qt_dims_slider.py
@@ -22,6 +22,7 @@ from .._constants import LoopMode
 from ..dialogs.qt_modal import QtPopup
 from ..qthreading import _new_worker_qthread
 from .qt_scrollbar import ModifiedScrollBar
+from .qt_range_slider import QHRangeSlider
 
 
 class QtDimSliderWidget(QWidget):
@@ -135,6 +136,33 @@ class QtDimSliderWidget(QWidget):
 
         # Listener to be used for sending events back to model:
         slider.valueChanged.connect(self._value_changed)
+
+        def slider_focused_listener():
+            self.dims.last_used = self.axis
+
+        # linking focus listener to the last used:
+        slider.sliderPressed.connect(slider_focused_listener)
+        self.slider = slider
+
+    def _create_interval_slider_widget(self):
+        """Creates an interval slider widget with two handles for a given axis."""
+        # Initialise slider
+        slider = QHRangeSlider()
+        slider.setFocusPolicy(Qt.NoFocus)
+
+        # Set min and max of slider range to match data range
+        data_range = 0, self.dims.nsteps[self.axis] - 1
+        slider.setRange(data_range)
+
+        # Set steps
+        slider.setSingleStep(1)
+        slider.setPageStep(1)
+
+        # Set min and max for slider handles
+        slider.setValues(self.dims.interval[self.axis])
+
+        # Listener to be used for sending events back to model:
+        slider.valuesChanged.connect(self._value_changed) # TODO: check whether this needs changing
 
         def slider_focused_listener():
             self.dims.last_used = self.axis

--- a/napari/components/_tests/test_dims.py
+++ b/napari/components/_tests/test_dims.py
@@ -197,3 +197,8 @@ def test_roll_skip_dummy_axis_3():
     assert dims.order == [2, 1, 0, 3]
     dims._roll()
     assert dims.order == [0, 1, 2, 3]
+
+def test_mode():
+    """Test for presence of mode property"""
+    dims = Dims()
+    assert hasattr(dims, 'mode')

--- a/napari/components/_tests/test_dims.py
+++ b/napari/components/_tests/test_dims.py
@@ -1,6 +1,7 @@
 import pytest
 
 from napari.components import Dims
+from napari.components.dims_constants import DimsMode
 
 
 def test_ndim():
@@ -202,3 +203,11 @@ def test_mode():
     """Test for presence of mode property"""
     dims = Dims()
     assert hasattr(dims, 'mode')
+
+def test_default_mode():
+    """Test for mode defaulting to Point and length of list changes on ndim change"""
+    dims = Dims(ndim=2)
+    assert dims.mode == [DimsMode.POINT for _ in range(dims.ndim)]
+
+    dims.ndim += 1
+    assert dims.mode == [DimsMode.POINT for _ in range(dims.ndim)]

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -39,6 +39,11 @@ class Dims:
         Number of steps available to each slider.
     ndim : int
         Number of dimensions.
+    mode : list of DimsMode
+        list of DimsMode, one for each dimension.
+    interval : list of 2-tuple
+        List of tuples (min, max) setting the current selection of the range
+        slider when in INTERVAL mode, one for each dimension
     displayed : tuple
         List of dimensions that are displayed.
     not_displayed : tuple

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -5,6 +5,9 @@ import numpy as np
 
 from .dims_constants import DimsMode
 from ..utils.events import EmitterGroup
+from ..utils.validators import validate_n_seq
+
+validate_2_tuple = validate_n_seq(2)
 
 
 class Dims:
@@ -60,6 +63,7 @@ class Dims:
             source=self,
             auto_connect=True,
             current_step=None,
+            interval=None,
             axis_labels=None,
             ndim=None,
             ndisplay=None,
@@ -348,6 +352,26 @@ class Dims:
         if self._current_step[axis] != step:
             self._current_step[axis] = step
             self.events.current_step(axis=axis, value=step)
+
+    def set_interval(self, axis: int, interval: tuple):
+        """Sets the interval slider interval at a given axis
+
+        Parameters
+        ----------
+        axis : int
+            Dimension index.
+        interval : 2-tuple of int or float
+            Value of min and max of the interval.
+        """
+        # validate inputs
+        axis = self._assert_axis_in_bounds(axis)
+        validate_2_tuple(interval)
+
+        # set interval
+        if self.interval[axis] == interval:
+            self.interval[axis] = interval
+            self.events.interval(axis=axis, value=interval)
+
 
     def _increment_dims_right(self, axis: int = None):
         """Increment dimensions to the right along given axis, or last used axis if None

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -3,6 +3,7 @@ from typing import Sequence, Union
 
 import numpy as np
 
+from .dims_constants import DimsMode
 from ..utils.events import EmitterGroup
 
 

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -131,6 +131,20 @@ class Dims:
         return point
 
     @property
+    def mode(self):
+        mode = [
+            DimsMode(0) for _ in range(self.ndim)
+        ]
+        return mode
+
+    @property
+    def interval(self):
+        """TODO: figure out how to initialise this sensibly now that range is in the world coordinates space
+        """
+        pass
+
+
+    @property
     def axis_labels(self):
         """List of labels for each axis."""
         return copy(self._axis_labels)

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -144,8 +144,6 @@ class Dims:
         ]
         return interval
 
-
-
     @property
     def axis_labels(self):
         """List of labels for each axis."""

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -139,9 +139,11 @@ class Dims:
 
     @property
     def interval(self):
-        """TODO: figure out how to initialise this sensibly now that range is in the world coordinates space
-        """
-        pass
+        interval = [
+            (min_val, max_val) for (min_val, max_val, _) in self.range
+        ]
+        return interval
+
 
 
     @property

--- a/napari/components/dims_constants.py
+++ b/napari/components/dims_constants.py
@@ -1,0 +1,3 @@
+class DimsMode:
+    def __init__(self):
+        pass

--- a/napari/components/dims_constants.py
+++ b/napari/components/dims_constants.py
@@ -1,3 +1,6 @@
-class DimsMode:
-    def __init__(self):
-        pass
+from enum import Enum
+
+
+class DimsMode(Enum):
+    POINT = 0
+    INTERVAL = 1


### PR DESCRIPTION
# Description
This PR is a work in progress implementation of changes discussed in #1744 relating to adding in the ability to project over intervals on an axis rather than point slicing which is done at the moment

@sofroniewn suggested the following approach

> - We might want to add back in the interval and slicing mode enum for our dims model
> - Then on the Qt side have it swap between the scroll bar and the range slider when the slicing mode changed
> - Then in the base layer rather than just use the point, use the point/ interval depending on the dims mode to do the slicing.
> - Then maybe easiest in the vispy_image_visual we can do a cpu based max intensity projection, and send that to the graphics card. Doing the max intensity projection on the gpu would be possible if projecting in one dimension, but not more due to the current vispy API (the library we use for rendering). Maybe that's ok though.
> - We'd probably want to roll back to point based slicing for all non-image layers at first, though it might be nice to support for our other layers later.

Progress up to now...
- `Dims` model now has an `interval` property which initialises properly
- `Dims` model has a `set_interval` method which sets both the interval and the step
- `Dims` model has an event emitter associated with the interval property
- `QtDimsSliderWidget` has an incomplete `_create_interval_slider_widget` method
- `QtDimsSliderWidget` attempts to update both step and range of the `Dims` model in its `_interval_values_changed` method

Any feedback/ideas on basically everything is appreciated - I'm still trying to wrap my head around the codebase and everything Qt related remains a bit mysterious




