### PR TITLE
Add compress=1 to tifffile imsave call

### DIFF
--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -27,7 +27,7 @@ def imsave(filename: str, data: np.ndarray):
     if ext in [".tif", ".tiff"]:
         import tifffile
 
-        tifffile.imsave(filename, data)
+        tifffile.imsave(filename, data, compress=1)
     else:
         import imageio
 


### PR DESCRIPTION
# Description

This compresses tiffs by default, which should help dramatically when saving labels volumes as tiffs with the default plugin.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
