### PR TITLE
Add a button to Qt Error Notification to show tracebacks.

### DIFF
--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -88,5 +88,8 @@ def test_notification_error(mock_show, monkeypatch):
         notif = ErrorNotification(e)
 
     dialog = NapariQtNotification.from_notification(notif)
-    bttn = dialog.row2_widget.children()[2]
+    bttn = dialog.row2_widget.findChild(QPushButton)
     assert bttn.text() == 'View Traceback'
+    mock_show.assert_not_called()
+    bttn.click()
+    mock_show.assert_called_once()

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -7,6 +7,7 @@ from qtpy.QtWidgets import QPushButton
 
 from napari._qt.dialogs.qt_notification import NapariQtNotification
 from napari.utils.notifications import (
+    ErrorNotification,
     Notification,
     NotificationSeverity,
     notification_manager,
@@ -73,3 +74,19 @@ def test_notification_display(mock_show, severity, monkeypatch):
     dialog.toggle_expansion()
     assert not dialog.property('expanded')
     dialog.close()
+
+
+@patch('napari._qt.dialogs.qt_notification.QDialog.show')
+def test_notification_error(mock_show, monkeypatch):
+    from napari.utils.settings import SETTINGS
+
+    monkeypatch.delenv('NAPARI_CATCH_ERRORS', raising=False)
+    monkeypatch.setattr(SETTINGS.application, 'gui_notification_level', 'info')
+    try:
+        raise ValueError('error!')
+    except ValueError as e:
+        notif = ErrorNotification(e)
+
+    dialog = NapariQtNotification.from_notification(notif)
+    bttn = dialog.row2_widget.children()[2]
+    assert bttn.text() == 'View Traceback'

--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -21,6 +21,7 @@ from qtpy.QtWidgets import (
     QMainWindow,
     QPushButton,
     QSizePolicy,
+    QTextEdit,
     QVBoxLayout,
     QWidget,
 )
@@ -307,11 +308,38 @@ class NapariQtNotification(QDialog):
     def from_notification(
         cls, notification: Notification
     ) -> NapariQtNotification:
+
+        from ...utils.notifications import ErrorNotification
+
+        actions = notification.actions
+
+        if isinstance(notification, ErrorNotification):
+
+            def show_tb(parent):
+                tbdialog = QDialog(parent=parent.parent())
+                tbdialog.setModal(True)
+                # this is about the minimum width to not get rewrap
+                # and the minimum height to not have scrollbar
+                tbdialog.resize(650, 270)
+                tbdialog.setLayout(QVBoxLayout())
+
+                text = QTextEdit()
+                text.setHtml(notification.as_html())
+                text.setReadOnly(True)
+                tbdialog.layout().addWidget(text)
+                tbdialog.show()
+
+            actions = tuple(notification.actions) + (
+                (trans._('View Traceback'), show_tb),
+            )
+        else:
+            actions = notification.actions
+
         return cls(
             message=notification.message,
             severity=notification.severity,
             source=notification.source,
-            actions=notification.actions,
+            actions=actions,
         )
 
     @classmethod

--- a/napari/utils/notifications.py
+++ b/napari/utils/notifications.py
@@ -106,6 +106,17 @@ class ErrorNotification(Notification):
         super().__init__(msg, NotificationSeverity.ERROR, actions)
         self.exception = exception
 
+    def as_html(self):
+        from ._tracebacks import get_tb_formatter
+
+        fmt = get_tb_formatter()
+        exc_info = (
+            self.exception.__class__,
+            self.exception,
+            self.exception.__traceback__,
+        )
+        return fmt(exc_info, as_html=True)
+
     def __str__(self):
         from ._tracebacks import get_tb_formatter
 


### PR DESCRIPTION
And have the "View Traceback", button localized.

# Description

Make it easier to see traceback when using the GUI. 
Notification button now have a "View traceback", that will pop up a window showing the traceback

## Type of change

- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
