### PR TITLE
Fix empty layer text

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -122,15 +122,18 @@ def test_empty_layer_with_edge_colormap():
 def test_empty_layer_with_text_properties():
     """Test initializing an empty layer with text defined"""
     default_properties = {'point_type': np.array([1.5], dtype=float)}
+    text_kwargs = {'text': 'point_type', 'color': 'red'}
     layer = Points(
         properties=default_properties,
-        text='point_type',
+        text=text_kwargs,
     )
     np.testing.assert_equal(layer.text.values, np.empty(0))
+    np.testing.assert_allclose(layer.text.color, [1, 0, 0, 1])
 
     # add a point and check that the appropriate text value was added
     layer.add([1, 1])
     np.testing.assert_equal(layer.text.values, ['1.5'])
+    np.testing.assert_allclose(layer.text.color, [1, 0, 0, 1])
 
 
 def test_empty_layer_with_text_formatted():

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -119,6 +119,34 @@ def test_empty_layer_with_edge_colormap():
     np.testing.assert_allclose(layer._edge.current_color, edge_color)
 
 
+def test_empty_layer_with_text_properties():
+    """Test initializing an empty layer with text defined"""
+    default_properties = {'point_type': np.array([1.5], dtype=float)}
+    layer = Points(
+        properties=default_properties,
+        text='point_type',
+    )
+    np.testing.assert_equal(layer.text.values, np.empty(0))
+
+    # add a point and check that the appropriate text value was added
+    layer.add([1, 1])
+    np.testing.assert_equal(layer.text.values, ['1.5'])
+
+
+def test_empty_layer_with_text_formatted():
+    """Test initializing an empty layer with text defined"""
+    default_properties = {'point_type': np.array([1.5], dtype=float)}
+    layer = Points(
+        properties=default_properties,
+        text='point_type: {point_type:.2f}',
+    )
+    np.testing.assert_equal(layer.text.values, np.empty(0))
+
+    # add a point and check that the appropriate text value was added
+    layer.add([1, 1])
+    np.testing.assert_equal(layer.text.values, ['point_type: 1.50'])
+
+
 def test_random_points():
     """Test instantiating Points layer with random 2D data."""
     shape = (10, 2)

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1488,7 +1488,7 @@ class Points(Layer):
                 range(totpoints, totpoints + len(self._clipboard['data']))
             )
 
-            if self._clipboard['text'] is not None:
+            if len(self._clipboard['text']) > 0:
                 self.text._values = np.concatenate(
                     (self.text.values, self._clipboard['text']), axis=0
                 )
@@ -1510,8 +1510,8 @@ class Points(Layer):
                 'indices': self._slice_indices,
             }
 
-            if self.text.values is None:
-                self._clipboard['text'] = None
+            if len(self.text.values) == 0:
+                self._clipboard['text'] = np.empty(0)
 
             else:
                 self._clipboard['text'] = deepcopy(self.text.values[index])

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -162,16 +162,19 @@ def test_properties_dataframe():
 def test_empty_layer_with_text_properties():
     """Test initializing an empty layer with text defined"""
     default_properties = {'shape_type': np.array([1.5], dtype=float)}
+    text_kwargs = {'text': 'shape_type', 'color': 'red'}
     layer = Shapes(
         properties=default_properties,
-        text='shape_type',
+        text=text_kwargs,
     )
     assert layer.text.mode == 'property'
     np.testing.assert_equal(layer.text.values, np.empty(0))
+    np.testing.assert_allclose(layer.text.color, [1, 0, 0, 1])
 
     # add a shape and check that the appropriate text value was added
     layer.add(np.random.random((1, 4, 2)))
     np.testing.assert_equal(layer.text.values, ['1.5'])
+    np.testing.assert_allclose(layer.text.color, [1, 0, 0, 1])
 
 
 def test_empty_layer_with_text_formatted():

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -159,6 +159,36 @@ def test_properties_dataframe():
     np.testing.assert_equal(layer.properties, properties)
 
 
+def test_empty_layer_with_text_properties():
+    """Test initializing an empty layer with text defined"""
+    default_properties = {'shape_type': np.array([1.5], dtype=float)}
+    layer = Shapes(
+        properties=default_properties,
+        text='shape_type',
+    )
+    assert layer.text.mode == 'property'
+    np.testing.assert_equal(layer.text.values, np.empty(0))
+
+    # add a shape and check that the appropriate text value was added
+    layer.add(np.random.random((1, 4, 2)))
+    np.testing.assert_equal(layer.text.values, ['1.5'])
+
+
+def test_empty_layer_with_text_formatted():
+    """Test initializing an empty layer with text defined"""
+    default_properties = {'shape_type': np.array([1.5], dtype=float)}
+    layer = Shapes(
+        properties=default_properties,
+        text='shape_type: {shape_type:.2f}',
+    )
+    assert layer.text.mode == 'formatted'
+    np.testing.assert_equal(layer.text.values, np.empty(0))
+
+    # add a shape and check that the appropriate text value was added
+    layer.add(np.random.random((1, 4, 2)))
+    np.testing.assert_equal(layer.text.values, ['shape_type: 1.50'])
+
+
 @pytest.mark.parametrize("properties", [properties_array, properties_list])
 def test_text_from_property_value(properties):
     """Test setting text from a property value"""

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2285,8 +2285,8 @@ class Shapes(Layer):
                 },
                 'indices': self._slice_indices,
             }
-            if self.text.values is None:
-                self._clipboard['text'] = None
+            if len(self.text.values) == 0:
+                self._clipboard['text'] = np.empty(0)
             else:
                 self._clipboard['text'] = deepcopy(self.text.values[index])
         else:
@@ -2322,7 +2322,7 @@ class Shapes(Layer):
                     shape, face_color=face_color, edge_color=edge_color
                 )
 
-            if self._clipboard['text'] is not None:
+            if len(self._clipboard['text']) > 0:
                 self.text._values = np.concatenate(
                     (self.text.values, self._clipboard['text']), axis=0
                 )

--- a/napari/layers/utils/_tests/test_text.py
+++ b/napari/layers/utils/_tests/test_text.py
@@ -4,6 +4,39 @@ import pytest
 from napari.layers.utils.text import TextManager
 
 
+def test_empty_text_manager_property():
+    """Test creating an empty text manager in property mode.
+    This is for creating an empty layer with text initialized.
+    """
+    properties = {'confidence': np.empty(0, dtype=np.float)}
+    text_manager = TextManager(
+        text='confidence', n_text=0, properties=properties
+    )
+    assert text_manager.mode == 'property'
+    assert text_manager.values is None
+
+    # add a text element
+    new_properties = {'confidence': np.array([0.5])}
+    text_manager.add(new_properties, 1)
+    np.testing.assert_equal(text_manager.values, ['0.5'])
+
+
+def test_empty_text_manager_format():
+    """Test creating an empty text manager in formatted mode.
+    This is for creating an empty layer with text initialized.
+    """
+    properties = {'confidence': np.empty(0, dtype=np.float)}
+    text = 'confidence: {confidence:.2f}'
+    text_manager = TextManager(text=text, n_text=0, properties=properties)
+    assert text_manager.mode == 'formatted'
+    assert text_manager.values is None
+
+    # add a text element
+    new_properties = {'confidence': np.array([0.5])}
+    text_manager.add(new_properties, 1)
+    np.testing.assert_equal(text_manager.values, ['0.50'])
+
+
 def test_text_manager_property():
     n_text = 3
     text = 'class'

--- a/napari/layers/utils/_tests/test_text.py
+++ b/napari/layers/utils/_tests/test_text.py
@@ -13,7 +13,7 @@ def test_empty_text_manager_property():
         text='confidence', n_text=0, properties=properties
     )
     assert text_manager.mode == 'property'
-    assert text_manager.values is None
+    np.testing.assert_equal(text_manager.values, np.empty(0))
 
     # add a text element
     new_properties = {'confidence': np.array([0.5])}
@@ -29,12 +29,12 @@ def test_empty_text_manager_format():
     text = 'confidence: {confidence:.2f}'
     text_manager = TextManager(text=text, n_text=0, properties=properties)
     assert text_manager.mode == 'formatted'
-    assert text_manager.values is None
+    np.testing.assert_equal(text_manager.values, np.empty(0))
 
     # add a text element
     new_properties = {'confidence': np.array([0.5])}
     text_manager.add(new_properties, 1)
-    np.testing.assert_equal(text_manager.values, ['0.50'])
+    np.testing.assert_equal(text_manager.values, ['confidence: 0.50'])
 
 
 def test_text_manager_property():

--- a/napari/layers/utils/text.py
+++ b/napari/layers/utils/text.py
@@ -115,6 +115,10 @@ class TextManager:
                 self._text_format_string = text
                 self._mode = text_mode
                 self._values = formatted_text
+            else:
+                self._mode = TextMode.NONE
+                self._text_format_string = ''
+                self._values = np.empty(0)
 
         else:
             self._set_text(text=text, n_text=n_text, properties=properties)
@@ -125,7 +129,7 @@ class TextManager:
         if len(properties) == 0 or n_text == 0 or text is None:
             self._mode = TextMode.NONE
             self._text_format_string = ''
-            self._values = None
+            self._values = np.empty(0)
         else:
             formatted_text, text_mode = format_text_properties(
                 text, n_text, properties
@@ -303,7 +307,7 @@ class TextManager:
         anchor_y : str
             THe vispy text anchor for the y axis
         """
-        if self._mode in [TextMode.FORMATTED, TextMode.PROPERTY]:
+        if len(self.values) > 0:
             anchor_coords, anchor_x, anchor_y = get_text_anchors(
                 view_data, ndisplay, self._anchor
             )

--- a/napari/layers/utils/text.py
+++ b/napari/layers/utils/text.py
@@ -96,13 +96,28 @@ class TextManager:
         self._blending = self._check_blending_mode(blending)
         self._visible = visible
 
-        self._set_text(text, n_text, properties)
+        self._initialize_text(text, n_text, properties)
         self.events.unblock_all()
 
     @property
     def values(self):
         """np.ndarray: the text values to be displayed"""
         return self._values
+
+    def _initialize_text(
+        self, text: Union[None, str], n_text: int, properties: dict = {}
+    ):
+        if n_text == 0:
+            if text is not None:
+                formatted_text, text_mode = format_text_properties(
+                    text, n_text, properties
+                )
+                self._text_format_string = text
+                self._mode = text_mode
+                self._values = formatted_text
+
+        else:
+            self._set_text(text=text, n_text=n_text, properties=properties)
 
     def _set_text(
         self, text: Union[None, str], n_text: int, properties: dict = {}

--- a/napari/layers/utils/text.py
+++ b/napari/layers/utils/text.py
@@ -96,7 +96,7 @@ class TextManager:
         self._blending = self._check_blending_mode(blending)
         self._visible = visible
 
-        self._initialize_text(text, n_text, properties)
+        self._set_text(text, n_text, properties)
         self.events.unblock_all()
 
     @property
@@ -104,29 +104,21 @@ class TextManager:
         """np.ndarray: the text values to be displayed"""
         return self._values
 
-    def _initialize_text(
-        self, text: Union[None, str], n_text: int, properties: dict = {}
-    ):
-        if n_text == 0:
-            if text is not None:
-                formatted_text, text_mode = format_text_properties(
-                    text, n_text, properties
-                )
-                self._text_format_string = text
-                self._mode = text_mode
-                self._values = formatted_text
-            else:
-                self._mode = TextMode.NONE
-                self._text_format_string = ''
-                self._values = np.empty(0)
-
-        else:
-            self._set_text(text=text, n_text=n_text, properties=properties)
-
     def _set_text(
         self, text: Union[None, str], n_text: int, properties: dict = {}
     ):
-        if len(properties) == 0 or n_text == 0 or text is None:
+        if text is None:
+            text = np.empty(0)
+        if n_text == 0 and len(text) != 0:
+            # initialize text but don't add text elements
+            formatted_text, text_mode = format_text_properties(
+                text, n_text, properties
+            )
+            self._text_format_string = text
+            self._mode = text_mode
+            self._values = formatted_text
+        elif len(properties) == 0 or len(text) == 0:
+            # set text mode to NONE if no props/text are provided
             self._mode = TextMode.NONE
             self._text_format_string = ''
             self._values = np.empty(0)


### PR DESCRIPTION
# Description
As described in #2115, initializing an empty layer with text pre-configured doesn't currently work. This PR adds that with the following API:

```python
default_properties = {'point_type': np.array([1.5], dtype=float)}
text_kwargs = {
    'text': 'point_type',
    'color': 'red'
}
layer = viewer.add_points(
    properties=default_properties,
    text=text_kwargs,
)

```

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# References
Closes #2115 

# How has this been tested?
- [x] added tests for initializing empty text
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
