### PR TITLE
Points layer enable interactive mode in add mode, don't add point when dragging, addresses #2146 (WIP)

### DIFF
--- a/napari/layers/points/_points_mouse_bindings.py
+++ b/napari/layers/points/_points_mouse_bindings.py
@@ -86,7 +86,17 @@ def select(layer, event):
 def add(layer, event):
     """Add a new point at the clicked position."""
     # on press
-    layer.add(layer.coordinates)
+    dragged = False
+    yield
+
+    # on move
+    while event.type == 'mouse_move':
+        dragged = True
+        yield
+
+    # on release
+    if not dragged:
+        layer.add(layer.coordinates)
 
 
 def highlight(layer, event):

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -337,7 +337,6 @@ def test_changing_modes():
 
     layer.mode = 'add'
     assert layer.mode == 'add'
-    assert layer.interactive is False
 
     layer.mode = 'select'
     assert layer.mode == 'select'

--- a/napari/layers/points/_tests/test_points_mouse_bindings.py
+++ b/napari/layers/points/_tests/test_points_mouse_bindings.py
@@ -112,19 +112,27 @@ def test_drag_in_add_mode(create_known_points_layer, Event):
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=True, modifiers=[])
+        Event(type='mouse_press', is_dragging=False, modifiers=[])
     )
     mouse_press_callbacks(layer, event)
 
+    known_non_point_end = [40, 60]
+    layer.position = known_non_point_end
+
+    # Simulate drag end
+    event = ReadOnlyWrapper(
+        Event(type='mouse_move', is_dragging=True, modifiers=[])
+    )
+    mouse_move_callbacks(layer, event)
+
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=True, modifiers=[])
+        Event(type='mouse_release', is_dragging=False, modifiers=[])
     )
     mouse_release_callbacks(layer, event)
 
-    # Check new point added at coordinates location
+    # Check that no new point has been added
     assert len(layer.data) == n_points
-    np.testing.assert_allclose(layer.data[-1], known_non_point)
 
 
 def test_select_point(create_known_points_layer, Event):

--- a/napari/layers/points/_tests/test_points_mouse_bindings.py
+++ b/napari/layers/points/_tests/test_points_mouse_bindings.py
@@ -101,6 +101,32 @@ def test_add_point(create_known_points_layer, Event):
     np.testing.assert_allclose(layer.data[-1], known_non_point)
 
 
+def test_drag_in_add_mode(create_known_points_layer, Event):
+    """Drag in add mode and make sure no point is added."""
+    layer, n_points, known_non_point = create_known_points_layer
+
+    # Add point at location where non exists
+    layer.mode = 'add'
+    layer.interactive = True
+    layer.position = known_non_point
+
+    # Simulate click
+    event = ReadOnlyWrapper(
+        Event(type='mouse_press', is_dragging=True, modifiers=[])
+    )
+    mouse_press_callbacks(layer, event)
+
+    # Simulate release
+    event = ReadOnlyWrapper(
+        Event(type='mouse_release', is_dragging=True, modifiers=[])
+    )
+    mouse_release_callbacks(layer, event)
+
+    # Check new point added at coordinates location
+    assert len(layer.data) == n_points
+    np.testing.assert_allclose(layer.data[-1], known_non_point)
+
+
 def test_select_point(create_known_points_layer, Event):
     """Select a point by clicking on one in select mode."""
     layer, n_points, _ = create_known_points_layer

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1357,7 +1357,7 @@ class Points(Layer):
 
         if mode == Mode.ADD:
             self.cursor = 'pointing'
-            self.interactive = False
+            self.interactive = True
             self.help = 'hold <space> to pan/zoom'
             self.selected_data = set()
             self._set_highlight()


### PR DESCRIPTION
# Description

This PR addresses #2146. 
When in  a points layer in add mode, this will enable interactive mode, enabling mouse wheel zoom and drag to pan.
Previous behaviour if interactive was True was that the click that would initiate a dragged pan would also add a point.
This is addressed by this PR.

One potentially unwanted side effect is that "fly-by" adding of points is no longer possible, i.e. the mouse pointer must 
come to a halt before clicking. A future improvement may be to check whether the dragging event lasted less than x number of milliseconds and determine that for very, very short drags the user probably wanted to add a point rather than pan.

## Type of change
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Changes existing behaviour, so I ticked braking change.
I am not sure the old behaviour is documented. 

# References
#2146

# How has this been tested?

A test that asserted that interactive == False has been removed.

I started on a test that ensures no point has been added when dragging, but in the test the point is still added.

## Final checklist:
- [x ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
