### PR TITLE
Drop items to be removed in 0.4.4

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -179,31 +179,6 @@ class ViewerModel(KeymapProvider, MousemapProvider):
         self.events.theme(value=self.theme)
 
     @property
-    def grid_size(self):
-        """tuple: Size of grid."""
-        warnings.warn(
-            (
-                "The viewer.grid_size parameter is deprecated and will be removed after version 0.4.4."
-                " Instead you should use viewer.grid.shape"
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.grid.shape
-
-    @grid_size.setter
-    def grid_size(self, grid_size):
-        warnings.warn(
-            (
-                "The viewer.grid_size parameter is deprecated and will be removed after version 0.4.4."
-                " Instead you should use viewer.grid.shape"
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        self.grid.shape = grid_size
-
-    @property
     def grid_stride(self):
         """int: Number of layers in each grid square."""
         warnings.warn(

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -179,31 +179,6 @@ class ViewerModel(KeymapProvider, MousemapProvider):
         self.events.theme(value=self.theme)
 
     @property
-    def grid_stride(self):
-        """int: Number of layers in each grid square."""
-        warnings.warn(
-            (
-                "The viewer.grid_stride parameter is deprecated and will be removed after version 0.4.4."
-                " Instead you should use viewer.grid.stride"
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.grid.stride
-
-    @grid_stride.setter
-    def grid_stride(self, grid_stride):
-        warnings.warn(
-            (
-                "The viewer.grid_stride parameter is deprecated and will be removed after version 0.4.4."
-                " Instead you should use viewer.grid.stride"
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        self.grid.stride = grid_stride
-
-    @property
     def status(self):
         """string: Status string"""
         return self._status
@@ -443,54 +418,6 @@ class ViewerModel(KeymapProvider, MousemapProvider):
         for i, layer in enumerate(self.layers):
             i_row, i_column = self.grid.position(n_layers - 1 - i, n_layers)
             self._subplot(layer, (i_row, i_column), extent)
-
-    def grid_view(self, n_row=None, n_column=None, stride=1):
-        """Arrange the current layers is a 2D grid.
-
-        Default behaviour is to make a square 2D grid.
-
-        Parameters
-        ----------
-        n_row : int, optional
-            Number of rows in the grid.
-        n_column : int, optional
-            Number of column in the grid.
-        stride : int, optional
-            Number of layers to place in each grid square before moving on to
-            the next square. The default ordering is to place the most visible
-            layer in the top left corner of the grid. A negative stride will
-            cause the order in which the layers are placed in the grid to be
-            reversed.
-        """
-        warnings.warn(
-            (
-                "The viewer.grid_view method is deprecated and will be removed after version 0.4.4."
-                " Instead you should use the viewer.grid.enabled = True to turn on the grid view,"
-                " and viewer.grid.shape and viewer.grid.stride to set the size and stride of the"
-                " grid respectively."
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        self.grid.stride = stride
-        if n_row is None:
-            n_row = -1
-        if n_column is None:
-            n_column = -1
-        self.grid.shape = (n_row, n_column)
-        self.grid.enabled = True
-
-    def stack_view(self):
-        """Arrange the current layers in a stack."""
-        warnings.warn(
-            (
-                "The viewer.stack_view method is deprecated and will be removed after version 0.4.4."
-                " Instead you should use the viewer.grid.enabled = False to turn off the grid view."
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        self.grid.enabled = False
 
     def _subplot(self, layer, position, extent):
         """Shift a layer to a specified position in a 2D grid.


### PR DESCRIPTION
# Description
This PR drops the following items tagged to be removed in 0.4.4

```
                "The viewer.grid_size parameter is deprecated and will be removed in version 0.4.4."
                " Instead you should use viewer.grid.shape"

                "The viewer.grid_stride parameter is deprecated and will be removed in version 0.4.4."
                " Instead you should use viewer.grid.stride"

                "The viewer.grid_view method is deprecated and will be removed in version 0.4.4."
                " Instead you should use the viewer.grid.enabled = True to turn on the grid view,"
                " and viewer.grid.shape and viewer.grid.stride to set the size and stride of the"
                " grid respectively."

                "The viewer.stack_view method is deprecated and will be removed in version 0.4.4."
                " Instead you should use the viewer.grid.enabled = False to turn off the grid view."
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)