### PR TITLE
Update set-env in make_release action

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -40,8 +40,8 @@ jobs:
           else
             RELEASE_NOTES="pre-release $TAG"
           fi
+          echo "tag=${TAG}" >> $GITHUB_ENV
           # https://help.github.com/en/actions/reference/workflow-commands-for-github-actions
-          echo "::set-env name=tag::$TAG"
           echo "::set-output name=contents::$RELEASE_NOTES"
       - name: Create Release
         id: create_release


### PR DESCRIPTION
# Description
`set-env` was deprecated (see [here](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)). I think this should fix it (worked for me in other projects), but I'm not sure how to test without making a release. `set-env` was deactivated on Nov. 16, so we will have to address this before 0.4.1.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
See deprecation notice [here](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) and the docs on setting environment variables [here](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files).

# How has this been tested?
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
