### PR TITLE
Fix active layer update

### DIFF
--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -521,6 +521,19 @@ def test_active_layer():
     assert viewer.active_layer is None
 
 
+def test_active_layer_status_update():
+    """Test status updates from active layer on cursor move."""
+    viewer = ViewerModel()
+    np.random.seed(0)
+    viewer.add_image(np.random.random((5, 5, 10, 15)))
+    viewer.add_image(np.random.random((5, 6, 5, 10, 15)))
+    assert len(viewer.layers) == 2
+    assert viewer.active_layer == viewer.layers[1]
+
+    viewer.cursor.position = [1, 1, 1, 1, 1]
+    assert viewer.status == viewer.active_layer.status
+
+
 def test_sliced_world_extent():
     """Test world extent after adding layers and slicing."""
     np.random.seed(0)

--- a/napari/components/add_layers_mixin.py
+++ b/napari/components/add_layers_mixin.py
@@ -52,8 +52,6 @@ class AddLayersMixin:
         """
         layer.events.select.connect(self._update_active_layer)
         layer.events.deselect.connect(self._update_active_layer)
-        layer.events.status.connect(self._update_status)
-        layer.events.help.connect(self._update_help)
         layer.events.interactive.connect(self._update_interactive)
         layer.events.cursor.connect(self._update_cursor)
         layer.events.cursor_size.connect(self._update_cursor_size)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -415,14 +415,6 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         self.events.layers_change()
         self._update_active_layer(event)
 
-    def _update_status(self, event):
-        """Set the viewer status with the `event.status` string."""
-        self.status = event.status
-
-    def _update_help(self, event):
-        """Set the viewer help with the `event.help` string."""
-        self.help = event.help
-
     def _update_interactive(self, event):
         """Set the viewer interactivity with the `event.interactive` bool."""
         self.interactive = event.interactive
@@ -439,6 +431,11 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         """Set the layer cursor position."""
         for layer in self.layers:
             layer.position = self.cursor.position
+
+        # Update status and help bar based on active layer
+        if self.active_layer is not None:
+            self.status = self.active_layer.status
+            self.help = self.active_layer.help
 
     def _on_grid_change(self, event):
         """Arrange the current layers is a 2D grid."""


### PR DESCRIPTION
# Description
This closes #1836, closes #1872, closes #1873 and closes #1874, by getting the status from our `active_layer`. What I like about this PR is that it unhooks two events from the layer to the viewer for the status property, which we probably don't want on the layer in the long run anyway, instead we could now have a method which was `layer.get_status(position)` which got the status at a certain position and we could call that whenever we wanted, which would be much cleaner than what we're doing now. We can save that refactor for the future.

Thanks for your issue and PRs @haesleinhuepf, and I hope you don't mind if we go with this approach.

I'll add a test and then this will be ready for review @jni.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)