### PR TITLE
async-35: OctreeDisplayOptions

### DIFF
--- a/napari/_qt/experimental/qt_poll.py
+++ b/napari/_qt/experimental/qt_poll.py
@@ -82,7 +82,7 @@ class QtPoll(QObject):
         # work and continue to be drawn even while the camera is stopped.
         self.timer.start()
 
-    def closeEvent(self, event: QEvent) -> None:
+    def closeEvent(self, _event: QEvent) -> None:
         """Cleanup and close.
 
         Parameters

--- a/napari/_qt/experimental/render/qt_octree_info.py
+++ b/napari/_qt/experimental/render/qt_octree_info.py
@@ -89,10 +89,10 @@ class QtOctreeInfoLayout(QVBoxLayout):
 
         def on_set_level(value: int) -> None:
             if value == 0:  # This is AUTO
-                self.layer.freeze_level = False
+                self.layer.display.freeze_level = False
             else:
                 level = value - 1  # Account for AUTO at 0
-                self.layer.freeze_level = True
+                self.layer.display.freeze_level = True
                 self.layer.octree_level = level
 
         def on_set_delay(_value: int) -> None:
@@ -155,7 +155,7 @@ class QtOctreeInfoLayout(QVBoxLayout):
             Set controls based on this layer.
         """
         self.level.set_value(
-            "AUTO" if not layer.freeze_level else layer.octree_level
+            "AUTO" if not layer.display.freeze_level else layer.octree_level
         )
         self.table.set_values(_get_table_values(layer))
 
@@ -176,7 +176,10 @@ class QtOctreeInfo(QFrame):
 
         # Initial update and connect for future updates.
         self._update()  # initial update
-        layer.events.freeze_level.connect(self._update)
+
+        # removing this event...
+        # layer.events.freeze_level.connect(self._update)
+
         layer.events.octree_level.connect(self._update)
         layer.events.tile_size.connect(self._update)
 

--- a/napari/_qt/experimental/render/qt_octree_info.py
+++ b/napari/_qt/experimental/render/qt_octree_info.py
@@ -101,14 +101,16 @@ class QtOctreeInfoLayout(QVBoxLayout):
             self.layer.delay_ms = NormalNoise(mean, std_dev)
 
         def on_set_track(value: int):
-            self.layer.track_view = value != 0
+            self.layer.display.track_view = value != 0
 
         # Toggle the ChunkCache.
         cache_enabled = chunk_loader.cache.enabled
         self._create_checkbox("Chunk Cache", cache_enabled, on_set_cache)
 
         # Toggle tracking: drawn tiles track view as it moves.
-        self._create_checkbox("Track View", layer.track_view, on_set_track)
+        self._create_checkbox(
+            "Track View", layer.display.track_view, on_set_track
+        )
 
         # Toggle debug grid drawn around tiles.
         self._create_checkbox("Show Grid", layer.show_grid, on_set_grid)

--- a/napari/_qt/experimental/render/qt_octree_info.py
+++ b/napari/_qt/experimental/render/qt_octree_info.py
@@ -85,7 +85,7 @@ class QtOctreeInfoLayout(QVBoxLayout):
             chunk_loader.cache.enabled = value != 0
 
         def on_set_grid(value: int) -> None:
-            self.layer.show_grid = value != 0
+            self.layer.display.show_grid = value != 0
 
         def on_set_level(value: int) -> None:
             if value == 0:  # This is AUTO
@@ -113,7 +113,9 @@ class QtOctreeInfoLayout(QVBoxLayout):
         )
 
         # Toggle debug grid drawn around tiles.
-        self._create_checkbox("Show Grid", layer.show_grid, on_set_grid)
+        self._create_checkbox(
+            "Show Grid", layer.display.show_grid, on_set_grid
+        )
 
         num_levels = layer.num_octree_levels
 

--- a/napari/_qt/experimental/render/qt_octree_info.py
+++ b/napari/_qt/experimental/render/qt_octree_info.py
@@ -6,7 +6,7 @@ import numpy as np
 from qtpy.QtWidgets import QCheckBox, QFrame, QVBoxLayout
 
 from ....components.experimental import chunk_loader
-from ....layers.image.experimental.octree_image import NormalNoise, OctreeImage
+from ....layers.image.experimental.octree_image import OctreeImage
 from .qt_render_widgets import QtLabeledComboBox, QtSimpleTable
 
 
@@ -34,32 +34,6 @@ def _get_table_values(layer: OctreeImage) -> dict:
         "Tile Shape": _shape([layer.tile_size, layer.tile_size]),
         "Layer Shape": _shape(level_info.image_shape),
     }
-
-
-def _create_mean_combo(on_set) -> QtLabeledComboBox:
-    """Return combo box for the mean noise setting.
-
-    Return
-    ------
-    QtLabeledComboBox
-        The new combo box.
-    """
-    options = {str(x): x for x in [0, 10, 20, 50, 100, 200, 500, 1000]}
-    return QtLabeledComboBox("Mean Delay (ms)", options, on_set)
-
-
-def _create_std_dev_combo(on_set) -> QtLabeledComboBox:
-    """Return combo box for the std dev noise setting.
-
-    Return
-    ------
-    QtLabeledComboBox
-        The new combo box.
-    """
-    options = {
-        str(x): x for x in [0, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000]
-    }
-    return QtLabeledComboBox("Std Dev (ms)", options, on_set)
 
 
 class QtOctreeInfoLayout(QVBoxLayout):
@@ -95,11 +69,6 @@ class QtOctreeInfoLayout(QVBoxLayout):
                 self.layer.display.freeze_level = True
                 self.layer.octree_level = level
 
-        def on_set_delay(_value: int) -> None:
-            mean = self.mean_combo.get_value()
-            std_dev = self.std_dev_combo.get_value()
-            self.layer.delay_ms = NormalNoise(mean, std_dev)
-
         def on_set_track(value: int):
             self.layer.display.track_view = value != 0
 
@@ -129,12 +98,6 @@ class QtOctreeInfoLayout(QVBoxLayout):
             "Octree Level", level_options, on_set_level
         )
         self.addWidget(self.level)
-
-        # Delay for debugging (simulates latency).
-        self.mean_combo = _create_mean_combo(on_set_delay)
-        self.addWidget(self.mean_combo)
-        self.std_dev_combo = _create_std_dev_combo(on_set_delay)
-        self.addWidget(self.std_dev_combo)
 
         # Show some keys and values about the octree.
         self.table = QtSimpleTable()

--- a/napari/_qt/experimental/render/qt_octree_info.py
+++ b/napari/_qt/experimental/render/qt_octree_info.py
@@ -29,7 +29,7 @@ def _get_table_values(layer: OctreeImage) -> dict:
     num_tiles = shape_in_tiles[0] * shape_in_tiles[1]
 
     return {
-        "Level": f"{layer.octree_level}",
+        "Level": f"{layer.data_level}",
         "Tiles": f"{_shape(shape_in_tiles)} = {num_tiles}",
         "Tile Shape": _shape([layer.tile_size, layer.tile_size]),
         "Layer Shape": _shape(level_info.image_shape),

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -139,7 +139,7 @@ class VispyTiledImageLayer(VispyImageLayer):
 
         # The grid is only for debugging and demos, yet it's quite useful
         # otherwise the tiles are kind of invisible.
-        if self.layer.show_grid:
+        if self.layer.display.show_grid:
             self.grid.update_grid(self.node.octree_chunks)
         else:
             self.grid.clear()

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -159,7 +159,7 @@ class VispyTiledImageLayer(VispyImageLayer):
         int
             The number of chunks that still need to be added.
         """
-        if not self.layer.track_view:
+        if not self.layer.display.track_view:
             # Tracking the view is the normal mode, where the tiles load in as
             # the view moves. Not tracking the view is only used for debugging
             # or demos, to show the tiles we "were" showing previously, without

--- a/napari/components/experimental/chunk/_info.py
+++ b/napari/components/experimental/chunk/_info.py
@@ -16,6 +16,8 @@ LOGGER = logging.getLogger("napari.async")
 
 
 class LoadCounts:
+    """Count statistics about loaded chunks."""
+
     def __init__(self):
         self.loads: int = 0
         self.chunks: int = 0
@@ -35,9 +37,8 @@ def _get_type_str(data) -> str:
     if data_type == list:
         if len(data) == 0:
             return "EMPTY"
-        else:
-            # Recursively get the type string of the zeroth level.
-            return _get_type_str(data[0])
+        # Recursively get the type string of the zeroth level.
+        return _get_type_str(data[0])
 
     if data_type == da.Array:
         # Special case this because otherwise data_type.__name__

--- a/napari/components/experimental/remote_commands.py
+++ b/napari/components/experimental/remote_commands.py
@@ -53,7 +53,7 @@ class RemoteCommands:
         """
         for layer in self.layers.selected:
             if isinstance(layer, OctreeImage):
-                layer.show_grid = show
+                layer.display.show_grid = show
 
     def _process_command(self, event):
         """Process this one command from the remote client.

--- a/napari/layers/image/experimental/_octree_multiscale_slice.py
+++ b/napari/layers/image/experimental/_octree_multiscale_slice.py
@@ -84,14 +84,15 @@ class OctreeMultiscaleSlice:
         """
         if self._octree is None:
             return None
+
         try:
             return self._octree.levels[self._octree_level].info
-        except IndexError:
+        except IndexError as exc:
             index = self._octree_level
             count = len(self._octree.levels)
             raise IndexError(
                 f"Octree level {index} is not in range(0, {count})"
-            )
+            ) from exc
 
     def get_intersection(self, view: OctreeView) -> OctreeIntersection:
         """Return this view's intersection with the octree.

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -81,10 +81,6 @@ class OctreeImage(Image):
         """
         return True
 
-    @property
-    def _empty(self) -> bool:
-        return False  # TODO_OCTREE: what here?
-
     def _update_thumbnail(self):
         # TODO_OCTREE: replace Image._update_thumbnail with nothing for
         # the moment until we decide how to do thumbnail.

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -1,4 +1,17 @@
 """OctreeImage class.
+
+OctreeImage is meant to eventually replace the existing Image class. The
+original Image class handled single-scale and multi-scale images, but they
+were handled quite differently. And the multi-scale did not use chunks or
+tiles.
+
+OctreeImage always uses chunk/tiles. Today those tiles are always small.
+However as a special case if an image is smaller than the max texture size,
+we could allow OctreeImage to set its tile size equal to that image size.
+
+At that point small images are single-tile single-level OctreeImages, which
+should be as efficient as single-scale images are today. And larger images
+have multiple-levels and multiple-tiles.
 """
 import logging
 from typing import List

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -2,16 +2,18 @@
 
 OctreeImage is meant to eventually replace the existing Image class. The
 original Image class handled single-scale and multi-scale images, but they
-were handled quite differently. And the multi-scale did not use chunks or
+were handled quite differently. And its multi-scale did not use chunks or
 tiles.
 
-OctreeImage always uses chunk/tiles. Today those tiles are always small.
+OctreeImage always uses chunk/tiles. Today those tiles are always "small".
 However as a special case if an image is smaller than the max texture size,
-we could allow OctreeImage to set its tile size equal to that image size.
+we could some day allow OctreeImage to set its tile size equal to that
+image size.
 
 At that point small images are single-tile single-level OctreeImages, which
-should be as efficient as single-scale images are today. And larger images
-have multiple-levels and multiple-tiles.
+should be as efficient as single-scale images are today.  And larger images
+have multiple-levels and multiple-tiles. So we can use one class and one
+code path for all images.
 """
 import logging
 from typing import List

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -1,16 +1,11 @@
 """OctreeImage class.
 """
 import logging
-from dataclasses import dataclass
 from typing import List
 
 import numpy as np
 
-from ....components.experimental.chunk import (
-    ChunkRequest,
-    async_config,
-    chunk_loader,
-)
+from ....components.experimental.chunk import ChunkRequest, chunk_loader
 from ....utils.events import Event
 from ..image import Image
 from ._chunked_slice_data import ChunkedSliceData
@@ -18,31 +13,9 @@ from ._octree_multiscale_slice import OctreeMultiscaleSlice, OctreeView
 from .octree_chunk import OctreeChunk, OctreeChunkKey
 from .octree_intersection import OctreeIntersection
 from .octree_level import OctreeLevelInfo
-from .octree_util import NormalNoise, SliceConfig
+from .octree_util import NormalNoise, OctreeDisplayOptions, SliceConfig
 
 LOGGER = logging.getLogger("napari.async.octree")
-
-
-@dataclass
-class OctreeDisplayOptions:
-    """Options for how to display the octree.
-
-    Attributes
-    -----------
-    tile_size : int
-        The size of the display tiles, for example 256.
-    freeze_level : bool
-        If True we do not automatically pick the right data level.
-    track_view : bool
-        If True the displayed tiles track the view, the normal mode.
-    show_grid : bool
-        If True draw a grid around the tiles for debugging or demos.
-    """
-
-    tile_size: int = async_config.octree.tile_size
-    freeze_level: bool = False
-    track_view: bool = True
-    show_grid: bool = True
 
 
 class OctreeImage(Image):
@@ -121,26 +94,9 @@ class OctreeImage(Image):
         return np.zeros((64, 64, 3))  # fake: does octree need this?
 
     @property
-    def track_view(self) -> bool:
-        """Return True if we changing what's dispays as the view changes.
-
-        Return
-        ------
-        bool
-            True if we are tracking the current view.
-        """
-        return self._display.track_view
-
-    @track_view.setter
-    def track_view(self, value: bool) -> None:
-        """Set whether we are tracking the current view.
-
-        Parameters
-        ----------
-        value : bool
-            True if we should track the current view.
-        """
-        self._display.track_view = value
+    def display(self) -> OctreeDisplayOptions:
+        """The display options for this octree image layer."""
+        return self._display
 
     @property
     def tile_size(self) -> int:
@@ -405,9 +361,7 @@ class OctreeImage(Image):
         # Update our self._view to to catpure the state of things right
         # before we are drawn. Our self._view will used by our
         # visible_chunks() method.
-        self._view = OctreeView(
-            corners, shape_threshold, self.freeze_level, self.track_view
-        )
+        self._view = OctreeView(corners, shape_threshold, self.display)
 
         if need_refresh:
             self.refresh()

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -1,19 +1,4 @@
 """OctreeImage class.
-
-OctreeImage is meant to eventually replace the existing Image class. The
-original Image class handled single-scale and multi-scale images, but they
-were handled quite differently. And its multi-scale did not use chunks or
-tiles.
-
-OctreeImage always uses chunk/tiles. Today those tiles are always "small".
-However as a special case if an image is smaller than the max texture size,
-we could some day allow OctreeImage to set its tile size equal to that
-image size.
-
-At that point small images are single-tile single-level OctreeImages, which
-should be as efficient as single-scale images are today.  And larger images
-have multiple-levels and multiple-tiles. So we can use one class and one
-code path for all images.
 """
 import logging
 from typing import List
@@ -40,9 +25,28 @@ LOGGER = logging.getLogger("napari.async.octree")
 class OctreeImage(Image):
     """OctreeImage layer.
 
-    Experimental variant of Image that renders using an Octree.
+    Experimental variant of Image that renders using an octree. For 2D
+    images the octree is really just a quadtree. For 3D volumes it will be
+    a real octree. This class is intended to eventually fully replace the
+    existing Image class.
 
-    Intended to eventually replace Image.
+    Background
+    ----------
+    OctreeImage is meant to eventually replace the existing Image class. The
+    original Image class handled single-scale and multi-scale images, but they
+    were handled quite differently. And its multi-scale did not use chunks or
+    tiles.
+
+    OctreeImage always uses chunk/tiles. Today those tiles are always
+    "small". However, as a special case, if an image is smaller than the
+    max texture size, we could some day allow OctreeImage to set its tile
+    size equal to that image size.
+
+    At that point "small" images would be single-tile single-level
+    OctreeImages. Therefore they should be as as efficient as the original
+    Image's single-scale images. But larger images would have
+    multiple-tiles and multiple-levels. The goal is to have one class and
+    one code path for all types of images.
     """
 
     def __init__(self, *args, **kwargs):

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -8,7 +8,6 @@ import numpy as np
 from ....components.experimental.chunk import ChunkRequest, chunk_loader
 from ....utils.events import Event
 from ..image import Image
-from ._chunked_slice_data import ChunkedSliceData
 from ._octree_multiscale_slice import OctreeMultiscaleSlice, OctreeView
 from .octree_chunk import OctreeChunk, OctreeChunkKey
 from .octree_intersection import OctreeIntersection
@@ -320,9 +319,6 @@ class OctreeImage(Image):
         # and we will draw it this frame.
         octree_chunk.data = satisfied_request.chunks.get('data')
         return True
-
-    def _on_data_loaded(self, data: ChunkedSliceData, sync: bool) -> None:
-        """The given data a was loaded, use it now."""
 
     def _update_draw(self, scale_factor, corner_pixels, shape_threshold):
 

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -436,6 +436,7 @@ class OctreeImage(Image):
         request : ChunkRequest
             This request was loaded.
         """
+        # Pass it to the slice, it will insert the newly loaded data into
+        # the OctreeChunk at the right location.
         if self._slice.on_chunk_loaded(request):
-            # Tell the visual to redraw with this new chunk.
-            self.events.loaded()
+            self.events.loaded()  # Redraw with teh new chunk.

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -81,6 +81,15 @@ class OctreeImage(Image):
         """
         return True
 
+    @property
+    def _empty(self) -> bool:
+        """Is this layer completely empty so it can't be drawn.
+
+        As with self.loaded, we are never really empty. Our VispyTiledImageLayer
+        can always be drawn. Even if there is nothing to draw.
+        """
+        return False
+
     def _update_thumbnail(self):
         # TODO_OCTREE: replace Image._update_thumbnail with nothing for
         # the moment until we decide how to do thumbnail.

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -73,9 +73,13 @@ class OctreeImage(Image):
         return (0, (0, 0))  # Fake for now until have octree version.
 
     @property
-    def loaded(self):
-        """Has the data for this layer been loaded yet."""
-        # TODO_OCTREE: what here?
+    def loaded(self) -> bool:
+        """Has the data for this layer been loaded yet.
+
+        As far as the visual system is concerned we are always "loaded" in
+        that we can always be drawn. Because our VispyTiledImageLayer can
+        always be drawn. Even if no chunk/tiles are loaded yet.
+        """
         return True
 
     @property

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -64,13 +64,11 @@ class OctreeImage(Image):
         self._delay_ms = NormalNoise()
 
         super().__init__(*args, **kwargs)
-        self.events.add(
-            freeze_level=Event, octree_level=Event, tile_size=Event
-        )
+        self.events.add(octree_level=Event, tile_size=Event)
 
     def _get_value(self):
         """Override Image._get_value()."""
-        return (0, (0, 0))  # Fake for now until have octree version.
+        return (0, (0, 0))  # TODO_OCTREE: need to implement this.
 
     @property
     def loaded(self) -> bool:
@@ -177,32 +175,6 @@ class OctreeImage(Image):
         if self._slice is None:
             return None
         return self._slice.octree_level_info
-
-    @property
-    def freeze_level(self) -> bool:
-        """Return True if we are forzen viewing a single octree level.
-
-        When viewing the octree normally, freeze_level is always False, but
-        during debugging or other special situations it might be on.
-
-        Returns
-        -------
-        bool
-            True if the view is currently frozen viewing on level.
-        """
-        return self._display.freeze_level
-
-    @freeze_level.setter
-    def freeze_level(self, freeze: bool) -> None:
-        """Set whether we are frozen viewing a single octree level.
-
-        Parameters
-        ----------
-        value : bool
-            True if we should determine the octree level automatically.
-        """
-        self._display.freeze_level = freeze
-        self.events.freeze_level()
 
     @property
     def data_level(self) -> int:

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -46,7 +46,6 @@ class OctreeImage(Image):
     """
 
     def __init__(self, *args, **kwargs):
-        self._display = OctreeDisplayOptions()
 
         self._view: OctreeView = None
 
@@ -63,8 +62,16 @@ class OctreeImage(Image):
         # computation.
         self._delay_ms = NormalNoise()
 
+        self._display = OctreeDisplayOptions()
+
+        # super().__init__ will call our _set_view_slice() which is kind
+        # of annoying since we are aren't fully constructed yet.
         super().__init__(*args, **kwargs)
+
         self.events.add(octree_level=Event, tile_size=Event)
+
+        # TODO_OCTREE: bad to have to set this after...
+        self._display.loaded_event = self.events.loaded
 
     def _get_value(self):
         """Override Image._get_value()."""
@@ -466,27 +473,3 @@ class OctreeImage(Image):
         self._delay_ms = delay_ms
         self._slice = None  # For now must explicitly delete it
         self.refresh()  # Create a new slice.
-
-    @property
-    def show_grid(self) -> bool:
-        """True if we are drawing a grid on top of the tiles.
-
-        Return
-        ------
-        bool
-            True if we are drawing a grid on top of the tiles.
-        """
-        return self._display.show_grid
-
-    @show_grid.setter
-    def show_grid(self, show: bool) -> None:
-        """Set whether we should draw a grid on top of the tiles.
-
-        Parameters
-        ----------
-        show : bool
-            True if we should draw a grid on top of the tiles.
-        """
-        if self._display.show_grid != show:
-            self._display.show_grid = show
-            self.events.loaded()  # redraw

--- a/napari/layers/image/experimental/octree_intersection.py
+++ b/napari/layers/image/experimental/octree_intersection.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from .octree_chunk import OctreeChunk
 from .octree_level import OctreeLevel
+from .octree_util import OctreeDisplayOptions
 
 
 class OctreeView(NamedTuple):
@@ -25,8 +26,7 @@ class OctreeView(NamedTuple):
 
     corners: np.ndarray
     canvas: np.ndarray
-    freeze_level: bool
-    track_view: bool
+    display: OctreeDisplayOptions
 
     @property
     def data_width(self) -> int:
@@ -47,7 +47,7 @@ class OctreeView(NamedTuple):
         bool
             True if the octree level should be selected automatically.
         """
-        return not self.freeze_level and self.track_view
+        return not self.display.freeze_level and self.display.track_view
 
 
 class OctreeIntersection:

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -163,9 +163,6 @@ class OctreeLevel:
 
         data = self.data[array_slice]
 
-        # if not delay_ms.is_zero:
-        #    data = _add_delay(data, delay_ms)
-
         return data
 
 

--- a/napari/layers/image/experimental/octree_tile_builder.py
+++ b/napari/layers/image/experimental/octree_tile_builder.py
@@ -36,6 +36,8 @@ def _none(items):
 def _add_delay(array, delay_ms: NormalNoise):
     """Add a random delay when this array is first accessed.
 
+    TODO_OCTREE: unused not but might use again...
+
     Parameters
     ----------
     noise : NormalNoise

--- a/napari/layers/image/experimental/octree_util.py
+++ b/napari/layers/image/experimental/octree_util.py
@@ -24,10 +24,39 @@ class OctreeDisplayOptions:
         If True draw a grid around the tiles for debugging or demos.
     """
 
+    def __init__(self):
+        self._show_grid = True
+
+        # TODO_OCTREE we set this after __init__ which is messy.
+        self.loaded_event = None
+
+    @property
+    def show_grid(self) -> bool:
+        """True if we are drawing a grid on top of the tiles.
+
+        Return
+        ------
+        bool
+            True if we are drawing a grid on top of the tiles.
+        """
+        return self._show_grid
+
+    @show_grid.setter
+    def show_grid(self, show: bool) -> None:
+        """Set whether we should draw a grid on top of the tiles.
+
+        Parameters
+        ----------
+        show : bool
+            True if we should draw a grid on top of the tiles.
+        """
+        if self._show_grid != show:
+            self._show_grid = show
+            self.loaded_event()  # redraw
+
     tile_size: int = async_config.octree.tile_size
     freeze_level: bool = False
     track_view: bool = True
-    show_grid: bool = True
 
 
 class TestImageSettings(NamedTuple):

--- a/napari/layers/image/experimental/octree_util.py
+++ b/napari/layers/image/experimental/octree_util.py
@@ -1,8 +1,33 @@
 """Octree utility classes.
 """
+from dataclasses import dataclass
 from typing import NamedTuple, Tuple
 
 import numpy as np
+
+from ....components.experimental.chunk import async_config
+
+
+@dataclass
+class OctreeDisplayOptions:
+    """Options for how to display the octree.
+
+    Attributes
+    -----------
+    tile_size : int
+        The size of the display tiles, for example 256.
+    freeze_level : bool
+        If True we do not automatically pick the right data level.
+    track_view : bool
+        If True the displayed tiles track the view, the normal mode.
+    show_grid : bool
+        If True draw a grid around the tiles for debugging or demos.
+    """
+
+    tile_size: int = async_config.octree.tile_size
+    freeze_level: bool = False
+    track_view: bool = True
+    show_grid: bool = True
 
 
 class TestImageSettings(NamedTuple):

--- a/napari/layers/image/experimental/octree_util.py
+++ b/napari/layers/image/experimental/octree_util.py
@@ -131,7 +131,6 @@ class SliceConfig(NamedTuple):
     base_shape: np.ndarray
     num_levels: int
     tile_size: int
-    delay_ms: NormalNoise = NormalNoise()
 
     @property
     def aspect_ratio(self):


### PR DESCRIPTION
# Description
* Factor out `OctreeDisplayOptions` from `OctreeImage`
   * Display options are not core `OctreeImage` things
   * Such as `show_grid`, `tile_size`, `freeze_level` and `track_view`
* Use the existing `Layer.data_level` and drop the special `OctreeImage._octree_level` attribute.
* Remove `delay_ms` and Noise stuff for now, might come back in webmon
* Big comment on `OctreeImage`
* Some other minor `OctreeImage` cleanup

# Comments
* This is partly in preparation for moving some `QtRender` stuff to webmon.
* We will probably send `DisplayOptions` back and forth as one message.
* Although it's helpful either way.

# Type of change
- [x] Refactor in experimental code

# Files

<img width="327" alt="Screen Shot 2020-12-06 at 10 49 24 PM" src="https://user-images.githubusercontent.com/4163446/101307401-5f57f280-3815-11eb-9ec9-0c5344ffd372.png">
