### PR TITLE
Fix magicgui catching the wrong exception when layer does not exist.

### DIFF
--- a/napari/utils/_magicgui.py
+++ b/napari/utils/_magicgui.py
@@ -156,7 +156,7 @@ def show_layer_result(gui, result: Any, return_type: Type[Layer]) -> None:
                         name = layer_datum[1].get('name')
                         viewer.layers[name].data = layer_datum[0]
                         continue
-                    except KeyError:
+                    except ValueError:
                         pass
                 # otherwise create a new layer from the layer data
                 viewer._add_layer_from_data(*layer_datum)
@@ -170,6 +170,6 @@ def show_layer_result(gui, result: Any, return_type: Type[Layer]) -> None:
     # the simpler behavior where they only return the layer data.
     try:
         viewer.layers[gui.result_name].data = result
-    except KeyError:
+    except ValueError:
         adder = getattr(viewer, f'add_{return_type.__name__.lower()}')
         adder(data=result, name=gui.result_name)


### PR DESCRIPTION
# Description
After update 0.4.1, magicgui fails when checking whether a layers exists already before creating it. It seems that the cause is the update to `LayerList`, which now raises a `ValueError` instead of a `KeyError` when the "result" layer is missing.
This fix seems to be enough, but I'm not sure if these are all the affected places.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
- [x] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
