### PR TITLE
async-31: Fix Monitor Feature Toggle

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -742,7 +742,7 @@ class Window:
 
 def _stop_monitor() -> None:
     """Stop the monitor service if configured to use it."""
-    if config.async_octree:
+    if config.monitor:
         from ..components.experimental.monitor import monitor
 
         monitor.stop()

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -831,7 +831,7 @@ def _create_qt_monitor(
     Optional[QtMonitor]
         The new monitor instance, if any
     """
-    if config.async_octree:
+    if config.monitor:
         from .experimental.qt_monitor import QtMonitor
 
         return QtMonitor(parent, camera)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1004,7 +1004,7 @@ def _get_image_class() -> layers.Image:
 
 def _create_remote_commands(layers: LayerList) -> None:
     """Start the monitor service if configured to use it."""
-    if not config.async_octree:
+    if not config.monitor:
         return None
 
     from ..components.experimental.monitor import monitor

--- a/napari/layers/image/experimental/octree_intersection.py
+++ b/napari/layers/image/experimental/octree_intersection.py
@@ -97,6 +97,8 @@ class OctreeIntersection:
             _clamp(span_tiles[1], 0, num_tiles - 1) + 1,
         ]
 
+        # TODO_OCTREE: BUG, range is not empty when it should be?
+
         # int() truncates which is what we want
         span_int = [int(x) for x in clamped]
         return range(*span_int)

--- a/napari/utils/config.py
+++ b/napari/utils/config.py
@@ -49,15 +49,20 @@ Set NAPARI_OCTREE=1 to enable experimental octree visuals. This
 will also turn on async loading, however to configure async
 loading you can set NAPARI_ASYNC to a config file path as above.
 
-Future
-------
-When we're done with octree development we want to return to one single
-image class, with one single type of visual. All of this config complexity
-is temporary.
+Shared Memory Server
+--------------------
+Experimentally, only enable if NAPARI_MON is set to the path of a config
+file. See this PR for more info: https://github.com/napari/napari/pull/1909.
 """
 
+# Async loading with a quadtree/octree.
 async_octree = _set("NAPARI_OCTREE")
+
+# Async loading with regular non-tiled Image class.
 async_loading = _set("NAPARI_ASYNC") or async_octree
+
+# Shared Memory Server
+monitor = _set("NAPARI_MON")
 
 """
 Image Layer Creation


### PR DESCRIPTION
# Description
* Fix bug that monitor was being enabled by `NAPARI_OCTREE`
* It's now correctly enabled only by `NAPARI_MON`
* Added some comments.

# Type
* [x] - Bug fix in regular code where it calls into experimental code.

# Files

<img width="304" alt="Screen Shot 2020-12-02 at 11 17 06 AM" src="https://user-images.githubusercontent.com/4163446/100899583-02181600-3490-11eb-8691-0920c462afe0.png">
