### PR TITLE
Use new selection model on existing `LayerList`

### DIFF
--- a/examples/add_points.py
+++ b/examples/add_points.py
@@ -18,7 +18,7 @@ with napari.gui_qt():
     viewer.add_points(points, size=size)
 
     # unselect the image layer
-    viewer.layers[0].selected = False
+    viewer.layers.selection.discard(viewer.layers[0])
 
     # adjust some of the points layer properties
     layer = viewer.layers[1]
@@ -30,9 +30,11 @@ with napari.gui_qt():
     layer.visible = False
     layer.visible = True
 
-    # change the layer selection
-    layer.selected = False
-    layer.selected = True
+    # select the layer
+    viewer.layers.selection.add(layer)
+    # deselect the layer
+    viewer.layers.selection.remove(layer)
+    # or: viewer.layers.selection.discard(layer)
 
     # change the layer opacity
     layer.opacity = 0.9
@@ -45,4 +47,3 @@ with napari.gui_qt():
 
     # change the layer mode
     layer.mode = 'add'
-

--- a/examples/dev/node_tree.py
+++ b/examples/dev/node_tree.py
@@ -49,7 +49,11 @@ root = Group(
 # pretty repr makes nested tree structure more interpretable
 print(root)
 root.events.reordered.connect(lambda e: print(e.value))
-root.selection.events.connect(lambda e: print("selection", e.type, e.value))
+root.selection.events.changed.connect(
+    lambda e: print(
+        f"selection changed.  added: {e.added}, removed: {e.removed}"
+    )
+)
 view = QtNodeTreeView(root)
 
 view.show()

--- a/napari/_qt/dialogs/_tests/test_qt_about_key_bindings.py
+++ b/napari/_qt/dialogs/_tests/test_qt_about_key_bindings.py
@@ -55,7 +55,7 @@ def test_updating_with_layer_change(make_napari_viewer, monkeypatch):
     # add a shape layer (different keybindings)
     viewer.add_shapes(None, shape_type='polygon')
     # check that the new layer is the active_layer
-    assert viewer.layers.selection.current == viewer.layers[1]
+    assert viewer.layers.selection.active == viewer.layers[1]
     # capture dialog text after active_layer events
     active_shape_layer_text = dialog.textEditBox.toHtml()
     # check that the text has changed for the new key bindings

--- a/napari/_qt/dialogs/_tests/test_qt_about_key_bindings.py
+++ b/napari/_qt/dialogs/_tests/test_qt_about_key_bindings.py
@@ -55,7 +55,7 @@ def test_updating_with_layer_change(make_napari_viewer, monkeypatch):
     # add a shape layer (different keybindings)
     viewer.add_shapes(None, shape_type='polygon')
     # check that the new layer is the active_layer
-    assert viewer.active_layer == viewer.layers[1]
+    assert viewer.layers.selection.current == viewer.layers[1]
     # capture dialog text after active_layer events
     active_shape_layer_text = dialog.textEditBox.toHtml()
     # check that the text has changed for the new key bindings

--- a/napari/_qt/layer_controls/qt_layer_controls_container.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_container.py
@@ -84,7 +84,7 @@ class QtLayerControlsContainer(QStackedWidget):
 
         self.viewer.layers.events.inserted.connect(self._add)
         self.viewer.layers.events.removed.connect(self._remove)
-        self.viewer.events.active_layer.connect(self._display)
+        viewer.layers.selection.events.current.connect(self._display)
 
     def _display(self, event):
         """Change the displayed controls to be those of the target layer.

--- a/napari/_qt/layer_controls/qt_layer_controls_container.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_container.py
@@ -89,7 +89,7 @@ class QtLayerControlsContainer(QStackedWidget):
 
         self.viewer.layers.events.inserted.connect(self._add)
         self.viewer.layers.events.removed.connect(self._remove)
-        viewer.layers.selection.events.current.connect(self._display)
+        viewer.layers.selection.events.active.connect(self._display)
 
     def _display(self, event):
         """Change the displayed controls to be those of the target layer.

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os.path
 import warnings
 from pathlib import Path
@@ -87,7 +89,7 @@ class QtViewer(QSplitter):
         Button controls for the napari viewer.
     """
 
-    def __init__(self, viewer: 'Viewer', welcome=False):
+    def __init__(self, viewer: Viewer, welcome=False):
 
         # Avoid circular import.
         from .layer_controls import QtLayerControlsContainer

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -39,6 +39,9 @@ from .._vispy import (  # isort:skip
     create_vispy_visual,
 )
 
+if TYPE_CHECKING:
+    from ..viewer import Viewer
+
 
 class QtViewer(QSplitter):
     """Qt view for the napari Viewer model.
@@ -83,7 +86,7 @@ class QtViewer(QSplitter):
         Button controls for the napari viewer.
     """
 
-    def __init__(self, viewer, welcome=False):
+    def __init__(self, viewer: 'Viewer', welcome=False):
 
         # Avoid circular import.
         from .layer_controls import QtLayerControlsContainer
@@ -180,7 +183,9 @@ class QtViewer(QSplitter):
 
         self._on_active_layer_change()
 
-        self.viewer.events.active_layer.connect(self._on_active_layer_change)
+        viewer.layers.selection.events.current.connect(
+            self._on_active_layer_change
+        )
         self.viewer.camera.events.interactive.connect(self._on_interactive)
         self.viewer.cursor.events.style.connect(self._on_cursor)
         self.viewer.cursor.events.size.connect(self._on_cursor)
@@ -340,8 +345,7 @@ class QtViewer(QSplitter):
         event : napari.utils.event.Event
             The napari event that triggered this method.
         """
-        active_layer = self.viewer.active_layer
-
+        active_layer = self.viewer.layers.selection.current
         if self._active_layer in self._key_map_handler.keymap_providers:
             self._key_map_handler.keymap_providers.remove(self._active_layer)
 
@@ -658,7 +662,7 @@ class QtViewer(QSplitter):
         self.viewer.cursor.position = self._map_canvas2world(list(event.pos))
         mouse_wheel_callbacks(self.viewer, event)
 
-        layer = self.viewer.active_layer
+        layer = self.viewer.layers.selection.current
         if layer is not None:
             mouse_wheel_callbacks(layer, event)
 
@@ -677,7 +681,7 @@ class QtViewer(QSplitter):
         self.viewer.cursor.position = self._map_canvas2world(list(event.pos))
         mouse_press_callbacks(self.viewer, event)
 
-        layer = self.viewer.active_layer
+        layer = self.viewer.layers.selection.current
         if layer is not None:
             mouse_press_callbacks(layer, event)
 
@@ -695,7 +699,7 @@ class QtViewer(QSplitter):
         self.viewer.cursor.position = self._map_canvas2world(list(event.pos))
         mouse_move_callbacks(self.viewer, event)
 
-        layer = self.viewer.active_layer
+        layer = self.viewer.layers.selection.current
         if layer is not None:
             mouse_move_callbacks(layer, event)
 
@@ -713,7 +717,7 @@ class QtViewer(QSplitter):
         self.viewer.cursor.position = self._map_canvas2world(list(event.pos))
         mouse_release_callbacks(self.viewer, event)
 
-        layer = self.viewer.active_layer
+        layer = self.viewer.layers.selection.current
         if layer is not None:
             mouse_release_callbacks(layer, event)
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -110,7 +110,6 @@ class QtViewer(QSplitter):
         self._key_map_handler = KeymapHandler()
         self._key_map_handler.keymap_providers = [self.viewer]
         self._key_bindings_dialog = None
-        self._active_layer = None
         self._console = None
 
         layerList = QWidget()
@@ -187,11 +186,8 @@ class QtViewer(QSplitter):
             'standard': QCursor(),
         }
 
-        self._on_active_layer_change()
-
-        viewer.layers.selection.events.active.connect(
-            self._on_active_layer_change
-        )
+        self._on_active_change()
+        viewer.layers.selection.events.active.connect(self._on_active_change)
         self.viewer.camera.events.interactive.connect(self._on_interactive)
         self.viewer.cursor.events.style.connect(self._on_cursor)
         self.viewer.cursor.events.size.connect(self._on_cursor)
@@ -345,7 +341,7 @@ class QtViewer(QSplitter):
         else:
             self.controls.setMaximumWidth(220)
 
-    def _on_active_layer_change(self, event=None):
+    def _on_active_change(self, event=None):
         """When active layer changes change keymap handler.
 
         Parameters
@@ -354,13 +350,11 @@ class QtViewer(QSplitter):
             The napari event that triggered this method.
         """
         active_layer = self.viewer.layers.selection.active
-        if self._active_layer in self._key_map_handler.keymap_providers:
-            self._key_map_handler.keymap_providers.remove(self._active_layer)
+        if active_layer in self._key_map_handler.keymap_providers:
+            self._key_map_handler.keymap_providers.remove(active_layer)
 
         if active_layer is not None:
             self._key_map_handler.keymap_providers.insert(0, active_layer)
-
-        self._active_layer = active_layer
 
         # If a QtAboutKeyBindings exists, update its text.
         if self._key_bindings_dialog is not None:

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -189,7 +189,7 @@ class QtViewer(QSplitter):
 
         self._on_active_layer_change()
 
-        viewer.layers.selection.events.current.connect(
+        viewer.layers.selection.events.active.connect(
             self._on_active_layer_change
         )
         self.viewer.camera.events.interactive.connect(self._on_interactive)
@@ -353,7 +353,7 @@ class QtViewer(QSplitter):
         event : napari.utils.event.Event
             The napari event that triggered this method.
         """
-        active_layer = self.viewer.layers.selection.current
+        active_layer = self.viewer.layers.selection.active
         if self._active_layer in self._key_map_handler.keymap_providers:
             self._key_map_handler.keymap_providers.remove(self._active_layer)
 
@@ -675,7 +675,7 @@ class QtViewer(QSplitter):
         self.viewer.cursor.position = self._map_canvas2world(list(event.pos))
         mouse_wheel_callbacks(self.viewer, event)
 
-        layer = self.viewer.layers.selection.current
+        layer = self.viewer.layers.selection.active
         if layer is not None:
             mouse_wheel_callbacks(layer, event)
 
@@ -694,7 +694,7 @@ class QtViewer(QSplitter):
         self.viewer.cursor.position = self._map_canvas2world(list(event.pos))
         mouse_press_callbacks(self.viewer, event)
 
-        layer = self.viewer.layers.selection.current
+        layer = self.viewer.layers.selection.active
         if layer is not None:
             mouse_press_callbacks(layer, event)
 
@@ -712,7 +712,7 @@ class QtViewer(QSplitter):
         self.viewer.cursor.position = self._map_canvas2world(list(event.pos))
         mouse_move_callbacks(self.viewer, event)
 
-        layer = self.viewer.layers.selection.current
+        layer = self.viewer.layers.selection.active
         if layer is not None:
             mouse_move_callbacks(layer, event)
 
@@ -730,7 +730,7 @@ class QtViewer(QSplitter):
         self.viewer.cursor.position = self._map_canvas2world(list(event.pos))
         mouse_release_callbacks(self.viewer, event)
 
-        layer = self.viewer.layers.selection.current
+        layer = self.viewer.layers.selection.active
         if layer is not None:
             mouse_release_callbacks(layer, event)
 

--- a/napari/_qt/tree/qt_tree_view.py
+++ b/napari/_qt/tree/qt_tree_view.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from itertools import chain, repeat
 from typing import TYPE_CHECKING
 
 from qtpy.QtCore import QItemSelection, QModelIndex, Qt
@@ -93,13 +94,11 @@ class QtNodeTreeView(QTreeView):
                 sel_model.setCurrentIndex(idx, sel_model.Current)
             return
         elif event.type == 'changed':
-            for idx in event.added:
+            for idx, sel in chain(
+                zip(event.added, repeat(sel_model.Select)),
+                zip(event.removed, repeat(sel_model.DeSelect)),
+            ):
                 model_idx = self.model().findIndex(idx)
                 if not model_idx.isValid():
                     continue
-                sel_model.select(model_idx, sel_model.Select)
-            for idx in event.removed:
-                model_idx = self.model().findIndex(idx)
-                if not model_idx.isValid():
-                    continue
-                sel_model.select(model_idx, sel_model.Deselect)
+                sel_model.select(model_idx, sel)

--- a/napari/_qt/tree/qt_tree_view.py
+++ b/napari/_qt/tree/qt_tree_view.py
@@ -71,7 +71,7 @@ class QtNodeTreeView(QTreeView):
 
     def currentChanged(self, current: QModelIndex, previous: QModelIndex):
         """The Qt current item has changed. Update the python model."""
-        self._root.selection.current = current.internalPointer()
+        self._root.selection._current = current.internalPointer()
         return super().currentChanged(current, previous)
 
     def selectionChanged(

--- a/napari/_qt/tree/qt_tree_view.py
+++ b/napari/_qt/tree/qt_tree_view.py
@@ -92,9 +92,14 @@ class QtNodeTreeView(QTreeView):
                 idx = self.model().findIndex(event.value)
                 sel_model.setCurrentIndex(idx, sel_model.Current)
             return
-        t = sel_model.Select if event.type == 'added' else sel_model.Deselect
-        for idx in event.value:
-            model_idx = self.model().findIndex(idx)
-            if not model_idx.isValid():
-                continue
-            sel_model.select(model_idx, t)
+        elif event.type == 'changed':
+            for idx in event.added:
+                model_idx = self.model().findIndex(idx)
+                if not model_idx.isValid():
+                    continue
+                sel_model.select(model_idx, sel_model.Select)
+            for idx in event.removed:
+                model_idx = self.model().findIndex(idx)
+                if not model_idx.isValid():
+                    continue
+                sel_model.select(model_idx, sel_model.Deselect)

--- a/napari/_qt/widgets/_tests/test_qt_layerlist.py
+++ b/napari/_qt/widgets/_tests/test_qt_layerlist.py
@@ -151,9 +151,8 @@ def test_removing_layers(qtbot):
 
     layers.append(layer_b)
     layers.append(layer_d)
-    # Select first and third layers
-    for layer, s in zip(layers, [True, True, False, False]):
-        layers.selection.add(layer) if s else layers.selection.discard(layer)
+    # Select first two
+    layers.selection = layers[:2]
     layers.remove_selected()
     assert view.vbox_layout.count() == 2 * (len(layers) + 1)
     assert check_layout_layers(view.vbox_layout, layers)
@@ -222,8 +221,7 @@ def test_reordering_layers(qtbot):
     layer_f = Image(np.random.random((15, 15)))
     layers.append(layer_e)
     layers.append(layer_f)
-    for layer, s in zip(layers, [False, True, False, False, True, False]):
-        layers.selection.add(layer) if s else layers.selection.discard(layer)
+    layers.selection = {layers[1], layers[4]}
     layers.move_selected(1, 2)
     assert view.vbox_layout.count() == 2 * (len(layers) + 1)
     assert check_layout_layers(view.vbox_layout, layers)

--- a/napari/_qt/widgets/_tests/test_qt_layerlist.py
+++ b/napari/_qt/widgets/_tests/test_qt_layerlist.py
@@ -153,7 +153,7 @@ def test_removing_layers(qtbot):
     layers.append(layer_d)
     # Select first and third layers
     for layer, s in zip(layers, [True, True, False, False]):
-        layer.selected = s
+        layers.selection.add(layer) if s else layers.selection.discard(layer)
     layers.remove_selected()
     assert view.vbox_layout.count() == 2 * (len(layers) + 1)
     assert check_layout_layers(view.vbox_layout, layers)
@@ -223,7 +223,7 @@ def test_reordering_layers(qtbot):
     layers.append(layer_e)
     layers.append(layer_f)
     for layer, s in zip(layers, [False, True, False, False, True, False]):
-        layer.selected = s
+        layers.selection.add(layer) if s else layers.selection.discard(layer)
     layers.move_selected(1, 2)
     assert view.vbox_layout.count() == 2 * (len(layers) + 1)
     assert check_layout_layers(view.vbox_layout, layers)

--- a/napari/_qt/widgets/qt_layerlist.py
+++ b/napari/_qt/widgets/qt_layerlist.py
@@ -303,7 +303,7 @@ class QtLayerList(QScrollArea):
         """
         if self._drag_name is None:
             # Unselect all the layers if not dragging a layer
-            self.layers.unselect_all()
+            self.layers.selection.clear()
             return
 
         modifiers = event.modifiers()
@@ -325,7 +325,7 @@ class QtLayerList(QScrollArea):
             self.layers.selection.toggle(layer)
         else:
             # If otherwise unselect all and leave clicked one selected
-            self.layers.unselect_all(ignore=layer)
+            self.layers.selection.clear()
             self.layers.selection.add(layer)
 
     def mouseMoveEvent(self, event):

--- a/napari/_qt/widgets/qt_layerlist.py
+++ b/napari/_qt/widgets/qt_layerlist.py
@@ -311,8 +311,9 @@ class QtLayerList(QScrollArea):
             # shift-click: select all layers between current and clicked
             clicked = self.layers.index(clicked_layer)
             current = self.layers.index(self.layers.selection.current)
-            selection = self.layers[slice(*sorted([clicked, current]))]
-            self.layers.selection.update(selection)
+            from_, to_ = sorted([clicked, current])
+            _to_select = self.layers[slice(from_, to_ + 1)]  # inclusive range
+            self.layers.selection.update(_to_select)
             self.layers.selection.current = clicked_layer
         elif modifiers == Qt.ControlModifier:
             # If control click toggle selected state of clicked layer

--- a/napari/_qt/widgets/qt_layerlist.py
+++ b/napari/_qt/widgets/qt_layerlist.py
@@ -304,6 +304,7 @@ class QtLayerList(QScrollArea):
         if self._drag_name is None:
             # Unselect all the layers if not dragging a layer
             self.layers.selection.clear()
+            self.layers.selection.current = None
             return
 
         modifiers = event.modifiers()
@@ -313,13 +314,14 @@ class QtLayerList(QScrollArea):
             # clicked one
             index = self.layers.index(layer)
             lastSelected = None
-            for i, layer in enumerate(self.layers):
-                if layer in self.layers.selection:
+            for i, lay in enumerate(self.layers):
+                if lay in self.layers.selection:
                     lastSelected = i
             r = [index, lastSelected]
             r.sort()
             for i in range(r[0], r[1] + 1):
                 self.layers.selection.add(self.layers[i])
+            self.layers.selection.current = layer
         elif modifiers == Qt.ControlModifier:
             # If control click toggle selected state
             self.layers.selection.toggle(layer)
@@ -327,6 +329,7 @@ class QtLayerList(QScrollArea):
             # If otherwise unselect all and leave clicked one selected
             self.layers.selection.clear()
             self.layers.selection.add(layer)
+            self.layers.selection.current = layer
 
     def mouseMoveEvent(self, event):
         """Drag and drop layer with mouse movement.

--- a/napari/_qt/widgets/qt_layerlist.py
+++ b/napari/_qt/widgets/qt_layerlist.py
@@ -99,25 +99,24 @@ class QtLayerList(QScrollArea):
         self.layers.events.inserted.connect(self._add)
         self.layers.events.removed.connect(self._remove)
         self.layers.events.reordered.connect(self._reorder)
-        self.layers.selection.events.connect(self._on_selection)
+        self.layers.selection.events.changed.connect(self._on_selection_change)
 
         self._drag_start_position = np.zeros(2)
         self._drag_name = None
 
         self.chunk_receiver = _create_chunk_receiver(self)
 
-    def _on_selection(self, event):
-        if event.type == 'added':
-            for layer in event.value:
-                w = self._find_widget(layer)
-                if w:
-                    w.setSelected(True)
-            self._ensure_visible(list(event.value)[-1])
-        elif event.type == 'removed':
-            for layer in event.value:
-                w = self._find_widget(layer)
-                if w:
-                    w.setSelected(False)
+    def _on_selection_change(self, event):
+        for layer in event.added:
+            w = self._find_widget(layer)
+            if w:
+                w.setSelected(True)
+        for layer in event.removed:
+            w = self._find_widget(layer)
+            if w:
+                w.setSelected(False)
+        if event.added:
+            self._ensure_visible(list(event.added)[-1])
 
     def _find_widget(self, layer):
         for i in range(self.vbox_layout.count()):

--- a/napari/_qt/widgets/qt_layerlist.py
+++ b/napari/_qt/widgets/qt_layerlist.py
@@ -306,26 +306,20 @@ class QtLayerList(QScrollArea):
             return
 
         modifiers = event.modifiers()
-        layer = self.layers[self._drag_name]
+        clicked_layer = self.layers[self._drag_name]
         if modifiers == Qt.ShiftModifier:
-            # If shift select all layers in between currently selected one and
-            # clicked one
-            index = self.layers.index(layer)
-            lastSelected = None
-            for i, lay in enumerate(self.layers):
-                if lay in self.layers.selection:
-                    lastSelected = i
-            r = [index, lastSelected]
-            r.sort()
-            for i in range(r[0], r[1] + 1):
-                self.layers.selection.add(self.layers[i])
-            self.layers.selection.current = layer
+            # shift-click: select all layers between current and clicked
+            clicked = self.layers.index(clicked_layer)
+            current = self.layers.index(self.layers.selection.current)
+            selection = self.layers[slice(*sorted([clicked, current]))]
+            self.layers.selection.update(selection)
+            self.layers.selection.current = clicked_layer
         elif modifiers == Qt.ControlModifier:
-            # If control click toggle selected state
-            self.layers.selection.toggle(layer)
+            # If control click toggle selected state of clicked layer
+            self.layers.selection.toggle(clicked_layer)
         else:
             # If otherwise unselect all and leave clicked one selected
-            self.layers.selection.active = layer
+            self.layers.selection.active = clicked_layer
 
     def mouseMoveEvent(self, event):
         """Drag and drop layer with mouse movement.

--- a/napari/_qt/widgets/qt_layerlist.py
+++ b/napari/_qt/widgets/qt_layerlist.py
@@ -307,14 +307,14 @@ class QtLayerList(QScrollArea):
 
         modifiers = event.modifiers()
         clicked_layer = self.layers[self._drag_name]
-        if modifiers == Qt.ShiftModifier and self.layers.selection.current:
+        if modifiers == Qt.ShiftModifier and self.layers.selection._current:
             # shift-click: select all layers between current and clicked
             clicked = self.layers.index(clicked_layer)
-            current = self.layers.index(self.layers.selection.current)
+            current = self.layers.index(self.layers.selection._current)
             from_, to_ = sorted([clicked, current])
             _to_select = self.layers[slice(from_, to_ + 1)]  # inclusive range
             self.layers.selection.update(_to_select)
-            self.layers.selection.current = clicked_layer
+            self.layers.selection._current = clicked_layer
         elif modifiers == Qt.ControlModifier:
             # If control click toggle selected state of clicked layer
             self.layers.selection.toggle(clicked_layer)

--- a/napari/_qt/widgets/qt_layerlist.py
+++ b/napari/_qt/widgets/qt_layerlist.py
@@ -20,6 +20,7 @@ from ...utils import config
 from ...utils.events import disconnect_events
 
 if TYPE_CHECKING:
+    from ...components.layerlist import LayerList
     from ..experimental.qt_chunk_receiver import QtChunkReceiver
 
 
@@ -65,7 +66,7 @@ class QtLayerList(QScrollArea):
         The layout instance in which the layouts appear.
     """
 
-    def __init__(self, layers):
+    def __init__(self, layers: 'LayerList'):
         super().__init__()
 
         self.layers = layers
@@ -97,11 +98,31 @@ class QtLayerList(QScrollArea):
         self.layers.events.inserted.connect(self._add)
         self.layers.events.removed.connect(self._remove)
         self.layers.events.reordered.connect(self._reorder)
+        self.layers.selection.events.connect(self._on_selection)
 
         self._drag_start_position = np.zeros(2)
         self._drag_name = None
 
         self.chunk_receiver = _create_chunk_receiver(self)
+
+    def _on_selection(self, event):
+        if event.type == 'added':
+            for layer in event.value:
+                w = self._find_widget(layer)
+                if w:
+                    w.setSelected(True)
+            self._ensure_visible(list(event.value)[-1])
+        elif event.type == 'removed':
+            for layer in event.value:
+                w = self._find_widget(layer)
+                if w:
+                    w.setSelected(False)
+
+    def _find_widget(self, layer):
+        for i in range(self.vbox_layout.count()):
+            w = self.vbox_layout.itemAt(i).widget()
+            if getattr(w, 'layer', None) == layer:
+                return w
 
     def _add(self, event):
         """Insert widget for layer `event.value` at index `event.index`.
@@ -114,10 +135,9 @@ class QtLayerList(QScrollArea):
         layer = event.value
         total = len(self.layers)
         index = 2 * (total - event.index) - 1
-        widget = QtLayerWidget(layer)
+        widget = QtLayerWidget(layer, selected=layer in self.layers.selection)
         self.vbox_layout.insertWidget(index, widget)
         self.vbox_layout.insertWidget(index + 1, QtDivider())
-        layer.events.select.connect(self._scroll_on_select)
 
     def _remove(self, event):
         """Remove widget for layer at index `event.index`.
@@ -194,17 +214,6 @@ class QtLayerList(QScrollArea):
             if new_value > self.verticalScrollBar().maximum():
                 new_value = self.verticalScrollBar().maximum()
             self.verticalScrollBar().setValue(new_value)
-
-    def _scroll_on_select(self, event):
-        """Scroll to ensure that the currently selected layer is visible.
-
-        Parameters
-        ----------
-        event : napari.utils.event.Event
-            The napari event that triggered this method.
-        """
-        layer = event.source
-        self._ensure_visible(layer)
 
     def _ensure_visible(self, layer):
         """Ensure layer widget for at particular layer is visible.
@@ -303,20 +312,20 @@ class QtLayerList(QScrollArea):
             # clicked one
             index = self.layers.index(layer)
             lastSelected = None
-            for i in range(len(self.layers)):
-                if self.layers[i].selected:
+            for i, layer in enumerate(self.layers):
+                if layer in self.layers.selection:
                     lastSelected = i
             r = [index, lastSelected]
             r.sort()
             for i in range(r[0], r[1] + 1):
-                self.layers[i].selected = True
+                self.layers.selection.add(self.layers[i])
         elif modifiers == Qt.ControlModifier:
             # If control click toggle selected state
-            layer.selected = not layer.selected
+            self.layers.selection.toggle(layer)
         else:
             # If otherwise unselect all and leave clicked one selected
             self.layers.unselect_all(ignore=layer)
-            layer.selected = True
+            self.layers.selection.add(layer)
 
     def mouseMoveEvent(self, event):
         """Drag and drop layer with mouse movement.
@@ -515,12 +524,10 @@ class QtLayerWidget(QFrame):
         Checkbox to toggle layer visibility.
     """
 
-    def __init__(self, layer):
+    def __init__(self, layer, selected=True):
         super().__init__()
 
         self.layer = layer
-        self.layer.events.select.connect(self._on_select_change)
-        self.layer.events.deselect.connect(self._on_deselect_change)
         self.layer.events.name.connect(self._on_name_change)
         self.layer.events.visible.connect(self._on_visible_change)
         self.layer.events.thumbnail.connect(self._on_thumbnail_change)
@@ -569,7 +576,7 @@ class QtLayerWidget(QFrame):
 
         msg = 'Click to select\nDrag to rearrange'
         self.setToolTip(msg)
-        self.setSelected(self.layer.selected)
+        self.setSelected(selected)
 
     def setSelected(self, state):
         """Select layer widget.
@@ -643,26 +650,6 @@ class QtLayerWidget(QFrame):
             Event from the Qt context.
         """
         event.ignore()
-
-    def _on_select_change(self, event=None):
-        """Update selected state of the layer.
-
-        Parameters
-        ----------
-        event : napari.utils.event.Event, optional
-            The napari event that triggered this method.
-        """
-        self.setSelected(True)
-
-    def _on_deselect_change(self, event=None):
-        """Update selected state of the layer.
-
-        Parameters
-        ----------
-        event : napari.utils.event.Event, optional
-            The napari event that triggered this method.
-        """
-        self.setSelected(False)
 
     def _on_name_change(self, event=None):
         """Update text displaying name of layer.

--- a/napari/_qt/widgets/qt_layerlist.py
+++ b/napari/_qt/widgets/qt_layerlist.py
@@ -307,7 +307,7 @@ class QtLayerList(QScrollArea):
 
         modifiers = event.modifiers()
         clicked_layer = self.layers[self._drag_name]
-        if modifiers == Qt.ShiftModifier:
+        if modifiers == Qt.ShiftModifier and self.layers.selection.current:
             # shift-click: select all layers between current and clicked
             clicked = self.layers.index(clicked_layer)
             current = self.layers.index(self.layers.selection.current)

--- a/napari/_qt/widgets/qt_layerlist.py
+++ b/napari/_qt/widgets/qt_layerlist.py
@@ -303,8 +303,7 @@ class QtLayerList(QScrollArea):
         """
         if self._drag_name is None:
             # Unselect all the layers if not dragging a layer
-            self.layers.selection.clear()
-            self.layers.selection.current = None
+            self.layers.selection.active = None
             return
 
         modifiers = event.modifiers()
@@ -327,9 +326,7 @@ class QtLayerList(QScrollArea):
             self.layers.selection.toggle(layer)
         else:
             # If otherwise unselect all and leave clicked one selected
-            self.layers.selection.clear()
-            self.layers.selection.add(layer)
-            self.layers.selection.current = layer
+            self.layers.selection.active = layer
 
     def mouseMoveEvent(self, event):
         """Drag and drop layer with mouse movement.

--- a/napari/_tests/test_adding_removing.py
+++ b/napari/_tests/test_adding_removing.py
@@ -105,6 +105,7 @@ def test_add_remove_layer_external_callbacks(
     # Check that no internal callbacks have been registered
     assert len(layer.events.callbacks) == 1
     for em in layer.events.emitters.values():
+        # warningEmitters are not connected when connecting to the emitterGroup
         if not isinstance(em, WarningEmitter):
             assert len(em.callbacks) == 1
 
@@ -121,5 +122,6 @@ def test_add_remove_layer_external_callbacks(
     # Check that all internal callbacks have been removed
     assert len(layer.events.callbacks) == 1
     for em in layer.events.emitters.values():
+        # warningEmitters are not connected when connecting to the emitterGroup
         if not isinstance(em, WarningEmitter):
             assert len(em.callbacks) == 1

--- a/napari/_tests/test_adding_removing.py
+++ b/napari/_tests/test_adding_removing.py
@@ -3,6 +3,7 @@ import pytest
 
 from napari._tests.utils import layer_test_data
 from napari.layers import Image
+from napari.utils.events.event import WarningEmitter
 
 
 def test_layers_removed_on_close(make_napari_viewer):
@@ -104,7 +105,8 @@ def test_add_remove_layer_external_callbacks(
     # Check that no internal callbacks have been registered
     assert len(layer.events.callbacks) == 1
     for em in layer.events.emitters.values():
-        assert len(em.callbacks) == 1
+        if not isinstance(em, WarningEmitter):
+            assert len(em.callbacks) == 1
 
     viewer.layers.append(layer)
     # Check layer added correctly
@@ -119,4 +121,5 @@ def test_add_remove_layer_external_callbacks(
     # Check that all internal callbacks have been removed
     assert len(layer.events.callbacks) == 1
     for em in layer.events.emitters.values():
-        assert len(em.callbacks) == 1
+        if not isinstance(em, WarningEmitter):
+            assert len(em.callbacks) == 1

--- a/napari/_tests/test_key_bindings.py
+++ b/napari/_tests/test_key_bindings.py
@@ -79,7 +79,7 @@ def test_layer_key_bindings(make_napari_viewer):
     view = viewer.window.qt_viewer
 
     layer = viewer.add_image(np.random.random((10, 20)))
-    layer.selected = True
+    viewer.layers.selection.add(layer)
 
     mock_press = Mock()
     mock_release = Mock()

--- a/napari/_tests/test_mouse_bindings.py
+++ b/napari/_tests/test_mouse_bindings.py
@@ -87,7 +87,7 @@ def test_layer_mouse_bindings(make_napari_viewer):
         viewer.show()
 
     layer = viewer.add_image(np.random.random((10, 20)))
-    layer.selected = True
+    viewer.layers.selection.add(layer)
 
     mock_press = Mock()
     mock_drag = Mock()
@@ -162,7 +162,7 @@ def test_unselected_layer_mouse_bindings(make_napari_viewer):
         viewer.show()
 
     layer = viewer.add_image(np.random.random((10, 20)))
-    layer.selected = False
+    viewer.layers.selection.remove(layer)
 
     mock_press = Mock()
     mock_drag = Mock()

--- a/napari/components/_tests/test_layers_list.py
+++ b/napari/components/_tests/test_layers_list.py
@@ -456,7 +456,7 @@ def test_layers_save_none_selected(tmpdir, layer_data_and_types):
 
 
 # the layer_data_and_types fixture is defined in napari/conftest.py
-def test_layers_save_seleteced(tmpdir, layer_data_and_types):
+def test_layers_save_selected(tmpdir, layer_data_and_types):
     """Test saving all layer data."""
     list_of_layers, _, _, filenames = layer_data_and_types
     layers = LayerList(list_of_layers)

--- a/napari/components/_tests/test_layers_list.py
+++ b/napari/components/_tests/test_layers_list.py
@@ -574,3 +574,26 @@ def test_name_uniqueness():
     layers.append(Image(np.random.random((10, 15)), name="Image"))
     layers.append(Image(np.random.random((10, 15)), name="Image"))
     assert [x.name for x in layers] == ['Image [1]', 'Image', 'Image [2]']
+
+
+def test_deprecated_selection():
+    """Test deprecated layer selection emits warnings."""
+    layers = LayerList()
+    layer = Image(np.random.random((10, 15)))
+    events = []
+
+    with pytest.warns(DeprecationWarning):
+        layer.events.select.connect(lambda e: events.append(e))
+        layer.events.deselect.connect(lambda e: events.append(e))
+
+    layers.append(layer)
+    assert events[-1].type == 'select'
+
+    with pytest.warns(DeprecationWarning):
+        assert layer.selected is True
+
+    with pytest.warns(DeprecationWarning):
+        layer.selected = False
+
+    assert events[-1].type == 'deselect'
+    assert layer not in layers.selection

--- a/napari/components/_tests/test_layers_list.py
+++ b/napari/components/_tests/test_layers_list.py
@@ -526,17 +526,17 @@ def test_deprecated_selection():
     layer = Image(np.random.random((10, 15)))
     events = []
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(FutureWarning):
         layer.events.select.connect(lambda e: events.append(e))
         layer.events.deselect.connect(lambda e: events.append(e))
 
     layers.append(layer)
     assert events[-1].type == 'select'
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(FutureWarning):
         assert layer.selected is True
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(FutureWarning):
         layer.selected = False
 
     assert events[-1].type == 'deselect'

--- a/napari/components/_tests/test_layers_list.py
+++ b/napari/components/_tests/test_layers_list.py
@@ -134,26 +134,6 @@ def test_clearing_layerlist():
     assert len(layers) == 0
 
 
-def test_unselect_all():
-    """
-    Test unselecting
-    """
-    layers = LayerList()
-    layer_a = Image(np.random.random((10, 10)))
-    layer_b = Image(np.random.random((15, 15)))
-    layer_c = Image(np.random.random((15, 15)))
-    layers.append(layer_a)
-    layers.append(layer_b)
-    layers.append(layer_c)
-
-    layers.unselect_all()
-    assert not layers.selection
-
-    layers.selection.update(layers)
-    layers.unselect_all(ignore=layer_b)
-    assert layers.selection == {layer_b}
-
-
 def test_remove_selected():
     """
     Test removing selected layers
@@ -247,29 +227,29 @@ def test_move_selected():
     layers.append(layer_d)
 
     # Check nothing moves if given same insert and origin
-    layers.unselect_all()
+    layers.selection.clear()
     layers.move_selected(2, 2)
     assert list(layers) == [layer_a, layer_b, layer_c, layer_d]
     assert layers.selection == {layer_c}
 
     # Move middle element to front of list and back
-    layers.unselect_all()
+    layers.selection.clear()
     layers.move_selected(2, 0)
     assert list(layers) == [layer_c, layer_a, layer_b, layer_d]
     assert layers.selection == {layer_c}
 
-    layers.unselect_all()
+    layers.selection.clear()
     layers.move_selected(0, 2)
     assert list(layers) == [layer_a, layer_b, layer_c, layer_d]
     assert layers.selection == {layer_c}
 
     # Move middle element to end of list and back
-    layers.unselect_all()
+    layers.selection.clear()
     layers.move_selected(2, 3)
     assert list(layers) == [layer_a, layer_b, layer_d, layer_c]
     assert layers.selection == {layer_c}
 
-    layers.unselect_all()
+    layers.selection.clear()
     layers.move_selected(3, 2)
     assert list(layers) == [layer_a, layer_b, layer_c, layer_d]
     assert layers.selection == {layer_c}
@@ -433,7 +413,7 @@ def test_layers_save_none_selected(tmpdir, layer_data_and_types):
     """Test saving all layer data."""
     list_of_layers, _, _, filenames = layer_data_and_types
     layers = LayerList(list_of_layers)
-    layers.unselect_all()
+    layers.selection.clear()
 
     path = os.path.join(tmpdir, 'layers_folder')
 
@@ -460,7 +440,7 @@ def test_layers_save_selected(tmpdir, layer_data_and_types):
     """Test saving all layer data."""
     list_of_layers, _, _, filenames = layer_data_and_types
     layers = LayerList(list_of_layers)
-    layers.unselect_all()
+    layers.selection.clear()
     layers.selection.update({layers[0], layers[2]})
 
     path = os.path.join(tmpdir, 'layers_folder')

--- a/napari/components/_tests/test_layers_list.py
+++ b/napari/components/_tests/test_layers_list.py
@@ -135,79 +135,23 @@ def test_clearing_layerlist():
 
 
 def test_remove_selected():
-    """
-    Test removing selected layers
-    """
+    """Test removing selected layers."""
     layers = LayerList()
     layer_a = Image(np.random.random((10, 10)))
     layer_b = Image(np.random.random((15, 15)))
     layer_c = Image(np.random.random((15, 15)))
-    layer_d = Image(np.random.random((15, 15)))
     layers.append(layer_a)
     layers.append(layer_b)
     layers.append(layer_c)
 
     # remove last added layer as only one selected
-    layers.selection.discard(layer_a)
-    layers.selection.discard(layer_b)
+    layers.selection.clear()
     layers.selection.add(layer_c)
     layers.remove_selected()
     assert list(layers) == [layer_a, layer_b]
 
-    # TODO: this just fixes the test...
-    layers.selection.add(layer_b)
-
-    # check that the next to last layer is now selected
-    assert [lay in layers.selection for lay in layers] == [False, True]
-
-    layers.remove_selected()
-    assert list(layers) == [layer_a]
-    # TODO: this just fixes the test...
-    layers.selection.add(layer_a)
-    assert [lay in layers.selection for lay in layers] == [True]
-
-    # select and remove first layer only
-    layers.append(layer_b)
-    layers.append(layer_c)
-    assert list(layers) == [layer_a, layer_b, layer_c]
-    layers.selection.add(layer_a)
-    layers.selection.discard(layer_b)
-    layers.selection.discard(layer_c)
-    layers.remove_selected()
-    # TODO: this just fixes the test...
-    layers.selection.add(layer_b)
-    assert list(layers) == [layer_b, layer_c]
-    assert [lay in layers.selection for lay in layers] == [True, False]
-
-    # select and remove first and last layer of four
-    layers.append(layer_a)
-    layers.append(layer_d)
-    assert list(layers) == [layer_b, layer_c, layer_a, layer_d]
-    layers.selection.discard(layer_a)
-    layers.selection.add(layer_b)
-    layers.selection.discard(layer_c)
-    layers.selection.add(layer_d)
-    layers.remove_selected()
-    assert list(layers) == [layer_c, layer_a]
-    # TODO: this just fixes the test...
-    layers.selection.add(layer_c)
-    assert [lay in layers.selection for lay in layers] == [True, False]
-
-    # select and remove middle two layers of four
-    layers.append(layer_b)
-    layers.append(layer_d)
-    layers.selection.add(layer_a)
-    layers.selection.add(layer_b)
-    layers.selection.discard(layer_c)
-    layers.selection.discard(layer_d)
-    layers.remove_selected()
-    assert list(layers) == [layer_c, layer_d]
-    # TODO: this just fixes the test...
-    layers.selection.add(layer_c)
-    assert [lay in layers.selection for lay in layers] == [True, False]
-
     # select and remove all layersay
-    layers.selection.update(layers)
+    layers.select_all()
     layers.remove_selected()
     assert len(layers) == 0
 

--- a/napari/components/_tests/test_layers_list.py
+++ b/napari/components/_tests/test_layers_list.py
@@ -147,11 +147,11 @@ def test_unselect_all():
     layers.append(layer_c)
 
     layers.unselect_all()
-    assert [lay in layers.selection for lay in layers] == [False] * 3
+    assert not layers.selection
 
     layers.selection.update(layers)
     layers.unselect_all(ignore=layer_b)
-    assert [lay in layers.selection for lay in layers] == [False, True, False]
+    assert layers.selection == {layer_b}
 
 
 def test_remove_selected():
@@ -250,56 +250,33 @@ def test_move_selected():
     layers.unselect_all()
     layers.move_selected(2, 2)
     assert list(layers) == [layer_a, layer_b, layer_c, layer_d]
-    assert [lay in layers.selection for lay in layers] == [
-        False,
-        False,
-        True,
-        False,
-    ]
+    assert layers.selection == {layer_c}
 
     # Move middle element to front of list and back
     layers.unselect_all()
     layers.move_selected(2, 0)
     assert list(layers) == [layer_c, layer_a, layer_b, layer_d]
-    assert [lay in layers.selection for lay in layers] == [
-        True,
-        False,
-        False,
-        False,
-    ]
+    assert layers.selection == {layer_c}
+
     layers.unselect_all()
     layers.move_selected(0, 2)
     assert list(layers) == [layer_a, layer_b, layer_c, layer_d]
-    assert [lay in layers.selection for lay in layers] == [
-        False,
-        False,
-        True,
-        False,
-    ]
+    assert layers.selection == {layer_c}
 
     # Move middle element to end of list and back
     layers.unselect_all()
     layers.move_selected(2, 3)
     assert list(layers) == [layer_a, layer_b, layer_d, layer_c]
-    assert [lay in layers.selection for lay in layers] == [
-        False,
-        False,
-        False,
-        True,
-    ]
+    assert layers.selection == {layer_c}
+
     layers.unselect_all()
     layers.move_selected(3, 2)
     assert list(layers) == [layer_a, layer_b, layer_c, layer_d]
-    assert [lay in layers.selection for lay in layers] == [
-        False,
-        False,
-        True,
-        False,
-    ]
+    assert layers.selection == {layer_c}
 
     # Select first two layers only
-    for layer, s in zip(layers, [True, True, False, False]):
-        layers.selection.add(layer) if s else layers.selection.discard(layer)
+    layers.selection = layers[:2]
+
     # Move unselected middle element to front of list even if others selected
     layers.move_selected(2, 0)
     assert list(layers) == [layer_c, layer_a, layer_b, layer_d]
@@ -308,113 +285,61 @@ def test_move_selected():
     assert list(layers) == [layer_a, layer_b, layer_c, layer_d]
 
     # Select first two layers only
-    for layer, s in zip(layers, [True, True, False, False]):
-        layers.selection.add(layer) if s else layers.selection.discard(layer)
+    layers.selection = layers[:2]
     # Check nothing moves if given same insert and origin and multiple selected
     layers.move_selected(0, 0)
     assert list(layers) == [layer_a, layer_b, layer_c, layer_d]
-    assert [lay in layers.selection for lay in layers] == [
-        True,
-        True,
-        False,
-        False,
-    ]
+    assert layers.selection == {layer_a, layer_b}
 
     # Check nothing moves if given same insert and origin and multiple selected
     layers.move_selected(1, 1)
     assert list(layers) == [layer_a, layer_b, layer_c, layer_d]
-    assert [lay in layers.selection for lay in layers] == [
-        True,
-        True,
-        False,
-        False,
-    ]
+    assert layers.selection == {layer_a, layer_b}
 
     # Move first two selected to middle of list
     layers.move_selected(0, 2)
     assert list(layers) == [layer_c, layer_a, layer_b, layer_d]
-    assert [lay in layers.selection for lay in layers] == [
-        False,
-        True,
-        True,
-        False,
-    ]
+    assert layers.selection == {layer_a, layer_b}
 
     # Move middle selected to front of list
     layers.move_selected(2, 0)
     assert list(layers) == [layer_a, layer_b, layer_c, layer_d]
-    assert [lay in layers.selection for lay in layers] == [
-        True,
-        True,
-        False,
-        False,
-    ]
+    assert layers.selection == {layer_a, layer_b}
 
     # Move first two selected to middle of list
     layers.move_selected(1, 2)
     assert list(layers) == [layer_c, layer_a, layer_b, layer_d]
-    assert [lay in layers.selection for lay in layers] == [
-        False,
-        True,
-        True,
-        False,
-    ]
+    assert layers.selection == {layer_a, layer_b}
 
     # Move middle selected to front of list
     layers.move_selected(1, 0)
     assert list(layers) == [layer_a, layer_b, layer_c, layer_d]
-    assert [lay in layers.selection for lay in layers] == [
-        True,
-        True,
-        False,
-        False,
-    ]
+    assert layers.selection == {layer_a, layer_b}
 
     # Select first and third layers only
-    for layer, s in zip(layers, [True, False, True, False]):
-        layers.selection.add(layer) if s else layers.selection.discard(layer)
+    layers.selection = layers[::2]
     # Move selection together to middle
     layers.move_selected(2, 2)
     assert list(layers) == [layer_b, layer_a, layer_c, layer_d]
-    assert [lay in layers.selection for lay in layers] == [
-        False,
-        True,
-        True,
-        False,
-    ]
+    assert layers.selection == {layer_a, layer_c}
     layers.move_multiple((1, 0, 2, 3), 0)
 
     # Move selection together to middle
     layers.move_selected(0, 1)
     assert list(layers) == [layer_b, layer_a, layer_c, layer_d]
-    assert [lay in layers.selection for lay in layers] == [
-        False,
-        True,
-        True,
-        False,
-    ]
+    assert layers.selection == {layer_a, layer_c}
     layers.move_multiple((1, 0, 2, 3), 0)
 
     # Move selection together to end
     layers.move_selected(2, 3)
     assert list(layers) == [layer_b, layer_d, layer_a, layer_c]
-    assert [lay in layers.selection for lay in layers] == [
-        False,
-        False,
-        True,
-        True,
-    ]
+    assert layers.selection == {layer_a, layer_c}
     layers.move_multiple((2, 0, 3, 1), 0)
 
     # Move selection together to end
     layers.move_selected(0, 3)
     assert list(layers) == [layer_b, layer_d, layer_a, layer_c]
-    assert [lay in layers.selection for lay in layers] == [
-        False,
-        False,
-        True,
-        True,
-    ]
+    assert layers.selection == {layer_a, layer_c}
     layers.move_multiple((2, 0, 3, 1), 0)
 
     layer_e = Image(np.random.random((15, 15)))
@@ -431,8 +356,7 @@ def test_move_selected():
         layer_f,
     ]
     # Select second and firth layers only
-    for layer, s in zip(layers, [False, True, False, False, True, False]):
-        layers.selection.add(layer) if s else layers.selection.discard(layer)
+    layers.selection = {layers[1], layers[4]}
 
     # Move selection together to middle
     layers.move_selected(1, 2)
@@ -444,14 +368,7 @@ def test_move_selected():
         layer_d,
         layer_f,
     ]
-    assert [lay in layers.selection for lay in layers] == [
-        False,
-        False,
-        True,
-        True,
-        False,
-        False,
-    ]
+    assert layers.selection == {layer_b, layer_e}
 
 
 def test_toggle_visibility():

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -508,7 +508,7 @@ def test_active_layer():
     assert viewer.layers.selection.current == viewer.layers[1]
 
     # Check no active layer after unselecting all
-    viewer.layers.unselect_all()
+    viewer.layers.selection.clear()
     assert viewer.layers.selection.current is None
 
     # Check selected layer is active

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -465,21 +465,14 @@ def test_selection():
     assert viewer.layers[0] in viewer.layers.selection
 
     viewer.add_image(np.random.random((10, 10)))
-    assert [lay in viewer.layers.selection for lay in viewer.layers] == [
-        False,
-        True,
-    ]
+    assert viewer.layers.selection == {viewer.layers[-1]}
 
     viewer.add_image(np.random.random((10, 10)))
-    assert [lay in viewer.layers.selection for lay in viewer.layers] == [
-        False
-    ] * 2 + [True]
+    assert viewer.layers.selection == {viewer.layers[-1]}
 
     viewer.layers.selection.update(viewer.layers)
     viewer.add_image(np.random.random((10, 10)))
-    assert [lay in viewer.layers.selection for lay in viewer.layers] == [
-        False
-    ] * 3 + [True]
+    assert viewer.layers.selection == {viewer.layers[-1]}
 
 
 def test_add_delete_layers():

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -462,18 +462,24 @@ def test_selection():
     """Test only last added is selected."""
     viewer = ViewerModel()
     viewer.add_image(np.random.random((10, 10)))
-    assert viewer.layers[0].selected is True
+    assert viewer.layers[0] in viewer.layers.selection
 
     viewer.add_image(np.random.random((10, 10)))
-    assert [lay.selected for lay in viewer.layers] == [False, True]
+    assert [lay in viewer.layers.selection for lay in viewer.layers] == [
+        False,
+        True,
+    ]
 
     viewer.add_image(np.random.random((10, 10)))
-    assert [lay.selected for lay in viewer.layers] == [False] * 2 + [True]
+    assert [lay in viewer.layers.selection for lay in viewer.layers] == [
+        False
+    ] * 2 + [True]
 
-    for lay in viewer.layers:
-        lay.selected = True
+    viewer.layers.selection.update(viewer.layers)
     viewer.add_image(np.random.random((10, 10)))
-    assert [lay.selected for lay in viewer.layers] == [False] * 3 + [True]
+    assert [lay in viewer.layers.selection for lay in viewer.layers] == [
+        False
+    ] * 3 + [True]
 
 
 def test_add_delete_layers():
@@ -496,29 +502,29 @@ def test_active_layer():
     viewer = ViewerModel()
     np.random.seed(0)
     # Check no active layer present
-    assert viewer.active_layer is None
+    assert viewer.layers.selection.current is None
 
     # Check added layer is active
     viewer.add_image(np.random.random((5, 5, 10, 15)))
     assert len(viewer.layers) == 1
-    assert viewer.active_layer == viewer.layers[0]
+    assert viewer.layers.selection.current == viewer.layers[0]
 
     # Check newly added layer is active
     viewer.add_image(np.random.random((5, 6, 5, 10, 15)))
     assert len(viewer.layers) == 2
-    assert viewer.active_layer == viewer.layers[1]
+    assert viewer.layers.selection.current == viewer.layers[1]
 
     # Check no active layer after unselecting all
     viewer.layers.unselect_all()
-    assert viewer.active_layer is None
+    assert viewer.layers.selection.current is None
 
     # Check selected layer is active
-    viewer.layers[0].selected = True
-    assert viewer.active_layer == viewer.layers[0]
+    viewer.layers.selection.add(viewer.layers[0])
+    assert viewer.layers.selection.current == viewer.layers[0]
 
     # Check no layer is active if both layers are selected
-    viewer.layers[1].selected = True
-    assert viewer.active_layer is None
+    viewer.layers.selection.add(viewer.layers[1])
+    assert viewer.layers.selection.current is None
 
 
 def test_active_layer_status_update():
@@ -528,10 +534,10 @@ def test_active_layer_status_update():
     viewer.add_image(np.random.random((5, 5, 10, 15)))
     viewer.add_image(np.random.random((5, 6, 5, 10, 15)))
     assert len(viewer.layers) == 2
-    assert viewer.active_layer == viewer.layers[1]
+    assert viewer.layers.selection.current == viewer.layers[1]
 
     viewer.cursor.position = [1, 1, 1, 1, 1]
-    assert viewer.status == viewer.active_layer.get_status(
+    assert viewer.status == viewer.layers.selection.current.get_status(
         viewer.cursor.position, world=True
     )
 
@@ -546,7 +552,7 @@ def test_active_layer_cursor_size():
 
     viewer.add_labels(np.random.random((10, 10)))
     assert len(viewer.layers) == 2
-    assert viewer.active_layer == viewer.layers[1]
+    assert viewer.layers.selection.current == viewer.layers[1]
 
     viewer.layers[1].mode = 'paint'
     # Labels layer has a default cursor size of 10

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -496,29 +496,29 @@ def test_active_layer():
     viewer = ViewerModel()
     np.random.seed(0)
     # Check no active layer present
-    assert viewer.layers.selection.current is None
+    assert viewer.layers.selection.active is None
 
     # Check added layer is active
     viewer.add_image(np.random.random((5, 5, 10, 15)))
     assert len(viewer.layers) == 1
-    assert viewer.layers.selection.current == viewer.layers[0]
+    assert viewer.layers.selection.active == viewer.layers[0]
 
     # Check newly added layer is active
     viewer.add_image(np.random.random((5, 6, 5, 10, 15)))
     assert len(viewer.layers) == 2
-    assert viewer.layers.selection.current == viewer.layers[1]
+    assert viewer.layers.selection.active == viewer.layers[1]
 
     # Check no active layer after unselecting all
     viewer.layers.selection.clear()
-    assert viewer.layers.selection.current is None
+    assert viewer.layers.selection.active is None
 
     # Check selected layer is active
     viewer.layers.selection.add(viewer.layers[0])
-    assert viewer.layers.selection.current == viewer.layers[0]
+    assert viewer.layers.selection.active == viewer.layers[0]
 
     # Check no layer is active if both layers are selected
     viewer.layers.selection.add(viewer.layers[1])
-    assert viewer.layers.selection.current is None
+    assert viewer.layers.selection.active is None
 
 
 def test_active_layer_status_update():
@@ -528,10 +528,10 @@ def test_active_layer_status_update():
     viewer.add_image(np.random.random((5, 5, 10, 15)))
     viewer.add_image(np.random.random((5, 6, 5, 10, 15)))
     assert len(viewer.layers) == 2
-    assert viewer.layers.selection.current == viewer.layers[1]
+    assert viewer.layers.selection.active == viewer.layers[1]
 
     viewer.cursor.position = [1, 1, 1, 1, 1]
-    assert viewer.status == viewer.layers.selection.current.get_status(
+    assert viewer.status == viewer.layers.selection.active.get_status(
         viewer.cursor.position, world=True
     )
 
@@ -546,7 +546,7 @@ def test_active_layer_cursor_size():
 
     viewer.add_labels(np.random.random((10, 10)))
     assert len(viewer.layers) == 2
-    assert viewer.layers.selection.current == viewer.layers[1]
+    assert viewer.layers.selection.active == viewer.layers[1]
 
     viewer.layers[1].mode = 'paint'
     # Labels layer has a default cursor size of 10

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -4,6 +4,7 @@ import pytest
 from napari._tests.utils import good_layer_data, layer_test_data
 from napari.components import ViewerModel
 from napari.utils.colormaps import AVAILABLE_COLORMAPS, Colormap
+from napari.utils.events.event import WarningEmitter
 
 
 def test_viewer_model():
@@ -665,7 +666,8 @@ def test_add_remove_layer_external_callbacks(Layer, data, ndim):
     # Check that no internal callbacks have been registered
     len(layer.events.callbacks) == 1
     for em in layer.events.emitters.values():
-        assert len(em.callbacks) == 1
+        if not isinstance(em, WarningEmitter):
+            assert len(em.callbacks) == 1
 
     viewer.layers.append(layer)
     # Check layer added correctly
@@ -681,7 +683,8 @@ def test_add_remove_layer_external_callbacks(Layer, data, ndim):
     # Check that all internal callbacks have been removed
     assert len(layer.events.callbacks) == 1
     for em in layer.events.emitters.values():
-        assert len(em.callbacks) == 1
+        if not isinstance(em, WarningEmitter):
+            assert len(em.callbacks) == 1
 
 
 @pytest.mark.parametrize(

--- a/napari/components/_viewer_key_bindings.py
+++ b/napari/components/_viewer_key_bindings.py
@@ -113,8 +113,7 @@ select_all.__doc__ = trans._("Selected all layers.")
 @ViewerModel.bind_key('Control-Shift-Delete')
 def remove_all_layers(viewer):
     """Remove all layers."""
-    viewer.layers.select_all()
-    viewer.layers.remove_selected()
+    viewer.layers.clear()
 
 
 remove_all_layers.__doc__ = trans._("Remove all layers.")

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -29,19 +29,18 @@ class LayerList(SelectableEventedList[Layer]):
         )
 
         # temporary: see note in _on_selection_event
-        self.selection.events.connect(self._on_selection_event)
+        self.selection.events.changed.connect(self._on_selection_changed)
 
-    def _on_selection_event(self, event):
+    def _on_selection_changed(self, event):
         # This method is a temporary workaround to the fact that the Points
         # layer needs to know when its selection state changes so that it can
         # update the highlight state.  This (and the layer._on_selection
         # method) can be removed once highlighting logic has been removed from
         # the layer model.
-        if event.type not in ('added', 'removed'):
-            return
-        selected = event.type == 'added'
-        for layer in event.value:
-            layer._on_selection(selected)
+        for layer in event.added:
+            layer._on_selection(True)
+        for layer in event.removed:
+            layer._on_selection(False)
 
     def __newlike__(self, data):
         return LayerList(data)

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -83,9 +83,6 @@ class LayerList(SelectableEventedList[Layer]):
         new_layer = self._type_check(value)
         new_layer.name = self._coerce_name(new_layer.name)
         super().insert(index, new_layer)
-        # Make layer selected and unselect all others
-        self.selection.clear()
-        self.selection.add(new_layer)
 
         # required for deprecated layer.selected property.  remove after 0.4.9
         new_layer._deprecated_layerlist = self
@@ -144,48 +141,6 @@ class LayerList(SelectableEventedList[Layer]):
             stacklevel=2,
         )
         self.selection.intersection_update({ignore} if ignore else {})
-
-    def select_all(self):
-        """Selects all layers."""
-        self.selection.update(self)
-
-    def remove_selected(self):
-        """Removes selected items from list."""
-        for i in list(self.selection):
-            self.remove(i)
-
-    def select_next(self, shift=False):
-        """Selects next item from list."""
-        selected_idx = [i for i, x in enumerate(self) if x in self.selection]
-        # if anything is selected
-        if selected_idx:
-            if selected_idx[-1] == len(self) - 1:
-                if shift is False:
-                    next = self[selected_idx[-1]]
-                    self.selection.intersection_update({next})
-            elif selected_idx[-1] < len(self) - 1:
-                next = self[selected_idx[-1] + 1]
-                if shift is False:
-                    self.selection.intersection_update({next})
-                self.selection.add(next)
-        elif len(self) > 0:
-            self.selection.add(self[-1])
-
-    def select_previous(self, shift=False):
-        """Selects previous item from list."""
-        selected_idx = [i for i, x in enumerate(self) if x in self.selection]
-
-        if selected_idx:
-            if selected_idx[0] == 0:
-                if shift is False:
-                    self.selection.intersection_update({self[0]})
-            elif selected_idx[0] > 0:
-                new = self[selected_idx[0] - 1]
-                if shift is False:
-                    self.selection.intersection_update({new})
-                self.selection.add(new)
-        elif len(self) > 0:
-            self.selection.add(self[0])
 
     def toggle_selected_visibility(self):
         """Toggle visibility of selected layers"""

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -37,7 +37,7 @@ class LayerList(SelectableEventedList[Layer]):
         # update the highlight state.  This (and the layer._on_selection
         # method) can be removed once highlighting logic has been removed from
         # the layer model.
-        if event.type == 'current':
+        if event.type not in ('added', 'removed'):
             return
         selected = event.type == 'added'
         for layer in event.value:

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -87,6 +87,9 @@ class LayerList(SelectableEventedList[Layer]):
         self.selection.clear()
         self.selection.add(new_layer)
 
+        # required for deprecated layer.selected property.  remove after 0.4.9
+        new_layer._deprecated_layerlist = self
+
     @property
     def selected(self):
         """List of selected layers."""

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -90,9 +90,9 @@ class LayerList(SelectableEventedList[Layer]):
     def selected(self):
         """List of selected layers."""
         warnings.warn(
-            "'layers.selected' is deprecated and will be removed in >=v0.4.9.  "
-            "Please use 'layers.selection'",
-            category=DeprecationWarning,
+            "'viewer.layers.selected' is deprecated and will be removed in or "
+            "after v0.4.9. Please use 'viewer.layers.selection'",
+            category=FutureWarning,
             stacklevel=2,
         )
         return self.selection
@@ -114,7 +114,7 @@ class LayerList(SelectableEventedList[Layer]):
         insert : int
             Index that item(s) will be inserted at
         """
-        if not self[index] in self.selection:
+        if self[index] not in self.selection:
             self.selection.select_only(self[index])
             moving = [index]
         else:
@@ -131,11 +131,11 @@ class LayerList(SelectableEventedList[Layer]):
             Layer that should not be unselected if specified.
         """
         warnings.warn(
-            "'layers.unselect_all()' is deprecated and will be removed in "
-            ">=v0.4.9. Please use 'layers.selection.clear()'.  To unselect "
-            "everything but a set of ignored layers, use "
-            r"'layers.selection.intersection_update({ignored})'",
-            category=DeprecationWarning,
+            "'viewer.layers.unselect_all()' is deprecated and will be removed "
+            "in or after v0.4.9. Please use 'viewer.layers.selection.clear()'."
+            " To unselect everything but a set of ignored layers, use "
+            r"'viewer.layers.selection.intersection_update({ignored})'",
+            category=FutureWarning,
             stacklevel=2,
         )
         self.selection.intersection_update({ignore} if ignore else {})

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -83,6 +83,9 @@ class LayerList(SelectableEventedList[Layer]):
         new_layer = self._type_check(value)
         new_layer.name = self._coerce_name(new_layer.name)
         super().insert(index, new_layer)
+        # Make layer selected and unselect all others
+        self.selection.clear()
+        self.selection.add(new_layer)
 
     @property
     def selected(self):
@@ -113,7 +116,7 @@ class LayerList(SelectableEventedList[Layer]):
             Index that item(s) will be inserted at
         """
         if not self[index] in self.selection:
-            self.unselect_all()
+            self.selection.clear()
             self.selection.add(self[index])
             moving = [index]
         else:
@@ -172,11 +175,12 @@ class LayerList(SelectableEventedList[Layer]):
         if selected_idx:
             if selected_idx[0] == 0:
                 if shift is False:
-                    self.unselect_all(ignore=self[0])
+                    self.selection.intersection_update({self[0]})
             elif selected_idx[0] > 0:
+                new = self[selected_idx[0] - 1]
                 if shift is False:
-                    self.unselect_all(ignore=self[selected_idx[0] - 1])
-                self.selection.add(self[selected_idx[0] - 1])
+                    self.selection.intersection_update({new})
+                self.selection.add(new)
         elif len(self) > 0:
             self.selection.add(self[0])
 

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -115,8 +115,7 @@ class LayerList(SelectableEventedList[Layer]):
             Index that item(s) will be inserted at
         """
         if not self[index] in self.selection:
-            self.selection.clear()
-            self.selection.add(self[index])
+            self.selection.select_only(self[index])
             moving = [index]
         else:
             moving = [i for i, x in enumerate(self) if x in self.selection]

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -27,9 +27,16 @@ class LayerList(SelectableEventedList[Layer]):
             basetype=Layer,
             lookup={str: lambda e: e.name},
         )
+
+        # temporary: see note in _on_selection_event
         self.selection.events.connect(self._on_selection_event)
 
     def _on_selection_event(self, event):
+        # This method is a temporary workaround to the fact that the Points
+        # layer needs to know when its selection state changes so that it can
+        # update the highlight state.  This (and the layer._on_selection
+        # method) can be removed once highlighting logic has been removed from
+        # the layer model.
         if event.type == 'current':
             return
         selected = event.type == 'added'
@@ -82,7 +89,9 @@ class LayerList(SelectableEventedList[Layer]):
         """List of selected layers."""
         warnings.warn(
             "'layers.selected' is deprecated and will be removed in >=v0.4.9.  "
-            "Please use 'layers.selection'"
+            "Please use 'layers.selection'",
+            category=DeprecationWarning,
+            stacklevel=2,
         )
         return self.selection
 
@@ -124,7 +133,9 @@ class LayerList(SelectableEventedList[Layer]):
             "'layers.unselect_all()' is deprecated and will be removed in "
             ">=v0.4.9. Please use 'layers.selection.clear()'.  To unselect "
             "everything but a set of ignored layers, use "
-            r"'layers.selection.intersection_update({ignored})'"
+            r"'layers.selection.intersection_update({ignored})'",
+            category=DeprecationWarning,
+            stacklevel=2,
         )
         self.selection.intersection_update({ignore} if ignore else {})
 

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -337,12 +337,10 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             layer.position = self.cursor.position
 
         # Update status and help bar based on active layer
-        active_layer = self.layers.selection.active
-        if active_layer is not None:
-            self.status = active_layer.get_status(
-                self.cursor.position, world=True
-            )
-            self.help = active_layer.help
+        active = self.layers.selection.active
+        if active is not None:
+            self.status = active.get_status(self.cursor.position, world=True)
+            self.help = active.help
 
     def _on_grid_change(self, event):
         """Arrange the current layers is a 2D grid."""

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -279,7 +279,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         warnings.warn(
             "'viewer.active_layer' is deprecated and will be removed in napari"
             " v0.4.9.  Please use 'viewer.layers.selection.active' instead.",
-            category=DeprecationWarning,
+            category=FutureWarning,
             stacklevel=2,
         )
         return self.layers.selection.active

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1,6 +1,7 @@
 import inspect
 import itertools
 import os
+import warnings
 from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
@@ -24,6 +25,7 @@ from ..layers.utils.stack_utils import split_channels
 from ..utils._register import create_func as create_add_method
 from ..utils.colormaps import ensure_colormap
 from ..utils.events import Event, EventedModel, disconnect_events
+from ..utils.events.event import WarningEmitter
 from ..utils.key_bindings import KeymapProvider
 from ..utils.misc import is_sequence
 from ..utils.mouse_bindings import MousemapProvider
@@ -134,6 +136,14 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
         # Add mouse callback
         self.mouse_wheel_callbacks.append(dims_scroll)
+
+        self.events.add(
+            active_layer=WarningEmitter(
+                "'viewer.events.active_layer' is deprecated and will be "
+                "removed in napari v0.4.9, use "
+                "'viewer.layers.selection.events.current' instead"
+            )
+        )
 
     @validator('theme')
     def _valid_theme(cls, v):
@@ -292,7 +302,23 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
     @property
     def active_layer(self):
+        warnings.warn(
+            "'viewer.active_layer' is deprecated and will be removed in napari"
+            " v0.4.9.  Please use 'viewer.layers.selection.current' instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return self.layers.selection.current
+
+    @active_layer.setter
+    def active_layer(self, layer):
+        warnings.warn(
+            "'viewer.active_layer' is deprecated and will be removed in napari"
+            " v0.4.9.  Please use 'viewer.layers.selection.current' instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        self.layers.selection.current = layer
 
     def _on_layers_change(self, event):
         if len(self.layers) == 0:

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -141,7 +141,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             active_layer=WarningEmitter(
                 "'viewer.events.active_layer' is deprecated and will be "
                 "removed in napari v0.4.9, use "
-                "'viewer.layers.selection.events.current' instead"
+                "'viewer.layers.selection.events.current' instead",
+                type='active_layer',
             )
         )
 

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -389,6 +389,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         layer = event.value
 
         # Connect individual layer events to viewer events
+        # TODO: in a future PR, we should now be able to connect viewer *only*
+        # to viewer.layers.events... and avoid direct viewer->layer connections
         layer.events.interactive.connect(self._update_interactive)
         layer.events.cursor.connect(self._update_cursor)
         layer.events.cursor_size.connect(self._update_cursor_size)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -293,7 +293,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         warnings.warn(
             "'viewer.active_layer' is deprecated and will be removed in napari"
             " v0.4.9.  Please use 'viewer.layers.selection.active' instead.",
-            category=DeprecationWarning,
+            category=FutureWarning,
             stacklevel=2,
         )
         self.layers.selection.active = value

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -132,7 +132,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         self.layers.events.removed.connect(self._on_remove_layer)
         self.layers.events.reordered.connect(self._on_grid_change)
         self.layers.events.reordered.connect(self._on_layers_change)
-        self.layers.selection.events.current.connect(self._update_active_layer)
+        self.layers.selection.events.active.connect(self._update_active_layer)
 
         # Add mouse callback
         self.mouse_wheel_callbacks.append(dims_scroll)
@@ -141,7 +141,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             active_layer=WarningEmitter(
                 "'viewer.events.active_layer' is deprecated and will be "
                 "removed in napari v0.4.9, use "
-                "'viewer.layers.selection.events.current' instead",
+                "'viewer.layers.selection.events.active' instead",
                 type='active_layer',
             )
         )
@@ -292,22 +292,21 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
     def active_layer(self):
         warnings.warn(
             "'viewer.active_layer' is deprecated and will be removed in napari"
-            " v0.4.9.  Please use 'viewer.layers.selection.current' instead.",
+            " v0.4.9.  Please use 'viewer.layers.selection.active' instead.",
             category=DeprecationWarning,
             stacklevel=2,
         )
-        return self.layers.selection.current
+        return self.layers.selection.active
 
     def __setattr__(self, name: str, value: Any) -> None:
         if name == 'active_layer':
             warnings.warn(
                 "'viewer.active_layer' is deprecated and will be removed in napari"
-                " v0.4.9.  Please use 'viewer.layers.selection.current' instead.",
+                " v0.4.9.  Please use 'viewer.layers.selection.active' instead.",
                 category=DeprecationWarning,
                 stacklevel=2,
             )
-            print('set current to', value)
-            self.layers.selection.current = value
+            self.layers.selection.active = value
         else:
             return super().__setattr__(name, value)
 
@@ -344,11 +343,12 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             layer.position = self.cursor.position
 
         # Update status and help bar based on active layer
-        if self.layers.selection.current is not None:
-            self.status = self.layers.selection.current.get_status(
+        active_layer = self.layers.selection.active
+        if active_layer is not None:
+            self.status = active_layer.get_status(
                 self.cursor.position, world=True
             )
-            self.help = self.layers.selection.current.help
+            self.help = active_layer.help
 
     def _on_grid_change(self, event):
         """Arrange the current layers is a 2D grid."""

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -281,6 +281,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         # if multiple layers are selected sets the active layer to None
 
         # TODO: remove this in favor of directly setting selection.current.
+        # This will be handled directly by the new QtLayerList, so this method
+        # can likely be removed at that time.
         active_layer = None
         for layer in self.layers:
             if active_layer is None and layer in self.layers.selection:

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -132,7 +132,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         self.layers.events.removed.connect(self._on_remove_layer)
         self.layers.events.reordered.connect(self._on_grid_change)
         self.layers.events.reordered.connect(self._on_layers_change)
-        self.layers.selection.events.active.connect(self._update_active_layer)
+        self.layers.selection.events.active.connect(self._on_active_layer)
 
         # Add mouse callback
         self.mouse_wheel_callbacks.append(dims_scroll)
@@ -267,16 +267,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         cur_theme = theme_names.index(self.theme)
         self.theme = theme_names[(cur_theme + 1) % len(theme_names)]
 
-    def _update_active_layer(self, event):
-        """Set the active layer by iterating over the layers list and
-        finding the first selected layer. If multiple layers are selected the
-        iteration stops and the active layer is set to be None
-
-        Parameters
-        ----------
-        event : Event
-            No Event parameters are used
-        """
+    def _on_active_layer(self, event):
+        """Update viewer state for a new active layer."""
         active_layer = event.value
         if active_layer is None:
             self.help = ''
@@ -299,6 +291,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         return self.layers.selection.active
 
     def __setattr__(self, name: str, value: Any) -> None:
+        # this method is only for the deprecation warning, because pydantic
+        # prevents using @active_layer.setter
         if name == 'active_layer':
             warnings.warn(
                 "'viewer.active_layer' is deprecated and will be removed in napari"

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -417,10 +417,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         layer.events.affine.connect(self._on_layers_change)
         layer.events.name.connect(self.layers._update_name)
 
-        # Make layer selected and unselect all others
-        self.layers.selection.add(layer)
-        self.layers.unselect_all(ignore=layer)
-
         # Update dims and grid model
         self._on_layers_change(None)
         self._on_grid_change(None)

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -277,13 +277,15 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             select=WarningEmitter(
                 "'layer.events.select' is deprecated and will be "
                 "removed in napari v0.4.9, use "
-                "'viewer.layers.selection.events.added' instead",
+                "'viewer.layers.selection.events.changed' instead, and inspect"
+                " the 'added' attribute on the event.",
                 type='select',
             ),
             deselect=WarningEmitter(
                 "'layer.events.deselect' is deprecated and will be "
                 "removed in napari v0.4.9, use "
-                "'viewer.layers.selection.events.removed' instead",
+                "'viewer.layers.selection.events.changed' instead, and inspect"
+                " the 'removed' attribute on the event.",
                 type='deselect',
             ),
         )

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -122,8 +122,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         Cursor position in world coordinates.
     ndim : int
         Dimensionality of the layer.
-    selected : bool
-        Flag if layer is selected in the viewer or not.
     thumbnail : (N, M, 4) array
         Array of thumbnail data for the layer.
     status : str
@@ -179,7 +177,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         self._opacity = opacity
         self._blending = Blending(blending)
         self._visible = visible
-        self._selected = True
         self._freeze = False
         self._status = 'Ready'
         self._help = ''
@@ -260,8 +257,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             blending=Event,
             opacity=Event,
             visible=Event,
-            select=Event,
-            deselect=Event,
             scale=Event,
             translate=Event,
             rotate=Event,
@@ -711,22 +706,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         return self._ndim
 
     @property
-    def selected(self):
-        """bool: Whether this layer is selected or not."""
-        return self._selected
-
-    @selected.setter
-    def selected(self, selected):
-        if selected == self.selected:
-            return
-        self._selected = selected
-
-        if selected:
-            self.events.select()
-        else:
-            self.events.deselect()
-
-    @property
     def status(self):
         """str: displayed in status bar bottom left."""
         warnings.warn(
@@ -1097,3 +1076,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         from ...plugins.io import save_layers
 
         return save_layers(path, [self], plugin=plugin)
+
+    def _on_selection(self, selected: bool):
+        pass

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -740,7 +740,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         warnings.warn(
             "'layer.selected' is deprecated and will be removed in v0.4.9. "
             "Please use `layer in viewer.layers.selection`",
-            category=DeprecationWarning,
+            category=FutureWarning,
             stacklevel=2,
         )
         layers = getattr(self, '_deprecated_layerlist', None)

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -754,7 +754,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             "'layer.selected' is deprecated and will be removed in v0.4.9. "
             "Please use `viewer.layers.selection.add(layer)` or "
             "`viewer.layers.selection.remove(layer)`",
-            category=DeprecationWarning,
+            category=FutureWarning,
             stacklevel=2,
         )
         layers = getattr(self, '_deprecated_layerlist', None)

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -474,6 +474,7 @@ class Points(Layer):
         self._set_editable()
 
     def _on_selection(self, selected):
+        # this method is slated for removal.  don't add anything new.
         if selected:
             self._set_highlight()
         else:

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -474,7 +474,6 @@ class Points(Layer):
         self._set_editable()
 
     def _on_selection(self, selected):
-        # this method is slated for removal.  don't add anything new.
         if selected:
             self._set_highlight()
         else:

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -473,22 +473,13 @@ class Points(Layer):
         self.events.data(value=self.data)
         self._set_editable()
 
-    @property
-    def selected(self):
-        """bool: Whether this layer is selected or not."""
-        return self._selected
-
-    @selected.setter
-    def selected(self, selected):
-        if selected == self.selected:
-            return
-        self._selected = selected
-
+    def _on_selection(self, selected):
         if selected:
-            self.events.select()
+            self._set_highlight()
         else:
-            self.events.deselect()
-        self._set_highlight()
+            self._highlight_box = None
+            self._highlight_index = []
+            self.events.highlight()
 
     @property
     def properties(self) -> Dict[str, np.ndarray]:
@@ -1306,65 +1297,56 @@ class Points(Layer):
             Bool that forces a redraw to occur when `True`
         """
         # Check if any point ids have changed since last call
-        if self.selected:
-            if (
-                self.selected_data == self._selected_data_stored
-                and self._value == self._value_stored
-                and np.all(self._drag_box == self._drag_box_stored)
-            ) and not force:
-                return
-            self._selected_data_stored = copy(self.selected_data)
-            self._value_stored = copy(self._value)
-            self._drag_box_stored = copy(self._drag_box)
+        if (
+            self.selected_data == self._selected_data_stored
+            and self._value == self._value_stored
+            and np.all(self._drag_box == self._drag_box_stored)
+        ) and not force:
+            return
+        self._selected_data_stored = copy(self.selected_data)
+        self._value_stored = copy(self._value)
+        self._drag_box_stored = copy(self._drag_box)
 
-            if self._value is not None or len(self._selected_view) > 0:
-                if len(self._selected_view) > 0:
-                    index = copy(self._selected_view)
-                    # highlight the hovered point if not in adding mode
-                    if (
-                        self._value in self._indices_view
-                        and self._mode == Mode.SELECT
-                        and not self._is_selecting
-                    ):
-                        hover_point = list(self._indices_view).index(
-                            self._value
-                        )
-                        if hover_point in index:
-                            pass
-                        else:
-                            index.append(hover_point)
-                    index.sort()
-                else:
-                    # only highlight hovered points in select mode
-                    if (
-                        self._value in self._indices_view
-                        and self._mode == Mode.SELECT
-                        and not self._is_selecting
-                    ):
-                        hover_point = list(self._indices_view).index(
-                            self._value
-                        )
-                        index = [hover_point]
+        if self._value is not None or len(self._selected_view) > 0:
+            if len(self._selected_view) > 0:
+                index = copy(self._selected_view)
+                # highlight the hovered point if not in adding mode
+                if (
+                    self._value in self._indices_view
+                    and self._mode == Mode.SELECT
+                    and not self._is_selecting
+                ):
+                    hover_point = list(self._indices_view).index(self._value)
+                    if hover_point in index:
+                        pass
                     else:
-                        index = []
-
-                self._highlight_index = index
+                        index.append(hover_point)
+                index.sort()
             else:
-                self._highlight_index = []
+                # only highlight hovered points in select mode
+                if (
+                    self._value in self._indices_view
+                    and self._mode == Mode.SELECT
+                    and not self._is_selecting
+                ):
+                    hover_point = list(self._indices_view).index(self._value)
+                    index = [hover_point]
+                else:
+                    index = []
 
-            # only display dragging selection box in 2D
-            if self._ndisplay == 2 and self._is_selecting:
-                pos = create_box(self._drag_box)
-                pos = pos[list(range(4)) + [0]]
-            else:
-                pos = None
-
-            self._highlight_box = pos
-            self.events.highlight()
+            self._highlight_index = index
         else:
-            self._highlight_box = None
             self._highlight_index = []
-            self.events.highlight()
+
+        # only display dragging selection box in 2D
+        if self._ndisplay == 2 and self._is_selecting:
+            pos = create_box(self._drag_box)
+            pos = pos[list(range(4)) + [0]]
+        else:
+            pos = None
+
+        self._highlight_box = pos
+        self.events.highlight()
 
     def _update_thumbnail(self):
         """Update thumbnail with current points and colors."""

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -538,21 +538,8 @@ class Shapes(Layer):
         self.events.data(value=self.data)
         self._set_editable()
 
-    @property
-    def selected(self):
-        """bool: Whether this layer is selected or not."""
-        return self._selected
-
-    @selected.setter
-    def selected(self, selected):
-        if selected == self.selected:
-            return
-        self._selected = selected
-
-        if selected:
-            self.events.select()
-        else:
-            self.events.deselect()
+    def _on_selection(self, selected: bool):
+        if not selected:
             self._finish_drawing()
 
     @property

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -542,6 +542,7 @@ class Shapes(Layer):
         self._set_editable()
 
     def _on_selection(self, selected: bool):
+        # this method is slated for removal.  don't add anything new.
         if not selected:
             self._finish_drawing()
 

--- a/napari/utils/events/_tests/test_selection.py
+++ b/napari/utils/events/_tests/test_selection.py
@@ -21,8 +21,8 @@ def test_selection():
     assert 1 in t.sel
     assert t.sel.current == 1
 
-    assert t.json() == r'{"sel": {"data": [1], "current": 1}}'
-    assert T(sel={"data": [1], "current": 1}) == t
+    assert t.json() == r'{"sel": {"selection": [1], "current": 1}}'
+    assert T(sel={"selection": [1], "current": 1}) == t
 
     t.sel.remove(1)
     assert not t.sel
@@ -31,4 +31,4 @@ def test_selection():
         T(sel=['asdf'])
 
     with pytest.raises(ValidationError):
-        T(sel={"data": [1], "current": 'asdf'})
+        T(sel={"selection": [1], "current": 'asdf'})

--- a/napari/utils/events/_tests/test_selection.py
+++ b/napari/utils/events/_tests/test_selection.py
@@ -11,18 +11,18 @@ def test_selection():
         sel: Selection[int]
 
     t = T(sel=[])
-    t.sel.events.current = Mock()
-    assert not t.sel.current
+    t.sel.events._current = Mock()
+    assert not t.sel._current
     assert not t.sel
     t.sel.add(1)
-    t.sel.current = 1
-    t.sel.events.current.assert_called_once()
+    t.sel._current = 1
+    t.sel.events._current.assert_called_once()
 
     assert 1 in t.sel
-    assert t.sel.current == 1
+    assert t.sel._current == 1
 
-    assert t.json() == r'{"sel": {"selection": [1], "current": 1}}'
-    assert T(sel={"selection": [1], "current": 1}) == t
+    assert t.json() == r'{"sel": {"selection": [1], "_current": 1}}'
+    assert T(sel={"selection": [1], "_current": 1}) == t
 
     t.sel.remove(1)
     assert not t.sel
@@ -31,4 +31,4 @@ def test_selection():
         T(sel=['asdf'])
 
     with pytest.raises(ValidationError):
-        T(sel={"selection": [1], "current": 'asdf'})
+        T(sel={"selection": [1], "_current": 'asdf'})

--- a/napari/utils/events/containers/__init__.py
+++ b/napari/utils/events/containers/__init__.py
@@ -1,6 +1,7 @@
 from ._evented_list import EventedList
 from ._nested_list import NestableEventedList
-from ._selection import Selection
+from ._selectable_list import SelectableEventedList
+from ._selection import Selectable, Selection
 from ._set import EventedSet
 from ._typed import TypedMutableSequence
 
@@ -9,5 +10,7 @@ __all__ = [
     'EventedSet',
     'NestableEventedList',
     'Selection',
+    'SelectableEventedList',
+    'Selectable',
     'TypedMutableSequence',
 ]

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -1,0 +1,10 @@
+from typing import TypeVar
+
+from ._evented_list import EventedList
+from ._selection import Selectable
+
+_T = TypeVar("_T")
+
+
+class SelectableEventedList(Selectable[_T], EventedList[_T]):
+    """List model that also supports selection."""

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -19,7 +19,7 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
         """Called before adding an item to the selection."""
         if value not in self:
             raise ValueError(
-                f"Cannot selection item that is not in list: {value!r}"
+                f"Cannot select item that is not in list: {value!r}"
             )
         return value
 

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -10,8 +10,62 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
     """List model that also supports selection."""
 
     def __init__(self, *args, **kwargs) -> None:
+        self.activate_on_insert = True
         super().__init__(*args, **kwargs)
         self.events.removed.connect(lambda e: self.selection.discard(e.value))
 
     # TODO: add strict check to make sure that things added to
     # selection/current are in the list?
+
+    def insert(self, index: int, value: _T):
+        super().insert(index, value)
+        if self.activate_on_insert:
+            # Make layer selected and unselect all others
+            self.activate(value)
+
+    def activate(self, value: _T):
+        """Set `value` as the current and only selected item."""
+        self.selection.select_only(value)
+        self.selection.current = value
+
+    def select_all(self):
+        """Select all items in the list."""
+        self.selection.update(self)
+
+    def remove_selected(self):
+        """Remove selected items from list."""
+        for i in list(self.selection):
+            self.remove(i)
+
+    def select_next(self, shift=False):
+        """Selects next item from list."""
+        selected_idx = [i for i, x in enumerate(self) if x in self.selection]
+        # if anything is selected
+        if selected_idx:
+            if selected_idx[-1] == len(self) - 1:
+                if shift is False:
+                    next = self[selected_idx[-1]]
+                    self.selection.intersection_update({next})
+            elif selected_idx[-1] < len(self) - 1:
+                next = self[selected_idx[-1] + 1]
+                if shift is False:
+                    self.selection.intersection_update({next})
+                self.selection.add(next)
+        elif len(self) > 0:
+            self.selection.add(self[-1])
+
+    def select_previous(self, shift=False):
+        """Selects previous item from list."""
+        selected_idx = [i for i, x in enumerate(self) if x in self.selection]
+
+        if selected_idx:
+            if selected_idx[0] == 0:
+                if shift is False:
+                    self.selection.intersection_update({self[0]})
+            elif selected_idx[0] > 0:
+                new = self[selected_idx[0] - 1]
+                if shift is False:
+                    self.selection.intersection_update({new})
+                self.selection.add(new)
+        elif len(self) > 0:
+            self.selection.add(self[0])

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -13,9 +13,15 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
         self.activate_on_insert = True
         super().__init__(*args, **kwargs)
         self.events.removed.connect(lambda e: self.selection.discard(e.value))
+        self.selection._pre_add_hook = self._preselect_hook
 
-    # TODO: add strict check to make sure that things added to
-    # selection/current are in the list?
+    def _preselect_hook(self, value):
+        """Called before adding an item to the selection."""
+        if value not in self:
+            raise ValueError(
+                f"Cannot selection item that is not in list: {value!r}"
+            )
+        return value
 
     def insert(self, index: int, value: _T):
         super().insert(index, value)

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -41,12 +41,12 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
     def select_next(self, step=1, shift=False):
         """Selects next item from list."""
         if self.selection:
-            idx = self.index(self.selection.current) + step
+            idx = self.index(self.selection._current) + step
             if len(self) > idx >= 0:
                 next_layer = self[idx]
                 if shift:
                     self.selection.add(next_layer)
-                    self.selection.current = next_layer
+                    self.selection._current = next_layer
                 else:
                     self.selection.active = next_layer
         elif len(self) > 0:

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -12,3 +12,6 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.events.removed.connect(lambda e: self.selection.discard(e.value))
+
+    # TODO: add strict check to make sure that things added to
+    # selection/current are in the list?

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -21,12 +21,7 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
         super().insert(index, value)
         if self.activate_on_insert:
             # Make layer selected and unselect all others
-            self.activate(value)
-
-    def activate(self, value: _T):
-        """Set `value` as the current and only selected item."""
-        self.selection.select_only(value)
-        self.selection.current = value
+            self.selection.active = value
 
     def select_all(self):
         """Select all items in the list."""

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -8,3 +8,7 @@ _T = TypeVar("_T")
 
 class SelectableEventedList(Selectable[_T], EventedList[_T]):
     """List model that also supports selection."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.events.removed.connect(lambda e: self.selection.discard(e.value))

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -32,35 +32,20 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
         for i in list(self.selection):
             self.remove(i)
 
-    def select_next(self, shift=False):
+    def select_next(self, step=1, shift=False):
         """Selects next item from list."""
-        selected_idx = [i for i, x in enumerate(self) if x in self.selection]
-        # if anything is selected
-        if selected_idx:
-            if selected_idx[-1] == len(self) - 1:
-                if shift is False:
-                    next = self[selected_idx[-1]]
-                    self.selection.intersection_update({next})
-            elif selected_idx[-1] < len(self) - 1:
-                next = self[selected_idx[-1] + 1]
-                if shift is False:
-                    self.selection.intersection_update({next})
-                self.selection.add(next)
+        if self.selection:
+            idx = self.index(self.selection.current) + step
+            if len(self) > idx >= 0:
+                next_layer = self[idx]
+                if shift:
+                    self.selection.add(next_layer)
+                    self.selection.current = next_layer
+                else:
+                    self.selection.active = next_layer
         elif len(self) > 0:
-            self.selection.add(self[-1])
+            self.selection.active = self[-1 if step > 0 else 0]
 
     def select_previous(self, shift=False):
         """Selects previous item from list."""
-        selected_idx = [i for i, x in enumerate(self) if x in self.selection]
-
-        if selected_idx:
-            if selected_idx[0] == 0:
-                if shift is False:
-                    self.selection.intersection_update({self[0]})
-            elif selected_idx[0] > 0:
-                new = self[selected_idx[0] - 1]
-                if shift is False:
-                    self.selection.intersection_update({new})
-                self.selection.add(new)
-        elif len(self) > 0:
-            self.selection.add(self[0])
+        self.select_next(-1, shift=shift)

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -10,7 +10,7 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
     """List model that also supports selection."""
 
     def __init__(self, *args, **kwargs) -> None:
-        self.activate_on_insert = True
+        self._activate_on_insert = True
         super().__init__(*args, **kwargs)
         self.events.removed.connect(lambda e: self.selection.discard(e.value))
         self.selection._pre_add_hook = self._preselect_hook
@@ -25,7 +25,7 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
 
     def insert(self, index: int, value: _T):
         super().insert(index, value)
-        if self.activate_on_insert:
+        if self._activate_on_insert:
             # Make layer selected and unselect all others
             self.selection.active = value
 

--- a/napari/utils/events/containers/_selection.py
+++ b/napari/utils/events/containers/_selection.py
@@ -62,9 +62,19 @@ class Selection(EventedSet[_T]):
         previous, self._current = self._current, index
         self.events.current(value=index, previous=previous)
 
+    def clear(self, keep_current: bool = False) -> None:
+        super().clear()
+        if not keep_current:
+            self.current = None
+
     def toggle(self, obj: _T):
         """Toggle selection state of obj."""
         self.symmetric_difference_update({obj})
+
+    def select_only(self, obj: _S):
+        """Unselect everything but `obj`. Add to selection if not present."""
+        self.add(obj)
+        self.intersection_update({obj})
 
     @classmethod
     def __get_validators__(cls):
@@ -128,7 +138,7 @@ class Selectable(Generic[_S]):
         return self._selection
 
     @selection.setter
-    def selection(self, new_selection) -> None:
+    def selection(self, new_selection: Iterable[_S]) -> None:
         """Set selection, without deleting selection model object."""
         self._selection.intersection_update(new_selection)
         self._selection.update(new_selection)

--- a/napari/utils/events/containers/_selection.py
+++ b/napari/utils/events/containers/_selection.py
@@ -54,7 +54,7 @@ class Selection(EventedSet[_T]):
 
     def __init__(self, data: Iterable[_T] = ()):
         self._active: Optional[_T] = None
-        self.__current = None
+        self._current_ = None
         super().__init__(data=data)
         self.events.add(_current=None, active=None)
         self.events.changed.connect(self._update_active)
@@ -75,9 +75,9 @@ class Selection(EventedSet[_T]):
     @_current.setter
     def _current(self, index: Optional[_T]):
         """Set current item."""
-        if index == self.__current:
+        if index == self._current_:
             return
-        self.__current = index
+        self._current_ = index
         self.events._current(value=index)
 
     @property
@@ -110,9 +110,9 @@ class Selection(EventedSet[_T]):
                 self._active = None
                 self.events.active(value=None)
 
-    def clear(self, keep__current: bool = False) -> None:
+    def clear(self, keep_current: bool = False) -> None:
         """Clear the selection."""
-        if not keep__current:
+        if not keep_current:
             self._current = None
         super().clear()
 
@@ -150,7 +150,7 @@ class Selection(EventedSet[_T]):
         # no type parameter was provided, just return
         if not field.sub_fields:
             obj = cls(data=data)
-            obj.__current = current
+            obj._current_ = current
             return obj
 
         # Selection[type] parameter was provided.  Validate contents
@@ -170,7 +170,7 @@ class Selection(EventedSet[_T]):
 
             raise ValidationError(errors, cls)  # type: ignore
         obj = cls(data=data)
-        obj.__current = current
+        obj._current_ = current
         return obj
 
     def _json_encode(self):

--- a/napari/utils/events/containers/_selection.py
+++ b/napari/utils/events/containers/_selection.py
@@ -119,8 +119,8 @@ class Selectable(Generic[_S]):
     """Mixin that adds a selection model to an object."""
 
     def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)  # type: ignore
         self._selection: Selection[_S] = Selection()
+        super().__init__(*args, **kwargs)  # type: ignore
 
     @property
     def selection(self) -> Selection[_S]:

--- a/napari/utils/events/containers/_selection.py
+++ b/napari/utils/events/containers/_selection.py
@@ -63,6 +63,10 @@ class Selection(EventedSet[_T]):
         clsname = type(self).__name__
         return f"{clsname}({repr(self._set)}, current={self.current})"
 
+    def __hash__(self) -> int:
+        """Make selection hashable."""
+        return id(self)
+
     @property
     def current(self) -> Optional[_T]:
         """Get current item."""

--- a/napari/utils/events/containers/_selection.py
+++ b/napari/utils/events/containers/_selection.py
@@ -76,13 +76,6 @@ class Selection(EventedSet[_T]):
         self._current = index
         self.events.current(value=index)
 
-    def _update_active(self, event=None):
-        """On a selection event, update the active item.
-
-        (An active item is a single selected item).
-        """
-        self.active = list(self)[0] if len(self) == 1 else None
-
     @property
     def active(self) -> Optional[_T]:
         """Return the currently active item or None."""
@@ -100,6 +93,18 @@ class Selection(EventedSet[_T]):
         self.clear() if value is None else self.select_only(value)
         self.current = value
         self.events.active(value=value)
+
+    def _update_active(self, event=None):
+        """On a selection event, update the active item based on selection.
+
+        (An active item is a single selected item).
+        """
+        if len(self) == 1:
+            self.active = list(self)[0]
+        elif len(self):
+            if self._active is not None:
+                self._active = None
+                self.events.active(value=None)
 
     def clear(self, keep_current: bool = False) -> None:
         """Clear the selection."""

--- a/napari/utils/events/containers/_selection.py
+++ b/napari/utils/events/containers/_selection.py
@@ -101,7 +101,7 @@ class Selection(EventedSet[_T]):
         """
         if len(self) == 1:
             self.active = list(self)[0]
-        elif len(self):
+        else:
             if self._active is not None:
                 self._active = None
                 self.events.active(value=None)

--- a/napari/utils/events/containers/_selection.py
+++ b/napari/utils/events/containers/_selection.py
@@ -70,7 +70,7 @@ class Selection(EventedSet[_T]):
     @property
     def _current(self) -> Optional[_T]:
         """Get current item."""
-        return self.__current
+        return self._current_
 
     @_current.setter
     def _current(self, index: Optional[_T]):

--- a/napari/utils/events/containers/_selection.py
+++ b/napari/utils/events/containers/_selection.py
@@ -18,8 +18,8 @@ class Selection(EventedSet[_T]):
     "current" item is mostly useful for (e.g.) keyboard actions: even with
     multiple items selected, you may only have one current item, and keyboard
     events (like up and down) can modify that current item.  It's possible to
-    have a current item without an active item, but an active item will almost
-    always be the current item.
+    have a current item without an active item, but an active item will always
+    be the current item.
 
     An item can be the current item and selected at the same time. Qt views
     will ensure that there is always a current item as keyboard navigation,
@@ -46,10 +46,10 @@ class Selection(EventedSet[_T]):
     changed (added: Set[_T], removed: Set[_T])
         Emitted when the set changes, includes item(s) that have been added
         and/or removed from the set.
-    current (value: _T)
-        emitted when the current item has changed.
     active (value: _T)
         emitted when the current item has changed.
+    _current (value: _T)
+        emitted when the current item has changed. (Private event)
     """
 
     def __init__(self, data: Iterable[_T] = ()):

--- a/napari/utils/events/containers/_selection.py
+++ b/napari/utils/events/containers/_selection.py
@@ -35,12 +35,9 @@ class Selection(EventedSet[_T]):
 
     Events
     ------
-    added (value: Set[_T])
-        emitted after an item or items are added to the set.
-        Will not be emitted if item was already in the set when added.
-    removed (value: Set[_T])
-        emitted after an item or items are removed from the set.
-        Will not be emitted if the item was not in the set when discarded.
+    changed (added: Set[_T], removed: Set[_T])
+        Emitted when the set changes, includes item(s) that have been added
+        and/or removed from the set.
     current (value: _T)
         emitted when the current item has changed.
     active (value: _T)
@@ -49,8 +46,7 @@ class Selection(EventedSet[_T]):
 
     def __init__(self, data: Iterable[_T] = (), active: Optional[_T] = None):
         super().__init__(data=data)
-        self.events.added.connect(self._update_active)
-        self.events.removed.connect(self._update_active)
+        self.events.changed.connect(self._update_active)
         self.events.add(current=None, active=None)
         self._active = active
         self._current: Optional[_T] = None

--- a/napari/utils/events/containers/_selection.py
+++ b/napari/utils/events/containers/_selection.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Iterable, Optional, TypeVar
+from typing import TYPE_CHECKING, Generic, Iterable, Optional, TypeVar
 
 from ._set import EventedSet
 
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from pydantic.fields import ModelField
 
 _T = TypeVar("_T")
+_S = TypeVar("_S")
 
 
 class Selection(EventedSet[_T]):
@@ -50,14 +51,20 @@ class Selection(EventedSet[_T]):
 
     @property
     def current(self) -> Optional[_T]:
+        """Get current item."""
         return self._current
 
     @current.setter
     def current(self, index: Optional[_T]):
+        """Set current item."""
         if index == self._current:
             return
         previous, self._current = self._current, index
         self.events.current(value=index, previous=previous)
+
+    def toggle(self, obj: _T):
+        """Toggle selection state of obj."""
+        self.symmetric_difference_update({obj})
 
     @classmethod
     def __get_validators__(cls):
@@ -106,3 +113,22 @@ class Selection(EventedSet[_T]):
     def _json_encode(self):
         """Return an object that can be used by json.dumps."""
         return {'data': super()._json_encode(), 'current': self.current}
+
+
+class Selectable(Generic[_S]):
+    """Mixin that adds a selection model to an object."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore
+        self._selection: Selection[_S] = Selection()
+
+    @property
+    def selection(self) -> Selection[_S]:
+        """Get current selection."""
+        return self._selection
+
+    @selection.setter
+    def selection(self, new_selection) -> None:
+        """Set selection, without deleting selection model object."""
+        self._selection.intersection_update(new_selection)
+        self._selection.update(new_selection)

--- a/napari/utils/events/containers/_set.py
+++ b/napari/utils/events/containers/_set.py
@@ -51,8 +51,14 @@ class EventedSet(MutableSet[_T]):
     def __len__(self) -> int:
         return len(self._set)
 
+    def _pre_add_hook(self, value):
+        # for subclasses to potentially check value before adding
+        return value
+
     def add(self, value: _T) -> None:
+        """Add an element to the set, if not already present."""
         if value not in self:
+            value = self._pre_add_hook(value)
             self._set.add(value)
             self.events.changed(added={value}, removed={})
 
@@ -89,6 +95,7 @@ class EventedSet(MutableSet[_T]):
         """Update this set with the union of this set and others"""
         to_add = set(others).difference(self._set)
         if to_add:
+            to_add = {self._pre_add_hook(i) for i in to_add}
             self._set.update(to_add)
             self.events.changed(added=set(to_add), removed={})
 

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -674,7 +674,6 @@ class WarningEmitter(EventEmitter):
 
         import warnings
 
-        print('warn')
         warnings.warn(
             self._message, category=self._category, stacklevel=self._stacklevel
         )
@@ -877,7 +876,8 @@ class EmitterGroup(EventEmitter):
         # while simultaneously eliminating the overhead if nobody is listening.
         if connect:
             for emitter in self:
-                self[emitter].connect(self)
+                if not isinstance(self[emitter], WarningEmitter):
+                    self[emitter].connect(self)
         else:
             for emitter in self:
                 self[emitter].disconnect(self)

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -49,7 +49,6 @@ For more information see http://github.com/vispy/vispy/wiki/API_Events
 
 """
 import inspect
-import traceback
 import weakref
 from collections import Counter
 from typing import (
@@ -66,7 +65,7 @@ from typing import (
 )
 
 from typing_extensions import Literal
-from vispy.util.logs import _handle_exception, logger
+from vispy.util.logs import _handle_exception
 
 
 class Event:
@@ -643,9 +642,18 @@ class WarningEmitter(EventEmitter):
     warning message.
     """
 
-    def __init__(self, message, *args, **kwargs):
+    def __init__(
+        self,
+        message,
+        category=DeprecationWarning,
+        stacklevel=3,
+        *args,
+        **kwargs,
+    ):
         self._message = message
         self._warned = False
+        self._category = category
+        self._stacklevel = stacklevel
         EventEmitter.__init__(self, *args, **kwargs)
 
     def connect(self, cb, *args, **kwargs):
@@ -664,8 +672,12 @@ class WarningEmitter(EventEmitter):
         if isinstance(cb, tuple) and getattr(cb[0], cb[1], None) is None:
             return
 
-        traceback.print_stack()
-        logger.warning(self._message)
+        import warnings
+
+        print('warn')
+        warnings.warn(
+            self._message, category=self._category, stacklevel=self._stacklevel
+        )
         self._warned = True
 
 

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -645,7 +645,7 @@ class WarningEmitter(EventEmitter):
     def __init__(
         self,
         message,
-        category=DeprecationWarning,
+        category=FutureWarning,
         stacklevel=3,
         *args,
         **kwargs,

--- a/napari/utils/tree/group.py
+++ b/napari/utils/tree/group.py
@@ -14,7 +14,7 @@ class Group(NestableEventedList[NodeType], Node, Selectable[NodeType]):
     The ``Group`` (aka composite) is an element that has sub-elements:
     which may be ``Nodes`` or other ``Groups``.  By inheriting from
     :class:`NestableEventedList`, ``Groups`` have basic python list-like
-    behavior and emit events when modified.  The main additions in this class
+    behavior and emit events when modified.  The main addition in this class
     is that when objects are added to a ``Group``, they are assigned a
     ``.parent`` attribute pointing to the group, which is removed upon
     deletion from the group.

--- a/napari/utils/tree/group.py
+++ b/napari/utils/tree/group.py
@@ -1,13 +1,14 @@
 from typing import Generator, Iterable, List, TypeVar
 
-from ..events import NestableEventedList, Selection
+from ..events import NestableEventedList
 from ..events.containers._nested_list import MaybeNestedIndex
+from ..events.containers._selection import Selectable
 from .node import Node
 
 NodeType = TypeVar("NodeType", bound=Node)
 
 
-class Group(NestableEventedList[NodeType], Node):
+class Group(NestableEventedList[NodeType], Node, Selectable[NodeType]):
     """An object that can contain other objects in a composite Tree pattern.
 
     The ``Group`` (aka composite) is an element that has sub-elements:
@@ -38,16 +39,7 @@ class Group(NestableEventedList[NodeType], Node):
     ):
         Node.__init__(self, name=name)
         NestableEventedList.__init__(self, data=children, basetype=basetype)
-        self._selection: Selection[NodeType] = Selection()
-
-    @property
-    def selection(self) -> Selection[NodeType]:
-        return self._selection
-
-    @selection.setter
-    def selection(self, new_selection) -> None:
-        self._selection.intersection_update(new_selection)
-        self._selection.update(new_selection)
+        Selectable.__init__(self)
 
     def __delitem__(self, key: MaybeNestedIndex):
         """Remove item at ``key``, and unparent."""


### PR DESCRIPTION
# Description
pulled out from #2423
This PR swaps out the old selection model (where layers have a `selected` attribute and the viewer has an `active_layer`) for the new selection model added in #2293, where the layerlist has a selection model at `viewer.layers.selection`.

**updated Mar 22 to reflect API in PR:**
```python
layer = viewer.layers[0]

# old selection API:
layer.selected = True
layer.selected = False

# new selection API:
viewer.layers.selection.add(layer)
viewer.layers.selection.remove(layer) # raises error if layer is not selected
viewer.layers.selection.discard(layer) # no error if layer is not selected

# layers.selection is just a normal set, so other set methods work
viewer.layers.selection.update({layer_a, layer_b})
# etc...

# to set the currently active layer:
# this will deselect everything but `layer`
viewer.layers.selection.active = layer
```

this PR uses the existing QtLayerList, but that will be relatively short-lived, as it will be soon be replaced by the new `QtListView`-based `QtLayerList` from #2423.  Having this in the commit history will be useful though just in case we need to revert to this state for any reason.

still need to go through and pay attention to deprecation warnings/aliases in this PR.  One particularly hard thing to deprecate is `layers.selected`... since we can't easily patch it with the new API, since the layer doesn't know about the layerlist.  @sofroniewn, does that mean we'll want to let this PR sit at this point for a while, and just put the deprecation warning in for now in a different PR?

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] refactor
- [x] breaking change 