### PR TITLE
Speed up adding layer (part of #1945)

### DIFF
--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -174,11 +174,22 @@ class LayerList(EventedList):
         -------
         extent_world : array, shape (2, D)
         """
+        return self._get_extent_world([layer.extent for layer in self])
+
+    def _get_extent_world(self, layer_extent_list):
+        """Extent of layers in world coordinates.
+
+        Default to 2D with (0, 512) min/ max values if no data is present.
+
+        Returns
+        -------
+        extent_world : array, shape (2, D)
+        """
         if len(self) == 0:
             min_v = [np.nan] * self.ndim
             max_v = [np.nan] * self.ndim
         else:
-            extrema = [layer.extent.world for layer in self]
+            extrema = [extent.world for extent in layer_extent_list]
             mins = [e[0][::-1] for e in extrema]
             maxs = [e[1][::-1] for e in extrema]
 
@@ -218,10 +229,13 @@ class LayerList(EventedList):
         -------
         step_size : array, shape (D,)
         """
+        return self._get_step_size([layer.extent for layer in self])
+
+    def _get_step_size(self, layer_extent_list):
         if len(self) == 0:
             return np.ones(self.ndim)
         else:
-            scales = [layer.extent.step[::-1] for layer in self]
+            scales = [extent.step[::-1] for extent in layer_extent_list]
             full_scales = list(
                 np.array(
                     list(itertools.zip_longest(*scales, fillvalue=np.nan))
@@ -233,8 +247,11 @@ class LayerList(EventedList):
     @property
     def extent(self) -> Extent:
         """Extent of layers in data and world coordinates."""
+        extent_list = [layer.extent for layer in self]
         return Extent(
-            data=None, world=self._extent_world, step=self._step_size
+            data=None,
+            world=self._get_extent_world(extent_list),
+            step=self._get_step_size(extent_list),
         )
 
     @property


### PR DESCRIPTION
# Description
This contains some, but not all, of the great work from @Czaki in speeding up adding layers. It has the improvements of where the subplot call is getting make and inside the layer list, but not the context manager or the caching. (It also has a little improvement of not reversing the grid list). I want to see how much better performance is without those two additions which are more complex. I feel like this PR we could merge right away without further discussion and it would already be a big improvement.

What are your thoughts @Czaki? I hope you don't mind that I quickly made this PR based on your work

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)