### PR TITLE
async-38: Better Multilevel Rendering

### DIFF
--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -264,7 +264,7 @@ class TiledImageVisual(ImageVisual):
         """
         for tile_data in list(self._tiles.tile_data):
             if tile_data.octree_chunk.key not in drawable_set:
-                print(f"REMOVE: {tile_data.octree_chunk}")
+                # print(f"REMOVE: {tile_data.octree_chunk}")
                 tile_index = tile_data.atlas_tile.index
                 self._remove_tile(tile_index)
 

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -264,6 +264,7 @@ class TiledImageVisual(ImageVisual):
         """
         for tile_data in list(self._tiles.tile_data):
             if tile_data.octree_chunk.key not in drawable_set:
+                print(f"REMOVE: {tile_data.octree_chunk}")
                 tile_index = tile_data.atlas_tile.index
                 self._remove_tile(tile_index)
 

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -173,6 +173,10 @@ class VispyTiledImageLayer(VispyImageLayer):
         else:
             self.grid.clear()
 
+        if stats.created > 0 or stats.deleted > 0:
+            for chunk in drawable_chunks:
+                print(f"drawn: {chunk}")
+
         return stats
 
     def _add_chunks(self, drawable_chunks: List[OctreeChunk]) -> int:

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -173,9 +173,9 @@ class VispyTiledImageLayer(VispyImageLayer):
         else:
             self.grid.clear()
 
-        if stats.created > 0 or stats.deleted > 0:
-            for chunk in drawable_chunks:
-                print(f"drawn: {chunk}")
+        # if stats.created > 0 or stats.deleted > 0:
+        #     for chunk in drawable_chunks:
+        #       print(f"drawn: {chunk}")
 
         return stats
 

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -269,7 +269,7 @@ class OctreeImage(Image):
     def get_drawable_chunks(
         self, drawn_chunk_set: Set[OctreeChunkKey]
     ) -> List[OctreeChunk]:
-        """Get the in the current slice which are drawable.
+        """Get the chunks in the current slice which are drawable.
 
         Parameters
         -----------


### PR DESCRIPTION
# Description

* Better multi-level rendering, less going to black.
* Now we draw the root tile all the time so we at least have something.

# Next Steps

This root tile is the first and only sort of speculative loading we are doing. We need a pretty good system soon that will let us easily specify out what to load, in some type of priority order:

1) Load X extra tiles on the current level as padding, so if the user pans they are ready to go.
2) Load a padded version of the current view 1 or 2 or 3 levels up?
3) Other ideas?

This should be specified in a config file or at least in a place that's easy for us to change. Because it might take some experimentation to find what we like. AND those settings might need to change for different types of data.

There should be a priority queue so these loads only happen if there is nothing more pressing to load. If you whip the view around, those priorities should get immediately shuffled to account for the new view.

# Demo

![napari-root-tilel-2](https://user-images.githubusercontent.com/4163446/101585271-703b6c00-39ad-11eb-861e-66a89f0387be.gif)

When we first zoom out nothing is being drawn at the ideal level. The drawn tiles are one level too low in the tree, they are too small, but they were in VRAM so we are using them. Meanwhile, most of the view is showing the root tile. But both the too-small and root-tile get replaced with the ideal tiles.

# Files

<img width="338" alt="Screen Shot 2020-12-08 at 11 27 37 PM" src="https://user-images.githubusercontent.com/4163446/101585047-facf9b80-39ac-11eb-907e-fc7032827cd6.png">
