### PR TITLE
ipython embed example

### DIFF
--- a/examples/embed_ipython.py
+++ b/examples/embed_ipython.py
@@ -1,6 +1,13 @@
 """
-Start napari and land directly in an embedded ipython console with qt event loop
+Start napari and land directly in an embedded ipython console with qt event loop.
+
+A similar effect can be achieved more simply with `viewer.update_console(locals())`,
+such as shown in https://github.com/napari/napari/blob/master/examples/update_console.py.
+
+However, differently from `update_console`, this will start an independent
+ipython console which can outlive the viewer.
 """
+
 import napari
 from IPython.terminal.embed import InteractiveShellEmbed
 
@@ -12,7 +19,7 @@ viewer = napari.Viewer()
 
 # embed ipython and run the magic command to use the qt event loop
 sh = InteractiveShellEmbed()
-sh.run_cell('%gui qt')
-sh()  # the ipython shell will open
+sh.run_cell('%gui qt')  # any valid python or ipython command can be run like this!
+sh()  # open the embedded shell
 
 # From there, you can access the script's scope, such as the variables `text` and `viewer`

--- a/examples/embed_ipython.py
+++ b/examples/embed_ipython.py
@@ -19,7 +19,7 @@ viewer = napari.Viewer()
 
 # embed ipython and run the magic command to use the qt event loop
 sh = InteractiveShellEmbed()
-sh.run_cell('%gui qt')  # any valid python or ipython command can be run like this!
+sh.enable_gui('qt')  # equivalent to using the '%gui qt' magic
 sh()  # open the embedded shell
 
 # From there, you can access the script's scope, such as the variables `text` and `viewer`

--- a/examples/embed_ipython.py
+++ b/examples/embed_ipython.py
@@ -1,0 +1,18 @@
+"""
+Start napari and land directly in an embedded ipython console with qt event loop
+"""
+import napari
+from IPython.terminal.embed import InteractiveShellEmbed
+
+# any code
+text = 'some text'
+
+# initalize viewer
+viewer = napari.Viewer()
+
+# embed ipython and run the magic command to use the qt event loop
+sh = InteractiveShellEmbed()
+sh.run_cell('%gui qt')
+sh()  # the ipython shell will open
+
+# From there, you can access the script's scope, such as the variables `text` and `viewer`


### PR DESCRIPTION
# Description
A short example that shows how to start napari from a python script and land directly in an embedded ipython console with access to the script's scope, as [discussed on zulip](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/non-blocking.20embedding.20ipython/near/229389718).

This is my first example contribution, so let me know if anything is off!