### PR TITLE
Fix preference cancel

### DIFF
--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -178,7 +178,6 @@ class PreferencesDialog(QDialog):
         """
 
         page = self._list.currentItem().text().split(" ")[0].lower()
-        # values_set = self.new_values
         different_values = list(new_set - values_set)
 
         if len(different_values) > 0:

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -119,10 +119,16 @@ class PreferencesDialog(QDialog):
 
     def on_click_cancel(self):
         """Restores the settings in place when dialog was launched."""
-        self.check_differences(
-            self._values_orig_set_list[self._list.currentIndex().row()],
-            self._values_set_list[self._list.currentIndex().row()],
-        )
+        # Need to check differences for each page.
+        for n in range(self._stack.count()):
+            # Must set the current row so that the proper set list is updated
+            # in check differences.
+            self._list.setCurrentRow(n)
+            self.check_differences(
+                self._values_orig_set_list[n],
+                self._values_set_list[n],
+            )
+        self._list.setCurrentRow(0)
         self.close()
 
     def add_page(self, schema, values):


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
This PR will make it so that multiple pages are fully supported on the preferences dialog.  The `cancel` button wasn't working, and the reason was because the values sets being compared were not correct. There needed to be a list of sets that would be references to compare the changes in each page.

This PR will close #2405 
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousando words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
