### PR TITLE
Fix track labels lookup

### DIFF
--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -57,6 +57,14 @@ def test_track_layer_data():
     assert np.all(layer.data == data)
 
 
+def test_track_layer_data_nonzero_time():
+    """Test data with time not starting at zero."""
+    data = np.zeros((100, 4))
+    data[:, 1] = np.arange(100, 200)
+    layer = Tracks(data)
+    assert np.all(layer.data == data)
+
+
 def test_track_layer_data_flipped():
     """Test data flipped."""
     data = np.zeros((100, 4))

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -57,10 +57,11 @@ def test_track_layer_data():
     assert np.all(layer.data == data)
 
 
-def test_track_layer_data_nonzero_time():
-    """Test data with time not starting at zero."""
+@pytest.mark.parametrize("time", [np.arange(100, 200), np.arange(100, 300, 2)])
+def test_track_layer_data_nonzero_time(time):
+    """Test data with sparse time stamps or not starting at zero."""
     data = np.zeros((100, 4))
-    data[:, 1] = np.arange(100, 200)
+    data[:, 1] = time
     layer = Tracks(data)
     assert np.all(layer.data == data)
 

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -57,11 +57,13 @@ def test_track_layer_data():
     assert np.all(layer.data == data)
 
 
-@pytest.mark.parametrize("time", [np.arange(100, 200), np.arange(100, 300, 2)])
-def test_track_layer_data_nonzero_time(time):
-    """Test data with sparse time stamps or not starting at zero."""
+@pytest.mark.parametrize(
+    "timestamps", [np.arange(100, 200), np.arange(100, 300, 2)]
+)
+def test_track_layer_data_nonzero_starting_time(timestamps):
+    """Test data with sparse timestamps or not starting at zero."""
     data = np.zeros((100, 4))
-    data[:, 1] = time
+    data[:, 1] = timestamps
     layer = Tracks(data)
     assert np.all(layer.data == data)
 

--- a/napari/layers/tracks/_track_utils.py
+++ b/napari/layers/tracks/_track_utils.py
@@ -386,6 +386,9 @@ class TrackManager:
         """ return track labels at the current time """
         # this is the slice into the time ordered points array
         lookup = self._points_lookup[current_time]
+        if lookup is None:
+            return [], []
+
         pos = self._points[lookup, ...]
         lbl = [f'ID:{i}' for i in self._points_id[lookup]]
         return lbl, pos

--- a/napari/layers/tracks/_track_utils.py
+++ b/napari/layers/tracks/_track_utils.py
@@ -124,7 +124,7 @@ class TrackManager:
         # will be an integer - however, the time index does not necessarily
         # need to be an int, and the shader will render correctly.
         frames = list(set(self._points[:, 0].astype(np.uint).tolist()))
-        self._points_lookup = [None] * (max(frames) + 1)
+        self._points_lookup = {}
         for f in frames:
             idx = np.where(self._points[:, 0] == f)[0]
             self._points_lookup[f] = slice(min(idx), max(idx) + 1, 1)
@@ -385,10 +385,10 @@ class TrackManager:
     def track_labels(self, current_time: int) -> tuple:
         """ return track labels at the current time """
         # this is the slice into the time ordered points array
-        lookup = self._points_lookup[current_time]
-        if lookup is None:
+        if current_time not in self._points_lookup:
             return [], []
 
+        lookup = self._points_lookup[current_time]
         pos = self._points[lookup, ...]
         lbl = [f'ID:{i}' for i in self._points_id[lookup]]
         return lbl, pos

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -533,12 +533,11 @@ class Tracks(Layer):
     @property
     def track_labels(self) -> tuple:
         """ return track labels at the current time """
+        labels, positions = self._manager.track_labels(self.current_time)
 
-        # check that current time is still within the frame map
-        if self.current_time < 0 or self.current_time > self._manager.max_time:
-            # need to return a tuple for pos to clear the vispy text visual
+        # if there are no labels, return empty for vispy
+        if not labels:
             return None, (None, None)
 
-        labels, positions = self._manager.track_labels(self.current_time)
         padded_positions = self._pad_display_data(positions)
         return labels, padded_positions


### PR DESCRIPTION
# Description
Bug fix for #1943 . 

The error occured due to the lookup for the track labels, not in the track renderer itself. The fix now returns None if there are no labels in the frame (e.g. track starts at t>0 and the slider is at t=0 etc..). I've added a couple of tests to check that this doesn't happen with sparse data too.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #1943 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] Added new tests for sparse time stamps and non-zero starting time
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have added tests that prove my fix is effective or that my feature works
