### PR TITLE
add missing release notes 0.4.5

### DIFF
--- a/docs/release/release_0_4_5.md
+++ b/docs/release/release_0_4_5.md
@@ -71,6 +71,7 @@ set matching contrast limits for multiple channels (#2226).
 - Include a line on adding screenshots/animations to PRs (#2219)
 - Skip perfmon test on windows pyside2 CI (#2223)
 - Generate api file for top-level napari package (#2237)
+- Fix API Reference link in docs (#2248)
 
 
 ## 9 authors added to this release (alphabetical)

--- a/docs/release/release_0_4_5.md
+++ b/docs/release/release_0_4_5.md
@@ -72,6 +72,7 @@ set matching contrast limits for multiple channels (#2226).
 - Skip perfmon test on windows pyside2 CI (#2223)
 - Generate api file for top-level napari package (#2237)
 - Fix API Reference link in docs (#2248)
+- Add missing release notes (#2250)
 
 
 ## 9 authors added to this release (alphabetical)

--- a/docs/release/release_0_4_5.md
+++ b/docs/release/release_0_4_5.md
@@ -75,6 +75,8 @@ set matching contrast limits for multiple channels (#2226).
 - Add pluginmanager fixture (#2247)
 - Fix API Reference link in docs (#2248)
 - Add missing release notes (#2250)
+- Update napari_plugin_tester docstring (#2251)
+- Remove pluginmanager fixture in favor of devtools repo (#2252)
 
 
 ## 9 authors added to this release (alphabetical)

--- a/docs/release/release_0_4_5.md
+++ b/docs/release/release_0_4_5.md
@@ -72,6 +72,7 @@ set matching contrast limits for multiple channels (#2226).
 - Skip perfmon test on windows pyside2 CI (#2223)
 - Generate api file for top-level napari package (#2237)
 - Better plugin errors surfacing in CLI with `--plugin-info` (#2244)
+- Add pluginmanager fixture (#2247)
 - Fix API Reference link in docs (#2248)
 - Add missing release notes (#2250)
 


### PR DESCRIPTION
# Description
Adds missing release notes to 0.4.5. We should wait until we make the next rc to merge this as we might still be adding things
