### PR TITLE
Extend release notes: Add breaking API changes in 0.4.7

### DIFF
--- a/docs/release/release_0_4_6.md
+++ b/docs/release/release_0_4_6.md
@@ -64,7 +64,11 @@ package name, url, or local file (#2319).
 - The ViewerModel is now a Pydantic BaseModel and so subclassing the Viewer might require
 reading some of the [Pydantic BaseModel documentation](https://pydantic-docs.helpmanual.io/usage/models/).
 Otherwise the API of the ViewerModel is unchanged.
-- If a magicgui-annotated function took an `napari.layers.Image` as parameter, this included `napari.layers.Labels` layers. Starting with 0.4.6, developers have to change the accepted parameter type to `napari.layers.Layer` if they want to consume images and labels. Note: in this way, also other layers will show up in the magicgui-generated pulldown. 
+- Because `Labels` no longer inherit from `Image` (#2307), magicgui function
+  parameters annotated as `napari.layers.Image` will no longer include
+  `napari.layers.Labels` layer types in the dropdown menu. (`napari.layers.Layer`
+  may still be used to show all layer types in the magicgui-generated dropdown
+  menu.)
 
 ## Build Tools and Support
 - Add missing release notes 0.4.5 (#2250)

--- a/docs/release/release_0_4_6.md
+++ b/docs/release/release_0_4_6.md
@@ -64,6 +64,7 @@ package name, url, or local file (#2319).
 - The ViewerModel is now a Pydantic BaseModel and so subclassing the Viewer might require
 reading some of the [Pydantic BaseModel documentation](https://pydantic-docs.helpmanual.io/usage/models/).
 Otherwise the API of the ViewerModel is unchanged.
+- If a magicgui-annotated function took an `napari.layers.Image` as parameter, this included `napari.layers.Labels` layers. Starting with 0.4.6, developers have to change the accepted parameter type to `napari.layers.Layer` if they want to consume images and labels. Note: in this way, also other layers will show up in the magicgui-generated pulldown. 
 
 ## Build Tools and Support
 - Add missing release notes 0.4.5 (#2250)

--- a/docs/release/release_0_4_7.md
+++ b/docs/release/release_0_4_7.md
@@ -122,7 +122,6 @@ See below for the full list of changes.
   version. Instead, use `layer.get_status(viewer.cursor.position, world=True)`
   (#2443).
 - Label-layers must be of integer type, float `Labels` layers are no longer allowed (see #2491)
-- If a magicgui-annotated function took an `napari.layers.Image` as parameter, this included `napari.layers.Labels` layers. Starting with 0.4.7, developers have to change the accepted parameter type to `napari.layers.Layer` if they want to consume images and labels.  
 
 ## Deprecations
 

--- a/docs/release/release_0_4_7.md
+++ b/docs/release/release_0_4_7.md
@@ -121,6 +121,8 @@ See below for the full list of changes.
 - `layer.status` was deprecated in version 0.4.4 and is removed in this
   version. Instead, use `layer.get_status(viewer.cursor.position, world=True)`
   (#2443).
+- Label-layers must be of integer type, float `Labels` layers are no longer allowed (see #2491)
+- If a magicgui-annotated function took an `napari.layers.Image` as parameter, this included `napari.layers.Labels` layers. Starting with 0.4.7, developers have to change the accepted parameter type to `napari.layers.Layer` if they want to consume images and labels.  
 
 ## Deprecations
 


### PR DESCRIPTION
# Description
Adds two points to the list of breaking API changes. 

## Type of change
- [x] This change ~requires~ is a documentation update

# References
closes #2492 

# How has this been tested?
not

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] no code changed