### PR TITLE
Fix API Reference link in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,4 +50,4 @@ here is more technical and focuses on understanding how napari works.
 # developer introduction
 
 Information on specific functions, classes, and methods is available in the
-{doc}`api`.
+[API Reference](api/index.rst).


### PR DESCRIPTION
# Description
the "API Reference" link in the text at the bottom of docs home page is linking to the API docs of napari-plugin-engine.