### PR TITLE
fix overly strict magic kwargs

### DIFF
--- a/docs/release/release_0_4_3.md
+++ b/docs/release/release_0_4_3.md
@@ -82,6 +82,7 @@ Finally we've added our [0.4 series roadmap](https://napari.org/docs/dev/develop
 - Coerce name before layer is added to layerlist (#2087)
 - Fix stale data in magicgui `*Data` parameters (#2088)
 - Make dock widgets non-tabbed (#2096)
+- Fix overly strict magic kwargs (#2099)
 
 
 ## API Changes

--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -89,7 +89,11 @@ def register_dock_widget(
         dock_widgets[key] = (_cls, kwargs)
 
 
-valid_magic_kwargs = set(signature(magicgui).parameters)
+magicgui_sig = {
+    name
+    for name, p in signature(magicgui).parameters.items()
+    if p.kind is p.KEYWORD_ONLY
+}
 
 
 def register_function_widget(
@@ -133,11 +137,14 @@ def register_function_widget(
             )
             continue
 
-        if set(magic_kwargs) - valid_magic_kwargs:
+        valid_magic_kwargs = set(signature(func).parameters) | magicgui_sig
+        extra_kwargs = set(magic_kwargs) - valid_magic_kwargs
+        if extra_kwargs:
             warn(
                 f'Plugin {plugin_name!r} provided invalid magicgui kwargs '
                 f'to {hook_name} for function {func.__name__!r}: '
-                f'{set(magic_kwargs) - valid_magic_kwargs}. Widget ignored.'
+                f'{extra_kwargs}. Valid kwargs are {valid_magic_kwargs}.'
+                'Widget ignored.'
             )
             continue
 

--- a/napari/plugins/_tests/test_plugin_widgets.py
+++ b/napari/plugins/_tests/test_plugin_widgets.py
@@ -25,6 +25,7 @@ fwidget_args = {
     'bad_tuple3': (func, 1, {}),
     'bad_double_tuple': ((func, {}), (func2, {})),
     'bad_magic_kwargs': (func, {"non_magicgui_kwarg": True}),
+    'good_magic_kwargs': (func, {'call_button': True, "x": {'max': 200}}),
 }
 
 


### PR DESCRIPTION
# Description
fixes #2098 by adding the parameters of the decorated function to the list of valid kwargs (test added)

The reason for the checking at all is to prevent a function from getting into the menu that is going to fail when called... and I think this is good now, but let me know if you want to just remove the checking altogether.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
test added


## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
