### PR TITLE
Fix too-late registration of napari types in magicgui

### DIFF
--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -13,9 +13,14 @@ from .viewer import Viewer  # isort:skip
 # see: https://github.com/napari/napari/issues/1347
 from scipy import stats  # noqa: F401
 
+# register napari object types with magicgui if it is installed
+from .utils import _magicgui, sys_info
+
+# This must come before .plugins
+_magicgui.register_types_with_magicgui()
+
 from ._event_loop import gui_qt, run
 from .plugins.io import save_layers
-from .utils import _magicgui, sys_info
 from .view_layers import (  # type: ignore
     view_image,
     view_labels,
@@ -27,8 +32,6 @@ from .view_layers import (  # type: ignore
     view_vectors,
 )
 
-# register napari object types with magicgui if it is installed
-_magicgui.register_types_with_magicgui()
 del _magicgui
 
 

--- a/napari/components/_tests/test_add_layers.py
+++ b/napari/components/_tests/test_add_layers.py
@@ -14,7 +14,7 @@ layer_data = [(lay[1], {}, lay[0].__name__.lower()) for lay in layer_test_data]
 def test_add_layers_with_plugins(layer_datum):
     """Test that add_layers_with_plugins adds the expected layer types."""
     with patch(
-        "napari.components.viewer_model.read_data_with_plugins",
+        "napari.plugins.io.read_data_with_plugins",
         MagicMock(return_value=[layer_datum]),
     ):
         v = ViewerModel()
@@ -24,7 +24,7 @@ def test_add_layers_with_plugins(layer_datum):
 
 
 @patch(
-    "napari.components.viewer_model.read_data_with_plugins",
+    "napari.plugins.io.read_data_with_plugins",
     MagicMock(return_value=[]),
 )
 def test_plugin_returns_nothing():
@@ -35,7 +35,7 @@ def test_plugin_returns_nothing():
 
 
 @patch(
-    "napari.components.viewer_model.read_data_with_plugins",
+    "napari.plugins.io.read_data_with_plugins",
     MagicMock(return_value=[(img,)]),
 )
 def test_viewer_open():
@@ -66,7 +66,7 @@ def test_add_layers_with_plugins_and_kwargs(layer_data, kwargs):
     see also: napari.components._test.test_prune_kwargs
     """
     with patch(
-        "napari.components.viewer_model.read_data_with_plugins",
+        "napari.plugins.io.read_data_with_plugins",
         MagicMock(return_value=layer_data),
     ):
         v = ViewerModel()

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import inspect
 import itertools
 import os
@@ -1074,7 +1072,7 @@ def _get_image_class() -> layers.Image:
     return layers.Image
 
 
-def _normalize_layer_data(data: LayerData) -> FullLayerData:
+def _normalize_layer_data(data: 'LayerData') -> 'FullLayerData':
     """Accepts any layerdata tuple, and returns a fully qualified tuple.
 
     Parameters
@@ -1115,11 +1113,11 @@ def _normalize_layer_data(data: LayerData) -> FullLayerData:
 
 
 def _unify_data_and_user_kwargs(
-    data: LayerData,
+    data: 'LayerData',
     kwargs: Optional[dict] = None,
     layer_type: Optional[str] = None,
     fallback_name: str = None,
-) -> FullLayerData:
+) -> 'FullLayerData':
     """Merge data returned from plugins with options specified by user.
 
     If ``data == (_data, _meta, _type)``.  Then:

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1,17 +1,26 @@
+from __future__ import annotations
+
 import inspect
 import itertools
 import os
 import warnings
 from functools import lru_cache
-from typing import Any, Dict, List, Optional, Sequence, Set, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Union,
+)
 
 import numpy as np
 
 from .. import layers
 from ..layers.image._image_utils import guess_labels
 from ..layers.utils.stack_utils import split_channels
-from ..plugins.io import read_data_with_plugins
-from ..types import FullLayerData, LayerData
 from ..utils import config
 from ..utils._register import create_func as create_add_method
 from ..utils.colormaps import ensure_colormap
@@ -32,6 +41,9 @@ from .layerlist import LayerList
 from .scale_bar import ScaleBar
 
 DEFAULT_THEME = 'dark'
+
+if TYPE_CHECKING:
+    from ..types import FullLayerData, LayerData
 
 
 class ViewerModel(KeymapProvider, MousemapProvider):
@@ -940,6 +952,8 @@ class ViewerModel(KeymapProvider, MousemapProvider):
         List[layers.Layer]
             A list of any layers that were added to the viewer.
         """
+        from ..plugins.io import read_data_with_plugins
+
         layer_data = read_data_with_plugins(path_or_paths, plugin=plugin)
 
         # glean layer names from filename. These will be used as *fallback*


### PR DESCRIPTION
# Description
This fixes a problem (noticed by @jni in https://github.com/jni/affinder/pull/12#issuecomment-763351375) wherein plugins are being discovered and registered _before_ our types have been registered with magicgui, breaking the ability for plugins to annotate things with forward references.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
