### PR TITLE
Don't run app bundling in forked repos

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -14,7 +14,7 @@ jobs:
   bundle:
     name: Bundle ${{ matrix.platform }}
     runs-on: ${{ matrix.platform }}
-    # if: github.repository == 'napari/napari'
+    if: github.repository == 'napari/napari'
     env:
       GITHUB_TOKEN: ${{ github.token }}
       DISPLAY: ":99.0"


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

I'm getting notifications about app bundling workflows running on my fork of napari. I think this is happening because I/we forgot to uncomment line 17 of `make_bundle.yml`, which is what restricts the app bundling to only run on the main repo. The cron scheduling is triggering the workflow to run on all forks right now.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Maintenance/CI

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

https://github.community/t/do-not-run-cron-workflows-in-forks/17636/2

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
I don't think there's an easy way to test these kind of CI changes.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
