### PR TITLE
Register sync_only pytest mark to fix warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,5 +77,7 @@ filterwarnings = [
   "ignore:Accessing zmq Socket:DeprecationWarning:jupyter_client"
 ]
 markers = [
-    "perfmon: marks tests that require perfmon to be enabled"
+    "perfmon: marks tests that require perfmon to be enabled",
+    "sync_only: Test should only be run synchronously"
 ]
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -99,7 +99,3 @@ ignore = E203,W503,E501,C901
 max-line-length = 79
 max-complexity = 18
 exclude = _vendor,vendored,__init__.py,examples,benchmarks,napari/resources/_qt_resources*.py
-
-[pytest]
-markers = 
-    sync_only: Test should only be run synchronously

--- a/setup.cfg
+++ b/setup.cfg
@@ -99,3 +99,7 @@ ignore = E203,W503,E501,C901
 max-line-length = 79
 max-complexity = 18
 exclude = _vendor,vendored,__init__.py,examples,benchmarks,napari/resources/_qt_resources*.py
+
+[pytest]
+markers = 
+    sync_only: Test should only be run synchronously


### PR DESCRIPTION
# Description
* Fix pytest warning about `sync_only`.

## Type of change
- [x] Fix CI warning

# References
* https://docs.pytest.org/en/stable/example/markers.html

# How has this been tested?
- [x] Running tests in CI

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
