### PR TITLE
async-22: Support Edge/Corner Tiles

### DIFF
--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -3,7 +3,7 @@
 A texture atlas is a large texture that stores many smaller texture tiles.
 """
 from collections import namedtuple
-from typing import Optional, Tuple
+from typing import NamedTuple, Optional, Tuple
 
 import numpy as np
 from vispy.gloo import Texture2D
@@ -16,6 +16,25 @@ _QUAD = np.array(
 # AtlasTile is returned from TextureAtlas2D.add_tile() so the caller has the
 # texture coordinates to render each tile in the atlas.
 AtlasTile = namedtuple('AtlasTile', "index tex_coords")
+
+
+class TileInfo(NamedTuple):
+    """Information about the tiles we are using in the atlas."""
+
+    shape: np.ndarray
+    ndim: int
+    height: int
+    width: int
+    depth: int
+
+    @classmethod
+    def from_shape(cls, shape: np.ndarray):
+        """Create a TileInfo from just the shape."""
+        ndim = len(shape)
+        assert ndim in [2, 3]  # 2D or 2D with color.
+        height, width = shape[:2]
+        depth = 1 if ndim == 2 else shape[2]
+        return cls(shape, ndim, height, width, depth)
 
 
 class TextureAtlas2D(Texture2D):
@@ -41,7 +60,7 @@ class TextureAtlas2D(Texture2D):
         self, tile_shape: tuple, shape_in_tiles: Tuple[int, int], **kwargs,
     ):
         # Each tile's shape in texels, for example (256, 256, 3).
-        self.tile_shape = tile_shape
+        self.tile_info = TileInfo.from_shape(tile_shape)
 
         # The full texture's shape in tiles, for example 4x4.
         self.shape_in_tiles = shape_in_tiles
@@ -49,8 +68,8 @@ class TextureAtlas2D(Texture2D):
         depth = 3  # TODO_OCTREE: get from the data
 
         # The full texture's shape in texels, for example 1024x1024.
-        height = self.tile_shape[0] * self.shape_in_tiles[0]
-        width = self.tile_shape[1] * self.shape_in_tiles[1]
+        height = self.tile_info.height * self.shape_in_tiles[0]
+        width = self.tile_info.width * self.shape_in_tiles[1]
         self.texture_shape = np.array([width, height, depth], dtype=np.int32)
 
         # Total number of texture slots in the atlas.
@@ -69,7 +88,8 @@ class TextureAtlas2D(Texture2D):
         ]
 
         if self.MARK_DELETED_TILES:
-            self.deleted_tile_data = np.empty(self.tile_shape, dtype=np.uint8)
+            shape = self.tile_info.shape
+            self.deleted_tile_data = np.empty(shape, dtype=np.uint8)
             self.deleted_tile_data[:] = (1, 1, 1)  # handle RGB or RGBA?
 
         super().__init__(shape=tuple(self.texture_shape), **kwargs)
@@ -114,7 +134,7 @@ class TextureAtlas2D(Texture2D):
         col = tile_index % width_tiles
 
         # Return as (X, Y).
-        return col * self.tile_shape[1], row * self.tile_shape[0]
+        return col * self.tile_info.width, row * self.tile_info.height
 
     def _calc_tex_coords(self, tile_index: int) -> np.ndarray:
         """Return the texture coordinates for this tile.
@@ -134,7 +154,7 @@ class TextureAtlas2D(Texture2D):
         """
         offset = self._offset(tile_index)
         pos = offset / self.texture_shape[:2]
-        shape = self.tile_shape[:2] / self.texture_shape[:2]
+        shape = self.tile_info.shape[:2] / self.texture_shape[:2]
 
         quad = _QUAD.copy()
         quad[:, :2] *= shape
@@ -150,7 +170,7 @@ class TextureAtlas2D(Texture2D):
         data : np.ndarray
             The image data for this one tile.
         """
-        if data.shape != self.tile_shape:
+        if data.shape != self.tile_info.shape:
             raise ValueError(
                 f"Adding tile with shape {data.shape} does not match TextureAtlas2D "
                 f"configured tile shape {self.tile_shape}"

--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -235,6 +235,15 @@ class TextureAtlas2D(Texture2D):
     def _set_tile_data(self, tile_index: int, data: np.ndarray) -> None:
         """Upload the texture data for this one tile.
 
+        Note the data might be smaller than a full tile slot. If so we
+        don't really care what texels are in the rest of the tile's slot.
+        They will not be drawn because we'll use the correct texture
+        coordinates for the small tile.
+
+        We could instead pad this data up to a full tile size. So we always
+        upload the same full size. So there is no dead space. But for now
+        we send just the exact data and no more. A tiny bit faster.
+
         Parameters
         ----------
         tile_index : int

--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -232,22 +232,21 @@ class TextureAtlas2D(Texture2D):
         if self.MARK_DELETED_TILES:
             self._set_tile_data(tile_index, self.deleted_tile_data)
 
-    def _set_tile_data(self, tile_index: int, data) -> None:
-        """Set the texture data for this one tile.
+    def _set_tile_data(self, tile_index: int, data: np.ndarray) -> None:
+        """Upload the texture data for this one tile.
 
         Parameters
         ----------
         tile_index : int
-            The index of the tile to set.
+            The index of the tile to upload.
         data
-            The new texture data for the tile.
+            The texture data for the tile.
         """
-        # Covert (X, Y) offset of this tile within the larger texture
-        # in the the (row, col) that Texture2D expects.
+        # Reverse the (X, Y) offset of this tile within the larger texture
+        # into the the (row, col) that Texture2D expects.
         offset = self._offset(tile_index)[::-1]
 
         # Texture2D.set_data() will use glTexSubImage2D() under the hood to
         # only write into the tile's portion of the larger texture. This is
-        # the main reason adding tiles to TextureAtlas2D is fast, we do not
-        # have to re-upload the whole texture each time.
+        # a big reason adding tiles to TextureAtlas2D is fast.
         self.set_data(data, offset=offset, copy=True)

--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -2,7 +2,6 @@
 
 A texture atlas is a large texture that stores many smaller texture tiles.
 """
-from collections import namedtuple
 from typing import NamedTuple, Optional, Tuple
 
 import numpy as np
@@ -13,9 +12,16 @@ _QUAD = np.array(
     [[0, 0], [1, 0], [1, 1], [0, 0], [1, 1], [0, 1]], dtype=np.float32,
 )
 
-# AtlasTile is returned from TextureAtlas2D.add_tile() so the caller has the
-# texture coordinates to render each tile in the atlas.
-AtlasTile = namedtuple('AtlasTile', "index tex_coords")
+
+class AtlasTile(NamedTuple):
+    """Information about one specific tile in the atlas.
+
+    AtlasTile is returned from TextureAtlas2D.add_tile() so the caller has
+    the texture coordinates to render each tile in the atlas.
+    """
+
+    index: int
+    tex_coords: np.ndarray
 
 
 class TileInfo(NamedTuple):

--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -187,8 +187,7 @@ class TextureAtlas2D(Texture2D):
         """
         quad = _QUAD.copy()
 
-        # TODO_OCTREE: store as np.array in ChunkData?
-        scale = np.array(chunk_data.scale, dtype=np.float32)
+        scale = chunk_data.scale
         scaled_shape = chunk_data.data.shape[:2] * scale
 
         # Modify in place.

--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -199,9 +199,11 @@ class TextureAtlas2D(Texture2D):
             The image data for this one tile.
         """
         if not self.spec.is_compatible(data):
+            # It will be not compatible of number of dimensions or depth
+            # are wrong. Or if the data is too big to fit in one tile.
             raise ValueError(
-                f"Adding tile with shape {data.shape} does not match TextureAtlas2D "
-                f"configured tile shape {self.tile_shape}"
+                f"Data with shape {data.shape} is not compatible with this "
+                f"TextureAtlas2D with tile shape {self.spec.shape}"
             )
 
         try:

--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -13,9 +13,9 @@ _QUAD = np.array(
     [[0, 0], [1, 0], [1, 1], [0, 0], [1, 1], [0, 1]], dtype=np.float32,
 )
 
-# TexInfo is returned from TextureAtlas2D.add_tile() so the caller has the
+# AtlasTile is returned from TextureAtlas2D.add_tile() so the caller has the
 # texture coordinates to render each tile in the atlas.
-TexInfo = namedtuple('TexInfo', "tile_index tex_coord")
+AtlasTile = namedtuple('AtlasTile', "index tex_coords")
 
 
 class TextureAtlas2D(Texture2D):
@@ -142,7 +142,7 @@ class TextureAtlas2D(Texture2D):
 
         return quad
 
-    def add_tile(self, data: np.ndarray) -> Optional[TexInfo]:
+    def add_tile(self, data: np.ndarray) -> Optional[AtlasTile]:
         """Add one tile to the atlas.
 
         Parameters
@@ -164,10 +164,10 @@ class TextureAtlas2D(Texture2D):
         # Upload the texture data for this one tile.
         self._set_tile_data(tile_index, data)
 
-        # Return TexInfo. The caller will need the texture coordinates to
+        # Return AtlasTile. The caller will need the texture coordinates to
         # render quads using our tiles.
         tex_coords = self._tex_coords[tile_index]
-        return TexInfo(tile_index, tex_coords)
+        return AtlasTile(tile_index, tex_coords)
 
     def remove_tile(self, tile_index: int) -> None:
         """Remove a tile from the texture atlas.

--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -24,7 +24,7 @@ class AtlasTile(NamedTuple):
     tex_coords: np.ndarray
 
 
-class TileInfo(NamedTuple):
+class TileSpec(NamedTuple):
     """Information about the tiles we are using in the atlas."""
 
     shape: np.ndarray
@@ -87,7 +87,7 @@ class TextureAtlas2D(Texture2D):
         self, tile_shape: tuple, shape_in_tiles: Tuple[int, int], **kwargs,
     ):
         # Each tile's shape in texels, for example (256, 256, 3).
-        self.tile_info = TileInfo.from_shape(tile_shape)
+        self.spec = TileSpec.from_shape(tile_shape)
 
         # The full texture's shape in tiles, for example 4x4.
         self.shape_in_tiles = shape_in_tiles
@@ -95,8 +95,8 @@ class TextureAtlas2D(Texture2D):
         depth = 3  # TODO_OCTREE: get from the data
 
         # The full texture's shape in texels, for example 1024x1024.
-        height = self.tile_info.height * self.shape_in_tiles[0]
-        width = self.tile_info.width * self.shape_in_tiles[1]
+        height = self.spec.height * self.shape_in_tiles[0]
+        width = self.spec.width * self.shape_in_tiles[1]
         self.texture_shape = np.array([width, height, depth], dtype=np.int32)
 
         # Total number of texture slots in the atlas.
@@ -116,7 +116,7 @@ class TextureAtlas2D(Texture2D):
         ]
 
         if self.MARK_DELETED_TILES:
-            shape = self.tile_info.shape
+            shape = self.spec.shape
             self.deleted_tile_data = np.empty(shape, dtype=np.uint8)
             self.deleted_tile_data[:] = (1, 1, 1)  # handle RGB or RGBA?
 
@@ -162,7 +162,7 @@ class TextureAtlas2D(Texture2D):
         col = tile_index % width_tiles
 
         # Return as (X, Y).
-        return col * self.tile_info.width, row * self.tile_info.height
+        return col * self.spec.width, row * self.spec.height
 
     def _calc_tex_coords(self, tile_index: int) -> np.ndarray:
         """Return the texture coordinates for this tile.
@@ -182,7 +182,7 @@ class TextureAtlas2D(Texture2D):
         """
         offset = self._offset(tile_index)
         pos = offset / self.texture_shape[:2]
-        shape = self.tile_info.shape[:2] / self.texture_shape[:2]
+        shape = self.spec.shape[:2] / self.texture_shape[:2]
 
         quad = _QUAD.copy()
         quad[:, :2] *= shape
@@ -198,7 +198,7 @@ class TextureAtlas2D(Texture2D):
         data : np.ndarray
             The image data for this one tile.
         """
-        if not self.tile_info.is_compatible(data):
+        if not self.spec.is_compatible(data):
             raise ValueError(
                 f"Adding tile with shape {data.shape} does not match TextureAtlas2D "
                 f"configured tile shape {self.tile_shape}"

--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -15,6 +15,31 @@ _QUAD = np.array(
 )
 
 
+def _chunk_verts(chunk_data: ChunkData) -> np.ndarray:
+    """Return a quad for the vertex buffer.
+
+    Parameters
+    ----------
+    chunk_data : ChunkData
+        Create a quad for this chunk.
+
+    Return
+    ------
+    np.darray
+        The quad vertices.
+    """
+    quad = _QUAD.copy()
+
+    scale = chunk_data.scale
+    scaled_shape = chunk_data.data.shape[:2] * scale
+
+    # Modify in place.
+    quad[:, :2] *= scaled_shape[::-1]  # Reverse into (X, Y) form.
+    quad[:, :2] += chunk_data.pos
+
+    return quad
+
+
 class AtlasTile(NamedTuple):
     """Information about one specific tile in the atlas.
 
@@ -172,30 +197,6 @@ class TextureAtlas2D(Texture2D):
 
         return row * self.spec.height, col * self.spec.width
 
-    def _vert_quad(self, chunk_data: ChunkData) -> np.ndarray:
-        """Return quad for the vertex buffer.
-
-        Parameters
-        ----------
-        chunk_data : ChunkData
-            Create a quad for this chunk.
-
-        Return
-        ------
-        np.darray
-            The quad vertices.
-        """
-        quad = _QUAD.copy()
-
-        scale = chunk_data.scale
-        scaled_shape = chunk_data.data.shape[:2] * scale
-
-        # Modify in place.
-        quad[:, :2] *= scaled_shape[::-1]  # Reverse into (X, Y) form.
-        quad[:, :2] += chunk_data.pos
-
-        return quad
-
     def _calc_tex_coords(
         self, tile_index: int, tile_shape: np.ndarray,
     ) -> np.ndarray:
@@ -255,7 +256,7 @@ class TextureAtlas2D(Texture2D):
 
         # Return AtlasTile. The caller will need the texture coordinates to
         # render quads using our tiles.
-        verts = self._vert_quad(chunk_data)
+        verts = _chunk_verts(chunk_data)
         tex_coords = self._get_tex_coords(tile_index, data)
         return AtlasTile(tile_index, verts, tex_coords)
 

--- a/napari/_vispy/experimental/tile_set.py
+++ b/napari/_vispy/experimental/tile_set.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import List
 
 from ...layers.image.experimental.octree_util import ChunkData
-from .texture_atlas import TexInfo
+from .texture_atlas import AtlasTile
 
 
 @dataclass
@@ -12,7 +12,7 @@ class TileData:
     """Statistics about chunks during the update process."""
 
     chunk_data: ChunkData  # The data that produced this tile.
-    tex_info: TexInfo  # Texture information from the texture atlas.
+    atlas_tile: AtlasTile  # Information from the texture atlas.
 
 
 class TileSet:
@@ -40,7 +40,7 @@ class TileSet:
         self._tiles.clear()
         self._chunks.clear()
 
-    def add(self, chunk_data: ChunkData, tex_info: TexInfo) -> None:
+    def add(self, chunk_data: ChunkData, atlas_tile: AtlasTile) -> None:
         """Add this TiledData to the set.
 
         Parameters
@@ -48,8 +48,8 @@ class TileSet:
         tile_data : TileData
             Add this to the set.
         """
-        tile_index = tex_info.tile_index
-        self._tiles[tile_index] = TileData(chunk_data, tex_info)
+        tile_index = atlas_tile.index
+        self._tiles[tile_index] = TileData(chunk_data, atlas_tile)
         self._chunks.add(chunk_data.key)
 
     def remove(self, tile_index: int) -> None:

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -23,58 +23,6 @@ _QUAD = np.array(
 )
 
 
-def _vert_quad(chunk_data: ChunkData) -> np.ndarray:
-    """Return quad for the vertex buffer.
-
-    Parameters
-    ----------
-    chunk_data : ChunkData
-        Create a quad for this chunk.
-
-    Return
-    ------
-    np.darray
-        The quad vertices.
-    """
-    quad = _QUAD.copy()
-
-    # TODO_OCTREE: store as np.array in ChunkData?
-    scale = np.array(chunk_data.scale, dtype=np.float32)
-    scaled_shape = chunk_data.data.shape[:2] * scale
-
-    # Modify XY's into place
-    quad[:, :2] *= scaled_shape
-    quad[:, :2] += chunk_data.pos
-
-    return quad
-
-
-def _tex_quad(chunk_data: ChunkData) -> np.ndarray:
-    """Return quad for the texture coordinate buffer.
-
-    Parameters
-    ----------
-    chunk_data : ChunkData
-        Create a quad for this chunk.
-
-    Return
-    ------
-    np.darray
-        The quad texture coordinates.
-    """
-    quad = _QUAD.copy()[:, :2]
-
-    # TODO_OCTREE: store as np.array in ChunkData?
-    scale = np.array(chunk_data.scale, dtype=np.float32)
-    scaled_shape = chunk_data.data.shape[:2] * scale
-
-    # Modify XY's into place
-    quad[:, :2] *= scaled_shape
-    quad[:, :2] += chunk_data.pos
-
-    return quad
-
-
 class TiledImageVisual(ImageVisual):
     """A larger image that's drawn using some number of smaller tiles.
 
@@ -229,7 +177,7 @@ class TiledImageVisual(ImageVisual):
             The tile's index.
         """
 
-        atlas_tile = self._texture_atlas.add_tile(chunk_data.data)
+        atlas_tile = self._texture_atlas.add_tile(chunk_data)
 
         if atlas_tile is None:
             return  # No slot available in the atlas.
@@ -286,13 +234,9 @@ class TiledImageVisual(ImageVisual):
         # maybe one one vertex buffer sized according to the max
         # number of tiles we expect. But grow if needed.
         for tile_data in self._tiles.tile_data:
-            chunk_data = tile_data.chunk_data
-
-            vert_quad = _vert_quad(chunk_data)
-            verts = np.vstack((verts, vert_quad))
-
-            tex_quad = tile_data.atlas_tile.tex_coords
-            tex_coords = np.vstack((tex_coords, tex_quad))
+            tile = tile_data.atlas_tile
+            verts = np.vstack((verts, tile.verts))
+            tex_coords = np.vstack((tex_coords, tile.tex_coords))
 
         # Set the base ImageVisual _subdiv_ buffers
         self._subdiv_position.set_data(verts)

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -229,12 +229,12 @@ class TiledImageVisual(ImageVisual):
             The tile's index.
         """
 
-        tex_info = self._texture_atlas.add_tile(chunk_data.data)
+        atlas_tile = self._texture_atlas.add_tile(chunk_data.data)
 
-        if tex_info is None:
+        if atlas_tile is None:
             return  # No slot available in the atlas.
 
-        self._tiles.add(chunk_data, tex_info)
+        self._tiles.add(chunk_data, atlas_tile)
         self._need_vertex_update = True
 
     def remove_tile(self, tile_index: int) -> None:
@@ -260,7 +260,7 @@ class TiledImageVisual(ImageVisual):
         """
         for tile_data in list(self._tiles.tile_data):
             if tile_data.chunk_data.key not in visible_set:
-                tile_index = tile_data.tex_info.tile_index
+                tile_index = tile_data.atlas_tile.index
                 self.remove_tile(tile_index)
 
     def _build_vertex_data(self) -> None:
@@ -291,7 +291,7 @@ class TiledImageVisual(ImageVisual):
             vert_quad = _vert_quad(chunk_data)
             verts = np.vstack((verts, vert_quad))
 
-            tex_quad = tile_data.tex_info.tex_coord
+            tex_quad = tile_data.atlas_tile.tex_coords
             tex_coords = np.vstack((tex_coords, tex_quad))
 
         # Set the base ImageVisual _subdiv_ buffers

--- a/napari/layers/image/experimental/octree_intersection.py
+++ b/napari/layers/image/experimental/octree_intersection.py
@@ -107,7 +107,7 @@ class OctreeIntersection:
         level_index = level_info.level_index
 
         scale = level_info.scale
-        scale_vec = [scale, scale]
+        scale_vec = np.array([scale, scale], dtype=np.float32)
 
         tile_size = level_info.octree_info.tile_size
         scaled_size = tile_size * scale
@@ -120,7 +120,7 @@ class OctreeIntersection:
             for col in self._col_range:
 
                 data = self.level.tiles[row][col]
-                pos = [x, y]
+                pos = np.array([x, y], dtype=np.float32)
 
                 # Only include chunks that have non-zero area. Not sure why
                 # some chunks are zero sized. But this will be a harmless

--- a/napari/layers/image/experimental/octree_util.py
+++ b/napari/layers/image/experimental/octree_util.py
@@ -1,6 +1,6 @@
 """Octree utility classes.
 """
-from typing import List, Tuple
+from typing import List, NamedTuple, Tuple
 
 import numpy as np
 
@@ -27,36 +27,31 @@ class OctreeInfo:
         self.tile_size = tile_size
 
 
-# TODO_OCTREE: this class is placeholder, needs work
-class ChunkData:
+class ChunkData(NamedTuple):
     """One chunk of the full image.
 
     A chunk is a 2D tile or a 3D sub-volume.
 
-    Parameters
+    We include level_index because id(data) is sometimes duplicated in #
+    adjacent levels, somehow. But it makes sense to include it anyway,
+    it's an important aspect of the chunk.
+
+    Attributes
     ----------
+    level_index : int
+        The octree level where this chunk is from.
     data : ArrayLike
         The data to draw for this chunk.
-    pos : Tuple[float, float]
+    pos : np.ndarray
         The x, y coordinates of the chunk.
-    size : float
-        The size of the chunk, the chunk is square/cubic.
+    scale : np.ndarray
+        The (x, y) scale of this chunk. Should be square/cubic.
     """
 
-    def __init__(
-        self,
-        level_index: int,
-        data: ArrayLike,
-        pos: Tuple[float, float],
-        scale: Tuple[float, float],
-    ):
-        # We need level_index because id(data) is sometimes duplicated in
-        # adjacent layers, somehow. But it makes sense to include it
-        # anyway, it's an important aspect of the chunk.
-        self.level_index = level_index
-        self.data = data
-        self.pos = pos
-        self.scale = scale
+    level_index: int
+    data: ArrayLike
+    pos: np.ndarray
+    scale: np.ndarray
 
     @property
     def key(self) -> Tuple[int, int, int]:


### PR DESCRIPTION
# Description
Adds to`TextureAtlas2D` support for the edge/corner tiles needed for non-power-of-two images. These non-full-size tiles still take up one full slot, say 256x256, but we compute their vertex buffer and tex coord buffers so that we draw only the portion of that tile that contains usable data. It looks like this:

<img width="623" alt="napari-non-square" src="https://user-images.githubusercontent.com/4163446/99116647-60a15100-25c2-11eb-832c-c4018c87f8ad.png">

# Background: Texture Packing

If we expected a lot of these small tiles we might get into packing the tiles into the atlas. This is something we are **not** planning to do. Because it would be complicated. And because most of our tiles will be full-size. Given they are coming from a quadtree/octree which is mostly "interior space". The wasted texture space is not a big deal for us.

To illustrate texture packing, though, he's an example. See how they fit different size tiles in the atlas. We are not planning to do this. Our atlas will always just be a perfect grid of same-sized tiles like it is today. It's just that some of that space will be blank, if it's part of an edge or corner tile.

![image](https://user-images.githubusercontent.com/4163446/99102808-9b988a00-25ac-11eb-9710-c7c2583d08a1.png)

# Future Work

Going to postpone but some obvious next steps:
* Get rid of `ChunkData`, vispy files cannot depend on that. Or move it.
* Use a single numpy arrays for the quads/verts. More compact.

# Type of change
- [x] New feature in experimental code

# Files

<img width="328" alt="async-22-fiels" src="https://user-images.githubusercontent.com/4163446/99117795-5c763300-25c4-11eb-8973-4e874f0aa7a1.png">
