### PR TITLE
fix typo in hookspecs docs

### DIFF
--- a/docs/source/plugins/hook_specifications.rst
+++ b/docs/source/plugins/hook_specifications.rst
@@ -38,9 +38,9 @@ from ``Layer.data``, and a ``meta`` dict that will correspond to the layer's
 Analysis hooks
 --------------
 
-.. autofunction:: napari_expertimental_provide_function
+.. autofunction:: napari_experimental_provide_function
 
 GUI hooks
 ---------
 
-.. autofunction:: napari_expertimental_provide_dock_widget
+.. autofunction:: napari_experimental_provide_dock_widget


### PR DESCRIPTION
# Description
I knew I should have tested this locally :joy:

https://napari.org/docs/dev/plugins/hook_specifications.html#analysis-hooks