### PR TITLE
Cleanup dockwidget removal

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -597,8 +597,12 @@ class Window:
             action.setShortcut(dock_widget.shortcut)
         self.window_menu.addAction(action)
 
-    def remove_dock_widget(self, widget):
+    def remove_dock_widget(self, widget: QWidget):
         """Removes specified dock widget.
+
+        If a QDockWidget is not provided, the existing QDockWidgets will be
+        searched for one whose inner widget (``.widget()``) is the provided
+        ``widget``.
 
         Parameters
         ----------
@@ -608,8 +612,23 @@ class Window:
         if widget == 'all':
             for dw in self._qt_window.findChildren(QDockWidget):
                 self._qt_window.removeDockWidget(dw)
+            return
+
+        if not isinstance(widget, QDockWidget):
+            for dw in self._qt_window.findChildren(QDockWidget):
+                if dw.widget() is widget:
+                    _dw: QDockWidget = dw
+                    break
+            else:
+                raise LookupError(
+                    f"Could not find a dock widget containing: {widget}"
+                )
         else:
-            self._qt_window.removeDockWidget(widget)
+            _dw = widget
+
+        if _dw.widget():
+            _dw.widget().setParent(None)
+        self._qt_window.removeDockWidget(_dw)
 
     def resize(self, width, height):
         """Resize the window.

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -588,7 +588,6 @@ class Window:
         dock_widget : QtViewerDockWidget
             `dock_widget` will be added to the main window.
         """
-        dock_widget.setParent(self._qt_window)
         self._qt_window.addDockWidget(dock_widget.qt_area, dock_widget)
         action = dock_widget.toggleViewAction()
         action.setStatusTip(dock_widget.name)
@@ -629,6 +628,12 @@ class Window:
         if _dw.widget():
             _dw.widget().setParent(None)
         self._qt_window.removeDockWidget(_dw)
+        self.window_menu.removeAction(_dw.toggleViewAction())
+        # Deleting the dock widget means any references to it will no longer
+        # work but it's not really useful anyway, since the inner widget has
+        # been removed. and anyway: people should be using add_dock_widget
+        # rather than directly using _add_viewer_dock_widget
+        _dw.deleteLater()
 
     def resize(self, width, height):
         """Resize the window.

--- a/napari/_qt/widgets/_tests/test_qt_dock_widget.py
+++ b/napari/_qt/widgets/_tests/test_qt_dock_widget.py
@@ -71,7 +71,9 @@ def test_remove_dock_widget_orphans_widget(make_test_viewer):
     assert not widg.parent()
     dw = viewer.window.add_dock_widget(widg, name='test')
     assert widg.parent() is dw
+    assert dw.toggleViewAction() in viewer.window.window_menu.actions()
     viewer.window.remove_dock_widget(dw)
+    assert dw.toggleViewAction() not in viewer.window.window_menu.actions()
     del dw
     # if dw didn't release widg, we'd get an exception when next accessing widg
     assert not widg.parent()

--- a/napari/_qt/widgets/_tests/test_qt_dock_widget.py
+++ b/napari/_qt/widgets/_tests/test_qt_dock_widget.py
@@ -9,14 +9,14 @@ def test_add_dock_widget(make_test_viewer):
     dwidg = viewer.window.add_dock_widget(widg, name='test')
     assert not dwidg.is_vertical
     assert viewer.window._qt_window.findChild(QDockWidget, 'test')
-    assert dwidg.widget == widg
+    assert dwidg.widget() == widg
     dwidg._on_visibility_changed(True)  # smoke test
 
     widg2 = QPushButton('button')
     dwidg2 = viewer.window.add_dock_widget(widg2, name='test2', area='right')
     assert dwidg2.is_vertical
     assert viewer.window._qt_window.findChild(QDockWidget, 'test2')
-    assert dwidg2.widget == widg2
+    assert dwidg2.widget() == widg2
     dwidg2._on_visibility_changed(True)  # smoke test
 
     with pytest.raises(ValueError):
@@ -46,13 +46,13 @@ def test_add_dock_widget_from_list(make_test_viewer):
         [widg, widg2], name='test', area='right'
     )
     assert viewer.window._qt_window.findChild(QDockWidget, 'test')
-    assert isinstance(dwidg.widget.layout, QVBoxLayout)
+    assert isinstance(dwidg.widget().layout, QVBoxLayout)
 
     dwidg = viewer.window.add_dock_widget(
         [widg, widg2], name='test2', area='bottom'
     )
     assert viewer.window._qt_window.findChild(QDockWidget, 'test2')
-    assert isinstance(dwidg.widget.layout, QHBoxLayout)
+    assert isinstance(dwidg.widget().layout, QHBoxLayout)
 
 
 def test_add_dock_widget_raises(make_test_viewer):
@@ -62,3 +62,30 @@ def test_add_dock_widget_raises(make_test_viewer):
 
     with pytest.raises(TypeError):
         viewer.window.add_dock_widget(widg, name='test')
+
+
+def test_remove_dock_widget_orphans_widget(make_test_viewer):
+    viewer = make_test_viewer()
+    widg = QPushButton('button')
+
+    assert not widg.parent()
+    dw = viewer.window.add_dock_widget(widg, name='test')
+    assert widg.parent() is dw
+    viewer.window.remove_dock_widget(dw)
+    del dw
+    # if dw didn't release widg, we'd get an exception when next accessing widg
+    assert not widg.parent()
+
+
+def test_remove_dock_widget_by_widget_reference(make_test_viewer):
+    viewer = make_test_viewer()
+    widg = QPushButton('button')
+
+    dw = viewer.window.add_dock_widget(widg, name='test')
+    assert widg.parent() is dw
+    assert dw in viewer.window._qt_window.findChildren(QDockWidget)
+    viewer.window.remove_dock_widget(widg)
+    with pytest.raises(LookupError):
+        # it's gone this time:
+        viewer.window.remove_dock_widget(widg)
+    assert not widg.parent()

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -79,9 +79,9 @@ class QtViewerDockWidget(QDockWidget):
         self.setMinimumWidth(50)
         self.setObjectName(name)
 
-        self.widget = combine_widgets(
-            widget, vertical=area in {'left', 'right'}
-        )
+        widget = combine_widgets(widget, vertical=area in {'left', 'right'})
+        self.setWidget(widget)
+
         self._features = self.features()
         self.dockLocationChanged.connect(self._set_title_orientation)
 
@@ -89,17 +89,6 @@ class QtViewerDockWidget(QDockWidget):
         self.title = QtCustomTitleBar(self)
         self.setTitleBarWidget(self.title)
         self.visibilityChanged.connect(self._on_visibility_changed)
-
-    @property
-    def widget(self):
-        """QWidget: widget that will be added as QDockWidget's main widget."""
-        return self._widget
-
-    @widget.setter
-    def widget(self, widget):
-        self.setWidget(widget)
-        widget.setParent(self)
-        self._widget = widget
 
     def setFeatures(self, features):
         super().setFeatures(features)


### PR DESCRIPTION
# Description
This closes #2035 (and hopefully also fixes https://github.com/napari/magicgui/issues/28) by calling `setParent(None)` on the "inner widget" of a dock widget (i.e. `dock_widget.widget().setParent(None)`) before removing the dock widget from the viewer (I also remove the corresponding QAction from the menu).

I went a step farther and call `dockwidget.deleteLater()` after removal.  By removing the inner widget, we've made the dock widget all but useless, and since _we_ are constructing that object ourselves with `add_dock_widget`, it seems fitting that `remove_dock_widget` should clean it up.  If anyone still has a reference to it and tries to use it, they'll get a "Qt Object deleted error".

Lastly, I made it so that if a non dock widget is provided to `remove_dock_widget`, it will find the parent dock widget and remove it, so this now works (meaning there is even less reason to retain the pointer to the dock widget):
```python
widget = QWidget()
viewer.add_dock_widget(widget)
viewer.remove_dock_widget(widget)
```
(this had also been pointed out in https://github.com/napari/magicgui/issues/28#issue-654824093)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] the test suite for my feature covers cases x, y, and z
- [x] all tests pass with my change
