### PR TITLE
fix magicgui.FunctionGui deprecation warning

### DIFF
--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -1,4 +1,3 @@
-import magicgui
 import pytest
 from napari_plugin_engine import napari_hook_implementation
 from qtpy.QtWidgets import QWidget
@@ -147,6 +146,8 @@ def test_making_plugin_dock_widgets(test_plugin_widgets, make_napari_viewer):
 
 def test_making_function_dock_widgets(test_plugin_widgets, make_napari_viewer):
     """Test that we can create magicgui widgets, and they get the viewer."""
+    import magicgui
+
     viewer = make_napari_viewer()
     actions = viewer.window._plugin_dock_widget_menu.actions()
 
@@ -157,7 +158,7 @@ def test_making_function_dock_widgets(test_plugin_widgets, make_napari_viewer):
     dw = viewer.window._dock_widgets['TestP3: magic']
     # make sure that it contains a magicgui widget
     magic_widget = dw.widget()._magic_widget
-    assert isinstance(magic_widget, magicgui.FunctionGui)
+    assert isinstance(magic_widget, magicgui.widgets.FunctionGui)
     # This magicgui widget uses the parameter annotation to receive a viewer
     assert isinstance(magic_widget.viewer.value, napari.Viewer)
     # The function just returns the viewer... make sure we can call it

--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -158,7 +158,11 @@ def test_making_function_dock_widgets(test_plugin_widgets, make_napari_viewer):
     dw = viewer.window._dock_widgets['TestP3: magic']
     # make sure that it contains a magicgui widget
     magic_widget = dw.widget()._magic_widget
-    assert isinstance(magic_widget, magicgui.widgets.FunctionGui)
+    FGui = getattr(magicgui.widgets, 'FunctionGui', None)
+    if FGui is None:
+        # pre magicgui 0.2.6
+        FGui = magicgui.FunctionGui
+    assert isinstance(magic_widget, FGui)
     # This magicgui widget uses the parameter annotation to receive a viewer
     assert isinstance(magic_widget.viewer.value, napari.Viewer)
     # The function just returns the viewer... make sure we can call it


### PR DESCRIPTION
# Description
This fixes the deprecation warning we're seeing in our tests (`magicgui.FunctionGui` now lives at `magicgui.widgets.FunctionGui`)