### PR TITLE
Add example code to hook documentation

### DIFF
--- a/napari/plugins/hook_specifications.py
+++ b/napari/plugins/hook_specifications.py
@@ -355,13 +355,13 @@ def napari_experimental_provide_function_widget() -> Union[
         
     Examples
     --------
-    >>> from magicgui import magicgui
-    >>> from napari_plugin_engine import napari_hook_implementation
+    >>> from napari.types import ImageData, LayerDataTuple
     >>> 
-    >>> @magicgui
-    >>> def my_function(input_image : 'napari.types.ImageData', factor : float = 1):
-    >>>     result_image = input_image * factor
-    >>>     return result_image
+    >>> def my_function(image : ImageData) -> LayerDataTuple:
+    >>>     # process the image
+    >>>     result = -image
+    >>>     # return it + some layer properties
+    >>>     return result, {'colormap':'turbo'}
     >>> 
     >>> @napari_hook_implementation
     >>> def napari_experimental_provide_function_widget():
@@ -397,7 +397,19 @@ def napari_experimental_provide_dock_widget() -> Union[
     >>>     def __init__(self, napari_viewer):
     >>>         self.viewer = napari_viewer
     >>>         super().__init__()
-    >>>         # ... add Qt GUI elements accessing the viewer here
+    >>> 
+    >>>         # initialize layout
+    >>>         layout = QGridLayout()
+    >>> 
+    >>>         # add a button
+    >>>         btn = QPushButton('Click me!', self)
+    >>>         def trigger():
+    >>>             print("napari has", len(napari_viewer.layers), "layers")
+    >>>         btn.clicked.connect(trigger)
+    >>>         layout.addWidget(btn)
+    >>> 
+    >>>         # activate layout
+    >>>         self.setLayout(layout)
     >>> 
     >>> @napari_hook_implementation
     >>> def napari_experimental_provide_dock_widget():

--- a/napari/plugins/hook_specifications.py
+++ b/napari/plugins/hook_specifications.py
@@ -352,6 +352,20 @@ def napari_experimental_provide_function_widget() -> Union[
         while the third element should provide keyword arguments for
         :meth:`napari.qt.Window.add_dock_widget` (though note that the
         ``shortcut=`` keyword is not yet supported).
+        
+    Examples
+    --------
+    >>> from magicgui import magicgui
+    >>> from napari_plugin_engine import napari_hook_implementation
+    >>> 
+    >>> @magicgui
+    >>> def my_function(input_image : 'napari.types.ImageData', factor : float = 1):
+    >>>     result_image = input_image * factor
+    >>>     return result_image
+    >>> 
+    >>> @napari_hook_implementation
+    >>> def napari_experimental_provide_function_widget():
+    >>>     return my_function
     """
 
 
@@ -373,4 +387,19 @@ def napari_experimental_provide_dock_widget() -> Union[
         containing keyword arguments for
         :meth:`napari.qt.Window.add_dock_widget` (though note that the
         ``shortcut=`` keyword is not yet supported).
+        
+    Examples
+    --------
+    >>> from qtpy.QtWidgets import QWidget
+    >>> from napari_plugin_engine import napari_hook_implementation
+    >>> 
+    >>> class MyWidget(QWidget):
+    >>>     def __init__(self, napari_viewer):
+    >>>         self.viewer = napari_viewer
+    >>>         super().__init__()
+    >>>         # ... add Qt GUI elements accessing the viewer here
+    >>> 
+    >>> @napari_hook_implementation
+    >>> def napari_experimental_provide_dock_widget():
+    >>>     return MyWidget    
     """

--- a/napari/plugins/hook_specifications.py
+++ b/napari/plugins/hook_specifications.py
@@ -352,17 +352,17 @@ def napari_experimental_provide_function_widget() -> Union[
         while the third element should provide keyword arguments for
         :meth:`napari.qt.Window.add_dock_widget` (though note that the
         ``shortcut=`` keyword is not yet supported).
-        
+
     Examples
     --------
     >>> from napari.types import ImageData, LayerDataTuple
-    >>> 
+    >>>
     >>> def my_function(image : ImageData) -> LayerDataTuple:
     >>>     # process the image
     >>>     result = -image
     >>>     # return it + some layer properties
     >>>     return result, {'colormap':'turbo'}
-    >>> 
+    >>>
     >>> @napari_hook_implementation
     >>> def napari_experimental_provide_function_widget():
     >>>     return my_function
@@ -387,31 +387,31 @@ def napari_experimental_provide_dock_widget() -> Union[
         containing keyword arguments for
         :meth:`napari.qt.Window.add_dock_widget` (though note that the
         ``shortcut=`` keyword is not yet supported).
-        
+
     Examples
     --------
     >>> from qtpy.QtWidgets import QWidget
     >>> from napari_plugin_engine import napari_hook_implementation
-    >>> 
+    >>>
     >>> class MyWidget(QWidget):
     >>>     def __init__(self, napari_viewer):
     >>>         self.viewer = napari_viewer
     >>>         super().__init__()
-    >>> 
+    >>>
     >>>         # initialize layout
     >>>         layout = QGridLayout()
-    >>> 
+    >>>
     >>>         # add a button
     >>>         btn = QPushButton('Click me!', self)
     >>>         def trigger():
     >>>             print("napari has", len(napari_viewer.layers), "layers")
     >>>         btn.clicked.connect(trigger)
     >>>         layout.addWidget(btn)
-    >>> 
+    >>>
     >>>         # activate layout
     >>>         self.setLayout(layout)
-    >>> 
+    >>>
     >>> @napari_hook_implementation
     >>> def napari_experimental_provide_dock_widget():
-    >>>     return MyWidget    
+    >>>     return MyWidget
     """


### PR DESCRIPTION
# Description
This adds example code to the hook documentation. 


WIP: The examples are not functional yet. napari doesn't show a menu entry and crashes when accessing `Plugins > Plugin Errors...` and selecting my project 'clEsperanto' where I tried this...


## Type of change
- [x] This change _is_ a documentation update

# References
https://napari.zulipchat.com/#narrow/stream/215289-release/topic/0.2E4.2E3/near/222655202
