### PR TITLE
More general fix for xarray indexing

### DIFF
--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -231,7 +231,10 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
 
         # Set data
         self.rgb = rgb
-        self._data = data
+        if 'xarray.core.dataarray.DataArray' in str(data.__class__):
+            self._data = data.values
+        else:
+            self._data = data
         if self.multiscale:
             self._data_level = len(self.data) - 1
             # Determine which level of the multiscale to use for the thumbnail.
@@ -331,7 +334,10 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
 
     @data.setter
     def data(self, data):
-        self._data = data
+        if 'xarray.core.dataarray.DataArray' in str(data.__class__):
+            self._data = data.values
+        else:
+            self._data = data
         self._update_dims()
         self.events.data(value=self.data)
         self._set_editable()

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -868,17 +868,6 @@ class Labels(_ImageBase):
 
             slice_coord = tuple(slice_coord)
 
-        # Fix indexing for xarray if necessary
-        # See http://xarray.pydata.org/en/stable/indexing.html#vectorized-indexing
-        # for difference from indexing numpy
-        try:
-            import xarray as xr
-
-            if isinstance(self.data, xr.DataArray):
-                slice_coord = tuple(xr.DataArray(i) for i in slice_coord)
-        except ImportError:
-            pass
-
         # slice_coord from square brush is tuple of slices per dimension
         # slice_coord from circle brush is tuple of coord. arrays per dimension
 


### PR DESCRIPTION
# Description
This is a more general fix to the issue of xarray having different slicing semantics than numpy than #2191. Rather than deal with those differences we just access the underlying numpy array and do all of our work on that.

I think this fixes the root of the problem and won't require more proliferation of special casing. However I think the downside here is that it could be confusing for a user to do:
```python
xr_data = xr.DataArray(....)

labels.data = xr_data

print(type(labels.data))
# and then use labels.data in the rest of their code
```
as `labels.data` will not provide the xarray methods the user would expect.

Is that too negative of a tradeoff for the added simplicity in the napari code?

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
Fixes: https://github.com/napari/napari/issues/2374
Replaces: https://github.com/napari/napari/pull/2191

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ necessary? ] I have commented my code, particularly in hard-to-understand areas
- [NA] I have made corresponding changes to the documentation
- [ TBD ] I have added tests that prove my fix is effective or that my feature works
