### PR TITLE
Add spiral indexing to bring in tiles at center of FOV first

### DIFF
--- a/napari/layers/image/experimental/_tests/test_octree_util.py
+++ b/napari/layers/image/experimental/_tests/test_octree_util.py
@@ -2,7 +2,7 @@ import pytest
 
 from napari.layers.image.experimental.octree_util import (
     linear_index,
-    sprial_index,
+    spiral_index,
 )
 
 
@@ -18,13 +18,13 @@ from napari.layers.image.experimental.octree_util import (
         [(22, 38), (2, 16)],
     ],
 )
-def test_sprial_index_against_linear(ranges):
-    """Test sprial index set and linear index set match"""
+def test_spiral_index_against_linear(ranges):
+    """Test spiral index set and linear index set match"""
 
     row_range, col_range = ranges
     row_range = range(*row_range)
     col_range = range(*col_range)
-    sprial = set(list(sprial_index(row_range, col_range)))
+    spiral = set(list(spiral_index(row_range, col_range)))
     linear = set(list(linear_index(row_range, col_range)))
 
-    assert sprial == linear
+    assert spiral == linear

--- a/napari/layers/image/experimental/_tests/test_octree_util.py
+++ b/napari/layers/image/experimental/_tests/test_octree_util.py
@@ -1,0 +1,30 @@
+import pytest
+
+from napari.layers.image.experimental.octree_util import (
+    linear_index,
+    sprial_index,
+)
+
+
+@pytest.mark.parametrize(
+    "ranges",
+    [
+        [(0, 7), (0, 9)],
+        [(0, 8), (0, 8)],
+        [(0, 8), (0, 9)],
+        [(0, 8), (0, 10)],
+        [(10, 23), (10, 24)],
+        [(21, 38), (2, 15)],
+        [(22, 38), (2, 16)],
+    ],
+)
+def test_sprial_index_against_linear(ranges):
+    """Test sprial index set and linear index set match"""
+
+    row_range, col_range = ranges
+    row_range = range(*row_range)
+    col_range = range(*col_range)
+    sprial = set(list(sprial_index(row_range, col_range)))
+    linear = set(list(linear_index(row_range, col_range)))
+
+    assert sprial == linear

--- a/napari/layers/image/experimental/octree_intersection.py
+++ b/napari/layers/image/experimental/octree_intersection.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from .octree_chunk import OctreeChunk
 from .octree_level import OctreeLevel
-from .octree_util import OctreeDisplayOptions, sprial_index
+from .octree_util import OctreeDisplayOptions, spiral_index
 
 
 class OctreeView(NamedTuple):
@@ -203,7 +203,7 @@ class OctreeIntersection:
         # every chunk within the view.
 
         # We use spiral indexing to get chunks from the center first
-        for row, col in sprial_index(self._row_range, self._col_range):
+        for row, col in spiral_index(self._row_range, self._col_range):
             chunk = self.level.get_chunk(row, col, create=create)
             if chunk is not None:
                 chunks.append(chunk)

--- a/napari/layers/image/experimental/octree_intersection.py
+++ b/napari/layers/image/experimental/octree_intersection.py
@@ -201,12 +201,52 @@ class OctreeIntersection:
         # OctreeChunks can be loaded or unloaded. Unloaded chunks are not
         # drawn until their data as been loaded in. But here we return
         # every chunk within the view.
-        for row in self._row_range:
-            for col in self._col_range:
-                chunk = self.level.get_chunk(row, col, create=create)
-                if chunk is not None:
-                    chunks.append(chunk)
 
+        def sprial_index(row_range, col_range):
+            """Generate a spiral index from a set of row and column indices.
+
+            A spiral index starts at the center point and moves out in a spiral
+            Paramters
+            ---------
+            row_range : range
+                Range of rows to be accessed.
+            col_range : range
+                Range of columns to be accessed.
+
+            Returns
+            -------
+            iterable
+                (row, column) tuples in order of a spiral index.
+            """
+
+            # Determine how many rows and columns need to be transvered
+            total_row = row_range.stop - row_range.start
+            total_col = row_range.stop - row_range.start
+            # Get center offset
+            row_center = (row_range.stop + row_range.start) // 2
+            col_center = (col_range.stop + col_range.start) // 2
+            # Let the first move be down
+            x = 0
+            y = 0
+            dx = 0
+            dy = -1
+            # Loop through the desired number of indices
+            for i_ in range(max(total_row, total_col) ** 2):
+                if (-total_row / 2 < row <= total_row / 2) and (
+                    -total_col / 2 < col <= total_col / 2
+                ):
+                    yield (row_center + x, col_center + y)
+                if x == y or (x < 0 and x == -y) or (x > 0 and x == 1 - y):
+                    dx, dy = -dy, dx
+                x, y = x + dx, y + dy
+
+        print('aaa', list(sprial_index(self._row_range, self._col_range)))
+        # We use spiral indexing to get chunks from the center first
+        for row, col in sprial_index(self._row_range, self._col_range):
+            chunk = self.level.get_chunk(row, col, create=create)
+            # Store visit to chunk location
+            if chunk is not None:
+                chunks.append(chunk)
         return chunks
 
     @property

--- a/napari/layers/image/experimental/octree_intersection.py
+++ b/napari/layers/image/experimental/octree_intersection.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from .octree_chunk import OctreeChunk
 from .octree_level import OctreeLevel
-from .octree_util import OctreeDisplayOptions
+from .octree_util import OctreeDisplayOptions, sprial_index
 
 
 class OctreeView(NamedTuple):
@@ -202,45 +202,6 @@ class OctreeIntersection:
         # drawn until their data as been loaded in. But here we return
         # every chunk within the view.
 
-        def sprial_index(row_range, col_range):
-            """Generate a spiral index from a set of row and column indices.
-
-            A spiral index starts at the center point and moves out in a spiral
-            Paramters
-            ---------
-            row_range : range
-                Range of rows to be accessed.
-            col_range : range
-                Range of columns to be accessed.
-
-            Returns
-            -------
-            iterable
-                (row, column) tuples in order of a spiral index.
-            """
-
-            # Determine how many rows and columns need to be transvered
-            total_row = row_range.stop - row_range.start
-            total_col = row_range.stop - row_range.start
-            # Get center offset
-            row_center = (row_range.stop + row_range.start) // 2
-            col_center = (col_range.stop + col_range.start) // 2
-            # Let the first move be down
-            x = 0
-            y = 0
-            dx = 0
-            dy = -1
-            # Loop through the desired number of indices
-            for i_ in range(max(total_row, total_col) ** 2):
-                if (-total_row / 2 < row <= total_row / 2) and (
-                    -total_col / 2 < col <= total_col / 2
-                ):
-                    yield (row_center + x, col_center + y)
-                if x == y or (x < 0 and x == -y) or (x > 0 and x == 1 - y):
-                    dx, dy = -dy, dx
-                x, y = x + dx, y + dy
-
-        print('aaa', list(sprial_index(self._row_range, self._col_range)))
         # We use spiral indexing to get chunks from the center first
         for row, col in sprial_index(self._row_range, self._col_range):
             chunk = self.level.get_chunk(row, col, create=create)

--- a/napari/layers/image/experimental/octree_intersection.py
+++ b/napari/layers/image/experimental/octree_intersection.py
@@ -205,7 +205,6 @@ class OctreeIntersection:
         # We use spiral indexing to get chunks from the center first
         for row, col in sprial_index(self._row_range, self._col_range):
             chunk = self.level.get_chunk(row, col, create=create)
-            # Store visit to chunk location
             if chunk is not None:
                 chunks.append(chunk)
         return chunks

--- a/napari/layers/image/experimental/octree_util.py
+++ b/napari/layers/image/experimental/octree_util.py
@@ -145,3 +145,65 @@ class OctreeMetadata(NamedTuple):
         For example HDTV resolution is 16:9 which has aspect ration 1.77.
         """
         return self.base_shape[1] / self.base_shape[0]
+
+
+def sprial_index(row_range, col_range):
+    """Generate a spiral index from a set of row and column indices.
+
+    A spiral index starts at the center point and moves out in a spiral
+    Paramters
+    ---------
+    row_range : range
+        Range of rows to be accessed.
+    col_range : range
+        Range of columns to be accessed.
+
+    Returns
+    -------
+    generator
+        (row, column) tuples in order of a spiral index.
+    """
+
+    # Determine how many rows and columns need to be transvered
+    total_row = row_range.stop - row_range.start
+    total_col = col_range.stop - col_range.start
+    # Get center offset
+    row_center = int(np.ceil((row_range.stop + row_range.start) / 2) - 1)
+    col_center = int(np.ceil((col_range.stop + col_range.start) / 2) - 1)
+    # Let the first move be down
+    x, y = 0, 0
+    dx, dy = 0, -1
+    # Loop through the desired number of indices
+    for i_ in range(max(total_row, total_col) ** 2):
+        # Check if values are in range
+        if (-total_row // 2 < x <= total_row // 2) and (
+            -total_col // 2 < y <= total_col // 2
+        ):
+            # Return desired row, col tuple
+            yield (row_center + x, col_center + y)
+        # Change direction at appropriate points
+        if x == y or (x < 0 and x == -y) or (x > 0 and x == 1 - y):
+            dx, dy = -dy, dx
+        x, y = x + dx, y + dy
+
+
+def linear_index(row_ranges, col_ranges):
+    """Generate a linear index from a set of row and column indices.
+
+    A linear index starts at the top left and procedes in a raster fashion.
+
+    Paramters
+    ---------
+    row_range : range
+        Range of rows to be accessed.
+    col_range : range
+        Range of columns to be accessed.
+
+    Returns
+    -------
+    generator
+        (row, column) tuples in order of a linear index.
+    """
+    for row in row_ranges:
+        for col in col_ranges:
+            yield (row, col)

--- a/napari/layers/image/experimental/octree_util.py
+++ b/napari/layers/image/experimental/octree_util.py
@@ -187,7 +187,7 @@ def sprial_index(row_range, col_range):
         x, y = x + dx, y + dy
 
 
-def linear_index(row_ranges, col_ranges):
+def linear_index(row_range, col_range):
     """Generate a linear index from a set of row and column indices.
 
     A linear index starts at the top left and procedes in a raster fashion.
@@ -204,6 +204,6 @@ def linear_index(row_ranges, col_ranges):
     generator
         (row, column) tuples in order of a linear index.
     """
-    for row in row_ranges:
-        for col in col_ranges:
+    for row in row_range:
+        for col in col_range:
             yield (row, col)

--- a/napari/layers/image/experimental/octree_util.py
+++ b/napari/layers/image/experimental/octree_util.py
@@ -204,6 +204,6 @@ def linear_index(row_range, col_range):
     generator
         (row, column) tuples in order of a linear index.
     """
-    for row in row_range:
-        for col in col_range:
-            yield (row, col)
+    from itertools import product
+    
+    yield from product(row_range, col_range)

--- a/napari/layers/image/experimental/octree_util.py
+++ b/napari/layers/image/experimental/octree_util.py
@@ -147,7 +147,7 @@ class OctreeMetadata(NamedTuple):
         return self.base_shape[1] / self.base_shape[0]
 
 
-def sprial_index(row_range, col_range):
+def spiral_index(row_range, col_range):
     """Generate a spiral index from a set of row and column indices.
 
     A spiral index starts at the center point and moves out in a spiral

--- a/napari/layers/image/experimental/octree_util.py
+++ b/napari/layers/image/experimental/octree_util.py
@@ -205,5 +205,5 @@ def linear_index(row_range, col_range):
         (row, column) tuples in order of a linear index.
     """
     from itertools import product
-    
+
     yield from product(row_range, col_range)


### PR DESCRIPTION
# Description
Adds support for spiral indexing to bring tiles at the center of the FOV to the front first. It's a fairly minor change, but i prefer it as the tiles now load center out as opposed to from the top left corner. It's a little subtle in these movies but see

With spiral from center (this PR):

https://user-images.githubusercontent.com/6531703/110230191-22f36b80-7ec4-11eb-9570-93cb68abe422.mov

With linear from top left corner (current master):

https://user-images.githubusercontent.com/6531703/110230202-3272b480-7ec4-11eb-96de-a45323bfefa2.mov

I've added fairly comprehensive tests of the spiral indexing itself.

This is now ready for review.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
