### PR TITLE
Fix close procedure

### DIFF
--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -8,6 +8,7 @@ from qtpy.QtWidgets import QApplication, QSplashScreen
 
 from napari import __version__
 
+from ..utils import config, perf
 from ..utils.perf import perf_config
 from .exceptions import ExceptionHandler
 from .qthreading import wait_for_workers_to_quit
@@ -136,6 +137,39 @@ def get_app(
     app.aboutToQuit.connect(wait_for_workers_to_quit)
 
     return app
+
+
+def quit_app():
+    """Close all windows and quit the QApplication if napari started it."""
+    QApplication.closeAllWindows()
+    # if we started the application then the app will be named 'napari'.
+    if QApplication.applicationName() == 'napari':
+        QApplication.quit()
+
+    # otherwise, something else created the QApp before us (such as
+    # %gui qt IPython magic).  If we quit the app in this case, then
+    # *later* attempts to instantiate a napari viewer won't work until
+    # the event loop is restarted with app.exec_().  So rather than
+    # quit just close all the windows (and clear our app icon).
+    else:
+        QApplication.setWindowIcon(QIcon())
+
+    if perf.USE_PERFMON:
+        # Write trace file before exit, if we were writing one.
+        # Is there a better place to make sure this is done on exit?
+        perf.timers.stop_trace_file()
+
+    if config.monitor:
+        # Stop the monitor service if we were using it
+        from ..components.experimental.monitor import monitor
+
+        monitor.stop()
+
+    if config.async_loading:
+        # Shutdown the chunkloader
+        from ..components.experimental.chunk import chunk_loader
+
+        chunk_loader.shutdown()
 
 
 @contextmanager

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -815,8 +815,17 @@ class Window:
 
     def show(self):
         """Resize, show, and bring forward the window."""
-        self._qt_window.resize(self._qt_window.layout().sizeHint())
-        self._qt_window.show()
+        try:
+            self._qt_window.resize(self._qt_window.layout().sizeHint())
+            self._qt_window.show()
+        except RuntimeError as e:
+            if "has been deleted" in str(e):
+                raise RuntimeError(
+                    "This viewer has already been closed and deleted. "
+                    "Please create a new one."
+                )
+            raise
+
         # Resize axis labels now that window is shown
         self.qt_viewer.dims._resize_axis_labels()
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -47,8 +47,8 @@ class _QtMainWindow(QMainWindow):
     # to their desired window icon
     _window_icon = NAPARI_ICON_PATH
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
         self.setWindowIcon(QIcon(self._window_icon))
         self.setAttribute(Qt.WA_DeleteOnClose)
         self.setUnifiedTitleAndToolBarOnMac(True)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -818,13 +818,11 @@ class Window:
         try:
             self._qt_window.resize(self._qt_window.layout().sizeHint())
             self._qt_window.show()
-        except RuntimeError as e:
-            if "has been deleted" in str(e):
-                raise RuntimeError(
-                    "This viewer has already been closed and deleted. "
-                    "Please create a new one."
-                )
-            raise
+        except (AttributeError, RuntimeError):
+            raise RuntimeError(
+                "This viewer has already been closed and deleted. "
+                "Please create a new one."
+            )
 
         # Resize axis labels now that window is shown
         self.qt_viewer.dims._resize_axis_labels()

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -61,6 +61,9 @@ class _QtMainWindow(QMainWindow):
 
         Regardless of whether cmd Q, cmd W, or the close button is used...
         """
+        # On some versions of Darwin, exiting while fullscreen seems to tickle
+        # some bug deep in NSWindow.  This forces the fullscreen keybinding
+        # test to complete its draw cycle, then pop back out of fullscreen.
         if self.isFullScreen():
             self.showNormal()
             for i in range(5):


### PR DESCRIPTION
# Description
This fixes what I messed up in my suggestions on #2215.  Here's the deal:
- as before, using Cmd-Q is considered a "global" action, and will close all application windows, that logic is now in `quit_app` ... next to `get_app` in `qt_event_loop.py`
- as before, using Cmd-W or pressing the mainWindow close button will close only that window, If you need to hook into that close event, use `_QMainWindow.closeEvent`.
- also added a better warning when someone tries to `viewer.show` an already-deleted viewer.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
