### PR TITLE
Add informations on what to do on error.

### DIFF
--- a/napari/_qt/dialogs/qt_error_notification.py
+++ b/napari/_qt/dialogs/qt_error_notification.py
@@ -306,7 +306,12 @@ class NapariNotification(QDialog):
         """Create a NapariNotifcation dialog from an exception object."""
         # TODO: this method could be used to recognize various exception
         # subclasses and populate the dialog accordingly.
-        msg = getattr(exception, 'message', str(exception))
+        extra_msg = (
+            "\nYou can start napari with NAPARI_CATCH_ERRORS=0 or "
+            "NAPARI_EXIT_ON_ERROR=1 to find more about this error"
+        )
+
+        msg = getattr(exception, 'message', str(exception)) + extra_msg
         severity = getattr(exception, 'severity', 'WARNING')
         source = None
         actions = getattr(exception, 'actions', ())


### PR DESCRIPTION
# Description

When an error is raised in QT and shows up in the UI give some extra
information on how one would restart napari in a way that shows the
traceback but crash napari.

## Type of change

- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How has this been tested?

Visually by introducing an error in the code.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

I'm not too sure if this needs to be checked from the tests as this happens on errors.
