### PR TITLE
Replace calls to layer.shape in tests

### DIFF
--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -16,7 +16,7 @@ def test_random_image():
     layer = Image(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer.rgb is False
     assert layer.multiscale is False
     assert layer._data_view.shape == shape[-2:]
@@ -31,7 +31,7 @@ def test_negative_image():
     layer = Image(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer.rgb is False
     assert layer._data_view.shape == shape[-2:]
 
@@ -40,7 +40,7 @@ def test_negative_image():
     layer = Image(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer.rgb is False
     assert layer._data_view.shape == shape[-2:]
 
@@ -52,7 +52,7 @@ def test_all_zeros_image():
     layer = Image(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer.rgb is False
     assert layer._data_view.shape == shape[-2:]
 
@@ -65,7 +65,7 @@ def test_integer_image():
     layer = Image(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer.rgb is False
     assert layer._data_view.shape == shape[-2:]
 
@@ -77,7 +77,7 @@ def test_bool_image():
     layer = Image(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer.rgb is False
     assert layer._data_view.shape == shape[-2:]
 
@@ -90,7 +90,7 @@ def test_3D_image():
     layer = Image(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer.rgb is False
     assert layer._data_view.shape == shape[-2:]
 
@@ -103,7 +103,7 @@ def test_3D_image_shape_1():
     layer = Image(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer.rgb is False
     assert layer._data_view.shape == shape[-2:]
 
@@ -116,7 +116,7 @@ def test_4D_image():
     layer = Image(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer.rgb is False
     assert layer._data_view.shape == shape[-2:]
 
@@ -129,7 +129,7 @@ def test_5D_image_shape_1():
     layer = Image(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer.rgb is False
     assert layer._data_view.shape == shape[-2:]
 
@@ -142,7 +142,7 @@ def test_rgb_image():
     layer = Image(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape) - 1
-    assert layer.shape == shape[:-1]
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape[:-1])
     assert layer.rgb is True
     assert layer._data_view.shape == shape[-3:]
 
@@ -155,7 +155,7 @@ def test_rgba_image():
     layer = Image(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape) - 1
-    assert layer.shape == shape[:-1]
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape[:-1])
     assert layer.rgb is True
     assert layer._data_view.shape == shape[-3:]
 
@@ -169,7 +169,7 @@ def test_negative_rgba_image():
     layer = Image(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape) - 1
-    assert layer.shape == shape[:-1]
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape[:-1])
     assert layer.rgb is True
     assert layer._data_view.shape == shape[-3:]
 
@@ -178,7 +178,7 @@ def test_negative_rgba_image():
     layer = Image(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape) - 1
-    assert layer.shape == shape[:-1]
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape[:-1])
     assert layer.rgb is True
     assert layer._data_view.shape == shape[-3:]
 
@@ -191,7 +191,7 @@ def test_non_rgb_image():
     layer = Image(data, rgb=False)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer.rgb is False
     assert layer._data_view.shape == shape[-2:]
 
@@ -218,7 +218,7 @@ def test_changing_image():
     layer.data = data_b
     assert np.all(layer.data == data_b)
     assert layer.ndim == len(shape_b)
-    assert layer.shape == shape_b
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape_b)
     assert layer.rgb is False
     assert layer._data_view.shape == shape_b[-2:]
 
@@ -236,7 +236,7 @@ def test_changing_image_dims():
     layer.data = data_b
     assert np.all(layer.data == data_b)
     assert layer.ndim == len(shape_b)
-    assert layer.shape == shape_b
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape_b)
     assert layer.rgb is False
     assert layer._data_view.shape == shape_b[-2:]
 

--- a/napari/layers/image/_tests/test_multiscale.py
+++ b/napari/layers/image/_tests/test_multiscale.py
@@ -15,7 +15,7 @@ def test_random_multiscale():
     assert layer.data == data
     assert layer.multiscale is True
     assert layer.ndim == len(shapes[0])
-    assert layer.shape == shapes[0]
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shapes[0])
     assert layer.rgb is False
     assert layer._data_view.ndim == 2
 
@@ -29,7 +29,7 @@ def test_infer_multiscale():
     assert layer.data == data
     assert layer.multiscale is True
     assert layer.ndim == len(shapes[0])
-    assert layer.shape == shapes[0]
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shapes[0])
     assert layer.rgb is False
     assert layer._data_view.ndim == 2
 
@@ -43,7 +43,7 @@ def test_infer_tuple_multiscale():
     assert layer.data == data
     assert layer.multiscale is True
     assert layer.ndim == len(shapes[0])
-    assert layer.shape == shapes[0]
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shapes[0])
     assert layer.rgb is False
     assert layer._data_view.ndim == 2
 
@@ -57,7 +57,7 @@ def test_blocking_multiscale():
     assert np.all(layer.data == data)
     assert layer.multiscale is False
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer.rgb is False
     assert layer._data_view.ndim == 2
 
@@ -72,7 +72,7 @@ def test_multiscale_tuple():
     assert layer.data == data
     assert layer.multiscale is True
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer.rgb is False
     assert layer._data_view.ndim == 2
 
@@ -85,7 +85,7 @@ def test_3D_multiscale():
     layer = Image(data, multiscale=True)
     assert layer.data == data
     assert layer.ndim == len(shapes[0])
-    assert layer.shape == shapes[0]
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shapes[0])
     assert layer.rgb is False
     assert layer._data_view.ndim == 2
 
@@ -98,7 +98,7 @@ def test_non_uniform_3D_multiscale():
     layer = Image(data, multiscale=True)
     assert layer.data == data
     assert layer.ndim == len(shapes[0])
-    assert layer.shape == shapes[0]
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shapes[0])
     assert layer.rgb is False
     assert layer._data_view.ndim == 2
 
@@ -111,7 +111,7 @@ def test_rgb_multiscale():
     layer = Image(data, multiscale=True)
     assert layer.data == data
     assert layer.ndim == len(shapes[0]) - 1
-    assert layer.shape == shapes[0][:-1]
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shapes[0][:-1])
     assert layer.rgb is True
     assert layer._data_view.ndim == 3
 
@@ -124,7 +124,7 @@ def test_3D_rgb_multiscale():
     layer = Image(data, multiscale=True)
     assert layer.data == data
     assert layer.ndim == len(shapes[0]) - 1
-    assert layer.shape == shapes[0][:-1]
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shapes[0][:-1])
     assert layer.rgb is True
     assert layer._data_view.ndim == 3
 
@@ -137,7 +137,7 @@ def test_non_rgb_image():
     layer = Image(data, multiscale=True, rgb=False)
     assert layer.data == data
     assert layer.ndim == len(shapes[0])
-    assert layer.shape == shapes[0]
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shapes[0])
     assert layer.rgb is False
 
 

--- a/napari/layers/image/_tests/test_volume.py
+++ b/napari/layers/image/_tests/test_volume.py
@@ -12,7 +12,7 @@ def test_random_volume():
     layer._slice_dims(ndisplay=3)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer._data_view.shape == shape[-3:]
 
 
@@ -24,7 +24,7 @@ def test_switching_displayed_dimensions():
     layer = Image(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
 
     # check displayed data is initially 2D
     assert layer._data_view.shape == shape[-2:]
@@ -41,7 +41,7 @@ def test_switching_displayed_dimensions():
     layer._slice_dims(ndisplay=3)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
 
     # check displayed data is initially 3D
     assert layer._data_view.shape == shape[-3:]
@@ -63,7 +63,7 @@ def test_all_zeros_volume():
     layer._slice_dims(ndisplay=3)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer._data_view.shape == shape[-3:]
 
 
@@ -76,7 +76,7 @@ def test_integer_volume():
     layer._slice_dims(ndisplay=3)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer._data_view.shape == shape[-3:]
 
 
@@ -89,7 +89,7 @@ def test_3D_volume():
     layer._slice_dims(ndisplay=3)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer._data_view.shape == shape[-3:]
 
 
@@ -102,7 +102,7 @@ def test_4D_volume():
     layer._slice_dims(ndisplay=3)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer._data_view.shape == shape[-3:]
 
 
@@ -118,7 +118,7 @@ def test_changing_volume():
     layer.data = data_b
     assert np.all(layer.data == data_b)
     assert layer.ndim == len(shape_b)
-    assert layer.shape == shape_b
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape_b)
     assert layer._data_view.shape == shape_b[-3:]
 
 
@@ -133,7 +133,9 @@ def test_scale():
     layer._slice_dims(ndisplay=3)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == full_shape
+    np.testing.assert_array_equal(
+        layer.extent.world[1] + layer.extent.step, full_shape
+    )
     # Note that the scale appears as the step size in the range
     assert layer._data_view.shape == shape[-3:]
 

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -14,7 +14,7 @@ def test_random_labels():
     layer = Labels(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer._data_view.shape == shape[-2:]
     assert layer.editable is True
 
@@ -26,7 +26,7 @@ def test_all_zeros_labels():
     layer = Labels(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer._data_view.shape == shape[-2:]
 
 
@@ -38,7 +38,7 @@ def test_3D_labels():
     layer = Labels(data)
     assert np.all(layer.data == data)
     assert layer.ndim == len(shape)
-    assert layer.shape == shape
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape)
     assert layer._data_view.shape == shape[-2:]
     assert layer.editable is True
 
@@ -59,7 +59,7 @@ def test_changing_labels():
     layer.data = data_b
     assert np.all(layer.data == data_b)
     assert layer.ndim == len(shape_b)
-    assert layer.shape == shape_b
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape_b)
     assert layer._data_view.shape == shape_b[-2:]
 
 
@@ -75,7 +75,7 @@ def test_changing_labels_dims():
     layer.data = data_b
     assert np.all(layer.data == data_b)
     assert layer.ndim == len(shape_b)
-    assert layer.shape == shape_b
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shape_b)
     assert layer._data_view.shape == shape_b[-2:]
 
 

--- a/napari/layers/labels/_tests/test_labels_pyramid.py
+++ b/napari/layers/labels/_tests/test_labels_pyramid.py
@@ -13,7 +13,7 @@ def test_random_multiscale():
     assert layer.multiscale is True
     assert layer.editable is False
     assert layer.ndim == len(shapes[0])
-    assert layer.shape == shapes[0]
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shapes[0])
     assert layer.rgb is False
     assert layer._data_view.ndim == 2
 
@@ -28,7 +28,7 @@ def test_infer_multiscale():
     assert layer.multiscale is True
     assert layer.editable is False
     assert layer.ndim == len(shapes[0])
-    assert layer.shape == shapes[0]
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shapes[0])
     assert layer.rgb is False
     assert layer._data_view.ndim == 2
 
@@ -43,6 +43,6 @@ def test_3D_multiscale():
     assert layer.multiscale is True
     assert layer.editable is False
     assert layer.ndim == len(shapes[0])
-    assert layer.shape == shapes[0]
+    np.testing.assert_array_equal(layer.extent.data[1] + 1, shapes[0])
     assert layer.rgb is False
     assert layer._data_view.ndim == 2

--- a/napari/layers/surface/_tests/test_surface.py
+++ b/napari/layers/surface/_tests/test_surface.py
@@ -69,7 +69,7 @@ def test_random_3D_timeseries_surface():
     assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data)])
     assert layer._data_view.shape[1] == 2
     assert layer._view_vertex_values.ndim == 1
-    assert layer.shape[0] == 22
+    assert layer.extent.data[1][0] == 22
 
     layer._slice_dims(ndisplay=3)
     assert layer._data_view.shape[1] == 3
@@ -93,8 +93,8 @@ def test_random_3D_multitimeseries_surface():
     assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data)])
     assert layer._data_view.shape[1] == 2
     assert layer._view_vertex_values.ndim == 1
-    assert layer.shape[0] == 16
-    assert layer.shape[1] == 22
+    assert layer.extent.data[1][0] == 16
+    assert layer.extent.data[1][1] == 22
 
     layer._slice_dims(ndisplay=3)
     assert layer._data_view.shape[1] == 3


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
This PR reduces the number of warnings when running the tests by replacing the deprecated calls to `layer.shape`, see https://github.com/napari/napari/issues/1805 and https://github.com/napari/napari/issues/1928.

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [X] all tests pass with my change

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality