### PR TITLE
Handle closing the main window via the close button and handle_exit for this case.

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -49,12 +49,58 @@ class _QtMainWindow(QMainWindow):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+
         self.setWindowIcon(QIcon(self._window_icon))
         self.setAttribute(Qt.WA_DeleteOnClose)
         self.setUnifiedTitleAndToolBarOnMac(True)
         center = QWidget(self)
         center.setLayout(QHBoxLayout())
         self.setCentralWidget(center)
+
+    def _delete_qt_window(self):
+        """Delete our self._qt_window."""
+        # On some versions of Darwin, exiting while fullscreen seems to tickle
+        # some bug deep in NSWindow.  This forces the fullscreen keybinding
+        # test to complete its draw cycle, then pop back out of fullscreen.
+        if self.isFullScreen():
+            self.showNormal()
+            for __ in range(8):
+                time.sleep(0.1)
+                QApplication.processEvents()
+
+        self._qt_viewer.close()
+
+    def _handle_exit(self):
+        """Handle exiting the aplication.
+
+        This will execute when closing via menu or via the close button of the main window.
+        """
+        # if the event loop was started in gui_qt() then the app will be
+        # named 'napari'. Since the Qapp was started by us, just close it.
+        if QApplication.applicationName() == 'napari':
+            QApplication.closeAllWindows()
+            QApplication.quit()
+        # otherwise, something else created the QApp before us (such as
+        # %gui qt IPython magic).  If we quit the app in this case, then
+        # *later* attempts to instantiate a napari viewer won't work until
+        # the event loop is restarted with app.exec_().  So rather than
+        # quit just close all the windows (and clear our app icon).
+        else:
+            QApplication.setWindowIcon(QIcon())
+            self._delete_qt_window()
+
+        if perf.USE_PERFMON:
+            # Write trace file before exit, if we were writing one.
+            # Is there a better place to make sure this is done on exit?
+            perf.timers.stop_trace_file()
+
+        _stop_monitor()
+        _shutdown_chunkloader()
+
+    def closeEvent(self, event):
+        """Override Qt event."""
+        self._handle_exit()
+        event.ignore()
 
 
 class Window:
@@ -91,6 +137,7 @@ class Window:
         # Connect the Viewer and create the Main Window
         self.qt_viewer = QtViewer(viewer)
         self._qt_window = _QtMainWindow()
+        self._qt_window._qt_viewer = self.qt_viewer
         self._qt_window.setWindowTitle(self.qt_viewer.viewer.title)
         self._qt_center = self._qt_window.centralWidget()
         self._status_bar = self._qt_window.statusBar()
@@ -231,31 +278,7 @@ class Window:
         exitAction = QAction('Exit', self._qt_window)
         exitAction.setShortcut('Ctrl+Q')
         exitAction.setMenuRole(QAction.QuitRole)
-
-        def handle_exit():
-            # if the event loop was started in gui_qt() then the app will be
-            # named 'napari'. Since the Qapp was started by us, just close it.
-            if QApplication.applicationName() == 'napari':
-                QApplication.closeAllWindows()
-                QApplication.quit()
-            # otherwise, something else created the QApp before us (such as
-            # %gui qt IPython magic).  If we quit the app in this case, then
-            # *later* attempts to instantiate a napari viewer won't work until
-            # the event loop is restarted with app.exec_().  So rather than
-            # quit just close all the windows (and clear our app icon).
-            else:
-                QApplication.setWindowIcon(QIcon())
-                self.close()
-
-            if perf.USE_PERFMON:
-                # Write trace file before exit, if we were writing one.
-                # Is there a better place to make sure this is done on exit?
-                perf.timers.stop_trace_file()
-
-            _stop_monitor()
-            _shutdown_chunkloader()
-
-        exitAction.triggered.connect(handle_exit)
+        exitAction.triggered.connect(self._qt_window._handle_exit)
 
         self.file_menu = self.main_menu.addMenu('&File')
         self.file_menu.addAction(open_images)
@@ -926,26 +949,12 @@ class Window:
 
     def close(self):
         """Close the viewer window and cleanup sub-widgets."""
-
-        # Someone is closing us twice? Only try to delete self._qt_window
-        # if we still have one.
-        if hasattr(self, '_qt_window'):
-            self._delete_qt_window()
-
-    def _delete_qt_window(self):
-        """Delete our self._qt_window."""
-
-        # On some versions of Darwin, exiting while fullscreen seems to tickle
-        # some bug deep in NSWindow.  This forces the fullscreen keybinding
-        # test to complete its draw cycle, then pop back out of fullscreen.
-        if self._qt_window.isFullScreen():
-            self._qt_window.showNormal()
-            for i in range(8):
-                time.sleep(0.1)
-                QApplication.processEvents()
-        self.qt_viewer.close()
-        self._qt_window.close()
-        del self._qt_window
+        try:
+            if hasattr(self, '_qt_window'):
+                self._qt_window.close()
+                del self._qt_window
+        except AttributeError:
+            pass
 
 
 def _stop_monitor() -> None:

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -47,9 +47,9 @@ class _QtMainWindow(QMainWindow):
     # to their desired window icon
     _window_icon = NAPARI_ICON_PATH
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-
+    def __init__(self, qt_viewer: QtViewer = None, parent=None) -> None:
+        super().__init__(parent=parent)
+        self._qt_viewer = qt_viewer
         self.setWindowIcon(QIcon(self._window_icon))
         self.setAttribute(Qt.WA_DeleteOnClose)
         self.setUnifiedTitleAndToolBarOnMac(True)
@@ -67,8 +67,8 @@ class _QtMainWindow(QMainWindow):
             for __ in range(8):
                 time.sleep(0.1)
                 QApplication.processEvents()
-
-        self._qt_viewer.close()
+        if self._qt_viewer is not None:
+            self._qt_viewer.close()
 
     def _handle_exit(self):
         """Handle exiting the aplication.
@@ -136,7 +136,7 @@ class Window:
 
         # Connect the Viewer and create the Main Window
         self.qt_viewer = QtViewer(viewer)
-        self._qt_window = _QtMainWindow()
+        self._qt_window = _QtMainWindow(qt_viewer=self.qt_viewer)
         self._qt_window._qt_viewer = self.qt_viewer
         self._qt_window.setWindowTitle(self.qt_viewer.viewer.title)
         self._qt_center = self._qt_window.centralWidget()


### PR DESCRIPTION
# Description

When the application is closed via the close (red x button) button on the main window the `handle_exit` was not being called.

This is needed so we can save geometry on the settings when closing with the menu action or via the close button.

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
