### PR TITLE
Fix magicgui test funcs

### DIFF
--- a/napari/utils/_tests/test_magicgui.py
+++ b/napari/utils/_tests/test_magicgui.py
@@ -12,11 +12,11 @@ def test_magicgui_returns_image(make_test_viewer):
     """make sure a magicgui function returning Image adds an Image."""
 
     @magicgui.magicgui
-    def add_image() -> Image:
+    def add_image(x) -> Image:
         return np.random.rand(10, 10)
 
     viewer = make_test_viewer()
-    viewer.window.add_dock_widget(add_image.Gui())
+    viewer.window.add_dock_widget(add_image)
     assert len(viewer.layers) == 0
     add_image()  # should add a new layer to the list
     assert len(viewer.layers) == 1
@@ -32,11 +32,11 @@ def test_magicgui_returns_label(make_test_viewer):
     """make sure a magicgui function returning Labels adds a Labels."""
 
     @magicgui.magicgui
-    def add_labels() -> Labels:
+    def add_labels(x) -> Labels:
         return np.random.rand(10, 10)
 
     viewer = make_test_viewer()
-    viewer.window.add_dock_widget(add_labels.Gui())
+    viewer.window.add_dock_widget(add_labels)
     assert len(viewer.layers) == 0
     add_labels()  # should add a new layer to the list
     assert len(viewer.layers) == 1
@@ -49,11 +49,11 @@ def test_magicgui_returns_layer_tuple(make_test_viewer):
     """make sure a magicgui function returning Layer adds the right type."""
 
     @magicgui.magicgui
-    def add_layer() -> Layer:
+    def add_layer(x) -> Layer:
         return [(np.random.rand(10, 3), {'size': 20, 'name': 'foo'}, 'points')]
 
     viewer = make_test_viewer()
-    viewer.window.add_dock_widget(add_layer.Gui())
+    viewer.window.add_dock_widget(add_layer)
     assert len(viewer.layers) == 0
 
     add_layer()  # should add a new layer to the list

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,4 +9,4 @@ fsspec
 zarr
 scikit-image
 pooch
-magicgui
+magicgui>=0.2.0


### PR DESCRIPTION
# Description
This exposed (and skirts for now) a weird bug I just discovered in which a magicgui widget that has no arguments is somehow not being assigned the proper parent chain.  And so it can't find the viewer.  I'll follow up with a fix for that bug when I figure it out, but for now, this will fix our failing tests with magicgui 0.2.0.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
