### PR TITLE
Revert "Return estimate for 3D texture size instead of hard-coded value"

### DIFF
--- a/docs/release/release_0_4_1.md
+++ b/docs/release/release_0_4_1.md
@@ -75,6 +75,7 @@ our colormap selection dropdown to make colormap selection easier.
 - Fix Py3.9 Big Sur bug (#1894)
 - Make control of grouping part of public api again (#1895)
 - Fix windows plugin dupe (#1899)
+- Revert #1857 "Return estimate for 3D texture size instead of hard-coded value" (#1907)
 
 ## API Changes
 

--- a/napari/_vispy/utils_gl.py
+++ b/napari/_vispy/utils_gl.py
@@ -46,14 +46,10 @@ def get_max_texture_sizes() -> Tuple[int, int]:
     if max_size_2d == ():
         max_size_2d = None
 
-    # vispy doesn't expose GL_MAX_3D_TEXTURE_SIZE so estimating based on
-    # memory requirements for 2D texture. This is not necessarily correct.
+    # vispy doesn't expose GL_MAX_3D_TEXTURE_SIZE so hard coding for now.
     # MAX_TEXTURE_SIZE_3D = gl.glGetParameter(gl.GL_MAX_3D_TEXTURE_SIZE)
     # if MAX_TEXTURE_SIZE_3D == ():
     #    MAX_TEXTURE_SIZE_3D = None
-    if max_size_2d is not None:
-        max_size_3d = round(max_size_2d ** (2.0 / 3.0))
-    else:
-        max_size_3d = None
+    max_size_3d = 2048
 
     return max_size_2d, max_size_3d


### PR DESCRIPTION
This reverts commit d557dc2229393d1499c0ba887c0a552240c302fe (#1857).

# Description

On my laptop this estimate was too conservative, resulting in unnecessary and aggressive downsampling of a 3D volume. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
