### PR TITLE
Add source to metadata

### DIFF
--- a/examples/open_image.py
+++ b/examples/open_image.py
@@ -14,7 +14,7 @@ with napari.gui_qt():
 
     # open locally stored image
     layers = viewer.open(image_local_filename)
-    print("Image " + layers[0].metadata['source'] + " loaded.")
+    print("Image " + layers[0].source + " loaded.")
 
     # open image from web
     layers = viewer.open(image_web_url)

--- a/examples/open_image.py
+++ b/examples/open_image.py
@@ -18,4 +18,4 @@ with napari.gui_qt():
 
     # open image from web
     layers = viewer.open(image_web_url)
-    print("Image " + layers[0].metadata['source'] + " loaded.")
+    print("Image " + layers[0].source + " loaded.")

--- a/examples/open_image.py
+++ b/examples/open_image.py
@@ -1,0 +1,21 @@
+"""
+Display one image using the add_image API.
+"""
+
+image_web_url = 'https://github.com/napari/napari/raw/master/docs/source/img/napari_logo.png'
+image_local_filename = '../docs/source/img/napari_logo.png'
+
+from skimage import data
+import napari
+
+with napari.gui_qt():
+    # create the viewer
+    viewer = napari.Viewer()
+
+    # open locally stored image
+    layers = viewer.open(image_local_filename)
+    print("Image " + layers[0].metadata['source'] + " loaded.")
+
+    # open image from web
+    layers = viewer.open(image_web_url)
+    print("Image " + layers[0].metadata['source'] + " loaded.")

--- a/napari/_tests/test_adding_removing.py
+++ b/napari/_tests/test_adding_removing.py
@@ -122,7 +122,7 @@ def test_add_remove_layer_external_callbacks(
         assert len(em.callbacks) == 1
 
 
-def test_open_metadata_source_stored(make_test_viewer):
+def test_open_source_stored(make_test_viewer):
 
     image_web_url = 'https://github.com/napari/napari/raw/master/docs/source/img/napari_logo.png'
 
@@ -132,3 +132,7 @@ def test_open_metadata_source_stored(make_test_viewer):
     layers = viewer.open(image_web_url)
     # check if the filename / url was stored in the metadata
     assert layers[0].source == image_web_url
+
+    # add another layer where source is supposed to be None
+    layer = viewer.add_image(np.zeros([2,2]))
+    assert layer.source == None

--- a/napari/_tests/test_adding_removing.py
+++ b/napari/_tests/test_adding_removing.py
@@ -121,6 +121,7 @@ def test_add_remove_layer_external_callbacks(
     for em in layer.events.emitters.values():
         assert len(em.callbacks) == 1
 
+
 def test_open_metadata_source_stored(make_test_viewer):
 
     image_web_url = 'https://github.com/napari/napari/raw/master/docs/source/img/napari_logo.png'

--- a/napari/_tests/test_adding_removing.py
+++ b/napari/_tests/test_adding_removing.py
@@ -120,3 +120,14 @@ def test_add_remove_layer_external_callbacks(
     assert len(layer.events.callbacks) == 1
     for em in layer.events.emitters.values():
         assert len(em.callbacks) == 1
+
+def test_open_metadata_source_stored(make_test_viewer):
+
+    image_web_url = 'https://github.com/napari/napari/raw/master/docs/source/img/napari_logo.png'
+
+    viewer = make_test_viewer()
+
+    # open layer(s) using a filename / url
+    layers = viewer.open(image_web_url)
+    # check if the filename / url was stored in the metadata
+    assert layers[0].metadata['source'] == image_web_url

--- a/napari/_tests/test_adding_removing.py
+++ b/napari/_tests/test_adding_removing.py
@@ -134,5 +134,5 @@ def test_open_source_stored(make_test_viewer):
     assert layers[0].source == image_web_url
 
     # add another layer where source is supposed to be None
-    layer = viewer.add_image(np.zeros([2,2]))
-    assert layer.source == None
+    layer = viewer.add_image(np.zeros([2, 2]))
+    assert layer.source is None

--- a/napari/_tests/test_adding_removing.py
+++ b/napari/_tests/test_adding_removing.py
@@ -131,4 +131,4 @@ def test_open_metadata_source_stored(make_test_viewer):
     # open layer(s) using a filename / url
     layers = viewer.open(image_web_url)
     # check if the filename / url was stored in the metadata
-    assert layers[0].metadata['source'] == image_web_url
+    assert layers[0].source == image_web_url

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1002,7 +1002,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
 
             # store the source of the layer
             for layer in new:
-                layer.source = filename
+                layer._source = filename
 
             added.extend(new)
         return added

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -995,8 +995,9 @@ class ViewerModel(KeymapHandler, KeymapProvider):
             )
             # actually add the layer
             new = self._add_layer_from_data(*_data)
-            # store the source of the layer in metadata
-            new.metadata['source'] = filename
+            # store the source of the layer in metadata, if not present yet
+            if not 'source' in new.metadata:
+                new.metadata['source'] = filename
             # some add_* methods return a List[Layer], others just a Layer
             # we want to always return a list
             added.extend(new if isinstance(new, list) else [new])

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -996,7 +996,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
             # actually add the layer
             new = self._add_layer_from_data(*_data)
             # store the source of the layer in metadata, if not present yet
-            if not 'source' in new.metadata:
+            if 'source' not in new.metadata:
                 new.metadata['source'] = filename
             # some add_* methods return a List[Layer], others just a Layer
             # we want to always return a list

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -996,8 +996,7 @@ class ViewerModel(KeymapHandler, KeymapProvider):
             # actually add the layer
             new = self._add_layer_from_data(*_data)
             # store the source of the layer in metadata, if not present yet
-            if 'source' not in new.metadata:
-                new.metadata['source'] = filename
+            new.metadata.setdefault('source', filename)
             # some add_* methods return a List[Layer], others just a Layer
             # we want to always return a list
             added.extend(new if isinstance(new, list) else [new])

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -995,6 +995,8 @@ class ViewerModel(KeymapHandler, KeymapProvider):
             )
             # actually add the layer
             new = self._add_layer_from_data(*_data)
+            # store the source of the layer in metadata
+            new.metadata['source'] = filename
             # some add_* methods return a List[Layer], others just a Layer
             # we want to always return a list
             added.extend(new if isinstance(new, list) else [new])

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -995,15 +995,16 @@ class ViewerModel(KeymapHandler, KeymapProvider):
             )
             # actually add the layer
             new = self._add_layer_from_data(*_data)
-            # store the source of the layer in metadata, if not present yet
-            if isinstance(new, list):
-                for layer in new:
-                    layer.metadata.setdefault('source', filename)
-            else:
-                new.metadata.setdefault('source', filename)
+
             # some add_* methods return a List[Layer], others just a Layer
             # we want to always return a list
-            added.extend(new if isinstance(new, list) else [new])
+            new = new if isinstance(new, list) else [new]
+
+            # store the source of the layer
+            for layer in new:
+                layer.source = filename
+
+            added.extend(new)
         return added
 
     def _add_layer_from_data(

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -996,7 +996,11 @@ class ViewerModel(KeymapHandler, KeymapProvider):
             # actually add the layer
             new = self._add_layer_from_data(*_data)
             # store the source of the layer in metadata, if not present yet
-            new.metadata.setdefault('source', filename)
+            if isinstance(new, list):
+                for layer in new:
+                    layer.metadata.setdefault('source', filename)
+            else:
+                new.metadata.setdefault('source', filename)
             # some add_* methods return a List[Layer], others just a Layer
             # we want to always return a list
             added.extend(new if isinstance(new, list) else [new])

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -138,6 +138,9 @@ class Layer(KeymapProvider, ABC):
     scale_factor : float
         Conversion factor from canvas coordinates to image coordinates, which
         depends on the current zoom level.
+    source : str
+        Contains the filename or URL, if the layer was loaded via napari. None otherwise.
+
 
 
     Notes
@@ -175,6 +178,7 @@ class Layer(KeymapProvider, ABC):
 
         self.dask_optimized_slicing = configure_dask(data)
         self.metadata = metadata or {}
+        self._source = None
         self._opacity = opacity
         self._blending = Blending(blending)
         self._visible = visible
@@ -1013,3 +1017,9 @@ class Layer(KeymapProvider, ABC):
         from ...plugins.io import save_layers
 
         return save_layers(path, [self], plugin=plugin)
+
+    @property
+    def source(self) -> Optional[str]:
+        """Return source (filename or URL) of data if loaded from a file. None otherwise.
+        """
+        return self._source


### PR DESCRIPTION
# Description
This PR makes napari store an image source in `layer.metadata['source']` after napari opened the image. (Closes #2033 ). Furthermore, it adds a code eample and a test to show how/that works.

## Type of change
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
I added a code example demonstrating how to access the meta data entry after opening an image.

# References

# How has this been tested?
- [ ] I added a test. Unfortunately, it throws a "Widgets leaked error" on my system. I'm not sure what that means. Let me know how I can improve this or if the test should live in a different place.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
