### PR TITLE
DOC: Formatting and Typos.

### DIFF
--- a/napari/layers/image/_image_slice.py
+++ b/napari/layers/image/_image_slice.py
@@ -82,7 +82,7 @@ class ImageSlice:
         ----------
         image : ArrayLike
             Set this as the main image.
-        thumbnail : ArrayLike
+        thumbnail_source : ArrayLike
             Derive the thumbnail from this image.
         """
         # Single scale images don't have a separate thumbnail so we just

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -195,7 +195,7 @@ def log_chunks(
     ----------
     label : str
         Prefix the log message with this label.
-    chunk : List[OctreeChunk]
+    chunks : List[OctreeChunk]
         The chunks to log.
     location : Optional[OctreeLocation]
         Append the log message with this location.

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -279,8 +279,8 @@ class OctreeImage(Image):
         visual quality, the imagery might look blurry.
 
         Parameters
-        -----------
-        drawn_chunk_set : Set[OctreeChunk]
+        ----------
+        drawn_set : Set[OctreeChunk]
             The chunks that are currently being drawn by the visual.
 
         Return

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -639,7 +639,7 @@ class Image(IntensityVisualizationMixin, Layer):
 
         Parameters
         ----------
-        request : ChunkRequest
+        data : ChunkRequest
             The request that was satisfied/loaded.
         sync : bool
             If True the chunk was loaded synchronously.

--- a/napari/layers/utils/stack_utils.py
+++ b/napari/layers/utils/stack_utils.py
@@ -34,7 +34,7 @@ def split_channels(
     data : array or list of array
     channel_axis : int
         Axis to split the image along.
-    kwargs: dict
+    kwargs : dict
         Keyword arguments will override the default image meta keys
         returned in each layer data tuple.
 


### PR DESCRIPTION
A couple of parameters had the wrong names when compared to the function
signature.

Space are also significant in definition list for numpydoc parsing, as
well as length of underlines in headers.