### PR TITLE
fix checks for runngin under cProfile and yappi

### DIFF
--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -25,8 +25,12 @@ def running_as_bundled_app() -> bool:
     """Infer whether we are running as a briefcase bundle"""
     # https://github.com/beeware/briefcase/issues/412
     # https://github.com/beeware/briefcase/pull/425
+    if sys.modules['__main__'].__spec__.name in {"cProfile", "yappi"}:
+        # check if run from profiler
+        return False
     app_module = sys.modules['__main__'].__package__
     metadata = importlib_metadata.metadata(app_module)
+
     return 'Briefcase-Version' in metadata
 
 

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -25,16 +25,11 @@ def running_as_bundled_app() -> bool:
     """Infer whether we are running as a briefcase bundle"""
     # https://github.com/beeware/briefcase/issues/412
     # https://github.com/beeware/briefcase/pull/425
-    main_module = sys.modules['__main__']
-    if (
-        hasattr(main_module, "__spec__")
-        and hasattr(main_module.__spec__, "name")
-        and main_module.__spec__.name in {"cProfile", "yappi"}
-    ):
-        # check if run from profiler
-        return False
     app_module = sys.modules['__main__'].__package__
-    metadata = importlib_metadata.metadata(app_module)
+    try:
+        metadata = importlib_metadata.metadata(app_module)
+    except importlib_metadata.PackageNotFoundError:
+        return False
 
     return 'Briefcase-Version' in metadata
 

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -25,7 +25,12 @@ def running_as_bundled_app() -> bool:
     """Infer whether we are running as a briefcase bundle"""
     # https://github.com/beeware/briefcase/issues/412
     # https://github.com/beeware/briefcase/pull/425
-    if sys.modules['__main__'].__spec__.name in {"cProfile", "yappi"}:
+    main_module = sys.modules['__main__']
+    if (
+        hasattr(main_module, "__spec__")
+        and hasattr(main_module.__spec__, "name")
+        and main_module.__spec__.name in {"cProfile", "yappi"}
+    ):
         # check if run from profiler
         return False
     app_module = sys.modules['__main__'].__package__


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

This is a fix for run napari code under cProfiler and yappi profilers. 

Without this try to profile napari with calling scripts ends with: 
```
...
    raise PackageNotFoundError(name)
importlib.metadata.PackageNotFoundError
```

which is caused by an empty `app_module` variable. 

command: `python -m cProfile -o file.pstat file.py`


A simple profile is needed as shown in #1885 and #1923. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
