### PR TITLE
DOC: autoreformat all the docstrings.

### DIFF
--- a/examples/live_tiffs.py
+++ b/examples/live_tiffs.py
@@ -32,7 +32,7 @@ with napari.gui_qt():
 
     def append(delayed_image):
         """Appends the image to viewer.
-        
+
         Parameters
         ----------
         delayed_image : dask.delayed function object

--- a/napari/_qt/dialogs/qt_error_notification.py
+++ b/napari/_qt/dialogs/qt_error_notification.py
@@ -271,7 +271,6 @@ class NapariNotification(QDialog):
     def setup_buttons(self, actions: ActionSequence = ()):
         """Add buttons to the dialog.
 
-
         Parameters
         ----------
         actions : tuple, optional

--- a/napari/_qt/experimental/qt_poll.py
+++ b/napari/_qt/experimental/qt_poll.py
@@ -97,7 +97,7 @@ class QtPoll(QObject):
 
         Parameters
         ----------
-        event : QEvent
+        _event : QEvent
             The close event.
         """
         self.timer.stop()

--- a/napari/_qt/qt_resources/__init__.py
+++ b/napari/_qt/qt_resources/__init__.py
@@ -82,7 +82,6 @@ def import_resources(
     out_path : str
         Path to the python resource file. File is already imported under `napari._qt_resources name`.
         Copy this file to make the SVGs and other resources available in bundled application.
-
     loader : Callable[[], module]
         Module loader
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -828,8 +828,8 @@ def _create_qt_poll(parent: QObject, camera: Camera) -> 'Optional[QtPoll]':
     camera : Camera
         Camera that the QtPoll object will listen to.
 
-    Return
-    ------
+    Returns
+    -------
     Optional[QtPoll]
         The new QtPoll instance, if we need one.
     """

--- a/napari/_qt/widgets/qt_layerlist.py
+++ b/napari/_qt/widgets/qt_layerlist.py
@@ -34,8 +34,8 @@ def _create_chunk_receiver(parent: QObject) -> 'Optional[QtChunkReceiver]':
     parent : QObject
         Parent of the chunk receiver.
 
-    Return
-    ------
+    Returns
+    -------
     Optional[QtChunkReceiver]
         The QtChunkReceiver instance to use.
     """

--- a/napari/_vendor/experimental/humanize/src/humanize/time.py
+++ b/napari/_vendor/experimental/humanize/src/humanize/time.py
@@ -247,31 +247,31 @@ def naturaldate(value):
 
 def _quotient_and_remainder(value, divisor, unit, minimum_unit, suppress):
     """Divide `value` by `divisor` returning the quotient and
-       the remainder as follows:
+    the remainder as follows:
 
-       If `unit` is `minimum_unit`, makes the quotient a float number
-       and the remainder will be zero. The rational is that if unit
-       is the unit of the quotient, we cannot
-       represent the remainder because it would require a unit smaller
-       than the minimum_unit.
+    If `unit` is `minimum_unit`, makes the quotient a float number
+    and the remainder will be zero. The rational is that if unit
+    is the unit of the quotient, we cannot
+    represent the remainder because it would require a unit smaller
+    than the minimum_unit.
 
-       >>> from humanize.time import _quotient_and_remainder, Unit
-       >>> _quotient_and_remainder(36, 24, Unit.DAYS, Unit.DAYS, [])
-       (1.5, 0)
+    >>> from humanize.time import _quotient_and_remainder, Unit
+    >>> _quotient_and_remainder(36, 24, Unit.DAYS, Unit.DAYS, [])
+    (1.5, 0)
 
-       If unit is in suppress, the quotient will be zero and the
-       remainder will be the initial value. The idea is that if we
-       cannot use unit, we are forced to use a lower unit so we cannot
-       do the division.
+    If unit is in suppress, the quotient will be zero and the
+    remainder will be the initial value. The idea is that if we
+    cannot use unit, we are forced to use a lower unit so we cannot
+    do the division.
 
-       >>> _quotient_and_remainder(36, 24, Unit.DAYS, Unit.HOURS, [Unit.DAYS])
-       (0, 36)
+    >>> _quotient_and_remainder(36, 24, Unit.DAYS, Unit.HOURS, [Unit.DAYS])
+    (0, 36)
 
-       In other case return quotient and remainder as `divmod` would
-       do it.
+    In other case return quotient and remainder as `divmod` would
+    do it.
 
-       >>> _quotient_and_remainder(36, 24, Unit.DAYS, Unit.HOURS, [])
-       (1, 12)
+    >>> _quotient_and_remainder(36, 24, Unit.DAYS, Unit.HOURS, [])
+    (1, 12)
 
     """
 
@@ -286,27 +286,27 @@ def _quotient_and_remainder(value, divisor, unit, minimum_unit, suppress):
 def _carry(value1, value2, ratio, unit, min_unit, suppress):
     """Return a tuple with two values as follows:
 
-       If the unit is in suppress multiplies value1
-       by ratio and add it to value2 (carry to right).
-       The idea is that if we cannot represent value1 we need
-       to represent it in a lower unit.
+    If the unit is in suppress multiplies value1
+    by ratio and add it to value2 (carry to right).
+    The idea is that if we cannot represent value1 we need
+    to represent it in a lower unit.
 
-       >>> from humanize.time import _carry, Unit
-       >>> _carry(2, 6, 24, Unit.DAYS, Unit.SECONDS, [Unit.DAYS])
-       (0, 54)
+    >>> from humanize.time import _carry, Unit
+    >>> _carry(2, 6, 24, Unit.DAYS, Unit.SECONDS, [Unit.DAYS])
+    (0, 54)
 
-       If the unit is the minimum unit, value2 is divided
-       by ratio and added to value1 (carry to left).
-       We assume that value2 has a lower unit so we need to
-       carry it to value1.
+    If the unit is the minimum unit, value2 is divided
+    by ratio and added to value1 (carry to left).
+    We assume that value2 has a lower unit so we need to
+    carry it to value1.
 
-        >>> _carry(2, 6, 24, Unit.DAYS, Unit.DAYS, [])
-        (2.25, 0)
+     >>> _carry(2, 6, 24, Unit.DAYS, Unit.DAYS, [])
+     (2.25, 0)
 
-       Otherwise, just return the same input:
+    Otherwise, just return the same input:
 
-       >>> _carry(2, 6, 24, Unit.DAYS, Unit.SECONDS, [])
-       (2, 6)
+    >>> _carry(2, 6, 24, Unit.DAYS, Unit.SECONDS, [])
+    (2, 6)
     """
     if unit == min_unit:
         return (value1 + value2 / ratio, 0)
@@ -319,20 +319,20 @@ def _carry(value1, value2, ratio, unit, min_unit, suppress):
 def _suitable_minimum_unit(min_unit, suppress):
     """Return a minimum unit suitable that is not suppressed.
 
-       If not suppressed, return the same unit:
+    If not suppressed, return the same unit:
 
-       >>> from humanize.time import _suitable_minimum_unit, Unit
-       >>> _suitable_minimum_unit(Unit.HOURS, [])
-       <Unit.HOURS: 4>
+    >>> from humanize.time import _suitable_minimum_unit, Unit
+    >>> _suitable_minimum_unit(Unit.HOURS, [])
+    <Unit.HOURS: 4>
 
-       But if suppressed, find a unit greather than the original one
-       that is not suppressed:
+    But if suppressed, find a unit greather than the original one
+    that is not suppressed:
 
-       >>> _suitable_minimum_unit(Unit.HOURS, [Unit.HOURS])
-       <Unit.DAYS: 5>
+    >>> _suitable_minimum_unit(Unit.HOURS, [Unit.HOURS])
+    <Unit.DAYS: 5>
 
-       >>> _suitable_minimum_unit(Unit.HOURS, [Unit.HOURS, Unit.DAYS])
-       <Unit.MONTHS: 6>
+    >>> _suitable_minimum_unit(Unit.HOURS, [Unit.HOURS, Unit.DAYS])
+    <Unit.MONTHS: 6>
     """
     if min_unit in suppress:
         for unit in Unit:
@@ -348,11 +348,11 @@ def _suitable_minimum_unit(min_unit, suppress):
 
 def _suppress_lower_units(min_unit, suppress):
     """Extend the suppressed units (if any) with all the units that are
-       lower than the minimum unit.
+    lower than the minimum unit.
 
-       >>> from humanize.time import _suppress_lower_units, Unit
-       >>> list(sorted(_suppress_lower_units(Unit.SECONDS, [Unit.DAYS])))
-       [<Unit.MICROSECONDS: 0>, <Unit.MILLISECONDS: 1>, <Unit.DAYS: 5>]
+    >>> from humanize.time import _suppress_lower_units, Unit
+    >>> list(sorted(_suppress_lower_units(Unit.SECONDS, [Unit.DAYS])))
+    [<Unit.MICROSECONDS: 0>, <Unit.MILLISECONDS: 1>, <Unit.DAYS: 5>]
     """
     suppress = set(suppress)
     for u in Unit:

--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -41,8 +41,8 @@ def _chunk_verts(octree_chunk: OctreeChunk) -> np.ndarray:
     octree_chunk : OctreeChunk
         Create a quad for this chunk.
 
-    Return
-    ------
+    Returns
+    -------
     np.darray
         The quad vertices.
     """
@@ -185,8 +185,8 @@ class TextureAtlas2D(Texture2D):
     def num_slots_free(self) -> int:
         """The number of available texture slots.
 
-        Return
-        ------
+        Returns
+        -------
         int
             The number of available texture slots.
         """
@@ -196,8 +196,8 @@ class TextureAtlas2D(Texture2D):
     def num_slots_used(self) -> int:
         """The number of texture slots currently in use.
 
-        Return
-        ------
+        Returns
+        -------
         int
             The number of texture slots currently in use.
         """
@@ -211,8 +211,8 @@ class TextureAtlas2D(Texture2D):
         tile_index : int
             Return the offset of this tile.
 
-        Return
-        ------
+        Returns
+        -------
         Tuple[int, int]
             The (row, col) offset of this tile in texels.
         """
@@ -239,8 +239,8 @@ class TextureAtlas2D(Texture2D):
         tile_shape : np.ndarray
             The shape of a single tile.
 
-        Return
-        ------
+        Returns
+        -------
         np.ndarray
             A (6, 2) array of texture coordinates.
         """
@@ -258,11 +258,11 @@ class TextureAtlas2D(Texture2D):
 
         Parameters
         ----------
-        data : np.ndarray
+        octree_chunk : np.ndarray
             The image data for this one tile.
 
-        Return
-        ------
+        Returns
+        -------
         Optional[AtlasTile]
             The AtlasTile if the tile was successfully added.
         """
@@ -305,8 +305,8 @@ class TextureAtlas2D(Texture2D):
         data : np.ndarray
             The image data for this tile.
 
-        Return
-        ------
+        Returns
+        -------
         np.ndarray
             The texture coordinates for the tile.
         """

--- a/napari/_vispy/experimental/tile_grid.py
+++ b/napari/_vispy/experimental/tile_grid.py
@@ -35,8 +35,8 @@ def _chunk_outline(chunk: OctreeChunk) -> np.ndarray:
     chunk : OctreeChunk
         Create outline of this chunk.
 
-    Return
-    ------
+    Returns
+    -------
     np.ndarray
         The verts for the outline.
     """
@@ -70,8 +70,8 @@ class TileGrid:
     def _create_line(self) -> Line:
         """Create the Line visual for the grid.
 
-        Return
-        ------
+        Returns
+        -------
         Line
             The new Line visual.
         """

--- a/napari/_vispy/experimental/tile_set.py
+++ b/napari/_vispy/experimental/tile_set.py
@@ -44,8 +44,8 @@ class TileSet:
     def __len__(self) -> int:
         """Return the number of tiles in the set.
 
-        Return
-        ------
+        Returns
+        -------
         int
             The number of tiles in the set.
         """
@@ -85,8 +85,8 @@ class TileSet:
     def chunk_set(self) -> Set[OctreeChunk]:
         """The set of chunks we drawing.
 
-        Return
-        ------
+        Returns
+        -------
         Set[OctreeChunk]
             The set of chunks we are drawing.
         """
@@ -96,8 +96,8 @@ class TileSet:
     def chunks(self) -> List[OctreeChunk]:
         """The chunks we are tracking.
 
-        Return
-        ------
+        Returns
+        -------
         List[OctreeChunk]
             The chunks we are tracking.
         """
@@ -107,8 +107,8 @@ class TileSet:
     def tile_data(self) -> List[TileData]:
         """The data for all tiles in the set unsorted.
 
-        Return
-        ------
+        Returns
+        -------
         List[TileData]
             The data for all the tiles in the set unsorted.
         """
@@ -123,8 +123,8 @@ class TileSet:
         smaller higher resolution tiles are drawn in front. This sorting
         allows us to show the "best available" data in all locations.
 
-        Return
-        ------
+        Returns
+        -------
         List[TileData]
             The data for all the tiles in the set sorted back to front.
         """
@@ -142,8 +142,8 @@ class TileSet:
         octree_chunk : OctreeChunk
             Check if this chunk is in the set.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if the set contains this chunk data.
         """

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -107,8 +107,8 @@ class TiledImageVisual(ImageVisual):
         tile_shape : np.ndarray
             The shape of our tiles such as (256, 256, 4).
 
-        Return
-        ------
+        Returns
+        -------
         TextureAtlas2D
             The newly created texture atlas.
         """
@@ -163,8 +163,8 @@ class TiledImageVisual(ImageVisual):
     def num_tiles(self) -> int:
         """The number tiles currently being drawn.
 
-        Return
-        ------
+        Returns
+        -------
         int
             The number of tiles currently being drawn.
         """
@@ -187,8 +187,8 @@ class TiledImageVisual(ImageVisual):
         chunks : List[OctreeChunk]
             Chunks that we may or may not already be drawing.
 
-        Return
-        ------
+        Returns
+        -------
         int
             The number of chunks that still need to be added.
         """
@@ -225,8 +225,8 @@ class TiledImageVisual(ImageVisual):
         octree_chunk : OctreeChunk
             The chunk we are adding.
 
-        Return
-        ------
+        Returns
+        -------
         int
             The newly added chunk's index.
         """
@@ -249,8 +249,8 @@ class TiledImageVisual(ImageVisual):
     def chunk_set(self) -> Set[OctreeChunk]:
         """Return the set of chunks we are drawing.
 
-        Return
-        ------
+        Returns
+        -------
         Set[OctreeChunk]
             The set of chunks we are drawing.
         """

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -97,8 +97,8 @@ class VispyTiledImageLayer(VispyImageLayer):
     def num_tiles(self) -> int:
         """The number of tiles currently being drawn.
 
-        Return
-        ------
+        Returns
+        -------
         int
             The number of tiles currently being drawn.
         """
@@ -163,10 +163,10 @@ class VispyTiledImageLayer(VispyImageLayer):
         if the camera isn't moving. We expect to be polled and drawn until
         we can finish adding the rest of the drawable chunks.
 
-        Return
-        ------
+        Returns
+        -------
         int
-             The number of chunks that still need to be added.
+            The number of chunks that still need to be added.
         """
         if not self.node.visible:
             return 0
@@ -196,8 +196,8 @@ class VispyTiledImageLayer(VispyImageLayer):
         3) Create tiles for newly drawable chunks, one or more.
         4) Optionally update our grid based on the now drawable chunks.
 
-        Return
-        ------
+        Returns
+        -------
         ChunkStats
             Statistics about the update process.
         """
@@ -254,8 +254,8 @@ class VispyTiledImageLayer(VispyImageLayer):
         drawable_chunks : List[OctreeChunk]
             Chunks we should add, if not already in the tiled image.
 
-        Return
-        ------
+        Returns
+        -------
         int
             The number of chunks that still need to be added.
         """

--- a/napari/_vispy/vispy_axes_visual.py
+++ b/napari/_vispy/vispy_axes_visual.py
@@ -40,7 +40,7 @@ def make_arrow_head(num_segments, axis):
     ----------
     num_segments : int
         Number of segments in the arrowhead.
-    axis :
+    axis
         Arrowhead direction.
 
     Returns

--- a/napari/components/experimental/chunk/_commands/_loader.py
+++ b/napari/components/experimental/chunk/_commands/_loader.py
@@ -153,7 +153,7 @@ class ChunkLoaderLayers:
 
         Parameters
         ----------
-        layer_id : int
+        index : int
             The layer id (from view.cmd.layers).
         layer : Layer
             The layer itself.

--- a/napari/components/experimental/chunk/_commands/_tables.py
+++ b/napari/components/experimental/chunk/_commands/_tables.py
@@ -20,7 +20,7 @@ def print_property_table(table: List[Tuple[str, Any]]) -> None:
 
     Parameters
     ----------
-    items
+    table
     """
     heading_width = max(len(x) for x, _ in table)
     for heading, value in table:

--- a/napari/components/experimental/chunk/_delay_queue.py
+++ b/napari/components/experimental/chunk/_delay_queue.py
@@ -126,8 +126,8 @@ class DelayQueue(threading.Thread):
         should_cancel : Callable[[ChunkRequest], bool]
             Cancel the request if this returns True.
 
-        Return
-        ------
+        Returns
+        -------
         List[ChunkRequests]
             The requests that were cancelled, if any.
         """
@@ -153,8 +153,8 @@ class DelayQueue(threading.Thread):
         now : float
             Current time in seconds.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if the entry was submitted.
         """

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -61,8 +61,8 @@ class ChunkLoader:
         layer_id : int
             The the LayerInfo for this layer.
 
-        Return
-        ------
+        Returns
+        -------
         Optional[LayerInfo]
             The LayerInfo if the layer has one.
         """
@@ -129,8 +129,8 @@ class ChunkLoader:
         should_cancel : Callable[[ChunkRequest], bool]
             Cancel the request if this returns True.
 
-        Return
-        ------
+        Returns
+        -------
         List[ChunkRequests]
             The requests that were cancelled, if any.
         """
@@ -146,8 +146,8 @@ class ChunkLoader:
         request : ChunkRequest
             The request to load.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if we loaded it.
         """
@@ -201,7 +201,7 @@ class ChunkLoader:
 
         Parameters
         ----------
-        future : Future
+        request : Future
             The future that finished or was cancelled.
 
         Notes
@@ -342,7 +342,7 @@ def _setup_logging(config: dict) -> None:
 
     Parameters
     ----------
-    octree_config : dict
+    config : dict
         The configuration data.
     """
     try:

--- a/napari/components/experimental/chunk/_pool.py
+++ b/napari/components/experimental/chunk/_pool.py
@@ -87,8 +87,8 @@ class LoaderPool:
         should_cancel : Callable[[ChunkRequest], bool]
             Cancel the request if this returns True.
 
-        Return
-        ------
+        Returns
+        -------
         List[ChunkRequests]
             The requests that were cancelled, if any.
         """

--- a/napari/components/experimental/chunk/_pool_group.py
+++ b/napari/components/experimental/chunk/_pool_group.py
@@ -35,8 +35,8 @@ class LoaderPoolGroup:
         octree_config : dict
             Octree configuration data.
 
-        Return
-        ------
+        Returns
+        -------
         Dict[int, LoaderPool]
             The loader to use for each priority
         """
@@ -51,8 +51,8 @@ class LoaderPoolGroup:
     def get_loader(self, priority) -> LoaderPool:
         """Return the LoaderPool for the given priority.
 
-        Return
-        ------
+        Returns
+        -------
         LoaderPool
             The LoaderPool for the given priority.
         """
@@ -93,8 +93,8 @@ class LoaderPoolGroup:
         should_cancel : Callable[[ChunkRequest], bool]
             Cancel the request if this returns True.
 
-        Return
-        ------
+        Returns
+        -------
         List[ChunkRequests]
             The requests that were cancelled, if any.
         """

--- a/napari/components/experimental/chunk/_request.py
+++ b/napari/components/experimental/chunk/_request.py
@@ -108,8 +108,8 @@ class ChunkRequest:
     def elapsed_ms(self) -> float:
         """The total time elapsed since the request was created.
 
-        Return
-        ------
+        Returns
+        -------
         float
             The total time elapsed since the chunk was created.
         """
@@ -119,8 +119,8 @@ class ChunkRequest:
     def load_ms(self) -> float:
         """The total time it took to load all chunks.
 
-        Return
-        ------
+        Returns
+        -------
         float
             The total time it took to return all chunks.
         """
@@ -132,8 +132,8 @@ class ChunkRequest:
     def num_chunks(self) -> int:
         """The number of chunks in this request.
 
-        Return
-        ------
+        Returns
+        -------
         int
             The number of chunks in this request.
         """
@@ -143,8 +143,8 @@ class ChunkRequest:
     def num_bytes(self) -> int:
         """The number of bytes that were loaded.
 
-        Return
-        ------
+        Returns
+        -------
         int
             The number of bytes that were loaded.
         """
@@ -154,8 +154,8 @@ class ChunkRequest:
     def in_memory(self) -> bool:
         """True if all chunks are ndarrays.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if all chunks are ndarrays.
         """

--- a/napari/components/experimental/monitor/_api.py
+++ b/napari/components/experimental/monitor/_api.py
@@ -153,8 +153,8 @@ class MonitorApi:
         The wrapper Monitor class accesses this and passes it to the
         MonitorService.
 
-        Return
-        ------
+        Returns
+        -------
         SharedMemoryManager
             The manager we created and are using.
         """

--- a/napari/components/experimental/monitor/_monitor.py
+++ b/napari/components/experimental/monitor/_monitor.py
@@ -27,8 +27,8 @@ def _load_config(path: str) -> dict:
     path : str
         The path of the JSON file we should load.
 
-    Return
-    ------
+    Returns
+    -------
     dict
         The parsed data from the JSON file.
     """
@@ -45,8 +45,8 @@ def _load_config(path: str) -> dict:
 def _load_monitor_config() -> Optional[dict]:
     """Return the MonitorService config file data, or None.
 
-    Return
-    ------
+    Returns
+    -------
     Optional[dict]
         The parsed config file data or None if no config.
     """
@@ -90,8 +90,8 @@ def _get_monitor_config() -> Optional[dict]:
     3) The NAPARI_MON environment variable is not defined.
     4) The NAPARI_MON config file cannot be found and parsed.
 
-    Return
-    ------
+    Returns
+    -------
     Optional[dict]
         The configuration for the MonitorService.
     """
@@ -152,8 +152,8 @@ class Monitor:
     def start(self) -> bool:
         """Start the monitor service, if it hasn't been started already.
 
-        Return
-        ------
+        Returns
+        -------
         bool
             True if we started the service or it was already started.
         """

--- a/napari/components/experimental/monitor/_utils.py
+++ b/napari/components/experimental/monitor/_utils.py
@@ -18,8 +18,8 @@ class NumpyJSONEncoder(json.JSONEncoder):
 def numpy_dumps(data: dict) -> str:
     """Return data as a JSON string.
 
-    Return
-    ------
+    Returns
+    -------
     str
         The JSON string.
     """
@@ -34,8 +34,8 @@ def base64_encoded_json(data: dict) -> str:
     data : dict
         The data to write as JSON then base64 encode.
 
-    Return
-    ------
+    Returns
+    -------
     str
         The base64 encoded JSON string.
     """

--- a/napari/components/experimental/remote/_commands.py
+++ b/napari/components/experimental/remote/_commands.py
@@ -56,7 +56,7 @@ class RemoteCommands:
 
         Parameters
         ----------
-        command : dict
+        event : dict
             The remote command.
         """
         command = event.command

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -498,7 +498,7 @@ class ViewerModel(KeymapProvider, MousemapProvider):
 
         Parameters
         ----------
-        layer : :class:`napari.layers.Layer`
+        event : :class:`napari.layers.Layer`
             Layer to add.
 
         Returns
@@ -645,7 +645,7 @@ class ViewerModel(KeymapProvider, MousemapProvider):
             A vector of shear values for an upper triangular n-D shear matrix.
             If a list then must have same length as the axis that is being
             expanded as channels.
-        affine: n-D array or napari.utils.transforms.Affine
+        affine : n-D array or napari.utils.transforms.Affine
             (N+1, N+1) affine transformation matrix in homogeneous coordinates.
             The first (N, N) entries correspond to a linear transform and
             the final column is a lenght N translation vector and a 1 or a napari

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -498,8 +498,8 @@ class ViewerModel(KeymapProvider, MousemapProvider):
 
         Parameters
         ----------
-        event : :class:`napari.layers.Layer`
-            Layer to add.
+        event :  napari.utils.event.Event
+            Event which will remove a layer.
 
         Returns
         -------

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -45,7 +45,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     shear : 1-D array or n-D array
         Either a vector of upper triangular values, or an nD shear matrix with
         ones along the main diagonal.
-    affine: n-D array or napari.utils.transforms.Affine
+    affine : n-D array or napari.utils.transforms.Affine
         (N+1, N+1) affine transformation matrix in homogeneous coordinates.
         The first (N, N) entries correspond to a linear transform and
         the final column is a lenght N translation vector and a 1 or a napari
@@ -99,7 +99,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     shear : 1-D array or n-D array
         Either a vector of upper triangular values, or an nD shear matrix with
         ones along the main diagonal.
-    affine: n-D array or napari.utils.transforms.Affine
+    affine : n-D array or napari.utils.transforms.Affine
         (N+1, N+1) affine transformation matrix in homogeneous coordinates.
         The first (N, N) entries correspond to a linear transform and
         the final column is a lenght N translation vector and a 1 or a napari

--- a/napari/layers/image/experimental/_chunked_slice_data.py
+++ b/napari/layers/image/experimental/_chunked_slice_data.py
@@ -102,7 +102,6 @@ class ChunkedSliceData(ImageSliceData):
         ----------
         layer : Layer
             The layer for this request.
-
         request : ChunkRequest
             The request that was loaded.
         """

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -275,7 +275,7 @@ class Octree:
         data fits inside a single tile.
 
         Parameters
-        -----------
+        ----------
         slice_id : int
             The id of the slice this octree is in.
         tile_size : int

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -81,7 +81,7 @@ class Image(IntensityVisualizationMixin, Layer):
     shear : 1-D array or n-D array
         Either a vector of upper triangular values, or an nD shear matrix with
         ones along the main diagonal.
-    affine: n-D array or napari.utils.transforms.Affine
+    affine : n-D array or napari.utils.transforms.Affine
         (N+1, N+1) affine transformation matrix in homogeneous coordinates.
         The first (N, N) entries correspond to a linear transform and
         the final column is a lenght N translation vector and a 1 or a napari

--- a/napari/layers/labels/_labels_utils.py
+++ b/napari/layers/labels/_labels_utils.py
@@ -40,7 +40,6 @@ def interpolate_coordinates(old_coord, new_coord, brush_size):
 def sphere_indices(radius, sphere_dims):
     """Generate centered indices within circle or n-dim sphere.
 
-
     Parameters
     -------
     radius : float

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -56,7 +56,7 @@ class Labels(Image):
     shear : 1-D array or n-D array
         Either a vector of upper triangular values, or an nD shear matrix with
         ones along the main diagonal.
-    affine: n-D array or napari.utils.transforms.Affine
+    affine : n-D array or napari.utils.transforms.Affine
         (N+1, N+1) affine transformation matrix in homogeneous coordinates.
         The first (N, N) entries correspond to a linear transform and
         the final column is a lenght N translation vector and a 1 or a napari

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -107,7 +107,7 @@ class Points(Layer):
     shear : 1-D array or n-D array
         Either a vector of upper triangular values, or an nD shear matrix with
         ones along the main diagonal.
-    affine: n-D array or napari.utils.transforms.Affine
+    affine : n-D array or napari.utils.transforms.Affine
         (N+1, N+1) affine transformation matrix in homogeneous coordinates.
         The first (N, N) entries correspond to a linear transform and
         the final column is a lenght N translation vector and a 1 or a napari

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -142,7 +142,7 @@ class Shapes(Layer):
     shear : 1-D array or n-D array
         Either a vector of upper triangular values, or an nD shear matrix with
         ones along the main diagonal.
-    affine: n-D array or napari.utils.transforms.Affine
+    affine : n-D array or napari.utils.transforms.Affine
         (N+1, N+1) affine transformation matrix in homogeneous coordinates.
         The first (N, N) entries correspond to a linear transform and
         the final column is a lenght N translation vector and a 1 or a napari

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -52,7 +52,7 @@ class Surface(IntensityVisualizationMixin, Layer):
     shear : 1-D array or n-D array
         Either a vector of upper triangular values, or an nD shear matrix with
         ones along the main diagonal.
-    affine: n-D array or napari.utils.transforms.Affine
+    affine : n-D array or napari.utils.transforms.Affine
         (N+1, N+1) affine transformation matrix in homogeneous coordinates.
         The first (N, N) entries correspond to a linear transform and
         the final column is a lenght N translation vector and a 1 or a napari

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -63,7 +63,7 @@ class Tracks(Layer):
     shear : 1-D array or n-D array
         Either a vector of upper triangular values, or an nD shear matrix with
         ones along the main diagonal.
-    affine: n-D array or napari.utils.transforms.Affine
+    affine : n-D array or napari.utils.transforms.Affine
         (N+1, N+1) affine transformation matrix in homogeneous coordinates.
         The first (N, N) entries correspond to a linear transform and
         the final column is a lenght N translation vector and a 1 or a napari

--- a/napari/layers/utils/stack_utils.py
+++ b/napari/layers/utils/stack_utils.py
@@ -211,7 +211,6 @@ def images_to_stack(
     kwargs : dict
         Dictionary of parameters values to override parameters
         from the first image in images list.
-
     Returns.
     -------
     stack : napari.layers.Image

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -69,7 +69,7 @@ class Vectors(Layer):
     shear : 1-D array or n-D array
         Either a vector of upper triangular values, or an nD shear matrix with
         ones along the main diagonal.
-    affine: n-D array or napari.utils.transforms.Affine
+    affine : n-D array or napari.utils.transforms.Affine
         (N+1, N+1) affine transformation matrix in homogeneous coordinates.
         The first (N, N) entries correspond to a linear transform and
         the final column is a lenght N translation vector and a 1 or a napari

--- a/napari/plugins/pypi.py
+++ b/napari/plugins/pypi.py
@@ -62,7 +62,7 @@ def get_packages_by_classifier(classifier: str) -> List[str]:
     """Search for packages declaring ``classifier`` on PyPI
 
     Yields
-    -------
+    ------
     name : str
         name of all packages at pypi that declare ``classifier``
     """

--- a/napari/utils/_magicgui.py
+++ b/napari/utils/_magicgui.py
@@ -102,7 +102,6 @@ def add_layer_data_to_viewer(gui, result, return_type):
     ... def make_layer() -> napari.types.ImageData:
     ...     return np.random.rand(256, 256)
 
-
     """
 
     if result is None:

--- a/napari/utils/_octree.py
+++ b/napari/utils/_octree.py
@@ -35,8 +35,8 @@ DEFAULT_OCTREE_CONFIG = {
 def _get_async_config() -> Optional[dict]:
     """Get configuration implied by NAPARI_ASYNC.
 
-    Return
-    ------
+    Returns
+    -------
     Optional[dict]
         The async config to use or None if async not specified.
     """
@@ -59,8 +59,8 @@ def _get_async_config() -> Optional[dict]:
 def get_octree_config() -> dict:
     """Return the config data from the user's file or the default data.
 
-    Return
-    ------
+    Returns
+    -------
     dict
         The config data we should use.
     """

--- a/napari/utils/config.py
+++ b/napari/utils/config.py
@@ -8,8 +8,8 @@ from ._octree import get_octree_config
 def _set(env_var: str) -> bool:
     """Return True if the env variable is set and non-zero.
 
-    Return
-    ------
+    Returns
+    -------
     bool
         True if the env var was set to a non-zero value.
     """

--- a/napari/utils/events/dataclass.py
+++ b/napari/utils/events/dataclass.py
@@ -200,9 +200,9 @@ def is_equal(v1, v2):
 
     Parameters
     ----------
-    v1: Any
+    v1 : Any
         first value
-    v2: Any
+    v2 : Any
         second value
 
     Returns
@@ -234,7 +234,7 @@ def _type_to_compare(type_) -> Optional[Callable[[Any, Any], bool]]:
 
     Parameters
     ----------
-    type_: type
+    type_ : type
     type to examine
 
     Returns

--- a/napari/utils/events/event_utils.py
+++ b/napari/utils/events/event_utils.py
@@ -8,7 +8,7 @@ def disconnect_events(emitter, listener):
     ----------
     emitter : napari.utils.events.event.EmitterGroup
         Emitter group.
-    listener: Object
+    listener : Object
         Any object that has been connected to.
     """
     for em in emitter.emitters.values():

--- a/napari/utils/perf/_event.py
+++ b/napari/utils/perf/_event.py
@@ -88,7 +88,7 @@ class PerfEvent:
     def update_end_ns(self, end_ns: int) -> None:
         """Update our end_ns with this new end_ns.
 
-        Properties
+        Attributes
         ----------
         end_ns : int
             The new ending time in nanoseconds.

--- a/napari/utils/perf/_timers.py
+++ b/napari/utils/perf/_timers.py
@@ -155,8 +155,8 @@ def block_timer(
     **kwargs : dict
         Additional keyword arguments for the "args" field of the event.
 
-    Example
-    -------
+    Examples
+    --------
     with block_timer("draw") as event:
         draw_stuff()
     print(f"The timer took {event.duration_ms} milliseconds.")

--- a/napari/utils/status_messages.py
+++ b/napari/utils/status_messages.py
@@ -49,7 +49,7 @@ def generate_layer_status(name, position, value):
         Name of the layer.
     position : tuple or list
         List of coordinates, say of the cursor.
-    value :  Any
+    value : Any
         The value to be printed.
 
     Returns

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -143,8 +143,8 @@ def get_theme(name):
     name : str
         Name of requested theme.
 
-    Returns:
-    --------
+    Returns
+    -------
     theme: dict of str: str
         Theme mapping elements to colors. A copy is created
         so that manipulating this theme can be done without
@@ -166,7 +166,7 @@ def register_theme(name, theme):
     ----------
     name : str
         Name of requested theme.
-    theme: dict of str: str
+    theme : dict of str: str
         Theme mapping elements to colors.
     """
     _themes[name] = theme
@@ -175,8 +175,8 @@ def register_theme(name, theme):
 def available_themes():
     """List available themes
 
-    Returns:
-    --------
+    Returns
+    -------
     list of str
         Names of available themes.
     """


### PR DESCRIPTION
This is based on my vélin prototype which parses docstings using
numpydoc and reformat them to follow the numpydoc format to the t.

It is of course a prototype so should be checked carefully and not
blindly trusted. I'll send another pull request to try to make it part
of CI and precomit.