### PR TITLE
Add contrast limits estimate for large plane

### DIFF
--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -318,7 +318,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
             input_data = self.data[-1]
         else:
             input_data = self.data
-        return calc_data_range(input_data)
+        return calc_data_range(input_data, rgb=self.rgb)
 
     @property
     def dtype(self):

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -13,6 +13,10 @@ data_dask = da.random.random(
     size=(100_000, 1000, 1000), chunks=(1, 1000, 1000)
 )
 
+data_dask_plane = da.random.random(
+    size=(100_000, 100_000), chunks=(1000, 1000)
+)
+
 
 def test_calc_data_range():
     # all zeros should return [0, 1] by default
@@ -68,6 +72,12 @@ def test_calc_data_fast_uint8():
 @pytest.mark.timeout(2)
 def test_calc_data_range_fast_big():
     val = calc_data_range(data_dask)
+    assert len(val) > 0
+
+
+@pytest.mark.timeout(2)
+def test_calc_data_range_fast_big_plane():
+    val = calc_data_range(data_dask_plane)
     assert len(val) > 0
 
 

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -4,13 +4,15 @@ import dask
 import numpy as np
 
 
-def calc_data_range(data):
+def calc_data_range(data, rgb=False):
     """Calculate range of data values. If all values are equal return [0, 1].
 
     Parameters
     ----------
     data : array
         Data to calculate range of values over.
+    rgb : bool
+        Flag if data is rgb.
 
     Returns
     -------
@@ -24,17 +26,32 @@ def calc_data_range(data):
     """
     if data.dtype == np.uint8:
         return [0, 255]
-    if np.prod(data.shape) > 1e6:
+    if np.prod(data.shape) > 1e7:
         # If data is very large take the average of the top, bottom, and
         # middle slices
-        bottom_plane_idx = (0,) * (data.ndim - 2)
-        middle_plane_idx = tuple(s // 2 for s in data.shape[:-2])
-        top_plane_idx = tuple(s - 1 for s in data.shape[:-2])
+        offset = 2 + int(rgb)
+        bottom_plane_idx = (0,) * (data.ndim - offset)
+        middle_plane_idx = tuple(s // 2 for s in data.shape[:-offset])
+        top_plane_idx = tuple(s - 1 for s in data.shape[:-offset])
         idxs = [bottom_plane_idx, middle_plane_idx, top_plane_idx]
-        reduced_data = [
-            [np.max(data[idx]) for idx in idxs],
-            [np.min(data[idx]) for idx in idxs],
-        ]
+        # If each plane is also very large, look only at a subset of the image
+        if (
+            np.prod(data.shape[-offset:]) > 1e7
+            and data.shape[-offset] > 64
+            and data.shape[-offset + 1] > 64
+        ):
+            # Find a centeral patch of the image to take
+            center = [int(s // 2) for s in data.shape[-offset:]]
+            cental_slice = tuple(slice(c - 31, c + 31) for c in center[:2])
+            reduced_data = [
+                [np.max(data[idx + cental_slice]) for idx in idxs],
+                [np.min(data[idx + cental_slice]) for idx in idxs],
+            ]
+        else:
+            reduced_data = [
+                [np.max(data[idx]) for idx in idxs],
+                [np.min(data[idx]) for idx in idxs],
+            ]
         # compute everything in one go
         reduced_data = dask.compute(*reduced_data)
     else:


### PR DESCRIPTION
# Description
This PR adds contrast limits estimation for large planes to support #2372 which allows us to render very large plans with tiled rendering. It doesn't look at the chunk structure of the data. Maybe one day this can be improved, but it will be better than nothing for #2372 and prevent some unpleasant crashes

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
