### PR TITLE
Fix for constant warning when using label brush

### DIFF
--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -374,17 +374,6 @@ class QtLabelsControls(QtLayerControls):
         """
         self.layer.color_mode = self.colorModeComboBox.currentData()
 
-    def change_brush_shape(self, brush_shape):
-        """Change paintbrush shape of label layer.
-
-        Parameters
-        ----------
-        brush_shape : str
-            CIRCLE (default) uses circle paintbrush (case insensitive).
-            SQUARE uses square paintbrush (case insensitive).
-        """
-        self.layer.brush_shape = self.brushShapeComboBox.currentData()
-
     def _on_contour_change(self, event=None):
         """Receive layer model contour value change event and update spinbox.
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -595,7 +595,7 @@ class Labels(_image_base_class):
             )
             self.mouse_drag_callbacks.append(pick)
         elif mode == Mode.PAINT:
-            self.cursor = self.brush_shape
+            self.cursor = str(self._brush_shape)
             # Convert from brush size in data coordinates to
             # cursor size in world coordinates
             data2world_scale = np.mean(
@@ -619,7 +619,7 @@ class Labels(_image_base_class):
             )
             self.mouse_drag_callbacks.append(draw)
         elif mode == Mode.ERASE:
-            self.cursor = self.brush_shape
+            self.cursor = str(self._brush_shape)
             # Convert from brush size in data coordinates to
             # cursor size in world coordinates
             data2world_scale = np.mean(
@@ -944,7 +944,7 @@ class Labels(_image_base_class):
             calls.
         """
         shape = self.data.shape
-        if self.brush_shape == "square":
+        if str(self._brush_shape) == "square":
             brush_size_dims = [self.brush_size] * self.ndim
             if not self.n_dimensional and self.ndim > 2:
                 for i in self._dims_not_displayed:
@@ -966,7 +966,7 @@ class Labels(_image_base_class):
             )
             slice_coord = tuple(map(np.ravel, np.mgrid[slice_coord]))
             slice_coord = indices_in_shape(slice_coord, shape)
-        elif self.brush_shape == "circle":
+        elif str(self._brush_shape) == "circle":
             slice_coord = [int(np.round(c)) for c in coord]
             if not self.n_dimensional and self.ndim > 2:
                 coord = [coord[i] for i in self._dims_displayed]


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
Use private _brush_shape in order to avoid getting warning every time you want to use the label brush.
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousando words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
