### PR TITLE
Proof of concept for layerlist also being an evented dataclass

### DIFF
--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -1,7 +1,7 @@
 import itertools
 import warnings
 from collections import namedtuple
-from dataclasses import InitVar, asdict
+from dataclasses import InitVar
 from typing import List, Optional, Tuple
 
 import numpy as np
@@ -50,14 +50,14 @@ class LayerList(EventedList):
         print('Custom code when layer gets removed')
         super().__delitem__(key)
 
-    def asdict(self):
-        # Needs to be used with `restore_asdict` decorator
-        layers_dict = asdict(self)
-        # Once layer is an evented dataclass
+    def __asdict__(self, result):
+        # Custom as dict method that appends the layer list
+        dict_result = dict(result)
+        # Once layer is an evented dataclass too
         # layers_dict['list'] = [layer.asdict() for layer in self]
         # Temporary place holder
-        layers_dict['list'] = [layer._get_state() for layer in self]
-        return layers_dict
+        dict_result['list'] = [layer._get_state() for layer in self]
+        return dict_result
 
     def _coerce_name(self, name, layer=None):
         """Coerce a name into a unique equivalent.

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -28,8 +28,9 @@ class LayerList(EventedList):
         Name of the active layer.
     """
 
+    # order matters
+    data: InitVar[Tuple] = ()
     active: Optional[str] = None
-    data: InitVar[Tuple] = ()  # type: ignore
 
     def __post_init__(self, data):
         super().__init__(

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -1,18 +1,20 @@
 import itertools
 import warnings
 from collections import namedtuple
-from dataclasses import InitVar
+from dataclasses import InitVar, asdict
 from typing import List, Optional, Tuple
 
 import numpy as np
 
 from ..layers import Layer
 from ..utils.events import EventedList, evented_dataclass
+from ..utils.events.dataclass import restore_asdict
 from ..utils.naming import inc_name_count
 
 Extent = namedtuple('Extent', 'data world step')
 
 
+@restore_asdict
 @evented_dataclass
 class LayerList(EventedList):
     """List-like layer collection with built-in reordering and callback hooks.
@@ -49,6 +51,15 @@ class LayerList(EventedList):
         """Insert ``value`` before index."""
         print('Custom code when layer gets removed')
         super().__delitem__(key)
+
+    def _asdict(self):
+        # Needs to be used with `restore_asdict` decorator
+        layers_dict = asdict(self)
+        # Once layer is an evented dataclass
+        # layers_dict['list'] = [layer.asdict() for layer in self]
+        # Temporary place holder
+        layers_dict['list'] = [layer._get_state() for layer in self]
+        return layers_dict
 
     def _coerce_name(self, name, layer=None):
         """Coerce a name into a unique equivalent.

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -1,17 +1,19 @@
 import itertools
 import warnings
 from collections import namedtuple
-from typing import List, Optional
+from dataclasses import InitVar
+from typing import List, Optional, Tuple
 
 import numpy as np
 
 from ..layers import Layer
-from ..utils.events import EventedList
+from ..utils.events import EventedList, evented_dataclass
 from ..utils.naming import inc_name_count
 
 Extent = namedtuple('Extent', 'data world step')
 
 
+@evented_dataclass
 class LayerList(EventedList):
     """List-like layer collection with built-in reordering and callback hooks.
 
@@ -19,15 +21,33 @@ class LayerList(EventedList):
     ----------
     data : iterable
         Iterable of napari.layer.Layer
+
+    Attributes
+    ----------
+    active : str
+        Name of the active layer.
     """
 
-    def __init__(self, data=()):
+    active: Optional[str] = None
+    data: InitVar[Tuple] = ()  # type: ignore
+
+    def __post_init__(self, data):
         super().__init__(
             data=data, basetype=Layer, lookup={str: lambda e: e.name},
         )
 
     def __newlike__(self, data):
         return LayerList(data)
+
+    def insert(self, index: int, value: Layer):
+        """Insert ``value`` before index."""
+        print('Custom code when layer gets added')
+        super().insert(index, value)
+
+    def __delitem__(self, key: int):
+        """Insert ``value`` before index."""
+        print('Custom code when layer gets removed')
+        super().__delitem__(key)
 
     def _coerce_name(self, name, layer=None):
         """Coerce a name into a unique equivalent.

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -8,13 +8,11 @@ import numpy as np
 
 from ..layers import Layer
 from ..utils.events import EventedList, evented_dataclass
-from ..utils.events.dataclass import restore_asdict
 from ..utils.naming import inc_name_count
 
 Extent = namedtuple('Extent', 'data world step')
 
 
-@restore_asdict
 @evented_dataclass
 class LayerList(EventedList):
     """List-like layer collection with built-in reordering and callback hooks.
@@ -52,7 +50,7 @@ class LayerList(EventedList):
         print('Custom code when layer gets removed')
         super().__delitem__(key)
 
-    def _asdict(self):
+    def asdict(self):
         # Needs to be used with `restore_asdict` decorator
         layers_dict = asdict(self)
         # Once layer is an evented dataclass

--- a/napari/utils/events/containers/_evented_list.py
+++ b/napari/utils/events/containers/_evented_list.py
@@ -224,11 +224,11 @@ class EventedList(TypedMutableSequence[_T]):
         dest_index -= len([i for i in to_move if i < dest_index])
 
         self.events.moving(index=to_move, new_index=dest_index)
-        with self.events.blocker_all():
-            items = [self[i] for i in to_move]
-            for i, src_index in enumerate(sorted(to_move, reverse=True)):
-                # Note this is not quite correct, needs to be fixed, off by one sometimes!!!!
-                self.move(src_index, dest_index + i)
+        items = [self[i] for i in to_move]
+        for i in sorted(to_move, reverse=True):
+            self._list.pop(i)
+        for item in items[::-1]:
+            self._list.insert(dest_index, item)
         self.events.moved(index=to_move, new_index=dest_index, value=items)
         self.events.reordered(value=self)
         return len(to_move)

--- a/napari/utils/events/dataclass.py
+++ b/napari/utils/events/dataclass.py
@@ -563,13 +563,9 @@ def evented_dataclass(
     if properties:
         # convert public dataclass fields to properties
         cls = convert_fields_to_properties(cls)
-    setattr(cls, 'asdict', _dc.asdict)
-    setattr(cls, 'update', update_from_dict)
-    return cls
 
-
-def restore_asdict(cls):
-    method = getattr(cls, '_asdict', None)
-    if method is not None:
-        setattr(cls, 'asdict', method)
+    if not hasattr(cls, 'asdict'):
+        setattr(cls, 'asdict', _dc.asdict)
+    if not hasattr(cls, 'update'):
+        setattr(cls, 'update', update_from_dict)
     return cls

--- a/napari/utils/events/dataclass.py
+++ b/napari/utils/events/dataclass.py
@@ -564,8 +564,10 @@ def evented_dataclass(
         # convert public dataclass fields to properties
         cls = convert_fields_to_properties(cls)
 
-    if not hasattr(cls, 'asdict'):
-        setattr(cls, 'asdict', _dc.asdict)
-    if not hasattr(cls, 'update'):
-        setattr(cls, 'update', update_from_dict)
+    def asdict(cls):
+        # If class has an `__asdict__` method use that, otherwise use dict.
+        return _dc.asdict(cls, dict_factory=getattr(cls, '__asdict__', dict))
+
+    setattr(cls, 'asdict', asdict)
+    setattr(cls, 'update', update_from_dict)
     return cls

--- a/napari/utils/events/dataclass.py
+++ b/napari/utils/events/dataclass.py
@@ -566,3 +566,10 @@ def evented_dataclass(
     setattr(cls, 'asdict', _dc.asdict)
     setattr(cls, 'update', update_from_dict)
     return cls
+
+
+def restore_asdict(cls):
+    method = getattr(cls, '_asdict', None)
+    if method is not None:
+        setattr(cls, 'asdict', method)
+    return cls


### PR DESCRIPTION
# Description
This PR is a minimal proof of concept of the layerlist being both an evented list and and evented dataclass.

The motivation for this are concerns about caching things like `layers.active` or `layers.extent` in #1952, #2018 and elsewhere, and then being able to emit events when they change. This allows us avoid adding custom events to the event emitter.

This PR also makes some changes to the move operation in the evented list which allows us to define our own methods in the `LayersList` that get called whenever a Layer gets added or removed from the layerlist, and not when the layers simply get rearranged. This will allow us to connect and disconnect layer events once when adding/ removing layers and not do that every time the list is reordered. ~~There's currently an off by one indexing bug, but that will be easy to fix once I work through the maths.~~ [EDIT: now fixed].

This will now add an `asdict` method to the `LayerList`, it's not quite so clear what to do here though, especially when we think about nesting `asdict` calls on the viewer :-( Previously I would have thought that we got a dict with a 'layers' key and values a tuple of `asdict` calls to the individual Layers, but now that isn't possible as we need an 'active' key somewhere ...
[EDIT: I guess here what I'd recommend is that we call asdict and then add a new key `list` with `asdict` called manually on each element] [EDITx2: we actually have to use an additional decorator to do this, see https://stackoverflow.com/questions/59882545/why-cant-i-override-to-dict-method-of-a-dataclass-object-that-uses-datacla, but it does work. I have now added to PR too].

I'm making this PR now though before going to far to get early feedback from @tlambert03 @jni and others before going further.