### PR TITLE
add reverse gray colormap

### DIFF
--- a/napari/utils/colormaps/matplotlib_cmaps.txt
+++ b/napari/utils/colormaps/matplotlib_cmaps.txt
@@ -3,6 +3,7 @@ magma
 inferno
 plasma
 gray
+gray_r
 hsv
 turbo
 twilight


### PR DESCRIPTION
# Description
This PR adds the reversed grayscale matplotlib colormap to the list of colormaps available from the viewer
![gray_r](https://user-images.githubusercontent.com/7307488/99197367-65b4fa80-2792-11eb-8e9f-e33ce16711ab.png)

The motivation for this was to be able to easily achieve the same visual effect of the minimum intensity projection in #1861 on light-on-dark valued data without manipulating the data itself

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
- [x] manual testing
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works


