### PR TITLE
Don't subclass `Layer` directly from `Image`, (adds `_ImageBase`)

### DIFF
--- a/napari/_vispy/utils.py
+++ b/napari/_vispy/utils.py
@@ -1,4 +1,13 @@
-from ..layers import Image, Layer, Points, Shapes, Surface, Tracks, Vectors
+from ..layers import (
+    Image,
+    Labels,
+    Layer,
+    Points,
+    Shapes,
+    Surface,
+    Tracks,
+    Vectors,
+)
 from ..utils.config import async_octree
 from .vispy_base_layer import VispyBaseLayer
 from .vispy_image_layer import VispyImageLayer
@@ -10,6 +19,7 @@ from .vispy_vectors_layer import VispyVectorsLayer
 
 layer_to_visual = {
     Image: VispyImageLayer,
+    Labels: VispyImageLayer,
     Points: VispyPointsLayer,
     Shapes: VispyShapesLayer,
     Surface: VispySurfaceLayer,

--- a/napari/layers/__init__.py
+++ b/napari/layers/__init__.py
@@ -4,6 +4,7 @@ Custom layers must inherit from Layer and pass along the
 `visual node <http://vispy.org/scene.html#module-vispy.scene.visuals>`_
 to the super constructor.
 """
+from inspect import isabstract
 
 from ..utils.misc import all_subclasses
 from .base import Layer
@@ -15,5 +16,10 @@ from .surface import Surface
 from .tracks import Tracks
 from .vectors import Vectors
 
-NAMES = {subclass.__name__.lower() for subclass in all_subclasses(Layer)}
+# isabstact check is to exclude _ImageBase class
+NAMES = {
+    subclass.__name__.lower()
+    for subclass in all_subclasses(Layer)
+    if not isabstract(subclass)
+}
 del all_subclasses

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -27,7 +27,7 @@ else:
 
 
 # Mixin must come before Layer
-class Image(IntensityVisualizationMixin, Layer):
+class _ImageBase(IntensityVisualizationMixin, Layer):
     """Image layer.
 
     Parameters
@@ -785,3 +785,7 @@ class Image(IntensityVisualizationMixin, Layer):
             # Convert the ChunkRequest to SliceData and use it.
             data = SliceDataClass.from_request(self, request)
             self._on_data_loaded(data, sync=False)
+
+
+class Image(_ImageBase):
+    pass

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -2,7 +2,6 @@
 """
 import types
 import warnings
-from abc import abstractmethod
 
 import numpy as np
 from scipy import ndimage as ndi
@@ -481,9 +480,23 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         """
         return self._slice.loaded
 
-    @abstractmethod
     def _raw_to_displayed(self, raw):
-        """Determine displayed image from raw image."""
+        """Determine displayed image from raw image.
+
+        For normal image layers, just return the actual image.
+
+        Parameters
+        ----------
+        raw : array
+            Raw array.
+
+        Returns
+        -------
+        image : array
+            Displayed array.
+        """
+        image = raw
+        return image
 
     def _set_view_slice(self):
         """Set the view given the indices to slice with."""
@@ -776,21 +789,3 @@ class Image(_ImageBase):
             }
         )
         return state
-
-    def _raw_to_displayed(self, raw):
-        """Determine displayed image from raw image.
-
-        For normal image layers, just return the actual image.
-
-        Parameters
-        ----------
-        raw : array
-            Raw array.
-
-        Returns
-        -------
-        image : array
-            Displayed array.
-        """
-        image = raw
-        return image

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -27,7 +27,7 @@ else:
 
 
 # It is important to contain at least one abstractmethod to properly exclude this class
-# in creating NAMES set inside __init__ file of labels module
+# in creating NAMES set inside of napari.layers.__init__
 # Mixin must come before Layer
 class _ImageBase(IntensityVisualizationMixin, Layer):
     """Image layer.

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -2,7 +2,7 @@
 """
 import types
 import warnings
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 
 import numpy as np
 from scipy import ndimage as ndi
@@ -30,7 +30,7 @@ else:
 # It is important to contain at least one abstractmethod to properly exclude this class
 # in creating NAMES set inside __init__ file of labels module
 # Mixin must come before Layer
-class _ImageBase(IntensityVisualizationMixin, Layer, metaclass=ABCMeta):
+class _ImageBase(IntensityVisualizationMixin, Layer):
     """Image layer.
 
     Parameters
@@ -480,16 +480,6 @@ class _ImageBase(IntensityVisualizationMixin, Layer, metaclass=ABCMeta):
         for the current slice has not been loaded.
         """
         return self._slice.loaded
-
-    @abstractmethod
-    def _get_state(self):
-        """Get dictionary of layer state.
-
-        Returns
-        -------
-        state : dict
-            Dictionary of layer state.
-        """
 
     @abstractmethod
     def _raw_to_displayed(self, raw):

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -2,6 +2,7 @@
 """
 import types
 import warnings
+from abc import ABCMeta, abstractmethod
 
 import numpy as np
 from scipy import ndimage as ndi
@@ -26,8 +27,10 @@ else:
     SliceDataClass = ImageSliceData
 
 
+# It is important to contain at least one abstractmethod to properly exclude this class
+# in creating NAMES set inside __init__ file of labels module
 # Mixin must come before Layer
-class _ImageBase(IntensityVisualizationMixin, Layer):
+class _ImageBase(IntensityVisualizationMixin, Layer, metaclass=ABCMeta):
     """Image layer.
 
     Parameters
@@ -478,6 +481,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         """
         return self._slice.loaded
 
+    @abstractmethod
     def _get_state(self):
         """Get dictionary of layer state.
 
@@ -486,40 +490,10 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         state : dict
             Dictionary of layer state.
         """
-        state = self._get_base_state()
-        state.update(
-            {
-                'rgb': self.rgb,
-                'multiscale': self.multiscale,
-                'colormap': self.colormap.name,
-                'contrast_limits': self.contrast_limits,
-                'interpolation': self.interpolation,
-                'rendering': self.rendering,
-                'iso_threshold': self.iso_threshold,
-                'attenuation': self.attenuation,
-                'gamma': self.gamma,
-                'data': self.data,
-            }
-        )
-        return state
 
+    @abstractmethod
     def _raw_to_displayed(self, raw):
-        """Determine displayed image from raw image.
-
-        For normal image layers, just return the actual image.
-
-        Parameters
-        ----------
-        raw : array
-            Raw array.
-
-        Returns
-        -------
-        image : array
-            Displayed array.
-        """
-        image = raw
-        return image
+        """Determine displayed image from raw image."""
 
     def _set_view_slice(self):
         """Set the view given the indices to slice with."""
@@ -788,4 +762,45 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
 
 
 class Image(_ImageBase):
-    pass
+    def _get_state(self):
+        """Get dictionary of layer state.
+
+        Returns
+        -------
+        state : dict
+            Dictionary of layer state.
+        """
+        state = self._get_base_state()
+        state.update(
+            {
+                'rgb': self.rgb,
+                'multiscale': self.multiscale,
+                'colormap': self.colormap.name,
+                'contrast_limits': self.contrast_limits,
+                'interpolation': self.interpolation,
+                'rendering': self.rendering,
+                'iso_threshold': self.iso_threshold,
+                'attenuation': self.attenuation,
+                'gamma': self.gamma,
+                'data': self.data,
+            }
+        )
+        return state
+
+    def _raw_to_displayed(self, raw):
+        """Determine displayed image from raw image.
+
+        For normal image layers, just return the actual image.
+
+        Parameters
+        ----------
+        raw : array
+            Raw array.
+
+        Returns
+        -------
+        image : array
+            Displayed array.
+        """
+        image = raw
+        return image

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -10,7 +10,7 @@ from ...utils.colormaps import (
     low_discrepancy_image,
 )
 from ...utils.events import Event
-from ..image import Image
+from ..image.image import _ImageBase
 from ..utils.color_transformations import transform_color
 from ..utils.layer_utils import dataframe_to_properties
 from ._labels_constants import LabelBrushShape, LabelColorMode, Mode
@@ -18,7 +18,7 @@ from ._labels_mouse_bindings import draw, pick
 from ._labels_utils import sphere_indices
 
 
-class Labels(Image):
+class Labels(_ImageBase):
     """Labels (or segmentation) layer.
 
     An image-like layer where every pixel contains an integer ID


### PR DESCRIPTION
# Description
This PR add `_ImageBase` abstract class as a common superclass for Image and Labels to 
prevent showing Labels in Image select Combobox (for example in magicgui) 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
