### PR TITLE
start magicgui apps too

### DIFF
--- a/napari/_qt/event_loop.py
+++ b/napari/_qt/event_loop.py
@@ -9,13 +9,13 @@ from qtpy.QtWidgets import QApplication, QSplashScreen
 from ..utils.perf import perf_config
 from .exceptions import ExceptionHandler
 
-NAPARI_APP_NAME = 'napari'
+APPLICATION_NAME = 'napari'
 try:
     from magicgui.application import APPLICATION_NAME as MGUI_APP_NAME
 except (ImportError, AttributeError):
     MGUI_APP_NAME = 'magicgui'
 
-COMPATIBLE_APPLICATIONS = (NAPARI_APP_NAME, MGUI_APP_NAME)
+COMPATIBLE_APPLICATIONS = (APPLICATION_NAME, MGUI_APP_NAME)
 
 
 def _create_application(argv) -> QApplication:
@@ -67,7 +67,7 @@ def gui_qt(*, startup_logo=False, gui_exceptions=False):
         # if this is the first time the Qt app is being instantiated, we set
         # the name, so that we know whether to raise_ in Window.show()
         app = _create_application(sys.argv)
-        app.setApplicationName(NAPARI_APP_NAME)
+        app.setApplicationName(APPLICATION_NAME)
         if startup_logo:
             logopath = join(dirname(__file__), '..', 'resources', 'logo.png')
             pm = QPixmap(logopath).scaled(

--- a/napari/_qt/event_loop.py
+++ b/napari/_qt/event_loop.py
@@ -9,14 +9,6 @@ from qtpy.QtWidgets import QApplication, QSplashScreen
 from ..utils.perf import perf_config
 from .exceptions import ExceptionHandler
 
-APPLICATION_NAME = 'napari'
-try:
-    from magicgui.application import APPLICATION_NAME as MGUI_APP_NAME
-except (ImportError, AttributeError):
-    MGUI_APP_NAME = 'magicgui'
-
-COMPATIBLE_APPLICATIONS = (APPLICATION_NAME, MGUI_APP_NAME)
-
 
 def _create_application(argv) -> QApplication:
     """Create our QApplication.
@@ -67,7 +59,7 @@ def gui_qt(*, startup_logo=False, gui_exceptions=False):
         # if this is the first time the Qt app is being instantiated, we set
         # the name, so that we know whether to raise_ in Window.show()
         app = _create_application(sys.argv)
-        app.setApplicationName(APPLICATION_NAME)
+        app.setApplicationName('napari')
         if startup_logo:
             logopath = join(dirname(__file__), '..', 'resources', 'logo.png')
             pm = QPixmap(logopath).scaled(
@@ -91,7 +83,7 @@ def gui_qt(*, startup_logo=False, gui_exceptions=False):
     # if the application already existed before this function was called,
     # there's no need to start it again.  By avoiding unnecessary calls to
     # ``app.exec_``, we avoid blocking.
-    if app.applicationName() in COMPATIBLE_APPLICATIONS:
+    if app.applicationName() in ('napari', 'magicgui'):
         if splash_widget and startup_logo:
             splash_widget.close()
         app.exec_()

--- a/napari/_qt/event_loop.py
+++ b/napari/_qt/event_loop.py
@@ -83,6 +83,9 @@ def gui_qt(*, startup_logo=False, gui_exceptions=False):
     # if the application already existed before this function was called,
     # there's no need to start it again.  By avoiding unnecessary calls to
     # ``app.exec_``, we avoid blocking.
+    # see also https://github.com/napari/napari/pull/2016
+    # we add 'magicgui' so that anyone using @magicgui *before* calling gui_qt
+    # will also have the application executed. (a bandaid for now?...)
     if app.applicationName() in ('napari', 'magicgui'):
         if splash_widget and startup_logo:
             splash_widget.close()

--- a/napari/_qt/event_loop.py
+++ b/napari/_qt/event_loop.py
@@ -9,6 +9,14 @@ from qtpy.QtWidgets import QApplication, QSplashScreen
 from ..utils.perf import perf_config
 from .exceptions import ExceptionHandler
 
+NAPARI_APP_NAME = 'napari'
+try:
+    from magicgui.application import APPLICATION_NAME as MGUI_APP_NAME
+except (ImportError, AttributeError):
+    MGUI_APP_NAME = 'magicgui'
+
+COMPATIBLE_APPLICATIONS = (NAPARI_APP_NAME, MGUI_APP_NAME)
+
 
 def _create_application(argv) -> QApplication:
     """Create our QApplication.
@@ -59,7 +67,7 @@ def gui_qt(*, startup_logo=False, gui_exceptions=False):
         # if this is the first time the Qt app is being instantiated, we set
         # the name, so that we know whether to raise_ in Window.show()
         app = _create_application(sys.argv)
-        app.setApplicationName('napari')
+        app.setApplicationName(NAPARI_APP_NAME)
         if startup_logo:
             logopath = join(dirname(__file__), '..', 'resources', 'logo.png')
             pm = QPixmap(logopath).scaled(
@@ -83,7 +91,7 @@ def gui_qt(*, startup_logo=False, gui_exceptions=False):
     # if the application already existed before this function was called,
     # there's no need to start it again.  By avoiding unnecessary calls to
     # ``app.exec_``, we avoid blocking.
-    if app.applicationName() == 'napari':
+    if app.applicationName() in COMPATIBLE_APPLICATIONS:
         if splash_widget and startup_logo:
             splash_widget.close()
         app.exec_()


### PR DESCRIPTION
# Description
it was discovered in https://github.com/napari/magicgui/issues/54 that creating a magicgui widget before then using `napari.gui_qt` will prevent the application from running at all.  For instance, if you run the following script from the command line, it will _not_ show the viewer... it will just seem to do nothing.

```python
import napari
from magicgui import magicgui

@magicgui
def test(x: int):
    pass

with napari.gui_qt():
    v = napari.Viewer()
```

The reason is that magicgui has instantiated the (global) Qt app when the decorator is called, but the `napari.gui_qt` context manager _only_ starts applications that are named `"napari"` (with the intention of avoiding unnecessary blocking in ipython):
https://github.com/napari/napari/blob/1d784cf8373495d9591594b6dd6ac479d5566ed1/napari/_qt/event_loop.py#L86-L89

I'm wondering if you'd consider the following PR to allow napari to start magicgui-created applications.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)


## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
