### PR TITLE
UI: Add keybindings to the Paint and Pick tooltips

### DIFF
--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -144,10 +144,10 @@ class QtLabelsControls(QtLayerControls):
             checked=True,
         )
         self.pick_button = QtModeRadioButton(
-            layer, 'picker', Mode.PICK, tooltip='Pick mode'
+            layer, 'picker', Mode.PICK, tooltip='Pick mode (L)'
         )
         self.paint_button = QtModeRadioButton(
-            layer, 'paint', Mode.PAINT, tooltip='Paint mode'
+            layer, 'paint', Mode.PAINT, tooltip='Paint mode (P)'
         )
         btn = 'Cmd' if sys.platform == 'darwin' else 'Ctrl'
         self.fill_button = QtModeRadioButton(


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
Added the keyboard shortcut to the tooltips of `Paint` and `Pick` when on the labels layer
![image](https://user-images.githubusercontent.com/10111092/106202866-87663100-6188-11eb-9eca-62aeda59cc3b.png)
![image](https://user-images.githubusercontent.com/10111092/106202881-8d5c1200-6188-11eb-9f85-7a93833f7373.png)

This brings them in line with the other buttons in that row so that all (except for Shuffle) have their keybinding in the tooltip, this increases the discoverability of these keybindings. When I was learning how to use the labels layer I was convinced that there were keybinds, but ended up figuring them out only by looking at the source code, which is not scalable.


## Type of change
<!-- Please delete options that are not relevant. -->
- [maybe?] Bug-fix (non-breaking change which fixes an issue)


# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
Does not close but is similar to https://github.com/napari/napari/issues/2135

# How has this been tested?
Visually by opening Napari. See screenshots above.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [NA?] I have commented my code, particularly in hard-to-understand areas
- [NA?] I have made corresponding changes to the documentation
- [NA?] I have added tests that prove my fix is effective or that my feature works
