### PR TITLE
only show status from layers if they are selected

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -417,7 +417,8 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
 
     def _update_status(self, event):
         """Set the viewer status with the `event.status` string."""
-        self.status = event.status
+        if event.source.selected:
+            self.status = event.status
 
     def _update_help(self, event):
         """Set the viewer help with the `event.help` string."""


### PR DESCRIPTION
# Description
The status bar of the main window only shows the status of the selected layer.
![image](https://user-images.githubusercontent.com/12660498/99157098-89ab0a00-26c6-11eb-9190-a9ab10b16988.png)

This fixes #1872 and is an alternative and/or potential addendum to #1873 . 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
closes #1872 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

I tested manually and I'm not sure if there are side effects because of this change. Looking forward to developer feedback :)

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
