### PR TITLE
Fix missing vispy.ext.six

### DIFF
--- a/napari/_vispy/vendored/image.py
+++ b/napari/_vispy/vendored/image.py
@@ -11,7 +11,6 @@ from vispy.color import get_colormap
 from vispy.visuals.shaders import Function, FunctionChain
 from vispy.visuals.transforms import NullTransform
 from vispy.visuals.visual import Visual
-from vispy.ext.six import string_types
 from vispy.io import load_spatial_filters
 
 VERT_SHADER = """
@@ -306,15 +305,11 @@ class ImageVisual(Visual):
 
     @property
     def clim(self):
-        return (
-            self._clim
-            if isinstance(self._clim, string_types)
-            else tuple(self._clim)
-        )
+        return self._clim if isinstance(self._clim, str) else tuple(self._clim)
 
     @clim.setter
     def clim(self, clim):
-        if isinstance(clim, string_types):
+        if isinstance(clim, str):
             if clim != 'auto':
                 raise ValueError('clim must be "auto" if a string')
             self._need_texture_upload = True
@@ -498,7 +493,7 @@ class ImageVisual(Visual):
             # deal with clim on CPU b/c of texture depth limits :(
             # can eventually do this by simulating 32-bit float... maybe
             clim = self._clim
-            if isinstance(clim, string_types) and clim == 'auto':
+            if isinstance(clim, str) and clim == 'auto':
                 clim = np.min(data), np.max(data)
             clim = np.asarray(clim, dtype=np.float32)
             data = data - clim[0]  # not inplace so we don't modify orig data
@@ -509,7 +504,7 @@ class ImageVisual(Visual):
             self._clim = np.array(clim)
         else:
             # assume that RGB data is already scaled (0, 1)
-            if isinstance(self._clim, string_types) and self._clim == 'auto':
+            if isinstance(self._clim, str) and self._clim == 'auto':
                 self._clim = (0, 1)
 
         self._texture_limits = np.array(self._clim)

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -59,7 +59,6 @@ import weakref
 from collections import OrderedDict
 from typing import Any
 
-from vispy.ext.six import string_types
 from vispy.util.logs import _handle_exception, logger
 
 
@@ -380,7 +379,7 @@ class EventEmitter(object):
                     ref = callback.__class__.__name__
             else:
                 ref = None
-        elif not isinstance(ref, string_types):
+        elif not isinstance(ref, str):
             raise TypeError('ref must be a bool or string')
         if ref is not None and ref in self._callback_refs:
             raise ValueError('ref "%s" is not unique' % ref)


### PR DESCRIPTION
# Description
* Change `stringtypes` to `str` in vendored vispy files `image.py` and `volume.py`.

# Details
* Latest vispy master removes `vispy.ext.six` module.
* Our vendored `image.py` and `volume.py` were using that module.
* Latest vispy code uses `str` instead of `string_types`.
    * Six's `string_types` was always just `str` for Python 3.
    * Six is a library for writing code that works unchanged on both Python 2 and 3.
* So this change is safe even if using the older vispy that does have `vispy.ext.six`.

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# References
* See [the definition of stringtypes](https://github.com/benjaminp/six/blob/master/six.py#L36-L53) in the six repo.

# Side Notes
* We black formatted the vendored files. This makes for spurious differences when you compare the files. Makes it harder to notice the true differences. 
* The ideal thing would be to undo the formatting and then make sure it's excluded from formatting going forward. This would have to be done carefully since presumably, we did make some changes that we need to preserve.

# How has this been tested?
- [X] Napari now runs.
