### PR TITLE
Fix overly sensitive Points layer dragging

### DIFF
--- a/napari/layers/points/_points_mouse_bindings.py
+++ b/napari/layers/points/_points_mouse_bindings.py
@@ -82,24 +82,20 @@ def select(layer, event):
     layer._set_highlight(force=True)
 
 
-DRAG_THRESHOLD = 5
+DRAG_DIST_THRESHOLD = 5
 
 
 def add(layer, event):
     """Add a new point at the clicked position."""
-    # on press
-    yield
 
-    # on move
-    while event.type == 'mouse_move':
+    if event.type == 'mouse_press':
+        start_pos = event.pos
+
+    while event.type != 'mouse_release':
         yield
 
-    # on release
-    d = 0
-    trail = event.trail()
-    if trail is not None:
-        d = np.linalg.norm(trail[0] - trail[-1])
-    if d < DRAG_THRESHOLD:
+    dist = np.linalg.norm(start_pos - event.pos)
+    if dist < DRAG_DIST_THRESHOLD:
         layer.add(layer.coordinates)
 
 

--- a/napari/layers/points/_points_mouse_bindings.py
+++ b/napari/layers/points/_points_mouse_bindings.py
@@ -82,19 +82,24 @@ def select(layer, event):
     layer._set_highlight(force=True)
 
 
+DRAG_THRESHOLD = 5
+
+
 def add(layer, event):
     """Add a new point at the clicked position."""
     # on press
-    dragged = False
     yield
 
     # on move
     while event.type == 'mouse_move':
-        dragged = True
         yield
 
     # on release
-    if not dragged:
+    d = 0
+    trail = event.trail()
+    if trail is not None:
+        d = np.linalg.norm(trail[0] - trail[-1])
+    if d < DRAG_THRESHOLD:
         layer.add(layer.coordinates)
 
 


### PR DESCRIPTION
# Description
fixes #2373 ... 
I tried playing with startDragDistance and time from Qt... but couldn't get them to work.  This PR just looks at the `event.trail()` method from the mouse event and adds a new point if the drag distance is less than "5"  (pixels? which I came to empirically ... happy to change).

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
