### PR TITLE
Fix some translation formatting.

### DIFF
--- a/napari/_qt/widgets/qt_dims_slider.py
+++ b/napari/_qt/widgets/qt_dims_slider.py
@@ -49,7 +49,7 @@ class QtDimSliderWidget(QWidget):
         self.play_button = None
         self.curslice_label = QLineEdit(self)
         self.curslice_label.setToolTip(
-            trans._('Current slice for axis {axis}'.format(axis=axis))
+            trans._('Current slice for axis {axis}').format(axis=axis)
         )
         # if we set the QIntValidator to actually reflect the range of the data
         # then an invalid (i.e. too large) index doesn't actually trigger the

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -100,38 +100,32 @@ class QtViewerButtons(QFrame):
         self.consoleButton = QtViewerPushButton(
             self.viewer,
             'console',
-            trans._(
-                "Open IPython terminal ({key1}-{key2}-C)".format(
-                    key1=KEY_SYMBOLS['Control'],
-                    key2=KEY_SYMBOLS['Shift'],
-                )
+            trans._("Open IPython terminal ({key1}-{key2}-C)").format(
+                key1=KEY_SYMBOLS['Control'],
+                key2=KEY_SYMBOLS['Shift'],
             ),
         )
         self.consoleButton.setProperty('expanded', False)
         self.rollDimsButton = QtViewerPushButton(
             self.viewer,
             'roll',
-            trans._(
-                "Roll dimensions order for display ({key}-E)".format(
-                    key=KEY_SYMBOLS['Control']
-                )
+            trans._("Roll dimensions order for display ({key}-E)").format(
+                key=KEY_SYMBOLS['Control']
             ),
             lambda: self.viewer.dims._roll(),
         )
         self.transposeDimsButton = QtViewerPushButton(
             self.viewer,
             'transpose',
-            trans._(
-                "Transpose displayed dimensions ({key}-T)".format(
-                    key=KEY_SYMBOLS['Control']
-                )
+            trans._("Transpose displayed dimensions ({key}-T)").format(
+                key=KEY_SYMBOLS['Control']
             ),
             lambda: self.viewer.dims._transpose(),
         )
         self.resetViewButton = QtViewerPushButton(
             self.viewer,
             'home',
-            trans._("Reset view ({key}-R)".format(key=KEY_SYMBOLS['Control'])),
+            trans._("Reset view ({key}-R)").format(key=KEY_SYMBOLS['Control']),
             lambda: self.viewer.reset_view(),
         )
 

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -36,7 +36,9 @@ class Theme(str):
         themes = available_themes()
         if value not in available_themes():
             raise ValueError(
-                trans._('must be one of {}'.format(", ".join(themes)))
+                trans._('must be one of {themes}').format(
+                    themes=", ".join(themes)
+                )
             )
 
         return value


### PR DESCRIPTION
I believe the call to format need to me outside the call for trans,
it make no sens  otherwise, say for example.

    trans._("Open file {file}".format(file=file))

.format() is called before trans, and there is no way for the
translation to provide translation for all the filenames,

Though in the opposite
    trans._("Open file {file}").format(file=file)

then the translation can provide the alternative:

    "Ouvrir le fichier {file}"

Which is then formatted.

This seem to be the same for KEY_SYMBOLS, the symbol depends on the
platform, and the user plaform, this I believe need to be translated
before formatting. If we want to translate thing like "Control",
"Space", "Shift" then those need to be done directly in the KEY_SYMBOLS,
like :

KEY_SYMBOLS = {
    'Shift': trans._('Shift'),
    ...
}

But not the other way around.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
