### PR TITLE
add minimum intensity projection shader to 3d rendering mode

### DIFF
--- a/napari/_vispy/vendored/volume.py
+++ b/napari/_vispy/vendored/volume.py
@@ -377,8 +377,35 @@ ISO_SNIPPETS = dict(
 
 ISO_FRAG_SHADER = FRAG_SHADER.format(**ISO_SNIPPETS)
 
+
+MINIP_SNIPPETS = dict(
+    before_loop="""
+        float minval = 99999.0; // The minimum encountered value
+        int mini = 0;  // Where the maximum value was encountered
+        """,
+    in_loop="""
+        if( val < minval ) {
+            minval = val;
+            mini = iter;
+        }
+        """,
+    after_loop="""
+        // Refine search for min value
+        loc = start_loc + step * (float(mini) - 0.5);
+        for (int i=0; i<10; i++) {
+            minval = min(minval, $sample(u_volumetex, loc).g);
+            loc += step * 0.1;
+        }
+        gl_FragColor = applyColormap(minval);
+        """,
+)
+
+MINIP_FRAG_SHADER = FRAG_SHADER.format(**MINIP_SNIPPETS)
+
+
 frag_dict = {
     'mip': MIP_FRAG_SHADER,
+    'minip': MINIP_FRAG_SHADER,
     'iso': ISO_FRAG_SHADER,
     'translucent': TRANSLUCENT_FRAG_SHADER,
     'additive': ADDITIVE_FRAG_SHADER,

--- a/napari/_vispy/vendored/volume.py
+++ b/napari/_vispy/vendored/volume.py
@@ -377,7 +377,6 @@ ISO_SNIPPETS = dict(
 
 ISO_FRAG_SHADER = FRAG_SHADER.format(**ISO_SNIPPETS)
 
-
 frag_dict = {
     'mip': MIP_FRAG_SHADER,
     'iso': ISO_FRAG_SHADER,

--- a/napari/_vispy/vendored/volume.py
+++ b/napari/_vispy/vendored/volume.py
@@ -423,7 +423,7 @@ class VolumeVisual(Visual):
         The contrast limits. The values in the volume are mapped to
         black and white corresponding to these values. Default maps
         between min and max.
-    method : {'mip', 'translucent', 'additive', 'iso'}
+    method : {'mip', 'minip', 'translucent', 'additive', 'iso'}
         The render method to use. See corresponding docs for details.
         Default 'mip'.
     threshold : float

--- a/napari/_vispy/vendored/volume.py
+++ b/napari/_vispy/vendored/volume.py
@@ -378,34 +378,8 @@ ISO_SNIPPETS = dict(
 ISO_FRAG_SHADER = FRAG_SHADER.format(**ISO_SNIPPETS)
 
 
-MINIP_SNIPPETS = dict(
-    before_loop="""
-        float minval = 99999.0; // The minimum encountered value
-        int mini = 0;  // Where the maximum value was encountered
-        """,
-    in_loop="""
-        if( val < minval ) {
-            minval = val;
-            mini = iter;
-        }
-        """,
-    after_loop="""
-        // Refine search for min value
-        loc = start_loc + step * (float(mini) - 0.5);
-        for (int i=0; i<10; i++) {
-            minval = min(minval, $sample(u_volumetex, loc).g);
-            loc += step * 0.1;
-        }
-        gl_FragColor = applyColormap(minval);
-        """,
-)
-
-MINIP_FRAG_SHADER = FRAG_SHADER.format(**MINIP_SNIPPETS)
-
-
 frag_dict = {
     'mip': MIP_FRAG_SHADER,
-    'minip': MINIP_FRAG_SHADER,
     'iso': ISO_FRAG_SHADER,
     'translucent': TRANSLUCENT_FRAG_SHADER,
     'additive': ADDITIVE_FRAG_SHADER,
@@ -423,7 +397,7 @@ class VolumeVisual(Visual):
         The contrast limits. The values in the volume are mapped to
         black and white corresponding to these values. Default maps
         between min and max.
-    method : {'mip', 'minip', 'translucent', 'additive', 'iso'}
+    method : {'mip', 'translucent', 'additive', 'iso'}
         The render method to use. See corresponding docs for details.
         Default 'mip'.
     threshold : float

--- a/napari/_vispy/volume.py
+++ b/napari/_vispy/volume.py
@@ -33,10 +33,11 @@ ATTENUATED_MIP_FRAG_SHADER = FRAG_SHADER.format(**ATTENUATED_MIP_SNIPPETS)
 
 frag_dict['attenuated_mip'] = ATTENUATED_MIP_FRAG_SHADER
 
+
 MINIP_SNIPPETS = dict(
     before_loop="""
         float minval = 99999.0; // The minimum encountered value
-        int mini = 0;  // Where the maximum value was encountered
+        int mini = 0;  // Where the minimum value was encountered
         """,
     in_loop="""
         if( val < minval ) {

--- a/napari/_vispy/volume.py
+++ b/napari/_vispy/volume.py
@@ -7,7 +7,6 @@ from .vendored.volume import FRAG_SHADER, frag_dict
 
 BaseVolume = create_visual_node(BaseVolumeVisual)
 
-
 ATTENUATED_MIP_SNIPPETS = dict(
     before_loop="""
         float maxval = -99999.0; // The maximum encountered value
@@ -33,7 +32,6 @@ ATTENUATED_MIP_FRAG_SHADER = FRAG_SHADER.format(**ATTENUATED_MIP_SNIPPETS)
 
 frag_dict['attenuated_mip'] = ATTENUATED_MIP_FRAG_SHADER
 
-
 MINIP_SNIPPETS = dict(
     before_loop="""
         float minval = 99999.0; // The minimum encountered value
@@ -58,7 +56,8 @@ MINIP_SNIPPETS = dict(
 
 MINIP_FRAG_SHADER = FRAG_SHADER.format(**MINIP_SNIPPETS)
 
-frag_dict['minip'] = MINIP_FRAG_SHADER
+frag_dict['MinIP'] = MINIP_FRAG_SHADER
+
 
 # Custom volume class is needed for better 3D rendering
 class Volume(BaseVolume):

--- a/napari/_vispy/volume.py
+++ b/napari/_vispy/volume.py
@@ -33,6 +33,31 @@ ATTENUATED_MIP_FRAG_SHADER = FRAG_SHADER.format(**ATTENUATED_MIP_SNIPPETS)
 
 frag_dict['attenuated_mip'] = ATTENUATED_MIP_FRAG_SHADER
 
+MINIP_SNIPPETS = dict(
+    before_loop="""
+        float minval = 99999.0; // The minimum encountered value
+        int mini = 0;  // Where the maximum value was encountered
+        """,
+    in_loop="""
+        if( val < minval ) {
+            minval = val;
+            mini = iter;
+        }
+        """,
+    after_loop="""
+        // Refine search for min value
+        loc = start_loc + step * (float(mini) - 0.5);
+        for (int i=0; i<10; i++) {
+            minval = min(minval, $sample(u_volumetex, loc).g);
+            loc += step * 0.1;
+        }
+        gl_FragColor = applyColormap(minval);
+        """,
+)
+
+MINIP_FRAG_SHADER = FRAG_SHADER.format(**MINIP_SNIPPETS)
+
+frag_dict['minip'] = MINIP_FRAG_SHADER
 
 # Custom volume class is needed for better 3D rendering
 class Volume(BaseVolume):

--- a/napari/_vispy/volume.py
+++ b/napari/_vispy/volume.py
@@ -56,7 +56,7 @@ MINIP_SNIPPETS = dict(
 
 MINIP_FRAG_SHADER = FRAG_SHADER.format(**MINIP_SNIPPETS)
 
-frag_dict['MinIP'] = MINIP_FRAG_SHADER
+frag_dict['minip'] = MINIP_FRAG_SHADER
 
 
 # Custom volume class is needed for better 3D rendering

--- a/napari/layers/image/_image_constants.py
+++ b/napari/layers/image/_image_constants.py
@@ -59,4 +59,5 @@ class Rendering(StringEnum):
     ADDITIVE = auto()
     ISO = auto()
     MIP = auto()
+    MINIP = auto()
     ATTENUATED_MIP = auto()

--- a/napari/layers/image/_image_constants.py
+++ b/napari/layers/image/_image_constants.py
@@ -44,6 +44,8 @@ class Rendering(StringEnum):
               the result is opaque.
             * mip: maximum intensity projection. Cast a ray and display the
               maximum value that was encountered.
+            * minip: minimum intensity projection. Cast a ray and display the
+              minimum value that was encountered.
             * attenuated_mip: attenuated maximum intensity projection. Cast a
               ray and attenuate values based on integral of encountered values,
               display the maximum value that was encountered after attenuation.


### PR DESCRIPTION
# Description
This PR adds a minimum intensity projection shader to the available shaders for the `VolumeVisual` object in  `_vispy.vendored.volume` - useful for looking at dark-on-light images

![min_intensity_projection](https://user-images.githubusercontent.com/7307488/98992452-7dd81000-252d-11eb-9ede-96b7d601b01d.gif)


## Type of change
- [x] New feature (non-breaking change which adds functionality)

# References
@tlambert03 explained how this whole part of the codebase works and fits together - huge thanks Talley!

# How has this been tested?
not sure how to 'test' this other than that it works on my data? please advise

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
