### PR TITLE
fix points delete

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -266,3 +266,14 @@ def test_removing_points_data(make_napari_viewer):
     pts_layer.data = np.zeros([0, 2])
 
     assert len(pts_layer.data) == 0
+
+
+def test_deleting_points(make_napari_viewer):
+    viewer = make_napari_viewer()
+    points = np.random.random((4, 2)) * 4
+
+    pts_layer = viewer.add_points(points)
+    pts_layer.selected_data = {0}
+    pts_layer.remove_selected()
+
+    assert len(pts_layer.data) == 3

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1415,8 +1415,10 @@ class Points(Layer):
         index.sort()
         if len(index) > 0:
             self._size = np.delete(self._size, index, axis=0)
-            self._edge._remove(indices_to_remove=index)
-            self._face._remove(indices_to_remove=index)
+            with self._edge.events.blocker_all():
+                self._edge._remove(indices_to_remove=index)
+            with self._face.events.blocker_all():
+                self._face._remove(indices_to_remove=index)
             for k in self.properties:
                 self.properties[k] = np.delete(
                     self.properties[k], index, axis=0


### PR DESCRIPTION
# Description
I just discovered that #2204 also broke deleting points due to an refresh-causing event being emitted during point removal. This PR adds a blocker as is done in #2383.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)


# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
- [x] Tested deleting points in `examples/add_points.py'
- [x] Added a test to the viewer tests
- [x]  all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
