### PR TITLE
[WIP] `viewer.show()` refactor

### DIFF
--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -28,7 +28,7 @@ class Viewer(ViewerModel):
         ndisplay=2,
         order=(),
         axis_labels=(),
-        show=True,
+        show=False,
     ):
         super().__init__(
             title=title,
@@ -36,11 +36,9 @@ class Viewer(ViewerModel):
             order=order,
             axis_labels=axis_labels,
         )
-        # having this import here makes all of Qt imported lazily, upon
-        # instantiating the first Viewer.
-        from .window import Window
-
-        self.window = Window(self, show=show)
+        self.window = None
+        if show:
+            self.show()
 
     def update_console(self, variables):
         """Update console's namespace with desired variables.
@@ -86,7 +84,18 @@ class Viewer(ViewerModel):
 
     def show(self):
         """Resize, show, and raise the viewer window."""
+        from . import run
+
+        if self.window is None or not self.window.is_alive:
+            # having this import here makes all of Qt imported lazily,
+            # upon showing a Viewer for the first time.
+            from .window import Window
+
+            self.window = Window(self, show=True)
+
         self.window.show()
+
+        run()
 
     def close(self):
         """Close the viewer window."""
@@ -94,7 +103,7 @@ class Viewer(ViewerModel):
         self.layers.clear()
         # Close the main window
         self.window.close()
-
+        self.window = None
         if config.async_loading:
             from .components.experimental.chunk import chunk_loader
 


### PR DESCRIPTION
# Description
trying to implement the `viewer.show()` pattern discussed at the end of #2225.  still WIP, but the current goal is to be able to do the following:

```python
import napari
v = napari.Viewer()
v.show()

# then close the viewer ...
# code more if you want
v.show()  # show it again.
```

This is perhaps a lofty goal.  But I think if we can do this successfully, it will indicate that we can completely clean up the GUI "view" of our `ViewerModel`, and recreate on demand.

currently, this gives an error `RuntimeError: wrapped C/C++ object of type CanvasBackendDesktop has been deleted`

<details>

```pytb
ERROR:root:Unhandled exception:
Traceback (most recent call last):
  File "/Users/talley/miniconda3/envs/napdev/lib/python3.8/site-packages/vispy/app/backends/_qt.py", line 825, in paintGL
    self._vispy_canvas.events.draw(region=None)
  File "/Users/talley/miniconda3/envs/napdev/lib/python3.8/site-packages/vispy/util/event.py", line 455, in __call__
    self._invoke_callback(cb, event)
  File "/Users/talley/miniconda3/envs/napdev/lib/python3.8/site-packages/vispy/util/event.py", line 473, in _invoke_callback
    _handle_exception(self.ignore_callback_errors,
  File "/Users/talley/miniconda3/envs/napdev/lib/python3.8/site-packages/vispy/util/event.py", line 471, in _invoke_callback
    cb(event)
  File "/Users/talley/Dropbox (HMS)/Python/forks/napari/napari/_vispy/vispy_camera.py", line 148, in on_draw
    self._camera.zoom = self.zoom
  File "/Users/talley/Dropbox (HMS)/Python/forks/napari/napari/utils/events/evented_model.py", line 89, in __setattr__
    getattr(self.events, name)(value=after)  # emit event
  File "/Users/talley/Dropbox (HMS)/Python/forks/napari/napari/utils/events/event.py", line 513, in __call__
    self._invoke_callback(cb, event)
  File "/Users/talley/Dropbox (HMS)/Python/forks/napari/napari/utils/events/event.py", line 530, in _invoke_callback
    _handle_exception(
  File "/Users/talley/Dropbox (HMS)/Python/forks/napari/napari/utils/events/event.py", line 528, in _invoke_callback
    cb(event)
  File "/Users/talley/Dropbox (HMS)/Python/forks/napari/napari/_vispy/vispy_camera.py", line 133, in _on_zoom_change
    self.zoom = self._camera.zoom
  File "/Users/talley/Dropbox (HMS)/Python/forks/napari/napari/_vispy/vispy_camera.py", line 110, in zoom
    if self.zoom == zoom:
  File "/Users/talley/Dropbox (HMS)/Python/forks/napari/napari/_vispy/vispy_camera.py", line 94, in zoom
    canvas_size = np.min(self._view.canvas.size)
  File "/Users/talley/miniconda3/envs/napdev/lib/python3.8/site-packages/vispy/app/canvas.py", line 336, in size
    size = self._backend._vispy_get_size()
  File "/Users/talley/miniconda3/envs/napdev/lib/python3.8/site-packages/vispy/app/backends/_qt.py", line 434, in _vispy_get_size
    g = self.geometry()
RuntimeError: wrapped C/C++ object of type CanvasBackendDesktop has been deleted
```

</details>

however... if I comment out _just_ this line where the canvas draw event is connect to the `VispyCamera.on_draw` method... then it works (meaning I'm able to create a viewer, close it, and then create a new one).

https://github.com/napari/napari/blob/a91ba740d767feab9f6f3135bcb34489901ebaa5/napari/_qt/qt_viewer.py#L208

that only gets me so far though: if I add any layers to the viewer before closing, it will also crash the next time I try to show it with `RuntimeError: wrapped C/C++ object of type ModifiedScrollBar has been deleted`

<details>

```pytb
----> 1 v.show()

~/Dropbox (HMS)/Python/forks/napari/napari/viewer.py in show(self)
     92             from .window import Window
     93
---> 94             self.window = Window(self, show=True)
     95
     96         self.window.show()

~/Dropbox (HMS)/Python/forks/napari/napari/_qt/qt_main_window.py in __init__(self, viewer, show)
    106         # Connect the Viewer and create the Main Window
    107         self._qt_window = _QtMainWindow()
--> 108         self.qt_viewer = QtViewer(viewer)
    109         self._qt_window.centralWidget().layout().addWidget(self.qt_viewer)
    110         self._qt_window.setWindowTitle(self.qt_viewer.viewer.title)

~/Dropbox (HMS)/Python/forks/napari/napari/_qt/qt_viewer.py in __init__(self, viewer, welcome)
    100
    101         self.viewer = viewer
--> 102         self.dims = QtDims(self.viewer.dims)
    103         self.controls = QtLayerControlsContainer(self.viewer)
    104         self.layers = QtLayerList(self.viewer.layers)

~/Dropbox (HMS)/Python/forks/napari/napari/_qt/widgets/qt_dims.py in __init__(self, dims, parent)
     55
     56         # Update the number of sliders now that the dims have been added
---> 57         self._update_nsliders()
     58         self.dims.events.ndim.connect(self._update_nsliders)
     59         self.dims.events.current_step.connect(self._update_slider)

~/Dropbox (HMS)/Python/forks/napari/napari/_qt/widgets/qt_dims.py in _update_nsliders(self, event)
    155         self._trim_sliders(0)
    156         self._create_sliders(self.dims.ndim)
--> 157         self._update_display()
    158         for i in range(self.dims.ndim):
    159             self._update_range(i)

~/Dropbox (HMS)/Python/forks/napari/napari/_qt/widgets/qt_dims.py in _update_display(self, event)
    131                 # Displayed dimensions correspond to non displayed sliders
    132                 self._displayed_sliders[axis] = False
--> 133                 self.dims.last_used = 0
    134                 widget.hide()
    135             else:

~/Dropbox (HMS)/Python/forks/napari/napari/utils/events/evented_model.py in __setattr__(self, name, value)
     87         are_equal = self.__eq_operators__.get(name, operator.eq)
     88         if not are_equal(after, before):
---> 89             getattr(self.events, name)(value=after)  # emit event
     90
     91     # expose the private EmitterGroup publically

~/Dropbox (HMS)/Python/forks/napari/napari/utils/events/event.py in __call__(self, *args, **kwargs)
    511                     continue
    512
--> 513                 self._invoke_callback(cb, event)
    514                 if event.blocked:
    515                     break

~/Dropbox (HMS)/Python/forks/napari/napari/utils/events/event.py in _invoke_callback(self, cb, event)
    528             cb(event)
    529         except Exception:
--> 530             _handle_exception(
    531                 self.ignore_callback_errors,
    532                 self.print_callback_errors,

~/Dropbox (HMS)/Python/forks/napari/napari/utils/events/event.py in _invoke_callback(self, cb, event)
    526     def _invoke_callback(self, cb, event):
    527         try:
--> 528             cb(event)
    529         except Exception:
    530             _handle_exception(

~/Dropbox (HMS)/Python/forks/napari/napari/_qt/widgets/qt_dims.py in _on_last_used_changed(self, event)
     84         for i, widget in enumerate(self.slider_widgets):
     85             sld = widget.slider
---> 86             sld.setProperty('last_used', i == self.dims.last_used)
     87             sld.style().unpolish(sld)
     88             sld.style().polish(sld)

RuntimeError: wrapped C/C++ object of type ModifiedScrollBar has been deleted
```
</details>

So, this PR may be open for a while, but the goal is to achieve what is shown in the first example.