### PR TITLE
Return estimate for 3D texture size instead of hard-coded value

### DIFF
--- a/napari/_vispy/utils_gl.py
+++ b/napari/_vispy/utils_gl.py
@@ -46,10 +46,11 @@ def get_max_texture_sizes() -> Tuple[int, int]:
     if max_size_2d == ():
         max_size_2d = None
 
-    # vispy doesn't expose GL_MAX_3D_TEXTURE_SIZE so hard coding for now.
+    # vispy doesn't expose GL_MAX_3D_TEXTURE_SIZE so estimating based on
+    # memory requirements for 2D texture. This is not necessarily correct.
     # MAX_TEXTURE_SIZE_3D = gl.glGetParameter(gl.GL_MAX_3D_TEXTURE_SIZE)
     # if MAX_TEXTURE_SIZE_3D == ():
     #    MAX_TEXTURE_SIZE_3D = None
-    max_size_3d = 2048
+    max_size_3d = round(max_size_2d ** (2.0 / 3.0))
 
     return max_size_2d, max_size_3d

--- a/napari/_vispy/utils_gl.py
+++ b/napari/_vispy/utils_gl.py
@@ -51,6 +51,9 @@ def get_max_texture_sizes() -> Tuple[int, int]:
     # MAX_TEXTURE_SIZE_3D = gl.glGetParameter(gl.GL_MAX_3D_TEXTURE_SIZE)
     # if MAX_TEXTURE_SIZE_3D == ():
     #    MAX_TEXTURE_SIZE_3D = None
-    max_size_3d = round(max_size_2d ** (2.0 / 3.0))
+    if max_size_2d is not None:
+        max_size_3d = round(max_size_2d ** (2.0 / 3.0))
+    else:
+        max_size_3d = None
 
     return max_size_2d, max_size_3d


### PR DESCRIPTION
# Description

Currently, `get_max_texture_sizes()` in `utils_gl.py` returns a hard-coded 3D texture size of `2048`.
According to the comment this is a workaround for vispy not exposing the correct value `gl.GL_MAX_3D_TEXTURE_SIZE`.
The hard-coded value of 2048 is equivalent to 8GB of RAM for the texture, which is only available on high end cards.

This PR offers a slightly improved workaround, working on the assumption that the memory required for the maximum 2D texture size is also the memory limit for the maximum 3D texture size. Therfore the third root of this memory requirement is returned (after rounding to the nearest integer). On my RTX 2060 card with 6GB VRAM this returns a reasonable value of `1024`, but I am not sure this will generally hold.

This is a stop-gap measure. I will have a look whether it is easy to change vispy to expose `GL_MAX_3D_TEXTURE_SIZE`.


## Type of change
- [x] New feature (non-breaking change which adds functionality)

# References
Comments in original source here https://github.com/napari/napari/blob/abdcfb2d0092f91ea4a72f389edd72adf6d84a89/napari/_vispy/utils_gl.py#L49

# How has this been tested?

- [x] manually tested on my machine

Note that there currently are no tests covering this function as far as I could see.
If one wanted to add a test, any ideas how to mock a graphics card to test this?

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
