### PR TITLE
octree: fix float64 and check downscale ratio

### DIFF
--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -247,6 +247,10 @@ class TextureAtlas2D(Texture2D):
             The image data for this one tile.
         """
         data = octree_chunk.data
+
+        if data.dtype == np.float64:
+            data = data.astype(np.float32)
+
         assert isinstance(data, np.ndarray)
 
         if not self.spec.is_compatible(data):

--- a/napari/layers/image/experimental/_octree_multiscale_slice.py
+++ b/napari/layers/image/experimental/_octree_multiscale_slice.py
@@ -84,7 +84,14 @@ class OctreeMultiscaleSlice:
         """
         if self._octree is None:
             return None
-        return self._octree.levels[self._octree_level].info
+        try:
+            return self._octree.levels[self._octree_level].info
+        except IndexError:
+            index = self._octree_level
+            count = len(self._octree.levels)
+            raise IndexError(
+                f"Octree level {index} is not in range(0, {count})"
+            )
 
     def get_intersection(self, view: OctreeView) -> OctreeIntersection:
         """Return this view's intersection with the octree.

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -1,5 +1,6 @@
 """Octree class.
 """
+import math
 from typing import List
 
 from ....utils.perf import block_timer
@@ -46,6 +47,8 @@ class Octree:
         self.data = data
         self.slice_config = slice_config
 
+        _check_downscale_ratio(self.data)  # We expect a ratio of 2.
+
         self.levels = [
             OctreeLevel(slice_id, data[i], slice_config, i)
             for i in range(len(data))
@@ -69,7 +72,7 @@ class Octree:
         assert self.levels[-1].info.num_tiles == 1
 
         # This now the total number of levels.
-        self.num_levels = len(data)
+        self.num_levels = len(self.data)
 
     def _get_extra_levels(self) -> List[OctreeLevel]:
         """Compute the extra levels and return them.
@@ -171,3 +174,23 @@ class Octree:
         """Print information about our tiles."""
         for level in self.levels:
             level.print_info()
+
+
+def _check_downscale_ratio(data) -> None:
+    """Report error if downscale ratio is not 2.
+
+    For now we only support downscale ratios of 2. We could support other
+    ratios, but the assumption that each octree level is half the size of
+    the previous one is baked in pretty deeply right now.
+    """
+    if not isinstance(data, list) or len(data) < 2:
+        return  # There aren't even two levels.
+
+    ratio = math.sqrt(data[0].size / data[1].size)
+
+    # Really should be exact, but it will most likely be off by a ton
+    # if its off, so allow a small fudge factor.
+    if not math.isclose(ratio, 2, rel_tol=0.01):
+        raise ValueError(
+            f"Multiscale data has downsampling ratio of {ratio}, expected 2."
+        )

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -177,11 +177,16 @@ class Octree:
 
 
 def _check_downscale_ratio(data) -> None:
-    """Report error if downscale ratio is not 2.
+    """Raise exception if downscale ratio is not 2.
 
     For now we only support downscale ratios of 2. We could support other
     ratios, but the assumption that each octree level is half the size of
     the previous one is baked in pretty deeply right now.
+
+    Raises
+    ------
+    ValueError
+        If downscale ratio is not 2.
     """
     if not isinstance(data, list) or len(data) < 2:
         return  # There aren't even two levels.


### PR DESCRIPTION
# Description
* TextureAtlas2D can now accept `float64` data, it's converted to `float32` just like `Image` did it.
* We now check the "downscale ratio" for incoming mutiscale data:
   * If not 2 we raise `ValueError: Multiscale data has downsampling ratio of 4.0, expected 2.`
   * We could support other ratios, but we don't today.
   * Using a downscale ratio of 2 the entire pyramid is about 1.5 times as big as level 0.
   * That is, it costs you 50% of your original size to have all the other levels.
* Another small fix we needed to check `self.data` not `data`.

## Type of change
- [x] Bug-fix in octree code

# References
* https://github.com/napari/napari/issues/1942

# How has this been tested?
- [x] Manual testing

# Files

<img width="319" alt="Screen Shot 2020-12-02 at 12 29 09 PM" src="https://user-images.githubusercontent.com/4163446/100908877-047f6d80-349a-11eb-8698-cc75fc1d6469.png">
