### PR TITLE
Add napari_layers getter to magicgui widgets, allow changing name

### DIFF
--- a/napari/utils/_tests/test_magicgui.py
+++ b/napari/utils/_tests/test_magicgui.py
@@ -225,3 +225,23 @@ def test_magicgui_data_updated(make_test_viewer):
     points.add((15, 15))
     # func will have been called with 1 data including 2 points
     np.testing.assert_allclose(_returns[-1], np.array([[10, 10], [15, 15]]))
+
+
+def test_magicgui_can_change_layer_name(make_test_viewer):
+    viewer = make_test_viewer()
+
+    @magicgui
+    def func() -> types.LayerDataTuple:
+        layers = func.napari_layers() if hasattr(func, 'napari_layers') else ()
+        first_id = id(layers[0]) if layers else None
+        name = 'second' if layers else 'first'
+        return (np.random.rand(10, 10), {'id': first_id, 'name': name})
+
+    viewer.window.add_dock_widget(func)
+    assert not viewer.layers
+    func()
+    assert viewer.layers[0].name == 'first'
+    func()
+    assert viewer.layers[0].name == 'second'
+    func()
+    assert viewer.layers[0].name == 'second'


### PR DESCRIPTION
# Description
Following up on the [discussion in zulip](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/updating.20magicgui-derived.20layers), this PR is a draft of how we might allow magicgui-decorated functions (that are annotated as returning a type that napari has registered) the ability to see what existing viewer layers they have added.  One application for this, is to query the `id` of their layers, so that they can update an existing layer _without_ needing to use the name as a unique key (in case `name` is one of the things they want to change... as @haesleinhuepf needed to do).

this is just a way I thought of to accomplish that... suggestions/rejections welcome :)

 