### PR TITLE
Split canvas color from theme

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -281,6 +281,12 @@ class Window:
         toggle_theme.setShortcut('Ctrl+Shift+T')
         toggle_theme.setStatusTip('Toggle theme')
         toggle_theme.triggered.connect(self.qt_viewer.viewer._toggle_theme)
+        toggle_canvas_color = QAction('Toggle canvas color', self._qt_window)
+        toggle_canvas_color.setShortcut('Ctrl+Shift+B')
+        toggle_canvas_color.setStatusTip('Toggle canvas color')
+        toggle_canvas_color.triggered.connect(
+            self.qt_viewer.viewer._toggle_canvas_color
+        )
         toggle_fullscreen = QAction('Toggle Full Screen', self._qt_window)
         toggle_fullscreen.setShortcut('Ctrl+F')
         toggle_fullscreen.setStatusTip('Toggle full screen')
@@ -294,6 +300,7 @@ class Window:
         self.view_menu.addAction(toggle_fullscreen)
         self.view_menu.addAction(toggle_visible)
         self.view_menu.addAction(toggle_theme)
+        self.view_menu.addAction(toggle_canvas_color)
         self.view_menu.addAction(toggle_play)
         self.view_menu.addSeparator()
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -181,10 +181,12 @@ class QtViewer(QSplitter):
         }
 
         self._update_theme()
+        self._update_canvas_color()
         self._on_active_layer_change()
 
         self.viewer.events.active_layer.connect(self._on_active_layer_change)
         self.viewer.events.theme.connect(self._update_theme)
+        self.viewer.events.canvas_color.connect(self._update_canvas_color)
         self.viewer.camera.events.interactive.connect(self._on_interactive)
         self.viewer.cursor.events.style.connect(self._on_cursor)
         self.viewer.cursor.events.size.connect(self._on_cursor)
@@ -543,7 +545,9 @@ class QtViewer(QSplitter):
         if self._console is not None:
             self.console._update_theme(theme, themed_stylesheet)
         self.setStyleSheet(themed_stylesheet)
-        self.canvas.bgcolor = theme['canvas']
+
+    def _update_canvas_color(self, event=None):
+        self.canvas.bgcolor = self.viewer.canvas_color
 
     def toggle_console_visibility(self, event=None):
         """Toggle console visible and not visible.

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -2,6 +2,7 @@ import os
 
 import numpy as np
 import pytest
+from qtpy.QtCore import QPoint
 
 from napari import layers
 from napari._tests.utils import (
@@ -117,6 +118,16 @@ def test_changing_theme(make_test_viewer):
 
     screenshot_light = viewer.screenshot(canvas_only=False)
     equal = (screenshot_dark == screenshot_light).min(-1)
+
+    # As canvas is main part of window (about 60%) so its area must be masked in these comparison.
+    size = viewer.window.qt_viewer.canvas.native.size()
+    coord = viewer.window.qt_viewer.canvas.native.mapTo(
+        viewer.window._qt_window, QPoint(0, 0)
+    )
+    equal[
+        coord.y() : coord.y() + size.height(),
+        coord.x() : coord.x() + size.width(),
+    ] = False
 
     # more than 99.5% of the pixels have changed
     assert (np.count_nonzero(equal) / equal.size) < 0.05, "Themes too similar"

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -136,6 +136,17 @@ def test_changing_theme(make_test_viewer):
         viewer.theme = 'nonexistent_theme'
 
 
+def test_canvas_color_change(make_test_viewer):
+    viewer = make_test_viewer()
+    assert viewer.canvas_color == "black"
+    screenshot_black = viewer.screenshot()
+    assert np.all(screenshot_black[..., :3] == 0)
+    viewer.canvas_color = "white"
+    assert viewer.canvas_color == "white"
+    screenshot_black = viewer.screenshot()
+    assert np.all(screenshot_black[..., :3] == 255)
+
+
 @pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)
 def test_roll_traspose_update(make_test_viewer, layer_class, data, ndim):
     """Check that transpose and roll preserve correct transform sequence."""

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -32,6 +32,7 @@ from .layerlist import LayerList
 from .scale_bar import ScaleBar
 
 DEFAULT_THEME = 'dark'
+DEFAULT_CANVAS_BACKGROUND = 'black'
 
 
 class ViewerModel(KeymapProvider, MousemapProvider):
@@ -74,6 +75,7 @@ class ViewerModel(KeymapProvider, MousemapProvider):
             active_layer=Event,
             theme=Event,
             layers_change=Event,
+            canvas_color=Event,
         )
 
         self.dims = Dims(
@@ -90,6 +92,7 @@ class ViewerModel(KeymapProvider, MousemapProvider):
         self._help = ''
         self._title = title
         self._theme = DEFAULT_THEME
+        self._canvas_color = DEFAULT_CANVAS_BACKGROUND
 
         self._active_layer = None
         self.grid = GridCanvas()
@@ -148,6 +151,18 @@ class ViewerModel(KeymapProvider, MousemapProvider):
             f"Palette not found among existing themes; "
             f"options are {available_themes()}."
         )
+
+    @property
+    def canvas_color(self):
+        """rurn canvas background"""
+        return self._canvas_color
+
+    @canvas_color.setter
+    def canvas_color(self, color):
+        if self._canvas_color == color:
+            return
+        self._canvas_color = color
+        self.events.canvas_color(value=self.theme)
 
     @property
     def theme(self):
@@ -378,6 +393,13 @@ class ViewerModel(KeymapProvider, MousemapProvider):
         theme_names = available_themes()
         cur_theme = theme_names.index(self.theme)
         self.theme = theme_names[(cur_theme + 1) % len(theme_names)]
+
+    def _toggle_canvas_color(self):
+        """Switch to next theme in list of themes"""
+        if self.canvas_color == "black":
+            self.canvas_color = "white"
+        else:
+            self.canvas_color = "black"
 
     def _update_active_layer(self, event):
         """Set the active layer by iterating over the layers list and


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

As discussed in #2074 this PR split canvas color from the theme. Some type of data looks better with black background (for example multichannel confocal data).

I need to use the light theme because part of QWidgets after applying the napari style are illegible. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
