### PR TITLE
Better plugin errors surfacing in CLI with `--plugin-info`

### DIFF
--- a/docs/release/release_0_4_5.md
+++ b/docs/release/release_0_4_5.md
@@ -71,6 +71,7 @@ set matching contrast limits for multiple channels (#2226).
 - Include a line on adding screenshots/animations to PRs (#2219)
 - Skip perfmon test on windows pyside2 CI (#2223)
 - Generate api file for top-level napari package (#2237)
+- Better plugin errors surfacing in CLI with `--plugin-info` (#2244)
 
 
 ## 9 authors added to this release (alphabetical)

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -24,6 +24,44 @@ class InfoAction(argparse.Action):
         # prevent unrelated INFO logs when doing "napari --info"
         logging.basicConfig(level=logging.WARNING)
         print(sys_info())
+        from .plugins import plugin_manager
+
+        errors = plugin_manager.get_errors()
+        if errors:
+            names = {e.plugin_name for e in errors}
+            print("\n‼️  Errors were detected in the following plugins:")
+            print("(Run 'napari --plugin-info -v' for more details)")
+            print("\n".join([f"  - {n}" for n in names]))
+        sys.exit()
+
+
+class PluginInfoAction(argparse.Action):
+    def __call__(self, *args, **kwargs):
+        # prevent unrelated INFO logs when doing "napari --info"
+        logging.basicConfig(level=logging.WARNING)
+        from .plugins import plugin_manager
+
+        print(plugin_manager)
+
+        verbose = '-v' in sys.argv or '--verbose' in sys.argv
+        errors = plugin_manager.get_errors()
+        if errors:
+            print("‼️  Some errors occurred:")
+            if not verbose:
+                print("   (use '-v') to show full tracebacks")
+            print("-" * 38)
+
+            for err in errors:
+                print(err.plugin_name)
+                print(f"  error: {err!r}")
+                print(f"  cause: {err.__cause__!r}")
+                if verbose:
+                    print("  traceback:")
+                    import traceback
+                    from textwrap import indent
+
+                    tb = traceback.format_tb(err.__cause__.__traceback__)
+                    print(indent("".join(tb), '   '))
         sys.exit()
 
 
@@ -116,6 +154,12 @@ def _run():
         action=InfoAction,
         nargs=0,
         help='show system information and exit',
+    )
+    parser.add_argument(
+        '--plugin-info',
+        action=PluginInfoAction,
+        nargs=0,
+        help='show information on plugins and exit',
     )
     parser.add_argument(
         '--citation',

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -159,7 +159,7 @@ def _run():
         '--plugin-info',
         action=PluginInfoAction,
         nargs=0,
-        help='show information on plugins and exit',
+        help='show information about plugins and exit',
     )
     parser.add_argument(
         '--citation',


### PR DESCRIPTION
# Description
Adds plugin error to `napari --info` with full details at `napari --plugin-info -v`

Currently, if someone makes an error in their plugin module such that it fails to even import, it simply doesn't show in the list of plugins.  It _does_ appear in the `Plugin errors` dialog, but that's hard to discover.  This PR adds two things to the CLI to help plugin devs:

1. if an error prevented a plugin from being registered, it shows up as follows:
```
❯ napari --info
...
Plugins:
  - console: 0.0.2
  - svg: 0.1.4

‼️  Errors were detected in the following plugins:
(Run 'napari --plugin-info -v' for more details)
  - test-plugin
```

2. if you run 'napari --plugin-info', it shows the full hookspec information, and a little info on any errors that occurred:
```sh
PluginManager for "napari"
(10 hook specs and 3 plugins)
---------------------------------------------
builtins v0.4.5.dev26+g77c5821e.d20210209    6 hooks
  - napari_get_reader
  - napari_get_writer
  - napari_write_image
  - napari_write_labels
  - napari_write_points
  - napari_write_shapes

console v0.0.2                        0 hooks

svg v0.1.4                            6 hooks
  - napari_get_writer
  - napari_write_image
  - napari_write_labels
  - napari_write_points
  - napari_write_shapes
  - napari_write_vectors


‼️  Some errors occurred:
   (use '-v') to show full tracebacks
--------------------------------------
test-plugin
  error: PluginImportError('Error while importing module _test')
  cause: ZeroDivisionError('division by zero')
```

3. and if you use a verbose flag with `--plugin-info` you get the full traceback:

```sh
‼️  Some errors occurred:
--------------------------------------
test-plugin
  error: PluginImportError('Error while importing module _test')
  cause: ZeroDivisionError('division by zero')
  traceback:
     File "/Users/talley/miniconda3/envs/napdev/lib/python3.8/site-packages/napari_plugin_engine/manager.py", line 292, in _load_and_register
       module = load(mod_name)
     File "/Users/talley/miniconda3/envs/napdev/lib/python3.8/site-packages/napari_plugin_engine/manager.py", line 1005, in load
       module = importlib.import_module(match.group('module'))
     File "/Users/talley/miniconda3/envs/napdev/lib/python3.8/importlib/__init__.py", line 127, in import_module
       return _bootstrap._gcd_import(name[level:], package, level)
     File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
     File "<frozen importlib._bootstrap>", line 991, in _find_and_load
     File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
     File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
     File "<frozen importlib._bootstrap_external>", line 783, in exec_module
     File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
     File "/Users/talley/Desktop/test/_test.py", line 9, in <module>
       1/0
```


would be nice to get this in for 0.4.5, since it's currently quite frustrating to find this otherwise.


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
