### PR TITLE
Support equality checking for arrays (or other unusual types) in EventedModel.

### DIFF
--- a/napari/utils/events/_tests/test_evented_model.py
+++ b/napari/utils/events/_tests/test_evented_model.py
@@ -112,9 +112,7 @@ def test_evented_model_array_updates():
 
         values: Array[int]
 
-    model = Model(
-        values=[1, 2, 3],
-    )
+    model = Model(values=[1, 2, 3])
 
     # Mock events
     model.events.values = Mock(model.events.values)

--- a/napari/utils/events/_tests/test_evented_model.py
+++ b/napari/utils/events/_tests/test_evented_model.py
@@ -1,6 +1,7 @@
 from typing import ClassVar
 from unittest.mock import Mock
 
+import dask.array as da
 import numpy as np
 import pytest
 from pydantic import Field
@@ -101,6 +102,88 @@ def test_evented_model_with_array():
     # try changing shape to something impossible to correctly reshape
     with pytest.raises(ValueError):
         model.shaped2_values = [1]
+
+
+def test_evented_model_array_updates():
+    """Test updating an evented pydantic model with an array."""
+
+    class Model(EventedModel):
+        """Demo evented model."""
+
+        values: Array[int]
+
+    model = Model(
+        values=[1, 2, 3],
+    )
+
+    # Mock events
+    model.events.values = Mock(model.events.values)
+
+    np.testing.assert_almost_equal(model.values, np.array([1, 2, 3]))
+
+    # Updating with new data
+    model.values = [1, 2, 4]
+    assert model.events.values.call_count == 1
+    np.testing.assert_almost_equal(
+        model.events.values.call_args[1]['value'], np.array([1, 2, 4])
+    )
+    model.events.values.reset_mock()
+
+    # Updating with same data, no event should be emitted
+    model.values = [1, 2, 4]
+    model.events.values.assert_not_called()
+
+
+def test_evented_model_array_equality():
+    """Test checking equality with an evented model with custom array."""
+
+    class Model(EventedModel):
+        """Demo evented model."""
+
+        values: Array[int]
+
+    model1 = Model(values=[1, 2, 3])
+    model2 = Model(values=[1, 5, 6])
+
+    assert model1 == model1
+    assert model1 != model2
+
+    model2.values = [1, 2, 3]
+    assert model1 == model2
+
+
+def test_evented_model_np_array_equality():
+    """Test checking equality with an evented model with direct numpy."""
+
+    class Model(EventedModel):
+        values: np.ndarray
+
+    model1 = Model(values=np.array([1, 2, 3]))
+    model2 = Model(values=np.array([1, 5, 6]))
+
+    assert model1 == model1
+    assert model1 != model2
+
+    model2.values = np.array([1, 2, 3])
+    assert model1 == model2
+
+
+def test_evented_model_da_array_equality():
+    """Test checking equality with an evented model with direct dask."""
+
+    class Model(EventedModel):
+        values: da.Array
+
+    r = da.ones((64, 64))
+    model1 = Model(values=r)
+    model2 = Model(values=da.ones((64, 64)))
+
+    assert model1 == model1
+    # dask arrays will only evaluate as equal if they are the same object.
+    assert model1 != model2
+
+    model2.values = r
+    assert model1 == model2
 
 
 def test_values_updated():


### PR DESCRIPTION
# Description
Supersedes and closes #2200.

The idea here is to add one more step the `ModelMetaclass.__new__` method that looks at the fields and constructs a `cls.__eq_operators__` dict that will work for each each field.  It uses `utils.misc.pick_equality_operator` to populate the dict based on the field type.  Since this is only for our own `EventedModel`, we can just update that function if we ever run into custom types that need special treatment.  (and nobody needs to put `__equality_checks__` on their classes anymore).

this `pick_equality_operator` function can also be used for #2226 (and in fact, may not even be necessary there once all of our `Layers` are also `EventedModels` 


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
