### PR TITLE
Fix shapes data setter

### DIFF
--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -141,6 +141,11 @@ def test_data_setter_with_properties():
     layer.data = new_data_2
     assert len(layer.properties['shape_type']) == n_new_shapes_2
 
+    # test setting to data with same shapes
+    new_data_3 = 20 * np.random.random((n_new_shapes_2, 4, 2))
+    layer.data = new_data_3
+    assert len(layer.properties['shape_type']) == n_new_shapes_2
+
 
 def test_properties_dataframe():
     """Test if properties can be provided as a DataFrame"""
@@ -266,6 +271,11 @@ def test_data_setter_with_text(properties):
     n_new_shapes_2 = 6
     new_data_2 = 20 * np.random.random((n_new_shapes_2, 4, 2))
     layer.data = new_data_2
+    assert len(layer.text.values) == n_new_shapes_2
+
+    # test setting to data with same shapes
+    new_data_3 = 20 * np.random.random((n_new_shapes_2, 4, 2))
+    layer.data = new_data_3
     assert len(layer.text.values) == n_new_shapes_2
 
 

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -256,11 +256,6 @@ def test_data_setter_with_text(properties):
     data = 20 * np.random.random(shape)
     layer = Shapes(data, properties=copy(properties), text='shape_type')
 
-    # add properties
-    properties = {'shape_type': _make_cycled_properties(['A', 'B'], shape[0])}
-    layer.properties = properties
-    np.testing.assert_equal(layer.properties, properties)
-
     # test setting to data with fewer shapes
     n_new_shapes = 4
     new_data = 20 * np.random.random((n_new_shapes, 4, 2))

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -122,7 +122,7 @@ def test_adding_properties(attribute):
 
 
 def test_data_setter_with_properties():
-    """Test adding properties to an existing layer"""
+    """Test layer data on a layer with properties via the data setter"""
     shape = (10, 4, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
@@ -255,7 +255,7 @@ def test_refresh_text():
 
 @pytest.mark.parametrize("properties", [properties_array, properties_list])
 def test_data_setter_with_text(properties):
-    """Test adding properties to an existing layer"""
+    """Test layer data on a layer with text via the data setter"""
     shape = (10, 4, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -121,6 +121,27 @@ def test_adding_properties(attribute):
         layer.properties = properties_2
 
 
+def test_data_setter_with_properties():
+    """Test adding properties to an existing layer"""
+    shape = (10, 4, 2)
+    np.random.seed(0)
+    data = 20 * np.random.random(shape)
+    properties = {'shape_type': _make_cycled_properties(['A', 'B'], shape[0])}
+    layer = Shapes(data, properties=properties)
+
+    # test setting to data with fewer shapes
+    n_new_shapes = 4
+    new_data = 20 * np.random.random((n_new_shapes, 4, 2))
+    layer.data = new_data
+    assert len(layer.properties['shape_type']) == n_new_shapes
+
+    # test setting to data with more shapes
+    n_new_shapes_2 = 6
+    new_data_2 = 20 * np.random.random((n_new_shapes_2, 4, 2))
+    layer.data = new_data_2
+    assert len(layer.properties['shape_type']) == n_new_shapes_2
+
+
 def test_properties_dataframe():
     """Test if properties can be provided as a DataFrame"""
     shape = (10, 4, 2)
@@ -225,6 +246,32 @@ def test_refresh_text():
     new_properties = {'shape_type': ['B'] * shape[0]}
     layer.properties = new_properties
     np.testing.assert_equal(layer.text.values, new_properties['shape_type'])
+
+
+@pytest.mark.parametrize("properties", [properties_array, properties_list])
+def test_data_setter_with_text(properties):
+    """Test adding properties to an existing layer"""
+    shape = (10, 4, 2)
+    np.random.seed(0)
+    data = 20 * np.random.random(shape)
+    layer = Shapes(data, properties=copy(properties), text='shape_type')
+
+    # add properties
+    properties = {'shape_type': _make_cycled_properties(['A', 'B'], shape[0])}
+    layer.properties = properties
+    np.testing.assert_equal(layer.properties, properties)
+
+    # test setting to data with fewer shapes
+    n_new_shapes = 4
+    new_data = 20 * np.random.random((n_new_shapes, 4, 2))
+    layer.data = new_data
+    assert len(layer.text.values) == n_new_shapes
+
+    # test setting to data with more shapes
+    n_new_shapes_2 = 6
+    new_data_2 = 20 * np.random.random((n_new_shapes_2, 4, 2))
+    layer.data = new_data_2
+    assert len(layer.text.values) == n_new_shapes_2
 
 
 def test_rectangles():

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -534,9 +534,6 @@ class Shapes(Layer):
         self._data_view = ShapeList()
         self.add(data, shape_type=shape_type)
 
-        n_new_shapes = number_of_shapes(data)
-        self.text.add(self.current_properties, n_new_shapes)
-
         self._update_dims()
         self.events.data(value=self.data)
         self._set_editable()
@@ -1487,14 +1484,30 @@ class Shapes(Layer):
             z_index = z_index or 0
 
         if n_new_shapes > 0:
-            for k in self.properties:
-                new_property = np.repeat(
-                    self.current_properties[k], n_new_shapes, axis=0
-                )
-                self.properties[k] = np.concatenate(
-                    (self.properties[k], new_property), axis=0
-                )
-            self.text.add(self.current_properties, n_new_shapes)
+            if len(self.properties) > 0:
+                first_prop_key = next(iter(self.properties))
+                n_prop_values = len(self.properties[first_prop_key])
+            else:
+                n_prop_values = 0
+            total_shapes = n_new_shapes + self.nshapes
+            if total_shapes > n_prop_values:
+                n_props_to_add = total_shapes - n_prop_values
+                for k in self.properties:
+                    new_property = np.repeat(
+                        self.current_properties[k], n_props_to_add, axis=0
+                    )
+                    self.properties[k] = np.concatenate(
+                        (self.properties[k], new_property), axis=0
+                    )
+                self.text.add(self.current_properties, n_props_to_add)
+            if total_shapes < n_prop_values:
+                for k in self.properties:
+                    self.properties[k] = self.properties[k][:total_shapes]
+                n_props_to_remove = n_prop_values - total_shapes
+                indices_to_remove = np.arange(n_prop_values)[
+                    -n_props_to_remove:
+                ]
+                self.text.remove(indices_to_remove)
 
             self._add_shapes(
                 data,

--- a/napari/layers/utils/_text_utils.py
+++ b/napari/layers/utils/_text_utils.py
@@ -150,7 +150,7 @@ def format_text_properties(text: str, n_text: int, properties: dict = {}):
 
     # If the text value is a property key, the text is the property values
     if text in properties:
-        formatted_text = np.array([str(v) for v in properties[text]])
+        formatted_text = np.resize([str(v) for v in properties[text]], n_text)
         text_mode = TextMode.PROPERTY
     elif ('{' in text) and ('}' in text):
         format_keys = _get_format_keys(text, properties)


### PR DESCRIPTION
# Description
Currently, Shapes the properties and text are not properly resized when the layer data is modified via the `Shapes.data` setter (see #2239). This PR fixes this by adding a check in the `Shapes.add` (called by the `Shapes.data` setter) method to ensure the properties and text are properly resized.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)


# References
Closes #2239 

# How has this been tested?
- [x] added test for the shapes data setter 
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
