### PR TITLE
Drops for 0.4.5

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1,7 +1,6 @@
 import inspect
 import itertools
 import os
-import warnings
 from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
@@ -26,9 +25,7 @@ from ..utils.events import EmitterGroup, Event, disconnect_events
 from ..utils.key_bindings import KeymapProvider
 from ..utils.misc import is_sequence
 from ..utils.mouse_bindings import MousemapProvider
-
-# Private _themes import needed until viewer.palette is dropped
-from ..utils.theme import _themes, available_themes, get_theme
+from ..utils.theme import available_themes
 from ._viewer_mouse_bindings import dims_scroll
 from .axes import Axes
 from .camera import Camera
@@ -126,40 +123,6 @@ class ViewerModel(KeymapProvider, MousemapProvider):
         return f'napari.Viewer: {self.title}'
 
     @property
-    def palette(self):
-        """Dict[str, str]: Color palette for styling the viewer."""
-        warnings.warn(
-            (
-                "The viewer.palette attribute is deprecated and will be removed after version 0.4.5."
-                " To access the palette you can call it using napari.utils.theme.register_theme"
-                " using the viewer.theme as the key."
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return get_theme(self.theme)
-
-    @palette.setter
-    def palette(self, palette):
-        warnings.warn(
-            (
-                "The viewer.palette attribute is deprecated and will be removed after version 0.4.5."
-                " To add a new palette you should add it using napari.utils.theme.register_theme"
-                " and then set the viewer.theme attribute."
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        for existing_theme_name, existing_theme in _themes.items():
-            if existing_theme == palette:
-                self.theme = existing_theme_name
-                return
-        raise ValueError(
-            f"Palette not found among existing themes; "
-            f"options are {available_themes()}."
-        )
-
-    @property
     def theme(self):
         """string or None : Color theme."""
         return self._theme
@@ -215,31 +178,6 @@ class ViewerModel(KeymapProvider, MousemapProvider):
             return
         self._title = title
         self.events.title(value=self._title)
-
-    @property
-    def interactive(self):
-        """bool: Determines if canvas pan/zoom interactivity is enabled or not."""
-        warnings.warn(
-            (
-                "The viewer.interactive parameter is deprecated and will be removed after version 0.4.5."
-                " Instead you should use viewer.camera.interactive"
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.camera.interactive
-
-    @interactive.setter
-    def interactive(self, interactive):
-        warnings.warn(
-            (
-                "The viewer.interactive parameter is deprecated and will be removed after version 0.4.5."
-                " Instead you should use viewer.camera.interactive"
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        self.camera.interactive = interactive
 
     @property
     def active_layer(self):

--- a/napari/utils/_magicgui.py
+++ b/napari/utils/_magicgui.py
@@ -11,7 +11,7 @@ of those custom classes, magicgui will know what to do with it.
 """
 import weakref
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type
 
 from .. import layers, types
 from ..utils.misc import ensure_list_of_layer_data_tuple
@@ -309,7 +309,9 @@ def _make_choice_data_setter(gui: 'CategoricalWidget', choice_name: str):
     return setter
 
 
-def add_layer_to_viewer(gui, result: Any) -> None:
+def add_layer_to_viewer(
+    gui, result: Any, return_type: Type[layers.Layer]
+) -> None:
     """Show a magicgui result in the viewer.
 
     Parameters
@@ -319,6 +321,8 @@ def add_layer_to_viewer(gui, result: Any) -> None:
         dock widget.
     result : Any
         The result of the function call.
+    return_type : type
+        The return annotation that was used in the decorated function.
 
     Examples
     --------

--- a/napari/utils/_tests/test_magicgui.py
+++ b/napari/utils/_tests/test_magicgui.py
@@ -8,7 +8,7 @@ from magicgui import magicgui
 
 from napari import Viewer, types
 from napari._tests.utils import layer_test_data
-from napari.layers import Image, Labels, Layer, Points
+from napari.layers import Image, Labels, Layer
 from napari.utils.misc import all_subclasses
 
 try:
@@ -41,78 +41,6 @@ for cls in all_subclasses(Layer):
     except StopIteration:
         # OctTree Image doesn't have layer_test_data
         pass
-
-
-def test_magicgui_returns_image(make_napari_viewer):
-    """make sure a magicgui function returning Image adds an Image.
-
-    This is deprecated and now emits a warning
-    """
-    viewer = make_napari_viewer()
-
-    @magicgui
-    def add_image() -> Image:
-        return np.random.rand(10, 10)
-
-    viewer.window.add_dock_widget(add_image)
-    assert len(viewer.layers) == 0
-    with pytest.warns(UserWarning):
-        add_image()  # should add a new layer to the list
-    assert len(viewer.layers) == 1
-    assert viewer.layers[0].name == 'add_image result'
-
-    with pytest.warns(UserWarning):
-        add_image()  # should just update existing layer on subsequent calls
-    assert len(viewer.layers) == 1
-    assert viewer.layers[0].name == 'add_image result'
-    assert isinstance(viewer.layers[0], Image)
-
-
-def test_magicgui_returns_label(make_napari_viewer):
-    """make sure a magicgui function returning Labels adds a Labels.
-
-    This is deprecated and now emits a warning
-    """
-    viewer = make_napari_viewer()
-
-    @magicgui
-    def add_labels() -> Labels:
-        return np.random.rand(10, 10)
-
-    viewer.window.add_dock_widget(add_labels)
-    assert len(viewer.layers) == 0
-    with pytest.warns(UserWarning):
-        add_labels()  # should add a new layer to the list
-    assert len(viewer.layers) == 1
-    assert viewer.layers[0].name == 'add_labels result'
-    assert isinstance(viewer.layers[0], Image)
-
-
-@pytest.mark.skipif(
-    bool(os.environ.get('CI') and sys.platform == "darwin"),
-    reason="segfault on mac CI",
-)
-def test_magicgui_returns_layer_tuple(make_napari_viewer):
-    """make sure a magicgui function returning Layer adds the right type.
-
-    This is deprecated and now emits a warning
-    """
-    viewer = make_napari_viewer()
-
-    @magicgui
-    def add_layer() -> Layer:
-        return [(np.random.rand(10, 3), {'size': 20, 'name': 'foo'}, 'points')]
-
-    viewer.window.add_dock_widget(add_layer)
-    assert len(viewer.layers) == 0
-
-    with pytest.warns(UserWarning):
-        add_layer()  # should add a new layer to the list
-    assert len(viewer.layers) == 1
-    layer = viewer.layers[0]
-    assert layer.name == 'foo'
-    assert isinstance(layer, Points)
-    assert layer.data.shape == (10, 3)
 
 
 @pytest.mark.parametrize('LayerType, data, ndim', test_data)


### PR DESCRIPTION
# Description
This PR drops the things marked for removal in 0.4.5

```
                "The viewer.palette attribute is deprecated and will be removed in version 0.4.5."	
                " To add a new palette you should add it using napari.utils.theme.register_theme"	
                " and then set the viewer.theme attribute."

                "The viewer.palette attribute is deprecated and will be removed in version 0.4.5."	
                " To add a new palette you should add it using napari.utils.theme.register_theme"	
                " and then set the viewer.theme attribute."

                "The viewer.interactive parameter is deprecated and will be removed in version 0.4.5."	
                " Instead you should use viewer.camera.interactive"

                'Annotating a magicgui function with a return type of '	
                '`napari.layers.Layer` is deprecated.  To indicate that your '	
                'function returns a layer data tuple, please use a return '	
                'annotation of `napari.types.LayerDataTuple` or '	
                '`List[napari.types.LayerDataTuple]`\n'	
                'This will raise an exception in napari v0.4.5'
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

