### PR TITLE
Fix affine composition order

### DIFF
--- a/napari/utils/transforms/_tests/test_transform_utils.py
+++ b/napari/utils/transforms/_tests/test_transform_utils.py
@@ -39,6 +39,17 @@ def test_decompose_linear_matrix(upper_triangular):
     np.testing.assert_almost_equal(B, C)
 
 
+def test_composition_order():
+    """Test composition order."""
+    # Order is rotate, shear, scale
+    rotate = np.array([[0, -1], [1, 0]])
+    shear = np.array([[1, 3], [0, 1]])
+    scale = [2, 5]
+
+    matrix = compose_linear_matrix(rotate, scale, shear)
+    np.testing.assert_almost_equal(matrix, rotate @ shear @ np.diag(scale))
+
+
 def test_shear_matrix_from_angle():
     """Test creating a shear matrix from an angle."""
     matrix = shear_matrix_from_angle(35)

--- a/napari/utils/transforms/transform_utils.py
+++ b/napari/utils/transforms/transform_utils.py
@@ -93,7 +93,7 @@ def compose_linear_matrix(rotate, scale, shear) -> np.array:
     full_scale = embed_in_identity_matrix(scale_mat, ndim)
     full_rotate = embed_in_identity_matrix(rotate_mat, ndim)
     full_shear = embed_in_identity_matrix(shear_mat, ndim)
-    return full_rotate @ full_scale @ full_shear
+    return full_rotate @ full_shear @ full_scale
 
 
 def expand_upper_triangular(vector):
@@ -194,12 +194,14 @@ def decompose_linear_matrix(
         tri = upper_tri.T
 
     scale = np.diag(tri).copy()
-    tri_normalized = tri / scale[:, np.newaxis]
 
+    # Take any reflection into account
     if np.linalg.det(rotate) < 0:
         scale[0] *= -1
         tri[0] *= -1
         rotate = matrix @ np.linalg.inv(tri)
+
+    tri_normalized = tri @ np.linalg.inv(np.diag(scale))
 
     if upper_triangular:
         shear = tri_normalized[np.triu(np.ones((n, n)), 1).astype(bool)]


### PR DESCRIPTION
# Description
This PR will close #1841 by fixing the affine composition order so scale happens first followed by shear and rotate, matching the documentation links provided by @zeroth.

I need to add some documentation and a test before this is ready to merge, but would appreciate feedback from @zeroth and @tlambert03 on whether this change is desirable/ fixes the described issues. Thanks!! cc @jni 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #1841

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
