### PR TITLE
Add `theme` parameter to `get_stylesheet`

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -154,6 +154,23 @@ class Window:
         if show:
             self.show()
 
+    def __getattr__(self, name):
+        if name == 'raw_stylesheet':
+            import warnings
+
+            warnings.warn(
+                (
+                    "The 'raw_stylesheet' attribute is deprecated and will be"
+                    "removed in version 0.4.7.  Please use "
+                    "`napari.qt.get_stylesheet` instead"
+                ),
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            return get_stylesheet()
+
+        return object.__getattribute__(self, name)
+
     def _add_menubar(self):
         """Add menubar to napari app."""
         self.main_menu = self._qt_window.menuBar()

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -27,7 +27,6 @@ from .. import plugins
 from ..utils import config, perf
 from ..utils.io import imsave
 from ..utils.misc import in_jupyter
-from ..utils.theme import get_theme, template
 from .dialogs.qt_about import QtAbout
 from .dialogs.qt_plugin_dialog import QtPluginDialog
 from .dialogs.qt_plugin_report import QtPluginErrReporter
@@ -97,8 +96,6 @@ class Window:
         Window menu.
     """
 
-    raw_stylesheet = get_stylesheet()
-
     def __init__(self, viewer, *, show: bool = True):
         # create QApplication if it doesn't already exist
         get_app()
@@ -107,7 +104,7 @@ class Window:
         self._qt_window = _QtMainWindow()
         self.qt_viewer = QtViewer(viewer)
         self._qt_window.centralWidget().layout().addWidget(self.qt_viewer)
-        self._qt_window.setWindowTitle(self.qt_viewer.viewer.title)
+        self._qt_window.setWindowTitle(viewer.title)
         self._status_bar = self._qt_window.statusBar()
 
         # Dictionary holding dock widgets
@@ -142,10 +139,10 @@ class Window:
         )
         self.window_menu.addSeparator()
 
-        self.qt_viewer.viewer.events.status.connect(self._status_changed)
-        self.qt_viewer.viewer.events.help.connect(self._help_changed)
-        self.qt_viewer.viewer.events.title.connect(self._title_changed)
-        self.qt_viewer.viewer.events.theme.connect(self._update_theme)
+        viewer.events.status.connect(self._status_changed)
+        viewer.events.help.connect(self._help_changed)
+        viewer.events.title.connect(self._title_changed)
+        viewer.events.theme.connect(self._update_theme)
 
         if perf.USE_PERFMON:
             # Add DebugMenu and dockPerformance if using perfmon.
@@ -859,17 +856,8 @@ class Window:
 
     def _update_theme(self, event=None):
         """Update widget color theme."""
-        # set window styles which don't use the primary stylesheet
-        # FIXME: this is a problem with the stylesheet not using properties
-        theme = get_theme(self.qt_viewer.viewer.theme)
-        self._status_bar.setStyleSheet(
-            template(
-                'QStatusBar { background: {{ background }}; '
-                'color: {{ text }}; }',
-                **theme,
-            )
-        )
-        self._qt_window.setStyleSheet(template(self.raw_stylesheet, **theme))
+        theme_name = self.qt_viewer.viewer.theme
+        self._qt_window.setStyleSheet(get_stylesheet(theme_name))
 
     def _status_changed(self, event):
         """Update status bar.

--- a/napari/_qt/qt_resources/__init__.py
+++ b/napari/_qt/qt_resources/__init__.py
@@ -134,16 +134,19 @@ def import_resources(
     return respath, load
 
 
-@lru_cache(maxsize=4)
-def get_stylesheet(extra: Optional[List[str]] = None) -> str:
-    """Combine all qss files into single (cached) style string.
-
-    Note, this string may still have {{ template_variables }} that need to be
-    replaced using the :func:`napari.utils.theme.template` function.  (i.e. the
-    output of this function serves as the input of ``template()``)
+@lru_cache(maxsize=12)
+def get_stylesheet(
+    theme: str = None, extra: Optional[List[str]] = None
+) -> str:
+    """Combine all qss files into single, possibly pre-themed, style string.
 
     Parameters
     ----------
+    theme : str, optional
+        Theme to apply to the stylesheet. If no theme is provided, the returned
+        stylesheet will still have ``{{ template_variables }}`` that need to be
+        replaced using the :func:`napari.utils.theme.template` function prior
+        to using the stylesheet.
     extra : list of str, optional
         Additional paths to QSS files to include in stylesheet, by default None
 
@@ -161,6 +164,12 @@ def get_stylesheet(extra: Optional[List[str]] = None) -> str:
         for file in extra:
             with open(file) as f:
                 stylesheet += f.read()
+
+    if theme:
+        from ...utils.theme import get_theme, template
+
+        return template(stylesheet, **get_theme(theme))
+
     return stylesheet
 
 

--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -37,6 +37,11 @@ QMainWindow::separator:hover {
     background: {{ highlight }};
 }
 
+QStatusBar { 
+  background: {{ background }};
+  color: {{ text }};
+}
+
 /* ------------- DockWidgets --------- */
 
 #QtCustomTitleBar {

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 import numpy as np
-from qtpy.QtCore import QCoreApplication, QObject, Qt
+from qtpy.QtCore import QCoreApplication, QObject, QSize, Qt
 from qtpy.QtGui import QCursor, QGuiApplication
 from qtpy.QtWidgets import QFileDialog, QSplitter, QVBoxLayout, QWidget
 
@@ -242,7 +242,10 @@ class QtViewer(QSplitter):
             parent=self,
             size=self.viewer._canvas_size[::-1],
         )
+        self.canvas.events.ignore_callback_errors = False
         self.canvas.events.draw.connect(self.dims.enable_play)
+        self.canvas.native.setMinimumSize(QSize(200, 200))
+        self.canvas.context.set_depth_func('lequal')
 
         self.canvas.connect(self.on_mouse_move)
         self.canvas.connect(self.on_mouse_press)

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -215,6 +215,25 @@ class QtViewer(QSplitter):
             self.viewer.layers, self._qt_poll
         )
 
+    def __getattr__(self, name):
+        if name == 'raw_stylesheet':
+            import warnings
+
+            from .qt_resources import get_stylesheet
+
+            warnings.warn(
+                (
+                    "The 'raw_stylesheet' attribute is deprecated and will be"
+                    "removed in version 0.4.7.  Please use "
+                    "`napari.qt.get_stylesheet` instead"
+                ),
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            return get_stylesheet()
+
+        return object.__getattribute__(self, name)
+
     def _create_canvas(self) -> None:
         """Create the canvas and hook up events."""
         self.canvas = VispyCanvas(

--- a/napari/_qt/widgets/qt_theme_sample.py
+++ b/napari/_qt/widgets/qt_theme_sample.py
@@ -42,12 +42,9 @@ from qtpy.QtWidgets import (
 )
 
 from ...utils.io import imsave
-from ...utils.theme import available_themes, get_theme, template
 from ..qt_resources import get_stylesheet
 from ..utils import QImg2array
 from .qt_range_slider import QHRangeSlider
-
-raw_stylesheet = get_stylesheet()
 
 blurb = """
 <h3>Heading</h3>
@@ -95,7 +92,7 @@ class SampleWidget(QWidget):
     def __init__(self, theme='dark', emphasized=False):
         super().__init__(None)
         self.setProperty('emphasized', emphasized)
-        self.setStyleSheet(template(raw_stylesheet, **get_theme(theme)))
+        self.setStyleSheet(get_stylesheet(theme))
         lay = QVBoxLayout()
         self.setLayout(lay)
         lay.addWidget(QPushButton('push button'))
@@ -159,6 +156,8 @@ class SampleWidget(QWidget):
 
 if __name__ == "__main__":
     import sys
+
+    from ...utils.theme import available_themes
 
     themes = [sys.argv[1]] if len(sys.argv) > 1 else available_themes()
     app = QApplication([])

--- a/napari/_vispy/vispy_canvas.py
+++ b/napari/_vispy/vispy_canvas.py
@@ -1,6 +1,5 @@
 """VispyCanvas class.
 """
-from qtpy.QtCore import QSize
 from vispy.scene import SceneCanvas
 
 from .utils_gl import get_max_texture_sizes
@@ -32,10 +31,6 @@ class VispyCanvas(SceneCanvas):
         # get_max_texture_sizes() will return the same results because it's
         # using an lru_cache.
         self.max_texture_sizes = get_max_texture_sizes()
-
-        self.events.ignore_callback_errors = False
-        self.native.setMinimumSize(QSize(200, 200))
-        self.context.set_depth_func('lequal')
 
     def _process_mouse_event(self, event):
         """Ignore mouse wheel events which have modifiers."""

--- a/napari/_vispy/vispy_canvas.py
+++ b/napari/_vispy/vispy_canvas.py
@@ -1,5 +1,6 @@
 """VispyCanvas class.
 """
+from qtpy.QtCore import QSize
 from vispy.scene import SceneCanvas
 
 from .utils_gl import get_max_texture_sizes
@@ -31,6 +32,10 @@ class VispyCanvas(SceneCanvas):
         # get_max_texture_sizes() will return the same results because it's
         # using an lru_cache.
         self.max_texture_sizes = get_max_texture_sizes()
+
+        self.events.ignore_callback_errors = False
+        self.native.setMinimumSize(QSize(200, 200))
+        self.context.set_depth_func('lequal')
 
     def _process_mouse_event(self, event):
         """Ignore mouse wheel events which have modifiers."""


### PR DESCRIPTION
# Description
There are a few different places where we repeat this pattern:
```python
from napari.qt import get_stylesheet
from napari.utils.theme import get_theme, template

raw_stylesheet = get_stylesheet()
theme = get_theme(theme_name)
obj.setStyleSheet(template(raw_stylesheet, **theme))
```
Not only does that force lots of imports everywhere, but it's repetitive, and doesn't take advantage of stylesheet caching (since the template needs to be reapplied each time).  This PR lets `get_stylesheet` optionally apply the theme templating:

```python
from napari.qt import get_stylesheet

qt_obj.setStyleSheet(get_stylesheet(theme_name))
```

It also removes the manual `QStatusBar` theming, which is no longer necessary with proper widget lineages.  The _only_ two blockers to full stylesheet inheritance now are the `canvas` object (which does not use stylesheets and needs to manually set `bgcolor`), and the `napari-console`, due to the fact that `qtconsole` also doesn't use the native stylesheet inheritance, but rather requires you to manually set it.

@sofroniewn, this PR will break napari-console, and requires the following change there:
```python

# qt_console.py
    def _update_theme(self, event=None):
        """Update the napari GUI theme."""
        from napari.utils.theme import get_theme
        from napari.qt import get_stylesheet

        theme = get_theme(self.viewer.theme)
		# qtconsole unfortunately won't inherit the parent stylesheet
        self.style_sheet = get_stylesheet(self.viewer.theme)
        self.syntax_style = theme["syntax_style"]
        bracket_color = QColor(*str_to_rgb(theme["highlight"]))
        self._bracket_matcher.format.setBackground(bracket_color)
``` 


It would be easy enough to also accomplish #2103 here too, we just need to decide on the API. (for instance, should it be `viewer.canvas_background_override` ... or should it be somewhere only in qt land, like `viewer.window.qt_viewer.canvas.background_override`  (my preference would be the latter, since we don't really "have" a public canvas concept at the moment

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
