### PR TITLE
Refine TypedMutableSequence.__getitem__ error type, add magicgui tests

### DIFF
--- a/napari/utils/_tests/test_magicgui.py
+++ b/napari/utils/_tests/test_magicgui.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import pytest
 
@@ -42,6 +44,7 @@ def test_magicgui_returns_label(make_test_viewer):
     assert isinstance(viewer.layers[0], Image)
 
 
+@pytest.mark.skipif(sys.platform == "darwin", reason="segfault on mac CI")
 def test_magicgui_returns_layer_tuple(make_test_viewer):
     """make sure a magicgui function returning Layer adds the right type."""
 

--- a/napari/utils/_tests/test_magicgui.py
+++ b/napari/utils/_tests/test_magicgui.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pytest
+
+from napari.layers import Image, Labels, Layer, Points
+
+magicgui = pytest.importorskip('magicgui', reason='please install magicgui.')
+
+
+def test_magicgui_returns_image(make_test_viewer):
+    """make sure a magicgui function returning Image adds an Image."""
+
+    @magicgui.magicgui
+    def add_image() -> Image:
+        return np.random.rand(10, 10)
+
+    viewer = make_test_viewer()
+    viewer.window.add_dock_widget(add_image.Gui())
+    assert len(viewer.layers) == 0
+    add_image()  # should add a new layer to the list
+    assert len(viewer.layers) == 1
+    assert viewer.layers[0].name == 'add_image result'
+
+    add_image()  # should just update existing layer on subsequent calls
+    assert len(viewer.layers) == 1
+    assert viewer.layers[0].name == 'add_image result'
+    assert isinstance(viewer.layers[0], Image)
+
+
+def test_magicgui_returns_label(make_test_viewer):
+    """make sure a magicgui function returning Labels adds a Labels."""
+
+    @magicgui.magicgui
+    def add_labels() -> Labels:
+        return np.random.rand(10, 10)
+
+    viewer = make_test_viewer()
+    viewer.window.add_dock_widget(add_labels.Gui())
+    assert len(viewer.layers) == 0
+    add_labels()  # should add a new layer to the list
+    assert len(viewer.layers) == 1
+    assert viewer.layers[0].name == 'add_labels result'
+    assert isinstance(viewer.layers[0], Image)
+
+
+def test_magicgui_returns_layer_tuple(make_test_viewer):
+    """make sure a magicgui function returning Layer adds the right type."""
+
+    @magicgui.magicgui
+    def add_layer() -> Layer:
+        return [(np.random.rand(10, 3), {'size': 20, 'name': 'foo'}, 'points')]
+
+    viewer = make_test_viewer()
+    viewer.window.add_dock_widget(add_layer.Gui())
+    assert len(viewer.layers) == 0
+
+    add_layer()  # should add a new layer to the list
+    assert len(viewer.layers) == 1
+    layer = viewer.layers[0]
+    assert layer.name == 'foo'
+    assert isinstance(layer, Points)
+    assert layer.data.shape == (10, 3)

--- a/napari/utils/events/containers/_typed.py
+++ b/napari/utils/events/containers/_typed.py
@@ -119,7 +119,33 @@ class TypedMutableSequence(MutableSequence[_T]):
         ...  # pragma: no cover
 
     def __getitem__(self, key):  # noqa: F811
-        _key = self.index(key) if type(key) in self._lookup else key
+        """Get an item from the list
+
+        Parameters
+        ----------
+        key : int, slice, or any type in self._lookup
+            The key to get.
+
+        Returns
+        -------
+        The value at `key`
+
+        Raises
+        ------
+        IndexError:
+            If ``type(key)`` is not in ``self._lookup`` (usually an int, like a regular
+            list), and the index is out of range.
+        KeyError:
+            If type(key) is in self._lookup and the key is not in the list (after)
+            applying the self._lookup[key] function to each item in the list
+        """
+        if type(key) in self._lookup:
+            try:
+                _key = self.index(key)
+            except ValueError as e:
+                raise KeyError(str(e)) from e
+        else:
+            _key = key
         result = self._list[_key]
         return self.__newlike__(result) if isinstance(result, list) else result
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,3 +9,4 @@ fsspec
 zarr
 scikit-image
 pooch
+magicgui


### PR DESCRIPTION
closes #1956  (supersedes it ... but thank you @brisvag for catching that very important error!)
This makes the error type of `TypedMutableSequence.__getitem__(key)` a little more refined:
1. If `type(key)` is in the `TypedMutableSequence._lookup` dict provided by the user (such as `str` in our `LayerList`), then if the item corresponding to `key` is not in the list, it raises `KeyError`.
2. If `key` is a regular integer (and `int` is not in `self._lookup` ... which would be strange anyway), it raises `IndexError`
3.  `TypedMutableSequence.index(key)` still raises a `ValueError` if `key` is not in the list.

also added a few basic magicgui tests to catch something like this in the future, and added magicgui to test requirements.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
