### PR TITLE
Add __array__ protocol to transforms.Affine

### DIFF
--- a/napari/utils/transforms/_tests/test_transforms.py
+++ b/napari/utils/transforms/_tests/test_transforms.py
@@ -240,6 +240,7 @@ def test_numpy_array_protocol(dimensionality):
         (transform @ coords.T).T[:, :-1], transform(coords[:, :-1])
     )
 
+
 @pytest.mark.parametrize('dimensionality', [2, 3])
 def test_affine_matrix_inverse(dimensionality):
     np.random.seed(0)

--- a/napari/utils/transforms/_tests/test_transforms.py
+++ b/napari/utils/transforms/_tests/test_transforms.py
@@ -226,6 +226,21 @@ def test_affine_matrix_compose(dimensionality):
 
 
 @pytest.mark.parametrize('dimensionality', [2, 3])
+def test_numpy_array_protocol(dimensionality):
+    N = dimensionality
+    A = np.eye(N + 1)
+    A[:-1] = np.random.random((N, N + 1))
+    transform = Affine(affine_matrix=A)
+    np.testing.assert_almost_equal(transform.affine_matrix, A)
+    np.testing.assert_almost_equal(np.asarray(transform), A)
+
+    coords = np.random.random((20, N + 1)) * 20
+    coords[:, -1] = 1
+    np.testing.assert_almost_equal(
+        (transform @ coords.T).T[:, :-1], transform(coords[:, :-1])
+    )
+
+@pytest.mark.parametrize('dimensionality', [2, 3])
 def test_affine_matrix_inverse(dimensionality):
     np.random.seed(0)
     N = dimensionality

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -431,6 +431,10 @@ class Affine(Transform):
         self.linear_matrix = affine_matrix[:-1, :-1]
         self.translate = affine_matrix[:-1, -1]
 
+    def __array__(self, *args, **kwargs):
+        """NumPy __array__ protocol to get the affine transform matrix."""
+        return self.affine_matrix
+
     @property
     def inverse(self) -> 'Affine':
         """Return the inverse transform."""


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

This allows us to treat our Affine transforms like normal arrays, which gives us a lot of convenient functionality, such as composing two Affine transforms by @-multiplying them. After repeatedly falling into the trap of trying `layer1.affine @ my_affine_matrix` and having it blow up in my face, I thought this would be a nice addition to the API. =)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
