### PR TITLE
Make dock widgets non-tabbed

### DIFF
--- a/docs/release/release_0_4_3.md
+++ b/docs/release/release_0_4_3.md
@@ -81,6 +81,7 @@ Finally we've added our [0.4 series roadmap](https://napari.org/docs/dev/develop
 - Add deprecated parameters for updating theme (#2074)
 - Coerce name before layer is added to layerlist (#2087)
 - Fix stale data in magicgui `*Data` parameters (#2088)
+- Make dock widgets non-tabbed (#2096)
 
 
 ## API Changes

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -665,7 +665,7 @@ class Window:
         return dock_widget
 
     def _add_viewer_dock_widget(
-        self, dock_widget: QtViewerDockWidget, tabify=True
+        self, dock_widget: QtViewerDockWidget, tabify=False
     ):
         """Add a QtViewerDockWidget to the main window
 


### PR DESCRIPTION
# Description
This PR mades dock widgeted non-tabbed by default, the behaviour before #2080. This should probably be a persistant setting so users can choose, but for now it's fine to revert as requested by @haesleinhuepf and @jni 


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Revert (non-breaking change which fixes an issue)
