### PR TITLE
Fix missing console widget

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -39,7 +39,7 @@ def test_qt_viewer_with_console(make_test_viewer):
     assert view._console is None
     # Check console is created when requested
     assert view.console is not None
-    assert view.dockConsole.widget == view.console
+    assert view.dockConsole.widget() is view.console
 
 
 def test_qt_viewer_toggle_console(make_test_viewer):
@@ -51,7 +51,7 @@ def test_qt_viewer_toggle_console(make_test_viewer):
     # Check console has been created when it is supposed to be shown
     view.toggle_console_visibility(None)
     assert view._console is not None
-    assert view.dockConsole.widget == view.console
+    assert view.dockConsole.widget() is view.console
 
 
 @pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -295,7 +295,7 @@ class QtViewer(QSplitter):
     @console.setter
     def console(self, console):
         self._console = console
-        self.dockConsole.widget = console
+        self.dockConsole.setWidget(console)
         self._update_theme()
 
     def _constrain_width(self, event):


### PR DESCRIPTION
# Description
fixes #2062 ... #2036 removed the `dockWidget.widget` attribute, which shouldn't have shadowed the QDockWidget.widget() attribute in the first place.  but I missed the one internal usage of that older API.  fixed tests here too