### PR TITLE
fix numpy warnings

### DIFF
--- a/napari/_vispy/_tests/test_vispy_multiscale.py
+++ b/napari/_vispy/_tests/test_vispy_multiscale.py
@@ -83,7 +83,7 @@ def test_multiscale_screenshot(make_napari_viewer):
     viewer.window.qt_viewer.view.canvas.size = (800, 600)
 
     screenshot = viewer.screenshot(canvas_only=True)
-    center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)
+    center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(int)
     target_center = np.array([255, 255, 255, 255], dtype='uint8')
     target_edge = np.array([0, 0, 0, 255], dtype='uint8')
     screen_offset = 3  # Offset is needed as our screenshots have black borders
@@ -119,7 +119,7 @@ def test_multiscale_screenshot_zoomed(make_napari_viewer):
     assert viewer.layers[0].data_level == 0
 
     screenshot = viewer.screenshot(canvas_only=True)
-    center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)
+    center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(int)
     target_center = np.array([255, 255, 255, 255], dtype='uint8')
     screen_offset = 3  # Offset is needed as our screenshots have black borders
 
@@ -150,7 +150,7 @@ def test_image_screenshot_zoomed(make_napari_viewer):
     viewer.window.qt_viewer.on_draw(None)
 
     screenshot = viewer.screenshot(canvas_only=True)
-    center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)
+    center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(int)
     target_center = np.array([255, 255, 255, 255], dtype='uint8')
     screen_offset = 3  # Offset is needed as our screenshots have black borders
 

--- a/napari/layers/utils/_tests/test_text.py
+++ b/napari/layers/utils/_tests/test_text.py
@@ -8,7 +8,7 @@ def test_empty_text_manager_property():
     """Test creating an empty text manager in property mode.
     This is for creating an empty layer with text initialized.
     """
-    properties = {'confidence': np.empty(0, dtype=np.float)}
+    properties = {'confidence': np.empty(0, dtype=float)}
     text_manager = TextManager(
         text='confidence', n_text=0, properties=properties
     )
@@ -25,7 +25,7 @@ def test_empty_text_manager_format():
     """Test creating an empty text manager in formatted mode.
     This is for creating an empty layer with text initialized.
     """
-    properties = {'confidence': np.empty(0, dtype=np.float)}
+    properties = {'confidence': np.empty(0, dtype=float)}
     text = 'confidence: {confidence:.2f}'
     text_manager = TextManager(text=text, n_text=0, properties=properties)
     assert text_manager.mode == 'formatted'


### PR DESCRIPTION
# Description
Fix warnings like: 

```
  
  napari/layers/utils/_tests/test_text.py::test_empty_text_manager_format
    /home/runner/work/napari/napari/napari/layers/utils/_tests/test_text.py:28: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
    Deprecated in NumPy 1.20; for more details and guidance: numpy.org/devdocs/release/1.20.0-notes.html#deprecations
      properties = {'confidence': np.empty(0, dtype=np.float)}
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
