### PR TITLE
skip testing examples on CI

### DIFF
--- a/docs/release/release_0_4_3.md
+++ b/docs/release/release_0_4_3.md
@@ -118,7 +118,7 @@ can still provide keymappings, but no longer handles keymappings from other obje
 - Update get-tag action (#2083)
 - Update magicgui examples (#2084)
 - Add examples tests (#2085)
-
+- Skip testing examples on CI (#2094)
 
 ## 8 authors added to this release (alphabetical)
 

--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -2,7 +2,12 @@ from pathlib import Path
 import napari
 import pytest
 import runpy
+import os
 
+if os.getenv("CI"):
+    pytest.skip(
+        "Need to debug segfaults before re-enabling.", allow_module_level=True
+    )
 
 # not testing these examples
 skip = [


### PR DESCRIPTION
# Description
merging #2085 has caused a lot "successful tests" that end in segfaults.  This PR skips the examples tests on CI for now, until I can debug what's going on