### PR TITLE
fix evented dataclass for python 3.9

### DIFF
--- a/napari/components/axes.py
+++ b/napari/components/axes.py
@@ -1,10 +1,10 @@
 import numpy as np
 
 from ..utils.colormaps.standardize_color import transform_single_color
-from ..utils.events.dataclass import Property, dataclass
+from ..utils.events.dataclass import Property, evented_dataclass
 
 
-@dataclass(events=True, properties=True)
+@evented_dataclass
 class Axes:
     """Axes indicating world coordinate origin and orientation.
 

--- a/napari/components/cursor.py
+++ b/napari/components/cursor.py
@@ -1,10 +1,10 @@
 from typing import Tuple
 
-from ..utils.events.dataclass import Property, dataclass
+from ..utils.events.dataclass import Property, evented_dataclass
 from ._viewer_constants import CursorStyle
 
 
-@dataclass(events=True, properties=True)
+@evented_dataclass
 class Cursor:
     """Cursor object with position and properties of the cursor.
 

--- a/napari/components/grid.py
+++ b/napari/components/grid.py
@@ -2,10 +2,10 @@ from typing import Tuple
 
 import numpy as np
 
-from ..utils.events.dataclass import Property, dataclass
+from ..utils.events.dataclass import Property, evented_dataclass
 
 
-@dataclass(events=True, properties=True)
+@evented_dataclass
 class GridCanvas:
     """Grid for canvas.
 

--- a/napari/components/scale_bar.py
+++ b/napari/components/scale_bar.py
@@ -1,11 +1,11 @@
 import numpy as np
 
 from ..utils.colormaps.standardize_color import transform_single_color
-from ..utils.events.dataclass import Property, dataclass
+from ..utils.events.dataclass import Property, evented_dataclass
 from ._viewer_constants import Position
 
 
-@dataclass(events=True, properties=True)
+@evented_dataclass
 class ScaleBar:
     """Scale bar indicating size in world coordinates.
 

--- a/napari/utils/events/__init__.py
+++ b/napari/utils/events/__init__.py
@@ -2,11 +2,11 @@ from .event import EmitterGroup, Event, EventEmitter  # isort:skip
 from .containers._evented_list import EventedList
 from .containers._nested_list import NestableEventedList
 from .containers._typed import TypedMutableSequence
-from .dataclass import dataclass
+from .dataclass import evented_dataclass
 from .types import SupportsEvents
 
 __all__ = [
-    'dataclass',
+    'evented_dataclass',
     'EmitterGroup',
     'Event',
     'EventedList',

--- a/napari/utils/events/_tests/test_dataclass.py
+++ b/napari/utils/events/_tests/test_dataclass.py
@@ -9,7 +9,7 @@ from typing_extensions import Annotated
 from napari.layers.base._base_constants import Blending
 from napari.layers.utils._text_constants import Anchor
 from napari.utils.events import EmitterGroup
-from napari.utils.events.dataclass import Property, dataclass
+from napari.utils.events.dataclass import Property, evented_dataclass
 
 
 @pytest.mark.parametrize("props, events", [(1, 1), (0, 1), (0, 0), (1, 0)])
@@ -20,7 +20,7 @@ def test_dataclass_with_properties(props, events):
     and events to make sure they work alone as well as together.
     """
 
-    @dataclass(properties=props, events=events)
+    @evented_dataclass(properties=props, events=events)
     class M:
         """Just a test.
 
@@ -109,7 +109,7 @@ def test_dataclass_with_properties(props, events):
 
 
 def test_dataclass_missing_vars_raises():
-    @dataclass(properties=True)
+    @evented_dataclass(properties=True, events=False)
     class M:
         a: int
         b: list = field(default_factory=list)
@@ -140,7 +140,7 @@ def test_dataclass_missing_vars_raises():
 
 
 def test_dataclass_coerces_types():
-    @dataclass(properties=True)
+    @evented_dataclass(properties=True, events=False)
     class M:
         x: int = 2
         anchor: Annotated[Anchor, str, Anchor] = Anchor.UPPER_LEFT
@@ -171,7 +171,7 @@ def test_Property_validation():
 
 
 def test_exception_resets_value():
-    @dataclass(events=True)
+    @evented_dataclass(events=True, properties=False)
     class M:
         x: int = 2
 
@@ -188,12 +188,12 @@ def test_exception_resets_value():
 def test_event_inheritance():
     """Test that subclasses include events from the superclass."""
 
-    @dataclass(events=True)
+    @evented_dataclass(events=True, properties=False)
     class A:
         a: int = 4
         x: int = 2
 
-    @dataclass(events=True)
+    @evented_dataclass(events=True, properties=False)
     class B(A):
         a: int = 2
         z: int = 4
@@ -210,24 +210,24 @@ def test_event_inheritance():
 def test_event_partial_inheritance():
     """Test events only included from classes decorated with events=True."""
 
-    @dataclass
+    @evented_dataclass(events=False, properties=False)
     class A:
         a: int = 4
         x: int = 2
 
-    @dataclass(events=True)
+    @evented_dataclass(events=True, properties=False)
     class B(A):
         a: int = 2
         z: int = 4
 
     assert set(B().events.emitters) == {'z', 'a'}
 
-    @dataclass(events=True)
+    @evented_dataclass(events=True, properties=False)
     class C:
         a: int = 4
         x: int = 2
 
-    @dataclass
+    @evented_dataclass(events=False, properties=False)
     class D(C):
         a: int = 2
         z: int = 4
@@ -236,7 +236,7 @@ def test_event_partial_inheritance():
 
 
 def test_dataclass_signature():
-    @dataclass(properties=True, events=True)
+    @evented_dataclass(properties=True, events=True)
     class A:
         a: str
         b: int = 2

--- a/napari/utils/events/_tests/test_dataclass.py
+++ b/napari/utils/events/_tests/test_dataclass.py
@@ -151,7 +151,11 @@ def test_dataclass_coerces_types():
     m.anchor = 'center'
     assert isinstance(m._anchor, Anchor)
     assert isinstance(m.anchor, str)
+
     assert isinstance(m.blending, Blending)
+    m.blending = 'additive'
+    assert isinstance(m._blending, Blending)
+    assert m.blending == Blending.ADDITIVE
 
 
 def test_Property_validation():

--- a/napari/utils/events/dataclass.py
+++ b/napari/utils/events/dataclass.py
@@ -321,7 +321,6 @@ def parse_annotated_types(cls: Type,) -> Dict[str, TypeGetSet]:
         if get_origin(typ) is Annotated:
             args = get_args(typ)
             d[: len(args)] = args
-        print('getorigin', name, typ, get_origin(typ), d[1], d[2])
         d[1] = _try_coerce(d[1], name)
         d[2] = _try_coerce(d[2], name)
         out[name] = TypeGetSet(*d)

--- a/napari/utils/events/dataclass.py
+++ b/napari/utils/events/dataclass.py
@@ -322,7 +322,7 @@ def stripped_annotated_types(cls):
 
 
 @tz.curry
-def dataclass(
+def evented_dataclass(
     cls: Type[C],
     *,
     init: bool = True,
@@ -331,14 +331,17 @@ def dataclass(
     order: bool = False,
     unsafe_hash: bool = False,
     frozen: bool = False,
-    events: bool = False,
-    properties: bool = False,
+    events: bool = True,
+    properties: bool = True,
 ) -> Type[C]:
     """Enhanced dataclass decorator with events and property descriptors.
 
     Examines PEP 526 __annotations__ to determine fields.  Fields are defined
     as class attributes with a type annotation.  Everything but ``events`` and
     ``properties`` are defined on the builtin dataclass decorator.
+
+    Note: if ``events==False`` and ``properties==False``, this is functionally
+    equivalent to the builtin ``dataclasses.dataclass``
 
     Parameters
     ----------


### PR DESCRIPTION
fixes #1954  ... and also renames `@dataclass(events=True, properties=True)` to just `@evented_dataclass` (which also makes it less confusing with `dataclasses.dataclass`)

@jni, this all can get simpler (with regard to using private things) if we dispense with the type checking on the usage of `Property`.  Currently, `Property` _must_ be used with two callable arguments in addition to the main type (see tests [here](https://github.com/napari/napari/blob/fa2f947b988d2c5cce772c652e89e7b34184c75f/napari/utils/events/_tests/test_dataclass.py#L157)).  If we are willing lose that type checking, we can simply make `Property = Annotated` ... and we don't need to use any of the `typing` private members.

however, if we want those checks, due to the way that `Annotated` works, it's _really_ hard to do so without actually vendoring a lot of the python `typing` module itself... (not just some stuff from `typing_extensions`).  The main reasons are [these](https://github.com/python/cpython/blob/761c5a1ce477b82cca35a79917c88d72d57ed776/Lib/typing.py#L1481), [`isinstance`](https://github.com/python/cpython/blob/761c5a1ce477b82cca35a79917c88d72d57ed776/Lib/typing.py#L1502), [checks](https://github.com/python/cpython/blob/761c5a1ce477b82cca35a79917c88d72d57ed776/Lib/typing.py#L1452) in typing_extensions (and now in typing itself):  `typing._AnnotatedAlias` is a very special that _must_ be returned by the `__class_getitem__` method of any Type annotation that wants to "seem like" an Annotated type.

All that said, I personally don't mind this that much (including the private attributes).  py 3.9 by adding `typing.Annotated`, was a reasonably big change, and it was to be expected that we'd need to do some tweaks at that point, but it seems unlikely to crop up much (and we can check with each major release).  but, your call: if you want me to remove the `Property` checking I can do so and minimize private usage.. 


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
