### PR TITLE
Save last working directory

### DIFF
--- a/napari/_qt/dialogs/screenshot_dialog.py
+++ b/napari/_qt/dialogs/screenshot_dialog.py
@@ -27,6 +27,7 @@ class ScreenshotDialog(QFileDialog):
         save_function: Callable[[str], Any],
         parent=None,
         directory=str(Path.home()),
+        history=None,
     ):
         super().__init__(parent, trans._("Save screenshot"))
         self.setAcceptMode(QFileDialog.AcceptSave)
@@ -35,6 +36,7 @@ class ScreenshotDialog(QFileDialog):
             trans._("Image files (*.png *.bmp *.gif *.tif *.tiff)")
         )
         self.setDirectory(directory)
+        self.setHistory(history)
 
         self.save_function = save_function
 

--- a/napari/_qt/perf/qt_debug_menu.py
+++ b/napari/_qt/perf/qt_debug_menu.py
@@ -12,6 +12,7 @@ from qtpy.QtCore import QTimer
 from qtpy.QtWidgets import QAction, QFileDialog
 
 from ...utils import perf
+from ...utils.settings import SETTINGS
 from ...utils.translations import trans
 
 
@@ -95,7 +96,7 @@ class PerformanceSubMenu:
         filename, _ = QFileDialog.getSaveFileName(
             parent=viewer,
             caption=trans._('Record performance trace file'),
-            directory=viewer._last_visited_dir,
+            directory=SETTINGS.application.last_visited_dir,
             filter=trans._("Trace Files (*.json)"),
         )
         if filename:

--- a/napari/_qt/perf/qt_debug_menu.py
+++ b/napari/_qt/perf/qt_debug_menu.py
@@ -12,7 +12,7 @@ from qtpy.QtCore import QTimer
 from qtpy.QtWidgets import QAction, QFileDialog
 
 from ...utils import perf
-from ...utils.settings import SETTINGS
+from ...utils.history import get_save_history, update_save_history
 from ...utils.translations import trans
 
 
@@ -93,10 +93,13 @@ class PerformanceSubMenu:
         """Open Save As dialog to start recording a trace file."""
         viewer = self.main_window.qt_viewer
 
-        filename, _ = QFileDialog.getSaveFileName(
+        dlg = QFileDialog()
+        hist = get_save_history()
+        dlg.setHistory(hist)
+        filename, _ = dlg.getSaveFileName(
             parent=viewer,
             caption=trans._('Record performance trace file'),
-            directory=SETTINGS.application.last_visited_dir,
+            directory=hist[0],
             filter=trans._("Trace Files (*.json)"),
         )
         if filename:
@@ -108,6 +111,8 @@ class PerformanceSubMenu:
             # Schedule this to avoid bogus "MetaCall" event for the entire
             # time the file dialog was up.
             QTimer.singleShot(0, start_trace)
+
+            update_save_history(filename)
 
     def _start_trace(self, path: str):
         perf.timers.start_trace_file(path)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -3,7 +3,6 @@ Custom Qt widgets that serve as native objects that the public-facing elements
 wrap.
 """
 import inspect
-import os
 import sys
 import time
 from itertools import chain, repeat

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1203,10 +1203,14 @@ class Window:
     def _screenshot_dialog(self):
         """Save screenshot of current display with viewer, default .png"""
         dial = ScreenshotDialog(
-            self.screenshot, self.qt_viewer, self.qt_viewer._last_visited_dir
+            self.screenshot,
+            self.qt_viewer,
+            SETTINGS.application.last_visited_dir,
         )
         if dial.exec_():
-            self._last_visited_dir = os.path.dirname(dial.selectedFiles()[0])
+            SETTINGS.application.last_visited_dir = os.path.dirname(
+                dial.selectedFiles()[0]
+            )
 
     def _restart(self):
         """Restart the napari application."""

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -26,6 +26,7 @@ from qtpy.QtWidgets import (
 
 from .. import plugins
 from ..utils import config, perf
+from ..utils.history import get_save_history, update_save_history
 from ..utils.io import imsave
 from ..utils.misc import in_jupyter, running_as_bundled_app
 from ..utils.settings import SETTINGS
@@ -1202,15 +1203,11 @@ class Window:
 
     def _screenshot_dialog(self):
         """Save screenshot of current display with viewer, default .png"""
-        dial = ScreenshotDialog(
-            self.screenshot,
-            self.qt_viewer,
-            SETTINGS.application.last_visited_dir,
-        )
+        hist = get_save_history()
+        dial = ScreenshotDialog(self.screenshot, self.qt_viewer, hist[0], hist)
+
         if dial.exec_():
-            SETTINGS.application.last_visited_dir = os.path.dirname(
-                dial.selectedFiles()[0]
-            )
+            update_save_history(dial.selectedFiles()[0])
 
     def _restart(self):
         """Restart the napari application."""

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os.path
 import warnings
 from typing import TYPE_CHECKING, Optional
 
@@ -12,6 +11,12 @@ from qtpy.QtWidgets import QFileDialog, QSplitter, QVBoxLayout, QWidget
 from ..components.camera import Camera
 from ..components.layerlist import LayerList
 from ..utils import config, perf
+from ..utils.history import (
+    get_open_history,
+    get_save_history,
+    update_open_history,
+    update_save_history,
+)
 from ..utils.interactions import (
     ReadOnlyWrapper,
     mouse_move_callbacks,
@@ -21,7 +26,6 @@ from ..utils.interactions import (
 )
 from ..utils.io import imsave
 from ..utils.key_bindings import KeymapHandler
-from ..utils.settings import SETTINGS
 from ..utils.theme import get_theme
 from ..utils.translations import trans
 from .containers import QtLayerList
@@ -455,10 +459,13 @@ class QtViewer(QSplitter):
             raise OSError(trans._("Nothing to save"))
 
         msg = trans._("selected") if selected else trans._("all")
-        filename, _ = QFileDialog.getSaveFileName(
+        dlg = QFileDialog()
+        hist = get_save_history()
+        dlg.setHistory(hist)
+        filename, _ = dlg.getSaveFileName(
             parent=self,
             caption=trans._('Save {msg} layers', msg=msg),
-            directory=SETTINGS.application.last_visited_dir,  # home dir by default
+            directory=hist[0],  # home dir by default
         )
 
         if filename:
@@ -467,9 +474,7 @@ class QtViewer(QSplitter):
                 error_messages = "\n".join(
                     [str(x.message.args[0]) for x in wa]
                 )
-                SETTINGS.application.last_visited_dir = os.path.dirname(
-                    saved[0]
-                )
+                update_save_history(saved[0])
 
             if not saved:
                 raise OSError(
@@ -502,46 +507,53 @@ class QtViewer(QSplitter):
 
     def _screenshot_dialog(self):
         """Save screenshot of current display, default .png"""
-        dial = ScreenshotDialog(
-            self.screenshot, self, SETTINGS.application.last_visited_dir
-        )
+        hist = get_save_history()
+        dial = ScreenshotDialog(self.screenshot, self, hist[0], hist)
         if dial.exec_():
-            SETTINGS.application.last_visited_dir = dial.selectedFiles()[0]
+            update_save_history(dial.selectedFiles()[0])
 
     def _open_files_dialog(self):
         """Add files from the menubar."""
-        filenames, _ = QFileDialog.getOpenFileNames(
+        dlg = QFileDialog()
+        hist = get_open_history()
+        dlg.setHistory(hist)
+        filenames, _ = dlg.getOpenFileNames(
             parent=self,
             caption=trans._('Select file(s)...'),
-            directory=SETTINGS.application.last_visited_dir,  # home dir by default
+            directory=hist[0],
         )
+
         if (filenames != []) and (filenames is not None):
             self.viewer.open(filenames)
-            SETTINGS.application.last_visited_dir = filenames[0]
+            update_open_history(filenames[0])
 
     def _open_files_dialog_as_stack_dialog(self):
         """Add files as a stack, from the menubar."""
-        filenames, _ = QFileDialog.getOpenFileNames(
+        dlg = QFileDialog()
+        hist = get_open_history()
+        dlg.setHistory(hist)
+        filenames, _ = dlg.getOpenFileNames(
             parent=self,
             caption=trans._('Select files...'),
-            directory=SETTINGS.application.last_visited_dir,  # home dir by default
+            directory=hist[0],  # home dir by default
         )
         if (filenames != []) and (filenames is not None):
             self.viewer.open(filenames, stack=True)
-            SETTINGS.application.last_visited_dir = os.path.dirname(
-                filenames[0]
-            )
+            update_open_history(filenames[0])
 
     def _open_folder_dialog(self):
         """Add a folder of files from the menubar."""
-        folder = QFileDialog.getExistingDirectory(
+        dlg = QFileDialog()
+        hist = get_open_history()
+        dlg.setHistory(hist)
+        folder = dlg.getExistingDirectory(
             parent=self,
             caption=trans._('Select folder...'),
-            directory=SETTINGS.application.last_visited_dir,  # home dir by default
+            directory=hist[0],  # home dir by default
         )
         if folder not in {'', None}:
             self.viewer.open([folder])
-            SETTINGS.application.last_visited_dir = os.path.dirname(folder)
+            update_open_history(folder)
 
     def _toggle_chunk_outlines(self):
         """Toggle whether we are drawing outlines around the chunks."""

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -474,7 +474,6 @@ class QtViewer(QSplitter):
                 error_messages = "\n".join(
                     [str(x.message.args[0]) for x in wa]
                 )
-                update_save_history(saved[0])
 
             if not saved:
                 raise OSError(
@@ -485,6 +484,8 @@ class QtViewer(QSplitter):
                         error_messages=error_messages,
                     )
                 )
+            else:
+                update_save_history(saved[0])
 
     def screenshot(self, path=None):
         """Take currently displayed screen and convert to an image array.

--- a/napari/utils/history.py
+++ b/napari/utils/history.py
@@ -4,7 +4,13 @@ from ..utils.settings import SETTINGS
 
 
 def update_open_history(filename):
-    """Updates open history of files in settings."""
+    """Updates open history of files in settings.
+
+    Parameters
+    ----------
+    filename : str
+        New file being added to open history.
+    """
     folders = SETTINGS.application.open_history
     new_loc = os.path.dirname(filename)
     if new_loc in folders:
@@ -13,11 +19,16 @@ def update_open_history(filename):
         folders.insert(0, new_loc)
     folders = folders[0:10]
     SETTINGS.application.open_history = folders
-    # SETTINGS.application.last_opened_dir = folders[0]
 
 
 def update_save_history(filename):
-    """Updates save history of files in settings."""
+    """Updates save history of files in settings.
+
+    Parameters
+    ----------
+    filename : str
+        New file being added to save history.
+    """
     folders = SETTINGS.application.save_history
     new_loc = os.path.dirname(filename)
     if new_loc in folders:
@@ -26,13 +37,13 @@ def update_save_history(filename):
         folders.insert(0, new_loc)
     folders = folders[0:10]
     SETTINGS.application.save_history = folders
-    # SETTINGS.application.last_saved_dir = folders[0]
 
 
 def get_open_history():
     """A helper for history handling."""
     folders = SETTINGS.application.open_history
     folders = [f for f in folders if os.path.isdir(f)]
+
     return folders
 
 
@@ -40,4 +51,5 @@ def get_save_history():
     """A helper for history handling."""
     folders = SETTINGS.application.save_history
     folders = [f for f in folders if os.path.isdir(f)]
+
     return folders

--- a/napari/utils/history.py
+++ b/napari/utils/history.py
@@ -1,0 +1,43 @@
+import os
+
+from ..utils.settings import SETTINGS
+
+
+def update_open_history(filename):
+    """Updates open history of files in settings."""
+    folders = SETTINGS.application.open_history
+    new_loc = os.path.dirname(filename)
+    if new_loc in folders:
+        folders.insert(0, folders.pop(folders.index(new_loc)))
+    else:
+        folders.insert(0, new_loc)
+    folders = folders[0:10]
+    SETTINGS.application.open_history = folders
+    # SETTINGS.application.last_opened_dir = folders[0]
+
+
+def update_save_history(filename):
+    """Updates save history of files in settings."""
+    folders = SETTINGS.application.save_history
+    new_loc = os.path.dirname(filename)
+    if new_loc in folders:
+        folders.insert(0, folders.pop(folders.index(new_loc)))
+    else:
+        folders.insert(0, new_loc)
+    folders = folders[0:10]
+    SETTINGS.application.save_history = folders
+    # SETTINGS.application.last_saved_dir = folders[0]
+
+
+def get_open_history():
+    """A helper for history handling."""
+    folders = SETTINGS.application.open_history
+    folders = [f for f in folders if os.path.isdir(f)]
+    return folders
+
+
+def get_save_history():
+    """A helper for history handling."""
+    folders = SETTINGS.application.save_history
+    folders = [f for f in folders if os.path.isdir(f)]
+    return folders

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -1,6 +1,7 @@
 """Settings management.
 """
 
+import os
 from enum import Enum
 from pathlib import Path
 from typing import List, Tuple
@@ -248,7 +249,8 @@ class ApplicationSettings(BaseNapariSettings):
         NotificationSeverity.NONE
     )
 
-    last_visited_dir: str = str(Path.home())
+    open_history: List = [os.path.dirname(Path.home())]
+    save_history: List = [os.path.dirname(Path.home())]
 
     class Config:
         # Pydantic specific configuration
@@ -268,7 +270,8 @@ class ApplicationSettings(BaseNapariSettings):
             "window_statusbar",
             "gui_notification_level",
             "console_notification_level",
-            "last_visited_dir",
+            "open_history",
+            "save_history",
         ]
 
 

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -2,7 +2,8 @@
 """
 
 from enum import Enum
-from typing import Tuple
+from pathlib import Path
+from typing import List, Tuple
 
 from pydantic import BaseSettings, Field
 
@@ -247,6 +248,8 @@ class ApplicationSettings(BaseNapariSettings):
         NotificationSeverity.NONE
     )
 
+    last_visited_dir: str = str(Path.home())
+
     class Config:
         # Pydantic specific configuration
         title = trans._("Application")
@@ -265,6 +268,7 @@ class ApplicationSettings(BaseNapariSettings):
             "window_statusbar",
             "gui_notification_level",
             "console_notification_level",
+            "last_visited_dir",
         ]
 
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
When opening or saving files, the last directory you saved to or opened from will be the directory you start from the next time you open an `open` or `save` file dialog.  

The most recent history seems to already be there in the recent places list on mac without using setHistory:
<img width="869" alt="Screen Shot 2021-03-24 at 6 55 24 PM" src="https://user-images.githubusercontent.com/54282105/112398566-80642680-8cd2-11eb-9704-07b79c2c3d8a.png">

Work from issue:
https://github.com/napari/product-heuristics-2020/issues/32

<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousando words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
