### PR TITLE
bugfix: update status only if the current layer is visible

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -483,7 +483,8 @@ class Layer(KeymapProvider, ABC):
         if self._position == _position:
             return
         self._position = _position
-        self._update_value_and_status()
+        if self.visible:
+            self._update_value_and_status()
 
     @property
     def dims(self):


### PR DESCRIPTION
# Description
This PR fixes https://github.com/napari/napari/issues/1872 : In case layers are invisible, intensity wasn't shown in the status bar. With this PR, the new behaviour is: While moving the mouse the uppermost layers intensity at the current position is shown.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
closes #1872 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
I tested it manually and I'm not 100% sure if side effects break other functionality. Looking forward to core-developers feedback :-)

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
