### PR TITLE
async-23: QtRender Fixes

### DIFF
--- a/napari/_qt/experimental/render/qt_mini_map.py
+++ b/napari/_qt/experimental/render/qt_mini_map.py
@@ -9,8 +9,9 @@ from qtpy.QtWidgets import QLabel
 from ....layers.image.experimental import OctreeIntersection, OctreeLevel
 from ....layers.image.experimental.octree_image import OctreeImage
 
-# Width of the map in the dockable widget.
-MAP_WIDTH = 200
+# Longest edge of map bitmap in pixels. So at most MAP_SIZE wide and at
+# most MAP_SIZE high. In case it's narrow one way or the other.
+MAP_SIZE = 220
 
 # Tiles are seen if they are visible within the current view, otherwise unseen.
 COLOR_SEEN = (255, 0, 0, 255)  # red
@@ -71,8 +72,14 @@ class QtMiniMap(QLabel):
         """
         aspect = intersection.level.info.octree_info.aspect
 
+        # Limit to at most MAP_SIZE pixels, in whichever dimension is the
+        # bigger one. So it's not too huge even if an odd shape.
+        if aspect > 1:
+            map_shape = math.ceil(MAP_SIZE / aspect), MAP_SIZE
+        else:
+            map_shape = MAP_SIZE, math.ceil(MAP_SIZE * aspect)
+
         # Shape of the map bitmap: (row_pixels, col_pixels)
-        map_shape = math.ceil(MAP_WIDTH / aspect), MAP_WIDTH
 
         # The map shape with RGBA pixels
         bitmap_shape = map_shape + (4,)

--- a/napari/_qt/experimental/render/qt_test_image.py
+++ b/napari/_qt/experimental/render/qt_test_image.py
@@ -40,9 +40,7 @@ IMAGE_TYPE_DEFAULT = "Tiled"
 TEST_IMAGES = {
     "Digits": {
         "shape": None,
-        "factory": lambda image_shape: create_test_image(
-            "0", (16, 16), image_shape
-        ),
+        "factory": lambda image_shape: create_test_image("0", image_shape),
     }
 }
 TEST_IMAGE_DEFAULT = "Digits"

--- a/napari/_qt/experimental/render/test_image.py
+++ b/napari/_qt/experimental/render/test_image.py
@@ -12,15 +12,13 @@ import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
 
-def draw_text_grid(image, text: str, grid_shape: Tuple[int, int]) -> None:
+def draw_text_grid(image, text: str) -> None:
     """Draw some text into the given image in a grid.
 
     Parameters
     ----------
     test : str
         The text to draw. For example a slice index like "3".
-    grid_shape : Tuple[int, int]
-        Draw the text in a grid of is [height, weight] shape.
     """
 
     try:
@@ -32,7 +30,11 @@ def draw_text_grid(image, text: str, grid_shape: Tuple[int, int]) -> None:
     color = 'rgb(255, 255, 255)'  # white
     draw = ImageDraw.Draw(image)
 
-    rows, cols = grid_shape[0], grid_shape[1]
+    width, height = image.size
+
+    text_size = 100  # approx guess with some padding
+
+    rows, cols = int(height / text_size), int(width / text_size)
 
     for row in range(rows + 1):
         for col in range(cols + 1):
@@ -44,16 +46,14 @@ def draw_text_grid(image, text: str, grid_shape: Tuple[int, int]) -> None:
 
 
 def create_test_image(
-    text,
-    digit_shape: Tuple[int, int],
-    image_shape: Tuple[int, int] = (1024, 1024),
+    text, image_shape: Tuple[int, int] = (1024, 1024),
 ) -> np.ndarray:
     """Create a test image for testing tiled rendering.
 
     The test image just has digits all over it. The digits will typically
-    be used to show the slice number.
+    be used to show the slice number like "0" or "42".
 
-    shape: Tuple[int, int]
+    image_shape: Tuple[int, int]
         The [height, width] shape of the image.
     """
     text = str(text)  # Might be an int.
@@ -66,5 +66,5 @@ def create_test_image(
 
     # Create the image, draw on the text, return it.
     image = Image.new('RGB', image_size)
-    draw_text_grid(image, text, digit_shape)
+    draw_text_grid(image, text)
     return np.array(image)


### PR DESCRIPTION
# Description
* Fixes to `QtMiniMap`, `QtTestImage` and `QtFrameRate`:
    * Fix QtMinimap to fit weird aspect images, in either direction.
    * Fix "digits" test image to show same-spaced digits for any sized test image.
    * Refactor framerate to use vectorized-numpy for color compute.

# Type of change
- [x] Bug-fixes and refactoring in experimental code

# Files

<img width="330" alt="async-23-files" src="https://user-images.githubusercontent.com/4163446/99151531-f3e19180-2669-11eb-87d3-65fe1a9cd1a3.png">

# How has this been tested?
- [x] Manual testing, existing unit tests.
