### PR TITLE
Add a simple grid object

### DIFF
--- a/examples/layers.py
+++ b/examples/layers.py
@@ -17,4 +17,4 @@ with napari.gui_qt():
     viewer.add_image(data.moon(), name='moon')
     viewer.add_image(np.random.random((512, 512)), name='random')
     viewer.add_image(data.binary_blobs(length=512, volume_fraction=0.2, n_dim=2), name='blobs')
-    viewer.grid_view()
+    viewer.grid.enabled = True

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -1,4 +1,3 @@
-import numpy as np
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QCheckBox, QFrame, QHBoxLayout, QPushButton
 
@@ -242,7 +241,7 @@ class QtGridViewButton(QCheckBox):
 
         self.viewer = viewer
         self.setToolTip('Toggle grid view')
-        self.viewer.events.grid.connect(self._on_grid_change)
+        self.viewer.grid.events.update.connect(self._on_grid_change)
         self.stateChanged.connect(self.change_grid)
         self._on_grid_change()
 
@@ -254,10 +253,7 @@ class QtGridViewButton(QCheckBox):
         state : qtpy.QtCore.Qt.CheckState
             State of the checkbox.
         """
-        if state == Qt.Checked:
-            self.viewer.stack_view()
-        else:
-            self.viewer.grid_view()
+        self.viewer.grid.enabled = not state == Qt.Checked
 
     def _on_grid_change(self, event=None):
         """Update grid layout size.
@@ -267,8 +263,8 @@ class QtGridViewButton(QCheckBox):
         event : qtpy.QtCore.QEvent
             Event from the Qt context.
         """
-        with self.viewer.events.grid.blocker():
-            self.setChecked(bool(np.all(self.viewer.grid_size == (1, 1))))
+        with self.viewer.grid.events.update.blocker():
+            self.setChecked(not self.viewer.grid.enabled)
 
 
 class QtNDisplayButton(QCheckBox):

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -250,7 +250,7 @@ def test_grid_mode(make_test_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
     # enter grid view
-    viewer.grid_view()
+    viewer.grid.enabled = True
     assert np.all(viewer.grid_size == (2, 3))
     assert viewer.grid_stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]
@@ -311,7 +311,7 @@ def test_grid_mode(make_test_viewer):
         np.testing.assert_almost_equal(screenshot[coord], c)
 
     # retun to stack view
-    viewer.stack_view()
+    viewer.grid.enabled = False
     assert np.all(viewer.grid_size == (1, 1))
     assert viewer.grid_stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -238,8 +238,9 @@ def test_grid_mode(make_test_viewer):
     data = np.ones((6, 15, 15))
     viewer.add_image(data, channel_axis=0, blending='translucent')
 
-    assert np.all(viewer.grid_size == (1, 1))
-    assert viewer.grid_stride == 1
+    assert not viewer.grid.enabled
+    assert viewer.grid.actual_size(6) == (1, 1)
+    assert viewer.grid.stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = np.zeros((6, 2))
     np.testing.assert_allclose(translations, expected_translations)
@@ -251,8 +252,9 @@ def test_grid_mode(make_test_viewer):
 
     # enter grid view
     viewer.grid.enabled = True
-    assert np.all(viewer.grid_size == (2, 3))
-    assert viewer.grid_stride == 1
+    assert viewer.grid.enabled
+    assert viewer.grid.actual_size(6) == (2, 3)
+    assert viewer.grid.stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = [
         [0, 0],
@@ -310,10 +312,11 @@ def test_grid_mode(make_test_viewer):
         )
         np.testing.assert_almost_equal(screenshot[coord], c)
 
-    # retun to stack view
+    # return to stack view
     viewer.grid.enabled = False
-    assert np.all(viewer.grid_size == (1, 1))
-    assert viewer.grid_stride == 1
+    assert not viewer.grid.enabled
+    assert viewer.grid.actual_size(6) == (1, 1)
+    assert viewer.grid.stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = np.zeros((6, 2))
     np.testing.assert_allclose(translations, expected_translations)

--- a/napari/_viewer_key_bindings.py
+++ b/napari/_viewer_key_bindings.py
@@ -124,9 +124,9 @@ def reset_view(viewer):
 def toggle_grid(viewer):
     """Toggle grid mode."""
     if np.all(viewer.grid_size == (1, 1)):
-        viewer.grid_view()
+        viewer.grid.enabled = True
     else:
-        viewer.stack_view()
+        viewer.grid.enabled = False
 
 
 @Viewer.bind_key('Control-Alt-P')

--- a/napari/components/_tests/test_grid.py
+++ b/napari/components/_tests/test_grid.py
@@ -1,0 +1,7 @@
+from napari.components.grid import Grid
+
+
+def test_grid():
+    """Test creating grid object"""
+    grid = Grid()
+    assert grid is not None

--- a/napari/components/_tests/test_grid.py
+++ b/napari/components/_tests/test_grid.py
@@ -1,7 +1,84 @@
 from napari.components.grid import Grid
 
 
-def test_grid():
+def test_grid_creation():
     """Test creating grid object"""
     grid = Grid()
     assert grid is not None
+    assert not grid.enabled
+    assert grid.size == (-1, -1)
+    assert grid.stride == 1
+
+
+def test_size_stride_creation():
+    """Test creating grid object"""
+    grid = Grid(size=(3, 4), stride=2)
+    assert grid.size == (3, 4)
+    assert grid.stride == 2
+
+
+def test_actual_size_and_position():
+    """Test actual size"""
+    grid = Grid(enabled=True)
+    assert grid.enabled
+
+    # 9 layers get put in a (3, 3) grid
+    assert grid.actual_size(9) == (3, 3)
+    assert grid.position(0, 9) == (0, 0)
+    assert grid.position(2, 9) == (0, 2)
+    assert grid.position(3, 9) == (1, 0)
+    assert grid.position(8, 9) == (2, 2)
+
+    # 5 layers get put in a (2, 3) grid
+    assert grid.actual_size(5) == (2, 3)
+    assert grid.position(0, 5) == (0, 0)
+    assert grid.position(2, 5) == (0, 2)
+    assert grid.position(3, 5) == (1, 0)
+
+    # 10 layers get put in a (3, 4) grid
+    assert grid.actual_size(10) == (3, 4)
+    assert grid.position(0, 10) == (0, 0)
+    assert grid.position(2, 10) == (0, 2)
+    assert grid.position(3, 10) == (0, 3)
+    assert grid.position(8, 10) == (2, 0)
+
+
+def test_actual_size_with_stride():
+    """Test actual size"""
+    grid = Grid(enabled=True, stride=2)
+    assert grid.enabled
+
+    # 7 layers get put in a (2, 2) grid
+    assert grid.actual_size(7) == (2, 2)
+    assert grid.position(0, 7) == (0, 0)
+    assert grid.position(1, 7) == (0, 0)
+    assert grid.position(2, 7) == (0, 1)
+    assert grid.position(3, 7) == (0, 1)
+    assert grid.position(6, 7) == (1, 1)
+
+    # 3 layers get put in a (1, 2) grid
+    assert grid.actual_size(3) == (1, 2)
+    assert grid.position(0, 3) == (0, 0)
+    assert grid.position(1, 3) == (0, 0)
+    assert grid.position(2, 3) == (0, 1)
+
+
+def test_actual_size_and_position_negative_stride():
+    """Test actual size"""
+    grid = Grid(enabled=True, stride=-1)
+    assert grid.enabled
+
+    # 9 layers get put in a (3, 3) grid
+    assert grid.actual_size(9) == (3, 3)
+    assert grid.position(0, 9) == (2, 2)
+    assert grid.position(2, 9) == (2, 0)
+    assert grid.position(3, 9) == (1, 2)
+    assert grid.position(8, 9) == (0, 0)
+
+
+def test_actual_size_grid_disabled():
+    """Test actual size with grid disabled"""
+    grid = Grid()
+    assert not grid.enabled
+    assert grid.actual_size(9) == (1, 1)
+    assert grid.position(3, 9) == (0, 0)

--- a/napari/components/_tests/test_grid.py
+++ b/napari/components/_tests/test_grid.py
@@ -1,9 +1,9 @@
-from napari.components.grid import Grid
+from napari.components.grid import GridCanvas
 
 
 def test_grid_creation():
     """Test creating grid object"""
-    grid = Grid()
+    grid = GridCanvas()
     assert grid is not None
     assert not grid.enabled
     assert grid.size == (-1, -1)
@@ -12,14 +12,14 @@ def test_grid_creation():
 
 def test_size_stride_creation():
     """Test creating grid object"""
-    grid = Grid(size=(3, 4), stride=2)
+    grid = GridCanvas(size=(3, 4), stride=2)
     assert grid.size == (3, 4)
     assert grid.stride == 2
 
 
 def test_actual_size_and_position():
     """Test actual size"""
-    grid = Grid(enabled=True)
+    grid = GridCanvas(enabled=True)
     assert grid.enabled
 
     # 9 layers get put in a (3, 3) grid
@@ -45,7 +45,7 @@ def test_actual_size_and_position():
 
 def test_actual_size_with_stride():
     """Test actual size"""
-    grid = Grid(enabled=True, stride=2)
+    grid = GridCanvas(enabled=True, stride=2)
     assert grid.enabled
 
     # 7 layers get put in a (2, 2) grid
@@ -65,7 +65,7 @@ def test_actual_size_with_stride():
 
 def test_actual_size_and_position_negative_stride():
     """Test actual size"""
-    grid = Grid(enabled=True, stride=-1)
+    grid = GridCanvas(enabled=True, stride=-1)
     assert grid.enabled
 
     # 9 layers get put in a (3, 3) grid
@@ -78,7 +78,7 @@ def test_actual_size_and_position_negative_stride():
 
 def test_actual_size_grid_disabled():
     """Test actual size with grid disabled"""
-    grid = Grid()
+    grid = GridCanvas()
     assert not grid.enabled
     assert grid.actual_size(9) == (1, 1)
     assert grid.position(3, 9) == (0, 0)

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -331,16 +331,18 @@ def test_grid():
     for i in range(6):
         data = np.random.random((15, 15))
         viewer.add_image(data)
-    assert np.all(viewer.grid_size == (1, 1))
-    assert viewer.grid_stride == 1
+    assert not viewer.grid.enabled
+    assert viewer.grid.actual_size(6) == (1, 1)
+    assert viewer.grid.stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = np.zeros((6, 2))
     np.testing.assert_allclose(translations, expected_translations)
 
     # enter grid view
     viewer.grid.enabled = True
-    assert np.all(viewer.grid_size == (2, 3))
-    assert viewer.grid_stride == 1
+    assert viewer.grid.enabled
+    assert viewer.grid.actual_size(6) == (2, 3)
+    assert viewer.grid.stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = [
         [0, 0],
@@ -354,16 +356,19 @@ def test_grid():
 
     # return to stack view
     viewer.grid.enabled = False
-    assert np.all(viewer.grid_size == (1, 1))
-    assert viewer.grid_stride == 1
+    assert not viewer.grid.enabled
+    assert viewer.grid.actual_size(6) == (1, 1)
+    assert viewer.grid.stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = np.zeros((6, 2))
     np.testing.assert_allclose(translations, expected_translations)
 
-    # reenter grid view
-    viewer.grid_view(n_column=2, n_row=3, stride=-2)
-    assert np.all(viewer.grid_size == (3, 2))
-    assert viewer.grid_stride == -2
+    # reenter grid view with new stride
+    viewer.grid.stride = -2
+    viewer.grid.enabled = True
+    assert viewer.grid.enabled
+    assert viewer.grid.actual_size(6) == (2, 2)
+    assert viewer.grid.stride == -2
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = [
         [0, 0],

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -338,7 +338,7 @@ def test_grid():
     np.testing.assert_allclose(translations, expected_translations)
 
     # enter grid view
-    viewer.grid_view()
+    viewer.grid.enabled = True
     assert np.all(viewer.grid_size == (2, 3))
     assert viewer.grid_stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]
@@ -353,7 +353,7 @@ def test_grid():
     np.testing.assert_allclose(translations, expected_translations[::-1])
 
     # return to stack view
-    viewer.stack_view()
+    viewer.grid.enabled = False
     assert np.all(viewer.grid_size == (1, 1))
     assert viewer.grid_stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]

--- a/napari/components/grid.py
+++ b/napari/components/grid.py
@@ -3,8 +3,11 @@ import numpy as np
 from ..utils.events import EmitterGroup
 
 
-class Grid:
-    """Grid mode.
+class GridCanvas:
+    """Grid for canvas.
+
+    Right now the only grid mode that is still inside one canvas with one
+    camera, but future grid modes could support multiple canvases.
 
     Attributes
     ----------
@@ -16,7 +19,7 @@ class Grid:
         Number of rows and columns in the grid. A value of -1 for either or
         both of will be used the row and column numbers will trigger an
         auto calculation of the necessary grid size to appropriately fill
-        all they layers at the appropriate stride.
+        all the layers at the appropriate stride.
     stride : int
         Number of layers to place in each grid square before moving on to
         the next square. The default ordering is to place the most visible
@@ -69,7 +72,7 @@ class Grid:
     def actual_size(self, nlayers=1):
         """Return the actual size of the grid.
 
-        This will return the size paramater, unless one of the row
+        This will return the size parameter, unless one of the row
         or column numbers is -1 in which case it will compute the
         optimal size of the grid given the number of layers and
         current stride.

--- a/napari/components/grid.py
+++ b/napari/components/grid.py
@@ -1,0 +1,140 @@
+import numpy as np
+
+from ..utils.events import EmitterGroup
+
+
+class Grid:
+    """Grid mode.
+
+    Attributes
+    ----------
+    events : EmitterGroup
+        Event emitter group
+    enabled : bool
+        If grid is enabled or not.
+    size : 2-tuple of int
+        Number of rows and columns in the grid. A value of -1 for either or
+        both of will be used the row and column numbers will trigger an
+        auto calculation of the necessary grid size to appropriately fill
+        all they layers at the appropriate stride.
+    stride : int
+        Number of layers to place in each grid square before moving on to
+        the next square. The default ordering is to place the most visible
+        layer in the top left corner of the grid. A negative stride will
+        cause the order in which the layers are placed in the grid to be
+        reversed.
+    """
+
+    def __init__(self, *, size=(-1, -1), stride=1, enabled=False):
+
+        # Events:
+        self.events = EmitterGroup(
+            source=self, auto_connect=True, update=None,
+        )
+
+        self._enabled = enabled
+        self._stride = stride
+        self._size = size
+
+    @property
+    def enabled(self):
+        """bool: If grid is enabled or not."""
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, enabled):
+        self._enabled = enabled
+        self.events.update()
+
+    @property
+    def size(self):
+        """2-tuple of int: Number of rows and columns in the grid."""
+        return self._size
+
+    @size.setter
+    def size(self, size):
+        self._size = tuple(size)
+        self.events.update()
+
+    @property
+    def stride(self):
+        """int: Number of layers in each grid square."""
+        return self._stride
+
+    @stride.setter
+    def stride(self, stride):
+        self._stride = stride
+        self.events.update()
+
+    def actual_size(self, nlayers=1):
+        """Return the actual size of the grid.
+
+        This will return the size paramater, unless one of the row
+        or column numbers is -1 in which case it will compute the
+        optimal size of the grid given the number of layers and
+        current stride.
+
+        If the grid is not enabled, this will return (1, 1).
+
+        Parameters
+        ----------
+        nlayers : int
+            Number of layers that need to be placed in the grid.
+
+        Returns
+        -------
+        size : 2-tuple of int
+            Number of rows and columns in the grid.
+        """
+        if self.enabled:
+            n_row, n_column = self.size
+            n_grid_squares = np.ceil(nlayers / abs(self.stride)).astype(int)
+
+            if n_row == -1 and n_column == -1:
+                n_column = np.ceil(np.sqrt(n_grid_squares)).astype(int)
+                n_row = np.ceil(n_grid_squares / n_column).astype(int)
+            elif n_row == -1:
+                n_row = np.ceil(n_grid_squares / n_column).astype(int)
+            elif n_column == -1:
+                n_column = np.ceil(n_grid_squares / n_row).astype(int)
+
+            n_row = max(1, n_row)
+            n_column = max(1, n_column)
+
+            return (n_row, n_column)
+        else:
+            return (1, 1)
+
+    def position(self, index, nlayers):
+        """Return the position of a given linear index in grid.
+
+        If the grid is not enabled, this will return (0, 0).
+
+        Parameters
+        ----------
+        index : int
+            Position of current layer in layer list.
+        nlayers : int
+            Number of layers that need to be placed in the grid.
+
+        Returns
+        -------
+        position : 2-tuple of int
+            Row and column position of current index in the grid.
+        """
+        if self.enabled:
+            n_row, n_column = self.actual_size(nlayers)
+
+            # Adjust for forward or reverse ordering
+            if self.stride > 0:
+                adj_i = nlayers - index - 1
+            else:
+                adj_i = index
+
+            adj_i = adj_i // abs(self.stride)
+            adj_i = adj_i % (n_row * n_column)
+            i_row = adj_i // n_column
+            i_column = adj_i % n_column
+            return (i_row, i_column)
+        else:
+            return (0, 0)

--- a/napari/components/grid.py
+++ b/napari/components/grid.py
@@ -126,7 +126,7 @@ class Grid:
             n_row, n_column = self.actual_size(nlayers)
 
             # Adjust for forward or reverse ordering
-            if self.stride > 0:
+            if self.stride < 0:
                 adj_i = nlayers - index - 1
             else:
                 adj_i = index

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -158,7 +158,7 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         """tuple: Size of grid."""
         warnings.warn(
             (
-                "The viewer.grid_size parameter is deprecated and will be removed after version 0.4.2."
+                "The viewer.grid_size parameter is deprecated and will be removed after version 0.4.3."
                 " Instead you should use viewer.grid.size"
             ),
             category=DeprecationWarning,
@@ -170,7 +170,7 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
     def grid_size(self, grid_size):
         warnings.warn(
             (
-                "The viewer.grid_size parameter is deprecated and will be removed after version 0.4.2."
+                "The viewer.grid_size parameter is deprecated and will be removed after version 0.4.3."
                 " Instead you should use viewer.grid.size"
             ),
             category=DeprecationWarning,
@@ -183,7 +183,7 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         """int: Number of layers in each grid square."""
         warnings.warn(
             (
-                "The viewer.grid_stride parameter is deprecated and will be removed after version 0.4.2."
+                "The viewer.grid_stride parameter is deprecated and will be removed after version 0.4.3."
                 " Instead you should use viewer.grid.stride"
             ),
             category=DeprecationWarning,
@@ -195,7 +195,7 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
     def grid_stride(self, grid_stride):
         warnings.warn(
             (
-                "The viewer.grid_stride parameter is deprecated and will be removed after version 0.4.2."
+                "The viewer.grid_stride parameter is deprecated and will be removed after version 0.4.3."
                 " Instead you should use viewer.grid.stride"
             ),
             category=DeprecationWarning,
@@ -444,7 +444,9 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
 
     def grid_view(self, n_row=None, n_column=None, stride=1):
         """Arrange the current layers is a 2D grid.
+
         Default behaviour is to make a square 2D grid.
+
         Parameters
         ----------
         n_row : int, optional
@@ -460,7 +462,7 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         """
         warnings.warn(
             (
-                "The viewer.grid_view method is deprecated and will be removed after version 0.4.2."
+                "The viewer.grid_view method is deprecated and will be removed after version 0.4.3."
                 " Instead you should use the viewer.grid.enabled = Turn to turn on the grid view,"
                 " and viewer.grid.size and viewer.grid.stride to set the size and stride of the"
                 " grid respectively."
@@ -481,7 +483,7 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         """
         warnings.warn(
             (
-                "The viewer.stack_view method is deprecated and will be removed after version 0.4.2."
+                "The viewer.stack_view method is deprecated and will be removed after version 0.4.3."
                 " Instead you should use the viewer.grid.enabled = False to turn off the grid view."
             ),
             category=DeprecationWarning,

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -11,7 +11,7 @@ from .axes import Axes
 from .camera import Camera
 from .cursor import Cursor
 from .dims import Dims
-from .grid import Grid
+from .grid import GridCanvas
 from .layerlist import LayerList
 from .scale_bar import ScaleBar
 
@@ -81,7 +81,7 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
 
         self._interactive = True
         self._active_layer = None
-        self.grid = Grid()
+        self.grid = GridCanvas()
         # 2-tuple indicating height and width
         self._canvas_size = (600, 800)
         self._palette = None

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 from ..utils.events import EmitterGroup, Event
@@ -150,6 +152,56 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
                 f"Theme '{theme}' not found; "
                 f"options are {list(self.themes)}."
             )
+
+    @property
+    def grid_size(self):
+        """tuple: Size of grid."""
+        warnings.warn(
+            (
+                "The viewer.grid_size parameter is deprecated and will be removed after version 0.4.2."
+                " Instead you should use viewer.grid.size"
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.grid.size
+
+    @grid_size.setter
+    def grid_size(self, grid_size):
+        warnings.warn(
+            (
+                "The viewer.grid_size parameter is deprecated and will be removed after version 0.4.2."
+                " Instead you should use viewer.grid.size"
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        self.grid.size = grid_size
+
+    @property
+    def grid_stride(self):
+        """int: Number of layers in each grid square."""
+        warnings.warn(
+            (
+                "The viewer.grid_stride parameter is deprecated and will be removed after version 0.4.2."
+                " Instead you should use viewer.grid.stride"
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.grid.stride
+
+    @grid_stride.setter
+    def grid_stride(self, grid_stride):
+        warnings.warn(
+            (
+                "The viewer.grid_stride parameter is deprecated and will be removed after version 0.4.2."
+                " Instead you should use viewer.grid.stride"
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        self.grid.stride = grid_stride
 
     @property
     def status(self):
@@ -389,6 +441,53 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         for i, layer in enumerate(self.layers):
             i_row, i_column = self.grid.position(i, len(self.layers))
             self._subplot(layer, (i_row, i_column))
+
+    def grid_view(self, n_row=None, n_column=None, stride=1):
+        """Arrange the current layers is a 2D grid.
+        Default behaviour is to make a square 2D grid.
+        Parameters
+        ----------
+        n_row : int, optional
+            Number of rows in the grid.
+        n_column : int, optional
+            Number of column in the grid.
+        stride : int, optional
+            Number of layers to place in each grid square before moving on to
+            the next square. The default ordering is to place the most visible
+            layer in the top left corner of the grid. A negative stride will
+            cause the order in which the layers are placed in the grid to be
+            reversed.
+        """
+        warnings.warn(
+            (
+                "The viewer.grid_view method is deprecated and will be removed after version 0.4.2."
+                " Instead you should use the viewer.grid.enabled = Turn to turn on the grid view,"
+                " and viewer.grid.size and viewer.grid.stride to set the size and stride of the"
+                " grid respectively."
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        self.grid.stride = stride
+        if n_row is None:
+            n_row = -1
+        if n_column is None:
+            n_column = -1
+        self.grid.size = (n_row, n_column)
+        self.grid.enabled = True
+
+    def stack_view(self):
+        """Arrange the current layers in a stack.
+        """
+        warnings.warn(
+            (
+                "The viewer.stack_view method is deprecated and will be removed after version 0.4.2."
+                " Instead you should use the viewer.grid.enabled = False to turn off the grid view."
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        self.grid.enabled = False
 
     def _subplot(self, layer, position):
         """Shift a layer to a specified position in a 2D grid.

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -438,7 +438,7 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
 
     def _on_grid_change(self, event):
         """Arrange the current layers is a 2D grid."""
-        for i, layer in enumerate(self.layers):
+        for i, layer in enumerate(self.layers[::-1]):
             i_row, i_column = self.grid.position(i, len(self.layers))
             self._subplot(layer, (i_row, i_column))
 


### PR DESCRIPTION
# Description
As people seem to like using grid mode and it will probably be around for a while, this PR is beginning to clean it up a little.

It adds a new `Grid` object which is very simple and holds a couple of attributes about the grid. Right now we still just use the stride to put elements in the grid, but we could now add two modes to the grid - one called `Regular` which uses the stride and one called `Positioned` (names to be determined) which would let you set the position of each layer in the grid as you wish. This could alleviate some of the robustness concerns @GenevieveBuckley have expressed about the current grid mode. I probably won't do that in this PR, but it's something that we now have space for.

This PR also does not move the grid information off the layer i.e. it does not close this PR #1690 or deal with any of the tricky camera/ coordinate system stuff. I'd like to do that in a follow-up PR after this one.

I still need to add some more tests, and I want to go back and add deprecation warnings in from of all the public methods that I have pulled. I should be able to preserve all their functionality.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
