### PR TITLE
async-43: New LoaderPoolGroup

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -781,6 +781,7 @@ def _stop_monitor() -> None:
 
 
 def _shutdown_chunkloader() -> None:
+    """Shutdown the ChunkLoader."""
     if config.async_loading:
         from ..components.experimental.chunk import chunk_loader
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -296,6 +296,7 @@ class Window:
                 perf.timers.stop_trace_file()
 
             _stop_monitor()
+            _shutdown_chunkloader()
 
         exitAction.triggered.connect(handle_exit)
 
@@ -777,3 +778,10 @@ def _stop_monitor() -> None:
         from ..components.experimental.monitor import monitor
 
         monitor.stop()
+
+
+def _shutdown_chunkloader() -> None:
+    if config.async_loading:
+        from ..components.experimental.chunk import chunk_loader
+
+        chunk_loader.shutdown()

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -211,7 +211,6 @@ class ChunkLoader:
         specify which thread the future's done callback will be called in,
         only that it will be called in some thread in the current process.
         """
-
         LOGGER.debug(
             "_done: load=%.3fms elapsed=%.3fms %s",
             request.load_ms,
@@ -304,6 +303,10 @@ class ChunkLoader:
         # cancelled.
         map(lambda x: x.result(), future_list)
         del self._futures[data_id]
+
+    def shutdown(self) -> None:
+        """When napari is shutting down."""
+        self._loaders.shutdown()
 
 
 @contextmanager

--- a/napari/components/experimental/chunk/_pool.py
+++ b/napari/components/experimental/chunk/_pool.py
@@ -117,7 +117,7 @@ class LoaderPool:
 
         return cancelled
 
-    def _submit(self, request: ChunkRequest) -> None:
+    def _submit(self, request: ChunkRequest) -> Optional[Future]:
         """Initiate an asynchronous load of the given request.
 
         Parameters
@@ -156,6 +156,12 @@ class LoaderPool:
         # Tell the loader this request finished.
         if self._on_done_loader is not None:
             self._on_done_loader(request)
+
+    def shutdown(self) -> None:
+        """Shutdown the pool."""
+        # Avoid crashes or hangs on exit.
+        self._delay_queue.shutdown()
+        self._executor.shutdown(wait=True)
 
     @staticmethod
     def _get_request(future: Future) -> Optional[ChunkRequest]:

--- a/napari/components/experimental/chunk/_pool.py
+++ b/napari/components/experimental/chunk/_pool.py
@@ -95,26 +95,21 @@ class LoaderPool:
         # Cancelling requests in the delay queue is fast and easy.
         cancelled = self._delay_queue.cancel_requests(should_cancel)
 
-        for request in cancelled:
-            assert isinstance(request, ChunkRequest)
-
         num_before = len(self._futures)
 
-        # Cancelling the futures is a little more work. If Future.cancel()
-        # returns False it means the a worker is already loading the request
-        # so it cannot be cancelled. This load will likely be pointless and
-        # we will throw it away.
+        # Cancelling futures may or may not work. Future.cancel() will
+        # return False if the worker is already loading the request and it
+        # cannot be cancelled.
         for request in list(self._futures.keys()):
             if self._futures[request].cancel():
                 del self._futures[request]
-                assert isinstance(request, ChunkRequest)
                 cancelled.append(request)
 
         num_after = len(self._futures)
         num_cancelled = num_before - num_after
 
         LOGGER.debug(
-            "cance_requests: %d -> %d futures (cancelled %d)",
+            "cancel_requests: %d -> %d futures (cancelled %d)",
             num_before,
             num_after,
             num_cancelled,

--- a/napari/components/experimental/chunk/_pool_group.py
+++ b/napari/components/experimental/chunk/_pool_group.py
@@ -59,7 +59,7 @@ class LoaderPoolGroup:
         use_priority = self._get_loader_priority(priority)
         return self._pools[use_priority]
 
-    @lru_cache
+    @lru_cache(max_size=64)
     def _get_loader_priority(self, priority: int) -> int:
         """Return the loader priority to use.
 

--- a/napari/components/experimental/chunk/_pool_group.py
+++ b/napari/components/experimental/chunk/_pool_group.py
@@ -66,8 +66,7 @@ class LoaderPoolGroup:
         This method is pretty fast, but since the mapping from priority to
         LoaderPool is static, use lru_cache.
         """
-        if priority < 0:
-            raise ValueError("Negative priority not allowed")
+        priority = max(priority, 0)  # No negative priorities.
         keys = sorted(self._pools.keys())
         index = bisect.bisect_left(keys, priority)
         if index < len(keys) and keys[index] == priority:

--- a/napari/components/experimental/chunk/_pool_group.py
+++ b/napari/components/experimental/chunk/_pool_group.py
@@ -103,6 +103,11 @@ class LoaderPoolGroup:
             cancelled.extend(pool.cancel_requests(should_cancel))
         return cancelled
 
+    def shutdown(self) -> None:
+        """Shutdown the pools."""
+        for pool in self._pools.values():
+            pool.shutdown()
+
 
 def _get_loader_configs(octree_config) -> Dict[int, dict]:
     """Return dict of loader configs for the octree.

--- a/napari/components/experimental/chunk/_pool_group.py
+++ b/napari/components/experimental/chunk/_pool_group.py
@@ -1,0 +1,146 @@
+"""LoaderPoolGroup class.
+"""
+import bisect
+from functools import lru_cache
+from typing import Callable, Dict, List
+
+from ._pool import DoneCallback, LoaderPool
+from ._request import ChunkRequest
+
+
+class LoaderPoolGroup:
+    """Holds the LoaderPools that the ChunkLoader is using.
+
+    Parameters
+    ----------
+    octree_config : dict
+        The full octree config data.
+
+    Attributes
+    ----------
+    _pools : Dict[int, LoaderPool]
+        The mapping from priority to loader pool.
+    """
+
+    def __init__(self, octree_config: dict, on_done: DoneCallback = None):
+        self._pools = self._create_pools(octree_config, on_done)
+
+    def _create_pools(
+        self, octree_config: dict, on_done: DoneCallback
+    ) -> Dict[int, LoaderPool]:
+        """Return the mapping from priorities to loaders.
+
+        Parameters
+        ----------
+        octree_config : dict
+            Octree configuration data.
+
+        Return
+        ------
+        Dict[int, LoaderPool]
+            The loader to use for each priority
+        """
+        configs = _get_loader_configs(octree_config)
+
+        # Create a LoaderPool for each priority.
+        return {
+            priority: LoaderPool(config, on_done)
+            for (priority, config) in configs.items()
+        }
+
+    def get_loader(self, priority) -> LoaderPool:
+        """Return the LoaderPool for the given priority.
+
+        Return
+        ------
+        LoaderPool
+            The LoaderPool for the given priority.
+        """
+        use_priority = self._get_loader_priority(priority)
+        return self._pools[use_priority]
+
+    @lru_cache
+    def _get_loader_priority(self, priority: int) -> int:
+        """Return the loader priority to use.
+
+        This method is pretty fast, but since the mapping from priority to
+        LoaderPool is static, use lru_cache.
+        """
+        if priority < 0:
+            raise ValueError("Negative priority not allowed")
+        keys = sorted(self._pools.keys())
+        index = bisect.bisect_left(keys, priority)
+        if index < len(keys) and keys[index] == priority:
+            return priority  # Exact hit on a pool, so use it.
+        return keys[index - 1]  # Use the pool just before the insertion point.
+
+    def load_async(self, request: ChunkRequest) -> None:
+        """Load this request asynchronously.
+
+        Parameters
+        ----------
+        request : ChunkRequest
+            The request to load.
+        """
+        self.get_loader(request.priority).load_async(request)
+
+    def cancel_requests(
+        self, should_cancel: Callable[[ChunkRequest], bool]
+    ) -> List[ChunkRequest]:
+        """Cancel pending requests based on the given filter.
+
+        Parameters
+        ----------
+        should_cancel : Callable[[ChunkRequest], bool]
+            Cancel the request if this returns True.
+
+        Return
+        ------
+        List[ChunkRequests]
+            The requests that were cancelled, if any.
+        """
+        cancelled = []
+        for pool in self._pools.values():
+            cancelled.extend(pool.cancel_requests(should_cancel))
+        return cancelled
+
+
+def _get_loader_configs(octree_config) -> Dict[int, dict]:
+    """Return dict of loader configs for the octree.
+
+    We merge each loader config with the defaults, so that each loader
+    config only needs to specify non-default values.
+
+    Parameters
+    ----------
+    octree_config : dict
+        The octree configuration data.
+
+    Returns
+    -------
+    Dict[int, dict]
+        A dictionary of loader configs.
+    """
+    try:
+        defaults = octree_config['loader_defaults']
+    except KeyError as exc:
+        raise KeyError("Missing 'loader_defaults' in octree config.") from exc
+
+    try:
+        configs = octree_config['octree']['loaders']
+    except KeyError:
+        # No octree specific loaders were specificed. We we just have one loader
+        # with default, zero priority should catch everything.
+        return {0: defaults}
+
+    def merge(config: dict) -> dict:
+        """Return config merged with the defaults.
+
+        Can't use dict constructor since we have int keys.
+        """
+        merged = defaults.copy()
+        merged.update(config)
+        return merged
+
+    # Return merged configs.
+    return {key: merge(config) for (key, config) in configs.items()}

--- a/napari/components/experimental/chunk/_pool_group.py
+++ b/napari/components/experimental/chunk/_pool_group.py
@@ -59,7 +59,7 @@ class LoaderPoolGroup:
         use_priority = self._get_loader_priority(priority)
         return self._pools[use_priority]
 
-    @lru_cache(max_size=64)
+    @lru_cache(maxsize=64)
     def _get_loader_priority(self, priority: int) -> int:
         """Return the loader priority to use.
 

--- a/napari/components/experimental/chunk/_request.py
+++ b/napari/components/experimental/chunk/_request.py
@@ -83,7 +83,12 @@ class ChunkRequest:
         Timing information about chunk load time.
     """
 
-    def __init__(self, location: ChunkLocation, chunks: Dict[str, ArrayLike]):
+    def __init__(
+        self,
+        location: ChunkLocation,
+        chunks: Dict[str, ArrayLike],
+        priority: int = 0,
+    ):
         # Make sure chunks dict is valid.
         for chunk_key, array in chunks.items():
             assert isinstance(chunk_key, str)
@@ -94,6 +99,8 @@ class ChunkRequest:
 
         self.create_time = time.time()
         self._timers: Dict[str, PerfEvent] = {}
+
+        self.priority = priority
 
     @property
     def elapsed_ms(self) -> float:

--- a/napari/components/experimental/chunk/_tests/test_loader.py
+++ b/napari/components/experimental/chunk/_tests/test_loader.py
@@ -1,0 +1,77 @@
+"""Test _get_loader_configs() function."""
+import pytest
+
+from napari.components.experimental.chunk._pool_group import (
+    LoaderPoolGroup,
+    _get_loader_configs,
+)
+
+
+def test_get_loader_config_error():
+    """Test that defaults are required."""
+    config = {}
+    with pytest.raises(KeyError):
+        _get_loader_configs(config)
+
+
+def test_get_loader_config_defaults():
+    """Test config that has defaults but no octree loaders."""
+    config = {
+        "loader_defaults": {
+            "force_synchronous": False,
+            "num_workers": 10,
+            "delay_queue_ms": 0,
+        },
+        "octree": {},
+    }
+    configs = _get_loader_configs(config)
+    assert len(configs) == 1
+    configs[0]['num_workers'] == 10
+    configs[0]['delay_queue_ms'] == 10
+
+
+TEST_CONFIG = {
+    "loader_defaults": {
+        "force_synchronous": False,
+        "num_workers": 10,
+        "delay_queue_ms": 0,
+    },
+    "octree": {
+        "loaders": {
+            0: {"num_workers": 10, "delay_queue_ms": 100},
+            3: {"num_workers": 5, "delay_queue_ms": 0},
+        },
+    },
+}
+
+
+def test_get_loader_config_override():
+    """Test two loaders that override the defaults."""
+    configs = _get_loader_configs(TEST_CONFIG)
+
+    # Check each config overrode the defaults.
+    assert len(configs) == 2
+    assert configs[0]['num_workers'] == 10
+    assert configs[3]['num_workers'] == 5
+    assert configs[0]['delay_queue_ms'] == 100
+    assert configs[3]['delay_queue_ms'] == 0
+
+    # Check the defaults are still there.
+    assert configs[0]['force_synchronous'] is False
+    assert configs[3]['force_synchronous'] is False
+
+
+def test_loader_pool_group():
+    group = LoaderPoolGroup(TEST_CONFIG)
+
+    with pytest.raises(ValueError):
+        group._get_loader_priority(-1)  # No negative priorities.
+
+    # Test _get_loader_priority() returns the priority of the pool we
+    # should use. The one at or below the priority we give it.
+    assert group._get_loader_priority(0) == 0
+    assert group._get_loader_priority(1) == 0
+    assert group._get_loader_priority(2) == 0
+    assert group._get_loader_priority(3) == 3
+    assert group._get_loader_priority(4) == 3
+    assert group._get_loader_priority(5) == 3

--- a/napari/components/experimental/chunk/_tests/test_loader.py
+++ b/napari/components/experimental/chunk/_tests/test_loader.py
@@ -64,9 +64,6 @@ def test_get_loader_config_override():
 def test_loader_pool_group():
     group = LoaderPoolGroup(TEST_CONFIG)
 
-    with pytest.raises(ValueError):
-        group._get_loader_priority(-1)  # No negative priorities.
-
     # Test _get_loader_priority() returns the priority of the pool we
     # should use. The one at or below the priority we give it.
     assert group._get_loader_priority(0) == 0

--- a/napari/layers/image/experimental/_octree_loader.py
+++ b/napari/layers/image/experimental/_octree_loader.py
@@ -162,7 +162,9 @@ class OctreeLoader:
 
         # Load everything in seen if needed.
         for chunk in seen.chunks():
+            # The ideal level is priority 0, 1 is one level above idea, etc.
             priority = chunk.location.level_index - ideal_level
+
             if chunk.in_memory:
                 drawable.append(chunk)
             elif chunk.needs_load and self._load_chunk(chunk, priority):
@@ -310,8 +312,6 @@ class OctreeLoader:
 
         # Mark that this chunk is being loaded.
         octree_chunk.loading = True
-
-        priority = octree_chunk.location.level_index
 
         # Create the ChunkRequest and load it with the ChunkLoader.
         request = ChunkRequest(octree_chunk.location, chunks, priority)

--- a/napari/layers/image/experimental/_octree_loader.py
+++ b/napari/layers/image/experimental/_octree_loader.py
@@ -80,7 +80,10 @@ class OctreeLoader:
         self._layer_ref = layer_ref
 
     def get_drawable_chunks(
-        self, drawn_set: Set[OctreeChunk], ideal_chunks: List[OctreeChunk],
+        self,
+        drawn_set: Set[OctreeChunk],
+        ideal_chunks: List[OctreeChunk],
+        ideal_level: int,
     ) -> List[OctreeChunk]:
         """Return the chunks that should be drawn.
 
@@ -159,9 +162,10 @@ class OctreeLoader:
 
         # Load everything in seen if needed.
         for chunk in seen.chunks():
+            priority = chunk.location.level_index - ideal_level
             if chunk.in_memory:
                 drawable.append(chunk)
-            elif chunk.needs_load and self._load_chunk(chunk):
+            elif chunk.needs_load and self._load_chunk(chunk, priority):
                 drawable.append(chunk)  # It was a sync load, ready to draw.
 
         # Useful for debugging but very spammy.
@@ -284,7 +288,7 @@ class OctreeLoader:
 
         return children + ancestors
 
-    def _load_chunk(self, octree_chunk: OctreeChunk) -> None:
+    def _load_chunk(self, octree_chunk: OctreeChunk, priority: int) -> None:
         """Load the data for one OctreeChunk.
 
         Parameters
@@ -307,8 +311,10 @@ class OctreeLoader:
         # Mark that this chunk is being loaded.
         octree_chunk.loading = True
 
+        priority = octree_chunk.location.level_index
+
         # Create the ChunkRequest and load it with the ChunkLoader.
-        request = ChunkRequest(octree_chunk.location, chunks)
+        request = ChunkRequest(octree_chunk.location, chunks, priority)
         satisfied_request = chunk_loader.load_request(request)
 
         if satisfied_request is None:

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -327,14 +327,14 @@ class OctreeImage(Image):
         # and in VRAM. When all loading is done, we will draw all the ideal
         # chunks.
         ideal_chunks = self._intersection.get_chunks(create=True)
-        level_index = self._intersection.level.info.level_index
+        ideal_level = self._intersection.level.info.level_index
 
         # log_chunks("ideal_chunks", ideal_chunks)
 
         # If we are seting the data level level automatically, then update
         # our level to match what was chosen for the intersection.
         if self._view.auto_level:
-            self._data_level = level_index
+            self._data_level = ideal_level
 
         # The loader will initiate loads on any ideal chunks which are not
         # yet in memory. And it will return the chunks we should draw. The
@@ -342,7 +342,9 @@ class OctreeImage(Image):
         # memory, but they also might be chunks from higher or lower levels
         # in the octree. In general we try to draw "cover the view" with
         # the "best available" data.
-        return self._slice.loader.get_drawable_chunks(drawn_set, ideal_chunks)
+        return self._slice.loader.get_drawable_chunks(
+            drawn_set, ideal_chunks, ideal_level
+        )
 
     def _update_draw(
         self, scale_factor, corner_pixels, shape_threshold

--- a/napari/utils/_octree.py
+++ b/napari/utils/_octree.py
@@ -12,7 +12,7 @@ from typing import Optional
 LOGGER = logging.getLogger("napari.loader")
 
 DEFAULT_OCTREE_CONFIG = {
-    "loader": {
+    "loader_defaults": {
         "log_path": None,
         "force_synchronous": False,
         "num_workers": 10,

--- a/napari/utils/_octree.py
+++ b/napari/utils/_octree.py
@@ -20,7 +20,15 @@ DEFAULT_OCTREE_CONFIG = {
         "auto_sync_ms": 30,
         "delay_queue_ms": 100,
     },
-    "octree": {"enabled": True, "tile_size": 256, "log_path": None},
+    "octree": {
+        "enabled": True,
+        "tile_size": 256,
+        "log_path": None,
+        "loaders": {
+            0: {"num_workers": 10, "delay_queue_ms": 100},
+            1: {"num_workers": 10, "delay_queue_ms": 0},
+        },
+    },
 }
 
 

--- a/napari/utils/_octree.py
+++ b/napari/utils/_octree.py
@@ -26,7 +26,7 @@ DEFAULT_OCTREE_CONFIG = {
         "log_path": None,
         "loaders": {
             0: {"num_workers": 10, "delay_queue_ms": 100},
-            1: {"num_workers": 10, "delay_queue_ms": 0},
+            2: {"num_workers": 10, "delay_queue_ms": 0},
         },
     },
 }


### PR DESCRIPTION
# Description
* New `LoaderPoolGroup` so `ChunkLoader` can have N `LoaderPools` at once:
    * One or more low-delayed ones for higher levels.
    * A higher delay one for the ideal level.

This seems better but it would take more analysis to really understand what's going on at run-time, and what settings are best, etc. But at least this gives us the ability to experiment. And it can be set back to a single pool if desired.
 
# Rational

While we can cancel not-yet-started chunks if they fall out of view, we cannot cancel in-progress ones. So if we move the camera rapidly, a single `LoaderPool` becomes full with in-progress requests which are now all out of view.

Using a `DelayQueue` seems like a good solution. We can trivially cancel delayed requests if they fall out of view. Then when the user stops moving, the pool is empty and we can fill it up with requests.

However we want to avoid showing nothing whenever possible. So if all requests are delayed, nothing will load. So we have a pool that only loads higher levels. A single tile from a higher levels +1, +2, +3 will cover 4, 9, 16 ideal tiles. So we load those without a deal.

The end result is we load the higher levels as we move around, but then once we pause for 100ms or so, we start loading the ideal tiles rapidly.

# Notes

* Must use PySide2. Crashes with PyQt5.
* Same as before, but just noting it.

# Type of change
- [x] New feature in experimental code

# How has this been tested?
- [x] Manual testing
- [x] New `test_loader.py` 
