### PR TITLE
DOC: Rename Section to conform to numpydocs (Return->Returns)

### DIFF
--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -336,8 +336,8 @@ def configure_loading(request):
 def _is_async_mode() -> bool:
     """Return True if we are currently loading chunks asynchronously
 
-    Return
-    ------
+    Returns
+    -------
     bool
         True if we are currently loading chunks asynchronously.
     """

--- a/napari/layers/image/_image_loader.py
+++ b/napari/layers/image/_image_loader.py
@@ -14,8 +14,8 @@ class ImageLoader:
         data : ImageSliceData
             The data to load.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if load happened synchronously.
         """
@@ -30,8 +30,8 @@ class ImageLoader:
         data : ImageSliceData
             Does this data match what we are loading?
 
-        Return
-        ------
+        Returns
+        -------
         bool
             Return True if data matches.
         """

--- a/napari/layers/image/_image_slice.py
+++ b/napari/layers/image/_image_slice.py
@@ -17,8 +17,8 @@ LOGGER = logging.getLogger("napari.loader")
 def _create_loader_class() -> ImageLoader:
     """Return correct ImageLoader for sync or async.
 
-    Return
-    ------
+    Returns
+    -------
     ImageLoader
         Return ImageLoader for sync or ChunkImageLoader for async.
     """
@@ -110,8 +110,8 @@ class ImageSlice:
         data : ImageSliceData
             The data to load into this slice.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             Return True if load was synchronous.
         """
@@ -126,8 +126,8 @@ class ImageSlice:
         data : ImageSliceData
             The newly loaded data we want to show.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if the data was used, False if was for the wrong slice.
         """

--- a/napari/layers/image/experimental/_chunk_set.py
+++ b/napari/layers/image/experimental/_chunk_set.py
@@ -22,8 +22,8 @@ class ChunkSet:
     def __len__(self) -> int:
         """Return the size of the size.
 
-        Return
-        ------
+        Returns
+        -------
         int
             The size of the set.
         """
@@ -32,8 +32,8 @@ class ChunkSet:
     def __contains__(self, chunk: OctreeChunk) -> bool:
         """Return true if the set contains this chunk.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if the set contains the given chunk.
         """
@@ -54,8 +54,8 @@ class ChunkSet:
     def chunks(self) -> List[OctreeChunk]:
         """Get all the chunks in the set.
 
-        Return
-        ------
+        Returns
+        -------
         List[OctreeChunk]
             All the chunks in the set.
         """
@@ -64,8 +64,8 @@ class ChunkSet:
     def has_location(self, location: OctreeLocation) -> bool:
         """Return True if the set contains this location.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if the set contains this location.
         """

--- a/napari/layers/image/experimental/_chunked_image_loader.py
+++ b/napari/layers/image/experimental/_chunked_image_loader.py
@@ -33,8 +33,8 @@ class ChunkedImageLoader(ImageLoader):
         data : ChunkedSliceData
             The data to load
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if load happened synchronously.
         """
@@ -63,8 +63,8 @@ class ChunkedImageLoader(ImageLoader):
         data : ChunkedSliceData
             Does this data match what we are loading?
 
-        Return
-        ------
+        Returns
+        -------
         bool
             Return True if data matches.
         """

--- a/napari/layers/image/experimental/_chunked_slice_data.py
+++ b/napari/layers/image/experimental/_chunked_slice_data.py
@@ -57,8 +57,8 @@ class ChunkedSliceData(ImageSliceData):
     def load_chunks(self) -> bool:
         """Load this slice data's chunks sync or async.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if chunks were loaded synchronously.
         """

--- a/napari/layers/image/experimental/_image_location.py
+++ b/napari/layers/image/experimental/_image_location.py
@@ -64,8 +64,8 @@ class ImageLocation(ChunkLocation):
     def _same_indices(self, other) -> bool:
         """Return True if this location has same indices as the other location.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if indices are the same.
         """
@@ -78,8 +78,8 @@ class ImageLocation(ChunkLocation):
     def __hash__(self) -> int:
         """Return has of this location.
 
-        Return
-        ------
+        Returns
+        -------
         int
             The hash of the location.
         """

--- a/napari/layers/image/experimental/_octree_loader.py
+++ b/napari/layers/image/experimental/_octree_loader.py
@@ -121,8 +121,8 @@ class OctreeLoader:
         ideal_chunks : List[OctreeChunk]
             The chunks which are visible to the current view.
 
-        Return
-        ------
+        Returns
+        -------
         List[OctreeChunk]
             The chunks that should be drawn.
         """
@@ -184,8 +184,8 @@ class OctreeLoader:
         "inside" a single pixel of the root tile. So it's just providing a
         background color at that point.
 
-        Return
-        ------
+        Returns
+        -------
         List[OctreeChunk]
             Any extra chunks we should draw.
         """
@@ -222,8 +222,8 @@ class OctreeLoader:
         drawn_set : Set[OctreeChunk]
             The chunks which the visual is currently drawing.
 
-        Return
-        ------
+        Returns
+        -------
         List[OctreeChunk]
             The chunks that should be drawn to cover this one ideal chunk.
         """
@@ -268,8 +268,8 @@ class OctreeLoader:
         ideal_chunk : OctreeChunk
             Get children and parents of this chunk.
 
-        Return
-        ------
+        Returns
+        -------
         List[OctreeNode]
             Parents and children we should load and/or draw.
         """

--- a/napari/layers/image/experimental/_octree_slice.py
+++ b/napari/layers/image/experimental/_octree_slice.py
@@ -69,8 +69,8 @@ class OctreeSlice:
         Because octree multiscale is async, we say we are loaded up front even
         though none of our chunks/tiles might be loaded yet.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if the data as been loaded.
         """
@@ -80,8 +80,8 @@ class OctreeSlice:
     def octree_level_info(self) -> Optional[OctreeLevelInfo]:
         """Information about the current octree level.
 
-        Return
-        ------
+        Returns
+        -------
         Optional[OctreeLevelInfo]
             Information about current octree level, if there is one.
         """
@@ -110,8 +110,8 @@ class OctreeSlice:
         view : OctreeView
             Intersect this view with the octree.
 
-        Return
-        ------
+        Returns
+        -------
         OctreeIntersection
             The given view's intersection with the octree.
         """
@@ -126,8 +126,8 @@ class OctreeSlice:
         view : OctreeView
             Get the OctreeLevel for this view.
 
-        Return
-        ------
+        Returns
+        -------
         OctreeLevel
             The automatically chosen OctreeLevel.
         """
@@ -145,8 +145,8 @@ class OctreeSlice:
         view : OctreeView
             Get the octree level index for this view.
 
-        Return
-        ------
+        Returns
+        -------
         int
             The automatically chosen octree level index.
         """
@@ -178,8 +178,8 @@ class OctreeSlice:
         location : OctreeLocation
             Return the chunk at this location.
 
-        Return
-        ------
+        Returns
+        -------
         OctreeChunk
             The returned chunk.
         """
@@ -196,8 +196,8 @@ class OctreeSlice:
         request : ChunkRequest
             The request for the chunk that was loaded.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if the chunk's data was added to the octree.
         """

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -90,8 +90,8 @@ class Octree:
         level_index : int
             Get the OctreeLevel with this index.
 
-        Return
-        ------
+        Returns
+        -------
         OctreeLevel
             The requested level.
         """
@@ -151,8 +151,8 @@ class Octree:
         octree_chunk : OctreeChunk
             Return the parent of this chunk.
 
-        Return
-        ------
+        Returns
+        -------
         Optional[OctreeChunk]
             The parent of the chunk if there was one or we created it.
         """
@@ -171,8 +171,8 @@ class Octree:
         octree_chunk : OctreeChunk
             Return the nearest ancestors of this chunk.
 
-        Return
-        ------
+        Returns
+        -------
         List[OctreeChunk]
             Up to num_level nearest ancestors of the given chunk. Sorted so the
             most-distant ancestor comes first.
@@ -219,8 +219,8 @@ class Octree:
         octree_chunk : OctreeChunk
             Return the children of this chunk.
 
-        Return
-        ------
+        Returns
+        -------
         List[OctreeChunk]
             The children of the given chunk.
         """
@@ -252,8 +252,8 @@ class Octree:
     def _get_extra_levels(self) -> List[OctreeLevel]:
         """Compute the extra levels and return them.
 
-        Return
-        ------
+        Returns
+        -------
         List[OctreeLevel]
             The extra levels.
         """
@@ -281,8 +281,8 @@ class Octree:
         tile_size : int
             Keep creating levels until one fits with a tile of this size.
 
-        Return
-        ------
+        Returns
+        -------
         List[OctreeLevels]
             The new downsampled levels we created.
 

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -147,8 +147,8 @@ class OctreeChunk:
     def in_memory(self) -> bool:
         """Return True if the data is fully in memory.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if data is fully in memory.
         """
@@ -161,9 +161,9 @@ class OctreeChunk:
         An unloaded chunk's data might be a Dask or similar deferred array.
         A loaded chunk's data is always an ndarray.
 
-        Return
-        ------
-            True if the chunk needs to be loaded.
+        Returns
+        -------
+        True if the chunk needs to be loaded.
         """
         return not self.in_memory and not self.loading
 

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -124,8 +124,8 @@ class OctreeImage(Image):
     def tile_size(self) -> int:
         """Return the edge length of single tile, for example 256.
 
-        Return
-        ------
+        Returns
+        -------
         int
             The edge length of a single tile.
         """
@@ -150,8 +150,8 @@ class OctreeImage(Image):
     def tile_shape(self) -> tuple:
         """Return the shape of a single tile, for example 256x256x3.
 
-        Return
-        ------
+        Returns
+        -------
         tuple
             The shape of a single tile.
         """
@@ -172,8 +172,8 @@ class OctreeImage(Image):
     def meta(self) -> OctreeMetadata:
         """Information about the current octree.
 
-        Return
-        ------
+        Returns
+        -------
         OctreeMetadata
             Octree dimensions and other info.
         """
@@ -233,8 +233,8 @@ class OctreeImage(Image):
     def num_octree_levels(self) -> int:
         """Return the total number of octree levels.
 
-        Return
-        ------
+        Returns
+        -------
         int
             The number of octree levels.
         """
@@ -283,8 +283,8 @@ class OctreeImage(Image):
         drawn_chunk_set : Set[OctreeChunk]
             The chunks that are currently being drawn by the visual.
 
-        Return
-        ------
+        Returns
+        -------
         List[OctreeChunk]
             The drawable chunks.
         """
@@ -374,8 +374,8 @@ class OctreeImage(Image):
     def _outside_data_range(self, indices) -> bool:
         """Return True if requested slice is outside of data range.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if requested slice is outside data range.
         """

--- a/napari/layers/image/experimental/octree_intersection.py
+++ b/napari/layers/image/experimental/octree_intersection.py
@@ -33,8 +33,8 @@ class OctreeView(NamedTuple):
     def data_width(self) -> int:
         """The width between the corners, in data coordinates.
 
-        Return
-        ------
+        Returns
+        -------
         int
             The width in data coordinates.
         """
@@ -44,8 +44,8 @@ class OctreeView(NamedTuple):
     def auto_level(self) -> bool:
         """True if the octree level should be selected automatically.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if the octree level should be selected automatically.
         """
@@ -142,8 +142,8 @@ class OctreeIntersection:
         span : Tuple[float, float]
             The span in image coordinates, [y0..y1]
 
-        Return
-        ------
+        Returns
+        -------
         range
             The range of tiles across the columns.
         """
@@ -158,8 +158,8 @@ class OctreeIntersection:
         span : Tuple[float, float]
             The span in image coordinates, [x0..x1]
 
-        Return
-        ------
+        Returns
+        -------
         range
             The range of tiles across the columns.
         """
@@ -213,8 +213,8 @@ class OctreeIntersection:
     def tile_state(self) -> dict:
         """Return tile state, for the monitor.
 
-        Return
-        ------
+        Returns
+        -------
         dict
             The tile state.
         """
@@ -232,8 +232,8 @@ class OctreeIntersection:
     def tile_config(self) -> dict:
         """Return tile config, for the monitor.
 
-        Return
-        ------
+        Returns
+        -------
         dict
             The file config.
         """

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -109,8 +109,8 @@ class OctreeLevel:
         create : bool
             If True, create the OctreeChunk if it does not exist.
 
-        Return
-        ------
+        Returns
+        -------
         Optional[OctreeChunk]
             The OctreeChunk if one existed or we just created it.
         """
@@ -142,8 +142,8 @@ class OctreeLevel:
         col : int
             The column in the level.
 
-        Return
-        ------
+        Returns
+        -------
         OctreeChunk
             The newly created chunk.
         """
@@ -188,8 +188,8 @@ class OctreeLevel:
         col : int
             The column coordinate.
 
-        Return
-        ------
+        Returns
+        -------
         ArrayLike
             The data at this location.
         """

--- a/napari/layers/image/experimental/octree_tile_builder.py
+++ b/napari/layers/image/experimental/octree_tile_builder.py
@@ -65,8 +65,8 @@ def create_downsampled_levels(
     image : np.darray
         The full image to create levels from.
 
-    Return
-    ------
+    Returns
+    -------
     List[np.ndarray]
         A list of levels where levels[0] is the first downsampled level.
     """

--- a/napari/layers/image/experimental/octree_util.py
+++ b/napari/layers/image/experimental/octree_util.py
@@ -12,8 +12,8 @@ from ....utils.config import octree_config
 def _get_tile_size() -> int:
     """Return the default tile size.
 
-    Return
-    ------
+    Returns
+    -------
     int
         The default tile size.
     """
@@ -46,8 +46,8 @@ class OctreeDisplayOptions:
     def show_grid(self) -> bool:
         """True if we are drawing a grid on top of the tiles.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if we are drawing a grid on top of the tiles.
         """
@@ -81,8 +81,8 @@ class NormalNoise(NamedTuple):
     def is_zero(self) -> bool:
         """Return True if there is no noise at all.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if there is no noise at all.
         """
@@ -92,8 +92,8 @@ class NormalNoise(NamedTuple):
     def get_value(self) -> float:
         """Get a random value.
 
-        Return
-        ------
+        Returns
+        -------
         float
             The random value.
         """


### PR DESCRIPTION
The numpydoc style guide
(https://numpydoc.readthedocs.io/en/latest/format.html) indicate that
the name of the section is "Returns", not "Return", and in one case the
content of the section is dedented for uniformity.

Note that "Returns" section are supposed to use the same formatting as
the "Parameters" section and have the type of what they return as a
definition list; but that's a longer endeavour.
