### PR TITLE
Change plugin window search from naming convention to pypi classifier

### DIFF
--- a/napari/plugins/pypi.py
+++ b/napari/plugins/pypi.py
@@ -141,9 +141,8 @@ def ensure_repo_is_napari_plugin(
 
     Parameters
     ----------
-    name : str
-        full repo name on github (e.g. "napari/napari")
-    branch : str
+    info : tuple
+        2-tuple containing full repo name on github (e.g. "napari/napari"), and
         branch to query (e.g. "master")
 
     Returns


### PR DESCRIPTION
# Description
This PR stops searching the PyPI API for packages that start with napari, and starts searching for the PyPI classifier. Because there are still github packages that provide a `napari.plugins` entry point that haven't updated their classifiers. This still does the github search as well.


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
