### PR TITLE
Provide `make_napari_viewer` as a pytest plugin, for external use.

### DIFF
--- a/docs/source/developers/TESTING.md
+++ b/docs/source/developers/TESTING.md
@@ -123,25 +123,25 @@ you create during testing are cleaned up at the end of each test:
         ...
     ```
 
-2. When writing a test that requires a `napari.Viewer` object, we provide our
-   own convenient fixture called `make_test_viewer` that will take care of
-   creating a viewer and cleaning up at the end of the test.  When using this
-   function, it is **not** necessary to use a `qtbot` fixture, nor should you do
-   any additional cleanup (such as using `qtbot.addWidget` or calling
-   `viewer.close()`) at the end of the test.  Duplicate cleanup may cause an
-   error.  Use the fixture as follows:
+2. When writing a test that requires a `napari.Viewer` object, we provide a
+   [pytest fixture](https://docs.pytest.org/en/stable/fixture.html) called
+   `make_napari_viewer` that will take care of creating a viewer and cleaning up
+   at the end of the test.  When using this function, it is **not** necessary to
+   use a `qtbot` fixture, nor should you do any additional cleanup (such as
+   using `qtbot.addWidget` or calling `viewer.close()`) at the end of the test.
+   Duplicate cleanup may cause an error.  Use the fixture as follows:
 
     ```python
-    # the make_test_viewer fixture is defined in napari/conftest.py
-    def test_something_with_a_viewer(make_test_viewer):
-        # make_test_viewer takes any keyword arguments that napari.Viewer() takes
-        viewer = make_test_viewer()
+    # the make_napari_viewer fixture is defined in napari/conftest.py
+    def test_something_with_a_viewer(make_napari_viewer):
+        # make_napari_viewer takes any keyword arguments that napari.Viewer() takes
+        viewer = make_napari_viewer()
 
         # do stuff with the viewer, no qtbot or viewer.close() methods needed.
         ...
     ```
 
-> If you're curious to see the actual `make_test_viewer` fixture definition, it's
+> If you're curious to see the actual `make_napari_viewer` fixture definition, it's
 > in `napari/conftest.py`
 
 ### Mocking: "Fake it till you make it"

--- a/napari/_qt/_tests/test_app.py
+++ b/napari/_qt/_tests/test_app.py
@@ -6,7 +6,7 @@ from napari._qt.qt_event_loop import set_app_id
 
 
 @pytest.mark.skipif(os.name != "Windows", reason="Windows specific")
-def test_windows_grouping_overwrite(make_test_viewer):
+def test_windows_grouping_overwrite(make_napari_viewer):
     import ctypes
 
     def get_app_id():

--- a/napari/_qt/_tests/test_exception_handler.py
+++ b/napari/_qt/_tests/test_exception_handler.py
@@ -29,9 +29,9 @@ def test_keyboard_interupt_handler(qtbot, capsys):
     assert capsys.readouterr().err == "Closed by KeyboardInterrupt\n"
 
 
-def test_exception_handler_gui(qtbot, make_test_viewer):
+def test_exception_handler_gui(qtbot, make_napari_viewer):
     """Test exception handler can create a NapariNotification"""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     handler = ExceptionHandler(gui_exceptions=True)
     with qtbot.waitSignal(handler.error, timeout=1000):
         handler.handle(ValueError, ValueError("whoops"), None)

--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -95,9 +95,9 @@ def test_plugin_widgets(monkeypatch):
         yield
 
 
-def test_plugin_widgets_menus(test_plugin_widgets, make_test_viewer):
+def test_plugin_widgets_menus(test_plugin_widgets, make_napari_viewer):
     """Test the plugin widgets get added to the window menu correctly."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     actions = viewer.window._plugin_dock_widget_menu.actions()
     assert len(actions) == 3
     expected_text = ['TestP1', 'TestP2: Widg3', 'TestP3: magic']
@@ -113,9 +113,9 @@ def test_plugin_widgets_menus(test_plugin_widgets, make_test_viewer):
     assert not actions[2].menu()
 
 
-def test_making_plugin_dock_widgets(test_plugin_widgets, make_test_viewer):
+def test_making_plugin_dock_widgets(test_plugin_widgets, make_napari_viewer):
     """Test that we can create dock widgets, and they get the viewer."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     actions = viewer.window._plugin_dock_widget_menu.actions()
 
     # trigger the 'TestP2: Widg3' action
@@ -145,9 +145,9 @@ def test_making_plugin_dock_widgets(test_plugin_widgets, make_test_viewer):
         action.trigger()
 
 
-def test_making_function_dock_widgets(test_plugin_widgets, make_test_viewer):
+def test_making_function_dock_widgets(test_plugin_widgets, make_napari_viewer):
     """Test that we can create magicgui widgets, and they get the viewer."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     actions = viewer.window._plugin_dock_widget_menu.actions()
 
     # trigger the 'TestP3: magic' action
@@ -167,9 +167,9 @@ def test_making_function_dock_widgets(test_plugin_widgets, make_test_viewer):
         actions[2].trigger()
 
 
-def test_clear_all_plugin_widgets(test_plugin_widgets, make_test_viewer):
+def test_clear_all_plugin_widgets(test_plugin_widgets, make_napari_viewer):
     """Test the the 'Remove Dock Widgets' menu item clears added widgets."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     actions = viewer.window._plugin_dock_widget_menu.actions()
     actions[1].trigger()
     actions[0].menu().actions()[1].trigger()

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -13,9 +13,9 @@ from napari._tests.utils import (
 from napari.utils.io import imread
 
 
-def test_qt_viewer(make_test_viewer):
+def test_qt_viewer(make_napari_viewer):
     """Test instantiating viewer."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     assert viewer.title == 'napari'
@@ -31,9 +31,9 @@ def test_qt_viewer(make_test_viewer):
     assert np.sum(view.dims._displayed_sliders) == 0
 
 
-def test_qt_viewer_with_console(make_test_viewer):
+def test_qt_viewer_with_console(make_napari_viewer):
     """Test instantiating console from viewer."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
     # Check no console is present before it is requested
     assert view._console is None
@@ -42,9 +42,9 @@ def test_qt_viewer_with_console(make_test_viewer):
     assert view.dockConsole.widget() is view.console
 
 
-def test_qt_viewer_toggle_console(make_test_viewer):
+def test_qt_viewer_toggle_console(make_napari_viewer):
     """Test instantiating console from viewer."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
     # Check no console is present before it is requested
     assert view._console is None
@@ -55,18 +55,18 @@ def test_qt_viewer_toggle_console(make_test_viewer):
 
 
 @pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)
-def test_add_layer(make_test_viewer, layer_class, data, ndim):
-    viewer = make_test_viewer(ndisplay=int(np.clip(ndim, 2, 3)))
+def test_add_layer(make_napari_viewer, layer_class, data, ndim):
+    viewer = make_napari_viewer(ndisplay=int(np.clip(ndim, 2, 3)))
     view = viewer.window.qt_viewer
 
     add_layer_by_type(viewer, layer_class, data)
     check_viewer_functioning(viewer, view, data, ndim)
 
 
-def test_new_labels(make_test_viewer):
+def test_new_labels(make_napari_viewer):
     """Test adding new labels layer."""
     # Add labels to empty viewer
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     viewer._new_labels()
@@ -79,7 +79,7 @@ def test_new_labels(make_test_viewer):
     assert np.sum(view.dims._displayed_sliders) == 0
 
     # Add labels with image already present
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     np.random.seed(0)
@@ -95,10 +95,10 @@ def test_new_labels(make_test_viewer):
     assert np.sum(view.dims._displayed_sliders) == 0
 
 
-def test_new_points(make_test_viewer):
+def test_new_points(make_napari_viewer):
     """Test adding new points layer."""
     # Add labels to empty viewer
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     viewer.add_points()
@@ -111,7 +111,7 @@ def test_new_points(make_test_viewer):
     assert np.sum(view.dims._displayed_sliders) == 0
 
     # Add points with image already present
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     np.random.seed(0)
@@ -127,10 +127,10 @@ def test_new_points(make_test_viewer):
     assert np.sum(view.dims._displayed_sliders) == 0
 
 
-def test_new_shapes_empty_viewer(make_test_viewer):
+def test_new_shapes_empty_viewer(make_napari_viewer):
     """Test adding new shapes layer."""
     # Add labels to empty viewer
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     viewer.add_shapes()
@@ -143,7 +143,7 @@ def test_new_shapes_empty_viewer(make_test_viewer):
     assert np.sum(view.dims._displayed_sliders) == 0
 
     # Add points with image already present
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     np.random.seed(0)
@@ -159,11 +159,11 @@ def test_new_shapes_empty_viewer(make_test_viewer):
     assert np.sum(view.dims._displayed_sliders) == 0
 
 
-def test_z_order_adding_removing_images(make_test_viewer):
+def test_z_order_adding_removing_images(make_napari_viewer):
     """Test z order is correct after adding/ removing images."""
     data = np.ones((10, 10))
 
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     vis = viewer.window.qt_viewer.layer_to_visual
     viewer.add_image(data, colormap='red', name='red')
     viewer.add_image(data, colormap='green', name='green')
@@ -192,9 +192,9 @@ def test_z_order_adding_removing_images(make_test_viewer):
     np.testing.assert_almost_equal(order, list(range(len(viewer.layers))))
 
 
-def test_screenshot(make_test_viewer):
+def test_screenshot(make_napari_viewer):
     "Test taking a screenshot"
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     np.random.seed(0)
     # Add image
@@ -223,9 +223,9 @@ def test_screenshot(make_test_viewer):
 
 
 @pytest.mark.skip("new approach")
-def test_screenshot_dialog(make_test_viewer, tmpdir):
+def test_screenshot_dialog(make_napari_viewer, tmpdir):
     """Test save screenshot functionality."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     np.random.seed(0)
     # Add image
@@ -268,7 +268,7 @@ def test_screenshot_dialog(make_test_viewer, tmpdir):
 @pytest.mark.parametrize(
     "dtype", ['int8', 'uint8', 'int16', 'uint16', 'float32']
 )
-def test_qt_viewer_data_integrity(make_test_viewer, dtype):
+def test_qt_viewer_data_integrity(make_napari_viewer, dtype):
     """Test that the viewer doesn't change the underlying array."""
 
     image = np.random.rand(10, 32, 32)
@@ -276,7 +276,7 @@ def test_qt_viewer_data_integrity(make_test_viewer, dtype):
     image = image.astype(dtype)
     imean = image.mean()
 
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     viewer.add_image(image.copy())
     datamean = viewer.layers[0].data.mean()
@@ -291,8 +291,8 @@ def test_qt_viewer_data_integrity(make_test_viewer, dtype):
     assert datamean == imean
 
 
-def test_points_layer_display_correct_slice_on_scale(make_test_viewer):
-    viewer = make_test_viewer()
+def test_points_layer_display_correct_slice_on_scale(make_napari_viewer):
+    viewer = make_napari_viewer()
     data = np.zeros((60, 60, 60))
     viewer.add_image(data, scale=[0.29, 0.26, 0.26])
     pts = viewer.add_points(name='test', size=1, ndim=3)

--- a/napari/_qt/dialogs/_tests/test_qt_about_key_bindings.py
+++ b/napari/_qt/dialogs/_tests/test_qt_about_key_bindings.py
@@ -3,9 +3,9 @@ import numpy as np
 from napari._qt.dialogs.qt_about_key_bindings import QtAboutKeyBindings
 
 
-def test_about_key_bindings_dialog(make_test_viewer):
+def test_about_key_bindings_dialog(make_napari_viewer):
     """Test creating QtAboutKeyBindings dialog window and its methods."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
     key_bindings_dialog = QtAboutKeyBindings(viewer, view._key_map_handler)
     assert key_bindings_dialog.viewer == viewer
@@ -22,9 +22,9 @@ def test_about_key_bindings_dialog(make_test_viewer):
         # messy...
 
 
-def test_show_key_bindings_dialog(make_test_viewer, monkeypatch):
+def test_show_key_bindings_dialog(make_napari_viewer, monkeypatch):
     """Test creating dialog with method of qt_viewer."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
     # check that dialog does not exist yet
     assert not view.findChild(QtAboutKeyBindings)
@@ -35,9 +35,9 @@ def test_show_key_bindings_dialog(make_test_viewer, monkeypatch):
     assert isinstance(view.findChild(QtAboutKeyBindings), QtAboutKeyBindings)
 
 
-def test_updating_with_layer_change(make_test_viewer, monkeypatch):
+def test_updating_with_layer_change(make_napari_viewer, monkeypatch):
     """Test that the dialog text updates when the active layer is changed."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
     # turn off showing the dialog for test
     monkeypatch.setattr(QtAboutKeyBindings, 'show', lambda *a: None)

--- a/napari/_qt/perf/_tests/test_perf.py
+++ b/napari/_qt/perf/_tests/test_perf.py
@@ -50,7 +50,7 @@ def qapp():
         qt_event_tracing.perf.perf_timer = original_perf_timer
 
 
-def test_trace_on_start(tmp_path, monkeypatch, make_test_viewer):
+def test_trace_on_start(tmp_path, monkeypatch, make_napari_viewer):
     """Make sure napari can write a perfmon trace file."""
 
     timers, _, _, _ = perf._timers._create_timer()
@@ -60,7 +60,7 @@ def test_trace_on_start(tmp_path, monkeypatch, make_test_viewer):
     trace_path = tmp_path / "trace.json"
     timers.start_trace_file(trace_path)
 
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     data = np.random.random((10, 15))
     viewer.add_image(data)
     viewer.close()

--- a/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -295,8 +295,8 @@ def test_play_button(qtbot):
         mock_popup.assert_called_once()
 
 
-def test_slice_labels(make_test_viewer):
-    viewer = make_test_viewer()
+def test_slice_labels(make_napari_viewer):
+    viewer = make_napari_viewer()
     np.random.seed(0)
     data = np.random.random((20, 10, 10))
     viewer.add_image(data)

--- a/napari/_qt/widgets/_tests/test_qt_dock_widget.py
+++ b/napari/_qt/widgets/_tests/test_qt_dock_widget.py
@@ -2,9 +2,9 @@ import pytest
 from qtpy.QtWidgets import QDockWidget, QHBoxLayout, QPushButton, QVBoxLayout
 
 
-def test_add_dock_widget(make_test_viewer):
+def test_add_dock_widget(make_napari_viewer):
     """Test basic add_dock_widget functionality"""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     widg = QPushButton('button')
     dwidg = viewer.window.add_dock_widget(widg, name='test')
     assert not dwidg.is_vertical
@@ -36,9 +36,9 @@ def test_add_dock_widget(make_test_viewer):
         )
 
 
-def test_add_dock_widget_from_list(make_test_viewer):
+def test_add_dock_widget_from_list(make_napari_viewer):
     """Test that we can add a list of widgets and they will be combined"""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     widg = QPushButton('button')
     widg2 = QPushButton('button')
 
@@ -55,17 +55,17 @@ def test_add_dock_widget_from_list(make_test_viewer):
     assert isinstance(dwidg.widget().layout, QHBoxLayout)
 
 
-def test_add_dock_widget_raises(make_test_viewer):
+def test_add_dock_widget_raises(make_napari_viewer):
     """Test that the widget passed must be a DockWidget."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     widg = object()
 
     with pytest.raises(TypeError):
         viewer.window.add_dock_widget(widg, name='test')
 
 
-def test_remove_dock_widget_orphans_widget(make_test_viewer):
-    viewer = make_test_viewer()
+def test_remove_dock_widget_orphans_widget(make_napari_viewer):
+    viewer = make_napari_viewer()
     widg = QPushButton('button')
 
     assert not widg.parent()
@@ -79,8 +79,8 @@ def test_remove_dock_widget_orphans_widget(make_test_viewer):
     assert not widg.parent()
 
 
-def test_remove_dock_widget_by_widget_reference(make_test_viewer):
-    viewer = make_test_viewer()
+def test_remove_dock_widget_by_widget_reference(make_napari_viewer):
+    viewer = make_napari_viewer()
     widg = QPushButton('button')
 
     dw = viewer.window.add_dock_widget(widg, name='test')

--- a/napari/_qt/widgets/_tests/test_qt_play.py
+++ b/napari/_qt/widgets/_tests/test_qt_play.py
@@ -98,9 +98,9 @@ def test_animation_thread_once(qtbot):
 
 
 @pytest.fixture()
-def view(make_test_viewer):
+def view(make_napari_viewer):
     """basic viewer with data that we will use a few times"""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     np.random.seed(0)
     data = np.random.random((10, 10, 15))

--- a/napari/_tests/test_adding_removing.py
+++ b/napari/_tests/test_adding_removing.py
@@ -5,9 +5,9 @@ from napari._tests.utils import layer_test_data
 from napari.layers import Image
 
 
-def test_layers_removed_on_close(make_test_viewer):
+def test_layers_removed_on_close(make_napari_viewer):
     """Test layers removed on close."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     # add layers
     viewer.add_image(np.random.random((30, 40)))
@@ -19,13 +19,13 @@ def test_layers_removed_on_close(make_test_viewer):
     assert len(viewer.layers) == 0
 
 
-def test_layer_multiple_viewers(make_test_viewer):
+def test_layer_multiple_viewers(make_napari_viewer):
     """Test layer on multiple viewers."""
     # Check that a layer can be added and removed from
     # mutliple viewers. See https://github.com/napari/napari/issues/1503
     # for more detail.
-    viewer_a = make_test_viewer()
-    viewer_b = make_test_viewer()
+    viewer_a = make_napari_viewer()
+    viewer_b = make_napari_viewer()
 
     # create layer
     layer = Image(np.random.random((30, 40)))
@@ -45,10 +45,10 @@ def test_layer_multiple_viewers(make_test_viewer):
     assert layer.opacity == 0.6
 
 
-def test_adding_removing_layer(make_test_viewer):
+def test_adding_removing_layer(make_napari_viewer):
     """Test adding and removing a layer."""
     np.random.seed(0)
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     # Create layer
     data = np.random.random((2, 6, 30, 40))
@@ -86,10 +86,10 @@ def test_adding_removing_layer(make_test_viewer):
 
 @pytest.mark.parametrize('Layer, data, ndim', layer_test_data)
 def test_add_remove_layer_external_callbacks(
-    make_test_viewer, Layer, data, ndim
+    make_napari_viewer, Layer, data, ndim
 ):
     """Test external callbacks for layer emmitters preserved."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     layer = Layer(data)
     # Check layer has been correctly created

--- a/napari/_tests/test_advanced.py
+++ b/napari/_tests/test_advanced.py
@@ -2,14 +2,14 @@ import numpy as np
 import pytest
 
 
-def test_4D_5D_images(make_test_viewer):
+def test_4D_5D_images(make_napari_viewer):
     """Test adding 4D followed by 5D image layers to the viewer.
 
     Initially only 2 sliders should be present, then a third slider should be
     created.
     """
     np.random.seed(0)
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     # add 4D image data
@@ -31,10 +31,10 @@ def test_4D_5D_images(make_test_viewer):
     assert np.sum(view.dims._displayed_sliders) == 3
 
 
-def test_5D_image_3D_rendering(make_test_viewer):
+def test_5D_image_3D_rendering(make_napari_viewer):
     """Test 3D rendering of a 5D image."""
     np.random.seed(0)
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     # add 4D image data
@@ -55,12 +55,12 @@ def test_5D_image_3D_rendering(make_test_viewer):
     assert np.sum(view.dims._displayed_sliders) == 2
 
 
-def test_change_image_dims(make_test_viewer):
+def test_change_image_dims(make_napari_viewer):
     """Test changing the dims and shape of an image layer in place and checking
     the numbers of sliders and their ranges changes appropriately.
     """
     np.random.seed(0)
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     # add 3D image data
@@ -97,14 +97,14 @@ def test_change_image_dims(make_test_viewer):
     assert np.sum(view.dims._displayed_sliders) == 1
 
 
-def test_range_one_image(make_test_viewer):
+def test_range_one_image(make_napari_viewer):
     """Test adding an image with a range one dimensions.
 
     There should be no slider shown for the axis corresponding to the range
     one dimension.
     """
     np.random.seed(0)
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     # add 5D image data with range one dimensions
@@ -127,14 +127,14 @@ def test_range_one_image(make_test_viewer):
     assert np.sum(view.dims._displayed_sliders) == 3
 
 
-def test_range_one_images_and_points(make_test_viewer):
+def test_range_one_images_and_points(make_napari_viewer):
     """Test adding images with range one dimensions and points.
 
     Initially no sliders should be present as the images have range one
     dimensions. On adding the points the sliders should be displayed.
     """
     np.random.seed(0)
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     # add 5D image data with range one dimensions
@@ -158,9 +158,9 @@ def test_range_one_images_and_points(make_test_viewer):
 
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning:jupyter_client")
-def test_update_console(make_test_viewer):
+def test_update_console(make_napari_viewer):
     """Test updating the console with local variables."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     # Check viewer in console
@@ -177,9 +177,9 @@ def test_update_console(make_test_viewer):
     assert view.console.shell.user_ns['b'] == b
 
 
-def test_changing_display_surface(make_test_viewer):
+def test_changing_display_surface(make_napari_viewer):
     """Test adding 3D surface and changing its display."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     np.random.seed(0)
@@ -218,9 +218,9 @@ def test_changing_display_surface(make_test_viewer):
         viewer.dims.set_point(0, s)
 
 
-def test_labels_undo_redo(make_test_viewer):
+def test_labels_undo_redo(make_napari_viewer):
     """Test undoing/redoing on the labels layer."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     data = np.zeros((50, 50), dtype=np.uint8)
     data[:5, :5] = 1

--- a/napari/_tests/test_draw.py
+++ b/napari/_tests/test_draw.py
@@ -8,9 +8,9 @@ import pytest
     sys.platform.startswith('win') or sys.platform.startswith('linux'),
     reason='Currently fails on certain CI due to error on canvas draw.',
 )
-def test_canvas_drawing(make_test_viewer):
+def test_canvas_drawing(make_napari_viewer):
     """Test drawing before and after adding and then deleting a layer."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     assert len(viewer.layers) == 0

--- a/napari/_tests/test_dtypes.py
+++ b/napari/_tests/test_dtypes.py
@@ -18,10 +18,10 @@ dtypes = [
 
 
 @pytest.mark.parametrize('dtype', dtypes)
-def test_image_dytpes(make_test_viewer, dtype):
+def test_image_dytpes(make_napari_viewer, dtype):
     """Test different dtype images."""
     np.random.seed(0)
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     # add dtype image data
     data = np.random.randint(20, size=(30, 40)).astype(dtype)

--- a/napari/_tests/test_function_widgets.py
+++ b/napari/_tests/test_function_widgets.py
@@ -3,11 +3,11 @@ import numpy as np
 import napari.layers
 
 
-def test_add_function_widget(make_test_viewer):
+def test_add_function_widget(make_napari_viewer):
     """Test basic add_function_widget functionality"""
     from qtpy.QtWidgets import QDockWidget
 
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     # Define a function.
     def image_sum(

--- a/napari/_tests/test_key_bindings.py
+++ b/napari/_tests/test_key_bindings.py
@@ -4,10 +4,10 @@ import numpy as np
 from vispy import keys
 
 
-def test_viewer_key_bindings(make_test_viewer):
+def test_viewer_key_bindings(make_napari_viewer):
     """Test adding key bindings to the viewer"""
     np.random.seed(0)
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     mock_press = Mock()
@@ -72,10 +72,10 @@ def test_viewer_key_bindings(make_test_viewer):
     mock_shift_release.reset_mock()
 
 
-def test_layer_key_bindings(make_test_viewer):
+def test_layer_key_bindings(make_napari_viewer):
     """Test adding key bindings to a layer"""
     np.random.seed(0)
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     layer = viewer.add_image(np.random.random((10, 20)))
@@ -140,9 +140,9 @@ def test_layer_key_bindings(make_test_viewer):
     mock_shift_release.reset_mock()
 
 
-def test_reset_scroll_progress(make_test_viewer):
+def test_reset_scroll_progress(make_napari_viewer):
     """Test select all key binding."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
     assert viewer.dims._scroll_progress == 0
 

--- a/napari/_tests/test_mouse_bindings.py
+++ b/napari/_tests/test_mouse_bindings.py
@@ -4,10 +4,10 @@ from unittest.mock import Mock
 import numpy as np
 
 
-def test_viewer_mouse_bindings(make_test_viewer):
+def test_viewer_mouse_bindings(make_napari_viewer):
     """Test adding mouse bindings to the viewer"""
     np.random.seed(0)
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     if os.getenv("CI"):
@@ -77,10 +77,10 @@ def test_viewer_mouse_bindings(make_test_viewer):
     mock_move.method.assert_not_called()
 
 
-def test_layer_mouse_bindings(make_test_viewer):
+def test_layer_mouse_bindings(make_napari_viewer):
     """Test adding mouse bindings to a layer that is selected"""
     np.random.seed(0)
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     if os.getenv("CI"):
@@ -152,10 +152,10 @@ def test_layer_mouse_bindings(make_test_viewer):
     mock_move.method.assert_not_called()
 
 
-def test_unselected_layer_mouse_bindings(make_test_viewer):
+def test_unselected_layer_mouse_bindings(make_napari_viewer):
     """Test adding mouse bindings to a layer that is not selected"""
     np.random.seed(0)
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     if os.getenv("CI"):

--- a/napari/_tests/test_notebook_display.py
+++ b/napari/_tests/test_notebook_display.py
@@ -3,9 +3,9 @@ import numpy as np
 from napari.utils import nbscreenshot
 
 
-def test_nbscreenshot(make_test_viewer):
+def test_nbscreenshot(make_napari_viewer):
     """Test taking a screenshot."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     np.random.seed(0)
     data = np.random.random((10, 15))

--- a/napari/_tests/test_numpy_like.py
+++ b/napari/_tests/test_numpy_like.py
@@ -4,9 +4,9 @@ import xarray as xr
 import zarr
 
 
-def test_dask_2D(make_test_viewer):
+def test_dask_2D(make_napari_viewer):
     """Test adding 2D dask image."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     da.random.seed(0)
     data = da.random.random((10, 15))
@@ -14,9 +14,9 @@ def test_dask_2D(make_test_viewer):
     assert np.all(viewer.layers[0].data == data)
 
 
-def test_dask_nD(make_test_viewer):
+def test_dask_nD(make_napari_viewer):
     """Test adding nD dask image."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     da.random.seed(0)
     data = da.random.random((10, 15, 6, 16))
@@ -24,9 +24,9 @@ def test_dask_nD(make_test_viewer):
     assert np.all(viewer.layers[0].data == data)
 
 
-def test_zarr_2D(make_test_viewer):
+def test_zarr_2D(make_napari_viewer):
     """Test adding 2D zarr image."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     data = zarr.zeros((200, 100), chunks=(40, 20))
     data[53:63, 10:20] = 1
@@ -35,9 +35,9 @@ def test_zarr_2D(make_test_viewer):
     assert np.all(viewer.layers[0].data == data)
 
 
-def test_zarr_nD(make_test_viewer):
+def test_zarr_nD(make_napari_viewer):
     """Test adding nD zarr image."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     data = zarr.zeros((200, 100, 50), chunks=(40, 20, 10))
     data[53:63, 10:20, :] = 1
@@ -46,9 +46,9 @@ def test_zarr_nD(make_test_viewer):
     assert np.all(viewer.layers[0].data == data)
 
 
-def test_zarr_dask_2D(make_test_viewer):
+def test_zarr_dask_2D(make_napari_viewer):
     """Test adding 2D dask image."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     data = zarr.zeros((200, 100), chunks=(40, 20))
     data[53:63, 10:20] = 1
@@ -57,9 +57,9 @@ def test_zarr_dask_2D(make_test_viewer):
     assert np.all(viewer.layers[0].data == zdata)
 
 
-def test_zarr_dask_nD(make_test_viewer):
+def test_zarr_dask_nD(make_napari_viewer):
     """Test adding nD zarr image."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     data = zarr.zeros((200, 100, 50), chunks=(40, 20, 10))
     data[53:63, 10:20, :] = 1
@@ -68,9 +68,9 @@ def test_zarr_dask_nD(make_test_viewer):
     assert np.all(viewer.layers[0].data == zdata)
 
 
-def test_xarray_2D(make_test_viewer):
+def test_xarray_2D(make_napari_viewer):
     """Test adding 2D xarray image."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     np.random.seed(0)
     data = np.random.random((10, 15))
@@ -79,9 +79,9 @@ def test_xarray_2D(make_test_viewer):
     assert np.all(viewer.layers[0].data == xdata)
 
 
-def test_xarray_nD(make_test_viewer):
+def test_xarray_nD(make_napari_viewer):
     """Test adding nD xarray image."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     np.random.seed(0)
     data = np.random.random((10, 15, 6, 16))

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -13,9 +13,9 @@ from napari._tests.utils import (
 from napari.utils._tests.test_naming import eval_with_filename
 
 
-def test_viewer(make_test_viewer):
+def test_viewer(make_napari_viewer):
     """Test instantiating viewer."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     view = viewer.window.qt_viewer
 
     assert viewer.title == 'napari'
@@ -46,8 +46,8 @@ def test_viewer(make_test_viewer):
 
 @pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)
 @pytest.mark.parametrize('visible', [True, False])
-def test_add_layer(make_test_viewer, layer_class, data, ndim, visible):
-    viewer = make_test_viewer()
+def test_add_layer(make_napari_viewer, layer_class, data, ndim, visible):
+    viewer = make_napari_viewer()
     layer = add_layer_by_type(viewer, layer_class, data, visible=visible)
     check_viewer_functioning(viewer, viewer.window.qt_viewer, data, ndim)
 
@@ -58,11 +58,11 @@ def test_add_layer(make_test_viewer, layer_class, data, ndim, visible):
 
 @pytest.mark.parametrize('layer_class, a_unique_name, ndim', layer_test_data)
 def test_add_layer_magic_name(
-    make_test_viewer, layer_class, a_unique_name, ndim
+    make_napari_viewer, layer_class, a_unique_name, ndim
 ):
     """Test magic_name works when using add_* for layers"""
     # Tests for issue #1709
-    viewer = make_test_viewer()  # noqa: F841
+    viewer = make_napari_viewer()  # noqa: F841
     layer = eval_with_filename(
         "add_layer_by_type(viewer, layer_class, a_unique_name)",
         "somefile.py",
@@ -70,9 +70,9 @@ def test_add_layer_magic_name(
     assert layer.name == "a_unique_name"
 
 
-def test_screenshot(make_test_viewer):
+def test_screenshot(make_napari_viewer):
     """Test taking a screenshot."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     np.random.seed(0)
     # Add image
@@ -104,9 +104,9 @@ def test_screenshot(make_test_viewer):
     assert screenshot.ndim == 3
 
 
-def test_changing_theme(make_test_viewer):
+def test_changing_theme(make_napari_viewer):
     """Test changing the theme updates the full window."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     viewer.add_points(data=None)
     assert viewer.theme == 'dark'
 
@@ -126,10 +126,10 @@ def test_changing_theme(make_test_viewer):
 
 
 @pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)
-def test_roll_traspose_update(make_test_viewer, layer_class, data, ndim):
+def test_roll_traspose_update(make_napari_viewer, layer_class, data, ndim):
     """Check that transpose and roll preserve correct transform sequence."""
 
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     np.random.seed(0)
 
@@ -158,9 +158,9 @@ def test_roll_traspose_update(make_test_viewer, layer_class, data, ndim):
     check_view_transform_consistency(layer, viewer, transf_dict)
 
 
-def test_toggling_axes(make_test_viewer):
+def test_toggling_axes(make_napari_viewer):
     """Test toggling axes."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     # Check axes are not visible
     assert not viewer.axes.visible
@@ -178,9 +178,9 @@ def test_toggling_axes(make_test_viewer):
     assert not viewer.axes.visible
 
 
-def test_toggling_scale_bar(make_test_viewer):
+def test_toggling_scale_bar(make_napari_viewer):
     """Test toggling scale bar."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     # Check scale bar is not visible
     assert not viewer.scale_bar.visible

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -24,11 +24,11 @@ skip_local_popups = pytest.mark.skipif(
 
 @skip_on_win_ci
 @skip_local_popups
-def test_z_order_adding_removing_images(make_test_viewer):
+def test_z_order_adding_removing_images(make_napari_viewer):
     """Test z order is correct after adding/ removing images."""
     data = np.ones((10, 10))
 
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
     viewer.add_image(data, colormap='red', name='red')
     viewer.add_image(data, colormap='green', name='green')
     viewer.add_image(data, colormap='blue', name='blue')
@@ -68,11 +68,11 @@ def test_z_order_adding_removing_images(make_test_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
-def test_z_order_images(make_test_viewer):
+def test_z_order_images(make_napari_viewer):
     """Test changing order of images changes z order in display."""
     data = np.ones((10, 10))
 
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
     viewer.add_image(data, colormap='red')
     viewer.add_image(data, colormap='blue')
     screenshot = viewer.screenshot(canvas_only=True)
@@ -89,11 +89,11 @@ def test_z_order_images(make_test_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
-def test_z_order_image_points(make_test_viewer):
+def test_z_order_image_points(make_napari_viewer):
     """Test changing order of image and points changes z order in display."""
     data = np.ones((10, 10))
 
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
     viewer.add_image(data, colormap='red')
     viewer.add_points([5, 5], face_color='blue', size=10)
     screenshot = viewer.screenshot(canvas_only=True)
@@ -110,11 +110,11 @@ def test_z_order_image_points(make_test_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
-def test_z_order_images_after_ndisplay(make_test_viewer):
+def test_z_order_images_after_ndisplay(make_napari_viewer):
     """Test z order of images remanins constant after chaning ndisplay."""
     data = np.ones((10, 10))
 
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
     viewer.add_image(data, colormap='red')
     viewer.add_image(data, colormap='blue')
     screenshot = viewer.screenshot(canvas_only=True)
@@ -139,11 +139,11 @@ def test_z_order_images_after_ndisplay(make_test_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
-def test_z_order_image_points_after_ndisplay(make_test_viewer):
+def test_z_order_image_points_after_ndisplay(make_napari_viewer):
     """Test z order of image and points remanins constant after chaning ndisplay."""
     data = np.ones((10, 10))
 
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
     viewer.add_image(data, colormap='red')
     viewer.add_points([5, 5], face_color='blue', size=10)
     screenshot = viewer.screenshot(canvas_only=True)
@@ -168,9 +168,9 @@ def test_z_order_image_points_after_ndisplay(make_test_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
-def test_changing_image_colormap(make_test_viewer):
+def test_changing_image_colormap(make_napari_viewer):
     """Test changing colormap changes rendering."""
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
 
     data = np.ones((20, 20, 20))
     layer = viewer.add_image(data, contrast_limits=[0, 1])
@@ -198,9 +198,9 @@ def test_changing_image_colormap(make_test_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
-def test_changing_image_gamma(make_test_viewer):
+def test_changing_image_gamma(make_napari_viewer):
     """Test changing gamma changes rendering."""
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
 
     data = np.ones((20, 20, 20))
     layer = viewer.add_image(data, contrast_limits=[0, 2])
@@ -228,9 +228,9 @@ def test_changing_image_gamma(make_test_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
-def test_grid_mode(make_test_viewer):
+def test_grid_mode(make_napari_viewer):
     """Test changing gamma changes rendering."""
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
 
     # Add images
     data = np.ones((6, 15, 15))
@@ -328,12 +328,12 @@ def test_grid_mode(make_test_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
-def test_changing_image_attenuation(make_test_viewer):
+def test_changing_image_attenuation(make_napari_viewer):
     """Test changing attenuation value changes rendering."""
     data = np.zeros((100, 10, 10))
     data[-1] = 1
 
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
     viewer.dims.ndisplay = 3
     viewer.add_image(data, contrast_limits=[0, 1])
     viewer.layers[0].rendering = 'attenuated_mip'
@@ -353,11 +353,11 @@ def test_changing_image_attenuation(make_test_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
-def test_labels_painting(make_test_viewer):
+def test_labels_painting(make_napari_viewer):
     """Test painting labels updates image."""
     data = np.zeros((100, 100))
 
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
     viewer.add_labels(data)
     layer = viewer.layers[0]
 
@@ -403,9 +403,9 @@ def test_labels_painting(make_test_viewer):
 @pytest.mark.skip("Welcome visual temporarily disabled")
 @skip_on_win_ci
 @skip_local_popups
-def test_welcome(make_test_viewer):
+def test_welcome(make_napari_viewer):
     """Test that something visible on launch."""
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
 
     # Check something is visible
     screenshot = viewer.screenshot(canvas_only=True)
@@ -427,9 +427,9 @@ def test_welcome(make_test_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
-def test_axes_visible(make_test_viewer):
+def test_axes_visible(make_napari_viewer):
     """Test that something appears when axes become visible."""
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
 
     # Check axes are not visible
     launch_screenshot = viewer.screenshot(canvas_only=True)
@@ -450,9 +450,9 @@ def test_axes_visible(make_test_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
-def test_scale_bar_visible(make_test_viewer):
+def test_scale_bar_visible(make_napari_viewer):
     """Test that something appears when scale bar becomes visible."""
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
 
     # Check scale bar is not visible
     launch_screenshot = viewer.screenshot(canvas_only=True)

--- a/napari/_vispy/_tests/test_image_rendering.py
+++ b/napari/_vispy/_tests/test_image_rendering.py
@@ -5,9 +5,9 @@ import numpy as np
 import pytest
 
 
-def test_image_rendering(make_test_viewer):
+def test_image_rendering(make_napari_viewer):
     """Test 3D image with different rendering."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     viewer.dims.ndisplay = 3
 
@@ -45,12 +45,12 @@ def test_image_rendering(make_test_viewer):
     sys.platform.startswith('win') or not os.getenv("CI"),
     reason='Screenshot tests are not supported on napari windows CI.',
 )
-def test_visibility_consistency(qtbot, make_test_viewer):
+def test_visibility_consistency(qtbot, make_napari_viewer):
     """Make sure toggling visibility maintains image contrast.
 
     see #1622 for details.
     """
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
 
     layer = viewer.add_image(
         np.random.random((200, 200)), contrast_limits=[0, 10]

--- a/napari/_vispy/_tests/test_vispy_big_images.py
+++ b/napari/_vispy/_tests/test_vispy_big_images.py
@@ -2,9 +2,9 @@ import numpy as np
 import pytest
 
 
-def test_big_2D_image(make_test_viewer):
+def test_big_2D_image(make_napari_viewer):
     """Test big 2D image with axis exceeding max texture size."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     shape = (20_000, 10)
     data = np.random.random(shape)
@@ -16,9 +16,9 @@ def test_big_2D_image(make_test_viewer):
         assert np.all(layer._transforms['tile2data'].scale == s)
 
 
-def test_big_3D_image(make_test_viewer):
+def test_big_3D_image(make_napari_viewer):
     """Test big 3D image with axis exceeding max texture size."""
-    viewer = make_test_viewer(ndisplay=3)
+    viewer = make_napari_viewer(ndisplay=3)
 
     shape = (5, 10, 3_000)
     data = np.random.random(shape)
@@ -34,9 +34,9 @@ def test_big_3D_image(make_test_viewer):
     "shape",
     [(2, 4), (256, 4048), (4, 20_000), (20_000, 4)],
 )
-def test_downsample_value(make_test_viewer, shape):
+def test_downsample_value(make_napari_viewer, shape):
     """Test getting correct value for downsampled data."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     data = np.zeros(shape)
     data[shape[0] // 2 :, shape[1] // 2 :] = 1

--- a/napari/_vispy/_tests/test_vispy_calls.py
+++ b/napari/_vispy/_tests/test_vispy_calls.py
@@ -3,9 +3,9 @@ from unittest.mock import patch
 import numpy as np
 
 
-def test_data_change_ndisplay_image(make_test_viewer):
+def test_data_change_ndisplay_image(make_napari_viewer):
     """Test change data calls for image layer with ndisplay change."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     np.random.seed(0)
     data = np.random.random((10, 15, 8))
@@ -22,9 +22,9 @@ def test_data_change_ndisplay_image(make_test_viewer):
     test_ndisplay_change(ndisplay=2)
 
 
-def test_data_change_ndisplay_labels(make_test_viewer):
+def test_data_change_ndisplay_labels(make_napari_viewer):
     """Test change data calls for labels layer with ndisplay change."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     np.random.seed(0)
     data = np.random.randint(20, size=(10, 15, 8))
@@ -42,9 +42,9 @@ def test_data_change_ndisplay_labels(make_test_viewer):
     test_ndisplay_change(ndisplay=2)
 
 
-def test_data_change_ndisplay_points(make_test_viewer):
+def test_data_change_ndisplay_points(make_napari_viewer):
     """Test change data calls for points layer with ndisplay change."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     np.random.seed(0)
     data = 20 * np.random.random((10, 3))
@@ -61,9 +61,9 @@ def test_data_change_ndisplay_points(make_test_viewer):
     test_ndisplay_change(ndisplay=2)
 
 
-def test_data_change_ndisplay_vectors(make_test_viewer):
+def test_data_change_ndisplay_vectors(make_napari_viewer):
     """Test change data calls for vectors layer with ndisplay change."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     np.random.seed(0)
     data = 20 * np.random.random((10, 2, 3))
@@ -80,9 +80,9 @@ def test_data_change_ndisplay_vectors(make_test_viewer):
     test_ndisplay_change(ndisplay=2)
 
 
-def test_data_change_ndisplay_shapes(make_test_viewer):
+def test_data_change_ndisplay_shapes(make_napari_viewer):
     """Test change data calls for shapes layer with ndisplay change."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     np.random.seed(0)
     data = 20 * np.random.random((10, 4, 3))
@@ -100,9 +100,9 @@ def test_data_change_ndisplay_shapes(make_test_viewer):
     test_ndisplay_change(ndisplay=2)
 
 
-def test_data_change_ndisplay_surface(make_test_viewer):
+def test_data_change_ndisplay_surface(make_napari_viewer):
     """Test change data calls for surface layer with ndisplay change."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     np.random.seed(0)
     vertices = np.random.random((10, 3))

--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -1,9 +1,9 @@
 import numpy as np
 
 
-def test_camera(make_test_viewer):
+def test_camera(make_napari_viewer):
     """Test vispy camera creation in 2D."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     vispy_camera = viewer.window.qt_viewer.camera
 
     np.random.seed(0)
@@ -23,9 +23,9 @@ def test_camera(make_test_viewer):
     np.testing.assert_almost_equal(viewer.camera.zoom, vispy_camera.zoom)
 
 
-def test_vispy_camera_update_from_model(make_test_viewer):
+def test_vispy_camera_update_from_model(make_napari_viewer):
     """Test vispy camera update from model in 2D."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     vispy_camera = viewer.window.qt_viewer.camera
 
     np.random.seed(0)
@@ -50,9 +50,9 @@ def test_vispy_camera_update_from_model(make_test_viewer):
     np.testing.assert_almost_equal(viewer.camera.zoom, vispy_camera.zoom)
 
 
-def test_camera_model_update_from_vispy(make_test_viewer):
+def test_camera_model_update_from_vispy(make_napari_viewer):
     """Test camera model updates from vispy in 2D."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     vispy_camera = viewer.window.qt_viewer.camera
 
     np.random.seed(0)
@@ -78,9 +78,9 @@ def test_camera_model_update_from_vispy(make_test_viewer):
     np.testing.assert_almost_equal(viewer.camera.zoom, vispy_camera.zoom)
 
 
-def test_3D_camera(make_test_viewer):
+def test_3D_camera(make_napari_viewer):
     """Test vispy camera creation in 3D."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     vispy_camera = viewer.window.qt_viewer.camera
 
     np.random.seed(0)
@@ -97,9 +97,9 @@ def test_3D_camera(make_test_viewer):
     np.testing.assert_almost_equal(viewer.camera.zoom, vispy_camera.zoom)
 
 
-def test_vispy_camera_update_from_model_3D(make_test_viewer):
+def test_vispy_camera_update_from_model_3D(make_napari_viewer):
     """Test vispy camera update from model in 3D."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     vispy_camera = viewer.window.qt_viewer.camera
 
     np.random.seed(0)
@@ -121,9 +121,9 @@ def test_vispy_camera_update_from_model_3D(make_test_viewer):
     np.testing.assert_almost_equal(viewer.camera.zoom, vispy_camera.zoom)
 
 
-def test_camera_model_update_from_vispy_3D(make_test_viewer):
+def test_camera_model_update_from_vispy_3D(make_napari_viewer):
     """Test camera model updates from vispy in 3D."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     vispy_camera = viewer.window.qt_viewer.camera
 
     np.random.seed(0)

--- a/napari/_vispy/_tests/test_vispy_multiscale.py
+++ b/napari/_vispy/_tests/test_vispy_multiscale.py
@@ -14,9 +14,9 @@ skip_local_popups = pytest.mark.skipif(
 )
 
 
-def test_multiscale(make_test_viewer):
+def test_multiscale(make_napari_viewer):
     """Test rendering of multiscale data."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     shapes = [(4000, 3000), (2000, 1500), (1000, 750), (500, 375)]
     np.random.seed(0)
@@ -52,9 +52,9 @@ def test_multiscale(make_test_viewer):
     assert value[1] is None
 
 
-def test_3D_multiscale_image(make_test_viewer):
+def test_3D_multiscale_image(make_napari_viewer):
     """Test rendering of 3D multiscale image uses lowest resolution."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     data = [np.random.random((128,) * 3), np.random.random((64,) * 3)]
     viewer.add_image(data)
@@ -71,9 +71,9 @@ def test_3D_multiscale_image(make_test_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
-def test_multiscale_screenshot(make_test_viewer):
+def test_multiscale_screenshot(make_napari_viewer):
     """Test rendering of multiscale data with screenshot."""
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
 
     shapes = [(4000, 3000), (2000, 1500), (1000, 750), (500, 375)]
     data = [np.ones(s) for s in shapes]
@@ -99,9 +99,9 @@ def test_multiscale_screenshot(make_test_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
-def test_multiscale_screenshot_zoomed(make_test_viewer):
+def test_multiscale_screenshot_zoomed(make_napari_viewer):
     """Test rendering of multiscale data with screenshot after zoom."""
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
     view = viewer.window.qt_viewer
 
     shapes = [(4000, 3000), (2000, 1500), (1000, 750), (500, 375)]
@@ -134,9 +134,9 @@ def test_multiscale_screenshot_zoomed(make_test_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
-def test_image_screenshot_zoomed(make_test_viewer):
+def test_image_screenshot_zoomed(make_napari_viewer):
     """Test rendering of image data with screenshot after zoom."""
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
     view = viewer.window.qt_viewer
 
     data = np.ones((4000, 3000))
@@ -165,10 +165,10 @@ def test_image_screenshot_zoomed(make_test_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
-def test_5D_multiscale(make_test_viewer):
+def test_5D_multiscale(make_napari_viewer):
     """Test 5D multiscale data."""
     # Show must be true to trigger multiscale draw and corner estimation
-    viewer = make_test_viewer(show=True)
+    viewer = make_napari_viewer(show=True)
     shapes = [(1, 2, 5, 20, 20), (1, 2, 5, 10, 10), (1, 2, 5, 5, 5)]
     np.random.seed(0)
     data = [np.random.random(s) for s in shapes]

--- a/napari/_vispy/_tests/test_vispy_points_layer.py
+++ b/napari/_vispy/_tests/test_vispy_points_layer.py
@@ -3,9 +3,9 @@ import pytest
 
 
 @pytest.mark.parametrize("opacity", [(0), (0.3), (0.7), (1)])
-def test_VispyPointsLayer(make_test_viewer, opacity):
+def test_VispyPointsLayer(make_napari_viewer, opacity):
     """Test on the VispyPointsLayer object."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     points = np.array([[100, 100], [200, 200], [300, 100]])
     layer = viewer.add_points(points, size=30, opacity=opacity)
     visual = viewer.window.qt_viewer.layer_to_visual[layer]

--- a/napari/components/experimental/chunk/_commands/_tests/test_loader.py
+++ b/napari/components/experimental/chunk/_commands/_tests/test_loader.py
@@ -5,9 +5,9 @@ from napari.components.experimental.chunk._commands import LoaderCommands
 
 
 @pytest.mark.async_only
-def test_help(make_test_viewer, capsys):
+def test_help(make_napari_viewer, capsys):
     """Test loader.help."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     loader = loader = viewer.experimental.cmds.loader
 
     loader.help
@@ -16,9 +16,9 @@ def test_help(make_test_viewer, capsys):
 
 
 @pytest.mark.async_only
-def test_no_layers(make_test_viewer, capsys):
+def test_no_layers(make_napari_viewer, capsys):
     """Test loader.layers with no layers."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     LoaderCommands(viewer.layers).layers
     out, _ = capsys.readouterr()
     for x in ["ID", "NAME", "LAYER"]:  # Just check a few.
@@ -26,9 +26,9 @@ def test_no_layers(make_test_viewer, capsys):
 
 
 @pytest.mark.async_only
-def test_one_layer(make_test_viewer, capsys):
+def test_one_layer(make_napari_viewer, capsys):
     """Test loader.layer with one layer."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     loader = viewer.experimental.cmds.loader
 
     data = np.random.random((10, 15))
@@ -40,9 +40,9 @@ def test_one_layer(make_test_viewer, capsys):
 
 
 @pytest.mark.async_only
-def test_many_layers(make_test_viewer, capsys):
+def test_many_layers(make_napari_viewer, capsys):
     """Test loader.layer with many layers."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     loader = viewer.experimental.cmds.loader
 
     num_images = 10
@@ -55,9 +55,9 @@ def test_many_layers(make_test_viewer, capsys):
 
 
 @pytest.mark.async_only
-def test_levels(make_test_viewer, capsys):
+def test_levels(make_napari_viewer, capsys):
     """Test loader.levels."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     loader = viewer.experimental.cmds.loader
 
     data = np.random.random((10, 15))

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -1,13 +1,9 @@
 import os
-import sys
-import warnings
 from functools import partial
-from typing import List
 
 import numpy as np
 import pytest
 
-from napari import Viewer
 from napari.components import LayerList
 from napari.layers import Image, Labels, Points, Shapes, Vectors
 from napari.plugins._builtins import (
@@ -64,49 +60,6 @@ def pytest_addoption(parser):
         default=False,
         help="run only asynchronous tests",
     )
-
-
-@pytest.fixture
-def qtbot(qtbot):
-    """A modified qtbot fixture that makes sure no widgets have been leaked."""
-    from qtpy.QtWidgets import QApplication
-
-    initial = QApplication.topLevelWidgets()
-    prior_exception = getattr(sys, 'last_value', None)
-
-    yield qtbot
-
-    # if an exception was raised during the test, we should just quit now and
-    # skip looking for leaked widgets.
-    if getattr(sys, 'last_value', None) is not prior_exception:
-        return
-
-    QApplication.processEvents()
-    leaks = set(QApplication.topLevelWidgets()).difference(initial)
-    # still not sure how to clean up some of the remaining vispy
-    # vispy.app.backends._qt.CanvasBackendDesktop widgets...
-    if any([n.__class__.__name__ != 'CanvasBackendDesktop' for n in leaks]):
-        raise AssertionError(f'Widgets leaked!: {leaks}')
-    if leaks:
-        warnings.warn(f'Widgets leaked!: {leaks}')
-
-
-@pytest.fixture(scope="function")
-def make_test_viewer(qtbot, request):
-    viewers: List[Viewer] = []
-
-    def actual_factory(*model_args, viewer_class=Viewer, **model_kwargs):
-        model_kwargs['show'] = model_kwargs.pop(
-            'show', request.config.getoption("--show-viewer")
-        )
-        viewer = viewer_class(*model_args, **model_kwargs)
-        viewers.append(viewer)
-        return viewer
-
-    yield actual_factory
-
-    for viewer in viewers:
-        viewer.close()
 
 
 @pytest.fixture(

--- a/napari/utils/_tests/test_magicgui.py
+++ b/napari/utils/_tests/test_magicgui.py
@@ -43,12 +43,12 @@ for cls in all_subclasses(Layer):
         pass
 
 
-def test_magicgui_returns_image(make_test_viewer):
+def test_magicgui_returns_image(make_napari_viewer):
     """make sure a magicgui function returning Image adds an Image.
 
     This is deprecated and now emits a warning
     """
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     @magicgui
     def add_image() -> Image:
@@ -68,12 +68,12 @@ def test_magicgui_returns_image(make_test_viewer):
     assert isinstance(viewer.layers[0], Image)
 
 
-def test_magicgui_returns_label(make_test_viewer):
+def test_magicgui_returns_label(make_napari_viewer):
     """make sure a magicgui function returning Labels adds a Labels.
 
     This is deprecated and now emits a warning
     """
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     @magicgui
     def add_labels() -> Labels:
@@ -92,12 +92,12 @@ def test_magicgui_returns_label(make_test_viewer):
     bool(os.environ.get('CI') and sys.platform == "darwin"),
     reason="segfault on mac CI",
 )
-def test_magicgui_returns_layer_tuple(make_test_viewer):
+def test_magicgui_returns_layer_tuple(make_napari_viewer):
     """make sure a magicgui function returning Layer adds the right type.
 
     This is deprecated and now emits a warning
     """
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     @magicgui
     def add_layer() -> Layer:
@@ -116,13 +116,13 @@ def test_magicgui_returns_layer_tuple(make_test_viewer):
 
 
 @pytest.mark.parametrize('LayerType, data, ndim', test_data)
-def test_magicgui_add_data(make_test_viewer, LayerType, data, ndim):
+def test_magicgui_add_data(make_napari_viewer, LayerType, data, ndim):
     """Test that annotating with napari.types.<layer_type>Data works.
 
     It expects a raw data format (like a numpy array) and will add a layer
     of the corresponding type to the viewer.
     """
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     dtype = getattr(types, f'{LayerType.__name__}Data')
 
     @magicgui
@@ -138,14 +138,14 @@ def test_magicgui_add_data(make_test_viewer, LayerType, data, ndim):
 
 
 @pytest.mark.parametrize('LayerType, data, ndim', test_data)
-def test_magicgui_get_data(make_test_viewer, LayerType, data, ndim):
+def test_magicgui_get_data(make_napari_viewer, LayerType, data, ndim):
     """Test that annotating parameters with napari.types.<layer_type>Data.
 
     This will provide the same dropdown menu appearance as when annotating
     a parameter with napari.layers.<layer_type>... but the function will
     receive `layer.data` rather than `layer`
     """
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
     dtype = getattr(types, f'{LayerType.__name__}Data')
 
     @magicgui
@@ -160,8 +160,8 @@ def test_magicgui_get_data(make_test_viewer, LayerType, data, ndim):
 
 
 @pytest.mark.parametrize('LayerType, data, ndim', test_data)
-def test_magicgui_add_layer(make_test_viewer, LayerType, data, ndim):
-    viewer = make_test_viewer()
+def test_magicgui_add_layer(make_napari_viewer, LayerType, data, ndim):
+    viewer = make_napari_viewer()
 
     @magicgui
     def add_layer() -> LayerType:
@@ -173,8 +173,8 @@ def test_magicgui_add_layer(make_test_viewer, LayerType, data, ndim):
     assert isinstance(viewer.layers[0], LayerType)
 
 
-def test_magicgui_add_layer_data_tuple(make_test_viewer):
-    viewer = make_test_viewer()
+def test_magicgui_add_layer_data_tuple(make_napari_viewer):
+    viewer = make_napari_viewer()
 
     @magicgui
     def add_layer() -> types.LayerDataTuple:
@@ -189,8 +189,8 @@ def test_magicgui_add_layer_data_tuple(make_test_viewer):
     assert isinstance(viewer.layers[0], Labels)
 
 
-def test_magicgui_add_layer_data_tuple_list(make_test_viewer):
-    viewer = make_test_viewer()
+def test_magicgui_add_layer_data_tuple_list(make_napari_viewer):
+    viewer = make_napari_viewer()
 
     @magicgui
     def add_layer() -> List[types.LayerDataTuple]:
@@ -205,9 +205,9 @@ def test_magicgui_add_layer_data_tuple_list(make_test_viewer):
     assert isinstance(viewer.layers[1], Labels)
 
 
-def test_magicgui_data_updated(make_test_viewer):
+def test_magicgui_data_updated(make_napari_viewer):
     """Test that magic data parameters stay up to date."""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     _returns = []  # the value of x returned from func
 
@@ -227,9 +227,9 @@ def test_magicgui_data_updated(make_test_viewer):
     np.testing.assert_allclose(_returns[-1], np.array([[10, 10], [15, 15]]))
 
 
-def test_magicgui_get_viewer(make_test_viewer):
+def test_magicgui_get_viewer(make_napari_viewer):
     """Test that annotating with napari.Viewer gets the Viewer"""
-    viewer = make_test_viewer()
+    viewer = make_napari_viewer()
 
     @magicgui
     def func(v: Viewer):

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -1,0 +1,62 @@
+import sys
+import warnings
+from typing import List
+
+import pytest
+
+
+@pytest.fixture
+def _strict_qtbot(qtbot):
+    """A modified qtbot fixture that makes sure no widgets have been leaked."""
+    from qtpy.QtWidgets import QApplication
+
+    initial = QApplication.topLevelWidgets()
+    prior_exception = getattr(sys, 'last_value', None)
+
+    yield qtbot
+
+    # if an exception was raised during the test, we should just quit now and
+    # skip looking for leaked widgets.
+    if getattr(sys, 'last_value', None) is not prior_exception:
+        return
+
+    QApplication.processEvents()
+    leaks = set(QApplication.topLevelWidgets()).difference(initial)
+    # still not sure how to clean up some of the remaining vispy
+    # vispy.app.backends._qt.CanvasBackendDesktop widgets...
+    if any([n.__class__.__name__ != 'CanvasBackendDesktop' for n in leaks]):
+        raise AssertionError(f'Widgets leaked!: {leaks}')
+    if leaks:
+        warnings.warn(f'Widgets leaked!: {leaks}')
+
+
+@pytest.fixture(scope="function")
+def make_test_viewer(_strict_qtbot, request):
+    """A fixture function that creates a napari viewer for use in testing.
+
+    This uses a strict qtbot variant that asserts that no widgets are left over
+    after the viewer is closed.
+
+    Examples
+    --------
+    >>> def test_adding_shapes(make_test_viewer):
+    ...     viewer = make_test_viewer()
+    ...     viewer.add_shapes()
+    ...     assert len(viewer.layers) == 1
+    """
+    from napari import Viewer
+
+    viewers: List[Viewer] = []
+
+    def actual_factory(*model_args, viewer_class=Viewer, **model_kwargs):
+        model_kwargs['show'] = model_kwargs.pop(
+            'show', request.config.getoption("--show-viewer")
+        )
+        viewer = viewer_class(*model_args, **model_kwargs)
+        viewers.append(viewer)
+        return viewer
+
+    yield actual_factory
+
+    for viewer in viewers:
+        viewer.close()

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -31,7 +31,7 @@ def _strict_qtbot(qtbot):
 
 
 @pytest.fixture(scope="function")
-def make_test_viewer(_strict_qtbot, request):
+def make_napari_viewer(_strict_qtbot, request):
     """A fixture function that creates a napari viewer for use in testing.
 
     This uses a strict qtbot variant that asserts that no widgets are left over
@@ -39,8 +39,8 @@ def make_test_viewer(_strict_qtbot, request):
 
     Examples
     --------
-    >>> def test_adding_shapes(make_test_viewer):
-    ...     viewer = make_test_viewer()
+    >>> def test_adding_shapes(make_napari_viewer):
+    ...     viewer = make_napari_viewer()
     ...     viewer.add_shapes()
     ...     assert len(viewer.layers) == 1
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,6 +111,8 @@ dev =
 [options.entry_points]
 console_scripts =
     napari = napari.__main__:main
+pytest11 =
+    napari = napari.utils._testsupport
 
 
 [flake8]


### PR DESCRIPTION
# Description
This PR would move some of our test fixtures (currently just make_test_viewer) into a new file (`napari.utils._testsupport`) to make it easier to export it as a pytest plugin at the `pytest11` entry_point.  This would make it easier for other packages to use that fixture (such as in napari/napari-console#7)

We might also consider renaming it to `make_napari_viewer` so that it is clearer where the fixture comes from when using externally.  We can also put additional fixtures in `_testsupport` if anyone wants

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
https://docs.pytest.org/en/stable/writing_plugins.html#making-your-plugin-installable-by-others

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
