### PR TITLE
refactor a qt dims test to not use the viewer

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -301,24 +301,3 @@ def test_points_layer_display_correct_slice_on_scale(make_napari_viewer):
     layer = viewer.layers[1]
     indices, scale = layer._slice_data(layer._slice_indices)
     np.testing.assert_equal(indices, [0])
-
-
-def test_slice_labels(make_napari_viewer):
-    viewer = make_napari_viewer()
-    np.random.seed(0)
-    data = np.random.random((20, 10, 10))
-    viewer.add_image(data)
-    view = viewer.window.qt_viewer
-
-    # make sure the totslice_label is showing the correct number
-    assert int(view.dims.slider_widgets[0].totslice_label.text()) == 19
-
-    # make sure setting the dims.point updates the slice label
-    label_edit = view.dims.slider_widgets[0].curslice_label
-    viewer.dims.set_point(0, 15)
-    assert int(label_edit.text()) == 15
-
-    # make sure setting the current slice label updates the model
-    label_edit.setText(str(8))
-    label_edit.editingFinished.emit()
-    assert viewer.dims.point[0] == 8

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -301,3 +301,24 @@ def test_points_layer_display_correct_slice_on_scale(make_napari_viewer):
     layer = viewer.layers[1]
     indices, scale = layer._slice_data(layer._slice_indices)
     np.testing.assert_equal(indices, [0])
+
+
+def test_slice_labels(make_napari_viewer):
+    viewer = make_napari_viewer()
+    np.random.seed(0)
+    data = np.random.random((20, 10, 10))
+    viewer.add_image(data)
+    view = viewer.window.qt_viewer
+
+    # make sure the totslice_label is showing the correct number
+    assert int(view.dims.slider_widgets[0].totslice_label.text()) == 19
+
+    # make sure setting the dims.point updates the slice label
+    label_edit = view.dims.slider_widgets[0].curslice_label
+    viewer.dims.set_point(0, 15)
+    assert int(label_edit.text()) == 15
+
+    # make sure setting the current slice label updates the model
+    label_edit.setText(str(8))
+    label_edit.editingFinished.emit()
+    assert viewer.dims.point[0] == 8

--- a/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -293,3 +293,24 @@ def test_play_button(qtbot):
     with patch.object(button.popup, 'show_above_mouse') as mock_popup:
         qtbot.mouseClick(button, Qt.RightButton)
         mock_popup.assert_called_once()
+
+
+def test_slice_labels(qtbot):
+    ndim = 4
+    dims = Dims(ndim)
+    dims.set_range(0, (0, 19, 1))
+    view = QtDims(dims)
+    qtbot.addWidget(view)
+
+    # make sure the totslice_label is showing the correct number
+    assert int(view.slider_widgets[0].totslice_label.text()) == 19
+
+    # make sure setting the dims.point updates the slice label
+    label_edit = view.slider_widgets[0].curslice_label
+    dims.set_point(0, 15)
+    assert int(label_edit.text()) == 15
+
+    # make sure setting the current slice label updates the model
+    label_edit.setText(str(8))
+    label_edit.editingFinished.emit()
+    assert dims.point[0] == 8

--- a/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -293,24 +293,3 @@ def test_play_button(qtbot):
     with patch.object(button.popup, 'show_above_mouse') as mock_popup:
         qtbot.mouseClick(button, Qt.RightButton)
         mock_popup.assert_called_once()
-
-
-def test_slice_labels(make_napari_viewer):
-    viewer = make_napari_viewer()
-    np.random.seed(0)
-    data = np.random.random((20, 10, 10))
-    viewer.add_image(data)
-    view = viewer.window.qt_viewer
-
-    # make sure the totslice_label is showing the correct number
-    assert int(view.dims.slider_widgets[0].totslice_label.text()) == 19
-
-    # make sure setting the dims.point updates the slice label
-    label_edit = view.dims.slider_widgets[0].curslice_label
-    viewer.dims.set_point(0, 15)
-    assert int(label_edit.text()) == 15
-
-    # make sure setting the current slice label updates the model
-    label_edit.setText(str(8))
-    label_edit.editingFinished.emit()
-    assert viewer.dims.point[0] == 8


### PR DESCRIPTION
# Description
This short PR just moves one of our tests using `make_napari_viewer` out of the individual `qt_dims` tests and up to the `qt_viewer` tests, as a good rule of thumb, I think a test using `make_napari_viewer` shouldn't be at the level of the individual widget even if it is testing something focused on that widget as it is importing the whole viewer and so could fail for larger reasons.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Refactor