### PR TITLE
Unpin qt version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,16 +60,20 @@ linux_task:
   name: linux ${PY_VER}
 
   container:
-    image: gcc:latest
+    image: ubuntu:latest
 
   env:
     PATH: $HOME/conda/bin:$PATH
+    TZ: America/Los_Angeles
     DISPLAY: ":99"
     CODECOV_TOKEN: ENCRYPTED[be41b51dac12576cfe9889ddd604d1f9db97cee5db0d98f7241fc8d5adf8d23da1135cd67e20b2ecec4005ac03083286]
 
   system_script:
+    - ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
     - apt-get update
     - apt-get install -y libgl1-mesa-glx xvfb libqt5x11extras5 herbstluftwm
+    - apt-get install -y libgl1-mesa-glx xvfb libqt5x11extras5 herbstluftwm curl git gcc
+    - apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0
 
   conda_script:
     - curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > install.sh
@@ -97,9 +101,6 @@ linux_task:
     - python -m pip install --retries 3 --upgrade pip
     - python -m pip install --retries 3 -r requirements/test.txt $PIP_FLAGS
     - python -m pip install --retries 3 pytest-cov codecov
-    # Needed due to failing 5.15.2 on Linux
-    # See https://github.com/napari/napari/pull/1925
-    - python -m pip install --retries 3 PySide2==5.15.1
     - python tools/minreq.py  # no-op if MIN_REQ is not set
     - python -m pip install -e .[pyside2] $PIP_FLAGS
 

--- a/docs/release/release_0_4_1.md
+++ b/docs/release/release_0_4_1.md
@@ -105,6 +105,7 @@ investigate some crashes that it seemed to be contributing to. See #1905.
 - Pin Pyside2 5.15.1 for linux CI and bundle build (#1925)
 - Update documentation for the nightly build release (#1932)
 - Install specific PySide version when building bundle (#1936)
+- Unpin Pyside2 5.15.1 and revert #1925 (#1937)
 
 ## 18 authors added to this release (alphabetical)
 


### PR DESCRIPTION
# Description

Because of this bug
https://bugreports.qt.io/browse/QTBUG-88688

Debian based image cannot be used to test Qt 5.15.2 release. 
A possible option is to switch to the ubuntu based image. This is done in this PR. But this increase build time. 

The possible workaround I to build a custom docker image for this. But then someone needs to maintain it. 

The debug process is hidden in  #1935 which is a register of the brute force approach. 

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
