### PR TITLE
Move palette off viewer

### DIFF
--- a/docs/source/developers/CONTRIBUTING.md
+++ b/docs/source/developers/CONTRIBUTING.md
@@ -86,8 +86,26 @@ QtDeleteButton {
 
 A theme is a set of colors used throughout napari.  See, for example, the
 builtin themes in `napari/utils/theme.py`.  To make a new theme, create a new
-`dict` in `palettes` with the same keys as one of the existing themes, and
-replace the values with your new colors.  To test out the theme, use the
+`dict` with the same keys as one of the existing themes, and
+replace the values with your new colors.  For example
+
+```python
+from napari.utils.theme import get_theme, register_theme
+
+
+blue_theme = get_theme('dark')
+blue_theme.update(
+    background='rgb(28, 31, 48)',
+    foreground='rgb(45, 52, 71)',
+    primary='rgb(80, 88, 108)',
+    current='rgb(184, 112, 0)',
+)
+
+register_theme('blue', blue_theme)
+```
+
+
+To test out the theme, use the
 `theme_sample.py` file from the command line as follows:
 
 ```sh

--- a/examples/new_theme.py
+++ b/examples/new_theme.py
@@ -4,7 +4,7 @@ Displays an image and sets the theme to new custom theme.
 
 from skimage import data
 import napari
-from napari.utils.theme import palettes
+from napari.utils.theme import available_themes, get_theme, register_theme
 
 with napari.gui_qt():
     # create the viewer with an image
@@ -12,16 +12,21 @@ with napari.gui_qt():
         data.astronaut(), rgb=True, name='astronaut'
     )
 
-    # Create a new palette. Note we must use either the `light` or
-    # `dark` folder to avoid needing to build new icons
-    blue_palette = palettes['dark'].copy()
-    blue_palette['background'] = 'rgb(28, 31, 48)'
-    blue_palette['foreground'] = 'rgb(45, 52, 71)'
-    blue_palette['primary'] = 'rgb(80, 88, 108)'
-    blue_palette['current'] = 'rgb(184, 112, 0)'
+    # List themes
+    print('Originally themes', available_themes())
 
-    # Add new theme to dictionary of available_themes
-    palettes['blues'] = blue_palette
+    blue_theme = get_theme('dark')
+    blue_theme.update(
+        background='rgb(28, 31, 48)',
+        foreground='rgb(45, 52, 71)',
+        primary='rgb(80, 88, 108)',
+        current='rgb(184, 112, 0)',
+    )
+
+    register_theme('blue', blue_theme)
+
+    # List themes
+    print('New themes', available_themes())
 
     # Set theme
-    viewer.theme = 'blues'
+    viewer.theme = 'blue'

--- a/examples/new_theme.py
+++ b/examples/new_theme.py
@@ -1,0 +1,27 @@
+"""
+Displays an image and sets the theme to new custom theme.
+"""
+
+from skimage import data
+import napari
+from napari.utils.theme import palettes
+
+with napari.gui_qt():
+    # create the viewer with an image
+    viewer = napari.view_image(
+        data.astronaut(), rgb=True, name='astronaut'
+    )
+
+    # Create a new palette. Note we must use either the `light` or
+    # `dark` folder to avoid needing to build new icons
+    blue_palette = palettes['dark'].copy()
+    blue_palette['background'] = 'rgb(28, 31, 48)'
+    blue_palette['foreground'] = 'rgb(45, 52, 71)'
+    blue_palette['primary'] = 'rgb(80, 88, 108)'
+    blue_palette['current'] = 'rgb(184, 112, 0)'
+
+    # Add new theme to dictionary of available_themes
+    palettes['blues'] = blue_palette
+
+    # Set theme
+    viewer.theme = 'blues'

--- a/napari/_qt/dialogs/qt_about_key_bindings.py
+++ b/napari/_qt/dialogs/qt_about_key_bindings.py
@@ -12,7 +12,7 @@ from qtpy.QtWidgets import (
 import napari
 
 from ...utils.interactions import get_key_bindings_summary
-from ...utils.theme import palettes
+from ...utils.theme import get_theme
 
 
 class QtAboutKeyBindings(QDialog):
@@ -64,8 +64,8 @@ class QtAboutKeyBindings(QDialog):
         # Can switch to a normal dict when our minimum Python is 3.7
         self.key_bindings_strs = OrderedDict()
         self.key_bindings_strs[self.ALL_ACTIVE_KEYBINDINGS] = ''
-        palette = palettes[self.qt_viewer.viewer.theme]
-        col = palette['secondary']
+        theme = get_theme(self.qt_viewer.viewer.theme)
+        col = theme['secondary']
         layers = [
             napari.layers.Image,
             napari.layers.Labels,
@@ -125,8 +125,8 @@ class QtAboutKeyBindings(QDialog):
         event : napari.utils.event.Event, optional
             The napari event that triggered this method, by default None.
         """
-        palette = palettes[self.qt_viewer.viewer.theme]
-        col = palette['secondary']
+        theme = get_theme(self.qt_viewer.viewer.theme)
+        col = theme['secondary']
         # Add class and instance viewer key bindings
         text = get_key_bindings_summary(self.viewer.active_keymap, col=col)
 

--- a/napari/_qt/dialogs/qt_about_key_bindings.py
+++ b/napari/_qt/dialogs/qt_about_key_bindings.py
@@ -12,6 +12,7 @@ from qtpy.QtWidgets import (
 import napari
 
 from ...utils.interactions import get_key_bindings_summary
+from ...utils.theme import palettes
 
 
 class QtAboutKeyBindings(QDialog):
@@ -63,7 +64,8 @@ class QtAboutKeyBindings(QDialog):
         # Can switch to a normal dict when our minimum Python is 3.7
         self.key_bindings_strs = OrderedDict()
         self.key_bindings_strs[self.ALL_ACTIVE_KEYBINDINGS] = ''
-        col = self.viewer.palette['secondary']
+        palette = palettes[self.qt_viewer.viewer.theme]
+        col = palette['secondary']
         layers = [
             napari.layers.Image,
             napari.layers.Labels,
@@ -94,7 +96,7 @@ class QtAboutKeyBindings(QDialog):
         self.layout.addWidget(self.textEditBox, 1)
 
         self.viewer.events.active_layer.connect(self.update_active_layer)
-        self.viewer.events.palette.connect(self.update_active_layer)
+        self.viewer.events.theme.connect(self.update_active_layer)
         self.update_active_layer()
 
     def change_layer_type(self, text):
@@ -123,7 +125,8 @@ class QtAboutKeyBindings(QDialog):
         event : napari.utils.event.Event, optional
             The napari event that triggered this method, by default None.
         """
-        col = self.viewer.palette['secondary']
+        palette = palettes[self.qt_viewer.viewer.theme]
+        col = palette['secondary']
         # Add class and instance viewer key bindings
         text = get_key_bindings_summary(self.viewer.active_keymap, col=col)
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -28,7 +28,7 @@ from ..utils import config, perf
 from ..utils.io import imsave
 from ..utils.misc import in_jupyter
 from ..utils.perf import perf_config
-from ..utils.theme import template
+from ..utils.theme import palettes, template
 from .dialogs.qt_about import QtAbout
 from .dialogs.qt_plugin_dialog import QtPluginDialog
 from .dialogs.qt_plugin_report import QtPluginErrReporter
@@ -167,7 +167,7 @@ class Window:
         self._qt_center.layout().addWidget(self.qt_viewer)
         self._qt_center.layout().setContentsMargins(4, 0, 4, 0)
 
-        self._update_palette()
+        self._update_theme()
 
         self._add_viewer_dock_widget(self.qt_viewer.dockConsole)
         self._add_viewer_dock_widget(self.qt_viewer.dockLayerControls)
@@ -176,7 +176,7 @@ class Window:
         self.qt_viewer.viewer.events.status.connect(self._status_changed)
         self.qt_viewer.viewer.events.help.connect(self._help_changed)
         self.qt_viewer.viewer.events.title.connect(self._title_changed)
-        self.qt_viewer.viewer.events.palette.connect(self._update_palette)
+        self.qt_viewer.viewer.events.theme.connect(self._update_theme)
 
         if perf.USE_PERFMON:
             # Add DebugMenu and dockPerformance if using perfmon.
@@ -649,11 +649,11 @@ class Window:
         self._qt_window.raise_()  # for macOS
         self._qt_window.activateWindow()  # for Windows
 
-    def _update_palette(self, event=None):
+    def _update_theme(self, event=None):
         """Update widget color palette."""
         # set window styles which don't use the primary stylesheet
         # FIXME: this is a problem with the stylesheet not using properties
-        palette = self.qt_viewer.viewer.palette
+        palette = palettes[self.qt_viewer.viewer.theme]
         self._status_bar.setStyleSheet(
             template(
                 'QStatusBar { background: {{ background }}; '

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -28,7 +28,7 @@ from ..utils import config, perf
 from ..utils.io import imsave
 from ..utils.misc import in_jupyter
 from ..utils.perf import perf_config
-from ..utils.theme import palettes, template
+from ..utils.theme import get_theme, template
 from .dialogs.qt_about import QtAbout
 from .dialogs.qt_plugin_dialog import QtPluginDialog
 from .dialogs.qt_plugin_report import QtPluginErrReporter
@@ -650,21 +650,21 @@ class Window:
         self._qt_window.activateWindow()  # for Windows
 
     def _update_theme(self, event=None):
-        """Update widget color palette."""
+        """Update widget color theme."""
         # set window styles which don't use the primary stylesheet
         # FIXME: this is a problem with the stylesheet not using properties
-        palette = palettes[self.qt_viewer.viewer.theme]
+        theme = get_theme(self.qt_viewer.viewer.theme)
         self._status_bar.setStyleSheet(
             template(
                 'QStatusBar { background: {{ background }}; '
                 'color: {{ text }}; }',
-                **palette,
+                **theme,
             )
         )
         self._qt_center.setStyleSheet(
-            template('QWidget { background: {{ background }}; }', **palette)
+            template('QWidget { background: {{ background }}; }', **theme)
         )
-        self._qt_window.setStyleSheet(template(self.raw_stylesheet, **palette))
+        self._qt_window.setStyleSheet(template(self.raw_stylesheet, **theme))
 
     def _status_changed(self, event):
         """Update status bar.

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -21,7 +21,7 @@ from ..utils.interactions import (
 )
 from ..utils.io import imsave
 from ..utils.key_bindings import components_to_key_combo
-from ..utils.theme import template
+from ..utils.theme import palettes, template
 from .dialogs.qt_about_key_bindings import QtAboutKeyBindings
 from .dialogs.screenshot_dialog import ScreenshotDialog
 from .tracing.qt_performance import QtPerformance
@@ -177,12 +177,12 @@ class QtViewer(QSplitter):
             'standard': QCursor(),
         }
 
-        self._update_palette()
+        self._update_theme()
 
         self.viewer.camera.events.interactive.connect(self._on_interactive)
         self.viewer.cursor.events.style.connect(self._on_cursor)
         self.viewer.cursor.events.size.connect(self._on_cursor)
-        self.viewer.events.palette.connect(self._update_palette)
+        self.viewer.events.theme.connect(self._update_theme)
         self.viewer.layers.events.reordered.connect(self._reorder_layers)
         self.viewer.layers.events.inserted.connect(self._on_add_layer_change)
         self.viewer.layers.events.removed.connect(self._remove_layer)
@@ -266,7 +266,7 @@ class QtViewer(QSplitter):
             self.viewer.events.layers_change.connect(
                 self.welcome._on_visible_change
             )
-            self.viewer.events.palette.connect(self.welcome._on_palette_change)
+            self.viewer.events.theme.connect(self.welcome._on_theme_change)
             self.canvas.events.resize.connect(self.welcome._on_canvas_change)
 
     def _create_performance_dock_widget(self):
@@ -296,7 +296,7 @@ class QtViewer(QSplitter):
     def console(self, console):
         self._console = console
         self.dockConsole.widget = console
-        self._update_palette()
+        self._update_theme()
 
     def _constrain_width(self, event):
         """Allow the layer controls to be wider, only if floated.
@@ -510,18 +510,17 @@ class QtViewer(QSplitter):
 
         self.canvas.native.setCursor(q_cursor)
 
-    def _update_palette(self, event=None):
+    def _update_theme(self, event=None):
         """Update the napari GUI theme."""
         # template and apply the primary stylesheet
-        themed_stylesheet = template(
-            self.raw_stylesheet, **self.viewer.palette
-        )
+        palette = palettes[self.viewer.theme]
+        themed_stylesheet = template(self.raw_stylesheet, **palette)
         if self._console is not None:
             self.console._update_palette(
                 self.viewer.palette, themed_stylesheet
             )
         self.setStyleSheet(themed_stylesheet)
-        self.canvas.bgcolor = self.viewer.palette['canvas']
+        self.canvas.bgcolor = palette['canvas']
 
     def toggle_console_visibility(self, event=None):
         """Toggle console visible and not visible.

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -21,7 +21,7 @@ from ..utils.interactions import (
 )
 from ..utils.io import imsave
 from ..utils.key_bindings import components_to_key_combo
-from ..utils.theme import palettes, template
+from ..utils.theme import get_theme, template
 from .dialogs.qt_about_key_bindings import QtAboutKeyBindings
 from .dialogs.screenshot_dialog import ScreenshotDialog
 from .tracing.qt_performance import QtPerformance
@@ -513,14 +513,12 @@ class QtViewer(QSplitter):
     def _update_theme(self, event=None):
         """Update the napari GUI theme."""
         # template and apply the primary stylesheet
-        palette = palettes[self.viewer.theme]
-        themed_stylesheet = template(self.raw_stylesheet, **palette)
+        theme = get_theme(self.viewer.theme)
+        themed_stylesheet = template(self.raw_stylesheet, **theme)
         if self._console is not None:
-            self.console._update_palette(
-                self.viewer.palette, themed_stylesheet
-            )
+            self.console._update_theme(theme, themed_stylesheet)
         self.setStyleSheet(themed_stylesheet)
-        self.canvas.bgcolor = palette['canvas']
+        self.canvas.bgcolor = theme['canvas']
 
     def toggle_console_visibility(self, event=None):
         """Toggle console visible and not visible.

--- a/napari/_qt/widgets/qt_console.py
+++ b/napari/_qt/widgets/qt_console.py
@@ -131,20 +131,20 @@ class QtConsole(RichJupyterWidget):
         # TODO: Try to get console from jupyter to run without a shift click
         # self.execute_on_complete_input = True
 
-    def _update_palette(self, palette, themed_stylesheet):
+    def _update_theme(self, theme, themed_stylesheet):
         """Update the napari GUI theme.
 
         Parameters
         ----------
-        palette : dict of str: str
-            Color palette with which to style the viewer.
+        theme : dict of str: str
+            Color theme with which to style the viewer.
             Property of napari.components.viewer_model.ViewerModel.
         themed_stylesheet : str
-            Stylesheet that has already been themed with the current palette.
+            Stylesheet that has already been themed with the current theme.
         """
         self.style_sheet = themed_stylesheet
-        self.syntax_style = palette['syntax_style']
-        bracket_color = QColor(*str_to_rgb(palette['highlight']))
+        self.syntax_style = theme['syntax_style']
+        bracket_color = QColor(*str_to_rgb(theme['highlight']))
         self._bracket_matcher.format.setBackground(bracket_color)
 
     def closeEvent(self, event):

--- a/napari/_qt/widgets/qt_theme_sample.py
+++ b/napari/_qt/widgets/qt_theme_sample.py
@@ -43,7 +43,7 @@ from qtpy.QtWidgets import (
 
 from ...resources import get_stylesheet
 from ...utils.io import imsave
-from ...utils.theme import palettes, template
+from ...utils.theme import available_themes, get_theme, template
 from ..utils import QImg2array
 from .qt_range_slider import QHRangeSlider
 
@@ -95,7 +95,7 @@ class SampleWidget(QWidget):
     def __init__(self, theme='dark', emphasized=False):
         super().__init__(None)
         self.setProperty('emphasized', emphasized)
-        self.setStyleSheet(template(raw_stylesheet, **palettes[theme]))
+        self.setStyleSheet(template(raw_stylesheet, **get_theme(theme)))
         lay = QVBoxLayout()
         self.setLayout(lay)
         lay.addWidget(QPushButton('push button'))
@@ -160,7 +160,7 @@ class SampleWidget(QWidget):
 if __name__ == "__main__":
     import sys
 
-    themes = [sys.argv[1]] if len(sys.argv) > 1 else palettes.keys()
+    themes = [sys.argv[1]] if len(sys.argv) > 1 else available_themes()
     app = QApplication([])
     widgets = []
     for n, theme in enumerate(themes):

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -122,12 +122,12 @@ def test_changing_theme(make_test_viewer):
     """Test changing the theme updates the full window."""
     viewer = make_test_viewer()
     viewer.add_points(data=None)
-    assert viewer.palette['folder'] == 'dark'
+    assert viewer.theme == 'dark'
 
     screenshot_dark = viewer.screenshot(canvas_only=False)
 
     viewer.theme = 'light'
-    assert viewer.palette['folder'] == 'light'
+    assert viewer.theme == 'light'
 
     screenshot_light = viewer.screenshot(canvas_only=False)
     equal = (screenshot_dark == screenshot_light).min(-1)

--- a/napari/_vispy/vispy_welcome_visual.py
+++ b/napari/_vispy/vispy_welcome_visual.py
@@ -7,7 +7,7 @@ from vispy.scene.visuals import Text
 from vispy.visuals.transforms import STTransform
 
 from ..utils.misc import str_to_rgb
-from ..utils.theme import darken, lighten, palettes
+from ..utils.theme import darken, get_theme, lighten
 from .image import Image as ImageNode
 
 
@@ -51,17 +51,17 @@ class VispyWelcomeVisual:
 
     def _on_theme_change(self, event):
         """Change colors of the logo and text."""
-        palette = palettes[self._viewer.theme]
-        if np.mean(str_to_rgb(palette['background'])[:3]) < 255 / 2:
+        theme = get_theme(self._viewer.theme)
+        if np.mean(str_to_rgb(theme['background'])[:3]) < 255 / 2:
             background_color = np.divide(
-                str_to_rgb(darken(palette['background'], 70)), 255
+                str_to_rgb(darken(theme['background'], 70)), 255
             )
         else:
             background_color = np.divide(
-                str_to_rgb(lighten(palette['background'], 70)), 255,
+                str_to_rgb(lighten(theme['background'], 70)), 255,
             )
 
-        foreground_color = np.divide(str_to_rgb(palette['primary']), 255,)
+        foreground_color = np.divide(str_to_rgb(theme['primary']), 255,)
         text_color = list(foreground_color) + [1]
 
         new_logo = np.zeros(self._logo_raw.shape)

--- a/napari/_vispy/vispy_welcome_visual.py
+++ b/napari/_vispy/vispy_welcome_visual.py
@@ -7,7 +7,7 @@ from vispy.scene.visuals import Text
 from vispy.visuals.transforms import STTransform
 
 from ..utils.misc import str_to_rgb
-from ..utils.theme import darken, lighten
+from ..utils.theme import darken, lighten, palettes
 from .image import Image as ImageNode
 
 
@@ -44,32 +44,24 @@ class VispyWelcomeVisual:
             '   - select File > Open from the menu\n'
             '   - call a viewer.add_* method'
         )
-        self.text_node.color = np.divide(
-            str_to_rgb(darken(self._viewer.palette['foreground'], 30)), 255
-        )
 
-        self._on_palette_change(None)
+        self._on_theme_change(None)
         self._on_visible_change(None)
         self._on_canvas_change(None)
 
-    def _on_palette_change(self, event):
+    def _on_theme_change(self, event):
         """Change colors of the logo and text."""
-        if (
-            np.mean(str_to_rgb(self._viewer.palette['background'])[:3])
-            < 255 / 2
-        ):
+        palette = palettes[self._viewer.theme]
+        if np.mean(str_to_rgb(palette['background'])[:3]) < 255 / 2:
             background_color = np.divide(
-                str_to_rgb(darken(self._viewer.palette['background'], 70)), 255
+                str_to_rgb(darken(palette['background'], 70)), 255
             )
         else:
             background_color = np.divide(
-                str_to_rgb(lighten(self._viewer.palette['background'], 70)),
-                255,
+                str_to_rgb(lighten(palette['background'], 70)), 255,
             )
 
-        foreground_color = np.divide(
-            str_to_rgb(self._viewer.palette['primary']), 255,
-        )
+        foreground_color = np.divide(str_to_rgb(palette['primary']), 255,)
         text_color = list(foreground_color) + [1]
 
         new_logo = np.zeros(self._logo_raw.shape)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -181,7 +181,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
         theme = get_theme(self.theme)
         self.axes.background_color = theme['canvas']
         self.scale_bar.background_color = theme['canvas']
-        self.events.theme()
+        self.events.theme(vale=self.theme)
 
     @property
     def grid_size(self):

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -28,6 +28,8 @@ from .grid import GridCanvas
 from .layerlist import LayerList
 from .scale_bar import ScaleBar
 
+DEFAULT_THEME = 'dark'
+
 
 class ViewerModel(KeymapHandler, KeymapProvider):
     """Viewer containing the rendered scene, layers, and controlling elements
@@ -54,11 +56,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
         List of contained layers.
     dims : Dimensions
         Contains axes, indices, dimensions and sliders.
-    themes : dict of str: dict of str: str
-        Preset color palettes.
     """
-
-    themes = palettes
 
     def __init__(self, title='napari', ndisplay=2, order=(), axis_labels=()):
         super().__init__()
@@ -71,7 +69,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
             title=Event,
             reset_view=Event,
             active_layer=Event,
-            palette=Event,
+            theme=Event,
             layers_change=Event,
         )
 
@@ -88,13 +86,12 @@ class ViewerModel(KeymapHandler, KeymapProvider):
         self._status = 'Ready'
         self._help = ''
         self._title = title
+        self._theme = DEFAULT_THEME
 
         self._active_layer = None
         self.grid = GridCanvas()
         # 2-tuple indicating height and width
         self._canvas_size = (600, 800)
-        self._palette = None
-        self.theme = 'dark'
 
         self.grid.events.connect(self.reset_view)
         self.grid.events.connect(self._on_grid_change)
@@ -128,40 +125,60 @@ class ViewerModel(KeymapHandler, KeymapProvider):
 
     @property
     def palette(self):
-        """dict of str: str : Color palette with which to style the viewer.
+        """napari.utils.theme.Palette: Color palette for styling the viewer.
         """
-        return self._palette
+        warnings.warn(
+            (
+                "The viewer.palette attribute is deprecated and will be removed after version 0.4.5."
+                " To access the palette you can call into napari.utils.theme.palettes dictionary"
+                " using the viewer.theme as the key."
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return palettes[self.theme]
 
     @palette.setter
     def palette(self, palette):
-        if palette == self.palette:
-            return
-
-        self._palette = palette
-        self.axes.background_color = self.palette['canvas']
-        self.scale_bar.background_color = self.palette['canvas']
-        self.events.palette()
+        warnings.warn(
+            (
+                "The viewer.palette attribute is deprecated and will be removed after version 0.4.5."
+                " To add a new palette you should add it to napari.utils.theme.palettes dictionary"
+                " and then set the viewer.theme attribute."
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        for existing_theme, existing_palette in palettes.items():
+            if existing_palette == palette:
+                self.theme = existing_theme
+                return
+        raise ValueError(
+            f"Palette not found among existing themes; "
+            f"options are {list(palettes)}."
+        )
 
     @property
     def theme(self):
         """string or None : Preset color palette.
         """
-        for theme, palette in self.themes.items():
-            if palette == self.palette:
-                return theme
+        return self._theme
 
     @theme.setter
     def theme(self, theme):
         if theme == self.theme:
             return
 
-        try:
-            self.palette = self.themes[theme]
-        except KeyError:
+        if theme in palettes:
+            self._theme = theme
+        else:
             raise ValueError(
-                f"Theme '{theme}' not found; "
-                f"options are {list(self.themes)}."
+                f"Theme '{theme}' not found; " f"options are {list(palettes)}."
             )
+        palette = palettes[self.theme]
+        self.axes.background_color = palette['canvas']
+        self.scale_bar.background_color = palette['canvas']
+        self.events.theme()
 
     @property
     def grid_size(self):
@@ -381,7 +398,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
     def _toggle_theme(self):
         """Switch to next theme in list of themes
         """
-        theme_names = list(self.themes.keys())
+        theme_names = list(palettes)
         cur_theme = theme_names.index(self.theme)
         self.theme = theme_names[(cur_theme + 1) % len(theme_names)]
 

--- a/napari/resources/build_icons.py
+++ b/napari/resources/build_icons.py
@@ -10,7 +10,7 @@ import sys
 from subprocess import SubprocessError, check_call
 from typing import Dict, List, Tuple
 
-from ..utils.theme import palettes as _palettes
+from ..utils.theme import _themes
 
 RESOURCES_DIR = os.path.abspath(os.path.dirname(__file__))
 SVGPATH = os.path.join(RESOURCES_DIR, 'icons')
@@ -21,7 +21,7 @@ svg_tag_open = re.compile(r'(<svg[^>]*>)')
 def themify_icons(
     dest_dir: str,
     svg_path: str = SVGPATH,
-    palettes: Dict[str, Dict[str, str]] = _palettes,
+    themes: Dict[str, Dict[str, str]] = _themes,
     color_lookup: Dict[str, str] = None,
 ) -> List[str]:
     """Create a new "themed" SVG file, for every SVG file in ``svg_path``.
@@ -34,10 +34,10 @@ def themify_icons(
     svg_path : str, optional
         The folder to look in for SVG files, by default will search in a folder
         named ``icons`` in the same directory as this file.
-    palettes : dict, optional
+    themes : dict, optional
         A mapping of ``theme_name: theme_dict``, where ``theme_dict`` is a
-        mapping of color classes to rgb strings. By default will uses palettes
-        from :const:`napari.resources.utils.theme.palettes`.
+        mapping of color classes to rgb strings. By default will uses themes
+        from :const:`napari.resources.utils.theme.themes`.
     color_lookup : dict, optional
         A mapping of icon name to color class.  If the icon name is not in the
         color_lookup, it's color class will be ``"icon"``.
@@ -73,14 +73,14 @@ def themify_icons(
     </style>"""
 
     files = []
-    for theme_name, palette in palettes.items():
-        palette_dir = os.path.join(dest_dir, theme_name)
-        os.makedirs(palette_dir, exist_ok=True)
+    for theme_name, theme in themes.items():
+        theme_dir = os.path.join(dest_dir, theme_name)
+        os.makedirs(theme_dir, exist_ok=True)
         for icon_name in icon_names:
             svg_name = icon_name + '.svg'
-            new_file = os.path.join(palette_dir, svg_name)
+            new_file = os.path.join(theme_dir, svg_name)
             color = color_lookup.get(icon_name, 'icon')
-            css = svg_style_insert.replace('{{ color }}', palette[color])
+            css = svg_style_insert.replace('{{ color }}', theme[color])
             with open(os.path.join(SVGPATH, svg_name), 'r') as fr:
                 contents = fr.read()
             with open(new_file, 'w') as fw:

--- a/napari/utils/_tests/test_theme.py
+++ b/napari/utils/_tests/test_theme.py
@@ -1,0 +1,42 @@
+from napari.utils.theme import available_themes, get_theme, register_theme
+
+
+def test_default_themes():
+    themes = available_themes()
+    assert 'dark' in themes
+    assert 'light' in themes
+
+
+def test_get_theme():
+    theme = get_theme('dark')
+    assert theme['folder'] == 'dark'
+
+
+def test_register_theme():
+    # Check that blue theme is not listed in available themes
+    themes = available_themes()
+    assert 'blue' not in themes
+
+    # Create new blue theme based on dark theme
+    blue_theme = get_theme('dark')
+    blue_theme.update(
+        background='rgb(28, 31, 48)',
+        foreground='rgb(45, 52, 71)',
+        primary='rgb(80, 88, 108)',
+        current='rgb(184, 112, 0)',
+    )
+
+    # Register blue theme
+    register_theme('blue', blue_theme)
+
+    # Check that blue theme is listed in available themes
+    themes = available_themes()
+    assert 'blue' in themes
+
+    # Check that the dark theme has not been overwritten
+    dark_theme = get_theme('dark')
+    assert not dark_theme['background'] == blue_theme['background']
+
+    # Check that blue theme can be gotten from available themes
+    theme = get_theme('blue')
+    assert theme['background'] == blue_theme['background']

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -12,7 +12,7 @@ except Exception:
     use_gradients = False
 
 
-palettes = {
+_themes = {
     'dark': {
         'folder': 'dark',
         'background': 'rgb(38, 41, 48)',
@@ -95,28 +95,76 @@ def gradient(stops, horizontal=True):
     return grad
 
 
-def template(css, **palette):
+def template(css, **theme):
     def darken_match(matchobj):
         color, percentage = matchobj.groups()
-        return darken(palette[color], percentage)
+        return darken(theme[color], percentage)
 
     def lighten_match(matchobj):
         color, percentage = matchobj.groups()
-        return lighten(palette[color], percentage)
+        return lighten(theme[color], percentage)
 
     def opacity_match(matchobj):
         color, percentage = matchobj.groups()
-        return opacity(palette[color], percentage)
+        return opacity(theme[color], percentage)
 
     def gradient_match(matchobj):
         horizontal = matchobj.groups()[1] == 'h'
         stops = [i.strip() for i in matchobj.groups()[1].split('-')]
         return gradient(stops, horizontal)
 
-    for k, v in palette.items():
+    for k, v in theme.items():
         css = gradient_pattern.sub(gradient_match, css)
         css = darken_pattern.sub(darken_match, css)
         css = lighten_pattern.sub(lighten_match, css)
         css = opacity_pattern.sub(opacity_match, css)
         css = css.replace('{{ %s }}' % k, v)
     return css
+
+
+def get_theme(name):
+    """Get a theme based on its name
+
+    Parameters
+    ----------
+    name : str
+        Name of requested theme.
+
+    Returns:
+    --------
+    theme: dict of str: str
+        Theme mapping elements to colors. A copy is created
+        so that manipulating this theme can be done without
+        side effects.
+    """
+    if name in _themes:
+        theme = _themes[name]
+        return theme.copy()
+    else:
+        raise ValueError(
+            f"Unrecognized theme {name}. Availabe themes are {available_themes()}"
+        )
+
+
+def register_theme(name, theme):
+    """Get a theme based on its name
+
+    Parameters
+    ----------
+    name : str
+        Name of requested theme.
+    theme: dict of str: str
+        Theme mapping elements to colors.
+    """
+    _themes[name] = theme
+
+
+def available_themes():
+    """List available themes
+
+    Returns:
+    --------
+    list of str
+        Names of available themes.
+    """
+    return list(_themes)


### PR DESCRIPTION
# Description
This PR will supersede #2013. It still moves palette off the viewer, leaving only the `viewer.theme` string, and the viewer now emits a `theme` event instead of the palette event, but it doesn't do anything else.

There's no NamedTuple, everything is still a dict. I left the dict of dict named `palettes`, I sort of like it, and didn't feel any need to change that now that we don't have any word for the one off thing. There is `theme` and `palettes` as the only two objects. I also didn't do any of the renaming of individual properties of the palettes.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
