### PR TITLE
Add update in-place to evented model

### DIFF
--- a/napari/utils/events/_tests/test_event_emitter.py
+++ b/napari/utils/events/_tests/test_event_emitter.py
@@ -1,0 +1,19 @@
+from napari.utils.events import EventEmitter
+
+
+def test_event_blocker_count_none():
+    """Test event emitter block counter with no emission."""
+    e = EventEmitter(type="test")
+    with e.blocker() as block:
+        pass
+    assert block.count == 0
+
+
+def test_event_blocker_count():
+    """Test event emitter block counter with emission."""
+    e = EventEmitter(type="test")
+    with e.blocker() as block:
+        e()
+        e()
+        e()
+    assert block.count == 3

--- a/napari/utils/events/_tests/test_evented_model.py
+++ b/napari/utils/events/_tests/test_evented_model.py
@@ -122,8 +122,31 @@ def test_values_updated():
     user1 = User(id=0)
     user2 = User(id=1, name='K')
 
+    # Add mocks
+    user1_events = Mock(user1.events)
+    user1.events.connect(user1_events)
+    user1.events.id = Mock(user1.events.id)
+    user2.events.id = Mock(user2.events.id)
+
+    # Check user1 and user2 dicts
     assert user1.dict() == {'id': 0, 'name': 'A'}
     assert user2.dict() == {'id': 1, 'name': 'K'}
 
+    # Update user1 from user2
     user1.update(user2)
     assert user1.dict() == {'id': 1, 'name': 'K'}
+
+    user1.events.id.assert_called_with(value=1)
+    user2.events.id.assert_not_called()
+    assert user1_events.call_count == 1
+    user1.events.id.reset_mock()
+    user2.events.id.reset_mock()
+    user1_events.reset_mock()
+
+    # Update user1 from user2 again, no event emission expected
+    user1.update(user2)
+    assert user1.dict() == {'id': 1, 'name': 'K'}
+
+    user1.events.id.assert_not_called()
+    user2.events.id.assert_not_called()
+    assert user1_events.call_count == 0

--- a/napari/utils/events/_tests/test_evented_model.py
+++ b/napari/utils/events/_tests/test_evented_model.py
@@ -123,7 +123,7 @@ def test_values_updated():
     user2 = User(id=1, name='K')
 
     assert user1.dict() == {'id': 0, 'name': 'A'}
-    assert user2.dict() == {'id': 0, 'name': 'K'}
+    assert user2.dict() == {'id': 1, 'name': 'K'}
 
-    user1.update(user2.dict())
-    assert user1.dict() == {'id': 0, 'name': 'K'}
+    user1.update(user2)
+    assert user1.dict() == {'id': 1, 'name': 'K'}

--- a/napari/utils/events/_tests/test_evented_model.py
+++ b/napari/utils/events/_tests/test_evented_model.py
@@ -101,3 +101,29 @@ def test_evented_model_with_array():
     # try changing shape to something impossible to correctly reshape
     with pytest.raises(ValueError):
         model.shaped2_values = [1]
+
+
+def test_values_updated():
+    class User(EventedModel):
+        """Demo evented model.
+
+        Parameters
+        ----------
+        id : int
+            User id.
+        name : str, optional
+            User name.
+        """
+
+        id: int
+        name: str = 'A'
+        age: ClassVar[int] = 100
+
+    user1 = User(id=0)
+    user2 = User(id=1, name='K')
+
+    assert user1.dict() == {'id': 0, 'name': 'A'}
+    assert user2.dict() == {'id': 0, 'name': 'K'}
+
+    user1.update(user2.dict())
+    assert user1.dict() == {'id': 0, 'name': 'K'}

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import ClassVar, Dict, Set
 
 from pydantic import BaseModel, PrivateAttr
@@ -75,3 +76,33 @@ class EventedModel(BaseModel):
     @property
     def events(self):
         return self._events
+
+    def asdict(self):
+        """Convert a model to a dictionary."""
+        warnings.warn(
+            (
+                "The `asdict` method has been renamed `dict` and is now deprecated. It will be"
+                " removed in 0.4.7"
+            ),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        return self.dict()
+
+    def update(self, values):
+        """Update a model in place.
+
+        Parameters
+        ----------
+        values : dict, napari.utils.events.EventedModel
+            Values to update the model with. If an EventedModel is passed it is first
+            converted to a dictionary. The keys of this dictionary must be found as
+            attributes on the current model.
+        """
+        if isinstance(values, self.__class__):
+            values = values.dict()
+        if not isinstance(values, dict):
+            raise ValueError(f"Unsupported update from {type(values)}")
+
+        for key, value in values.items():
+            self.key = value

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -99,7 +99,7 @@ class EventedModel(BaseModel):
             converted to a dictionary. The keys of this dictionary must be found as
             attributes on the current model.
         """
-        if isinstance(values, self.__class__) and hasattr(values, 'dict'):
+        if isinstance(values, self.__class__):
             values = values.dict()
         if not isinstance(values, dict):
             raise ValueError(f"Unsupported update from {type(values)}")

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -105,4 +105,4 @@ class EventedModel(BaseModel):
             raise ValueError(f"Unsupported update from {type(values)}")
 
         for key, value in values.items():
-            self.key = value
+            setattr(self, key, value)

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -99,7 +99,7 @@ class EventedModel(BaseModel):
             converted to a dictionary. The keys of this dictionary must be found as
             attributes on the current model.
         """
-        if isinstance(values, self.__class__):
+        if isinstance(values, self.__class__) and hasattr(values, 'dict'):
             values = values.dict()
         if not isinstance(values, dict):
             raise ValueError(f"Unsupported update from {type(values)}")


### PR DESCRIPTION
# Description
Following the merge of #2127, this PR would add and deprectate the `asdict` alias for the pydantic builtin `dict` method. It also adds the `update` method from #1966 which was added by @Czaki. The behavior there including event emission is identical to the behavior as before, but I can now use a private variable to avoid the double equality check.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Deprecation
