### PR TITLE
BUG: prevent garbage collection of viewer during startup.

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -230,13 +230,24 @@ def _run():
         splash = NapariSplashScreen()
         splash.close()  # will close once event loop starts
 
-        view_path(
+        # viewer is unused but _must_  be kept around.
+        # it will be referenced by the global window only
+        # once napari has finished starting
+        # but in the meantime if the garbage collector runs;
+        # it will collect it and hang napari at start time.
+        # in a way that is machine, os, time (and likely weather dependant).
+        _viewer = view_path(  # noqa: F841
             args.paths,
             stack=args.stack,
             plugin=args.plugin,
             layer_type=args.layer_type,
             **kwargs,
         )
+        # avoid regression; aggressively garbage collect _now_ to make sure we
+        # don't leak this again
+        import gc
+
+        gc.collect()
         run(gui_exceptions=True)
 
 

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -243,11 +243,7 @@ def _run():
             layer_type=args.layer_type,
             **kwargs,
         )
-        # avoid regression; aggressively garbage collect _now_ to make sure we
-        # don't leak this again
-        import gc
 
-        gc.collect()
         run(gui_exceptions=True)
 
 


### PR DESCRIPTION
I got regular hang at startup, depending on the code I'm modifying;
this is one of the things I found that can get GC'd and hang at startup.
There might be others; but at least this one will reduce the size of the
GC debug log to help me tracked my other issue.


--- 


I can also return _viewer from the function to make it part of the API and keep a reference around. 

I'll also appreciate is someone can try on their machine, keep the `collect()` call and confirm that they also see a hang at startup if the value is not assigned.