### PR TITLE
Pydantic evented dataclass

### DIFF
--- a/napari/_qt/widgets/qt_dims.py
+++ b/napari/_qt/widgets/qt_dims.py
@@ -130,7 +130,7 @@ class QtDims(QWidget):
             if axis in self.dims.displayed or nsteps[axis] <= 1:
                 # Displayed dimensions correspond to non displayed sliders
                 self._displayed_sliders[axis] = False
-                self.dims.last_used = None
+                self.dims.last_used = 0
                 widget.hide()
             else:
                 # Non displayed dimensions correspond to displayed sliders
@@ -245,7 +245,7 @@ class QtDims(QWidget):
         slider_widget.deleteLater()
         nsliders = np.sum(self._displayed_sliders)
         self.setMinimumHeight(int(nsliders * self.SLIDERHEIGHT))
-        self.dims.last_used = None
+        self.dims.last_used = 0
 
     def play(
         self,

--- a/napari/_qt/widgets/qt_dims_slider.py
+++ b/napari/_qt/widgets/qt_dims_slider.py
@@ -186,7 +186,7 @@ class QtDimSliderWidget(QWidget):
         nsteps = self.dims.nsteps[self.axis] - 1
         if nsteps == 0:
             displayed_sliders[self.axis] = False
-            self.qt_dims.last_used = None
+            self.qt_dims.last_used = 0
             self.hide()
         else:
             if (

--- a/napari/_vispy/vispy_camera.py
+++ b/napari/_vispy/vispy_camera.py
@@ -77,13 +77,17 @@ class VispyCamera:
             center = self._view.camera.center[:2]
 
         # Switch from VisPy ordering to NumPy ordering
-        return tuple(center[::-1])
+        center = tuple(center[::-1])
+        if len(center) == 2:
+            center = (0.0,) + center
+        return center
 
     @center.setter
     def center(self, center):
         if self.center == tuple(center):
             return
         self._view.camera.center = center[::-1]
+        self._view.camera.view_changed()
 
     @property
     def zoom(self):
@@ -137,7 +141,7 @@ class VispyCamera:
 
         Update camera model angles, center, and zoom.
         """
-        with self._camera.events.center.blocker(self._on_angles_change):
+        with self._camera.events.angles.blocker(self._on_angles_change):
             self._camera.angles = self.angles
         with self._camera.events.center.blocker(self._on_center_change):
             self._camera.center = self.center

--- a/napari/components/_viewer_constants.py
+++ b/napari/components/_viewer_constants.py
@@ -1,4 +1,4 @@
-from enum import auto
+from enum import Enum, auto
 
 from ..utils.misc import StringEnum
 
@@ -19,21 +19,29 @@ class Position(StringEnum):
     BOTTOM_LEFT = auto()
 
 
-class CursorStyle(StringEnum):
-    """CursorStyle: Style on the cursor.
+# class CursorStyle(StringEnum):
+#     """CursorStyle: Style on the cursor.
 
-    Sets the style of the cursor
-            * square: A square
-            * circle: A circle
-            * cross: A cross
-            * forbidden: A forbidden symbol
-            * pointing: A finger for pointing
-            * standard: The standard cursor
-    """
+#     Sets the style of the cursor
+#             * square: A square
+#             * circle: A circle
+#             * cross: A cross
+#             * forbidden: A forbidden symbol
+#             * pointing: A finger for pointing
+#             * standard: The standard cursor
+#     """
 
-    SQUARE = auto()
-    CIRCLE = auto()
-    CROSS = auto()
-    FORBIDDEN = auto()
-    POINTING = auto()
-    STANDARD = auto()
+#     SQUARE = auto()
+#     CIRCLE = auto()
+#     CROSS = auto()
+#     FORBIDDEN = auto()
+#     POINTING = auto()
+#     STANDARD = auto()
+
+
+class CursorStyle(str, Enum):
+    SQUARE = 'square'
+    CIRCLE = 'circle'
+    FORBIDDEN = 'forbidden'
+    POINTING = 'pointing'
+    STANDARD = 'standard'

--- a/napari/components/axes.py
+++ b/napari/components/axes.py
@@ -1,12 +1,8 @@
-from dataclasses import field
-
 import numpy as np
+from pydantic import BaseModel, Field, validator
 
-# from pydantic import validator
-from pydantic.dataclasses import dataclass
-
-# from ..utils.colormaps.standardize_color import transform_single_color
-from ..utils.events.event_utils import PydanticConfig, evented
+from ..utils.colormaps.standardize_color import transform_single_color
+from ..utils.events.event_utils import evented
 
 
 class _ArrayMeta(type):
@@ -41,12 +37,11 @@ class Array(np.ndarray, metaclass=_ArrayMeta):
 
 
 def make_default_color_array():
-    return np.array([1, 1, 1, 1])
+    return np.ones(4)
 
 
 @evented
-@dataclass(config=PydanticConfig)
-class Axes:
+class Axes(BaseModel):
     """Axes indicating world coordinate origin and orientation.
 
     Attributes
@@ -77,10 +72,13 @@ class Axes:
     colored: bool = True
     dashed: bool = False
     arrows: bool = True
-    background_color: Array[float, (-1, 4)] = field(
+    background_color: Array[float, (4,)] = Field(
         default_factory=make_default_color_array
     )
 
-    # @validator('background_color', pre=True)
-    # def _ensure_color(cls, v):
-    #     return transform_single_color(v)
+    class Config:
+        validate_assignment = True
+
+    @validator('background_color', pre=True)
+    def _ensure_color(cls, v):
+        return transform_single_color(v)

--- a/napari/components/axes.py
+++ b/napari/components/axes.py
@@ -1,3 +1,5 @@
+from dataclasses import field
+
 import numpy as np
 
 # from pydantic import validator
@@ -38,8 +40,12 @@ class Array(np.ndarray, metaclass=_ArrayMeta):
         return result
 
 
+def make_default_color_array():
+    return np.array([1, 1, 1, 1])
+
+
 @evented
-@dataclass(config=PydanticConfig, eq=False)
+@dataclass(config=PydanticConfig)
 class Axes:
     """Axes indicating world coordinate origin and orientation.
 
@@ -71,10 +77,9 @@ class Axes:
     colored: bool = True
     dashed: bool = False
     arrows: bool = True
-    background_color: Array[float, (-1, 4)] = np.array([1, 1, 1, 1])
-
-    def __eq__(self, other):
-        return True
+    background_color: Array[float, (-1, 4)] = field(
+        default_factory=make_default_color_array
+    )
 
     # @validator('background_color', pre=True)
     # def _ensure_color(cls, v):

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -35,5 +35,5 @@ class Camera:
     interactive: bool = True
 
     @validator('center', 'angles', pre=True)
-    def ensure_3_tuple(cls, v):
+    def _ensure_3_tuple(cls, v):
         return ensure_3_tuple(v)

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -1,19 +1,13 @@
-# from dataclasses import dataclass
-from functools import partial
 from typing import Tuple
 
 from pydantic.dataclasses import dataclass
 
 from ..utils.events.event_utils import evented
-from ..utils.misc import ensure_n_tuple
-
-# from ..utils.events.dataclass import evented_dataclass
-
 
 Float_3_Tuple = Tuple[float, float, float]
-ensure_3_tuple = partial(ensure_n_tuple, n=3)
 
 
+# Pydandic config so that assigments are validated
 class Config:
     validate_assignment = True
 

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -2,17 +2,24 @@
 from functools import partial
 from typing import Tuple
 
-from ..utils.events.dataclass import evented_dataclass
+from pydantic.dataclasses import dataclass
 
-# from ..utils.events.event_utils import evented
+from ..utils.events.event_utils import evented
 from ..utils.misc import ensure_n_tuple
+
+# from ..utils.events.dataclass import evented_dataclass
+
 
 Float_3_Tuple = Tuple[float, float, float]
 ensure_3_tuple = partial(ensure_n_tuple, n=3)
 
 
-# @evented
-@evented_dataclass
+class Config:
+    validate_assignment = True
+
+
+@evented
+@dataclass(config=Config)
 class Camera:
     """Camera object modeling position and view of the camera.
 
@@ -29,9 +36,7 @@ class Camera:
         If the camera interactivity is enabled or not.
     """
 
-    # center: Property[Len_3_Tuple, None, ensure_3_tuple] = (0, 0, 0)
     center: Float_3_Tuple = (0.0, 0.0, 0.0)
     zoom: float = 1.0
     angles: Float_3_Tuple = (0.0, 0.0, 90.0)
-    # angles: Property[Len_3_Tuple, None, ensure_3_tuple] = (0, 0, 90)
     interactive: bool = True

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -1,10 +1,14 @@
+from functools import partial
 from typing import Tuple
 
+from pydantic import validator
 from pydantic.dataclasses import dataclass
 
 from ..utils.events.event_utils import evented
+from ..utils.misc import ensure_n_tuple
 
 Float_3_Tuple = Tuple[float, float, float]
+ensure_3_tuple = partial(ensure_n_tuple, n=3)
 
 
 # Pydandic config so that assigments are validated
@@ -34,3 +38,7 @@ class Camera:
     zoom: float = 1.0
     angles: Float_3_Tuple = (0.0, 0.0, 90.0)
     interactive: bool = True
+
+    @validator('center', 'angles', pre=True)
+    def ensure_3_tuple(cls, v):
+        return ensure_3_tuple(v)

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -1,13 +1,17 @@
+# from dataclasses import dataclass
 from functools import partial
 from typing import Tuple
 
-from ..utils.events.dataclass import Property, evented_dataclass
+from ..utils.events.dataclass import evented_dataclass
+
+# from ..utils.events.event_utils import evented
 from ..utils.misc import ensure_n_tuple
 
-Len_3_Tuple = Tuple[float, float, float]
+Float_3_Tuple = Tuple[float, float, float]
 ensure_3_tuple = partial(ensure_n_tuple, n=3)
 
 
+# @evented
 @evented_dataclass
 class Camera:
     """Camera object modeling position and view of the camera.
@@ -25,7 +29,9 @@ class Camera:
         If the camera interactivity is enabled or not.
     """
 
-    center: Property[Len_3_Tuple, None, ensure_3_tuple] = (0, 0, 0)
-    zoom: float = 1
-    angles: Property[Len_3_Tuple, None, ensure_3_tuple] = (0, 0, 90)
+    # center: Property[Len_3_Tuple, None, ensure_3_tuple] = (0, 0, 0)
+    center: Float_3_Tuple = (0.0, 0.0, 0.0)
+    zoom: float = 1.0
+    angles: Float_3_Tuple = (0.0, 0.0, 90.0)
+    # angles: Property[Len_3_Tuple, None, ensure_3_tuple] = (0, 0, 90)
     interactive: bool = True

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -1,10 +1,9 @@
 from functools import partial
 from typing import Tuple
 
-from pydantic import validator
-from pydantic.dataclasses import dataclass
+from pydantic import BaseModel, validator
 
-from ..utils.events.event_utils import PydanticConfig, evented
+from ..utils.events.event_utils import evented
 from ..utils.misc import ensure_n_tuple
 
 Float_3_Tuple = Tuple[float, float, float]
@@ -12,8 +11,7 @@ ensure_3_tuple = partial(ensure_n_tuple, n=3)
 
 
 @evented
-@dataclass(config=PydanticConfig)
-class Camera:
+class Camera(BaseModel):
     """Camera object modeling position and view of the camera.
 
     Attributes
@@ -33,6 +31,9 @@ class Camera:
     zoom: float = 1.0
     angles: Float_3_Tuple = (0.0, 0.0, 90.0)
     interactive: bool = True
+
+    class Config:
+        validate_assignment = True
 
     @validator('center', 'angles', pre=True)
     def _ensure_3_tuple(cls, v):

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -4,20 +4,15 @@ from typing import Tuple
 from pydantic import validator
 from pydantic.dataclasses import dataclass
 
-from ..utils.events.event_utils import evented
+from ..utils.events.event_utils import PydanticConfig, evented
 from ..utils.misc import ensure_n_tuple
 
 Float_3_Tuple = Tuple[float, float, float]
 ensure_3_tuple = partial(ensure_n_tuple, n=3)
 
 
-# Pydandic config so that assigments are validated
-class Config:
-    validate_assignment = True
-
-
 @evented
-@dataclass(config=Config)
+@dataclass(config=PydanticConfig)
 class Camera:
     """Camera object modeling position and view of the camera.
 

--- a/napari/components/cursor.py
+++ b/napari/components/cursor.py
@@ -1,11 +1,13 @@
 from typing import Tuple
 
-from ..utils.events.dataclass import Property, evented_dataclass
+from pydantic import BaseModel
+
+from ..utils.events.event_utils import evented
 from ._viewer_constants import CursorStyle
 
 
-@evented_dataclass
-class Cursor:
+@evented
+class Cursor(BaseModel):
     """Cursor object with position and properties of the cursor.
 
     Attributes
@@ -30,7 +32,10 @@ class Cursor:
             * standard: The standard cursor
     """
 
-    position: Property[Tuple, None, tuple] = ()
+    position: Tuple[float, ...] = ()
     scaled: bool = True
     size: int = 1
-    style: Property[CursorStyle, str, CursorStyle] = CursorStyle.STANDARD
+    style: CursorStyle = CursorStyle.STANDARD
+
+    class Config:
+        validate_assignment = True

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -330,7 +330,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
             grid_size = [1] * (len(scene_size) - len(grid_size)) + grid_size
         size = np.multiply(scene_size, grid_size)
         center = np.add(corner, np.divide(size, 2))[-self.dims.ndisplay :]
-        center = [0] * (self.dims.ndisplay - len(center)) + list(center)
+        center = [0] * (3 - len(center)) + list(center)
         self.camera.center = center
         # zoom is definied as the number of canvas pixels per world pixel
         # The default value used below will zoom such that the whole field

--- a/napari/utils/events/dataclass.py
+++ b/napari/utils/events/dataclass.py
@@ -286,6 +286,7 @@ def add_events_to_class(cls: Type[C]) -> Type[C]:
     def evented_post_init(self: T, *initvars) -> None:
 
         # create an EmitterGroup with an EventEmitter for each field
+        # in the dataclass, skip those with metadata={'events' = False}
         if hasattr(self, 'events') and isinstance(self.events, EmitterGroup):
             for em in self.events.emitters:
                 e_fields.pop(em, None)
@@ -295,7 +296,6 @@ def add_events_to_class(cls: Type[C]) -> Type[C]:
                 source=self, auto_connect=False, **e_fields,
             )
 
-        # in the dataclass, skip those with metadata={'events' = False}
         # call original __post_init__
         if orig_post_init is not None:
             orig_post_init(self, *initvars)
@@ -489,7 +489,6 @@ def evented_dataclass(
     frozen: bool = False,
     events: bool = True,
     properties: bool = True,
-    typed: bool = False,
 ) -> Type[C]:
     """Enhanced dataclass decorator with events and property descriptors.
 

--- a/napari/utils/events/dataclass.py
+++ b/napari/utils/events/dataclass.py
@@ -284,8 +284,8 @@ def add_events_to_class(cls: Type[C]) -> Type[C]:
     compare_dict.update(compare_dict_base)
 
     def evented_post_init(self: T, *initvars) -> None:
+
         # create an EmitterGroup with an EventEmitter for each field
-        # in the dataclass, skip those with metadata={'events' = False}
         if hasattr(self, 'events') and isinstance(self.events, EmitterGroup):
             for em in self.events.emitters:
                 e_fields.pop(em, None)
@@ -294,6 +294,8 @@ def add_events_to_class(cls: Type[C]) -> Type[C]:
             self.events = EmitterGroup(
                 source=self, auto_connect=False, **e_fields,
             )
+
+        # in the dataclass, skip those with metadata={'events' = False}
         # call original __post_init__
         if orig_post_init is not None:
             orig_post_init(self, *initvars)
@@ -487,6 +489,7 @@ def evented_dataclass(
     frozen: bool = False,
     events: bool = True,
     properties: bool = True,
+    typed: bool = False,
 ) -> Type[C]:
     """Enhanced dataclass decorator with events and property descriptors.
 

--- a/napari/utils/events/dataclass.py
+++ b/napari/utils/events/dataclass.py
@@ -284,7 +284,6 @@ def add_events_to_class(cls: Type[C]) -> Type[C]:
     compare_dict.update(compare_dict_base)
 
     def evented_post_init(self: T, *initvars) -> None:
-
         # create an EmitterGroup with an EventEmitter for each field
         # in the dataclass, skip those with metadata={'events' = False}
         if hasattr(self, 'events') and isinstance(self.events, EmitterGroup):
@@ -295,7 +294,6 @@ def add_events_to_class(cls: Type[C]) -> Type[C]:
             self.events = EmitterGroup(
                 source=self, auto_connect=False, **e_fields,
             )
-
         # call original __post_init__
         if orig_post_init is not None:
             orig_post_init(self, *initvars)

--- a/napari/utils/events/event_utils.py
+++ b/napari/utils/events/event_utils.py
@@ -1,7 +1,7 @@
 import dataclasses as _dc
 import weakref
 
-from .dataclass import _type_to_compare, is_equal
+from .dataclass import _type_to_compare, is_equal, update_from_dict
 from .event import EmitterGroup
 
 
@@ -73,6 +73,9 @@ def evented(cls):
 
     setattr(cls, '__setattr__', new_setattr)
     setattr(cls, '__equality_checks__', compare_dict)
+
+    setattr(cls, 'asdict', _dc.asdict)
+    setattr(cls, 'update', update_from_dict)
     return cls
 
 

--- a/napari/utils/events/event_utils.py
+++ b/napari/utils/events/event_utils.py
@@ -1,7 +1,6 @@
-import dataclasses as _dc
 import weakref
 
-from .dataclass import _type_to_compare, is_equal, update_from_dict
+from .dataclass import _type_to_compare, is_equal
 from .event import EmitterGroup
 
 
@@ -31,15 +30,18 @@ def disconnect_events(emitter, listener):
 
 def evented(cls):
     # get field which should be evented
-    _fields = [
-        _dc._get_field(cls, name, type_)
-        for name, type_ in cls.__dict__.get('__annotations__', {}).items()
-    ]
-    e_fields = {
-        fld.name: None
-        for fld in _fields
-        if fld._field_type is _dc._FIELD and fld.metadata.get("events", True)
-    }
+    # _fields = [
+    #     _dc._get_field(cls, name, type_)
+    #     for name, type_ in cls.__dict__.get('__annotations__', {}).items()
+    # ]
+    # e_fields = {
+    #     fld.name: None
+    #     for fld in _fields
+    #     if fld._field_type is _dc._FIELD and fld.metadata.get("events", True)
+    # }
+
+    _fields = list(cls.__fields__)
+    e_fields = {fld: None for fld in _fields}
 
     # create an EmitterGroup with an EventEmitter for each field
     if hasattr(cls, 'events') and isinstance(cls.events, EmitterGroup):
@@ -74,8 +76,8 @@ def evented(cls):
     setattr(cls, '__setattr__', new_setattr)
     setattr(cls, '__equality_checks__', compare_dict)
 
-    setattr(cls, 'asdict', _dc.asdict)
-    setattr(cls, 'update', update_from_dict)
+    # setattr(cls, 'asdict', _dc.asdict)
+    # setattr(cls, 'update', update_from_dict)
     return cls
 
 
@@ -134,3 +136,4 @@ def set_with_events(self, name, value, original_setattr):
 # Pydandic config so that assigments are validated
 class PydanticConfig:
     validate_assignment = True
+    arbitrary_types_allowed = True

--- a/napari/utils/events/event_utils.py
+++ b/napari/utils/events/event_utils.py
@@ -1,4 +1,8 @@
+import dataclasses as _dc
 import weakref
+
+from .dataclass import _type_to_compare, is_equal
+from .event import EmitterGroup
 
 
 def disconnect_events(emitter, listener):
@@ -23,3 +27,97 @@ def disconnect_events(emitter, listener):
                 listener
             ):
                 em.disconnect(callback)
+
+
+def evented(cls):
+    # get field which should be evented
+    _fields = [
+        _dc._get_field(cls, name, type_)
+        for name, type_ in cls.__dict__.get('__annotations__', {}).items()
+    ]
+    e_fields = {
+        fld.name: None
+        for fld in _fields
+        if fld._field_type is _dc._FIELD and fld.metadata.get("events", True)
+    }
+
+    # create an EmitterGroup with an EventEmitter for each field
+    if hasattr(cls, 'events') and isinstance(cls.events, EmitterGroup):
+        for em in cls.events.emitters:
+            e_fields.pop(em, None)
+        cls.events.add(**e_fields)
+    else:
+        cls.events = EmitterGroup(source=cls, auto_connect=False, **e_fields,)
+
+    # create dict with compare functions for fields which cannot be compared
+    # using standard equal operator, like numpy arrays.
+    # it will be set to __equality_checks__ class parameter.
+    compare_dict_base = getattr(cls, "__equality_checks__", {})
+    compare_dict = {
+        n: t
+        for n, t in {
+            name: _type_to_compare(type_)
+            for name, type_ in cls.__dict__.get('__annotations__', {}).items()
+            if name not in compare_dict_base
+        }.items()
+        if t is not None  # walrus operator is supported from python 3.8
+    }
+    # use compare functions provided by class creator.
+    compare_dict.update(compare_dict_base)
+
+    # modify __setattr__ with version that emits an event when setting
+    setattr(cls, '__setattr__', set_with_events)
+    setattr(cls, '__equality_checks__', compare_dict)
+    return cls
+
+
+def set_with_events(self, name, value):
+    """Modified __setattr__ method that emits an event when set.
+
+    Events will *only* be emitted if the ``name`` of the attribute being set
+    is one of the dataclass fields (i.e. ``name in self.__annotations__``),
+    and the dataclass ``__post_init__` method has already been called.
+
+    Also looks for and calls an optional ``_on_name_set()`` method afterwards.
+
+    Order of operations:
+        1. Call the original ``__setattr__`` function to set the value
+        2. Look for an ``_on_name_set`` method on the object
+            a. If present, call it with the current value
+            b. That method can do anything (including changing the value, or
+               emitting its own events if necessary).  If changing the value,
+               it should check to make sure that it is different than the
+               current value before setting, or a ``RecursionError`` may occur.
+            c. If that method returns ``True``. Return *without* emitting
+               an event.
+        3. If ``_on_name_set`` has not returned ``True``, then emit an event
+           from the EventEmitter with the corresponding ``name`` in the.
+           e.g. ``self.events.<name>(value=value)``.
+
+    Parameters
+    ----------
+    self : C
+        An instance of the decorated dataclass of Type[C]
+    name : str
+        The name of the attribute being set.
+    value : Any
+        The new value for the attribute.
+    fields : set of str
+        Only emit events for field names in this set.
+    """
+    if name not in getattr(self, 'events', {}):
+        # fallback to default behavior
+        object.__setattr__(self, name, value)
+        return
+
+    # grab current value
+    before = getattr(self, name, object())
+    object.__setattr__(self, name, value)
+
+    # if different we emit the event with new value
+    after = getattr(self, name)
+    print('callleeedd?????', name, before, after)
+    if not self.__equality_checks__.get(name, is_equal)(after, before):
+        # use gettattr again in case `_on_name_set` has modified it
+        print('emmmiiisss?????')
+        getattr(self.events, name)(value=after)  # type: ignore

--- a/napari/utils/events/event_utils.py
+++ b/napari/utils/events/event_utils.py
@@ -129,3 +129,8 @@ def set_with_events(self, name, value, original_setattr):
     if not self.__equality_checks__.get(name, is_equal)(after, before):
         # use gettattr again in case `_on_name_set` has modified it
         getattr(self.events, name)(value=after)  # type: ignore
+
+
+# Pydandic config so that assigments are validated
+class PydanticConfig:
+    validate_assignment = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
     napari-svg>=0.1.4
     numpy>=1.16.0
     numpydoc>=0.9.2
+    pydantic>=1.7.3
     Pillow!=7.1.0,!=7.1.1  # not a direct dependency, but 7.1.0 and 7.1.1 broke imageio
     psutil>=5.0
     PyOpenGL>=3.1.0


### PR DESCRIPTION
# Description
This PR is a proof of concept of making an evented pydantic dataclass. As mentioned in #2009 in I dropped the `Properties` functionality and decided to just make a new decorator `evented` that can decorate any dataclass, pydantic or not. I've preserved through the `asdict` and `update` methods too.

I'd call this very much a proof of concept. What's nice though is that it if we like this we could gradually role this change out to all our evented dataclasses. Note these are a lot less powerful than the other ones, there is no special setter, no special getter, and no private `_on_*_set` method, but for many of our evented dataclasses we might not need the additional functionality.

Very curious what @jni @tlambert03 and others think. A major motivation for this (as discussed in #2009) is that it now makes things like interpolation between states possible, serialization is much cleaner, and to quote @tlambert03 who originall proposed this in https://github.com/napari/napari/issues/1436#issuecomment-657281399

> If we implemented this thoroughly with pydantic, we'd have a rock solid model that was nearly guaranteed to be consistent.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Refactor (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
Closes #2009
