### PR TITLE
patch mac bundle differently

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install briefcase==0.3.1 tomlkit wheel
+          python -m pip install briefcase==0.3.1 tomlkit wheel dmgbuild>=1.4.2
           python -m pip install -e .[pyside2]
       - name: get tag
         shell: bash

--- a/bundle.py
+++ b/bundle.py
@@ -94,18 +94,11 @@ def patch_dmgbuild():
     # see https://github.com/al45tair/dmgbuild/pull/18
     with open(core.__file__, 'r') as f:
         src = f.read()
-    if (
-        'max(total_size / 1024' not in src
-        and "all_args = ['/usr/bin/hdiutil', cmd]" not in src
-    ):
-        return
     with open(core.__file__, 'w') as f:
         f.write(
             src.replace(
-                'max(total_size / 1024', 'max(total_size / 1000'
-            ).replace(
-                "all_args = ['/usr/bin/hdiutil', cmd]",
-                "all_args = ['sudo', '/usr/bin/hdiutil', cmd]",
+                "shutil.rmtree(os.path.join(mount_point, '.Trashes'), True)",
+                "shutil.rmtree(os.path.join(mount_point, '.Trashes'), True);time.sleep(30)",
             )
         )
         print("patched dmgbuild.core")


### PR DESCRIPTION
# Description
Patch mac bundle without using sudo. I tested fix version 1 (sudo) and this one, and I found this patch is more consistent in addressing the issue and does not require sudo. I made a comment on the dmgbuild issue, will let the owner decide whether this should be added to dmgbuild or not. It is tricky because the sleep is 30 seconds long, which could be too long for many people.

what it does: it adds a sleep of 30 second BEFORE first attempt to detach the disk, I confirmed that once the first attempt is made, the disk management pretty much hang and is unlikely to respond again, therefore the sleep and try later has little chance in working again

ps.: disabling mds on build machine also have a positive impact, but in my testing it is not sufficient alone without the sleep, I inspected lsof on the volume but there is nothing after mds is disabled. If the issue persist, disable mds via
```
sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.metadata.mds.plist
```

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# References
closes #1611
https://github.com/napari/napari/pull/1844
https://github.com/al45tair/dmgbuild/issues/26

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- manually tested on pipeline

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
