### PR TITLE
async-36: New OctreeChunkLoader

### DIFF
--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -139,7 +139,7 @@ class TiledImageVisual(ImageVisual):
         #     return self._data.shape[:2][::-1]
         #
         # We don't have a self._data so what do we put here? Maybe need
-        # a bounds for all the currently visible tiles?
+        # a bounds for all the currently drawable tiles?
         # return self._texture_atlas.texture_shape[:2]
         #
         return (1024, 1024)
@@ -232,14 +232,14 @@ class TiledImageVisual(ImageVisual):
         # to include this new chunk.
         self._need_vertex_update = True
 
-    def prune_tiles(self, visible_set: Set[OctreeChunk]) -> None:
-        """Remove tiles that are not part of the given visible set.
+    def prune_tiles(self, drawable_set: Set[OctreeChunk]) -> None:
+        """Remove tiles that are not part of the given drawable set.
 
-        visible_set : Set[OctreeChunk]
-            The set of currently visible chunks.
+        drawable_set : Set[OctreeChunk]
+            The set of currently drawable chunks.
         """
         for tile_data in list(self._tiles.tile_data):
-            if tile_data.octree_chunk.key not in visible_set:
+            if tile_data.octree_chunk.key not in drawable_set:
                 tile_index = tile_data.atlas_tile.index
                 self._remove_tile(tile_index)
 

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -23,7 +23,7 @@ TiledImageNode = create_visual_node(TiledImageVisual)
 class ChunkStats:
     """Statistics about chunks during the update process."""
 
-    seen: int = 0
+    drawable: int = 0
     start: int = 0
     deleted: int = 0
     remaining: int = 0
@@ -90,7 +90,7 @@ class VispyTiledImageLayer(VispyImageLayer):
         ImageVisual has a set_data() method but we don't. No one can set
         the data for the whole image, that's why it's a tiled image in the
         first place. Instead of set_data() we pull our data one chunk at a
-        time by calling self.layer.visible_chunks in our _update_view()
+        time by calling self.layer.drawable_chunks in our _update_view()
         method.
 
         Raises
@@ -101,35 +101,37 @@ class VispyTiledImageLayer(VispyImageLayer):
         raise NotImplementedError()
 
     def _update_drawn_chunks(self) -> ChunkStats:
-        """Add or remove tiles to match the chunks which are currently visible.
+        """Add or remove tiles to match the chunks which are currently drawable.
 
-        1) Remove tiles which are no longer visible.
-        2) Create tiles for newly visible chunks.
-        3) Optionally update our grid based on the now visible chunks.
+        1) Remove tiles which are no longer drawable.
+        2) Create tiles for newly drawable chunks.
+        3) Optionally update our grid based on the now drawable chunks.
 
         Return
         ------
         ChunkStats
             Statistics about the update process.
         """
-        # Get the currently visible chunks from the layer.
-        visible_chunks: List[OctreeChunk] = self.layer.visible_chunks
+        # Get the currently drawable chunks from the layer.
+        drawable_chunks: List[OctreeChunk] = self.layer.drawable_chunks
 
-        # Record some stats about this update process, where stats.seen are
-        # the number of visible chunks.
-        stats = ChunkStats(seen=len(visible_chunks))
+        # Record some stats about this update process, where stats.drawable are
+        # the number of drawable chunks.
+        stats = ChunkStats(drawable=len(drawable_chunks))
 
-        # Create the visible set of chunks using their keys.
+        # Create the drawable set of chunks using their keys.
         # TODO_OCTREE: use __hash__ not OctreeChunk.key, using __hash__
         # did not immediately work, but we should try again.
-        visible_set = set(octree_chunk.key for octree_chunk in visible_chunks)
+        drawable_set = set(
+            octree_chunk.key for octree_chunk in drawable_chunks
+        )
 
         # Then number of tiles we have before the update.
         stats.start = self.num_tiles
 
-        # Make tiles as stale if their chunk is no longer visible. However,
+        # Make tiles as stale if their chunk is no longer drawable. However,
         # stale tiles will still be drawn until replaced by something newer.
-        self.node.prune_tiles(visible_set)
+        self.node.prune_tiles(drawable_set)
 
         # The low point, after removing but before adding.
         stats.low = self.num_tiles
@@ -137,10 +139,10 @@ class VispyTiledImageLayer(VispyImageLayer):
         # Which means we deleted this many tiles.
         stats.deleted = stats.start - stats.low
 
-        # Remaining is how many tiles in visible_chunks still need to be
+        # Remaining is how many tiles in drawable_chunks still need to be
         # added. We don't necessarily add them all so that we don't tank
         # the framerate.
-        stats.remaining = self._add_chunks(visible_chunks)
+        stats.remaining = self._add_chunks(drawable_chunks)
 
         # Final number of tiles after adding, which implies how many were
         # created.
@@ -148,7 +150,7 @@ class VispyTiledImageLayer(VispyImageLayer):
         stats.created = stats.final - stats.low
 
         # The grid is only for debugging and demos, yet it's quite useful
-        # otherwise the tiles are kind of invisible.
+        # otherwise you can't really see the borders between the tiles.
         if self.layer.display.show_grid:
             self.grid.update_grid(self.node.octree_chunks)
         else:
@@ -156,12 +158,12 @@ class VispyTiledImageLayer(VispyImageLayer):
 
         return stats
 
-    def _add_chunks(self, visible_chunks: List[OctreeChunk]) -> int:
-        """Add some or all of these visible chunks to the tiled image.
+    def _add_chunks(self, drawable_chunks: List[OctreeChunk]) -> int:
+        """Add some or all of these drawable chunks to the tiled image.
 
         Parameters
         ----------
-        visible_chunks : List[OctreeChunk]
+        drawable_chunks : List[OctreeChunk]
             Chunks we should add, if not already in the tiled image.
 
         Return
@@ -176,7 +178,7 @@ class VispyTiledImageLayer(VispyImageLayer):
             # updating them.
             return 0  # Nothing more to add
 
-        # Add tiles for visible chunks that do not already have a tile.
+        # Add tiles for drawable chunks that do not already have a tile.
         # This might not add all the chunks, because doing so might
         # tank the framerate.
         #
@@ -187,13 +189,13 @@ class VispyTiledImageLayer(VispyImageLayer):
         # card do its business.
         #
         # Any chunks not added this frame will have a chance to be
-        # added the next frame, if they are still on the visible_chunks
+        # added the next frame, if they are still on the drawable_chunks
         # list next frame. It's important we keep asking the layer for
-        # the visible chunks every frame. We don't want to queue up and
+        # the drawable chunks every frame. We don't want to queue up and
         # add chunks which might no longer be needed, because the
         # camera might move every frame. The situation might be
         # evolving rapidly if the camera is moving a lot.
-        return self.node.add_chunks(visible_chunks)
+        return self.node.add_chunks(drawable_chunks)
 
     def _update_tile_shape(self) -> None:
         """If the tile shape was changed, update our node."""
@@ -211,16 +213,16 @@ class VispyTiledImageLayer(VispyImageLayer):
             self.node.set_tile_shape(tile_shape)
 
     def _update_view(self) -> int:
-        """Update the tiled image based on what's visible in the layer.
+        """Update the tiled image based on what's drawable in the layer.
 
         We call self._update_chunks() which asks the layer what chunks are
-        visible, then it potentially loads some of those chunks, if we
-        didn't already have them. This method returns how many visible
+        drawable, then it potentially loads some of those chunks, if we
+        didn't already have them. This method returns how many drawable
         chunks still need to be added.
 
         If we return non-zero, we expect to be polled and drawn again, even
         if the camera isn't moving. Polled and drawn until we can finish
-        adding the rest of the visible chunks.
+        adding the rest of the drawable chunks.
 
         Return
         ------
@@ -251,7 +253,7 @@ class VispyTiledImageLayer(VispyImageLayer):
 
         This is called when the camera moves, or when we have chunks that
         need to be loaded. We update which tiles we are drawing based on
-        which chunks are currently visible.
+        which chunks are currently drawable.
         """
         super()._on_poll()
 

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -92,6 +92,11 @@ class VispyTiledImageLayer(VispyImageLayer):
         first place. Instead of set_data() we pull our data one chunk at a
         time by calling self.layer.visible_chunks in our _update_view()
         method.
+
+        Raises
+        ------
+        NotImplementedError
+            Always raises this.
         """
         raise NotImplementedError()
 
@@ -101,6 +106,11 @@ class VispyTiledImageLayer(VispyImageLayer):
         1) Remove tiles which are no longer visible.
         2) Create tiles for newly visible chunks.
         3) Optionally update our grid based on the now visible chunks.
+
+        Return
+        ------
+        ChunkStats
+            Statistics about the update process.
         """
         # Get the currently visible chunks from the layer.
         visible_chunks: List[OctreeChunk] = self.layer.visible_chunks
@@ -186,7 +196,7 @@ class VispyTiledImageLayer(VispyImageLayer):
         return self.node.add_chunks(visible_chunks)
 
     def _update_tile_shape(self) -> None:
-        """Check if the tile shape was changed on us."""
+        """If the tile shape was changed, update our node."""
         # This might be overly dynamic, but for now if we see there's a new
         # tile shape we nuke our texture atlas and start over with the new
         # shape.

--- a/napari/components/experimental/chunk/__init__.py
+++ b/napari/components/experimental/chunk/__init__.py
@@ -1,6 +1,7 @@
-"""ChunkLoader and related.
+"""ChunkLoader module.
 """
 from ._config import async_config
 from ._loader import chunk_loader, synchronous_loading, wait_for_async
-from ._request import ChunkKey, ChunkRequest, LayerKey
-from ._utils import LayerRef, get_data_id
+from ._request import ChunkKey, ChunkRequest
+from ._utils import LayerRef
+from .layer_key import LayerKey

--- a/napari/components/experimental/chunk/__init__.py
+++ b/napari/components/experimental/chunk/__init__.py
@@ -2,4 +2,5 @@
 """
 from ._config import async_config
 from ._loader import chunk_loader, synchronous_loading, wait_for_async
-from ._request import ChunkKey, ChunkRequest
+from ._request import ChunkKey, ChunkRequest, LayerKey
+from ._utils import LayerRef, get_data_id

--- a/napari/components/experimental/chunk/_commands/_loader.py
+++ b/napari/components/experimental/chunk/_commands/_loader.py
@@ -58,7 +58,7 @@ class InfoDisplayer:
         stats = info.stats
         counts = stats.counts
 
-        self.data_type = info.data_type
+        self.data_type = info.layer_ref.data_type
         self.num_loads = counts.loads
         self.num_chunks = counts.chunks
         self.sync = LOAD_TYPE_STR[self.info.load_type]

--- a/napari/components/experimental/chunk/_commands/_loader.py
+++ b/napari/components/experimental/chunk/_commands/_loader.py
@@ -2,8 +2,6 @@
 """
 from typing import List
 
-import dask.array as da
-
 from ....._vendor.experimental.humanize.src.humanize import naturalsize
 from .....layers.base import Layer
 from .....layers.image import Image
@@ -75,30 +73,6 @@ class NoInfoDisplayer:
 
     def __getattr__(self, name):
         return "--"
-
-
-def _get_type_str(data) -> str:
-    """Get human readable name for the data's type.
-
-    Returns
-    -------
-    str
-        A string like "ndarray" or "dask".
-    """
-    if isinstance(data, list):
-        if len(data) == 0:
-            return "EMPTY"
-        else:
-            # Recursively get the type string of the zeroth level.
-            return _get_type_str(data[0])
-
-    if type(data) == da.Array:
-        # Special case this because otherwise data_type.__name__
-        # below would just return "Array".
-        return "dask"
-
-    # For class numpy.ndarray this returns "ndarray"
-    return type(data).__name__
 
 
 def _get_size_str(data) -> str:

--- a/napari/components/experimental/chunk/_config.py
+++ b/napari/components/experimental/chunk/_config.py
@@ -150,7 +150,7 @@ def _create_async_config(data: dict) -> AsyncConfig:
 
     octree_config = OctreeConfig(tile_size=octree_data.get("tile_size", 64))
 
-    config = AsyncConfig(
+    new_config = AsyncConfig(
         log_path=data.get("log_path"),
         force_synchronous=data.get("force_synchronous", True),
         num_workers=data.get("num_workers", 6),
@@ -160,11 +160,11 @@ def _create_async_config(data: dict) -> AsyncConfig:
         octree=octree_config,
     )
 
-    _log_to_file(config.log_path)
+    _log_to_file(new_config.log_path)
     LOGGER.info("_create_async_config = ")
-    LOGGER.info(json.dumps(data, indent=4, sort_keys=True))
+    LOGGER.info(json.dumps(new_config, indent=4, sort_keys=True))
 
-    return config
+    return new_config
 
 
 # The global config settings instance.

--- a/napari/components/experimental/chunk/_delay_queue.py
+++ b/napari/components/experimental/chunk/_delay_queue.py
@@ -177,8 +177,8 @@ class DelayQueue(threading.Thread):
             else:
                 # Oldest entry is not due, return time until it is.
                 return self.entries[0].submit_time - now
-        else:
-            return None  # There are no more entries.
+
+        return None  # There are no more entries.
 
     def flush(self):
         """Submit all entries right now."""

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -16,7 +16,7 @@ from ....utils.events import EmitterGroup
 from ._cache import ChunkCache
 from ._config import async_config
 from ._delay_queue import DelayQueue
-from ._info import LayerInfo, LoadType
+from ._info import LayerInfo, LayerRef, LoadType
 from ._request import ChunkKey, ChunkRequest
 
 LOGGER = logging.getLogger("napari.async")
@@ -118,24 +118,23 @@ class ChunkLoader:
         return self.layer_map.get(layer_id)
 
     def create_request(
-        self, layer, key: ChunkKey, chunks: Dict[str, ArrayLike]
+        self, layer_ref: LayerRef, key: ChunkKey, chunks: Dict[str, ArrayLike]
     ) -> ChunkRequest:
         """Create a ChunkRequest for submission to load_chunk.
 
         Parameters
         ----------
-        layer : Layer
-            The layer that's requesting the data.
+        layer_ref : LayerRef
+            Reference to the layer that's requesting the data.
         key : ChunkKey
             The key for the request.
         chunks : Dict[str, ArrayLike]
             The arrays we want to load.
         """
-        layer_id = key.layer_key.layer_id
+        layer_id = layer_ref.layer_id
 
-        # Add a LayerInfo if we don't already have one.
         if layer_id not in self.layer_map:
-            self.layer_map[layer_id] = LayerInfo(layer)
+            self.layer_map[layer_id] = LayerInfo(layer_ref)
 
         # Return the new request.
         return ChunkRequest(key, chunks)
@@ -397,7 +396,7 @@ class ChunkLoader:
 
         for future_list in self.futures.values():
             # Result blocks until the future is done or cancelled
-            [future.result() for future in future_list]
+            map(lambda x: x.result(), future_list)
 
     def wait_for_data_id(self, data_id: int) -> None:
         """Wait for the given data to be loaded.
@@ -421,8 +420,9 @@ class ChunkLoader:
             data_id,
         )
 
-        # Call result() will block until the future has finished or was cancelled.
-        [future.result() for future in future_list]
+        # Calling result() will block until the future has finished or was
+        # cancelled.
+        map(lambda x: x.result(), future_list)
         del self.futures[data_id]
 
 

--- a/napari/components/experimental/chunk/_request.py
+++ b/napari/components/experimental/chunk/_request.py
@@ -6,10 +6,8 @@ from typing import NamedTuple, Optional, Tuple
 
 import numpy as np
 
-from ....layers.base.base import Layer
 from ....types import ArrayLike, Dict
 from ....utils.perf import PerfEvent, block_timer
-from ._utils import get_data_id
 
 LOGGER = logging.getLogger("napari.async")
 
@@ -78,11 +76,8 @@ class ChunkKey:
         The combined key, everything hashed together.
     """
 
-    def __init__(self, layer: Layer, indices: Tuple[Optional[slice], ...]):
-        self.layer_key = LayerKey(
-            id(layer), get_data_id(layer), layer._data_level, indices
-        )
-
+    def __init__(self, layer_key: LayerKey):
+        self.layer_key = layer_key
         self.key = hash(self._get_hash_values())
 
     def _get_hash_values(self):
@@ -132,21 +127,46 @@ class ChunkRequest:
 
     @property
     def data_id(self) -> int:
+        """Return the data_id for this request.
+
+        Return
+        ------
+        int
+            The data_id for this request.
+        """
         return self.key.layer_key.data_id
 
     @property
     def num_chunks(self) -> int:
-        """Return the number of chunks in this request."""
+        """Return the number of chunks in this request.
+
+        Return
+        ------
+        int
+            The number of chunks in this request.
+        """
         return len(self.chunks)
 
     @property
     def num_bytes(self) -> int:
-        """Return the number of bytes that were loaded."""
+        """Return the number of bytes that were loaded.
+
+        Return
+        ------
+        int
+            The number of bytes that were loaded.
+        """
         return sum(array.nbytes for array in self.chunks.values())
 
     @property
     def in_memory(self) -> bool:
-        """Return True if all chunks are ndarrays."""
+        """Return True if all chunks are ndarrays.
+
+        Return
+        ------
+        bool
+            True if all chunks are ndarrays.
+        """
         return all(isinstance(x, np.ndarray) for x in self.chunks.values())
 
     @contextlib.contextmanager

--- a/napari/components/experimental/chunk/_request.py
+++ b/napari/components/experimental/chunk/_request.py
@@ -2,60 +2,18 @@
 """
 import contextlib
 import logging
-from typing import NamedTuple, Optional, Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 
 from ....types import ArrayLike, Dict
 from ....utils.perf import PerfEvent, block_timer
+from .layer_key import LayerKey
 
 LOGGER = logging.getLogger("napari.async")
 
 # We convert slices to tuple for hashing.
 SliceTuple = Tuple[Optional[int], Optional[int], Optional[int]]
-
-
-def _flatten(indices) -> tuple:
-    """Return a flat tuple of integers to represent the indices.
-
-    Slice objects are not hashable, so we convert them.
-    """
-    result = []
-    for x in indices:
-        if isinstance(x, slice):
-            result.extend([x.start, x.stop, x.step])
-        else:
-            result.append(x)
-    return tuple(result)
-
-
-class LayerKey(NamedTuple):
-    """The key for a layer and its important properties.
-
-    Attributes
-    ----------
-    layer_id : int
-        The id of the layer making the request.
-    data_id : int
-        The id of the data in the layer.
-    data_level : int
-        The level in the data (for multi-scale).
-    indices : Tuple[Optional[slice], ...]
-        The indices of the slice.
-    """
-
-    layer_id: int
-    data_id: int
-    data_level: int
-    indices: Tuple[Optional[slice], ...]
-
-    def _get_hash_values(self):
-        return (
-            self.layer_id,
-            self.data_id,
-            self.data_level,
-            _flatten(self.indices),
-        )
 
 
 class ChunkKey:

--- a/napari/components/experimental/chunk/_tests/test_chunk.py
+++ b/napari/components/experimental/chunk/_tests/test_chunk.py
@@ -7,7 +7,6 @@ from napari.components.experimental.chunk import (
     LayerKey,
     LayerRef,
     chunk_loader,
-    get_data_id,
 )
 from napari.layers.image import Image
 from napari.utils import config
@@ -19,20 +18,14 @@ def _create_layer() -> Image:
     return Image(data)
 
 
-def _create_layer_key(layer, indices) -> LayerKey:
-    return LayerKey(
-        id(layer), get_data_id(layer.data), layer._data_level, indices,
-    )
-
-
 def test_chunk_key():
     """Test the ChunkKey class."""
 
     layer1 = _create_layer()
     layer2 = _create_layer()
 
-    layer_key1 = _create_layer_key(layer1, (0, 0))
-    layer_key2 = _create_layer_key(layer2, (0, 0))
+    layer_key1 = LayerKey.from_layer(layer1, (0, 0))
+    layer_key2 = LayerKey.from_layer(layer2, (0, 0))
 
     # key1 and key2 should be identical.
     key1 = ChunkKey(layer_key1)
@@ -50,7 +43,7 @@ def test_chunk_key():
     assert key1b != key2
 
     # key4 has different indices.
-    layer_key3 = _create_layer_key(layer2, (0, 1))
+    layer_key3 = LayerKey.from_layer(layer2, (0, 1))
     key3 = ChunkKey(layer_key3)
     assert key1 != key3
     assert key1b != key3

--- a/napari/components/experimental/chunk/_tests/test_chunk.py
+++ b/napari/components/experimental/chunk/_tests/test_chunk.py
@@ -63,7 +63,8 @@ def test_loader():
         return  # temporary until we add the @async_only pytest mark
 
     layer = _create_layer()
-    key = ChunkKey(layer, (0, 0))
+    layer_key = LayerKey.from_layer(layer, (0, 0))
+    key = ChunkKey(layer_key)
 
     shape = (64, 32)
     transpose_shape = (32, 64)

--- a/napari/components/experimental/chunk/_tests/test_chunk.py
+++ b/napari/components/experimental/chunk/_tests/test_chunk.py
@@ -35,32 +35,33 @@ def test_chunk_key():
     layer_key2 = _create_layer_key(layer2, (0, 0))
 
     # key1 and key2 should be identical.
-    key1 = ChunkKey(layer_key1, (0, 0))
-    key2 = ChunkKey(layer_key1, (0, 0))
-    assert key1 == key2
-    assert key1.key == key2.key
+    key1 = ChunkKey(layer_key1)
+    key1b = ChunkKey(layer_key1)
+    assert key1 == key1b
+    assert key1.key == key1b.key
 
     # Check key1 attributes.
     assert key1.layer_key.layer_id == id(layer1)
     assert key1.layer_key.data_level == layer1.data_level
 
-    # key3 is for a different layer.
-    key3 = ChunkKey(layer_key2, (0, 0))
-    assert key1 != key3
-    assert key2 != key3
+    # key2 is for a different layer.
+    key2 = ChunkKey(layer_key2)
+    assert key1 != key2
+    assert key2 != key2
 
     # key4 has different indices.
-    key4 = ChunkKey(layer_key2, (0, 1))
-    assert key1 != key4
-    assert key2 != key4
-    assert key3 != key4
+    layer_key3 = _create_layer_key(layer2, (0, 1))
+    key3 = ChunkKey(layer_key3)
+    assert key1 != key3
+    assert key1b != key3
+    assert key2 != key3
 
-    # key5 matches key4.
-    key5 = ChunkKey(layer_key2, (0, 1))
-    assert key1 != key5
-    assert key2 != key5
-    assert key3 != key5
-    assert key4 == key5
+    # key4 matches key3.
+    key4 = ChunkKey(layer_key3, (0, 1))
+    assert key1 != key4
+    assert key1b != key4
+    assert key2 != key4
+    assert key3 == key4
 
 
 def test_loader():

--- a/napari/components/experimental/chunk/_tests/test_chunk.py
+++ b/napari/components/experimental/chunk/_tests/test_chunk.py
@@ -50,7 +50,7 @@ def test_chunk_key():
     assert key2 != key3
 
     # key4 matches key3.
-    key4 = ChunkKey(layer_key3, (0, 1))
+    key4 = ChunkKey(layer_key3)
     assert key1 != key4
     assert key1b != key4
     assert key2 != key4

--- a/napari/components/experimental/chunk/_tests/test_chunk.py
+++ b/napari/components/experimental/chunk/_tests/test_chunk.py
@@ -47,7 +47,7 @@ def test_chunk_key():
     # key2 is for a different layer.
     key2 = ChunkKey(layer_key2)
     assert key1 != key2
-    assert key2 != key2
+    assert key1b != key2
 
     # key4 has different indices.
     layer_key3 = _create_layer_key(layer2, (0, 1))

--- a/napari/components/experimental/chunk/_tests/test_chunk.py
+++ b/napari/components/experimental/chunk/_tests/test_chunk.py
@@ -19,7 +19,7 @@ def _create_layer() -> Image:
     return Image(data)
 
 
-def _create_key(layer, indices) -> LayerKey:
+def _create_layer_key(layer, indices) -> LayerKey:
     return LayerKey(
         id(layer), get_data_id(layer.data), layer._data_level, indices,
     )
@@ -31,12 +31,12 @@ def test_chunk_key():
     layer1 = _create_layer()
     layer2 = _create_layer()
 
-    key1 = _create_key(layer1, (0, 0))
-    key2 = _create_key(layer2, (0, 0))
+    layer_key1 = _create_layer_key(layer1, (0, 0))
+    layer_key2 = _create_layer_key(layer2, (0, 0))
 
     # key1 and key2 should be identical.
-    key1 = ChunkKey(key1, (0, 0))
-    key2 = ChunkKey(key1, (0, 0))
+    key1 = ChunkKey(layer_key1, (0, 0))
+    key2 = ChunkKey(layer_key1, (0, 0))
     assert key1 == key2
     assert key1.key == key2.key
 
@@ -45,18 +45,18 @@ def test_chunk_key():
     assert key1.layer_key.data_level == layer1.data_level
 
     # key3 is for a different layer.
-    key3 = ChunkKey(key2, (0, 0))
+    key3 = ChunkKey(layer_key2, (0, 0))
     assert key1 != key3
     assert key2 != key3
 
     # key4 has different indices.
-    key4 = ChunkKey(key2, (0, 1))
+    key4 = ChunkKey(layer_key2, (0, 1))
     assert key1 != key4
     assert key2 != key4
     assert key3 != key4
 
     # key5 matches key4.
-    key5 = ChunkKey(key2, (0, 1))
+    key5 = ChunkKey(layer_key2, (0, 1))
     assert key1 != key5
     assert key2 != key5
     assert key3 != key5

--- a/napari/components/experimental/chunk/_utils.py
+++ b/napari/components/experimental/chunk/_utils.py
@@ -1,11 +1,13 @@
 """ChunkLoader utilities.
 """
-from typing import Optional
+import weakref
+from typing import NamedTuple, Optional
 
+import dask.array as da
 import numpy as np
 
 
-def get_data_id(layer) -> int:
+def get_data_id(data) -> int:
     """Return the data_id to use for this layer.
 
     Parameters
@@ -19,12 +21,69 @@ def get_data_id(layer) -> int:
     changes the data out from under a layer, we do not want to use the
     wrong chunks.
     """
-    data = layer.data
     if isinstance(data, list):
         assert data  # data should not be empty for image layers.
         return id(data[0])  # Just use the ID from the 0'th layer.
 
     return id(data)  # Not a list, just use it.
+
+
+def _get_type_str(data) -> str:
+    """Get human readable name for the data's type.
+
+    Returns
+    -------
+    str
+        A string like "ndarray" or "dask".
+    """
+    data_type = type(data)
+
+    if data_type == list:
+        if len(data) == 0:
+            return "EMPTY"
+        # Recursively get the type string of the zeroth level.
+        return _get_type_str(data[0])
+
+    if data_type == da.Array:
+        # Special case this because otherwise data_type.__name__
+        # below would just return "Array".
+        return "dask"
+
+    # For class numpy.ndarray this returns "ndarray"
+    return data_type.__name__
+
+
+class LayerRef(NamedTuple):
+    """Weak reference to a layer.
+
+    We do not want to hold a reference in case the later is deleted while
+    a load is in progress. We want to let the layer get deleted, and
+    when the load finishes we'll just throw it away. Since its layer is done.
+
+    Attributes
+    ----------
+    layer_id : int
+        The id of the layer.
+    reference : weakref.ReferenceType
+        A weak reference to the layer
+    data_type : str
+        String describing the data type the layer holds.
+    """
+
+    layer_id: int
+    weak_ref: weakref.ReferenceType
+    data_type: str
+
+    @classmethod
+    def create_from_layer(cls, layer):
+        """Return a LayerRef created from this layer.
+
+        Parameters
+        ----------
+        layer
+            Create the LayerRef from this layer.
+        """
+        return cls(id(layer), weakref.ref(layer), _get_type_str(layer.data))
 
 
 class StatWindow:

--- a/napari/components/experimental/chunk/layer_key.py
+++ b/napari/components/experimental/chunk/layer_key.py
@@ -1,0 +1,71 @@
+"""LayerKey class.
+
+We put this in its own file because (eventually) this should be the only
+ChunkLoader file that imports layer.
+
+Ideally ChunkLoader does not depend on layers at all. We may or may not
+actually do that, but at the very least we want to keep track of where
+we do depend on layer.
+"""
+from typing import NamedTuple, Optional, Tuple
+
+from ....layers import Layer
+from ._utils import get_data_id
+
+
+class LayerKey(NamedTuple):
+    """The key for a layer and its important properties.
+
+    Attributes
+    ----------
+    layer_id : int
+        The id of the layer making the request.
+    data_id : int
+        The id of the data in the layer.
+    data_level : int
+        The level in the data (for multi-scale).
+    indices : Tuple[Optional[slice], ...]
+        The indices of the slice.
+    """
+
+    layer_id: int
+    data_id: int
+    data_level: int
+    indices: Tuple[Optional[slice], ...]
+
+    def _get_hash_values(self):
+        return (
+            self.layer_id,
+            self.data_id,
+            self.data_level,
+            _flatten(self.indices),
+        )
+
+    @classmethod
+    def from_layer(cls, layer: Layer, indices):
+        """Return LayerKey based on this layer and its indices.
+
+        Parameters
+        ----------
+        layer : Layer
+            Create a LayerKey for this layer.
+        indices : ???
+            The indices we are viewing.
+        """
+        return cls(
+            id(layer), get_data_id(layer.data), layer._data_level, indices
+        )
+
+
+def _flatten(indices) -> tuple:
+    """Return a flat tuple of integers to represent the indices.
+
+    Slice objects are not hashable, so we convert them.
+    """
+    result = []
+    for x in indices:
+        if isinstance(x, slice):
+            result.extend([x.start, x.stop, x.step])
+        else:
+            result.append(x)
+    return tuple(result)

--- a/napari/layers/image/experimental/_chunked_image_loader.py
+++ b/napari/layers/image/experimental/_chunked_image_loader.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Optional
 
-from ....components.experimental.chunk import ChunkKey, LayerKey, get_data_id
+from ....components.experimental.chunk import ChunkKey, LayerKey
 from .._image_loader import ImageLoader
 from ._chunked_slice_data import ChunkedSliceData
 
@@ -37,11 +37,9 @@ class ChunkedImageLoader(ImageLoader):
             True if load happened synchronously.
         """
         layer = data.layer
-        layer_key = LayerKey(
-            id(layer), get_data_id(layer.data), layer._data_level, data.indices
-        )
-
+        layer_key = LayerKey.from_layer(layer, data.indices)
         key = ChunkKey(layer_key)
+
         LOGGER.debug("ChunkedImageLoader.load: %s", key)
 
         if self.current_key is not None and self.current_key == key:

--- a/napari/layers/image/experimental/_chunked_image_loader.py
+++ b/napari/layers/image/experimental/_chunked_image_loader.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Optional
 
-from ....components.experimental.chunk import ChunkKey
+from ....components.experimental.chunk import ChunkKey, LayerKey, get_data_id
 from .._image_loader import ImageLoader
 from ._chunked_slice_data import ChunkedSliceData
 
@@ -36,7 +36,12 @@ class ChunkedImageLoader(ImageLoader):
         bool
             True if load happened synchronously.
         """
-        key = ChunkKey(data.layer, data.indices)
+        layer = data.layer
+        layer_key = LayerKey(
+            id(layer), get_data_id(layer.data), layer._data_level, data.indices
+        )
+
+        key = ChunkKey(layer_key)
         LOGGER.debug("ChunkedImageLoader.load: %s", key)
 
         if self.current_key is not None and self.current_key == key:

--- a/napari/layers/image/experimental/_chunked_slice_data.py
+++ b/napari/layers/image/experimental/_chunked_slice_data.py
@@ -6,6 +6,7 @@ from typing import Optional
 from ....components.experimental.chunk import (
     ChunkKey,
     ChunkRequest,
+    LayerRef,
     chunk_loader,
 )
 from ....types import ArrayLike
@@ -76,7 +77,8 @@ class ChunkedSliceData(ImageSliceData):
             chunks['thumbnail_source'] = self.thumbnail_source
 
         # Create the ChunkRequest and load it with the ChunkLoader.
-        self.request = chunk_loader.create_request(self.layer, key, chunks)
+        layer_ref = LayerRef.create_from_layer(self.layer)
+        self.request = chunk_loader.create_request(layer_ref, key, chunks)
         satisfied_request = chunk_loader.load_chunk(self.request)
 
         if satisfied_request is None:

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -1,0 +1,111 @@
+"""OctreeChunkLoader class.
+
+Uses ChunkLoader to load OctreeChunk's in the octree.
+"""
+import logging
+from typing import List
+
+from ....components.experimental.chunk import LayerKey, LayerRef, chunk_loader
+from .octree_chunk import OctreeChunk, OctreeChunkKey
+
+LOGGER = logging.getLogger("napari.async.octree")
+
+
+class OctreeChunkLoader:
+    """Load chunks for the octree."""
+
+    def __init__(self, layer_ref: LayerRef):
+        self._layer_ref = layer_ref
+        self._last_visible_set = set()
+
+    def get_drawable_chunks(
+        self, visible: List[OctreeChunk], layer_key: LayerKey
+    ) -> List[OctreeChunk]:
+        """Of the given visible chunks, return only the ones that are drawable.
+
+        Drawable chunks are typically the ones that are fully in memory.
+        Either they were always in memory, or they are now in memory after
+        having been loaded asynchronously by the hunkLoader.
+
+        Parameters
+        ----------
+        visible : List[OctreeChunk]
+            The chunks which are visible to the camera.
+        """
+        visible_set = set(octree_chunk.key for octree_chunk in visible)
+
+        # Remove any chunks from our self._last_visible set which are no
+        # longer in view.
+        for key in list(self._last_visible_set):
+            if key not in visible_set:
+                self._last_visible_set.remove(key)
+
+        count = len(visible)
+
+        def _log(i, label, chunk):
+            LOGGER.debug(
+                "Visible Chunk: %d of %d -> %s: %s", i, count, label, chunk
+            )
+
+        drawable = []  # TODO_OCTREE combine list/set
+        visible_set = set()
+        for i, octree_chunk in enumerate(visible):
+
+            if not chunk_loader.cache.enabled:
+                new_in_view = octree_chunk.key not in self._last_visible_set
+                if new_in_view and octree_chunk.in_memory:
+                    # Not using cache, so if this chunk just came into view
+                    # clear it out, so it gets reloaded.
+                    octree_chunk.clear()
+
+            if octree_chunk.in_memory:
+                # The chunk is fully in memory, we can view it right away.
+                # _log(i, "ALREADY LOADED", octree_chunk)
+                drawable.append(octree_chunk)
+                visible_set.add(octree_chunk.key)
+            elif octree_chunk.loading:
+                # The chunk is being loaded, do not view it yet.
+                _log(i, "LOADING:", octree_chunk)
+            else:
+                # The chunk is not in memory and is not being loaded, so
+                # we are going to load it.
+                sync_load = self._load_chunk(octree_chunk, layer_key)
+                if sync_load:
+                    # The chunk was loaded synchronously. Either it hit the
+                    # cache, or it's fast-loading data. We can draw it now.
+                    _log(i, "SYNC LOAD", octree_chunk)
+                    drawable.append(octree_chunk)
+                    visible_set.add(octree_chunk.key)
+                else:
+                    # An async load was initiated, sometime later our
+                    # self._on_chunk_loaded method will be called.
+                    _log(i, "ASYNC LOAD", octree_chunk)
+
+        # Update our _last_visible_set with what is in view.
+        for octree_chunk in drawable:
+            self._last_visible_set.add(octree_chunk.key)
+
+        return drawable
+
+    def _load_chunk(
+        self, octree_chunk: OctreeChunk, layer_key: LayerKey
+    ) -> None:
+
+        key = OctreeChunkKey(layer_key, octree_chunk.location)
+
+        chunks = {'data': octree_chunk.data}
+
+        octree_chunk.loading = True
+
+        # Create the ChunkRequest and load it with the ChunkLoader.
+        request = chunk_loader.create_request(self._layer_ref, key, chunks)
+
+        satisfied_request = chunk_loader.load_chunk(request)
+
+        if satisfied_request is None:
+            return False  # Load was async.
+
+        # Load was sync so we can insert the data into the octree
+        # and we will draw it this frame.
+        octree_chunk.data = satisfied_request.chunks.get('data')
+        return True

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -3,7 +3,7 @@
 Uses ChunkLoader to load OctreeChunk's in the octree.
 """
 import logging
-from typing import List
+from typing import List, Set
 
 from ....components.experimental.chunk import LayerKey, LayerRef, chunk_loader
 from .octree_chunk import OctreeChunk, OctreeChunkKey
@@ -12,17 +12,23 @@ LOGGER = logging.getLogger("napari.async.octree")
 
 
 class OctreeChunkLoader:
-    """Load chunks for the octree.
+    """Load data into the OctreeChunks in the octree.
 
     Parameters
     ----------
     layer_ref : LayerRef
         A weak reference to the layer we are loading chunks for.
+
+    Attributes
+    ----------
+    _last_visible : Set[OctreeChunkKey]
+        Chunks we saw last frame, so we can recognize chunks have just
+        come into view.
     """
 
     def __init__(self, layer_ref: LayerRef):
         self._layer_ref = layer_ref
-        self._last_visible = set()
+        self._last_visible: Set[OctreeChunkKey] = set()
 
     def get_drawable_chunks(
         self, visible: List[OctreeChunk], layer_key: LayerKey

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -35,29 +35,34 @@ class OctreeChunkLoader:
     ) -> List[OctreeChunk]:
         """Return the chunks that can be drawn, of the visible chunks.
 
-        Drawable chunks are typically the ones that are fully in memory.
-        Either they were always in memory, or they are now in memory after
-        having been loaded asynchronously by the hunkLoader.
+        Visible chunks are within the bounds of the OctreeView, but those
+        chunks may or may not be drawable. Drawable chunks are typically
+        ones that were fully in memory to start, or have been loaded
+        so the data is now in memory.
 
         Parameters
         ----------
         visible : List[OctreeChunk]
             The chunks which are visible to the camera.
+        layer_key : LayerKey
+            The layer we loading chunks into.
 
         Return
         ------
         List[OctreeChunk]
             The chunks that can be drawn.
         """
+        # How many visible chunks are we dealing with.
+        count = len(visible)
+
+        # Create a set for fast access.
         visible_set = set(octree_chunk.key for octree_chunk in visible)
 
-        # Remove any chunks from our self._last_visible set which are no
-        # longer in view.
+        # Remove chunks from self._last_visible if they are no longer
+        # in the visible set. If they are no longer in view.
         for key in list(self._last_visible):
             if key not in visible_set:
                 self._last_visible.remove(key)
-
-        count = len(visible)
 
         def _log(i, label, chunk):
             LOGGER.debug(

--- a/napari/layers/image/experimental/_octree_multiscale_slice.py
+++ b/napari/layers/image/experimental/_octree_multiscale_slice.py
@@ -159,7 +159,12 @@ class OctreeMultiscaleSlice:
         return min(math.floor(math.log2(ratio)), self._octree.num_levels - 1)
 
     def get_visible_chunks(self, view: OctreeView) -> List[OctreeChunk]:
-        """Return the chunks currently in view.
+        """Get the chunks within this view that are visible.
+
+        Paramaters
+        ----------
+        view : OctreeView
+            Return chunks that are within this view.
 
         Return
         ------

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -1,11 +1,10 @@
 """OctreeChunk class
 """
-from typing import NamedTuple, Optional, Tuple
+from typing import NamedTuple
 
 import numpy as np
 
-from ....components.experimental.chunk import ChunkKey
-from ....layers import Layer
+from ....components.experimental.chunk import ChunkKey, LayerKey
 from ....types import ArrayLike
 
 
@@ -63,13 +62,10 @@ class OctreeChunkKey(ChunkKey):
     """
 
     def __init__(
-        self,
-        layer: Layer,
-        indices: Tuple[Optional[slice], ...],
-        location: OctreeLocation,
+        self, layer_key: LayerKey, location: OctreeLocation,
     ):
         self.location = location
-        super().__init__(layer, indices)
+        super().__init__(layer_key)
 
     def _get_hash_values(self):
         # TODO_OCTREE: can't we just has with parent's hashed key instead

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -1,16 +1,14 @@
 """OctreeImage class.
+
+An eventual replacement for Image that combines single-scale and
+chunked/tiled multi-scale into one implementation.
 """
 import logging
 from typing import List
 
 import numpy as np
 
-from ....components.experimental.chunk import (
-    ChunkRequest,
-    LayerKey,
-    LayerRef,
-    get_data_id,
-)
+from ....components.experimental.chunk import ChunkRequest, LayerKey, LayerRef
 from ....utils.events import Event
 from ..image import Image
 from ._octree_chunk_loader import OctreeChunkLoader
@@ -257,10 +255,7 @@ class OctreeImage(Image):
         self.frame_count += 1
 
         indices = np.array(self._slice_indices)
-
-        layer_key = LayerKey(
-            id(self), get_data_id(self.data), self._data_level, indices
-        )
+        layer_key = LayerKey.from_layer(self, indices)
 
         return self._loader.get_drawable_chunks(chunks, layer_key)
 

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -9,118 +9,18 @@ from ....components.experimental.chunk import (
     ChunkRequest,
     LayerKey,
     LayerRef,
-    chunk_loader,
     get_data_id,
 )
 from ....utils.events import Event
 from ..image import Image
+from ._octree_chunk_loader import OctreeChunkLoader
 from ._octree_multiscale_slice import OctreeMultiscaleSlice, OctreeView
-from .octree_chunk import OctreeChunk, OctreeChunkKey
+from .octree_chunk import OctreeChunk
 from .octree_intersection import OctreeIntersection
 from .octree_level import OctreeLevelInfo
 from .octree_util import OctreeDisplayOptions, SliceConfig
 
 LOGGER = logging.getLogger("napari.async.octree")
-
-
-class OctreeChunkLoader:
-    """Load chunks for the octree."""
-
-    def __init__(self, layer_ref: LayerRef):
-        self._layer_ref = layer_ref
-        self._last_visible_set = set()
-
-    def get_drawable_chunks(
-        self, visible: List[OctreeChunk], layer_key: LayerKey
-    ) -> List[OctreeChunk]:
-        """Of the given visible chunks, return only the ones that are drawable.
-
-        Drawable chunks are typically the ones that are fully in memory.
-        Either they were always in memory, or they are now in memory after
-        having been loaded asynchronously by the hunkLoader.
-
-        Parameters
-        ----------
-        visible : List[OctreeChunk]
-            The chunks which are visible to the camera.
-        """
-        visible_set = set(octree_chunk.key for octree_chunk in visible)
-
-        # Remove any chunks from our self._last_visible set which are no
-        # longer in view.
-        for key in list(self._last_visible_set):
-            if key not in visible_set:
-                self._last_visible_set.remove(key)
-
-        count = len(visible)
-
-        def _log(i, label, chunk):
-            LOGGER.debug(
-                "Visible Chunk: %d of %d -> %s: %s", i, count, label, chunk
-            )
-
-        drawable = []  # TODO_OCTREE combine list/set
-        visible_set = set()
-        for i, octree_chunk in enumerate(visible):
-
-            if not chunk_loader.cache.enabled:
-                new_in_view = octree_chunk.key not in self._last_visible_set
-                if new_in_view and octree_chunk.in_memory:
-                    # Not using cache, so if this chunk just came into view
-                    # clear it out, so it gets reloaded.
-                    octree_chunk.clear()
-
-            if octree_chunk.in_memory:
-                # The chunk is fully in memory, we can view it right away.
-                # _log(i, "ALREADY LOADED", octree_chunk)
-                drawable.append(octree_chunk)
-                visible_set.add(octree_chunk.key)
-            elif octree_chunk.loading:
-                # The chunk is being loaded, do not view it yet.
-                _log(i, "LOADING:", octree_chunk)
-            else:
-                # The chunk is not in memory and is not being loaded, so
-                # we are going to load it.
-                sync_load = self._load_chunk(octree_chunk, layer_key)
-                if sync_load:
-                    # The chunk was loaded synchronously. Either it hit the
-                    # cache, or it's fast-loading data. We can draw it now.
-                    _log(i, "SYNC LOAD", octree_chunk)
-                    drawable.append(octree_chunk)
-                    visible_set.add(octree_chunk.key)
-                else:
-                    # An async load was initiated, sometime later our
-                    # self._on_chunk_loaded method will be called.
-                    _log(i, "ASYNC LOAD", octree_chunk)
-
-        # Update our _last_visible_set with what is in view.
-        for octree_chunk in drawable:
-            self._last_visible_set.add(octree_chunk.key)
-
-        return drawable
-
-    def _load_chunk(
-        self, octree_chunk: OctreeChunk, layer_key: LayerKey
-    ) -> None:
-
-        key = OctreeChunkKey(layer_key, octree_chunk.location)
-
-        chunks = {'data': octree_chunk.data}
-
-        octree_chunk.loading = True
-
-        # Create the ChunkRequest and load it with the ChunkLoader.
-        request = chunk_loader.create_request(self._layer_ref, key, chunks)
-
-        satisfied_request = chunk_loader.load_chunk(request)
-
-        if satisfied_request is None:
-            return False  # Load was async.
-
-        # Load was sync so we can insert the data into the octree
-        # and we will draw it this frame.
-        octree_chunk.data = satisfied_request.chunks.get('data')
-        return True
 
 
 class OctreeImage(Image):

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -31,21 +31,26 @@ class OctreeImage(Image):
 
     Background
     ----------
-    OctreeImage is meant to eventually replace the existing Image class. The
-    original Image class handled single-scale and multi-scale images, but they
-    were handled quite differently. And its multi-scale did not use chunks or
-    tiles.
+    The original Image class handled single-scale and multi-scale images,
+    but they were handled quite differently. And its multi-scale did not
+    use chunks or tiles. It worked well locally, but was basically unusable
+    for remote or high latency data.
 
     OctreeImage always uses chunk/tiles. Today those tiles are always
     "small". However, as a special case, if an image is smaller than the
     max texture size, we could some day allow OctreeImage to set its tile
     size equal to that image size.
 
-    At that point "small" images would be single-tile single-level
-    OctreeImages. Therefore they should be as as efficient as the original
-    Image's single-scale images. But larger images would have
-    multiple-tiles and multiple-levels. The goal is to have one class and
-    one code path for all types of images.
+    At that point "small" images would be draw with a single texture,
+    the same way the old Image class drew then. So it would be very
+    efficient.
+
+    But larger images would have multiple chunks/tiles and multiple levels.
+    Unlike the original Image class multi-scale, the chunks/tiles mean we
+    only have to incrementally load more data as the user pans and zooms.
+
+    The goal is OctreeImage gets renamed to just Image and it efficiently
+    handles images of any size. It make take a while to get there.
     """
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
# Description
* Create new `OctreeChunkLoader` class
    * In preparation for multi-level loader/renderering.
    * We want something outside of `OctreeImage` to manage multi-level loading/rendering.
    * `OctreeChunkLoader` is a starting point.
* Create new `LayerRef` tuple
    * So `OctreeChunkLoader` can submit chunk requests without a reference to OctreeLayer. 
    * So Layer depends on `OctreeChunkLoader` but not the reverse.
    * This is better anyway: so `ChunkLoader` depends less on layers.
        * We can probably break the dependency 100% with some more effort.
* A few random `pylint` fixes.

## Type of change
- [x] Refactoring in experimental code