### PR TITLE
Fix nd text on shapes layer

### DIFF
--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -227,6 +227,26 @@ def test_refresh_text():
     np.testing.assert_equal(layer.text.values, new_properties['shape_type'])
 
 
+def test_nd_text():
+    """Test slicing of text coords with nD shapes"""
+    shapes_data = [
+        [[0, 10, 10, 10], [0, 10, 20, 20], [0, 10, 10, 20], [0, 10, 20, 10]],
+        [[1, 20, 30, 30], [1, 20, 50, 50], [1, 20, 50, 30], [1, 20, 30, 50]],
+    ]
+    properties = {'shape_type': ['A', 'B']}
+    text_kwargs = {'text': 'shape_type', 'anchor': 'center'}
+    layer = Shapes(shapes_data, properties=properties, text=text_kwargs)
+    assert layer.ndim == 4
+
+    layer._slice_dims(point=[0, 10, 0, 0], ndisplay=2)
+    np.testing.assert_equal(layer._indices_view, [0])
+    np.testing.assert_equal(layer._view_text_coords[0], [15, 15])
+
+    layer._slice_dims(point=[1, 0, 0, 0], ndisplay=3)
+    np.testing.assert_equal(layer._indices_view, [1])
+    np.testing.assert_equal(layer._view_text_coords[0], [20, 45, 45])
+
+
 def test_rectangles():
     """Test instantiating Shapes layer with a random 2D rectangles."""
     # Test a single four corner rectangle

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -240,11 +240,11 @@ def test_nd_text():
 
     layer._slice_dims(point=[0, 10, 0, 0], ndisplay=2)
     np.testing.assert_equal(layer._indices_view, [0])
-    np.testing.assert_equal(layer._view_text_coords[0], [15, 15])
+    np.testing.assert_equal(layer._view_text_coords[0], [[15, 15]])
 
     layer._slice_dims(point=[1, 0, 0, 0], ndisplay=3)
     np.testing.assert_equal(layer._indices_view, [1])
-    np.testing.assert_equal(layer._view_text_coords[0], [20, 45, 45])
+    np.testing.assert_equal(layer._view_text_coords[0], [[20, 40, 40]])
 
 
 def test_rectangles():

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1293,8 +1293,19 @@ class Shapes(Layer):
         text_coords : (N x D) np.ndarray
             Array of coordindates for the N text elements in view
         """
+        # get the coordinates of the vertices for the shapes in view
+        in_view_shapes_coords = [
+            self._data_view.data[i] for i in self._indices_view
+        ]
+
+        # get the coordinates for the dimensions being displayed
+        sliced_in_view_coords = [
+            position[:, self._dims_displayed]
+            for position in in_view_shapes_coords
+        ]
+
         return self.text.compute_text_coords(
-            self._data_view.data, self._ndisplay
+            sliced_in_view_coords, self._ndisplay
         )
 
     @property


### PR DESCRIPTION
# Description
As described in #2311, the text coordinates are not properly sliced for ndim > 3. This PR fixes this by adding slicing of the shapes coordinates to the `Shapes._view_text_coords()` method.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)


# References
Closes #2311 

# How has this been tested?
- [x] Added a test for text coord slicing in the shapes layer
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
