### PR TITLE
compatibility with magicgui v0.2.0

### DIFF
--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -183,5 +183,9 @@ def combine_widgets(
         ):
             container.layout.addStretch()
         return container
+    elif isinstance(getattr(widgets, 'native', None), QWidget):
+        # compatibility with magicgui v0.2.0 which no longer uses QWidgets
+        # directly. Like vispy, the backend widget is at widget.native
+        return widgets.native  # type: ignore
     else:
         raise TypeError('"widget" must be a QWidget or a sequence of QWidgets')

--- a/napari/utils/_magicgui.py
+++ b/napari/utils/_magicgui.py
@@ -90,7 +90,8 @@ def get_layers(gui, layer_type: Type[Layer] = None) -> Tuple[Layer, ...]:
         dock widget.
     layer_type : type
         This is the exact type used in the type hint of the user's
-        function. It may be a subclass of napari.layers.Layer
+        function. It may be a subclass of napari.layers.Layer.
+        REMOVED in magicgui v0.2.0!
 
     Returns
     -------
@@ -107,6 +108,9 @@ def get_layers(gui, layer_type: Type[Layer] = None) -> Tuple[Layer, ...]:
     ...     return layer.data.mean()
 
     """
+    # in magicgui v0.2.0 `gui` will be the magicgui parameter widget itself,
+    # which contains all of the necessary information.
+    # the layer type (which was just the annotation), is at gui.annotation
     if layer_type is None:
         gui, layer_type = gui.native, gui.annotation
     # else:

--- a/napari/utils/_magicgui.py
+++ b/napari/utils/_magicgui.py
@@ -17,10 +17,10 @@ from ..layers import Layer
 from ..viewer import Viewer
 
 try:
-    from magicgui import register_type as _magictype
+    from magicgui import register_type
 except ImportError:
 
-    def _magictype(*args, **kwargs):
+    def register_type(*args, **kwargs):
         pass
 
 
@@ -38,8 +38,8 @@ def register_types_with_magicgui():
             corresponding layer type will be added.
             see `show_layer_result` for detail
     """
-    _magictype(Layer, choices=get_layers, return_callback=show_layer_result)
-    _magictype(Viewer, choices=get_viewers)
+    register_type(Layer, choices=get_layers, return_callback=show_layer_result)
+    register_type(Viewer, choices=get_viewers)
 
 
 def find_viewer_ancestor(widget: QWidget) -> Optional[Viewer]:
@@ -55,7 +55,12 @@ def find_viewer_ancestor(widget: QWidget) -> Optional[Viewer]:
     viewer : napari.Viewer or None
         Viewer instance if one exists, else None.
     """
-    parent = widget.parent()
+    # magicgui v0.2.0 widgets are no longer QWidget subclasses, but the native
+    # widget is available at widget.native
+    if hasattr(widget, 'native') and isinstance(widget.native, QWidget):
+        parent = widget.native.parent()
+    else:
+        parent = widget.parent()
     while parent:
         if hasattr(parent, 'qt_viewer'):
             return parent.qt_viewer.viewer
@@ -75,7 +80,7 @@ def get_viewers(gui, *args) -> Tuple[Viewer, ...]:
         return tuple(v for v in globals().values() if isinstance(v, Viewer))
 
 
-def get_layers(gui, layer_type: Type[Layer]) -> Tuple[Layer, ...]:
+def get_layers(gui, layer_type: Type[Layer] = None) -> Tuple[Layer, ...]:
     """Retrieve layers of type `layer_type`, from the Viewer the gui is in.
 
     Parameters
@@ -102,6 +107,18 @@ def get_layers(gui, layer_type: Type[Layer]) -> Tuple[Layer, ...]:
     ...     return layer.data.mean()
 
     """
+    if layer_type is None:
+        gui, layer_type = gui.native, gui.annotation
+    # else:
+    #     import warnings
+    #     from magicgui import __version__ as magicgui_version
+    #
+    #     warnings.warn(
+    #         f"A future version of napari will no longer support magicgui "
+    #         f"<0.2.0. (You have v{magicgui_version}). "
+    #         "Please use `pip install -U magicgui` to update to >=0.2.0",
+    #         FutureWarning,
+    #     )
 
     viewer = find_viewer_ancestor(gui)
     if viewer:


### PR DESCRIPTION
# Description
magicgui v0.2.0 (https://github.com/napari/magicgui/pull/43) is close to being ready.  The biggest change for napari is that a magicgui widget is no longer a `QWidget` directly.  Rather, (like vispy), it is composed of a backend widget which is available at `widget.native`.  This PR makes napari compatible with both the current version of magicgui and the future version (if you want to try out https://github.com/napari/magicgui/pull/43, you'll also need this).

I'll post a more thorough comment over there about all the changes, but I've been very careful to make sure that all (or as much as possible) of the previous API continues to work (with warnings), for now.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# References
https://github.com/napari/magicgui/pull/43

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
