### PR TITLE
Add hook implementation function name to plugin call order sorter

### DIFF
--- a/napari/_qt/widgets/qt_eliding_label.py
+++ b/napari/_qt/widgets/qt_eliding_label.py
@@ -9,18 +9,22 @@ class ElidingLabel(QLabel):
     def __init__(self, text='', parent=None):
         super().__init__(parent)
         self._text = text
-        self.fm = QFontMetrics(self.font())
 
     def setText(self, txt):
         self._text = txt
-        short = self.fm.elidedText(self._text, Qt.ElideRight, self.width())
+        short = self._getShortText(self.width())
         super().setText(short)
 
     def resizeEvent(self, rEvent):
         width = rEvent.size().width()
-        short = self.fm.elidedText(self._text, Qt.ElideRight, width)
+        short = self._getShortText(width)
         super().setText(short)
         rEvent.accept()
+
+    def _getShortText(self, width):
+        self.fm = QFontMetrics(self.font())
+        short = self.fm.elidedText(self._text, Qt.ElideRight, width)
+        return short
 
 
 class MultilineElidedLabel(QFrame):

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Union
 
 from napari_plugin_engine import HookCaller, HookImplementation, PluginManager
 from qtpy.QtCore import QEvent, Qt, Signal, Slot
+from qtpy.QtGui import QFont
 from qtpy.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -76,21 +77,17 @@ class ImplementationListItem(QFrame):
         self.position_label = QLabel()
         self.update_position_label()
 
-        # ~~~just show function name
+        # ~~~show plugin name + function name
         self.setToolTip("Click and drag to change call order")
-        self.plugin_name_label = QLabel(
-            f"{item.hook_implementation.function.__name__}"
+        self.plugin_name_label = QLabel(item.hook_implementation.plugin_name)
+        plugin_name_font = QFont()
+        plugin_name_font.setPointSize(8)
+        self.plugin_name_label.setFont(plugin_name_font)
+        self.function_name_label = QLabel(
+            item.hook_implementation.function.__name__
         )
 
-        # ~~~show plugin name + function name
-        # self.setToolTip("Click and drag to change call order")
-        # self.plugin_name_label = QLabel(f"{item.hook_implementation.plugin_name}: {item.hook_implementation.function.__name__}")
-
-        # ~~~show plugin name in tooltip
-        # self.setToolTip(f"Plugin: {item.hook_implementation.plugin_name}\n\nClick and drag to change call order")
-        # self.plugin_name_label = QLabel(f"{item.hook_implementation.function.__name__}")
-
-        # ~~~show plugin name if named as spec, otherwise function name
+        # ~~~show plugin name if named as spec, otherwise function name with plugin tooltip
         # has_spec = bool(item.hook_implementation._specname)
         # display_name = item.hook_implementation.function.__name__ if has_spec\
         #             else item.hook_implementation.plugin_name
@@ -107,6 +104,7 @@ class ImplementationListItem(QFrame):
         )
         layout.addWidget(self.position_label)
         layout.addWidget(self.enabled_checkbox)
+        layout.addWidget(self.function_name_label)
         layout.addWidget(self.plugin_name_label)
         layout.setStretch(2, 1)
         layout.setContentsMargins(0, 0, 0, 0)

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -21,6 +21,7 @@ from qtpy.QtWidgets import (
 
 from ...plugins import plugin_manager as napari_plugin_manager
 from ..utils import drag_with_pixmap
+from ..widgets.qt_eliding_label import ElidingLabel
 
 
 def rst2html(text):
@@ -78,8 +79,19 @@ class ImplementationListItem(QFrame):
 
         # ~~~show plugin name + function name
         self.setToolTip("Click and drag to change call order")
-        self.plugin_name_label = QLabel(item.hook_implementation.plugin_name)
+        self.plugin_name_label = ElidingLabel(parent=self)
         self.plugin_name_label.setObjectName('small_text')
+        self.plugin_name_label.setText(item.hook_implementation.plugin_name)
+        sizePolicy = QSizePolicy(
+            QSizePolicy.MinimumExpanding, QSizePolicy.Preferred
+        )
+        sizePolicy.setHorizontalStretch(1)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(
+            self.plugin_name_label.sizePolicy().hasHeightForWidth()
+        )
+        self.plugin_name_label.setSizePolicy(sizePolicy)
+
         self.function_name_label = QLabel(
             item.hook_implementation.function.__name__
         )

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -86,12 +86,6 @@ class ImplementationListItem(QFrame):
         )
         plugin_name_size_policy.setHorizontalStretch(2)
         self.plugin_name_label.setSizePolicy(plugin_name_size_policy)
-        self.plugin_name_label.setStyleSheet(
-            """QLabel{
-            background-color: blue
-        }
-        """
-        )
 
         self.function_name_label = QLabel(
             item.hook_implementation.function.__name__
@@ -106,7 +100,7 @@ class ImplementationListItem(QFrame):
         layout.addWidget(self.position_label)
         layout.addWidget(self.enabled_checkbox)
         layout.addWidget(self.function_name_label)
-        layout.addWidget(self.plugin_name_label, alignment=Qt.AlignRight)
+        layout.addWidget(self.plugin_name_label)
         layout.setStretch(2, 1)
         layout.setContentsMargins(0, 0, 0, 0)
 

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -5,7 +5,6 @@ from typing import List, Optional, Union
 
 from napari_plugin_engine import HookCaller, HookImplementation, PluginManager
 from qtpy.QtCore import QEvent, Qt, Signal, Slot
-from qtpy.QtGui import QFont
 from qtpy.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -80,21 +79,10 @@ class ImplementationListItem(QFrame):
         # ~~~show plugin name + function name
         self.setToolTip("Click and drag to change call order")
         self.plugin_name_label = QLabel(item.hook_implementation.plugin_name)
-        plugin_name_font = QFont()
-        plugin_name_font.setPointSize(8)
-        self.plugin_name_label.setFont(plugin_name_font)
+        self.plugin_name_label.setObjectName('small_text')
         self.function_name_label = QLabel(
             item.hook_implementation.function.__name__
         )
-
-        # ~~~show plugin name if named as spec, otherwise function name with plugin tooltip
-        # has_spec = bool(item.hook_implementation._specname)
-        # display_name = item.hook_implementation.function.__name__ if has_spec\
-        #             else item.hook_implementation.plugin_name
-        # tooltip_prefix = f"Plugin: {item.hook_implementation.plugin_name}\n\n" if has_spec\
-        #             else ''
-        # self.setToolTip(f"{tooltip_prefix}Click and drag to change call order")
-        # self.plugin_name_label = QLabel(display_name)
 
         self.enabled_checkbox = QCheckBox(self)
         self.enabled_checkbox.setToolTip("Uncheck to disable this plugin")

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -67,7 +67,6 @@ class ImplementationListItem(QFrame):
 
     def __init__(self, item: QListWidgetItem, parent: QWidget = None):
         super().__init__(parent)
-        self.setToolTip("Click and drag to change call order")
         self.item = item
         self.opacity = QGraphicsOpacityEffect(self)
         self.setGraphicsEffect(self.opacity)
@@ -77,7 +76,29 @@ class ImplementationListItem(QFrame):
         self.position_label = QLabel()
         self.update_position_label()
 
-        self.plugin_name_label = QLabel(item.hook_implementation.plugin_name)
+        # ~~~just show function name
+        self.setToolTip("Click and drag to change call order")
+        self.plugin_name_label = QLabel(
+            f"{item.hook_implementation.function.__name__}"
+        )
+
+        # ~~~show plugin name + function name
+        # self.setToolTip("Click and drag to change call order")
+        # self.plugin_name_label = QLabel(f"{item.hook_implementation.plugin_name}: {item.hook_implementation.function.__name__}")
+
+        # ~~~show plugin name in tooltip
+        # self.setToolTip(f"Plugin: {item.hook_implementation.plugin_name}\n\nClick and drag to change call order")
+        # self.plugin_name_label = QLabel(f"{item.hook_implementation.function.__name__}")
+
+        # ~~~show plugin name if named as spec, otherwise function name
+        # has_spec = bool(item.hook_implementation._specname)
+        # display_name = item.hook_implementation.function.__name__ if has_spec\
+        #             else item.hook_implementation.plugin_name
+        # tooltip_prefix = f"Plugin: {item.hook_implementation.plugin_name}\n\n" if has_spec\
+        #             else ''
+        # self.setToolTip(f"{tooltip_prefix}Click and drag to change call order")
+        # self.plugin_name_label = QLabel(display_name)
+
         self.enabled_checkbox = QCheckBox(self)
         self.enabled_checkbox.setToolTip("Uncheck to disable this plugin")
         self.enabled_checkbox.stateChanged.connect(self._set_enabled)

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -81,6 +81,11 @@ class ImplementationListItem(QFrame):
         self.plugin_name_label = ElidingLabel(parent=self)
         self.plugin_name_label.setObjectName('small_text')
         self.plugin_name_label.setText(item.hook_implementation.plugin_name)
+        plugin_name_size_policy = QSizePolicy(
+            QSizePolicy.MinimumExpanding, QSizePolicy.Preferred
+        )
+        plugin_name_size_policy.setHorizontalStretch(2)
+        self.plugin_name_label.setSizePolicy(plugin_name_size_policy)
 
         self.function_name_label = QLabel(
             item.hook_implementation.function.__name__

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -86,6 +86,12 @@ class ImplementationListItem(QFrame):
         )
         plugin_name_size_policy.setHorizontalStretch(2)
         self.plugin_name_label.setSizePolicy(plugin_name_size_policy)
+        self.plugin_name_label.setStyleSheet(
+            """QLabel{
+            background-color: blue
+        }
+        """
+        )
 
         self.function_name_label = QLabel(
             item.hook_implementation.function.__name__
@@ -100,7 +106,7 @@ class ImplementationListItem(QFrame):
         layout.addWidget(self.position_label)
         layout.addWidget(self.enabled_checkbox)
         layout.addWidget(self.function_name_label)
-        layout.addWidget(self.plugin_name_label)
+        layout.addWidget(self.plugin_name_label, alignment=Qt.AlignRight)
         layout.setStretch(2, 1)
         layout.setContentsMargins(0, 0, 0, 0)
 

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -77,20 +77,10 @@ class ImplementationListItem(QFrame):
         self.position_label = QLabel()
         self.update_position_label()
 
-        # ~~~show plugin name + function name
         self.setToolTip("Click and drag to change call order")
         self.plugin_name_label = ElidingLabel(parent=self)
         self.plugin_name_label.setObjectName('small_text')
         self.plugin_name_label.setText(item.hook_implementation.plugin_name)
-        sizePolicy = QSizePolicy(
-            QSizePolicy.MinimumExpanding, QSizePolicy.Preferred
-        )
-        sizePolicy.setHorizontalStretch(1)
-        sizePolicy.setVerticalStretch(0)
-        sizePolicy.setHeightForWidth(
-            self.plugin_name_label.sizePolicy().hasHeightForWidth()
-        )
-        self.plugin_name_label.setSizePolicy(sizePolicy)
 
         self.function_name_label = QLabel(
             item.hook_implementation.function.__name__


### PR DESCRIPTION
# Description
As discussed at the dev meeting, having multiple hook implementations in a single file works out of the box, but each implementation is displayed by plugin name in the call order sorter, which is confusing.
![plugin_call_order_original](https://user-images.githubusercontent.com/17995243/107722506-27988a00-6d33-11eb-94a9-c909445fd1e0.png)

The two display options which we agreed were most reasonable were
1. Display both the function name and the plugin name in the widget
2. Display the plugin name if the hook implementation doesn't have a custom name, and the function name if it does, leaving the plugin name to a tooltip.

Screenshots of what each option would look like:
![plugin_call_order_both](https://user-images.githubusercontent.com/17995243/107722522-2ebf9800-6d33-11eb-82a9-ac0e6998b241.png) ![plugin_call_order_tooltip](https://user-images.githubusercontent.com/17995243/107722527-3121f200-6d33-11eb-829a-eb07f0ccfd4f.png)

I think option 1 is the nicest, but interested to hear what people would prefer.
