### PR TITLE
Make again control of grouping part of public api

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -3,8 +3,6 @@ Custom Qt widgets that serve as native objects that the public-facing elements
 wrap.
 """
 import os
-import platform
-import sys
 import time
 
 from qtpy.QtCore import Qt
@@ -106,21 +104,9 @@ class Window:
             # Will patch based on config file.
             perf_config.patch_callables()
 
-        if (
-            platform.system() == "Windows"
-            and not getattr(sys, 'frozen', False)
-            and self._napari_app_id
-        ):
-            import ctypes
-
-            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
-                self._napari_app_id
-            )
-
         logopath = os.path.join(
             os.path.dirname(__file__), '..', 'resources', 'logo.png'
         )
-        app.setWindowIcon(QIcon(logopath))
 
         # see docstring of `wait_for_workers_to_quit` for caveats on killing
         # workers at shutdown.
@@ -130,6 +116,7 @@ class Window:
         self.qt_viewer = QtViewer(viewer)
 
         self._qt_window = QMainWindow()
+        self._qt_window.setWindowIcon(QIcon(logopath))
         self._qt_window.setAttribute(Qt.WA_DeleteOnClose)
         self._qt_window.setUnifiedTitleAndToolBarOnMac(True)
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -22,6 +22,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from .. import __version__
 from ..resources import get_stylesheet
 from ..utils import perf
 from ..utils.io import imsave
@@ -101,30 +102,28 @@ class Window:
 
             # Will patch based on config file.
             perf_config.patch_callables()
+        _napari_app_id = getattr(
+            viewer,
+            "_napari_app_id",
+            'napari.napari.viewer.' + str(__version__),
+        )
         if (
             platform.system() == "Windows"
             and not getattr(sys, 'frozen', False)
-            and hasattr(viewer, "_napari_app_id")
-            and viewer._napari_app_id
+            and _napari_app_id
         ):
             import ctypes
 
             ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
-                viewer._napari_app_id
+                _napari_app_id
             )
 
         logopath = os.path.join(
             os.path.dirname(__file__), '..', 'resources', 'logo.png'
         )
 
-        if (
-            hasattr(viewer, "_napari_global_logo")
-            and viewer._napari_global_logo
-        ):
+        if getattr(viewer, "_napari_global_logo", True):
             app = QApplication.instance()
-            logopath = os.path.join(
-                os.path.dirname(__file__), 'resources', 'logo.png'
-            )
             app.setWindowIcon(QIcon(logopath))
 
         # see docstring of `wait_for_workers_to_quit` for caveats on killing

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,3 +1,11 @@
+import os
+import platform
+import sys
+
+from qtpy.QtGui import QIcon
+from qtpy.QtWidgets import QApplication
+
+from . import __version__
 from ._qt import Window
 from .components import ViewerModel
 from .utils import config
@@ -22,6 +30,9 @@ class Viewer(ViewerModel):
         Whether to show the viewer after instantiation. by default True.
     """
 
+    _napari_app_id = 'napari.napari.viewer.' + str(__version__)
+    _napari_global_logo = True
+
     def __init__(
         self,
         *,
@@ -38,6 +49,22 @@ class Viewer(ViewerModel):
             axis_labels=axis_labels,
         )
         self.window = Window(self, show=show)
+        if (
+            platform.system() == "Windows"
+            and not getattr(sys, 'frozen', False)
+            and self._napari_app_id
+        ):
+            import ctypes
+
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
+                self._napari_app_id
+            )
+            if self._napari_global_logo:
+                app = QApplication.instance()
+                logopath = os.path.join(
+                    os.path.dirname(__file__), 'resources', 'logo.png'
+                )
+                app.setWindowIcon(QIcon(logopath))
 
     def update_console(self, variables):
         """Update console's namespace with desired variables.

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -59,12 +59,12 @@ class Viewer(ViewerModel):
             ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
                 self._napari_app_id
             )
-            if self._napari_global_logo:
-                app = QApplication.instance()
-                logopath = os.path.join(
-                    os.path.dirname(__file__), 'resources', 'logo.png'
-                )
-                app.setWindowIcon(QIcon(logopath))
+        if self._napari_global_logo:
+            app = QApplication.instance()
+            logopath = os.path.join(
+                os.path.dirname(__file__), 'resources', 'logo.png'
+            )
+            app.setWindowIcon(QIcon(logopath))
 
     def update_console(self, variables):
         """Update console's namespace with desired variables.

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,10 +1,3 @@
-import os
-import platform
-import sys
-
-from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QApplication
-
 from . import __version__
 from ._qt import Window
 from .components import ViewerModel
@@ -30,7 +23,11 @@ class Viewer(ViewerModel):
         Whether to show the viewer after instantiation. by default True.
     """
 
+    # set _napari_app_id to False to avoid overwriting dock icon on windows
+    # set _napari_app_id to custom string to prevent grouping different base viewer
     _napari_app_id = 'napari.napari.viewer.' + str(__version__)
+
+    # set _napari_global_logo to control if napari logo should be set as application logo
     _napari_global_logo = True
 
     def __init__(
@@ -49,22 +46,6 @@ class Viewer(ViewerModel):
             axis_labels=axis_labels,
         )
         self.window = Window(self, show=show)
-        if (
-            platform.system() == "Windows"
-            and not getattr(sys, 'frozen', False)
-            and self._napari_app_id
-        ):
-            import ctypes
-
-            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
-                self._napari_app_id
-            )
-        if self._napari_global_logo:
-            app = QApplication.instance()
-            logopath = os.path.join(
-                os.path.dirname(__file__), 'resources', 'logo.png'
-            )
-            app.setWindowIcon(QIcon(logopath))
 
     def update_console(self, variables):
         """Update console's namespace with desired variables.


### PR DESCRIPTION
# Description
This PR revert part of changes from #1808 to take control of grouping windows on Windows to be part of public API. 
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

The other option is to make `Window` class part of public API but there are methods like `screenshot` and `update_console` which user may need to copy to own code. 
