### PR TITLE
Hide welcome visual

### DIFF
--- a/docs/release/release_0_4_1.md
+++ b/docs/release/release_0_4_1.md
@@ -75,6 +75,7 @@ our colormap selection dropdown to make colormap selection easier.
 - Fix Py3.9 Big Sur bug (#1894)
 - Make control of grouping part of public api again (#1895)
 - Fix windows plugin dupe (#1899)
+- Hide welcome visual (#1922)
 
 ## API Changes
 

--- a/docs/release/release_0_4_1.md
+++ b/docs/release/release_0_4_1.md
@@ -19,6 +19,9 @@ for volumetric data. Finally, we made some useful visual improvements, such as
 displaying text labels identifying axes on our axes visual, and colorbars in
 our colormap selection dropdown to make colormap selection easier.
 
+A small note: we have temporarily disabled the viewer's welcome visual while we
+investigate some crashes that it seemed to be contributing to. See #1905.
+
 ## New Features
 
 - Live tiff loader example (#1610)

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -85,7 +85,7 @@ class QtViewer(QSplitter):
 
     raw_stylesheet = get_stylesheet()
 
-    def __init__(self, viewer, welcome=True):
+    def __init__(self, viewer, welcome=False):
 
         # Avoid circular import.
         from .layer_controls import QtLayerControlsContainer

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -400,10 +400,11 @@ def test_labels_painting(make_test_viewer):
     assert screenshot[:, :, :2].max() > 0
 
 
+@pytest.mark.skip("Welcome visual temporarily disabled")
 @skip_on_win_ci
 @skip_local_popups
 def test_welcome(make_test_viewer):
-    """Test that something appears when axes become visible."""
+    """Test that something visible on launch."""
     viewer = make_test_viewer(show=True)
 
     # Check something is visible


### PR DESCRIPTION
# Description
Following the recommendations of @Czaki in #1905 this PR would hide the welcome visual which has been causing some bugs with pyqt5. It's clear that the bugs are not caused by the welcome, but having the welcome makes it worse.

I think in a future PR we could consider moving the welcome out of vispy into Qt, but I'd rather do that under less pressure then the upcoming 0.4.1 release, which I think should go out tomorrow.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
