### PR TITLE
Use not mutable fields on Viewer where appropriate

### DIFF
--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -683,3 +683,24 @@ def test_add_remove_layer_external_callbacks(Layer, data, ndim):
     assert len(layer.events.callbacks) == 1
     for em in layer.events.emitters.values():
         assert len(em.callbacks) == 1
+
+
+@pytest.mark.parametrize(
+    'field', ['camera', 'cursor', 'dims', 'grid', 'layers', 'scale_bar']
+)
+def test_not_mutable_fields(field):
+    """Test appropriate fields are not mutable."""
+    viewer = ViewerModel()
+
+    # Check attribute lives on the viewer
+    assert hasattr(viewer, field)
+    # Check attribute does not have an event emitter
+    assert not hasattr(viewer.events, field)
+
+    # Check attribute is not settable
+    with pytest.raises(TypeError) as err:
+        setattr(viewer, field, 'test')
+
+    assert 'has allow_mutation set to False and cannot be assigned' in str(
+        err.value
+    )

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -82,17 +82,17 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         Contains axes, indices, dimensions and sliders.
     """
 
-    # After https://github.com/samuelcolvin/pydantic/pull/2196 is released
-    # make all of these fields with allow_mutation=False
-    axes: Axes = Axes()
-    camera: Camera = Camera()
-    cursor: Cursor = Cursor()
-    dims: Dims = Dims()
-    grid: GridCanvas = GridCanvas()
+    # Using allow_mutation=False means these attributes aren't settable and don't
+    # have an event emitter associated with them
+    axes: Axes = Field(default_factory=Axes, allow_mutation=False)
+    camera: Camera = Field(default_factory=Camera, allow_mutation=False)
+    cursor: Cursor = Field(default_factory=Cursor, allow_mutation=False)
+    dims: Dims = Field(default_factory=Dims, allow_mutation=False)
+    grid: GridCanvas = Field(default_factory=GridCanvas, allow_mutation=False)
     layers: LayerList = Field(
-        default_factory=LayerList
+        default_factory=LayerList, allow_mutation=False
     )  # Need to create custom JSON encoder for layer!
-    scale_bar: ScaleBar = ScaleBar()
+    scale_bar: ScaleBar = Field(default_factory=ScaleBar, allow_mutation=False)
 
     active_layer: Optional[
         Layer

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -122,9 +122,13 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        # add events for each field
         self._events.source = self
-        self._events.add(**dict.fromkeys(self.__fields__))
+        # add event emitters for each field which is mutable
+        fields = []
+        for name, field in self.__fields__.items():
+            if field.field_info.allow_mutation:
+                fields.append(name)
+        self._events.add(**dict.fromkeys(fields))
 
     def __setattr__(self, name, value):
         if name not in getattr(self, 'events', {}):

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     psutil>=5.0
     PyOpenGL>=3.1.0
     PyYAML>=5.1
-    pydantic>=1.7.3, !=1.8.0  # 1.8.0 broke something
+    pydantic>=1.8.1
     qtpy>=1.7.0
     scipy>=1.2.0
     tifffile>=2020.2.16


### PR DESCRIPTION
# Description
Following the release of pydantic 1.8.x and https://github.com/samuelcolvin/pydantic/pull/2196 we can now use field not mutable fields where appropriate on our Viewer. This will prevent people from overwriting the dims, or trying to set things that cannot be set. We also won't add event emitters for these fields as they cannot be changed.

Technically this is a breaking change, but I'm not quite sure how anyone would have successfully set these things before!  

It should be reviewed after we fix our CI with `1.8.1` (see #2322). Note this will bump our min pydantic requirement to `1.8.1` as `allow_mutation=False` was previously not supported.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
