### PR TITLE
Broken link fixed for Handling Code of Conduct Reports

### DIFF
--- a/docs/developers/code_of_conduct.md
+++ b/docs/developers/code_of_conduct.md
@@ -62,7 +62,7 @@ If your report involves any members of the committee, or if they feel they have 
 
 ## Incident reporting resolution & Code of Conduct enforcement
 
-*This section summarizes the most important points, more details can be found in [napari Code of Conduct - How to follow up on a report.](https://github.com/napari/napari/blob/master/docs/CODE_OF_CONDUCT_REPORTING.md)*
+*This section summarizes the most important points, more details can be found in [napari Code of Conduct - How to follow up on a report.](https://github.com/napari/napari/blob/master/docs/developers/code_of_conduct_reporting.md)*
 
 We will investigate and respond to all complaints. The napari Code of Conduct Committee will protect the identity of the reporter, and treat the content of complaints as confidential (unless the reporter agrees otherwise).
 


### PR DESCRIPTION
# Description
Broken link to Handling Code of Conduct Reports

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)
