### PR TITLE
Fix rgb for octree

### DIFF
--- a/napari/_vispy/experimental/_tests/test_vispy_tiled_image.py
+++ b/napari/_vispy/experimental/_tests/test_vispy_tiled_image.py
@@ -135,3 +135,45 @@ def test_tiled_changing_contrast_limits(
 
     screenshot = viewer.screenshot(canvas_only=True)
     np.testing.assert_allclose(screenshot[tuple(center_coord)], target_center)
+
+
+@pytest.mark.async_only
+@pytest.mark.skip("NAPARI_OCTREE env var cannot be dynamically set")
+@skip_on_win_ci
+@skip_local_popups
+def test_tiled_rgb(qtbot, monkeypatch, make_napari_viewer):
+    """Test changing contrast limits of tiled data."""
+    # Enable tiled rendering
+    monkeypatch.setenv("NAPARI_OCTREE", "1")
+
+    viewer = make_napari_viewer(show=True)
+    # Set canvas size to target amount
+    viewer.window.qt_viewer.view.canvas.size = (800, 600)
+
+    shapes = [(4000, 3000, 3), (2000, 1500, 3), (1000, 750, 3), (500, 375, 3)]
+    data = [128 * np.ones(s, np.uint8) for s in shapes]
+    layer = viewer.add_image(data, multiscale=True, rgb=True)
+
+    visual = viewer.window.qt_viewer.layer_to_visual[layer]
+
+    # Check visual is a tiled image visual
+    assert isinstance(visual, VispyTiledImageLayer)
+
+    # Wait until the chunks have added, ToDo change this to a qtbot.waitSignal
+    qtbot.wait(SHORT_LOADING_DELAY)
+
+    # Take the screenshot
+    screenshot = viewer.screenshot(canvas_only=True)
+    center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)
+    target_center = np.array([128, 128, 128, 255], dtype='uint8')
+    target_edge = np.array([0, 0, 0, 255], dtype='uint8')
+    screen_offset = 3  # Offset is needed as our screenshots have black borders
+
+    # Center pixel should be gray
+    np.testing.assert_allclose(screenshot[tuple(center_coord)], target_center)
+    np.testing.assert_allclose(
+        screenshot[screen_offset, screen_offset], target_edge
+    )
+    np.testing.assert_allclose(
+        screenshot[-screen_offset, -screen_offset], target_edge
+    )

--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -286,7 +286,7 @@ class TextureAtlas2D(Texture2D):
 
         assert isinstance(data, np.ndarray)
 
-        # Make sure data is of a type acceptable to vispy
+        # Make sure data is of a dtype acceptable to vispy
         data = fix_data_dtype(data)
 
         if not self.spec.is_compatible(data):

--- a/napari/_vispy/experimental/texture_atlas.py
+++ b/napari/_vispy/experimental/texture_atlas.py
@@ -8,6 +8,7 @@ import numpy as np
 from vispy.gloo import Texture2D
 
 from ...layers.image.experimental import OctreeChunk
+from ..utils_gl import fix_data_dtype
 
 # Two triangles which cover a [0..1, 0..1] quad.
 _QUAD = np.array(
@@ -272,9 +273,6 @@ class TextureAtlas2D(Texture2D):
         """
         data = octree_chunk.data
 
-        if data.dtype == np.float64:
-            data = data.astype(np.float32)
-
         # normalize by contrast limits if provided. This normalization
         # will not be required after https://github.com/vispy/vispy/pull/1920/
         # and at that point should be changed.
@@ -288,8 +286,8 @@ class TextureAtlas2D(Texture2D):
 
         assert isinstance(data, np.ndarray)
 
-        # Convert all data to float32
-        data = data.astype(np.float32)
+        # Make sure data is of a type acceptable to vispy
+        data = fix_data_dtype(data)
 
         if not self.spec.is_compatible(data):
             # It will be not compatible of number of dimensions or depth

--- a/napari/_vispy/utils_gl.py
+++ b/napari/_vispy/utils_gl.py
@@ -4,9 +4,18 @@ from contextlib import contextmanager
 from functools import lru_cache
 from typing import Tuple
 
+import numpy as np
 from vispy.app import Canvas
 from vispy.gloo import gl
 from vispy.gloo.context import get_current_canvas
+
+texture_dtypes = [
+    np.dtype(np.int8),
+    np.dtype(np.uint8),
+    np.dtype(np.int16),
+    np.dtype(np.uint16),
+    np.dtype(np.float32),
+]
 
 
 @contextmanager
@@ -53,3 +62,34 @@ def get_max_texture_sizes() -> Tuple[int, int]:
     max_size_3d = 2048
 
     return max_size_2d, max_size_3d
+
+
+def fix_data_dtype(data):
+    """Makes sure the dtype of the data is accetpable to vispy.
+
+    Acceptable types are int8, uint8, int16, uint16, float32, float64.
+
+    Parameters
+    ----------
+    data : np.ndarray
+        Data that will need to be of right type.
+
+    Returns
+    -------
+    np.ndarray
+        Data that is of right type and will be passed to vispy.
+    """
+
+    dtype = np.dtype(data.dtype)
+    if dtype in texture_dtypes:
+        return data
+    else:
+        try:
+            dtype = dict(i=np.int16, f=np.float32, u=np.uint16, b=np.uint8)[
+                dtype.kind
+            ]
+        except KeyError:  # not an int or float
+            raise TypeError(
+                f'type {dtype} not allowed for texture; must be one of {set(texture_dtypes)}'  # noqa: E501
+            )
+        return data.astype(dtype)

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -5,17 +5,9 @@ from vispy.color import Colormap as VispyColormap
 from vispy.scene.node import Node
 
 from .image import Image as ImageNode
+from .utils_gl import fix_data_dtype
 from .vispy_base_layer import VispyBaseLayer
 from .volume import Volume as VolumeNode
-
-texture_dtypes = [
-    np.dtype(np.int8),
-    np.dtype(np.uint8),
-    np.dtype(np.int16),
-    np.dtype(np.uint16),
-    np.dtype(np.float32),
-    np.dtype(np.float64),
-]
 
 
 class ImageLayerNode:
@@ -82,10 +74,6 @@ class VispyImageLayer(VispyBaseLayer):
         self.node.order = self.order
         self.reset()
 
-    def _data_astype(self, data, dtype):
-        """Broken out as a separate function so we can time with perfmon."""
-        return data.astype(dtype)
-
     def _on_data_change(self, event=None):
         if not self.layer.loaded:
             # Do nothing if we are not yet loaded. Calling astype below could
@@ -97,17 +85,7 @@ class VispyImageLayer(VispyBaseLayer):
     def _set_node_data(self, node, data):
         """Our self.layer._data_view has been updated, update our node."""
 
-        dtype = np.dtype(data.dtype)
-        if dtype not in texture_dtypes:
-            try:
-                dtype = dict(
-                    i=np.int16, f=np.float32, u=np.uint16, b=np.uint8
-                )[dtype.kind]
-            except KeyError:  # not an int or float
-                raise TypeError(
-                    f'type {dtype} not allowed for texture; must be one of {set(texture_dtypes)}'  # noqa: E501
-                )
-            data = self._data_astype(data, dtype)
+        data = fix_data_dtype(data)
 
         if self.layer._ndisplay == 3 and self.layer.ndim == 2:
             data = np.expand_dims(data, axis=0)


### PR DESCRIPTION
# Description
Follow up from #2349, I broke the rgb behavior for that PR due to a bad dtype conversion, I've fixed this now. All should be working fine now. Can you give this a quick look @tlambert03! 

[EDIT: I've added another test that passes locally, but am skipping due to the env var setting]

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)