### PR TITLE
Add base shape outline for single scale tiled

### DIFF
--- a/napari/_vispy/experimental/tile_grid.py
+++ b/napari/_vispy/experimental/tile_grid.py
@@ -80,18 +80,26 @@ class TileGrid:
         line.parent = self.parent
         return line
 
-    def update_grid(self, chunks: List[OctreeChunk]) -> None:
-        """Update grid for this set of chunks.
+    def update_grid(self, chunks: List[OctreeChunk], base_shape=None) -> None:
+        """Update grid for this set of chunks and the whole boundary.
 
         Parameters
         ----------
         chunks : List[ImageChunks]
             Add a grid that outlines these chunks.
+        base_shape : List[int], optional
+            Height and width of the full resolution level.
         """
         verts = np.zeros((0, 2), dtype=np.float32)
         for octree_chunk in chunks:
             chunk_verts = _chunk_outline(octree_chunk)
             verts = np.vstack([verts, chunk_verts])
+
+        # Add in the base shape outline if provided
+        if base_shape is not None:
+            outline = _OUTLINE.copy()  # Copy and modify in place.
+            outline[:, :2] *= base_shape[::-1]
+            verts = np.vstack([verts, outline])
 
         self.line.set_data(verts)
 

--- a/napari/_vispy/experimental/vispy_tiled_image_layer.py
+++ b/napari/_vispy/experimental/vispy_tiled_image_layer.py
@@ -240,7 +240,14 @@ class VispyTiledImageLayer(VispyImageLayer):
         # The grid is only for debugging and demos, yet it's quite useful
         # otherwise you can't really see the borders between the tiles.
         if self.layer.display.show_grid:
-            self.grid.update_grid(self.node.octree_chunks)
+            # If a only a single scale octree then show the outline of the base shape too
+            if self.layer._slice._meta.num_levels == 1:
+                base_shape = self.layer._slice._meta.base_shape
+            else:
+                base_shape = None
+            self.grid.update_grid(
+                self.node.octree_chunks, base_shape=base_shape
+            )
         else:
             self.grid.clear()
 


### PR DESCRIPTION
# Description
Add base shape outline for single scaled tiled rendering. Suggested by @GenevieveBuckley.

This is ready for review @jni @GenevieveBuckley 

<img width="1200" alt="Screen Shot 2021-03-14 at 2 08 29 PM" src="https://user-images.githubusercontent.com/6531703/111084332-0dd39980-84cf-11eb-8971-b496d3113c90.png">
