### PR TITLE
async-32: Faster Octree Rendering

### DIFF
--- a/napari/_qt/experimental/qt_poll.py
+++ b/napari/_qt/experimental/qt_poll.py
@@ -1,0 +1,78 @@
+"""QtPoll class.
+"""
+from qtpy.QtCore import QObject, QTimer
+
+from ...components.camera import Camera
+from ...utils.events import EmitterGroup
+
+POLL_INTERVAL_MS = 16.666  # About 60HZ
+
+
+class QtPoll(QObject):
+    """Polls anything once per frame via an event.
+
+    Created for VispyTiledImageLayer. We poll the visual when the camera
+    moves. But the visuals sometimes load multiple chunks amortized over a
+    number of frames. And it needs to continue to do that, continue
+    loading chunks, even though the mouse is not moving.
+
+    QtPoll will poll those visuals using a timer, until they report they
+    are done and no longer need polling. Then we go quiet, and nothing will
+    be polled until the camera moves again.
+
+    An analogy is a snow globe. The user moving the mouse is shaking up
+    the snow globe. And we need to keep polling/updating things until
+    all the flakes settle down. Then everything will stay 100% still
+    until the mouse is moved again.
+
+    Parameters
+    ----------
+    parent : QObject
+        Parent Qt object.
+    camera : Camera
+        The viewer's main camera.
+    """
+
+    def __init__(self, parent: QObject, camera: Camera):
+        super().__init__(parent)
+
+        self.events = EmitterGroup(source=self, auto_connect=True, poll=None)
+        camera.events.connect(self._on_camera)
+
+        self.timer = QTimer()
+        self.timer.setInterval(POLL_INTERVAL_MS)
+        self.timer.timeout.connect(self._on_timer)
+
+    def _on_camera(self, _event) -> None:
+        """Called when camera view changes at all."""
+        if self.timer.isActive():
+            # Do nothing since the timer is already going. It's possible we
+            # should poll anyway, and risk double poll? But for now let's
+            # let the timer do it until we know more.
+            return
+
+        # Poll right away to kick things off instantly.
+        self._poll()
+
+        # Start the timer so that we keep polling even if the camera
+        # doesn't move again.
+        self.timer.start()
+
+    def _on_timer(self) -> None:
+        """Called when the timer is running."""
+        self._poll()
+
+    def _poll(self) -> None:
+        """Poll everyone listening to our event."""
+        event = self.events.poll()
+
+        if not event.handled:
+            # No one needed polling, so stop the timer, no polling will
+            # happen until the camera moves again.
+            self.timer.stop()
+            return
+
+        # Somone handled the event. They need to be polled even if the
+        # camera stops moving. So start the timer. So they can finish
+        # loading data or animating something.
+        self.timer.start()

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -348,7 +348,7 @@ class QtViewer(QSplitter):
             Layer to be added.
         """
         vispy_layer = create_vispy_visual(layer)
-        self.viewer.camera.events.center.connect(vispy_layer._on_camera_move)
+        self.viewer.camera.events.connect(vispy_layer._on_camera_move)
 
         vispy_layer.node.parent = self.view.scene
         vispy_layer.order = len(self.viewer.layers) - 1

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -352,9 +352,10 @@ class QtViewer(QSplitter):
         """
         vispy_layer = create_vispy_visual(layer)
 
-        # Visuals might need to be polled when the camera moves and during
-        # a short period after the movement stops.
-        self._qt_poll.events.poll.connect(vispy_layer._on_poll)
+        if self._qt_poll is not None:
+            # Visuals might need to be polled when the camera moves and during
+            # a short period after the movement stops.
+            self._qt_poll.events.poll.connect(vispy_layer._on_poll)
 
         vispy_layer.node.parent = self.view.scene
         vispy_layer.order = len(self.viewer.layers) - 1

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -26,6 +26,7 @@ class ChunkStats:
     seen: int = 0
     start: int = 0
     deleted: int = 0
+    remaining: int = 0
     low: int = 0
     created: int = 0
     final: int = 0
@@ -116,9 +117,7 @@ class VispyTiledImageLayer(VispyImageLayer):
         stats.low = self.num_tiles
         stats.deleted = stats.start - stats.low
 
-        if self.layer.track_view:
-            # Add tiles for visible chunks that do not already have a tile.
-            self.node.add_chunks(visible_chunks)
+        stats.remaining = self._add_chunks(visible_chunks)
 
         stats.final = self.num_tiles
         stats.created = stats.final - stats.low
@@ -129,6 +128,45 @@ class VispyTiledImageLayer(VispyImageLayer):
             self.grid.clear()
 
         return stats
+
+    def _add_chunks(self, visible_chunks: List[OctreeChunk]) -> int:
+        """Add some or all of these visible chunks to the tiled image.
+
+        Parameters
+        ----------
+        visible_chunks : List[OctreeChunk]
+            Chunks we should add, if not already in the tiled image.
+
+        Return
+        ------
+        int
+            The number of chunks that still need to be added.
+        """
+        if not self.layer.track_view:
+            # Tracking the view is the normal mode, where the tiles load in as
+            # the view moves. Not tracking the view is only used for debugging
+            # or demos, to show the tiles we "were" showing previously, without
+            # updating them.
+            return 0  # Nothing more to add
+
+        # Add tiles for visible chunks that do not already have a tile.
+        # This might not add all the chunks, because doing so might
+        # tank the framerate.
+        #
+        # Even though the chunks are already in RAM, we have to do some
+        # processing and then we have to move the data to VRAM. That time
+        # cost might not happen here, we probably are just queueing up a
+        # transfer that will happen when we next call glFlush() to let the
+        # card do its business.
+        #
+        # Any chunks not added this frame will have a chance to be
+        # added the next frame, if they are still on the visible_chunks
+        # list next frame. It's important we keep asking the layer for
+        # the visible chunks every frame. We don't want to queue up and
+        # add chunks which might no longer be needed, because the
+        # camera might move every frame. The situation might be
+        # evolving rapidly if the camera is moving a lot.
+        return self.node.add_chunks(visible_chunks)
 
     def _update_tile_shape(self) -> None:
         """Check if the tile shape was changed on us."""
@@ -143,7 +181,21 @@ class VispyTiledImageLayer(VispyImageLayer):
         if self.node.tile_shape != tile_shape:
             self.node.set_tile_shape(tile_shape)
 
-    def _update_view(self):
+    def _update_view(self) -> int:
+        """Update the tiled image based on what's visible in the layer.
+
+        We asked the layer what chunks are visible, then we load some of
+        those chunk, if we don't already have them. We return how many
+        visible chunks, that we don't have, still need to be added.
+
+        If we return non-zero, we expect to drawn again quickly, so that we
+        can add some more chunks.
+
+        Return
+        ------
+        int
+             The number of chunks that still need to be added, in a future frame.
+        """
         if not self.node.visible:
             return
 
@@ -158,6 +210,8 @@ class VispyTiledImageLayer(VispyImageLayer):
                 f"create: {stats.created} delete: {stats.deleted} "
                 f"time: {elapsed.duration_ms:.3f}ms"
             )
+
+        return stats.remaining
 
     def _on_camera_move(self, event=None) -> None:
         """Called on any camera movement.

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -213,13 +213,24 @@ class VispyTiledImageLayer(VispyImageLayer):
 
         return stats.remaining
 
-    def _on_camera_move(self, event=None) -> None:
-        """Called on any camera movement.
+    def _on_poll(self, event=None) -> None:
+        """Called when the camera moves or we otherwise need polling.
 
         Update tiles based on which chunks are currently visible.
         """
-        super()._on_camera_move()
-        self._update_view()
+        super()._on_poll()
+
+        # Mark the event "handled" if we have more chunks to load.
+        #
+        # By saying the poll event was "handled" we're telling QtPoll to
+        # keep polling us, even if the camera stops moving. So that we can
+        # finish up the loads/draws with a potentially still camera.
+        #
+        # We'll be polled until no visuals handle the event, meaning
+        # no visuals need polling. Then all is quiet until the camera
+        # moves again.
+        need_polling = self._update_view() > 0
+        event.handled = need_polling
 
     def _on_loaded(self, _event):
         self._update_view()

--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -152,6 +152,11 @@ class VispyBaseLayer(ABC):
         self._on_blending_change()
         self._on_matrix_change()
 
-    def _on_camera_move(self, event=None):
-        """Camera was moved."""
+    def _on_poll(self, event=None):
+        """Called when camera moves, before we are drawn.
+
+        Optionally called for some period once the camera stops, so the
+        visual can finish up what it was doing, such as loading data into
+        VRAM or animating itself.
+        """
         pass


### PR DESCRIPTION
# Description
* Fix the big hiccup when octree level changes, the pop loading ~40 new tiles in some cases.
* Now loads only 1 chunk/tile into VRAM per frame. So 40 takes a second or two depending on framerate.
* New `QtPoll` object manages a timer to poll even when camera stops moving.
* Timer shuts off when no one needs polling.

The snow globe analogy is moving the mouse/camera shakes up the globe, so we have to poll/update/draw it until everything settles, then it stays off until someone moves the camera again.

# The Bad News
* Still a hiccup the very first time, loading off disk.
* But then it's good you can go in/out many times.
* Need to investigate, there's some non-async part happening.
* Maybe it needs amortizing also...
* But before it was a 2-second hang every single time.

# Demo

![napari-qt-poll-2](https://user-images.githubusercontent.com/4163446/100971052-32999780-3504-11eb-899e-9c5c40447d03.gif)

Notice the console on left printing when the polling stops (prints not checked in). Polling stops when no polled objects signal they need more polling.

# Trace

<img width="902" alt="Screen Shot 2020-12-03 at 12 23 33 AM" src="https://user-images.githubusercontent.com/4163446/100968689-d5034c00-34ff-11eb-923a-de3a1b62ccd8.png">

One load per frame, even if the camera stops moving.

40ms is 25Hz, should be faster but okay for now.

# Future Work

Keep drawing the old tiles until the new ones are loaded. To avoid going to black. I can look at this next. Going to try to do it all in `TiledImageVisual` so the octree doesn't really have to manage it. As discussed in https://github.com/napari/napari/issues/1942#issuecomment-737527373

## Type of change
- [x] New feature in experimental code.

# How has this been tested?
- [x] Manual Testing