### PR TITLE
Unify evented/nestedEvented list APIs

### DIFF
--- a/napari/utils/events/_tests/test_evented_list.py
+++ b/napari/utils/events/_tests/test_evented_list.py
@@ -147,7 +147,9 @@ def test_move(test_list):
         ((2,), 0, [2, 0, 1, 3, 4, 5, 6, 7]),  # move single item
         ((2, 4), -2, [0, 1, 3, 5, 6, 2, 4, 7]),  # negative indexing
         ([0, 2, 3], 6, [1, 4, 5, 0, 2, 3, 6, 7]),  # move back
+        ([3, 0, 2], 6, [1, 4, 5, 3, 0, 2, 6, 7]),  # move back reorder
         ([4, 7], 1, [0, 4, 7, 1, 2, 3, 5, 6]),  # move forward
+        ([7, 4], 1, [0, 7, 4, 1, 2, 3, 5, 6]),  # move forward reorder
         ([0, 5, 6], 3, [1, 2, 0, 5, 6, 3, 4, 7]),  # move in between
         ([slice(None, 3)], 6, [3, 4, 5, 0, 1, 2, 6, 7]),  # move slice back
         ([slice(5, 8)], 2, [0, 1, 5, 6, 7, 2, 3, 4]),  # move slice forward

--- a/napari/utils/events/_tests/test_evented_list.py
+++ b/napari/utils/events/_tests/test_evented_list.py
@@ -1,5 +1,5 @@
 from collections.abc import MutableSequence
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import numpy as np
 import pytest
@@ -73,8 +73,8 @@ def test_list_interface_parity(test_list, regular_list, meth):
     else:
         test_list_method(*args)  # smoke test
 
-    for call, expect in zip(test_list.events.call_args_list, expected):
-        event = call.args[0]
+    for c, expect in zip(test_list.events.call_args_list, expected):
+        event = c.args[0]
         assert event.type == expect
 
 
@@ -194,8 +194,24 @@ def test_move_multiple_mimics_slice_reorder():
     data[:] = [data[i] for i in new_order]
     assert el == new_order
     assert el == data
-    el.events.moving.assert_called()
-    el.events.moved.assert_called()
+    assert el.events.moving.call_args_list == [
+        call(index=1, new_index=0),
+        call(index=5, new_index=1),
+        call(index=4, new_index=2),
+        call(index=5, new_index=3),
+        call(index=6, new_index=4),
+        call(index=7, new_index=5),
+        call(index=7, new_index=6),
+    ]
+    assert el.events.moved.call_args_list == [
+        call(index=1, new_index=0, value=1),
+        call(index=5, new_index=1, value=5),
+        call(index=4, new_index=2, value=3),
+        call(index=5, new_index=3, value=4),
+        call(index=6, new_index=4, value=6),
+        call(index=7, new_index=5, value=7),
+        call(index=7, new_index=6, value=2),
+    ]
     el.events.reordered.assert_called_with(value=new_order)
 
     # move_multiple also works omitting the insertion index
@@ -296,8 +312,8 @@ def test_nested_events(meth, group_index):
         method(*args)
 
     # make sure the correct event type and number was emitted
-    for call, expected in zip(ne_list.events.call_args_list, expected_events):
-        event = call.args[0]
+    for c, expected in zip(ne_list.events.call_args_list, expected_events):
+        event = c.args[0]
         assert event.type == expected
         if group_index == ():
             # in the root group, the index will be an int relative to root
@@ -347,8 +363,33 @@ def test_nested_move_multiple(sources, dest, expectation):
     ne_list.events.reordered.assert_called_with(value=expectation)
 
 
-def test_arbitrary_child_events():
-    """Test that any object that supports the events protocol bubbles events.
+class E:
+    def __init__(self):
+        self.events = EmitterGroup(test=None)
+
+
+def test_child_events():
+    """Test that evented lists bubble child events."""
+    # create a random object that emits events
+    e_obj = E()
+    # and two nestable evented lists
+    root = EventedList()
+    observed = []
+    root.events.connect(lambda e: observed.append(e))
+    root.append(e_obj)
+    e_obj.events.test(value="hi")
+    obs = [(e.type, e.index, getattr(e, 'value', None)) for e in observed]
+    expected = [
+        ('inserting', 0, None),  # before we inserted b into root
+        ('inserted', 0, e_obj),  # after b was inserted into root
+        ('test', 0, 'hi'),  # when e_obj emitted an event called "test"
+    ]
+    for o, e in zip(obs, expected):
+        assert o == e
+
+
+def test_nested_child_events():
+    """Test that nested lists bubbles nested child events.
 
     If you add an object that implements the ``SupportsEvents`` Protocol
     (i.e. has an attribute ``events`` that is an ``EmitterGroup``), to a
@@ -359,9 +400,6 @@ def test_arbitrary_child_events():
 
     See docstring of :ref:`NestableEventedList` for more info.
     """
-
-    class E:
-        events = EmitterGroup(test=None)
 
     # create a random object that emits events
     e_obj = E()

--- a/napari/utils/events/_tests/test_evented_list.py
+++ b/napari/utils/events/_tests/test_evented_list.py
@@ -152,6 +152,7 @@ def test_move(test_list):
         ([slice(None, 3)], 6, [3, 4, 5, 0, 1, 2, 6, 7]),  # move slice back
         ([slice(5, 8)], 2, [0, 1, 5, 6, 7, 2, 3, 4]),  # move slice forward
         ([slice(1, 8, 2)], 3, [0, 2, 1, 3, 5, 7, 4, 6]),  # move slice between
+        ([1, 3, 5, 7], 3, [0, 2, 1, 3, 5, 7, 4, 6]),  # same as above
         ([slice(None, 8, 3)], 4, [1, 2, 0, 3, 6, 4, 5, 7]),
         ([0, 2, 3, 2, 3], 6, [1, 4, 5, 0, 2, 3, 6, 7]),  # strip dupe indices
         ([slice(None, 8, 3), 0, 3, 6], 4, [1, 2, 0, 3, 6, 4, 5, 7]),
@@ -173,8 +174,8 @@ def test_move_multiple(sources, dest, expectation):
 
     el.move_multiple(sources, dest)
     assert el == expectation
-    el.events.moving.assert_called_once()
-    el.events.moved.assert_called_once()
+    el.events.moving.assert_called()
+    el.events.moved.assert_called()
     el.events.reordered.assert_called_with(value=expectation)
 
 
@@ -191,12 +192,8 @@ def test_move_multiple_mimics_slice_reorder():
     data[:] = [data[i] for i in new_order]
     assert el == new_order
     assert el == data
-    el.events.moving.assert_called_with(index=new_order, new_index=0)
-    el.events.moved.assert_called_with(
-        index=new_order,
-        new_index=0,
-        value=new_order,
-    )
+    el.events.moving.assert_called()
+    el.events.moved.assert_called()
     el.events.reordered.assert_called_with(value=new_order)
 
     # move_multiple also works omitting the insertion index

--- a/napari/utils/events/containers/_evented_list.py
+++ b/napari/utils/events/containers/_evented_list.py
@@ -298,7 +298,7 @@ class EventedList(TypedMutableSequence[_T]):
             if src != dest_index:
                 # we need to decrement the src_i by 1 for each time we have
                 # previously pulled items out from in front of the src_i
-                src -= sum(map(_le(src), popped))
+                src -= sum([x <= src for x in popped])
                 # if source is past the insertion point, increment src for each
                 # previous insertion
                 if src >= dest_index:
@@ -317,8 +317,3 @@ class EventedList(TypedMutableSequence[_T]):
         # it would just emit a "changed" event for each moved index in the list
         self._list.reverse()
         self.events.reordered(value=self)
-
-
-def _le(y):
-    """create a new function that accepts a single value x, returns x < y."""
-    return lambda x: x <= y

--- a/napari/utils/events/containers/_evented_list.py
+++ b/napari/utils/events/containers/_evented_list.py
@@ -23,9 +23,10 @@ cover this in test_evented_list.py)
 """
 
 import logging
-from typing import Callable, Dict, Iterable, Sequence, Tuple, Type, Union
+from typing import Callable, Dict, Iterable, List, Sequence, Tuple, Type, Union
 
-from ..event import EmitterGroup
+from ..event import EmitterGroup, Event
+from ..types import SupportsEvents
 from ._typed import _L, _T, Index, TypedMutableSequence
 
 logger = logging.getLogger(__name__)
@@ -149,6 +150,7 @@ class EventedList(TypedMutableSequence[_T]):
         # delete from the end
         for parent, index in sorted(self._delitem_indices(key), reverse=True):
             parent.events.removing(index=index)
+            self._disconnect_child_emitters(parent[index])
             item = parent._list.pop(index)
             parent.events.removed(index=index, value=item)
 
@@ -157,6 +159,28 @@ class EventedList(TypedMutableSequence[_T]):
         self.events.inserting(index=index)
         super().insert(index, value)
         self.events.inserted(index=index, value=value)
+        self._connect_child_emitters(value)
+
+    def _reemit_child_event(self, event: Event):
+        """An item in the list emitted an event.  Re-emit with index"""
+        if not hasattr(event, 'index'):
+            setattr(event, 'index', self.index(event.source))
+        # reemit with this object's EventEmitter of the same type if present
+        # otherwise just emit with the EmitterGroup itself
+        getattr(self.events, event.type, self.events)(event)
+
+    def _disconnect_child_emitters(self, child: _T):
+        """Disconnect all events from the child from the reemitter."""
+        if isinstance(child, SupportsEvents):
+            child.events.disconnect(self._reemit_child_event)
+
+    def _connect_child_emitters(self, child: _T):
+        """Connect all events from the child to be reemitted."""
+        if isinstance(child, SupportsEvents):
+            # make sure the event source has been set on the child
+            if child.events.source is None:
+                child.events.source = child
+            child.events.connect(self._reemit_child_event)
 
     def move(self, src_index: int, dest_index: int = 0) -> bool:
         """Insert object at ``src_index`` before ``dest_index``.
@@ -166,18 +190,20 @@ class EventedList(TypedMutableSequence[_T]):
         """
         if dest_index < 0:
             dest_index += len(self) + 1
+        if dest_index in (src_index, src_index + 1):
+            return False
+
+        self.events.moving(index=src_index, new_index=dest_index)
+        item = self._list.pop(src_index)
         if dest_index > src_index:
             dest_index -= 1
-
-        self.events.moving(index=src_index, dest_index=dest_index)
-        item = self._list.pop(src_index)
         self._list.insert(dest_index, item)
-        self.events.moved(index=src_index, dest_index=dest_index, value=item)
+        self.events.moved(index=src_index, new_index=dest_index, value=item)
         self.events.reordered(value=self)
         return True
 
     def move_multiple(
-        self, sources: Sequence[Index], dest_index: int = 0
+        self, sources: Iterable[Index], dest_index: int = 0
     ) -> int:
         """Move a batch of indices, to a single destination.
 
@@ -206,10 +232,46 @@ class EventedList(TypedMutableSequence[_T]):
             If the destination index is a slice, or any of the source indices
             are not ``int`` or ``slice``.
         """
+        logger.debug(
+            f"move_multiple(sources={sources}, dest_index={dest_index})"
+        )
+
+        # calling list here makes sure that there are no index errors up front
+        move_plan = list(self._move_plan(sources, dest_index))
+
+        # don't assume index adjacency ... so move one at a time
+        # this *could* be simplified with an intermediate list ... but this
+        # provides any listening objects to note each moving object
+        with self.events.reordered.blocker():
+            for src, dest in move_plan:
+                self.move(src, dest)
+
+        self.events.reordered(value=self)
+        return len(move_plan)
+
+    def _move_plan(self, sources: Iterable[Index], dest_index: int):
+        """Prepared indices for a multi-move.
+
+        Given a set of ``sources`` from anywhere in the list,
+        and a single ``dest_index``, this function computes and yields
+        ``(from_index, to_index)`` tuples that can be used sequentially in
+        single move operations.  It keeps track of what has moved where and
+        updates the source and destination indices to reflect the model at each
+        point in the process.
+
+        This is useful for a drag-drop operation with a QtModel/View.
+
+        Parameters
+        ----------
+        sources : Iterable[tuple[int, ...]]
+            An iterable of tuple[int] that should be moved to ``dest_index``.
+        dest_index : Tuple[int]
+            The destination for sources.
+        """
         if isinstance(dest_index, slice):
             raise TypeError("Destination index may not be a slice")
 
-        to_move = []
+        to_move: List[int] = []
         for idx in sources:
             if isinstance(idx, slice):
                 to_move.extend(list(range(*idx.indices(len(self)))))
@@ -218,27 +280,38 @@ class EventedList(TypedMutableSequence[_T]):
             else:
                 raise TypeError("Can only move integer or slice indices")
 
-        # remove duplicates while maintaing order, python 3.7+
         to_move = list(dict.fromkeys(to_move))
 
         if dest_index < 0:
             dest_index += len(self) + 1
-        dest_index -= len([i for i in to_move if i < dest_index])
 
-        self.events.moving(index=to_move, new_index=dest_index)
-        items = [self[i] for i in to_move]
-        for i in sorted(to_move, reverse=True):
-            self._list.pop(i)
-        for item in items[::-1]:
-            self._list.insert(dest_index, item)
-        self.events.moved(index=to_move, new_index=dest_index, value=items)
-        self.events.reordered(value=self)
-        return len(to_move)
+        d_inc = 0
+        popped: List[int] = []
+        for i, src in enumerate(to_move):
+            if src != dest_index:
+                # we need to decrement the src_i by 1 for each time we have
+                # previously pulled items out from in front of the src_i
+                src -= sum(map(_le(src), popped))
+                # if source is past the insertion point, increment for each
+                # previous insertion
+                if src >= dest_index:
+                    src += i
+                yield src, dest_index + d_inc
+
+            popped.append(src)
+            # if we moved up, move back the destination index
+            if dest_index <= src:
+                d_inc += 1
 
     def reverse(self) -> None:
         """Reverse list *IN PLACE*."""
         # reimplementing this method to emit a change event
-        # If this method were removed, .reverse() would still be availalbe,
+        # If this method were removed, .reverse() would still be available,
         # it would just emit a "changed" event for each moved index in the list
         self._list.reverse()
         self.events.reordered(value=self)
+
+
+def _le(y):
+    # create a new function that accepts a single value x, returns x < y
+    return lambda x: x <= y

--- a/napari/utils/events/containers/_evented_list.py
+++ b/napari/utils/events/containers/_evented_list.py
@@ -298,7 +298,7 @@ class EventedList(TypedMutableSequence[_T]):
             if src != dest_index:
                 # we need to decrement the src_i by 1 for each time we have
                 # previously pulled items out from in front of the src_i
-                src -= sum([x <= src for x in popped])
+                src -= sum(x <= src for x in popped)
                 # if source is past the insertion point, increment src for each
                 # previous insertion
                 if src >= dest_index:

--- a/napari/utils/events/containers/_nested_list.py
+++ b/napari/utils/events/containers/_nested_list.py
@@ -19,7 +19,7 @@ from typing import (
 )
 
 from ..event import Event
-from ._evented_list import EventedList, Index, _le
+from ._evented_list import EventedList, Index
 
 logger = logging.getLogger(__name__)
 
@@ -303,7 +303,7 @@ class NestableEventedList(EventedList[_T]):
                     raise NotImplementedError(
                         "Can't yet deal with slice source indices in multimove"
                     )
-                _idx[_parlen] += sum(map(_le(_idx[_parlen]), dumped))
+                _idx[_parlen] += sum([x <= _idx[_parlen] for x in dumped])
                 idx = tuple(_idx)
 
             src_par, src_i = split_nested_index(idx)
@@ -314,11 +314,11 @@ class NestableEventedList(EventedList[_T]):
 
             # we need to decrement the src_i by 1 for each time we have
             # previously pulled items out from in front of the src_i
-            src_i -= sum(map(_le(src_i), popped.get(src_par, [])))
+            src_i -= sum([x <= src_i for x in popped.get(src_par, [])])
 
             # we need to decrement the dest_i by 1 for each time we have
             # previously pulled items out from in front of the dest_i
-            ddec = sum(map(_le(dest_i), popped.get(dest_par, [])))
+            ddec = sum([x <= dest_i for x in popped.get(dest_par, [])])
 
             # skip noop
             if src_par == dest_par and src_i == dest_i - ddec:

--- a/napari/utils/events/containers/_nested_list.py
+++ b/napari/utils/events/containers/_nested_list.py
@@ -303,7 +303,7 @@ class NestableEventedList(EventedList[_T]):
                     raise NotImplementedError(
                         "Can't yet deal with slice source indices in multimove"
                     )
-                _idx[_parlen] += sum([x <= _idx[_parlen] for x in dumped])
+                _idx[_parlen] += sum(x <= _idx[_parlen] for x in dumped)
                 idx = tuple(_idx)
 
             src_par, src_i = split_nested_index(idx)
@@ -314,11 +314,11 @@ class NestableEventedList(EventedList[_T]):
 
             # we need to decrement the src_i by 1 for each time we have
             # previously pulled items out from in front of the src_i
-            src_i -= sum([x <= src_i for x in popped.get(src_par, [])])
+            src_i -= sum(x <= src_i for x in popped.get(src_par, []))
 
             # we need to decrement the dest_i by 1 for each time we have
             # previously pulled items out from in front of the dest_i
-            ddec = sum([x <= dest_i for x in popped.get(dest_par, [])])
+            ddec = sum(x <= dest_i for x in popped.get(dest_par, []))
 
             # skip noop
             if src_par == dest_par and src_i == dest_i - ddec:

--- a/napari/utils/events/containers/_nested_list.py
+++ b/napari/utils/events/containers/_nested_list.py
@@ -19,7 +19,7 @@ from typing import (
 )
 
 from ..event import Event
-from ._evented_list import EventedList, Index
+from ._evented_list import EventedList, Index, _le
 
 logger = logging.getLogger(__name__)
 
@@ -414,8 +414,3 @@ class NestableEventedList(EventedList[_T]):
                         yield i
         else:
             yield from super()._iter_indices(start, stop)
-
-
-def _le(y):
-    # create a new function that accepts a single value x, returns x < y
-    return lambda x: x <= y


### PR DESCRIPTION
# Description
pulled out from #2423
This unifies some of the move and event-emission logic between the `EventedList` and the `NestedEventedList`.  It makes it so that an `EventedList` now re-emits events from any items in the list that support events (so that a view can only listen to the list itself, rather than connecting to every item in the list).  There is a compromise being made here, which is that in multi-move operations, there is now a move event emitted for _each_ individual move in the sequence.  This is how the nested list already was, and this _greatly_ simplifies connecting a `QAbstractItemModel`.  If curious, we're currently using [`beginMoveRows`](https://doc.qt.io/qt-5/qabstractitemmodel.html#beginMoveRows) and `endMoveRows` in Qt... which allows Qt to handle changing all of the "persistent model indices" accordingly (but only supports moving contiguous chunks).  The alternative (described in the docs linked above), is to update all indices in the model ourselves using [`changePersistentIndexList`](https://doc.qt.io/qt-5/qabstractitemmodel.html#changePersistentIndexList).  This is not so hard with a standard list, but it gets much harder with a nested/tree model.  If performance demands it in the future, it's something we can "upgrade".


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] refactor
