### PR TITLE
Cleanup theme

### DIFF
--- a/docs/source/developers/CONTRIBUTING.md
+++ b/docs/source/developers/CONTRIBUTING.md
@@ -86,16 +86,16 @@ QtDeleteButton {
 
 A theme is a set of colors used throughout napari.  See, for example, the
 builtin themes in `napari/utils/theme.py`.  To make a new theme, create a new
-`dict` in `palettes` with the same keys as one of the existing themes, and
-replace the values with your new colors.  To test out the theme, use the
+`napari.utils.theme.Palette` and add it to the `available_themes` with the
+a key that will be the theme name.  To test out the theme, use the
 `theme_sample.py` file from the command line as follows:
 
 ```sh
-python -m napari._qt.theme_sample
+python -m napari._qt.widgets.qt_theme_sample
 ```
 *note*: you may specify a theme with one additional argument on the command line:
 ```sh
-python -m napari._qt.theme_sample dark
+python -m napari._qt.widgets.qt_theme_sample dark
 ```
 (providing no arguments will show all themes in `theme.py`)
 

--- a/examples/new_theme.py
+++ b/examples/new_theme.py
@@ -1,0 +1,36 @@
+"""
+Displays an image and sets the theme to 'light'.
+"""
+
+from skimage import data
+import napari
+from napari.utils.theme import Palette, available_themes
+
+with napari.gui_qt():
+    # create the viewer with an image
+    viewer = napari.view_image(
+        data.astronaut(), rgb=True, name='astronaut'
+    )
+
+    # Create a new palette. Note we must use either the `light` or
+    # `dark` folder to avoid needing to build new icons
+    blue_palette = Palette(
+        folder='dark',
+        background='rgb(28, 31, 48)',
+        foreground='rgb(45, 52, 71)',
+        primary='rgb(80, 88, 108)',
+        secondary='rgb(134, 142, 147)',
+        highlight='rgb(106, 115, 128)',
+        text='rgb(240, 241, 242)',
+        icon='rgb(209, 210, 212)',
+        warning='rgb(153, 18, 31)',
+        current='rgb(184, 112, 0)',
+        syntax_style='native',
+        console='rgb(0, 0, 0)',
+        canvas='black',
+    )
+    # Add new theme to dictionary of available_themes
+    available_themes['blues'] = blue_palette
+
+    # Set theme
+    viewer.theme = 'blues'

--- a/napari/_qt/dialogs/qt_about_key_bindings.py
+++ b/napari/_qt/dialogs/qt_about_key_bindings.py
@@ -63,7 +63,7 @@ class QtAboutKeyBindings(QDialog):
         # Can switch to a normal dict when our minimum Python is 3.7
         self.key_bindings_strs = OrderedDict()
         self.key_bindings_strs[self.ALL_ACTIVE_KEYBINDINGS] = ''
-        col = self.viewer.palette['secondary']
+        col = self.viewer.palette.secondary
         layers = [
             napari.layers.Image,
             napari.layers.Labels,
@@ -123,7 +123,7 @@ class QtAboutKeyBindings(QDialog):
         event : napari.utils.event.Event, optional
             The napari event that triggered this method, by default None.
         """
-        col = self.viewer.palette['secondary']
+        col = self.viewer.palette.secondary
         # Add class and instance viewer key bindings
         text = get_key_bindings_summary(self.viewer.active_keymap, col=col)
 

--- a/napari/_qt/dialogs/qt_about_key_bindings.py
+++ b/napari/_qt/dialogs/qt_about_key_bindings.py
@@ -12,6 +12,7 @@ from qtpy.QtWidgets import (
 import napari
 
 from ...utils.interactions import get_key_bindings_summary
+from ...utils.theme import available_themes
 
 
 class QtAboutKeyBindings(QDialog):
@@ -63,7 +64,8 @@ class QtAboutKeyBindings(QDialog):
         # Can switch to a normal dict when our minimum Python is 3.7
         self.key_bindings_strs = OrderedDict()
         self.key_bindings_strs[self.ALL_ACTIVE_KEYBINDINGS] = ''
-        col = self.viewer.palette.secondary
+        palette = available_themes[self.qt_viewer.viewer.theme]
+        col = palette.secondary
         layers = [
             napari.layers.Image,
             napari.layers.Labels,
@@ -94,7 +96,7 @@ class QtAboutKeyBindings(QDialog):
         self.layout.addWidget(self.textEditBox, 1)
 
         self.viewer.events.active_layer.connect(self.update_active_layer)
-        self.viewer.events.palette.connect(self.update_active_layer)
+        self.viewer.events.theme.connect(self.update_active_layer)
         self.update_active_layer()
 
     def change_layer_type(self, text):
@@ -123,7 +125,8 @@ class QtAboutKeyBindings(QDialog):
         event : napari.utils.event.Event, optional
             The napari event that triggered this method, by default None.
         """
-        col = self.viewer.palette.secondary
+        palette = available_themes[self.qt_viewer.viewer.theme]
+        col = palette.secondary
         # Add class and instance viewer key bindings
         text = get_key_bindings_summary(self.viewer.active_keymap, col=col)
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -28,7 +28,7 @@ from ..utils import config, perf
 from ..utils.io import imsave
 from ..utils.misc import in_jupyter
 from ..utils.perf import perf_config
-from ..utils.theme import template
+from ..utils.theme import available_themes, template
 from .dialogs.qt_about import QtAbout
 from .dialogs.qt_plugin_dialog import QtPluginDialog
 from .dialogs.qt_plugin_report import QtPluginErrReporter
@@ -176,7 +176,7 @@ class Window:
         self.qt_viewer.viewer.events.status.connect(self._status_changed)
         self.qt_viewer.viewer.events.help.connect(self._help_changed)
         self.qt_viewer.viewer.events.title.connect(self._title_changed)
-        self.qt_viewer.viewer.events.palette.connect(self._update_palette)
+        self.qt_viewer.viewer.events.theme.connect(self._update_palette)
 
         if perf.USE_PERFMON:
             # Add DebugMenu and dockPerformance if using perfmon.
@@ -653,18 +653,23 @@ class Window:
         """Update widget color palette."""
         # set window styles which don't use the primary stylesheet
         # FIXME: this is a problem with the stylesheet not using properties
-        palette = dict(self.qt_viewer.viewer.palette._asdict())
+        palette = available_themes[self.qt_viewer.viewer.theme]
+        palette_dict = dict(palette._asdict())
         self._status_bar.setStyleSheet(
             template(
                 'QStatusBar { background: {{ background }}; '
                 'color: {{ text }}; }',
-                **palette,
+                **palette_dict,
             )
         )
         self._qt_center.setStyleSheet(
-            template('QWidget { background: {{ background }}; }', **palette)
+            template(
+                'QWidget { background: {{ background }}; }', **palette_dict
+            )
         )
-        self._qt_window.setStyleSheet(template(self.raw_stylesheet, **palette))
+        self._qt_window.setStyleSheet(
+            template(self.raw_stylesheet, **palette_dict)
+        )
 
     def _status_changed(self, event):
         """Update status bar.

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -653,7 +653,7 @@ class Window:
         """Update widget color palette."""
         # set window styles which don't use the primary stylesheet
         # FIXME: this is a problem with the stylesheet not using properties
-        palette = self.qt_viewer.viewer.palette
+        palette = dict(self.qt_viewer.viewer.palette._asdict())
         self._status_bar.setStyleSheet(
             template(
                 'QStatusBar { background: {{ background }}; '

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -21,7 +21,7 @@ from ..utils.interactions import (
 )
 from ..utils.io import imsave
 from ..utils.key_bindings import components_to_key_combo
-from ..utils.theme import template
+from ..utils.theme import available_themes, template
 from .dialogs.qt_about_key_bindings import QtAboutKeyBindings
 from .dialogs.screenshot_dialog import ScreenshotDialog
 from .tracing.qt_performance import QtPerformance
@@ -182,7 +182,7 @@ class QtViewer(QSplitter):
         self.viewer.camera.events.interactive.connect(self._on_interactive)
         self.viewer.cursor.events.style.connect(self._on_cursor)
         self.viewer.cursor.events.size.connect(self._on_cursor)
-        self.viewer.events.palette.connect(self._update_palette)
+        self.viewer.events.theme.connect(self._update_palette)
         self.viewer.layers.events.reordered.connect(self._reorder_layers)
         self.viewer.layers.events.inserted.connect(self._on_add_layer_change)
         self.viewer.layers.events.removed.connect(self._remove_layer)
@@ -266,7 +266,7 @@ class QtViewer(QSplitter):
             self.viewer.events.layers_change.connect(
                 self.welcome._on_visible_change
             )
-            self.viewer.events.palette.connect(self.welcome._on_palette_change)
+            self.viewer.events.theme.connect(self.welcome._on_palette_change)
             self.canvas.events.resize.connect(self.welcome._on_canvas_change)
 
     def _create_performance_dock_widget(self):
@@ -513,12 +513,14 @@ class QtViewer(QSplitter):
     def _update_palette(self, event=None):
         """Update the napari GUI theme."""
         # template and apply the primary stylesheet
-        palette = dict(self.viewer.palette._asdict())
-        themed_stylesheet = template(self.raw_stylesheet, **palette)
+
+        palette = available_themes[self.viewer.theme]
+        palette_dict = dict(palette._asdict())
+        themed_stylesheet = template(self.raw_stylesheet, **palette_dict)
         if self._console is not None:
-            self.console._update_palette(palette, themed_stylesheet)
+            self.console._update_palette(palette_dict, themed_stylesheet)
         self.setStyleSheet(themed_stylesheet)
-        self.canvas.bgcolor = self.viewer.palette.canvas
+        self.canvas.bgcolor = palette.canvas
 
     def toggle_console_visibility(self, event=None):
         """Toggle console visible and not visible.

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -513,15 +513,12 @@ class QtViewer(QSplitter):
     def _update_palette(self, event=None):
         """Update the napari GUI theme."""
         # template and apply the primary stylesheet
-        themed_stylesheet = template(
-            self.raw_stylesheet, **self.viewer.palette
-        )
+        palette = dict(self.viewer.palette._asdict())
+        themed_stylesheet = template(self.raw_stylesheet, **palette)
         if self._console is not None:
-            self.console._update_palette(
-                self.viewer.palette, themed_stylesheet
-            )
+            self.console._update_palette(palette, themed_stylesheet)
         self.setStyleSheet(themed_stylesheet)
-        self.canvas.bgcolor = self.viewer.palette['canvas']
+        self.canvas.bgcolor = self.viewer.palette.canvas
 
     def toggle_console_visibility(self, event=None):
         """Toggle console visible and not visible.

--- a/napari/_qt/widgets/qt_theme_sample.py
+++ b/napari/_qt/widgets/qt_theme_sample.py
@@ -7,11 +7,11 @@ Examples
 --------
 To use from the command line:
 
-$ python -m napari._qt.theme_sample
+$ python -m napari._qt.widgets.qt_theme_sample
 
 To generate a screenshot within python:
 
->>> from napari._qt.theme_sample import SampleWidget
+>>> from napari._qt.widgets.theme_sample import SampleWidget
 >>> widg = SampleWidget(theme='dark')
 >>> screenshot = widg.screenshot()
 """
@@ -43,7 +43,7 @@ from qtpy.QtWidgets import (
 
 from ...resources import get_stylesheet
 from ...utils.io import imsave
-from ...utils.theme import palettes, template
+from ...utils.theme import available_themes, template
 from ..utils import QImg2array
 from .qt_range_slider import QHRangeSlider
 
@@ -95,7 +95,8 @@ class SampleWidget(QWidget):
     def __init__(self, theme='dark', emphasized=False):
         super().__init__(None)
         self.setProperty('emphasized', emphasized)
-        self.setStyleSheet(template(raw_stylesheet, **palettes[theme]))
+        palette = dict(available_themes[theme]._asdict())
+        self.setStyleSheet(template(raw_stylesheet, **palette))
         lay = QVBoxLayout()
         self.setLayout(lay)
         lay.addWidget(QPushButton('push button'))
@@ -160,7 +161,7 @@ class SampleWidget(QWidget):
 if __name__ == "__main__":
     import sys
 
-    themes = [sys.argv[1]] if len(sys.argv) > 1 else palettes.keys()
+    themes = [sys.argv[1]] if len(sys.argv) > 1 else available_themes.keys()
     app = QApplication([])
     widgets = []
     for n, theme in enumerate(themes):

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -122,12 +122,12 @@ def test_changing_theme(make_test_viewer):
     """Test changing the theme updates the full window."""
     viewer = make_test_viewer()
     viewer.add_points(data=None)
-    assert viewer.palette['folder'] == 'dark'
+    assert viewer.palette.folder == 'dark'
 
     screenshot_dark = viewer.screenshot(canvas_only=False)
 
     viewer.theme = 'light'
-    assert viewer.palette['folder'] == 'light'
+    assert viewer.palette.folder == 'light'
 
     screenshot_light = viewer.screenshot(canvas_only=False)
     equal = (screenshot_dark == screenshot_light).min(-1)

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -122,12 +122,12 @@ def test_changing_theme(make_test_viewer):
     """Test changing the theme updates the full window."""
     viewer = make_test_viewer()
     viewer.add_points(data=None)
-    assert viewer.palette.folder == 'dark'
+    assert viewer.theme == 'dark'
 
     screenshot_dark = viewer.screenshot(canvas_only=False)
 
     viewer.theme = 'light'
-    assert viewer.palette.folder == 'light'
+    assert viewer.theme == 'light'
 
     screenshot_light = viewer.screenshot(canvas_only=False)
     equal = (screenshot_dark == screenshot_light).min(-1)

--- a/napari/_vispy/vispy_welcome_visual.py
+++ b/napari/_vispy/vispy_welcome_visual.py
@@ -7,7 +7,7 @@ from vispy.scene.visuals import Text
 from vispy.visuals.transforms import STTransform
 
 from ..utils.misc import str_to_rgb
-from ..utils.theme import darken, lighten
+from ..utils.theme import available_themes, darken, lighten
 from .image import Image as ImageNode
 
 
@@ -44,8 +44,9 @@ class VispyWelcomeVisual:
             '   - select File > Open from the menu\n'
             '   - call a viewer.add_* method'
         )
+        palette = available_themes[self._viewer.theme]
         self.text_node.color = np.divide(
-            str_to_rgb(darken(self._viewer.palette.foreground, 30)), 255
+            str_to_rgb(darken(palette.foreground, 30)), 255
         )
 
         self._on_palette_change(None)
@@ -54,18 +55,17 @@ class VispyWelcomeVisual:
 
     def _on_palette_change(self, event):
         """Change colors of the logo and text."""
-        if np.mean(str_to_rgb(self._viewer.palette.background)[:3]) < 255 / 2:
+        palette = available_themes[self._viewer.theme]
+        if np.mean(str_to_rgb(palette.background)[:3]) < 255 / 2:
             background_color = np.divide(
-                str_to_rgb(darken(self._viewer.palette.background, 70)), 255
+                str_to_rgb(darken(palette.background, 70)), 255
             )
         else:
             background_color = np.divide(
-                str_to_rgb(lighten(self._viewer.palette.background, 70)), 255,
+                str_to_rgb(lighten(palette.background, 70)), 255,
             )
 
-        foreground_color = np.divide(
-            str_to_rgb(self._viewer.palette.primary), 255,
-        )
+        foreground_color = np.divide(str_to_rgb(palette.primary), 255,)
         text_color = list(foreground_color) + [1]
 
         new_logo = np.zeros(self._logo_raw.shape)

--- a/napari/_vispy/vispy_welcome_visual.py
+++ b/napari/_vispy/vispy_welcome_visual.py
@@ -45,7 +45,7 @@ class VispyWelcomeVisual:
             '   - call a viewer.add_* method'
         )
         self.text_node.color = np.divide(
-            str_to_rgb(darken(self._viewer.palette['foreground'], 30)), 255
+            str_to_rgb(darken(self._viewer.palette.foreground, 30)), 255
         )
 
         self._on_palette_change(None)
@@ -54,21 +54,17 @@ class VispyWelcomeVisual:
 
     def _on_palette_change(self, event):
         """Change colors of the logo and text."""
-        if (
-            np.mean(str_to_rgb(self._viewer.palette['background'])[:3])
-            < 255 / 2
-        ):
+        if np.mean(str_to_rgb(self._viewer.palette.background)[:3]) < 255 / 2:
             background_color = np.divide(
-                str_to_rgb(darken(self._viewer.palette['background'], 70)), 255
+                str_to_rgb(darken(self._viewer.palette.background, 70)), 255
             )
         else:
             background_color = np.divide(
-                str_to_rgb(lighten(self._viewer.palette['background'], 70)),
-                255,
+                str_to_rgb(lighten(self._viewer.palette.background, 70)), 255,
             )
 
         foreground_color = np.divide(
-            str_to_rgb(self._viewer.palette['primary']), 255,
+            str_to_rgb(self._viewer.palette.primary), 255,
         )
         text_color = list(foreground_color) + [1]
 

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -138,8 +138,8 @@ class ViewerModel(KeymapHandler, KeymapProvider):
             return
 
         self._palette = palette
-        self.axes.background_color = self.palette['canvas']
-        self.scale_bar.background_color = self.palette['canvas']
+        self.axes.background_color = self.palette.canvas
+        self.scale_bar.background_color = self.palette.canvas
         self.events.palette()
 
     @property

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -18,7 +18,7 @@ from ..utils.colormaps import ensure_colormap
 from ..utils.events import EmitterGroup, Event, disconnect_events
 from ..utils.key_bindings import KeymapHandler, KeymapProvider
 from ..utils.misc import is_sequence
-from ..utils.theme import palettes
+from ..utils.theme import available_themes
 from ._viewer_mouse_bindings import dims_scroll
 from .axes import Axes
 from .camera import Camera
@@ -27,6 +27,8 @@ from .dims import Dims
 from .grid import GridCanvas
 from .layerlist import LayerList
 from .scale_bar import ScaleBar
+
+DEFAULT_THEME = 'dark'
 
 
 class ViewerModel(KeymapHandler, KeymapProvider):
@@ -54,11 +56,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
         List of contained layers.
     dims : Dimensions
         Contains axes, indices, dimensions and sliders.
-    themes : dict of str: dict of str: str
-        Preset color palettes.
     """
-
-    themes = palettes
 
     def __init__(self, title='napari', ndisplay=2, order=(), axis_labels=()):
         super().__init__()
@@ -71,7 +69,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
             title=Event,
             reset_view=Event,
             active_layer=Event,
-            palette=Event,
+            theme=Event,
             layers_change=Event,
         )
 
@@ -88,13 +86,12 @@ class ViewerModel(KeymapHandler, KeymapProvider):
         self._status = 'Ready'
         self._help = ''
         self._title = title
+        self._theme = DEFAULT_THEME
 
         self._active_layer = None
         self.grid = GridCanvas()
         # 2-tuple indicating height and width
         self._canvas_size = (600, 800)
-        self._palette = None
-        self.theme = 'dark'
 
         self.grid.events.connect(self.reset_view)
         self.grid.events.connect(self._on_grid_change)
@@ -128,40 +125,61 @@ class ViewerModel(KeymapHandler, KeymapProvider):
 
     @property
     def palette(self):
-        """dict of str: str : Color palette with which to style the viewer.
+        """napari.utils.theme.Palette: Color palette for styling the viewer.
         """
-        return self._palette
+        warnings.warn(
+            (
+                "The viewer.palette attribute is deprecated and will be removed after version 0.4.5."
+                " To access the palette you can call into napari.utils.theme.available_themes dictionary"
+                " using the viewer.theme as the key."
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return available_themes[self.theme]
 
     @palette.setter
     def palette(self, palette):
-        if palette == self.palette:
-            return
-
-        self._palette = palette
-        self.axes.background_color = self.palette.canvas
-        self.scale_bar.background_color = self.palette.canvas
-        self.events.palette()
+        warnings.warn(
+            (
+                "The viewer.palette attribute is deprecated and will be removed after version 0.4.5."
+                " To add a new palette you should add it to napari.utils.theme.available_themes dictionary"
+                " and then set the viewer.theme attribute."
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        for existing_theme, existing_palette in available_themes.items():
+            if existing_palette == palette:
+                self.theme = existing_theme
+                return
+        raise ValueError(
+            f"Palette not found among existing themes; "
+            f"options are {list(available_themes)}."
+        )
 
     @property
     def theme(self):
         """string or None : Preset color palette.
         """
-        for theme, palette in self.themes.items():
-            if palette == self.palette:
-                return theme
+        return self._theme
 
     @theme.setter
     def theme(self, theme):
         if theme == self.theme:
             return
 
-        try:
-            self.palette = self.themes[theme]
-        except KeyError:
+        if theme in available_themes:
+            self._theme = theme
+        else:
             raise ValueError(
                 f"Theme '{theme}' not found; "
-                f"options are {list(self.themes)}."
+                f"options are {list(available_themes)}."
             )
+        palette = available_themes[self.theme]
+        self.axes.background_color = palette.canvas
+        self.scale_bar.background_color = palette.canvas
+        self.events.theme()
 
     @property
     def grid_size(self):
@@ -381,7 +399,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
     def _toggle_theme(self):
         """Switch to next theme in list of themes
         """
-        theme_names = list(self.themes.keys())
+        theme_names = list(available_themes)
         cur_theme = theme_names.index(self.theme)
         self.theme = theme_names[(cur_theme + 1) % len(theme_names)]
 

--- a/napari/resources/build_icons.py
+++ b/napari/resources/build_icons.py
@@ -10,7 +10,7 @@ import sys
 from subprocess import SubprocessError, check_call
 from typing import Dict, List, Tuple
 
-from ..utils.theme import palettes as _palettes
+from ..utils.theme import available_themes as _available_themes
 
 RESOURCES_DIR = os.path.abspath(os.path.dirname(__file__))
 SVGPATH = os.path.join(RESOURCES_DIR, 'icons')
@@ -21,7 +21,7 @@ svg_tag_open = re.compile(r'(<svg[^>]*>)')
 def themify_icons(
     dest_dir: str,
     svg_path: str = SVGPATH,
-    palettes: Dict[str, Dict[str, str]] = _palettes,
+    available_themes: Dict[str, Dict[str, str]] = _available_themes,
     color_lookup: Dict[str, str] = None,
 ) -> List[str]:
     """Create a new "themed" SVG file, for every SVG file in ``svg_path``.
@@ -34,10 +34,10 @@ def themify_icons(
     svg_path : str, optional
         The folder to look in for SVG files, by default will search in a folder
         named ``icons`` in the same directory as this file.
-    palettes : dict, optional
+    available_themes : dict, optional
         A mapping of ``theme_name: theme_dict``, where ``theme_dict`` is a
-        mapping of color classes to rgb strings. By default will uses palettes
-        from :const:`napari.resources.utils.theme.palettes`.
+        mapping of color classes to rgb strings. By default will uses available_themes
+        from :const:`napari.resources.utils.theme.available_themes`.
     color_lookup : dict, optional
         A mapping of icon name to color class.  If the icon name is not in the
         color_lookup, it's color class will be ``"icon"``.
@@ -73,14 +73,16 @@ def themify_icons(
     </style>"""
 
     files = []
-    for theme_name, palette in palettes.items():
+    for theme_name, palette in available_themes.items():
         palette_dir = os.path.join(dest_dir, theme_name)
         os.makedirs(palette_dir, exist_ok=True)
         for icon_name in icon_names:
             svg_name = icon_name + '.svg'
             new_file = os.path.join(palette_dir, svg_name)
             color = color_lookup.get(icon_name, 'icon')
-            css = svg_style_insert.replace('{{ color }}', palette[color])
+            css = svg_style_insert.replace(
+                '{{ color }}', getattr(palette, color, '')
+            )
             with open(os.path.join(SVGPATH, svg_name), 'r') as fr:
                 contents = fr.read()
             with open(new_file, 'w') as fw:

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -2,6 +2,7 @@
 # pygments - see here for examples https://help.farbox.com/pygments.html
 import re
 from ast import literal_eval
+from typing import NamedTuple
 
 try:
     from qtpy import QT_VERSION
@@ -12,37 +13,55 @@ except Exception:
     use_gradients = False
 
 
+class Palette(NamedTuple):
+    """Palette for sytling the viewer."""
+
+    folder: str
+    background: str
+    foreground: str
+    primary: str
+    secondary: str
+    highlight: str
+    text: str
+    icon: str
+    warning: str
+    current: str
+    syntax_style: str
+    console: str
+    canvas: str
+
+
 palettes = {
-    'dark': {
-        'folder': 'dark',
-        'background': 'rgb(38, 41, 48)',
-        'foreground': 'rgb(65, 72, 81)',
-        'primary': 'rgb(90, 98, 108)',
-        'secondary': 'rgb(134, 142, 147)',
-        'highlight': 'rgb(106, 115, 128)',
-        'text': 'rgb(240, 241, 242)',
-        'icon': 'rgb(209, 210, 212)',
-        'warning': 'rgb(153, 18, 31)',
-        'current': 'rgb(0, 122, 204)',
-        'syntax_style': 'native',
-        'console': 'rgb(0, 0, 0)',
-        'canvas': 'black',
-    },
-    'light': {
-        'folder': 'light',
-        'background': 'rgb(239, 235, 233)',
-        'foreground': 'rgb(214, 208, 206)',
-        'primary': 'rgb(188, 184, 181)',
-        'secondary': 'rgb(150, 146, 144)',
-        'highlight': 'rgb(163, 158, 156)',
-        'text': 'rgb(59, 58, 57)',
-        'icon': 'rgb(107, 105, 103)',
-        'warning': 'rgb(255, 18, 31)',
-        'current': 'rgb(253, 240, 148)',
-        'syntax_style': 'default',
-        'console': 'rgb(255, 255, 255)',
-        'canvas': 'white',
-    },
+    'dark': Palette(
+        folder='dark',
+        background='rgb(38, 41, 48)',
+        foreground='rgb(65, 72, 81)',
+        primary='rgb(90, 98, 108)',
+        secondary='rgb(134, 142, 147)',
+        highlight='rgb(106, 115, 128)',
+        text='rgb(240, 241, 242)',
+        icon='rgb(209, 210, 212)',
+        warning='rgb(153, 18, 31)',
+        current='rgb(0, 122, 204)',
+        syntax_style='native',
+        console='rgb(0, 0, 0)',
+        canvas='black',
+    ),
+    'light': Palette(
+        folder='light',
+        background='rgb(239, 235, 233)',
+        foreground='rgb(214, 208, 206)',
+        primary='rgb(188, 184, 181)',
+        secondary='rgb(150, 146, 144)',
+        highlight='rgb(163, 158, 156)',
+        text='rgb(59, 58, 57)',
+        icon='rgb(107, 105, 103)',
+        warning='rgb(255, 18, 31)',
+        current='rgb(253, 240, 148)',
+        syntax_style='default',
+        console='rgb(255, 255, 255)',
+        canvas='white',
+    ),
 }
 
 gradient_pattern = re.compile(r'([vh])gradient\((.+)\)')

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -31,7 +31,7 @@ class Palette(NamedTuple):
     canvas: str
 
 
-palettes = {
+available_themes = {
     'dark': Palette(
         folder='dark',
         background='rgb(38, 41, 48)',


### PR DESCRIPTION
# Description
Following the recommendations of @tlambert03 in #2006 this PR deprecates the `viewer.palette` attribute in favour of the `napari.utils.theme.available_themes` dictionary which is global and can be indexed into with the `viewer.theme` key. See discussion here https://github.com/napari/napari/pull/2006#discussion_r541670787 in particular.

The `viewer.palette` has deprecations warnings on its getter and setter. The `palette` event is replaced by the `theme` event.

I've also added `example/new_theme.py` so people can see what it is like to create a new custom theme.

I've also made our `palettes` now `Palette` named-tuples which makes the immutable, which they should be/ already were practically speaking.

I've verified that our icon build process still works and our example styled widgets still work, but might be worth double checking i havn't introduced anything funky here.

I'd much appreciate review from @tlambert03 here as this was built on his ideas!

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)