### PR TITLE
Support for EventedList.__setitem__ with array-like items

### DIFF
--- a/napari/utils/events/_tests/test_evented_list.py
+++ b/napari/utils/events/_tests/test_evented_list.py
@@ -406,6 +406,7 @@ def test_event_group_depr():
 
 
 def test_array_like_setitem():
+    """Test that EventedList.__setitem__ works for array-like items"""
     array = np.array((10, 10))
     evented_list = EventedList([array])
     evented_list[0] = array

--- a/napari/utils/events/_tests/test_evented_list.py
+++ b/napari/utils/events/_tests/test_evented_list.py
@@ -1,6 +1,7 @@
 from collections.abc import MutableSequence
 from unittest.mock import Mock
 
+import numpy as np
 import pytest
 
 from napari.utils.events import EmitterGroup, EventedList, NestableEventedList
@@ -402,3 +403,9 @@ def test_event_group_depr():
         assert events["b"] == events["a"]
     with pytest.raises(KeyError):
         events["c"].connect()
+
+
+def test_array_like_setitem():
+    array = np.array((10, 10))
+    evented_list = EventedList([array])
+    evented_list[0] = array

--- a/napari/utils/events/containers/_evented_list.py
+++ b/napari/utils/events/containers/_evented_list.py
@@ -107,7 +107,7 @@ class EventedList(TypedMutableSequence[_T]):
 
     def __setitem__(self, key, value):
         old = self._list[key]
-        if value == old:
+        if value is old:
             return
         if isinstance(key, slice):
             if not isinstance(value, Iterable):

--- a/napari/utils/events/containers/_evented_list.py
+++ b/napari/utils/events/containers/_evented_list.py
@@ -107,7 +107,7 @@ class EventedList(TypedMutableSequence[_T]):
 
     def __setitem__(self, key, value):
         old = self._list[key]
-        if value is old:
+        if value is old:  # https://github.com/napari/napari/pull/2120
             return
         if isinstance(key, slice):
             if not isinstance(value, Iterable):


### PR DESCRIPTION
This PR would closes #2117 

Using `EventedList.__setitem__` would break with array-like items, raising a `ValueError` 

```python
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

@tlambert03 suggested and compared three solutions
- the `is` keyword, checking that two names reference the same object
- `np.array_equal`, which works with non-arrays too
- a `try`/`except` block, catching the `ValueError` and handling appropriately

`is` was by far the fastest in Talley's tests.

The purpose of this check was to avoid emitting an event if the item didn't really change, so checking for identity rather than equality seems like the best solution.

I tried to add a test but got some unrelated errors when trying to run it

```python
  File "/home/aburt/programming/napari/napari/utils/events/_tests/test_evented_list.py", line 7, in <module>
    from napari.utils.events import EmitterGroup, EventedList, NestableEventedList
  File "/home/aburt/programming/napari/napari/__init__.py", line 7, in <module>
    from .viewer import Viewer  # isort:skip
  File "/home/aburt/programming/napari/napari/viewer.py", line 1, in <module>
    from .components import ViewerModel
  File "/home/aburt/programming/napari/napari/components/__init__.py", line 24, in <module>
    from . import _viewer_key_bindings  # isort:skip
  File "/home/aburt/programming/napari/napari/components/_viewer_key_bindings.py", line 3, in <module>
    from .viewer_model import ViewerModel
  File "/home/aburt/programming/napari/napari/components/viewer_model.py", line 13, in <module>
    from ..plugins.io import read_data_with_plugins
  File "/home/aburt/programming/napari/napari/plugins/__init__.py", line 174, in <module>
    plugin_manager.hook.napari_experimental_provide_dock_widget.call_historic(
TypeError: call_historic() got an unexpected keyword argument 'with_impl'
```
