### PR TITLE
Github plugin visibility change

### DIFF
--- a/docs/source/plugins/for_plugin_developers.rst
+++ b/docs/source/plugins/for_plugin_developers.rst
@@ -249,8 +249,12 @@ functionality for napari.
 
 If you are using Github, add the `"napari-plugin" topic
 <https://github.com/topics/napari-plugin>`_ to your repo so other developers can
-see your work.
-
+see your work, if the repo is setup correctly in setup.py as a napari plugin, it would
+also show up in napari plugin installation menu when user open napari. However, though
+currently napari users would be able to see github repos tagged with the
+`"napari-plugin" topic <https://github.com/topics/napari-plugin>`_, we could
+deprecate github repo matching in the future to only support matching via PyPI with
+`'Framework :: napari'` [classifier] to unify practices of tagging plugin packages
 
 When you are ready for users, announce your plugin on the `Image.sc Forum
 <https://forum.image.sc/tag/napari>`_.

--- a/docs/source/plugins/for_plugin_developers.rst
+++ b/docs/source/plugins/for_plugin_developers.rst
@@ -249,12 +249,8 @@ functionality for napari.
 
 If you are using Github, add the `"napari-plugin" topic
 <https://github.com/topics/napari-plugin>`_ to your repo so other developers can
-see your work, if the repo is setup correctly in setup.py as a napari plugin, it would
-also show up in napari plugin installation menu when user open napari. However, though
-currently napari users would be able to see github repos tagged with the
-`"napari-plugin" topic <https://github.com/topics/napari-plugin>`_, we could
-deprecate github repo matching in the future to only support matching via PyPI with
-`'Framework :: napari'` [classifier] to unify practices of tagging plugin packages
+see your work.
+
 
 When you are ready for users, announce your plugin on the `Image.sc Forum
 <https://forum.image.sc/tag/napari>`_.

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -288,6 +288,7 @@ class QPluginList(QListWidget):
 class QtPluginDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
+        self._search_github = False
         self.installer = Installer()
         self.setup_ui()
         self.installer.set_output_widget(self.stdout_text)
@@ -344,7 +345,9 @@ class QtPluginDialog(QDialog):
         # self.v_splitter.setSizes([70 * self.installed_list.count(), 10, 10])
 
         # fetch available plugins
-        self.worker = create_worker(iter_napari_plugin_info)
+        self.worker = create_worker(
+            iter_napari_plugin_info, search_github=self._search_github
+        )
 
         def _handle_yield(project_info):
             if project_info.name in already_installed:
@@ -400,10 +403,13 @@ class QtPluginDialog(QDialog):
         mov.start()
         self.show_status_btn = QPushButton("Show Status", self)
         self.show_status_btn.setFixedWidth(100)
+        self.search_github_btn = QPushButton("Show Github Plugins", self)
+        self.search_github_btn.setFixedWidth(150)
         self.show_sorter_btn = QPushButton("<< Show Sorter", self)
         self.close_btn = QPushButton("Close", self)
         self.close_btn.clicked.connect(self.reject)
         buttonBox.addWidget(self.show_status_btn)
+        buttonBox.addWidget(self.search_github_btn)
         buttonBox.addWidget(self.working_indicator)
         buttonBox.addWidget(self.process_error_indicator)
         buttonBox.addStretch()
@@ -415,6 +421,10 @@ class QtPluginDialog(QDialog):
         self.show_status_btn.setCheckable(True)
         self.show_status_btn.setChecked(False)
         self.show_status_btn.toggled.connect(self._toggle_status)
+
+        self.search_github_btn.setCheckable(True)
+        self.search_github_btn.setChecked(self._search_github)
+        self.search_github_btn.toggled.connect(self._toggle_search_github)
 
         self.show_sorter_btn.setCheckable(True)
         self.show_sorter_btn.setChecked(False)
@@ -438,6 +448,15 @@ class QtPluginDialog(QDialog):
         else:
             self.show_status_btn.setText("Show Status")
             self.stdout_text.hide()
+
+    def _toggle_search_github(self, search_github):
+        if search_github:
+            self.search_github_btn.setText("Hide Github Plugins")
+            self._search_github = True
+        else:
+            self.search_github_btn.setText("Show Github Plugins")
+            self._search_github = False
+        self.refresh()
 
 
 if __name__ == "__main__":

--- a/napari/plugins/pypi.py
+++ b/napari/plugins/pypi.py
@@ -1,6 +1,16 @@
 """
 These convenience functions will be useful for searching pypi for packages
 that match the plugin naming convention, and retrieving related metadata.
+
+Right now there are two matching mechanism: pypi classifier and github topics.
+If the repo is setup correctly in setup.py as a napari plugin, it would
+also show up in napari plugin installation menu when user open napari.
+
+However, though currently napari users would be able to see github repos tagged
+with the "napari-plugin" topic <https://github.com/topics/napari-plugin>,
+we could deprecate github repo matching in the future to only support matching
+via PyPI with 'Framework :: napari' [classifier] to unify practices of
+tagging plugin packages.
 """
 import json
 import os


### PR DESCRIPTION
# Description
Addressed discrepancy between docs and code in plugin visibility to users, update the documentation that we will be using GitHub topics to search for plugins that are not on PyPI, also added a description that this may be deprecated in the future in favor of the PyPI classifier

Added a toggle that by default hide plugins only from Github in favor of PyPI releases, user can unhide the plugins from Github if needed

## Type of change
- New feature (non-breaking change which adds functionality)
- Documentation

# References
some of the backgrounds are discussed in https://github.com/napari/napari-plugin-engine/issues/16


# How has this been tested?
Manually tested the interface

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
