### PR TITLE
WIP Fast labels rendering

### DIFF
--- a/examples/add_labels.py
+++ b/examples/add_labels.py
@@ -2,7 +2,7 @@
 Display a labels layer above of an image layer using the add_labels and
 add_image APIs
 """
-
+import numpy as np
 from skimage import data
 from skimage.filters import threshold_otsu
 from skimage.segmentation import clear_border
@@ -22,7 +22,7 @@ with napari.gui_qt():
     cleared = remove_small_objects(clear_border(bw), 20)
 
     # label image regions
-    label_image = label(cleared)
+    label_image = label(cleared).astype(np.int32)
 
     # initialise viewer with coins image
     viewer = napari.view_image(image, name='coins', rgb=False)

--- a/napari/_vispy/utils.py
+++ b/napari/_vispy/utils.py
@@ -1,7 +1,17 @@
-from ..layers import Image, Layer, Points, Shapes, Surface, Tracks, Vectors
+from ..layers import (
+    Image,
+    Labels,
+    Layer,
+    Points,
+    Shapes,
+    Surface,
+    Tracks,
+    Vectors,
+)
 from ..utils.config import async_octree
 from .vispy_base_layer import VispyBaseLayer
 from .vispy_image_layer import VispyImageLayer
+from .vispy_labels_layer import VispyLabelsLayer
 from .vispy_points_layer import VispyPointsLayer
 from .vispy_shapes_layer import VispyShapesLayer
 from .vispy_surface_layer import VispySurfaceLayer
@@ -9,6 +19,7 @@ from .vispy_tracks_layer import VispyTracksLayer
 from .vispy_vectors_layer import VispyVectorsLayer
 
 layer_to_visual = {
+    Labels: VispyLabelsLayer,
     Image: VispyImageLayer,
     Points: VispyPointsLayer,
     Shapes: VispyShapesLayer,

--- a/napari/_vispy/vispy_labels_layer.py
+++ b/napari/_vispy/vispy_labels_layer.py
@@ -1,0 +1,214 @@
+import warnings
+
+import numpy as np
+from vispy.color import Colormap as VispyColormap
+from vispy.scene.node import Node
+from vispy.scene.visuals import Image as ImageNode
+
+from .vispy_base_layer import VispyBaseLayer
+from .volume import Volume as VolumeNode
+
+texture_dtypes = [
+    np.dtype(np.int8),
+    np.dtype(np.uint8),
+    np.dtype(np.int16),
+    np.dtype(np.uint16),
+    np.dtype(np.float32),
+    np.dtype(np.float64),
+]
+
+
+class ImageLayerNode:
+    def __init__(self, custom_node: Node = None):
+        self._custom_node = custom_node
+        self._image_node = ImageNode(None, method='auto')
+        self._volume_node = VolumeNode(np.zeros((1, 1, 1)), clim=[0, 1])
+
+    def get_node(self, ndisplay: int) -> Node:
+
+        # Return custom node if we have one.
+        if self._custom_node is not None:
+            return self._custom_node
+
+        # Return Image or Volume node based on 2D or 3D.
+        if ndisplay == 2:
+            return self._image_node
+        return self._volume_node
+
+
+class VispyLabelsLayer(VispyBaseLayer):
+    def __init__(self, layer, node=None):
+
+        # Use custom node from caller, or our standard image/volume nodes.
+        self._layer_node = ImageLayerNode(node)
+
+        # Default to 2D (image) node.
+        super().__init__(layer, self._layer_node.get_node(2))
+
+        self._array_like = True
+
+        self.layer.events.rendering.connect(self._on_rendering_change)
+        self.layer.events.interpolation.connect(self._on_interpolation_change)
+        self.layer.events.colormap.connect(self._on_colormap_change)
+        self.layer.events.contrast_limits.connect(
+            self._on_contrast_limits_change
+        )
+        self.layer.events.gamma.connect(self._on_gamma_change)
+        self.layer.events.iso_threshold.connect(self._on_iso_threshold_change)
+        self.layer.events.attenuation.connect(self._on_attenuation_change)
+
+        self._on_display_change()
+        self._on_data_change()
+
+    def _on_display_change(self, data=None):
+
+        parent = self.node.parent
+        self.node.parent = None
+
+        self.node = self._layer_node.get_node(self.layer._ndisplay)
+
+        if data is None:
+            data = np.zeros((1,) * self.layer._ndisplay)
+
+        if self.layer._empty:
+            self.node.visible = False
+        else:
+            self.node.visible = self.layer.visible
+
+        if self.layer.loaded:
+            self.node.set_data(data)
+
+        self.node.parent = parent
+        self.node.order = self.order
+        self.reset()
+
+    def _data_astype(self, data, dtype):
+        """Broken out as a separate function so we can time with perfmon."""
+        return data.astype(dtype)
+
+    def _on_data_change(self, event=None):
+        if not self.layer.loaded:
+            # Do nothing if we are not yet loaded. Calling astype below could
+            # be very expensive. Lets not do it until our data has been loaded.
+            return
+
+        self._set_node_data(self.node, self.layer._data_view)
+
+    def _set_node_data(self, node, data):
+        """Our self.layer._data_view has been updated, update our node."""
+
+        dtype = np.dtype(data.dtype)
+        if dtype not in texture_dtypes:
+            try:
+                dtype = dict(
+                    i=np.int16, f=np.float32, u=np.uint16, b=np.uint8
+                )[dtype.kind]
+            except KeyError:  # not an int or float
+                raise TypeError(
+                    f'type {dtype} not allowed for texture; must be one of {set(texture_dtypes)}'  # noqa: E501
+                )
+            data = self._data_astype(data, dtype)
+
+        if self.layer._ndisplay == 3 and self.layer.ndim == 2:
+            data = np.expand_dims(data, axis=0)
+
+        # Check if data exceeds MAX_TEXTURE_SIZE and downsample
+        if self.MAX_TEXTURE_SIZE_2D is not None and self.layer._ndisplay == 2:
+            data = self.downsample_texture(data, self.MAX_TEXTURE_SIZE_2D)
+        elif (
+            self.MAX_TEXTURE_SIZE_3D is not None and self.layer._ndisplay == 3
+        ):
+            data = self.downsample_texture(data, self.MAX_TEXTURE_SIZE_3D)
+
+        # Check if ndisplay has changed current node type needs updating
+        if (
+            self.layer._ndisplay == 3 and not isinstance(node, VolumeNode)
+        ) or (self.layer._ndisplay == 2 and not isinstance(node, ImageNode)):
+            self._on_display_change(data)
+        else:
+            node.set_data(data)
+
+        if self.layer._empty:
+            node.visible = False
+        else:
+            node.visible = self.layer.visible
+
+        # Call to update order of translation values with new dims:
+        self._on_matrix_change()
+        node.update()
+
+    def _on_interpolation_change(self, event=None):
+        self.node.interpolation = self.layer.interpolation
+
+    def _on_rendering_change(self, event=None):
+        if isinstance(self.node, VolumeNode):
+            self.node.method = self.layer.rendering
+            self._on_attenuation_change()
+            self._on_iso_threshold_change()
+
+    def _on_colormap_change(self, event=None):
+        self.node.cmap = VispyColormap(*self.layer.colormap)
+
+    def _on_contrast_limits_change(self, event=None):
+        self.node.clim = self.layer.contrast_limits
+
+    def _on_gamma_change(self, event=None):
+        if len(self.node.shared_program.frag._set_items) > 0:
+            self.node.gamma = self.layer.gamma
+
+    def _on_iso_threshold_change(self, event=None):
+        if isinstance(self.node, VolumeNode):
+            self.node.threshold = self.layer.iso_threshold
+
+    def _on_attenuation_change(self, event=None):
+        if isinstance(self.node, VolumeNode):
+            self.node.attenuation = self.layer.attenuation
+
+    def reset(self, event=None):
+        self._reset_base()
+        self._on_interpolation_change()
+        self._on_colormap_change()
+        self._on_contrast_limits_change()
+        self._on_gamma_change()
+        self._on_rendering_change()
+
+    def downsample_texture(self, data, MAX_TEXTURE_SIZE):
+        """Downsample data based on maximum allowed texture size.
+
+        Parameters
+        ----------
+        data : array
+            Data to be downsampled if needed.
+        MAX_TEXTURE_SIZE : int
+            Maximum allowed texture size.
+
+        Returns
+        -------
+        data : array
+            Data that now fits inside texture.
+        """
+        if np.any(np.greater(data.shape, MAX_TEXTURE_SIZE)):
+            if self.layer.multiscale:
+                raise ValueError(
+                    f"Shape of individual tiles in multiscale {data.shape} "
+                    f"cannot exceed GL_MAX_TEXTURE_SIZE "
+                    f"{MAX_TEXTURE_SIZE}. Rendering is currently in "
+                    f"{self.layer._ndisplay}D mode."
+                )
+            warnings.warn(
+                f"data shape {data.shape} exceeds GL_MAX_TEXTURE_SIZE "
+                f"{MAX_TEXTURE_SIZE} in at least one axis and "
+                f"will be downsampled. Rendering is currently in "
+                f"{self.layer._ndisplay}D mode."
+            )
+            downsample = np.ceil(
+                np.divide(data.shape, MAX_TEXTURE_SIZE)
+            ).astype(int)
+            scale = np.ones(self.layer.ndim)
+            for i, d in enumerate(self.layer._dims_displayed):
+                scale[d] = downsample[i]
+            self.layer._transforms['tile2data'].scale = scale
+            self._on_matrix_change()
+            slices = tuple(slice(None, None, ds) for ds in downsample)
+            data = data[slices]
+        return data

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -614,56 +614,6 @@ class Labels(Image):
         image : array
             Image mapped between 0 and 1 to be displayed.
         """
-        if (
-            not self.show_selected_label
-            and self._color_mode == LabelColorMode.DIRECT
-        ):
-            u, inv = np.unique(raw, return_inverse=True)
-            image = np.array(
-                [
-                    self._label_color_index[x]
-                    if x in self._label_color_index
-                    else self._label_color_index[None]
-                    for x in u
-                ]
-            )[inv].reshape(raw.shape)
-        elif (
-            not self.show_selected_label
-            and self._color_mode == LabelColorMode.AUTO
-        ):
-            image = np.where(
-                raw > 0, low_discrepancy_image(raw, self._seed), 0
-            )
-        elif (
-            self.show_selected_label
-            and self._color_mode == LabelColorMode.AUTO
-        ):
-            selected = self._selected_label
-            image = np.where(
-                raw == selected,
-                low_discrepancy_image(selected, self._seed),
-                0,
-            )
-        elif (
-            self.show_selected_label
-            and self._color_mode == LabelColorMode.DIRECT
-        ):
-            selected = self._selected_label
-            if selected not in self._label_color_index:
-                selected = None
-            index = self._label_color_index
-            image = np.where(
-                raw == selected,
-                index[selected],
-                np.where(
-                    raw != self._background_label,
-                    index[None],
-                    index[self._background_label],
-                ),
-            )
-        else:
-            raise ValueError("Unsupported Color Mode")
-
         if self.contour:
             image = np.zeros_like(raw)
             struct_elem = ndi.generate_binary_structure(raw.ndim, 1)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -4,11 +4,7 @@ from typing import Dict, Union
 import numpy as np
 from scipy import ndimage as ndi
 
-from ...utils.colormaps import (
-    color_dict_to_colormap,
-    label_colormap,
-    low_discrepancy_image,
-)
+from ...utils.colormaps import color_dict_to_colormap, label_colormap
 from ...utils.events import Event
 from ..image import Image
 from ..utils.color_transformations import transform_color
@@ -614,6 +610,7 @@ class Labels(Image):
         image : array
             Image mapped between 0 and 1 to be displayed.
         """
+        image = raw
         if self.contour:
             image = np.zeros_like(raw)
             struct_elem = ndi.generate_binary_structure(raw.ndim, 1)
@@ -621,10 +618,7 @@ class Labels(Image):
                 raw, footprint=struct_elem
             ) != ndi.grey_erosion(raw, footprint=struct_elem)
             image[boundaries] = raw[boundaries]
-            image = np.where(
-                raw > 0, low_discrepancy_image(image, self._seed), 0
-            )
-
+        print(f'{image.dtype=}')
         return image
 
     def new_colormap(self):


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousando words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This is the beginning of an attempt to use vispy/vispy#1920 (ie you need that PR's version of VisPy) to speed up labels rendering (for now, only in 2D). Still lots to do but wanted to post it up here for reference after a pair session with @OKaluza @djhoese.

Currently this fails with a big and scary traceback from VisPy 😂 

<details>

<summary>
current traceback
</summary>

```pytb
 $ python examples/add_labels.py
image.dtype=dtype('int32')
image.dtype=dtype('int64')
image.dtype=dtype('int64')
image.dtype=dtype('int32')
image.dtype=dtype('int32')
data.dtype=dtype('int32')
data.dtype=dtype('int32')
data.dtype=dtype('int32')
ERROR:root:Unhandled exception:
Traceback (most recent call last):
  File "/Users/jni/projects/vispy/vispy/app/backends/_qt.py", line 844, in paintGL
    self._vispy_canvas.events.draw(region=None)
  File "/Users/jni/projects/vispy/vispy/util/event.py", line 454, in __call__
    self._invoke_callback(cb, event)
  File "/Users/jni/projects/vispy/vispy/util/event.py", line 472, in _invoke_callback
    _handle_exception(self.ignore_callback_errors,
  File "/Users/jni/projects/vispy/vispy/util/event.py", line 470, in _invoke_callback
    cb(event)
  File "/Users/jni/projects/vispy/vispy/scene/canvas.py", line 217, in on_draw
    self._draw_scene()
  File "/Users/jni/projects/vispy/vispy/scene/canvas.py", line 266, in _draw_scene
    self.draw_visual(self.scene)
  File "/Users/jni/projects/vispy/vispy/scene/canvas.py", line 304, in draw_visual
    node.draw()
  File "/Users/jni/projects/vispy/vispy/scene/visuals.py", line 99, in draw
    self._visual_superclass.draw(self)
  File "/Users/jni/projects/vispy/vispy/visuals/visual.py", line 436, in draw
    if self._prepare_draw(view=self) is False:
  File "/Users/jni/projects/vispy/vispy/visuals/image.py", line 856, in _prepare_draw
    self._build_texture()
  File "/Users/jni/projects/vispy/vispy/visuals/image.py", line 815, in _build_texture
    self._texture.set_data(self._data)
  File "/Users/jni/projects/vispy/vispy/visuals/image.py", line 329, in set_data
    self._reformat_if_necessary(data)
  File "/Users/jni/projects/vispy/vispy/visuals/image.py", line 322, in _reformat_if_necessary
    self._resize(data.shape, internalformat=internalformat)
  File "/Users/jni/projects/vispy/vispy/gloo/texture.py", line 277, in _resize
    internalformat = self._check_internalformat_change(internalformat, shape[-1])
  File "/Users/jni/projects/vispy/vispy/gloo/texture.py", line 260, in _check_internalformat_change
    raise ValueError(
ValueError: Invalid texture internalformat: 'r32'. Allowed formats: {'r8': 1, 'r16': 1, 'r16f': 1, 'r32f': 1, 'rg8': 2, 'rg16': 2, 'rg16f': 2, 'rg32f': 2, 'rgb8': 3, 'rgb16': 3, 'rgb16f': 3, 'rgb32f': 3, 'rgba8': 4, 'rgba16': 4, 'rgba16f': 4, 'rgba32f': 4, 'luminance': 1, 'alpha': 1, 'red': 1, 'luminance_alpha': 2, 'rg': 2, 'rgb': 3, 'rgba': 4}

ERROR:root:Unhandled exception:
Traceback (most recent call last):
  File "/Users/jni/projects/vispy/vispy/app/backends/_qt.py", line 844, in paintGL
    self._vispy_canvas.events.draw(region=None)
  File "/Users/jni/projects/vispy/vispy/util/event.py", line 454, in __call__
    self._invoke_callback(cb, event)
  File "/Users/jni/projects/vispy/vispy/util/event.py", line 472, in _invoke_callback
    _handle_exception(self.ignore_callback_errors,
  File "/Users/jni/projects/vispy/vispy/util/event.py", line 470, in _invoke_callback
    cb(event)
  File "/Users/jni/projects/vispy/vispy/scene/canvas.py", line 217, in on_draw
    self._draw_scene()
  File "/Users/jni/projects/vispy/vispy/scene/canvas.py", line 266, in _draw_scene
    self.draw_visual(self.scene)
  File "/Users/jni/projects/vispy/vispy/scene/canvas.py", line 304, in draw_visual
    node.draw()
  File "/Users/jni/projects/vispy/vispy/scene/visuals.py", line 99, in draw
    self._visual_superclass.draw(self)
  File "/Users/jni/projects/vispy/vispy/visuals/visual.py", line 436, in draw
    if self._prepare_draw(view=self) is False:
  File "/Users/jni/projects/vispy/vispy/visuals/image.py", line 856, in _prepare_draw
    self._build_texture()
  File "/Users/jni/projects/vispy/vispy/visuals/image.py", line 815, in _build_texture
    self._texture.set_data(self._data)
  File "/Users/jni/projects/vispy/vispy/visuals/image.py", line 329, in set_data
    self._reformat_if_necessary(data)
  File "/Users/jni/projects/vispy/vispy/visuals/image.py", line 322, in _reformat_if_necessary
    self._resize(data.shape, internalformat=internalformat)
  File "/Users/jni/projects/vispy/vispy/gloo/texture.py", line 277, in _resize
    internalformat = self._check_internalformat_change(internalformat, shape[-1])
  File "/Users/jni/projects/vispy/vispy/gloo/texture.py", line 260, in _check_internalformat_change
    raise ValueError(
ValueError: Invalid texture internalformat: 'r32'. Allowed formats: {'r8': 1, 'r16': 1, 'r16f': 1, 'r32f': 1, 'rg8': 2, 'rg16': 2, 'rg16f': 2, 'rg32f': 2, 'rgb8': 3, 'rgb16': 3, 'rgb16f': 3, 'rgb32f': 3, 'rgba8': 4, 'rgba16': 4, 'rgba16f': 4, 'rgba32f': 4, 'luminance': 1, 'alpha': 1, 'red': 1, 'luminance_alpha': 2, 'rg': 2, 'rgb': 3, 'rgba': 4}

ERROR:root:Unhandled exception:
Traceback (most recent call last):
  File "/Users/jni/projects/vispy/vispy/app/backends/_qt.py", line 844, in paintGL
    self._vispy_canvas.events.draw(region=None)
  File "/Users/jni/projects/vispy/vispy/util/event.py", line 454, in __call__
    self._invoke_callback(cb, event)
  File "/Users/jni/projects/vispy/vispy/util/event.py", line 472, in _invoke_callback
    _handle_exception(self.ignore_callback_errors,
  File "/Users/jni/projects/vispy/vispy/util/event.py", line 470, in _invoke_callback
    cb(event)
  File "/Users/jni/projects/vispy/vispy/scene/canvas.py", line 217, in on_draw
    self._draw_scene()
  File "/Users/jni/projects/vispy/vispy/scene/canvas.py", line 266, in _draw_scene
    self.draw_visual(self.scene)
  File "/Users/jni/projects/vispy/vispy/scene/canvas.py", line 304, in draw_visual
    node.draw()
  File "/Users/jni/projects/vispy/vispy/scene/visuals.py", line 99, in draw
    self._visual_superclass.draw(self)
  File "/Users/jni/projects/vispy/vispy/visuals/visual.py", line 436, in draw
    if self._prepare_draw(view=self) is False:
  File "/Users/jni/projects/vispy/vispy/visuals/image.py", line 856, in _prepare_draw
    self._build_texture()
  File "/Users/jni/projects/vispy/vispy/visuals/image.py", line 815, in _build_texture
    self._texture.set_data(self._data)
  File "/Users/jni/projects/vispy/vispy/visuals/image.py", line 329, in set_data
    self._reformat_if_necessary(data)
  File "/Users/jni/projects/vispy/vispy/visuals/image.py", line 322, in _reformat_if_necessary
    self._resize(data.shape, internalformat=internalformat)
  File "/Users/jni/projects/vispy/vispy/gloo/texture.py", line 277, in _resize
    internalformat = self._check_internalformat_change(internalformat, shape[-1])
  File "/Users/jni/projects/vispy/vispy/gloo/texture.py", line 260, in _check_internalformat_change
    raise ValueError(
ValueError: Invalid texture internalformat: 'r32'. Allowed formats: {'r8': 1, 'r16': 1, 'r16f': 1, 'r32f': 1, 'rg8': 2, 'rg16': 2, 'rg16f': 2, 'rg32f': 2, 'rgb8': 3, 'rgb16': 3, 'rgb16f': 3, 'rgb32f': 3, 'rgba8': 4, 'rgba16': 4, 'rgba16f': 4, 'rgba32f': 4, 'luminance': 1, 'alpha': 1, 'red': 1, 'luminance_alpha': 2, 'rg': 2, 'rgb': 3, 'rgba': 4}
```

</details>

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References

See #204, #569, #713, #1759, napari/product-heuristics-2020#38

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
