### PR TITLE
`Selectable` mixin and `SelectableEventedList`

### DIFF
--- a/napari/utils/events/containers/__init__.py
+++ b/napari/utils/events/containers/__init__.py
@@ -1,6 +1,7 @@
 from ._evented_list import EventedList
 from ._nested_list import NestableEventedList
-from ._selection import Selection
+from ._selectable_list import SelectableEventedList
+from ._selection import Selectable, Selection
 from ._set import EventedSet
 from ._typed import TypedMutableSequence
 
@@ -9,5 +10,7 @@ __all__ = [
     'EventedSet',
     'NestableEventedList',
     'Selection',
+    'SelectableEventedList',
+    'Selectable',
     'TypedMutableSequence',
 ]

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -1,0 +1,10 @@
+from typing import TypeVar
+
+from ._evented_list import EventedList
+from ._selection import Selectable
+
+_T = TypeVar("_T")
+
+
+class SelectableEventedList(Selectable[_T], EventedList[_T]):
+    """List model that also supports selection."""

--- a/napari/utils/events/containers/_selection.py
+++ b/napari/utils/events/containers/_selection.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Iterable, Optional, TypeVar
+from typing import TYPE_CHECKING, Generic, Iterable, Optional, TypeVar
 
 from ._set import EventedSet
 
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from pydantic.fields import ModelField
 
 _T = TypeVar("_T")
+_S = TypeVar("_S")
 
 
 class Selection(EventedSet[_T]):
@@ -50,14 +51,20 @@ class Selection(EventedSet[_T]):
 
     @property
     def current(self) -> Optional[_T]:
+        """Get current item."""
         return self._current
 
     @current.setter
     def current(self, index: Optional[_T]):
+        """Set current item."""
         if index == self._current:
             return
         previous, self._current = self._current, index
         self.events.current(value=index, previous=previous)
+
+    def toggle(self, obj: _T):
+        """Toggle selection state of obj."""
+        self.symmetric_difference_update({obj})
 
     @classmethod
     def __get_validators__(cls):
@@ -106,3 +113,22 @@ class Selection(EventedSet[_T]):
     def _json_encode(self):
         """Return an object that can be used by json.dumps."""
         return {'data': super()._json_encode(), 'current': self.current}
+
+
+class Selectable(Generic[_S]):
+    """Mixin that adds a selection model to an object."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore
+        self._selection: Selection[_S] = Selection()
+
+    @property
+    def selection(self) -> Selection[_S]:
+        """Get current selection."""
+        return self._selection
+
+    @selection.setter
+    def selection(self, new_selection) -> None:
+        """Set selection, without deleting selection model object."""
+        self._selection.intersection_update(new_selection)
+        self._selection.update(new_selection)

--- a/napari/utils/tree/group.py
+++ b/napari/utils/tree/group.py
@@ -14,7 +14,7 @@ class Group(NestableEventedList[NodeType], Node, Selectable[NodeType]):
     The ``Group`` (aka composite) is an element that has sub-elements:
     which may be ``Nodes`` or other ``Groups``.  By inheriting from
     :class:`NestableEventedList`, ``Groups`` have basic python list-like
-    behavior and emit events when modified.  The main additions in this class
+    behavior and emit events when modified.  The main addition in this class
     is that when objects are added to a ``Group``, they are assigned a
     ``.parent`` attribute pointing to the group, which is removed upon
     deletion from the group.

--- a/napari/utils/tree/group.py
+++ b/napari/utils/tree/group.py
@@ -1,13 +1,14 @@
 from typing import Generator, Iterable, List, TypeVar
 
-from ..events import NestableEventedList, Selection
+from ..events import NestableEventedList
 from ..events.containers._nested_list import MaybeNestedIndex
+from ..events.containers._selection import Selectable
 from .node import Node
 
 NodeType = TypeVar("NodeType", bound=Node)
 
 
-class Group(NestableEventedList[NodeType], Node):
+class Group(NestableEventedList[NodeType], Node, Selectable[NodeType]):
     """An object that can contain other objects in a composite Tree pattern.
 
     The ``Group`` (aka composite) is an element that has sub-elements:
@@ -38,16 +39,7 @@ class Group(NestableEventedList[NodeType], Node):
     ):
         Node.__init__(self, name=name)
         NestableEventedList.__init__(self, data=children, basetype=basetype)
-        self._selection: Selection[NodeType] = Selection()
-
-    @property
-    def selection(self) -> Selection[NodeType]:
-        return self._selection
-
-    @selection.setter
-    def selection(self, new_selection) -> None:
-        self._selection.intersection_update(new_selection)
-        self._selection.update(new_selection)
+        Selectable.__init__(self)
 
     def __delitem__(self, key: MaybeNestedIndex):
         """Remove item at ``key``, and unparent."""


### PR DESCRIPTION
# Description
pulled out from #2423, this just adds a `Selectable` mixin, and a `SelectableEventedList` that will be the basis of the new `LayerList` (prior to turning it into a `LayerGroup`.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
