### PR TITLE
Test for warning rather than error on flat multiscale

### DIFF
--- a/napari/layers/image/_image_utils.py
+++ b/napari/layers/image/_image_utils.py
@@ -1,5 +1,7 @@
 """guess_rgb, guess_multiscale, guess_labels.
 """
+import warnings
+
 import numpy as np
 
 
@@ -57,21 +59,24 @@ def guess_multiscale(data):
         # pyramid with only one level, unwrap
         return False, data[0]
     if len(sizes) > 1:
-        consistent = bool(np.all(sizes[:-1] > sizes[1:]))
+        consistent = bool(np.all(sizes[:-1] >= sizes[1:]))
         flat = bool(np.all(sizes == sizes[0]))
         if flat:
             # note: the individual array case should be caught by the first
             # code line in this function, hasattr(ndim) and ndim > 1.
-            raise ValueError(
-                'Input data should be an array-like object, or a sequence of '
-                'arrays of decreasing size. Got arrays of single shape: '
+            # note also: this may be desirable behaviour when we want
+            # different chunking patterns in 2D and 3D view, since 3D only
+            # loads the lowest resolution volume.
+            warnings.warn(
+                'Input data should be an array-like object, or a sequence '
+                'of arrays of decreasing size. Got arrays of single shape: '
                 f'{shapes[0]}'
             )
         if not consistent:
             raise ValueError(
-                'Input data should be an array-like object, or a sequence of '
-                'arrays of decreasing size. Got arrays in incorrect order, '
-                f'shapes: {shapes}'
+                'Input data should be an array-like object, or a sequence '
+                'of arrays of decreasing size. Got arrays in incorrect '
+                f'order, shapes: {shapes}'
             )
         return True, data
     else:

--- a/napari/layers/image/_tests/test_image_utils.py
+++ b/napari/layers/image/_tests/test_image_utils.py
@@ -70,11 +70,11 @@ def test_guess_multiscale_strip_single_scale():
 
 
 def test_guess_multiscale_non_array_list():
-    """Check that non-decreasing list input raises ValueError"""
+    """Check that non-decreasing list input warns"""
     data = [
         np.empty((10, 15, 6)),
     ] * 2  # noqa: E231
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         _, _ = guess_multiscale(data)
 
 


### PR DESCRIPTION
# Description

I have a moderately sized array of shape approximately (200, 50, 500, 500). I don't need actual multiscale, but I do want to use different chunking for 2D view and 3D view. It's slightly an implementation-detail based hack but I thought I would give my array as a multiscale, with the 0 scale having chunksize (1, 1, 500, 500), and the 1 scale having chunksize (50, 500, 500). This makes a significant difference when scrolling through the timepoints in both 2D and 3D.

Current behaviour is to error when given two arrays of the same shape. Here I propose to simply warn.

Other alternatives:

- check whether arrays have a `chunksize` attribute and compare on that,
  keeping current behaviour the unchanged for non-chunked arrays.
- always allow inconsistent multiscale, leaving the user to use the API
  appropriately.
- something else?

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
