### PR TITLE
async-37: Multilevel Rendering

### DIFF
--- a/napari/_vispy/experimental/tile_set.py
+++ b/napari/_vispy/experimental/tile_set.py
@@ -105,14 +105,34 @@ class TileSet:
 
     @property
     def tile_data(self) -> List[TileData]:
-        """Return the data for all tiles in the set.
+        """Return the data for all tiles in the set, unsorted.
 
         Return
         ------
         List[TileData]
-            Data for all the tiles in the set.
+            Data for all the tiles in the set sorted back to front.
         """
         return self._tiles.values()
+
+    @property
+    def tile_data_sorted(self) -> List[TileData]:
+        """Return the data for all tiles in the set, sorted back to front.
+
+        We return tiles from higher octree levels first. These are the
+        larger coarser tiles. These are "the background" while smaller
+        higher resolution tiles are drawn in front. So we show the "best
+        available" data in all locations.
+
+        Return
+        ------
+        List[TileData]
+            Data for all the tiles in the set sorted back to front.
+        """
+        return sorted(
+            self._tiles.values(),
+            key=lambda x: x.octree_chunk.location.level_index,
+            reverse=True,
+        )
 
     def contains_octree_chunk(self, octree_chunk: OctreeChunk) -> bool:
         """Return True if the set contains this chunk.

--- a/napari/_vispy/experimental/tile_set.py
+++ b/napari/_vispy/experimental/tile_set.py
@@ -82,6 +82,17 @@ class TileSet:
         del self._tiles[tile_index]
 
     @property
+    def chunk_set(self) -> Set[OctreeChunkKey]:
+        """Return the set of chunks we drawing.
+
+        Return
+        ------
+        Set[OctreeChunkKey]
+            The set of chunks we are drawing.
+        """
+        return self._chunks
+
+    @property
     def chunks(self) -> List[OctreeChunk]:
         """Return all the chunks we are tracking.
 

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -279,6 +279,7 @@ class TiledImageVisual(ImageVisual):
             self._tiles.remove(tile_index)
             self._texture_atlas.remove_tile(tile_index)
 
+            # Must rebuild to remove this from what we are drawing.
             self._need_vertex_update = True
         except IndexError as exc:
             # Fatal error right now, but maybe in weird situation we should

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -312,7 +312,7 @@ class TiledImageVisual(ImageVisual):
         verts = np.zeros((0, 2), dtype=np.float32)
         tex_coords = np.zeros((0, 2), dtype=np.float32)
 
-        # TODO_OCTREE: We can probably avoid vstack here? Maybe one one
+        # TODO_OCTREE: We can probably avoid vstack here? Maybe create one
         # vertex buffer sized according to the max number of tiles we
         # expect? But grow it if we exceed our guess?
         for tile_data in self._tiles.tile_data_sorted:

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -14,6 +14,8 @@ from typing import List, Set
 
 import numpy as np
 
+from napari.layers.image.experimental.octree_chunk import OctreeChunkKey
+
 from ...layers.image.experimental import OctreeChunk
 from ..vendored import ImageVisual
 from ..vendored.image import _build_color_transform
@@ -233,16 +235,26 @@ class TiledImageVisual(ImageVisual):
         atlas_tile = self._texture_atlas.add_tile(octree_chunk)
 
         if atlas_tile is None:
-            # TODO_OCTREE: What should we do here?
-            return  # No slot available in the atlas.
+            return  # No slot was available in the atlas. That's bad.
 
-        # Add to our mapping between chunks and tiles.
+        # Add our mapping between chunks and atlas tiles.
         self._tiles.add(octree_chunk, atlas_tile)
 
         # Set this flag so we call self._build_vertex_data() the next time
         # we are drawn. It will create new vertex and texture coordinates
         # buffers to include this new chunk.
         self._need_vertex_update = True
+
+    @property
+    def chunk_set(self) -> Set[OctreeChunkKey]:
+        """Return the set of chunks we are drawing.
+
+        Return
+        ------
+        Set[OctreeChunkKey]
+            The set of chunks we are drawing.
+        """
+        return self._tiles.chunk_set
 
     def prune_tiles(self, drawable_set: Set[OctreeChunk]) -> None:
         """Remove tiles that are not part of the drawable set.

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -1,6 +1,14 @@
 """TiledImageVisual class
 
 A visual that draws tiles using a texture atlas.
+
+Ultimately TiledImageVisual cannot depend on OctreeChunk. And Octree
+code should not depend on TiledImageVisual! So there really can be
+no class or named tuple that gets passed between them.
+
+Instead, we'll probably just have a function signature that takes things
+like the pos, size and depth of each tile as separate arguments. But
+for now both do depend on OctreeChunk.
 """
 from typing import List, Set
 

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -233,7 +233,7 @@ class TiledImageVisual(ImageVisual):
         self._need_vertex_update = True
 
     def prune_tiles(self, drawable_set: Set[OctreeChunk]) -> None:
-        """Remove tiles that are not part of the given drawable set.
+        """Remove tiles that are not part of the drawable set.
 
         drawable_set : Set[OctreeChunk]
             The set of currently drawable chunks.

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -25,7 +25,7 @@ SHAPE_IN_TILES = (16, 16)
 
 
 class TiledImageVisual(ImageVisual):
-    """An image that is drawn using one or more "tiles".
+    """An image that is drawn using one or more chunks or tiles.
 
     A regular ImageVisual is a single image drawn as a single rectangle
     with a single texture. A tiled TiledImageVisual also has a single
@@ -37,7 +37,7 @@ class TiledImageVisual(ImageVisual):
     texture can hold 256 different (256, 256) tiles.
 
     When the TiledImageVisual draws, it draws a single list of quads. Each
-    quad's texture coordinates refer to a potentially different texture in
+    quad's texture coordinates potentially refers to a different texture in
     the atlas.
 
     The quads can be located anywhere, even in 3D. TiledImageVisual does
@@ -47,23 +47,24 @@ class TiledImageVisual(ImageVisual):
 
     For example, one quad might have a (256, 256) texture, but it's
     physically tiny on the screen. While the next quad is also showing a
-    (256, 256) texture, but it's really big on that same screen. This
-    ability comes in handy for octree rendering, because we will often draw
-    multiple levels of the octree at the same time.
+    (256, 256) texture, it has to be, but that quad is really big on that
+    same screen. This ability to have different size quads comes in handy
+    for octree rendering, where we often draw chunks from multiple levels
+    of the octree at the same time.
 
     Adding or removing tiles from a TiledImageVisual is efficient. Only the
     bytes in the the tile(s) being updated are sent to the card. The Vispy
     method BaseTexture.set_data() has an "offset" argument. When setting
     texture data with an offset under the hood Vispy calls
     glTexSubImage2D(). It will only update the rectangular region within
-    the texture that's being updated. This is critical to making the whole
-    thing work.
+    the texture that's being updated. This is critical to making
+    TiledImageVisual efficient.
 
     In addition, uploading new tiles does not cause the shader to be
     rebuilt. This is another reason TiledImageVisual is faster than
-    creating a stand-alone ImageVisuals to draw each tile. Each new
-    ImageVisual results in a shader build today. Although, that's pretty
-    wasteful, and could probably be optimized in the future.
+    creating a stand-alone ImageVisuals, where each new ImageVisual results
+    in a shader build today. If that were fixed TiledImageVisual would
+    still be faster, but the speed gap would be smaller.
 
     Parameters
     ----------

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -314,7 +314,7 @@ class TiledImageVisual(ImageVisual):
         # TODO_OCTREE: We can probably avoid vstack here? Maybe one one
         # vertex buffer sized according to the max number of tiles we
         # expect? But grow it if we exceed our guess?
-        for tile_data in self._tiles.tile_data:
+        for tile_data in self._tiles.tile_data_sorted:
             atlas_tile = tile_data.atlas_tile
             verts = np.vstack((verts, atlas_tile.verts))
             tex_coords = np.vstack((tex_coords, atlas_tile.tex_coords))

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -30,7 +30,6 @@ class ChunkStats:
     start: int = 0
     remaining: int = 0
     low: int = 0
-    created: int = 0
     final: int = 0
 
     @property

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -1,7 +1,8 @@
 """VispyTiledImageLayer class.
 
-A tiled image that uses TiledImageVisual and TextureAtlas2D so
-adding/removing tiles is extremely fast.
+A tiled image that uses TiledImageVisual and TextureAtlas2D so that adding
+and removing tiles is faster than if we created a separate ImageVisual for
+each.
 """
 from dataclasses import dataclass
 from typing import List

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -15,7 +15,9 @@ from ..vispy_image_layer import VispyImageLayer
 from .tile_grid import TileGrid
 from .tiled_image_visual import TiledImageVisual
 
-# Create the scene graph Node version of this visual.
+# Create the scene graph Node version of this visual. Visuals are kind of mix
+# of the visual itself and a scene graph node that can added to the scene
+# and transformed.
 TiledImageNode = create_visual_node(TiledImageVisual)
 
 

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -2,7 +2,7 @@
 
 A tiled image that uses TiledImageVisual and TextureAtlas2D so that adding
 and removing tiles is faster than if we created a separate ImageVisual for
-each.
+each tile.
 """
 from dataclasses import dataclass
 from typing import List
@@ -16,9 +16,9 @@ from ..vispy_image_layer import VispyImageLayer
 from .tile_grid import TileGrid
 from .tiled_image_visual import TiledImageVisual
 
-# Create the scene graph Node version of this visual. Visuals are kind of mix
-# of the visual itself and a scene graph node that can added to the scene
-# and transformed.
+# Create the scene graph Node version of this visual. Visuals are a mix of
+# the visual itself and a scene graph node. The scene graph node is what
+# can added to the scene and transformed.
 TiledImageNode = create_visual_node(TiledImageVisual)
 
 

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -131,7 +131,7 @@ class ChunkLoader:
         chunks : Dict[str, ArrayLike]
             The arrays we want to load.
         """
-        layer_id = layer_ref.layer_id
+        layer_id = layer_ref.layer_key.layer_id
 
         if layer_id not in self.layer_map:
             self.layer_map[layer_id] = LayerInfo(layer_ref)

--- a/napari/components/experimental/chunk/_tests/test_chunk.py
+++ b/napari/components/experimental/chunk/_tests/test_chunk.py
@@ -77,7 +77,7 @@ def test_loader():
     data2 = data * 2
 
     # Create the ChunkRequest.
-    layer_ref = LayerRef.create_from_layer(layer)
+    layer_ref = LayerRef.create_from_layer(layer, (0, 0))
     request = chunk_loader.create_request(layer_ref, key, chunks)
 
     # Should be compatible with the layer we made it from!

--- a/napari/components/experimental/chunk/_utils.py
+++ b/napari/components/experimental/chunk/_utils.py
@@ -6,26 +6,7 @@ from typing import NamedTuple, Optional
 import dask.array as da
 import numpy as np
 
-
-def get_data_id(data) -> int:
-    """Return the data_id to use for this layer.
-
-    Parameters
-    ----------
-    layer
-        The layer to get the data_id from.
-
-    Notes
-    -----
-    We use data_id rather than just the layer_id, because if someone
-    changes the data out from under a layer, we do not want to use the
-    wrong chunks.
-    """
-    if isinstance(data, list):
-        assert data  # data should not be empty for image layers.
-        return id(data[0])  # Just use the ID from the 0'th layer.
-
-    return id(data)  # Not a list, just use it.
+from .layer_key import LayerKey
 
 
 def _get_type_str(data) -> str:
@@ -70,12 +51,12 @@ class LayerRef(NamedTuple):
         String describing the data type the layer holds.
     """
 
-    layer_id: int
+    layer_key: LayerKey
     weak_ref: weakref.ReferenceType
     data_type: str
 
     @classmethod
-    def create_from_layer(cls, layer):
+    def create_from_layer(cls, layer, indices):
         """Return a LayerRef created from this layer.
 
         Parameters
@@ -83,7 +64,8 @@ class LayerRef(NamedTuple):
         layer
             Create the LayerRef from this layer.
         """
-        return cls(id(layer), weakref.ref(layer), _get_type_str(layer.data))
+        layer_key = LayerKey.from_layer(layer, indices)
+        return cls(layer_key, weakref.ref(layer), _get_type_str(layer.data))
 
 
 class StatWindow:

--- a/napari/components/experimental/chunk/layer_key.py
+++ b/napari/components/experimental/chunk/layer_key.py
@@ -10,7 +10,27 @@ we do depend on layer.
 from typing import NamedTuple, Optional, Tuple
 
 from ....layers import Layer
-from ._utils import get_data_id
+
+
+def get_data_id(data) -> int:
+    """Return the data_id to use for this layer.
+
+    Parameters
+    ----------
+    layer
+        The layer to get the data_id from.
+
+    Notes
+    -----
+    We use data_id rather than just the layer_id, because if someone
+    changes the data out from under a layer, we do not want to use the
+    wrong chunks.
+    """
+    if isinstance(data, list):
+        assert data  # data should not be empty for image layers.
+        return id(data[0])  # Just use the ID from the 0'th layer.
+
+    return id(data)  # Not a list, just use it.
 
 
 class LayerKey(NamedTuple):

--- a/napari/layers/image/experimental/_chunked_slice_data.py
+++ b/napari/layers/image/experimental/_chunked_slice_data.py
@@ -72,12 +72,12 @@ class ChunkedSliceData(ImageSliceData):
         # Always load the image.
         chunks = {'image': self.image}
 
-        # Optionally load the thumbnail_source if it exists.
+        # Optionally load th e thumbnail_source if it exists.
         if self.thumbnail_source is not None:
             chunks['thumbnail_source'] = self.thumbnail_source
 
         # Create the ChunkRequest and load it with the ChunkLoader.
-        layer_ref = LayerRef.create_from_layer(self.layer)
+        layer_ref = LayerRef.create_from_layer(self.layer, self.indices)
         self.request = chunk_loader.create_request(layer_ref, key, chunks)
         satisfied_request = chunk_loader.load_chunk(self.request)
 

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -19,71 +19,76 @@ class OctreeChunkLoader:
     ----------
     layer_ref : LayerRef
         A weak reference to the layer we are loading chunks for.
-
-    Attributes
-    ----------
-    _last_visible : Set[OctreeChunkKey]
-        Chunks we saw last frame, so we can recognize chunks which have just
-        come into view.
     """
 
     def __init__(self, octree: Octree, layer_ref: LayerRef):
         self._octree = octree
         self._layer_ref = layer_ref
-        self._last_visible: Set[OctreeChunkKey] = set()
 
     def get_drawable_chunks(
-        self, visible: List[OctreeChunk], layer_key: LayerKey
+        self,
+        drawn_chunk_set: Set[OctreeChunkKey],
+        ideal_chunks: List[OctreeChunk],
+        layer_key: LayerKey,
     ) -> List[OctreeChunk]:
         """Return the chunks that should be drawn.
 
-        Visible chunks are within the bounds of the OctreeView, but those
+        The ideal chunks are within the bounds of the OctreeView, but those
         chunks may or may not be drawable. Drawable chunks are typically
         ones that were fully in memory to start, or have been
         asynchronously loaded so their data is now in memory.
 
-        This routine might return drawable chunks for levels other than
-        the target level we are drawing. This is called multi-level rendering
-        and it's core feature of quadtree/octree rendering.
+        This routine might return drawable chunks for levels other than the
+        ideal level. This is called multi-level rendering and it's core
+        feature of quadtree/octree rendering.
 
         Background
         -----------
-        Generally we want to draw the "best available" data. The target
+        Generally we want to draw the "best available" data. The ideal
         level was chosen because its image pixels best match the screen
-        pixels. So if available we always prefer to draw chunks at the
-        target level.
+        pixels. So if loaded, we prefer drawing the ideal chunks.
 
-        However we strongly want to avoid drawing nothing. So if a chunk is
-        not available in the target level, we search of a suitable substitute.
-        There are just two directions to search:
+        However, we strongly want to avoid drawing nothing. So if an ideal
+        chunk is not available, we search for a suitable substitute. There
+        are just two directions to search:
 
-        1) Look for a drawable chunk at a higher (coarser) level.
-        2) Look for a drawable chunk at a lower (finer) level.
+        1) Up, look for a drawable chunk at a higher (coarser) level.
+        2) Down, look for a drawable chunk at a lower (finer) level.
 
         A parent chunk, at a higher level, will cover more than just the
-        missing target level chunk. While a child chunk, at a lower level,
-        will only cover a fraction of the missing target level chunk.
+        missing ideal chunk. While a child chunk, at a lower level, will
+        only cover a fraction of the missing ideal chunk. And so on
+        recursively through multiple levels.
 
         The TiledImageVisual can draw overlapping tiles/chunks. For example
-        suppose below B and C are in the target level. But in this case
-        B is drawable but C is not. We search up from C and find A.
+        suppose below B and C are ideal chunks, but B is drawable while C
+        is not. We search up from C and find A.
+
         ----------
         |    A   |
         | --- ---|
         |  B | C |
         |---------
+
         We return B and A as drawable chunks. TiledImageVisual will render
-        A first and then B. So looking at the region coverede by A, the 1/4
-        occupied by B will be at the target resolution, the remaining 3/4
-        will be at a a lower resoution.
+        A first and then B. So looking at the region covered by A, the 1/4
+        occupied by B will be at the ideal resolution, while the remaining
+        3/4 will be at a lower resoution.
 
         In many cases drawing one level lower resolution than the target will
         be barely noticeable by the user. And once the chunk is loaded it
         will update to full resolution.
 
+        Drawing one level too high should not be noticeable at all by the
+        user, it just means the card is doing the downsampling. The only
+        downside there is drawing lots of tiles might be slow and it will
+        hold more data in memory than is necessary.
+
         Parameters
         ----------
-        visible : List[OctreeChunk]
+        drawn_chunk_set : Set[OctreeChunkKey]
+            The chunks which the visual is currently drawing.
+        ideal_chunks : List[OctreeChunk]
             The chunks which are visible to the current view.
         layer_key : LayerKey
             The layer we loading chunks into.
@@ -91,30 +96,91 @@ class OctreeChunkLoader:
         Return
         ------
         List[OctreeChunk]
-            The chunks that can be drawn.
+            The chunks that should be drawn.
         """
-        # Create a set for fast membership testing.
-        visible_set = set(octree_chunk.key for octree_chunk in visible)
-
-        # Remove chunks from self._last_visible if they are no longer
-        # in the visible set. If they are no longer in view.
-        for key in list(self._last_visible):
-            if key not in visible_set:
-                self._last_visible.remove(key)
-
         drawable = []  # Create this list of drawable chunks.
 
-        # Get drawables for every visible chunks. This might be the chunk itself
-        # or it might be stand-ins from other levels.
-        for octree_chunk in visible:
-            chunk_drawables = self._get_drawables(octree_chunk, layer_key)
+        # Get drawables for every ideal chunk. This will be the chunk itself
+        # if it's drawable. Otherwise it might be some number of substitute
+        # chunks from higher or lower levels.
+        for octree_chunk in ideal_chunks:
+            chunk_drawables = self._get_drawables(
+                drawn_chunk_set, octree_chunk, layer_key
+            )
             drawable.extend(chunk_drawables)
 
-        # Update our _last_visible set with what is in view.
-        for octree_chunk in drawable:
-            self._last_visible.add(octree_chunk.key)
-
         return drawable
+
+    def _get_drawables(
+        self,
+        drawn_chunk_set: Set[OctreeChunkKey],
+        ideal_chunk: OctreeChunk,
+        layer_key: LayerKey,
+    ) -> bool:
+        """Return True if this chunk is ready to be drawn.
+
+        Parameters
+        ----------
+        drawn_chunk_set : Set[OctreeChunkKey]
+            The chunks which the visual is currently drawing.
+        ideal_chunk : OctreeChunk
+            The ideal chunk we'd like to draw.
+        layer_key : LayerKey
+            The layer we loading chunks into.
+
+        Return
+        ------
+        bool
+            True if this chunk can be drawn.
+        """
+        # If the chunk is fully in memory, then it's drawable.
+        if ideal_chunk.in_memory:
+            # If it's being drawn already, then keep drawing it.
+            if ideal_chunk.key in drawn_chunk_set:
+                return [ideal_chunk]
+
+            # It's in memory but it's NOT being drawn yet. Maybe it has not
+            # been paged into VRAM. Draw substitues until it starts being
+            # drawn.
+            return self._get_substitutes(ideal_chunk)
+
+        # The chunk is not in memory. If it's being loaded, draw
+        # substitutes until the load finishes.
+        if ideal_chunk.loading:
+            return self._get_substitutes(ideal_chunk)
+
+        # The chunk is not in memory and is not being loaded, so try
+        # loading it now. We'd like to draw this chunk!
+        sync_load = self._load_chunk(ideal_chunk, layer_key)
+
+        # If the chunk was loaded synchronously, we can draw it now.
+        if sync_load:
+            return [ideal_chunk]
+
+        # Otherwise, an async load was initiated, and sometime later
+        # OctreeImage.on_chunk_loaded will be called with the chunk's
+        # loaded data. But we can't draw it now.
+        return self._get_substitutes(ideal_chunk)
+
+    def _get_substitutes(self, ideal_chunk: OctreeChunk) -> List[OctreeChunk]:
+        """Return the chunks we should draw in place of the ideal chunk.
+
+        Parameters
+        ----------
+        ideal_chunk : OctreeChunk
+            Get chunks to draw in place of this one.
+
+        Return
+        ------
+        List[OctreeNode]
+            Draw these chunks in place of the ideal one.
+        """
+        # TODO_OCTREE: This is just the very start of the search algorithm
+        # as a test. This will be extended soon.
+        parent_chunk = self._octree.get_parent(ideal_chunk)
+        if parent_chunk is None:
+            return []  # No immediate parent
+        return [parent_chunk]
 
     def _load_chunk(
         self, octree_chunk: OctreeChunk, layer_key: LayerKey
@@ -128,15 +194,16 @@ class OctreeChunkLoader:
         layer_key : LayerKey
             The key for layer we are loading the data for.
         """
-        # Key that points to a specific location in the octree.
+        # Get a key that points to this specific location in the octree.
         key = OctreeChunkKey(layer_key, octree_chunk.location)
 
-        # We only load one chunk per request right now, so we just
+        # The ChunkLoader takes a dict of chunks that should be loaded at
+        # the same time. We only ever ask for one chunk right now, so just
         # call it 'data'.
         chunks = {'data': octree_chunk.data}
 
-        # Mark that a load is in progress for this OctreeChunk. So
-        # we don't initiate a second load for one reason.
+        # Mark that a load is in progress for this OctreeChunk. We don't
+        # want to initiate a second load for the same chunk.
         octree_chunk.loading = True
 
         # Create the ChunkRequest and load it with the ChunkLoader.
@@ -152,80 +219,13 @@ class OctreeChunkLoader:
         # The load was sync so it's already done, some situations were
         # the ChunkLoader loads synchronously:
         #
-        # 1) Its force_synchronous config option is set.
-        # 2) The data already is an ndarray, there's nothing to load.
+        # 1) The force_synchronous config option is set.
+        # 2) The data already was an ndarray, there's nothing to "load".
         # 3) The data is Dask or similar, but based on past loads it's
-        #    loading so quickly, we decided to load it synchronously.
+        #    loading so quickly that we decided to load it synchronously.
         # 4) The data is Dask or similar, but we already loaded this
         # exact chunk before, so it was in the cache.
         #
-        # Whatever the reason, we can insert the data into the octree and
-        # we will draw it this frame.
+        # Whatever the reason, the data is now ready to draw.
         octree_chunk.data = satisfied_request.chunks.get('data')
         return True
-
-    def _get_drawables(
-        self, octree_chunk: OctreeChunk, layer_key: LayerKey
-    ) -> bool:
-        """Return True if this chunk is ready to be drawn.
-
-        Parameters
-        ----------
-        octree_chunk : OctreeChunk
-            Prepare to draw this chunk.
-
-        Return
-        ------
-        bool
-            True if this chunk can be drawn.
-        """
-        # If the cache is disabled, and this chunk just came into view,
-        # the we nuke the contents. This forces a re-load of the data.
-        #
-        # In the future we might strip every chunk that goes out of
-        # view. Then this will not be needed.
-        if not chunk_loader.cache.enabled:
-            new_in_view = octree_chunk.key not in self._last_visible
-            if new_in_view and octree_chunk.in_memory:
-                octree_chunk.clear()
-
-        # If the chunk is fully in memory, then it's drawable.
-        if octree_chunk.in_memory:
-            return [octree_chunk]  # Draw the chunk itself.
-
-        # If the chunk is loading, it's not drawable yet.
-        if octree_chunk.loading:
-            return self._get_replacements(octree_chunk)
-
-        # The chunk is not in memory and is not being loaded, but it is
-        # in view. So try loading it.
-        sync_load = self._load_chunk(octree_chunk, layer_key)
-
-        # If the chunk was loaded synchronously, we can draw it now.
-        if sync_load:
-            return [octree_chunk]  # Draw the chunk itself.
-
-        # Otherwise, an async load was initiated, and sometime later
-        # OctreeImage.on_chunk_loaded will be called with the chunk's
-        # loaded data. But we can't draw it now.
-        return self._get_replacements(octree_chunk)
-
-    def _get_replacements(
-        self, octree_chunk: OctreeChunk
-    ) -> List[OctreeChunk]:
-        """Return chunks we are draw in place of the given chunk.
-
-        Parameters
-        ----------
-        octree_chunk : OctreeChunk
-            Get chunks to draw in place of this one.
-
-        Return
-        ------
-        List[OctreeNode]
-            Draw this chunks as a replacement.
-        """
-        parent_chunk = self._octree.get_parent(octree_chunk)
-        if parent_chunk is None:
-            return []  # No immediate parent
-        return [parent_chunk]

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -142,8 +142,9 @@ class OctreeChunkLoader:
                 return [ideal_chunk]
 
             # It's in memory but it's NOT being drawn yet. Maybe it has not
-            # been paged into VRAM. Draw substitues until it starts being
-            # drawn.
+            # been paged into VRAM. Draw both the ideal chunk AND
+            # substitutes until it starts being drawn. We draw both so
+            # the visual keeps trying to add the idea one.
             print(f"in_memory and not drawn: level {ideal_chunk.location}")
             return [ideal_chunk] + self._get_substitutes(ideal_chunk)
 

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -109,6 +109,7 @@ class OctreeChunkLoader:
             )
             drawable.extend(chunk_drawables)
 
+        print(f"num_drawable = {len(drawable)}")
         return drawable
 
     def _get_drawables(
@@ -137,12 +138,14 @@ class OctreeChunkLoader:
         if ideal_chunk.in_memory:
             # If it's being drawn already, then keep drawing it.
             if ideal_chunk.key in drawn_chunk_set:
+                print(f"in_memory and draw: level {ideal_chunk.location}")
                 return [ideal_chunk]
 
             # It's in memory but it's NOT being drawn yet. Maybe it has not
             # been paged into VRAM. Draw substitues until it starts being
             # drawn.
-            return self._get_substitutes(ideal_chunk)
+            print(f"in_memory and not drawn: level {ideal_chunk.location}")
+            return [ideal_chunk] + self._get_substitutes(ideal_chunk)
 
         # The chunk is not in memory. If it's being loaded, draw
         # substitutes until the load finishes.
@@ -175,11 +178,14 @@ class OctreeChunkLoader:
         List[OctreeNode]
             Draw these chunks in place of the ideal one.
         """
+        print(f"_get_substitute: ideal={ideal_chunk.location}")
         # TODO_OCTREE: This is just the very start of the search algorithm
         # as a test. This will be extended soon.
         parent_chunk = self._octree.get_parent(ideal_chunk)
         if parent_chunk is None:
+            print("_get_substitute: found none")
             return []  # No immediate parent
+        print(f"_get_substitute: found {parent_chunk.location}")
         return [parent_chunk]
 
     def _load_chunk(

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -223,4 +223,5 @@ class OctreeChunkLoader:
         List[OctreeNode]
             Draw this chunks as a replacement.
         """
+        # parent_chunk = octree_chunk
         return []  # nothing yet

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -182,12 +182,23 @@ class OctreeChunkLoader:
         print(f"_get_substitute: ideal={ideal_chunk.location}")
         # TODO_OCTREE: This is just the very start of the search algorithm
         # as a test. This will be extended soon.
-        parent_chunk = self._octree.get_parent(ideal_chunk)
-        if parent_chunk is None:
-            print("_get_substitute: found none")
-            return []  # No immediate parent
-        print(f"_get_substitute: found {parent_chunk.location}")
-        return [parent_chunk]
+
+        # Get any direct children we have. These make create substitutes
+        # in that they have all the resolution we need. The only drawback
+        # is that it's more chunks to draw, and they take up more
+        # memory than the ideal chunks would.
+        children = self._octree.get_children(ideal_chunk)
+
+        if len(children) < 4:
+            # We don't have all the children, so we need more coverage
+            # to substitute for the ideal chunk. Grab a parent or more
+            # distant ancestor.
+            parent = self._octree.get_parent(ideal_chunk)
+            if parent is not None:
+                return [parent] + children
+
+        # All we have are the children, could be between 0 and 4 of them.
+        return children
 
     def _load_chunk(
         self, octree_chunk: OctreeChunk, layer_key: LayerKey

--- a/napari/layers/image/experimental/_octree_multiscale_slice.py
+++ b/napari/layers/image/experimental/_octree_multiscale_slice.py
@@ -51,11 +51,13 @@ class OctreeMultiscaleSlice:
         self._layer_ref = layer_ref
         self._slice_config = slice_config
 
-        self._loader: OctreeChunkLoader = OctreeChunkLoader(layer_ref)
-
         slice_id = id(self)
         self._octree = Octree(slice_id, data, slice_config)
         self._octree_level = self._octree.num_levels - 1
+
+        self._loader: OctreeChunkLoader = OctreeChunkLoader(
+            self._octree, layer_ref
+        )
 
         thumbnail_image = np.zeros(
             (64, 64, 3)

--- a/napari/layers/image/experimental/_octree_multiscale_slice.py
+++ b/napari/layers/image/experimental/_octree_multiscale_slice.py
@@ -276,8 +276,9 @@ class OctreeMultiscaleSlice:
             self.octree_level = intersection.level.info.level_index
 
         # Return all of the chunks in this intersection, creating chunks if
-        # they don't already exist.
-        return intersection.get_chunks(create_chunks=True)
+        # they don't already exist. We create them because we want to load
+        # the data in these locations.
+        return intersection.get_chunks(create=True)
 
     def _get_octree_chunk(self, location: OctreeLocation) -> OctreeChunk:
         """Return the OctreeChunk at his location.

--- a/napari/layers/image/experimental/_octree_multiscale_slice.py
+++ b/napari/layers/image/experimental/_octree_multiscale_slice.py
@@ -4,7 +4,7 @@ For viewing one slice of a multiscale image using an octree.
 """
 import logging
 import math
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Set
 
 import numpy as np
 
@@ -13,7 +13,7 @@ from ....types import ArrayLike
 from .._image_view import ImageView
 from ._octree_chunk_loader import OctreeChunkLoader
 from .octree import Octree
-from .octree_chunk import OctreeChunk, OctreeLocation
+from .octree_chunk import OctreeChunk, OctreeChunkKey, OctreeLocation
 from .octree_intersection import OctreeIntersection, OctreeView
 from .octree_level import OctreeLevel, OctreeLevelInfo
 from .octree_util import SliceConfig
@@ -53,6 +53,10 @@ class OctreeMultiscaleSlice:
 
         slice_id = id(self)
         self._octree = Octree(slice_id, data, slice_config)
+
+        # Note that self._octree might have more levels than len(data) because
+        # in some cases we add on extra levels. We add on levels until the
+        # root tile consists of only a single tile.
         self._octree_level = self._octree.num_levels - 1
 
         self._loader: OctreeChunkLoader = OctreeChunkLoader(
@@ -84,6 +88,12 @@ class OctreeMultiscaleSlice:
         level : int
             The new level to display.
         """
+        num_levels = self._octree.num_levels
+        if level < 0 or level >= num_levels:
+            raise ValueError(
+                f"Octree level {level} is not in range(0, {num_levels})"
+            )
+
         self._octree_level = level
 
     @property
@@ -108,12 +118,12 @@ class OctreeMultiscaleSlice:
             return None
 
         try:
-            return self._octree.levels[self._octree_level].info
+            return self._octree.levels[self.octree_level].info
         except IndexError as exc:
-            index = self._octree_level
-            count = len(self._octree.levels)
+            index = self.octree_level
+            num_levels = len(self._octree.levels)
             raise IndexError(
-                f"Octree level {index} is not in range(0, {count})"
+                f"Octree level {index} is not in range(0, {num_levels})"
             ) from exc
 
     def get_intersection(self, view: OctreeView) -> OctreeIntersection:
@@ -148,6 +158,7 @@ class OctreeMultiscaleSlice:
         index = self._get_auto_level_index(view)
         if index < 0 or index >= self._octree.num_levels:
             raise ValueError(f"Invalid octree level {index}")
+
         return self._octree.levels[index]
 
     def _get_auto_level_index(self, view: OctreeView) -> int:
@@ -165,7 +176,7 @@ class OctreeMultiscaleSlice:
         """
         if not view.auto_level:
             # Return current level, do not update it.
-            return self._octree_level
+            return self.octree_level
 
         # Find the right level automatically. Choose a level where the texels
         # in the octree tiles are around the same size as screen pixels.
@@ -178,13 +189,18 @@ class OctreeMultiscaleSlice:
             return 0  # Show the best we've got!
 
         # Choose the right level...
-        return min(math.floor(math.log2(ratio)), self._octree.num_levels - 1)
+        max_level = self._octree.num_levels - 1
+        return min(math.floor(math.log2(ratio)), max_level)
 
-    def get_drawable_chunks(self, view: OctreeView) -> List[OctreeChunk]:
+    def get_drawable_chunks(
+        self, drawn_chunk_set: Set[OctreeChunkKey], view: OctreeView
+    ) -> List[OctreeChunk]:
         """Get the chunks that should be drawn to depict this view.
 
         Parameters
         ----------
+        drawn_chunk_set : Set[OctreeChunkKey]
+            The chunks that are currently being drawn by the visual.
         view : OctreeView
             Get the chunks for this view.
 
@@ -193,22 +209,51 @@ class OctreeMultiscaleSlice:
         List[OctreeChunk]
             The chunks to draw.
         """
-        # The visible chunks are every chunk within view, whether or not we
-        # have data to draw it.
-        visible_chunks = self._get_visible_chunks(view)
+        # Get the ideal chunks, the ones best match the current screen
+        # resolution.
+        ideal_chunks = self._get_ideal_chunks(view)
+
         layer_key = self._layer_ref.layer_key
 
-        # Calling get_drawable_chunks() will return the chunks that are
-        # ready to be drawn. Also, it might initiate async loads so that
-        # more chunks will be drawable in the near future.
-        return self._loader.get_drawable_chunks(visible_chunks, layer_key)
+        # Let the loader decide what chunks should be drawn. It will
+        # only return chunks which are fully loaded and read to be drawn.
+        #
+        # It might return chunks from a higher or lower level than the
+        # ideal level. Also it might initiate async loads so that more
+        # chunks will be drawable in the near future.
+        return self._loader.get_drawable_chunks(
+            drawn_chunk_set, ideal_chunks, layer_key
+        )
 
-    def _get_visible_chunks(self, view: OctreeView) -> List[OctreeChunk]:
-        """Get the chunks within this view at the right level of the octree.
+    def _get_ideal_chunks(self, view: OctreeView) -> List[OctreeChunk]:
+        """Get the ideal chunks we want to draw for this view.
 
-        The call to get_intersection() will chose the appropriate level
-        of the octree to intersect, and then return an intersection at
-        that level.
+        The call to get_intersection() will chose the appropriate level of
+        the octree to intersect, and then return all the chunks within the
+        intersection with that level.
+
+        These are the "ideal" chunks because they are at the level whose
+        resolution best matches the current screen resolution.
+
+        Drawing chunks at a lower level than this will work fine, but it's
+        a waste in that those chunks will just be downsampled by the card.
+        You won't see any "extra" resolution at all. The card can do this
+        super fast, so the issue not such much speed as it is RAM and VRAM.
+
+        For example, suppose we want to draw 40 ideal chunks at level N,
+        and the chunks are (256, 256, 3) with dtype uint8. That's around
+        8MB.
+
+        If instead we draw lower levels than the ideal, the number of
+        chunks and storage goes up quickly:
+
+        Level (N - 1) is 160 chunks = 32M
+        Level (N - 2) is 640 chunks = 126M
+        Level (N - 3) is 2560 chunks = 503M
+
+        In the opposite direction, drawing chunks from a higher, the number
+        of chunks and storage goes down quickly. The only issue there is
+        visual quality, the imagery might look blurry.
 
         Paramaters
         ----------
@@ -228,7 +273,7 @@ class OctreeMultiscaleSlice:
         # If we are choosing the level automatically, then update our level
         # with the level chosen for the intersection.
         if view.auto_level:
-            self._octree_level = intersection.level.info.level_index
+            self.octree_level = intersection.level.info.level_index
 
         # Return all of the chunks in this intersection, creating chunks if
         # they don't already exist.

--- a/napari/layers/image/experimental/_octree_multiscale_slice.py
+++ b/napari/layers/image/experimental/_octree_multiscale_slice.py
@@ -159,7 +159,11 @@ class OctreeMultiscaleSlice:
         return min(math.floor(math.log2(ratio)), self._octree.num_levels - 1)
 
     def get_visible_chunks(self, view: OctreeView) -> List[OctreeChunk]:
-        """Get the chunks within this view that are visible.
+        """Get the chunks within this view at the right level of the octree.
+
+        The call to get_intersection() will chose the appropriate level
+        of the octree to intersect, and then return an intersection at
+        that level.
 
         Paramaters
         ----------
@@ -174,15 +178,16 @@ class OctreeMultiscaleSlice:
         intersection = self.get_intersection(view)
 
         if intersection is None:
-            return []
+            return []  # No visible chunks.
 
+        # If we are choosing the level automatically, then update our level
+        # with the level chosen for the intersection.
         if view.auto_level:
-            # Update our self._octree_level based on what level was automatically
-            # selected by the intersection.
             self._octree_level = intersection.level.info.level_index
 
-        # Return the chunks in this intersection.
-        return intersection.get_chunks(id(self))
+        # Return all of the chunks in this intersection, creating chunks if
+        # they don't already exist.
+        return intersection.get_chunks(create_chunks=True)
 
     def _get_octree_chunk(self, location: OctreeLocation) -> OctreeChunk:
         """Return the OctreeChunk at his location.

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -72,7 +72,7 @@ class Octree:
         # Now the root should definitely contain only a single tile.
         assert self.levels[-1].info.num_tiles == 1
 
-        # This now the total number of levels.
+        # This is now the total number of levels, including the extra ones.
         self.num_levels = len(self.data)
 
     def get_parent(self, octree_chunk: OctreeChunk) -> Optional[OctreeChunk]:

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -123,18 +123,17 @@ class Octree:
         Return
         ------
         Optional[OctreeChunk]
-            The parent of the chunk if there was one or we created it.
+            The nearest ancestor of the chunk if we found one.
         """
         location = octree_chunk.location
 
-        # Start at the current level.
+        # Start at the current level and work our way up.
         level_index = location.level_index
         row, col = location.row, location.col
 
-        # Search up towards the root.
+        # Search up one level at a time.
         while level_index < self.num_levels - 1:
 
-            # Go up one level.
             level_index += 1
             row, col = int(row / 2), int(col / 2)
             level: OctreeLevel = self.levels[level_index]

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -76,7 +76,7 @@ class Octree:
         self.num_levels = len(self.data)
 
     def get_parent(self, octree_chunk: OctreeChunk) -> Optional[OctreeChunk]:
-        """Return the parent of this octree_chunk or None if this is the root.
+        """Return the parent of this octree_chunk if there is one.
 
         Parameters
         ----------
@@ -86,17 +86,23 @@ class Octree:
         Return
         ------
         Optional[OctreeChunk]
-            The parent of the trunk if there was one.
+            The parent of the chunk if there was one.
         """
         location = octree_chunk.location
 
         if location.level_index == self.num_levels - 1:
             return None  # This is the root so no parent.
 
-        row, col = location.row / 2, location.col / 2
-        parent_level = self.levels[location.level_index + 1]
+        parent_level_index = location.level_index + 1
+        parent_level = self.levels[parent_level_index]
+
+        # Cut row, col in half for the corresponding parent indices.
+        row, col = int(location.row / 2), int(location.col / 2)
+
+        print(f"Looking for parent at ({parent_level_index}, {row}, {col}")
 
         # For now this is None unless there already is an OctreeChunk here.
+        # We do not create OctreeChunks here, although we could.
         return parent_level.get_chunk(row, col)
 
     def _get_extra_levels(self) -> List[OctreeLevel]:
@@ -216,6 +222,8 @@ def _check_downscale_ratio(data) -> None:
     if not isinstance(data, list) or len(data) < 2:
         return  # There aren't even two levels.
 
+    # _dump_levels(data)
+
     ratio = math.sqrt(data[0].size / data[1].size)
 
     # Really should be exact, but it will most likely be off by a ton
@@ -224,3 +232,17 @@ def _check_downscale_ratio(data) -> None:
         raise ValueError(
             f"Multiscale data has downsampling ratio of {ratio}, expected 2."
         )
+
+
+def _dump_levels(data) -> None:
+    """Print the levels and the size of the levels."""
+    last_size = None
+    for level in data:
+        if last_size is not None:
+            downscale = math.sqrt(last_size / level.size)
+            print(
+                f"size={level.size} shape={level.shape} downscale={downscale}"
+            )
+        else:
+            print(f"size={level.size} shape={level.shape} base level")
+        last_size = level.size

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -106,6 +106,45 @@ class Octree:
         row, col = int(location.row / 2), int(location.col / 2)
         return parent_level.get_chunk(row, col, create=create)
 
+    def get_nearest_ancestor(
+        self, octree_chunk: OctreeChunk
+    ) -> Optional[OctreeChunk]:
+        """Return the nearest ancestor of this octree_chunk.
+
+        This will not create OctreeNodes. It will return None if we don't
+        find any existing ancestors. Either they don't exist, or we are
+        at the root so there are no ancestors.
+
+        Parameters
+        ----------
+        octree_chunk : OctreeChunk
+            Return the nearest ancestor of this chunk.
+
+        Return
+        ------
+        Optional[OctreeChunk]
+            The parent of the chunk if there was one or we created it.
+        """
+        location = octree_chunk.location
+
+        # Start at the current level.
+        level_index = location.level_index
+        row, col = location.row, location.col
+
+        # Search up towards the root.
+        while level_index < self.num_levels - 1:
+
+            # Go up one level.
+            level_index += 1
+            row, col = int(row / 2), int(col / 2)
+            level: OctreeLevel = self.levels[level_index]
+            ancestor = level.get_chunk(row, col)
+
+            if ancestor is not None:
+                return ancestor  # Found one.
+
+        return None  # No ancestor found.
+
     def get_children(
         self, octree_chunk: OctreeChunk, create: bool = False
     ) -> List[OctreeChunk]:

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -22,9 +22,7 @@ class OctreeChunkGeom(NamedTuple):
 class OctreeLocation(NamedTuple):
     """Location of one chunk within the octree.
 
-    This is used as part of the OctreeChunkKey to uniquely identify a
-    chunk. The OctreeChunkKey is used when we load chunk and used
-    related to the cache.
+    Part of the OctreeChunkKey to uniquely identify a chunk.
     """
 
     slice_id: int
@@ -45,11 +43,10 @@ class OctreeLocation(NamedTuple):
 
 
 class OctreeChunkKey(ChunkKey):
-    """A ChunkKey that adds some octree specific fields.
+    """A ChunkKey plus some octree specific fields.
 
-    The ChunkLoader uses ChunkKey to identify chunks. So that it can cache
-    chunks if they have the same key. And so it can identify after they
-    have been loaded.
+    The ChunkLoader uses ChunkKey to identify chunks, for example for
+    caching or just tracking what has been loaded.
 
     Parameters
     ----------
@@ -68,8 +65,8 @@ class OctreeChunkKey(ChunkKey):
         super().__init__(layer_key)
 
     def _get_hash_values(self):
-        # TODO_OCTREE: can't we just has with parent's hashed key instead
-        # of creating a single big has value? Probably.
+        # TODO_OCTREE: can't we just hash in the parent's hashed key with
+        # our additional values? Probably, but we do it from scratch here.
         parent = super()._get_hash_values()
         return parent + (self.location,)
 
@@ -91,16 +88,19 @@ class OctreeChunk:
     The highest level of the tree contains a single chunk which depicts the
     entire image, whether 2D or 3D.
 
-    Attributes
+    Parameters
     ----------
     data : ArrayLike
         The data to draw for this chunk.
-    _orig_data : ArrayLike
-        The original unloaded data that we use to implement OctreeChunk.clear().
     location : OctreeLocation
         The location of this chunk, including the level_index, row, col.
     geom : OctreeChunkGeom
         The x, y coordinates and scale of the chunk.
+
+    Attributes
+    ----------
+    _orig_data : ArrayLike
+        The original unloaded data that we use to implement OctreeChunk.clear().
     loading : bool
         If True the chunk has been queued to be loaded.
     """

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -78,10 +78,11 @@ class OctreeChunk:
     """A geographically meaningful portion of the full 2D or 3D image.
 
     For 2D images a chunk is a "tile". It's a 2D square region of pixels
-    which are part of the full 2D image. If it's in level 0 of the octree,
-    the pixels are 1:1 identical to the portion of the full image. The tile
-    is full resolution. If it's in level 1 or greater the pixels are
-    downsampled from the full resolution image.
+    which are part of the full 2D image.
+
+    If it's in level 0 of the octree, the pixels are 1:1 identical to the
+    full image. If it's in level 1 or greater the pixels are downsampled
+    from the full resolution image.
 
     For 3D, not yet implemented, a chunk is a sub-volume. Again for level 0
     the voxels are at the full resolution of the full image, but for other

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -32,8 +32,8 @@ class OctreeLocation(NamedTuple):
 
     def __str__(self):
         return (
-            f"location=({self.level_index}, {self.row}, {self.col}) "
-            f"slice={self.slice_id} id={id(self)}"
+            f"location =({self.level_index}, {self.row}, {self.col}) "
+            # f"slice={self.slice_id} id={id(self)}"
         )
 
     @classmethod

--- a/napari/layers/image/experimental/octree_intersection.py
+++ b/napari/layers/image/experimental/octree_intersection.py
@@ -57,34 +57,44 @@ class OctreeIntersection:
     ----------
     level : OctreeLevel
         The octree level that we intersected with.
-    corners_2d : np.ndarray
-        The lower left and upper right corners of the view in data coordinates.
+    view : OctreeView
+        The view we are intersecting with the octree.
     """
 
     def __init__(self, level: OctreeLevel, view: OctreeView):
         self.level = level
-        self.corners = view.corners
+        self._corners = view.corners
 
-        info = self.level.info
+        level_info = self.level.info
 
         # TODO_OCTREE: don't split rows/cols so all these pairs of variables
         # are just one variable each? Use numpy more.
         rows, cols = view.corners[:, 0], view.corners[:, 1]
 
-        base = info.slice_config.base_shape
+        base = level_info.slice_config.base_shape
 
         self.normalized_range = np.array(
             [np.clip(rows / base[0], 0, 1), np.clip(cols / base[1], 0, 1)]
         )
 
-        scaled_rows = rows / info.scale
-        scaled_cols = cols / info.scale
+        scaled_rows = rows / level_info.scale
+        scaled_cols = cols / level_info.scale
 
         self._row_range = self.row_range(scaled_rows)
         self._col_range = self.column_range(scaled_cols)
 
-    def tile_range(self, span, num_tiles):
-        """Return tiles indices needed to draw the span."""
+    def tile_range(
+        self, span: Tuple[float, float], num_tiles_total: int
+    ) -> range:
+        """Return tiles indices needed to draw the span.
+
+        Parameters
+        ----------
+        span : Tuple[float, float]
+            The span in image coordinates.
+        num_tiles_total : int
+            The total number of tiles in this direction.
+        """
 
         def _clamp(val, min_val, max_val):
             return max(min(val, max_val), min_val)
@@ -93,8 +103,8 @@ class OctreeIntersection:
 
         span_tiles = [span[0] / tile_size, span[1] / tile_size]
         clamped = [
-            _clamp(span_tiles[0], 0, num_tiles - 1),
-            _clamp(span_tiles[1], 0, num_tiles - 1) + 1,
+            _clamp(span_tiles[0], 0, num_tiles_total - 1),
+            _clamp(span_tiles[1], 0, num_tiles_total - 1) + 1,
         ]
 
         # TODO_OCTREE: BUG, range is not empty when it should be?
@@ -104,12 +114,33 @@ class OctreeIntersection:
         return range(*span_int)
 
     def row_range(self, span: Tuple[float, float]) -> range:
-        """Return row indices which span image coordinates [y0..y1]."""
+        """Return row range of tiles for this span.
+        Parameters
+        ----------
+        span : Tuple[float, float]
+            The span in image coordinates, [y0..y1]
+
+        Return
+        ------
+        range
+            The range of tiles across the columns.
+        """
         tile_rows = self.level.info.shape_in_tiles[0]
         return self.tile_range(span, tile_rows)
 
     def column_range(self, span: Tuple[float, float]) -> range:
-        """Return column indices which span image coordinates [x0..x1]."""
+        """Return column range of tiles for this span.
+
+        Parameters
+        ----------
+        span : Tuple[float, float]
+            The span in image coordinates, [x0..x1]
+
+        Return
+        ------
+        range
+            The range of tiles across the columns.
+        """
         tile_cols = self.level.info.shape_in_tiles[1]
         return self.tile_range(span, tile_cols)
 
@@ -128,7 +159,7 @@ class OctreeIntersection:
         return _inside(row, self._row_range) and _inside(col, self._col_range)
 
     def get_chunks(self, create_chunks=False) -> List[OctreeChunk]:
-        """Return chunks inside this intersection.
+        """Return all of the chunks in this intersection.
 
         Parameters
         ----------
@@ -136,7 +167,7 @@ class OctreeIntersection:
             If True, create an OctreeChunk at any location that does
             not already have a chunk.
         """
-        chunks = []
+        chunks = []  # The chunks in the intersection.
 
         # Get every chunk that is within the rectangular region. These are
         # all the chunks we might possibly draw, because they are within
@@ -148,7 +179,7 @@ class OctreeIntersection:
         #
         # OctreeChunks can be loaded or unloaded. Unloaded chunks are not
         # drawn until their data as been loaded in. But here we return
-        # every chunk within the rectangle.
+        # every chunk within the view.
         for row in self._row_range:
             for col in self._col_range:
                 chunk = self.level.get_chunk(
@@ -161,7 +192,7 @@ class OctreeIntersection:
 
     @property
     def tile_state(self) -> dict:
-        """Return tile state.
+        """Return tile state, for the monitor.
 
         Return
         ------
@@ -176,13 +207,13 @@ class OctreeIntersection:
                 # A list of (row, col) pairs of visible tiles.
                 "seen": seen,
                 # The two corners of the view in data coordinates ((x0, y0), (x1, y1)).
-                "corners": self.corners,
+                "corners": self._corners,
             }
         }
 
     @property
     def tile_config(self) -> dict:
-        """Return tile config
+        """Return tile config, for the monitor.
 
         Return
         ------

--- a/napari/layers/image/experimental/octree_intersection.py
+++ b/napari/layers/image/experimental/octree_intersection.py
@@ -158,14 +158,14 @@ class OctreeIntersection:
 
         return _inside(row, self._row_range) and _inside(col, self._col_range)
 
-    def get_chunks(self, create_chunks=False) -> List[OctreeChunk]:
+    def get_chunks(self, create=False) -> List[OctreeChunk]:
         """Return all of the chunks in this intersection.
 
         Parameters
         ----------
-        create_chunks : bool
+        create : bool
             If True, create an OctreeChunk at any location that does
-            not already have a chunk.
+            not already have one.
         """
         chunks = []  # The chunks in the intersection.
 
@@ -182,9 +182,7 @@ class OctreeIntersection:
         # every chunk within the view.
         for row in self._row_range:
             for col in self._col_range:
-                chunk = self.level.get_chunk(
-                    row, col, create_chunks=create_chunks
-                )
+                chunk = self.level.get_chunk(row, col, create=create)
                 if chunk is not None:
                     chunks.append(chunk)
 

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -81,11 +81,11 @@ class OctreeLevel:
         self._tiles = {}
 
     def get_chunk(
-        self, row: int, col: int, create_chunks=False
+        self, row: int, col: int, create=False
     ) -> Optional[OctreeChunk]:
         """Return the OctreeChunk at this location if it exists.
 
-        If create_chunks is True, an OctreeChunk will be created if one
+        If create is True, an OctreeChunk will be created if one
         does not exist at this location.
 
         Parameters
@@ -94,19 +94,19 @@ class OctreeLevel:
             The row in the level.
         col : int
             The column in the level.
-        create_chunks : bool
+        create : bool
             If True, create the OctreeChunk if it does not exist.
 
         Return
         ------
         Optional[OctreeChunk]
-            The OctreeChunk if one exists at this location.
+            The OctreeChunk if one existed or we just created it.
         """
         try:
             return self._tiles[(row, col)]
         except KeyError:
-            if not create_chunks:
-                return None
+            if not create:
+                return None  # It didn't exist so we're done.
 
         # Create a chunk at this location and return it.
         octree_chunk = self._create_chunk(row, col)


### PR DESCRIPTION
# Description
* Implement multi-level rendering so we render the "best available" data when possible
* Avoids going to black unless we really have no data loaded for that location.
* Only works if everything is RAM, so gently move back and forth over a transition point.
    * If you move around quickly it will still go to black a lot. Looking into that.

# Details
* New `TileSet.tile_data_sorted()` method which sorts tiles by octree level
    * This is how we draw higher/coarser tiles first, so any descendants appear on top. 
* Now `VispyTiledImageLayer` passes the `TileSet` `chunk_set` into `OctreeImage.get_drawable_chunks`. So that `OctreeImage` and more so `OctreeChunkLoader` know what's currently being drawn.
* Most of the new logic is in `OctreeChunkLoader` and `Octree` methods `Octree.get_children()` `Octree.get_nearest_ancestor()`.

## Type of change
- [x] New feature in experimental code

# Files
<img width="355" alt="Screen Shot 2020-12-08 at 2 06 10 PM" src="https://user-images.githubusercontent.com/4163446/101529651-d947c300-395e-11eb-929e-bce41d107dc2.png">

# References
* [Quadtree](https://en.wikipedia.org/wiki/Quadtree) and [Tiled rendering](https://en.wikipedia.org/wiki/Tiled_rendering) - Wikipedia
* [Quadtree and Octrees](https://www.i-programmer.info/programming/theory/1679-quadtrees-and-octrees.html) - Mike James
* [Working with Terrain](https://sandboxdocs.readthedocs.io/en/latest/tutorials/working-with-terrain/) - Sandbox
* [Terrain Rendering](https://software.intel.com/content/www/us/en/develop/articles/terrain-rendering.html) - Intel
* [Rendering of Large Textures for Real-Time Vizualization](https://www.sbgames.org/sbgames2017/papers/ComputacaoShort/175392.pdf) - Backes, et al
* [Bing Maps Tile System](https://docs.microsoft.com/en-us/bingmaps/articles/bing-maps-tile-system) - Microsoft
* [Terrain in Battlefield 3](https://media.contentapi.ea.com/content/dam/eacom/frostbite/files/gdc12-terrain-in-battlefield3.pdf) - EA (DICE)
* [Terrain Rendering in Far Cry 5](https://twvideo01.ubm-us.net/o1/vault/gdc2018/presentations/TerrainRenderingFarCry5.pdf) - Ubisoft

# Terrain?

We reference terrain links because our images are "terrain sized". One of our test images is (300,000, 900,000) pixels. Often people with images that large are dealing with terrain. However, our rendering is *much* simpler than terrain rendering for three reasons:

1. Terrain is usually viewed in 3D with perspective. We are viewing top-down in 2D.
2. Therefore terrain is **always** rendering multiple resolutions, we do only when loading.
3. Terrain has varied elevations and geometry, our geometry is always perfectly flat.

With terrain they usually render in perspective, flying over the terrain. In that case, you are **always** rendering multiple levels of the quadtree. You render high resolution up close, and then progressively lower resolutions into the distance.

For us, we only render multiple resolutions when loads are in progress. Once things have "settled down" we are always rendering just a single level, a simple grid. So while aggressively zooming our rendering is terrain-like, but in the steady-state, ours is simpler, more image-like.

Also with terrain not only do you have geometry, that geometry also needs to be high resolution up-close and coarser in the distance. So again ours is simpler. Yet ours is not trivial since we do have to render multiple levels of the quadtree while loads are in progress, so that basic technique is the same.
