### PR TITLE
async-26: Artificial Delay and fixes

### DIFF
--- a/napari/_qt/experimental/render/qt_mini_map.py
+++ b/napari/_qt/experimental/render/qt_mini_map.py
@@ -153,7 +153,7 @@ def _draw_intersection(intersection: OctreeIntersection) -> np.ndarray:
     np.ndarray
         The bitmap showing the intersection.
     """
-    aspect = intersection.level.info.image_config.aspect
+    aspect = intersection.level.info.image_config.aspect_ratio
     level: OctreeLevel = intersection.level
 
     # Map shape plus RGBA depth.

--- a/napari/_qt/experimental/render/qt_render_widgets.py
+++ b/napari/_qt/experimental/render/qt_render_widgets.py
@@ -112,15 +112,22 @@ class QtLabeledComboBox(QWidget):
         The text label for the control.
     options : dict
         We display the keys and return the values.
+    callback : Callable[[int], None]
+        Called when the value is changed by the user.
     """
 
-    def __init__(self, label: str, options: dict):
+    def __init__(
+        self, label: str, options: dict, callback: Callable[[int], None] = None
+    ):
         super().__init__()
         self.options = options
         layout = QHBoxLayout()
 
         self.combo = QComboBox()
         self.combo.addItems(list(options.keys()))
+
+        if callback is not None:
+            self.combo.activated[int].connect(callback)
 
         layout.addWidget(QLabel(label))
         layout.addWidget(self.combo)
@@ -138,6 +145,16 @@ class QtLabeledComboBox(QWidget):
         for index, opt_value in enumerate(self.options.values()):
             if opt_value == value:
                 self.combo.setCurrentIndex(index)
+
+    def set_index(self, index: int) -> None:
+        """Set what the combo box is showing based on the index.
+
+        Parameters
+        ----------
+        index : int
+            Set the combo box to this index.
+        """
+        self.combo.setCurrentIndex(index)
 
     def get_value(self) -> str:
         """Get the current value of the combo box.

--- a/napari/_qt/experimental/render/qt_test_image.py
+++ b/napari/_qt/experimental/render/qt_test_image.py
@@ -15,7 +15,7 @@ from qtpy.QtWidgets import (
 )
 
 from ....components.experimental.chunk import async_config
-from ....layers.image.experimental import ImageConfig
+from ....layers.image.experimental import TestImageSettings
 from ....utils import config
 from .image_creator import create_test_image_multi
 from .qt_render_widgets import QtLabeledComboBox, QtLabeledSpinBox
@@ -32,6 +32,7 @@ IMAGE_SHAPE_RANGE = range(1, 65536, 100)
 # We can create 3 types of images layers.
 IMAGE_TYPES = {
     "Normal": config.CREATE_IMAGE_NORMAL,
+    "Compound": config.CREATE_IMAGE_COMPOUND,
     "Tiled": config.CREATE_IMAGE_TILED,
 }
 IMAGE_TYPE_DEFAULT = "Tiled"
@@ -41,8 +42,8 @@ IMAGE_TYPE_DEFAULT = "Tiled"
 TEST_IMAGES = {
     "Digits": {
         "shape": None,
-        "factory": lambda image_config: create_test_image_multi(
-            "0", image_config
+        "factory": lambda image_settings: create_test_image_multi(
+            "0", image_settings
         ),
     },
 }
@@ -205,15 +206,15 @@ class QtTestImageLayout(QVBoxLayout):
         )
 
     @property
-    def image_config(self) -> ImageConfig:
-        """The desired image configuration.
+    def settings(self) -> TestImageSettings:
+        """The desired image settings.
 
         Return
         ------
-        ImageConfig
-            The desired image configuration.
+        ImageSetttings
+            The desired image settings.
         """
-        return ImageConfig.create(
+        return TestImageSettings(
             self.shape_controls.variable.get_shape(),
             self.tile_size.spin.value(),
         )
@@ -245,12 +246,12 @@ class QtTestImage(QFrame):
         image_name = self.layout.name.currentText()
         spec = TEST_IMAGES[image_name]
         factory = spec['factory']
-        image_config = self.layout.image_config
+        image_settings = self.layout.settings
 
         if spec['shape'] is None:
             # This image has a settable shape provided by the UI, so we
             # pass the image_config into the factory.
-            data = factory(image_config)
+            data = factory(image_settings)
         else:
             # This image comes in just one specific shape, so the factory
             # takes no arguments.
@@ -276,4 +277,4 @@ class QtTestImage(QFrame):
         # kind of odd. And the class has to handle the value changing on
         # the fly. It would be better if they could be arguments or
         # passed in on construction somehow.
-        layer.tile_size = image_config.tile_size
+        layer.tile_size = image_settings.tile_size

--- a/napari/layers/image/experimental/__init__.py
+++ b/napari/layers/image/experimental/__init__.py
@@ -3,6 +3,6 @@
 from .octree_intersection import OctreeIntersection
 from .octree_level import OctreeLevel
 from .octree_tile_builder import create_multi_scale_from_image
-from .octree_util import ImageConfig, OctreeChunk
+from .octree_util import ImageConfig, OctreeChunk, TestImageSettings
 
 # from .octree_image import OctreeImage  # circular

--- a/napari/layers/image/experimental/_octree_multiscale_slice.py
+++ b/napari/layers/image/experimental/_octree_multiscale_slice.py
@@ -50,6 +50,19 @@ class OctreeMultiscaleSlice:
         """
         return self._octree_level
 
+    @octree_level.setter
+    def octree_level(self, level: int) -> None:
+        """Set the octree level that the slice is showing.
+
+        This will be ignore if AUTO_LEVEL is one.
+
+        Parameters
+        ----------
+        level : int
+            The new level to display.
+        """
+        self._octree_level = level
+
     @property
     def loaded(self) -> bool:
         """Return True if the data has been loaded.

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -86,5 +86,7 @@ class Octree:
         data : List[ArrayLike]
             Create the octree from this multi-scale data.
         """
-        levels = create_levels_from_multiscale_data(data, image_config)
+        tile_size = image_config.tile_size
+        delay_ms = image_config.delay_ms
+        levels = create_levels_from_multiscale_data(data, tile_size, delay_ms)
         return Octree(image_config, levels)

--- a/napari/layers/image/experimental/octree_util.py
+++ b/napari/layers/image/experimental/octree_util.py
@@ -11,6 +11,23 @@ from ....types import ArrayLike
 TileArray = List[List[np.ndarray]]
 
 
+class TestImageSettings(NamedTuple):
+    """Settings for a test image we are creating."""
+
+    base_shape: Tuple[int, int]
+    tile_size: int
+
+
+class NormalNoise(NamedTuple):
+    mean: float = 0
+    std_dev: float = 0
+
+    @property
+    def is_zero(self) -> bool:
+        """Return true if there is no noise at all."""
+        return self.mean == 0 and self.std_dev == 0
+
+
 class OctreeChunkGeom(NamedTuple):
     """Position and scale of the chunk, for rendering."""
 
@@ -71,22 +88,17 @@ class ImageConfig(NamedTuple):
     """Configuration for a tiled image."""
 
     base_shape: Tuple[int, int]
-    aspect: float
+    num_levels: int
     tile_size: int
-    rand_loc: float
-    rand_scale: float
+    delay_ms: NormalNoise = NormalNoise()
 
-    @classmethod
-    def create(
-        cls,
-        base_shape: Tuple[int, int],
-        tile_size: int,
-        rand_loc: float = None,
-        rand_scale: float = None,
-    ):
-        """Create ImageConfig."""
-        aspect = base_shape[1] / base_shape[0]
-        return cls(base_shape, aspect, tile_size, rand_loc, rand_scale)
+    @property
+    def aspect_ratio(self):
+        """Return the width:height aspect ratio of the base image.
+
+        For example HDTV resolution is 16:9 which is 1.77.
+        """
+        return self.base_shape[1] / self.base_shape[0]
 
 
 class OctreeChunk:


### PR DESCRIPTION
# Description
* QtRender GUI now lets you add a random delay to the tile loading.
* Improved `QtLabeledComboBox` and use it in more places.
* New `TestImageSettings` named tuple.
* Use `_slice_indices` to slice the data before we send it to the octree slice.
   * Towards supporting real zarr files

## Type of change
- [x] Misc features and refactoring in experimental code.

# How has this been tested?
- [x] Manual testing, existing test suite

# Files
<img width="342" alt="async-26-files" src="https://user-images.githubusercontent.com/4163446/99462166-180ad000-2901-11eb-82a9-073b7cd13534.png">