### PR TITLE
Prepare for evented viewer

### DIFF
--- a/napari/_qt/layer_controls/qt_layer_controls_container.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_container.py
@@ -80,7 +80,7 @@ class QtLayerControlsContainer(QStackedWidget):
         self.empty_widget = QFrame()
         self.widgets = {}
         self.addWidget(self.empty_widget)
-        self._display(None)
+        self.setCurrentWidget(self.empty_widget)
 
         self.viewer.layers.events.inserted.connect(self._add)
         self.viewer.layers.events.removed.connect(self._remove)
@@ -94,11 +94,7 @@ class QtLayerControlsContainer(QStackedWidget):
         event : Event
             Event with the target layer at `event.item`.
         """
-        if event is None:
-            layer = None
-        else:
-            layer = event.item
-
+        layer = event.value
         if layer is None:
             self.setCurrentWidget(self.empty_widget)
         else:

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -674,7 +674,7 @@ class Window:
         event : napari.utils.event.Event
             The napari event that triggered this method.
         """
-        self._status_bar.showMessage(event.text)
+        self._status_bar.showMessage(event.value)
 
     def _title_changed(self, event):
         """Update window title.
@@ -684,7 +684,7 @@ class Window:
         event : napari.utils.event.Event
             The napari event that triggered this method.
         """
-        self._qt_window.setWindowTitle(event.text)
+        self._qt_window.setWindowTitle(event.value)
 
     def _help_changed(self, event):
         """Update help message on status bar.
@@ -694,7 +694,7 @@ class Window:
         event : napari.utils.event.Event
             The napari event that triggered this method.
         """
-        self._help.setText(event.text)
+        self._help.setText(event.value)
 
     def _screenshot_dialog(self):
         """Save screenshot of current display with viewer, default .png"""

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -244,7 +244,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
         if status == self.status:
             return
         self._status = status
-        self.events.status(text=self._status)
+        self.events.status(value=self._status)
 
     @property
     def help(self):
@@ -258,7 +258,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
         if help == self.help:
             return
         self._help = help
-        self.events.help(text=self._help)
+        self.events.help(value=self._help)
 
     @property
     def title(self):
@@ -271,7 +271,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
         if title == self.title:
             return
         self._title = title
-        self.events.title(text=self._title)
+        self.events.title(value=self._title)
 
     @property
     def interactive(self):
@@ -317,7 +317,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
         if active_layer is not None:
             self.keymap_providers.insert(0, active_layer)
 
-        self.events.active_layer(item=self._active_layer)
+        self.events.active_layer(value=self._active_layer)
 
     @property
     def _sliced_extent_world(self) -> np.ndarray:


### PR DESCRIPTION
# Description
Super simple PR that makes some changes to standardize event payload names ahead of the transition to an evented viewermodel. These changes were being carried in #2005, #1489 and would have been needed in any new approach PR, like using pydantic. I thought it just made sense to get them in now so I don't have to duplicated them everywhere else.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

