### PR TITLE
async-20: Better QtTestImage

### DIFF
--- a/napari/_qt/experimental/render/qt_render_container.py
+++ b/napari/_qt/experimental/render/qt_render_container.py
@@ -35,6 +35,7 @@ class QtRenderContainer(QStackedWidget):
         self.viewer = viewer
 
         self.setMouseTracking(True)
+        self.setMinimumWidth(250)
 
         # We show QtRender even if no layer is selected. But in that case the
         # only control are to create test images.

--- a/napari/_qt/experimental/render/qt_test_image.py
+++ b/napari/_qt/experimental/render/qt_test_image.py
@@ -12,7 +12,6 @@ from qtpy.QtWidgets import (
     QPushButton,
     QVBoxLayout,
 )
-from skimage import data as skimage_data
 
 from ....utils import config
 from .qt_labeled_spin_box import QtLabeledSpinBox
@@ -36,17 +35,30 @@ TEST_IMAGES = {
         "factory": lambda image_shape: create_test_image(
             "0", (16, 16), image_shape
         ),
-    },
-    "Astronaut": {
-        "shape": (512, 512),
-        "factory": lambda: skimage_data.astronaut(),
-    },
-    "Chelsea": {
-        "shape": (300, 451),
-        "factory": lambda: skimage_data.chelsea(),
-    },
-    "Coffee": {"shape": (400, 600), "factory": lambda: skimage_data.coffee()},
+    }
 }
+TEST_IMAGE_DEFAULT = "Digits"
+
+# Add skimage.data images if installed. Napari does not depend on
+# skimage but many developers will have it.
+try:
+    import skimage.data as data
+
+    TEST_IMAGES.update(
+        {
+            "Astronaut": {
+                "shape": (512, 512),
+                "factory": lambda: data.astronaut(),
+            },
+            "Chelsea": {
+                "shape": (300, 451),
+                "factory": lambda: data.chelsea(),
+            },
+            "Coffee": {"shape": (400, 600), "factory": lambda: data.coffee()},
+        }
+    )
+except ImportError:
+    pass  # These images won't be listed.
 
 
 class QtSetShape(QGroupBox):
@@ -140,7 +152,7 @@ class QtTestImageLayout(QVBoxLayout):
         self.addWidget(button)
 
         # Set the initially selected image.
-        self._on_name("Digits")
+        self._on_name(TEST_IMAGE_DEFAULT)
 
     def _on_name(self, value: str) -> None:
         """Called when a new image name is selected.

--- a/napari/_qt/experimental/render/qt_test_image.py
+++ b/napari/_qt/experimental/render/qt_test_image.py
@@ -1,11 +1,14 @@
 """QtTestImage and QtTestImageLayout classes.
 """
+from collections import namedtuple
 from typing import Callable, Tuple
 
 from qtpy.QtWidgets import (
     QCheckBox,
     QComboBox,
     QFrame,
+    QGroupBox,
+    QLabel,
     QPushButton,
     QVBoxLayout,
 )
@@ -13,7 +16,7 @@ from skimage import data as skimage_data
 
 from ....utils import config
 from .qt_labeled_spin_box import QtLabeledSpinBox
-from .test_image import create_tiled_text_array
+from .test_image import create_test_image
 
 Callback = Callable[[], None]
 IntCallback = Callable[[int], None]
@@ -21,15 +24,77 @@ IntCallback = Callable[[int], None]
 TILE_SIZE_DEFAULT = 64
 TILE_SIZE_RANGE = range(1, 4096, 100)
 
-IMAGE_SIZE_DEFAULT = (1024, 1024)  # (width, height)
-IMAGE_SIZE_RANGE = range(1, 65536, 100)
+IMAGE_SHAPE_DEFAULT = (1024, 1024)  # (height, width)
+IMAGE_SHAPE_RANGE = range(1, 65536, 100)
 
+# The test images which QtTestImage can create. There is a drop-down and
+# the user can pick any one of these. Some are fixed shape, while others
+# allow you to request a specific shape.
 TEST_IMAGES = {
-    "Digits": lambda size: create_tiled_text_array("0", 16, 16, size),
-    "Astronaut": lambda size: skimage_data.astronaut(),
-    "Chelsea": lambda size: skimage_data.chelsea(),
-    "Coffee": lambda size: skimage_data.coffee(),
+    "Digits": {
+        "shape": None,
+        "factory": lambda image_shape: create_test_image(
+            "0", (16, 16), image_shape
+        ),
+    },
+    "Astronaut": {
+        "shape": (512, 512),
+        "factory": lambda: skimage_data.astronaut(),
+    },
+    "Chelsea": {
+        "shape": (300, 451),
+        "factory": lambda: skimage_data.chelsea(),
+    },
+    "Coffee": {"shape": (400, 600), "factory": lambda: skimage_data.coffee()},
 }
+
+
+class QtSetShape(QGroupBox):
+    """Controls to set the shape of an image."""
+
+    def __init__(self):
+        super().__init__("Dimensions")
+
+        layout = QVBoxLayout()
+        self.height = QtLabeledSpinBox(
+            "Height", IMAGE_SHAPE_DEFAULT[0], IMAGE_SHAPE_RANGE
+        )
+        layout.addLayout(self.height)
+        self.width = QtLabeledSpinBox(
+            "Width", IMAGE_SHAPE_DEFAULT[1], IMAGE_SHAPE_RANGE
+        )
+        layout.addLayout(self.width)
+        self.setLayout(layout)
+
+    def get_shape(self) -> Tuple[int, int]:
+        """Return the currently configured shape.
+
+        Return
+        ------
+        Tuple[int, int]
+            The requestsed [height, width] shape.
+        """
+        return self.height.spin.value(), self.width.spin.value()
+
+
+class QtFixedShape(QGroupBox):
+    """Controls to display the fixed shape of an image."""
+
+    def __init__(self):
+        super().__init__("Details")
+
+        layout = QVBoxLayout()
+        self.shape = QLabel("Shape: ???")
+        layout.addWidget(self.shape)
+        self.setLayout(layout)
+
+    def set_shape(self, shape: Tuple[int, int]) -> None:
+        """Set the shape to show in the labels.
+
+        shape : Tuple[int, int]
+            The shape to show in the labels.
+        """
+        self.shape.setText(f"Shape: ({shape[0]}, {shape[1]})")
 
 
 class QtTestImageLayout(QVBoxLayout):
@@ -45,16 +110,19 @@ class QtTestImageLayout(QVBoxLayout):
         super().__init__()
         self.addStretch(1)
 
-        # Dimension controls.
-        self.width = QtLabeledSpinBox(
-            "Image Width", IMAGE_SIZE_DEFAULT[0], IMAGE_SIZE_RANGE
-        )
-        self.height = QtLabeledSpinBox(
-            "Image Height", IMAGE_SIZE_DEFAULT[1], IMAGE_SIZE_RANGE
-        )
-        self.addLayout(self.width)
-        self.addLayout(self.height)
+        self.name = QComboBox()
+        self.name.addItems(TEST_IMAGES.keys())
+        self.name.activated[str].connect(self._on_name)
+        self.addWidget(self.name)
 
+        ShapeControls = namedtuple('ShapeControls', "set fixed")
+        self.shape_controls = ShapeControls(QtSetShape(), QtFixedShape())
+
+        # Add both, but only one will be visible at a time.
+        self.addWidget(self.shape_controls.set)
+        self.addWidget(self.shape_controls.fixed)
+
+        # User can always set the tile size. Tiles always square for now.
         self.tile_size = QtLabeledSpinBox(
             "Tile Size", TILE_SIZE_DEFAULT, TILE_SIZE_RANGE
         )
@@ -65,25 +133,47 @@ class QtTestImageLayout(QVBoxLayout):
         self.octree.setChecked(1)
         self.addWidget(self.octree)
 
-        self.style = QComboBox()
-        self.style.addItems(TEST_IMAGES.keys())
-        self.addWidget(self.style)
-
         # The create button.
         button = QPushButton("Create Test Image")
         button.setToolTip("Create a new test image")
         button.clicked.connect(on_create)
         self.addWidget(button)
 
-    def get_image_size(self) -> Tuple[int, int]:
-        """Return the configured image size.
+        # Set the initially selected image.
+        self._on_name("Digits")
+
+    def _on_name(self, value: str) -> None:
+        """Called when a new image name is selected.
+
+        Set which image controls are visible based on the spec of
+        the newly selected image.
+
+        Parameters
+        ----------
+        value : str
+            The new image name.
+        """
+        spec = TEST_IMAGES[value]
+
+        if spec['shape'] is None:
+            # Image has a settable shape.
+            self.shape_controls.set.show()
+            self.shape_controls.fixed.hide()
+        else:
+            # Image has a fixed shape.
+            self.shape_controls.set.hide()
+            self.shape_controls.fixed.show()
+            self.shape_controls.fixed.set_shape(spec['shape'])
+
+    def get_image_shape(self) -> Tuple[int, int]:
+        """Return the configured image shape.
 
         Return
         ------
         Tuple[int, int]
-            The [width, height] requested by the user.
+            The [height, width] shape requested by the user.
         """
-        return (self.width.spin.value(), self.height.spin.value())
+        return self.shape_controls.set.get_shape()
 
     def get_tile_size(self) -> int:
         """Return the configured tile size.
@@ -105,8 +195,8 @@ class QtTestImage(QFrame):
         The napari viewer.
     """
 
-    # This is a class attribute so that we use a unique index napari-wide,
-    # not just within in this one QtRender widget, this one layer.
+    # Class attribute so system-wide we create unique names, even if
+    # created from different QtRender widgets for different layers.
     image_index = 0
 
     def __init__(self, viewer):
@@ -116,17 +206,28 @@ class QtTestImage(QFrame):
         self.setLayout(self.layout)
 
     def _create_test_image(self) -> None:
-        """Create a new test image."""
-        # We create regular Images or OctreeImages.
-        config.create_octree_images = self.layout.octree.isChecked()
+        """Create a new test image layer."""
 
-        image_size = self.layout.get_image_size()
-        image_name = self.layout.style.currentText()
-        data = TEST_IMAGES[image_name](image_size)
+        # Get the spec for the current selected type of image.
+        image_name = self.layout.name.currentText()
+        spec = TEST_IMAGES[image_name]
+        factory = spec['factory']
+
+        if spec['shape'] is None:
+            # Image has a settable shape provided by the UI.
+            shape = self.layout.get_image_shape()
+            data = factory(shape)
+        else:
+            # Image comes in just one specific shape.
+            data = factory()
 
         # Give each layer a unique name.
         unique_name = f"test-image-{QtTestImage.image_index:003}"
         QtTestImage.image_index += 1
 
+        # Set config to create Octree or regular images.
+        config.create_octree_images = self.layout.octree.isChecked()
+
+        # Add the new image layer.
         layer = self.viewer.add_image(data, rgb=True, name=unique_name)
         layer.tile_size = self.layout.get_tile_size()

--- a/napari/_qt/experimental/render/test_image.py
+++ b/napari/_qt/experimental/render/test_image.py
@@ -3,28 +3,25 @@
 This is a throw-away file for creating a test image for octree rendering
 development. If we keep test images in the product long term we'll
 have a nicer way to generate them.
+
+Long term we probably do not want to use PIL for example.
 """
+from typing import Tuple
+
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
 
-def draw_text(image, text, nx=0.5, ny=0.5):
+def draw_text_grid(image, text: str, grid_shape: Tuple[int, int]) -> None:
+    """Draw some text into the given image in a grid.
 
-    font = ImageFont.truetype('Arial Black.ttf', size=72)
-    (text_width, text_height) = font.getsize(text)
-    x = nx * image.width - text_width / 2
-    y = ny * image.height - text_height / 2
-
-    color = 'rgb(255, 255, 255)'  # white
-
-    draw = ImageDraw.Draw(image)
-    draw.text((x, y), text, fill=color, font=font)
-    draw.rectangle([0, 0, image.width, image.height], width=5)
-
-
-def draw_text_tiled(image, text, nrows=1, ncols=1):
-
-    print(f"Creating {nrows}x{ncols} text image: {text}")
+    Parameters
+    ----------
+    test : str
+        The text to draw. For example a slice index like "3".
+    grid_shape : Tuple[int, int]
+        Draw the text in a grid of is [height, weight] shape.
+    """
 
     try:
         font = ImageFont.truetype('Arial Black.ttf', size=74)
@@ -35,31 +32,39 @@ def draw_text_tiled(image, text, nrows=1, ncols=1):
     color = 'rgb(255, 255, 255)'  # white
     draw = ImageDraw.Draw(image)
 
-    for row in range(nrows + 1):
-        for col in range(ncols + 1):
-            x = (col / ncols) * image.width - text_width / 2
-            y = (row / nrows) * image.height - text_height / 2
+    rows, cols = grid_shape[0], grid_shape[1]
+
+    for row in range(rows + 1):
+        for col in range(cols + 1):
+            y = (row / rows) * image.height - text_height / 2
+            x = (col / cols) * image.width - text_width / 2
 
             draw.text((x, y), text, fill=color, font=font)
     draw.rectangle([0, 0, image.width, image.height], outline=color, width=5)
 
 
-def create_text_array(text, nx=0.5, ny=0.5, size=(1024, 1024)):
-    text = str(text)
-    image = Image.new('RGB', size)
-    draw_text(image, text, nx, ny)
-    return np.array(image)
+def create_test_image(
+    text,
+    digit_shape: Tuple[int, int],
+    image_shape: Tuple[int, int] = (1024, 1024),
+) -> np.ndarray:
+    """Create a test image for testing tiled rendering.
 
+    The test image just has digits all over it. The digits will typically
+    be used to show the slice number.
 
-def create_tiled_text_array(text, nrows, ncols, size=(1024, 1024)):
-    text = str(text)
-    image = Image.new('RGB', size)
-    draw_text_tiled(image, text, nrows, ncols)
-    return np.array(image)
+    shape: Tuple[int, int]
+        The [height, width] shape of the image.
+    """
+    text = str(text)  # Might be an int.
 
+    # Image.new wants (width, height) so swap them.
+    image_size = (
+        image_shape[1],
+        image_shape[0],
+    )
 
-def create_tiled_test_1(text, nrows, ncols, size=(1024, 1024)):
-    text = str(text)
-    image = Image.new('RGB', size)
-    draw_text_tiled(image, text, nrows, ncols)
+    # Create the image, draw on the text, return it.
+    image = Image.new('RGB', image_size)
+    draw_text_grid(image, text, digit_shape)
     return np.array(image)


### PR DESCRIPTION
# Description
The `TEST_IMAGES` dict can now specific that a test image has a settable shape or a fixed shape.

A fixed shape looks like this in the UI:

<img width="234" alt="napari-test-1" src="https://user-images.githubusercontent.com/4163446/98138626-4ca67280-1e91-11eb-8af9-183e64f9776c.png">

A settable shape looks like this:

<img width="240" alt="napari-test-0" src="https://user-images.githubusercontent.com/4163446/98139101-ca6a7e00-1e91-11eb-8c32-56bdba5bb982.png">

## Type of change
- [x] New feature in experimental code

# Files

<img width="331" alt="async-20-files" src="https://user-images.githubusercontent.com/4163446/98139255-fa198600-1e91-11eb-941f-e39389049540.png">

# Explanation
It might seem unconventional to have this sort of UI inside napari, since you can easily open images. However, I think it will be useful for rendering work. Soon we'll have URL's of remote images, we'll have 3d images, different time series types, etc. I think it's good for someone working on rendering to have easy access to a selection of test images to quickly put rendering through its paces. And so repro cases are easy to report if it can be reproduced on a specific test image.

Repro cases with test images will be much easier to deal with than requiring loading someone's specific and potentially hard to access data.

# How has this been tested?
- [x] Manual testing

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
