### PR TITLE
Add environment flag for sparse library

### DIFF
--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -41,7 +41,7 @@ del stats
 
 import os
 
-os.environ['SPARSE_AUTO_DENSIFY'] = '1'
+os.environ.setdefault('SPARSE_AUTO_DENSIFY', '1')
 
 
 __all__ = [

--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -38,6 +38,12 @@ del _magicgui
 
 del stats
 
+
+import os
+
+os.environ['SPARSE_AUTO_DENSIFY'] = '1'
+
+
 __all__ = [
     'Viewer',
     'save_layers',


### PR DESCRIPTION
In order to support sparse labels passively, we need to set this environment flag to allow `np.asarray` calls on sparse arrays to proceed without raising an error. See [here](https://sparse.pydata.org/en/0.2.0/user_manual/operations/basic.html#auto-densification).

Was really unsure where to put this - we need it before any `add_...` calls are made. Very happy to take suggestions on where this should go.
