### PR TITLE
update latest tag alone with nightly build

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -86,3 +86,11 @@ jobs:
           asset_name: napari-${{ runner.os }}.zip
           asset_content_type: application/zip
           max_releases: 1
+      - name: Update latest tag
+        uses: EndBug/latest-tag@latest
+        if: ${{ github.event_name == 'schedule' }}
+        with:
+          description: latest code released from nightly build
+          tag-name: latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description
update latest tag alone with nightly build. this would help refresh 
https://github.com/napari/napari/releases/tag/latest

right now it is confusing because the artifacts are being uploaded and updated, but the page seems to indicate that our nightly build is not working

## Type of change
CI update

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
