### PR TITLE
Documentation typos

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -419,7 +419,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
         Parameters
         ----------
-        event :  napari.utils.event.Event
+        event : napari.utils.event.Event
             Event which will remove a layer.
 
         Returns

--- a/napari/layers/utils/_link_layers.py
+++ b/napari/layers/utils/_link_layers.py
@@ -166,7 +166,7 @@ def _get_common_evented_attributes(
     exclude : set, optional
         Layer attributes that make no sense to link, or may error on changing.
         {'thumbnail', 'status', 'name', 'data'}
-    private : bool, optional
+    with_private : bool, optional
         include private attributes
 
     Returns

--- a/napari/plugins/io.py
+++ b/napari/plugins/io.py
@@ -209,7 +209,7 @@ def _is_null_layer_sentinel(layer_data: Union[LayerData, Any]) -> bool:
 
     Parameters
     ----------
-    layer_data: LayerData
+    layer_data : LayerData
         The layer data returned from a reader function to check
 
     Returns

--- a/napari/utils/events/containers/_nested_list.py
+++ b/napari/utils/events/containers/_nested_list.py
@@ -287,7 +287,7 @@ class NestableEventedList(EventedList[_T]):
             The destination for sources.
 
         Yields
-        -------
+        ------
         Generator[tuple[int, ...], None, None]
             [description]
 


### PR DESCRIPTION
# Description

Extra or missing space; wrong underline length, and parameters names.