### PR TITLE
Install specific PySide version when building bundle

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -46,7 +46,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install briefcase==0.3.1 tomlkit wheel dmgbuild>=1.4.2
-          python -m pip install -e .[pyside2]
+          python -m pip install PySide2==5.14.2.3
+          python -m pip install -e .
       - name: get tag
         shell: bash
         run: |

--- a/bundle.py
+++ b/bundle.py
@@ -18,7 +18,7 @@ APP = 'napari'
 # PySide2:
 # python bundle.py --add 'PySide2==5.15.0' 'ome-zarr'
 
-EXTRA_REQS = ["pip", "PySide2==5.14.2.2", "scikit-image", "zarr"]
+EXTRA_REQS = ["pip", "PySide2==5.14.2.3", "scikit-image", "zarr"]
 
 
 WINDOWS = os.name == 'nt'

--- a/docs/release/release_0_4_1.md
+++ b/docs/release/release_0_4_1.md
@@ -104,6 +104,7 @@ investigate some crashes that it seemed to be contributing to. See #1905.
 - Fix linux bundle by linking gdbm library 3 to 5 (#1918)
 - Pin Pyside2 5.15.1 for linux CI and bundle build (#1925)
 - Update documentation for the nightly build release (#1932)
+- Install specific PySide version when building bundle (#1936)
 
 ## 18 authors added to this release (alphabetical)
 


### PR DESCRIPTION
# Description

This is an attempt to fix #1865. I haven't really been able to verify it on my Windows partition (see below), but I strongly suspect this will fix things.

During my testing, I first tried to get an editable install of napari by using master and doing `pip install -e .[pyside2]` as in the bundle script (before these changes). This installed PySide2 5.15.2. Then, building the bundle reproduced the error seen by @DragaDoncila in #1865. After a few attempts with git bisect, I went down to 0.4.0, and found that *that* build wasn't working either! **But**, after some help from @DragaDoncila, I realised that I was on 0.4.0, but *my PySide2 was still 5.15.2*, even though we declared `PySide2<5.15` in that version. This is a byproduct of pip not testing for environment consistency. (Which is sometimes a feature, I'll note — not a knock on pip, just something that was unexpected.) So, I uninstalled PySide2, reinstalled it at 5.14.2.3, and presto! I had a working package.

The only problem is that I have since been unable to get a **non-working** package! 😂 I've deleted everything I could think to delete and reinstalled on master, and there's still something around that's causing the bundle to work.

**Update:** As I wrote this, I realised that `git clean -f` does not, in fact, clean everything. 😂 For that, you need `git clean -x`, which includes not just untracked but also *ignored* files such as our resources files.

I'm not sure I'll get a chance to try another clean run tonight but I do now think this should fix the issue — probably an incompatibility between resource files. Indeed, in [this comment](https://github.com/napari/napari/issues/1865#issuecomment-726457805) by @DragaDoncila we see that the resource files have the Qt version embedded in the file name, while in [this comment](https://github.com/napari/napari/issues/1865#issuecomment-726452332) @tlambert03 mentions that he pre-builds the Qt resources — but that presumably uses the PySide2 from the build environment? In which case, unpinning Qt would have caused the Qt resource bundling to fail, and the symptoms experienced by @DragaDoncila and myself.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
