### PR TITLE
Add info evented dataclass

### DIFF
--- a/examples/custom_key_bindings.py
+++ b/examples/custom_key_bindings.py
@@ -16,14 +16,14 @@ with napari.gui_qt():
     @viewer.bind_key('a')
     def accept_image(viewer):
         msg = 'this is a good image'
-        viewer.status = msg
+        viewer.info.status = msg
         print(msg)
         next(viewer)
 
     @viewer.bind_key('r')
     def reject_image(viewer):
         msg = 'this is a bad image'
-        viewer.status = msg
+        viewer.info.status = msg
         print(msg)
         next(viewer)
 
@@ -36,12 +36,12 @@ with napari.gui_qt():
     @napari.Viewer.bind_key('w')
     def hello(viewer):
         # on press
-        viewer.status = 'hello world!'
+        viewer.info.status = 'hello world!'
 
         yield
 
         # on release
-        viewer.status = 'goodbye world :('
+        viewer.info.status = 'goodbye world :('
 
     # change viewer title
-    viewer.title = 'quality control images'
+    viewer.info.title = 'quality control images'

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -18,7 +18,7 @@ def test_qt_viewer(make_test_viewer):
     viewer = make_test_viewer()
     view = viewer.window.qt_viewer
 
-    assert viewer.title == 'napari'
+    assert viewer.info.title == 'napari'
     assert view.viewer == viewer
     # Check no console is present before it is requested
     assert view._console is None

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -146,7 +146,7 @@ class Window:
         self._qt_center = QWidget(self._qt_window)
 
         self._qt_window.setCentralWidget(self._qt_center)
-        self._qt_window.setWindowTitle(self.qt_viewer.viewer.title)
+        self._qt_window.setWindowTitle(self.qt_viewer.viewer.info.title)
         self._qt_center.setLayout(QHBoxLayout())
         self._status_bar = QStatusBar()
         self._qt_window.setStatusBar(self._status_bar)
@@ -173,9 +173,9 @@ class Window:
         self._add_viewer_dock_widget(self.qt_viewer.dockLayerControls)
         self._add_viewer_dock_widget(self.qt_viewer.dockLayerList)
 
-        self.qt_viewer.viewer.events.status.connect(self._status_changed)
-        self.qt_viewer.viewer.events.help.connect(self._help_changed)
-        self.qt_viewer.viewer.events.title.connect(self._title_changed)
+        self.qt_viewer.viewer.info.events.status.connect(self._status_changed)
+        self.qt_viewer.viewer.info.events.help.connect(self._help_changed)
+        self.qt_viewer.viewer.info.events.title.connect(self._title_changed)
         self.qt_viewer.viewer.events.palette.connect(self._update_palette)
 
         if perf.USE_PERFMON:
@@ -674,7 +674,7 @@ class Window:
         event : napari.utils.event.Event
             The napari event that triggered this method.
         """
-        self._status_bar.showMessage(event.text)
+        self._status_bar.showMessage(self.qt_viewer.viewer.info.status)
 
     def _title_changed(self, event):
         """Update window title.
@@ -684,7 +684,7 @@ class Window:
         event : napari.utils.event.Event
             The napari event that triggered this method.
         """
-        self._qt_window.setWindowTitle(event.text)
+        self._qt_window.setWindowTitle(self.qt_viewer.viewer.info.title)
 
     def _help_changed(self, event):
         """Update help message on status bar.
@@ -694,7 +694,7 @@ class Window:
         event : napari.utils.event.Event
             The napari event that triggered this method.
         """
-        self._help.setText(event.text)
+        self._help.setText(self.qt_viewer.viewer.info.help)
 
     def _screenshot_dialog(self):
         """Save screenshot of current display with viewer, default .png"""

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -19,7 +19,7 @@ def test_viewer(make_test_viewer):
     viewer = make_test_viewer()
     view = viewer.window.qt_viewer
 
-    assert viewer.title == 'napari'
+    assert viewer.info.title == 'napari'
     assert view.viewer == viewer
 
     assert len(viewer.layers) == 0

--- a/napari/components/_tests/test_info.py
+++ b/napari/components/_tests/test_info.py
@@ -1,0 +1,8 @@
+from napari.components.info import ViewerInfo
+
+
+def test_info():
+    """Test creating ViewerInfo object"""
+    info = ViewerInfo()
+    assert info is not None
+    assert info.title == 'napari'

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -9,13 +9,13 @@ from napari.utils.colormaps import AVAILABLE_COLORMAPS, Colormap
 def test_viewer_model():
     """Test instantiating viewer model."""
     viewer = ViewerModel()
-    assert viewer.title == 'napari'
+    assert viewer.info.title == 'napari'
     assert len(viewer.layers) == 0
     assert viewer.dims.ndim == 2
 
     # Create viewer model with custom title
     viewer = ViewerModel(title='testing')
-    assert viewer.title == 'testing'
+    assert viewer.info.title == 'testing'
 
 
 def test_add_image():
@@ -531,7 +531,7 @@ def test_active_layer_status_update():
     assert viewer.active_layer == viewer.layers[1]
 
     viewer.cursor.position = [1, 1, 1, 1, 1]
-    assert viewer.status == viewer.active_layer.status
+    assert viewer.info.status == viewer.active_layer.status
 
 
 def test_active_layer_cursor_size():

--- a/napari/components/info.py
+++ b/napari/components/info.py
@@ -1,0 +1,20 @@
+from ..utils.events.dataclass import evented_dataclass
+
+
+@evented_dataclass
+class ViewerInfo:
+    """Object modeling basic information for the viewer.
+
+    Attributes
+    ----------
+    help : str
+        Help string displayed in the bottom right of the viewer status bar.
+    status : str
+        Status string displayed in the bottom left of the viewer status bar.
+    title : str
+        Title of the viewer window.
+    """
+
+    help: str = ''
+    status: str = 'Ready'
+    title: str = 'napari'

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -25,6 +25,7 @@ from .camera import Camera
 from .cursor import Cursor
 from .dims import Dims
 from .grid import GridCanvas
+from .info import ViewerInfo
 from .layerlist import LayerList
 from .scale_bar import ScaleBar
 
@@ -66,9 +67,6 @@ class ViewerModel(KeymapHandler, KeymapProvider):
         self.events = EmitterGroup(
             source=self,
             auto_connect=True,
-            status=Event,
-            help=Event,
-            title=Event,
             interactive=Event,
             reset_view=Event,
             active_layer=Event,
@@ -85,10 +83,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
         self.cursor = Cursor()
         self.axes = Axes()
         self.scale_bar = ScaleBar()
-
-        self._status = 'Ready'
-        self._help = ''
-        self._title = title
+        self.info = ViewerInfo(title=title)
 
         self._interactive = True
         self._active_layer = None
@@ -129,7 +124,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
 
     def __str__(self):
         """Simple string representation"""
-        return f'napari.Viewer: {self.title}'
+        return f'napari.Viewer: {self.info.title}'
 
     @property
     def palette(self):
@@ -222,41 +217,80 @@ class ViewerModel(KeymapHandler, KeymapProvider):
     def status(self):
         """string: Status string
         """
-        return self._status
+        warnings.warn(
+            (
+                "The viewer.status parameter is deprecated and will be removed after version 0.4.5."
+                " Instead you should use viewer.info.status"
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.info.status
 
     @status.setter
     def status(self, status):
-        if status == self.status:
-            return
-        self._status = status
-        self.events.status(text=self._status)
+        warnings.warn(
+            (
+                "The viewer.status parameter is deprecated and will be removed after version 0.4.5."
+                " Instead you should use viewer.info.status"
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        self.info.status = status
 
     @property
     def help(self):
         """string: String that can be displayed to the
         user in the status bar with helpful usage tips.
         """
-        return self._help
+        warnings.warn(
+            (
+                "The viewer.help parameter is deprecated and will be removed after version 0.4.5."
+                " Instead you should use viewer.info.help"
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.info.help
 
     @help.setter
     def help(self, help):
-        if help == self.help:
-            return
-        self._help = help
-        self.events.help(text=self._help)
+        warnings.warn(
+            (
+                "The viewer.help parameter is deprecated and will be removed after version 0.4.5."
+                " Instead you should use viewer.info.help"
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        self.info.help = help
 
     @property
     def title(self):
         """string: String that is displayed in window title.
         """
-        return self._title
+        warnings.warn(
+            (
+                "The viewer.title parameter is deprecated and will be removed after version 0.4.5."
+                " Instead you should use viewer.info.title"
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.info.title
 
     @title.setter
     def title(self, title):
-        if title == self.title:
-            return
-        self._title = title
-        self.events.title(text=self._title)
+        warnings.warn(
+            (
+                "The viewer.title parameter is deprecated and will be removed after version 0.4.5."
+                " Instead you should use viewer.info.title"
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        self.info.title = title
 
     @property
     def interactive(self):
@@ -400,14 +434,14 @@ class ViewerModel(KeymapHandler, KeymapProvider):
                 break
 
         if active_layer is None:
-            self.status = 'Ready'
-            self.help = ''
+            self.info.status = 'Ready'
+            self.info.help = ''
             self.cursor.style = 'standard'
             self.interactive = True
             self.active_layer = None
         else:
-            self.status = active_layer.status
-            self.help = active_layer.help
+            self.info.status = active_layer.status
+            self.info.help = active_layer.help
             self.cursor.style = active_layer.cursor
             self.cursor.size = active_layer.cursor_size
             self.interactive = active_layer.interactive
@@ -447,8 +481,8 @@ class ViewerModel(KeymapHandler, KeymapProvider):
 
         # Update status and help bar based on active layer
         if self.active_layer is not None:
-            self.status = self.active_layer.status
-            self.help = self.active_layer.help
+            self.info.status = self.active_layer.status
+            self.info.help = self.active_layer.help
 
     def _on_grid_change(self, event):
         """Arrange the current layers is a 2D grid."""

--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -22,12 +22,12 @@ into two statements with the yield keyword::
     @viewer.bind_key('h')
     def hello_world(viewer):
         # on key press
-        viewer.status = 'hello world!'
+        viewer.info.status = 'hello world!'
 
         yield
 
         # on key release
-        viewer.status = 'goodbye world :('
+        viewer.info.status = 'goodbye world :('
 
 To create a keymap that will block others, ``bind_key(..., ...)```.
 """
@@ -233,12 +233,12 @@ def bind_key(keymap, key, func=UNDEFINED, *, overwrite=False):
         @viewer.bind_key('h')
         def hello_world(viewer):
             # on key press
-            viewer.status = 'hello world!'
+            viewer.info.status = 'hello world!'
 
             yield
 
             # on key release
-            viewer.status = 'goodbye world :('
+            viewer.info.status = 'goodbye world :('
 
     To create a keymap that will block others, ``bind_key(..., ...)```.
     """


### PR DESCRIPTION
# Description
Like #2006 this PR comes from a discussion during the dev meeting today about simplifying the viewermodel object in preparation from #2005 and follows @zeroth suggestion of the `info` dataclass.

The `help`, `status`, and `title` events are dropped and the `viewer.help`, `viewer.status`, `viewer.title` events are deprecated, and replaced by `viewer.info.help`, `viewer.info.status`, `viewer.info.title` respectively.

With #2006, this PR, and #1952 we will be very close to removing all evented attributes from the `ViewerModel` and can then make the `ViewerModel` a simple (frozen?) dataclass of evented dataclasses.

Note the diff # of lines changed here is misleading due to all the deprecation warnings added.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)