### PR TITLE
[WIP] add support for octree labels

### DIFF
--- a/napari/_qt/layer_controls/qt_layer_controls_container.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_container.py
@@ -22,10 +22,12 @@ layer_to_controls = {
 
 if config.async_loading:
     from ...layers.image.experimental.octree_image import OctreeImage
+    from ...layers.labels.experimental.octree_labels import OctreeLabels
 
     # The user visible layer controls for OctreeImage layers are identical
     # to the regular image layer controls, for now.
     layer_to_controls[OctreeImage] = QtImageControls
+    layer_to_controls[OctreeLabels] = QtLabelsControls
 
 
 def create_qt_layer_controls(layer):

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -514,9 +514,10 @@ class QtViewer(QSplitter):
     def _toggle_chunk_outlines(self):
         """Toggle whether we are drawing outlines around the chunks."""
         from ..layers.image.experimental.octree_image import OctreeImage
+        from ..layers.labels.experimental.octree_labels import OctreeLabels
 
         for layer in self.viewer.layers:
-            if isinstance(layer, OctreeImage):
+            if isinstance(layer, (OctreeImage, OctreeLabels)):
                 layer.display.show_grid = not layer.display.show_grid
 
     def _on_interactive(self, event):

--- a/napari/_vispy/utils.py
+++ b/napari/_vispy/utils.py
@@ -30,10 +30,14 @@ layer_to_visual = {
 
 if async_octree:
     from ..layers.image.experimental.octree_image import OctreeImage
+    from ..layers.labels.experimental.octree_labels import OctreeLabels
     from .experimental.vispy_tiled_image_layer import VispyTiledImageLayer
 
     # Insert OctreeImage in front so it gets picked over plain Image.
-    new_mapping = {OctreeImage: VispyTiledImageLayer}
+    new_mapping = {
+        OctreeImage: VispyTiledImageLayer,
+        OctreeLabels: VispyTiledImageLayer,
+    }
     new_mapping.update(layer_to_visual)
     layer_to_visual = new_mapping
 

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -18,7 +18,7 @@ import numpy as np
 from pydantic import Extra, Field, validator
 
 from .. import layers
-from ..layers import Image, Layer
+from ..layers import Image, Labels, Layer
 from ..layers.image._image_utils import guess_labels
 from ..layers.utils.stack_utils import split_channels
 from ..utils import config
@@ -880,6 +880,16 @@ def _get_image_class() -> Image:
     return Image
 
 
+def _get_labels_class() -> Labels:
+    """Return Image or OctreeImage based config settings."""
+    if config.async_octree:
+        from ..layers.labels.experimental.octree_labels import OctreeLabels
+
+        return OctreeLabels
+
+    return Labels
+
+
 def _normalize_layer_data(data: 'LayerData') -> 'FullLayerData':
     """Accepts any layerdata tuple, and returns a fully qualified tuple.
 
@@ -1040,8 +1050,9 @@ def valid_add_kwargs() -> Dict[str, Set[str]]:
     return valid
 
 
+_get_labels_class()
 for _layer in (
-    layers.Labels,
+    Labels,
     layers.Points,
     layers.Shapes,
     layers.Surface,

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1050,9 +1050,9 @@ def valid_add_kwargs() -> Dict[str, Set[str]]:
     return valid
 
 
-_get_labels_class()
+labels_class = _get_labels_class()
 for _layer in (
-    Labels,
+    labels_class,
     layers.Points,
     layers.Shapes,
     layers.Surface,

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from ....components.experimental.chunk import ChunkRequest, LayerRef
 from ....utils.events import Event
-from ..image import Image
+from ..image import _ImageBase
 from ._octree_slice import OctreeSlice, OctreeView
 from .octree_chunk import OctreeChunk
 from .octree_intersection import OctreeIntersection
@@ -20,7 +20,7 @@ from .octree_util import OctreeDisplayOptions, OctreeMetadata
 LOGGER = logging.getLogger("napari.octree.image")
 
 
-class OctreeImage(Image):
+class _OctreeImageBase(_ImageBase):
     """Image layer rendered using an octree.
 
     Experimental variant of Image that renders using an octree. For 2D
@@ -492,3 +492,30 @@ class OctreeImage(Image):
             "tile_state": self._intersection.tile_state,
             "tile_config": self._intersection.tile_config,
         }
+
+
+class OctreeImage(_OctreeImageBase):
+    def _get_state(self):
+        """Get dictionary of layer state.
+
+        Returns
+        -------
+        state : dict
+            Dictionary of layer state.
+        """
+        state = self._get_base_state()
+        state.update(
+            {
+                'rgb': self.rgb,
+                'multiscale': self.multiscale,
+                'colormap': self.colormap.name,
+                'contrast_limits': self.contrast_limits,
+                'interpolation': self.interpolation,
+                'rendering': self.rendering,
+                'iso_threshold': self.iso_threshold,
+                'attenuation': self.attenuation,
+                'gamma': self.gamma,
+                'data': self.data,
+            }
+        )
+        return state

--- a/napari/layers/labels/experimental/octree_labels.py
+++ b/napari/layers/labels/experimental/octree_labels.py
@@ -5,23 +5,21 @@ from typing import Dict, Union
 import numpy as np
 from scipy import ndimage as ndi
 
-from ...utils.colormaps import (
+from ....utils.colormaps import (
     color_dict_to_colormap,
     label_colormap,
     low_discrepancy_image,
 )
-from ...utils.events import Event
-
-# from ..image.image import _ImageBase
-from ..image.experimental.octree_image import _OctreeImageBase
-from ..utils.color_transformations import transform_color
-from ..utils.layer_utils import dataframe_to_properties
-from ._labels_constants import LabelBrushShape, LabelColorMode, Mode
-from ._labels_mouse_bindings import draw, pick
-from ._labels_utils import indices_in_shape, sphere_indices
+from ....utils.events import Event
+from ...image.experimental.octree_image import _OctreeImageBase
+from ...utils.color_transformations import transform_color
+from ...utils.layer_utils import dataframe_to_properties
+from .._labels_constants import LabelBrushShape, LabelColorMode, Mode
+from .._labels_mouse_bindings import draw, pick
+from .._labels_utils import indices_in_shape, sphere_indices
 
 
-class Labels(_OctreeImageBase):
+class OctreeLabels(_OctreeImageBase):
     """Labels (or segmentation) layer.
 
     An image-like layer where every pixel contains an integer ID

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -11,9 +11,7 @@ from ...utils.colormaps import (
     low_discrepancy_image,
 )
 from ...utils.events import Event
-
-# from ..image.image import _ImageBase
-from ..image.experimental.octree_image import _OctreeImageBase
+from ..image.image import _ImageBase
 from ..utils.color_transformations import transform_color
 from ..utils.layer_utils import dataframe_to_properties
 from ._labels_constants import LabelBrushShape, LabelColorMode, Mode
@@ -21,7 +19,7 @@ from ._labels_mouse_bindings import draw, pick
 from ._labels_utils import indices_in_shape, sphere_indices
 
 
-class Labels(_OctreeImageBase):
+class Labels(_ImageBase):
     """Labels (or segmentation) layer.
 
     An image-like layer where every pixel contains an integer ID

--- a/napari/types.py
+++ b/napari/types.py
@@ -70,6 +70,7 @@ else:
 
 
 ImageData = NewType("ImageData", ArrayBase)
+OctreeimageData = NewType("OctreeimageData", ArrayBase)
 LabelsData = NewType("LabelsData", ArrayBase)
 PointsData = NewType("PointsData", ArrayBase)
 ShapesData = NewType("ShapesData", List[ArrayBase])

--- a/napari/utils/_register.py
+++ b/napari/utils/_register.py
@@ -12,7 +12,10 @@ template = """def {name}{signature}:
 
 
 def create_func(cls, name=None, doc=None):
-    cls_name = cls.__name__
+    if cls.__name__ == 'OctreeLabels':
+        cls_name = 'Labels'
+    else:
+        cls_name = cls.__name__
 
     if name is None:
         name = camel_to_snake(cls_name)


### PR DESCRIPTION
# Description
This PR will add support for letting the labels layer use the octree - it's a little cumbersome right now and just duplicates the entire labels layer but inheriting from the `OctreeImage` instead of the `Image` (using the new `Base` construct too).

It doesn't actually work right now so I probably have more to do before figuring out how to do this without duplication, but this seemed like this easiest thing to try first!

I'll update this when I have something working

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
