### PR TITLE
Standardize grid events

### DIFF
--- a/docs/release/release_0_4_1.md
+++ b/docs/release/release_0_4_1.md
@@ -88,9 +88,6 @@ investigate some crashes that it seemed to be contributing to. See #1905.
   Instead, use ``viewer.grid.enabled = <True/False>``. (#1821)
 - ``Viewer.grid_stride`` and ``Viewer.grid_size`` are deprecated. Instead,
   use ``Viewer.grid.stride`` and ``Viewer.grid.shape``. (#1821, #1847)
-- Use ``Viewer.grid.events.update`` is removed, there are now
-  individual events for each attribute. Use ``Viewer.grid.events.connect``
-  to connect with all of them. (#1926)
 
 ## Build Tools and Docs
 
@@ -140,4 +137,3 @@ investigate some crashes that it seemed to be contributing to. See #1905.
 - [Philip Winston](https://github.com/napari/napari/commits?author=pwinston) - @pwinston
 - [Talley Lambert](https://github.com/napari/napari/commits?author=tlambert03) - @tlambert03
 - [Volker Hilsenstein](https://github.com/napari/napari/commits?author=VolkerH) - @VolkerH
-

--- a/docs/release/release_0_4_1.md
+++ b/docs/release/release_0_4_1.md
@@ -59,6 +59,7 @@ investigate some crashes that it seemed to be contributing to. See #1905.
 - Async-26: Artificial Delay and fixes (#1891)
 - Add properties event (#1896)
 - Async-27: Sparse Octree (#1892)
+- Standardize grid events (#1926)
 
 ## Bug Fixes
 
@@ -87,6 +88,9 @@ investigate some crashes that it seemed to be contributing to. See #1905.
   Instead, use ``viewer.grid.enabled = <True/False>``. (#1821)
 - ``Viewer.grid_stride`` and ``Viewer.grid_size`` are deprecated. Instead,
   use ``Viewer.grid.stride`` and ``Viewer.grid.shape``. (#1821, #1847)
+- Use ``Viewer.grid.events.update`` is removed, there are now
+  individual events for each attribute. Use ``Viewer.grid.events.connect``
+  to connect with all of them. (#1926)
 
 ## Build Tools and Docs
 

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -241,7 +241,7 @@ class QtGridViewButton(QCheckBox):
 
         self.viewer = viewer
         self.setToolTip('Toggle grid view')
-        self.viewer.grid.events.update.connect(self._on_grid_change)
+        self.viewer.grid.events.connect(self._on_grid_change)
         self.stateChanged.connect(self.change_grid)
         self._on_grid_change()
 
@@ -263,7 +263,7 @@ class QtGridViewButton(QCheckBox):
         event : qtpy.QtCore.QEvent
             Event from the Qt context.
         """
-        with self.viewer.grid.events.update.blocker():
+        with self.viewer.grid.events.blocker():
             self.setChecked(not self.viewer.grid.enabled)
 
 

--- a/napari/components/grid.py
+++ b/napari/components/grid.py
@@ -32,7 +32,11 @@ class GridCanvas:
 
         # Events:
         self.events = EmitterGroup(
-            source=self, auto_connect=True, update=None,
+            source=self,
+            auto_connect=True,
+            enabled=None,
+            stride=None,
+            shape=None,
         )
 
         self._enabled = enabled
@@ -47,7 +51,7 @@ class GridCanvas:
     @enabled.setter
     def enabled(self, enabled):
         self._enabled = enabled
-        self.events.update()
+        self.events.enabled()
 
     @property
     def shape(self):
@@ -57,7 +61,7 @@ class GridCanvas:
     @shape.setter
     def shape(self, shape):
         self._shape = tuple(shape)
-        self.events.update()
+        self.events.shape()
 
     @property
     def stride(self):
@@ -67,7 +71,7 @@ class GridCanvas:
     @stride.setter
     def stride(self, stride):
         self._stride = stride
-        self.events.update()
+        self.events.stride()
 
     def actual_shape(self, nlayers=1):
         """Return the actual shape of the grid.

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -87,8 +87,8 @@ class ViewerModel(AddLayersMixin, KeymapHandler, KeymapProvider):
         self._palette = None
         self.theme = 'dark'
 
-        self.grid.events.update.connect(self.reset_view)
-        self.grid.events.update.connect(self._on_grid_change)
+        self.grid.events.connect(self.reset_view)
+        self.grid.events.connect(self._on_grid_change)
         self.dims.events.ndisplay.connect(self._update_layers)
         self.dims.events.ndisplay.connect(self.reset_view)
         self.dims.events.order.connect(self._update_layers)


### PR DESCRIPTION
# Description
This PR standardizes the grid events, which will fix backwards compatibility for #1913

It removes `grid.events.update` and makes events for the individual attributes. `grid.events.update.connect` is functionally now equivalent to `grid.events.connect` as the update event got every time any one of those attributes changed. As we didn't actually release the  `grid.events.update` code no deprecation warning has been provided.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Refactor (non-breaking change which fixes an issue)
