### PR TITLE
Move interactive from viewer to camera

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -178,7 +178,7 @@ class QtViewer(QSplitter):
 
         self._update_palette()
 
-        self.viewer.events.interactive.connect(self._on_interactive)
+        self.viewer.camera.events.interactive.connect(self._on_interactive)
         self.viewer.cursor.events.style.connect(self._on_cursor)
         self.viewer.cursor.events.size.connect(self._on_cursor)
         self.viewer.events.palette.connect(self._update_palette)
@@ -474,7 +474,7 @@ class QtViewer(QSplitter):
         event : napari.utils.event.Event
             The napari event that triggered this method.
         """
-        self.view.interactive = self.viewer.interactive
+        self.view.interactive = self.viewer.camera.interactive
 
     def _on_cursor(self, event):
         """Set the appearance of the mouse cursor.

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -21,8 +21,11 @@ class Camera:
     angles : 3-tuple
         Euler angles of camera in 3D viewing (rx, ry, rz), in degrees.
         Only used during 3D viewing.
+    interactive : bool
+        If the camera interactivity is enabled or not.
     """
 
     center: Property[Len_3_Tuple, None, ensure_3_tuple] = (0, 0, 0)
     zoom: float = 1
     angles: Property[Len_3_Tuple, None, ensure_3_tuple] = (0, 0, 90)
+    interactive: bool = True

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -258,34 +258,28 @@ class ViewerModel(KeymapHandler, KeymapProvider):
 
     @property
     def interactive(self):
-        """bool: Determines if canvas pan/zoom interactivity is enabled or not.
-        """
+        """bool: Determines if canvas pan/zoom interactivity is enabled or not."""
         warnings.warn(
             (
                 "The viewer.interactive parameter is deprecated and will be removed after version 0.4.5."
-                " Instead interactivity is determined automatically from the active layer, accessible at"
-                " viewer.active_layer.interactive"
+                " Instead you should use viewer.camera.interactive"
             ),
             category=DeprecationWarning,
             stacklevel=2,
         )
-        if self.active_layer is None:
-            return True
-        else:
-            self.active_layer.interactive
+        return self.camera.interactive
 
     @interactive.setter
     def interactive(self, interactive):
         warnings.warn(
             (
                 "The viewer.interactive parameter is deprecated and will be removed after version 0.4.5."
-                " Instead interactivity is determined automatically from the active layer, accessible at"
-                " viewer.active_layer.interactive and is no longer independently settable"
+                " Instead you should use viewer.camera.interactive"
             ),
             category=DeprecationWarning,
             stacklevel=2,
         )
-        return
+        self.camera.interactive = interactive
 
     @property
     def active_layer(self):
@@ -419,14 +413,14 @@ class ViewerModel(KeymapHandler, KeymapProvider):
             self.status = 'Ready'
             self.help = ''
             self.cursor.style = 'standard'
-            self.interactive = True
+            self.camera.interactive = True
             self.active_layer = None
         else:
             self.status = active_layer.status
             self.help = active_layer.help
             self.cursor.style = active_layer.cursor
             self.cursor.size = active_layer.cursor_size
-            self.interactive = active_layer.interactive
+            self.camera.interactive = active_layer.interactive
             self.active_layer = active_layer
 
     def _on_layers_change(self, event):
@@ -446,7 +440,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
 
     def _update_interactive(self, event):
         """Set the viewer interactivity with the `event.interactive` bool."""
-        self.interactive = event.interactive
+        self.camera.interactive = event.interactive
 
     def _update_cursor(self, event):
         """Set the viewer cursor with the `event.cursor` string."""

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -69,7 +69,6 @@ class ViewerModel(KeymapHandler, KeymapProvider):
             status=Event,
             help=Event,
             title=Event,
-            interactive=Event,
             reset_view=Event,
             active_layer=Event,
             palette=Event,
@@ -90,7 +89,6 @@ class ViewerModel(KeymapHandler, KeymapProvider):
         self._help = ''
         self._title = title
 
-        self._interactive = True
         self._active_layer = None
         self.grid = GridCanvas()
         # 2-tuple indicating height and width
@@ -262,14 +260,32 @@ class ViewerModel(KeymapHandler, KeymapProvider):
     def interactive(self):
         """bool: Determines if canvas pan/zoom interactivity is enabled or not.
         """
-        return self._interactive
+        warnings.warn(
+            (
+                "The viewer.interactive parameter is deprecated and will be removed after version 0.4.5."
+                " Instead interactivity is determined automatically from the active layer, accessible at"
+                " viewer.active_layer.interactive"
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        if self.active_layer is None:
+            return True
+        else:
+            self.active_layer.interactive
 
     @interactive.setter
     def interactive(self, interactive):
-        if interactive == self.interactive:
-            return
-        self._interactive = interactive
-        self.events.interactive()
+        warnings.warn(
+            (
+                "The viewer.interactive parameter is deprecated and will be removed after version 0.4.5."
+                " Instead interactivity is determined automatically from the active layer, accessible at"
+                " viewer.active_layer.interactive and is no longer independently settable"
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return
 
     @property
     def active_layer(self):


### PR DESCRIPTION
# Description
This PR moves the `viewer.interactive` to `viewer.camera.interactive` where it is a much better fit, as it describes whether the interactivity of the camera is enabled or not.

This PR drops the `viewer.events.interactive`, and adds deprecation warnings too `viewer.interactive`.

It continues the trend of moving evented properties off the viewer model itself.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)