### PR TITLE
Undo calling pyrcc with python sys.executable

### DIFF
--- a/docs/release/release_0_4_3.md
+++ b/docs/release/release_0_4_3.md
@@ -82,6 +82,8 @@ Finally we've added our [0.4 series roadmap](https://napari.org/docs/dev/develop
 - Coerce name before layer is added to layerlist (#2087)
 - Fix stale data in magicgui `*Data` parameters (#2088)
 - Make dock widgets non-tabbed (#2096)
+- Fix overly strict magic kwargs (#2099)
+- Undo calling pyrcc with python sys.executable (#2102)
 
 
 ## API Changes

--- a/napari/_qt/qt_resources/build_icons.py
+++ b/napari/_qt/qt_resources/build_icons.py
@@ -225,7 +225,7 @@ def build_pyqt_resources(out_path: str, overwrite: bool = False) -> str:
     #     napari-pyqt5
     for name in _find_rcc_or_raise():
         try:
-            check_call([sys.executable, name, '-o', out_path, qrc_path])
+            check_call([name, '-o', out_path, qrc_path])
             break
         except SubprocessError:
             pass


### PR DESCRIPTION
# Description
As discovered and mentioned by @brisvag [on zulip](https://napari.zulipchat.com/#narrow/stream/215289-release/topic/0.2E4.2E3/near/222489756), one change added in #2030 introduced an error building icons for people using a system-wide PyQt5 build.  (@brisvag is using arch-linux pyqt5 system package, rather than pip installed pyqt5).  The "fix" in #2030 was more pre-emptive... It would help in cases where the icons in a bundle were built with a different pyqt backend than the bundle itself is built with.  That's a rare enough case, that i think we should just revert until someone says they have that issue.
