### PR TITLE
PR: Ensure Preferences dialog can only be opened once

### DIFF
--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -22,6 +22,7 @@ class PreferencesDialog(QDialog):
     """Preferences Dialog for Napari user settings."""
 
     resized = Signal(QSize)
+    closed = Signal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -66,6 +67,11 @@ class PreferencesDialog(QDialog):
 
         self.make_dialog()
         self._list.setCurrentRow(0)
+
+    def closeEvent(self, event):
+        """Override to emit signal."""
+        self.closed.emit()
+        super().closeEvent(event)
 
     def resizeEvent(self, event):
         """Override to emit signal."""

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -456,6 +456,8 @@ class Window:
             self._qt_window._preferences_dialog = win
             win.closed.connect(self._on_preferences_closed)
             win.show()
+        else:
+            self._qt_window._preferences_dialog.raise_()
 
     def _on_preferences_closed(self):
         """Reset preferences dialog variable."""

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -61,6 +61,7 @@ class _QtMainWindow(QMainWindow):
         self.setCentralWidget(center)
 
         self._maximized_flag = False
+        self._preferences_dialog = None
         self._preferences_dialog_size = QSize()
         self._status_bar = self.statusBar()
 
@@ -443,13 +444,22 @@ class Window:
 
     def _open_preferences(self):
         """Edit preferences from the menubar."""
-        win = PreferencesDialog(parent=self._qt_window)
-        win.resized.connect(self._qt_window._update_preferences_dialog_size)
+        if self._qt_window._preferences_dialog is None:
+            win = PreferencesDialog(parent=self._qt_window)
+            win.resized.connect(
+                self._qt_window._update_preferences_dialog_size
+            )
 
-        if self._qt_window._preferences_dialog_size:
-            win.resize(self._qt_window._preferences_dialog_size)
+            if self._qt_window._preferences_dialog_size:
+                win.resize(self._qt_window._preferences_dialog_size)
 
-        win.show()
+            self._qt_window._preferences_dialog = win
+            win.closed.connect(self._on_preferences_closed)
+            win.show()
+
+    def _on_preferences_closed(self):
+        """Reset preferences dialog variable."""
+        self._qt_window._preferences_dialog = None
 
     def _add_view_menu(self):
         """Add 'View' menu to app menubar."""


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousando words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Preferences dialog, should be opened once. Now we make sure that is the case.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
