### PR TITLE
Avoid importing xarray (and other array libs) for equality checkers

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -145,6 +145,7 @@ jobs:
           TOXENV: ${{ matrix.toxenv }}
           NUMPY_EXPERIMENTAL_ARRAY_FUNCTION: ${{ matrix.MIN_REQ || 1 }}
           PYVISTA_OFF_SCREEN: True
+          MIN_REQ: ${{ matrix.MIN_REQ }}
 
       - name: Coverage
         if: runner.os == 'Linux' && matrix.python == '3.9'

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -123,6 +123,7 @@ jobs:
           TOXENV: ${{ matrix.toxenv }}
           NUMPY_EXPERIMENTAL_ARRAY_FUNCTION: ${{ matrix.MIN_REQ || 1 }}
           PYVISTA_OFF_SCREEN: True
+          MIN_REQ: ${{ matrix.MIN_REQ }}
 
       - name: Coverage
         if: runner.os == 'Linux' && matrix.python == '3.9'

--- a/napari/_tests/test_import_time.py
+++ b/napari/_tests/test_import_time.py
@@ -1,7 +1,13 @@
+import os
 import subprocess
 import sys
 
+import pytest
 
+
+@pytest.mark.skipif(
+    bool(os.environ.get('MIN_REQ')), reason='skip import time test on MIN_REQ'
+)
 def test_import_time(tmp_path):
     cmd = [sys.executable, '-X', 'importtime', '-c', 'import napari']
     proc = subprocess.run(cmd, capture_output=True, check=True)

--- a/napari/_tests/test_import_time.py
+++ b/napari/_tests/test_import_time.py
@@ -9,9 +9,10 @@ def test_import_time(tmp_path):
     last_line = log.splitlines()[-1]
     time, name = [i.strip() for i in last_line.split("|")[-2:]]
 
-    # we may need to change this threshold
-    assert name == 'napari'
-    assert int(time) < 1_000_000, "napari import taking longer than 1 sec!"
+    # # This is too hard to do on CI... but we have the time here if we can
+    # # figure out how to use it
+    # assert name == 'napari'
+    # assert int(time) < 1_000_000, "napari import taking longer than 1 sec!"
     print(f"\nnapari took {int(time)/1e6:0.3f} seconds to import")
 
     # common culprit of slow imports

--- a/napari/_tests/test_import_time.py
+++ b/napari/_tests/test_import_time.py
@@ -1,0 +1,18 @@
+import subprocess
+import sys
+
+
+def test_import_time(tmp_path):
+    cmd = [sys.executable, '-X', 'importtime', '-c', 'import napari']
+    proc = subprocess.run(cmd, capture_output=True, check=True)
+    log = proc.stderr.decode()
+    last_line = log.splitlines()[-1]
+    time, name = [i.strip() for i in last_line.split("|")[-2:]]
+
+    # we may need to change this threshold
+    assert name == 'napari'
+    assert int(time) < 1_000_000, "napari import taking longer than 1 sec!"
+    print(f"\nnapari took {int(time)/1e6:0.3f} seconds to import")
+
+    # common culprit of slow imports
+    assert 'pkg_resources' not in log

--- a/napari/utils/_tests/test_misc.py
+++ b/napari/utils/_tests/test_misc.py
@@ -139,7 +139,11 @@ def test_equality_operator():
     import xarray as xr
     import zarr
 
+    class MyNPArray(np.ndarray):
+        pass
+
     assert pick_equality_operator(np.ones((1, 1))) == np.array_equal
+    assert pick_equality_operator(MyNPArray([1, 1])) == np.array_equal
     assert pick_equality_operator(da.ones((1, 1))) == operator.is_
     assert pick_equality_operator(zarr.ones((1, 1))) == operator.is_
     assert (

--- a/napari/utils/_tests/test_misc.py
+++ b/napari/utils/_tests/test_misc.py
@@ -9,6 +9,7 @@ from napari.utils.misc import (
     abspath_or_url,
     ensure_iterable,
     ensure_sequence_of_iterables,
+    pick_equality_operator,
 )
 
 ITERABLE = (0, 1, 2)
@@ -128,3 +129,19 @@ def test_abspath_or_url():
 
     with pytest.raises(TypeError):
         abspath_or_url({'a', '~'})
+
+
+def test_equality_operator():
+    import operator
+
+    import dask.array as da
+    import numpy as np
+    import xarray as xr
+    import zarr
+
+    assert pick_equality_operator(np.ones((1, 1))) == np.array_equal
+    assert pick_equality_operator(da.ones((1, 1))) == operator.is_
+    assert pick_equality_operator(zarr.ones((1, 1))) == operator.is_
+    assert (
+        pick_equality_operator(xr.DataArray(np.ones((1, 1)))) == np.array_equal
+    )

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -400,29 +400,17 @@ def pick_equality_operator(obj) -> Callable[[Any, Any], bool]:
 
     type_ = type(obj) if not inspect.isclass(obj) else obj
 
-    if issubclass(type_, np.ndarray):
-        return np.array_equal
-
-    import dask.array
-
-    if issubclass(type_, dask.array.Array):
-        return operator.is_
-
-    try:
-        import zarr.core
-
-        if issubclass(type_, zarr.core.Array):
-            return operator.is_
-    except ImportError:
-        pass
-
-    try:
-        import xarray.core.dataarray
-
-        if issubclass(type_, xarray.core.dataarray.DataArray):
-            return np.array_equal
-    except ImportError:
-        pass
+    _known_arrays = {
+        'numpy.ndarray': np.array_equal,  # numpy.ndarray
+        'dask.Array': operator.is_,  # dask.array.core.Array
+        'zarr.Array': operator.is_,  # zarr.core.Array
+        'xarray.DataArray': np.array_equal,  # xarray.core.dataarray.DataArray
+    }
+    for base in type_.mro():
+        key = f'{base.__module__.split(".", maxsplit=1)[0]}.{base.__name__}'
+        func = _known_arrays.get(key)
+        if func:
+            return func
 
     return operator.eq
 

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -400,6 +400,8 @@ def pick_equality_operator(obj) -> Callable[[Any, Any], bool]:
 
     type_ = type(obj) if not inspect.isclass(obj) else obj
 
+    # yes, it's a little riskier, but we are checking namespaces instead of
+    # actual `issubclass` here to avoid slow import times
     _known_arrays = {
         'numpy.ndarray': np.array_equal,  # numpy.ndarray
         'dask.Array': operator.is_,  # dask.array.core.Array

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ passenv =
     DISPLAY XAUTHORITY
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
     PYVISTA_OFF_SCREEN
+    MIN_REQ
 # Set various environment variables, depending on the factors in
 # the tox environment being run
 setenv =


### PR DESCRIPTION
# Description
@cgohlke [pointed out](https://github.com/napari/napari/issues/758#issuecomment-786885653) that xarray is importing pkg_resources, and [we import xarray here](https://github.com/napari/napari/blob/68822f8f2ef618cc727442bc5c1a35e70198aa64/napari/utils/misc.py#L419-L425)).  So this PR uses a namespaces to check for subclassing instead of importing.  It's a little riskier, but I added a test that should notify us if any of these packages change their namespacing.

@cgohlke, thank you _so_ much for continuing to notify us about slow imports! 


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
