### PR TITLE
generate api file for top-level napari package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,6 @@
 
 docs:
 	rm -rf docs/_build/html
+	find docs/api ! -name 'index.rst' -type f -exec rm -f {} +
 	pip install -qr docs/requirements.txt
 	jb build docs

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -36,6 +36,11 @@ For those wishing to add custom functionality to their project.
    napari.utils.perf
 
 
+.. autosummary::
+   :hidden:
+   :toctree:
+   napari
+
 Starting the Event Loop
 -----------------------
 


### PR DESCRIPTION
I noticed that some of the functions under the top-level napari package didn't get their documentation generated so I fixed that.

<img width="1358" alt="Screen Shot 2021-02-08 at 5 09 34 PM" src="https://user-images.githubusercontent.com/29165011/107301483-717e2900-6a30-11eb-9027-b2c70b4311d7.png">
