### PR TITLE
Make get_stylesheet public

### DIFF
--- a/napari/qt/__init__.py
+++ b/napari/qt/__init__.py
@@ -1,5 +1,6 @@
 from .._qt.qt_event_loop import get_app, run
 from .._qt.qt_main_window import Window
+from .._qt.qt_resources import get_stylesheet
 from .._qt.qt_viewer import QtViewer
 from .._qt.widgets.qt_viewer_buttons import QtNDisplayButton, QtViewerButtons
 from .threading import create_worker, thread_worker
@@ -12,5 +13,6 @@ __all__ = (
     'thread_worker',
     'Window',
     'get_app',
+    'get_stylesheet',
     'run',
 )


### PR DESCRIPTION
# Description
Following a request from @Czaki in zulip this would expose the `get_stylesheet` method publically under our `napari.qt` namespace.