### PR TITLE
async-27: Sparse Octree

### DIFF
--- a/napari/_qt/experimental/render/image_creator.py
+++ b/napari/_qt/experimental/render/image_creator.py
@@ -13,7 +13,7 @@ import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
 from ....layers.image.experimental import (
-    ImageConfig,
+    SliceConfig,
     create_multi_scale_from_image,
 )
 from ....utils.perf import block_timer
@@ -70,19 +70,19 @@ def draw_text_grid(image, text: str) -> None:
     draw.rectangle([0, 0, image.width, image.height], outline=color, width=5)
 
 
-def create_test_image(text, config: ImageConfig) -> np.ndarray:
+def create_test_image(text, slice_config: SliceConfig) -> np.ndarray:
     """Create a test image for testing tiled rendering.
 
     The test image just has digits all over it. The digits will typically
     be used to show the slice number like "0" or "42".
 
-    image_config: ImageConfig
-        The shape of the image to create and other details.
+    slice_config: SliceConfig
+        The base image shape and other details.
     """
     text = str(text)  # Might be an int.
 
     # Image.new wants (width, height) so swap them.
-    image_size = config.image_shape[::-1]
+    image_size = slice_config.image_shape[::-1]
 
     # Create the image, draw on the text, return it.
     image = Image.new('RGB', image_size)
@@ -90,19 +90,19 @@ def create_test_image(text, config: ImageConfig) -> np.ndarray:
     return np.array(image)
 
 
-def create_test_image_multi(text, image_config: ImageConfig) -> np.ndarray:
+def create_test_image_multi(text, slice_config: SliceConfig) -> np.ndarray:
     """Create a multiscale test image for testing tiled rendering.
 
     The test image is blank with digits all over it. The digits will
     typically be used to show the slice number.
 
-    image_config: ImageConfig
-        The shape and other details about the image to be created.
+    slice_config: SliceConfig
+        The base image shape and other details.
     """
     text = str(text)  # Convert in case it's an int.
 
     # Image.new wants (width, height) so swap them.
-    image_size = image_config.base_shape[::-1]
+    image_size = slice_config.base_shape[::-1]
 
     # Create the image, draw on the text, return it.
     image = Image.new('RGB', image_size)
@@ -112,4 +112,4 @@ def create_test_image_multi(text, image_config: ImageConfig) -> np.ndarray:
     with block_timer("create_multi_scale_from_image", print_time=True):
         # This is create all the octree layers, each coarser one
         # downsampled from the previous level.
-        return create_multi_scale_from_image(data, image_config.tile_size)
+        return create_multi_scale_from_image(data, slice_config.tile_size)

--- a/napari/_qt/experimental/render/qt_mini_map.py
+++ b/napari/_qt/experimental/render/qt_mini_map.py
@@ -83,11 +83,8 @@ def _draw_tiles(
     scale_xy : Tuple[float, float]
         The scale to draw things that.
     """
-
-    return  # need to redo this for sparse octree
-
-    """
     level = intersection.level
+    shape = level.info.slice_config.base_shape
 
     y = 0
     for row in range(shape[0]):
@@ -113,7 +110,6 @@ def _draw_tiles(
             rect.draw(bitmap, color)
             x += scaled[1]
         y += scaled[0]
-    """
 
 
 def _get_bitmap_shape(aspect: float) -> np.ndarray:
@@ -154,7 +150,7 @@ def _draw_intersection(intersection: OctreeIntersection) -> np.ndarray:
     np.ndarray
         The bitmap showing the intersection.
     """
-    aspect = intersection.level.info86.aspect_ratio
+    aspect = intersection.level.info.slice_config.aspect_ratio
     level: OctreeLevel = intersection.level
 
     # Map shape plus RGBA depth.

--- a/napari/_qt/experimental/render/qt_octree_info.py
+++ b/napari/_qt/experimental/render/qt_octree_info.py
@@ -89,10 +89,10 @@ class QtOctreeInfoLayout(QVBoxLayout):
 
         def on_set_level(value: int) -> None:
             if value == 0:  # This is AUTO
-                self.layer.auto_level = True
+                self.layer.freeze_level = False
             else:
                 level = value - 1  # Account for AUTO at 0
-                self.layer.auto_level = False
+                self.layer.freeze_level = True
                 self.layer.octree_level = level
 
         def on_set_delay(_value: int) -> None:
@@ -153,7 +153,7 @@ class QtOctreeInfoLayout(QVBoxLayout):
             Set controls based on this layer.
         """
         self.level.set_value(
-            "AUTO" if layer.auto_level else layer.octree_level
+            "AUTO" if not layer.freeze_level else layer.octree_level
         )
         self.table.set_values(_get_table_values(layer))
 
@@ -174,7 +174,7 @@ class QtOctreeInfo(QFrame):
 
         # Initial update and connect for future updates.
         self._update()  # initial update
-        layer.events.auto_level.connect(self._update)
+        layer.events.freeze_level.connect(self._update)
         layer.events.octree_level.connect(self._update)
         layer.events.tile_size.connect(self._update)
 

--- a/napari/_qt/experimental/render/qt_render.py
+++ b/napari/_qt/experimental/render/qt_render.py
@@ -12,6 +12,8 @@ from .qt_mini_map import QtMiniMap
 from .qt_octree_info import QtOctreeInfo
 from .qt_test_image import QtTestImage
 
+SHOW_MINIMAP = False
+
 
 class QtRender(QWidget):
     """Dockable widget for render controls.
@@ -41,8 +43,9 @@ class QtRender(QWidget):
             # Octree specific controls and widgets.
             layout.addWidget(QtOctreeInfo(layer))
 
-            self.mini_map = QtMiniMap(layer)
-            layout.addWidget(self.mini_map)
+            if SHOW_MINIMAP:
+                self.mini_map = QtMiniMap(layer)
+                layout.addWidget(self.mini_map)
 
             self.viewer.camera.events.center.connect(self._on_camera_move)
 
@@ -58,5 +61,6 @@ class QtRender(QWidget):
 
     def _on_camera_move(self, _event=None):
         """Called when the camera was moved."""
-        self.mini_map.update()
+        if SHOW_MINIMAP:
+            self.mini_map.update()
         self.frame_rate.on_camera_move()

--- a/napari/_qt/experimental/render/qt_test_image.py
+++ b/napari/_qt/experimental/render/qt_test_image.py
@@ -250,7 +250,7 @@ class QtTestImage(QFrame):
 
         if spec['shape'] is None:
             # This image has a settable shape provided by the UI, so we
-            # pass the image_config into the factory.
+            # pass the settings into the factory.
             data = factory(image_settings)
         else:
             # This image comes in just one specific shape, so the factory

--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -134,12 +134,12 @@ class TextureAtlas2D(Texture2D):
         # The full texture's shape in tiles, for example 4x4.
         self.shape_in_tiles = shape_in_tiles
 
-        depth = 3  # TODO_OCTREE: get from the data
-
         # The full texture's shape in texels, for example 1024x1024.
         height = self.spec.height * self.shape_in_tiles[0]
         width = self.spec.width * self.shape_in_tiles[1]
-        self.full_shape = np.array([width, height, depth], dtype=np.int32)
+        self.full_shape = np.array(
+            [width, height, self.spec.depth], dtype=np.int32
+        )
 
         # Total number of texture slots in the atlas.
         self.num_slots_total = shape_in_tiles[0] * shape_in_tiles[1]

--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -7,7 +7,7 @@ from typing import NamedTuple, Optional, Tuple
 import numpy as np
 from vispy.gloo import Texture2D
 
-from ...layers.image.experimental.octree_util import OctreeChunk
+from ...layers.image.experimental import OctreeChunk
 
 # Two triangles which cover a [0..1, 0..1] quad.
 _QUAD = np.array(

--- a/napari/_vispy/experimental/tile_grid.py
+++ b/napari/_vispy/experimental/tile_grid.py
@@ -8,7 +8,7 @@ import numpy as np
 from vispy.scene.node import Node
 from vispy.scene.visuals import Line
 
-from ...layers.image.experimental.octree_util import OctreeChunk
+from ...layers.image.experimental import OctreeChunk
 
 # Draw with lines of this width and color.
 GRID_WIDTH = 3

--- a/napari/_vispy/experimental/tile_set.py
+++ b/napari/_vispy/experimental/tile_set.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import List
 
-from ...layers.image.experimental.octree_util import OctreeChunk
+from ...layers.image.experimental import OctreeChunk
 from .texture_atlas import AtlasTile
 
 

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -6,7 +6,7 @@ from typing import List, Set
 
 import numpy as np
 
-from ...layers.image.experimental.octree_util import OctreeChunk
+from ...layers.image.experimental import OctreeChunk
 from ..vendored import ImageVisual
 from ..vendored.image import _build_color_transform
 from .texture_atlas import TextureAtlas2D

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -8,8 +8,8 @@ from typing import List
 
 from vispy.scene.visuals import create_visual_node
 
+from ...layers.image.experimental import OctreeChunk
 from ...layers.image.experimental.octree_image import OctreeImage
-from ...layers.image.experimental.octree_util import OctreeChunk
 from ...utils.perf import block_timer
 from ..vispy_image_layer import VispyImageLayer
 from .tile_grid import TileGrid

--- a/napari/components/experimental/chunk/_config.py
+++ b/napari/components/experimental/chunk/_config.py
@@ -46,7 +46,7 @@ AsyncConfig = namedtuple(
 # The octree config settings.
 OctreeConfig = namedtuple("OctreeConfig", ["tile_size"],)
 
-DEFAULT_OCTREE_CONFIG = {"tile_size": 64}
+DEFAULT_OCTREE_CONFIG = {"tile_size": 256}
 
 
 def _log_to_file(path: str) -> None:

--- a/napari/components/experimental/chunk/_config.py
+++ b/napari/components/experimental/chunk/_config.py
@@ -98,14 +98,25 @@ def _get_config_data() -> dict:
     """
     value = os.getenv("NAPARI_ASYNC")
 
-    if value == "1" or (value == "0" and config.async_octree):
-        # Async is enabled with defaults.
-        async_defaults = DEFAULT_ASYNC_CONFIG
-        async_defaults['octree'] = DEFAULT_OCTREE_CONFIG
-        return async_defaults
+    if (value is None or value == "0") and not config.async_octree:
+        # Async is disabled. Note, while async is experimental if
+        # NAPARI_ASYNC and NAPARI_OCTREE are both not set, then actually
+        # this code will not be run. No async related code is even
+        # imported.
+        #
+        # However long term, using DEFAULT_SYNC_CONFIG means the
+        # ChunkLoader is being used, but ChunkLoader.synchronous
+        # is set True. Meaning every single load is synchronous.
+        #
+        # Once the feature is not experimental that will probably
+        # be the way to turn async "off". It will still run through
+        # the ChunkLoader, but the loads will be synchronous.
+        return DEFAULT_SYNC_CONFIG
 
-    if value is None or value == "0":
-        return DEFAULT_SYNC_CONFIG  # Async is disabled.
+    # Async is enabled with defaults.
+    async_defaults = DEFAULT_ASYNC_CONFIG
+    async_defaults['octree'] = DEFAULT_OCTREE_CONFIG
+    return async_defaults
 
     return _load_config(value)  # Load the user's JSON config file.
 

--- a/napari/components/experimental/chunk/_info.py
+++ b/napari/components/experimental/chunk/_info.py
@@ -118,8 +118,9 @@ class LoadStats:
             True if the load was synchronous.
         """
         try:
-            # Use the special "load_chunks" timer for all chunks combined.
-            load_ms = request.timers['load_chunks'].duration_ms
+            # Use the special "ChunkRequest.load_chunks" timer to time
+            # the loading of all the chunks in this request combine.
+            load_ms = request.timers['ChunkRequest.load_chunks'].duration_ms
 
             # Update our StatWindow.
             self.window_ms.add(load_ms)
@@ -135,7 +136,7 @@ class LoadStats:
         self.counts.bytes += num_bytes
 
         # Time to load all chunks.
-        load_ms = request.timers['load_chunks'].duration_ms
+        load_ms = request.timers['ChunkRequest.load_chunks'].duration_ms
 
         # Update our StatWindows.
         self.window_bytes.add(num_bytes)

--- a/napari/components/experimental/chunk/_request.py
+++ b/napari/components/experimental/chunk/_request.py
@@ -176,7 +176,7 @@ class ChunkRequest:
         We time the overall load with the special name "load_chunks" and then
         we time each chunk as it loads, using it's array name as the key.
         """
-        with self.chunk_timer("load_chunks"):
+        with self.chunk_timer("ChunkRequest.load_chunks"):
             for key, array in self.chunks.items():
                 with self.chunk_timer(key):
                     loaded_array = np.asarray(array)

--- a/napari/layers/image/experimental/__init__.py
+++ b/napari/layers/image/experimental/__init__.py
@@ -1,8 +1,9 @@
 """layers.image.experimental
 """
+from .octree_chunk import OctreeChunk, OctreeChunkGeom
 from .octree_intersection import OctreeIntersection
 from .octree_level import OctreeLevel
 from .octree_tile_builder import create_multi_scale_from_image
-from .octree_util import ImageConfig, OctreeChunk, TestImageSettings
+from .octree_util import SliceConfig, TestImageSettings
 
 # from .octree_image import OctreeImage  # circular

--- a/napari/layers/image/experimental/_octree_multiscale_slice.py
+++ b/napari/layers/image/experimental/_octree_multiscale_slice.py
@@ -11,9 +11,10 @@ from ....components.experimental.chunk import ChunkRequest
 from ....types import ArrayLike
 from .._image_view import ImageView
 from .octree import Octree
+from .octree_chunk import OctreeChunk, OctreeLocation
 from .octree_intersection import OctreeIntersection
 from .octree_level import OctreeLevelInfo
-from .octree_util import ImageConfig, OctreeChunk, OctreeLocation
+from .octree_util import SliceConfig
 
 LOGGER = logging.getLogger("napari.async.octree")
 
@@ -24,14 +25,14 @@ class OctreeMultiscaleSlice:
     def __init__(
         self,
         data,
-        image_config: ImageConfig,
+        slice_config: SliceConfig,
         image_converter: Callable[[ArrayLike], ArrayLike],
     ):
         self.data = data
 
-        self._image_config = image_config
+        self._slice_config = slice_config
 
-        self._octree = Octree.from_multiscale_data(data, image_config)
+        self._octree = Octree(id(self), data, slice_config)
         self._octree_level = self._octree.num_levels - 1
 
         thumbnail_image = np.zeros(
@@ -99,7 +100,7 @@ class OctreeMultiscaleSlice:
 
         # Find the right level automatically.
         width = corners_2d[1][1] - corners_2d[0][1]
-        tile_size = self._octree.image_config.tile_size
+        tile_size = self._octree.slice_config.tile_size
         num_tiles = width / tile_size
 
         # TODO_OCTREE: compute from canvas dimensions instead

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -13,12 +13,15 @@ def _dim_str(dim: tuple) -> None:
     return f"{dim[0]} x {dim[1]} = {intword(dim[0] * dim[1])}"
 
 
-def _print_levels(label: str, levels: List[OctreeLevel]):
+def _print_levels(
+    label: str, levels: List[OctreeLevel], start: int = 0
+) -> None:
     print(f"{label} {len(levels)} levels:")
     for i, level in enumerate(levels):
         image_str = _dim_str(level.info.image_shape)
         tiles_str = _dim_str(level.info.shape_in_tiles)
-        print(f"    Level {i}: {image_str} pixels -> {tiles_str} tiles")
+        level = start + i
+        print(f"    Level {level}: {image_str} pixels -> {tiles_str} tiles")
 
 
 class Octree:
@@ -70,6 +73,7 @@ class Octree:
             )
 
         _print_levels("Octree input data has", self.levels)
+        original_levels = len(self.levels)
 
         # If root level contains more than one tile, add more levels
         # until the root does consist of a single tile.
@@ -77,7 +81,11 @@ class Octree:
             with block_timer("_create_additional_levels") as timer:
                 more_levels = self._create_additional_levels(slice_id)
 
-            _print_levels(f"In {timer.duration_ms:.3f}ms created", more_levels)
+            _print_levels(
+                f"In {timer.duration_ms:.3f}ms created",
+                more_levels,
+                start=original_levels,
+            )
             self.levels.extend(more_levels)
 
             print(f"Tree now has {len(self.levels)} total levels.")

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -1,6 +1,10 @@
 """Octree class.
 """
+from typing import List
+
+from ....utils.perf import block_timer
 from .octree_level import OctreeLevel
+from .octree_tile_builder import create_downsampled_levels
 from .octree_util import SliceConfig
 
 
@@ -29,6 +33,8 @@ class Octree:
 
     Parameters
     ----------
+    slice_id : int:
+        The id of the slice this octree is in.
     base_shape : Tuple[int, int]
         The shape of the full base image.
     levels : Levels
@@ -43,7 +49,105 @@ class Octree:
             OctreeLevel(slice_id, data[i], slice_config, i)
             for i in range(len(data))
         ]
+
+        if not self.levels:
+            # Probably we will allow empty trees, but for now raise:
+            raise ValueError(
+                f"Data of shape {data.shape} resulted " "no octree levels?"
+            )
+
+        # If root level contains more than one tile, add more levels
+        # until the root does consist of a single tile.
+        if self.levels[-1].info.num_tiles > 1:
+            with block_timer("Create additional levels", print_time=True):
+                additional_levels = self._create_additional_levels(slice_id)
+
+            print(f"Created {len(additional_levels)} additional levels.")
+            self.levels.extend(additional_levels)
+
+            print(f"Tree now has {len(self.levels)} total levels.")
+
+        # Now the root should definitely contain only a single tile.
+        assert self.levels[-1].info.num_tiles == 1
+
+        # This now the total number of levels.
         self.num_levels = len(data)
+
+    def _create_additional_levels(self, slice_id: int) -> List[OctreeLevel]:
+        """Add additional levels to the octree.
+
+        Keep adding levels until we each a root level where the image
+        data fits inside a single tile.
+
+        Parameters
+        -----------
+        slice_id : int
+            The id of the slice this octree is in.
+        tile_size : int
+            Keep creating levels until one fits with a tile of this size.
+
+        Return
+        ------
+        List[OctreeLevels]
+            The new downsampled levels we created.
+
+        Notes
+        -----
+        If we created this octree data, the root/highest level would
+        consist of a single tile. However, if we are reading someone
+        else's multiscale data, they did not know our tile size. Or they
+        might not have imagined someone using tiled rendering at all.
+        So their root level might be pretty large. We've seen root
+        levels larger than 8000x8000 pixels.
+
+        It would be nice in this case if our root level could use a
+        really large tile size as a special case. So small tiles for most
+        levels, but then one big tile as the root.
+
+        However, today our TiledImageVisual can't handle that. It can't
+        handle a mix of tile sizes, and TextureAtlas2D can't even
+        allocate multiple textures!
+
+        So for now, we compute/downsample additional levels ourselves and
+        add them to the data. We do this until we reach a level that does
+        fit within a single tile.
+
+        For example for that 8000x8000 pixel root level, if we are using
+        256x256 tiles we'll keep adding levels until we get to a level
+        that fits within 256x256.
+
+        Unfortunately, we can't be sure our downsampling approach will
+        match the rest of the data. The levels we add might be more/less
+        blurry than the original ones, or have different downsampling
+        artifacts. That's probably okay because these are low-resolution
+        levels, but still it would be better to show their root level
+        verbatim on a single large tiles.
+
+        Also, this is slow due to the downsampling, but also slow due to
+        having to load the full root level into memory. If we had a root
+        level that was tile sized, then we could load that very quickly.
+        That issue does not go away even if we have a special large-size
+        root tile. For best performance multiscale data should be built
+        down to a very small root tile, the extra storage is negligible.
+        """
+
+        # Create additional data levels so that the root level
+        # consists of only a single tile, using our standard/only
+        # tile size.
+        tile_size = self.slice_config.tile_size
+        new_levels = create_downsampled_levels(self.data[-1], tile_size)
+
+        # Add the data.
+        self.data.extend(new_levels)
+
+        # Return an OctreeLevel for each new data level.
+        num_current = len(self.levels)
+        return [
+            OctreeLevel(
+                slice_id, new_data, self.slice_config, num_current + index,
+            )
+            for index, new_data in enumerate(new_levels)
+        ]
 
     def print_info(self):
         """Print information about our tiles."""

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -1,18 +1,7 @@
 """Octree class.
 """
-from typing import List
-
-import numpy as np
-
-from ....types import ArrayLike
 from .octree_level import OctreeLevel
-from .octree_tile_builder import (
-    create_levels_from_multiscale_data,
-    create_multi_scale_from_image,
-)
-from .octree_util import ImageConfig, TileArray
-
-Levels = List[TileArray]
+from .octree_util import SliceConfig
 
 
 class Octree:
@@ -46,47 +35,17 @@ class Octree:
         All the levels of the tree.
     """
 
-    def __init__(self, image_config: ImageConfig, levels: Levels):
-        self.image_config = image_config
+    def __init__(self, slice_id: int, data, slice_config: SliceConfig):
+        self.data = data
+        self.slice_config = slice_config
 
-        # One OctreeLevel per level.
         self.levels = [
-            OctreeLevel(image_config, i, level)
-            for (i, level) in enumerate(levels)
+            OctreeLevel(slice_id, data[i], slice_config, i)
+            for i in range(len(data))
         ]
-        self.num_levels = len(self.levels)
+        self.num_levels = len(data)
 
     def print_info(self):
         """Print information about our tiles."""
         for level in self.levels:
             level.print_info()
-
-    @classmethod
-    def from_image(cls, image: np.ndarray, tile_size: int):
-        """Create octree from given single image.
-
-        Parameters
-        ----------
-        image : ndarray
-            Create the octree for this single image.
-        """
-        levels = create_multi_scale_from_image(image, tile_size)
-
-        info = ImageConfig.create(image.shape, tile_size)
-        return Octree(info, levels)
-
-    @classmethod
-    def from_multiscale_data(
-        cls, data: List[ArrayLike], image_config: ImageConfig
-    ):
-        """Create octree from multiscale data.
-
-        Parameters
-        ----------
-        data : List[ArrayLike]
-            Create the octree from this multi-scale data.
-        """
-        tile_size = image_config.tile_size
-        delay_ms = image_config.delay_ms
-        levels = create_levels_from_multiscale_data(data, tile_size, delay_ms)
-        return Octree(image_config, levels)

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -1,0 +1,151 @@
+"""OctreeChunk class
+"""
+from typing import NamedTuple, Optional, Tuple
+
+import numpy as np
+
+from ....components.experimental.chunk import ChunkKey
+from ....layers import Layer
+from ....types import ArrayLike
+
+
+class OctreeChunkGeom(NamedTuple):
+    """Position and scale of the chunk, for rendering."""
+
+    pos: np.ndarray
+    scale: np.ndarray
+
+
+class OctreeLocation(NamedTuple):
+    """Location of one chunk within the octree."""
+
+    slice_id: int
+    level_index: int
+    row: int
+    col: int
+
+    def __str__(self):
+        return (
+            f"location=({self.level_index}, {self.row}, {self.col}) "
+            f"slice={self.slice_id} id={id(self)}"
+        )
+
+    @classmethod
+    def create_null(cls):
+        """Create null location that points to nothing."""
+        return cls(0, 0, 0, 0, np.zeros(0), np.zeros(0))
+
+
+class OctreeChunk:
+    """One chunk of the full 2D or 3D image in the octree.
+
+    A chunk is a 2D tile or a 3D sub-volume.
+
+    We include level_index because id(data) is sometimes duplicated in #
+    adjacent levels, somehow. But it makes sense to include it anyway,
+    it's an important aspect of the chunk.
+
+    Attributes
+    ----------
+    level_index : int
+        The octree level where this chunk is from.
+    data : ArrayLike
+        The data to draw for this chunk.
+    pos : np.ndarray
+        The x, y coordinates of the chunk.
+    scale : np.ndarray
+        The (x, y) scale of this chunk. Should be square/cubic.
+    """
+
+    def __init__(
+        self, data: ArrayLike, location: OctreeLocation, geom: OctreeChunkGeom
+    ):
+        self._data = data
+        self._orig_data = data  # For now hold on to implement clear()
+        self.location = location
+        self.geom = geom
+        self.loading = False
+
+    def __str__(self):
+        return f"{self.location}"
+
+    @property
+    def data(self) -> ArrayLike:
+        """Return the data associated with this chunk."""
+        return self._data
+
+    @data.setter
+    def data(self, data: np.ndarray) -> None:
+        try:
+            assert not self.in_memory  # Should not set twice.
+        except AssertionError:
+            pass
+        print(f"set_data {self}")
+        self._data = data
+        self.loading = False
+
+    @property
+    def key(self) -> Tuple[int, int, int]:
+        """The unique key for this chunk.
+
+        Switch to __hash__? Didn't immediately work.
+        """
+        return (
+            self.geom.pos[0],
+            self.geom.pos[1],
+            self.location.level_index,
+        )
+
+    @property
+    def in_memory(self) -> bool:
+        """Return True if the data is fully in memory."""
+        return isinstance(self.data, np.ndarray)
+
+    @property
+    def needs_load(self) -> bool:
+        """Return true if this chunk needs to loaded.
+
+        An unloaded chunk's data might be a Dask or similar deferred array.
+        A loaded chunk's data is always ndarray, It's always real binary
+        data in memory.
+        """
+        return not self.in_memory and not self.loading
+
+    def clear(self) -> None:
+        """Clear out our loaded data, return to the original.
+
+        This is only done when running without the cache, so that we reload
+        the data again. With computation the loaded data might be different
+        each time.
+        """
+        self._data = self._orig_data
+        self.loading = False
+
+
+class OctreeChunkKey(ChunkKey):
+    """Add octree specific identity information to the generic ChunkKey.
+
+    Parameters
+    ----------
+    layer : Layer
+        The OctreeImage layer.
+    indices : Tuple[Optional[slice], ...]
+        The indices of the image we are viewing.
+    location : OctreeLocation
+        The location of the chunk within the octree we are loading.
+    """
+
+    def __init__(
+        self,
+        layer: Layer,
+        indices: Tuple[Optional[slice], ...],
+        location: OctreeLocation,
+    ):
+        self.location = location
+        super().__init__(layer, indices)
+
+    def _get_hash_values(self):
+        # TODO_OCTREE: can't we just has with parent's hashed key instead
+        # of creating a single big has value? Probably.
+        parent = super()._get_hash_values()
+        return parent + (self.location,)

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -109,14 +109,11 @@ class OctreeChunk:
         data : np.ndarray
             The new data for the chunk.
         """
-        print(f"set_data {self}")
-
         # An ndarray mean it's actual bytes in memory.
         assert isinstance(data, np.ndarray)
 
+        # Assign and say this in-progress load is now finished.
         self._data = data
-
-        # Declary in-progress load is now finished.
         self.loading = False
 
     @property

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -39,7 +39,7 @@ class OctreeImage(Image):
         self._track_view = True
         self._slice = None
 
-        self.show_grid = True  # Get/set directly.
+        self._show_grid = True
 
         # Temporary to implement a disabled cache.
         self._last_visible_set = set()
@@ -481,3 +481,12 @@ class OctreeImage(Image):
         self._delay_ms = delay_ms
         self._slice = None  # For now must explicitly delete it
         self.refresh()  # Create a new slice.
+
+    @property
+    def show_grid(self) -> bool:
+        return self._show_grid
+
+    @show_grid.setter
+    def show_grid(self, show: bool) -> None:
+        self._show_grid = show
+        self.events.loaded()  # redraw

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -299,7 +299,8 @@ class OctreeImage(Image):
             else:
                 # The chunk is not in memory and is not being loaded, so
                 # we are going to load it.
-                if self._load_chunk(octree_chunk):
+                sync_load = self._load_chunk(octree_chunk)
+                if sync_load:
                     # The chunk was loaded synchronously. Either it hit the
                     # cache, or it's fast-loading data. We can draw it now.
                     _log(i, len(chunks), "SYNC LOAD", octree_chunk)
@@ -350,8 +351,12 @@ class OctreeImage(Image):
         super()._update_draw(scale_factor, corner_pixels, shape_threshold)
 
         # Compute our 2D corners from the incoming n-d corner_pixels
-        data_corners = self._transforms[1:].simplified.inverse(corner_pixels)
-        corners = data_corners[:, self._dims.displayed]
+        # TODO_OCTREE: Throw in the two copies to fix weird bug, need
+        # to fix it for real soon.
+        data_corners = (
+            self._transforms[1:].simplified.inverse(corner_pixels).copy()
+        )
+        corners = data_corners[:, self._dims.displayed].copy()
 
         # Update our self._view to to catpure the state of things right
         # before we are drawn. Our self._view will used by our

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -5,17 +5,19 @@ from typing import List
 
 import numpy as np
 
-from ....components.experimental.chunk import ChunkRequest, chunk_loader
+from ....components.experimental.chunk import (
+    ChunkRequest,
+    async_config,
+    chunk_loader,
+)
 from ....utils.events import Event
 from ..image import Image
 from ._chunked_slice_data import ChunkedSliceData
-from ._octree_multiscale_slice import OctreeMultiscaleSlice
+from ._octree_multiscale_slice import OctreeMultiscaleSlice, OctreeView
 from .octree_chunk import OctreeChunk, OctreeChunkKey
 from .octree_intersection import OctreeIntersection
 from .octree_level import OctreeLevelInfo
 from .octree_util import NormalNoise, SliceConfig
-
-DEFAULT_TILE_SIZE = 64  # TODO_OCTREE: get from somewhere else
 
 LOGGER = logging.getLogger("napari.async.octree")
 
@@ -29,13 +31,14 @@ class OctreeImage(Image):
     """
 
     def __init__(self, *args, **kwargs):
-        self._tile_size = DEFAULT_TILE_SIZE
+        self._tile_size = async_config.octree.tile_size
 
         # Is this the same as Image._data_level? Which should we use?
         self._octree_level = None
 
-        self._corners_2d = None
-        self._auto_level = True
+        self._view: OctreeView = None
+
+        self._freeze_level = False
         self._track_view = True
         self._slice = None
 
@@ -53,7 +56,9 @@ class OctreeImage(Image):
         self._delay_ms = NormalNoise()
 
         super().__init__(*args, **kwargs)
-        self.events.add(auto_level=Event, octree_level=Event, tile_size=Event)
+        self.events.add(
+            freeze_level=Event, octree_level=Event, tile_size=Event
+        )
 
     def _get_value(self):
         """Override Image._get_value()."""
@@ -171,30 +176,30 @@ class OctreeImage(Image):
         return self._slice.octree_level_info
 
     @property
-    def auto_level(self) -> bool:
-        """Return True if we are computing the octree level automatically.
+    def freeze_level(self) -> bool:
+        """Return True if we are forzen viewing a single octree level.
 
-        When viewing the octree normally, auto_level is always True, but
-        during debugging or other special situations it might be off.
+        When viewing the octree normally, freeze_level is always False, but
+        during debugging or other special situations it might be on.
 
         Returns
         -------
         bool
-            True if we are computing the octree level automatically.
+            True if the view is currently frozen viewing on level.
         """
-        return self._auto_level
+        return self._freeze_level
 
-    @auto_level.setter
-    def auto_level(self, value: bool) -> None:
-        """Set whether we are choosing the octree level automatically.
+    @freeze_level.setter
+    def freeze_level(self, freeze: bool) -> None:
+        """Set whether we are frozen viewing a single octree level.
 
         Parameters
         ----------
         value : bool
             True if we should determine the octree level automatically.
         """
-        self._auto_level = value
-        self.events.auto_level()
+        self._freeze_level = freeze
+        self.events.freeze_level()
 
     @property
     def octree_level(self):
@@ -241,14 +246,10 @@ class OctreeImage(Image):
     @property
     def visible_chunks(self) -> List[OctreeChunk]:
         """Chunks in the current slice which in currently in view."""
-        # OCTREE_TODO: simplify this method...
-        # This will be None if we have not been drawn yet.
-        if self._slice is None or self._corners_2d is None:
+        if self._slice is None or self._view is None:
             return []
 
-        auto_level = self.auto_level and self.track_view
-
-        chunks = self._slice.get_visible_chunks(self._corners_2d, auto_level)
+        chunks = self._slice.get_visible_chunks(self._view)
 
         LOGGER.debug(
             "OctreeImage.visible_chunks: frame=%d num_chunks=%d",
@@ -343,13 +344,21 @@ class OctreeImage(Image):
     def _update_draw(self, scale_factor, corner_pixels, shape_threshold):
 
         # Need refresh if have not been draw at all yet.
-        need_refresh = self._corners_2d is None
-
-        # Compute self._corners_2d which we use for intersections.
-        data_corners = self._transforms[1:].simplified.inverse(corner_pixels)
-        self._corners_2d = self._convert_to_corners_2d(data_corners)
+        # TODO_OCTREE: why? do we really?
+        need_refresh = self._view is None
 
         super()._update_draw(scale_factor, corner_pixels, shape_threshold)
+
+        # Compute our 2D corners from the incoming n-d corner_pixels
+        data_corners = self._transforms[1:].simplified.inverse(corner_pixels)
+        corners = data_corners[:, self._dims.displayed]
+
+        # Update our self._view to to catpure the state of things right
+        # before we are drawn. Our self._view will used by our
+        # visible_chunks() method.
+        self._view = OctreeView(
+            corners, shape_threshold, self.freeze_level, self.track_view
+        )
 
         if need_refresh:
             self.refresh()
@@ -365,13 +374,7 @@ class OctreeImage(Image):
         if self._slice is None:
             return None
 
-        return self._slice.get_intersection(self._corners_2d, self.auto_level)
-
-    def _convert_to_corners_2d(self, data_corners):
-        """
-        Get data corners in 2d.
-        """
-        return data_corners[:, self._dims.displayed]
+        return self._slice.get_intersection(self._view)
 
     def _outside_data_range(self, indices) -> bool:
         """Return True if requested slice is outside of data range.
@@ -484,9 +487,23 @@ class OctreeImage(Image):
 
     @property
     def show_grid(self) -> bool:
+        """True if we are drawing a grid on top of the tiles.
+
+        Return
+        ------
+        bool
+            True if we are drawing a grid on top of the tiles.
+        """
         return self._show_grid
 
     @show_grid.setter
     def show_grid(self, show: bool) -> None:
+        """Set whether we should draw a grid on top of the tiles.
+
+        Parameters
+        ----------
+        show : bool
+            True if we should draw a grid on top of the tiles.
+        """
         self._show_grid = show
         self.events.loaded()  # redraw

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -10,9 +10,10 @@ from ....utils.events import Event
 from ..image import Image
 from ._chunked_slice_data import ChunkedSliceData
 from ._octree_multiscale_slice import OctreeMultiscaleSlice
+from .octree_chunk import OctreeChunk, OctreeChunkKey
 from .octree_intersection import OctreeIntersection
 from .octree_level import OctreeLevelInfo
-from .octree_util import ImageConfig, NormalNoise, OctreeChunk, OctreeChunkKey
+from .octree_util import NormalNoise, SliceConfig
 
 DEFAULT_TILE_SIZE = 64  # TODO_OCTREE: get from somewhere else
 
@@ -144,17 +145,17 @@ class OctreeImage(Image):
         self.refresh()  # Create a new slice.
 
     @property
-    def image_config(self) -> ImageConfig:
+    def slice_config(self) -> SliceConfig:
         """Return information about the current octree.
 
         Return
         ------
-        ImageConfig
-            Basic image configuration.
+        SliceConfig
+            Configuration information.
         """
         if self._slice is None:
             return None
-        return self._slice.image_config
+        return self._slice.slice_config
 
     @property
     def octree_level_info(self) -> OctreeLevelInfo:
@@ -416,7 +417,7 @@ class OctreeImage(Image):
         if self._outside_data_range(indices):
             return
 
-        image_config = ImageConfig(
+        slice_config = SliceConfig(
             self.data[0].shape, len(self.data), self._tile_size, self._delay_ms
         )
 
@@ -428,7 +429,7 @@ class OctreeImage(Image):
         slice_data = [level_data[indices] for level_data in self.data]
 
         self._slice = OctreeMultiscaleSlice(
-            slice_data, image_config, self._raw_to_displayed,
+            slice_data, slice_config, self._raw_to_displayed,
         )
 
     def _get_slice_indices(self) -> tuple:

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -371,10 +371,7 @@ class OctreeImage(Image):
         """
         Get data corners in 2d.
         """
-        # TODO_OCTREE: This is placeholder. Need to handle dims correctly.
-        if self.ndim == 2:
-            return data_corners
-        return data_corners[:, 1:3]
+        return data_corners[:, self._dims.displayed]
 
     def _outside_data_range(self, indices) -> bool:
         """Return True if requested slice is outside of data range.
@@ -417,12 +414,16 @@ class OctreeImage(Image):
         if self._outside_data_range(indices):
             return
 
-        slice_config = SliceConfig(
-            self.data[0].shape, len(self.data), self._tile_size, self._delay_ms
-        )
-
         # Indices to get at the data we are currently viewing.
         indices = self._get_slice_indices()
+
+        # TODO_OCTREE: easier way to do this?
+        base_shape = self.data[0].shape
+        base_shape_2d = [base_shape[i] for i in self._dims.displayed]
+
+        slice_config = SliceConfig(
+            base_shape_2d, len(self.data), self._tile_size, self._delay_ms
+        )
 
         # OctreeMultiscaleSlice wants all the levels, but only the dimensions
         # of each level that we are currently viewing.

--- a/napari/layers/image/experimental/octree_intersection.py
+++ b/napari/layers/image/experimental/octree_intersection.py
@@ -34,7 +34,7 @@ class OctreeView(NamedTuple):
 
         Return
         ------
-            The width.
+            The width in data coordinates.
         """
         return self.corners[1][1] - self.corners[0][1]
 
@@ -68,23 +68,19 @@ class OctreeIntersection:
 
         # TODO_OCTREE: don't split rows/cols so all these pairs of variables
         # are just one variable each? Use numpy more.
-        self.rows = view.corners[:, 0]
-        self.cols = view.corners[:, 1]
+        rows, cols = view.corners[:, 0], view.corners[:, 1]
 
         base = info.slice_config.base_shape
 
         self.normalized_range = np.array(
-            [
-                np.clip(self.rows / base[0], 0, 1),
-                np.clip(self.cols / base[1], 0, 1),
-            ]
+            [np.clip(rows / base[0], 0, 1), np.clip(cols / base[1], 0, 1)]
         )
 
-        self.rows /= info.scale
-        self.cols /= info.scale
+        scaled_rows = rows / info.scale
+        scaled_cols = cols / info.scale
 
-        self._row_range = self.row_range(self.rows)
-        self._col_range = self.column_range(self.cols)
+        self._row_range = self.row_range(scaled_rows)
+        self._col_range = self.column_range(scaled_cols)
 
     def tile_range(self, span, num_tiles):
         """Return tiles indices needed to draw the span."""

--- a/napari/layers/image/experimental/octree_intersection.py
+++ b/napari/layers/image/experimental/octree_intersection.py
@@ -4,8 +4,8 @@ from typing import List, Tuple
 
 import numpy as np
 
+from .octree_chunk import OctreeChunk
 from .octree_level import OctreeLevel
-from .octree_util import OctreeChunk, OctreeChunkGeom, OctreeLocation
 
 # TODO_OCTREE: These types might be a horrible idea but trying it for now.
 Float2 = np.ndarray  # [x, y] dtype=float64 (default type)
@@ -36,7 +36,7 @@ class OctreeIntersection:
         self.rows: Float2 = self.corners_2d[:, 0]
         self.cols: Float2 = self.corners_2d[:, 1]
 
-        base = info.image_config.base_shape
+        base = info.slice_config.base_shape
 
         self.normalized_range = np.array(
             [
@@ -57,7 +57,7 @@ class OctreeIntersection:
         def _clamp(val, min_val, max_val):
             return max(min(val, max_val), min_val)
 
-        tile_size = self.level.info.image_config.tile_size
+        tile_size = self.level.info.slice_config.tile_size
 
         span_tiles = [span[0] / tile_size, span[1] / tile_size]
         clamped = [
@@ -93,63 +93,34 @@ class OctreeIntersection:
 
         return _inside(row, self._row_range) and _inside(col, self._col_range)
 
-    def get_chunks(self, slice_id) -> List[OctreeChunk]:
+    def get_chunks(self, create_chunks=False) -> List[OctreeChunk]:
         """Return chunks inside this intersection.
 
         Parameters
         ----------
-        intersection : OctreeIntersection
-            Describes some subset of one octree level.
+        create_chunks : bool
+            If True, create an OctreeChunk at any location that does
+            not already have a chunk.
         """
         chunks = []
 
-        level_info = self.level.info
-        level_index = level_info.level_index
-
-        scale = level_info.scale
-        scale_vec = np.array([scale, scale], dtype=np.float32)
-
-        tile_size = level_info.image_config.tile_size
-        scaled_size = tile_size * scale
-
         # Get every chunk that is within the rectangular region. These are
-        # all the chunks we might possible draw, because they are within
+        # all the chunks we might possibly draw, because they are within
         # the current view.
         #
-        # Chunks will either contain the original data, or they will
-        # contain an OctreeChunk. This implies the chunk was viewed before.
+        # If we've accessed the chunk recently the existing OctreeChunk
+        # will be returned, otherwise a new OctreeChunk is created
+        # and returned.
         #
-        # If the chunk is not yet an OctreeChunk we turn it into one. The
-        # main reason we have OctreeChunks is so that have service as the
-        # home for a pending chunk, a chunk in the process of being loaded.
-        #
-        # We will draw the chunk only when that load has finished. But here
-        # we just return all the chunks that are within the intersection.
-        y = self._row_range.start * scaled_size
+        # OctreeChunks can be loaded or unloaded. Unloaded chunks are not
+        # drawn until their data as been loaded in. But here we return
+        # every chunk within the rectangle.
         for row in self._row_range:
-            x = self._col_range.start * scaled_size
             for col in self._col_range:
-
-                data = self.level.tiles[row][col]
-
-                if isinstance(data, OctreeChunk):
-                    # Location is already an OctreeChunk, so return it.
-                    chunks.append(data)
-                else:
-                    # Location is not an OctreeChunk yet, turn it into one now.
-                    location = OctreeLocation(slice_id, level_index, row, col)
-
-                    # Geom is used by the visual for rendering.
-                    pos = np.array([x, y], dtype=np.float32)
-                    geom = OctreeChunkGeom(pos, scale_vec)
-
-                    # Replace the location with the newly created chunk.
-                    chunk = OctreeChunk(data, location, geom)
-                    self.level.tiles[row][col] = chunk
-
+                chunk = self.level.get_chunk(
+                    row, col, create_chunks=create_chunks
+                )
+                if chunk is not None:
                     chunks.append(chunk)
-
-                x += scaled_size
-            y += scaled_size
 
         return chunks

--- a/napari/layers/image/experimental/octree_intersection.py
+++ b/napari/layers/image/experimental/octree_intersection.py
@@ -25,14 +25,16 @@ class OctreeIntersection:
     def __init__(self, level: OctreeLevel, corners_2d: np.ndarray):
         self.level = level
 
-        # We modify below with self.rows /= info.scale which we should
-        # probably not do!
+        # OCTREE_TODO: We modify below with self.rows /= info.scale which
+        # we should probably not do! Without this copy all things go
+        # haywire, because we are altering the incoming array. There's
+        # no const params in Python!
         self.corners_2d = corners_2d.copy()
 
         info = self.level.info
 
         # TODO_OCTREE: don't split rows/cols so all these pairs of variables
-        # are just one variable each?
+        # are just one variable each? Use numpy more.
         self.rows: Float2 = self.corners_2d[:, 0]
         self.cols: Float2 = self.corners_2d[:, 1]
 

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -1,5 +1,6 @@
 """OctreeLevel and OctreeLevelInfo classes.
 """
+import math
 from typing import Optional
 
 import numpy as np
@@ -38,9 +39,11 @@ class OctreeLevelInfo:
         scaled_size = tile_size * self.scale
 
         self.shape_in_tiles = [
-            int(base[0] / scaled_size),
-            int(base[1] / scaled_size),
+            math.ceil(base[0] / scaled_size),
+            math.ceil(base[1] / scaled_size),
         ]
+
+        self.num_tiles = self.shape_in_tiles[0] * self.shape_in_tiles[1]
 
 
 class OctreeLevel:
@@ -71,6 +74,9 @@ class OctreeLevel:
     ):
         self.slice_id = slice_id
         self.data = data
+
+        # TODO_OCTREE: change from "info" to "meta"/"metadata"?
+        # info is kind of dumb sounding.
         self.info = OctreeLevelInfo(slice_config, level_index)
         self.tiles = {}
 

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -78,7 +78,7 @@ class OctreeLevel:
         # TODO_OCTREE: change from "info" to "meta"/"metadata"?
         # info is kind of dumb sounding.
         self.info = OctreeLevelInfo(slice_config, level_index)
-        self.tiles = {}
+        self._tiles = {}
 
     def get_chunk(
         self, row: int, col: int, create_chunks=False
@@ -102,14 +102,14 @@ class OctreeLevel:
             The OctreeChunk if one exists at this location.
         """
         try:
-            return self.tiles[(row, col)]
+            return self._tiles[(row, col)]
         except KeyError:
             if not create_chunks:
                 return None
 
         # Create a chunk at this location and return it.
         octree_chunk = self._create_chunk(row, col)
-        self.tiles[(row, col)] = octree_chunk
+        self._tiles[(row, col)] = octree_chunk
         return octree_chunk
 
     def _create_chunk(self, row: int, col: int) -> OctreeChunk:

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -1,8 +1,12 @@
 """OctreeLevel and OctreeLevelInfo classes.
 """
-from typing import Tuple
+from typing import Optional
 
-from .octree_util import ImageConfig, TileArray
+import numpy as np
+
+from ....types import ArrayLike
+from .octree_chunk import OctreeChunk, OctreeChunkGeom, OctreeLocation
+from .octree_util import SliceConfig
 
 
 class OctreeLevelInfo:
@@ -10,7 +14,7 @@ class OctreeLevelInfo:
 
     Parameters
     ----------
-    image_config : ImageConfig
+    slice_config : SliceConfig
         Information about the entire octree.
     level_index : int
         The index of this level within the whole tree.
@@ -18,24 +22,25 @@ class OctreeLevelInfo:
         The (height, width) dimensions of this level in terms of tiles.
     """
 
-    def __init__(
-        self,
-        image_config: ImageConfig,
-        level_index: int,
-        shape_in_tiles: Tuple[int, int],
-    ):
-        self.image_config = image_config
+    def __init__(self, slice_config: SliceConfig, level_index: int):
+        self.slice_config = slice_config
 
         self.level_index = level_index
         self.scale = 2 ** self.level_index
 
-        base = image_config.base_shape
+        base = slice_config.base_shape
         self.image_shape = (
             int(base[0] / self.scale),
             int(base[1] / self.scale),
         )
 
-        self.shape_in_tiles = shape_in_tiles
+        tile_size = self.slice_config.tile_size
+        scaled_size = tile_size * self.scale
+
+        self.shape_in_tiles = [
+            int(base[0] / scaled_size),
+            int(base[1] / scaled_size),
+        ]
 
 
 class OctreeLevel:
@@ -47,17 +52,111 @@ class OctreeLevel:
 
     Parameters
     ----------
-    image_config : ImageConfig
-        Basic image configuration.
+    slice_id : int
+        The id of the OctreeMultiscaleSlice we are in.
+    data : ArrayLike
+        The data for this level.
+    slice_config : SliceConfig
+        The base image shape and other details.
     level_index : int
         Index of this specific level (0 is full resolution).
-    tile : TileArray
-        The tiles for this level.
     """
 
     def __init__(
-        self, image_config: ImageConfig, level_index: int, tiles: TileArray
+        self,
+        slice_id: int,
+        data: ArrayLike,
+        slice_config: SliceConfig,
+        level_index: int,
     ):
-        shape_in_tiles = [len(tiles), len(tiles[0])]
-        self.info = OctreeLevelInfo(image_config, level_index, shape_in_tiles)
-        self.tiles = tiles
+        self.slice_id = slice_id
+        self.data = data
+        self.info = OctreeLevelInfo(slice_config, level_index)
+        self.tiles = {}
+
+    def get_chunk(
+        self, row: int, col: int, create_chunks=False
+    ) -> Optional[OctreeChunk]:
+        """Return the OctreeChunk at this location if it exists.
+
+        If create is True, an OctreeChunk will be created if one does not exist.
+
+        Parameters
+        ----------
+        row : int
+            The row in the level.
+        col : int
+            The column in the level.
+        create_chunks : bool
+            If True, create the OctreeChunk if it does not exist.
+
+        Return
+        ------
+        Optional[OctreeChunk]
+            The OctreeChunk if one exists at this location.
+        """
+        try:
+            return self.tiles[(row, col)]
+        except KeyError:
+            if not create_chunks:
+                return None
+
+        # Create a chunk at this location and return it.
+        octree_chunk = self._create_chunk(row, col)
+        self.tiles[(row, col)] = octree_chunk
+        return octree_chunk
+
+    def _create_chunk(self, row: int, col: int) -> OctreeChunk:
+        """Create a new OctreeChunk for this location in the level.
+
+        Parameters
+        ----------
+        row : int
+            The row in the level.
+        col : int
+            The column in the level.
+
+        Return
+        ------
+        OctreeChunk
+            The newly created chunk.
+        """
+        level_index = self.info.level_index
+        location = OctreeLocation(self.slice_id, level_index, row, col)
+
+        scale = self.info.scale
+        scale_vec = np.array([scale, scale], dtype=np.float32)
+
+        tile_size = self.info.slice_config.tile_size
+        scaled_size = tile_size * scale
+
+        pos = np.array(
+            [col * scaled_size, row * scaled_size], dtype=np.float32
+        )
+
+        # Geom is used by the visual for rendering this chunk.
+        geom = OctreeChunkGeom(pos, scale_vec)
+
+        data = self._get_data(row, col)
+
+        # Return the newly created chunk.
+        return OctreeChunk(data, location, geom)
+
+    def _get_data(self, row: int, col: int) -> ArrayLike:
+
+        tile_size = self.info.slice_config.tile_size
+
+        array_slice = (
+            slice(row * tile_size, (row + 1) * tile_size),
+            slice(col * tile_size, (col + 1) * tile_size),
+        )
+
+        if self.data.ndim == 3:
+            array_slice += (slice(None),)  # Add the colors.
+
+        data = self.data[array_slice]
+
+        # if not delay_ms.is_zero:
+        #    data = _add_delay(data, delay_ms)
+
+        return data

--- a/napari/layers/image/experimental/octree_tile_builder.py
+++ b/napari/layers/image/experimental/octree_tile_builder.py
@@ -9,7 +9,7 @@ as you browse a large image that doesn't have tiles, they are created in
 the background. But that's pretty speculative and far out.
 """
 import time
-from typing import List, Optional
+from typing import List
 
 import dask
 import dask.array as da
@@ -17,7 +17,9 @@ import numpy as np
 from scipy import ndimage as ndi
 
 from ....types import ArrayLike
-from .octree_util import NormalNoise, TileArray
+from .octree_util import NormalNoise
+
+TileArray = List[List[ArrayLike]]
 
 
 def _get_tile(tiles: TileArray, row, col):
@@ -29,10 +31,6 @@ def _get_tile(tiles: TileArray, row, col):
 
 def _none(items):
     return all(x is None for x in items)
-
-
-def _one_tile(tiles: TileArray) -> bool:
-    return len(tiles) == 1 and len(tiles[0]) == 1
 
 
 def _add_delay(array, delay_ms: NormalNoise):
@@ -51,58 +49,6 @@ def _add_delay(array, delay_ms: NormalNoise):
         return array
 
     return da.from_delayed(delayed(array), array.shape, array.dtype)
-
-
-def create_tiles(
-    array: np.ndarray, tile_size: int, delay_ms: Optional[NormalNoise] = None
-) -> np.ndarray:
-    """
-    Return an NxM array of (tile_size, tile_size) ndarrays except the edge
-    tiles might be smaller if the array did not divide evenly.
-
-    TODO_OCTREE: Could we use slices_from_chunks() from dask.array.core to
-    do this without loops, faster? Right now this is just used for
-    testing/development, but if we do this in production, maybe upgrade it.
-
-    Parameters
-    ----------
-    array : np.ndarray
-        The array to create tiles out of.
-    tiles_size : int
-        Edge length of the square tiles.
-    """
-    # Array is either ndim==2 (grayscale) or ndim==3 (RGB).
-    if array.ndim < 2 or array.ndim > 3:
-        raise ValueError(f"Unexpected array dimension {array.ndim}")
-    rows, cols = array.shape[:2]
-
-    tiles = []
-
-    print(f"create_tiles array={array.shape} tile_size={tile_size}")
-
-    row = 0
-    while row < rows:
-        row_tiles = []
-        col = 0
-        while col < cols:
-            array_slice = (
-                slice(row, row + tile_size),
-                slice(col, col + tile_size),
-            )
-            if array.ndim == 3:
-                array_slice += (slice(None),)  # Add the colors.
-
-            tile = array[array_slice]
-
-            if not delay_ms.is_zero:
-                tile = _add_delay(tile, delay_ms)
-
-            row_tiles.append(tile)
-            col += tile_size
-        tiles.append(row_tiles)
-        row += tile_size
-
-    return tiles
 
 
 def _combine_tiles(*tiles: np.ndarray) -> np.ndarray:
@@ -231,22 +177,3 @@ def create_multi_scale_from_image(
         levels.append(next_level)
 
     return levels
-
-
-def create_levels_from_multiscale_data(
-    data: List[ArrayLike], tile_size: int, delay_ms: NormalNoise
-):
-    """Create octree levels from multiscale data.
-
-    The data is already a list of ArrayLike levels, each own downsampled
-    by half. We are just creating the TileArray list of lists format
-    that the octree code expects today.
-
-    We'll almost certainly replace this lists of lists format with Dask or
-    some nicer chunked format. But this is what we've done since day one
-    until we upgrade it.
-    """
-
-    return [
-        create_tiles(level_data, tile_size, delay_ms) for level_data in data
-    ]

--- a/napari/layers/image/experimental/octree_util.py
+++ b/napari/layers/image/experimental/octree_util.py
@@ -74,7 +74,7 @@ class SliceConfig(NamedTuple):
     own tile size.
     """
 
-    base_shape: np.darray
+    base_shape: np.ndarray
     num_levels: int
     tile_size: int
     delay_ms: NormalNoise = NormalNoise()

--- a/napari/layers/image/experimental/octree_util.py
+++ b/napari/layers/image/experimental/octree_util.py
@@ -42,9 +42,39 @@ class NormalNoise(NamedTuple):
 
 
 class SliceConfig(NamedTuple):
-    """Configuration for a tiled image."""
+    """Configuration for a tiled image.
 
-    base_shape: Tuple[int, int]
+    Attributes
+    ----------
+    base_shape : np.ndarray
+        The base [height, width] shape of the entire full resolution image.
+    num_levels : int
+        The number of octree levels in the image.
+    tile_size : int
+        The default tile size. However each OctreeLevel has its own tile size
+        which can override this.
+
+    Notes
+    -----
+    This SliceConfig.tile_size will be used by the OctreeLevels in the tree
+    in general. But the highest level OctreeLevel might use a larger size
+    so that it can consist of a single chunk.
+
+    For example we might be using 256x256 tiles in general. For best
+    performance it might make sense to have octree levels such that the
+    highest level fits inside a single 256x256 tiles.
+
+    But if we are displaying user provided data, they did not know our tile
+    size. Instead their root level might be something pretty big, like
+    6000x6000. In that case we use 6000x6000 as the tile size in our root,
+    so the root level consists of a single tile.
+
+    TODO_OCTREE: we don't actually support larger size tiles yet! However
+    it's still a good idea to assume that each OctreeLevel could have its
+    own tile size.
+    """
+
+    base_shape: np.darray
     num_levels: int
     tile_size: int
     delay_ms: NormalNoise = NormalNoise()

--- a/napari/layers/image/experimental/octree_util.py
+++ b/napari/layers/image/experimental/octree_util.py
@@ -1,14 +1,8 @@
 """Octree utility classes.
 """
-from typing import List, NamedTuple, Optional, Tuple
+from typing import NamedTuple, Tuple
 
 import numpy as np
-
-from ....components.experimental.chunk import ChunkKey
-from ....layers import Layer
-from ....types import ArrayLike
-
-TileArray = List[List[np.ndarray]]
 
 
 class TestImageSettings(NamedTuple):
@@ -19,72 +13,35 @@ class TestImageSettings(NamedTuple):
 
 
 class NormalNoise(NamedTuple):
+    """Noise with a normal distribution."""
+
     mean: float = 0
     std_dev: float = 0
 
     @property
     def is_zero(self) -> bool:
-        """Return true if there is no noise at all."""
+        """Return True if there is no noise at all.
+
+        Return
+        ------
+        bool
+            True if there is no noise at all.
+        """
         return self.mean == 0 and self.std_dev == 0
 
+    @property
+    def get_value(self) -> float:
+        """Get a random value.
 
-class OctreeChunkGeom(NamedTuple):
-    """Position and scale of the chunk, for rendering."""
-
-    pos: np.ndarray
-    scale: np.ndarray
-
-
-class OctreeLocation(NamedTuple):
-    """Location of one chunk within the octree."""
-
-    slice_id: int
-    level_index: int
-    row: int
-    col: int
-
-    def __str__(self):
-        return (
-            f"location=({self.level_index}, {self.row}, {self.col}) "
-            f"slice={self.slice_id} id={id(self)}"
-        )
-
-    @classmethod
-    def create_null(cls):
-        """Create null location that points to nothing."""
-        return cls(0, 0, 0, 0, np.zeros(0), np.zeros(0))
+        Return
+        ------
+        float
+            The random value.
+        """
+        return np.random.normal(self.mean, self.std_dev)
 
 
-class OctreeChunkKey(ChunkKey):
-    """Add octree specific identity information to the generic ChunkKey.
-
-    Parameters
-    ----------
-    layer : Layer
-        The OctreeImage layer.
-    indices : Tuple[Optional[slice], ...]
-        The indices of the image we are viewing.
-    location : OctreeLocation
-        The location of the chunk within the octree we are loading.
-    """
-
-    def __init__(
-        self,
-        layer: Layer,
-        indices: Tuple[Optional[slice], ...],
-        location: OctreeLocation,
-    ):
-        self.location = location
-        super().__init__(layer, indices)
-
-    def _get_hash_values(self):
-        # TODO_OCTREE: can't we just has with parent's hashed key instead
-        # of creating a single big has value? Probably.
-        parent = super()._get_hash_values()
-        return parent + (self.location,)
-
-
-class ImageConfig(NamedTuple):
+class SliceConfig(NamedTuple):
     """Configuration for a tiled image."""
 
     base_shape: Tuple[int, int]
@@ -99,89 +56,3 @@ class ImageConfig(NamedTuple):
         For example HDTV resolution is 16:9 which is 1.77.
         """
         return self.base_shape[1] / self.base_shape[0]
-
-
-class OctreeChunk:
-    """One chunk of the full 2D or 3D image in the octree.
-
-    A chunk is a 2D tile or a 3D sub-volume.
-
-    We include level_index because id(data) is sometimes duplicated in #
-    adjacent levels, somehow. But it makes sense to include it anyway,
-    it's an important aspect of the chunk.
-
-    Attributes
-    ----------
-    level_index : int
-        The octree level where this chunk is from.
-    data : ArrayLike
-        The data to draw for this chunk.
-    pos : np.ndarray
-        The x, y coordinates of the chunk.
-    scale : np.ndarray
-        The (x, y) scale of this chunk. Should be square/cubic.
-    """
-
-    def __init__(
-        self, data: ArrayLike, location: OctreeLocation, geom: OctreeChunkGeom
-    ):
-        self._data = data
-        self._orig_data = data  # For now hold on to implement clear()
-        self.location = location
-        self.geom = geom
-        self.loading = False
-
-    def __str__(self):
-        return f"{self.location}"
-
-    @property
-    def data(self) -> ArrayLike:
-        """Return the data associated with this chunk."""
-        return self._data
-
-    @data.setter
-    def data(self, data: np.ndarray) -> None:
-        try:
-            assert not self.in_memory  # Should not set twice.
-        except AssertionError:
-            pass
-        print(f"set_data {self}")
-        self._data = data
-        self.loading = False
-
-    @property
-    def key(self) -> Tuple[int, int, int]:
-        """The unique key for this chunk.
-
-        Switch to __hash__? Didn't immediately work.
-        """
-        return (
-            self.geom.pos[0],
-            self.geom.pos[1],
-            self.location.level_index,
-        )
-
-    @property
-    def in_memory(self) -> bool:
-        """Return True if the data is fully in memory."""
-        return isinstance(self.data, np.ndarray)
-
-    @property
-    def needs_load(self) -> bool:
-        """Return true if this chunk needs to loaded.
-
-        An unloaded chunk's data might be a Dask or similar deferred array.
-        A loaded chunk's data is always ndarray, It's always real binary
-        data in memory.
-        """
-        return not self.in_memory and not self.loading
-
-    def clear(self) -> None:
-        """Clear out our loaded data, return to the original.
-
-        This is only done when running without the cache, so that we reload
-        the data again. With computation the loaded data might be different
-        each time.
-        """
-        self._data = self._orig_data
-        self.loading = False


### PR DESCRIPTION
# Description
* Get rid of the empty `List[List[ArrayLike]]` for unviewed parts of levels
    * We create `OctreeChunk` only for chunks which are in view
    * Unused parts use zero bytes, beyond the `self.data` itself.
    * Needed because level 0 wanted 30M+ tiles in one case.
* Fix dimensionality issues with loading an example Zarr file, such as slicing.
* New `_create_additional_levels()` which extends a user provided multiscale down to a single tile root.
    * The coarsest level for some user data is like 6000x6000, way bigger than a tile.
    * In that case creating the additional levels down to a single tile takes only around 200ms.
    * Long term we might want to support multiple tile sizes in one dataset.

# Demo

This is `4495402.zarr` off SSD: `NAPARI_OCTREE=1 napari /data-ext/4495402.zarr`

![napari-octree-zoom](https://user-images.githubusercontent.com/4163446/99585746-c02da100-29b4-11eb-862c-12a8b5eafd4c.gif)

The data works remotely from `https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/4495402.zarr` but it's incredibly slow, like many seconds per tile. I have to put in some metrics to see if that's just data transfer time or what.

# Refactoring
* `ImageConfig` -> `SliceConfig`
* Factor out new `octree_chunk.py` from `octree_util.py`.

## Type of change
- [x] New features in experimental code

# Files

<img width="348" alt="async-27-files" src="https://user-images.githubusercontent.com/4163446/99585797-d0458080-29b4-11eb-96fd-6e6f4d79c16c.png">
