### PR TITLE
Remove brush shape from label UI

### DIFF
--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -13,7 +13,6 @@ from qtpy.QtWidgets import (
 )
 
 from ...layers.labels._labels_constants import (
-    LABEL_BRUSH_SHAPE_TRANSLATIONS,
     LABEL_COLOR_MODE_TRANSLATIONS,
     Mode,
 )

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -203,19 +203,6 @@ class QtLabelsControls(QtLayerControls):
         button_row.setSpacing(4)
         button_row.setContentsMargins(0, 0, 0, 5)
 
-        brush_shape_comboBox = QComboBox(self)
-        for index, (data, text) in enumerate(
-            LABEL_BRUSH_SHAPE_TRANSLATIONS.items()
-        ):
-            data = data.value
-            brush_shape_comboBox.addItem(text, data)
-            if self.layer.brush_shape == data:
-                brush_shape_comboBox.setCurrentIndex(index)
-
-        brush_shape_comboBox.activated[str].connect(self.change_brush_shape)
-        self.brushShapeComboBox = brush_shape_comboBox
-        self._on_brush_shape_change()
-
         color_mode_comboBox = QComboBox(self)
         for index, (data, text) in enumerate(
             LABEL_COLOR_MODE_TRANSLATIONS.items()
@@ -244,8 +231,6 @@ class QtLabelsControls(QtLayerControls):
         self.grid_layout.addWidget(self.opacitySlider, 2, 1, 1, 3)
         self.grid_layout.addWidget(QLabel(trans._('brush size:')), 3, 0, 1, 1)
         self.grid_layout.addWidget(self.brushSizeSlider, 3, 1, 1, 3)
-        self.grid_layout.addWidget(QLabel(trans._('brush shape:')), 4, 0, 1, 1)
-        self.grid_layout.addWidget(self.brushShapeComboBox, 4, 1, 1, 3)
         self.grid_layout.addWidget(QLabel(trans._('blending:')), 5, 0, 1, 1)
         self.grid_layout.addWidget(self.blendComboBox, 5, 1, 1, 3)
         self.grid_layout.addWidget(QLabel(trans._('color mode:')), 6, 0, 1, 1)
@@ -486,23 +471,6 @@ class QtLabelsControls(QtLayerControls):
                     index
                 ):
                     self.colorModeComboBox.setCurrentIndex(index)
-                    break
-
-    def _on_brush_shape_change(self, event=None):
-        """Receive brush shape change event and update dropdown menu.
-
-        Parameters
-        ----------
-        event : napari.utils.event.Event
-            The napari event that triggered this method.
-        """
-        with self.layer.events.brush_shape.blocker():
-            # `self.brushShapeComboBox.findData` is not returning the correct index.
-            for index in range(self.brushShapeComboBox.count()):
-                if self.layer.brush_shape == self.brushShapeComboBox.itemData(
-                    index
-                ):
-                    self.brushShapeComboBox.setCurrentIndex(index)
                     break
 
     def _on_editable_change(self, event=None):

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -480,8 +480,9 @@ class Labels(_image_base_class):
 
         warnings.warn(
             (
-                "The square brush shape is deprecated and will be removed in version 0.4.9."
-                "Afterward, only the circle brush shape will be available."
+                "The square brush shape is deprecated and will be removed in version 0.4.9. "
+                "Afterward, only the circle brush shape will be available, "
+                "and the layer.brush_shape attribute will be removed."
             ),
             category=FutureWarning,
             stacklevel=2,
@@ -495,8 +496,9 @@ class Labels(_image_base_class):
 
         warnings.warn(
             (
-                "The square brush shape is deprecated and will be removed in version 0.4.9."
-                "Afterward, only the circle brush shape will be available."
+                "The square brush shape is deprecated and will be removed in version 0.4.9. "
+                "Afterward, only the circle brush shape will be available, "
+                "and the layer.brush_shape attribute will be removed."
             ),
             category=FutureWarning,
             stacklevel=2,

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -478,21 +478,30 @@ class Labels(_image_base_class):
     def brush_shape(self):
         """str: Paintbrush shape"""
 
-        if str(self._brush_shape) == 'square':
-            warnings.warn(
-                (
-                    "The square brush shape is deprecated and will be removed in version 0.4.9."
-                    "Afterward, only the circle brush shape will be available."
-                ),
-                category=FutureWarning,
-                stacklevel=2,
-            )
+        warnings.warn(
+            (
+                "The square brush shape is deprecated and will be removed in version 0.4.9."
+                "Afterward, only the circle brush shape will be available."
+            ),
+            category=FutureWarning,
+            stacklevel=2,
+        )
 
         return str(self._brush_shape)
 
     @brush_shape.setter
     def brush_shape(self, brush_shape):
         """Set current brush shape."""
+
+        warnings.warn(
+            (
+                "The square brush shape is deprecated and will be removed in version 0.4.9."
+                "Afterward, only the circle brush shape will be available."
+            ),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+
         self._brush_shape = LabelBrushShape(brush_shape)
         self.cursor = self.brush_shape
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -480,9 +480,11 @@ class Labels(_image_base_class):
 
         warnings.warn(
             (
-                "The square brush shape is deprecated and will be removed in version 0.4.9. "
-                "Afterward, only the circle brush shape will be available, "
-                "and the layer.brush_shape attribute will be removed."
+                trans._(
+                    "The square brush shape is deprecated and will be removed in version 0.4.9. "
+                    "Afterward, only the circle brush shape will be available, "
+                    "and the layer.brush_shape attribute will be removed."
+                )
             ),
             category=FutureWarning,
             stacklevel=2,
@@ -496,9 +498,11 @@ class Labels(_image_base_class):
 
         warnings.warn(
             (
-                "The square brush shape is deprecated and will be removed in version 0.4.9. "
-                "Afterward, only the circle brush shape will be available, "
-                "and the layer.brush_shape attribute will be removed."
+                trans._(
+                    "The square brush shape is deprecated and will be removed in version 0.4.9. "
+                    "Afterward, only the circle brush shape will be available, "
+                    "and the layer.brush_shape attribute will be removed."
+                )
             ),
             category=FutureWarning,
             stacklevel=2,

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -477,6 +477,17 @@ class Labels(_image_base_class):
     @property
     def brush_shape(self):
         """str: Paintbrush shape"""
+
+        if str(self._brush_shape) == 'square':
+            warnings.warn(
+                (
+                    "The square brush shape is deprecated and will be removed in version 0.4.9."
+                    "Afterward, only the circle brush shape will be available."
+                ),
+                category=FutureWarning,
+                stacklevel=2,
+            )
+
         return str(self._brush_shape)
 
     @brush_shape.setter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ filterwarnings = [
   "ignore:pythonw executable not found:UserWarning:",
   "ignore:data shape .* exceeds GL_MAX_TEXTURE_SIZE:UserWarning",
   "ignore:For best performance with Dask arrays in napari:UserWarning:",
+  "ignore:The square brush shape is deprecated and will be removed:FutureWarning",
 ]
 markers = [
     "sync_only: Test should only be run synchronously",


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
This issue: https://github.com/napari/product-heuristics-2020/issues/25
mentions that the drop down menu for the label brush shape isn't needed, because the circle is only shape needed.  I have removed it, and tried to remove anything that would include the square shape.

I am unsure if I removed too much or too little, so please look very carefully when reviewing!  Thanks!

