### PR TITLE
Explicitly document ability to implement multiple of the same hook

### DIFF
--- a/docs/plugins/for_plugin_developers.rst
+++ b/docs/plugins/for_plugin_developers.rst
@@ -191,7 +191,7 @@ implementation decorator:
    def whatever_name_you_want(path: str):
       ...
 
-This allows you to specify multiple hook implementations for each plugin without needing
+This allows you to specify multiple hook implementations of the same hook specification in the same file, without needing
 an entirely new module or entry point.
 
 .. _plugin-discovery:

--- a/docs/plugins/for_plugin_developers.rst
+++ b/docs/plugins/for_plugin_developers.rst
@@ -192,7 +192,7 @@ implementation decorator:
       ...
 
 This allows you to specify multiple hook implementations of the same hook 
-specification in the same file, without needing an entirely new module or entry point.
+specification in the same module or class, without needing a separate entry point.
 
 .. _plugin-discovery:
 

--- a/docs/plugins/for_plugin_developers.rst
+++ b/docs/plugins/for_plugin_developers.rst
@@ -191,8 +191,8 @@ implementation decorator:
    def whatever_name_you_want(path: str):
       ...
 
-This allows you to specify multiple hook implementations of the same hook specification in the same file, without needing
-an entirely new module or entry point.
+This allows you to specify multiple hook implementations of the same hook 
+specification in the same file, without needing an entirely new module or entry point.
 
 .. _plugin-discovery:
 

--- a/docs/plugins/for_plugin_developers.rst
+++ b/docs/plugins/for_plugin_developers.rst
@@ -191,6 +191,9 @@ implementation decorator:
    def whatever_name_you_want(path: str):
       ...
 
+This allows you to specify multiple hook implementations for each plugin without needing
+an entirely new module or entry point.
+
 .. _plugin-discovery:
 
 Step 3: Make your plugin discoverable

--- a/napari/plugins/hook_specifications.py
+++ b/napari/plugins/hook_specifications.py
@@ -341,7 +341,9 @@ def napari_experimental_provide_function() -> Union[
     -------
     function(s) : FunctionType or list of FunctionType
         Implementations should provide either a single function, or a list of
-        functions. The functions should have Python type annotations so that
+        functions. Note that this does not preclude specifying multiple
+        separate implementations in the same file.
+        The functions should have Python type annotations so that
         `magicgui <https://napari.org/magicgui>`_ can generate a widget from
         them.
 
@@ -385,7 +387,8 @@ def napari_experimental_provide_dock_widget() -> Union[
         that ``shortcut=`` keyword is not yet supported).
 
         Implementations may also return a list, in which each item must be a
-        callable or ``(callable, dict)`` tuple.
+        callable or ``(callable, dict)`` tuple. Note that this does not
+        preclude specifying multiple separate implementations in the same file.
 
     Examples
     --------

--- a/napari/plugins/hook_specifications.py
+++ b/napari/plugins/hook_specifications.py
@@ -342,7 +342,7 @@ def napari_experimental_provide_function() -> Union[
     function(s) : FunctionType or list of FunctionType
         Implementations should provide either a single function, or a list of
         functions. Note that this does not preclude specifying multiple
-        separate implementations in the same file.
+        separate implementations in the same module or class.
         The functions should have Python type annotations so that
         `magicgui <https://napari.org/magicgui>`_ can generate a widget from
         them.
@@ -388,7 +388,8 @@ def napari_experimental_provide_dock_widget() -> Union[
 
         Implementations may also return a list, in which each item must be a
         callable or ``(callable, dict)`` tuple. Note that this does not
-        preclude specifying multiple separate implementations in the same file.
+        preclude specifying multiple separate implementations in the same module
+        or class.
 
     Examples
     --------


### PR DESCRIPTION
As above, added notes to documentation and docstrings to highlight ability to specify multiple hooks of the same spec in the same file. I didn't add a heap of detail, happy to expand more if it's deemed necessary.