### PR TITLE
Improve label paint lag

### DIFF
--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -14,6 +14,7 @@ texture_dtypes = [
     np.dtype(np.int16),
     np.dtype(np.uint16),
     np.dtype(np.float32),
+    np.dtype(np.float64),
 ]
 
 

--- a/napari/layers/image/_image_slice.py
+++ b/napari/layers/image/_image_slice.py
@@ -94,7 +94,13 @@ class ImageSlice:
             image = np.clip(image, 0, 1)
             thumbnail_source = np.clip(thumbnail_source, 0, 1)
         self.image.raw = image
-        self.thumbnail.raw = thumbnail_source
+
+        # save a computation of view image if thumbnail and image is equal
+        if thumbnail_source is image:
+            self.thumbnail._raw = self.image._raw
+            self.thumbnail._view = self.image._view
+        else:
+            self.thumbnail.raw = thumbnail_source
 
     def load(self, data: ImageSliceData) -> bool:
         """Load this data into the slice.

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -66,8 +66,6 @@ def draw(layer, event):
                 layer.fill(c, new_label, refresh=False)
         if not refresh_future or refresh_future.done():
             refresh_future = refresh_executor.submit(refresh, layer)
-        else:
-            print("skipped")
         last_cursor_coord = layer.coordinates
         yield
 

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -1,21 +1,5 @@
-from concurrent.futures import ThreadPoolExecutor
-
 from ._labels_constants import Mode
 from ._labels_utils import interpolate_coordinates
-
-refresh_executor = ThreadPoolExecutor(max_workers=1)
-
-
-def refresh(layer):
-    """Refresh the layer.
-
-    Move layer refresh to a method executed on another thread, to relieve main
-    event loop from heavy lifting and lagging due to cpu bound update through
-    vispy, see https://github.com/napari/product-heuristics-2020/issues/38.
-    (a better but not yet merged fix:https://github.com/vispy/vispy/pull/1912)
-
-    """
-    layer.refresh()
 
 
 def draw(layer, event):
@@ -38,7 +22,6 @@ def draw(layer, event):
     eraser
     """
     # on press
-    refresh_future = None
     layer._save_history()
     layer._block_saving = True
     if layer._mode == Mode.ERASE:
@@ -64,13 +47,11 @@ def draw(layer, event):
                 layer.paint(c, new_label, refresh=False)
             elif layer._mode == Mode.FILL:
                 layer.fill(c, new_label, refresh=False)
-        if not refresh_future or refresh_future.done():
-            refresh_future = refresh_executor.submit(refresh, layer)
+        layer.refresh()
         last_cursor_coord = layer.coordinates
         yield
 
     # on release
-    refresh_executor.submit(refresh, layer)
     layer._block_saving = False
 
 


### PR DESCRIPTION
# Description
optimize label draw computation flow, in an attempt to address heuristics finding around painting lag. The lag is more significant as the size of the image grow, at around 4k resolution, painting is pretty much inaccurate to mouse position anymore due to the lag.

This particular fix increases responsiveness by around 60% for single images, however, because the lag is quite severe at the level of a 4k image, it is barely visible 


## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# References
https://github.com/napari/product-heuristics-2020/issues/38
https://github.com/napari/napari/pull/1993

# How has this been tested?
- [X] example: the test suite for my feature covers cases x, y, and z
- [X] example: all tests pass with my change

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
