### PR TITLE
Prevent monitor information refering to one of first issues

### DIFF
--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -148,7 +148,7 @@ def sys_info(as_html=False):
 
         screen_list = QGuiApplication.screens()
         for i, screen in enumerate(screen_list, start=1):
-            text += f"  - screen #{i}: resolution {screen.geometry().width()}x{screen.geometry().height()}, scale {screen.devicePixelRatio()}<br>"
+            text += f"  - screen {i}: resolution {screen.geometry().width()}x{screen.geometry().height()}, scale {screen.devicePixelRatio()}<br>"
     except Exception as e:
         text += f"  - failed to load screen information {e}"
 


### PR DESCRIPTION
# Description
Fis fix oversight in My previous PR. Current pasting of napari information will create a reference to one of the first PR/issues (because it numbering `#1` etc). 

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
