### PR TITLE
Notification Manager (Qt-independent)

### DIFF
--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -20,6 +20,7 @@ from .utils import _magicgui, sys_info
 _magicgui.register_types_with_magicgui()
 
 from ._event_loop import gui_qt, run
+from .notifications import notification_manager
 from .plugins.io import save_layers
 from .view_layers import (  # type: ignore
     view_image,

--- a/napari/_qt/exceptions.py
+++ b/napari/_qt/exceptions.py
@@ -7,7 +7,7 @@ from typing import Optional, Type
 
 from qtpy.QtCore import QObject, Signal
 
-from .dialogs.qt_error_notification import NapariNotification
+from .dialogs.qt_notification import NapariNotification
 
 
 def _set_true(var) -> bool:

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -55,6 +55,17 @@ class QtLayerButtons(QFrame):
             lambda: self.viewer._new_labels(),
         )
 
+        def raise_():
+            raise ValueError("clicked")
+
+        def warn_():
+            import warnings
+
+            warnings.warn("warn!")
+
+        self.newPointsButton.clicked.connect(raise_)
+        self.newShapesButton.clicked.connect(warn_)
+
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.newPointsButton)

--- a/napari/notifications.py
+++ b/napari/notifications.py
@@ -1,0 +1,147 @@
+import os
+import sys
+import warnings
+from enum import auto
+from time import time
+from types import TracebackType
+from typing import Any, Callable, List, Sequence, Tuple, Type, Union
+
+from .utils.events import Event, EventEmitter
+from .utils.misc import StringEnum
+
+
+class NotificationSeverity(StringEnum):
+    """Severity levels for the notification dialog.  Along with icons for each."""
+
+    ERROR = auto()
+    WARNING = auto()
+    INFO = auto()
+    NONE = auto()
+
+    def as_icon(self):
+        return {
+            self.ERROR: "ⓧ",
+            self.WARNING: "⚠️",
+            self.INFO: "ⓘ",
+            self.NONE: "",
+        }[self]
+
+
+ActionSequence = Sequence[Tuple[str, Callable[[], None]]]
+
+
+# Event subclasses specific to the Canvas
+class Notification(Event):
+    def __init__(
+        self,
+        message: str,
+        severity: Union[
+            str, NotificationSeverity
+        ] = NotificationSeverity.WARNING,
+        # source: Optional[str] = None, # TODO
+        actions: ActionSequence = (),
+        type: str = 'notification',
+        native: Any = None,
+        **kwargs,
+    ):
+
+        super().__init__(type, **kwargs)
+        self._time = time()
+        self.message = message
+        self.severity = NotificationSeverity(severity)
+        # self.source = source  # TODO
+        self.actions = actions
+
+    @property
+    def time(self):
+        return self._time
+
+    @classmethod
+    def from_exception(cls, exc: BaseException, **kwargs) -> 'Notification':
+        return ErrorNotification(exc, **kwargs)
+
+    @classmethod
+    def from_warning(cls, warning: Warning, **kwargs) -> 'Notification':
+        return WarningNotification(warning, **kwargs)
+
+
+class ErrorNotification(Notification):
+    exception: BaseException
+
+    def __init__(self, exception: BaseException, *args, **kwargs):
+        msg = getattr(exception, 'message', str(exception))
+        severity = getattr(exception, 'severity', 'ERROR')
+        actions = getattr(exception, 'actions', ())
+        super().__init__(msg, severity, actions, type='error')
+        self.exception = exception
+
+
+class WarningNotification(Notification):
+    warning: Warning
+
+    def __init__(self, warning: Warning, *args, **kwargs):
+        msg = getattr(warning, 'message', str(warning))
+        severity = getattr(warning, 'severity', 'WARNING')
+        actions = getattr(warning, 'actions', ())
+        super().__init__(msg, severity, actions, type='warning')
+        self.warning = warning
+
+
+class NotificationManager:
+    record: List[Notification]
+    _instance: 'NotificationManager' = None
+
+    def __new__(cls):
+        # singleton
+        if cls._instance is None:
+            cls._instance = object.__new__(cls)
+            sys.excepthook = cls._instance.receive_error
+            warnings.__showwarning__ = warnings.showwarning
+            warnings.showwarning = cls._instance.receive_warning
+        return cls._instance
+
+    def __init__(self) -> None:
+        self.record: List[Notification] = []
+        self.exit_on_error = os.getenv('NAPARI_EXIT_ON_ERROR') in ('1', 'True')
+        self.notification_ready = self.changed = EventEmitter(
+            source=self, event_class=Notification
+        )
+
+    def dispatch(self, notification: Notification):
+        self.record.append(notification)
+        self.notification_ready(notification)
+
+    def receive_error(
+        self,
+        exctype: Type[Exception] = None,
+        value: Exception = None,
+        traceback: TracebackType = None,
+    ):
+        if isinstance(value, KeyboardInterrupt):
+            print("Closed by KeyboardInterrupt", file=sys.stderr)
+            sys.exit(1)
+        if self.exit_on_error:
+            sys.__excepthook__(exctype, value, traceback)
+            sys.exit(1)
+        self.dispatch(Notification.from_exception(value))
+
+    def receive_warning(
+        self,
+        message: Warning,
+        category: Type[Warning],
+        filename: str,
+        lineno: int,
+        file=None,
+        line=None,
+    ):
+        self.dispatch(Notification.from_warning(message))
+
+    def receive_info(self, message: str):
+        self.dispatch(Notification(message, 'INFO'))
+
+
+notification_manager = NotificationManager()
+
+
+def show_info(message: str):
+    notification_manager.receive_info(message)


### PR DESCRIPTION
# Description
Here is rough sketch of what I've been imagining for our notification model.  (see also discussion at #794, #1511 and #2167)

The basic idea is that we have a `NotificationManager` singleton.  On creation, the notification manager overrides `sys.excepthook` and `warnings.showwarning` with its own `receive_error` and `receive_warning` methods.  When it receives an error/warning/info message, it creates a `Notification` instance (which is a subclass of `events.Event`), adds that instance to `NotificationManager.record` (this provides the persistence layer) and emits a `notification_ready` event.  Any front end (such as a `QApplication`, `IPython`, etc) can connect itself to that event, and show a message (so the presentation of the notification is decoupled from the collection and emission of them).  For Qt, I have deleted the `_qt/exceptions.py` file (and our previous sys.excepthook override there), and just added this line when we create the QApp:

```python
notification_manager.notification_ready.connect(NapariNotification.show_notification)
```

Here's an example of showing an error (with traceback), showing a warning, and accessing the full log of notifications (note, in this movie, I made the add points button raise an exception, and the add shapes button creates a warning):


https://user-images.githubusercontent.com/1609449/105860810-fb071300-5fbb-11eb-9d0d-78872212638d.mov

styles and naming and all that stuff can obviously change.  curious to get thoughts on the general pattern. @sofroniewn, @jni, @Carreau 