### PR TITLE
bump minimum numpy requirement to 1.16.5 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     IPython>=7.7.0
     napari-plugin-engine>=0.1.8
     napari-svg>=0.1.4
-    numpy>=1.16.0
+    numpy>=1.16.5
     numpydoc>=0.9.2
     Pillow!=7.1.0,!=7.1.1  # not a direct dependency, but 7.1.0 and 7.1.1 broke imageio
     psutil>=5.0
@@ -68,11 +68,11 @@ install_requires =
 # this syntax may change in the future
 
 [options.extras_require]
-pyside2 = 
+pyside2 =
     PySide2>=5.12.3,!=5.15.0
 pyside =  # alias for pyside2
     %(pyside2)s
-pyqt5 = 
+pyqt5 =
     PyQt5>=5.12.3,!=5.15.0
 pyqt =  # alias for pyqt5
     %(pyqt5)s


### PR DESCRIPTION
This PR raises the minimum numpy version to 1.16.5, solving problems with other dependencies in naparis minimum requirements tests #2045 

supersedes #2048 
