### PR TITLE
Make qt_viewer private

### DIFF
--- a/napari/_qt/_tests/test_exception_handler.py
+++ b/napari/_qt/_tests/test_exception_handler.py
@@ -35,7 +35,7 @@ def test_exception_handler_gui(qtbot, make_test_viewer):
     handler = ExceptionHandler(gui_exceptions=True)
     with qtbot.waitSignal(handler.error, timeout=1000):
         handler.handle(ValueError, ValueError("whoops"), None)
-    assert handler.message in viewer.window.qt_viewer.canvas.native.children()
+    assert handler.message in viewer.window._qt_viewer.canvas.native.children()
     handler.message.toggle_expansion()
     assert handler.message.property('expanded') is True
     handler.message.toggle_expansion()

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -16,7 +16,7 @@ from napari.utils.io import imread
 def test_qt_viewer(make_test_viewer):
     """Test instantiating viewer."""
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     assert viewer.title == 'napari'
     assert view.viewer == viewer
@@ -34,7 +34,7 @@ def test_qt_viewer(make_test_viewer):
 def test_qt_viewer_with_console(make_test_viewer):
     """Test instantiating console from viewer."""
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
     # Check no console is present before it is requested
     assert view._console is None
     # Check console is created when requested
@@ -45,7 +45,7 @@ def test_qt_viewer_with_console(make_test_viewer):
 def test_qt_viewer_toggle_console(make_test_viewer):
     """Test instantiating console from viewer."""
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
     # Check no console is present before it is requested
     assert view._console is None
     # Check console has been created when it is supposed to be shown
@@ -57,7 +57,7 @@ def test_qt_viewer_toggle_console(make_test_viewer):
 @pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)
 def test_add_layer(make_test_viewer, layer_class, data, ndim):
     viewer = make_test_viewer(ndisplay=int(np.clip(ndim, 2, 3)))
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     add_layer_by_type(viewer, layer_class, data)
     check_viewer_functioning(viewer, view, data, ndim)
@@ -67,7 +67,7 @@ def test_new_labels(make_test_viewer):
     """Test adding new labels layer."""
     # Add labels to empty viewer
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     viewer._new_labels()
     assert np.max(viewer.layers[0].data) == 0
@@ -80,7 +80,7 @@ def test_new_labels(make_test_viewer):
 
     # Add labels with image already present
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     np.random.seed(0)
     data = np.random.random((10, 15))
@@ -99,7 +99,7 @@ def test_new_points(make_test_viewer):
     """Test adding new points layer."""
     # Add labels to empty viewer
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     viewer.add_points()
     assert len(viewer.layers[0].data) == 0
@@ -112,7 +112,7 @@ def test_new_points(make_test_viewer):
 
     # Add points with image already present
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     np.random.seed(0)
     data = np.random.random((10, 15))
@@ -131,7 +131,7 @@ def test_new_shapes_empty_viewer(make_test_viewer):
     """Test adding new shapes layer."""
     # Add labels to empty viewer
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     viewer.add_shapes()
     assert len(viewer.layers[0].data) == 0
@@ -144,7 +144,7 @@ def test_new_shapes_empty_viewer(make_test_viewer):
 
     # Add points with image already present
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     np.random.seed(0)
     data = np.random.random((10, 15))
@@ -164,7 +164,7 @@ def test_z_order_adding_removing_images(make_test_viewer):
     data = np.ones((10, 10))
 
     viewer = make_test_viewer()
-    vis = viewer.window.qt_viewer.layer_to_visual
+    vis = viewer.window._qt_viewer.layer_to_visual
     viewer.add_image(data, colormap='red', name='red')
     viewer.add_image(data, colormap='green', name='green')
     viewer.add_image(data, colormap='blue', name='blue')
@@ -218,7 +218,7 @@ def test_screenshot(make_test_viewer):
     viewer.add_shapes(data)
 
     # Take screenshot
-    screenshot = viewer.window.qt_viewer.screenshot()
+    screenshot = viewer.window._qt_viewer.screenshot()
     assert screenshot.ndim == 3
 
 
@@ -251,17 +251,17 @@ def test_screenshot_dialog(make_test_viewer, tmpdir):
     # Save screenshot
     input_filepath = os.path.join(tmpdir, 'test-save-screenshot')
     mock_return = (input_filepath, '')
-    with mock.patch('napari._qt.qt_viewer.QFileDialog') as mocker, mock.patch(
-        'napari._qt.qt_viewer.QMessageBox'
+    with mock.patch('napari._qt._qt_viewer.QFileDialog') as mocker, mock.patch(
+        'napari._qt._qt_viewer.QMessageBox'
     ) as mocker2:
         mocker.getSaveFileName.return_value = mock_return
         mocker2.warning.return_value = QMessageBox.Yes
-        viewer.window.qt_viewer._screenshot_dialog()
+        viewer.window._qt_viewer._screenshot_dialog()
     # Assert behaviour is correct
     expected_filepath = input_filepath + '.png'  # add default file extension
     assert os.path.exists(expected_filepath)
     output_data = imread(expected_filepath)
-    expected_data = viewer.window.qt_viewer.screenshot()
+    expected_data = viewer.window._qt_viewer.screenshot()
     assert np.allclose(output_data, expected_data)
 
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -481,7 +481,7 @@ class QtViewer(QSplitter):
         if cursor == 'square':
             # make sure the square fits within the current canvas
             if size < 8 or size > (
-                min(*self.viewer.window.qt_viewer.canvas.size) - 4
+                min(*self.viewer.window._qt_viewer.canvas.size) - 4
             ):
                 q_cursor = self._cursors['cross']
             else:

--- a/napari/_qt/tracing/qt_debug_menu.py
+++ b/napari/_qt/tracing/qt_debug_menu.py
@@ -90,7 +90,7 @@ class PerformanceSubMenu:
 
     def _start_trace_dialog(self):
         """Open Save As dialog to start recording a trace file."""
-        viewer = self.main_window.qt_viewer
+        viewer = self.main_window._qt_viewer
 
         filename, _ = QFileDialog.getSaveFileName(
             parent=viewer,

--- a/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -299,7 +299,7 @@ def test_slice_labels(make_test_viewer):
     np.random.seed(0)
     data = np.random.random((20, 10, 10))
     viewer.add_image(data)
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     # make sure the totslice_label is showing the correct number
     assert int(view.dims.slider_widgets[0].totslice_label.text()) == 19

--- a/napari/_qt/widgets/_tests/test_qt_play.py
+++ b/napari/_qt/widgets/_tests/test_qt_play.py
@@ -106,7 +106,7 @@ def view(make_test_viewer):
     data = np.random.random((10, 10, 15))
     viewer.add_image(data)
 
-    return viewer.window.qt_viewer
+    return viewer.window._qt_viewer
 
 
 def test_play_raises_index_errors(qtbot, view):

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -48,7 +48,7 @@ class QtViewerDockWidget(QDockWidget):
         allowed_areas: Optional[List[str]] = None,
         shortcut=None,
     ):
-        self.qt_viewer = qt_viewer
+        self._qt_viewer = qt_viewer
         super().__init__(name)
         self.name = name
 
@@ -109,7 +109,7 @@ class QtViewerDockWidget(QDockWidget):
         # if you subclass QtViewerDockWidget and override the keyPressEvent
         # method, be sure to call super().keyPressEvent(event) at the end of
         # your method to pass uncaught key-combinations to the viewer.
-        return self.qt_viewer.keyPressEvent(event)
+        return self._qt_viewer.keyPressEvent(event)
 
     def _set_title_orientation(self, area):
         if area in (Qt.LeftDockWidgetArea, Qt.RightDockWidgetArea):

--- a/napari/_tests/test_advanced.py
+++ b/napari/_tests/test_advanced.py
@@ -10,7 +10,7 @@ def test_4D_5D_images(make_test_viewer):
     """
     np.random.seed(0)
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     # add 4D image data
     data = np.random.random((2, 6, 30, 40))
@@ -35,7 +35,7 @@ def test_5D_image_3D_rendering(make_test_viewer):
     """Test 3D rendering of a 5D image."""
     np.random.seed(0)
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     # add 4D image data
     data = np.random.random((2, 10, 12, 13, 14))
@@ -61,7 +61,7 @@ def test_change_image_dims(make_test_viewer):
     """
     np.random.seed(0)
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     # add 3D image data
     data = np.random.random((10, 30, 40))
@@ -105,7 +105,7 @@ def test_range_one_image(make_test_viewer):
     """
     np.random.seed(0)
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     # add 5D image data with range one dimensions
     data = np.random.random((1, 1, 1, 100, 200))
@@ -135,7 +135,7 @@ def test_range_one_images_and_points(make_test_viewer):
     """
     np.random.seed(0)
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     # add 5D image data with range one dimensions
     data = np.random.random((1, 1, 1, 100, 200))
@@ -161,7 +161,7 @@ def test_range_one_images_and_points(make_test_viewer):
 def test_update_console(make_test_viewer):
     """Test updating the console with local variables."""
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     # Check viewer in console
     assert view.console.kernel_client is not None
@@ -180,7 +180,7 @@ def test_update_console(make_test_viewer):
 def test_changing_display_surface(make_test_viewer):
     """Test adding 3D surface and changing its display."""
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     np.random.seed(0)
     vertices = 20 * np.random.random((10, 3))

--- a/napari/_tests/test_draw.py
+++ b/napari/_tests/test_draw.py
@@ -11,7 +11,7 @@ import pytest
 def test_canvas_drawing(make_test_viewer):
     """Test drawing before and after adding and then deleting a layer."""
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     assert len(viewer.layers) == 0
     # Check canvas context is not none before drawing, as currently on

--- a/napari/_tests/test_key_bindings.py
+++ b/napari/_tests/test_key_bindings.py
@@ -9,7 +9,7 @@ def test_viewer_key_bindings(make_test_viewer):
     """
     np.random.seed(0)
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     mock_press = Mock()
     mock_release = Mock()
@@ -78,7 +78,7 @@ def test_layer_key_bindings(make_test_viewer):
     """
     np.random.seed(0)
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     layer = viewer.add_image(np.random.random((10, 20)))
     layer.selected = True
@@ -145,7 +145,7 @@ def test_layer_key_bindings(make_test_viewer):
 def test_reset_scroll_progress(make_test_viewer):
     """Test select all key binding."""
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
     assert viewer.dims._scroll_progress == 0
 
     view.canvas.events.key_press(key=keys.Key('Control'))

--- a/napari/_tests/test_mouse_bindings.py
+++ b/napari/_tests/test_mouse_bindings.py
@@ -9,7 +9,7 @@ def test_viewer_mouse_bindings(make_test_viewer):
     """
     np.random.seed(0)
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     if os.getenv("CI"):
         viewer.show()
@@ -83,7 +83,7 @@ def test_layer_mouse_bindings(make_test_viewer):
     """
     np.random.seed(0)
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     if os.getenv("CI"):
         viewer.show()
@@ -159,7 +159,7 @@ def test_unselected_layer_mouse_bindings(make_test_viewer):
     """
     np.random.seed(0)
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     if os.getenv("CI"):
         viewer.show()

--- a/napari/_tests/test_view_layers.py
+++ b/napari/_tests/test_view_layers.py
@@ -130,7 +130,7 @@ def test_view(qtbot, layer_type, data, ndim):
     viewer = getattr(napari, f'view_{layer_type.__name__.lower()}')(
         data, show=False
     )
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
     check_viewer_functioning(viewer, view, data, ndim)
     viewer.close()
 

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -16,7 +16,7 @@ from napari.utils._tests.test_naming import eval_with_filename
 def test_viewer(make_test_viewer):
     """Test instantiating viewer."""
     viewer = make_test_viewer()
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     assert viewer.title == 'napari'
     assert view.viewer == viewer
@@ -63,7 +63,7 @@ def test_no_qt_loop():
 def test_add_layer(make_test_viewer, layer_class, data, ndim, visible):
     viewer = make_test_viewer()
     layer = add_layer_by_type(viewer, layer_class, data, visible=visible)
-    check_viewer_functioning(viewer, viewer.window.qt_viewer, data, ndim)
+    check_viewer_functioning(viewer, viewer.window._qt_viewer, data, ndim)
 
     # Run all class key bindings
     for func in layer.class_keymap.values():

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -141,7 +141,7 @@ def check_view_transform_consistency(layer, viewer, transf_dict):
         return None
 
     # Get an handle on visual layer:
-    vis_lyr = viewer.window.qt_viewer.layer_to_visual[layer]
+    vis_lyr = viewer.window._qt_viewer.layer_to_visual[layer]
     # Visual layer attributes should match expected from viewer dims:
     for transf_name, transf in transf_dict.items():
         disp_dims = viewer.dims.displayed  # dimensions displayed in 2D

--- a/napari/_vispy/_tests/test_vispy_big_images.py
+++ b/napari/_vispy/_tests/test_vispy_big_images.py
@@ -10,7 +10,7 @@ def test_big_2D_image(make_test_viewer):
     shape = (20_000, 10)
     data = np.random.random(shape)
     layer = viewer.add_image(data, multiscale=False)
-    visual = viewer.window.qt_viewer.layer_to_visual[layer]
+    visual = viewer.window._qt_viewer.layer_to_visual[layer]
     assert visual.node is not None
     if visual.MAX_TEXTURE_SIZE_2D is not None:
         s = np.ceil(np.divide(shape, visual.MAX_TEXTURE_SIZE_2D)).astype(int)
@@ -25,7 +25,7 @@ def test_big_3D_image(make_test_viewer):
     shape = (5, 10, 3_000)
     data = np.random.random(shape)
     layer = viewer.add_image(data, multiscale=False)
-    visual = viewer.window.qt_viewer.layer_to_visual[layer]
+    visual = viewer.window._qt_viewer.layer_to_visual[layer]
     assert visual.node is not None
     if visual.MAX_TEXTURE_SIZE_3D is not None:
         s = np.ceil(np.divide(shape, visual.MAX_TEXTURE_SIZE_3D)).astype(int)

--- a/napari/_vispy/_tests/test_vispy_calls.py
+++ b/napari/_vispy/_tests/test_vispy_calls.py
@@ -10,7 +10,7 @@ def test_data_change_ndisplay_image(make_test_viewer):
     np.random.seed(0)
     data = np.random.random((10, 15, 8))
     layer = viewer.add_image(data)
-    visual = viewer.window.qt_viewer.layer_to_visual[layer]
+    visual = viewer.window._qt_viewer.layer_to_visual[layer]
 
     @patch.object(visual, '_on_data_change', wraps=visual._on_data_change)
     def test_ndisplay_change(mocked_method, ndisplay=3):
@@ -30,7 +30,7 @@ def test_data_change_ndisplay_labels(make_test_viewer):
     data = np.random.randint(20, size=(10, 15, 8))
     layer = viewer.add_labels(data)
 
-    visual = viewer.window.qt_viewer.layer_to_visual[layer]
+    visual = viewer.window._qt_viewer.layer_to_visual[layer]
 
     @patch.object(visual, '_on_data_change', wraps=visual._on_data_change)
     def test_ndisplay_change(mocked_method, ndisplay=3):
@@ -49,7 +49,7 @@ def test_data_change_ndisplay_points(make_test_viewer):
     np.random.seed(0)
     data = 20 * np.random.random((10, 3))
     layer = viewer.add_points(data)
-    visual = viewer.window.qt_viewer.layer_to_visual[layer]
+    visual = viewer.window._qt_viewer.layer_to_visual[layer]
 
     @patch.object(visual, '_on_data_change', wraps=visual._on_data_change)
     def test_ndisplay_change(mocked_method, ndisplay=3):
@@ -68,7 +68,7 @@ def test_data_change_ndisplay_vectors(make_test_viewer):
     np.random.seed(0)
     data = 20 * np.random.random((10, 2, 3))
     layer = viewer.add_vectors(data)
-    visual = viewer.window.qt_viewer.layer_to_visual[layer]
+    visual = viewer.window._qt_viewer.layer_to_visual[layer]
 
     @patch.object(visual, '_on_data_change', wraps=visual._on_data_change)
     def test_ndisplay_change(mocked_method, ndisplay=3):
@@ -88,7 +88,7 @@ def test_data_change_ndisplay_shapes(make_test_viewer):
     data = 20 * np.random.random((10, 4, 3))
     layer = viewer.add_shapes(data)
 
-    visual = viewer.window.qt_viewer.layer_to_visual[layer]
+    visual = viewer.window._qt_viewer.layer_to_visual[layer]
 
     @patch.object(visual, '_on_data_change', wraps=visual._on_data_change)
     def test_ndisplay_change(mocked_method, ndisplay=3):
@@ -111,7 +111,7 @@ def test_data_change_ndisplay_surface(make_test_viewer):
     data = (vertices, faces, values)
     layer = viewer.add_surface(data)
 
-    visual = viewer.window.qt_viewer.layer_to_visual[layer]
+    visual = viewer.window._qt_viewer.layer_to_visual[layer]
 
     @patch.object(visual, '_on_data_change', wraps=visual._on_data_change)
     def test_ndisplay_change(mocked_method, ndisplay=3):

--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -4,7 +4,7 @@ import numpy as np
 def test_camera(make_test_viewer):
     """Test vispy camera creation in 2D."""
     viewer = make_test_viewer()
-    vispy_camera = viewer.window.qt_viewer.camera
+    vispy_camera = viewer.window._qt_viewer.camera
 
     np.random.seed(0)
     data = np.random.random((11, 11, 11))
@@ -25,7 +25,7 @@ def test_camera(make_test_viewer):
 def test_vispy_camera_update_from_model(make_test_viewer):
     """Test vispy camera update from model in 2D."""
     viewer = make_test_viewer()
-    vispy_camera = viewer.window.qt_viewer.camera
+    vispy_camera = viewer.window._qt_viewer.camera
 
     np.random.seed(0)
     data = np.random.random((11, 11, 11))
@@ -51,7 +51,7 @@ def test_vispy_camera_update_from_model(make_test_viewer):
 def test_camera_model_update_from_vispy(make_test_viewer):
     """Test camera model updates from vispy in 2D."""
     viewer = make_test_viewer()
-    vispy_camera = viewer.window.qt_viewer.camera
+    vispy_camera = viewer.window._qt_viewer.camera
 
     np.random.seed(0)
     data = np.random.random((11, 11, 11))
@@ -78,7 +78,7 @@ def test_camera_model_update_from_vispy(make_test_viewer):
 def test_3D_camera(make_test_viewer):
     """Test vispy camera creation in 3D."""
     viewer = make_test_viewer()
-    vispy_camera = viewer.window.qt_viewer.camera
+    vispy_camera = viewer.window._qt_viewer.camera
 
     np.random.seed(0)
     data = np.random.random((11, 11, 11))
@@ -98,7 +98,7 @@ def test_3D_camera(make_test_viewer):
 def test_vispy_camera_update_from_model_3D(make_test_viewer):
     """Test vispy camera update from model in 3D."""
     viewer = make_test_viewer()
-    vispy_camera = viewer.window.qt_viewer.camera
+    vispy_camera = viewer.window._qt_viewer.camera
 
     np.random.seed(0)
     data = np.random.random((11, 11, 11))
@@ -123,7 +123,7 @@ def test_vispy_camera_update_from_model_3D(make_test_viewer):
 def test_camera_model_update_from_vispy_3D(make_test_viewer):
     """Test camera model updates from vispy in 3D."""
     viewer = make_test_viewer()
-    vispy_camera = viewer.window.qt_viewer.camera
+    vispy_camera = viewer.window._qt_viewer.camera
 
     np.random.seed(0)
     data = np.random.random((11, 11, 11))

--- a/napari/_vispy/_tests/test_vispy_multiscale.py
+++ b/napari/_vispy/_tests/test_vispy_multiscale.py
@@ -25,8 +25,8 @@ def test_multiscale(make_test_viewer):
     layer = viewer.layers[0]
 
     # Set canvas size to target amount
-    viewer.window.qt_viewer.view.canvas.size = (800, 600)
-    viewer.window.qt_viewer.on_draw(None)
+    viewer.window._qt_viewer.view.canvas.size = (800, 600)
+    viewer.window._qt_viewer.on_draw(None)
 
     # Check that current level is first large enough to fill the canvas with
     # a greater than one pixel depth
@@ -66,7 +66,7 @@ def test_3D_multiscale_image(make_test_viewer):
     assert viewer.layers[0].data_level == 1
 
     # Note that draw command must be explicitly triggered in our tests
-    viewer.window.qt_viewer.on_draw(None)
+    viewer.window._qt_viewer.on_draw(None)
 
 
 @skip_on_win_ci
@@ -80,7 +80,7 @@ def test_multiscale_screenshot(make_test_viewer):
     _ = viewer.add_image(data, multiscale=True, contrast_limits=[0, 1])
 
     # Set canvas size to target amount
-    viewer.window.qt_viewer.view.canvas.size = (800, 600)
+    viewer.window._qt_viewer.view.canvas.size = (800, 600)
 
     screenshot = viewer.screenshot(canvas_only=True)
     center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)
@@ -102,7 +102,7 @@ def test_multiscale_screenshot(make_test_viewer):
 def test_multiscale_screenshot_zoomed(make_test_viewer):
     """Test rendering of multiscale data with screenshot after zoom."""
     viewer = make_test_viewer(show=True)
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     shapes = [(4000, 3000), (2000, 1500), (1000, 750), (500, 375)]
     data = [np.ones(s) for s in shapes]
@@ -113,7 +113,7 @@ def test_multiscale_screenshot_zoomed(make_test_viewer):
 
     # Set zoom of camera to show highest resolution tile
     view.view.camera.rect = [1000, 1000, 200, 150]
-    viewer.window.qt_viewer.on_draw(None)
+    viewer.window._qt_viewer.on_draw(None)
 
     # Check that current level is bottom level of multiscale
     assert viewer.layers[0].data_level == 0
@@ -137,7 +137,7 @@ def test_multiscale_screenshot_zoomed(make_test_viewer):
 def test_image_screenshot_zoomed(make_test_viewer):
     """Test rendering of image data with screenshot after zoom."""
     viewer = make_test_viewer(show=True)
-    view = viewer.window.qt_viewer
+    view = viewer.window._qt_viewer
 
     data = np.ones((4000, 3000))
     _ = viewer.add_image(data, multiscale=False, contrast_limits=[0, 1])
@@ -147,7 +147,7 @@ def test_image_screenshot_zoomed(make_test_viewer):
 
     # Set zoom of camera to show highest resolution tile
     view.view.camera.rect = [1000, 1000, 200, 150]
-    viewer.window.qt_viewer.on_draw(None)
+    viewer.window._qt_viewer.on_draw(None)
 
     screenshot = viewer.screenshot(canvas_only=True)
     center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)

--- a/napari/_vispy/_tests/test_vispy_points_layer.py
+++ b/napari/_vispy/_tests/test_vispy_points_layer.py
@@ -8,5 +8,5 @@ def test_VispyPointsLayer(make_test_viewer, opacity):
     viewer = make_test_viewer()
     points = np.array([[100, 100], [200, 200], [300, 100]])
     layer = viewer.add_points(points, size=30, opacity=opacity)
-    visual = viewer.window.qt_viewer.layer_to_visual[layer]
+    visual = viewer.window._qt_viewer.layer_to_visual[layer]
     assert visual.node.opacity == opacity

--- a/napari/benchmarks/benchmark_qt_viewer_image.py
+++ b/napari/benchmarks/benchmark_qt_viewer_image.py
@@ -62,8 +62,8 @@ class QtViewerImageSuite:
 
     def time_zoom(self, n):
         """Time to zoom in and zoom out."""
-        self.viewer.window.qt_viewer.view.camera.zoom(0.5, center=(0.5, 0.5))
-        self.viewer.window.qt_viewer.view.camera.zoom(2.0, center=(0.5, 0.5))
+        self.viewer.window._qt_viewer.view.camera.zoom(0.5, center=(0.5, 0.5))
+        self.viewer.window._qt_viewer.view.camera.zoom(2.0, center=(0.5, 0.5))
 
     def time_refresh(self, n):
         """Time to refresh view."""
@@ -97,8 +97,8 @@ class QtViewerSingleImageSuite:
 
     def time_zoom(self):
         """Time to zoom in and zoom out."""
-        self.viewer.window.qt_viewer.view.camera.zoom(0.5, center=(0.5, 0.5))
-        self.viewer.window.qt_viewer.view.camera.zoom(2.0, center=(0.5, 0.5))
+        self.viewer.window._qt_viewer.view.camera.zoom(0.5, center=(0.5, 0.5))
+        self.viewer.window._qt_viewer.view.camera.zoom(2.0, center=(0.5, 0.5))
 
     def time_set_data(self):
         """Time to set view slice."""
@@ -140,8 +140,8 @@ class QtViewerSingleInvisbleImageSuite:
 
     def time_zoom(self):
         """Time to zoom in and zoom out."""
-        self.viewer.window.qt_viewer.view.camera.zoom(0.5, center=(0.5, 0.5))
-        self.viewer.window.qt_viewer.view.camera.zoom(2.0, center=(0.5, 0.5))
+        self.viewer.window._qt_viewer.view.camera.zoom(0.5, center=(0.5, 0.5))
+        self.viewer.window._qt_viewer.view.camera.zoom(2.0, center=(0.5, 0.5))
 
     def time_set_data(self):
         """Time to set view slice."""

--- a/napari/benchmarks/benchmark_qt_viewer_labels.py
+++ b/napari/benchmarks/benchmark_qt_viewer_labels.py
@@ -31,8 +31,8 @@ class QtViewerSingleLabelsSuite:
 
     def time_zoom(self):
         """Time to zoom in and zoom out."""
-        self.viewer.window.qt_viewer.view.camera.zoom(0.5, center=(0.5, 0.5))
-        self.viewer.window.qt_viewer.view.camera.zoom(2.0, center=(0.5, 0.5))
+        self.viewer.window._qt_viewer.view.camera.zoom(0.5, center=(0.5, 0.5))
+        self.viewer.window._qt_viewer.view.camera.zoom(2.0, center=(0.5, 0.5))
 
     def time_set_view_slice(self):
         """Time to set view slice."""

--- a/napari/utils/_magicgui.py
+++ b/napari/utils/_magicgui.py
@@ -58,7 +58,7 @@ def find_viewer_ancestor(widget: QWidget) -> Optional[Viewer]:
     parent = widget.parent()
     while parent:
         if hasattr(parent, 'qt_viewer'):
-            return parent.qt_viewer.viewer
+            return parent._qt_viewer.viewer
         parent = parent.parent()
     return None
 

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -52,10 +52,10 @@ class Viewer(ViewerModel):
             give (list/tuple/str) then the variable values looked up in the
             callers frame.
         """
-        if self.window.qt_viewer.console is None:
+        if self.window._qt_viewer.console is None:
             return
         else:
-            self.window.qt_viewer.console.push(variables)
+            self.window._qt_viewer.console.push(variables)
 
     def screenshot(self, path=None, *, canvas_only=True):
         """Take currently displayed screen and convert to an image array.
@@ -76,7 +76,7 @@ class Viewer(ViewerModel):
             upper-left corner of the rendered region.
         """
         if canvas_only:
-            image = self.window.qt_viewer.screenshot(path=path)
+            image = self.window._qt_viewer.screenshot(path=path)
         else:
             image = self.window.screenshot(path=path)
         return image


### PR DESCRIPTION
# Description
As an alternative to #1799 this PR would make the `window.qt_viewer` private, so `window._qt_viewer`. I'm not necessarily sure I prefer this approach, but wanted to put it out there to see what it's like.

For me, it's always been an oversight since the model/ view refactoring that it is possible to access the qt elements and vispy elements through `viewer.window.qt_viewer` and every time I see us recommend that to people or people being forced to use that I'm really pained as I don't see any of our Qt elements or vispy elements as part of our public API that should be accessible from the `viewer`.

Having `_qt_viewer` be private would then at least signal that modifying these elements is undesired and can lead to unpredictable behaviour (as it in fact does). We can then focus on safe ways to expose the critical functionality that people are trying to access, without always recommending this bad practice.

I also think that as we get closer to stuff like #1875 having this separation is going to be even more critical as otherwise people could end up with mismatched states etc.

I know we added a public Qt module in #1122 with `QtViewer`, but I don't think we need to change that right now as that is a separate use case.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

