### PR TITLE
Relax dock_widget_hookspec to accept callable.

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -564,9 +564,6 @@ class Window:
         # if the signature is looking a for a napari viewer, pass it.
         kwargs = {}
         for param in inspect.signature(Widget.__init__).parameters.values():
-            if param.name == 'napari_viewer':
-                kwargs['napari_viewer'] = self.qt_viewer.viewer
-                break
             if param.annotation in ('napari.viewer.Viewer', Viewer):
                 kwargs[param.name] = self.qt_viewer.viewer
                 break

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -564,6 +564,9 @@ class Window:
         # if the signature is looking a for a napari viewer, pass it.
         kwargs = {}
         for param in inspect.signature(Widget.__init__).parameters.values():
+            if param.name == 'napari_viewer':
+                kwargs['napari_viewer'] = self.qt_viewer.viewer
+                break
             if param.annotation in ('napari.viewer.Viewer', Viewer):
                 kwargs[param.name] = self.qt_viewer.viewer
                 break

--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -26,6 +26,7 @@ if sys.platform.startswith('linux') and running_as_bundled_app():
 
 
 if TYPE_CHECKING:
+    from magicgui.widgets import FunctionGui
     from qtpy.QtWidgets import QWidget
 
 
@@ -38,7 +39,10 @@ with plugin_manager.discovery_blocked():
     plugin_manager.register(_builtins, name='builtins')
 
 
-dock_widgets: Dict[Tuple[str, str], Tuple[Type['QWidget'], dict]] = dict()
+dock_widgets: Dict[
+    Tuple[str, str],
+    Tuple[Callable[..., Union['FunctionGui', 'QWidget']], dict],
+] = dict()
 function_widgets: Dict[Tuple[str, str], Tuple[Callable, dict, dict]] = dict()
 
 
@@ -63,10 +67,10 @@ def register_dock_widget(
         else:
             _cls, kwargs = (arg, {})
 
-        if not (isclass(_cls) and issubclass(_cls, QWidget)):
+        if not callable(_cls):
             warn(
-                f'Plugin {plugin_name!r} provided an invalid '
-                f'widget type to {hook_name}: {_cls!r}. Widget ignored.'
+                f'Plugin {plugin_name!r} provided a non-callable object '
+                f'(widget) to {hook_name}: {_cls!r}. Widget ignored.'
             )
             continue
 

--- a/napari/plugins/hook_specifications.py
+++ b/napari/plugins/hook_specifications.py
@@ -381,7 +381,7 @@ def napari_experimental_provide_dock_widget() -> Union[
 
     Returns
     -------
-    resul : callable or tuple or list of callables or list of tuples
+    result : callable or tuple or list of callables or list of tuples
         A "callable" in this context is a classe or functions that, when
         called, returns an instance of either a
         :class:`~qtpy.QtWidgets.QWidget` or a

--- a/napari/plugins/hook_specifications.py
+++ b/napari/plugins/hook_specifications.py
@@ -373,7 +373,7 @@ def napari_experimental_provide_function_widget() -> Union[
 def napari_experimental_provide_dock_widget() -> Union[
     AugmentedWidget, List[AugmentedWidget]
 ]:
-    """Provide QWidget classes to be instantiated and docked on the viewer.
+    """Provide functions that return widgets to be docked in the viewer.
 
     This hook specification is marked as experimental as the API or how the
     returned value is handled may change here more frequently then the
@@ -381,37 +381,61 @@ def napari_experimental_provide_dock_widget() -> Union[
 
     Returns
     -------
-    dock_widget(s) : QWidget class or list of QWidget classes
-        Implementations should return either QWidget classes (one or a list),
-        or tuple(s) containing QWidget classes as well as a dictionary
-        containing keyword arguments for
-        :meth:`napari.qt.Window.add_dock_widget` (though note that the
-        ``shortcut=`` keyword is not yet supported).
+    resul : callable or tuple or list of callables or list of tuples
+        A "callable" in this context is a classe or functions that, when
+        called, returns an instance of either a
+        :class:`~qtpy.QtWidgets.QWidget` or a
+        :class:`~magicgui.widgets.FunctionGui`.
+
+        Implementations of this hook specification must return a callable, or a
+        tuple of ``(callable, dict)``, where the dict contains keyword
+        arguments for :meth:`napari.qt.Window.add_dock_widget`. (note, however,
+        that ``shortcut=`` keyword is not yet supported).
+
+        Implementations may also return a list, in which each item must be a
+        callable or ``(callable, dict)`` tuple.
 
     Examples
     --------
+    An example with a QtWidget:
+
     >>> from qtpy.QtWidgets import QWidget
     >>> from napari_plugin_engine import napari_hook_implementation
     >>>
     >>> class MyWidget(QWidget):
-    >>>     def __init__(self, napari_viewer):
-    >>>         self.viewer = napari_viewer
-    >>>         super().__init__()
-    >>>
-    >>>         # initialize layout
-    >>>         layout = QGridLayout()
-    >>>
-    >>>         # add a button
-    >>>         btn = QPushButton('Click me!', self)
-    >>>         def trigger():
-    >>>             print("napari has", len(napari_viewer.layers), "layers")
-    >>>         btn.clicked.connect(trigger)
-    >>>         layout.addWidget(btn)
-    >>>
-    >>>         # activate layout
-    >>>         self.setLayout(layout)
+    ...     def __init__(self, napari_viewer):
+    ...         self.viewer = napari_viewer
+    ...         super().__init__()
+    ...
+    ...         # initialize layout
+    ...         layout = QGridLayout()
+    ...
+    ...         # add a button
+    ...         btn = QPushButton('Click me!', self)
+    ...         def trigger():
+    ...             print("napari has", len(napari_viewer.layers), "layers")
+    ...         btn.clicked.connect(trigger)
+    ...         layout.addWidget(btn)
+    ...
+    ...         # activate layout
+    ...         self.setLayout(layout)
     >>>
     >>> @napari_hook_implementation
     >>> def napari_experimental_provide_dock_widget():
-    >>>     return MyWidget
+    ...     return MyWidget
+
+    An example using magicgui:
+
+    >>> from magicgui import magic_factory
+    >>> from napari_plugin_engine import napari_hook_implementation
+    >>>
+    >>> @magic_factory(auto_call=True, threshold={'max': 2 ** 16})
+    >>> def threshold(
+    ...     data: 'napari.types.ImageData', threshold: int
+    ... ) -> 'napari.types.LabelsData':
+    ...     return (data > threshold).astype(int)
+    >>>
+    >>> @napari_hook_implementation
+    >>> def napari_experimental_provide_dock_widget():
+    ...     return threshold
     """

--- a/napari/plugins/hook_specifications.py
+++ b/napari/plugins/hook_specifications.py
@@ -382,7 +382,7 @@ def napari_experimental_provide_dock_widget() -> Union[
     Returns
     -------
     result : callable or tuple or list of callables or list of tuples
-        A "callable" in this context is a classe or functions that, when
+        A "callable" in this context is a class or function that, when
         called, returns an instance of either a
         :class:`~qtpy.QtWidgets.QWidget` or a
         :class:`~magicgui.widgets.FunctionGui`.

--- a/napari/types.py
+++ b/napari/types.py
@@ -17,10 +17,9 @@ import numpy as np
 if TYPE_CHECKING:
     import dask.array
     import zarr
-
-
-if TYPE_CHECKING:
+    from magicgui.widgets import FunctionGui
     from qtpy.QtWidgets import QWidget
+
 
 # This is a WOEFULLY inadequate stub for a duck-array type.
 # Mostly, just a placeholder for the concept of needing an ArrayLike type.
@@ -49,10 +48,12 @@ ExcInfo = Union[
 AugmentedFunction = Union[
     Callable, Tuple[Callable, dict], Tuple[Callable, dict, dict]
 ]
-AugmentedWidget = Union[Type['QWidget'], Tuple[Type['QWidget'], dict]]
+
+WidgetCallable = Callable[..., Union['FunctionGui', 'QWidget']]
+AugmentedWidget = Union[WidgetCallable, Tuple[WidgetCallable, dict]]
 
 
-# these types are mostly "intentionality" placeholders.  While it's still hard
+# these types are mostly "intentionality" placeholders.  While ƒit's still hard
 # to use actual types to define what is acceptable data for a given layer,
 # these types let us point to a concrete namespace to indicate "this data is
 # intended to be (and is capable of) being turned into X layer type".

--- a/napari/types.py
+++ b/napari/types.py
@@ -53,7 +53,7 @@ WidgetCallable = Callable[..., Union['FunctionGui', 'QWidget']]
 AugmentedWidget = Union[WidgetCallable, Tuple[WidgetCallable, dict]]
 
 
-# these types are mostly "intentionality" placeholders.  While ƒit's still hard
+# these types are mostly "intentionality" placeholders.  While it's still hard
 # to use actual types to define what is acceptable data for a given layer,
 # these types let us point to a concrete namespace to indicate "this data is
 # intended to be (and is capable of) being turned into X layer type".


### PR DESCRIPTION
# Description
As originally proposed in https://github.com/napari/napari/issues/2114#issuecomment-761620026, and discussed in zulip, this PR would relax the `provide_dock_widget` hookspec from something that must provide a QWidget class, to something that must provide any callable that returns an instance of a QWidget, or a magicgui Widget. (i.e. `Callable[..., Union[QWidget, FunctionGui]]`).
This might make it easier for developers to delay expensive imports.  Also, combined with https://github.com/napari/magicgui/pull/117, it would allow someone to use magicgui and `@magic_factory` entirely on their end (without providing us any "magic_kwargs"), and switch to the `provide_dock_widget` hookspec.  

If we want to (totally up for discussion) we could actually drop the function_widget hookspec for now, and no longer depend on magicgui for now.  Devs can still use magicgui if they want, and we still support it, but we no longer do the widget creation for them.

(this could leave open the `provide_function` hookspec for more narrow-visioned pipeline-like applications).

@jni, with this PR, and with https://github.com/napari/magicgui/pull/117, I was able to run your affinder PR (https://github.com/jni/affinder/pull/12) by just changing `@magicgui` to `@magic_factory` on `start_affinder`

I have, for now, dropped support for the `napari_viewer` parameter in the `QWidget.__init__`.  Very much open to putting it back, but it's harder to support that with a generic callable or `MagicFactory` (and it doesn't fit the "one way to do it" philosophy).

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
