### PR TITLE
Fix Labels `save_history` benchmark

### DIFF
--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -39,7 +39,8 @@ class Labels2DSuite:
 
     def time_save_history(self, n):
         """Time to save history."""
-        self.layer._save_history()
+        coords = [int(coord) for coord in self.layer.coordinates]
+        self.layer._save_history((coords, self.data[coords], 1))
 
     def time_raw_to_displayed(self, n):
         """Time to convert raw to displayed."""

--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -3,7 +3,6 @@
 # or the napari documentation on benchmarking
 # https://github.com/napari/napari/blob/master/docs/BENCHMARKS.md
 import numpy as np
-from skimage.draw import disk
 
 from napari.layers import Labels
 
@@ -37,14 +36,6 @@ class Labels2DSuite:
     def time_get_value(self, n):
         """Time to get current value."""
         self.layer.get_value((0,) * 2)
-
-    def time_save_history(self, n):
-        """Time to save history."""
-        coords = tuple([n // 2 for _ in range(2)])
-        rr, cc = disk(center=coords, radius=3)
-        self.layer._save_history(
-            ((rr, cc), self.data[rr, cc], self.layer.selected_label)
-        )
 
     def time_raw_to_displayed(self, n):
         """Time to convert raw to displayed."""
@@ -106,19 +97,6 @@ class Labels3DSuite:
     def time_get_value(self, n):
         """Time to get current value."""
         self.layer.get_value((0,) * 3)
-
-    def time_save_history(self, n):
-        """Time to save history."""
-        current_slice = n // 2
-        coords = tuple([n // 2 for _ in range(2)])
-        rr, cc = disk(center=coords, radius=3)
-        self.layer._save_history(
-            (
-                (current_slice, rr, cc),
-                self.data[current_slice, rr, cc],
-                self.layer.selected_label,
-            )
-        )
 
     def time_raw_to_displayed(self, n):
         """Time to convert raw to displayed."""

--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -3,6 +3,7 @@
 # or the napari documentation on benchmarking
 # https://github.com/napari/napari/blob/master/docs/BENCHMARKS.md
 import numpy as np
+from skimage.draw import disk
 
 from napari.layers import Labels
 
@@ -39,8 +40,11 @@ class Labels2DSuite:
 
     def time_save_history(self, n):
         """Time to save history."""
-        coords = [int(coord) for coord in self.layer.coordinates]
-        self.layer._save_history((coords, self.data[coords], 1))
+        coords = tuple([n // 2 for _ in range(2)])
+        rr, cc = disk(center=coords, radius=3)
+        self.layer._save_history(
+            ((rr, cc), self.data[rr, cc], self.layer.selected_label)
+        )
 
     def time_raw_to_displayed(self, n):
         """Time to convert raw to displayed."""
@@ -105,7 +109,16 @@ class Labels3DSuite:
 
     def time_save_history(self, n):
         """Time to save history."""
-        self.layer._save_history()
+        current_slice = int(self.layer.coordinates[0])
+        coords = tuple([n // 2 for _ in range(2)])
+        rr, cc = disk(center=coords, radius=3)
+        self.layer._save_history(
+            (
+                (current_slice, rr, cc),
+                self.data[current_slice, rr, cc],
+                self.layer.selected_label,
+            )
+        )
 
     def time_raw_to_displayed(self, n):
         """Time to convert raw to displayed."""

--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -109,7 +109,7 @@ class Labels3DSuite:
 
     def time_save_history(self, n):
         """Time to save history."""
-        current_slice = int(self.layer.coordinates[0])
+        current_slice = n // 2
         coords = tuple([n // 2 for _ in range(2)])
         rr, cc = disk(center=coords, radius=3)
         self.layer._save_history(


### PR DESCRIPTION
# Description
The `save_history` benchmark doesn't work since we merged #2339 as it now takes a parameter rather than saving the whole slice. I've changed both the 2D and the 3D suite to save a disk of arbitrary radius 3 into the centre of the image (an equally arbitrary choice).

I'm not sure if that's the best approach, maybe we want to save something bigger, or something that increases with the size of the image? @jni @sofroniewn any thoughts?

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
