### PR TITLE
Allow reader_function to return empty layer list

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -793,7 +793,7 @@ class ViewerModel(KeymapProvider, MousemapProvider):
         """
         from ..plugins.io import read_data_with_plugins
 
-        layer_data = read_data_with_plugins(path_or_paths, plugin=plugin)
+        layer_data = read_data_with_plugins(path_or_paths, plugin=plugin) or []
 
         # glean layer names from filename. These will be used as *fallback*
         # names, if the plugin does not return a name kwarg in their meta dict.

--- a/napari/plugins/hook_specifications.py
+++ b/napari/plugins/hook_specifications.py
@@ -53,7 +53,7 @@ def napari_get_reader(path: Union[str, List[str]]) -> Optional[ReaderFunction]:
 
     This is the primary "**reader plugin**" function.  It accepts a path or
     list of paths, and returns a list of data to be added to the ``Viewer``.
-    The function may return an empty list to indicate that the file was read
+    The function may return ``[(None, )]`` to indicate that the file was read
     successfully, but did not contain any data.
 
     The main place this hook is used is in :func:`Viewer.open()

--- a/napari/plugins/hook_specifications.py
+++ b/napari/plugins/hook_specifications.py
@@ -53,6 +53,8 @@ def napari_get_reader(path: Union[str, List[str]]) -> Optional[ReaderFunction]:
 
     This is the primary "**reader plugin**" function.  It accepts a path or
     list of paths, and returns a list of data to be added to the ``Viewer``.
+    The function may return an empty list to indicate that the file was read
+    successfully, but did not contain any data.
 
     The main place this hook is used is in :func:`Viewer.open()
     <napari.components.viewer_model.ViewerModel.open>`, via the

--- a/napari/plugins/io.py
+++ b/napari/plugins/io.py
@@ -217,15 +217,13 @@ def _is_null_layer_sentinel(layer_data: Union[LayerData, Any]) -> bool:
     bool
         True, if the layer_data indicates an empty file, False otherwise
     """
-    if not layer_data or not isinstance(layer_data, list):
-        return False
-    if len(layer_data) != 1:
-        return False
-    if not layer_data[0] or not isinstance(layer_data[0], tuple):
-        return False
-    if len(layer_data[0]) != 1:
-        return False
-    return layer_data[0][0] is None
+    return (
+        isinstance(layer_data, list)
+        and len(layer_data) == 1
+        and isinstance(layer_data[0], tuple)
+        and len(layer_data[0]) == 1
+        and layer_data[0][0] is None
+    )
 
 
 def _write_multiple_layers_with_plugins(


### PR DESCRIPTION
# Description
Allow reader plugin functions to return `[]` for indicating empty files, see #2201 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# References
closes #2201 
closes #2210

# How has this been tested?

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works