### PR TITLE
Fix EventedModel signatures with PySide2 imported

### DIFF
--- a/napari/utils/events/_tests/test_evented_model.py
+++ b/napari/utils/events/_tests/test_evented_model.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import ClassVar
 from unittest.mock import Mock
 
@@ -231,3 +232,14 @@ def test_values_updated():
     user1.events.id.assert_not_called()
     user2.events.id.assert_not_called()
     assert user1_events.call_count == 0
+
+
+def test_evented_model_signature():
+    class T(EventedModel):
+        x: int
+        y: str = 'yyy'
+        z = b'zzz'
+
+    assert isinstance(T.__signature__, inspect.Signature)
+    sig = inspect.signature(T)
+    assert str(sig) == "(*, x: int, y: str = 'yyy', z: bytes = b'zzz') -> None"

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -32,6 +32,12 @@ def no_class_attributes():
     manager basically "opts-out" of pydantic's ``ClassAttribute`` strategy,
     thereby directly setting the ``cls.__signature__`` to an instance of
     ``inspect.Signature``.
+
+    For additional context, see:
+    - https://github.com/napari/napari/issues/2264
+    - https://github.com/napari/napari/pull/2265
+    - https://bugreports.qt.io/browse/PYSIDE-1004
+    - https://codereview.qt-project.org/c/pyside/pyside-setup/+/261411
     """
 
     if "PySide2" not in sys.modules:

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -1,16 +1,54 @@
 import operator
+import sys
 import warnings
+from contextlib import contextmanager
 from typing import Any, Callable, ClassVar, Dict, Set
 
-from pydantic import BaseModel, PrivateAttr
-from pydantic.main import ModelMetaclass
+from pydantic import BaseModel, PrivateAttr, main, utils
 
 from ...utils.misc import pick_equality_operator
 from .custom_types import JSON_ENCODERS
 from .event import EmitterGroup, Event
 
 
-class EqualityMetaclass(ModelMetaclass):
+@contextmanager
+def no_class_attributes():
+    """Context in which pydantic.main.ClassAttribute just passes value 2.
+
+    Due to a very annoying decision by PySide2, all class ``__signature__``
+    attributes may only be assigned **once**.  (This seems to be regardless of
+    whether the class has anything to do with PySide2 or not).  Furthermore,
+    the PySide2 ``__signature__`` attribute seems to break the python
+    descriptor protocol, which means that class attributes that have a
+    ``__get__`` method will not be able to successfully retrieve their value
+    (instead, the descriptor object itself will be accessed).
+
+    This plays terribly with Pydantic, which assigns a ``ClassAttribute``
+    object to the value of ``cls.__signature__`` in ``ModelMetaclass.__new__``
+    in order to avoid masking the call signature of object instances that have
+    a ``__call__`` method (https://github.com/samuelcolvin/pydantic/pull/1466).
+
+    So, because we only get to set the ``__signature__`` once, this context
+    manager basically "opts-out" of pydantic's ``ClassAttribute`` strategy,
+    thereby directly setting the ``cls.__signature__`` to an instance of
+    ``inspect.Signature``.
+    """
+
+    if "PySide2" not in sys.modules:
+        yield
+        return
+
+    # monkey patch the pydantic ClassAttribute object
+    # the second argument to ClassAttribute is the inspect.Signature object
+    main.ClassAttribute = lambda x, y: y
+    try:
+        yield
+    finally:
+        # undo our monkey patch
+        main.ClassAttribute = utils.ClassAttribute
+
+
+class EventedMetaclass(main.ModelMetaclass):
     """pydantic ModelMetaclass that preps "equality checking" operations.
 
     A metaclass is the thing that "constructs" a class, and ``ModelMetaclass``
@@ -25,7 +63,8 @@ class EqualityMetaclass(ModelMetaclass):
     """
 
     def __new__(mcs, name, bases, namespace, **kwargs):
-        cls = super().__new__(mcs, name, bases, namespace, **kwargs)
+        with no_class_attributes():
+            cls = super().__new__(mcs, name, bases, namespace, **kwargs)
         cls.__eq_operators__ = {
             n: pick_equality_operator(f.type_)
             for n, f in cls.__fields__.items()
@@ -33,7 +72,7 @@ class EqualityMetaclass(ModelMetaclass):
         return cls
 
 
-class EventedModel(BaseModel, metaclass=EqualityMetaclass):
+class EventedModel(BaseModel, metaclass=EventedMetaclass):
 
     # add private attributes for event emission
     _events: EmitterGroup = PrivateAttr(default_factory=EmitterGroup)
@@ -63,8 +102,8 @@ class EventedModel(BaseModel, metaclass=EqualityMetaclass):
         # https://pydantic-docs.helpmanual.io/usage/exporting_models/#modeljson
         json_encoders = JSON_ENCODERS
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
         # add events for each field
         self._events.source = self


### PR DESCRIPTION
# Description
fixes #2264.  This fixes a strange and unfortunate clash resulting from decisions made by PySide2 and pydantic (neither of which I feel we'd have much luck changing upstream).  I put a more thorough explanation in the code docstring itself, but here's the gist:

1. when PySide2 fixed [this bug](https://bugreports.qt.io/browse/PYSIDE-1004), they [made the decision](https://codereview.qt-project.org/c/pyside/pyside-setup/+/261411) to make (all?) python `__signature__` objects dynamically writable (as they should be), but _only_ once (?!).
2. Pydantic, in attempting to [fix signature conflicts](https://github.com/samuelcolvin/pydantic/pull/1466) in cases where a class defines a `__call__` method, uses a descriptor object called [`ClassAttribute`](https://github.com/samuelcolvin/pydantic/blob/13928e5b98dd2bc6c1e61546de20d870a9e3d3e9/pydantic/utils.py#L565) to wrap their custom `inspect.Signature` object during class creation.  such that `cls.__signature__ = ClassAttribute('__signature__', actual_signature)`
3. when accessing `obj.__signature__` PySide2 seems to just return that `ClassAttribute` descriptor rather than calling its `__get__` method... so `inspect.signature` fails.

This PR temporarily monkeypatches pydantic's `ClassAttribute` object to just pass through the signature object directly when constructing our classes... then undoes the patch.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added a test to make sure that signatures are working
- [x] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
