### PR TITLE
Use fancy indexing rather than full slices for label editing undo

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -392,15 +392,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         layer.events.affine.connect(self._on_layers_change)
         layer.events.name.connect(self.layers._update_name)
 
-        # For the labels layer we need to reset the undo/ redo
-        # history whenever the displayed slice changes. Once
-        # we have full undo/ redo functionality, this can be
-        # dropped.
-        if hasattr(layer, '_reset_history'):
-            self.dims.events.ndisplay.connect(layer._reset_history)
-            self.dims.events.order.connect(layer._reset_history)
-            self.dims.events.current_step.connect(layer._reset_history)
-
         # Make layer selected and unselect all others
         layer.selected = True
         self.layers.unselect_all(ignore=layer)
@@ -433,11 +424,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         disconnect_events(layer.events, self)
         disconnect_events(layer.events, self.layers)
 
-        # For the labels layer disconnect history resets
-        if hasattr(layer, '_reset_history'):
-            self.dims.events.ndisplay.disconnect(layer._reset_history)
-            self.dims.events.order.disconnect(layer._reset_history)
-            self.dims.events.current_step.disconnect(layer._reset_history)
         self._on_layers_change(None)
         self._on_grid_change(None)
 

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -22,8 +22,6 @@ def draw(layer, event):
     eraser
     """
     # on press
-    layer._save_history()
-    layer._block_saving = True
     if layer._mode == Mode.ERASE:
         new_label = layer._background_label
     else:
@@ -37,6 +35,7 @@ def draw(layer, event):
     last_cursor_coord = layer.coordinates
     yield
 
+    layer._block_saving = True
     # on move
     while event.type == 'mouse_move':
         interp_coord = interpolate_coordinates(

--- a/napari/layers/labels/_labels_utils.py
+++ b/napari/layers/labels/_labels_utils.py
@@ -63,3 +63,43 @@ def sphere_indices(radius, sphere_dims):
     mask_indices = indices[distances_sq <= radius ** 2].astype(int)
 
     return mask_indices
+
+
+def indices_in_shape(idxs, shape):
+    """Return idxs after filtering out indices that are not in given shape.
+
+    Parameters
+    ----------
+    idxs : tuple of array of int, or 2D array of int
+        The input coordinates. These should be in one of two formats:
+
+        - a tuple of 1D arrays, as for NumPy fancy indexing, or
+        - a 2D array of shape (ncoords, ndim), as a list of coordinates
+
+    shape : tuple of int
+        The shape in which all indices must fit.
+
+    Returns
+    -------
+    idxs_filtered : tuple of array of int, or 2D array of int
+        The subset of the input idxs that falls within shape.
+
+    Examples
+    --------
+    >>> idxs0 = (np.array([5, 45, 2]), np.array([6, 5, -5]))
+    >>> indices_in_shape(idxs0, (10, 10))
+    (array([5]), array([6]))
+    >>> idxs1 = np.transpose(idxs0)
+    >>> indices_in_shape(idxs1, (10, 10))
+    array([[5, 6]])
+    """
+    np_index = isinstance(idxs, tuple)
+    if np_index:  # normalize to 2D coords array
+        idxs = np.transpose(idxs)
+    keep_coords = np.logical_and(
+        np.all(idxs >= 0, axis=1), np.all(idxs < np.array(shape), axis=1)
+    )
+    filtered = idxs[keep_coords]
+    if np_index:  # convert back to original format
+        filtered = tuple(filtered.T)
+    return filtered

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -709,6 +709,25 @@ class Labels(_ImageBase):
             self._undo_history.popleft()
 
     def _save_history(self, value):
+        """Save a history "atom" to the undo history.
+
+        A history "atom" is a single change operation to the array. A history
+        *item* is a collection of atoms that were applied together to make a
+        single change. For example, when dragging and painting, at each mouse
+        callback we create a history "atom", but we save all those atoms in
+        a single history item, since we would want to undo one drag in one
+        undo operation.
+
+        Parameters
+        ----------
+        value: 3-tuple of arrays
+            The value is a 3-tuple containing:
+
+            - a numpy multi-index, pointing to the array elements that were
+              changed
+            - the values corresponding to those elements before the change
+            - the value(s) after the change
+        """
         self._redo_history = deque()
         if not self._block_saving:
             self._undo_history.append([value])
@@ -717,6 +736,24 @@ class Labels(_ImageBase):
             self._undo_history[-1].append(value)
 
     def _load_history(self, before, after, undoing=True):
+        """Load a history item and apply it to the array.
+
+        Parameters
+        ----------
+        before : list of history items
+            The list of elements from which we want to load.
+        after : list of history items
+            The list of element to which to append the loaded element. In the
+            case of an undo operation, this is the redo queue, and vice versa.
+        undoing : bool
+            Whether we are undoing (default) or redoing. In the case of
+            redoing, we apply the "after change" element of a history element
+            (the third element of the history "atom").
+
+        See Also
+        --------
+        `Labels._save_history`
+        """
         if len(before) == 0:
             return
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -711,16 +711,19 @@ class Labels(_ImageBase):
     def _save_history(self, value):
         self._redo_history = deque()
         if not self._block_saving:
-            self._undo_history.append(value)
+            self._undo_history.append([value])
             self._trim_history()
+        else:
+            self._undo_history[-1].append(value)
 
     def _load_history(self, before, after):
         if len(before) == 0:
             return
 
-        prev_indices, prev_values = before.pop()
-        after.append((prev_indices, prev_values))
-        self.data[prev_indices] = prev_values
+        history_item = before.pop()
+        after.append(reversed(history_item))
+        for prev_indices, prev_values in reversed(history_item):
+            self.data[prev_indices] = prev_values
 
         self.refresh()
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -783,8 +783,7 @@ class Labels(_ImageBase):
                     matches, labeled_matches == match_label
                 )
 
-        if refresh is True:
-            self._save_history((matches, labels[matches]))
+        self._save_history((matches, labels[matches]))
 
         # Replace target pixels with new_label
         labels[matches] = new_label
@@ -883,8 +882,7 @@ class Labels(_ImageBase):
         # slice_coord from circle brush is tuple of coord. arrays per dimension
 
         # save the existing values to the history
-        if refresh is True:
-            self._save_history((slice_coord, self.data[slice_coord]))
+        self._save_history((slice_coord, self.data[slice_coord]))
 
         # update the labels image
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -783,14 +783,27 @@ class Labels(_ImageBase):
                     matches, labeled_matches == match_label
                 )
 
-        self._save_history((np.nonzero(matches), labels[matches]))
+        match_indices_local = np.nonzero(matches)
+        if not (self.n_dimensional or self.ndim == 2):
+            n_idx = len(match_indices_local[0])
+            match_indices = []
+            j = 0
+            for d in range(self.ndim):
+                if d in self._dims_not_displayed:
+                    match_indices.append(np.full(n_idx, int_coord[d]))
+                else:
+                    match_indices.append(match_indices_local[j])
+                    j += 1
+            match_indices = tuple(match_indices)
+        else:
+            match_indices = match_indices_local
+
+        self._save_history(
+            (match_indices, self.data[match_indices], new_label)
+        )
 
         # Replace target pixels with new_label
-        labels[matches] = new_label
-
-        if not (self.n_dimensional or self.ndim == 2):
-            # if working with just the slice, update the rest of the raw data
-            self.data[tuple(self._slice_indices)] = labels
+        self.data[match_indices] = new_label
 
         if refresh is True:
             self.refresh()

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -783,7 +783,7 @@ class Labels(_ImageBase):
                     matches, labeled_matches == match_label
                 )
 
-        self._save_history((matches, labels[matches]))
+        self._save_history((np.nonzero(matches), labels[matches]))
 
         # Replace target pixels with new_label
         labels[matches] = new_label

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -721,7 +721,7 @@ class Labels(_ImageBase):
             return
 
         history_item = before.pop()
-        after.append(reversed(history_item))
+        after.append(list(reversed(history_item)))
         for prev_indices, prev_values in reversed(history_item):
             self.data[prev_indices] = prev_values
 


### PR DESCRIPTION
# Description

This is a WIP PR that should improve our compatibility with other array types (almost none of which have .copy()), as well as improve undo behaviour in general — this will work with n-dimensional painting, rather than only in-plane painting.

Currently non-n-dimensional fill in a 3D+ setting is not working, because the code takes a different path that ends up writing a complete slice to the data.  I should be able to harmonize the paths to use fancy indexing without too much trouble, it's just late and I wanted to push this. ;)

This is in context of @DragaDoncila's work with sparse arrays, but we ran into the lack of .copy() with @AbigailMcGovern's zarpaint also (where we had to monkeypatch .copy() into a TensorStore object).

CC @DragaDoncila

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
