### PR TITLE
QtAboutKeyBindings patch

### DIFF
--- a/napari/_qt/dialogs/_tests/test_qt_about_key_bindings.py
+++ b/napari/_qt/dialogs/_tests/test_qt_about_key_bindings.py
@@ -1,0 +1,20 @@
+from napari._qt.dialogs.qt_about_key_bindings import QtAboutKeyBindings
+
+
+def test_about_key_bindings_dialog(make_test_viewer):
+    """Test creating QtAboutKeyBindings dialog window and its methods."""
+    viewer = make_test_viewer()
+    view = viewer.window.qt_viewer
+    key_bindings_dialog = QtAboutKeyBindings(viewer, view._key_map_handler)
+    assert key_bindings_dialog.viewer == viewer
+    assert key_bindings_dialog.key_map_handler == view._key_map_handler
+
+    # check ability to update the active layer, should've ran during init too
+    key_bindings_dialog.update_active_layer()
+
+    # check ability to change layer type selected in dropdown
+    for layer in key_bindings_dialog.key_bindings_strs.keys():
+        key_bindings_dialog.change_layer_type(layer)
+        # Could test to make sure text has been updated, but `toHtml` does not
+        # return the same str that is provided to `setHtml`, so this could get
+        # messy...

--- a/napari/_qt/dialogs/_tests/test_qt_about_key_bindings.py
+++ b/napari/_qt/dialogs/_tests/test_qt_about_key_bindings.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from napari._qt.dialogs.qt_about_key_bindings import QtAboutKeyBindings
 
 
@@ -31,3 +33,33 @@ def test_show_key_bindings_dialog(make_test_viewer, monkeypatch):
     # create the dialog and make sure that it now exists
     view.show_key_bindings_dialog()
     assert isinstance(view.findChild(QtAboutKeyBindings), QtAboutKeyBindings)
+
+
+def test_updating_with_layer_change(make_test_viewer, monkeypatch):
+    """Test that the dialog text updates when the active layer is changed."""
+    viewer = make_test_viewer()
+    view = viewer.window.qt_viewer
+    # turn off showing the dialog for test
+    monkeypatch.setattr(QtAboutKeyBindings, 'show', lambda *a: None)
+    view.show_key_bindings_dialog()
+    dialog = view.findChild(QtAboutKeyBindings)
+
+    # add an image layer
+    viewer.add_image(np.random.random((5, 5, 10, 15)))
+    # capture dialog text after active_layer events
+    active_img_layer_text = dialog.textEditBox.toHtml()
+    dialog.update_active_layer()  # force an to update to dialog
+    # check that the text didn't update without a change in the active layer
+    assert dialog.textEditBox.toHtml() == active_img_layer_text
+
+    # add a shape layer (different keybindings)
+    viewer.add_shapes(None, shape_type='polygon')
+    # check that the new layer is the active_layer
+    assert viewer.active_layer == viewer.layers[1]
+    # capture dialog text after active_layer events
+    active_shape_layer_text = dialog.textEditBox.toHtml()
+    # check that the text has changed for the new key bindings
+    assert active_shape_layer_text != active_img_layer_text
+    dialog.update_active_layer()  # force an update to dialog
+    # check that the text didn't update without a change in the active layer
+    assert dialog.textEditBox.toHtml() == active_shape_layer_text

--- a/napari/_qt/dialogs/_tests/test_qt_about_key_bindings.py
+++ b/napari/_qt/dialogs/_tests/test_qt_about_key_bindings.py
@@ -18,3 +18,16 @@ def test_about_key_bindings_dialog(make_test_viewer):
         # Could test to make sure text has been updated, but `toHtml` does not
         # return the same str that is provided to `setHtml`, so this could get
         # messy...
+
+
+def test_show_key_bindings_dialog(make_test_viewer, monkeypatch):
+    """Test creating dialog with method of qt_viewer."""
+    viewer = make_test_viewer()
+    view = viewer.window.qt_viewer
+    # check that dialog does not exist yet
+    assert not view.findChild(QtAboutKeyBindings)
+    # turn off showing the dialog for test
+    monkeypatch.setattr(QtAboutKeyBindings, 'show', lambda *a: None)
+    # create the dialog and make sure that it now exists
+    view.show_key_bindings_dialog()
+    assert isinstance(view.findChild(QtAboutKeyBindings), QtAboutKeyBindings)

--- a/napari/_qt/dialogs/qt_about_key_bindings.py
+++ b/napari/_qt/dialogs/qt_about_key_bindings.py
@@ -99,7 +99,6 @@ class QtAboutKeyBindings(QDialog):
         self.layout.addLayout(layer_type_layout)
         self.layout.addWidget(self.textEditBox, 1)
 
-        self.viewer.events.active_layer.connect(self.update_active_layer)
         self.viewer.events.theme.connect(self.update_active_layer)
         self.update_active_layer()
 

--- a/napari/_qt/dialogs/qt_about_key_bindings.py
+++ b/napari/_qt/dialogs/qt_about_key_bindings.py
@@ -64,7 +64,7 @@ class QtAboutKeyBindings(QDialog):
         # Can switch to a normal dict when our minimum Python is 3.7
         self.key_bindings_strs = OrderedDict()
         self.key_bindings_strs[self.ALL_ACTIVE_KEYBINDINGS] = ''
-        theme = get_theme(self.qt_viewer.viewer.theme)
+        theme = get_theme(self.viewer.theme)
         col = theme['secondary']
         layers = [
             napari.layers.Image,
@@ -125,7 +125,7 @@ class QtAboutKeyBindings(QDialog):
         event : napari.utils.event.Event, optional
             The napari event that triggered this method, by default None.
         """
-        theme = get_theme(self.qt_viewer.viewer.theme)
+        theme = get_theme(self.viewer.theme)
         col = theme['secondary']
         # Add class and instance viewer key bindings
         text = get_key_bindings_summary(self.viewer.active_keymap, col=col)

--- a/napari/_qt/dialogs/qt_about_key_bindings.py
+++ b/napari/_qt/dialogs/qt_about_key_bindings.py
@@ -23,7 +23,7 @@ class QtAboutKeyBindings(QDialog):
     viewer : napari.components.ViewerModel
         Napari viewer containing the rendered scene, layers, and controls.
 
-    key_map_handler: napari.utils.key_bindings.KeyMapHandler
+    key_map_handler : napari.utils.key_bindings.KeyMapHandler
         Handler for key mapping and calling functionality.
 
     Attributes

--- a/napari/_qt/dialogs/qt_about_key_bindings.py
+++ b/napari/_qt/dialogs/qt_about_key_bindings.py
@@ -23,6 +23,9 @@ class QtAboutKeyBindings(QDialog):
     viewer : napari.components.ViewerModel
         Napari viewer containing the rendered scene, layers, and controls.
 
+    key_map_handler: napari.utils.key_bindings.KeyMapHandler
+        Handler for key mapping and calling functionality.
+
     Attributes
     ----------
     key_bindings_strs : collections.OrderedDict

--- a/napari/_qt/dialogs/qt_about_key_bindings.py
+++ b/napari/_qt/dialogs/qt_about_key_bindings.py
@@ -47,7 +47,7 @@ class QtAboutKeyBindings(QDialog):
 
     ALL_ACTIVE_KEYBINDINGS = 'All active key bindings'
 
-    def __init__(self, viewer, parent=None):
+    def __init__(self, viewer, key_map_handler, parent=None):
         super().__init__(parent=parent)
 
         self.viewer = viewer
@@ -64,6 +64,7 @@ class QtAboutKeyBindings(QDialog):
         # Can switch to a normal dict when our minimum Python is 3.7
         self.key_bindings_strs = OrderedDict()
         self.key_bindings_strs[self.ALL_ACTIVE_KEYBINDINGS] = ''
+        self.key_map_handler = key_map_handler
         theme = get_theme(self.viewer.theme)
         col = theme['secondary']
         layers = [
@@ -128,8 +129,9 @@ class QtAboutKeyBindings(QDialog):
         theme = get_theme(self.viewer.theme)
         col = theme['secondary']
         # Add class and instance viewer key bindings
-        text = get_key_bindings_summary(self.viewer.active_keymap, col=col)
-
+        text = get_key_bindings_summary(
+            self.key_map_handler.active_keymap, col=col
+        )
         # Update layer speficic key bindings if all active are displayed
         self.key_bindings_strs[self.ALL_ACTIVE_KEYBINDINGS] = text
         if self.layerTypeComboBox.currentText() == self.ALL_ACTIVE_KEYBINDINGS:

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -106,6 +106,7 @@ class QtViewer(QSplitter):
         self.viewerButtons = QtViewerButtons(self.viewer)
         self._key_map_handler = KeymapHandler()
         self._key_map_handler.keymap_providers = [self.viewer]
+        self._key_bindings_dialog = None
         self._active_layer = None
         self._console = None
 
@@ -573,10 +574,15 @@ class QtViewer(QSplitter):
         )
 
     def show_key_bindings_dialog(self, event=None):
-        dialog = QtAboutKeyBindings(
-            self.viewer, self._key_map_handler, parent=self
-        )
-        dialog.show()
+        if self._key_bindings_dialog is None:
+            self._key_bindings_dialog = QtAboutKeyBindings(
+                self.viewer, self._key_map_handler, parent=self
+            )
+        # make sure the dialog is shown
+        self._key_bindings_dialog.show()
+        # make sure the the dialog gets focus
+        self._key_bindings_dialog.raise_()  # for macOS
+        self._key_bindings_dialog.activateWindow()  # for Windows
 
     def _map_canvas2world(self, position):
         """Map position from canvas pixels into world coordinates.

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -330,6 +330,10 @@ class QtViewer(QSplitter):
 
         self._active_layer = active_layer
 
+        # If a QtAboutKeyBindings exists, update its text.
+        if self._key_bindings_dialog is not None:
+            self._key_bindings_dialog.update_active_layer()
+
     def _on_add_layer_change(self, event):
         """When a layer is added, set its parent and order.
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -573,7 +573,9 @@ class QtViewer(QSplitter):
         )
 
     def show_key_bindings_dialog(self, event=None):
-        dialog = QtAboutKeyBindings(self.viewer, parent=self)
+        dialog = QtAboutKeyBindings(
+            self.viewer, self._key_map_handler, parent=self
+        )
         dialog.show()
 
     def _map_canvas2world(self, position):


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
This should restore the ability to open the QtAboutKeyBindings dialog window. See #2128.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
closes #2128, implemented fix as suggested by @sofroniewn in the issue. 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all existing tests pass (or are skipped) with my change


## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works 
