### PR TITLE
Fix lower triangular shear values

### DIFF
--- a/napari/utils/transforms/_tests/test_transform_utils.py
+++ b/napari/utils/transforms/_tests/test_transform_utils.py
@@ -2,11 +2,11 @@ import numpy as np
 import pytest
 
 from napari.utils.transforms.transform_utils import (
-    check_shear_triangular,
     compose_linear_matrix,
     decompose_linear_matrix,
-    is_lower_triangular,
-    is_upper_triangular,
+    is_matrix_lower_triangular,
+    is_matrix_triangular,
+    is_matrix_upper_triangular,
     shear_matrix_from_angle,
 )
 
@@ -51,23 +51,22 @@ lower = np.array([[1, 0], [1, 1]])
 full = np.array([[1, 1], [1, 1]])
 
 
-def test_is_upper_triangular():
+def test_is_matrix_upper_triangular():
     """Test if a matrix is upper triangular."""
-    assert is_upper_triangular(upper)
-    assert not is_upper_triangular(lower)
-    assert not is_upper_triangular(full)
+    assert is_matrix_upper_triangular(upper)
+    assert not is_matrix_upper_triangular(lower)
+    assert not is_matrix_upper_triangular(full)
 
 
-def test_is_lower_triangular():
+def test_is_matrix_lower_triangular():
     """Test if a matrix is lower triangular."""
-    assert not is_lower_triangular(upper)
-    assert is_lower_triangular(lower)
-    assert not is_lower_triangular(full)
+    assert not is_matrix_lower_triangular(upper)
+    assert is_matrix_lower_triangular(lower)
+    assert not is_matrix_lower_triangular(full)
 
 
-def test_check_shear_triangular():
-    """Determine shear triangular of matrix."""
-    assert check_shear_triangular(upper)
-    assert not check_shear_triangular(lower)
-    with pytest.raises(ValueError):
-        check_shear_triangular(full)
+def test_is_matrix_triangular():
+    """Test if a matrix is triangular."""
+    assert is_matrix_triangular(upper)
+    assert is_matrix_triangular(lower)
+    assert not is_matrix_triangular(full)

--- a/napari/utils/transforms/_tests/test_transform_utils.py
+++ b/napari/utils/transforms/_tests/test_transform_utils.py
@@ -1,26 +1,35 @@
 import numpy as np
+import pytest
 
 from napari.utils.transforms.transform_utils import (
+    check_shear_triangular,
     compose_linear_matrix,
     decompose_linear_matrix,
+    is_lower_triangular,
+    is_upper_triangular,
     shear_matrix_from_angle,
 )
 
 
-def test_decompose_linear_matrix():
+@pytest.mark.parametrize('upper_triangular', [True, False])
+def test_decompose_linear_matrix(upper_triangular):
     """Test composing and decomposing a linear matrix."""
     np.random.seed(0)
 
     # Decompose linear matrix
     A = np.random.random((2, 2))
-    rotate, scale, shear = decompose_linear_matrix(A)
+    rotate, scale, shear = decompose_linear_matrix(
+        A, upper_triangular=upper_triangular
+    )
 
     # Compose linear matrix and check it matches
     B = compose_linear_matrix(rotate, scale, shear)
     np.testing.assert_almost_equal(A, B)
 
     # Decompose linear matrix and check it matches
-    rotate_B, scale_B, shear_B = decompose_linear_matrix(B)
+    rotate_B, scale_B, shear_B = decompose_linear_matrix(
+        B, upper_triangular=upper_triangular
+    )
     np.testing.assert_almost_equal(rotate, rotate_B)
     np.testing.assert_almost_equal(scale, scale_B)
     np.testing.assert_almost_equal(shear, shear_B)
@@ -35,3 +44,30 @@ def test_shear_matrix_from_angle():
     matrix = shear_matrix_from_angle(35)
     np.testing.assert_almost_equal(np.diag(matrix), [1] * 3)
     np.testing.assert_almost_equal(matrix[-1, 0], np.tan(np.deg2rad(55)))
+
+
+upper = np.array([[1, 1], [0, 1]])
+lower = np.array([[1, 0], [1, 1]])
+full = np.array([[1, 1], [1, 1]])
+
+
+def test_is_upper_triangular():
+    """Test if a matrix is upper triangular."""
+    assert is_upper_triangular(upper)
+    assert not is_upper_triangular(lower)
+    assert not is_upper_triangular(full)
+
+
+def test_is_lower_triangular():
+    """Test if a matrix is lower triangular."""
+    assert not is_lower_triangular(upper)
+    assert is_lower_triangular(lower)
+    assert not is_lower_triangular(full)
+
+
+def test_check_shear_triangular():
+    """Determine shear triangular of matrix."""
+    assert check_shear_triangular(upper)
+    assert not check_shear_triangular(lower)
+    with pytest.raises(ValueError):
+        check_shear_triangular(full)

--- a/napari/utils/transforms/_tests/test_transforms.py
+++ b/napari/utils/transforms/_tests/test_transforms.py
@@ -248,16 +248,16 @@ def test_repeat_shear_setting():
     # decomposition of shear is working
     mat = np.eye(3)
     mat[2, 0] = 0.5
-    transform = Affine(shear=mat)
+    transform = Affine(shear=mat.copy())
     # Check shear decomposed into lower triangular
     np.testing.assert_almost_equal(mat, transform.shear)
 
     # Set shear to same value
-    transform.shear = mat
+    transform.shear = mat.copy()
     # Check shear still decomposed into lower triangular
     np.testing.assert_almost_equal(mat, transform.shear)
 
     # Set shear to same value
-    transform.shear = mat
+    transform.shear = mat.copy()
     # Check shear still decomposed into lower triangular
     np.testing.assert_almost_equal(mat, transform.shear)

--- a/napari/utils/transforms/_tests/test_transforms.py
+++ b/napari/utils/transforms/_tests/test_transforms.py
@@ -240,3 +240,24 @@ def test_affine_matrix_inverse(dimensionality):
     np.testing.assert_almost_equal(
         transform.inverse.affine_matrix, np.linalg.inv(A)
     )
+
+
+def test_repeat_shear_setting():
+    """Test repeatedly settting shear lower triangular."""
+    # Note this test is needed to check lower triangular
+    # decomposition of shear is working
+    mat = np.eye(3)
+    mat[2, 0] = 0.5
+    transform = Affine(shear=mat)
+    # Check shear decomposed into lower triangular
+    np.testing.assert_almost_equal(mat, transform.shear)
+
+    # Set shear to same value
+    transform.shear = mat
+    # Check shear still decomposed into lower triangular
+    np.testing.assert_almost_equal(mat, transform.shear)
+
+    # Set shear to same value
+    transform.shear = mat
+    # Check shear still decomposed into lower triangular
+    np.testing.assert_almost_equal(mat, transform.shear)

--- a/napari/utils/transforms/_tests/test_transforms.py
+++ b/napari/utils/transforms/_tests/test_transforms.py
@@ -243,7 +243,7 @@ def test_affine_matrix_inverse(dimensionality):
 
 
 def test_repeat_shear_setting():
-    """Test repeatedly settting shear lower triangular."""
+    """Test repeatedly setting shear with a lower triangular matrix."""
     # Note this test is needed to check lower triangular
     # decomposition of shear is working
     mat = np.eye(3)

--- a/napari/utils/transforms/transform_utils.py
+++ b/napari/utils/transforms/transform_utils.py
@@ -277,12 +277,9 @@ def is_matrix_triangular(matrix):
     bool
         Whether matrix is triangular or not.
     """
-    if is_matrix_upper_triangular(matrix) or is_matrix_lower_triangular(
+    return is_matrix_upper_triangular(matrix) or is_matrix_lower_triangular(
         matrix
-    ):
-        return True
-    else:
-        return False
+    )
 
 
 def check_shear_triangular(matrix):

--- a/napari/utils/transforms/transform_utils.py
+++ b/napari/utils/transforms/transform_utils.py
@@ -280,34 +280,3 @@ def is_matrix_triangular(matrix):
     return is_matrix_upper_triangular(matrix) or is_matrix_lower_triangular(
         matrix
     )
-
-
-def check_shear_triangular(matrix):
-    """Check if a matrix is triangular.
-
-    Raises an error if neither upper or lower triangular.
-    1-D arrays are taken to be upper triangular.
-
-    Parameters
-    ----------
-    matrix : np.ndarray
-        Matrix to be checked.
-
-    Returns
-    -------
-    bool
-        True if matrix upper triangular, False if not.
-    """
-    if np.array(matrix).ndim == 2:
-        if is_matrix_upper_triangular(matrix):
-            return True
-        elif is_matrix_lower_triangular(matrix):
-            return False
-        else:
-            raise ValueError(
-                f'Only upper triangular or lower triangular matrices are '
-                f'accepted for shear, got {matrix}. For other matrices, set the '
-                f'affine_matrix or linear_matrix directly.'
-            )
-    else:
-        return True

--- a/napari/utils/transforms/transform_utils.py
+++ b/napari/utils/transforms/transform_utils.py
@@ -232,7 +232,7 @@ def shear_matrix_from_angle(angle, ndim=3, axes=(-1, 0)):
     return matrix
 
 
-def is_upper_triangular(matrix):
+def is_matrix_upper_triangular(matrix):
     """Check if a matrix is upper triangular.
 
     Parameters
@@ -248,7 +248,7 @@ def is_upper_triangular(matrix):
     return np.allclose(matrix, np.triu(matrix))
 
 
-def is_lower_triangular(matrix):
+def is_matrix_lower_triangular(matrix):
     """Check if a matrix is lower triangular.
 
     Parameters
@@ -262,6 +262,27 @@ def is_lower_triangular(matrix):
         Whether matrix is lower triangular or not.
     """
     return np.allclose(matrix, np.tril(matrix))
+
+
+def is_matrix_triangular(matrix):
+    """Check if a matrix is triangular.
+
+    Parameters
+    ----------
+    matrix : np.ndarray
+        Matrix to be checked.
+
+    Returns
+    -------
+    bool
+        Whether matrix is triangular or not.
+    """
+    if is_matrix_upper_triangular(matrix) or is_matrix_lower_triangular(
+        matrix
+    ):
+        return True
+    else:
+        return False
 
 
 def check_shear_triangular(matrix):
@@ -281,9 +302,9 @@ def check_shear_triangular(matrix):
         True if matrix upper triangular, False if not.
     """
     if np.array(matrix).ndim == 2:
-        if is_upper_triangular(matrix):
+        if is_matrix_upper_triangular(matrix):
             return True
-        elif is_lower_triangular(matrix):
+        elif is_matrix_lower_triangular(matrix):
             return False
         else:
             raise ValueError(

--- a/napari/utils/transforms/transform_utils.py
+++ b/napari/utils/transforms/transform_utils.py
@@ -233,7 +233,7 @@ def shear_matrix_from_angle(angle, ndim=3, axes=(-1, 0)):
 
 
 def is_upper_triangular(matrix):
-    """Check if a matrix is identity plus upper triangular.
+    """Check if a matrix is upper triangular.
 
     Parameters
     ----------
@@ -243,13 +243,13 @@ def is_upper_triangular(matrix):
     Returns
     -------
     bool
-        Whether matrix is identity plus upper triangular or not.
+        Whether matrix is upper triangular or not.
     """
-    return np.allclose(matrix, np.eye(matrix.shape[0]) + np.triu(matrix))
+    return np.allclose(matrix, np.triu(matrix))
 
 
 def is_lower_triangular(matrix):
-    """Check if a matrix is identity plus lower triangular.
+    """Check if a matrix is lower triangular.
 
     Parameters
     ----------
@@ -259,9 +259,9 @@ def is_lower_triangular(matrix):
     Returns
     -------
     bool
-        Whether matrix is identity plus lower triangular or not.
+        Whether matrix is lower triangular or not.
     """
-    return np.allclose(matrix, np.eye(matrix.shape[0]) + np.tril(matrix, -1))
+    return np.allclose(matrix, np.tril(matrix))
 
 
 def check_shear_triangular(matrix):
@@ -287,9 +287,9 @@ def check_shear_triangular(matrix):
             return False
         else:
             raise ValueError(
-                'Only upper triangular or lower triangular matrices are '
-                'accepted for shear. For other matrices, set the '
-                'affine_matrix or linear_matrix directly.'
+                f'Only upper triangular or lower triangular matrices are '
+                f'accepted for shear, got {matrix}. For other matrices, set the '
+                f'affine_matrix or linear_matrix directly.'
             )
     else:
         return True


### PR DESCRIPTION
# Description
This fixes the shear decomposition for lower triangular matrices. It closes #1826 and #1830 by enabling round trips with lower triangular shear matrices. It doesn't change our API, but makes it now conform to user expectations (I hope), by detecting whether lower triangular or upper triangular matrices are being used and doing the decomposition appropriately as needed. Tests have also been added, but it could probably do with some real world testing too!!

Thanks to input from @tlambert03 @jni @zeroth @VolkerH @GenevieveBuckley. This is now ready for review.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #1826
Closes #1830

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] Tests added

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
