### PR TITLE
Save app reference in Window.__init__

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -80,7 +80,8 @@ class Window:
 
     def __init__(self, viewer, *, show: bool = True):
         # create QApplication if it doesn't already exist
-        get_app()
+        # note: the return value must be retained to prevent garbage collection
+        _ = get_app()
 
         # Connect the Viewer and create the Main Window
         self.qt_viewer = QtViewer(viewer)


### PR DESCRIPTION
# Description
This fixes a critical regression that got introduced #2065 by not saving the result of `get_app()`.  This should go in before 0.4.3

Unfortunately, it's really hard to test for this, because pytest-qt will have already created a QApp, so it will just work all the time, and deleting the pytest app often causes segfaults.  I added a note to not remove it