### PR TITLE
Add bbox annotator example

### DIFF
--- a/examples/bbox_annotator.py
+++ b/examples/bbox_annotator.py
@@ -1,6 +1,7 @@
 from magicgui.widgets import ComboBox, Container
 import napari
 import numpy as np
+from skimage import data
 
 
 # set up the annotation values and text display properties
@@ -56,9 +57,18 @@ def create_label_menu(shapes_layer, label_property, labels):
     return label_widget
 
 
+# create a stack with the camera image shifted in each slice
+n_slices = 5
+base_image = data.camera()
+image = np.zeros((n_slices, base_image.shape[0], base_image.shape[1]), dtype=base_image.dtype)
+for slice_idx in range(n_slices):
+    shift = 1 + 10 * slice_idx
+    image[slice_idx, ...] = np.pad(base_image, ((0, 0), (shift, 0)), mode='constant')[:, :-shift]
+
+
 with napari.gui_qt():
     # create a viewer with a fake t+2D image
-    viewer = napari.view_image(np.random.random((5, 200, 200)))
+    viewer = napari.view_image(image)
 
     # create an empty shapes layer initialized with
     # text set to display the box label

--- a/examples/bbox_annotator.py
+++ b/examples/bbox_annotator.py
@@ -57,8 +57,11 @@ def create_label_menu(shapes_layer, label_property, labels):
 
 
 with napari.gui_qt():
+    # create a viewer with a fake t+2D image
     viewer = napari.view_image(np.random.random((5, 200, 200)))
 
+    # create an empty shapes layer initialized with
+    # text set to display the box label
     text_kwargs = {
         'text': text_property,
         'size': text_size,
@@ -78,7 +81,7 @@ with napari.gui_qt():
         labels=box_annotations
     )
     # add the label selection gui to the viewer as a dock widget
-    viewer.window.add_dock_widget(label_widget, area='right')
+    viewer.window.add_dock_widget(label_widget, area='right', name='label_widget')
 
     # set the shapes layer mode to adding rectangles
     shapes.mode = 'add_rectangle'

--- a/examples/bbox_annotator.py
+++ b/examples/bbox_annotator.py
@@ -44,7 +44,7 @@ def create_label_menu(shapes_layer, label_property, labels):
     shapes_layer.events.current_properties.connect(update_label_menu)
 
     def label_changed(event):
-        """This is acallback that update the current properties on the Shapes layer
+        """This is a callback that update the current properties on the Shapes layer
         when the label menu selection changes
         """
         selected_label = event.value

--- a/examples/bbox_annotator.py
+++ b/examples/bbox_annotator.py
@@ -1,0 +1,83 @@
+import napari
+from magicgui.widgets import ComboBox, Container
+import numpy as np
+
+
+# set up the annotation values and text display properties
+box_annotations = ['person', 'sky', 'camera']
+text_property = 'box_label'
+text_color = 'green'
+text_size = 30
+
+# create the GUI for selecting the values
+def create_label_menu(shapes_layer, label_property, labels):
+    """Create a label menu widget that can be added to the napari viewer dock
+
+    Parameters:
+    -----------
+    shapes_layer : napari.layers.Shapes
+        a napari shapes layer
+    label_property : str
+        the name of the shapes property to use the displayed text
+    labels : List[str]
+        list of the possible text labels values.
+
+    Returns:
+    --------
+    label_widget : magicgui.widgets.Container
+        the container widget with the label combobox
+    """
+    # Create the label selection menu
+    label_menu = ComboBox(label='text label', choices=labels)
+    label_widget = Container(widgets=[label_menu])
+
+    def update_label_menu(event):
+        """This is a callback function that updates the label menu when
+        the current properties of the Shapes layer change
+        """
+        new_label = str(shapes_layer.current_properties[label_property][0])
+        if new_label != label_menu.value:
+            label_menu.value = new_label
+
+    shapes_layer.events.current_properties.connect(update_label_menu)
+
+    def label_changed(event):
+        """This is acallback that update the current properties on the Shapes layer
+        when the label menu selection changes
+        """
+        selected_label = event.value
+        current_properties = shapes_layer.current_properties
+        current_properties[label_property] = np.asarray([selected_label])
+        shapes_layer.current_properties = current_properties
+
+    label_menu.changed.connect(label_changed)
+
+    return label_widget
+
+
+with napari.gui_qt():
+    viewer = napari.view_image(np.random.random((5, 200, 200)))
+
+    text_kwargs = {
+        'text': text_property,
+        'size': text_size,
+        'color': text_color
+    }
+    shapes = viewer.add_shapes(
+        face_color='black',
+        properties={text_property: box_annotations},
+        text=text_kwargs,
+        ndim=3
+    )
+
+    # create the label section gui
+    label_widget = create_label_menu(
+        shapes_layer=shapes,
+        label_property=text_property,
+        labels=box_annotations
+    )
+    # add the label selection gui to the viewer as a dock widget
+    viewer.window.add_dock_widget(label_widget, area='right')
+
+    # set the shapes layer mode to adding rectangles
+    shapes.mode = 'add_rectangle'

--- a/examples/bbox_annotator.py
+++ b/examples/bbox_annotator.py
@@ -8,7 +8,7 @@ from skimage import data
 box_annotations = ['person', 'sky', 'camera']
 text_property = 'box_label'
 text_color = 'green'
-text_size = 30
+text_size = 20
 
 
 # create the GUI for selecting the values

--- a/examples/bbox_annotator.py
+++ b/examples/bbox_annotator.py
@@ -1,5 +1,5 @@
-import napari
 from magicgui.widgets import ComboBox, Container
+import napari
 import numpy as np
 
 
@@ -8,6 +8,7 @@ box_annotations = ['person', 'sky', 'camera']
 text_property = 'box_label'
 text_color = 'green'
 text_size = 30
+
 
 # create the GUI for selecting the values
 def create_label_menu(shapes_layer, label_property, labels):


### PR DESCRIPTION
# Description
As suggested by @jni in [this image.sc thread](https://forum.image.sc/t/bounding-box-annotations-with-text/46607/15?), this PR adds an example of using napari to annotate t+2D images with bounding boxes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# References
[image.sc post](https://forum.image.sc/t/bounding-box-annotations-with-text/46607/15?)

# How has this been tested?
- [x] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
