### PR TITLE
Generic Button to toggle state.

### DIFF
--- a/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -51,46 +51,20 @@ QtViewerPushButton[mode="home"] {
   image: url(":/themes/{{ folder }}/home.svg");
 }
 
-QtBistateButton[mode="ndisplay_button"]::indicator:unchecked {
+QtStateButton[mode="ndisplay_button"]:checked {
   image: url(":/themes/{{ folder }}/3D.svg");
 }
 
-QtBistateButton[mode="ndisplay_button"]::indicator:checked {
+QtStateButton[mode="ndisplay_button"] {
   image: url(":/themes/{{ folder }}/2D.svg");
 }
 
-QtBistateButton{
-    background-color: {{ foreground }};
-    min-width : 28px;
-    max-width : 28px;
-    min-height : 28px;
-    max-height : 28px;
-    border-radius: 3px;
-    border: 0px;
-    padding: 0px;
-}
-
-QtBistateButton::indicator {
-    background-color: {{ foreground }};
-    min-width : 28px;
-    max-width : 28px;
-    min-height : 28px;
-    max-height : 28px;
-    border-radius: 3px;
-    border: 0px;
-    padding: 0px;
-}
-
-QCheckBox[mode="grid_view_button"]::indicator:unchecked {
+QtStateButton[mode="grid_view_button"]:checked {
   image: url(":/themes/{{ folder }}/square.svg");
 }
 
-QCheckBox[mode="grid_view_button"]::indicator:checked {
+QtStateButton[mode="grid_view_button"] {
   image: url(":/themes/{{ folder }}/grid.svg");
-}
-
-QtBistateButton::indicator:hover {
-  background-color: {{ primary }};
 }
 
 QtModeRadioButton {

--- a/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -51,39 +51,15 @@ QtViewerPushButton[mode="home"] {
   image: url(":/themes/{{ folder }}/home.svg");
 }
 
-QtNDisplayButton {
-    background-color: {{ foreground }};
-    min-width : 28px;
-    max-width : 28px;
-    min-height : 28px;
-    max-height : 28px;
-    border-radius: 3px;
-    border: 0px;
-    padding: 0px;
-}
-
-QtNDisplayButton::indicator {
-    min-width : 28px;
-    max-width : 28px;
-    min-height : 28px;
-    max-height : 28px;
-    border: 0px;
-    padding: 0px;
-}
-
-QtNDisplayButton::indicator:unchecked {
+QtBistateButton[mode="ndisplay_button"]::indicator:unchecked {
   image: url(":/themes/{{ folder }}/3D.svg");
 }
 
-QtNDisplayButton::indicator:checked {
+QtBistateButton[mode="ndisplay_button"]::indicator:checked {
   image: url(":/themes/{{ folder }}/2D.svg");
 }
 
-QtNDisplayButton::indicator:hover {
-  background-color: {{ primary }};
-}
-
-QtGridViewButton {
+QtBistateButton{
     background-color: {{ foreground }};
     min-width : 28px;
     max-width : 28px;
@@ -94,7 +70,7 @@ QtGridViewButton {
     padding: 0px;
 }
 
-QtGridViewButton::indicator {
+QtBistateButton::indicator {
     background-color: {{ foreground }};
     min-width : 28px;
     max-width : 28px;
@@ -105,15 +81,15 @@ QtGridViewButton::indicator {
     padding: 0px;
 }
 
-QtGridViewButton::indicator:unchecked {
+QCheckBox[mode="grid_view_button"]::indicator:unchecked {
   image: url(":/themes/{{ folder }}/square.svg");
 }
 
-QtGridViewButton::indicator:checked {
+QCheckBox[mode="grid_view_button"]::indicator:checked {
   image: url(":/themes/{{ folder }}/grid.svg");
 }
 
-QtGridViewButton::indicator:hover {
+QtBistateButton::indicator:hover {
   background-color: {{ primary }};
 }
 

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -298,7 +298,7 @@ class QtBistateButton(QCheckBox):
         self._on_change()
 
     def change(self, state):
-        """Toggle between grid view mode and (the ordinary) stack view mode.
+        """Toggle between the multiple states of this button.
 
         Parameters
         ----------
@@ -313,7 +313,7 @@ class QtBistateButton(QCheckBox):
         setattr(self._target, self._attribute, newstate)
 
     def _on_change(self, event=None):
-        """Update grid layout size.
+        """Called wen mirrored value changes
 
         Parameters
         ----------

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -262,7 +262,7 @@ class QtStateButton(QtViewerPushButton):
         object on which you want to change the property when button pressed.
     attribute:
         name of attribute on `object` you wish to change.
-    event: EventEmitter
+    events: EventEmitter
         event emitter that will trigger when value is changed
     onstate: Any
         value to use for ``setattr(object, attribute, onstate)`` when clicking

--- a/napari/qt/__init__.py
+++ b/napari/qt/__init__.py
@@ -2,13 +2,12 @@ from .._qt.qt_event_loop import get_app, run
 from .._qt.qt_main_window import Window
 from .._qt.qt_resources import compile_qt_svgs, get_stylesheet
 from .._qt.qt_viewer import QtViewer
-from .._qt.widgets.qt_viewer_buttons import QtNDisplayButton, QtViewerButtons
+from .._qt.widgets.qt_viewer_buttons import QtViewerButtons
 from .threading import create_worker, thread_worker
 
 __all__ = (
     'compile_qt_svgs',
     'create_worker',
-    'QtNDisplayButton',
     'QtViewer',
     'QtViewerButtons',
     'thread_worker',


### PR DESCRIPTION
To work better with the action manager we do want a more generic way to
represent buttons that toggle between two states; currently this is only
done in two places: QtNDisplayButton and QtGridViewButton whcih are
checkboxes and not Button; thus they do not have the same interface.

Instead of subclassing checkbox and target the qss on the new class;
create generic QtBistateButton that sets the mode for qss targetting and
has a well defined set of parameters.

There is an increase in number of indirection; so a small increase of
complexity; but this is likely reusable for other button ; for example
the toggle console button is a push button and coudl reflect wether the
console is shown or not.


## Type of change
- [x] Refactor: Same functionality, differently, change internal API
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Manually opening existing examples and checking that buttons still looks ok and behave.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works


--- 

I'm not good at naming; so better name welcome.