### PR TITLE
[WIP] expose alternative vispy shading modes for meshes

### DIFF
--- a/napari/_qt/layer_controls/qt_surface_controls.py
+++ b/napari/_qt/layer_controls/qt_surface_controls.py
@@ -1,5 +1,7 @@
-from qtpy.QtWidgets import QHBoxLayout, QLabel
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QComboBox, QHBoxLayout, QLabel
 
+from ...layers.surface._surface_constants import Shading
 from .qt_image_controls_base import QtBaseImageControls
 
 
@@ -28,6 +30,15 @@ class QtSurfaceControls(QtBaseImageControls):
         colormap_layout.addWidget(self.colormapComboBox)
         colormap_layout.addStretch(1)
 
+        shading_comboBox = QComboBox(self)
+        shading_comboBox.addItems(Shading.keys())
+        index = shading_comboBox.findText(
+            self.layer.shading, Qt.MatchFixedString
+        )
+        shading_comboBox.setCurrentIndex(index)
+        shading_comboBox.activated[str].connect(self.changeShading)
+        self.shadingComboBox = shading_comboBox
+
         # grid_layout created in QtLayerControls
         # addWidget(widget, row, column, [row_span, column_span])
         self.grid_layout.addWidget(QLabel('opacity:'), 0, 0)
@@ -40,6 +51,18 @@ class QtSurfaceControls(QtBaseImageControls):
         self.grid_layout.addLayout(colormap_layout, 3, 1)
         self.grid_layout.addWidget(QLabel('blending:'), 4, 0)
         self.grid_layout.addWidget(self.blendComboBox, 4, 1)
+        self.grid_layout.addWidget(QLabel('shading:'), 5, 0)
+        self.grid_layout.addWidget(self.shadingComboBox, 5, 1)
+
         self.grid_layout.setRowStretch(5, 1)
         self.grid_layout.setColumnStretch(1, 1)
         self.grid_layout.setSpacing(4)
+
+    def changeShading(self, text):
+        """Change shading value on the surface layer.
+        Parameters
+        ----------
+        text : str
+            Name of shading mode, eg: 'flat', 'smooth', 'none'.
+        """
+        self.layer.shading = text

--- a/napari/_vispy/mesh.py
+++ b/napari/_vispy/mesh.py
@@ -1,0 +1,250 @@
+import numpy as np
+from vispy.color import Color, get_colormap
+from vispy.gloo.buffer import VertexBuffer
+from vispy.scene.visuals import create_visual_node
+from vispy.visuals.visual import Visual
+
+from .vendored import MeshVisual as BaseMeshVisual
+
+# Unified shader
+shader_template = """
+{setup}
+void main() {{
+    {main_function}
+}}
+"""
+
+standard_vertex_snippets = dict(
+    setup="""
+    varying vec4 v_base_color;
+    """,
+    main_function="""
+    v_base_color = $color_transform($base_color);
+    gl_Position = $transform($to_vec4($position));
+    """,
+)
+
+standard_vertex_shader = shader_template.format(**standard_vertex_snippets)
+
+shaded_vertex_snippets = dict(
+    setup="""
+    varying vec3 v_normal_vec;
+    varying vec3 v_light_vec;
+    varying vec3 v_eye_vec;
+    varying vec4 v_ambientk;
+    varying vec4 v_light_color;
+    varying vec4 v_base_color;
+    """,
+    main_function="""
+    v_ambientk = $ambientk;
+    v_light_color = $light_color;
+    v_base_color = $color_transform($base_color);
+    vec4 pos_scene = $visual2scene($to_vec4($position));
+    vec4 normal_scene = $visual2scene(vec4($normal, 1.0));
+    vec4 origin_scene = $visual2scene(vec4(0.0, 0.0, 0.0, 1.0));
+    normal_scene /= normal_scene.w;
+    origin_scene /= origin_scene.w;
+    vec3 normal = normalize(normal_scene.xyz - origin_scene.xyz);
+    v_normal_vec = normal; //VARYING COPY
+    vec4 pos_front = $scene2doc(pos_scene);
+    pos_front.z += 0.01;
+    pos_front = $doc2scene(pos_front);
+    pos_front /= pos_front.w;
+    vec4 pos_back = $scene2doc(pos_scene);
+    pos_back.z -= 0.01;
+    pos_back = $doc2scene(pos_back);
+    pos_back /= pos_back.w;
+    vec3 eye = normalize(pos_front.xyz - pos_back.xyz);
+    v_eye_vec = eye; //VARYING COPY
+    vec3 light = normalize($light_dir.xyz);
+    v_light_vec = light; //VARYING COPY
+    gl_Position = $transform($to_vec4($position));
+    """,
+)
+
+shaded_vertex_shader = shader_template.format(**shaded_vertex_snippets)
+
+standard_fragment_snippets = dict(
+    setup="""
+    varying vec4 v_base_color;
+    """,
+    main_function="""
+    gl_FragColor = v_base_color;
+    """,
+)
+
+standard_fragment_shader = shader_template.format(**standard_fragment_snippets)
+
+shaded_fragment_snippets = dict(
+    setup="""
+    varying vec3 v_normal_vec;
+    varying vec3 v_light_vec;
+    varying vec3 v_eye_vec;
+    varying vec4 v_ambientk;
+    varying vec4 v_light_color;
+    varying vec4 v_base_color;
+    """,
+    main_function="""
+    //DIFFUSE
+    float diffusek = dot(v_light_vec, v_normal_vec);
+    // clamp, because 0 < theta < pi/2
+    diffusek  = clamp(diffusek, 0.0, 1.0);
+    vec4 diffuse_color = v_light_color * diffusek;
+    //SPECULAR
+    //reflect light wrt normal for the reflected ray, then
+    //find the angle made with the eye
+    float speculark = 0.0;
+    if ($shininess > 0.) {
+        speculark = dot(reflect(v_light_vec, v_normal_vec), v_eye_vec);
+        speculark = clamp(speculark, 0.0, 1.0);
+        //raise to the material's shininess, multiply with a
+        //small factor for spread
+        speculark = 20.0 * pow(speculark, 1.0 / $shininess);
+    }
+    vec4 specular_color = v_light_color * speculark;
+    gl_FragColor = v_base_color * (v_ambientk + diffuse_color) + specular_color;
+    """,
+)
+
+shaded_fragment_shader = shader_template.format(**shaded_fragment_snippets)
+
+# variables in the shaded shader but not the standard shader
+shaded_only_variables = (
+    'v_normal_vec',
+    'v_light_vec',
+    'v_eye_vec',
+    'v_ambientk',
+    'v_light_color',
+)
+
+shader_dict = {
+    'standard': {
+        'frag': standard_fragment_shader,
+        'vert': standard_vertex_shader,
+    },
+    'shaded': {
+        'frag': shaded_fragment_shader,
+        'vert': shaded_vertex_shader,
+    },
+}
+
+
+# Custom MeshVisual class to unify shader code for easier switching
+# between shading modes
+class MeshVisual(BaseMeshVisual):
+    def __init__(
+        self,
+        vertices=None,
+        faces=None,
+        vertex_colors=None,
+        face_colors=None,
+        color=(0.5, 0.5, 1, 1),
+        vertex_values=None,
+        meshdata=None,
+        shading=None,
+        mode='triangles',
+        **kwargs,
+    ):
+
+        # Function for computing phong shading
+        # self._phong = Function(phong_template)
+
+        # Visual.__init__ -> prepare_transforms() -> uses shading
+        self.shading = shading
+
+        Visual.__init__(self, vcode='', fcode='', **kwargs)
+
+        self.set_gl_state('translucent', depth_test=True, cull_face=False)
+
+        # Define buffers
+        self._vertices = VertexBuffer(np.zeros((0, 3), dtype=np.float32))
+        self._normals = VertexBuffer(np.zeros((0, 3), dtype=np.float32))
+        self._ambient_light_color = Color((0.3, 0.3, 0.3, 1.0))
+        self._light_dir = (10, 5, -5)
+        self._shininess = 1.0 / 200.0
+        self._cmap = get_colormap('cubehelix')
+        self._clim = 'auto'
+
+        # Uniform color
+        self._color = Color(color)
+
+        # Init
+        self._bounds = None
+        # Note we do not call subclass set_data -- often the signatures
+        # do no match.
+        MeshVisual.set_data(
+            self,
+            vertices=vertices,
+            faces=faces,
+            vertex_colors=vertex_colors,
+            face_colors=face_colors,
+            vertex_values=vertex_values,
+            meshdata=meshdata,
+            color=color,
+        )
+
+        # primitive mode
+        self._draw_mode = mode
+        self.freeze()
+
+    @property
+    def shading(self):
+        """The shading method used."""
+        return self._shading
+
+    @shading.setter
+    def shading(self, shading):
+        known_shading_modes = (None, 'flat', 'smooth')
+        if shading not in known_shading_modes:
+            raise ValueError(
+                f'Shading should be in {known_shading_modes}, not {shading}'
+            )
+        self.shader = self._shading_to_shader(shading)
+        self._shading = shading
+
+    def _shading_to_shader(self, shading):
+        """Infer which shader to use from shading mode"""
+        standard_shading_modes = [None]
+        shaded_shading_modes = ['flat', 'smooth']
+        if shading in standard_shading_modes:
+            shader = 'standard'
+        elif shading in shaded_shading_modes:
+            shader = 'shaded'
+        return shader
+
+    @property
+    def shader(self):
+        """The shader to use
+
+        Current options are:
+
+            * standard: no lighting is used in the computation of colors.
+            * shaded: lighting is used in the computation of color
+              (Phong shading - https://en.wikipedia.org/wiki/Phong_shading)
+        """
+        return self._shader
+
+    @shader.setter
+    def shader(self, shader):
+        known_shaders = list(shader_dict.keys())
+        if shader not in known_shaders:
+            raise ValueError(
+                f'Shader should be in {known_shaders}, not {shader}'
+            )
+        self._shader = shader
+        self._cleanup_shared_program()
+
+        self.shared_program.frag = shader_dict[shader]['frag']
+        self.shared_program.vert = shader_dict[shader]['vert']
+        self.update()
+
+    def _cleanup_shared_program(self):
+        """Remove extra variables which may become invalid on shader change"""
+        common_variables = [
+            v for v in shaded_only_variables if v in self.shared_program
+        ]
+        for v in common_variables:
+            self.shared_program[v] = None
+
+
+Mesh = create_visual_node(MeshVisual)

--- a/napari/_vispy/mesh.py
+++ b/napari/_vispy/mesh.py
@@ -248,5 +248,19 @@ class MeshVisual(BaseMeshVisual):
         for v in common_variables:
             self.shared_program[v] = None
 
+    @staticmethod
+    def _prepare_transforms(view):
+        tr = view.transforms.get_transform()
+        if 'transform' in view.view_program.vert.template_vars:
+            view.view_program.vert['transform'] = tr  # .simplified
+
+        if view.shading is not None:
+            visual2scene = view.transforms.get_transform('visual', 'scene')
+            scene2doc = view.transforms.get_transform('scene', 'document')
+            doc2scene = view.transforms.get_transform('document', 'scene')
+            view.shared_program.vert['visual2scene'] = visual2scene
+            view.shared_program.vert['scene2doc'] = scene2doc
+            view.shared_program.vert['doc2scene'] = doc2scene
+
 
 Mesh = create_visual_node(MeshVisual)

--- a/napari/_vispy/mesh.py
+++ b/napari/_vispy/mesh.py
@@ -194,6 +194,7 @@ class MeshVisual(BaseMeshVisual):
 
     @shading.setter
     def shading(self, shading):
+        print(shading)
         known_shading_modes = (None, 'flat', 'smooth')
         if shading not in known_shading_modes:
             raise ValueError(
@@ -201,6 +202,7 @@ class MeshVisual(BaseMeshVisual):
             )
         self.shader = self._shading_to_shader(shading)
         self._shading = shading
+        self._update_shared_program()
 
     def _shading_to_shader(self, shading):
         """Infer which shader to use from shading mode"""
@@ -248,10 +250,23 @@ class MeshVisual(BaseMeshVisual):
         for v in common_variables:
             self.shared_program[v] = None
 
+    def _update_shaders(self):
+        self.shared_program.frag = shader_dict[self._shader]['frag']
+        self.shared_program.vert = shader_dict[self._shader]['vert']
+
+    def _update_shared_program(self):
+        if hasattr(self, 'shared_program'):
+            self._cleanup_shared_program()
+            self._update_shaders()
+            self._prepare_transforms(self)
+
     @staticmethod
     def _prepare_transforms(view):
-        tr = view.transforms.get_transform()
+        if not hasattr(view, '_program'):
+            return
+
         if 'transform' in view.view_program.vert.template_vars:
+            tr = view.transforms.get_transform()
             view.view_program.vert['transform'] = tr  # .simplified
 
         if view.shading is not None:

--- a/napari/_vispy/mesh.py
+++ b/napari/_vispy/mesh.py
@@ -232,11 +232,13 @@ class MeshVisual(BaseMeshVisual):
                 f'Shader should be in {known_shaders}, not {shader}'
             )
         self._shader = shader
-        self._cleanup_shared_program()
 
-        self.shared_program.frag = shader_dict[shader]['frag']
-        self.shared_program.vert = shader_dict[shader]['vert']
-        self.update()
+        # need to check if shared program has been created yet
+        if getattr(self, 'shared_program', None):
+            self._cleanup_shared_program()
+            self.shared_program.frag = shader_dict[shader]['frag']
+            self.shared_program.vert = shader_dict[shader]['vert']
+            self.update()
 
     def _cleanup_shared_program(self):
         """Remove extra variables which may become invalid on shader change"""

--- a/napari/_vispy/vendored/__init__.py
+++ b/napari/_vispy/vendored/__init__.py
@@ -1,2 +1,3 @@
 from .volume import VolumeVisual
 from .image import ImageVisual
+from .mesh import MeshVisual

--- a/napari/_vispy/vendored/mesh.py
+++ b/napari/_vispy/vendored/mesh.py
@@ -1,0 +1,512 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+# -----------------------------------------------------------------------------
+
+""" A MeshVisual Visual that uses the new shader Function.
+"""
+
+from __future__ import division
+
+import numpy as np
+
+from vispy.visuals.visual import Visual
+from from vispy.visuals.shaders import Function, FunctionChain
+from vispy.gloo import VertexBuffer
+from vispy.geometry import MeshData
+from vispy.color import Color, get_colormap
+
+# Shaders for lit rendering (using phong shading)
+shading_vertex_template = """
+varying vec3 v_normal_vec;
+varying vec3 v_light_vec;
+varying vec3 v_eye_vec;
+
+varying vec4 v_ambientk;
+varying vec4 v_light_color;
+varying vec4 v_base_color;
+
+void main() {
+    v_ambientk = $ambientk;
+    v_light_color = $light_color;
+    v_base_color = $color_transform($base_color);
+
+
+    vec4 pos_scene = $visual2scene($to_vec4($position));
+    vec4 normal_scene = $visual2scene(vec4($normal, 1.0));
+    vec4 origin_scene = $visual2scene(vec4(0.0, 0.0, 0.0, 1.0));
+
+    normal_scene /= normal_scene.w;
+    origin_scene /= origin_scene.w;
+
+    vec3 normal = normalize(normal_scene.xyz - origin_scene.xyz);
+    v_normal_vec = normal; //VARYING COPY
+
+    vec4 pos_front = $scene2doc(pos_scene);
+    pos_front.z += 0.01;
+    pos_front = $doc2scene(pos_front);
+    pos_front /= pos_front.w;
+
+    vec4 pos_back = $scene2doc(pos_scene);
+    pos_back.z -= 0.01;
+    pos_back = $doc2scene(pos_back);
+    pos_back /= pos_back.w;
+
+    vec3 eye = normalize(pos_front.xyz - pos_back.xyz);
+    v_eye_vec = eye; //VARYING COPY
+
+    vec3 light = normalize($light_dir.xyz);
+    v_light_vec = light; //VARYING COPY
+
+    gl_Position = $transform($to_vec4($position));
+}
+"""
+
+shading_fragment_template = """
+varying vec3 v_normal_vec;
+varying vec3 v_light_vec;
+varying vec3 v_eye_vec;
+
+varying vec4 v_ambientk;
+varying vec4 v_light_color;
+varying vec4 v_base_color;
+
+void main() {
+    //DIFFUSE
+    float diffusek = dot(v_light_vec, v_normal_vec);
+    // clamp, because 0 < theta < pi/2
+    diffusek  = clamp(diffusek, 0.0, 1.0);
+    vec4 diffuse_color = v_light_color * diffusek;
+
+    //SPECULAR
+    //reflect light wrt normal for the reflected ray, then
+    //find the angle made with the eye
+    float speculark = 0.0;
+    if ($shininess > 0.) {
+        speculark = dot(reflect(v_light_vec, v_normal_vec), v_eye_vec);
+        speculark = clamp(speculark, 0.0, 1.0);
+        //raise to the material's shininess, multiply with a
+        //small factor for spread
+        speculark = 20.0 * pow(speculark, 1.0 / $shininess);
+    }
+    vec4 specular_color = v_light_color * speculark;
+    gl_FragColor = v_base_color * (v_ambientk + diffuse_color) + specular_color;
+}
+"""  # noqa
+
+# Shader code for non lighted rendering
+vertex_template = """
+varying vec4 v_base_color;
+
+void main() {
+    v_base_color = $color_transform($base_color);
+    gl_Position = $transform($to_vec4($position));
+}
+"""
+
+fragment_template = """
+varying vec4 v_base_color;
+void main() {
+    gl_FragColor = v_base_color;
+}
+"""
+
+
+# Functions that can be used as is (don't have template variables)
+# Consider these stored in a central location in vispy ...
+
+vec3to4 = Function("""
+vec4 vec3to4(vec3 xyz) {
+    return vec4(xyz, 1.0);
+}
+""")
+
+vec2to4 = Function("""
+vec4 vec2to4(vec2 xyz) {
+    return vec4(xyz, 0.0, 1.0);
+}
+""")
+
+
+_null_color_transform = 'vec4 pass(vec4 color) { return color; }'
+_clim = 'float cmap(float val) { return (val - $cmin) / ($cmax - $cmin); }'
+
+
+# Eventually this could be de-duplicated with visuals/image.py, which does
+# something similar (but takes a ``color`` instead of ``float``)
+def _build_color_transform(data, cmap, clim=(0., 1.)):
+    if data.ndim == 2 and data.shape[1] == 1:
+        fun = Function(_clim)
+        fun['cmin'] = clim[0]
+        fun['cmax'] = clim[1]
+        fun = FunctionChain(None, [fun, Function(cmap.glsl_map)])
+    else:
+        fun = Function(_null_color_transform)
+    return fun
+
+
+class MeshVisual(Visual):
+    """Mesh visual
+
+    Parameters
+    ----------
+    vertices : array-like | None
+        The vertices.
+    faces : array-like | None
+        The faces.
+    vertex_colors : array-like | None
+        Colors to use for each vertex.
+    face_colors : array-like | None
+        Colors to use for each face.
+    color : instance of Color
+        The color to use.
+    vertex_values : array-like | None
+        The values to use for each vertex (for colormapping).
+    meshdata : instance of MeshData | None
+        The meshdata.
+    shading : str | None
+        Shading to use.
+    mode : str
+        The drawing mode.
+    **kwargs : dict
+        Keyword arguments to pass to `Visual`.
+    """
+    def __init__(self, vertices=None, faces=None, vertex_colors=None,
+                 face_colors=None, color=(0.5, 0.5, 1, 1), vertex_values=None,
+                 meshdata=None, shading=None, mode='triangles', **kwargs):
+
+        # Function for computing phong shading
+        # self._phong = Function(phong_template)
+
+        # Visual.__init__ -> prepare_transforms() -> uses shading
+        self.shading = shading
+
+        if shading is not None:
+            Visual.__init__(self, vcode=shading_vertex_template,
+                            fcode=shading_fragment_template,
+                            **kwargs)
+
+        else:
+            Visual.__init__(self, vcode=vertex_template,
+                            fcode=fragment_template,
+                            **kwargs)
+
+        self.set_gl_state('translucent', depth_test=True,
+                          cull_face=False)
+
+        # Define buffers
+        self._vertices = VertexBuffer(np.zeros((0, 3), dtype=np.float32))
+        self._normals = VertexBuffer(np.zeros((0, 3), dtype=np.float32))
+        self._ambient_light_color = Color((0.3, 0.3, 0.3, 1.0))
+        self._light_dir = (10, 5, -5)
+        self._shininess = 1. / 200.
+        self._cmap = get_colormap('cubehelix')
+        self._clim = 'auto'
+
+        # Uniform color
+        self._color = Color(color)
+
+        # Init
+        self._bounds = None
+        # Note we do not call subclass set_data -- often the signatures
+        # do no match.
+        MeshVisual.set_data(
+            self, vertices=vertices, faces=faces, vertex_colors=vertex_colors,
+            face_colors=face_colors, vertex_values=vertex_values,
+            meshdata=meshdata, color=color)
+
+        # primitive mode
+        self._draw_mode = mode
+        self.freeze()
+
+    def set_data(self, vertices=None, faces=None, vertex_colors=None,
+                 face_colors=None, color=None, vertex_values=None,
+                 meshdata=None):
+        """Set the mesh data
+
+        Parameters
+        ----------
+        vertices : array-like | None
+            The vertices.
+        faces : array-like | None
+            The faces.
+        vertex_colors : array-like | None
+            Colors to use for each vertex.
+        face_colors : array-like | None
+            Colors to use for each face.
+        color : instance of Color
+            The color to use.
+        vertex_values : array-like | None
+            Values for each vertex.
+        meshdata : instance of MeshData | None
+            The meshdata.
+        """
+        if meshdata is not None:
+            self._meshdata = meshdata
+        else:
+            self._meshdata = MeshData(vertices=vertices, faces=faces,
+                                      vertex_colors=vertex_colors,
+                                      face_colors=face_colors,
+                                      vertex_values=vertex_values)
+        self._bounds = self._meshdata.get_bounds()
+        if color is not None:
+            self._color = Color(color)
+        self.mesh_data_changed()
+
+    @property
+    def clim(self):
+        return (self._clim if isinstance(self._clim, str) else
+                tuple(self._clim))
+
+    @clim.setter
+    def clim(self, clim):
+        if isinstance(clim, str):
+            if clim != 'auto':
+                raise ValueError('clim must be "auto" if a string')
+        else:
+            clim = np.array(clim, float)
+            if clim.shape != (2,):
+                raise ValueError('clim must have two elements')
+        self._clim = clim
+        self.mesh_data_changed()
+
+    @property
+    def _clim_values(self):
+        if isinstance(self._clim, str):  # == 'auto'
+            if self._meshdata.has_vertex_value():
+                clim = self._meshdata.get_vertex_values()
+                clim = (np.min(clim), np.max(clim))
+            else:
+                clim = (0, 1)
+        else:
+            clim = self._clim
+        return clim
+
+    @property
+    def cmap(self):
+        return self._cmap
+
+    @cmap.setter
+    def cmap(self, cmap):
+        self._cmap = get_colormap(cmap)
+        self.mesh_data_changed()
+
+    @property
+    def mode(self):
+        """The triangle mode used to draw this mesh.
+
+        Options are:
+
+            * 'triangles': Draw one triangle for every three vertices
+              (eg, [1,2,3], [4,5,6], [7,8,9)
+            * 'triangle_strip': Draw one strip for every vertex excluding the
+              first two (eg, [1,2,3], [2,3,4], [3,4,5])
+            * 'triangle_fan': Draw each triangle from the first vertex and the
+              last two vertices (eg, [1,2,3], [1,3,4], [1,4,5])
+        """
+        return self._draw_mode
+
+    @mode.setter
+    def mode(self, m):
+        modes = ['triangles', 'triangle_strip', 'triangle_fan']
+        if m not in modes:
+            raise ValueError("Mesh mode must be one of %s" % ', '.join(modes))
+        self._draw_mode = m
+
+    @property
+    def mesh_data(self):
+        """The mesh data"""
+        return self._meshdata
+
+    @property
+    def color(self):
+        """The uniform color for this mesh"""
+        return self._color
+
+    @color.setter
+    def color(self, c):
+        """Set the uniform color of the mesh
+
+        This value is only used if per-vertex or per-face colors are not
+        specified.
+
+        Parameters
+        ----------
+        c : instance of Color
+            The color to use.
+        """
+        if c is not None:
+            self._color = Color(c)
+        self.mesh_data_changed()
+
+    def mesh_data_changed(self):
+        self._data_changed = True
+        self.update()
+
+    def _update_data(self):
+        md = self.mesh_data
+
+        v = md.get_vertices(indexed='faces')
+        if v is None:
+            return False
+        if v.shape[-1] == 2:
+            v = np.concatenate((v, np.zeros((v.shape[:-1] + (1,)))), -1)
+        self._vertices.set_data(v, convert=True)
+        if self.shading == 'smooth':
+            normals = md.get_vertex_normals(indexed='faces')
+            self._normals.set_data(normals, convert=True)
+        elif self.shading == 'flat':
+            normals = md.get_face_normals(indexed='faces')
+            self._normals.set_data(normals, convert=True)
+        else:
+            self._normals.set_data(np.zeros((0, 3), dtype=np.float32))
+        if md.has_vertex_color():
+            colors = md.get_vertex_colors(indexed='faces')
+            colors = colors.astype(np.float32)
+        elif md.has_face_color():
+            colors = md.get_face_colors(indexed='faces')
+            colors = colors.astype(np.float32)
+        elif md.has_vertex_value():
+            colors = md.get_vertex_values(indexed='faces')
+            colors = colors.ravel()[:, np.newaxis]
+            colors = colors.astype(np.float32)
+        else:
+            colors = self._color.rgba
+
+        self.shared_program.vert['position'] = self._vertices
+
+        self.shared_program['texture2D_LUT'] = self._cmap.texture_lut() \
+            if (hasattr(self._cmap, 'texture_lut')) else None
+
+        # Position input handling
+        if v.shape[-1] == 2:
+            self.shared_program.vert['to_vec4'] = vec2to4
+        elif v.shape[-1] == 3:
+            self.shared_program.vert['to_vec4'] = vec3to4
+        else:
+            raise TypeError("Vertex data must have shape (...,2) or (...,3).")
+
+        # Shading and colors
+        #
+        # If non-lit shading is used, then just pass the colors
+        # Otherwise, the shader uses a base_color to represent the underlying
+        # color, which is then lit with the lighting model
+        self.shared_program.vert['color_transform'] = \
+            _build_color_transform(colors, self._cmap, self._clim_values)
+        if colors.ndim == 1:
+            self.shared_program.vert['base_color'] = colors
+        else:
+            self.shared_program.vert['base_color'] = VertexBuffer(colors)
+        if self.shading is not None:
+            # Normal data comes via vertex shader
+            if self._normals.size > 0:
+                normals = self._normals
+            else:
+                normals = (1., 0., 0.)
+
+            self.shared_program.vert['normal'] = normals
+
+            # Additional phong properties
+            self.shared_program.vert['light_dir'] = self._light_dir
+            self.shared_program.vert['light_color'] = (1.0, 1.0, 1.0, 1.0)
+            self.shared_program.vert['ambientk'] = \
+                self._ambient_light_color.rgba
+            self.shared_program.frag['shininess'] = self._shininess
+
+        self._data_changed = False
+
+    @property
+    def shininess(self):
+        """The shininess"""
+        return self._shininess
+
+    @shininess.setter
+    def shininess(self, shine):
+        """Set the shininess
+
+        Parameters
+        ----------
+        shine : float
+            The shininess to use.
+        """
+        self._shininess = float(shine)
+        self.mesh_data_changed()
+
+    @property
+    def ambient_light_color(self):
+        """The ambient light color"""
+        return self._ambient_light_color
+
+    @ambient_light_color.setter
+    def ambient_light_color(self, ambient):
+        """Set the ambient light
+
+        Parameters
+        ----------
+        color : instance of Color
+            The color to use.
+        """
+        self._ambient_light_color = Color(ambient)
+        self.mesh_data_changed()
+
+    @property
+    def light_dir(self):
+        """The light direction"""
+        return self._light_dir
+
+    @light_dir.setter
+    def light_dir(self, direction):
+        """Set the light direction
+
+        Parameters
+        ----------
+        direction : ndarray, shape (3,)
+            The light direction.
+        """
+        direction = np.array(direction, float).ravel()
+        if direction.size != 3 or not np.isfinite(direction).all():
+            raise ValueError('Invalid direction %s' % direction)
+        self._light_dir = tuple(direction)
+        self.mesh_data_changed()
+
+    @property
+    def shading(self):
+        """ The shading method used.
+        """
+        return self._shading
+
+    @shading.setter
+    def shading(self, value):
+        assert value in (None, 'flat', 'smooth')
+        self._shading = value
+
+    def _prepare_draw(self, view):
+        if self._data_changed:
+            if self._update_data() is False:
+                return False
+            self._data_changed = False
+
+    def draw(self, *args, **kwds):
+        Visual.draw(self, *args, **kwds)
+
+    @staticmethod
+    def _prepare_transforms(view):
+        tr = view.transforms.get_transform()
+        view.view_program.vert['transform'] = tr  # .simplified
+
+        if view.shading is not None:
+            visual2scene = view.transforms.get_transform('visual', 'scene')
+            scene2doc = view.transforms.get_transform('scene', 'document')
+            doc2scene = view.transforms.get_transform('document', 'scene')
+            view.shared_program.vert['visual2scene'] = visual2scene
+            view.shared_program.vert['scene2doc'] = scene2doc
+            view.shared_program.vert['doc2scene'] = doc2scene
+
+    def _compute_bounds(self, axis, view):
+        if self._bounds is None:
+            return None
+        if axis >= len(self._bounds):
+            return (0, 0)
+        else:
+            return self._bounds[axis]

--- a/napari/_vispy/vendored/mesh.py
+++ b/napari/_vispy/vendored/mesh.py
@@ -12,7 +12,7 @@ from __future__ import division
 import numpy as np
 
 from vispy.visuals.visual import Visual
-from from vispy.visuals.shaders import Function, FunctionChain
+from vispy.visuals.shaders import Function, FunctionChain
 from vispy.gloo import VertexBuffer
 from vispy.geometry import MeshData
 from vispy.color import Color, get_colormap

--- a/napari/_vispy/vispy_surface_layer.py
+++ b/napari/_vispy/vispy_surface_layer.py
@@ -14,8 +14,7 @@ class VispySurfaceLayer(VispyBaseLayer):
     """
 
     def __init__(self, layer):
-        node = Mesh()
-
+        node = Mesh(shading=layer.shading)
         super().__init__(layer, node)
 
         self.layer.events.colormap.connect(self._on_colormap_change)
@@ -23,6 +22,7 @@ class VispySurfaceLayer(VispyBaseLayer):
             self._on_contrast_limits_change
         )
         self.layer.events.gamma.connect(self._on_gamma_change)
+        self.layer.events.shading.connect(self._on_shading_change)
 
         self.reset()
         self._on_data_change()
@@ -72,6 +72,9 @@ class VispySurfaceLayer(VispyBaseLayer):
 
     def _on_gamma_change(self, event=None):
         self._on_colormap_change()
+
+    def _on_shading_change(self, event=None):
+        self.node.shading = self.layer.shading
 
     def reset(self, event=None):
         self._reset_base()

--- a/napari/_vispy/vispy_surface_layer.py
+++ b/napari/_vispy/vispy_surface_layer.py
@@ -1,7 +1,7 @@
 import numpy as np
 from vispy.color import Colormap as VispyColormap
-from vispy.scene.visuals import Mesh
 
+from .mesh import Mesh
 from .vispy_base_layer import VispyBaseLayer
 
 
@@ -14,7 +14,7 @@ class VispySurfaceLayer(VispyBaseLayer):
     """
 
     def __init__(self, layer):
-        node = Mesh(shading=layer.shading)
+        node = Mesh()
         super().__init__(layer, node)
 
         self.layer.events.colormap.connect(self._on_colormap_change)

--- a/napari/_vispy/vispy_surface_layer.py
+++ b/napari/_vispy/vispy_surface_layer.py
@@ -74,7 +74,11 @@ class VispySurfaceLayer(VispyBaseLayer):
         self._on_colormap_change()
 
     def _on_shading_change(self, event=None):
-        self.node.shading = self.layer.shading
+        if self.layer.shading == 'none':
+            self.node.shading = None
+        else:
+            self.node.shading = self.layer.shading
+        self.node.mesh_data_changed()
 
     def reset(self, event=None):
         self._reset_base()

--- a/napari/_vispy/vispy_surface_layer.py
+++ b/napari/_vispy/vispy_surface_layer.py
@@ -26,6 +26,7 @@ class VispySurfaceLayer(VispyBaseLayer):
 
         self.reset()
         self._on_data_change()
+        self._on_shading_change()
 
     def _on_data_change(self, event=None):
         if len(self.layer._data_view) == 0 or len(self.layer._view_faces) == 0:

--- a/napari/layers/surface/_surface_constants.py
+++ b/napari/layers/surface/_surface_constants.py
@@ -1,0 +1,25 @@
+from enum import auto
+
+from ...utils.misc import StringEnum
+
+
+class Shading(StringEnum):
+    """Shading: Shading mode for the surface.
+
+    Selects a preset shading mode in vispy that determines how
+    color is computed in the scene.
+    See also: https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glShadeModel.xml
+            Shading.NONE
+                Computed color is interpreted as input color, unaffected by
+                lighting. Corresponds to shading='none'.
+            Shading.FLAT
+                Computed colours are the color at a specific vertex for each
+                primitive in the mesh. Corresponds to shading='flat'.
+            Shading.SMOOTH
+                Computed colors are interpolated between vertices for each
+                primitive in the mesh. Corresponds to shading='smooth'
+    """
+
+    NONE = auto()
+    FLAT = auto()
+    SMOOTH = auto()

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -7,6 +7,7 @@ from ...utils.events import Event
 from ..base import Layer
 from ..intensity_mixin import IntensityVisualizationMixin
 from ..utils.layer_utils import calc_data_range
+from ._surface_constants import Shading
 
 
 # Mixin must come before Layer
@@ -256,22 +257,12 @@ class Surface(IntensityVisualizationMixin, Layer):
 
     @property
     def shading(self):
-        return self._shading
+        return str(self._shading)
 
     @shading.setter
-    def shading(self, shading_mode):
-        if shading_mode in self._shading_modes:
-            self._shading = shading_mode
-            self.events.shading(value=shading_mode)
-
-    @property
-    def _shading_modes(self):
-        modes = (
-            'none',
-            'flat',
-            'smooth',
-        )
-        return modes
+    def shading(self, shading):
+        self._shading = Shading(shading)
+        self.events.shading(value=self._shading)
 
     def _get_state(self):
         """Get dictionary of layer state.

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -124,6 +124,7 @@ class Surface(IntensityVisualizationMixin, Layer):
         affine=None,
         opacity=1,
         blending='translucent',
+        shading='flat',
         visible=True,
     ):
 
@@ -144,7 +145,7 @@ class Surface(IntensityVisualizationMixin, Layer):
             visible=visible,
         )
 
-        self.events.add(interpolation=Event, rendering=Event)
+        self.events.add(interpolation=Event, rendering=Event, shading=Event)
 
         # Set contrast_limits and colormaps
         self._gamma = gamma
@@ -168,6 +169,9 @@ class Surface(IntensityVisualizationMixin, Layer):
 
         # Trigger generation of view slice and thumbnail
         self._update_dims()
+
+        # Shading mode
+        self._shading = shading
 
     def _calc_data_range(self):
         return calc_data_range(self.vertex_values)
@@ -249,6 +253,25 @@ class Surface(IntensityVisualizationMixin, Layer):
                 maxs = list(self.vertex_values.shape[:-1]) + list(maxs)
             extrema = np.vstack([mins, maxs])
         return extrema
+
+    @property
+    def shading(self):
+        return self._shading
+
+    @shading.setter
+    def shading(self, shading_mode):
+        if shading_mode in self._shading_modes:
+            self._shading = shading_mode
+            self.events.shading(value=shading_mode)
+
+    @property
+    def _shading_modes(self):
+        modes = (
+            'none',
+            'flat',
+            'smooth',
+        )
+        return modes
 
     def _get_state(self):
         """Get dictionary of layer state.

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -125,7 +125,7 @@ class Surface(IntensityVisualizationMixin, Layer):
         affine=None,
         opacity=1,
         blending='translucent',
-        shading='flat',
+        shading='none',
         visible=True,
     ):
 


### PR DESCRIPTION
Work in progress towards exposing the alternative shading modes for meshes @sofroniewn brought up in #2407 

The current code updates the underlying vispy mesh visual appropriately when the `shading` attribute of the layer is changed, as it stands this doesn't trigger a redraw with the new shading. Next steps are to figure out how to update the shading mode used for rendering (ideally without reinstantiating the vispy visual, although this may require changes on the vispy side)

example code
```python
import numpy as np

import napari

# create the viewer and window
viewer = napari.Viewer(ndisplay=3)

data = np.array([[0, 0, 0], [0, 20, 10], [10, 0, -10], [10, 10, -10]])
faces = np.array([[0, 1, 2], [1, 2, 3]])
values = np.linspace(0, 1, len(data))

# add the surface
layer = viewer.add_surface((data, faces, values))

# get the vispy layer
vispy_layer = viewer.window.qt_viewer.layer_to_visual[layer]

# play with the shading mode
print(f'layer shading before modification...\n napari: {layer.shading}\n vispy: {vispy_layer.node.shading}')
layer.shading = 'smooth'
print(f'layer shading after modification...\n napari: {layer.shading}\n vispy: {vispy_layer.node.shading}')
```

Output:
```
layer shading before modification...
 napari: flat
 vispy: flat
layer shading after modification...
 napari: smooth
 vispy: smooth
```

If the example errors on you you might need vispy/vispy#2007

edit: 21/03/16 made some progress
- changing shading mode is now controlled via an Enum exposed as a QComboBox in the surface layer controls
- tried to unify shading modes to avoid having to keep multiple Mesh objects around, I think the shader code is good but something isn't initialising properly