### PR TITLE
fix cursor size

### DIFF
--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -534,6 +534,24 @@ def test_active_layer_status_update():
     assert viewer.status == viewer.active_layer.status
 
 
+def test_active_layer_cursor_size():
+    """Test cursor size update on active layer."""
+    viewer = ViewerModel()
+    np.random.seed(0)
+    viewer.add_image(np.random.random((10, 10)))
+    # Base layer has a default cursor size of 1
+    assert viewer.cursor.size == 1
+
+    viewer.add_labels(np.random.random((10, 10)))
+    assert len(viewer.layers) == 2
+    assert viewer.active_layer == viewer.layers[1]
+
+    viewer.layers[1].mode = 'paint'
+    # Labels layer has a default cursor size of 10
+    # due to paintbrush
+    assert viewer.cursor.size == 10
+
+
 def test_sliced_world_extent():
     """Test world extent after adding layers and slicing."""
     np.random.seed(0)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -411,6 +411,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
             self.status = active_layer.status
             self.help = active_layer.help
             self.cursor.style = active_layer.cursor
+            self.cursor.size = active_layer.cursor_size
             self.interactive = active_layer.interactive
             self.active_layer = active_layer
 

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -186,7 +186,7 @@ class Layer(KeymapProvider, ABC):
         self._status = 'Ready'
         self._help = ''
         self._cursor = 'standard'
-        self._cursor_size = None
+        self._cursor_size = 1
         self._interactive = True
         self._value = None
         self.scale_factor = 1


### PR DESCRIPTION
# Description
Close #1982 by fixing cursor size on init. I'll be honest its not 100% clear to me why this was actually working before, nor why #1955 broke it. This definitely seems like the needed behavior though, and I've added a test to confirm it.

I'm hoping there won't be any other surprise regressions from #1955.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)