### PR TITLE
Fix json encoder inheritance on nested submodels for pydantic>=1.8.0

### DIFF
--- a/napari/utils/events/_tests/test_evented_model.py
+++ b/napari/utils/events/_tests/test_evented_model.py
@@ -284,3 +284,19 @@ def test_evented_model_serialization():
     assert raw == '{"obj": {"a": 1, "b": "hi"}, "shaped": [1.0, 2.0, 3.0]}'
     deserialized = Model.parse_raw(raw)
     assert deserialized == m
+
+
+def test_nested_evented_model_serialization():
+    """Test that encoders on nested sub-models can be used by top model."""
+
+    class NestedModel(EventedModel):
+        obj: MyObj
+
+    class Model(EventedModel):
+        nest: NestedModel
+
+    m = Model(nest={'obj': {"a": 1, "b": "hi"}})
+    raw = m.json()
+    assert raw == r'{"nest": {"obj": {"a": 1, "b": "hi"}}}'
+    deserialized = Model.parse_raw(raw)
+    assert deserialized == m

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -84,7 +84,12 @@ class EventedMetaclass(main.ModelMetaclass):
             # NOTE: a _json_encode field must return an object that can be
             # passed to json.dumps ... but it needn't return a string.
             if hasattr(f.type_, '_json_encode'):
-                cls.__config__.json_encoders[f.type_] = f.type_._json_encode
+                encoder = f.type_._json_encode
+                cls.__config__.json_encoders[f.type_] = encoder
+                # also add it to the base config
+                # required for pydantic>=1.8.0 due to:
+                # https://github.com/samuelcolvin/pydantic/pull/2064
+                EventedModel.__config__.json_encoders[f.type_] = encoder
         return cls
 
 


### PR DESCRIPTION
# Description
fixes #2322

pydantic 1.8.0 [changed](https://github.com/samuelcolvin/pydantic/pull/2064) the way that json_encoders are inherited and merged, which created an issue for our [field json encoder discovery](#2297), with _nested_ fields (in this case the `ColorCycle` encoder _was_ getting detected, but it was only added to the immediate parent `CategoricalColormap` model... but was lost by the `ColorManager` model).

This PR makes sure that json_encoders discovered on fields also get added back to the base `EventedModel` json encoders so that future models may also use them.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added tests for nested json encoder inheritance
- [x] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
