### PR TITLE
Allow no vertex values to be passed to surface layer

### DIFF
--- a/napari/layers/surface/_tests/test_surface.py
+++ b/napari/layers/surface/_tests/test_surface.py
@@ -22,6 +22,22 @@ def test_random_surface():
     assert layer._view_vertex_values.ndim == 1
 
 
+def test_random_surface_no_values():
+    """Test instantiating Surface layer with random 2D data but no vertex values."""
+    np.random.seed(0)
+    vertices = np.random.random((10, 2))
+    faces = np.random.randint(10, size=(6, 3))
+    data = (vertices, faces)
+    layer = Surface(data)
+    assert layer.ndim == 2
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data)])
+    assert np.all(layer.vertices == vertices)
+    assert np.all(layer.faces == faces)
+    assert np.all(layer.vertex_values == np.ones(len(vertices)))
+    assert layer._data_view.shape[1] == 2
+    assert layer._view_vertex_values.ndim == 1
+
+
 def test_random_3D_surface():
     """Test instantiating Surface layer with random 3D data."""
     np.random.seed(0)

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -19,7 +19,7 @@ class Surface(IntensityVisualizationMixin, Layer):
     data : 2-tuple or 3-tuple of array
         The first element of the tuple is an (N, D) array of vertices of
         mesh triangles. The second is an (M, 3) array of int of indices
-        of the mesh triangles. The third optional third element is the
+        of the mesh triangles. The optional third element is the
         (K0, ..., KL, N) array of values used to color vertices where the
         additional L dimensions are used to color the same mesh with
         different values. If not provided, it defaults to ones.


### PR DESCRIPTION
# Description
A very small PR that allows no vertex values to be passed to the surface layer. It will become more helpful after the improvements of #2407

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
