### PR TITLE
Add style evented dataclass

### DIFF
--- a/examples/set_theme.py
+++ b/examples/set_theme.py
@@ -13,4 +13,4 @@ with napari.gui_qt():
     )
 
     # set the theme to 'light'
-    viewer.theme = 'light'
+    viewer.style.theme = 'light'

--- a/napari/_qt/dialogs/qt_about_key_bindings.py
+++ b/napari/_qt/dialogs/qt_about_key_bindings.py
@@ -63,7 +63,7 @@ class QtAboutKeyBindings(QDialog):
         # Can switch to a normal dict when our minimum Python is 3.7
         self.key_bindings_strs = OrderedDict()
         self.key_bindings_strs[self.ALL_ACTIVE_KEYBINDINGS] = ''
-        col = self.viewer.palette['secondary']
+        col = self.viewer.style.palette['secondary']
         layers = [
             napari.layers.Image,
             napari.layers.Labels,
@@ -94,7 +94,7 @@ class QtAboutKeyBindings(QDialog):
         self.layout.addWidget(self.textEditBox, 1)
 
         self.viewer.events.active_layer.connect(self.update_active_layer)
-        self.viewer.events.palette.connect(self.update_active_layer)
+        self.viewer.style.events.connect(self.update_active_layer)
         self.update_active_layer()
 
     def change_layer_type(self, text):
@@ -123,7 +123,7 @@ class QtAboutKeyBindings(QDialog):
         event : napari.utils.event.Event, optional
             The napari event that triggered this method, by default None.
         """
-        col = self.viewer.palette['secondary']
+        col = self.viewer.style.palette['secondary']
         # Add class and instance viewer key bindings
         text = get_key_bindings_summary(self.viewer.active_keymap, col=col)
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -176,7 +176,7 @@ class Window:
         self.qt_viewer.viewer.events.status.connect(self._status_changed)
         self.qt_viewer.viewer.events.help.connect(self._help_changed)
         self.qt_viewer.viewer.events.title.connect(self._title_changed)
-        self.qt_viewer.viewer.events.palette.connect(self._update_palette)
+        self.qt_viewer.viewer.style.events.connect(self._update_palette)
 
         if perf.USE_PERFMON:
             # Add DebugMenu and dockPerformance if using perfmon.
@@ -320,7 +320,9 @@ class Window:
         toggle_theme = QAction('Toggle Theme', self._qt_window)
         toggle_theme.setShortcut('Ctrl+Shift+T')
         toggle_theme.setStatusTip('Toggle theme')
-        toggle_theme.triggered.connect(self.qt_viewer.viewer._toggle_theme)
+        toggle_theme.triggered.connect(
+            self.qt_viewer.viewer.style._advance_theme
+        )
         toggle_fullscreen = QAction('Toggle Full Screen', self._qt_window)
         toggle_fullscreen.setShortcut('Ctrl+F')
         toggle_fullscreen.setStatusTip('Toggle full screen')
@@ -653,7 +655,7 @@ class Window:
         """Update widget color palette."""
         # set window styles which don't use the primary stylesheet
         # FIXME: this is a problem with the stylesheet not using properties
-        palette = self.qt_viewer.viewer.palette
+        palette = self.qt_viewer.viewer.style.palette
         self._status_bar.setStyleSheet(
             template(
                 'QStatusBar { background: {{ background }}; '

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -181,7 +181,7 @@ class QtViewer(QSplitter):
         self.viewer.events.interactive.connect(self._on_interactive)
         self.viewer.cursor.events.style.connect(self._on_cursor)
         self.viewer.cursor.events.size.connect(self._on_cursor)
-        self.viewer.events.palette.connect(self._update_palette)
+        self.viewer.style.events.connect(self._update_palette)
         self.viewer.layers.events.reordered.connect(self._reorder_layers)
         self.viewer.layers.events.inserted.connect(self._on_add_layer_change)
         self.viewer.layers.events.removed.connect(self._remove_layer)
@@ -263,7 +263,7 @@ class QtViewer(QSplitter):
             self.viewer.events.layers_change.connect(
                 self.welcome._on_visible_change
             )
-            self.viewer.events.palette.connect(self.welcome._on_palette_change)
+            self.viewer.style.events.connect(self.welcome._on_palette_change)
             self.canvas.events.resize.connect(self.welcome._on_canvas_change)
 
     def _create_performance_dock_widget(self):
@@ -510,14 +510,14 @@ class QtViewer(QSplitter):
         """Update the napari GUI theme."""
         # template and apply the primary stylesheet
         themed_stylesheet = template(
-            self.raw_stylesheet, **self.viewer.palette
+            self.raw_stylesheet, **self.viewer.style.palette
         )
         if self._console is not None:
             self.console._update_palette(
-                self.viewer.palette, themed_stylesheet
+                self.viewer.style.palette, themed_stylesheet
             )
         self.setStyleSheet(themed_stylesheet)
-        self.canvas.bgcolor = self.viewer.palette['canvas']
+        self.canvas.bgcolor = self.viewer.style.palette['canvas']
 
     def toggle_console_visibility(self, event=None):
         """Toggle console visible and not visible.

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -122,12 +122,12 @@ def test_changing_theme(make_test_viewer):
     """Test changing the theme updates the full window."""
     viewer = make_test_viewer()
     viewer.add_points(data=None)
-    assert viewer.palette['folder'] == 'dark'
+    assert viewer.style.palette['folder'] == 'dark'
 
     screenshot_dark = viewer.screenshot(canvas_only=False)
 
-    viewer.theme = 'light'
-    assert viewer.palette['folder'] == 'light'
+    viewer.style.theme = 'light'
+    assert viewer.style.palette['folder'] == 'light'
 
     screenshot_light = viewer.screenshot(canvas_only=False)
     equal = (screenshot_dark == screenshot_light).min(-1)
@@ -136,7 +136,7 @@ def test_changing_theme(make_test_viewer):
     assert (np.count_nonzero(equal) / equal.size) < 0.05, "Themes too similar"
 
     with pytest.raises(ValueError):
-        viewer.theme = 'nonexistent_theme'
+        viewer.style.theme = 'nonexistent_theme'
 
 
 @pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)

--- a/napari/_vispy/vispy_welcome_visual.py
+++ b/napari/_vispy/vispy_welcome_visual.py
@@ -45,7 +45,8 @@ class VispyWelcomeVisual:
             '   - call a viewer.add_* method'
         )
         self.text_node.color = np.divide(
-            str_to_rgb(darken(self._viewer.palette['foreground'], 30)), 255
+            str_to_rgb(darken(self._viewer.style.palette['foreground'], 30)),
+            255,
         )
 
         self._on_palette_change(None)
@@ -55,20 +56,25 @@ class VispyWelcomeVisual:
     def _on_palette_change(self, event):
         """Change colors of the logo and text."""
         if (
-            np.mean(str_to_rgb(self._viewer.palette['background'])[:3])
+            np.mean(str_to_rgb(self._viewer.style.palette['background'])[:3])
             < 255 / 2
         ):
             background_color = np.divide(
-                str_to_rgb(darken(self._viewer.palette['background'], 70)), 255
+                str_to_rgb(
+                    darken(self._viewer.style.palette['background'], 70)
+                ),
+                255,
             )
         else:
             background_color = np.divide(
-                str_to_rgb(lighten(self._viewer.palette['background'], 70)),
+                str_to_rgb(
+                    lighten(self._viewer.style.palette['background'], 70)
+                ),
                 255,
             )
 
         foreground_color = np.divide(
-            str_to_rgb(self._viewer.palette['primary']), 255,
+            str_to_rgb(self._viewer.style.palette['primary']), 255,
         )
         text_color = list(foreground_color) + [1]
 

--- a/napari/components/_tests/test_style.py
+++ b/napari/components/_tests/test_style.py
@@ -1,0 +1,22 @@
+import pytest
+
+from napari.components.style import Style
+
+
+def test_changing_theme():
+    """Test changing the theme."""
+    style = Style()
+    assert style.theme == 'dark'
+    assert style.palette['folder'] == 'dark'
+
+    style.theme = 'light'
+    assert style.palette['folder'] == 'light'
+
+
+def test_non_existant_theme():
+    """Test non existant theme raises an error."""
+    style = Style()
+    assert style.theme == 'dark'
+
+    with pytest.raises(ValueError):
+        style.theme = 'nonexistent_theme'

--- a/napari/components/style.py
+++ b/napari/components/style.py
@@ -1,0 +1,68 @@
+from typing import Dict
+
+from ..utils.events.dataclass import evented_dataclass
+from ..utils.theme import palettes
+
+DEFAULT_THEME = 'dark'
+CUSTOM_THEME = 'custom'
+
+
+@evented_dataclass
+class Style:
+    """Style object with style information for the viewer.
+
+    Parameters
+    ----------
+    pallete : dict
+        Color pallete for the viewer
+    theme : str
+        Theme for the viewer.
+
+    Attributes
+    ----------
+    available_themes : dict of str: dict of str: str
+        Available palettes indexed by theme.
+    pallete : dict of str: str
+        Color pallete for the viewer
+    theme : str
+        Theme for the viewer.
+    """
+
+    palette: Dict[str, str] = None
+    theme: str = DEFAULT_THEME
+
+    def __post_init__(self):
+        self._on_theme_set(self.theme)
+
+    def _on_theme_set(self, theme):
+        """Update the palette based on the theme."""
+        if theme in palettes:
+            self._palette = self.available_themes[theme]
+        else:
+            raise ValueError(
+                f"Theme '{theme}' not found; "
+                f"options are {list(self.available_themes)}."
+            )
+
+    def _on_pallet_set(self, palette):
+        """Set the theme to be custom."""
+        # If pallet is set directly then theme is set to be custom
+        for existing_theme, existing_palette in self.available_themes.items():
+            if existing_palette == palette:
+                self._theme = existing_theme
+                return
+        self._theme = CUSTOM_THEME
+
+    @property
+    def available_themes(self):
+        """dict of str: dict of str: str. Preset color palettes, indexed by theme."""
+        return palettes
+
+    def _advance_theme(self):
+        """Advance theme to next theme in list of themes."""
+        themes = list(self.available_themes)
+        if self.theme in themes:
+            new_theme_index = (themes.index(self.theme) + 1) % len(themes)
+        else:
+            new_theme_index = 0
+        self.theme = themes[new_theme_index]

--- a/napari/components/style.py
+++ b/napari/components/style.py
@@ -46,7 +46,7 @@ class Style:
 
     def _on_pallet_set(self, palette):
         """Set the theme to be custom."""
-        # If pallet is set directly then theme is set to be custom
+        # If pallete is set directly then theme is set to be custom
         for existing_theme, existing_palette in self.available_themes.items():
             if existing_palette == palette:
                 self._theme = existing_theme

--- a/napari/components/style.py
+++ b/napari/components/style.py
@@ -66,3 +66,9 @@ class Style:
         else:
             new_theme_index = 0
         self.theme = themes[new_theme_index]
+
+    def __hash__(self):
+        # Need to add an unsafe hash for event system due to mutable Dict,
+        # see https://docs.python.org/3/library/dataclasses.html#module-level-decorators-classes-and-functions
+        # for more information.
+        return id(self)


### PR DESCRIPTION
# Description
As discussed during team meeting today this PR would further simplify the viewermodel, making PRs like #2005 easier by adding an evented dataclass for the styles, which holds the theme and palettes (suggested by @zeroth). I know @Czaki you use the light theme so you might be interested in this change too.

Everything is backwards compatible with deprecation warnings apart from the `viewer.events.palette` which is dropped and should now be replaced by `viewer.style.events`.

Note that I'd say a goal is to continue this refactoring until there are no more evented attributes directly on the model, at which point #2005 will be much simpler. Note also the diffs on this PR aren't a true indication of the simplification due to the deprecation warnings that have been added.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Refactor (non-breaking change which fixes an issue)
