### PR TITLE
async-44: Fix Pixel Shift Bug

### DIFF
--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -48,10 +48,7 @@ def _chunk_verts(octree_chunk: OctreeChunk) -> np.ndarray:
         The quad vertices.
     """
     geom = octree_chunk.geom
-    scaled_shape = octree_chunk.data.shape[:2] * geom.scale
-    size = scaled_shape[::-1]  # Reverse into (X, Y) form.
-
-    return _quad(size, geom.pos)
+    return _quad(geom.size, geom.pos)
 
 
 class AtlasTile(NamedTuple):
@@ -217,7 +214,7 @@ class TextureAtlas2D(Texture2D):
         """Return the texture coordinates for this tile.
 
         This is only called from __init__ when we pre-compute the
-        texture coordinates for every tiles.
+        texture coordinates for every tile.
 
         Parameters
         ----------
@@ -295,7 +292,7 @@ class TextureAtlas2D(Texture2D):
         if self.spec.shape == data.shape:
             return self._tex_coords[tile_index]
 
-        # It's smaller than a full size tile, so compute exact coords.
+        # Edge or corner tile, compute exact coords.
         return self._calc_tex_coords(tile_index, data.shape)
 
     def remove_tile(self, tile_index: int) -> None:

--- a/napari/_vispy/experimental/tile_grid.py
+++ b/napari/_vispy/experimental/tile_grid.py
@@ -42,9 +42,7 @@ def _chunk_outline(chunk: OctreeChunk) -> np.ndarray:
     """
     geom = chunk.geom
     x, y = geom.pos
-    h, w = chunk.data.shape[:2]
-    w *= geom.scale[1]
-    h *= geom.scale[0]
+    w, h = geom.size
 
     outline = _OUTLINE.copy()
 

--- a/napari/components/experimental/chunk/_pool_group.py
+++ b/napari/components/experimental/chunk/_pool_group.py
@@ -147,4 +147,4 @@ def _get_loader_configs(octree_config) -> Dict[int, dict]:
         return merged
 
     # Return merged configs.
-    return {key: merge(config) for (key, config) in configs.items()}
+    return {int(key): merge(config) for (key, config) in configs.items()}

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -12,14 +12,10 @@ LOGGER = logging.getLogger("napari.octree")
 
 
 class OctreeChunkGeom(NamedTuple):
-    """Position and scale of the chunk, for rendering.
-
-    Stored in the OctreeChunk so that we calculate them just once
-    at OctreeChunk creation time. So the visual does not have to.
-    """
+    """Position and size of the chunk, for rendering."""
 
     pos: np.ndarray
-    scale: np.ndarray
+    size: np.ndarray
 
 
 class OctreeLocation(ChunkLocation):
@@ -90,7 +86,7 @@ class OctreeChunk:
     location : OctreeLocation
         The location of this chunk, including the level_index, row, col.
     geom : OctreeChunkGeom
-        The x, y coordinates and scale of the chunk.
+        The position and size of the chunk.
 
     Attributes
     ----------

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -179,7 +179,6 @@ class OctreeLevel:
             array_slice += (slice(None),)  # Add the colors.
 
         data = self.data[array_slice]
-        print(f"data.shape={data.shape}")
 
         return data
 


### PR DESCRIPTION
# Description
* This PR is really just cleanup, but some nice cleanup related to geom/visual.
* The real fix is in the DZI plugin: https://github.com/manzt/napari-dzi-zarr/pull/5

# Before

![pixel-shift-before](https://user-images.githubusercontent.com/4163446/103384079-16692600-4ac3-11eb-9bc1-1fc9c83a6ac8.gif)

# After

![pixel-shift-fixed](https://user-images.githubusercontent.com/4163446/103384144-4dd7d280-4ac3-11eb-98b3-bf1f76e59c51.gif)

# DZI Examples

On this site: http://boschproject.org/#/book/
Click to open the viewer, then use devtools->network to find the URL such as:
http://boschproject.org/dzi/65_66_67_MCPVIS.dzi
http://boschproject.org/dzi/13_14_15_MCPVIS.dzi

# Pixel Shift

Looking at this data:
`NAPARI_OCTREE=1 napari http://hyper-resolution.org/dzi/Rijksmuseum/SK-C-5/SK-C-5_VIS_20-um_2019-12-21.dzi`

There is sometimes a slight shift of a pixel or two when we transition from a lower resolution to a higher resolution. You can see the man in white seems to shift left a bit when the higher resolution starts to draw:

![pixel-shift](https://user-images.githubusercontent.com/4163446/103323172-9cc43000-4a0f-11eb-8cd3-4c3afc136497.gif)

After the above fixes, it seems like our vertex and texture coordinates are all "perfect" in that everything seems exactly what I expect. So I decided to write out the tile data we are using as PNG's. Here is the level 9 corner tile:

![tile_9_1_1](https://user-images.githubusercontent.com/4163446/103323251-faf11300-4a0f-11eb-8417-1bab29557a12.png)

Here is the level 8 corner tile:

![tile_8_3_2](https://user-images.githubusercontent.com/4163446/103323271-13f9c400-4a10-11eb-8a99-b14d5d288c4b.png)

Doubling the size of the level 9 tile and then putting them together in photoshop we see the pixel shift:

![pixel-shift-photoshop](https://user-images.githubusercontent.com/4163446/103323460-f37e3980-4a10-11eb-9009-1914ee5a62b5.gif)

Since this shows up in Photoshop it's tempting to say they didn't downsample things as carefully as they could have. They are off by a pixel or so. And so the shift is in the data and we can't fix that.

But maybe there some convention here based on the level sizes that they are not actually meant to cover the same physical area, as we assume there are and we assume in napari. So the levels themselves don't sit right on top of each other? Which on the surface seems crazy.

Or maybe this issue is a commonly made "mistake" and we have to try to account for it?

# Overlap

The DZI format has an overlap param. The DZI file above looks like:

```
<?xml version="1.0" encoding="UTF-8"?>
<Image xmlns="http://schemas.microsoft.com/deepzoom/2008"
  Format="jpeg"
  Overlap="1"
  TileSize="254"
  >
  <Size 
    Height="193750"
    Width="231250"
  />
</Image>
```

This discusses what overlap is: https://github.com/VoidVolker/MagickSlicer/issues/2#issue-97766225

And this explains why they (optionally) have overlap: https://github.com/libvips/libvips/issues/795#issuecomment-344788597

It's because some rendering engines have cracks between the tiles of they draw non-overlapping tiles jammed up edge-to-edge. 

Napari's DZI plugin handles overlap here:
https://github.com/manzt/napari-dzi-zarr/blob/master/napari_dzi_zarr/store.py#L82-L107


# Type of change
- [x] Bug-fix in experimental
