### PR TITLE
[Points layer]skip rounding of numbers when comparing data slice

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -289,3 +289,15 @@ def test_qt_viewer_data_integrity(make_test_viewer, dtype):
     viewer.dims.ndisplay = 2
     datamean = viewer.layers[0].data.mean()
     assert datamean == imean
+
+
+def test_points_layer_display_correct_slice_on_scale(make_test_viewer):
+    viewer = make_test_viewer()
+    data = np.zeros((60, 60, 60))
+    viewer.add_image(data, scale=[0.29, 0.26, 0.26])
+    pts = viewer.add_points(name='test', size=1, ndim=3)
+    pts.add((8.7, 0, 0))
+    viewer.dims.set_point(0, 30 * 0.29)  # middle plane
+    layer = viewer.layers[1]
+    indices, scale = layer._slice_data(layer._slice_indices)
+    np.testing.assert_equal(indices, [0])

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -594,7 +594,8 @@ class Layer(KeymapProvider, ABC):
             step=abs(self.scale),
         )
 
-    def _compute_slice_indices(self, rounding=True):
+    @property
+    def _slice_indices(self):
         """(D, ) array: Slice indices in data coordinates."""
         inv_transform = self._transforms['data2world'].inverse
 
@@ -624,7 +625,7 @@ class Layer(KeymapProvider, ABC):
 
         world_pts = [self._dims_point[ax] for ax in self._dims_not_displayed]
         data_pts = slice_inv_transform(world_pts)
-        if rounding:
+        if not hasattr(self, "_round_index") or self._round_index:
             # A round is taken to convert these values to slicing integers
             data_pts = np.round(data_pts).astype(int)
 
@@ -633,10 +634,6 @@ class Layer(KeymapProvider, ABC):
             indices[ax] = data_pts[i]
 
         return tuple(indices)
-
-    @property
-    def _slice_indices(self):
-        return self._compute_slice_indices()
 
     @abstractmethod
     def _get_ndim(self):

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -594,8 +594,7 @@ class Layer(KeymapProvider, ABC):
             step=abs(self.scale),
         )
 
-    @property
-    def _slice_indices(self):
+    def _compute_slice_indices(self, rounding=True):
         """(D, ) array: Slice indices in data coordinates."""
         inv_transform = self._transforms['data2world'].inverse
 
@@ -625,14 +624,19 @@ class Layer(KeymapProvider, ABC):
 
         world_pts = [self._dims_point[ax] for ax in self._dims_not_displayed]
         data_pts = slice_inv_transform(world_pts)
-        # A round is taken to convert these values to slicing integers
-        data_pts = np.round(data_pts).astype(int)
+        if rounding:
+            # A round is taken to convert these values to slicing integers
+            data_pts = np.round(data_pts).astype(int)
 
         indices = [slice(None)] * self.ndim
         for i, ax in enumerate(self._dims_not_displayed):
             indices[ax] = data_pts[i]
 
         return tuple(indices)
+
+    @property
+    def _slice_indices(self):
+        return self._compute_slice_indices()
 
     @abstractmethod
     def _get_ndim(self):

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1520,7 +1520,7 @@ class Points(Layer):
                 slice_indices = np.where(matches)[0].astype(int)
                 return slice_indices, scale
             else:
-                data = self.data[:, not_disp].astype('int')
+                data = self.data[:, not_disp]
                 matches = np.all(data == indices[not_disp], axis=1)
                 slice_indices = np.where(matches)[0].astype(int)
                 return slice_indices, 1
@@ -1557,7 +1557,9 @@ class Points(Layer):
     def _set_view_slice(self):
         """Sets the view given the indices to slice with."""
         # get the indices of points in view
-        indices, scale = self._slice_data(self._slice_indices)
+        indices, scale = self._slice_data(
+            self._compute_slice_indices(rounding=False)
+        )
         self._view_size_scale = scale
         self._indices_view = indices
         # get the selected points that are in view

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -379,6 +379,7 @@ class Points(Layer):
         self._drag_box_stored = None
         self._is_selecting = False
         self._clipboard = {}
+        self._round_index = False
 
         with self.block_update_properties():
             self._edge_color_property = ''
@@ -1557,9 +1558,7 @@ class Points(Layer):
     def _set_view_slice(self):
         """Sets the view given the indices to slice with."""
         # get the indices of points in view
-        indices, scale = self._slice_data(
-            self._compute_slice_indices(rounding=False)
-        )
+        indices, scale = self._slice_data(self._slice_indices)
         self._view_size_scale = scale
         self._indices_view = indices
         # get the selected points that are in view


### PR DESCRIPTION
# Description
Fix points layer rounding issue when comparing data vs slice plane

## Type of change
- Bug-fix (non-breaking change which fixes an issue)

# References
closes #1967 

# How has this been tested?
- manually tested the new behavior is working as expected

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
