### PR TITLE
async-33: Cleanup QtPoll and Tiled Visuals

### DIFF
--- a/napari/_qt/experimental/qt_poll.py
+++ b/napari/_qt/experimental/qt_poll.py
@@ -1,6 +1,9 @@
 """QtPoll class.
+
+Poll visuals or other objects so they can do things even when the
+mouse/camera are not moving. Usually for just a short period of time.
 """
-from qtpy.QtCore import QObject, QTimer
+from qtpy.QtCore import QEvent, QObject, QTimer
 
 from ...components.camera import Camera
 from ...utils.events import EmitterGroup
@@ -11,19 +14,20 @@ POLL_INTERVAL_MS = 16.666  # About 60HZ
 class QtPoll(QObject):
     """Polls anything once per frame via an event.
 
-    Created for VispyTiledImageLayer. We poll the visual when the camera
-    moves. But the visuals sometimes load multiple chunks amortized over a
-    number of frames. And it needs to continue to do that, continue
-    loading chunks, even though the mouse is not moving.
+    QtPoll was first created for VispyTiledImageLayer. It polls the visual
+    when the camera moves. However, we also want visuals to keep loading
+    chunks even when the camera stops. We want the visual to finish up
+    anything that was in progress. Before it goes fully idle.
 
-    QtPoll will poll those visuals using a timer, until they report they
-    are done and no longer need polling. Then we go quiet, and nothing will
-    be polled until the camera moves again.
+    QtPoll will poll those visuals using a timer. If the visual says the
+    event was "handled" it means the visual has more work to do. If that
+    happens, QtPoll will continue to poll and draw the visual it until the
+    visual is done with the in-progress work.
 
-    An analogy is a snow globe. The user moving the mouse is shaking up
-    the snow globe. And we need to keep polling/updating things until
-    all the flakes settle down. Then everything will stay 100% still
-    until the mouse is moved again.
+    An analogy is a snow globe. The user moving the camera shakes up the
+    snow globe. We need to keep polling/drawing things until all the snow
+    settles down. Then everything will stay completely still until the
+    camera is moved again, shaking up the globe once more.
 
     Parameters
     ----------
@@ -45,19 +49,22 @@ class QtPoll(QObject):
 
     def _on_camera(self, _event) -> None:
         """Called when camera view changes at all."""
-        # Poll right away. If the timer is running, it's probably being
-        # starved out by the mouse button being down. If we do double poll
-        # nothing should break, but if we don't poll then everything is
-        # frozen. Poll away.
+        # Poll right away. If the timer is running, it's generally starved
+        # out by the mouse button being down. Not sure why. If we end up
+        # "double polling" it *should* be harmless. However, if we don't
+        # poll then everything is frozen. So better to poll.
         self._poll()
 
-        # Start the timer so that we keep polling even if the camera
-        # doesn't move again. Again if mouse is down the timer is
-        # starved, but we want it running in case the mouse stops.
+        # Start the timer so that we will keep polling even if the camera
+        # doesn't move again. Although the mouse movement is starving out
+        # the timer right now, we need the timer going so we keep polling
+        # even if the mouse stops.
         self.timer.start()
 
     def _on_timer(self) -> None:
         """Called when the timer is running."""
+        # The timer is running which means someone we are polling still has
+        # work to do.
         self._poll()
 
     def _poll(self) -> None:
@@ -65,23 +72,23 @@ class QtPoll(QObject):
         event = self.events.poll()
 
         if not event.handled:
-            # No one needed polling, so stop the timer, no polling will
+            # No one needed polling, so stop the timer. No polling will
             # happen until the camera moves again.
             self.timer.stop()
             return
 
         # Someone handled the event. They need to be polled even if the
-        # camera stops moving. So start the timer. They can finish loading
-        # data or animating something even while the camera is stopped.
+        # camera stops moving. So start the timer. They can finish their
+        # work and continue to be drawn even while the camera is stopped.
         self.timer.start()
 
-    def closeEvent(self, event) -> None:
+    def closeEvent(self, event: QEvent) -> None:
         """Cleanup and close.
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
-            Event from the Qt context.
+        event : QEvent
+            The close event.
         """
         self.timer.stop()
         self.deleteLater()

--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -58,7 +58,7 @@ class AtlasTile(NamedTuple):
     """Information about one specific tile in the atlas.
 
     AtlasTile is returned from TextureAtlas2D.add_tile() so the caller has
-    the texture coordinates to render each tile in the atlas.
+    the verts and texture coordinates to render each tile in the atlas.
     """
 
     index: int

--- a/napari/_vispy/experimental/tile_set.py
+++ b/napari/_vispy/experimental/tile_set.py
@@ -1,4 +1,6 @@
 """TileSet class.
+
+TiledImageVisual uses this to track its tiles.
 """
 from dataclasses import dataclass
 from typing import List

--- a/napari/_vispy/experimental/tile_set.py
+++ b/napari/_vispy/experimental/tile_set.py
@@ -1,20 +1,25 @@
 """TileSet class.
 
-TiledImageVisual uses this to track its tiles.
+TiledImageVisual uses this class to track the tiles its drawing.
 """
-from dataclasses import dataclass
-from typing import Dict, List, Set
+from typing import Dict, List, NamedTuple, Set
 
 from ...layers.image.experimental import OctreeChunk, OctreeChunkKey
 from .texture_atlas import AtlasTile
 
 
-@dataclass
-class TileData:
-    """Tie together the chunk and its tile."""
+class TileData(NamedTuple):
+    """TileSet stores these.
 
-    octree_chunk: OctreeChunk  # The chunk that created the tile.
-    atlas_tile: AtlasTile  # Verts and tex coords for the tile.
+    This class ties together the chunk and the tile that was creates for
+    that chunk.
+    """
+
+    # The chunk that created the tile.
+    octree_chunk: OctreeChunk
+
+    # Verts and tex coords for the tile.
+    atlas_tile: AtlasTile
 
 
 class TileSet:

--- a/napari/_vispy/experimental/tile_set.py
+++ b/napari/_vispy/experimental/tile_set.py
@@ -47,8 +47,10 @@ class TileSet:
 
         Parameters
         ----------
-        tile_data : TileData
-            Add this to the set.
+        octree_chunk : OctreeChunk
+            The chunk we are adding to the tile set.
+        atlas_tile : AtlasTile
+            The atlas tile that was created for this chunks.
         """
         tile_index = atlas_tile.index
         self._tiles[tile_index] = TileData(octree_chunk, atlas_tile)

--- a/napari/_vispy/experimental/tile_set.py
+++ b/napari/_vispy/experimental/tile_set.py
@@ -11,10 +11,10 @@ from .texture_atlas import AtlasTile
 
 @dataclass
 class TileData:
-    """Statistics about chunks during the update process."""
+    """Tie together the chunk and its tile."""
 
-    octree_chunk: OctreeChunk  # The data that produced this tile.
-    atlas_tile: AtlasTile  # Information from the texture atlas.
+    octree_chunk: OctreeChunk  # The chunk that created the tile.
+    atlas_tile: AtlasTile  # Verts and tex coords for the tile.
 
 
 class TileSet:

--- a/napari/_vispy/experimental/tile_set.py
+++ b/napari/_vispy/experimental/tile_set.py
@@ -28,6 +28,13 @@ class TileSet:
     """The tiles we are drawing.
 
     Fast test for membership in both directions: dict and a set.
+
+    Attributes
+    ----------
+    _tiles : Dict[int, TileData]
+        Maps tile_index to the the TileData we have for that tile.
+    _chunks : Set[OctreeChunkKey]
+        The chunks we have in the set, for fast membership tests.
     """
 
     def __init__(self):
@@ -75,23 +82,23 @@ class TileSet:
 
     @property
     def chunks(self) -> List[OctreeChunk]:
-        """Return all the chunk data that we have.
+        """Return all the chunks we are tracking.
 
         Return
         ------
         List[OctreeChunk]
-            All the chunk data in the set.
+            All the chunks in the set.
         """
         return [tile_data.octree_chunk for tile_data in self._tiles.values()]
 
     @property
     def tile_data(self) -> List[TileData]:
-        """Return all the tile data in the set.
+        """Return data for all tiles in the set.
 
         Return
         ------
         List[TileData]
-            All the tile data in the set.
+            Data for all the tiles in the set.
         """
         return self._tiles.values()
 

--- a/napari/_vispy/experimental/tile_set.py
+++ b/napari/_vispy/experimental/tile_set.py
@@ -25,9 +25,24 @@ class TileData(NamedTuple):
 
 
 class TileState:
+    """The state stored for every tile in the TileSet.
+
+    Parameters
+    ----------
+    octree_chunk : OctreeChunk
+        The chunk that produced this tile.
+    atlas_tile : AtlasTile
+        The vert and tex coord information for the tile.
+
+    Attributes
+    ----------
+    stale : bool
+        Stale tiles are going to be replaced soon.
+    """
+
     def __init__(self, octree_chunk: OctreeChunk, atlas_tile: AtlasTile):
-        self.data = TileData(octree_chunk, atlas_tile)
-        self.stale = False
+        self.data: TileData = TileData(octree_chunk, atlas_tile)
+        self.stale: bool = False
 
 
 class TileSet:

--- a/napari/_vispy/experimental/tile_set.py
+++ b/napari/_vispy/experimental/tile_set.py
@@ -1,6 +1,6 @@
 """TileSet class.
 
-TiledImageVisual uses this class to track the tiles its drawing.
+TiledImageVisual uses this class to track the tiles it's drawing.
 """
 from typing import Dict, List, NamedTuple, Set
 
@@ -9,7 +9,7 @@ from .texture_atlas import AtlasTile
 
 
 class TileData(NamedTuple):
-    """TileSet stores one TileState per tile, each one has a TileData.
+    """TileSet stores one TileData per tile.
 
     Attributes
     ----------
@@ -24,27 +24,6 @@ class TileData(NamedTuple):
     atlas_tile: AtlasTile
 
 
-class TileState:
-    """The state stored for every tile in the TileSet.
-
-    Parameters
-    ----------
-    octree_chunk : OctreeChunk
-        The chunk that produced this tile.
-    atlas_tile : AtlasTile
-        The vert and tex coord information for the tile.
-
-    Attributes
-    ----------
-    stale : bool
-        Stale tiles are going to be replaced soon.
-    """
-
-    def __init__(self, octree_chunk: OctreeChunk, atlas_tile: AtlasTile):
-        self.data: TileData = TileData(octree_chunk, atlas_tile)
-        self.stale: bool = False
-
-
 class TileSet:
     """The tiles we are drawing.
 
@@ -52,14 +31,14 @@ class TileSet:
 
     Attributes
     ----------
-    _tiles : Dict[int, TileState]
-        Maps tile_index to the the TileStat we have for that tile.
+    _tiles : Dict[int, TileData]
+        Maps tile_index to the the TileData we have for that tile.
     _chunks : Set[OctreeChunkKey]
         The chunks we have in the set, for fast membership tests.
     """
 
     def __init__(self):
-        self._tiles: Dict[int, TileState] = {}
+        self._tiles: Dict[int, TileData] = {}
         self._chunks: Set[OctreeChunkKey] = set()
 
     def __len__(self) -> int:
@@ -89,28 +68,14 @@ class TileSet:
         """
         tile_index = atlas_tile.index
 
-        self._tiles[tile_index] = TileState(octree_chunk, atlas_tile)
+        self._tiles[tile_index] = TileData(octree_chunk, atlas_tile)
         self._chunks.add(octree_chunk.key)
 
-    def mark_stale(self, tile_index: int) -> None:
-        """Mark this tile as stale.
-
-        Stale means we might continue to draw the tile, but it's expected
-        to be replaced soon. Note with an octree the replacement might be
-        physically smaller or bigger. One tile might be replaced by four
-        smaller tiles. Or four tiles might be replaced by one bigger tile.
-
-        Parameters
-        ----------
-        tile_index : int
-            The tile to mark stale.
-        """
-
     def remove(self, tile_index: int) -> None:
-        """Remove the TileState at this index from the set.
+        """Remove the TileData at this index from the set.
 
         tile_index : int
-            Remove the TileState at this index.
+            Remove the TileData at this index.
         """
         octree_chunk = self._tiles[tile_index].octree_chunk
         self._chunks.remove(octree_chunk.key)
@@ -125,18 +90,16 @@ class TileSet:
         List[OctreeChunk]
             All the chunks in the set.
         """
-        return [
-            tile_state.data.octree_chunk for tile_state in self._tiles.values()
-        ]
+        return [tile_data.octree_chunk for tile_data in self._tiles.values()]
 
     @property
-    def tile_state(self) -> List[TileState]:
-        """Return the state for all tiles in the set.
+    def tile_data(self) -> List[TileData]:
+        """Return the data for all tiles in the set.
 
         Return
         ------
-        List[TileState]
-            State for all the tiles in the set.
+        List[TileData]
+            Data for all the tiles in the set.
         """
         return self._tiles.values()
 

--- a/napari/_vispy/experimental/tile_set.py
+++ b/napari/_vispy/experimental/tile_set.py
@@ -3,9 +3,9 @@
 TiledImageVisual uses this to track its tiles.
 """
 from dataclasses import dataclass
-from typing import List
+from typing import Dict, List, Set
 
-from ...layers.image.experimental import OctreeChunk
+from ...layers.image.experimental import OctreeChunk, OctreeChunkKey
 from .texture_atlas import AtlasTile
 
 
@@ -24,8 +24,8 @@ class TileSet:
     """
 
     def __init__(self):
-        self._tiles = {}
-        self._chunks = set()
+        self._tiles: Dict[int, TileData] = {}
+        self._chunks: Set[OctreeChunkKey] = set()
 
     def __len__(self) -> int:
         """Return the number of tiles in the set.

--- a/napari/_vispy/experimental/tile_set.py
+++ b/napari/_vispy/experimental/tile_set.py
@@ -9,16 +9,18 @@ from .texture_atlas import AtlasTile
 
 
 class TileData(NamedTuple):
-    """TileSet stores these.
+    """TileSet stores one TileData per tile.
 
-    This class ties together the chunk and the tile that was creates for
-    that chunk.
+    Attributes
+    ----------
+    octree_chunk : OctreeChunk
+        The chunk that created the tile.
+
+    atlas_tile : AtlasTile
+        The tile that was created from the chunk.
     """
 
-    # The chunk that created the tile.
     octree_chunk: OctreeChunk
-
-    # Verts and tex coords for the tile.
     atlas_tile: AtlasTile
 
 

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -19,12 +19,12 @@ SHAPE_IN_TILES = (16, 16)
 class TiledImageVisual(ImageVisual):
     """An image that is drawn using one or more "tiles".
 
-    Are regular ImageVisual is a single image drawn as a single rectangle
+    A regular ImageVisual is a single image drawn as a single rectangle
     with a single texture. A tiled TiledImageVisual also has a single
     texture, but that texture is a TextureAtlas2D.
 
     A texture atlas is basically a single texture that contains smaller
-    textures within it, like quilt. In our cases the smaller textures are
+    textures within it, like a quilt. In our cases the smaller textures are
     all the same size, for example (256, 256). For example a 4k x 4k
     texture can hold 256 different (256, 256) tiles.
 
@@ -33,8 +33,8 @@ class TiledImageVisual(ImageVisual):
     the atlas.
 
     The quads can be located anywhere, even in 3D. TiledImageVisual does
-    not know if it's drawn an octree or a grid, or just a scatter of tiles.
-    A key point is while the the textures are all the same size, the quads
+    not know if it's drawing an octree or a grid, or just a scatter of tiles.
+    A key point is while the texture tiles are all the same size, the quads
     can all be different sizes.
 
     For example, one quad might have a (256, 256) texture, but it's
@@ -44,7 +44,7 @@ class TiledImageVisual(ImageVisual):
     multiple levels of the octree at the same time.
 
     Adding or removing tiles from a TiledImageVisual is efficient. Only the
-    bytes in the tile(s) being updated are sent to the card. The Vispy
+    bytes in the the tile(s) being updated are sent to the card. The Vispy
     method BaseTexture.set_data() has an "offset" argument. When setting
     texture data with an offset under the hood Vispy calls
     glTexSubImage2D(). It will only update the rectangular region within
@@ -54,8 +54,8 @@ class TiledImageVisual(ImageVisual):
     In addition, uploading new tiles does not cause the shader to be
     rebuilt. This is another reason TiledImageVisual is faster than
     creating a stand-alone ImageVisuals to draw each tile. Each new
-    ImageVisual results in a shader build today. Although, that could be
-    optimized in the future.
+    ImageVisual results in a shader build today. Although, that's pretty
+    wasteful, and could probably be optimized in the future.
 
     Parameters
     ----------

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -177,6 +177,7 @@ class TiledImageVisual(ImageVisual):
         int
             The number of chunks that still need to be added.
         """
+        # Get the new chunks, ones we are not currently drawing.
         new_chunks = [
             octree_chunk
             for octree_chunk in chunks

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -160,12 +160,12 @@ class TiledImageVisual(ImageVisual):
         return self._tiles.chunks
 
     def add_chunks(self, chunks: List[OctreeChunk]) -> int:
-        """Any any chunks that we are not already drawing.
+        """Any one or more chunks that we are not already drawing.
 
         Parameters
         ----------
         chunks : List[OctreeChunk]
-            Add any of these we are not already drawing.
+            Chunks that we may or may not already be drawing.
 
         Return
         ------
@@ -186,18 +186,17 @@ class TiledImageVisual(ImageVisual):
             # ideally we want to add as many chunks as possible, but
             # without tanking the frame rate.
             #
-            # But recent measurements showed it taking 50ms to add one
-            # 256x256 pixel chunk! So there is only time to add one. Long
-            # term hopefully we set a budget like 10ms, and add as many
-            # chunks as we can without going over that budget.
+            # But recent measurements showed it taking 40ms to add one
+            # 256x256 pixel chunk! So there is only time to add about one.
+            #
+            # Long term hopefully we set a budget like 10ms, and add as
+            # many chunks as we can without going over that budget.
+            # Dynamically monitoring how much we've added.
             break
 
-        # Return how many chunks we did NOT add, so the system knows we
-        # need to be drawn even if there is no movement of anything.
-        #
-        # Essentially we are animating here, animating the transfer of new
-        # chunks into VRAM over time. So that animation should continue
-        # until its done even if the user is doing nothing.
+        # Return how many chunks we did NOT add. So the system knows we
+        # have more chunks to add. So we will get polled and drawn event if
+        # the camera is not moving.
         return len(new_chunks)
 
     def add_one_chunk(self, octree_chunk: OctreeChunk) -> None:

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -187,21 +187,22 @@ class TiledImageVisual(ImageVisual):
             # Add the first one in the list.
             self.add_one_chunk(new_chunks.pop(0))
 
-            # For now break so that we only add ONE chunk per frame. But
-            # ideally we want to add as many chunks as possible, but
-            # without tanking the frame rate.
+            # In the future we might add several chunks here. We want
+            # to add as many as we can without harming the framerate
+            # too much.
             #
-            # But recent measurements showed it taking 40ms to add one
-            # 256x256 pixel chunk! So there is only time to add about one.
+            # For now just add ONE chunk per frame. We've timed (256, 256)
+            # pixel chunks taking a whopping 40ms to load into VRAM!
+            # Probably due to CPU-side processing we are doing. So today
+            # there really is only time to add one.
             #
-            # Long term hopefully we set a budget like 10ms, and add as
-            # many chunks as we can without going over that budget.
-            # Dynamically monitoring how much we've added.
+            # Even if adds were fast, adding just one is not horrible.
+            # The frame rate will stay smooth. But adding more if they
+            # fit within the budget is better.
             break
 
-        # Return how many chunks we did NOT add. So the system knows we
-        # have more chunks to add. So we will get polled and drawn event if
-        # the camera is not moving.
+        # Return how many chunks we did NOT add. So we will get polled and
+        # drawn until all the chunks have been added.
         return len(new_chunks)
 
     def add_one_chunk(self, octree_chunk: OctreeChunk) -> None:
@@ -244,10 +245,10 @@ class TiledImageVisual(ImageVisual):
                 # still draw it, but it's going to soon by replaced by something
                 # newer.
                 #
-                # If we are drawing tiles for an octree, the user is
+                # If we are drawing tiles for an octree, the camera is
                 # probably zooming in or out. We want to keep drawing the
                 # stale tiles until the tiles from the new octree level are
-                # loaded and adding to this visual.
+                # loaded and added to this visual.
                 tile_state.stale = True
 
     def _remove_tile(self, tile_index: int) -> None:

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -230,7 +230,7 @@ class TiledImageVisual(ImageVisual):
         # to include this new chunk.
         self._need_vertex_update = True
 
-    def prune_tiles(self, visible_set: Set[OctreeChunk]) -> None:
+    def mark_tiles_stale(self, visible_set: Set[OctreeChunk]) -> None:
         """Mark tiles as stale if not part of the visible set.
 
         visible_set : Set[OctreeChunk]
@@ -299,7 +299,7 @@ class TiledImageVisual(ImageVisual):
         # Set the base ImageVisual's _subdiv_ buffers. ImageVisual has two
         # modes: imposter and subdivision. So far TiledImageVisual
         # implicitly is always in subdivision mode. Not sure if we'd ever
-        # support imposter, or if that even makes sense with tiles.
+        # support imposter, or if that even makes sense with tiles?
         self._subdiv_position.set_data(verts)
         self._subdiv_texcoord.set_data(tex_coords)
         self._need_vertex_update = False

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -169,7 +169,7 @@ class TiledImageVisual(ImageVisual):
         Return
         ------
         int
-            The number of checks remaining that need to be added.
+            The number of chunks that still need to be added.
         """
         new_chunks = [
             octree_chunk
@@ -179,7 +179,7 @@ class TiledImageVisual(ImageVisual):
 
         while new_chunks:
             # Add the first one in the list.
-            self.add_one_tile(new_chunks.pop(0))
+            self.add_one_chunk(new_chunks.pop(0))
 
             # For now break so that we only add ONE chunk per frame. But
             # ideally we want to add as many chunks as possible, but
@@ -199,13 +199,13 @@ class TiledImageVisual(ImageVisual):
         # until its done even if the user is doing nothing.
         return len(new_chunks)
 
-    def add_one_tile(self, octree_chunk: OctreeChunk) -> None:
-        """Add one tile to the tiled image.
+    def add_one_chunk(self, octree_chunk: OctreeChunk) -> None:
+        """Add one chunk to the tiled image.
 
         Parameters
         ----------
         octree_chunk : OctreeChunk
-            The data for the tile we are adding.
+            The chunk we are adding.
 
         Return
         ------
@@ -233,8 +233,8 @@ class TiledImageVisual(ImageVisual):
             self._tiles.remove(tile_index)
             self._texture_atlas.remove_tile(tile_index)
             self._need_vertex_update = True
-        except IndexError:
-            raise RuntimeError(f"Tile index {tile_index} not found.")
+        except IndexError as exc:
+            raise RuntimeError(f"Tile index {tile_index} not found.") from exc
 
     def prune_tiles(self, visible_set: Set[OctreeChunk]) -> None:
         """Remove tiles that are not part of the given visible set.

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -73,8 +73,9 @@ class TiledImageVisual(ImageVisual):
         # Initialize our parent ImageVisual.
         super().__init__(*args, **kwargs)
 
-        # Must create the texture atlas after calling __init__ so
-        # the attribute self._interpolation exists.
+        # We must create the texture atlas after calling __init__ because
+        # we need to use the attribute self._interpolation which
+        # ImageVisual.__init__ creates.
         self.unfreeze()
         self._texture_atlas = self._create_texture_atlas(tile_shape)
         self.freeze()

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -288,9 +288,9 @@ class TiledImageVisual(ImageVisual):
         verts = np.zeros((0, 2), dtype=np.float32)
         tex_coords = np.zeros((0, 2), dtype=np.float32)
 
-        # TODO_OCTREE: We can probably avoid vstack here if clever,
-        # maybe one one vertex buffer sized according to the max
-        # number of tiles we expect? But grow if needed?
+        # TODO_OCTREE: We can probably avoid vstack here? Maybe one one
+        # vertex buffer sized according to the max number of tiles we
+        # expect? But grow it if we exceed our guess?
         for tile_state in self._tiles.tile_state:
             atlas_tile = tile_state.data.atlas_tile
             verts = np.vstack((verts, atlas_tile.verts))

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -150,7 +150,7 @@ class TiledImageVisual(ImageVisual):
         return self._texture_atlas.num_slots_used
 
     @property
-    def octree_chunk(self) -> List[OctreeChunk]:
+    def octree_chunks(self) -> List[OctreeChunk]:
         """Return data for the chunks we are drawing.
 
         List[OctreeChunk]

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -188,11 +188,13 @@ class VispyTiledImageLayer(VispyImageLayer):
         """Check if the tile shape was changed on us."""
         # This might be overly dynamic, but for now if we see there's a new
         # tile shape we nuke our texture atlas and start over with the new
-        # tile shape.
+        # shape.
         #
-        # We added this because the QtTestImage GUI sets the tile shape
-        # after the layer is created. But the ability might come in handy
-        # and it was not hard to implement.
+        # We added this because the QtTestImage GUI currently set the tile
+        # shape after the layer is created. Thus potentially changing the
+        # same on the fly. But this "on the fly change" might come in handy
+        # and it was not hard to implement, but we could probably drop it
+        # if it becomes a pain.
         tile_shape = self.layer.tile_shape
         if self.node.tile_shape != tile_shape:
             self.node.set_tile_shape(tile_shape)

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -123,7 +123,7 @@ class VispyTiledImageLayer(VispyImageLayer):
         stats.created = stats.final - stats.low
 
         if self.layer.show_grid:
-            self.grid.update_grid(self.node.octree_chunk)
+            self.grid.update_grid(self.node.octree_chunks)
         else:
             self.grid.clear()
 

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -234,9 +234,11 @@ class VispyTiledImageLayer(VispyImageLayer):
         return stats.remaining
 
     def _on_poll(self, event=None) -> None:
-        """Called when the camera moves or we otherwise need polling.
+        """Called before we are drawn.
 
-        Update tiles based on which chunks are currently visible.
+        This is called when the camera moves, or when we have chunks that
+        need to be loaded. We update which tiles we are drawing based on
+        which chunks are currently visible.
         """
         super()._on_poll()
 

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -197,7 +197,7 @@ class VispyTiledImageLayer(VispyImageLayer):
              The number of chunks that still need to be added, in a future frame.
         """
         if not self.node.visible:
-            return
+            return 0
 
         self._update_tile_shape()  # In case the tile shape changed!
 

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -105,7 +105,8 @@ class VispyTiledImageLayer(VispyImageLayer):
         # Get the currently visible chunks from the layer.
         visible_chunks: List[OctreeChunk] = self.layer.visible_chunks
 
-        # Record some stats about this update process.
+        # Record some stats about this update process, where stats.seen are
+        # the number of visible chunks.
         stats = ChunkStats(seen=len(visible_chunks))
 
         # Create the visible set of chunks using their keys.

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -117,8 +117,9 @@ class VispyTiledImageLayer(VispyImageLayer):
         # Then number of tiles we have before the update.
         stats.start = self.num_tiles
 
-        # Remove tiles for chunks which are no longer visible.
-        self.node.prune_tiles(visible_set)
+        # Make tiles as stale if their chunk is no longer visible. However,
+        # stale tiles will still be drawn until replaced by something newer.
+        self.node.mark_tiles_stale(visible_set)
 
         # The low point, after removing but before adding.
         stats.low = self.num_tiles

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -119,7 +119,7 @@ class VispyTiledImageLayer(VispyImageLayer):
 
         # Make tiles as stale if their chunk is no longer visible. However,
         # stale tiles will still be drawn until replaced by something newer.
-        self.node.mark_tiles_stale(visible_set)
+        self.node.prune_tiles(visible_set)
 
         # The low point, after removing but before adding.
         stats.low = self.num_tiles

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -202,17 +202,19 @@ class VispyTiledImageLayer(VispyImageLayer):
     def _update_view(self) -> int:
         """Update the tiled image based on what's visible in the layer.
 
-        We asked the layer what chunks are visible, then we load some of
-        those chunk, if we don't already have them. We return how many
-        visible chunks, that we don't have, still need to be added.
+        We call self._update_chunks() which asks the layer what chunks are
+        visible, then it potentially loads some of those chunk, if we
+        didn't already have them. This returns how many visible chunks,
+        that we don't have, still need to be added.
 
-        If we return non-zero, we expect to drawn again quickly, so that we
-        can add some more chunks.
+        If we return non-zero, we expect to be polled and drawn again,
+        whether or not the camera moves, so we can finish adding the rest
+        of the visible chunks.
 
         Return
         ------
         int
-             The number of chunks that still need to be added, in a future frame.
+             The number of chunks that still need to be added.
         """
         if not self.node.visible:
             return 0
@@ -250,5 +252,6 @@ class VispyTiledImageLayer(VispyImageLayer):
         need_polling = self._update_view() > 0
         event.handled = need_polling
 
-    def _on_loaded(self, _event):
+    def _on_loaded(self, _event) -> None:
+        """The layer loaded new data, so update or view."""
         self._update_view()

--- a/napari/layers/image/experimental/__init__.py
+++ b/napari/layers/image/experimental/__init__.py
@@ -1,6 +1,6 @@
 """layers.image.experimental
 """
-from .octree_chunk import OctreeChunk, OctreeChunkGeom
+from .octree_chunk import OctreeChunk, OctreeChunkGeom, OctreeChunkKey
 from .octree_intersection import OctreeIntersection
 from .octree_level import OctreeLevel
 from .octree_tile_builder import create_multi_scale

--- a/napari/layers/image/experimental/_octree_multiscale_slice.py
+++ b/napari/layers/image/experimental/_octree_multiscale_slice.py
@@ -178,7 +178,19 @@ class OctreeMultiscaleSlice:
         # Return the chunks in this intersection.
         return intersection.get_chunks(id(self))
 
-    def _get_octree_chunk(self, location: OctreeLocation):
+    def _get_octree_chunk(self, location: OctreeLocation) -> OctreeChunk:
+        """Return the OctreeChunk at his location.
+
+        Parameters
+        ----------
+        location : OctreeLocation
+            Return the chunk at this location.
+
+        Return
+        ------
+        OctreeChunk
+            The returned chunk.
+        """
         level = self._octree.levels[location.level_index]
         return level.get_chunk(location.row, location.col)
 
@@ -202,9 +214,10 @@ class OctreeMultiscaleSlice:
 
         octree_chunk = self._get_octree_chunk(location)
         if not isinstance(octree_chunk, OctreeChunk):
-            # This location in the octree is not a OctreeChunk. That's unexpected,
-            # becauase locations are turned into OctreeChunk's when a load
-            # is initiated. So this is an error, but log it and keep going.
+            # This location in the octree does not contain an OctreeChunk.
+            # That's unexpected, becauase locations are turned into
+            # OctreeChunk's when a load is initiated. So this is an error,
+            # but log it and keep going, maybe some transient weirdness.
             LOGGER.error(
                 "on_chunk_loaded: missing OctreeChunk: %s", octree_chunk
             )
@@ -223,8 +236,9 @@ class OctreeMultiscaleSlice:
         # chunk now has an ndarray as its data, and it can be rendered.
         octree_chunk.data = incoming_data
 
-        # OctreeChunk should no longer need to be loaded. We can probably
-        # remove this check eventually, but for now to be sure.
+        # Now needs_load should be false, since this OctreeChunk was
+        # loaded. We can probably remove this check eventually, but for now
+        # to be sure.
         assert not self._get_octree_chunk(location).needs_load
 
         return True  # Chunk was loaded.

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -8,6 +8,8 @@ from ....components.experimental.chunk import ChunkKey
 from ....layers import Layer
 from ....types import ArrayLike
 
+OctreeChunkKey = Tuple[int, int, int]
+
 
 class OctreeChunkGeom(NamedTuple):
     """Position and scale of the chunk, for rendering.
@@ -117,7 +119,7 @@ class OctreeChunk:
         self.loading = False
 
     @property
-    def key(self) -> Tuple[int, int, int]:
+    def key(self) -> OctreeChunkKey:
         """The unique key for this chunk.
 
         TODO_OCTREE: Switch to __hash__? Tried __hash__ a while ago and ran

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -85,7 +85,8 @@ class OctreeLevel:
     ) -> Optional[OctreeChunk]:
         """Return the OctreeChunk at this location if it exists.
 
-        If create is True, an OctreeChunk will be created if one does not exist.
+        If create_chunks is True, an OctreeChunk will be created if one
+        does not exist at this location.
 
         Parameters
         ----------


### PR DESCRIPTION
# Description
* Was going to create "compositing" `TiledImageVisual`
* But just ended up doing clean in `QtPoll` and the visual classes mostly.
* Next PR might look at hang on load, which is annoying, and then soon the multi-level rendering.

The goal is not never to go "blank". If we load the root tile up front, it's only (256, 256) pixels, then at the very worst we can display that. But quite often we should have something only one or two levels off. Which in many case the user will not even notice.

## Type of change
- [x] Cleanup in experimental octree-related code

# Files

<img width="329" alt="Screen Shot 2020-12-04 at 5 33 27 PM" src="https://user-images.githubusercontent.com/4163446/101222105-0d696e00-3657-11eb-94c4-de7519ed968f.png">

# References

Didn't go down the compositing road at all with this PR, but keeps these for future reference.

* [Compositing window manager](https://en.wikipedia.org/wiki/Compositing_window_manager) - Wikipedia
* [Layered Windows, Blending Images](https://docs.microsoft.com/en-us/archive/msdn-magazine/2005/december/c-at-work-layered-windows-blending-images) - MSDN (2005)
* [Windows, UI and Composition](https://mtaulty.com/2015/12/17/m_15996/) - Mike Taulty (2015)
* [Alpha Compositing](https://developer.apple.com/documentation/accelerate/vimage/vimage_operations/alpha_compositing) - Apple
* [Wayland](https://wiki.archlinux.org/index.php/wayland) - archlinux

# How has this been tested?
- [x] Manual Testing