### PR TITLE
Fix labels data setter

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -85,6 +85,7 @@ def test_changing_labels():
     """Test changing Labels data."""
     shape_a = (10, 15)
     shape_b = (20, 12)
+    shape_c = (10, 10)
     np.random.seed(0)
     data_a = np.random.randint(20, size=shape_a)
     data_b = np.random.randint(20, size=shape_b)
@@ -94,6 +95,14 @@ def test_changing_labels():
     assert layer.ndim == len(shape_b)
     np.testing.assert_array_equal(layer.extent.data[1] + 1, shape_b)
     assert layer._data_view.shape == shape_b[-2:]
+
+    data_c = np.zeros(shape_c, dtype=bool)
+    layer.data = data_c
+    assert np.issubdtype(layer.data.dtype, np.integer)
+
+    data_c = data_c.astype(np.float32)
+    with pytest.raises(TypeError):
+        layer.data = data_c
 
 
 def test_changing_labels_dims():

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -3,6 +3,7 @@ import itertools
 import numpy as np
 import pytest
 import xarray as xr
+from numpy.core.numerictypes import issubdtype
 from skimage import data
 
 from napari._tests.utils import check_layer_world_data_extent
@@ -55,19 +56,29 @@ def test_3D_labels():
 
 def test_float_labels():
     """Test instantiating labels layer with floats"""
-    shape = (10, 10)
     np.random.seed(0)
-    data = np.random.uniform(0, 20, size=shape)
-    with pytest.warns(UserWarning):
-        layer = Labels(data)
-        assert np.issubdtype(layer.data.dtype, np.integer)
+    data = np.random.uniform(0, 20, size=(10, 10))
+    with pytest.raises(TypeError):
+        Labels(data)
 
     data0 = np.random.uniform(20, size=(20, 20))
     data1 = data0[::2, ::2].astype(np.int32)
     data = [data0, data1]
-    with pytest.warns(UserWarning):
-        layer = Labels(data)
-        assert all(np.issubdtype(d.dtype, np.integer) for d in layer.data)
+    with pytest.raises(TypeError):
+        Labels(data)
+
+
+def test_bool_labels():
+    """Test instantiating labels layer with bools"""
+    data = np.zeros((10, 10), dtype=bool)
+    layer = Labels(data)
+    assert issubdtype(layer.data.dtype, np.integer)
+
+    data0 = np.zeros((20, 20), dtype=bool)
+    data1 = data0[::2, ::2].astype(np.int32)
+    data = [data0, data1]
+    layer = Labels(data)
+    assert all(issubdtype(d.dtype, np.integer) for d in layer.data)
 
 
 def test_changing_labels():

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -396,8 +396,8 @@ class Labels(_image_base_class):
             if np.issubdtype(data_level.dtype, np.floating):
                 raise TypeError(
                     trans._(
-                        "Only integer types are supported for Labels layers, but data contains {}."
-                    ).format(data_level.dtype)
+                        "Only integer types are supported for Labels layers, but data contains {data_level_type}."
+                    ).format(data_level_type=data_level.dtype)
                 )
             if data_level.dtype == bool:
                 int_data.append(data_level.astype(np.int8))

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -387,20 +387,22 @@ class Labels(_image_base_class):
         self.color_mode = color_mode
 
     def _ensure_int_labels(self, data):
-        """Ensure data is integer by converting from bool if required, raising an error otherwise"""
+        """Ensure data is integer by converting from bool if required, raising an error otherwise."""
         looks_multiscale, data = guess_multiscale(data)
         if not looks_multiscale:
             data = [data]
         int_data = []
-        for d in data:
-            if np.issubdtype(d.dtype, np.floating):
+        for data_level in data:
+            if np.issubdtype(data_level.dtype, np.floating):
                 raise TypeError(
-                    f"Only integer types are supported for Labels layers, but data contains {d.dtype}."
+                    trans._(
+                        "Only integer types are supported for Labels layers, but data contains {}."
+                    ).format(data_level.dtype)
                 )
-            if d.dtype == bool:
-                int_data.append(d.astype(np.int8))
+            if data_level.dtype == bool:
+                int_data.append(data_level.astype(np.int8))
             else:
-                int_data.append(d)
+                int_data.append(data_level)
         data = int_data
         if not looks_multiscale:
             data = data[0]

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -331,6 +331,19 @@ class Labels(_image_base_class):
         self.events.selected_label()
 
     @property
+    def data(self):
+        """array: Image data."""
+        return self._data
+
+    @data.setter
+    def data(self, data):
+        data = self._ensure_int_labels(data)
+        self._data = data
+        self._update_dims()
+        self.events.data(value=self.data)
+        self._set_editable()
+
+    @property
     def properties(self) -> Dict[str, np.ndarray]:
         """dict {str: array (N,)}, DataFrame: Properties for each label."""
         return self._properties


### PR DESCRIPTION
# Description
Add labels data setter that ensures labels are either `bools` or `ints`, otherwise raises `TypeError`.
Add tests both for initialising layers with float/bool data and for setting the data.

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #2491 