### PR TITLE
fix channel_axis for affine transforms in add_image

### DIFF
--- a/napari/layers/utils/_tests/test_stack_utils.py
+++ b/napari/layers/utils/_tests/test_stack_utils.py
@@ -249,3 +249,23 @@ def test_split_channels_affine_napari(kwargs):
     for d, meta, _ in result_list:
         assert d.shape == (128, 128)
         assert np.array_equal(meta['affine'].affine_matrix, np.eye(3))
+
+
+def test_split_channels_multi_affine_napari(kwargs):
+    kwargs['affine'] = [
+        Affine(scale=[1, 1]),
+        Affine(scale=[2, 2]),
+        Affine(scale=[3, 3]),
+    ]
+
+    data = np.random.randint(0, 200, (3, 128, 128))
+    result_list = split_channels(data, 0, **kwargs)
+
+    assert len(result_list) == 3
+    for idx, result_data in enumerate(result_list):
+        d, meta, _ = result_data
+        assert d.shape == (128, 128)
+        assert np.array_equal(
+            meta['affine'].affine_matrix,
+            Affine(scale=[idx + 1, idx + 1]).affine_matrix,
+        )

--- a/napari/layers/utils/_tests/test_stack_utils.py
+++ b/napari/layers/utils/_tests/test_stack_utils.py
@@ -7,6 +7,7 @@ from napari.layers.utils.stack_utils import (
     split_channels,
     stack_to_images,
 )
+from napari.utils.transforms import Affine
 
 
 def test_stack_to_images_basic():
@@ -156,6 +157,8 @@ def test_images_to_stack_none_scale():
             'blending': None,
             'visible': True,
             'multiscale': None,
+            'rotate': None,
+            'affine': None,
         },
         {
             'rgb': None,
@@ -224,3 +227,25 @@ def test_split_channels_missing_keywords():
     for d, meta, _ in result_list:
         assert d.shape == (128, 128)
         assert meta['blending'] == 'additive'
+
+
+def test_split_channels_affine_nparray(kwargs):
+    kwargs['affine'] = np.eye(3)
+    data = np.random.randint(0, 200, (3, 128, 128))
+    result_list = split_channels(data, 0, **kwargs)
+
+    assert len(result_list) == 3
+    for d, meta, _ in result_list:
+        assert d.shape == (128, 128)
+        assert np.array_equal(meta['affine'], np.eye(3))
+
+
+def test_split_channels_affine_napari(kwargs):
+    kwargs['affine'] = Affine(affine_matrix=np.eye(3))
+    data = np.random.randint(0, 200, (3, 128, 128))
+    result_list = split_channels(data, 0, **kwargs)
+
+    assert len(result_list) == 3
+    for d, meta, _ in result_list:
+        assert d.shape == (128, 128)
+        assert np.array_equal(meta['affine'].affine_matrix, np.eye(3))

--- a/napari/layers/utils/stack_utils.py
+++ b/napari/layers/utils/stack_utils.py
@@ -52,7 +52,13 @@ def split_channels(
     kwargs['blending'] = kwargs.get('blending') or 'additive'
     kwargs.setdefault('colormap', None)
     # these arguments are *already* iterables in the single-channel case.
-    iterable_kwargs = {'scale', 'translate', 'contrast_limits', 'metadata'}
+    iterable_kwargs = {
+        'scale',
+        'translate',
+        'affine',
+        'contrast_limits',
+        'metadata',
+    }
 
     # turn the kwargs dict into a mapping of {key: iterator}
     # so that we can use {k: next(v) for k, v in kwargs.items()} below

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -144,7 +144,8 @@ def ensure_sequence_of_iterables(obj, length: Optional[int] = None):
     In [4]: ensure_sequence_of_iterables(None)
     Out[4]: repeat(None)
     """
-    if obj and is_sequence(obj) and is_iterable(obj[0]):
+
+    if obj is not None and is_sequence(obj) and is_iterable(obj[0]):
         if length is not None and len(obj) != length:
             raise ValueError(f"length of {obj} must equal {length}")
         return obj


### PR DESCRIPTION
# Description
Fixes issue #2024 where passing a single napari `Affine` object didn't work when a channel stack is split with `channel_axis` kwarg in `viewer.add_image`. Also fixes when a single `np.array` matrix is added as the `affine` kwarg.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
closes #2024

# How has this been tested?
- [x] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

added tests using both an np.array and a napari `Affine` object
