### PR TITLE
Fix bug with modification of `AVAILABLE_COLORMAPS` when iterate over its. 

### DIFF
--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -1,4 +1,5 @@
 import os
+from threading import Lock
 from typing import Dict, List, Tuple, Union
 
 import numpy as np
@@ -346,6 +347,8 @@ ALL_COLORMAPS.update(BOP_COLORMAPS)
 
 # ... sorted alphabetically by name
 AVAILABLE_COLORMAPS = {k: v for k, v in sorted(ALL_COLORMAPS.items())}
+# lock to allow update of AVAILABLE_COLORMAPS in threads
+AVAILABLE_COLORMAPS_LOCK = Lock()
 
 # curated colormap sets
 # these are selected to look good or at least reasonable when using additive
@@ -406,94 +409,97 @@ def ensure_colormap(colormap: ValidColormapArg) -> Colormap:
     TypeError
         If ``colormap`` is not a ``str``, ``dict``, ``tuple``, or ``Colormap``
     """
-    if isinstance(colormap, str):
-        name = colormap
-        if name not in AVAILABLE_COLORMAPS:
-            cmap = vispy_or_mpl_colormap(name)  # raises KeyError if not found
+    with AVAILABLE_COLORMAPS_LOCK:
+        if isinstance(colormap, str):
+            name = colormap
+            if name not in AVAILABLE_COLORMAPS:
+                cmap = vispy_or_mpl_colormap(
+                    name
+                )  # raises KeyError if not found
+                AVAILABLE_COLORMAPS[name] = cmap
+        elif isinstance(colormap, Colormap):
+            AVAILABLE_COLORMAPS[colormap.name] = colormap
+            name = colormap.name
+        elif isinstance(colormap, VispyColormap):
+            # if a vispy colormap instance is provided, make sure we don't already
+            # know about it before adding a new unnamed colormap
+            name = None
+            for key, val in AVAILABLE_COLORMAPS.items():
+                if colormap == val:
+                    name = key
+                    break
+            if not name:
+                name = increment_unnamed_colormap(AVAILABLE_COLORMAPS)
+            # Convert from vispy colormap
+            cmap = convert_vispy_colormap(colormap, name=name)
             AVAILABLE_COLORMAPS[name] = cmap
-    elif isinstance(colormap, Colormap):
-        AVAILABLE_COLORMAPS[colormap.name] = colormap
-        name = colormap.name
-    elif isinstance(colormap, VispyColormap):
-        # if a vispy colormap instance is provided, make sure we don't already
-        # know about it before adding a new unnamed colormap
-        name = None
-        for key, val in AVAILABLE_COLORMAPS.items():
-            if colormap == val:
-                name = key
-                break
-        if not name:
-            name = increment_unnamed_colormap(AVAILABLE_COLORMAPS)
-        # Convert from vispy colormap
-        cmap = convert_vispy_colormap(colormap, name=name)
-        AVAILABLE_COLORMAPS[name] = cmap
 
-    elif isinstance(colormap, tuple):
-        if not (
-            len(colormap) == 2
-            and (
-                isinstance(colormap[1], VispyColormap)
-                or isinstance(colormap[1], Colormap)
-            )
-            and isinstance(colormap[0], str)
-        ):
-            raise TypeError(
-                "When providing a tuple as a colormap argument, the first "
-                "element must be a string and the second a Colormap instance"
-            )
-        name, cmap = colormap
-        # Convert from vispy colormap
-        if isinstance(cmap, VispyColormap):
-            cmap = convert_vispy_colormap(cmap, name=name)
-        else:
-            cmap.name = name
-        AVAILABLE_COLORMAPS[name] = cmap
-
-    elif isinstance(colormap, dict):
-        if 'colors' in colormap and not (
-            isinstance(colormap['colors'], VispyColormap)
-            or isinstance(colormap['colors'], Colormap)
-        ):
-            cmap = Colormap(**colormap)
-            name = cmap.name
+        elif isinstance(colormap, tuple):
+            if not (
+                len(colormap) == 2
+                and (
+                    isinstance(colormap[1], VispyColormap)
+                    or isinstance(colormap[1], Colormap)
+                )
+                and isinstance(colormap[0], str)
+            ):
+                raise TypeError(
+                    "When providing a tuple as a colormap argument, the first "
+                    "element must be a string and the second a Colormap instance"
+                )
+            name, cmap = colormap
+            # Convert from vispy colormap
+            if isinstance(cmap, VispyColormap):
+                cmap = convert_vispy_colormap(cmap, name=name)
+            else:
+                cmap.name = name
             AVAILABLE_COLORMAPS[name] = cmap
-        elif not all(
-            (isinstance(i, VispyColormap) or isinstance(i, Colormap))
-            for i in colormap.values()
-        ):
-            raise TypeError(
-                "When providing a dict as a colormap, "
-                "all values must be Colormap instances"
-            )
-        else:
-            # Convert from vispy colormaps
-            for key, cmap in colormap.items():
-                # Convert from vispy colormap
-                if isinstance(cmap, VispyColormap):
-                    cmap = convert_vispy_colormap(cmap, name=key)
-                else:
-                    cmap.name = key
-                name = key
-                colormap[name] = cmap
-            AVAILABLE_COLORMAPS.update(colormap)
-            if len(colormap) == 1:
-                name = list(colormap)[0]  # first key in dict
-            elif len(colormap) > 1:
-                name = list(colormap.keys())[0]
-                import warnings
 
-                warnings.warn(
-                    "only the first item in a colormap dict is used as an argument"
+        elif isinstance(colormap, dict):
+            if 'colors' in colormap and not (
+                isinstance(colormap['colors'], VispyColormap)
+                or isinstance(colormap['colors'], Colormap)
+            ):
+                cmap = Colormap(**colormap)
+                name = cmap.name
+                AVAILABLE_COLORMAPS[name] = cmap
+            elif not all(
+                (isinstance(i, VispyColormap) or isinstance(i, Colormap))
+                for i in colormap.values()
+            ):
+                raise TypeError(
+                    "When providing a dict as a colormap, "
+                    "all values must be Colormap instances"
                 )
             else:
-                raise ValueError(
-                    "Received an empty dict as a colormap argument."
-                )
-    else:
-        raise TypeError(
-            f'invalid type for colormap: {type(colormap)}. '
-            'Must be a {str, tuple, dict, napari.utils.Colormap, '
-            'vispy.colors.Colormap}'
-        )
+                # Convert from vispy colormaps
+                for key, cmap in colormap.items():
+                    # Convert from vispy colormap
+                    if isinstance(cmap, VispyColormap):
+                        cmap = convert_vispy_colormap(cmap, name=key)
+                    else:
+                        cmap.name = key
+                    name = key
+                    colormap[name] = cmap
+                AVAILABLE_COLORMAPS.update(colormap)
+                if len(colormap) == 1:
+                    name = list(colormap)[0]  # first key in dict
+                elif len(colormap) > 1:
+                    name = list(colormap.keys())[0]
+                    import warnings
+
+                    warnings.warn(
+                        "only the first item in a colormap dict is used as an argument"
+                    )
+                else:
+                    raise ValueError(
+                        "Received an empty dict as a colormap argument."
+                    )
+        else:
+            raise TypeError(
+                f'invalid type for colormap: {type(colormap)}. '
+                'Must be a {str, tuple, dict, napari.utils.Colormap, '
+                'vispy.colors.Colormap}'
+            )
 
     return AVAILABLE_COLORMAPS[name]


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

This is my proposition to fix bug from #2182., 
This PR introduces a global lock and protect the content of `ensure_colormap` function to prevent changes in `AVAILABLE_COLORMAPS` dict when iterating over its content. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
https://docs.python.org/3/library/threading.html#using-locks-conditions-and-semaphores-in-the-with-statement

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
