### PR TITLE
A rough sketch of integrating midi controll (WIP)

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -441,6 +441,16 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         self._on_layers_change(None)
         self._on_grid_change(None)
 
+    def on_midi(self, status, data1, data2, _time_ms):
+        def is_control_change(status):
+            return (status & 0xb0) == 0xb0
+        if is_control_change(status):
+            axis=data1
+            (min_val, max_val, step_size) = self.dims.range[axis]
+            self.dims.set_point(axis,
+                                min_val+(max_val-min_val)*data2/127.0)
+
+            
     def add_layer(self, layer: Layer) -> Layer:
         """Add a layer to the viewer.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ install_requires =
     toolz>=0.10.0
     vispy>=0.6.4
     wrapt>=1.11.1
+    python-rtmidi 
 
 
 # for explanation of %(extra)s syntax see:


### PR DESCRIPTION
Maps dimension sliders to midi controlls. The QT<->midi connection is
after https://www.alexallmont.com/midi-responsive-qt/

# Description
Allows MIDI control of the dimension sliders, thus allowing navigation of a multi-dim dataset without distraction of hunting around with the mouse. 

This is an initial sketch. Some things which need to be done:

1. Allow user selection of midi controller to use 
2. One set of rotaries for single step while other set for faster navigation through the dimensions (can be layer 1 and layer 2)
3. Ideally a MIDI-map design equivalent to keymap so that midi controllers can be flexibly mapped to various UI functions. (E.g. Gamma, min, max would be very useful for me)
4. Non QT5 implementation?



## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
