### PR TITLE
Only raise leaked widgets errors in tests if no other exception was raised

### DIFF
--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -88,7 +88,8 @@ def qtbot(qtbot):
 
     yield qtbot
 
-    # only if an exception wasn't raised should we look for leaked widgets.
+    # if an exception was raised during the test, we should just quit now and
+    # skip looking for leaked widgets.
     if getattr(sys, 'last_value', None) is not prior_exception:
         return
 

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -89,17 +89,17 @@ def qtbot(qtbot):
     yield qtbot
 
     # only if an exception wasn't raised should we look for leaked widgets.
-    if getattr(sys, 'last_value', None) is prior_exception:
-        QApplication.processEvents()
-        leaks = set(QApplication.topLevelWidgets()).difference(initial)
-        # still not sure how to clean up some of the remaining vispy
-        # vispy.app.backends._qt.CanvasBackendDesktop widgets...
-        if any(
-            [n.__class__.__name__ != 'CanvasBackendDesktop' for n in leaks]
-        ):
-            raise AssertionError(f'Widgets leaked!: {leaks}')
-        if leaks:
-            warnings.warn(f'Widgets leaked!: {leaks}')
+    if getattr(sys, 'last_value', None) is not prior_exception:
+        return
+
+    QApplication.processEvents()
+    leaks = set(QApplication.topLevelWidgets()).difference(initial)
+    # still not sure how to clean up some of the remaining vispy
+    # vispy.app.backends._qt.CanvasBackendDesktop widgets...
+    if any([n.__class__.__name__ != 'CanvasBackendDesktop' for n in leaks]):
+        raise AssertionError(f'Widgets leaked!: {leaks}')
+    if leaks:
+        warnings.warn(f'Widgets leaked!: {leaks}')
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
# Description
People seem to gravitate to the "leaked widgets" error in tests, before looking at other test errors.  And if another exception has occurred,  widget cleanup fails and leaks tend to happen.  Point is, leaked widgets don't matter if you had other errors... This PR makes it so that leaked widget errors only get raised if no other error was raised in the test