### PR TITLE
async-34: Octree Performance

### DIFF
--- a/napari/components/experimental/chunk/_config.py
+++ b/napari/components/experimental/chunk/_config.py
@@ -98,27 +98,37 @@ def _get_config_data() -> dict:
     """
     value = os.getenv("NAPARI_ASYNC")
 
-    if (value in [None, "0"]) and not config.async_octree:
-        # Async is disabled. Note, while async is experimental if
-        # NAPARI_ASYNC and NAPARI_OCTREE are both not set, then actually
-        # this code will not be run. No async related code is even
-        # imported.
-        #
-        # However long term, using DEFAULT_SYNC_CONFIG means the
-        # ChunkLoader is being used, but ChunkLoader.force_synchronous is
-        # set True. Meaning every single load is synchronous.
-        #
-        # Once the feature is not experimental that will probably
-        # be the way to turn async "off". It will still run through
-        # the ChunkLoader, but the loads will be synchronous.
-        return DEFAULT_SYNC_CONFIG
+    # Path to the async config file is one was specified.
+    config_path = value if (value is not None and value != "1") else None
 
-    # Async is enabled with defaults.
-    async_defaults = DEFAULT_ASYNC_CONFIG
-    async_defaults['octree'] = DEFAULT_OCTREE_CONFIG
-    return async_defaults
+    # If NAPARI_ASYNC was set then we are explicilty use async.
+    explicit_async = value not in [None, "0"]
 
-    return _load_config(value)  # Load the user's JSON config file.
+    # If config.async_octree was set, that implies we have to use async.
+    use_async = explicit_async or config.async_octree
+
+    if config_path is not None:
+        return _load_config(config_path)  # Load the user's JSON config file.
+
+    if use_async:
+        # Async is enabled with defaults.
+        async_defaults = DEFAULT_ASYNC_CONFIG
+        async_defaults['octree'] = DEFAULT_OCTREE_CONFIG
+        return async_defaults
+
+    # Async is disabled. Note, while async is experimental if
+    # NAPARI_ASYNC and NAPARI_OCTREE are both not set, then actually
+    # this code will not be run. No async related code is even
+    # imported.
+    #
+    # However long term, using DEFAULT_SYNC_CONFIG means the
+    # ChunkLoader is being used, but ChunkLoader.force_synchronous is
+    # set True. Meaning every single load is synchronous.
+    #
+    # Once the feature is not experimental that will probably
+    # be the way to turn async "off". It will still run through
+    # the ChunkLoader, but the loads will be synchronous.
+    return DEFAULT_SYNC_CONFIG
 
 
 def _create_async_config(data: dict) -> AsyncConfig:
@@ -142,7 +152,7 @@ def _create_async_config(data: dict) -> AsyncConfig:
 
     config = AsyncConfig(
         log_path=data.get("log_path"),
-        force_synchronous=data.get("synchronous", True),
+        force_synchronous=data.get("force_synchronous", True),
         num_workers=data.get("num_workers", 6),
         use_processes=data.get("use_processes", False),
         auto_sync_ms=data.get("auto_sync_ms", 30),

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -350,7 +350,9 @@ class OctreeImage(Image):
     def _on_data_loaded(self, data: ChunkedSliceData, sync: bool) -> None:
         """The given data a was loaded, use it now."""
 
-    def _update_draw(self, scale_factor, corner_pixels, shape_threshold):
+    def _update_draw(
+        self, scale_factor, corner_pixels, shape_threshold
+    ) -> None:
         """Override Layer._update_draw completely.
 
         The base Layer._update_draw does stuff for the legacy multi-scale

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -352,25 +352,18 @@ class OctreeImage(Image):
 
     def _update_draw(self, scale_factor, corner_pixels, shape_threshold):
 
-        # Need refresh if have not been draw at all yet.
-        # TODO_OCTREE: why? do we really?
-        need_refresh = self._view is None
-
         super()._update_draw(scale_factor, corner_pixels, shape_threshold)
 
         # Compute our 2D corners from the incoming n-d corner_pixels
         data_corners = self._transforms[1:].simplified.inverse(corner_pixels)
         corners = data_corners[:, self._dims_displayed]
 
-        # Update our self._view to to catpure the state of things right
+        # Update our self._view to to capture the state of things right
         # before we are drawn. Our self._view will used by our
         # visible_chunks() method.
         self._view = OctreeView(
             corners, shape_threshold, self.freeze_level, self.track_view
         )
-
-        if need_refresh:
-            self.refresh()
 
     def get_intersection(self) -> OctreeIntersection:
         """The the interesection between the current view and the octree.

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -351,9 +351,13 @@ class OctreeImage(Image):
         """The given data a was loaded, use it now."""
 
     def _update_draw(self, scale_factor, corner_pixels, shape_threshold):
+        """Override Layer._update_draw completely.
 
-        super()._update_draw(scale_factor, corner_pixels, shape_threshold)
+        The base Layer._update_draw does stuff for the legacy multi-scale
+        that we don't want. And it calls refresh() which we don't need.
 
+        We create our OctreeView() here which has the corners in it.
+        """
         # Compute our 2D corners from the incoming n-d corner_pixels
         data_corners = self._transforms[1:].simplified.inverse(corner_pixels)
         corners = data_corners[:, self._dims_displayed]

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -357,6 +357,17 @@ class OctreeImage(Image):
         that we don't want. And it calls refresh() which we don't need.
 
         We create our OctreeView() here which has the corners in it.
+
+        Parameters
+        ----------
+        scale_factor : float
+            Scale factor going from canvas to world coordinates.
+        corner_pixels : array
+            Coordinates of the top-left and bottom-right canvas pixels in the
+            world coordinates.
+        shape_threshold : tuple
+            Requested shape of field of view in data coordinates.
+
         """
         # Compute our 2D corners from the incoming n-d corner_pixels
         data_corners = self._transforms[1:].simplified.inverse(corner_pixels)


### PR DESCRIPTION
# Description
* Improve mutli-scale astronaut zarr file test case in #1942
* No longer chain to `Layer._update_draw()`
* Not need for `OctreeImage` and causes refreshes which are slow and not needed.

# Files

* [x] - Bug fixes in experimental code

<img width="346" alt="Screen Shot 2020-12-06 at 4 07 42 PM" src="https://user-images.githubusercontent.com/4163446/101292391-3156bc00-37dd-11eb-81fc-563393970789.png">


# Observations
I'm seeing synchronous hangs over 200ms with (256, 256) tiles. The IO is async, and we are using `TiledImageVisual` so this is unexpected. In the past IO and creating one `ImageVisual` per tile were the two big sources of sync hangs. Those two problems are solved, we think, yet something is causing synchronous hangs here.

One thing I noticed is he uses `float64` I guess it’s just because that’s the numpy default? This results in chunks that are almost 1600kb instead of 200kb if using 1 byte/color. We convert to `float32` inside of `TiledImageVisual` but that’s still 4X bigger than 1 byte per color.

A tiled viewer with its own format would use 1 byte per color here, if that captures the actual amount of underlying information. So we have to figure out can we gracefully handle 8X more data? Or can we reduce the amount of data sooner? Or is something else going on here?

# webmon

I saw the almost 1600kb chunks in webmon and wondered why they were so big. The chunk shape is `(256, 256, 3)` but the type is `float64` so 8 bytes/color. So `256 * 256 * 3 * 8` = `1,572,864 bytes` which is what's in the graph:

<img width="367" alt="Screen Shot 2020-12-06 at 2 22 27 PM" src="https://user-images.githubusercontent.com/4163446/101290165-817a5200-37ce-11eb-9523-80c1900218d6.png">

# Trace

In the trace below the top is `uint8`, the bottom is the original `float64` that the code in #1942 produces.

It's `float64` because `skimage.transform.pyramid_gaussian` converts the `uint8` astronaut image to `float64`. For the top case I converted it back to `uint8` while creating the zarr file:

        for i, layer in enumerate(pyramid):
            layer = (255 * layer).astype(np.uint8)

You can see the loads take over 3X for `float64`. It's 8X more data but it makes sense it wouldn't take 8X longer. But this is all async, it shouldn't image the frame rate. But you can see the framerate chugs in both cases.

<img width="1223" alt="Screen Shot 2020-12-06 at 3 26 02 PM" src="https://user-images.githubusercontent.com/4163446/101291520-6c55f100-37d7-11eb-8ee8-59bc921bbc3d.png">

The slow frame for `uint8` here was 177ms and for `float64` it was 275ms. So `float64` makes it worse. But the goal is in both cases no frame takes more than around 30-50ms. Since we are just loading one tile per frame. So it's unclear what's creating the hiccup right now. Need to look closer.

<img width="1191" alt="Screen Shot 2020-12-06 at 3 31 35 PM" src="https://user-images.githubusercontent.com/4163446/101291631-41b86800-37d8-11eb-9d85-aa063dff5378.png">

# Slow Frame

This is the slow frame with `uint8` so it's doing a shader build? Or why is it so slow? I assume `TiledImageVisual` does have to do one shader build at some point. But you'd think that would be super early. And there are multiple slow frames here. Is `TiledImageVisual` periodically rebuilding the shared? The intent of `TiledImageVisual` is that we can add/remove tiles without rebuilding the shader. That's a big reason it's supposed to be faster than multiple `ImageVisuals`.

<img width="948" alt="Screen Shot 2020-12-06 at 3 39 19 PM" src="https://user-images.githubusercontent.com/4163446/101291776-40d40600-37d9-11eb-95ab-b37632a2669e.png">

I don't think`Layer.refresh` or `VispyImageLayer._on_data_change` or `VispyImageLayer._on_display` change need to be called for `OctreeImage` layers. I think that leads to all sorts of weird stuff. I think it even creates a new `OctreeMultiscaleSlice`. I think maybe this is just legacy `Image` stuff we need to bypass when using `OctreeImage`. I'll. have to try some things.
