### PR TITLE
async-42: New LoaderPool and remove ChunkKey

### DIFF
--- a/napari/_vispy/experimental/tile_set.py
+++ b/napari/_vispy/experimental/tile_set.py
@@ -4,7 +4,7 @@ TiledImageVisual uses this class to track the tiles it's drawing.
 """
 from typing import Dict, List, NamedTuple, Set
 
-from ...layers.image.experimental import OctreeChunk, OctreeChunkKey
+from ...layers.image.experimental import OctreeChunk
 from .texture_atlas import AtlasTile
 
 
@@ -33,13 +33,13 @@ class TileSet:
     ----------
     _tiles : Dict[int, TileData]
         Maps tile_index to the the TileData we have for that tile.
-    _chunks : Set[OctreeChunkKey]
+    _chunks : Set[OctreeChunk]
         The chunks we have in the set, for fast membership tests.
     """
 
     def __init__(self):
         self._tiles: Dict[int, TileData] = {}
-        self._chunks: Set[OctreeChunkKey] = set()
+        self._chunks: Set[OctreeChunk] = set()
 
     def __len__(self) -> int:
         """Return the number of tiles in the set.
@@ -69,7 +69,7 @@ class TileSet:
         tile_index = atlas_tile.index
 
         self._tiles[tile_index] = TileData(octree_chunk, atlas_tile)
-        self._chunks.add(octree_chunk.key)
+        self._chunks.add(octree_chunk)
 
     def remove(self, tile_index: int) -> None:
         """Remove the TileData at this index from the set.
@@ -78,16 +78,16 @@ class TileSet:
             Remove the TileData at this index.
         """
         octree_chunk = self._tiles[tile_index].octree_chunk
-        self._chunks.remove(octree_chunk.key)
+        self._chunks.remove(octree_chunk)
         del self._tiles[tile_index]
 
     @property
-    def chunk_set(self) -> Set[OctreeChunkKey]:
+    def chunk_set(self) -> Set[OctreeChunk]:
         """Return the set of chunks we drawing.
 
         Return
         ------
-        Set[OctreeChunkKey]
+        Set[OctreeChunk]
             The set of chunks we are drawing.
         """
         return self._chunks
@@ -147,4 +147,4 @@ class TileSet:
         bool
             True if the set contains this chunk data.
         """
-        return octree_chunk.key in self._chunks
+        return octree_chunk in self._chunks

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -14,8 +14,6 @@ from typing import List, Set
 
 import numpy as np
 
-from napari.layers.image.experimental.octree_chunk import OctreeChunkKey
-
 from ...layers.image.experimental import OctreeChunk
 from ..vendored import ImageVisual
 from ..vendored.image import _build_color_transform
@@ -249,12 +247,12 @@ class TiledImageVisual(ImageVisual):
         self._need_vertex_update = True
 
     @property
-    def chunk_set(self) -> Set[OctreeChunkKey]:
+    def chunk_set(self) -> Set[OctreeChunk]:
         """Return the set of chunks we are drawing.
 
         Return
         ------
-        Set[OctreeChunkKey]
+        Set[OctreeChunk]
             The set of chunks we are drawing.
         """
         return self._tiles.chunk_set

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -186,9 +186,12 @@ class VispyTiledImageLayer(VispyImageLayer):
 
         if stats.created > 0 or stats.deleted > 0:
             LOGGER.debug(
-                f"tiles: {stats.start} -> {stats.final} "
-                f"create: {stats.created} delete: {stats.deleted} "
-                f"time: {elapsed.duration_ms:.3f}ms"
+                "tiles: %d -> %d create: %d delete: %d time: %.3fms",
+                stats.start,
+                stats.final,
+                stats.created,
+                stats.deleted,
+                elapsed.duration_ms,
             )
 
         return stats.remaining

--- a/napari/components/experimental/chunk/__init__.py
+++ b/napari/components/experimental/chunk/__init__.py
@@ -1,6 +1,4 @@
 """ChunkLoader module.
 """
 from ._loader import chunk_loader, synchronous_loading, wait_for_async
-from ._request import ChunkKey, ChunkRequest
-from ._utils import LayerRef
-from .layer_key import LayerKey
+from ._request import ChunkLocation, ChunkRequest, LayerRef

--- a/napari/components/experimental/chunk/_cache.py
+++ b/napari/components/experimental/chunk/_cache.py
@@ -99,8 +99,8 @@ class ChunkCache:
         if not self.enabled:
             LOGGER.debug("ChunkCache.add_chunk: cache is disabled")
             return
-        LOGGER.debug("add_chunk: %s", request.key.location)
-        self.chunks[request.key.key] = request.chunks
+        LOGGER.debug("add_chunk: %s", request.location)
+        self.chunks[request.location] = request.chunks
 
     def get_chunks(self, request: ChunkRequest) -> Optional[ChunkArrays]:
         """Return the cached data for this request if it was cached.
@@ -119,10 +119,10 @@ class ChunkCache:
             LOGGER.info("ChunkCache.get_chunk: disabled")
             return None
 
-        data = self.chunks.get(request.key.key)
+        data = self.chunks.get(request.location)
         LOGGER.info(
             "get_chunk: %s %s",
-            request.key.location,
+            request.location,
             "found" if data is not None else "not found",
         )
         return data

--- a/napari/components/experimental/chunk/_cache.py
+++ b/napari/components/experimental/chunk/_cache.py
@@ -125,4 +125,4 @@ class ChunkCache:
             request.key.location,
             "found" if data is not None else "not found",
         )
-        return
+        return data

--- a/napari/components/experimental/chunk/_commands/_loader.py
+++ b/napari/components/experimental/chunk/_commands/_loader.py
@@ -58,7 +58,7 @@ class InfoDisplayer:
         stats = info.stats
         counts = stats.counts
 
-        self.data_type = info.layer_ref.data_type
+        self.data_type = "???"  # We need to add this back...
         self.num_loads = counts.loads
         self.num_chunks = counts.chunks
         self.sync = LOAD_TYPE_STR[self.info.load_type]

--- a/napari/components/experimental/chunk/_delay_queue.py
+++ b/napari/components/experimental/chunk/_delay_queue.py
@@ -104,7 +104,7 @@ class DelayQueue(threading.Thread):
 
         with self.lock:
             self.entries[:] = [
-                x for x in self.entries if x.request.key.data_id != data_id
+                x for x in self.entries if x.request.data_id != data_id
             ]
 
     def submit(self, entry: QueueEntry, now: float) -> bool:

--- a/napari/components/experimental/chunk/_delay_queue.py
+++ b/napari/components/experimental/chunk/_delay_queue.py
@@ -1,42 +1,60 @@
 """DelayQueue class.
+
+Delays a configurable amount of time before submitting a request.
 """
 import logging
 import threading
 import time
-from collections import namedtuple
-from typing import List, Optional
+from typing import Callable, List, NamedTuple, Optional
 
 from ....utils.perf import add_counter_event
+from ._request import ChunkRequest
 
 LOGGER = logging.getLogger("napari.loader")
 
-# Each queue entry contains the request we are going to submit, and the
-# time in seconds when it should be submitted.
-QueueEntry = namedtuple('QueueEntry', ["request", "submit_time"])
+
+class QueueEntry(NamedTuple):
+    """The request we are doing to submit and when to submit it.
+
+    Parameters
+    ----------
+    request : ChunkRequest
+        The request to submit.
+    submit_time : float
+        The time to submit the request in time.time() seconds.
+    """
+
+    request: ChunkRequest
+    submit_time: float
 
 
 class DelayQueue(threading.Thread):
     """A threaded queue that delays request submission.
 
-    The DelayQueue exists because it's hard to cancel requests which
-    have been given to the thread or process pool. But it's trivial
-    to cancel requests from the DelayQueue.
+    The DelayQueue exists so we can avoid spamming the ChunkLoader loader
+    pools with requests for chunks that are potentially going to be out of
+    view before they are loaded.
 
-    We could just throw away the stale results, but that could generate
-    a lot of unnecessary network traffic and a lot of unnecessary
-    background computation in some cases.
+    For example, when rapidly scrolling through slices, it would be
+    pointless to submit requests for every new slice we pass through.
+    Instead by using a small delay, we hold back submitting our requests
+    until the user has settled on a specific slice.
 
-    So the GUI thread calls DelayQueue.clear() every time the user switches
-    to a new slice. This trivially clears the requests still in this queue.
+    Similarly with the Octree, when panning and zooming rapidly we might
+    choose to delay so that we don't waste time loading chunks that
+    will quickly be out of view.
 
-    The net result with much less wasted background effort. And because of
-    this when the user does pause, there are generally resources available
-    to immediately start on that load.
+    With the Octree however we do want to show something as you pan and
+    zoom around. For this reason ChunkLoader can have multiple loader pools
+    each with different delays Typically we we delay the "ideal level"
+    chunks the most, but we load coarser levels sooner. So we show the user
+    something quickly, but we only load the full set of ideal chunks when
+    the camera movement has settled down.
 
     Parameters
     ----------
     delay_queue_ms : float
-        Delay the request for this many milliseconds before submission.
+        Delay the request for this many milliseconds.
     submit_func
         Call this function to submit the request.
 
@@ -44,24 +62,28 @@ class DelayQueue(threading.Thread):
     ----------
     delay_seconds : float
         Delay each request by this many seconds.
-    submit_func
-        We call this function to submit the request.
-    entries : List[QueueEntry]
+    _submit_func : Callable[[ChunkRequest], None]
+        Call this function to submit the request.
+    _entries : List[QueueEntry]
         The entries in the queue.
-    lock : threading.Lock
+    _lock : threading.Lock
         Lock access to the self.entires queue.
-    event : threading.Event
+    _event : threading.Event
         Event we signal to wake up the worker.
     """
 
-    def __init__(self, delay_queue_ms: float, submit_func):
+    def __init__(
+        self,
+        delay_queue_ms: float,
+        submit_func: Callable[[ChunkRequest], None],
+    ):
         super().__init__(daemon=True)
         self.delay_seconds: float = (delay_queue_ms / 1000)
-        self.submit_func = submit_func
+        self._submit_func = submit_func
 
-        self.entries: List[QueueEntry] = []
-        self.lock = threading.Lock()
-        self.event = threading.Event()
+        self._entries: List[QueueEntry] = []
+        self._lock = threading.Lock()
+        self._event = threading.Event()
 
         self.start()
 
@@ -74,38 +96,50 @@ class DelayQueue(threading.Thread):
             Insert this request into the queue.
         """
         if self.delay_seconds == 0:
-            self.submit_func(request)  # Submit with no delay.
+            self._submit_func(request)  # Submit with no delay.
             return
 
-        LOGGER.info("DelayQueue.add: data_id=%d", request.data_id)
+        LOGGER.info("DelayQueue.add: %s", request.location)
 
         # Create entry with the time to submit it.
         submit_time = time.time() + self.delay_seconds
         entry = QueueEntry(request, submit_time)
 
-        with self.lock:
-            self.entries.append(entry)
-            num_entries = len(self.entries)
+        with self._lock:
+            self._entries.append(entry)
+            num_entries = len(self._entries)
 
         add_counter_event("delay_queue", entries=num_entries)
 
         if num_entries == 1:
-            self.event.set()  # The list was empty so wake up the worker.
+            self._event.set()  # The list was empty so wake up the worker.
 
-    def clear(self, data_id: int) -> None:
-        """Remove any entires for this data_id.
+    def cancel_requests(
+        self, should_cancel: Callable[[ChunkRequest], bool]
+    ) -> List[ChunkRequest]:
+        """Cancel pending requests based on the given filter.
 
         Parameters
         ----------
-        data_id : int
-            Remove entries for this data_id.
-        """
-        LOGGER.info("DelayQueue.clear: data_id=%d", data_id)
+        should_cancel : Callable[[ChunkRequest], bool]
+            Cancel the request if this returns True.
 
-        with self.lock:
-            self.entries[:] = [
-                x for x in self.entries if x.request.data_id != data_id
-            ]
+        Return
+        ------
+        List[ChunkRequests]
+            The requests that were cancelled, if any.
+        """
+        keep = []
+        cancel = []
+        with self._lock:
+            for entry in self._entries:
+                if should_cancel(entry.request):
+                    cancel.append(entry.request)
+                else:
+                    keep.append(entry)
+            self._entries = keep
+
+        return cancel
 
     def submit(self, entry: QueueEntry, now: float) -> bool:
         """Submit and return True if entry is ready to be submitted.
@@ -124,32 +158,30 @@ class DelayQueue(threading.Thread):
         """
         # If entry is due to be submitted.
         if entry.submit_time < now:
-            LOGGER.info(
-                "DelayQueue.submit: data_id=%d", entry.request.data_id,
-            )
-            self.submit_func(entry.request)
+            LOGGER.info("DelayQueue.submit: %s", entry.request.location)
+            self._submit_func(entry.request)
             return True  # We submitted this request.
         return False
 
     def run(self):
         """The DelayQueue thread's main method.
 
-        Submit all due entires, then sleep or wait on self.event
+        Submit all due entires, then sleep or wait on self._event
         for new entries.
         """
         while True:
             now = time.time()
 
-            with self.lock:
+            with self._lock:
                 seconds = self._submit_due_entries(now)
-                num_entries = len(self.entries)
+                num_entries = len(self._entries)
 
             add_counter_event("delay_queue", entries=num_entries)
 
             if seconds is None:
                 # There were no entries left, so wait until there is one.
-                self.event.wait()
-                self.event.clear()
+                self._event.wait()
+                self._event.clear()
             else:
                 # Sleep until the next entry is due. This will tend to
                 # oversleep by a few milliseconds, but close enough for our
@@ -170,19 +202,19 @@ class DelayQueue(threading.Thread):
         Optional[float]
             Seconds until next entry is due, or None if no next entry.
         """
-        while self.entries:
+        while self._entries:
             # Submit the oldest entry if it's due.
-            if self.submit(self.entries[0], now):
-                self.entries.pop(0)  # Remove the one we just submitted.
+            if self.submit(self._entries[0], now):
+                self._entries.pop(0)  # Remove the one we just submitted.
             else:
                 # Oldest entry is not due, return time until it is.
-                return self.entries[0].submit_time - now
+                return self._entries[0].submit_time - now
 
         return None  # There are no more entries.
 
     def flush(self):
         """Submit all entries right now."""
-        with self.lock:
-            for entry in self.entries:
-                self.submit_func(entry.request)
-            self.entries = []
+        with self._lock:
+            for entry in self._entries:
+                self._submit_func(entry.request)
+            self._entries = []

--- a/napari/components/experimental/chunk/_info.py
+++ b/napari/components/experimental/chunk/_info.py
@@ -6,8 +6,8 @@ from enum import Enum
 
 from ....components.experimental.monitor import monitor
 from ....layers.base import Layer
-from ._request import ChunkRequest
-from ._utils import LayerRef, StatWindow
+from ._request import ChunkRequest, LayerRef
+from ._utils import StatWindow
 
 LOGGER = logging.getLogger("napari.loader")
 
@@ -197,9 +197,9 @@ class LayerInfo:
         layer : Layer
             The layer for this ChunkRequest.
         """
-        layer = self.layer_ref.weak_ref()
+        layer = self.layer_ref.layer
         if layer is None:
-            layer_id = self.layer_ref.layer_key.layer_id
+            layer_id = self.layer_ref.layer_id
             LOGGER.debug("LayerInfo.get_layer: layer %d was deleted", layer_id)
         return layer
 

--- a/napari/components/experimental/chunk/_info.py
+++ b/napari/components/experimental/chunk/_info.py
@@ -179,7 +179,7 @@ class LayerInfo:
     We store a weak reference because we do not want an in-progress request
     to prevent a layer from being deleted. Meanwhile, once a request has
     finished, we can de-reference the weakref to make sure the layer was
-    note deleted during the load process.
+    not deleted during the load process.
     """
 
     def __init__(self, layer_ref: LayerRef, auto_sync_ms):

--- a/napari/components/experimental/chunk/_info.py
+++ b/napari/components/experimental/chunk/_info.py
@@ -6,7 +6,6 @@ from enum import Enum
 
 from ....components.experimental.monitor import monitor
 from ....layers.base import Layer
-from ....utils.config import octree_config
 from ._request import ChunkRequest
 from ._utils import LayerRef, StatWindow
 
@@ -183,10 +182,10 @@ class LayerInfo:
     note deleted during the load process.
     """
 
-    def __init__(self, layer_ref: LayerRef):
+    def __init__(self, layer_ref: LayerRef, auto_sync_ms):
         self.layer_ref = layer_ref
         self.load_type: LoadType = LoadType.AUTO
-        self.auto_sync_ms = octree_config['loader']['auto_sync_ms']
+        self.auto_sync_ms = auto_sync_ms
 
         self.stats = LoadStats()
 

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -1,95 +1,37 @@
 """ChunkLoader class.
 
 Loads chunks synchronously or asynchronously using worker threads or
-processes. A chunk could be an OctreeChunk or it could be a whole screen of
-data with the pre-Octree Image class.
+processes. A chunk could be an OctreeChunk or it could be a pre-Octree
+array from a single or multi-scale image.
 """
 import logging
-import os
-from concurrent.futures import (
-    CancelledError,
-    Future,
-    ProcessPoolExecutor,
-    ThreadPoolExecutor,
-)
+from concurrent.futures import CancelledError, Future
 from contextlib import contextmanager
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, Optional, Tuple
 
 from ....types import ArrayLike
 from ....utils.config import octree_config
 from ....utils.events import EmitterGroup
 from ._cache import ChunkCache
-from ._delay_queue import DelayQueue
 from ._info import LayerInfo, LayerRef, LoadType
+from ._pool import LoaderPool
 from ._request import ChunkKey, ChunkRequest
 
 LOGGER = logging.getLogger("napari.loader")
 
-# Executor for either a thread pool or a process pool.
-PoolExecutor = Union[ThreadPoolExecutor, ProcessPoolExecutor]
-
-
-def _is_enabled(env_var) -> bool:
-    """Return True if env_var is defined and not zero."""
-    return os.getenv(env_var, "0") != "0"
-
-
-def _chunk_loader_worker(request: ChunkRequest) -> ChunkRequest:
-    """This is the worker thread or process that loads the array.
-
-    We call np.asarray() in a worker because it might lead to IO or
-    computation which would block the GUI thread.
-
-    Parameters
-    ----------
-    request : ChunkRequest
-        The request to load.
-    """
-    request.load_chunks()  # loads all chunks in the request
-    return request
-
-
-def _create_executor(use_processes: bool, num_workers: int) -> PoolExecutor:
-    """Return the thread or process pool executor.
-
-    Parameters
-    ----------
-    use_processes : bool
-        If True use processes, otherwise threads.
-    num_workers : int
-        The number of worker threads or processes.
-    """
-    if use_processes:
-        LOGGER.debug("Process pool num_workers=%d", num_workers)
-        return ProcessPoolExecutor(max_workers=num_workers)
-
-    LOGGER.debug("Thread pool num_workers=%d", num_workers)
-    return ThreadPoolExecutor(max_workers=num_workers)
-
 
 class ChunkLoader:
-    """Loads chunks synchronously or asynchronously in worker thread or processes.
+    """Loads chunks in worker threads or processes.
 
-    We cannot call np.asarray() in the GUI thread because it might block on
-    IO or a computation. So the ChunkLoader calls np.asarray() in a worker
-    if doing async loading.
+    A ChunkLoader contains one or more LoaderPools. Each LoaderPool has
+    a thread or process pool.
 
     Attributes
     ----------
-    synchronous : bool
-        If True all requests are loaded synchronously.
-    num_workers : int
-        The number of workers.
-    executor : PoolExecutor
-        The thread or process pool executor.
-    futures : Dict[int, List[Future]]
-        In progress futures for each layer (data_id).
     layer_map : Dict[int, LayerInfo]
         Stores a LayerInfo about each layer we are tracking.
     cache : ChunkCache
         Cache of previously loaded chunks.
-    delay_queue : DelayQueue
-        Requests sit in here for a bit before submission.
     events : EmitterGroup
         We only signal one event: chunk_loaded.
     """
@@ -97,28 +39,20 @@ class ChunkLoader:
     def __init__(self):
         _setup_logging(octree_config)
 
-        config = octree_config['loader']
-        self.force_synchronous: bool = bool(config['force_synchronous'])
-        self.num_workers: int = int(config['num_workers'])
-        self.use_processes: bool = bool(config['use_processes'])
+        loader_config = octree_config['loader']
 
-        self.executor: PoolExecutor = _create_executor(
-            self.use_processes, self.num_workers
-        )
+        self.force_synchronous: bool = bool(loader_config['force_synchronous'])
+        self.auto_sync_ms = loader_config['auto_sync_ms']
+        self.octree_enabled = octree_config['octree']['enabled']
 
-        self._futures: Dict[int, List[Future]] = {}
         self.layer_map: Dict[int, LayerInfo] = {}
         self.cache: ChunkCache = ChunkCache()
-
-        # The DelayeQueue prevents us from spamming the worker pool when
-        # the user is rapidly scrolling through slices.
-        self.delay_queue = DelayQueue(
-            config['delay_queue_ms'], self._submit_async
-        )
 
         self.events = EmitterGroup(
             source=self, auto_connect=True, chunk_loaded=None
         )
+
+        self._loader = LoaderPool(loader_config, self._done)
 
     def get_info(self, layer_id: int) -> Optional[LayerInfo]:
         """Get LayerInfo for this layer or None."""
@@ -147,7 +81,7 @@ class ChunkLoader:
         layer_id = layer_ref.layer_key.layer_id
 
         if layer_id not in self.layer_map:
-            self.layer_map[layer_id] = LayerInfo(layer_ref)
+            self.layer_map[layer_id] = LayerInfo(layer_ref, self.auto_sync_ms)
 
         # Return the new request.
         return ChunkRequest(key, chunks)
@@ -175,26 +109,22 @@ class ChunkLoader:
         on_chunk_loaded() will be called from the GUI thread.
         """
         if self._load_synchronously(request):
-            return request, None
+            return request
 
         # Check the cache first.
         chunks = self.cache.get_chunks(request)
 
         if chunks is not None:
             request.chunks = chunks
-            return request, None
+            return request
 
-        # Clear any pending requests for this specific data_id.
-        # TODO_OCTREE: turn this off because all our request come from the
-        # same data_id. But maybe we can clear pending on something more
-        # specific?
-        # self._clear_pending(request.key.data_id)
+        if not self.octree_enabled:
+            # Pre-octree we can clear pendint requests from any other data_id,
+            # generally from other slices besides this one.
+            self._loader.clear_pending(request.data_id)
 
-        # Add to the delay queue, the delay queue will call our
-        # _submit_async() method later on if the delay expires without the
-        # request getting cancelled.
-        # self.delay_queue.add(request)
-        return None, self._submit_async(request)
+        self._loader.load_async(request)
+        return None  # None means load was async.
 
     def _load_synchronously(self, request: ChunkRequest) -> bool:
         """Return True if we loaded the request.
@@ -255,70 +185,6 @@ class ChunkLoader:
         # Finally, load synchronously if it's an ndarray (in memory) otherwise
         # it's Dask or something else and we load async.
         return request.in_memory
-
-    def _submit_async(self, request: ChunkRequest) -> None:
-        """Initiate an asynchronous load of the given request.
-
-        Parameters
-        ----------
-        request : ChunkRequest
-            Contains the arrays to load.
-        """
-        # Submit the future. It will call ChunkLoader._done when done.
-        future = self.executor.submit(_chunk_loader_worker, request)
-        future.add_done_callback(self._done)
-
-        # Store the future in case we need to cancel it.
-        future_list = self._futures.setdefault(request.data_id, [])
-        future_list.append(future)
-
-        LOGGER.debug(
-            "_submit_async: %s elapsed=%.3fms num_futures=%d",
-            request.key.location,
-            request.elapsed_ms,
-            len(future_list),
-        )
-
-        return future
-
-    def _clear_pending(self, data_id: int) -> None:
-        """Clear any pending requests for this data_id.
-
-        Parameters
-        ----------
-        data_id : int
-            Clear all requests associated with this data_id.
-        """
-        LOGGER.debug("_clear_pending %d", data_id)
-
-        # Clear delay queue first. These requests are trivial to clear
-        # because they have not even been submitted to the worker pool.
-        self.delay_queue.clear(data_id)
-
-        # Get list of futures we submitted to the pool.
-        future_list = self._futures.setdefault(data_id, [])
-
-        # Try to cancel all futures in the list, but cancel() will return
-        # False if the task already started running.
-        num_before = len(future_list)
-        future_list[:] = [x for x in future_list if x.cancel()]
-        num_after = len(future_list)
-        num_cleared = num_before - num_after
-
-        # Delete the list entirely if empty
-        if num_after == 0:
-            del self._futures[data_id]
-
-        # Log what we did.
-        if num_before == 0:
-            LOGGER.debug("_clear_pending: empty")
-        else:
-            LOGGER.debug(
-                "_clear_pending: %d of %d cleared -> %d remain",
-                num_cleared,
-                num_before,
-                num_after,
-            )
 
     @staticmethod
     def _get_request(future: Future) -> Optional[ChunkRequest]:
@@ -479,7 +345,7 @@ def wait_for_async():
     chunk_loader.wait_for_all()
 
 
-def _setup_logging(octree_config: dict) -> None:
+def _setup_logging(config: dict) -> None:
     """Setup logging.
 
     String Formatting
@@ -497,12 +363,16 @@ def _setup_logging(octree_config: dict) -> None:
         The configuration data.
     """
     try:
-        _log_to_file("napari.loader", octree_config['loader']['log_path'])
+        log_path = config['loader']['log_path']
+        if log_path is not None:
+            _log_to_file("napari.loader", log_path)
     except KeyError:
         pass
 
     try:
-        _log_to_file("napari.octree", octree_config['octree']['log_path'])
+        log_path = config['loader']['log_path']
+        if log_path is not None:
+            _log_to_file("napari.octree", log_path)
     except KeyError:
         pass
 
@@ -515,10 +385,10 @@ def _log_to_file(name: str, path: str) -> None:
     path : str
         Log to this file path.
     """
-    format = "%(levelname)s - %(name)s - %(message)s"
+    log_format = "%(levelname)s - %(name)s - %(message)s"
     logger = logging.getLogger(name)
     fh = logging.FileHandler(path)
-    formatter = logging.Formatter(format)
+    formatter = logging.Formatter(log_format)
     fh.setFormatter(formatter)
     logger.addHandler(fh)
     logger.setLevel(logging.DEBUG)

--- a/napari/components/experimental/chunk/_pool.py
+++ b/napari/components/experimental/chunk/_pool.py
@@ -1,0 +1,168 @@
+"""LoaderPool class.
+
+ChunkLoader has one or more of these. They load data in worker pools.
+"""
+import logging
+from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
+from typing import Callable, Dict, List, Union
+
+from ._delay_queue import DelayQueue
+from ._request import ChunkRequest
+
+# Executor for either a thread pool or a process pool.
+PoolExecutor = Union[ThreadPoolExecutor, ProcessPoolExecutor]
+
+LOGGER = logging.getLogger("napari.loader")
+
+
+class LoaderPool:
+    """Loads chunks asynchronously in worker threads or processes.
+
+    We cannot call np.asarray() in the GUI thread because it might block on
+    IO or a computation. So we call np.asarray() in _chunk_loader_worker()
+    instead.
+
+    Parameters
+    ----------
+    config : dict
+        Our configuration, see napari.utils._octree.py for format.
+    done_callback : Callable[[Future], None]
+        Called when a future finishes.
+
+    Attributes
+    ----------
+    force_synchronous : bool
+        If True all requests are loaded synchronously.
+    num_workers : int
+        The number of workers.
+    use_processes | bool
+        Use processess as workers, otherwise use threads.
+    _executor : PoolExecutor
+        The thread or process pool executor.
+    _futures : Dict[int, List[Future]]
+        In progress futures for each layer (data_id).
+    _delay_queue : DelayQueue
+        Requests sit in here for a bit before submission.
+    """
+
+    def __init__(self, config: dict, done_callback: Callable[[Future], None]):
+        self.config = config
+        self._done = done_callback
+
+        self.num_workers: int = int(config['num_workers'])
+        self.use_processes: bool = bool(config['use_processes'])
+
+        self._executor: PoolExecutor = _create_executor(
+            self.use_processes, self.num_workers
+        )
+        self._futures: Dict[int, List[Future]] = {}
+        self._delay_queue = DelayQueue(config['delay_queue_ms'], self._submit)
+
+    def load_async(self, request: ChunkRequest) -> None:
+        """Load this request asynchronously.
+
+        Parameters
+        ----------
+        request : ChunkRequest
+            The request to load.
+        """
+        # Add to the DelayQueue which will call our self._submit() method
+        # right away, if zero delay, or after the configured delay.
+        self._delay_queue.add(request)
+
+    def _submit(self, request: ChunkRequest) -> None:
+        """Initiate an asynchronous load of the given request.
+
+        Parameters
+        ----------
+        request : ChunkRequest
+            Contains the arrays to load.
+        """
+        # Submit the future. Have it call self._done when finished.
+        future = self._executor.submit(_chunk_loader_worker, request)
+        future.add_done_callback(self._done)
+
+        # Store the future in case we need to cancel it.
+        future_list = self._futures.setdefault(request.data_id, [])
+        future_list.append(future)
+
+        LOGGER.debug(
+            "_submit_async: %s elapsed=%.3fms num_futures=%d",
+            request.key.location,
+            request.elapsed_ms,
+            len(future_list),
+        )
+
+        return future
+
+    def clear_pending(self, data_id: int) -> None:
+        """Clear any pending requests for this data_id.
+
+        Parameters
+        ----------
+        data_id : int
+            Clear all requests associated with this data_id.
+        """
+        LOGGER.debug("_clear_pending %d", data_id)
+
+        # Clear delay queue first. These requests are trivial to clear
+        # because they have not even been submitted to the worker pool.
+        self._delay_queue.clear(data_id)
+
+        # Get list of futures we submitted to the pool.
+        future_list = self._futures.setdefault(data_id, [])
+
+        # Try to cancel all futures in the list, but cancel() will return
+        # False if the task already started running.
+        num_before = len(future_list)
+        future_list[:] = [x for x in future_list if x.cancel()]
+        num_after = len(future_list)
+        num_cleared = num_before - num_after
+
+        # Delete the list entirely if empty
+        if num_after == 0:
+            del self._futures[data_id]
+
+        # Log what we did.
+        if num_before == 0:
+            LOGGER.debug("_clear_pending: empty")
+        else:
+            LOGGER.debug(
+                "_clear_pending: %d of %d cleared -> %d remain",
+                num_cleared,
+                num_before,
+                num_after,
+            )
+
+
+def _create_executor(use_processes: bool, num_workers: int) -> PoolExecutor:
+    """Return the thread or process pool executor.
+
+    Parameters
+    ----------
+    use_processes : bool
+        If True use processes, otherwise threads.
+    num_workers : int
+        The number of worker threads or processes.
+    """
+    if use_processes:
+        LOGGER.debug("Process pool num_workers=%d", num_workers)
+        return ProcessPoolExecutor(max_workers=num_workers)
+
+    LOGGER.debug("Thread pool num_workers=%d", num_workers)
+    return ThreadPoolExecutor(max_workers=num_workers)
+
+
+def _chunk_loader_worker(request: ChunkRequest) -> ChunkRequest:
+    """This is the worker thread or process that loads the array.
+
+    We call np.asarray() in a worker because it might lead to IO or
+    computation which would block the GUI thread.
+
+    Parameters
+    ----------
+    request : ChunkRequest
+        The request to load.
+    """
+    request.load_chunks()  # loads all chunks in the request
+    return request

--- a/napari/components/experimental/chunk/_request.py
+++ b/napari/components/experimental/chunk/_request.py
@@ -1,15 +1,15 @@
-"""ChunkKey and ChunkRequest classes.
+"""ChunkLocation and ChunkRequest classes.
 """
 import contextlib
 import logging
 import time
-from typing import Optional, Tuple
+import weakref
+from typing import NamedTuple, Optional, Tuple
 
 import numpy as np
 
 from ....types import ArrayLike, Dict
 from ....utils.perf import PerfEvent, block_timer
-from .layer_key import LayerKey
 
 LOGGER = logging.getLogger("napari.loader")
 
@@ -17,46 +17,43 @@ LOGGER = logging.getLogger("napari.loader")
 SliceTuple = Tuple[Optional[int], Optional[int], Optional[int]]
 
 
-class ChunkKey:
-    """The key for one single ChunkRequest.
+class LayerRef(NamedTuple):
+    layer_id: int
+    layer_ref: weakref.ReferenceType
+
+    @property
+    def layer(self):
+        return self.layer_ref()
+
+    @classmethod
+    def from_layer(cls, layer):
+        return cls(id(layer), weakref.ref(layer))
+
+
+class ChunkLocation:
+    """Location of the chunk.
+
+    ChunkLocation is the base class for two classes:
+        ImageLocation - pre-octree async loading
+        OctreeLocation - octree async loading
 
     Parameters
     ----------
-    layer : Layer
-        The layer which is loading the chunk.
-    indices : Indices
-        The indices of the layer we are loading.
-
-    Attributes
-    ----------
-    layer_key : LayerKey
-        The layer specific parts of the key.
-    key : Tuple
-        The combined key, everything hashed together.
+    layer_id : int
+        The id of the layer containing the chunks.
+    layer_ref : weakref.ReferenceType
+        Weak reference to the layer.
     """
 
-    def __init__(self, layer_key: LayerKey):
-        self.layer_key = layer_key
-        self.key = hash(self.get_hash_values())
-
-    def get_hash_values(self):
-        return self.layer_key.get_hash_values()
-
-    def __str__(self):
-        layer_key = self.layer_key
-        return (
-            f"layer_id={layer_key.layer_id} data_id={layer_key.data_id} "
-            f"data_level={layer_key.data_level} indices={layer_key.indices}"
-        )
-
-    def __eq__(self, other):
-        return self.key == other.key
+    def __init__(self, layer_ref: LayerRef):
+        self.layer_ref = layer_ref
 
     @property
-    def location(self):
-        # Derived OctreeChunkKey has a location, we don't, but we could maybe
-        # print the indices or something here?
-        return "none"
+    def layer_id(self) -> int:
+        return self.layer_ref.layer_id
+
+    def __eq__(self, other) -> bool:
+        return self.layer_ref.layer_id == other.layer_ref.layer_id
 
 
 class ChunkRequest:
@@ -64,15 +61,16 @@ class ChunkRequest:
 
     Parameters
     ----------
-    key : ChunkKey
-        The key of the request.
+    location : ChunkLocation
+        The location of this chunk. Probably a class derived from ChunkLocation
+        such as ImageLocation or OctreeLocation.
     chunks : Dict[str, ArrayLike]
         One or more arrays that we need to load.
 
     Attributes
     ----------
-    key : ChunkKey
-        The key of the request.
+    location : ChunkLocation
+        The location of the chunks.
     chunks : Dict[str, ArrayLike]
         One or more arrays that we need to load.
     create_time : float
@@ -81,16 +79,15 @@ class ChunkRequest:
         Timing information about chunk load time.
     """
 
-    def __init__(self, key: ChunkKey, chunks: Dict[str, ArrayLike]):
-        # Make sure chunks dict is what we expect.
+    def __init__(self, location: ChunkLocation, chunks: Dict[str, ArrayLike]):
+        # Make sure chunks dict is valid.
         for chunk_key, array in chunks.items():
             assert isinstance(chunk_key, str)
             assert array is not None
 
-        self.key = key
+        self.location = location
         self.chunks = chunks
 
-        # TODO_OCTREE: Use time.time() or perf_counter_ns here?
         self.create_time = time.time()
         self._timers: Dict[str, PerfEvent] = {}
 
@@ -117,17 +114,6 @@ class ChunkRequest:
         return sum(
             perf_timer.duration_ms for perf_timer in self._timers.values()
         )
-
-    @property
-    def data_id(self) -> int:
-        """Return the data_id for this request.
-
-        Return
-        ------
-        int
-            The data_id for this request.
-        """
-        return self.key.layer_key.data_id
 
     @property
     def num_chunks(self) -> int:

--- a/napari/components/experimental/chunk/_request.py
+++ b/napari/components/experimental/chunk/_request.py
@@ -48,12 +48,16 @@ class ChunkLocation:
     def __init__(self, layer_ref: LayerRef):
         self.layer_ref = layer_ref
 
+    def __eq__(self, other) -> bool:
+        return self.layer_ref.layer_id == other.layer_ref.layer_id
+
     @property
     def layer_id(self) -> int:
         return self.layer_ref.layer_id
 
-    def __eq__(self, other) -> bool:
-        return self.layer_ref.layer_id == other.layer_ref.layer_id
+    @classmethod
+    def from_layer(cls, layer):
+        return cls(LayerRef.from_layer(layer))
 
 
 class ChunkRequest:

--- a/napari/components/experimental/chunk/_request.py
+++ b/napari/components/experimental/chunk/_request.py
@@ -37,10 +37,10 @@ class ChunkKey:
 
     def __init__(self, layer_key: LayerKey):
         self.layer_key = layer_key
-        self.key = hash(self._get_hash_values())
+        self.key = hash(self.get_hash_values())
 
-    def _get_hash_values(self):
-        return self.layer_key._get_hash_values()
+    def get_hash_values(self):
+        return self.layer_key.get_hash_values()
 
     def __str__(self):
         layer_key = self.layer_key

--- a/napari/components/experimental/chunk/_tests/test_chunk.py
+++ b/napari/components/experimental/chunk/_tests/test_chunk.py
@@ -1,12 +1,11 @@
 """Tests for components.experimental.chunk."""
-import weakref
-
 import numpy as np
 import pytest
 
 from napari.components.experimental.chunk import (
     ChunkLocation,
     ChunkRequest,
+    LayerRef,
     chunk_loader,
 )
 from napari.layers.image import Image
@@ -24,24 +23,16 @@ def test_base_location():
     The base ChunkLocation is not really used, only the derived
     ImageLocation and OctreeLocation are, but test it anyway.
     """
-    layer1 = _create_layer()
-    layer2 = _create_layer()
+    layer_ref1 = LayerRef.from_layer(_create_layer())
+    layer_ref2 = LayerRef.from_layer(_create_layer())
 
-    location1a = ChunkLocation(layer1)
-    location1b = ChunkLocation(layer1)
-    location2 = ChunkLocation(layer2)
+    location1a = ChunkLocation(layer_ref1)
+    location1b = ChunkLocation(layer_ref1)
+    location2 = ChunkLocation(layer_ref2)
 
     assert location1a == location1b
     assert location1a != location2
     assert location1b != location2
-
-    # Check attributes.
-    assert location1a.layer_id == id(layer1)
-    assert location1a.layer_ref == weakref.ref(layer1)
-    assert location1b.layer_id == id(layer1)
-    assert location1b.layer_ref == weakref.ref(layer1)
-    assert location2.layer_id == id(layer2)
-    assert location2.layer_ref == weakref.ref(layer2)
 
 
 @pytest.mark.async_only

--- a/napari/components/experimental/chunk/_utils.py
+++ b/napari/components/experimental/chunk/_utils.py
@@ -1,12 +1,9 @@
 """ChunkLoader utilities.
 """
-import weakref
-from typing import NamedTuple, Optional
+from typing import Optional
 
 import dask.array as da
 import numpy as np
-
-from .layer_key import LayerKey
 
 
 def _get_type_str(data) -> str:
@@ -32,40 +29,6 @@ def _get_type_str(data) -> str:
 
     # For class numpy.ndarray this returns "ndarray"
     return data_type.__name__
-
-
-class LayerRef(NamedTuple):
-    """Weak reference to a layer.
-
-    We do not want to hold a reference in case the later is deleted while
-    a load is in progress. We want to let the layer get deleted, and
-    when the load finishes we'll just throw it away. Since its layer is done.
-
-    Attributes
-    ----------
-    layer_id : int
-        The id of the layer.
-    reference : weakref.ReferenceType
-        A weak reference to the layer
-    data_type : str
-        String describing the data type the layer holds.
-    """
-
-    layer_key: LayerKey
-    weak_ref: weakref.ReferenceType
-    data_type: str
-
-    @classmethod
-    def create_from_layer(cls, layer, indices):
-        """Return a LayerRef created from this layer.
-
-        Parameters
-        ----------
-        layer
-            Create the LayerRef from this layer.
-        """
-        layer_key = LayerKey.from_layer(layer, indices)
-        return cls(layer_key, weakref.ref(layer), _get_type_str(layer.data))
 
 
 class StatWindow:

--- a/napari/components/experimental/chunk/layer_key.py
+++ b/napari/components/experimental/chunk/layer_key.py
@@ -53,7 +53,7 @@ class LayerKey(NamedTuple):
     data_level: int
     indices: Tuple[Optional[slice], ...]
 
-    def _get_hash_values(self):
+    def get_hash_values(self):
         return (
             self.layer_id,
             self.data_id,

--- a/napari/components/experimental/commands.py
+++ b/napari/components/experimental/commands.py
@@ -9,6 +9,16 @@ experimental.cmds.loader
 
 
 class CommandProcessor:
+    """Container for the LoaderCommand.
+
+    Implements the console command "viewer.experimental.cmds.loader".
+
+    Parameters
+    ----------
+    layers
+        The viewer's layers.
+    """
+
     def __init__(self, layers):
         self.layers = layers
 
@@ -23,6 +33,16 @@ class CommandProcessor:
 
 
 class ExperimentalNamespace:
+    """Container for the CommandProcessor.
+
+    Implements the console command "viewer.experimental.cmds".
+
+    Parameters
+    ----------
+    layers
+        The viewer's layers.
+    """
+
     def __init__(self, layers):
         self.layers = layers
 

--- a/napari/components/experimental/commands.py
+++ b/napari/components/experimental/commands.py
@@ -24,6 +24,7 @@ class CommandProcessor:
 
     @property
     def loader(self):
+        """The loader related commands."""
         from .chunk._commands import LoaderCommands
 
         return LoaderCommands(self.layers)
@@ -48,6 +49,7 @@ class ExperimentalNamespace:
 
     @property
     def cmds(self):
+        """All experimental commands."""
         return CommandProcessor(self.layers)
 
     def __repr__(self):

--- a/napari/layers/image/experimental/__init__.py
+++ b/napari/layers/image/experimental/__init__.py
@@ -1,7 +1,6 @@
 """layers.image.experimental
 """
-from .octree_chunk import OctreeChunk, OctreeChunkGeom, OctreeChunkKey
+from .octree_chunk import OctreeChunk, OctreeChunkGeom, OctreeLocation
 from .octree_intersection import OctreeIntersection
 from .octree_level import OctreeLevel
-from .octree_tile_builder import create_multi_scale
-from .octree_util import SliceConfig, TestImageSettings
+from .octree_util import OctreeInfo, TestImageSettings

--- a/napari/layers/image/experimental/__init__.py
+++ b/napari/layers/image/experimental/__init__.py
@@ -3,4 +3,4 @@
 from .octree_chunk import OctreeChunk, OctreeChunkGeom, OctreeLocation
 from .octree_intersection import OctreeIntersection
 from .octree_level import OctreeLevel
-from .octree_util import OctreeInfo, TestImageSettings
+from .octree_util import TestImageSettings

--- a/napari/layers/image/experimental/_chunk_set.py
+++ b/napari/layers/image/experimental/_chunk_set.py
@@ -1,6 +1,6 @@
 """ChunkSet class.
 
-Used by the OctreeChunkLoader.
+Used by the OctreeLoader.
 """
 from typing import Dict, List, Set
 
@@ -11,7 +11,7 @@ class ChunkSet:
     """A set of chunks with fast location membership test.
 
     We use a dict as an ordered set, and then a set with just the locations
-    so OctreeChunkLoader._cancel_futures() can quickly test if a location is
+    so OctreeLoader._cancel_futures() can quickly test if a location is
     in the set.
     """
 

--- a/napari/layers/image/experimental/_chunked_image_loader.py
+++ b/napari/layers/image/experimental/_chunked_image_loader.py
@@ -3,9 +3,9 @@
 import logging
 from typing import Optional
 
-from ....components.experimental.chunk import ChunkKey, LayerKey
 from .._image_loader import ImageLoader
 from ._chunked_slice_data import ChunkedSliceData
+from ._image_location import ImageLocation
 
 LOGGER = logging.getLogger("napari.loader")
 
@@ -15,13 +15,13 @@ class ChunkedImageLoader(ImageLoader):
 
     Attributes
     ----------
-    current_key : Optional[ChunkKey]
-        The ChunkKey we are currently loading or showing.
+    _current : Optional[ImageLocation]
+        The location we are currently loading or showing.
     """
 
     def __init__(self):
         # We're showing nothing to start.
-        self.current_key: Optional[ChunkKey] = None
+        self._current: Optional[ImageLocation] = None
 
     def load(self, data: ChunkedSliceData) -> bool:
         """Load this ChunkedSliceData (sync or async).
@@ -36,21 +36,19 @@ class ChunkedImageLoader(ImageLoader):
         bool
             True if load happened synchronously.
         """
-        layer = data.layer
-        layer_key = LayerKey.from_layer(layer, data.indices)
-        key = ChunkKey(layer_key)
+        location = ImageLocation(data.layer, data.indices)
 
-        LOGGER.debug("ChunkedImageLoader.load: %s", key)
+        LOGGER.debug("ChunkedImageLoader.load")
 
-        if self.current_key is not None and self.current_key == key:
+        if self._current is not None and self._current == location:
             # We are already showing this slice, or its being loaded
-            # asynchronously. TODO_ASYNC: does this still happen?
+            # asynchronously.
             return False
 
         # Now "showing" this slice, even if it hasn't loaded yet.
-        self.current_key = key
+        self._current = location
 
-        if data.load_chunks(key):
+        if data.load_chunks():
             return True  # Load was sync, load is done.
 
         return False  # Load was async, so not loaded yet.
@@ -68,14 +66,12 @@ class ChunkedImageLoader(ImageLoader):
         bool
             Return True if data matches.
         """
-        key = data.request.key
+        location = data.request.location
 
-        if self.current_key == key:
-            LOGGER.debug("ChunkedImageLoader.match: accept %s", key)
+        if self._current == location:
+            LOGGER.debug("ChunkedImageLoader.match: accept %s", location)
             return True
 
-        # Probably we are scrolling through slices and we are no longer
-        # showing this slice, so drop it. Even if we don't use it, it
-        # should get into the cache, so the load wasn't totally wasted.
-        LOGGER.debug("ChunkedImageLoader.match: reject %s", key)
+        # Data was for a slice we are no longer looking at.
+        LOGGER.debug("ChunkedImageLoader.match: reject %s", location)
         return False

--- a/napari/layers/image/experimental/_chunked_slice_data.py
+++ b/napari/layers/image/experimental/_chunked_slice_data.py
@@ -3,15 +3,11 @@
 import logging
 from typing import Optional
 
-from ....components.experimental.chunk import (
-    ChunkKey,
-    ChunkRequest,
-    LayerRef,
-    chunk_loader,
-)
+from ....components.experimental.chunk import ChunkRequest, chunk_loader
 from ....types import ArrayLike
 from ...base import Layer
 from .._image_slice_data import ImageSliceData
+from ._image_location import ImageLocation
 
 LOGGER = logging.getLogger("napari.loader")
 
@@ -56,13 +52,8 @@ class ChunkedSliceData(ImageSliceData):
         self.request = request
         self.thumbnail_image = None
 
-    def load_chunks(self, key: ChunkKey) -> bool:
+    def load_chunks(self) -> bool:
         """Load this slice data's chunks sync or async.
-
-        Parameters
-        ----------
-        key : ChunkKey
-            The key for the chunks we are going to load.
 
         Return
         ------
@@ -76,11 +67,21 @@ class ChunkedSliceData(ImageSliceData):
         if self.thumbnail_source is not None:
             chunks['thumbnail_source'] = self.thumbnail_source
 
-        # Create the ChunkRequest and load it with the ChunkLoader.
-        layer_ref = LayerRef.create_from_layer(self.layer, self.indices)
-        self.request = chunk_loader.create_request(layer_ref, key, chunks)
+        def _should_cancel(chunk_request: ChunkRequest) -> bool:
+            """Cancel any requests for this same data_id.
 
-        satisfied_request = chunk_loader.load_chunk(self.request)
+            The must be requests for other slices, but we only ever show
+            one slice at a time, so they are stale.
+            """
+            return chunk_request.location.data_id == id(self.image)
+
+        # Cancel loads for any other data_id/slice besides this one.
+        chunk_loader.cancel_requests(_should_cancel)
+
+        # Create the request and load it.
+        location = ImageLocation(self.layer, self.indices)
+        self.request = ChunkRequest(location, chunks)
+        satisfied_request = chunk_loader.load_request(self.request)
 
         if satisfied_request is None:
             return False  # Load was async.
@@ -103,7 +104,7 @@ class ChunkedSliceData(ImageSliceData):
         request : ChunkRequest
             The request that was loaded.
         """
-        indices = request.key.layer_key.indices
+        indices = request.location.indices
         image = request.chunks.get('image')
         thumbnail_slice = request.chunks.get('thumbnail_slice')
         return cls(layer, indices, image, thumbnail_slice, request)

--- a/napari/layers/image/experimental/_chunked_slice_data.py
+++ b/napari/layers/image/experimental/_chunked_slice_data.py
@@ -80,8 +80,7 @@ class ChunkedSliceData(ImageSliceData):
         layer_ref = LayerRef.create_from_layer(self.layer, self.indices)
         self.request = chunk_loader.create_request(layer_ref, key, chunks)
 
-        LOGGER.debug("ChunkedSliceData calling chunk_loader.load_chunk")
-        satisfied_request, _future = chunk_loader.load_chunk(self.request)
+        satisfied_request = chunk_loader.load_chunk(self.request)
 
         if satisfied_request is None:
             return False  # Load was async.

--- a/napari/layers/image/experimental/_image_location.py
+++ b/napari/layers/image/experimental/_image_location.py
@@ -4,6 +4,8 @@ ImageLocation is the pre-octree Image class's ChunkLocation. When we request
 that the ChunkLoader load a chunk, we use this ChunkLocation to identify
 the chunk we are requesting and once it's loaded.
 """
+import numpy as np
+
 from ....components.experimental.chunk import ChunkLocation, LayerRef
 from ....layers import Layer
 
@@ -50,13 +52,23 @@ class ImageLocation(ChunkLocation):
         self.data_level: int = layer._data_level
         self.indices = indices
 
+    def __str__(self):
+        return f"location=({self.data_id}, {self.data_level}, {self.indices}) "
+
     def __eq__(self, other) -> bool:
         return (
             super().__eq__(other)
             and self.data_id == other.data_id
             and self.data_level == other.data_level
-            and self.indices == other.indices
+            and self._same_indices(other)
         )
+
+    def _same_indices(self, other):
+        # TODO_OCTREE: Why is this sometimes ndarray and sometimes not?
+        # We should normalize when the ImageLocation is constructed?
+        if isinstance(self.indices, np.ndarray):
+            return (self.indices == other.indices).all()
+        return self.indices == other.indices
 
     def __hash__(self) -> int:
         return hash(

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -3,13 +3,16 @@
 Uses ChunkLoader to load data into OctreeChunks in the octree.
 """
 import logging
-from concurrent.futures import Future
-from typing import Dict, List, Set
+from typing import List, Set
 
-from ....components.experimental.chunk import LayerRef, chunk_loader
+from ....components.experimental.chunk import (
+    ChunkRequest,
+    LayerRef,
+    chunk_loader,
+)
 from ._chunk_set import ChunkSet
 from .octree import Octree
-from .octree_chunk import OctreeChunk, OctreeChunkKey, OctreeLocation
+from .octree_chunk import OctreeChunk, OctreeLocation
 
 LOGGER = logging.getLogger("napari.octree.loader")
 LOADER = logging.getLogger("napari.loader.futures")
@@ -60,27 +63,24 @@ class OctreeChunkLoader:
     Parameters
     ----------
     octree : Octree
-        The octree we are loading chunks for, and that we are drawing.
+        We are loading chunks for this octree.
     layer_ref : LayerRef
-        A weak reference to the layer we are loading chunks for.
+        A weak reference to the layer the octree lives in.
 
     Attributes
     ----------
-    _futures : Future
-        Futures for chunks which are loading or queued for loading.
-    _last_seen : Set[OctreeLocation]
-        What did we see last frame. Only for logging.
+    _octree : Octree
+        We are loading chunks for this octree.
+    _layer_ref : LayerRef
+        A weak reference to the layer the octree lives in.
     """
 
     def __init__(self, octree: Octree, layer_ref: LayerRef):
         self._octree = octree
         self._layer_ref = layer_ref
 
-        self._futures: Dict[OctreeLocation, Future] = {}
-        self._last_seen: ChunkSet = ChunkSet()
-
     def get_drawable_chunks(
-        self, drawn_set: Set[OctreeChunkKey], ideal_chunks: List[OctreeChunk],
+        self, drawn_set: Set[OctreeChunk], ideal_chunks: List[OctreeChunk],
     ) -> List[OctreeChunk]:
         """Return the chunks that should be drawn.
 
@@ -113,7 +113,7 @@ class OctreeChunkLoader:
 
         Parameters
         ----------
-        drawn_chunk_set : Set[OctreeChunkKey]
+        drawn_chunk_set : Set[OctreeChunk]
             The chunks which the visual is currently drawing.
         ideal_chunks : List[OctreeChunk]
             The chunks which are visible to the current view.
@@ -148,14 +148,12 @@ class OctreeChunkLoader:
         # better to see them first, even though they are lower resolution.
         seen.add(ideal_chunks)
 
-        # Cancel all futures (in progress loads) that are no longer seen
-        # chunks. When panning or zooming quickly we create and cancel a
-        # *lot* of futures. Which is fine, it's pretty fast, and we very
-        # much want to avoid loading chunks that we no long need.
-        self._cancel_futures(seen)
-
-        # Save off these for next time, only for logging purposes.
-        self._last_seen = seen
+        # Cancel in-progress loads for any chunks we can no long see. When
+        # panning or zooming rapidly, it's very common that chunks fall out
+        # of view before the load was even started. We need to cancel those
+        # loads or it will tie up the loader loading chunks we aren't even
+        # going to display.
+        self._cancel_unseen(seen)
 
         drawable = []
 
@@ -166,31 +164,10 @@ class OctreeChunkLoader:
             elif chunk.needs_load and self._load_chunk(chunk):
                 drawable.append(chunk)  # It was a sync load, ready to draw.
 
-        # Useful for debugging but spammy.
+        # Useful for debugging but very spammy.
         # log_chunks("drawable", drawable)
-        # self._log_futures()
 
         return drawable
-
-    def _seen_changed(self, drawable: Set[OctreeChunk]) -> bool:
-        """Return True if the locations we are drawing changed.
-
-        Parameters
-        ----------
-        drawable : Set[OctreeChunk]
-            The chunks we are going to draw.
-
-        Return
-        ------
-        bool
-            True if the locations we are drawing changed.
-        """
-        # If different sizes there was definitively a change!
-        if len(drawable) != len(self._last_seen):
-            return True
-
-        # Return True only if there was a change in the set.
-        return drawable != self._last_drawable
 
     def _get_permanent_chunks(self) -> List[OctreeChunk]:
         """Get any permanent chunks we want to always draw.
@@ -214,7 +191,7 @@ class OctreeChunkLoader:
         return [root_tile]
 
     def _get_coverage(
-        self, ideal_chunk: OctreeChunk, drawn_set: Set[OctreeChunkKey]
+        self, ideal_chunk: OctreeChunk, drawn_set: Set[OctreeChunk]
     ) -> List[OctreeChunk]:
         """Return the chunks to draw for this one ideal chunk.
 
@@ -236,7 +213,7 @@ class OctreeChunkLoader:
         ----------
         ideal_chunk : OctreeChunk
             The ideal chunk we'd like to draw.
-        drawn_set : Set[OctreeChunkKey]
+        drawn_set : Set[OctreeChunk]
             The chunks which the visual is currently drawing.
 
         Return
@@ -247,7 +224,7 @@ class OctreeChunkLoader:
 
         # If the ideal chunk is already being drawn, that's all we need,
         # there is no point in returning more than that.
-        if ideal_chunk.in_memory and ideal_chunk.key in drawn_set:
+        if ideal_chunk.in_memory and ideal_chunk in drawn_set:
             return [ideal_chunk]
 
         # Get alternates for this chunk, from other levels.
@@ -266,10 +243,10 @@ class OctreeChunkLoader:
         # best user experience is to see imagery quickly even if not at the
         # ideal level.
         def keep_chunk(chunk) -> bool:
-            lower = chunk.location.level_index < ideal_level_index
+            lower_level = chunk.location.level_index < ideal_level_index
 
-            if lower:
-                return chunk.key in drawn_set
+            if lower_level:
+                return chunk in drawn_set
 
             return True  # Keep all higher level chunks.
 
@@ -320,10 +297,6 @@ class OctreeChunkLoader:
         assert not octree_chunk.in_memory
         assert not octree_chunk.loading
 
-        # Create a key that points to this specific location in the octree.
-        layer_key = self._layer_ref.layer_key
-        key = OctreeChunkKey(layer_key, octree_chunk.location)
-
         # The ChunkLoader takes a dict of chunks that should be loaded at
         # the same time. Today we only ever ask it to a load a single chunk
         # at a time. In the future we might want to load multiple layers at
@@ -335,124 +308,68 @@ class OctreeChunkLoader:
         octree_chunk.loading = True
 
         # Create the ChunkRequest and load it with the ChunkLoader.
-        request = chunk_loader.create_request(self._layer_ref, key, chunks)
-        satisfied_request, future = chunk_loader.load_chunk(request)
+        request = ChunkRequest(octree_chunk.location, chunks)
+        satisfied_request = chunk_loader.load_request(request)
 
-        if satisfied_request is not None:
-            # The load was synchronous. Some situations were the
-            # ChunkLoader loads synchronously:
-            #
-            # 1) The force_synchronous config option is set.
-            # 2) The data already was an ndarray, there's nothing to "load".
-            # 3) The data is Dask or similar, but based on past loads it's
-            #    loading so quickly that we decided to load it synchronously.
-            # 4) The data is Dask or similar, but we already loaded this
-            #    exact chunk before, so it was in the cache.
-            #
+        if satisfied_request is None:
+            # An async load was initiated. The load will probably happen in a
+            # worker thread. When the load completes QtChunkReceiver will call
+            # OctreeImage.on_chunk_loaded() with the data.
+            return False
 
-            # Whatever the reason, the data is now ready to draw.
-            octree_chunk.data = satisfied_request.chunks.get('data')
-            assert octree_chunk.in_memory
+        # The load was synchronous. Some situations were the
+        # ChunkLoader loads synchronously:
+        #
+        # 1) The force_synchronous config option is set.
+        # 2) The data already was an ndarray, there's nothing to "load".
+        # 3) The data is Dask or similar, but based on past loads it's
+        #    loading so quickly that we decided to load it synchronously.
+        # 4) The data is Dask or similar, but we already loaded this
+        #    exact chunk before, so it was in the cache.
+        #
 
-            # The chunk as been loaded. It can be a drawable chunk that we
-            # return to the visual.
-            return True
+        # Whatever the reason, the data is now ready to draw.
+        octree_chunk.data = satisfied_request.chunks.get('data')
 
-        # An async load was initiated. The load will probably happen in a
-        # worker thread. When the load completes QtChunkReceiver will call
-        # OctreeImage.on_chunk_loaded() with the data.
+        # The chunk has been loaded, it's now a drawable chunk.
+        assert octree_chunk.in_memory
+        return True
 
-        # We save the future in case we need to cancel it if the camera
-        # move such that the chunk is no longer needed. We can only cancel
-        # the future if the worker thread has not started loading it.
-        assert future
-        self._futures[octree_chunk.location] = future
-
-        return False
-
-    def _log_futures(self) -> None:
-        """Log the futures we are currently tracking."""
-        LOGGER.debug("%d futures:", len(self._futures))
-        for i, location in enumerate(self._futures.keys()):
-            LOGGER.debug("Future %d: %s", i, location)
-
-    def _cancel_futures(self, seen: ChunkSet) -> None:
-        """Cancel futures not in the seen set.
-
-        Any futures no longer seen are stale. There is no point in loading
-        them. So we cancel them. If a worker has already started on the
-        load we can't cancel it, but that chunk will be ignored when it
-        does load.
+    def _cancel_unseen(self, seen: ChunkSet) -> None:
+        """Cancel in-progress loads not in the seen set.
 
         Parameters
         ----------
         seen : ChunkSet
             The set of chunks the loader can see.
         """
-        before = len(self._futures)
 
-        if before == 0:
-            return
+        def _should_cancel(chunk_request: ChunkRequest) -> bool:
+            """Cancel if we are no longer seeing this location."""
+            return not seen.has_location(chunk_request.location)
 
-        # Iterate through every future.
-        for location, future in list(self._futures.items()):
-            # If the location was not seen by the current view.
-            if not seen.has_location(location):
-                # Cancel the load. If Future.cancel() returns False, a
-                # worker has alreadying started loading it and we can't
-                # cancel it.
-                if future.cancel():
-                    self._cancel_load(location)
+        cancelled = chunk_loader.cancel_requests(_should_cancel)
 
-    def _cancel_load(self, location: OctreeLocation) -> None:
-        """Set that this chunk is no longer loading.
+        for request in cancelled:
+            self._on_cancel_request(request.location)
+
+    def _on_cancel_request(self, location: OctreeLocation) -> None:
+        """Request for this location was cancelled.
 
         Parameters
         ----------
-        chunk : OctreeChunk
+        location : OctreeLocation
             Set that this chunk is no longer loading.
         """
-        try:
-            del self._futures[location]
-        except KeyError:
-            # Our self.on_chunk_loaded might have been called even
-            # while we were iterating! In which case the future
-            # might no longer exist. Log for now, but not an error.
-            LOGGER.warning("_cancel_load: Missing future %s", location)
-
-        # Don't create the chunk, but it ought to be there since there was
-        # a load in progress.
+        # Get chunk for this location, don't create the chunk, but it ought
+        # to be there since there was a load in progress.
         chunk: OctreeChunk = self._octree.get_chunk_at_location(
             location, create=False
         )
 
         if chunk is None:
             LOADER.error("_cancel_load: Chunk did not exist %s", location)
-        else:
-            chunk.loading = False
+            return
 
-    def on_chunk_loaded(self, octree_chunk: OctreeChunk) -> None:
-        """The given OctreeChunk was loaded.
-
-        Clear out this chunks future since it's been satisfied.
-
-        Parameters
-        ----------
-        octree_chunk : OctreeChunk
-            The octree chunk that was loaded.
-        """
-        location = octree_chunk.location
-
-        try:
-            del self._futures[location]
-            LOADER.debug(
-                "on_chunk_loaded %s num_features=%d",
-                location,
-                len(self._futures),
-            )
-
-        except KeyError:
-            # This can happen if the location went out of view and the
-            # future was deleted in self._cancel_futures. Log for now
-            # but it's really not an error at all.
-            LOGGER.debug("on_chunk_loaded: Missing Future %s", location)
+        # Chunk is no longer loading.
+        chunk.loading = False

--- a/napari/layers/image/experimental/_octree_chunk_loader.py
+++ b/napari/layers/image/experimental/_octree_chunk_loader.py
@@ -418,7 +418,7 @@ class OctreeChunkLoader:
             # Our self.on_chunk_loaded might have been called even
             # while we were iterating! In which case the future
             # might no longer exist. Log for now, but not an error.
-            LOGGER.warn("_cancel_load: Missing future %s", location)
+            LOGGER.warning("_cancel_load: Missing future %s", location)
 
         # Don't create the chunk, but it ought to be there since there was
         # a load in progress.

--- a/napari/layers/image/experimental/_octree_loader.py
+++ b/napari/layers/image/experimental/_octree_loader.py
@@ -1,4 +1,4 @@
-"""OctreeChunkLoader class.
+"""OctreeLoader class.
 
 Uses ChunkLoader to load data into OctreeChunks in the octree.
 """
@@ -24,7 +24,7 @@ LOADER = logging.getLogger("napari.loader.futures")
 NUM_ANCESTORS_LEVELS = 3
 
 
-class OctreeChunkLoader:
+class OctreeLoader:
     """Load data into OctreeChunks in the octree.
 
     The loader is given drawn_set, the chunks we are currently drawing, and

--- a/napari/layers/image/experimental/_octree_multiscale_slice.py
+++ b/napari/layers/image/experimental/_octree_multiscale_slice.py
@@ -11,7 +11,7 @@ import numpy as np
 from ....components.experimental.chunk import ChunkRequest, LayerRef
 from ....types import ArrayLike
 from .._image_view import ImageView
-from ._octree_chunk_loader import OctreeChunkLoader
+from ._octree_loader import OctreeLoader
 from .octree import Octree
 from .octree_chunk import OctreeChunk, OctreeLocation
 from .octree_intersection import OctreeIntersection, OctreeView
@@ -35,7 +35,7 @@ class OctreeMultiscaleSlice:
 
     Attributes
     ----------
-    loader : OctreeChunkLoader
+    loader : OctreeLoader
         Uses the napari ChunkLoader to load OctreeChunks.
 
     """
@@ -53,9 +53,7 @@ class OctreeMultiscaleSlice:
         slice_id = id(self)
         self._octree = Octree(slice_id, data, meta)
 
-        self.loader: OctreeChunkLoader = OctreeChunkLoader(
-            self._octree, layer_ref
-        )
+        self.loader: OctreeLoader = OctreeLoader(self._octree, layer_ref)
 
         thumbnail_image = np.zeros(
             (64, 64, 3)

--- a/napari/layers/image/experimental/_octree_slice.py
+++ b/napari/layers/image/experimental/_octree_slice.py
@@ -1,4 +1,4 @@
-"""OctreeMultiscaleSlice class.
+"""OctreeSlice class.
 
 For viewing one slice of a multiscale image using an octree.
 """
@@ -21,7 +21,7 @@ from .octree_util import OctreeMetadata
 LOGGER = logging.getLogger("napari.octree.slice")
 
 
-class OctreeMultiscaleSlice:
+class OctreeSlice:
     """View a slice of an multiscale image using an octree.
 
     Parameters

--- a/napari/layers/image/experimental/_tests/test_location.py
+++ b/napari/layers/image/experimental/_tests/test_location.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+from napari.layers.image import Image
+from napari.layers.image.experimental._image_location import ImageLocation
+
+
+def _create_layer() -> Image:
+    """Return a small random Image layer."""
+    data = np.random.random((32, 16))
+    return Image(data)
+
+
+def test_image_location():
+    """Test the pre-octree ImageLocation class.
+
+    An ImageLocation is just BaseLocation plus indices.
+    """
+
+    layer1 = _create_layer()
+    layer2 = _create_layer()
+
+    locations1_0 = (
+        ImageLocation(layer1, (0, 0)),
+        ImageLocation(layer1, (0, 0)),
+    )
+
+    locations1_1 = (
+        ImageLocation(layer1, (0, 1)),
+        ImageLocation(layer1, (0, 1)),
+    )
+
+    locations2_0 = (
+        ImageLocation(layer2, (0, 0)),
+        ImageLocation(layer2, (0, 0)),
+    )
+
+    locations2_1 = (
+        ImageLocation(layer2, (0, 1)),
+        ImageLocation(layer2, (0, 1)),
+    )
+
+    # All identical pairs should be the same.
+    assert locations1_0[0] == locations1_0[1]
+    assert locations1_1[0] == locations1_1[1]
+    assert locations2_0[0] == locations2_0[1]
+    assert locations2_1[0] == locations2_1[1]
+
+    # Nothing else should be the same
+    for i in range(0, 2):
+        assert locations1_0[i] != locations1_1[i]
+        assert locations1_0[i] != locations2_0[i]
+        assert locations1_0[i] != locations2_1[i]

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -28,7 +28,7 @@ class OctreeLocation(ChunkLocation):
     Parameters
     ----------
     slice_id : int
-        The id of the OctreeMultiscaleSlice we are in.
+        The id of the OctreeSlice we are in.
     level_index : int
         The octree level index.
     row : int

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -1,11 +1,11 @@
-"""OctreeChunk class
+"""OctreeLocation and OctreeChunk classes.
 """
 import logging
 from typing import List, NamedTuple
 
 import numpy as np
 
-from ....components.experimental.chunk import ChunkKey, LayerKey
+from ....components.experimental.chunk import ChunkLocation, LayerRef
 from ....types import ArrayLike
 
 LOGGER = logging.getLogger("napari.octree")
@@ -15,23 +15,41 @@ class OctreeChunkGeom(NamedTuple):
     """Position and scale of the chunk, for rendering.
 
     Stored in the OctreeChunk so that we calculate them just once
-    at OctreeChunk creation time.
+    at OctreeChunk creation time. So the visual does not have to.
     """
 
     pos: np.ndarray
     scale: np.ndarray
 
 
-class OctreeLocation(NamedTuple):
+class OctreeLocation(ChunkLocation):
     """Location of one chunk within the octree.
 
-    Part of the OctreeChunkKey to uniquely identify a chunk.
+    Parameters
+    ----------
+    slice_id : int
+        The id of the OctreeMultiscaleSlice we are in.
+    level_index : int
+        The octree level index.
+    row : int
+        The chunk row.
+    col : int
+        The chunk col.
     """
 
-    slice_id: int
-    level_index: int
-    row: int
-    col: int
+    def __init__(
+        self,
+        layer_ref: LayerRef,
+        slice_id: int,
+        level_index: int,
+        row: int,
+        col: int,
+    ):
+        super().__init__(layer_ref)
+        self.slice_id: int = slice_id
+        self.level_index: int = level_index
+        self.row: int = row
+        self.col: int = col
 
     def __str__(self):
         return f"location=({self.level_index}, {self.row}, {self.col}) "
@@ -47,44 +65,6 @@ class OctreeLocation(NamedTuple):
     def __hash__(self) -> int:
         return hash((self.slice_id, self.level_index, self.row, self.col))
 
-    @classmethod
-    def create_null(cls):
-        """Create null location that points to nothing."""
-        return cls(0, 0, 0, 0, np.zeros(0), np.zeros(0))
-
-
-class OctreeChunkKey(ChunkKey):
-    """A ChunkKey plus some octree specific fields.
-
-    The ChunkLoader uses ChunkKey to identify chunks, for example for
-    caching or just tracking what has been loaded.
-
-    Parameters
-    ----------
-    layer : Layer
-        The OctreeImage layer.
-    indices : Tuple[Optional[slice], ...]
-        The indices of the image we are viewing.
-    location : OctreeLocation
-        The location of the chunk within the octree.
-    """
-
-    def __init__(
-        self, layer_key: LayerKey, location: OctreeLocation,
-    ):
-        self._location = location
-        super().__init__(layer_key)
-
-    @property
-    def location(self):
-        return self._location
-
-    def get_hash_values(self):
-        # TODO_OCTREE: can't we just hash in the parent's hashed key with
-        # our additional values? Probably, but we do it from scratch here.
-        parent = super().get_hash_values()
-        return parent + (self.location,)
-
 
 class OctreeChunk:
     """A geographically meaningful portion of the full 2D or 3D image.
@@ -92,9 +72,9 @@ class OctreeChunk:
     For 2D images a chunk is a "tile". It's a 2D square region of pixels
     which are part of the full 2D image.
 
-    If it's in level 0 of the octree, the pixels are 1:1 identical to the
-    full image. If it's in level 1 or greater the pixels are downsampled
-    from the full resolution image.
+    For level 0 of the octree, the pixels are 1:1 identical to the full
+    image. For level 1 or greater the pixels are downsampled from the full
+    resolution image.
 
     For 3D, not yet implemented, a chunk is a sub-volume. Again for level 0
     the voxels are at the full resolution of the full image, but for other
@@ -164,19 +144,6 @@ class OctreeChunk:
         # Assign and note the loading process has now finished.
         self._data = data
         self.loading = False
-
-    @property
-    def key(self) -> OctreeChunkKey:
-        """The unique key for this chunk.
-
-        TODO_OCTREE: Switch to __hash__? Tried __hash__ a while ago and ran
-        into problems, but maybe try again.
-        """
-        return (
-            self.geom.pos[0],
-            self.geom.pos[1],
-            self.location.level_index,
-        )
 
     @property
     def in_memory(self) -> bool:

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -79,10 +79,10 @@ class OctreeChunkKey(ChunkKey):
     def location(self):
         return self._location
 
-    def _get_hash_values(self):
+    def get_hash_values(self):
         # TODO_OCTREE: can't we just hash in the parent's hashed key with
         # our additional values? Probably, but we do it from scratch here.
-        parent = super()._get_hash_values()
+        parent = super().get_hash_values()
         return parent + (self.location,)
 
 

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -11,7 +11,7 @@ import numpy as np
 from ....components.experimental.chunk import ChunkRequest, LayerRef
 from ....utils.events import Event
 from ..image import Image
-from ._octree_multiscale_slice import OctreeMultiscaleSlice, OctreeView
+from ._octree_slice import OctreeSlice, OctreeView
 from .octree_chunk import OctreeChunk
 from .octree_intersection import OctreeIntersection
 from .octree_level import OctreeLevelInfo
@@ -56,12 +56,12 @@ class OctreeImage(Image):
     _view : OctreeView
         Describes a view frustum which implies what portion of the OctreeImage
         needs to be draw.
-    _slice : OctreeMultiscaleSlice
-        When _set_view_slice() is called we create a OctreeMultiscaleSlice()
+    _slice : OctreeSlice
+        When _set_view_slice() is called we create a OctreeSlice()
         that's looking at some specific slice of the data.
 
         While the Image._slice was the data that was drawn on the screen,
-        an OctreeMultiscaleSlice contains a full Octree. The OctreeImage
+        an OctreeSlice contains a full Octree. The OctreeImage
         visuals (VispyTiledImageLayer and TiledImageVisual) draw only
         the portion for OctreeImage which is visible in the OctreeView.
     _display : OctreeDisplayOptions
@@ -71,7 +71,7 @@ class OctreeImage(Image):
     def __init__(self, *args, **kwargs):
 
         self._view: OctreeView = None
-        self._slice: OctreeMultiscaleSlice = None
+        self._slice: OctreeSlice = None
         self._intersection: OctreeIntersection = None
         self._display = OctreeDisplayOptions()
 
@@ -441,13 +441,13 @@ class OctreeImage(Image):
             layer_ref, base_shape_2d, len(self.data), self._display.tile_size
         )
 
-        # OctreeMultiscaleSlice wants all the levels, but only the dimensions
+        # OctreeSlice wants all the levels, but only the dimensions
         # of each level that we are currently viewing.
         slice_data = [level_data[indices] for level_data in self.data]
         layer_ref = LayerRef.from_layer(self)
 
         # Create the slice, it will create the actual Octree.
-        self._slice = OctreeMultiscaleSlice(
+        self._slice = OctreeSlice(
             slice_data, layer_ref, meta, self._raw_to_displayed,
         )
 

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -12,10 +12,10 @@ from ....components.experimental.chunk import ChunkRequest, LayerRef
 from ....utils.events import Event
 from ..image import Image
 from ._octree_multiscale_slice import OctreeMultiscaleSlice, OctreeView
-from .octree_chunk import OctreeChunk, OctreeChunkKey
+from .octree_chunk import OctreeChunk
 from .octree_intersection import OctreeIntersection
 from .octree_level import OctreeLevelInfo
-from .octree_util import OctreeDisplayOptions, SliceConfig
+from .octree_util import OctreeDisplayOptions, OctreeMetadata
 
 LOGGER = logging.getLogger("napari.octree.image")
 
@@ -176,17 +176,17 @@ class OctreeImage(Image):
         return tile_shape
 
     @property
-    def slice_config(self) -> SliceConfig:
+    def meta(self) -> OctreeMetadata:
         """Return information about the current octree.
 
         Return
         ------
-        SliceConfig
-            Configuration information.
+        OctreeMetadata
+            Octree dimensions and other info.
         """
         if self._slice is None:
             return None
-        return self._slice.slice_config
+        return self._slice.meta
 
     @property
     def octree_level_info(self) -> OctreeLevelInfo:
@@ -264,7 +264,7 @@ class OctreeImage(Image):
         """
 
     def get_drawable_chunks(
-        self, drawn_set: Set[OctreeChunkKey]
+        self, drawn_set: Set[OctreeChunk]
     ) -> List[OctreeChunk]:
         """Get the chunks in the current slice which are drawable.
 
@@ -298,7 +298,7 @@ class OctreeImage(Image):
 
         Parameters
         -----------
-        drawn_chunk_set : Set[OctreeChunkKey]
+        drawn_chunk_set : Set[OctreeChunk]
             The chunks that are currently being drawn by the visual.
 
         Return
@@ -435,21 +435,20 @@ class OctreeImage(Image):
         base_shape = self.data[0].shape
         base_shape_2d = [base_shape[i] for i in self._dims_displayed]
 
-        slice_config = SliceConfig(
-            base_shape_2d, len(self.data), self._display.tile_size
+        layer_ref = LayerRef.from_layer(self)
+
+        meta = OctreeMetadata(
+            layer_ref, base_shape_2d, len(self.data), self._display.tile_size
         )
 
         # OctreeMultiscaleSlice wants all the levels, but only the dimensions
         # of each level that we are currently viewing.
         slice_data = [level_data[indices] for level_data in self.data]
-
-        # Create _layer_ref that matches the current indices and slice.
-        indices = self._get_slice_indices()
-        layer_ref = LayerRef.create_from_layer(self, indices)
+        layer_ref = LayerRef.from_layer(self)
 
         # Create the slice, it will create the actual Octree.
         self._slice = OctreeMultiscaleSlice(
-            slice_data, layer_ref, slice_config, self._raw_to_displayed,
+            slice_data, layer_ref, meta, self._raw_to_displayed,
         )
 
     def _get_slice_indices(self) -> tuple:
@@ -475,7 +474,7 @@ class OctreeImage(Image):
             "on_chunk_loaded: load=%.3fms elapsed=%.3fms location = %s",
             request.load_ms,
             request.elapsed_ms,
-            request.key.location,
+            request.location,
         )
 
         # Pass it to the slice, it will insert the newly loaded data into

--- a/napari/layers/image/experimental/octree_intersection.py
+++ b/napari/layers/image/experimental/octree_intersection.py
@@ -89,7 +89,7 @@ class OctreeIntersection:
         # are just one variable each? Use numpy more.
         rows, cols = view.corners[:, 0], view.corners[:, 1]
 
-        base = level_info.slice_config.base_shape
+        base = level_info.meta.base_shape
 
         self.normalized_range = np.array(
             [np.clip(rows / base[0], 0, 1), np.clip(cols / base[1], 0, 1)]
@@ -117,7 +117,7 @@ class OctreeIntersection:
         def _clamp(val, min_val, max_val):
             return max(min(val, max_val), min_val)
 
-        tile_size = self.level.info.slice_config.tile_size
+        tile_size = self.level.info.meta.tile_size
 
         span_tiles = [span[0] / tile_size, span[1] / tile_size]
         clamped = [
@@ -235,14 +235,14 @@ class OctreeIntersection:
             The file config.
         """
         # TODO_OCTREE: Need to cleanup and re-name and organize
-        # OctreeLevelInfo and SliceConfig attrbiutes. Messy.
+        # OctreeLevelInfo and OctreeMetadata attrbiutes. Messy.
         level = self.level
         image_shape = level.info.image_shape
         shape_in_tiles = level.info.shape_in_tiles
 
-        slice_config = level.info.slice_config
-        base_shape = slice_config.base_shape
-        tile_size = slice_config.tile_size
+        meta = level.info.meta
+        base_shape = meta.base_shape
+        tile_size = meta.tile_size
 
         return {
             "base_shape": base_shape,

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -58,7 +58,7 @@ class OctreeLevel:
     Parameters
     ----------
     slice_id : int
-        The id of the OctreeMultiscaleSlice we are in.
+        The id of the OctreeSlice we are in.
     data : ArrayLike
         The data for this level.
     meta : OctreeMetadata

--- a/napari/layers/image/experimental/octree_tile_builder.py
+++ b/napari/layers/image/experimental/octree_tile_builder.py
@@ -212,19 +212,3 @@ def create_downsampled_levels(
         level_index += 1
 
     return levels
-
-
-def create_multi_scale(image: np.ndarray, tile_size: int) -> List[np.ndarray]:
-    """Turn an image into a multi-scale image with levels.
-
-    Parameters
-    ----------
-    image : np.darray
-        The full image to create levels from.
-
-    Return
-    ------
-    List[np.ndarray]
-        A list of levels where levels[0] is the input image.
-    """
-    return [image] + create_downsampled_levels(image, tile_size)

--- a/napari/layers/image/experimental/octree_util.py
+++ b/napari/layers/image/experimental/octree_util.py
@@ -5,6 +5,7 @@ from typing import NamedTuple, Tuple
 
 import numpy as np
 
+from ....components.experimental.chunk import LayerRef
 from ....utils.config import octree_config
 
 
@@ -106,7 +107,7 @@ class NormalNoise(NamedTuple):
         return np.random.normal(self.mean, self.std_dev)
 
 
-class SliceConfig(NamedTuple):
+class OctreeMetadata(NamedTuple):
     """Configuration for a tiled image.
 
     Attributes
@@ -121,7 +122,7 @@ class SliceConfig(NamedTuple):
 
     Notes
     -----
-    This SliceConfig.tile_size will be used by the OctreeLevels in the tree
+    This OctreeMetadata.tile_size will be used by the OctreeLevels in the tree
     in general. But the highest level OctreeLevel might use a larger size
     so that it can consist of a single chunk.
 
@@ -139,6 +140,7 @@ class SliceConfig(NamedTuple):
     own tile size.
     """
 
+    layer_ref: LayerRef
     base_shape: np.ndarray
     num_levels: int
     tile_size: int

--- a/napari/utils/_octree.py
+++ b/napari/utils/_octree.py
@@ -12,8 +12,8 @@ from typing import Optional
 LOGGER = logging.getLogger("napari.loader")
 
 DEFAULT_OCTREE_CONFIG = {
-    "log_path": None,
     "loader": {
+        "log_path": None,
         "force_synchronous": False,
         "num_workers": 10,
         "use_processes": False,
@@ -23,7 +23,16 @@ DEFAULT_OCTREE_CONFIG = {
     "octree": {
         "enabled": True,
         "tile_size": 256,
-        "preload": {"level": 2, "level+1": 3, "level+2": 4},
+        "log_path": None,
+        "loaders": {
+            0: {
+                "force_synchronous": False,
+                "num_workers": 10,
+                "use_processes": False,
+                "auto_sync_ms": 30,
+                "delay_queue_ms": 100,
+            }
+        },
     },
 }
 

--- a/napari/utils/_octree.py
+++ b/napari/utils/_octree.py
@@ -20,20 +20,7 @@ DEFAULT_OCTREE_CONFIG = {
         "auto_sync_ms": 30,
         "delay_queue_ms": 100,
     },
-    "octree": {
-        "enabled": True,
-        "tile_size": 256,
-        "log_path": None,
-        "loaders": {
-            0: {
-                "force_synchronous": False,
-                "num_workers": 10,
-                "use_processes": False,
-                "auto_sync_ms": 30,
-                "delay_queue_ms": 100,
-            }
-        },
-    },
+    "octree": {"enabled": True, "tile_size": 256, "log_path": None},
 }
 
 

--- a/napari/utils/config.py
+++ b/napari/utils/config.py
@@ -41,16 +41,17 @@ Enabled one of two ways:
 
 2) Set NAPARI_OCTREE=/tmp/config.json use a config file.
 
-See napari/utils/config_octree.py for the config file format.
+See napari/utils/_octree.py for the config file format.
 
 Shared Memory Server
 --------------------
-Experimentally, only enable if NAPARI_MON is set to the path of a config
-file. See this PR for more info: https://github.com/napari/napari/pull/1909.
+Experimental shared memory service. Only enabled if NAPARI_MON is set to
+the path of a config file. See this PR for more info:
+https://github.com/napari/napari/pull/1909.
 """
 
-# Config for async/octree. If None then neither is enabled.
-# If octree_config['octree']['enabled'] is False only async is enabled.
+# Config for async/octree. If octree_config['octree']['enabled'] is False
+# only async is enabled, not the octree.
 octree_config = get_octree_config()
 
 # Shorthand for async loading with or without an octree.


### PR DESCRIPTION
# Description
* Split out new `LoaderPool` class from the existing `ChunkLoader` class.
    * This is a nice improvement even if we didn't want multiple pools.
    * Plan is to create multiple pools with configurable delays in next PR
* `OctreeLoader` no longer stores futures:
    * Instead it passes `should_cancel` predicate to:
        * New `DelayQueue.cancel_requests()`.
        * New `ChunkLoader.cancel_requests()`.
        * New `LoaderPool.cancel_requests()`.
    * So `ChunkLoader` clients can cancel based on any criteria.
    * For `Octree` we cancel chunks no longer seen.
    * Means future layers can cancel based on any algorithm they want.
   
# Big Cleanup Removing ChunkKey etc.

* Remove `ChunkKey`, `OctreeChunkKey`
    * OctreeChunk is hashable directly.
    * So `chunks.add(chunk.key)` becomes `chunks.add(chunk)`
* Location is sort of the new key:
    * Base class: `ChunkLocation`
    * Pre-octree images: `ImageLocation`, basically just the slice indices
    * Octree images: `OctreeLocation` which already existed: level, row, col.
    * Both have `__hash__` and `__eq__`.
    * `request.key.key` becomes `request.location`.
    * `request.key.location` becomes `request.location`.
* Remove `LayerKey` use `LayerRef` intead.
* Cleanup `DelayQueue`.
* Rename `SliceConfig` to `OctreeMetadata`.

This is a big change but it's to the "easy" plumbing stuff. Doesn't really change the visuals or the octree, which contain the real algorithms. So it's lower risk in that sense. If chunks load then it's working.

# Other Cleanup
* Rename `OctreeChunkLoader` to `OctreeLoader`
    * There are no other "octree loaders" so the shorter name is sufficient.
* Rename `OctreeMultiscaleSlice` to `OctreeSlice`
    * Long ago there was an earlier type of octree slice, now there is only one.

# Background On DelayQueue

We invented the DelayQueue and used it pre-octree. The idea was to delay queueing a load request for around 100ms. This helped a **ton** with the Torch ML computation. In that case, we also used "auto-sync". So we had two "auto-sync" layers and one delayed async layer. With the DelayQueue you could scroll around freely showing the two sync layers, and then when you stopped scrolling the Torch layer would show up. The 100ms delay was not really noticeable.

We disabled the DelayQueue and auto-sync for the octree because they wouldn't work as-is. However, it might make sense to at least bring back the DelayQueue if we can have multiple pools with different delays. In particular delay the "ideal chunks" so we don't queue those as we are zipping around. So we only queue them when we pause at some location.

# Type of change
- [x] New features in experimental code

# How has this been tested?
- [x] Manual testing
