### PR TITLE
rename artifact for nightly build releases

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -83,6 +83,6 @@ jobs:
           upload_url: https://uploads.github.com/repos/napari/napari/releases/34273071/assets{?name,label} # nightly build release from https://api.github.com/repos/napari/napari/releases
           release_id: 34273071
           asset_path: napari-${{ env.version }}-${{ runner.os }}.zip
-          asset_name: napari-${{ env.version }}.zip
+          asset_name: napari-${{ runner.os }}.zip
           asset_content_type: application/zip
           max_releases: 1

--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -83,6 +83,6 @@ jobs:
           upload_url: https://uploads.github.com/repos/napari/napari/releases/34273071/assets{?name,label} # nightly build release from https://api.github.com/repos/napari/napari/releases
           release_id: 34273071
           asset_path: napari-${{ env.version }}-${{ runner.os }}.zip
-          asset_name: napari-${{ env.version }}-${{ runner.os }}.zip
+          asset_name: napari-${{ env.version }}.zip
           asset_content_type: application/zip
           max_releases: 1


### PR DESCRIPTION
# Description
rename artifact for nightly build releases, so that they always overwrite the previous one regardless of the version tag

## Type of change
ci change

## Reference
https://github.com/napari/napari/pull/1918

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
