### PR TITLE
[Attempt 1]move label layer refresh in between draws to another thread

### DIFF
--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -66,8 +66,6 @@ def draw(layer, event):
                 layer.fill(c, new_label, refresh=False)
         if not refresh_future or refresh_future.done():
             refresh_future = refresh_executor.submit(refresh, layer)
-        else:
-            print("skipped")
         last_cursor_coord = layer.coordinates
         yield
 


### PR DESCRIPTION
# Description
move label layer refresh to another thread during the draw, in an attempt to address heuristics finding around painting lag. The lag is more significant as the size of the image grow, at around 4k resolution, painting is pretty much inaccurate to mouse position anymore due to the lag.

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# References
https://github.com/napari/product-heuristics-2020/issues/38

# How has this been tested?
- [X] example: the test suite for my feature covers cases x, y, and z
- [X] example: all tests pass with my change

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
