### PR TITLE
Deprecate layer.position and layer.coordinates

### DIFF
--- a/examples/custom_mouse_functions.py
+++ b/examples/custom_mouse_functions.py
@@ -27,8 +27,9 @@ with napari.gui_qt():
 
     @labels_layer.mouse_drag_callbacks.append
     def get_connected_component_shape(layer, event):
-        cords = np.round(layer.coordinates).astype(int)
-        val = layer.get_value(layer.coordinates)
+        data_coordinates = layer.world_to_data(event.position)
+        cords = np.round(data_coordinates).astype(int)
+        val = layer.get_value(data_coordinates)
         if val is None:
             return
         if val != 0:
@@ -50,7 +51,6 @@ with napari.gui_qt():
             msg = f'clicked at {cords} on background which is ignored'
         print(msg)
 
-
     # Handle click or drag events separately
     @labels_layer.mouse_drag_callbacks.append
     def click_drag(layer, event):
@@ -59,7 +59,7 @@ with napari.gui_qt():
         yield
         # on move
         while event.type == 'mouse_move':
-            print(event.pos)
+            print(event.position)
             dragged = True
             yield
         # on release

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -655,78 +655,71 @@ class QtViewer(QSplitter):
         """
         self.viewer._canvas_size = tuple(self.canvas.size[::-1])
 
+    def _process_mouse_event(self, mouse_callbacks, event):
+        """Called whenever mouse pressed in canvas.
+        Parameters
+        ----------
+        mouse_callbacks : function
+            Mouse callbacks function.
+        event : vispy.event.Event
+            The vispy event that triggered this method.
+        """
+        if event.pos is None:
+            return
+
+        # Update the cursor position
+        self.viewer.cursor.position = self._map_canvas2world(list(event.pos))
+
+        # Add the cursor position to the event
+        event.position = self.viewer.cursor.position
+
+        # Put a read only wrapper on the event
+        event = ReadOnlyWrapper(event)
+        mouse_callbacks(self.viewer, event)
+
+        layer = self.viewer.active_layer
+        if layer is not None:
+            mouse_callbacks(layer, event)
+
     def on_mouse_wheel(self, event):
         """Called whenever mouse wheel activated in canvas.
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : vispy.event.Event
+            The vispy event that triggered this method.
         """
-        if event.pos is None:
-            return
-
-        event = ReadOnlyWrapper(event)
-        self.viewer.cursor.position = self._map_canvas2world(list(event.pos))
-        mouse_wheel_callbacks(self.viewer, event)
-
-        layer = self.viewer.active_layer
-        if layer is not None:
-            mouse_wheel_callbacks(layer, event)
+        self._process_mouse_event(mouse_wheel_callbacks, event)
 
     def on_mouse_press(self, event):
         """Called whenever mouse pressed in canvas.
 
         Parameters
         ----------
-        event : napari.utils.event.Event
-            The napari event that triggered this method.
+        event : vispy.event.Event
+            The vispy event that triggered this method.
         """
-        if event.pos is None:
-            return
-
-        event = ReadOnlyWrapper(event)
-        self.viewer.cursor.position = self._map_canvas2world(list(event.pos))
-        mouse_press_callbacks(self.viewer, event)
-
-        layer = self.viewer.active_layer
-        if layer is not None:
-            mouse_press_callbacks(layer, event)
+        self._process_mouse_event(mouse_press_callbacks, event)
 
     def on_mouse_move(self, event):
         """Called whenever mouse moves over canvas.
 
         Parameters
         ----------
-        event : napari.utils.event.Event
-            The napari event that triggered this method.
+        event : vispy.event.Event
+            The vispy event that triggered this method.
         """
-        if event.pos is None:
-            return
-
-        self.viewer.cursor.position = self._map_canvas2world(list(event.pos))
-        mouse_move_callbacks(self.viewer, event)
-
-        layer = self.viewer.active_layer
-        if layer is not None:
-            mouse_move_callbacks(layer, event)
+        self._process_mouse_event(mouse_move_callbacks, event)
 
     def on_mouse_release(self, event):
         """Called whenever mouse released in canvas.
 
         Parameters
         ----------
-        event : napari.utils.event.Event
-            The napari event that triggered this method.
+        event : vispy.event.Event
+            The vispy event that triggered this method.
         """
-        if event.pos is None:
-            return
-
-        self.viewer.cursor.position = self._map_canvas2world(list(event.pos))
-        mouse_release_callbacks(self.viewer, event)
-
-        layer = self.viewer.active_layer
-        if layer is not None:
-            mouse_release_callbacks(layer, event)
+        self._process_mouse_event(mouse_release_callbacks, event)
 
     def on_draw(self, event):
         """Called whenever the canvas is drawn.

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -374,24 +374,48 @@ def test_labels_painting(make_napari_viewer):
 
     # Simulate click
     Event = collections.namedtuple(
-        'Event', field_names=['type', 'is_dragging']
+        'Event', field_names=['type', 'is_dragging', 'position']
     )
 
     # Simulate click
-    event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            position=viewer.cursor.position,
+        )
+    )
     mouse_press_callbacks(layer, event)
 
     viewer.cursor.position = (100, 100)
 
     # Simulate drag
-    event = ReadOnlyWrapper(Event(type='mouse_move', is_dragging=True))
+    event = ReadOnlyWrapper(
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            position=viewer.cursor.position,
+        )
+    )
     mouse_move_callbacks(layer, event)
 
     # Simulate release
-    event = ReadOnlyWrapper(Event(type='mouse_release', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            position=viewer.cursor.position,
+        )
+    )
     mouse_release_callbacks(layer, event)
 
-    event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            position=viewer.cursor.position,
+        )
+    )
     mouse_press_callbacks(layer, event)
 
     screenshot = viewer.screenshot(canvas_only=True)

--- a/napari/_vispy/_tests/test_vispy_big_images.py
+++ b/napari/_vispy/_tests/test_vispy_big_images.py
@@ -52,4 +52,7 @@ def test_downsample_value(make_napari_viewer, shape):
 
     for test_point, expected_value in zip(test_points, expected_values):
         viewer.cursor.position = test_point
-        assert layer.get_value(layer.coordinates) == expected_value
+        assert (
+            layer.get_value(viewer.cursor.position, world=True)
+            == expected_value
+        )

--- a/napari/_vispy/_tests/test_vispy_multiscale.py
+++ b/napari/_vispy/_tests/test_vispy_multiscale.py
@@ -38,17 +38,17 @@ def test_multiscale(make_napari_viewer):
 
     # Test value at top left corner of image
     viewer.cursor.position = (0, 0)
-    value = layer.get_value(layer.coordinates)
+    value = layer.get_value(viewer.cursor.position, world=True)
     np.testing.assert_allclose(value, (2, data[2][(0, 0)]))
 
     # Test value at bottom right corner of image
     viewer.cursor.position = (3995, 2995)
-    value = layer.get_value(layer.coordinates)
+    value = layer.get_value(viewer.cursor.position, world=True)
     np.testing.assert_allclose(value, (2, data[2][(999, 749)]))
 
     # Test value outside image
     viewer.cursor.position = (4000, 3000)
-    value = layer.get_value(layer.coordinates)
+    value = layer.get_value(viewer.cursor.position, world=True)
     assert value[1] is None
 
 

--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -48,18 +48,18 @@ class Labels2DSuite:
     def time_paint_square(self, n):
         """Time to paint square."""
         self.layer.brush_shape = 'square'
-        self.layer.paint(self.layer.coordinates, self.layer.selected_label)
+        self.layer.paint((0,) * 2, self.layer.selected_label)
 
     def time_paint_circle(self, n):
         """Time to paint circle."""
         self.layer.brush_shape = 'circle'
-        self.layer.paint(self.layer.coordinates, self.layer.selected_label)
+        self.layer.paint((0,) * 2, self.layer.selected_label)
 
     def time_fill(self, n):
         """Time to fill."""
         self.layer.fill(
-            self.layer.coordinates,
-            self.layer._value,
+            (0,) * 2,
+            1,
             self.layer.selected_label,
         )
 
@@ -113,18 +113,18 @@ class Labels3DSuite:
     def time_paint_square(self, n):
         """Time to paint square."""
         self.layer.brush_shape = 'square'
-        self.layer.paint(self.layer.coordinates, self.layer.selected_label)
+        self.layer.paint((0,) * 3, self.layer.selected_label)
 
     def time_paint_circle(self, n):
         """Time to paint circle."""
         self.layer.brush_shape = 'circle'
-        self.layer.paint(self.layer.coordinates, self.layer.selected_label)
+        self.layer.paint((0,) * 3, self.layer.selected_label)
 
     def time_fill(self, n):
         """Time to fill."""
         self.layer.fill(
-            self.layer.coordinates,
-            self.layer._value,
+            (0,) * 3,
+            1,
             self.layer.selected_label,
         )
 

--- a/napari/benchmarks/benchmark_qt_viewer_labels.py
+++ b/napari/benchmarks/benchmark_qt_viewer_labels.py
@@ -56,13 +56,13 @@ class QtViewerSingleLabelsSuite:
 
     def time_paint(self):
         """Time to paint."""
-        self.layer.paint(self.layer.coordinates, self.layer.selected_label)
+        self.layer.paint((0,) * 2, self.layer.selected_label)
 
     def time_fill(self):
         """Time to fill."""
         self.layer.fill(
-            self.layer.coordinates,
-            self.layer._value,
+            (0,) * 2,
+            1,
             self.layer.selected_label,
         )
 

--- a/napari/benchmarks/benchmark_shapes_layer.py
+++ b/napari/benchmarks/benchmark_shapes_layer.py
@@ -15,7 +15,7 @@ from napari.utils.interactions import (
 )
 
 Event = collections.namedtuple(
-    'Event', field_names=['type', 'is_dragging', 'modifiers']
+    'Event', field_names=['type', 'is_dragging', 'modifiers', 'position']
 )
 
 
@@ -108,53 +108,119 @@ class ShapesInteractionSuite:
         self.layer = Shapes(self.data, shape_type='polygon')
         self.layer.mode = 'select'
 
-        # create events
-        self.click_event = ReadOnlyWrapper(
-            Event(type='mouse_press', is_dragging=False, modifiers=[])
-        )
-        self.release_event = ReadOnlyWrapper(
-            Event(type='mouse_release', is_dragging=False, modifiers=[])
-        )
-        self.drag_event = ReadOnlyWrapper(
-            Event(type='mouse_move', is_dragging=True, modifiers=[])
-        )
-
         # initialize the position and select a shape
-        self.layer.position = tuple(np.mean(self.layer.data[0], axis=0))
+        position = tuple(np.mean(self.layer.data[0], axis=0))
 
+        # create events
+        click_event = ReadOnlyWrapper(
+            Event(
+                type='mouse_press',
+                is_dragging=False,
+                modifiers=[],
+                position=position,
+            )
+        )
         # Simulate click
-        mouse_press_callbacks(self.layer, self.click_event)
+        mouse_press_callbacks(self.layer, click_event)
+
+        release_event = ReadOnlyWrapper(
+            Event(
+                type='mouse_release',
+                is_dragging=False,
+                modifiers=[],
+                position=position,
+            )
+        )
 
         # Simulate release
-        mouse_release_callbacks(self.layer, self.release_event)
+        mouse_release_callbacks(self.layer, release_event)
 
     def time_drag_shape(self, n):
         """Time to process 5 shape drag events"""
+        # initialize the position and select a shape
+        position = tuple(np.mean(self.layer.data[0], axis=0))
+
+        # create events
+        click_event = ReadOnlyWrapper(
+            Event(
+                type='mouse_press',
+                is_dragging=False,
+                modifiers=[],
+                position=position,
+            )
+        )
+
         # Simulate click
-        mouse_press_callbacks(self.layer, self.click_event)
+        mouse_press_callbacks(self.layer, click_event)
+
+        # create events
+        drag_event = ReadOnlyWrapper(
+            Event(
+                type='mouse_press',
+                is_dragging=True,
+                modifiers=[],
+                position=position,
+            )
+        )
 
         # start drag event
-        mouse_move_callbacks(self.layer, self.drag_event)
+        mouse_move_callbacks(self.layer, drag_event)
 
         # simulate 5 drag events
         for _ in range(5):
-            self.layer.position = tuple(np.add(self.layer.position, [10, 5]))
+            position = tuple(np.add(position, [10, 5]))
+            drag_event = ReadOnlyWrapper(
+                Event(
+                    type='mouse_press',
+                    is_dragging=True,
+                    modifiers=[],
+                    position=position,
+                )
+            )
+
             # Simulate move, click, and release
-            mouse_move_callbacks(self.layer, self.drag_event)
+            mouse_move_callbacks(self.layer, drag_event)
+
+        release_event = ReadOnlyWrapper(
+            Event(
+                type='mouse_release',
+                is_dragging=False,
+                modifiers=[],
+                position=position,
+            )
+        )
 
         # Simulate release
-        mouse_release_callbacks(self.layer, self.release_event)
+        mouse_release_callbacks(self.layer, release_event)
 
     time_drag_shape.param_names = ['n_shapes']
 
     def time_select_shape(self, n):
         """Time to process shape selection events"""
-        self.layer.position = tuple(np.mean(self.layer.data[1], axis=0))
+        position = tuple(np.mean(self.layer.data[1], axis=0))
 
+        # create events
+        click_event = ReadOnlyWrapper(
+            Event(
+                type='mouse_press',
+                is_dragging=False,
+                modifiers=[],
+                position=position,
+            )
+        )
         # Simulate click
-        mouse_press_callbacks(self.layer, self.click_event)
+        mouse_press_callbacks(self.layer, click_event)
+
+        release_event = ReadOnlyWrapper(
+            Event(
+                type='mouse_release',
+                is_dragging=False,
+                modifiers=[],
+                position=position,
+            )
+        )
 
         # Simulate release
-        mouse_release_callbacks(self.layer, self.release_event)
+        mouse_release_callbacks(self.layer, release_event)
 
     time_select_shape.param_names = ['n_shapes']

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1,6 +1,7 @@
 import inspect
 import itertools
 import os
+import warnings
 from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
@@ -321,8 +322,13 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
     def _on_cursor_position_change(self, event):
         """Set the layer cursor position."""
-        for layer in self.layers:
-            layer.position = self.cursor.position
+        with warnings.catch_warnings():
+            # Catch the deprecation warning on layer.position
+            warnings.filterwarnings(
+                'ignore', message='layer.position is deprecated'
+            )
+            for layer in self.layers:
+                layer.position = self.cursor.position
 
         # Update status and help bar based on active layer
         if self.active_layer is not None:

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -464,15 +464,30 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     @property
     def position(self):
         """tuple: Cursor position in world slice coordinates."""
+        warnings.warn(
+            "layer.position is deprecated and will be removed in version 0.4.9."
+            " It should no longer be used as layers should no longer know where the"
+            " cursor position is. You can get the cursor position in world coordinates"
+            " from viewer.cursor.position.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return self._position
 
     @position.setter
     def position(self, position):
+        warnings.warn(
+            "layer.position is deprecated and will be removed in version 0.4.9."
+            " It should no longer be used as layers should no longer know where the"
+            " cursor position is. You can get the cursor position in world coordinates"
+            " from viewer.cursor.position.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         _position = position[-self.ndim :]
         if self._position == _position:
             return
         self._position = _position
-        self._value = self.get_value(self.position, world=True)
 
     @property
     def _dims_displayed(self):
@@ -528,7 +543,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         self._ndim = ndim
 
         self.refresh()
-        self._value = self.get_value(self.position, world=True)
 
     @property
     @abstractmethod
@@ -727,27 +741,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             self.events.deselect()
 
     @property
-    def status(self):
-        """str: displayed in status bar bottom left."""
-        warnings.warn(
-            (
-                "The status attribute is deprecated and will be removed in version 0.4.6."
-                " Instead you should use the get_status method with the position where you"
-                " want to get the status from."
-            ),
-            category=FutureWarning,
-            stacklevel=2,
-        )
-        return self._status
-
-    @status.setter
-    def status(self, status):
-        if status == self.status:
-            return
-        self.events.status(status=status)
-        self._status = status
-
-    @property
     def help(self):
         """str: displayed in status bar bottom right."""
         return self._help
@@ -885,8 +878,10 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         """
         raise NotImplementedError()
 
-    def get_value(self, position=None, *, world=False):
+    def get_value(self, position, *, world=False):
         """Value of the data at a position.
+
+        If the layer is not visible, return None.
 
         Parameters
         ----------
@@ -899,24 +894,18 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         Returns
         -------
         value : tuple, None
-            Value of the data.
+            Value of the data. If the layer is not visible return None.
         """
         if self.visible:
-            if position is None:
-                warnings.warn(
-                    (
-                        "The position argument of get_value will no longer be optional in 0.4.6."
-                        " Instead you should provide the position where you want to get the value."
-                    ),
-                    category=FutureWarning,
-                    stacklevel=2,
-                )
-                position = self.coordinates
-            elif world:
-                position = self._world_to_data(position)
-            return self._get_value(position=tuple(position))
+            if world:
+                position = self.world_to_data(position)
+            value = self._get_value(position=tuple(position))
         else:
-            return None
+            value = None
+        # This should be removed as soon as possible, it is still
+        # used in Points and Shapes.
+        self._value = value
+        return value
 
     @contextmanager
     def block_update_properties(self):
@@ -940,16 +929,24 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             self.set_view_slice()
             self.events.set_data()
             self._update_thumbnail()
-            self._value = self.get_value(self.position, world=True)
             self._set_highlight(force=True)
 
     @property
     def coordinates(self):
         """Cursor position in data coordinates."""
+        warnings.warn(
+            "layer.coordinates is deprecated and will be removed in version 0.4.9."
+            " It should no longer be used as layers should no longer know where the"
+            " cursor position is. You can get the cursor position in world coordinates"
+            " from viewer.cursor.position. You can then transform that into data"
+            " coordinates using the layer.world_to_data method.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         # Note we ignore the first transform which is tile2data
-        return self._world_to_data(self.position)
+        return self.world_to_data(self._position)
 
-    def _world_to_data(self, position):
+    def world_to_data(self, position):
         """Convert from world coordinates to data coordinates.
 
         Parameters
@@ -1034,10 +1031,10 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             category=DeprecationWarning,
             stacklevel=2,
         )
-        coordinates = self.coordinates
+        coordinates = self.world_to_data(self._position)
         return [coordinates[i] for i in self._dims_displayed]
 
-    def get_status(self, position=None, *, world=False):
+    def get_status(self, position, *, world=False):
         """Status message of the data at a coordinate position.
 
         Parameters
@@ -1055,25 +1052,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         """
         value = self.get_value(position, world=world)
         return generate_layer_status(self.name, position, value)
-
-    def get_message(self):
-        """Generate a status message based on the coordinates and value
-
-        Returns
-        -------
-        msg : string
-            String containing a message that can be used as a status update.
-        """
-        warnings.warn(
-            (
-                "The get_message method is deprecated and will be removed in version 0.4.6."
-                " Instead you should use the get_status method with the position where you"
-                " want to get the status from."
-            ),
-            category=FutureWarning,
-            stacklevel=2,
-        )
-        return generate_layer_status(self.name, self.coordinates, self._value)
 
     def save(self, path: str, plugin: Optional[str] = None) -> List[str]:
         """Save this layer to ``path`` with default (or specified) plugin.

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -510,8 +510,7 @@ def test_value():
     np.random.seed(0)
     data = np.random.random((10, 15))
     layer = Image(data)
-    value = layer.get_value(layer.coordinates)
-    assert layer.coordinates == (0, 0)
+    value = layer.get_value((0,) * 2)
     assert value == data[0, 0]
 
 
@@ -520,7 +519,7 @@ def test_message():
     np.random.seed(0)
     data = np.random.random((10, 15))
     layer = Image(data)
-    msg = layer.get_status(layer.position)
+    msg = layer.get_status((0,) * 2)
     assert type(msg) == str
 
 

--- a/napari/layers/image/_tests/test_multiscale.py
+++ b/napari/layers/image/_tests/test_multiscale.py
@@ -323,8 +323,7 @@ def test_value():
     np.random.seed(0)
     data = [np.random.random(s) for s in shapes]
     layer = Image(data, multiscale=True)
-    value = layer.get_value(layer.coordinates)
-    assert layer.coordinates == (0, 0)
+    value = layer.get_value((0,) * 2)
     assert layer.data_level == 2
     np.testing.assert_allclose(value, (2, data[2][0, 0]))
 
@@ -335,7 +334,7 @@ def test_corner_value():
     np.random.seed(0)
     data = [np.random.random(s) for s in shapes]
     layer = Image(data, multiscale=True)
-    value = layer.get_value(layer.coordinates)
+    value = layer.get_value((0,) * 2)
     target_position = (39, 19)
     target_level = 0
     layer.data_level = target_level
@@ -343,15 +342,13 @@ def test_corner_value():
     layer.refresh()
 
     # Test position at corner of image
-    layer.position = target_position
-    value = layer.get_value(layer.coordinates)
+    value = layer.get_value(target_position)
     np.testing.assert_allclose(
         value, (target_level, data[target_level][target_position])
     )
 
     # Test position at outside image
-    layer.position = (40, 20)
-    value = layer.get_value(layer.coordinates)
+    value = layer.get_value((40, 20))
     assert value[1] is None
 
 
@@ -361,7 +358,7 @@ def test_message():
     np.random.seed(0)
     data = [np.random.random(s) for s in shapes]
     layer = Image(data, multiscale=True)
-    msg = layer.get_status(layer.position)
+    msg = layer.get_status((0,) * 2)
     assert type(msg) == str
 
 

--- a/napari/layers/image/_tests/test_volume.py
+++ b/napari/layers/image/_tests/test_volume.py
@@ -146,8 +146,7 @@ def test_value():
     data = np.random.random((10, 15, 20))
     layer = Image(data)
     layer._slice_dims(ndisplay=3)
-    value = layer.get_value(layer.coordinates)
-    assert layer.coordinates == (0, 0, 0)
+    value = layer.get_value((0,) * 3)
     assert value == data[0, 0, 0]
 
 
@@ -157,5 +156,5 @@ def test_message():
     data = np.random.random((10, 15, 20))
     layer = Image(data)
     layer._slice_dims(ndisplay=3)
-    msg = layer.get_status(layer.position)
+    msg = layer.get_status((0,) * 3)
     assert type(msg) == str

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -21,6 +21,7 @@ def draw(layer, event):
     pixels will be changed to background and this tool functions like an
     eraser
     """
+    coordinates = layer.world_to_data(event.position)
     # on press
     if layer._mode == Mode.ERASE:
         new_label = layer._background_label
@@ -28,18 +29,19 @@ def draw(layer, event):
         new_label = layer.selected_label
 
     if layer._mode in [Mode.PAINT, Mode.ERASE]:
-        layer.paint(layer.coordinates, new_label)
+        layer.paint(coordinates, new_label)
     elif layer._mode == Mode.FILL:
-        layer.fill(layer.coordinates, new_label)
+        layer.fill(coordinates, new_label)
 
-    last_cursor_coord = layer.coordinates
+    last_cursor_coord = coordinates
     yield
 
     layer._block_saving = True
     # on move
     while event.type == 'mouse_move':
+        coordinates = layer.world_to_data(event.position)
         interp_coord = interpolate_coordinates(
-            last_cursor_coord, layer.coordinates, layer.brush_size
+            last_cursor_coord, coordinates, layer.brush_size
         )
         for c in interp_coord:
             if layer._mode in [Mode.PAINT, Mode.ERASE]:
@@ -47,7 +49,7 @@ def draw(layer, event):
             elif layer._mode == Mode.FILL:
                 layer.fill(c, new_label, refresh=False)
         layer.refresh()
-        last_cursor_coord = layer.coordinates
+        last_cursor_coord = coordinates
         yield
 
     # on release
@@ -57,4 +59,4 @@ def draw(layer, event):
 def pick(layer, event):
     """Change the selected label to the same as the region clicked."""
     # on press
-    layer.selected_label = layer._value or 0
+    layer.selected_label = layer.get_value(event.position, world=True) or 0

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -224,19 +224,19 @@ def test_properties():
     assert layer.properties == properties
     assert layer._label_index == label_index
 
-    current_label = layer.get_value(layer.coordinates)
-    layer_message = layer.get_status(layer.position)
+    current_label = layer.get_value((0, 0))
+    layer_message = layer.get_status((0, 0))
     assert layer_message.endswith(f'Class {current_label - 1}')
 
     properties = {'class': ['Background']}
     layer = Labels(data, properties=properties)
-    layer_message = layer.get_status(layer.position)
+    layer_message = layer.get_status((0, 0))
     assert layer_message.endswith("[No Properties]")
 
     properties = {'class': ['Background', 'Class 12'], 'index': [0, 12]}
     label_index = {0: 0, 12: 1}
     layer = Labels(data, properties=properties)
-    layer_message = layer.get_status(layer.position)
+    layer_message = layer.get_status((0, 0))
     assert layer._label_index == label_index
     assert layer_message.endswith('Class 12')
 
@@ -259,19 +259,19 @@ def test_multiscale_properties():
     assert layer.properties == properties
     assert layer._label_index == label_index
 
-    current_label = layer.get_value(layer.coordinates)[1]
-    layer_message = layer.get_status(layer.position)
+    current_label = layer.get_value((0, 0))[1]
+    layer_message = layer.get_status((0, 0))
     assert layer_message.endswith(f'Class {current_label - 1}')
 
     properties = {'class': ['Background']}
     layer = Labels(data, properties=properties)
-    layer_message = layer.get_status(layer.position)
+    layer_message = layer.get_status((0, 0))
     assert layer_message.endswith("[No Properties]")
 
     properties = {'class': ['Background', 'Class 12'], 'index': [0, 12]}
     label_index = {0: 0, 12: 1}
     layer = Labels(data, properties=properties)
-    layer_message = layer.get_status(layer.position)
+    layer_message = layer.get_status((0, 0))
     assert layer._label_index == label_index
     assert layer_message.endswith('Class 12')
 
@@ -656,8 +656,7 @@ def test_value():
     np.random.seed(0)
     data = np.random.randint(20, size=(10, 15))
     layer = Labels(data)
-    value = layer.get_value(layer.coordinates)
-    assert layer.coordinates == (0, 0)
+    value = layer.get_value((0, 0))
     assert value == data[0, 0]
 
 
@@ -666,7 +665,7 @@ def test_message():
     np.random.seed(0)
     data = np.random.randint(20, size=(10, 15))
     layer = Labels(data)
-    msg = layer.get_status(layer.position)
+    msg = layer.get_status((0, 0))
     assert type(msg) == str
 
 

--- a/napari/layers/labels/_tests/test_labels_mouse_bindings.py
+++ b/napari/layers/labels/_tests/test_labels_mouse_bindings.py
@@ -22,7 +22,9 @@ def Event():
         A new tuple subclass named Event that can be used to create a
         NamedTuple object with fields "type" and "is_dragging".
     """
-    return collections.namedtuple('Event', field_names=['type', 'is_dragging'])
+    return collections.namedtuple(
+        'Event', field_names=['type', 'is_dragging', 'position']
+    )
 
 
 @pytest.mark.parametrize(
@@ -37,20 +39,23 @@ def test_paint(Event, brush_shape, expected_sum):
     layer.brush_shape = brush_shape
     layer.mode = 'paint'
     layer.selected_label = 3
-    layer.position = (0, 0)
 
     # Simulate click
-    event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_press', is_dragging=False, position=(0, 0))
+    )
     mouse_press_callbacks(layer, event)
 
-    layer.position = (19, 19)
-
     # Simulate drag
-    event = ReadOnlyWrapper(Event(type='mouse_move', is_dragging=True))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_move', is_dragging=True, position=(19, 19))
+    )
     mouse_move_callbacks(layer, event)
 
     # Simulate release
-    event = ReadOnlyWrapper(Event(type='mouse_release', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_release', is_dragging=False, position=(19, 19))
+    )
     mouse_release_callbacks(layer, event)
 
     # Painting goes from (0, 0) to (19, 19) with a brush size of 10, changing
@@ -73,20 +78,23 @@ def test_paint_scale(Event, brush_shape, expected_sum):
     layer.brush_shape = brush_shape
     layer.mode = 'paint'
     layer.selected_label = 3
-    layer.position = (0, 0)
 
     # Simulate click
-    event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_press', is_dragging=False, position=(0, 0))
+    )
     mouse_press_callbacks(layer, event)
 
-    layer.position = (39, 39)
-
     # Simulate drag
-    event = ReadOnlyWrapper(Event(type='mouse_move', is_dragging=True))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_move', is_dragging=True, position=(39, 39))
+    )
     mouse_move_callbacks(layer, event)
 
     # Simulate release
-    event = ReadOnlyWrapper(Event(type='mouse_release', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_release', is_dragging=False, position=(39, 39))
+    )
     mouse_release_callbacks(layer, event)
 
     # Painting goes from (0, 0) to (19, 19) with a brush size of 10, changing
@@ -109,20 +117,23 @@ def test_erase(Event, brush_shape, expected_sum):
     layer.mode = 'erase'
     layer.brush_shape = brush_shape
     layer.selected_label = 3
-    layer.position = (0, 0)
 
     # Simulate click
-    event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_press', is_dragging=False, position=(0, 0))
+    )
     mouse_press_callbacks(layer, event)
 
-    layer.position = (19, 19)
-
     # Simulate drag
-    event = ReadOnlyWrapper(Event(type='mouse_move', is_dragging=True))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_move', is_dragging=True, position=(19, 19))
+    )
     mouse_move_callbacks(layer, event)
 
     # Simulate release
-    event = ReadOnlyWrapper(Event(type='mouse_release', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_release', is_dragging=False, position=(19, 19))
+    )
     mouse_release_callbacks(layer, event)
 
     # Painting goes from (0, 0) to (19, 19) with a brush size of 10, changing
@@ -143,17 +154,18 @@ def test_pick(Event):
     assert layer.selected_label == 1
 
     layer.mode = 'pick'
-    layer.position = (0, 0)
 
     # Simulate click
-    event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_press', is_dragging=False, position=(0, 0))
+    )
     mouse_press_callbacks(layer, event)
     assert layer.selected_label == 2
 
-    layer.position = (19, 19)
-
     # Simulate click
-    event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_press', is_dragging=False, position=(19, 19))
+    )
     mouse_press_callbacks(layer, event)
     assert layer.selected_label == 3
 
@@ -170,22 +182,24 @@ def test_fill(Event):
     assert np.unique(layer.data[-5:, :5]) == 1
 
     layer.mode = 'fill'
-    layer.position = (0, 0)
     layer.selected_label = 4
 
     # Simulate click
-    event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_press', is_dragging=False, position=(0, 0))
+    )
     mouse_press_callbacks(layer, event)
     assert np.unique(layer.data[:5, :5]) == 4
     assert np.unique(layer.data[-5:, -5:]) == 3
     assert np.unique(layer.data[:5, -5:]) == 1
     assert np.unique(layer.data[-5:, :5]) == 1
 
-    layer.position = (19, 19)
     layer.selected_label = 5
 
     # Simulate click
-    event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_press', is_dragging=False, position=(19, 19))
+    )
     mouse_press_callbacks(layer, event)
     assert np.unique(layer.data[:5, :5]) == 4
     assert np.unique(layer.data[-5:, -5:]) == 5
@@ -207,11 +221,12 @@ def test_fill_nD_plane(Event):
     assert np.unique(layer.data[0, 8:10, 8:10]) == 2
 
     layer.mode = 'fill'
-    layer.position = (0, 0, 0)
     layer.selected_label = 4
 
     # Simulate click
-    event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_press', is_dragging=False, position=(0, 0, 0))
+    )
     mouse_press_callbacks(layer, event)
     assert np.unique(layer.data[0, :5, :5]) == 4
     assert np.unique(layer.data[1:5, :5, :5]) == 2
@@ -220,11 +235,12 @@ def test_fill_nD_plane(Event):
     assert np.unique(layer.data[-5:, :5, -5:]) == 1
     assert np.unique(layer.data[0, 8:10, 8:10]) == 2
 
-    layer.position = (0, 19, 19)
     layer.selected_label = 5
 
     # Simulate click
-    event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_press', is_dragging=False, position=(0, 19, 19))
+    )
     mouse_press_callbacks(layer, event)
     assert np.unique(layer.data[0, :5, :5]) == 4
     assert np.unique(layer.data[1:5, :5, :5]) == 2
@@ -251,11 +267,12 @@ def test_fill_nD_all(Event):
 
     layer.n_dimensional = True
     layer.mode = 'fill'
-    layer.position = (0, 0, 0)
     layer.selected_label = 4
 
     # Simulate click
-    event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_press', is_dragging=False, position=(0, 0, 0))
+    )
     mouse_press_callbacks(layer, event)
     assert np.unique(layer.data[:5, :5, :5]) == 4
     assert np.unique(layer.data[-5:, -5:, -5:]) == 3
@@ -263,11 +280,12 @@ def test_fill_nD_all(Event):
     assert np.unique(layer.data[-5:, :5, -5:]) == 1
     assert np.unique(layer.data[0, 8:10, 8:10]) == 2
 
-    layer.position = (0, 19, 19)
     layer.selected_label = 5
 
     # Simulate click
-    event = ReadOnlyWrapper(Event(type='mouse_press', is_dragging=False))
+    event = ReadOnlyWrapper(
+        Event(type='mouse_press', is_dragging=False, position=(0, 19, 19))
+    )
     mouse_press_callbacks(layer, event)
     assert np.unique(layer.data[:5, :5, :5]) == 4
     assert np.unique(layer.data[-5:, -5:, -5:]) == 3

--- a/napari/layers/points/_points_mouse_bindings.py
+++ b/napari/layers/points/_points_mouse_bindings.py
@@ -24,22 +24,20 @@ def select(layer, event):
         'Shift' in event.modifiers or 'Control' in event.modifiers
     )
 
+    # Get value under the cursor, for points, this is the index of the highlighted
+    # if any, or None.
+    value = layer.get_value(event.position, world=True)
     # if modifying selection add / remove any from existing selection
     if modify_selection:
-        # layer._value is defined in the base layer and contains the value
-        # under the cursor. For points, this is the index of the highlighted
-        # point.
-        if layer._value is not None:
-            layer.selected_data = _toggle_selected(
-                layer.selected_data, layer._value
-            )
+        if value is not None:
+            layer.selected_data = _toggle_selected(layer.selected_data, value)
     else:
-        if layer._value is not None:
+        if value is not None:
             # If the current index is not in the current list make it the only
             # index selected, otherwise don't change the selection so that
             # the current selection can be dragged together.
-            if layer._value not in layer.selected_data:
-                layer.selected_data = {layer._value}
+            if value not in layer.selected_data:
+                layer.selected_data = {value}
         else:
             layer.selected_data = set()
     layer._set_highlight()
@@ -48,11 +46,12 @@ def select(layer, event):
 
     # on move
     while event.type == 'mouse_move':
+        coordinates = layer.world_to_data(event.position)
         # If not holding modifying selection and points selected then drag them
         if not modify_selection and len(layer.selected_data) > 0:
-            layer._move(layer.selected_data, layer.coordinates)
+            layer._move(layer.selected_data, coordinates)
         else:
-            coord = [layer.coordinates[i] for i in layer._dims_displayed]
+            coord = [coordinates[i] for i in layer._dims_displayed]
             layer._is_selecting = True
             if layer._drag_start is None:
                 layer._drag_start = coord
@@ -95,7 +94,8 @@ def add(layer, event):
 
     # on release
     if not dragged:
-        layer.add(layer.coordinates)
+        coordinates = layer.world_to_data(event.position)
+        layer.add(coordinates)
 
 
 def highlight(layer, event):

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1364,12 +1364,11 @@ def test_value():
     data = 20 * np.random.random(shape)
     data[-1] = [0, 0]
     layer = Points(data)
-    value = layer.get_value(layer.coordinates)
-    assert layer.coordinates == (0, 0)
+    value = layer.get_value((0, 0))
     assert value == 9
 
     layer.data = layer.data + 20
-    value = layer.get_value(layer.coordinates)
+    value = layer.get_value((0, 0))
     assert value is None
 
 
@@ -1380,7 +1379,7 @@ def test_message():
     data = 20 * np.random.random(shape)
     data[-1] = [0, 0]
     layer = Points(data)
-    msg = layer.get_status(layer.position)
+    msg = layer.get_status((0,) * 2)
     assert type(msg) == str
 
 

--- a/napari/layers/points/_tests/test_points_mouse_bindings.py
+++ b/napari/layers/points/_tests/test_points_mouse_bindings.py
@@ -23,7 +23,7 @@ def Event():
         NamedTuple object with fields "type", "is_dragging", and "modifiers".
     """
     return collections.namedtuple(
-        'Event', field_names=['type', 'is_dragging', 'modifiers']
+        'Event', field_names=['type', 'is_dragging', 'modifiers', 'position']
     )
 
 
@@ -61,13 +61,23 @@ def test_not_adding_or_selecting_point(create_known_points_layer, Event):
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=(0, 0),
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=(0, 0),
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -82,17 +92,26 @@ def test_add_point(create_known_points_layer, Event):
 
     # Add point at location where non exists
     layer.mode = 'add'
-    layer.position = known_non_point
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_point,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_point,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -108,26 +127,39 @@ def test_drag_in_add_mode(create_known_points_layer, Event):
     # Add point at location where non exists
     layer.mode = 'add'
     layer.interactive = True
-    layer.position = known_non_point
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_point,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     known_non_point_end = [40, 60]
-    layer.position = known_non_point_end
 
     # Simulate drag end
     event = ReadOnlyWrapper(
-        Event(type='mouse_move', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            modifiers=[],
+            position=known_non_point_end,
+        )
     )
     mouse_move_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_point_end,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -140,17 +172,27 @@ def test_select_point(create_known_points_layer, Event):
     layer, n_points, _ = create_known_points_layer
 
     layer.mode = 'select'
-    layer.position = tuple(layer.data[0])
+    position = tuple(layer.data[0])
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -165,17 +207,27 @@ def test_after_in_add_mode_point(create_known_points_layer, Event):
 
     layer.mode = 'add'
     layer.mode = 'pan_zoom'
-    layer.position = tuple(layer.data[0])
+    position = tuple(layer.data[0])
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -190,17 +242,27 @@ def test_after_in_select_mode_point(create_known_points_layer, Event):
 
     layer.mode = 'select'
     layer.mode = 'pan_zoom'
-    layer.position = tuple(layer.data[0])
+    position = tuple(layer.data[0])
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -214,18 +276,28 @@ def test_unselect_select_point(create_known_points_layer, Event):
     layer, n_points, _ = create_known_points_layer
 
     layer.mode = 'select'
-    layer.position = tuple(layer.data[0])
+    position = tuple(layer.data[0])
     layer.selected_data = {2, 3}
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -239,18 +311,28 @@ def test_add_select_point(create_known_points_layer, Event):
     layer, n_points, _ = create_known_points_layer
 
     layer.mode = 'select'
-    layer.position = tuple(layer.data[0])
+    position = tuple(layer.data[0])
     layer.selected_data = {2, 3}
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=['Shift'])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=['Shift'],
+            position=position,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=['Shift'])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=['Shift'],
+            position=position,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -264,18 +346,28 @@ def test_remove_select_point(create_known_points_layer, Event):
     layer, n_points, _ = create_known_points_layer
 
     layer.mode = 'select'
-    layer.position = tuple(layer.data[0])
+    position = tuple(layer.data[0])
     layer.selected_data = {0, 2, 3}
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=['Shift'])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=['Shift'],
+            position=position,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=['Shift'])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=['Shift'],
+            position=position,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -289,17 +381,26 @@ def test_not_selecting_point(create_known_points_layer, Event):
     layer, n_points, known_non_point = create_known_points_layer
 
     layer.mode = 'select'
-    layer.position = known_non_point
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_point,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_point,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -312,19 +413,28 @@ def test_unselecting_points(create_known_points_layer, Event):
     layer, n_points, known_non_point = create_known_points_layer
 
     layer.mode = 'select'
-    layer.position = known_non_point
     layer.selected_data = {2, 3}
     assert len(layer.selected_data) == 2
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_point,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_point,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -337,30 +447,45 @@ def test_selecting_all_points_with_drag(create_known_points_layer, Event):
     layer, n_points, known_non_point = create_known_points_layer
 
     layer.mode = 'select'
-    layer.position = known_non_point
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_point,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate drag start
     event = ReadOnlyWrapper(
-        Event(type='mouse_move', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            modifiers=[],
+            position=known_non_point,
+        )
     )
     mouse_move_callbacks(layer, event)
 
-    layer.position = [0, 0]
     # Simulate drag end
     event = ReadOnlyWrapper(
-        Event(type='mouse_move', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_move', is_dragging=True, modifiers=[], position=(0, 0)
+        )
     )
     mouse_move_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=True,
+            modifiers=[],
+            position=(0, 0),
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -373,30 +498,48 @@ def test_selecting_no_points_with_drag(create_known_points_layer, Event):
     layer, n_points, known_non_point = create_known_points_layer
 
     layer.mode = 'select'
-    layer.position = known_non_point
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_point,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate drag start
     event = ReadOnlyWrapper(
-        Event(type='mouse_move', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            modifiers=[],
+            position=known_non_point,
+        )
     )
     mouse_move_callbacks(layer, event)
 
-    layer.position = [50, 60]
     # Simulate drag end
     event = ReadOnlyWrapper(
-        Event(type='mouse_move', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            modifiers=[],
+            position=(50, 60),
+        )
     )
     mouse_move_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=True,
+            modifiers=[],
+            position=(50, 60),
+        )
     )
     mouse_release_callbacks(layer, event)
 

--- a/napari/layers/shapes/_shapes_key_bindings.py
+++ b/napari/layers/shapes/_shapes_key_bindings.py
@@ -37,14 +37,14 @@ def hold_to_lock_aspect_ratio(layer):
     else:
         layer._aspect_ratio = 1
     if layer._is_moving:
-        _move(layer, layer.coordinates)
+        _move(layer, layer._moving_coordinates)
 
     yield
 
     # on key release
     layer._fixed_aspect = False
     if layer._is_moving:
-        _move(layer, layer.coordinates)
+        _move(layer, layer._moving_coordinates)
 
 
 @Shapes.bind_key('R')

--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -44,6 +44,9 @@ def select(layer, event):
     # on move
     while event.type == 'mouse_move':
         coordinates = layer.world_to_data(event.position)
+        # ToDo: Need to pass moving_coordinates to allow fixed aspect ratio
+        # keybinding to work, this should be dropped
+        layer._moving_coordinates = coordinates
         # Drag any selected shapes
         if len(layer.selected_data) == 0:
             _drag_selection_box(layer, coordinates)

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -1453,17 +1453,16 @@ def test_value():
     data = 20 * np.random.random(shape)
     data[-1, :] = [[0, 0], [0, 10], [10, 0], [10, 10]]
     layer = Shapes(data)
-    value = layer.get_value(layer.coordinates)
-    assert layer.coordinates == (0, 0)
+    value = layer.get_value((0,) * 2)
     assert value == (9, None)
 
     layer.mode = 'select'
     layer.selected_data = {9}
-    value = layer.get_value(layer.coordinates)
+    value = layer.get_value((0,) * 2)
     assert value == (9, 7)
 
     layer = Shapes(data + 5)
-    value = layer.get_value(layer.coordinates)
+    value = layer.get_value((0,) * 2)
     assert value == (None, None)
 
 
@@ -1473,7 +1472,7 @@ def test_message():
     np.random.seed(0)
     data = 20 * np.random.random(shape)
     layer = Shapes(data)
-    msg = layer.get_status(layer.position)
+    msg = layer.get_status((0,) * 2)
     assert type(msg) == str
 
 

--- a/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
@@ -297,10 +297,16 @@ def test_drag_shape(create_known_shapes_layer, Event):
     layer, n_shapes, _ = create_known_shapes_layer
 
     layer.mode = 'select'
+    # Zoom in so as to not select any vertices
+    layer.scale_factor = 0.01
     orig_data = layer.data[0].copy()
     assert len(layer.selected_data) == 0
 
     position = tuple(np.mean(layer.data[0], axis=0))
+
+    # Check shape under cursor
+    value = layer.get_value(position, world=True)
+    assert value == (0, None)
 
     # Simulate click
     event = ReadOnlyWrapper(
@@ -325,6 +331,10 @@ def test_drag_shape(create_known_shapes_layer, Event):
 
     assert len(layer.selected_data) == 1
     assert layer.selected_data == {0}
+
+    # Check shape but not vertex under cursor
+    value = layer.get_value(event.position, world=True)
+    assert value == (0, None)
 
     # Simulate click
     event = ReadOnlyWrapper(

--- a/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
@@ -23,7 +23,7 @@ def Event():
         NamedTuple object with fields "type", "is_dragging", and "modifiers".
     """
     return collections.namedtuple(
-        'Event', field_names=['type', 'is_dragging', 'modifiers']
+        'Event', field_names=['type', 'is_dragging', 'modifiers', 'position']
     )
 
 
@@ -60,13 +60,23 @@ def test_not_adding_or_selecting_shape(create_known_shapes_layer, Event):
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=(0, 0),
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=(0, 0),
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -82,25 +92,38 @@ def test_add_simple_shape(shape_type, create_known_shapes_layer, Event):
 
     # Add shape at location where non exists
     layer.mode = 'add_' + shape_type
-    layer.position = known_non_shape
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_shape,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     known_non_shape_end = [40, 60]
-    layer.position = known_non_shape_end
     # Simulate drag end
     event = ReadOnlyWrapper(
-        Event(type='mouse_move', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            modifiers=[],
+            position=known_non_shape_end,
+        )
     )
     mouse_move_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_shape_end,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -120,21 +143,34 @@ def test_add_complex_shape(shape_type, create_known_shapes_layer, Event):
     desired_shape = [[20, 30], [10, 50], [60, 40], [80, 20]]
     # Add shape at location where non exists
     layer.mode = 'add_' + shape_type
-    layer.position = desired_shape[0]
 
     for coord in desired_shape:
-        layer.position = coord
         # Simulate move, click, and release
         event = ReadOnlyWrapper(
-            Event(type='mouse_move', is_dragging=False, modifiers=[])
+            Event(
+                type='mouse_move',
+                is_dragging=False,
+                modifiers=[],
+                position=coord,
+            )
         )
         mouse_move_callbacks(layer, event)
         event = ReadOnlyWrapper(
-            Event(type='mouse_press', is_dragging=False, modifiers=[])
+            Event(
+                type='mouse_press',
+                is_dragging=False,
+                modifiers=[],
+                position=coord,
+            )
         )
         mouse_press_callbacks(layer, event)
         event = ReadOnlyWrapper(
-            Event(type='mouse_release', is_dragging=False, modifiers=[])
+            Event(
+                type='mouse_release',
+                is_dragging=False,
+                modifiers=[],
+                position=coord,
+            )
         )
         mouse_release_callbacks(layer, event)
 
@@ -154,17 +190,26 @@ def test_vertex_insert(create_known_shapes_layer, Event):
     n_coord = len(layer.data[0])
     layer.mode = 'vertex_insert'
     layer.selected_data = {0}
-    layer.position = known_non_shape
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_shape,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate drag end
     event = ReadOnlyWrapper(
-        Event(type='mouse_move', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            modifiers=[],
+            position=known_non_shape,
+        )
     )
     mouse_move_callbacks(layer, event)
 
@@ -183,17 +228,27 @@ def test_vertex_remove(create_known_shapes_layer, Event):
     n_coord = len(layer.data[0])
     layer.mode = 'vertex_remove'
     layer.selected_data = {0}
-    layer.position = tuple(layer.data[0][0])
+    position = tuple(layer.data[0][0])
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate drag end
     event = ReadOnlyWrapper(
-        Event(type='mouse_move', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_move_callbacks(layer, event)
 
@@ -208,17 +263,27 @@ def test_select_shape(mode, create_known_shapes_layer, Event):
     layer, n_shapes, _ = create_known_shapes_layer
 
     layer.mode = mode
-    layer.position = tuple(layer.data[0][0])
+    position = tuple(layer.data[0][0])
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -235,16 +300,26 @@ def test_drag_shape(create_known_shapes_layer, Event):
     orig_data = layer.data[0].copy()
     assert len(layer.selected_data) == 0
 
-    layer.position = tuple(np.mean(layer.data[0], axis=0))
+    position = tuple(np.mean(layer.data[0], axis=0))
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_press_callbacks(layer, event)
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -253,23 +328,43 @@ def test_drag_shape(create_known_shapes_layer, Event):
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=True,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_press_callbacks(layer, event)
     # start drag event
     event = ReadOnlyWrapper(
-        Event(type='mouse_move', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_move_callbacks(layer, event)
-    layer.position = tuple(np.add(layer.position, [10, 5]))
+    position = tuple(np.add(position, [10, 5]))
     # Simulate move, click, and release
     event = ReadOnlyWrapper(
-        Event(type='mouse_move', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_move_callbacks(layer, event)
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=True,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -285,24 +380,39 @@ def test_drag_vertex(create_known_shapes_layer, Event):
 
     layer.mode = 'direct'
     layer.selected_data = {0}
-    layer.position = tuple(layer.data[0][0])
+    position = tuple(layer.data[0][0])
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_press_callbacks(layer, event)
 
-    layer.position = [0, 0]
+    position = [0, 0]
     # Simulate move, click, and release
     event = ReadOnlyWrapper(
-        Event(type='mouse_move', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_move_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=True,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -332,17 +442,27 @@ def test_after_in_add_mode_shape(mode, create_known_shapes_layer, Event):
 
     layer.mode = mode
     layer.mode = 'pan_zoom'
-    layer.position = tuple(layer.data[0][0])
+    position = tuple(layer.data[0][0])
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -357,18 +477,28 @@ def test_unselect_select_shape(mode, create_known_shapes_layer, Event):
     layer, n_shapes, _ = create_known_shapes_layer
 
     layer.mode = mode
-    layer.position = tuple(layer.data[0][0])
+    position = tuple(layer.data[0][0])
     layer.selected_data = {1}
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=position,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -383,17 +513,26 @@ def test_not_selecting_shape(mode, create_known_shapes_layer, Event):
     layer, n_shapes, known_non_shape = create_known_shapes_layer
 
     layer.mode = mode
-    layer.position = known_non_shape
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_shape,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_shape,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -407,19 +546,28 @@ def test_unselecting_shapes(mode, create_known_shapes_layer, Event):
     layer, n_shapes, known_non_shape = create_known_shapes_layer
 
     layer.mode = mode
-    layer.position = known_non_shape
     layer.selected_data = {0, 1}
     assert len(layer.selected_data) == 2
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_shape,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_shape,
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -433,30 +581,45 @@ def test_selecting_shapes_with_drag(mode, create_known_shapes_layer, Event):
     layer, n_shapes, known_non_shape = create_known_shapes_layer
 
     layer.mode = mode
-    layer.position = known_non_shape
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_shape,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate drag start
     event = ReadOnlyWrapper(
-        Event(type='mouse_move', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            modifiers=[],
+            position=known_non_shape,
+        )
     )
     mouse_move_callbacks(layer, event)
 
-    layer.position = [0, 0]
     # Simulate drag end
     event = ReadOnlyWrapper(
-        Event(type='mouse_move', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_move', is_dragging=True, modifiers=[], position=(0, 0)
+        )
     )
     mouse_move_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=True,
+            modifiers=[],
+            position=(0, 0),
+        )
     )
     mouse_release_callbacks(layer, event)
 
@@ -470,30 +633,48 @@ def test_selecting_no_shapes_with_drag(mode, create_known_shapes_layer, Event):
     layer, n_shapes, known_non_shape = create_known_shapes_layer
 
     layer.mode = mode
-    layer.position = known_non_shape
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(type='mouse_press', is_dragging=False, modifiers=[])
+        Event(
+            type='mouse_press',
+            is_dragging=False,
+            modifiers=[],
+            position=known_non_shape,
+        )
     )
     mouse_press_callbacks(layer, event)
 
     # Simulate drag start
     event = ReadOnlyWrapper(
-        Event(type='mouse_move', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            modifiers=[],
+            position=known_non_shape,
+        )
     )
     mouse_move_callbacks(layer, event)
 
-    layer.position = [50, 60]
     # Simulate drag end
     event = ReadOnlyWrapper(
-        Event(type='mouse_move', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            modifiers=[],
+            position=(50, 60),
+        )
     )
     mouse_move_callbacks(layer, event)
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(type='mouse_release', is_dragging=True, modifiers=[])
+        Event(
+            type='mouse_release',
+            is_dragging=True,
+            modifiers=[],
+            position=(50, 60),
+        )
     )
     mouse_release_callbacks(layer, event)
 

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -422,6 +422,9 @@ class Shapes(Layer):
         self._fixed_aspect = False
         self._aspect_ratio = 1
         self._is_moving = False
+        # _moving_coordinates are needed for fixing aspect ratio during
+        # a resize
+        self._moving_coordinates = None
         self._fixed_index = 0
         self._is_selecting = False
         self._drag_box = None

--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -525,8 +525,7 @@ def test_value():
     data = np.random.random((10, 2, 2))
     data[:, 0, :] = 20 * data[:, 0, :]
     layer = Vectors(data)
-    value = layer.get_value(layer.coordinates)
-    assert layer.coordinates == (0, 0)
+    value = layer.get_value((0,) * 2)
     assert value is None
 
 
@@ -536,7 +535,7 @@ def test_message():
     data = np.random.random((10, 2, 2))
     data[:, 0, :] = 20 * data[:, 0, :]
     layer = Vectors(data)
-    msg = layer.get_status(layer.position)
+    msg = layer.get_status((0,) * 2)
     assert type(msg) == str
 
 


### PR DESCRIPTION
# Description
This PR supersedes #2249 and will deprecate `layer.position` and `layer.coordinates`. It adds `event.position` to the mouse events, which is the position of the cursor in world coordinates. It also removes some of the deprecated ability to call `layer.get_value()` and `layer.get_status()` without any position and the `layer.status` attribute. It also makes the `layer.world_to_data` transform public, and to get the old `layer.coordinates` you can do `layer.world_to_data(event.position)` or `layer.world_to_data(viewer.cursor.position)` depending on where you are/ what you want.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Deprecation
