### PR TITLE
Change grid size to shape

### DIFF
--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -237,7 +237,7 @@ def test_grid_mode(make_test_viewer):
     viewer.add_image(data, channel_axis=0, blending='translucent')
 
     assert not viewer.grid.enabled
-    assert viewer.grid.actual_size(6) == (1, 1)
+    assert viewer.grid.actual_shape(6) == (1, 1)
     assert viewer.grid.stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = np.zeros((6, 2))
@@ -251,7 +251,7 @@ def test_grid_mode(make_test_viewer):
     # enter grid view
     viewer.grid.enabled = True
     assert viewer.grid.enabled
-    assert viewer.grid.actual_size(6) == (2, 3)
+    assert viewer.grid.actual_shape(6) == (2, 3)
     assert viewer.grid.stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = [
@@ -313,7 +313,7 @@ def test_grid_mode(make_test_viewer):
     # return to stack view
     viewer.grid.enabled = False
     assert not viewer.grid.enabled
-    assert viewer.grid.actual_size(6) == (1, 1)
+    assert viewer.grid.actual_shape(6) == (1, 1)
     assert viewer.grid.stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = np.zeros((6, 2))

--- a/napari/components/_tests/test_grid.py
+++ b/napari/components/_tests/test_grid.py
@@ -6,50 +6,50 @@ def test_grid_creation():
     grid = GridCanvas()
     assert grid is not None
     assert not grid.enabled
-    assert grid.size == (-1, -1)
+    assert grid.shape == (-1, -1)
     assert grid.stride == 1
 
 
-def test_size_stride_creation():
+def test_shape_stride_creation():
     """Test creating grid object"""
-    grid = GridCanvas(size=(3, 4), stride=2)
-    assert grid.size == (3, 4)
+    grid = GridCanvas(shape=(3, 4), stride=2)
+    assert grid.shape == (3, 4)
     assert grid.stride == 2
 
 
-def test_actual_size_and_position():
-    """Test actual size"""
+def test_actual_shape_and_position():
+    """Test actual shape"""
     grid = GridCanvas(enabled=True)
     assert grid.enabled
 
     # 9 layers get put in a (3, 3) grid
-    assert grid.actual_size(9) == (3, 3)
+    assert grid.actual_shape(9) == (3, 3)
     assert grid.position(0, 9) == (0, 0)
     assert grid.position(2, 9) == (0, 2)
     assert grid.position(3, 9) == (1, 0)
     assert grid.position(8, 9) == (2, 2)
 
     # 5 layers get put in a (2, 3) grid
-    assert grid.actual_size(5) == (2, 3)
+    assert grid.actual_shape(5) == (2, 3)
     assert grid.position(0, 5) == (0, 0)
     assert grid.position(2, 5) == (0, 2)
     assert grid.position(3, 5) == (1, 0)
 
     # 10 layers get put in a (3, 4) grid
-    assert grid.actual_size(10) == (3, 4)
+    assert grid.actual_shape(10) == (3, 4)
     assert grid.position(0, 10) == (0, 0)
     assert grid.position(2, 10) == (0, 2)
     assert grid.position(3, 10) == (0, 3)
     assert grid.position(8, 10) == (2, 0)
 
 
-def test_actual_size_with_stride():
-    """Test actual size"""
+def test_actual_shape_with_stride():
+    """Test actual shape"""
     grid = GridCanvas(enabled=True, stride=2)
     assert grid.enabled
 
     # 7 layers get put in a (2, 2) grid
-    assert grid.actual_size(7) == (2, 2)
+    assert grid.actual_shape(7) == (2, 2)
     assert grid.position(0, 7) == (0, 0)
     assert grid.position(1, 7) == (0, 0)
     assert grid.position(2, 7) == (0, 1)
@@ -57,28 +57,28 @@ def test_actual_size_with_stride():
     assert grid.position(6, 7) == (1, 1)
 
     # 3 layers get put in a (1, 2) grid
-    assert grid.actual_size(3) == (1, 2)
+    assert grid.actual_shape(3) == (1, 2)
     assert grid.position(0, 3) == (0, 0)
     assert grid.position(1, 3) == (0, 0)
     assert grid.position(2, 3) == (0, 1)
 
 
-def test_actual_size_and_position_negative_stride():
-    """Test actual size"""
+def test_actual_shape_and_position_negative_stride():
+    """Test actual shape"""
     grid = GridCanvas(enabled=True, stride=-1)
     assert grid.enabled
 
     # 9 layers get put in a (3, 3) grid
-    assert grid.actual_size(9) == (3, 3)
+    assert grid.actual_shape(9) == (3, 3)
     assert grid.position(0, 9) == (2, 2)
     assert grid.position(2, 9) == (2, 0)
     assert grid.position(3, 9) == (1, 2)
     assert grid.position(8, 9) == (0, 0)
 
 
-def test_actual_size_grid_disabled():
-    """Test actual size with grid disabled"""
+def test_actual_shape_grid_disabled():
+    """Test actual shape with grid disabled"""
     grid = GridCanvas()
     assert not grid.enabled
-    assert grid.actual_size(9) == (1, 1)
+    assert grid.actual_shape(9) == (1, 1)
     assert grid.position(3, 9) == (0, 0)

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -332,7 +332,7 @@ def test_grid():
         data = np.random.random((15, 15))
         viewer.add_image(data)
     assert not viewer.grid.enabled
-    assert viewer.grid.actual_size(6) == (1, 1)
+    assert viewer.grid.actual_shape(6) == (1, 1)
     assert viewer.grid.stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = np.zeros((6, 2))
@@ -341,7 +341,7 @@ def test_grid():
     # enter grid view
     viewer.grid.enabled = True
     assert viewer.grid.enabled
-    assert viewer.grid.actual_size(6) == (2, 3)
+    assert viewer.grid.actual_shape(6) == (2, 3)
     assert viewer.grid.stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = [
@@ -357,7 +357,7 @@ def test_grid():
     # return to stack view
     viewer.grid.enabled = False
     assert not viewer.grid.enabled
-    assert viewer.grid.actual_size(6) == (1, 1)
+    assert viewer.grid.actual_shape(6) == (1, 1)
     assert viewer.grid.stride == 1
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = np.zeros((6, 2))
@@ -367,7 +367,7 @@ def test_grid():
     viewer.grid.stride = -2
     viewer.grid.enabled = True
     assert viewer.grid.enabled
-    assert viewer.grid.actual_size(6) == (2, 2)
+    assert viewer.grid.actual_shape(6) == (2, 2)
     assert viewer.grid.stride == -2
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = [

--- a/napari/components/grid.py
+++ b/napari/components/grid.py
@@ -15,10 +15,10 @@ class GridCanvas:
         Event emitter group
     enabled : bool
         If grid is enabled or not.
-    size : 2-tuple of int
+    shape : 2-tuple of int
         Number of rows and columns in the grid. A value of -1 for either or
         both of will be used the row and column numbers will trigger an
-        auto calculation of the necessary grid size to appropriately fill
+        auto calculation of the necessary grid shape to appropriately fill
         all the layers at the appropriate stride.
     stride : int
         Number of layers to place in each grid square before moving on to
@@ -28,7 +28,7 @@ class GridCanvas:
         reversed.
     """
 
-    def __init__(self, *, size=(-1, -1), stride=1, enabled=False):
+    def __init__(self, *, shape=(-1, -1), stride=1, enabled=False):
 
         # Events:
         self.events = EmitterGroup(
@@ -37,7 +37,7 @@ class GridCanvas:
 
         self._enabled = enabled
         self._stride = stride
-        self._size = size
+        self._shape = shape
 
     @property
     def enabled(self):
@@ -50,13 +50,13 @@ class GridCanvas:
         self.events.update()
 
     @property
-    def size(self):
+    def shape(self):
         """2-tuple of int: Number of rows and columns in the grid."""
-        return self._size
+        return self._shape
 
-    @size.setter
-    def size(self, size):
-        self._size = tuple(size)
+    @shape.setter
+    def shape(self, shape):
+        self._shape = tuple(shape)
         self.events.update()
 
     @property
@@ -69,12 +69,12 @@ class GridCanvas:
         self._stride = stride
         self.events.update()
 
-    def actual_size(self, nlayers=1):
-        """Return the actual size of the grid.
+    def actual_shape(self, nlayers=1):
+        """Return the actual shape of the grid.
 
-        This will return the size parameter, unless one of the row
+        This will return the shape parameter, unless one of the row
         or column numbers is -1 in which case it will compute the
-        optimal size of the grid given the number of layers and
+        optimal shape of the grid given the number of layers and
         current stride.
 
         If the grid is not enabled, this will return (1, 1).
@@ -86,11 +86,11 @@ class GridCanvas:
 
         Returns
         -------
-        size : 2-tuple of int
+        shape : 2-tuple of int
             Number of rows and columns in the grid.
         """
         if self.enabled:
-            n_row, n_column = self.size
+            n_row, n_column = self.shape
             n_grid_squares = np.ceil(nlayers / abs(self.stride)).astype(int)
 
             if n_row == -1 and n_column == -1:
@@ -126,7 +126,7 @@ class GridCanvas:
             Row and column position of current index in the grid.
         """
         if self.enabled:
-            n_row, n_column = self.actual_size(nlayers)
+            n_row, n_column = self.actual_shape(nlayers)
 
             # Adjust for forward or reverse ordering
             if self.stride < 0:

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -159,24 +159,24 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         warnings.warn(
             (
                 "The viewer.grid_size parameter is deprecated and will be removed after version 0.4.3."
-                " Instead you should use viewer.grid.size"
+                " Instead you should use viewer.grid.shape"
             ),
             category=DeprecationWarning,
             stacklevel=2,
         )
-        return self.grid.size
+        return self.grid.shape
 
     @grid_size.setter
     def grid_size(self, grid_size):
         warnings.warn(
             (
                 "The viewer.grid_size parameter is deprecated and will be removed after version 0.4.3."
-                " Instead you should use viewer.grid.size"
+                " Instead you should use viewer.grid.shape"
             ),
             category=DeprecationWarning,
             stacklevel=2,
         )
-        self.grid.size = grid_size
+        self.grid.shape = grid_size
 
     @property
     def grid_stride(self):
@@ -303,7 +303,7 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         extent = self._sliced_extent_world
         scene_size = extent[1] - extent[0]
         corner = extent[0]
-        grid_size = list(self.grid.actual_size(len(self.layers)))
+        grid_size = list(self.grid.actual_shape(len(self.layers)))
         if len(scene_size) > len(grid_size):
             grid_size = [1] * (len(scene_size) - len(grid_size)) + grid_size
         size = np.multiply(scene_size, grid_size)
@@ -464,7 +464,7 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
             (
                 "The viewer.grid_view method is deprecated and will be removed after version 0.4.3."
                 " Instead you should use the viewer.grid.enabled = Turn to turn on the grid view,"
-                " and viewer.grid.size and viewer.grid.stride to set the size and stride of the"
+                " and viewer.grid.shape and viewer.grid.stride to set the size and stride of the"
                 " grid respectively."
             ),
             category=DeprecationWarning,
@@ -475,7 +475,7 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
             n_row = -1
         if n_column is None:
             n_column = -1
-        self.grid.size = (n_row, n_column)
+        self.grid.shape = (n_row, n_column)
         self.grid.enabled = True
 
     def stack_view(self):


### PR DESCRIPTION
# Description
This PR changes `grid.size` to `grid.shape`. It pulls this change out of #1827, which needs more work. Note that `grid.size` was only added in #1821 and has not yet been released, so I think its fine to change now.

The rational for making this change is that I think `shape` is more appropriate for an integer value of the numbers of rows/ columns in a grid (think array.shape) whereas `size` would be better for say a float describing how large each grid actually was in world coordinates. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
