### PR TITLE
Remove callsignature

### DIFF
--- a/napari/layers/_tests/test_serialize.py
+++ b/napari/layers/_tests/test_serialize.py
@@ -1,8 +1,9 @@
+import inspect
+
 import numpy as np
 import pytest
 
 from napari._tests.utils import layer_test_data
-from napari.utils.misc import callsignature
 
 
 @pytest.mark.parametrize('Layer, data, ndim', layer_test_data)
@@ -16,7 +17,7 @@ def test_attrs_arrays(Layer, data, ndim):
     properties = layer._get_state()
 
     # Check every property is in call signature
-    signature = callsignature(Layer)
+    signature = inspect.signature(Layer)
 
     for prop in properties.keys():
         assert prop in signature.parameters

--- a/napari/utils/_tests/test_misc.py
+++ b/napari/utils/_tests/test_misc.py
@@ -7,7 +7,6 @@ import pytest
 from napari.utils.misc import (
     StringEnum,
     abspath_or_url,
-    callsignature,
     ensure_iterable,
     ensure_sequence_of_iterables,
 )
@@ -66,65 +65,6 @@ def test_ensure_iterable(input, expected):
     zipped = zip(range(3), ensure_iterable(input), expected)
     for i, result, expectation in zipped:
         assert result == expectation
-
-
-def test_callsignature():
-    # no arguments
-    assert str(callsignature(lambda: None)) == '()'
-
-    # one arg
-    assert str(callsignature(lambda a: None)) == '(a)'
-
-    # multiple args
-    assert str(callsignature(lambda a, b: None)) == '(a, b)'
-
-    # arbitrary args
-    assert str(callsignature(lambda *args: None)) == '(*args)'
-
-    # arg + arbitrary args
-    assert str(callsignature(lambda a, *az: None)) == '(a, *az)'
-
-    # default arg
-    assert str(callsignature(lambda a=42: None)) == '(a=a)'
-
-    # multiple default args
-    assert str(callsignature(lambda a=0, b=1: None)) == '(a=a, b=b)'
-
-    # arg + default arg
-    assert str(callsignature(lambda a, b=42: None)) == '(a, b=b)'
-
-    # arbitrary kwargs
-    assert str(callsignature(lambda **kwargs: None)) == '(**kwargs)'
-
-    # default arg + arbitrary kwargs
-    assert str(callsignature(lambda a=42, **kwargs: None)) == '(a=a, **kwargs)'
-
-    # arg + default arg + arbitrary kwargs
-    assert str(callsignature(lambda a, b=42, **kw: None)) == '(a, b=b, **kw)'
-
-    # arbitrary args + arbitrary kwargs
-    assert str(callsignature(lambda *args, **kw: None)) == '(*args, **kw)'
-
-    # arg + default arg + arbitrary kwargs
-    assert (
-        str(callsignature(lambda a, b=42, *args, **kwargs: None))
-        == '(a, b=b, *args, **kwargs)'
-    )
-
-    # kwonly arg
-    assert str(callsignature(lambda *, a: None)) == '(a=a)'
-
-    # arg + kwonly arg
-    assert str(callsignature(lambda a, *, b: None)) == '(a, b=b)'
-
-    # default arg + kwonly arg
-    assert str(callsignature(lambda a=42, *, b: None)) == '(a=a, b=b)'
-
-    # kwonly args + everything
-    assert (
-        str(callsignature(lambda a, b=42, *, c, d=5, **kwargs: None))
-        == '(a, b=b, c=c, d=d, **kwargs)'
-    )
 
 
 def test_string_enum():

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -319,34 +319,6 @@ class CallDefault(inspect.Parameter):
         return formatted
 
 
-class CallSignature(inspect.Signature):
-    _parameter_cls = CallDefault
-
-    def __str__(self):
-        """do not render separators
-
-        commented code is what was taken out from
-        the copy/pasted inspect module code :)
-        """
-        result = []
-        # render_pos_only_separator = False
-        # render_kw_only_separator = True
-        for param in self.parameters.values():
-            formatted = str(param)
-            result.append(formatted)
-
-        rendered = '({})'.format(', '.join(result))
-
-        if self.return_annotation is not inspect._empty:
-            anno = inspect.formatannotation(self.return_annotation)
-            rendered += f' -> {anno}'
-
-        return rendered
-
-
-callsignature = CallSignature.from_callable
-
-
 def all_subclasses(cls: Type) -> set:
     """Recursively find all subclasses of class ``cls``.
 


### PR DESCRIPTION
# Description

This PR removes the `callsignature` subclass of `inspect.Signature`.  It was there to provide modified string rendering of an `inspect.Signature`.  It was breaking in a PR I was playing with because it made the assumption that there were no return annotations in the signature.  I think in most cases it's better to use `inspect.replace` to make a new `Signature` that reflects how you want the signature to look (and leave the string rendering to `Signature` itself), rather than manual string parsing and concatenation.  This also isn't something we use in more than a single place, which has been updated to use `inspect.replace`


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)



# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
