### PR TITLE
Exclude qt 5.15.2

### DIFF
--- a/docs/release/release_0_4_1.md
+++ b/docs/release/release_0_4_1.md
@@ -101,6 +101,7 @@ investigate some crashes that it seemed to be contributing to. See #1905.
 - Bump qtconsole version requirement to fix #1854 (#1855)
 - Update set-env in make_release action (#1897)
 - Fix set-env for bundle build (#1901)
+- Exclude qt 5.12.2 (#1927)
 
 ## 18 authors added to this release (alphabetical)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,11 +69,11 @@ install_requires =
 
 [options.extras_require]
 pyside2 = 
-    PySide2>=5.12.3,!=5.15.0, !=5.15.2
+    PySide2>=5.12.3,!=5.15.0,!=5.15.2
 pyside =  # alias for pyside2
     %(pyside2)s
 pyqt5 = 
-    PyQt5>=5.12.3,!=5.15.0, !=5.15.2
+    PyQt5>=5.12.3,!=5.15.0,!=5.15.2
 pyqt =  # alias for pyqt5
     %(pyqt5)s
 qt =  # alias for pyqt5

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,11 +69,11 @@ install_requires =
 
 [options.extras_require]
 pyside2 = 
-    PySide2>=5.12.3,!=5.15.0
+    PySide2>=5.12.3,!=5.15.0, !=5.15.2
 pyside =  # alias for pyside2
     %(pyside2)s
 pyqt5 = 
-    PyQt5>=5.12.3,!=5.15.0
+    PyQt5>=5.12.3,!=5.15.0, !=5.15.2
 pyqt =  # alias for pyqt5
     %(pyqt5)s
 qt =  # alias for pyqt5


### PR DESCRIPTION
# Description
This PR closes #1925 and #1920 by excluding 5.15.2, which was causing all linux CI tests to fail, particularly a threading related one. We should figure out why `5.15.2` was causing that fail and try and fix, but in mean time we can just exclude as it only came out a couple days ago. Thoughts @Czaki?

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
