### PR TITLE
Sticky notification pannel

### DIFF
--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -170,7 +170,7 @@ def test_clear_all_plugin_widgets(test_plugin_widgets, make_napari_viewer):
     actions = viewer.window._plugin_dock_widget_menu.actions()
     actions[1].trigger()
     actions[0].menu().actions()[1].trigger()
-    assert len(viewer.window._dock_widgets) == 2
+    assert len(viewer.window._dock_widgets) == 3
     clear_action = next(
         a
         for a in viewer.window.window_menu.actions()

--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -105,10 +105,13 @@ class QNotificationList(QListWidget):
         self.notification_manager = notification_manager
         self.setSortingEnabled(True)
         self.notification_manager.notification_ready.connect(self.addItem)
+        self.destroyed.connect(
+            lambda: self.notification_manager.notification_ready.disconnect(
+                self.addItem
+            )
+        )
 
-    # @Slot(Notification)
     def addItem(self, notif: Notification):
-        pass
         # don't add duplicates
         widg = QNotificationListItem(notif, parent=self)
         item = QListWidgetItem(parent=self)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -28,10 +28,12 @@ from ..utils import config, perf
 from ..utils.history import get_save_history, update_save_history
 from ..utils.io import imsave
 from ..utils.misc import in_jupyter, running_as_bundled_app
+from ..utils.notifications import notification_manager
 from ..utils.settings import SETTINGS
 from ..utils.translations import trans
 from .dialogs.preferences_dialog import PreferencesDialog
 from .dialogs.qt_about import QtAbout
+from .dialogs.qt_notification import QNotificationList
 from .dialogs.qt_plugin_dialog import QtPluginDialog
 from .dialogs.qt_plugin_report import QtPluginErrReporter
 from .dialogs.screenshot_dialog import ScreenshotDialog
@@ -330,6 +332,13 @@ class Window:
             self._add_viewer_dock_widget(self.qt_viewer.dockPerformance)
         else:
             self._debug_menu = None
+
+        self.notification_area = QNotificationList(
+            notification_manager, parent=self._qt_window
+        )
+        self.add_dock_widget(
+            self.notification_area, area="right", name='Notifications area'
+        )
 
         if show:
             self.show()

--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -490,11 +490,11 @@ NapariQtNotification #severity_icon {
 
 /* ------------ Plugin Dialog ------------ */
 
-QPluginList {
+QPluginList, QNotificationList {
   background: {{ console }};
 }
 
-PluginListItem {
+PluginListItem, #QNotificationListItem {
   background: {{ darken(foreground, 20) }};
   padding: 0;
   margin: 2px 4px;


### PR DESCRIPTION
This is on top of #2205 and build a persistent notification manager that show past notification for the current session.

Test with  `python examples/dev/gui_notifications.py`

<img width="680" alt="Screen Shot 2021-04-02 at 1 27 08 PM" src="https://user-images.githubusercontent.com/335567/113451612-2db3fa00-93b7-11eb-9bb8-4e3e3a8b1336.png">

We can refine the UI like add buttons later, but I'm trying to keep this minimal before adding functionalities.

