### PR TITLE
async-41: Better Octree Performance

### DIFF
--- a/napari/_qt/experimental/qt_chunk_receiver.py
+++ b/napari/_qt/experimental/qt_chunk_receiver.py
@@ -1,13 +1,9 @@
 """QtChunkReceiver and QtGuiEvent classes.
 """
-import logging
-
 from qtpy.QtCore import QObject, Signal
 
 from ...components.experimental.chunk import chunk_loader
 from ...utils.events import EmitterGroup, Event, EventEmitter
-
-LOGGER = logging.getLogger('napari.loader')
 
 
 class QtGuiEvent(QObject):
@@ -125,10 +121,6 @@ class QtChunkReceiver:
         """
         layer = event.original_event.layer
         request = event.original_event.request
-
-        LOGGER.info(
-            "QtChunkReceiver._on_chunk_loaded_gui: data_id=%d", request.data_id
-        )
 
         layer.on_chunk_loaded(request)  # Pass the chunk to its layer.
 

--- a/napari/_qt/experimental/qt_chunk_receiver.py
+++ b/napari/_qt/experimental/qt_chunk_receiver.py
@@ -7,7 +7,7 @@ from qtpy.QtCore import QObject, Signal
 from ...components.experimental.chunk import chunk_loader
 from ...utils.events import EmitterGroup, Event, EventEmitter
 
-LOGGER = logging.getLogger('napari.async')
+LOGGER = logging.getLogger('napari.loader')
 
 
 class QtGuiEvent(QObject):

--- a/napari/_qt/experimental/qt_poll.py
+++ b/napari/_qt/experimental/qt_poll.py
@@ -9,7 +9,6 @@ from typing import Optional
 
 from qtpy.QtCore import QEvent, QObject, QTimer
 
-from ...components.camera import Camera
 from ...utils.events import EmitterGroup
 
 # When running a timer we use this interval.
@@ -50,19 +49,22 @@ class QtPoll(QObject):
         The viewer's main camera.
     """
 
-    def __init__(self, parent: QObject, camera: Camera):
+    def __init__(self, parent: QObject):
         super().__init__(parent)
 
         self.events = EmitterGroup(source=self, auto_connect=True, poll=None)
-        camera.events.connect(self._on_camera)
 
         self.timer = QTimer()
         self.timer.setInterval(POLL_INTERVAL_MS)
         self.timer.timeout.connect(self._on_timer)
         self._interval = IntervalTimer()
 
-    def _on_camera(self, _event) -> None:
+    def on_camera(self, _event) -> None:
         """Called when camera view changes at all."""
+        self.wake_up()
+
+    def wake_up(self, _event=None) -> None:
+        """Wake up QtPoll so it starts polling."""
         if self._interval.elapsed_ms < IGNORE_INTERVAL_MS:
             return  # Double called during one frame?
 

--- a/napari/_qt/experimental/qt_poll.py
+++ b/napari/_qt/experimental/qt_poll.py
@@ -3,7 +3,6 @@
 Poll visuals or other objects so they can do things even when the
 mouse/camera are not moving. Usually for just a short period of time.
 """
-import logging
 import time
 from typing import Optional
 
@@ -19,8 +18,6 @@ POLL_INTERVAL_MS = 16.666  # About 60HZ
 # "center" changed and then the "zoom" changed even if it was really from
 # the same camera movement.
 IGNORE_INTERVAL_MS = 10
-
-LOGGER = logging.getLogger("napari.monitor")
 
 
 class QtPoll(QObject):
@@ -66,21 +63,22 @@ class QtPoll(QObject):
     def wake_up(self, _event=None) -> None:
         """Wake up QtPoll so it starts polling."""
         # Start the timer so that we start polling. We used to poll once
-        # right away here, but led to crashes. Because we polled during
+        # right away here, but it led to crashes. Because we polled during
         # a paintGL event?
         if not self.timer.isActive():
             self.timer.start()
 
     def _on_timer(self) -> None:
-        """Called when the timer is running."""
-        # The timer is running which means someone we are polling still has
-        # work to do.
+        """Called when the timer is running.
+
+        The timer is running which means someone we are polling still has
+        work to do.
+        """
         self._poll()
 
     def _poll(self) -> None:
         """Called on camera move or with the timer."""
-        # Poll everyone listening to our event, which might include
-        # visuals and the monitor.
+        # Listeners might include visuals and the monitor.
         event = self.events.poll()
 
         # Listeners will "handle" the event if they need more polling. If

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -335,7 +335,7 @@ class QtViewer(QSplitter):
         # QtPoll is experimental.
         if self._qt_poll is not None:
             # If a QtPoll exists, connect the new layer visual to QtPoll's
-            # poll event. So QtPoll will call VipyBaseImage._on_poll() when
+            # poll event. QtPoll will call VipyBaseImage._on_poll() when
             # the camera moves or the timer goes off.
             self._qt_poll.events.poll.connect(vispy_layer._on_poll)
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -332,11 +332,18 @@ class QtViewer(QSplitter):
         """
         vispy_layer = create_vispy_visual(layer)
 
-        # If a QtPoll exists, connect the new layer visual to its poll
-        # event. So QtPoll will call VipyBaseImage._on_poll() when the
-        # camera moves or on a timer if needed.
+        # QtPoll is experimental.
         if self._qt_poll is not None:
+            # If a QtPoll exists, connect the new layer visual to QtPoll's
+            # poll event. So QtPoll will call VipyBaseImage._on_poll() when
+            # the camera moves or the timer goes off.
             self._qt_poll.events.poll.connect(vispy_layer._on_poll)
+
+            # In the other direction, some visuals need to tell
+            # QtPoll to start polling. When they receive new data
+            # and need to be polled to load it over time.
+            if vispy_layer.events is not None:
+                vispy_layer.events.loaded.connect(self._qt_poll.wake_up)
 
         vispy_layer.node.parent = self.view.scene
         vispy_layer.order = len(self.viewer.layers) - 1
@@ -839,7 +846,9 @@ def _create_qt_poll(parent: QObject, camera: Camera) -> 'Optional[QtPoll]':
 
     from .experimental.qt_poll import QtPoll
 
-    return QtPoll(parent, camera)
+    qt_poll = QtPoll(parent)
+    camera.events.connect(qt_poll.on_camera)
+    return qt_poll
 
 
 def _create_remote_manager(

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -862,7 +862,10 @@ def _create_remote_manager(
 
     # Start the monitor so we can access its events. The monitor has no
     # dependencies to napari except to utils.Event.
-    monitor.start()
+    started = monitor.start()
+
+    if not started:
+        return None  # Probably not >= Python 3.9, so no manager is needed.
 
     # Create the remote manager and have monitor call its process_command()
     # method to execute commands from clients.

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -334,14 +334,14 @@ class QtViewer(QSplitter):
 
         # QtPoll is experimental.
         if self._qt_poll is not None:
-            # If a QtPoll exists, connect the new layer visual to QtPoll's
-            # poll event. QtPoll will call VipyBaseImage._on_poll() when
-            # the camera moves or the timer goes off.
+            # QtPoll will call VipyBaseImage._on_poll() when the camera
+            # moves or the timer goes off.
             self._qt_poll.events.poll.connect(vispy_layer._on_poll)
 
             # In the other direction, some visuals need to tell
             # QtPoll to start polling. When they receive new data
-            # and need to be polled to load it over time.
+            # and need to be polled to load it over some number
+            # of frames.
             if vispy_layer.events is not None:
                 vispy_layer.events.loaded.connect(self._qt_poll.wake_up)
 

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -22,7 +22,14 @@ from ..vendored.image import _build_color_transform
 from .texture_atlas import TextureAtlas2D
 from .tile_set import TileSet
 
-# Shape of she whole texture in tiles. Hardcode for now.
+# Shape of she whole texture in tiles. Hardcode for now. TODO_OCTREE: We
+# need to calculate this based on the tile size. Long term we want to
+# support huge tiles. So big images/layers will get small tiles, but if the
+# layer can fit within the max texture size, as big as (16384, 16384) then
+# it might be more efficient to put that in a single tiles.
+#
+# This might require that we can support multiple TexturAtlas2D objects
+# per TiledImageVisual.
 SHAPE_IN_TILES = (16, 16)
 
 
@@ -201,17 +208,12 @@ class TiledImageVisual(ImageVisual):
 
             # In the future we might add several chunks here. We want
             # to add as many as we can without tanking the framerate
-            # too much.
+            # too much. But for now we just add one, because we
+            # were seeing adding taking 40ms for one (256, 256) tile!
             #
-            # For now, we just add ONE chunk per frame. We've timed (256,
-            # 256) pixel chunks taking a whopping 40ms to load into VRAM!
-            # Probably due to CPU-side processing we are doing? So today
-            # there really is only time to add one chunk.
-            #
-            # Even if adds were fast, adding just one is not horrible.
-            # The frame rate will stay smooth. But adding more if they
-            # fit within the budget would get the newer/better data
-            # drawn faster.
+            # But if that improves, we might want to multiple tiles here,
+            # up to some budget limit. Although not the cost of adding
+            # most happens later when glFlush() is called.
             break
 
         # Return how many chunks we did NOT add. The system should continue
@@ -235,14 +237,15 @@ class TiledImageVisual(ImageVisual):
         atlas_tile = self._texture_atlas.add_tile(octree_chunk)
 
         if atlas_tile is None:
-            return  # No slot was available in the atlas. That's bad.
+            # TODO_OCTREE: No slot was available in the atlas. That's bad,
+            # but not sure what we should do in this case.
+            return
 
         # Add our mapping between chunks and atlas tiles.
         self._tiles.add(octree_chunk, atlas_tile)
 
-        # Set this flag so we call self._build_vertex_data() the next time
-        # we are drawn. It will create new vertex and texture coordinates
-        # buffers to include this new chunk.
+        # Call self._build_vertex_data() the next time we are drawn, so
+        # can update things to draw this new chunk.
         self._need_vertex_update = True
 
     @property
@@ -263,7 +266,7 @@ class TiledImageVisual(ImageVisual):
             The set of currently drawable chunks.
         """
         for tile_data in list(self._tiles.tile_data):
-            if tile_data.octree_chunk.key not in drawable_set:
+            if tile_data.octree_chunk not in drawable_set:
                 # print(f"REMOVE: {tile_data.octree_chunk}")
                 tile_index = tile_data.atlas_tile.index
                 self._remove_tile(tile_index)

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -122,12 +122,84 @@ class VispyTiledImageLayer(VispyImageLayer):
         """
         raise NotImplementedError()
 
+    def _update_tile_shape(self) -> None:
+        """If the tile shape was changed, update our node."""
+        # This might be overly dynamic, but for now if we see there's a new
+        # tile shape we nuke our texture atlas and start over with the new
+        # shape.
+        #
+        # We added this because the QtTestImage GUI currently set the tile
+        # shape after the layer is created. Thus potentially changing the
+        # same on the fly. But this "on the fly change" might come in handy
+        # and it was not hard to implement, but we could probably drop it
+        # if it becomes a pain.
+        tile_shape = self.layer.tile_shape
+        if self.node.tile_shape != tile_shape:
+            self.node.set_tile_shape(tile_shape)
+
+    def _on_poll(self, event=None) -> None:
+        """Called before we are drawn.
+
+        This is called when the camera moves, or when we have chunks that
+        need to be loaded. We update which tiles we are drawing based on
+        which chunks are currently drawable.
+        """
+        super()._on_poll()
+
+        # Mark the event "handled" if we have more chunks to load.
+        #
+        # By saying the poll event was "handled" we're telling QtPoll to
+        # keep polling us, even if the camera stops moving. So that we can
+        # finish up the loads/draws with a potentially still camera.
+        #
+        # We'll be polled until no visuals handle the event, meaning
+        # no visuals need polling. Then all is quiet until the camera
+        # moves again.
+        num_remaining = self._update_view()
+        need_polling = num_remaining > 0
+        event.handled = need_polling
+
+    def _update_view(self) -> int:
+        """Update the tiled image based on what's drawable in the layer.
+
+        We call self._update_draw_chunks() which asks the layer what chunks
+        are drawable, then it potentially loads some of those chunks, if we
+        didn't already have them. This method returns how many drawable
+        chunks still need to be added.
+
+        If we return non-zero, we expect to be polled and drawn again, even
+        if the camera isn't moving. We expect to be polled and drawn until
+        we can finish adding the rest of the drawable chunks.
+
+        Return
+        ------
+        int
+             The number of chunks that still need to be added.
+        """
+        if not self.node.visible:
+            return 0
+
+        self._update_tile_shape()  # In case the tile shape changed!
+
+        with block_timer("_update_drawn_chunks") as elapsed:
+            stats = self._update_drawn_chunks()
+
+        if stats.created > 0 or stats.deleted > 0:
+            LOGGER.debug(
+                f"tiles: {stats.start} -> {stats.final} "
+                f"create: {stats.created} delete: {stats.deleted} "
+                f"time: {elapsed.duration_ms:.3f}ms"
+            )
+
+        return stats.remaining
+
     def _update_drawn_chunks(self) -> ChunkStats:
         """Add or remove tiles to match the chunks which are currently drawable.
 
-        1) Remove tiles which are no longer drawable.
-        2) Create tiles for newly drawable chunks.
-        3) Optionally update our grid based on the now drawable chunks.
+        1) Ask layer for drawable chunks. Their data is in-memory ndarrays.
+        2) Remove tiles which are no longer drawable.
+        3) Create tiles for newly drawable chunks, one or more.
+        4) Optionally update our grid based on the now drawable chunks.
 
         Return
         ------
@@ -138,29 +210,22 @@ class VispyTiledImageLayer(VispyImageLayer):
         drawn_chunk_set = self.node.chunk_set
 
         # Get the currently drawable chunks from the layer. We pass it the
-        # drawn_chunk_set because depending on what we are drawing, the layer
-        # might want to pass us substitute chunks.
-        #
-        # For example with quadtree/octree rendering it might send a tile
-        # from a higher level. Once the preferred chunk is drawing, it can
-        # stop sending us that one.
+        # drawn_chunk_set because that might influence what chunks it
+        # returns. For example if an ideal chunk is being drawn, there is
+        # no reason to send any high level chunks to provide coverage.
         drawable_chunks: List[OctreeChunk] = self.layer.get_drawable_chunks(
             drawn_chunk_set
         )
 
-        # Record some stats about this update process, where stats.drawable are
-        # the number of drawable chunks we are starting with.
+        # Record some stats about this update process. The first one,
+        # stats.drawable, is the number of drawable chunks from the layer.
         stats = ChunkStats(drawable=len(drawable_chunks))
 
         # Create the drawable set of chunks using their keys, so we can
         # check membership quickly.
-        # TODO_OCTREE: use __hash__ not OctreeChunk.key? Using __hash__
-        # did not immediately work, but we should try again.
-        drawable_set = set(
-            octree_chunk.key for octree_chunk in drawable_chunks
-        )
+        drawable_set = set(drawable_chunks)
 
-        # The number of tiles we are currently draw before the update.
+        # The number of tiles we are currently drawing before the update.
         stats.start = self.num_tiles
 
         # Remove tiles if their chunk is no longer in the drawable set.
@@ -169,12 +234,12 @@ class VispyTiledImageLayer(VispyImageLayer):
         # The low point, after removing but before adding.
         stats.low = self.num_tiles
 
-        # Remaining is how many tiles in drawable_chunks still need to be
-        # added. We don't necessarily add them all in one frame so that we
-        # don't tank the framerate.
+        # This is how many tiles in drawable_chunks still need to be added.
+        # We don't necessarily add them all in one frame since that might
+        # tank the framerate.
         stats.remaining = self._add_chunks(drawable_chunks)
 
-        # Final number of tiles we are drawing after adding.
+        # This is the final number of tiles we are drawing after adding.
         stats.final = self.num_tiles
 
         # The grid is only for debugging and demos, yet it's quite useful
@@ -202,8 +267,7 @@ class VispyTiledImageLayer(VispyImageLayer):
         if not self.layer.display.track_view:
             # Tracking the view is the normal mode, where the tiles load in as
             # the view moves. Not tracking the view is only used for debugging
-            # or demos, to show the tiles we "were" showing previously, without
-            # updating them.
+            # or demos. To show what were being drawn.
             return 0  # Nothing more to add
 
         # Add tiles for drawable chunks that do not already have a tile.
@@ -216,84 +280,13 @@ class VispyTiledImageLayer(VispyImageLayer):
         # transfer that will happen when we next call glFlush() to let the
         # card do its business.
         #
-        # Any chunks not added this frame will have a chance to be
-        # added the next frame, if they are still on the drawable_chunks
-        # list next frame. It's important we keep asking the layer for
-        # the drawable chunks every frame. We don't want to queue up and
-        # add chunks which might no longer be needed, because the
-        # camera might move every frame. The situation might be
-        # evolving rapidly if the camera is moving a lot.
+        # Any chunks not added this frame will have a chance to be added
+        # the next frame, if they are still on the drawable_chunks list
+        # next frame. It's important we keep asking the layer for the
+        # drawable chunks every frame. We don't want to queue up and add
+        # chunks which might no longer be needed. The camera might move
+        # every frame.
         return self.node.add_chunks(drawable_chunks)
-
-    def _update_tile_shape(self) -> None:
-        """If the tile shape was changed, update our node."""
-        # This might be overly dynamic, but for now if we see there's a new
-        # tile shape we nuke our texture atlas and start over with the new
-        # shape.
-        #
-        # We added this because the QtTestImage GUI currently set the tile
-        # shape after the layer is created. Thus potentially changing the
-        # same on the fly. But this "on the fly change" might come in handy
-        # and it was not hard to implement, but we could probably drop it
-        # if it becomes a pain.
-        tile_shape = self.layer.tile_shape
-        if self.node.tile_shape != tile_shape:
-            self.node.set_tile_shape(tile_shape)
-
-    def _update_view(self) -> int:
-        """Update the tiled image based on what's drawable in the layer.
-
-        We call self._update_chunks() which asks the layer what chunks are
-        drawable, then it potentially loads some of those chunks, if we
-        didn't already have them. This method returns how many drawable
-        chunks still need to be added.
-
-        If we return non-zero, we expect to be polled and drawn again, even
-        if the camera isn't moving. Polled and drawn until we can finish
-        adding the rest of the drawable chunks.
-
-        Return
-        ------
-        int
-             The number of chunks that still need to be added.
-        """
-        if not self.node.visible:
-            return 0
-
-        self._update_tile_shape()  # In case the tile shape changed!
-
-        with block_timer("_update_drawn_chunks") as elapsed:
-            stats = self._update_drawn_chunks()
-
-        if stats.created > 0 or stats.deleted > 0:
-            LOGGER.debug(
-                f"tiles: {stats.start} -> {stats.final} "
-                f"create: {stats.created} delete: {stats.deleted} "
-                f"time: {elapsed.duration_ms:.3f}ms"
-            )
-
-        return stats.remaining
-
-    def _on_poll(self, event=None) -> None:
-        """Called before we are drawn.
-
-        This is called when the camera moves, or when we have chunks that
-        need to be loaded. We update which tiles we are drawing based on
-        which chunks are currently drawable.
-        """
-        super()._on_poll()
-
-        # Mark the event "handled" if we have more chunks to load.
-        #
-        # By saying the poll event was "handled" we're telling QtPoll to
-        # keep polling us, even if the camera stops moving. So that we can
-        # finish up the loads/draws with a potentially still camera.
-        #
-        # We'll be polled until no visuals handle the event, meaning
-        # no visuals need polling. Then all is quiet until the camera
-        # moves again.
-        need_polling = self._update_view() > 0
-        event.handled = need_polling
 
     def _on_loaded(self, _event) -> None:
         """The layer loaded new data, so update our view."""

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -4,6 +4,7 @@ A tiled image that uses TiledImageVisual and TextureAtlas2D so that adding
 and removing tiles is faster than if we created a separate ImageVisual for
 each tile.
 """
+import logging
 from dataclasses import dataclass
 from typing import List
 
@@ -20,6 +21,8 @@ from .tiled_image_visual import TiledImageVisual
 # the visual itself and a scene graph node. The scene graph node is what
 # can added to the scene and transformed.
 TiledImageNode = create_visual_node(TiledImageVisual)
+
+LOGGER = logging.getLogger("napari.async.octree.visual")
 
 
 @dataclass
@@ -173,10 +176,6 @@ class VispyTiledImageLayer(VispyImageLayer):
         else:
             self.grid.clear()
 
-        # if stats.created > 0 or stats.deleted > 0:
-        #     for chunk in drawable_chunks:
-        #       print(f"drawn: {chunk}")
-
         return stats
 
     def _add_chunks(self, drawable_chunks: List[OctreeChunk]) -> int:
@@ -258,10 +257,8 @@ class VispyTiledImageLayer(VispyImageLayer):
         with block_timer("_update_drawn_chunks") as elapsed:
             stats = self._update_drawn_chunks()
 
-        # Print for now, but switch log file soon. Should be no prints
-        # in production code.
         if stats.created > 0 or stats.deleted > 0:
-            print(
+            LOGGER.debug(
                 f"tiles: {stats.start} -> {stats.final} "
                 f"create: {stats.created} delete: {stats.deleted} "
                 f"time: {elapsed.duration_ms:.3f}ms"

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -22,7 +22,7 @@ from .tiled_image_visual import TiledImageVisual
 # can added to the scene and transformed.
 TiledImageNode = create_visual_node(TiledImageVisual)
 
-LOGGER = logging.getLogger("napari.async.octree.visual")
+LOGGER = logging.getLogger("napari.octree.visual")
 
 
 @dataclass

--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -43,6 +43,7 @@ class VispyBaseLayer(ABC):
 
     def __init__(self, layer, node):
         super().__init__()
+        self.events = None  # Some derived classes have events.
 
         self.layer = layer
         self._array_like = False

--- a/napari/components/experimental/chunk/_cache.py
+++ b/napari/components/experimental/chunk/_cache.py
@@ -7,7 +7,7 @@ from ...._vendor.experimental.cachetools import LRUCache
 from ....types import ArrayLike
 from ._request import ChunkRequest
 
-LOGGER = logging.getLogger("napari.async")
+LOGGER = logging.getLogger("napari.async.cache")
 
 # ChunkCache size as a fraction of total RAM. Keep it small for now until
 # we figure out how ChunkCache will work with the Dask cache, and do
@@ -99,7 +99,7 @@ class ChunkCache:
         if not self.enabled:
             LOGGER.debug("ChunkCache.add_chunk: cache is disabled")
             return
-        LOGGER.debug("ChunkCache.add_chunk: %s", request.key.location)
+        LOGGER.debug("add_chunk: %s", request.key.location)
         self.chunks[request.key.key] = request.chunks
 
     def get_chunks(self, request: ChunkRequest) -> Optional[ChunkArrays]:
@@ -118,5 +118,5 @@ class ChunkCache:
         if not self.enabled:
             LOGGER.info("ChunkCache.get_chunk: disabled")
             return None
-        LOGGER.info("ChunkCache.get_chunk: %s", request.key)
+        LOGGER.info("get_chunk: %s", request.key.location)
         return self.chunks.get(request.key.key)

--- a/napari/components/experimental/chunk/_cache.py
+++ b/napari/components/experimental/chunk/_cache.py
@@ -103,20 +103,26 @@ class ChunkCache:
         self.chunks[request.key.key] = request.chunks
 
     def get_chunks(self, request: ChunkRequest) -> Optional[ChunkArrays]:
-        """Return the cached data for this request or None.
+        """Return the cached data for this request if it was cached.
 
         Parameters
         ----------
         request : ChunkRequest
-            We should lookup cached data for this request.
+            Look for cached data for this request.
 
         Returns
         -------
-        ChunkArrays, optional
+        Optional[ChunkArrays]
             The cached data or None of it was not found in the cache.
         """
         if not self.enabled:
             LOGGER.info("ChunkCache.get_chunk: disabled")
             return None
-        LOGGER.info("get_chunk: %s", request.key.location)
-        return self.chunks.get(request.key.key)
+
+        data = self.chunks.get(request.key.key)
+        LOGGER.info(
+            "get_chunk: %s -> ",
+            request.key.location,
+            "found" if data is not None else "not found",
+        )
+        return

--- a/napari/components/experimental/chunk/_cache.py
+++ b/napari/components/experimental/chunk/_cache.py
@@ -121,7 +121,7 @@ class ChunkCache:
 
         data = self.chunks.get(request.key.key)
         LOGGER.info(
-            "get_chunk: %s -> %s",
+            "get_chunk: %s %s",
             request.key.location,
             "found" if data is not None else "not found",
         )

--- a/napari/components/experimental/chunk/_cache.py
+++ b/napari/components/experimental/chunk/_cache.py
@@ -7,7 +7,7 @@ from ...._vendor.experimental.cachetools import LRUCache
 from ....types import ArrayLike
 from ._request import ChunkRequest
 
-LOGGER = logging.getLogger("napari.async.cache")
+LOGGER = logging.getLogger("napari.loader.cache")
 
 # ChunkCache size as a fraction of total RAM. Keep it small for now until
 # we figure out how ChunkCache will work with the Dask cache, and do

--- a/napari/components/experimental/chunk/_cache.py
+++ b/napari/components/experimental/chunk/_cache.py
@@ -121,7 +121,7 @@ class ChunkCache:
 
         data = self.chunks.get(request.key.key)
         LOGGER.info(
-            "get_chunk: %s -> ",
+            "get_chunk: %s -> %s",
             request.key.location,
             "found" if data is not None else "not found",
         )

--- a/napari/components/experimental/chunk/_cache.py
+++ b/napari/components/experimental/chunk/_cache.py
@@ -97,9 +97,9 @@ class ChunkCache:
             Add the data in this request to the cache.
         """
         if not self.enabled:
-            LOGGER.info("ChunkCache.add_chunk: disabled")
+            LOGGER.debug("ChunkCache.add_chunk: cache is disabled")
             return
-        LOGGER.info("ChunkCache.add_chunk: %s", request.key)
+        LOGGER.debug("ChunkCache.add_chunk: %s", request.key.location)
         self.chunks[request.key.key] = request.chunks
 
     def get_chunks(self, request: ChunkRequest) -> Optional[ChunkArrays]:

--- a/napari/components/experimental/chunk/_delay_queue.py
+++ b/napari/components/experimental/chunk/_delay_queue.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 
 from ....utils.perf import add_counter_event
 
-LOGGER = logging.getLogger("napari.async")
+LOGGER = logging.getLogger("napari.loader")
 
 # Each queue entry contains the request we are going to submit, and the
 # time in seconds when it should be submitted.

--- a/napari/components/experimental/chunk/_info.py
+++ b/napari/components/experimental/chunk/_info.py
@@ -208,9 +208,8 @@ class LayerInfo:
         """
         layer = self.layer_ref.weak_ref()
         if layer is None:
-            LOGGER.debug(
-                "LayerInfo.get_layer: layer %d was deleted", self.layer_id
-            )
+            layer_id = self.layer_ref.layer_key.layer_id
+            LOGGER.debug("LayerInfo.get_layer: layer %d was deleted", layer_id)
         return layer
 
     @property

--- a/napari/components/experimental/chunk/_info.py
+++ b/napari/components/experimental/chunk/_info.py
@@ -1,6 +1,7 @@
 """LoadType, LoadStats and LayerInfo.
 """
 import logging
+import time
 from enum import Enum
 
 from ....components.experimental.monitor import monitor
@@ -124,7 +125,13 @@ class LoadStats:
         if monitor:
             # Send stats about this one load.
             monitor.send_message(
-                {"load": {"num_bytes": num_bytes, "load_ms": load_ms}}
+                {
+                    "load": {
+                        "time": time.time(),
+                        "num_bytes": num_bytes,
+                        "load_ms": load_ms,
+                    }
+                }
             )
 
     @property

--- a/napari/components/experimental/chunk/_info.py
+++ b/napari/components/experimental/chunk/_info.py
@@ -10,7 +10,7 @@ from ....utils.config import octree_config
 from ._request import ChunkRequest
 from ._utils import LayerRef, StatWindow
 
-LOGGER = logging.getLogger("napari.async")
+LOGGER = logging.getLogger("napari.loader")
 
 
 class LoadCounts:

--- a/napari/components/experimental/chunk/_info.py
+++ b/napari/components/experimental/chunk/_info.py
@@ -126,7 +126,7 @@ class LoadStats:
             # Send stats about this one load.
             monitor.send_message(
                 {
-                    "load": {
+                    "load_chunk": {
                         "time": time.time(),
                         "num_bytes": num_bytes,
                         "load_ms": load_ms,

--- a/napari/components/experimental/chunk/_info.py
+++ b/napari/components/experimental/chunk/_info.py
@@ -92,15 +92,7 @@ class LoadStats:
         sync : bool
             True if the load was synchronous.
         """
-        try:
-            # Use the special "ChunkRequest.load_chunks" timer to time
-            # the loading of all the chunks in this request combine.
-            load_ms = request.timers['ChunkRequest.load_chunks'].duration_ms
-
-            # Update our StatWindow.
-            self.window_ms.add(load_ms)
-        except KeyError:
-            pass  # there was no 'load_chunks" timer...
+        self.window_ms.add(request.load_ms)  # Update our StatWindow.
 
         # Record the number of loads and chunks.
         self.counts.loads += 1
@@ -111,7 +103,7 @@ class LoadStats:
         self.counts.bytes += num_bytes
 
         # Time to load all chunks.
-        load_ms = request.timers['ChunkRequest.load_chunks'].duration_ms
+        load_ms = request.load_ms
 
         # Update our StatWindows.
         self.window_bytes.add(num_bytes)

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -23,7 +23,7 @@ from ._delay_queue import DelayQueue
 from ._info import LayerInfo, LayerRef, LoadType
 from ._request import ChunkKey, ChunkRequest
 
-LOGGER = logging.getLogger("napari.async.loader")
+LOGGER = logging.getLogger("napari.loader")
 
 # Executor for either a thread pool or a process pool.
 PoolExecutor = Union[ThreadPoolExecutor, ProcessPoolExecutor]
@@ -95,7 +95,7 @@ class ChunkLoader:
     """
 
     def __init__(self):
-        _setup_logging(octree_config['log_path'])
+        _setup_logging(octree_config)
 
         config = octree_config['loader']
         self.force_synchronous: bool = bool(config['force_synchronous'])
@@ -468,21 +468,23 @@ def wait_for_async():
     chunk_loader.wait_for_all()
 
 
-def _setup_logging(path: str) -> None:
+def _setup_logging(octree_config: dict) -> None:
     """Setup logging.
-
-    We log napari.async and napari.octree to the same file right now, but
-    we keep async and octree separate so we can do something fancier in the
-    future.
 
     Parameters
     ----------
-    path : str
-        Log to a file with this path.
+    octree_config : dict
+        The configuration data.
     """
-    if path:
-        _log_to_file("napari.async", path)
-        _log_to_file("napari.octree", path)
+    try:
+        _log_to_file("napari.loader", octree_config['loader']['log_path'])
+    except KeyError:
+        pass
+
+    try:
+        _log_to_file("napari.octree", octree_config['octree']['log_path'])
+    except KeyError:
+        pass
 
 
 def _log_to_file(name: str, path: str) -> None:

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -123,6 +123,12 @@ class ChunkLoader:
     ) -> ChunkRequest:
         """Create a ChunkRequest for submission to load_chunk.
 
+        TODO_OCTREE: We have this method mainly so we can create an
+        entry in self.layer_map. But it seems like it would be simpler
+        if users of ChunkLoader could just create a ChunkRequest on
+        their own. And we create the layer_map entry on submission?
+        These seems kind of historical?
+
         Parameters
         ----------
         layer_ref : LayerRef

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -365,8 +365,9 @@ class ChunkLoader:
             return  # Future was cancelled, nothing to do.
 
         LOGGER.debug(
-            "_done: elapsed=%.3fms location=%s",
+            "_done: elapsed=%.3fms load=%.3fms location=%s",
             request.elapsed_ms,
+            request.load_ms,
             request.key.location,
         )
 

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -179,7 +179,7 @@ class ChunkLoader:
         chunks = self.cache.get_chunks(request)
 
         if chunks is not None:
-            LOGGER.debug("load_chunk: cache hit %s", request.key)
+            LOGGER.debug("load_chunk: cache hit %s", request.key.location)
             request.chunks = chunks
             return request, None
 

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -481,12 +481,15 @@ def _log_to_file(path: str) -> None:
     path : str
         Log to this file path.
     """
+    # This file uses "napari.async.loader" but we want to load all of
+    # "napari.async" by default.
+    logger = logging.getLogger("napari.async")
     if path:
         fh = logging.FileHandler(path)
         formatter = logging.Formatter(LOG_FORMAT)
         fh.setFormatter(formatter)
-        LOGGER.addHandler(fh)
-        LOGGER.setLevel(logging.DEBUG)
+        logger.addHandler(fh)
+        logger.setLevel(logging.DEBUG)
 
 
 """

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -222,8 +222,11 @@ class ChunkLoader:
 
         # If it's been loading "fast" then load synchronously. There's no
         # point is loading async if it loads really fast.
-        if info.loads_fast:
-            return True
+
+        # TODO_OCTREE: disable this in a nice way for octree. It made sense
+        # for single-scale time series, but not for octree.
+        # if info.loads_fast:
+        #    return True
 
         # Finally, load synchronously if it's an ndarray (in memory) otherwise
         # it's Dask or something else and we load async.

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -365,9 +365,9 @@ class ChunkLoader:
             return  # Future was cancelled, nothing to do.
 
         LOGGER.debug(
-            "_done: elapsed=%.3fms load=%.3fms location=%s",
-            request.elapsed_ms,
+            "_done: load=%.3fms elapsed=%.3fms location=%s",
             request.load_ms,
+            request.elapsed_ms,
             request.key.location,
         )
 

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -179,11 +179,11 @@ class ChunkLoader:
         chunks = self.cache.get_chunks(request)
 
         if chunks is not None:
-            LOGGER.info("load_chunk: cache hit %s", request.key)
+            LOGGER.debug("load_chunk: cache hit %s", request.key)
             request.chunks = chunks
             return request, None
 
-        LOGGER.info("load_chunk: cache miss %s", request.key.location)
+        LOGGER.debug("load_chunk: cache miss %s", request.key.location)
 
         # Clear any pending requests for this specific data_id.
         # TODO_OCTREE: turn this off because all our request come from the

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -95,7 +95,8 @@ class ChunkLoader:
     """
 
     def __init__(self):
-        _log_to_file(octree_config['log_path'])
+        _setup_logging(octree_config['log_path'])
+
         config = octree_config['loader']
         self.force_synchronous: bool = bool(config['force_synchronous'])
         self.num_workers: int = int(config['num_workers'])
@@ -470,26 +471,38 @@ def wait_for_async():
     chunk_loader.wait_for_all()
 
 
-LOG_FORMAT = "%(levelname)s - %(name)s - %(message)s"
+def _setup_logging(path: str) -> None:
+    """Setup logging.
+
+    We log napari.async and napari.octree to the same file right now, but
+    we keep async and octree separate so we can do something fancier in the
+    future.
+
+    Parameters
+    ----------
+    path : str
+        Log to a file with this path.
+    """
+    if path:
+        _log_to_file("napari.async", path)
+        _log_to_file("napari.octree", path)
 
 
-def _log_to_file(path: str) -> None:
-    """Log "napari.async" messages to the given file.
+def _log_to_file(name: str, path: str) -> None:
+    """Log "name" messages to the given file path.
 
     Parameters
     ----------
     path : str
         Log to this file path.
     """
-    # This file uses "napari.async.loader" but we want to load all of
-    # "napari.async" by default.
-    logger = logging.getLogger("napari.async")
-    if path:
-        fh = logging.FileHandler(path)
-        formatter = logging.Formatter(LOG_FORMAT)
-        fh.setFormatter(formatter)
-        logger.addHandler(fh)
-        logger.setLevel(logging.DEBUG)
+    format = "%(levelname)s - %(name)s - %(message)s"
+    logger = logging.getLogger(name)
+    fh = logging.FileHandler(path)
+    formatter = logging.Formatter(format)
+    fh.setFormatter(formatter)
+    logger.addHandler(fh)
+    logger.setLevel(logging.DEBUG)
 
 
 """

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -377,7 +377,7 @@ class ChunkLoader:
         # complicated.
         self.cache.add_chunks(request)
 
-        # Lookup this Request's LayerInfo.
+        # Lookup this request's LayerInfo.
         info = self._get_layer_info(request)
 
         # Resolve the weakref.
@@ -388,8 +388,8 @@ class ChunkLoader:
 
         info.stats.on_load_finished(request, sync=False)
 
-        # Fire event to tell QtChunkReceiver to forward this chunk to its
-        # layer in the GUI thread.
+        # Fire chunk_loaded event  to tell QtChunkReceiver to forward this
+        # chunk to its layer in the GUI thread.
         self.events.chunk_loaded(layer=layer, request=request)
 
     def _get_layer_info(self, request: ChunkRequest) -> LayerInfo:

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -262,20 +262,20 @@ class ChunkLoader:
         request : ChunkRequest
             Contains the arrays to load.
         """
-        LOGGER.debug(
-            "_submit_async: elapsed=%.3fms %s",
-            request.elapsed_ms,
-            request.key.location,
-        )
-
-        # Submit the future, have it call ChunkLoader._done when done.
+        # Submit the future. It will call ChunkLoader._done when done.
         future = self.executor.submit(_chunk_loader_worker, request)
         future.add_done_callback(self._done)
 
         # Store the future in case we need to cancel it.
-        self._futures.setdefault(request.data_id, []).append(future)
+        future_list = self._futures.setdefault(request.data_id, [])
+        future_list.append(future)
 
-        LOGGER.debug("_submit_async: num_futures=%d", len(self._futures))
+        LOGGER.debug(
+            "_submit_async: %s elapsed=%.3fms num_futures=%d",
+            request.key.location,
+            request.elapsed_ms,
+            len(future_list),
+        )
 
         return future
 

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -175,15 +175,12 @@ class ChunkLoader:
         if self._load_synchronously(request):
             return request, None
 
-        # Check the cache first.
+        # Check the cache first. This logs for us.
         chunks = self.cache.get_chunks(request)
 
         if chunks is not None:
-            LOGGER.debug("load_chunk: cache hit %s", request.key.location)
             request.chunks = chunks
             return request, None
-
-        LOGGER.debug("load_chunk: cache miss %s", request.key.location)
 
         # Clear any pending requests for this specific data_id.
         # TODO_OCTREE: turn this off because all our request come from the

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -257,7 +257,7 @@ class ChunkLoader:
         # https://docs.python.org/3/howto/logging.html#optimization
         # https://blog.pilosus.org/posts/2020/01/24/python-f-strings-in-logging/
         LOGGER.debug(
-            "_submit_async: elapsed=%.3f %s",
+            "_submit_async: elapsed=%.3fms %s",
             request.elapsed_ms,
             request.key.location,
         )
@@ -357,7 +357,7 @@ class ChunkLoader:
             return  # Future was cancelled, nothing to do.
 
         LOGGER.debug(
-            "_done: elapsed=%.3f location=%s",
+            "_done: elapsed=%.3fms location=%s",
             request.elapsed_ms,
             request.key.location,
         )

--- a/napari/components/experimental/chunk/_request.py
+++ b/napari/components/experimental/chunk/_request.py
@@ -77,7 +77,7 @@ class ChunkRequest:
         One or more arrays that we need to load.
     create_time : float
         The time the request was created.
-    timers : Dict[str, PerfEvent]
+    _timers : Dict[str, PerfEvent]
         Timing information about chunk load time.
     """
 
@@ -92,11 +92,31 @@ class ChunkRequest:
 
         # TODO_OCTREE: Use time.time() or perf_counter_ns here?
         self.create_time = time.time()
-        self.timers: Dict[str, PerfEvent] = {}
+        self._timers: Dict[str, PerfEvent] = {}
 
     @property
     def elapsed_ms(self) -> float:
+        """The total time elapsed since the request was created.
+
+        Return
+        ------
+        float
+            The total time elapsed since the chunk was created.
+        """
         return (time.time() - self.create_time) * 1000
+
+    @property
+    def load_ms(self) -> float:
+        """The total time it took to load all chunks.
+
+        Return
+        ------
+        float
+            The total time it took to return all chunks.
+        """
+        return sum(
+            perf_timer.duration_ms for perf_timer in self._timers.values()
+        )
 
     @property
     def data_id(self) -> int:
@@ -143,8 +163,8 @@ class ChunkRequest:
         return all(isinstance(x, np.ndarray) for x in self.chunks.values())
 
     @contextlib.contextmanager
-    def chunk_timer(self, name):
-        """Time a block of code and save the PerfEvent in self.timers.
+    def _chunk_timer(self, name):
+        """Time a block of code and save the PerfEvent in self._timers.
 
         We want to time our loads whether perfmon is enabled or not, since
         the auto-async feature needs to work in all cases.
@@ -161,7 +181,7 @@ class ChunkRequest:
         """
         with block_timer(name) as event:
             yield event
-        self.timers[name] = event
+        self._timers[name] = event
 
     def load_chunks(self):
         """Load all of our chunks now in this thread.
@@ -169,11 +189,10 @@ class ChunkRequest:
         We time the overall load with the special name "load_chunks" and then
         we time each chunk as it loads, using it's array name as the key.
         """
-        with self.chunk_timer("ChunkRequest.load_chunks"):
-            for key, array in self.chunks.items():
-                with self.chunk_timer(key):
-                    loaded_array = np.asarray(array)
-                    self.chunks[key] = loaded_array
+        for key, array in self.chunks.items():
+            with self._chunk_timer(key):
+                loaded_array = np.asarray(array)
+                self.chunks[key] = loaded_array
 
     def transpose_chunks(self, order: tuple) -> None:
         """Transpose all our chunks.

--- a/napari/components/experimental/chunk/_request.py
+++ b/napari/components/experimental/chunk/_request.py
@@ -2,6 +2,7 @@
 """
 import contextlib
 import logging
+import time
 from typing import Optional, Tuple
 
 import numpy as np
@@ -51,23 +52,31 @@ class ChunkKey:
     def __eq__(self, other):
         return self.key == other.key
 
+    @property
+    def location(self):
+        # Derived OctreeChunkKey has a location, we don't, but we could maybe
+        # print the indices or something here?
+        return "none"
+
 
 class ChunkRequest:
-    """A request asking the ChunkLoader to load one or more arrays.
+    """A request asking the ChunkLoader to load data.
 
     Parameters
     ----------
     key : ChunkKey
         The key of the request.
     chunks : Dict[str, ArrayLike]
-        The chunk arrays we need to load.
+        One or more arrays that we need to load.
 
     Attributes
     ----------
     key : ChunkKey
         The key of the request.
     chunks : Dict[str, ArrayLike]
-        The chunk arrays we need to load.
+        One or more arrays that we need to load.
+    create_time : float
+        The time the request was created.
     timers : Dict[str, PerfEvent]
         Timing information about chunk load time.
     """
@@ -81,7 +90,13 @@ class ChunkRequest:
         self.key = key
         self.chunks = chunks
 
+        # TODO_OCTREE: Use time.time() or perf_counter_ns here?
+        self.create_time = time.time()
         self.timers: Dict[str, PerfEvent] = {}
+
+    @property
+    def elapsed_ms(self) -> float:
+        return (time.time() - self.create_time) * 1000
 
     @property
     def data_id(self) -> int:

--- a/napari/components/experimental/chunk/_request.py
+++ b/napari/components/experimental/chunk/_request.py
@@ -11,7 +11,7 @@ from ....types import ArrayLike, Dict
 from ....utils.perf import PerfEvent, block_timer
 from .layer_key import LayerKey
 
-LOGGER = logging.getLogger("napari.async")
+LOGGER = logging.getLogger("napari.loader")
 
 # We convert slices to tuple for hashing.
 SliceTuple = Tuple[Optional[int], Optional[int], Optional[int]]

--- a/napari/components/experimental/chunk/_tests/test_chunk.py
+++ b/napari/components/experimental/chunk/_tests/test_chunk.py
@@ -78,7 +78,7 @@ def test_loader():
 
     # Create the ChunkRequest.
     layer_ref = LayerRef.create_from_layer(layer, (0, 0))
-    request, _future = chunk_loader.create_request(layer_ref, key, chunks)
+    request = chunk_loader.create_request(layer_ref, key, chunks)
 
     # Should be compatible with the layer we made it from!
     # assert request.is_compatible(layer)

--- a/napari/components/experimental/chunk/_tests/test_chunk.py
+++ b/napari/components/experimental/chunk/_tests/test_chunk.py
@@ -78,13 +78,13 @@ def test_loader():
 
     # Create the ChunkRequest.
     layer_ref = LayerRef.create_from_layer(layer, (0, 0))
-    request = chunk_loader.create_request(layer_ref, key, chunks)
+    request, _future = chunk_loader.create_request(layer_ref, key, chunks)
 
     # Should be compatible with the layer we made it from!
     # assert request.is_compatible(layer)
 
     # Load the ChunkRequest.
-    request = chunk_loader.load_chunk(request)
+    request, _future = chunk_loader.load_chunk(request)
 
     # Data should only match data not data2.
     assert np.all(data == request.image.data)

--- a/napari/components/experimental/monitor/_api.py
+++ b/napari/components/experimental/monitor/_api.py
@@ -7,7 +7,6 @@ from threading import Event
 from typing import NamedTuple
 
 from ....utils.events import EmitterGroup
-from ._utils import numpy_dumps
 
 LOGGER = logging.getLogger("napari.monitor")
 
@@ -216,5 +215,4 @@ class MonitorApi:
         message : dict
             Message to send to clients.
         """
-        LOGGER.info("Send napari message: %s", numpy_dumps(message))
         self._remote.napari_messages.put(message)

--- a/napari/components/experimental/monitor/_monitor.py
+++ b/napari/components/experimental/monitor/_monitor.py
@@ -147,7 +147,6 @@ class Monitor:
     @property
     def run_command_event(self):
         """The MonitorAPI fires this event for commands from clients."""
-        assert self._running
         return self._api.events.run_command
 
     def start(self) -> bool:

--- a/napari/components/experimental/remote/_messages.py
+++ b/napari/components/experimental/remote/_messages.py
@@ -65,5 +65,7 @@ class RemoteMessages:
         delta = now - last if last is not None else 0
         delta_ms = delta * 1000
 
-        monitor.send_message({'frame_time_ms': delta_ms})
+        monitor.send_message(
+            {'frame_time': {'time': now, 'delta_ms': delta_ms}}
+        )
         self._last_time = now

--- a/napari/layers/image/_image_slice.py
+++ b/napari/layers/image/_image_slice.py
@@ -11,7 +11,7 @@ from ._image_loader import ImageLoader
 from ._image_slice_data import ImageSliceData
 from ._image_view import ImageView
 
-LOGGER = logging.getLogger("napari.async")
+LOGGER = logging.getLogger("napari.loader")
 
 
 def _create_loader_class() -> ImageLoader:

--- a/napari/layers/image/_image_slice_data.py
+++ b/napari/layers/image/_image_slice_data.py
@@ -1,14 +1,11 @@
 """ImageSliceData class.
 """
-import logging
 from typing import Optional, Tuple
 
 import numpy as np
 
 from ...types import ArrayLike
 from ..base import Layer
-
-LOGGER = logging.getLogger("napari.async")
 
 
 class ImageSliceData:

--- a/napari/layers/image/experimental/_chunk_set.py
+++ b/napari/layers/image/experimental/_chunk_set.py
@@ -1,0 +1,72 @@
+"""ChunkSet class.
+
+Used by the OctreeChunkLoader.
+"""
+from typing import Dict, List, Set
+
+from .octree_chunk import OctreeChunk, OctreeLocation
+
+
+class ChunkSet:
+    """A set of chunks with fast location membership test.
+
+    We use a dict as an ordered set, and then a set with just the locations
+    so OctreeChunkLoader._cancel_futures() can quickly test if a location is
+    in the set.
+    """
+
+    def __init__(self):
+        self._dict: Dict[OctreeChunk, int] = {}
+        self._locations: Set[OctreeLocation] = set()
+
+    def __len__(self) -> int:
+        """Return the size of the size.
+
+        Return
+        ------
+        int
+            The size of the set.
+        """
+        return len(self._dict)
+
+    def __contains__(self, chunk: OctreeChunk) -> bool:
+        """Return true if the set contains this chunk.
+
+        Return
+        ------
+        bool
+            True if the set contains the given chunk.
+        """
+        return chunk in self._dict
+
+    def add(self, chunks: List[OctreeChunk]) -> None:
+        """Add these chunks to the set.
+
+        Parameters
+        ----------
+        chunks : List[OctreeChunk]
+            Add these chunks to the set.
+        """
+        for chunk in chunks:
+            self._dict[chunk] = 1
+            self._locations.add(chunk.location)
+
+    def chunks(self) -> List[OctreeChunk]:
+        """Get all the chunks in the set.
+
+        Return
+        ------
+        List[OctreeChunk]
+            All the chunks in the set.
+        """
+        return self._dict.keys()
+
+    def has_location(self, location: OctreeLocation) -> bool:
+        """Return True if the set contains this location.
+
+        Return
+        ------
+        bool
+            True if the set contains this location.
+        """
+        return location in self._locations

--- a/napari/layers/image/experimental/_chunked_image_loader.py
+++ b/napari/layers/image/experimental/_chunked_image_loader.py
@@ -7,7 +7,7 @@ from ....components.experimental.chunk import ChunkKey, LayerKey
 from .._image_loader import ImageLoader
 from ._chunked_slice_data import ChunkedSliceData
 
-LOGGER = logging.getLogger("napari.async")
+LOGGER = logging.getLogger("napari.loader")
 
 
 class ChunkedImageLoader(ImageLoader):

--- a/napari/layers/image/experimental/_chunked_slice_data.py
+++ b/napari/layers/image/experimental/_chunked_slice_data.py
@@ -79,7 +79,7 @@ class ChunkedSliceData(ImageSliceData):
         # Create the ChunkRequest and load it with the ChunkLoader.
         layer_ref = LayerRef.create_from_layer(self.layer, self.indices)
         self.request = chunk_loader.create_request(layer_ref, key, chunks)
-        satisfied_request = chunk_loader.load_chunk(self.request)
+        satisfied_request, _future = chunk_loader.load_chunk(self.request)
 
         if satisfied_request is None:
             return False  # Load was async.

--- a/napari/layers/image/experimental/_chunked_slice_data.py
+++ b/napari/layers/image/experimental/_chunked_slice_data.py
@@ -79,6 +79,8 @@ class ChunkedSliceData(ImageSliceData):
         # Create the ChunkRequest and load it with the ChunkLoader.
         layer_ref = LayerRef.create_from_layer(self.layer, self.indices)
         self.request = chunk_loader.create_request(layer_ref, key, chunks)
+
+        LOGGER.debug("ChunkedSliceData calling chunk_loader.load_chunk")
         satisfied_request, _future = chunk_loader.load_chunk(self.request)
 
         if satisfied_request is None:

--- a/napari/layers/image/experimental/_chunked_slice_data.py
+++ b/napari/layers/image/experimental/_chunked_slice_data.py
@@ -13,7 +13,7 @@ from ....types import ArrayLike
 from ...base import Layer
 from .._image_slice_data import ImageSliceData
 
-LOGGER = logging.getLogger("napari.async")
+LOGGER = logging.getLogger("napari.loader")
 
 
 class ChunkedSliceData(ImageSliceData):

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -24,7 +24,7 @@ NUM_ANCESTORS_LEVELS = 3
 class OctreeChunkLoader:
     """Load data into OctreeChunks in the octree.
 
-    The loader is given draw_set, the chunks we are currently drawing, and
+    The loader is given drawn_set, the chunks we are currently drawing, and
     ideal_chunks, the chunks which are in view at the desired level of the
     octree.
 
@@ -218,33 +218,25 @@ class OctreeChunkLoader:
     ) -> List[OctreeChunk]:
         """Return the chunks to draw for this one ideal chunk.
 
-        If the ideal chunk is already being drawn, we just return it.
-        Nothing else needs to be drawn. Otherwise we look up down the tree
-        to find what chunks we can to draw to "cover" this chunk.
+        If the ideal chunk is already being drawn, we return it alone. It's
+        all we need to draw to cover the chunk. If it's not being draw we
+        look up down the tree to find what chunks we can to draw to "cover"
+        this chunk.
 
-        Note that drawn_chunk_set might be smaller than what
-        get_drawable_chunks has been returning, because it only contains
-        chunks that actually got drawn to the screen.
+        Note that drawn_set might be smaller than what get_drawable_chunks
+        has been returning, because it only contains chunks that are
+        actually got drawn to the screen. That are in VRAM.
 
-        We return drawable chunks to the visual, but the visual might take
-        some number of frames to get them all on the screen. This is
-        because it takes time to move a chunk's data into VRAM, so the
-        visual tends to only draw so many new chunks per frame. Right
-        now in fact it only draws one new chunk per frame.
-
-        So if we return the same 40 in-memory chunks from our
-        get_drawable_chunks() every frame, it might be 40 frames until they
-        are all actually drawn on the screen.
-
-        For this reason we return multiple chunks for an ideal chunk even
-        if the ideal chunk itself is in memory. Once the ideal chunk is in
-        the draw_set though, can return just the ideal chunk alone.
+        The visual might take time to load chunks into VRAM. So we might
+        return the same chunks from get_drawable_chunks() many times
+        in a row before it gets drawn. It might only one chunk per
+        frame into VRAM, for example.
 
         Parameters
         ----------
         ideal_chunk : OctreeChunk
             The ideal chunk we'd like to draw.
-        drawn_chunk_set : Set[OctreeChunkKey]
+        drawn_set : Set[OctreeChunkKey]
             The chunks which the visual is currently drawing.
 
         Return
@@ -299,7 +291,8 @@ class OctreeChunkLoader:
             Parents and children we should load and/or draw.
         """
         # Get any direct children which are in memory. Do not create
-        # OctreeChunks or use children that are not already in memory.
+        # OctreeChunks or use children that are not already in memory
+        # because it's better to create and load higher levels.
         children = self._octree.get_children(
             ideal_chunk, create=False, in_memory=True
         )

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -12,6 +12,12 @@ from .octree_chunk import OctreeChunk, OctreeChunkKey, OctreeLocation
 
 LOGGER = logging.getLogger("napari.octree.loader")
 
+# TODO_OCTREE make this a config. This is how many levels "up" we look
+# for tiles to draw at levels above the ideal how. These tiles give
+# us lots of coverage quickly, so we load and draw then even before
+# the ideal level
+NUM_ANCESTORS_LEVELS = 3
+
 
 class OctreeChunkLoader:
     """Load data into OctreeChunks in the octree.
@@ -339,7 +345,7 @@ class OctreeChunkLoader:
         keep = [chunk for chunk in family if keep_chunk(chunk)]
 
         LOGGER.debug(
-            "_get_coverage: Keeping %d of %d for ",
+            "_get_coverage: Keeping %d of %d for %s",
             len(keep),
             len(family),
             ideal_chunk.location,
@@ -374,7 +380,9 @@ class OctreeChunkLoader:
         # all four children, we still consider loading and drawing these
         # because they will provide more coverage. They will cover the
         # ideal chunk plus more.
-        ancestors = self._octree.get_ancestors(ideal_chunk)
+        ancestors = self._octree.get_ancestors(
+            ideal_chunk, NUM_ANCESTORS_LEVELS
+        )
 
         return children + ancestors
 

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -118,15 +118,16 @@ class OctreeChunkLoader:
         drawable = []
         locations = set()
 
+        # Get any chunks we always want to draw no matter where the
+        # view is. For now this is just the root tile, so that we have
+        # some minimal coverage. On a big enough dataset we might be
+        # "inside" a single pixel of the root tile! So it's just
+        # providing a background color.
+        drawable.extend(self._get_permanent_chunks())
+        locations.update([chunk.location for chunk in drawable])
+
         # For every chunk we'd ideally like to draw.
         for ideal_chunk in ideal_chunks:
-
-            # Get any chunks we always want to draw no matter where the
-            # view is. For now this is just the root tile, so that we have
-            # some minimal coverage. On a big enough dataset we might be
-            # "inside" a single pixel of the root tile! So it's just
-            # providing a background color.
-            drawable.extend(self._get_permanent_chunks())
 
             # Get the drawnable chunks which will hopefully "cover" that
             # ideal chunks. This could be just the ideal chunks itself, or

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -7,6 +7,7 @@ from concurrent.futures import Future
 from typing import Dict, List, Set
 
 from ....components.experimental.chunk import LayerRef, chunk_loader
+from ._chunk_set import ChunkSet
 from .octree import Octree
 from .octree_chunk import OctreeChunk, OctreeChunkKey, OctreeLocation
 
@@ -18,29 +19,6 @@ LOADER = logging.getLogger("napari.loader.futures")
 # us lots of coverage quickly, so we load and draw then even before
 # the ideal level
 NUM_ANCESTORS_LEVELS = 3
-
-
-class ChunkSet:
-    def __init__(self):
-        self._dict = {}
-        self._locations = set()
-
-    def __len__(self) -> int:
-        return len(self._dict)
-
-    def __contains__(self, chunk: OctreeChunk) -> bool:
-        return chunk in self._dict
-
-    def add(self, chunks: List[OctreeChunk]) -> None:
-        for chunk in chunks:
-            self._dict[chunk] = 1
-            self._locations.add(chunk.location)
-
-    def chunks(self) -> List[OctreeChunk]:
-        return self._dict.keys()
-
-    def has_location(self, location: OctreeLocation) -> bool:
-        return location in self._locations
 
 
 class OctreeChunkLoader:

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -10,7 +10,7 @@ from ....components.experimental.chunk import LayerRef, chunk_loader
 from .octree import Octree
 from .octree_chunk import OctreeChunk, OctreeChunkKey, OctreeLocation
 
-LOGGER = logging.getLogger("napari.async.octree")
+LOGGER = logging.getLogger("napari.octree.loader")
 
 
 class OctreeChunkLoader:

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -166,24 +166,11 @@ class OctreeChunkLoader:
             elif chunk.needs_load and self._load_chunk(chunk):
                 drawable.append(chunk)  # It was a sync load, ready to draw.
 
-        self._log_chunks("drawable", None, drawable)  # Log for now.
-        self._log_futures()  # Log for now.
-        return drawable
+        # Useful for debugging but spammy.
+        # log_chunks("drawable", drawable)
+        # self._log_futures()
 
-    def _log_chunks(
-        self, label: str, location: OctreeLocation, chunks: List[OctreeChunk]
-    ) -> None:
-        LOGGER.debug(
-            "%s has %d chunks %s", label, len(chunks), location,
-        )
-        for i, chunk in enumerate(chunks):
-            LOGGER.debug(
-                "Chunk %d %s in_memory=%d loading=%d",
-                i,
-                chunk.location,
-                chunk.in_memory,
-                chunk.loading,
-            )
+        return drawable
 
     def _seen_changed(self, drawable: Set[OctreeChunk]) -> bool:
         """Return True if the locations we are drawing changed.
@@ -269,14 +256,10 @@ class OctreeChunkLoader:
         # If the ideal chunk is already being drawn, that's all we need,
         # there is no point in returning more than that.
         if ideal_chunk.in_memory and ideal_chunk.key in drawn_set:
-            LOGGER.debug("_get_coverage: Ideal Only %s", ideal_chunk.location)
             return [ideal_chunk]
 
         # Get alternates for this chunk, from other levels.
         family = self._get_family(ideal_chunk)
-
-        for chunk in family:
-            LOGGER.debug("Family %s", chunk.location)
 
         ideal_level_index = ideal_chunk.location.level_index
 
@@ -299,9 +282,6 @@ class OctreeChunkLoader:
             return True  # Keep all higher level chunks.
 
         keep = [chunk for chunk in family if keep_chunk(chunk)]
-
-        for chunk in keep:
-            LOGGER.debug("Keeping %s", chunk.location)
 
         return keep
 
@@ -406,6 +386,7 @@ class OctreeChunkLoader:
         return False
 
     def _log_futures(self) -> None:
+        """Log the futures we are currently tracking."""
         LOGGER.debug("%d futures:", len(self._futures))
         for i, location in enumerate(self._futures.keys()):
             LOGGER.debug("Future %d: %s", i, location)

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -404,17 +404,6 @@ class OctreeChunkLoader:
                 if future.cancel():
                     self._cancel_load(location)
 
-        kept = len(self._futures)
-        cancelled = before - kept
-
-        if before > 0 or kept > 0:
-            LOADER.debug(
-                "Futures: before=%d cancelled=%d kept=%d",
-                before,
-                cancelled,
-                kept,
-            )
-
     def _cancel_load(self, location: OctreeLocation) -> None:
         """Set that this chunk is no longer loading.
 

--- a/napari/layers/image/experimental/_octree_multiscale_slice.py
+++ b/napari/layers/image/experimental/_octree_multiscale_slice.py
@@ -18,7 +18,7 @@ from .octree_intersection import OctreeIntersection, OctreeView
 from .octree_level import OctreeLevel, OctreeLevelInfo
 from .octree_util import SliceConfig
 
-LOGGER = logging.getLogger("napari.async.octree.slice")
+LOGGER = logging.getLogger("napari.octree.slice")
 
 
 class OctreeMultiscaleSlice:

--- a/napari/layers/image/experimental/_octree_multiscale_slice.py
+++ b/napari/layers/image/experimental/_octree_multiscale_slice.py
@@ -206,7 +206,7 @@ class OctreeMultiscaleSlice:
 
         if octree_chunk is None:
             # This location in the octree does not contain an OctreeChunk.
-            # That's unexpected, becauase locations are turned into
+            # That's unexpected, because locations are turned into
             # OctreeChunk's when a load is initiated. So this is an error,
             # but log it and keep going, maybe some transient weirdness.
             LOGGER.error(
@@ -232,5 +232,8 @@ class OctreeMultiscaleSlice:
         octree_chunk.data = incoming_data
         assert octree_chunk.in_memory
         assert not octree_chunk.needs_load
+
+        # Tell loader so it can delete future which is no longer relevant.
+        self.loader.on_chunk_loaded(octree_chunk)
 
         return True  # Chunk was added.

--- a/napari/layers/image/experimental/_octree_multiscale_slice.py
+++ b/napari/layers/image/experimental/_octree_multiscale_slice.py
@@ -221,12 +221,10 @@ class OctreeMultiscaleSlice:
         # Loaded data should always be an ndarray.
         assert isinstance(incoming_data, np.ndarray)
 
-        # Add that data to the octree's OctreeChunk. Now
-        # octree_chunk.in_memory is True and we can pass the chunk as a
-        # drawable chunk to the visual.
+        # Add that data to the octree's OctreeChunk. Now the chunk can be draw.
         octree_chunk.data = incoming_data
 
-        # Check the obvious (for now).
+        # Setting data should mean:
         assert octree_chunk.in_memory
         assert not octree_chunk.needs_load
 

--- a/napari/layers/image/experimental/_octree_multiscale_slice.py
+++ b/napari/layers/image/experimental/_octree_multiscale_slice.py
@@ -197,10 +197,9 @@ class OctreeMultiscaleSlice:
             # The original load finished, but we are now showing a new slice.
             # Don't consider it error, just ignore the chunk.
             LOGGER.debug(
-                "OctreeMultiscaleSlice.on_chunk_loaded: wrong slice_id: %s",
-                location,
+                "on_chunk_loaded: wrong slice_id: %s", location,
             )
-            return False  # Do not load.
+            return False  # Do not add the chunk.
 
         octree_chunk = self._get_octree_chunk(location)
 
@@ -210,15 +209,11 @@ class OctreeMultiscaleSlice:
             # OctreeChunk's when a load is initiated. So this is an error,
             # but log it and keep going, maybe some transient weirdness.
             LOGGER.error(
-                "OctreeMultiscaleSlice.on_chunk_loaded: missing OctreeChunk: %s",
-                octree_chunk,
+                "on_chunk_loaded: missing OctreeChunk: %s", octree_chunk,
             )
-            return False  # Did not add the chun.
+            return False  # Did not add the chunk.
 
-        # Looks good, we are adding this chunk.
-        LOGGER.debug(
-            "OctreeMultiscaleSlice.on_chunk_loaded: adding %s", octree_chunk
-        )
+        LOGGER.debug("on_chunk_loaded: adding %s", octree_chunk)
 
         # Get the data from the request.
         incoming_data = request.chunks.get('data')
@@ -230,10 +225,12 @@ class OctreeMultiscaleSlice:
         # octree_chunk.in_memory is True and we can pass the chunk as a
         # drawable chunk to the visual.
         octree_chunk.data = incoming_data
+
+        # Check the obvious (for now).
         assert octree_chunk.in_memory
         assert not octree_chunk.needs_load
 
-        # Tell loader so it can delete future which is no longer relevant.
+        # Tell the loader. It will delete the future.
         self.loader.on_chunk_loaded(octree_chunk)
 
         return True  # Chunk was added.

--- a/napari/layers/image/experimental/_octree_multiscale_slice.py
+++ b/napari/layers/image/experimental/_octree_multiscale_slice.py
@@ -18,7 +18,7 @@ from .octree_intersection import OctreeIntersection, OctreeView
 from .octree_level import OctreeLevel, OctreeLevelInfo
 from .octree_util import SliceConfig
 
-LOGGER = logging.getLogger("napari.async.octree")
+LOGGER = logging.getLogger("napari.async.octree.slice")
 
 
 class OctreeMultiscaleSlice:
@@ -189,7 +189,10 @@ class OctreeMultiscaleSlice:
             # There was probably a load in progress when the slice was changed.
             # The original load finished, but we are now showing a new slice.
             # Don't consider it error, just ignore the chunk.
-            LOGGER.debug("on_chunk_loaded: wrong slice_id: %s", location)
+            LOGGER.debug(
+                "OctreeMultiscaleSlice.on_chunk_loaded: wrong slice_id: %s",
+                location,
+            )
             return False  # Do not load.
 
         octree_chunk = self._get_octree_chunk(location)
@@ -199,12 +202,15 @@ class OctreeMultiscaleSlice:
             # OctreeChunk's when a load is initiated. So this is an error,
             # but log it and keep going, maybe some transient weirdness.
             LOGGER.error(
-                "on_chunk_loaded: missing OctreeChunk: %s", octree_chunk
+                "OctreeMultiscaleSlice.on_chunk_loaded: missing OctreeChunk: %s",
+                octree_chunk,
             )
             return False  # Do not load.
 
         # Looks good, we are loading this chunk.
-        LOGGER.debug("on_chunk_loaded: loading %s", octree_chunk)
+        LOGGER.debug(
+            "OctreeMultiscaleSlice.on_chunk_loaded: loading %s", octree_chunk
+        )
 
         # Get the data from the request.
         incoming_data = request.chunks.get('data')

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -224,12 +224,12 @@ class Octree:
             child_level.get_chunk(row + 1, col + 1, create=create),
         ]
 
+        # Keep non-None children, and if requested in-memory ones.
         def keep_chunk(octree_chunk) -> bool:
             return octree_chunk is not None and (
                 not in_memory or octree_chunk.in_memory
             )
 
-        # Keep non-None children, and if requested in-memory ones.
         return list(filter(keep_chunk, children))
 
     def _get_extra_levels(self) -> List[OctreeLevel]:

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -64,8 +64,7 @@ class Octree:
                 f"Data of shape {data.shape} resulted " "no octree levels?"
             )
 
-        LOGGER.info("Multiscale data has %d levels: ", len(self.levels))
-        log_levels(self.levels)
+        LOGGER.info("Multiscale data has %d levels.", len(self.levels))
 
         # If root level contains more than one tile, add extra levels
         # until the root does consist of a single tile. We have to do this
@@ -73,7 +72,8 @@ class Octree:
         if self.levels[-1].info.num_tiles > 1:
             self.levels.extend(self._get_extra_levels())
 
-        LOGGER.info(f"Tree now has {len(self.levels)} total levels.")
+        LOGGER.info(f"Octree now has {len(self.levels)} total levels:")
+        log_levels(self.levels)
 
         # Now the root should definitely contain only a single tile.
         assert self.levels[-1].info.num_tiles == 1
@@ -229,7 +229,6 @@ class Octree:
             len(extra_levels),
             timer.duration_ms,
         )
-        log_levels(extra_levels, start_level=len(self.levels))
 
         return extra_levels
 
@@ -295,7 +294,9 @@ class Octree:
         # consists of only a single tile, using our standard/only
         # tile size.
         tile_size = self.slice_config.tile_size
-        new_levels = create_downsampled_levels(self.data[-1], tile_size)
+        new_levels = create_downsampled_levels(
+            self.data[-1], len(self.data), tile_size
+        )
 
         # Add the data.
         self.data.extend(new_levels)

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -195,15 +195,21 @@ class Octree:
         level_index = location.level_index
         row, col = location.row, location.col
 
-        max_level = min(self.num_levels - 1, level_index + num_levels)
+        stop_level = min(self.num_levels - 1, level_index + num_levels)
 
         # Search up one level at a time.
-        while level_index <= max_level:
+        while level_index < stop_level:
 
             # Get the next level up. Coords are halved each level.
             level_index += 1
             row, col = int(row / 2), int(col / 2)
-            level: OctreeLevel = self.levels[level_index]
+
+            try:
+                level: OctreeLevel = self.levels[level_index]
+            except IndexError as exc:
+                raise IndexError(
+                    f"Level {level_index} is not in range(0, {len(self.levels)})"
+                ) from exc
 
             # Get chunk at this location.
             ancestor = level.get_chunk(row, col, create=True)
@@ -211,7 +217,7 @@ class Octree:
             ancestors.append(ancestor)
 
         # Reverse to provide the most distant ancestor first.
-        return reversed(ancestors)
+        return list(reversed(ancestors))
 
     def get_children(
         self,

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -1,5 +1,6 @@
 """Octree class.
 """
+import logging
 import math
 from typing import List, Optional
 
@@ -8,6 +9,8 @@ from .octree_chunk import OctreeChunk
 from .octree_level import OctreeLevel, log_levels
 from .octree_tile_builder import create_downsampled_levels
 from .octree_util import SliceConfig
+
+LOGGER = logging.getLogger("napari.async.octree")
 
 
 class Octree:
@@ -61,7 +64,8 @@ class Octree:
                 f"Data of shape {data.shape} resulted " "no octree levels?"
             )
 
-        log_levels("Octree input data has", self.levels)
+        LOGGER.info("Octree input data has %d levels: ", len(self.levels))
+        log_levels(self.levels)
 
         # If root level contains more than one tile, add extra levels
         # until the root does consist of a single tile. We have to do this
@@ -220,8 +224,12 @@ class Octree:
         with block_timer("_create_extra_levels") as timer:
             extra_levels = self._create_extra_levels(self.slice_id)
 
-        label = f"In {timer.duration_ms:.3f}ms created"
-        log_levels(label, extra_levels, num_levels)
+        LOGGER.info(
+            "Created %d additional levels in %.3f",
+            len(self.levels),
+            timer.duration_ms,
+        )
+        log_levels(extra_levels, start_level=num_levels)
 
         print(f"Tree now has {len(self.levels)} total levels.")
 

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -225,7 +225,7 @@ class Octree:
             extra_levels = self._create_extra_levels(self.slice_id)
 
         LOGGER.info(
-            "Created %d additional levels in %.3f",
+            "Created %d additional levels in %.3fms",
             len(self.levels),
             timer.duration_ms,
         )

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -10,7 +10,7 @@ from .octree_level import OctreeLevel, log_levels
 from .octree_tile_builder import create_downsampled_levels
 from .octree_util import SliceConfig
 
-LOGGER = logging.getLogger("napari.async.octree")
+LOGGER = logging.getLogger("napari.octree")
 
 
 class Octree:
@@ -64,7 +64,7 @@ class Octree:
                 f"Data of shape {data.shape} resulted " "no octree levels?"
             )
 
-        LOGGER.info("Octree input data has %d levels: ", len(self.levels))
+        LOGGER.info("Multiscale data has %d levels: ", len(self.levels))
         log_levels(self.levels)
 
         # If root level contains more than one tile, add extra levels
@@ -72,6 +72,8 @@ class Octree:
         # because we cannot draw tiles larger than the standard size right now.
         if self.levels[-1].info.num_tiles > 1:
             self.levels.extend(self._get_extra_levels())
+
+        LOGGER.info(f"Tree now has {len(self.levels)} total levels.")
 
         # Now the root should definitely contain only a single tile.
         assert self.levels[-1].info.num_tiles == 1
@@ -219,19 +221,15 @@ class Octree:
         List[OctreeLevel]
             The extra levels.
         """
-        num_levels = len(self.levels)
-
         with block_timer("_create_extra_levels") as timer:
             extra_levels = self._create_extra_levels(self.slice_id)
 
         LOGGER.info(
             "Created %d additional levels in %.3fms",
-            len(self.levels),
+            len(extra_levels),
             timer.duration_ms,
         )
-        log_levels(extra_levels, start_level=num_levels)
-
-        print(f"Tree now has {len(self.levels)} total levels.")
+        log_levels(extra_levels, start_level=len(self.levels))
 
         return extra_levels
 

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -1,11 +1,14 @@
 """OctreeChunk class
 """
-from typing import NamedTuple
+import logging
+from typing import List, NamedTuple
 
 import numpy as np
 
 from ....components.experimental.chunk import ChunkKey, LayerKey
 from ....types import ArrayLike
+
+LOGGER = logging.getLogger("napari.octree")
 
 
 class OctreeChunkGeom(NamedTuple):
@@ -214,3 +217,31 @@ class OctreeChunk:
         """
         self._data = self._orig_data
         self.loading = False
+
+
+def log_chunks(
+    label: str, chunks: List[OctreeChunk], location: OctreeLocation = None,
+) -> None:
+    """Log the given chunks with an intro header message.
+
+    Parameters
+    ----------
+    label : str
+        Prefix the log message with this label.
+    chunk : List[OctreeChunk]
+        The chunks to log.
+    location : Optional[OctreeLocation]
+        Append the log message with this location.
+    """
+    if location is None:
+        LOGGER.debug("%s has %d chunks:", label, len(chunks))
+    else:
+        LOGGER.debug("%s has %d chunks at %s", label, len(chunks), location)
+    for i, chunk in enumerate(chunks):
+        LOGGER.debug(
+            "Chunk %d %s in_memory=%d loading=%d",
+            i,
+            chunk.location,
+            chunk.in_memory,
+            chunk.loading,
+        )

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -119,6 +119,9 @@ class OctreeChunk:
     def __str__(self):
         return f"{self.location}"
 
+    def __hash__(self):
+        return hash(self.location)
+
     @property
     def data(self) -> ArrayLike:
         """Return the data associated with this chunk.

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -33,6 +33,14 @@ class OctreeLocation(NamedTuple):
     def __str__(self):
         return f"location=({self.level_index}, {self.row}, {self.col}) "
 
+    def __eq__(self, other) -> bool:
+        return (
+            self.slice_id == other.slice_id
+            and self.level_index == other.level_index
+            and self.row == other.row
+            and self.col == other.col
+        )
+
     @classmethod
     def create_null(cls):
         """Create null location that points to nothing."""

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -41,6 +41,9 @@ class OctreeLocation(NamedTuple):
             and self.col == other.col
         )
 
+    def __hash__(self) -> int:
+        return hash((self.slice_id, self.level_index, self.row, self.col))
+
     @classmethod
     def create_null(cls):
         """Create null location that points to nothing."""

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -31,10 +31,7 @@ class OctreeLocation(NamedTuple):
     col: int
 
     def __str__(self):
-        return (
-            f"location =({self.level_index}, {self.row}, {self.col}) "
-            # f"slice={self.slice_id} id={id(self)}"
-        )
+        return f"location=({self.level_index}, {self.row}, {self.col}) "
 
     @classmethod
     def create_null(cls):
@@ -61,8 +58,12 @@ class OctreeChunkKey(ChunkKey):
     def __init__(
         self, layer_key: LayerKey, location: OctreeLocation,
     ):
-        self.location = location
+        self._location = location
         super().__init__(layer_key)
+
+    @property
+    def location(self):
+        return self._location
 
     def _get_hash_values(self):
         # TODO_OCTREE: can't we just hash in the parent's hashed key with

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -326,12 +326,7 @@ class OctreeImage(Image):
         ideal_chunks = self._intersection.get_chunks(create=True)
         level_index = self._intersection.level.info.level_index
 
-        LOGGER.debug(
-            "get_drawable_chunks: Found %d ideal chunks on level %d",
-            len(ideal_chunks),
-            level_index,
-        )
-        # log_chunks("ideas_chunks", ideal_chunks)
+        # log_chunks("ideal_chunks", ideal_chunks)
 
         # If we are seting the data level level automatically, then update
         # our level to match what was chosen for the intersection.

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -334,7 +334,7 @@ class OctreeImage(Image):
 
         # Log the ideal chunks (for now).
         for i, chunk in enumerate(ideal_chunks):
-            LOGGER.debug("Chunk {i}: %s", i, chunk.location)
+            LOGGER.debug("Chunk %d: %s", i, chunk.location)
 
         # If we are seting the data level level automatically, then update
         # our level to match what was chosen for the intersection.

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -334,7 +334,7 @@ class OctreeImage(Image):
 
         # Log the ideal chunks (for now).
         for i, chunk in enumerate(ideal_chunks):
-            LOGGER.debug("Chunk %d: %s", i, chunk.location)
+            LOGGER.debug("Chunk %d %s", i, chunk.location)
 
         # If we are seting the data level level automatically, then update
         # our level to match what was chosen for the intersection.

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -469,10 +469,14 @@ class OctreeImage(Image):
             request.elapsed_ms,
             request.key.location,
         )
+
         # Pass it to the slice, it will insert the newly loaded data into
         # the OctreeChunk at the right location.
         if self._slice.on_chunk_loaded(request):
-            self.events.loaded()  # Redraw with teh new chunk.
+            # Redraw with the new chunk.
+            # TODO_OCTREE: Call this at most once per frame? It's a bad
+            # idea to call it for every chunk?
+            self.events.loaded()
 
     @property
     def remote_messages(self) -> dict:

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -17,7 +17,7 @@ from .octree_intersection import OctreeIntersection
 from .octree_level import OctreeLevelInfo
 from .octree_util import OctreeDisplayOptions, SliceConfig
 
-LOGGER = logging.getLogger("napari.octree")
+LOGGER = logging.getLogger("napari.octree.image")
 
 
 class OctreeImage(Image):
@@ -476,7 +476,8 @@ class OctreeImage(Image):
             This request was loaded.
         """
         LOGGER.info(
-            "OctreeImage.on_chunk_loaded: elapsed = %.3f location = %s",
+            "on_chunk_loaded: load=%.3fms elapsed=%.3fms location = %s",
+            request.load_ms,
             request.elapsed_ms,
             request.key.location,
         )
@@ -487,6 +488,7 @@ class OctreeImage(Image):
             # Redraw with the new chunk.
             # TODO_OCTREE: Call this at most once per frame? It's a bad
             # idea to call it for every chunk?
+            LOGGER.debug("Calling event loaded()")
             self.events.loaded()
 
     @property

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -307,7 +307,6 @@ class OctreeImage(Image):
         List[OctreeChunk]
             The drawable chunks.
         """
-        LOGGER.debug("get_drawable_chunks")
 
         if self._slice is None or self._view is None:
             LOGGER.debug("get_drawable_chunks: No slice or view")
@@ -332,6 +331,10 @@ class OctreeImage(Image):
             len(ideal_chunks),
             level_index,
         )
+
+        # Log the ideal chunks (for now).
+        for i, chunk in enumerate(ideal_chunks):
+            LOGGER.debug("Chunk {i}: %s", i, chunk.location)
 
         # If we are seting the data level level automatically, then update
         # our level to match what was chosen for the intersection.

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -331,7 +331,7 @@ class OctreeImage(Image):
             len(ideal_chunks),
             level_index,
         )
-        # self._log_chunks(ideal_chunks)
+        # log_chunks("ideas_chunks", ideal_chunks)
 
         # If we are seting the data level level automatically, then update
         # our level to match what was chosen for the intersection.
@@ -347,23 +347,6 @@ class OctreeImage(Image):
         return self._slice.loader.get_drawable_chunks(
             drawn_chunk_set, ideal_chunks
         )
-
-    def _log_chunks(chunks: List[OctreeChunk]) -> None:
-        """Log these chunks.
-
-        Parameters
-        ----------
-        chunks : List[OctreeChunks]
-            The chunks to log.
-        """
-        for i, chunk in enumerate(chunks):
-            LOGGER.debug(
-                "Chunk %d %s in_memory=%d loading=%d",
-                i,
-                chunk.location,
-                chunk.in_memory,
-                chunk.loading,
-            )
 
     def _update_draw(
         self, scale_factor, corner_pixels, shape_threshold

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -268,10 +268,9 @@ class OctreeImage(Image):
     ) -> List[OctreeChunk]:
         """Get the chunks in the current slice which are drawable.
 
-        The visual calls this and then draws what we send it.
-
-        The call to get_intersection() will chose the appropriate level of
-        the octree to intersect, and then return all the chunks within the
+        The visual calls this and then draws what we send it. The call to
+        get_intersection() will chose the appropriate level of the octree
+        to intersect, and then return all the chunks within the
         intersection with that level.
 
         These are the "ideal" chunks because they are at the level whose
@@ -311,8 +310,13 @@ class OctreeImage(Image):
             LOGGER.debug("get_drawable_chunks: No slice or view")
             return []  # There is nothing to draw.
 
+        # TODO_OCTREE: Make this a config option, maybe different
+        # expansion_factor each level above the ideal level?
+        expansion_factor = 1.1
+        view = self._view.expand(expansion_factor)
+
         # Get the current intersection and save it off.
-        self._intersection = self._slice.get_intersection(self._view)
+        self._intersection = self._slice.get_intersection(view)
 
         if self._intersection is None:
             LOGGER.debug("get_drawable_chunks: Intersection is empty")

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -464,6 +464,11 @@ class OctreeImage(Image):
         request : ChunkRequest
             This request was loaded.
         """
+        LOGGER.info(
+            "OctreeImage.on_chunk_loaded: elapsed = %.3f location = %s",
+            request.elapsed_ms,
+            request.key.location,
+        )
         # Pass it to the slice, it will insert the newly loaded data into
         # the OctreeChunk at the right location.
         if self._slice.on_chunk_loaded(request):

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -331,16 +331,7 @@ class OctreeImage(Image):
             len(ideal_chunks),
             level_index,
         )
-
-        # Log the ideal chunks (for now).
-        for i, chunk in enumerate(ideal_chunks):
-            LOGGER.debug(
-                "Chunk %d %s in_memory=%d loading=%d",
-                i,
-                chunk.location,
-                chunk.in_memory,
-                chunk.loading,
-            )
+        # self._log_chunks(ideal_chunks)
 
         # If we are seting the data level level automatically, then update
         # our level to match what was chosen for the intersection.
@@ -356,6 +347,23 @@ class OctreeImage(Image):
         return self._slice.loader.get_drawable_chunks(
             drawn_chunk_set, ideal_chunks
         )
+
+    def _log_chunks(chunks: List[OctreeChunk]) -> None:
+        """Log these chunks.
+
+        Parameters
+        ----------
+        chunks : List[OctreeChunks]
+            The chunks to log.
+        """
+        for i, chunk in enumerate(chunks):
+            LOGGER.debug(
+                "Chunk %d %s in_memory=%d loading=%d",
+                i,
+                chunk.location,
+                chunk.in_memory,
+                chunk.loading,
+            )
 
     def _update_draw(
         self, scale_factor, corner_pixels, shape_threshold

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -334,7 +334,13 @@ class OctreeImage(Image):
 
         # Log the ideal chunks (for now).
         for i, chunk in enumerate(ideal_chunks):
-            LOGGER.debug("Chunk %d %s", i, chunk.location)
+            LOGGER.debug(
+                "Chunk %d %s in_memory=%d loading=%d",
+                i,
+                chunk.location,
+                chunk.in_memory,
+                chunk.loading,
+            )
 
         # If we are seting the data level level automatically, then update
         # our level to match what was chosen for the intersection.

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -264,7 +264,7 @@ class OctreeImage(Image):
         """
 
     def get_drawable_chunks(
-        self, drawn_chunk_set: Set[OctreeChunkKey]
+        self, drawn_set: Set[OctreeChunkKey]
     ) -> List[OctreeChunk]:
         """Get the chunks in the current slice which are drawable.
 
@@ -307,7 +307,6 @@ class OctreeImage(Image):
         List[OctreeChunk]
             The drawable chunks.
         """
-
         if self._slice is None or self._view is None:
             LOGGER.debug("get_drawable_chunks: No slice or view")
             return []  # There is nothing to draw.
@@ -339,9 +338,7 @@ class OctreeImage(Image):
         # memory, but they also might be chunks from higher or lower levels
         # in the octree. In general we try to draw "cover the view" with
         # the "best available" data.
-        return self._slice.loader.get_drawable_chunks(
-            drawn_chunk_set, ideal_chunks
-        )
+        return self._slice.loader.get_drawable_chunks(drawn_set, ideal_chunks)
 
     def _update_draw(
         self, scale_factor, corner_pixels, shape_threshold
@@ -483,7 +480,7 @@ class OctreeImage(Image):
             # Redraw with the new chunk.
             # TODO_OCTREE: Call this at most once per frame? It's a bad
             # idea to call it for every chunk?
-            LOGGER.debug("Calling event loaded()")
+            LOGGER.debug("on_chunk_loaded calling loaded()")
             self.events.loaded()
 
     @property

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -17,7 +17,7 @@ from .octree_intersection import OctreeIntersection
 from .octree_level import OctreeLevelInfo
 from .octree_util import OctreeDisplayOptions, SliceConfig
 
-LOGGER = logging.getLogger("napari.async.octree")
+LOGGER = logging.getLogger("napari.octree")
 
 
 class OctreeImage(Image):

--- a/napari/layers/image/experimental/octree_intersection.py
+++ b/napari/layers/image/experimental/octree_intersection.py
@@ -18,10 +18,8 @@ class OctreeView(NamedTuple):
         The two (row, col) corners in data coordinates, base image pixels.
     canvas : np.ndarray
         The shape of the canvas, the window we are drawing into.
-    freeze_level : bool
-        If True the octree level will not be automatically chosen.
-    track_view : bool
-        If True which chunks are being rendered should update as the view is moved.
+    display : OctreeDisplayOptions
+        How to display the view.
     """
 
     corners: np.ndarray
@@ -48,6 +46,26 @@ class OctreeView(NamedTuple):
             True if the octree level should be selected automatically.
         """
         return not self.display.freeze_level and self.display.track_view
+
+    def expand(self, expansion_factor: float) -> 'OctreeView':
+        """Return expanded view.
+
+        We expand the view so that load some tiles around the edge, so if
+        you pan they are more likely to be already loaded.
+
+        Parameters
+        ----------
+        expansion_factor : float
+            Expand the view by this much. Contract if less than 1.
+        """
+        assert expansion_factor > 0
+
+        extents = self.corners[1] - self.corners[0]
+        padding = ((extents * expansion_factor) - extents) / 2
+        new_corners = np.array(
+            (self.corners[0] - padding, self.corners[1] + padding)
+        )
+        return OctreeView(new_corners, self.canvas, self.display)
 
 
 class OctreeIntersection:

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -169,16 +169,17 @@ class OctreeLevel:
         return data
 
 
-def log_levels(label: str, levels: List[OctreeLevel], start: int = 0) -> None:
+def log_levels(levels: List[OctreeLevel], start_level: int = 0) -> None:
     """Log the dimensions of each level nicely.
+
+    We take start_level so we can log the "extra" levels we created but
+    with their correct level numbers.
 
     Parameters
     ----------
-    label : str
-        Prepend this to the header line.
     levels : List[OctreeLevel]
         Print information about these levels.
-    start : int
+    start_level : int
         Start the indexing at this number, shift the indexes up.
     """
     from ...._vendor.experimental.humanize.src.humanize import intword
@@ -186,9 +187,8 @@ def log_levels(label: str, levels: List[OctreeLevel], start: int = 0) -> None:
     def _dim_str(dim: tuple) -> None:
         return f"{dim[0]} x {dim[1]} = {intword(dim[0] * dim[1])}"
 
-    LOGGER.info(f"{label} {len(levels)} levels:")
     for index, level in enumerate(levels):
-        level_index = start + index
+        level_index = start_level + index
         image_str = _dim_str(level.info.image_shape)
         tiles_str = _dim_str(level.info.shape_in_tiles)
         LOGGER.info(

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -10,7 +10,7 @@ from ....types import ArrayLike
 from .octree_chunk import OctreeChunk, OctreeChunkGeom, OctreeLocation
 from .octree_util import SliceConfig
 
-LOGGER = logging.getLogger("napari.async.octree")
+LOGGER = logging.getLogger("napari.octree")
 
 
 class OctreeLevelInfo:

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -104,17 +104,18 @@ class OctreeLevel:
         Optional[OctreeChunk]
             The OctreeChunk if one existed or we just created it.
         """
-        rows, cols = self.info.shape_in_tiles
-        if row < 0 or row >= rows or col < 0 or col >= cols:
-            # Chunk coordinates not in the level.
-            level_str = f" {self.info.level_index} ({rows}, {cols})"
-            raise KeyError(f"Chunk ({row}, {col}) not in level {level_str}")
-
         try:
             return self._tiles[(row, col)]
         except KeyError:
             if not create:
                 return None  # It didn't exist so we're done.
+
+        rows, cols = self.info.shape_in_tiles
+        if row < 0 or row >= rows or col < 0 or col >= cols:
+            # Chunk coordinates not in the level. Not an exception because
+            # callers might be trying to get children just out of bounds,
+            # for non-power-of-two base images.
+            return None
 
         # Create a chunk at this location and return it.
         octree_chunk = self._create_chunk(row, col)

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -41,12 +41,11 @@ class OctreeLevelInfo:
         tile_size = self.slice_config.tile_size
         scaled_size = tile_size * self.scale
 
-        self.shape_in_tiles = [
-            math.ceil(base[0] / scaled_size),
-            math.ceil(base[1] / scaled_size),
-        ]
+        self.rows = math.ceil(base[0] / scaled_size)
+        self.cols = math.ceil(base[1] / scaled_size)
 
-        self.num_tiles = self.shape_in_tiles[0] * self.shape_in_tiles[1]
+        self.shape_in_tiles = [self.rows, self.cols]
+        self.num_tiles = self.rows * self.cols
 
 
 class OctreeLevel:
@@ -105,6 +104,12 @@ class OctreeLevel:
         Optional[OctreeChunk]
             The OctreeChunk if one existed or we just created it.
         """
+        rows, cols = self.info.shape_in_tiles
+        if row < 0 or row >= rows or col < 0 or col >= cols:
+            # Chunk coordinates not in the level.
+            level_str = f" {self.info.level_index} ({rows}, {cols})"
+            raise KeyError(f"Chunk ({row}, {col}) not in level {level_str}")
+
         try:
             return self._tiles[(row, col)]
         except KeyError:

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -1,5 +1,6 @@
 """OctreeLevel and OctreeLevelInfo classes.
 """
+import logging
 import math
 from typing import List, Optional
 
@@ -8,6 +9,8 @@ import numpy as np
 from ....types import ArrayLike
 from .octree_chunk import OctreeChunk, OctreeChunkGeom, OctreeLocation
 from .octree_util import SliceConfig
+
+LOGGER = logging.getLogger("napari.async.octree")
 
 
 class OctreeLevelInfo:
@@ -166,10 +169,8 @@ class OctreeLevel:
         return data
 
 
-def print_levels(
-    label: str, levels: List[OctreeLevel], start: int = 0
-) -> None:
-    """Print the dimensions of each level nicely.
+def log_levels(label: str, levels: List[OctreeLevel], start: int = 0) -> None:
+    """Log the dimensions of each level nicely.
 
     Parameters
     ----------
@@ -185,11 +186,11 @@ def print_levels(
     def _dim_str(dim: tuple) -> None:
         return f"{dim[0]} x {dim[1]} = {intword(dim[0] * dim[1])}"
 
-    print(f"{label} {len(levels)} levels:")
+    LOGGER.info(f"{label} {len(levels)} levels:")
     for index, level in enumerate(levels):
         level_index = start + index
         image_str = _dim_str(level.info.image_shape)
         tiles_str = _dim_str(level.info.shape_in_tiles)
-        print(
-            f"    Level {level_index}: {image_str} pixels -> {tiles_str} tiles"
+        LOGGER.info(
+            f"Level {level_index}: {image_str} pixels -> {tiles_str} tiles"
         )

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -185,7 +185,7 @@ def log_levels(levels: List[OctreeLevel], start_level: int = 0) -> None:
     from ...._vendor.experimental.humanize.src.humanize import intword
 
     def _dim_str(dim: tuple) -> None:
-        return f"{dim[0]} x {dim[1]} = {intword(dim[0] * dim[1])}"
+        return f"({dim[0]}, {dim[1]}) = {intword(dim[0] * dim[1])}"
 
     for index, level in enumerate(levels):
         level_index = start_level + index

--- a/napari/layers/image/experimental/octree_tile_builder.py
+++ b/napari/layers/image/experimental/octree_tile_builder.py
@@ -8,6 +8,7 @@ Long term we might possible make tiles in the background at some point. So
 as you browse a large image that doesn't have tiles, they are created in
 the background. But that's pretty speculative and far out.
 """
+import logging
 import time
 from typing import List
 
@@ -20,6 +21,8 @@ from ....types import ArrayLike
 from .octree_util import NormalNoise
 
 TileArray = List[List[ArrayLike]]
+
+LOGGER = logging.getLogger("napari.async.octree")
 
 
 def _get_tile(tiles: TileArray, row, col):
@@ -187,6 +190,7 @@ def create_downsampled_levels(
     # Repeat until we have level that will fit in a single tile, that will
     # be come the root/highest level.
     while max(previous.shape) > tile_size:
+        LOGGER.info("Downsampling %s level", previous.shape)
         next_level = ndi.zoom(
             previous, zoom, mode='nearest', prefilter=True, order=1
         )

--- a/napari/layers/image/experimental/octree_tile_builder.py
+++ b/napari/layers/image/experimental/octree_tile_builder.py
@@ -23,7 +23,7 @@ from .octree_util import NormalNoise
 
 TileArray = List[List[ArrayLike]]
 
-LOGGER = logging.getLogger("napari.async.octree")
+LOGGER = logging.getLogger("napari.octree")
 
 
 def _get_tile(tiles: TileArray, row, col):

--- a/napari/layers/image/experimental/octree_tile_builder.py
+++ b/napari/layers/image/experimental/octree_tile_builder.py
@@ -190,9 +190,7 @@ def create_downsampled_levels(
     level_index = next_level_index
 
     if max(previous.shape) > tile_size:
-        LOGGER.info(
-            "Downsampling extra levels until we have a single tile level..."
-        )
+        LOGGER.info("Downsampling levels to a single tile...")
 
     # Repeat until we have level that will fit in a single tile, that will
     # be come the root/highest level.

--- a/napari/layers/image/experimental/octree_tile_builder.py
+++ b/napari/layers/image/experimental/octree_tile_builder.py
@@ -159,7 +159,7 @@ def _create_coarser_level(tiles: TileArray) -> TileArray:
 
 
 def create_downsampled_levels(
-    image: np.ndarray, tile_size: int
+    image: np.ndarray, next_level_index: int, tile_size: int
 ) -> List[np.ndarray]:
     """Return a list of levels coarser then this own.
 
@@ -187,6 +187,7 @@ def create_downsampled_levels(
 
     levels = []
     previous = image
+    level_index = next_level_index
 
     if max(previous.shape) > tile_size:
         LOGGER.info(
@@ -200,12 +201,17 @@ def create_downsampled_levels(
             next_level = ndi.zoom(
                 previous, zoom, mode='nearest', prefilter=True, order=1
             )
+
         LOGGER.info(
-            "Downsampled %s level in %.3fms", previous.shape, timer.duration_ms
+            "Level %d downsampled %s in %.3fms",
+            level_index,
+            previous.shape,
+            timer.duration_ms,
         )
 
         levels.append(next_level)
         previous = levels[-1]
+        level_index += 1
 
     return levels
 

--- a/napari/utils/_octree.py
+++ b/napari/utils/_octree.py
@@ -15,7 +15,7 @@ DEFAULT_OCTREE_CONFIG = {
     "log_path": None,
     "loader": {
         "force_synchronous": False,
-        "num_workers": 6,
+        "num_workers": 1,
         "use_processes": False,
         "auto_sync_ms": 30,
         "delay_queue_ms": 100,

--- a/napari/utils/_octree.py
+++ b/napari/utils/_octree.py
@@ -9,7 +9,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
-LOGGER = logging.getLogger("napari.async")
+LOGGER = logging.getLogger("napari.loader")
 
 DEFAULT_OCTREE_CONFIG = {
     "log_path": None,

--- a/napari/utils/_octree.py
+++ b/napari/utils/_octree.py
@@ -15,7 +15,7 @@ DEFAULT_OCTREE_CONFIG = {
     "log_path": None,
     "loader": {
         "force_synchronous": False,
-        "num_workers": 1,
+        "num_workers": 10,
         "use_processes": False,
         "auto_sync_ms": 30,
         "delay_queue_ms": 100,
@@ -26,20 +26,6 @@ DEFAULT_OCTREE_CONFIG = {
         "preload": {"level": 2, "level+1": 3, "level+2": 4},
     },
 }
-
-
-def _log_to_file(path: str) -> None:
-    """Log "napari.async" messages to the given file.
-
-    Parameters
-    ----------
-    path : str
-        Log to this file path.
-    """
-    if path:
-        fh = logging.FileHandler(path)
-        LOGGER.addHandler(fh)
-        LOGGER.setLevel(logging.DEBUG)
 
 
 def _get_async_config() -> Optional[dict]:


### PR DESCRIPTION
# Description
* Add canceling in-progress loads if no longer in view.
    * We had this for single-scale but never octree. 
* Add priority scheme to load 3, 2 and 1 level up first.
* Fix "double poll" issue in `QtPoll` with new `IntervalTimer`.
* Add event so visual can "wake up" QtPoll when new data is loaded.
    * Because new data might be loaded "out of the blue"
    * With no camera movement or loading happening at all.
    * But we need to start polling to load the chunks into VRAM.

# Demo 1

`NAPARI_OCTREE=1 napari https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/4495402.zarr`

Which requires `pip install ome-zarr`.

![napari-octree](https://user-images.githubusercontent.com/4163446/102445538-b02bd000-3ff9-11eb-8970-055745e97e18.gif)

This dataset takes like 1-2 seconds to load a single tile. So if you move enough, you have to wait that long since all workers will be loading stale data. We can cancel queued loads, but not ones already in progress, at least today.  It's impossible to cancel arbitrary workers, but we might be able to cancel network requests but it won't be easy.

There are still some bugs where tiles don't load, but the  "cancel in-progress loads" and "priority loading" are at least roughly working now.

# Demo 2

`NAPARI_OCTREE=1 napari http://hyper-resolution.org/dzi/Rijksmuseum/SK-C-5/SK-C-5_VIS_20-um_2019-12-21.dzi`

Which requires `pip install napari-dzi-zarr`.

This dataset loads in like 250ms per tile.

![napari-octree-3](https://user-images.githubusercontent.com/4163446/102446990-0d755080-3ffd-11eb-8698-a0320b6a8576.gif)

# Demo 3

![napari-octree-2](https://user-images.githubusercontent.com/4163446/102446447-cd619e00-3ffb-11eb-81a3-62d853800e8b.gif)

# Webmon

* Much better frame rate plot in https://github.com/pwinston/webmon/pull/21

![frame-rate-2](https://user-images.githubusercontent.com/4163446/102003003-16e67c00-3cd0-11eb-9c3f-ef7f097dfaf5.gif)

# Type of change
- [x] New feature in experimental code

# How has this been tested?
- [x] Manual testing
