### PR TITLE
Move plugin sorter

### DIFF
--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -139,7 +139,7 @@ class PreferencesDialog(QDialog):
         """Restores the settings in place when dialog was launched."""
         # Need to check differences for each page.
         for n in range(self._stack.count()):
-            # Must set the current row so that the proper set list is updated
+            # Must set the current row so that the proper list is updated
             # in check differences.
             self._list.setCurrentRow(n)
             page = self._list.currentItem().text().split(" ")[0].lower()
@@ -147,6 +147,7 @@ class PreferencesDialog(QDialog):
                 self._values_orig_dict[page],
                 self._values_dict[page],
             )
+
         self._list.setCurrentRow(0)
         self.close()
 

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -83,6 +83,7 @@ class PreferencesDialog(QDialog):
 
     def make_dialog(self):
         """Removes settings not to be exposed to user and creates dialog pages."""
+
         # Because there are multiple pages, need to keep a dictionary of values dicts.
         # One set of keywords are for each page, then in each entry for a page, there are dicts
         # of setting and its value.
@@ -114,7 +115,7 @@ class PreferencesDialog(QDialog):
         Returns
         -------
         schema : dict
-            Json schema of the setting page
+            Json schema of the setting page.
         values : dict
             Dictionary of values currently set for each parameter in the settings.
         properties : dict
@@ -228,10 +229,10 @@ class PreferencesDialog(QDialog):
 
         Parameters
         ----------
-        new_dict: dict
+        new_dict : dict
             Dict that has the most recent changes by user. Each key is a setting value
             and each item is the value.
-        old_dict: dict
+        old_dict : dict
             Dict wtih values set at the begining of preferences dialog session.
 
         """
@@ -249,11 +250,11 @@ class PreferencesDialog(QDialog):
 
         Parameters
         ----------
-        new_dict: dict
-            Dict that has the most recent changes by user. Each key is a setting value
+        new_dict : dict
+            Dict that has the most recent changes by user. Each key is a setting parameter
             and each item is the value.
-        old_dict: dict
-            Dict wtih values set at the begining of preferences dialog session.
+        old_dict : dict
+            Dict wtih values set at the beginning of the preferences dialog session.
         """
         page = self._list.currentItem().text().split(" ")[0].lower()
         self._values_changed(page, new_dict, old_dict)

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -21,7 +21,7 @@ class PreferencesDialog(QDialog):
     """Preferences Dialog for Napari user settings."""
 
     ui_schema = {
-        "plugins_call_order": {"ui:widget": "plugins"},
+        "call_order": {"ui:widget": "plugins"},
     }
 
     resized = Signal(QSize)

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -83,7 +83,9 @@ class PreferencesDialog(QDialog):
 
     def make_dialog(self):
         """Removes settings not to be exposed to user and creates dialog pages."""
-        # Because there are multiple pages, need to keep a list of values sets.
+        # Because there are multiple pages, need to keep a dictionary of values dicts.
+        # One set of keywords are for each page, then in each entry for a page, there are dicts
+        # of setting and its value.
         self._values_orig_dict = {}
         self._values_dict = {}
         self._setting_changed_dict = {}
@@ -193,7 +195,17 @@ class PreferencesDialog(QDialog):
         return form
 
     def _values_changed(self, page, new_dict, old_dict):
-        """"""
+        """Loops through each setting in a page to determine if it changed.
+
+        Parameters
+        ----------
+        new_dict: dict
+            Dict that has the most recent changes by user. Each key is a setting value
+            and each item is the value.
+        old_dict: dict
+            Dict wtih values set at the begining of preferences dialog session.
+
+        """
         for setting_name, value in new_dict.items():
             if value != old_dict[setting_name]:
                 self._setting_changed_dict[page][setting_name] = value
@@ -208,11 +220,11 @@ class PreferencesDialog(QDialog):
 
         Parameters
         ----------
-        new_list : list
-            The list of new values, with tuples of key value pairs for each
-            setting.
-        values_list : list
-            The old list of values.
+        new_dict: dict
+            Dict that has the most recent changes by user. Each key is a setting value
+            and each item is the value.
+        old_dict: dict
+            Dict wtih values set at the begining of preferences dialog session.
         """
         page = self._list.currentItem().text().split(" ")[0].lower()
         self._values_changed(page, new_dict, old_dict)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -23,6 +23,8 @@ from qtpy.QtWidgets import (
 )
 
 from .. import plugins
+
+# from ..plugins import load_plugin_manager_settings
 from ..utils import config, perf
 from ..utils.io import imsave
 from ..utils.misc import in_jupyter
@@ -64,6 +66,10 @@ class _QtMainWindow(QMainWindow):
         self._preferences_dialog = None
         self._preferences_dialog_size = QSize()
         self._status_bar = self.statusBar()
+
+        plugins.load_plugin_manager_settings(
+            SETTINGS.plugins.plugins_call_order
+        )
 
     def _load_window_settings(self):
         """

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -23,8 +23,6 @@ from qtpy.QtWidgets import (
 )
 
 from .. import plugins
-
-# from ..plugins import load_plugin_manager_settings
 from ..utils import config, perf
 from ..utils.io import imsave
 from ..utils.misc import in_jupyter
@@ -40,8 +38,6 @@ from .qt_event_loop import NAPARI_ICON_PATH, get_app, quit_app
 from .qt_resources import get_stylesheet
 from .qt_viewer import QtViewer
 from .utils import QImg2array, qbytearray_to_str, str_to_qbytearray
-
-# from .widgets.qt_plugin_sorter import QtPluginSorter
 from .widgets.qt_viewer_dock_widget import QtViewerDockWidget
 
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -67,6 +67,9 @@ class _QtMainWindow(QMainWindow):
         # set SETTINGS plugin defaults.
         plugins.load_settings_plugin_defaults(SETTINGS)
 
+        # set the values in plugins to match the ones saved in SETTINGS
+        plugins.plugin_manager.set_call_order(SETTINGS.plugins.call_order)
+
     def _load_window_settings(self):
         """
         Load window layout settings from configuration.

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -67,6 +67,9 @@ class _QtMainWindow(QMainWindow):
         self._preferences_dialog_size = QSize()
         self._status_bar = self.statusBar()
 
+        # set plugins defaults
+        plugins.load_settings_plugin_defaults(SETTINGS)
+
         plugins.load_plugin_manager_settings(
             SETTINGS.plugins.plugins_call_order
         )

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -40,7 +40,8 @@ from .qt_event_loop import NAPARI_ICON_PATH, get_app, quit_app
 from .qt_resources import get_stylesheet
 from .qt_viewer import QtViewer
 from .utils import QImg2array, qbytearray_to_str, str_to_qbytearray
-from .widgets.qt_plugin_sorter import QtPluginSorter
+
+# from .widgets.qt_plugin_sorter import QtPluginSorter
 from .widgets.qt_viewer_dock_widget import QtViewerDockWidget
 
 
@@ -634,14 +635,14 @@ class Window:
         pip_install_action.triggered.connect(self._show_plugin_install_dialog)
         self.plugins_menu.addAction(pip_install_action)
 
-        order_plugin_action = QAction(
-            trans._("Plugin Call Order..."), self._qt_window
-        )
-        order_plugin_action.setStatusTip(
-            trans._('Change call order for plugins')
-        )
-        order_plugin_action.triggered.connect(self._show_plugin_sorter)
-        self.plugins_menu.addAction(order_plugin_action)
+        # order_plugin_action = QAction(
+        #     trans._("Plugin Call Order..."), self._qt_window
+        # )
+        # order_plugin_action.setStatusTip(
+        #     trans._('Change call order for plugins')
+        # )
+        # order_plugin_action.triggered.connect(self._show_plugin_sorter)
+        # self.plugins_menu.addAction(order_plugin_action)
 
         report_plugin_action = QAction(
             trans._("Plugin Errors..."), self._qt_window
@@ -691,15 +692,15 @@ class Window:
 
         self.plugins_menu.addMenu(self._plugin_dock_widget_menu)
 
-    def _show_plugin_sorter(self):
-        """Show dialog that allows users to sort the call order of plugins."""
-        plugin_sorter = QtPluginSorter(parent=self._qt_window)
-        if hasattr(self, 'plugin_sorter_widget'):
-            self.plugin_sorter_widget.show()
-        else:
-            self.plugin_sorter_widget = self.add_dock_widget(
-                plugin_sorter, name=trans._('Plugin Sorter'), area="right"
-            )
+    # def _show_plugin_sorter(self):
+    #     """Show dialog that allows users to sort the call order of plugins."""
+    #     plugin_sorter = QtPluginSorter(parent=self._qt_window)
+    #     if hasattr(self, 'plugin_sorter_widget'):
+    #         self.plugin_sorter_widget.show()
+    #     else:
+    #         self.plugin_sorter_widget = self.add_dock_widget(
+    #             plugin_sorter, name=trans._('Plugin Sorter'), area="right"
+    #         )
 
     def _show_plugin_install_dialog(self):
         """Show dialog that allows users to sort the call order of plugins."""

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -70,10 +70,6 @@ class _QtMainWindow(QMainWindow):
         # set plugins defaults
         plugins.load_settings_plugin_defaults(SETTINGS)
 
-        plugins.load_plugin_manager_settings(
-            SETTINGS.plugins.plugins_call_order
-        )
-
     def _load_window_settings(self):
         """
         Load window layout settings from configuration.

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -68,7 +68,7 @@ class _QtMainWindow(QMainWindow):
         self._preferences_dialog_size = QSize()
         self._status_bar = self.statusBar()
 
-        # set plugins defaults
+        # set SETTINGS plugin defaults.
         plugins.load_settings_plugin_defaults(SETTINGS)
 
     def _load_window_settings(self):
@@ -635,15 +635,6 @@ class Window:
         pip_install_action.triggered.connect(self._show_plugin_install_dialog)
         self.plugins_menu.addAction(pip_install_action)
 
-        # order_plugin_action = QAction(
-        #     trans._("Plugin Call Order..."), self._qt_window
-        # )
-        # order_plugin_action.setStatusTip(
-        #     trans._('Change call order for plugins')
-        # )
-        # order_plugin_action.triggered.connect(self._show_plugin_sorter)
-        # self.plugins_menu.addAction(order_plugin_action)
-
         report_plugin_action = QAction(
             trans._("Plugin Errors..."), self._qt_window
         )
@@ -691,16 +682,6 @@ class Window:
                 action.triggered.connect(_add_widget)
 
         self.plugins_menu.addMenu(self._plugin_dock_widget_menu)
-
-    # def _show_plugin_sorter(self):
-    #     """Show dialog that allows users to sort the call order of plugins."""
-    #     plugin_sorter = QtPluginSorter(parent=self._qt_window)
-    #     if hasattr(self, 'plugin_sorter_widget'):
-    #         self.plugin_sorter_widget.show()
-    #     else:
-    #         self.plugin_sorter_widget = self.add_dock_widget(
-    #             plugin_sorter, name=trans._('Plugin Sorter'), area="right"
-    #         )
 
     def _show_plugin_install_dialog(self):
         """Show dialog that allows users to sort the call order of plugins."""

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -68,7 +68,8 @@ class _QtMainWindow(QMainWindow):
         plugins.load_settings_plugin_defaults(SETTINGS)
 
         # set the values in plugins to match the ones saved in SETTINGS
-        plugins.plugin_manager.set_call_order(SETTINGS.plugins.call_order)
+        if SETTINGS.plugins.call_order is not None:
+            plugins.plugin_manager.set_call_order(SETTINGS.plugins.call_order)
 
     def _load_window_settings(self):
         """

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -291,6 +291,12 @@ class QtViewer(QSplitter):
             )
             self.viewer.events.theme.connect(self.welcome._on_theme_change)
             self.canvas.events.resize.connect(self.welcome._on_canvas_change)
+            self.viewer.events.plugins_call_order.connect(
+                self._on_plugins_change
+            )
+
+    def _on_plugins_change(self):
+        print('change plugins!')
 
     def _create_performance_dock_widget(self):
         """Create the dock widget that shows performance metrics."""

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -291,12 +291,6 @@ class QtViewer(QSplitter):
             )
             self.viewer.events.theme.connect(self.welcome._on_theme_change)
             self.canvas.events.resize.connect(self.welcome._on_canvas_change)
-            self.viewer.events.plugins_call_order.connect(
-                self._on_plugins_change
-            )
-
-    def _on_plugins_change(self):
-        print('change plugins!')
 
     def _create_performance_dock_widget(self):
         """Create the dock widget that shows performance metrics."""

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -69,6 +69,11 @@ class ImplementationListItem(QFrame):
         unchecked, the opacity of the item is decreased.
     """
 
+    # Signal
+    on_changed = (
+        Signal()
+    )  # emitted when user changes whether plugin is enabled.
+
     def __init__(self, item: QListWidgetItem, parent: QWidget = None):
         super().__init__(parent)
         self.item = item
@@ -113,6 +118,7 @@ class ImplementationListItem(QFrame):
         """Set the enabled state of this hook implementation to ``state``."""
         self.item.hook_implementation.enabled = bool(state)
         self.opacity.setOpacity(1 if state else 0.5)
+        self.on_changed.emit()
 
     def update_position_label(self, order=None):
         """Update the label showing the position of this item in the list.
@@ -149,6 +155,9 @@ class QtHookImplementationListWidget(QListWidget):
     """
 
     order_changed = Signal(list)  # emitted when the user changes the order.
+    on_changed = (
+        Signal()
+    )  # emitted when user changes whether plugin is enabled.
 
     def __init__(
         self,
@@ -204,6 +213,7 @@ class QtHookImplementationListWidget(QListWidget):
         item.hook_implementation = hook_implementation
         self.addItem(item)
         widg = ImplementationListItem(item, parent=self)
+        widg.on_changed.connect(self.on_changed.emit)
         item.setSizeHint(widg.sizeHint())
         self.order_changed.connect(widg.update_position_label)
         self.setItemWidget(item, widg)
@@ -300,6 +310,7 @@ class QtPluginSorter(QWidget):
         self.hook_combo_box.currentIndexChanged.connect(self._on_hook_change)
         self.hook_list = QtHookImplementationListWidget(parent=self)
         self.hook_list.order_changed.connect(self._change_settings_plugins)
+        self.hook_list.on_changed.connect(self._change_settings_plugins)
 
         title = QLabel(trans._('Plugin Sorter'))
         title.setObjectName("h3")

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -167,15 +167,8 @@ class QtHookImplementationListWidget(QListWidget):
             QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding
         )
         self.order_changed.connect(self.permute_hook)
-        self.order_changed.connect(self._order_change)
         self.hook_caller: Optional[HookCaller] = None
         self.set_hook_caller(hook_caller)
-
-    def _order_change(self):
-        print('changing order!')
-        # set the new order in settings?
-        # SETTINGS.plugins.plugins_call_order = self.value()
-        # print(self.value())
 
     def set_hook_caller(self, hook_caller: Optional[HookCaller]):
         """Set the list widget to show hook implementations for ``hook_caller``.
@@ -300,30 +293,15 @@ class QtPluginSorter(QWidget):
 
         # populate comboBox with all of the hooks known by the plugin manager
 
-        self.setValue()
-        # for name, hook_caller in plugin_manager.hooks.items():
-        #     # only show hooks with specifications
-        #     if not hook_caller.spec:
-        #         continue
+        self.setWidgetValues()
 
-        #     if firstresult_only:
-        #         # if the firstresult_only option is set
-        #         # we only want to include hook_specifications that declare the
-        #         # "firstresult" option as True.
-        #         if not hook_caller.spec.opts.get('firstresult', False):
-        #             continue
-        #     self.hook_combo_box.addItem(
-        #         name.replace("napari_", ""), hook_caller
-        #     )
         self.hook_combo_box.setToolTip(
             trans._("select the hook specification to reorder")
         )
         self.hook_combo_box.currentIndexChanged.connect(self._on_hook_change)
         self.hook_list = QtHookImplementationListWidget(parent=self)
-        self.hook_list.order_changed.connect(self._change_plugins)
+        self.hook_list.order_changed.connect(self._change_settings_plugins)
 
-        print(self.hook_combo_box.currentText())
-        print(self.hook_combo_box.count())
         title = QLabel(trans._('Plugin Sorter'))
         title.setObjectName("h3")
 
@@ -359,9 +337,8 @@ class QtPluginSorter(QWidget):
         if initial_hook is not None:
             self.set_hookname(initial_hook)
 
-    def _change_plugins(self):
-        print('changing order again!')
-        # set the new order in settings?
+    def _change_settings_plugins(self):
+        """"""
         SETTINGS.plugins.plugins_call_order = self.value()
 
     def set_hookname(self, hook: str):
@@ -404,9 +381,8 @@ class QtPluginSorter(QWidget):
                 'plugins_call_order',
                 self.value(),
             )
-            print('setting defaults')
 
-    def setValue(self):
+    def setWidgetValues(self):
         """"""
         # set value of the plugin sorter widget to the value saved in settings.
 

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -292,7 +292,6 @@ class QtPluginSorter(QWidget):
         self.firstresult_only = firstresult_only
 
         # populate comboBox with all of the hooks known by the plugin manager
-
         self.setWidgetValues()
 
         self.hook_combo_box.setToolTip(
@@ -338,7 +337,7 @@ class QtPluginSorter(QWidget):
             self.set_hookname(initial_hook)
 
     def _change_settings_plugins(self):
-        """"""
+        """Update settings if plugin call order changes."""
         SETTINGS.plugins.plugins_call_order = self.value()
 
     def set_hookname(self, hook: str):
@@ -374,7 +373,9 @@ class QtPluginSorter(QWidget):
         self._on_hook_change(self.hook_combo_box.currentIndex())
 
     def set_setting_default_value(self):
-        """"""
+        """On start up, this function is used to set the defaults in settings.
+        Note: use before loading in the saved settings.
+        """
         if SETTINGS._defaults["plugins"].plugins_call_order is None:
             setattr(
                 SETTINGS._defaults['plugins'],
@@ -383,9 +384,9 @@ class QtPluginSorter(QWidget):
             )
 
     def setWidgetValues(self):
-        """"""
-        # set value of the plugin sorter widget to the value saved in settings.
+        """Set the lists in the QtPluginSorter to match the order saved in settings."""
 
+        # Set the values in the plugin manager to match the settings order.
         plugins.load_plugin_manager_settings(
             SETTINGS.plugins.plugins_call_order
         )
@@ -406,13 +407,14 @@ class QtPluginSorter(QWidget):
             )
 
     def value(self):
-        """
-        state = (
-            ("get_writer", "svg", True),
-            ("get_writer", "builtins", True)
-            ("get_reader", "svg", True),
+        """Get the plugin_sort_order for settings from the order in the plugin manager.
+
+        state = [
+            ("napari_get_writer", "svg", True),
+            ("napari_get_writer", "builtins", True)
+            ("napari_get_reader", "svg", True),
             ...
-        )
+        ]
         """
         plugin_sort_order = []
         for name, hook_caller in self.plugin_manager.hooks.items():

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -411,7 +411,8 @@ class QtPluginSorter(QWidget):
 
     def setWidgetValues(self):
         """Set the values in the plugin manager to match the settings order."""
-        plugins.plugin_manager.set_call_order(SETTINGS.plugins.call_order)
+        if SETTINGS.plugins.call_order is not None:
+            plugins.plugin_manager.set_call_order(SETTINGS.plugins.call_order)
 
     def value(self):
         """Returns the call order from the plugin manager.

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -70,10 +70,7 @@ class ImplementationListItem(QFrame):
         unchecked, the opacity of the item is decreased.
     """
 
-    # Signal
-    on_changed = (
-        Signal()
-    )  # emitted when user changes whether plugin is enabled.
+    on_changed = Signal()  # when user changes whether plugin is enabled.
 
     def __init__(self, item: QListWidgetItem, parent: QWidget = None):
         super().__init__(parent)

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -3,7 +3,6 @@
 import re
 from typing import List, Optional, Union
 
-from ...plugins import PluginManager
 from napari_plugin_engine import HookCaller, HookImplementation
 from qtpy.QtCore import QEvent, Qt, Signal, Slot
 from qtpy.QtWidgets import (
@@ -21,6 +20,7 @@ from qtpy.QtWidgets import (
 )
 
 from ... import plugins
+from ...plugins import PluginManager
 from ...plugins import plugin_manager as napari_plugin_manager
 from ...utils.settings import SETTINGS
 from ...utils.translations import trans
@@ -365,7 +365,7 @@ class QtPluginSorter(QWidget):
     def _change_settings_plugins(self):
         """Update settings if plugin call order changes."""
         SETTINGS.plugins.call_order = self.plugin_manager.call_order()
-    
+
     def set_hookname(self, hook: str):
         """Change the hook specification shown in the list widget.
 
@@ -412,16 +412,14 @@ class QtPluginSorter(QWidget):
     def setWidgetValues(self):
         """Set the values in the plugin manager to match the settings order."""
         plugins.plugin_manager.set_call_order(SETTINGS.plugins.call_order)
-    
 
     def value(self):
         """Returns the call order from the plugin manager.
 
-            Returns
-            -------
-            call_order : CallOrderDict
+        Returns
+        -------
+        call_order : CallOrderDict
 
         """
-
 
         return plugins.plugin_manager.call_order()

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -302,7 +302,6 @@ class QtPluginSorter(QWidget):
         self.hook_combo_box.addItem(self.NULL_OPTION, None)
 
         # populate comboBox with all of the hooks known by the plugin manager
-        self.setWidgetValues()
 
         for name, hook_caller in plugin_manager.hooks.items():
             # only show hooks with specifications
@@ -408,11 +407,6 @@ class QtPluginSorter(QWidget):
                 'call_order',
                 self.plugin_manager.call_order(),
             )
-
-    def setWidgetValues(self):
-        """Set the values in the plugin manager to match the settings order."""
-        if SETTINGS.plugins.call_order is not None:
-            plugins.plugin_manager.set_call_order(SETTINGS.plugins.call_order)
 
     def value(self):
         """Returns the call order from the plugin manager.

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -153,9 +153,7 @@ class QtHookImplementationListWidget(QListWidget):
     """
 
     order_changed = Signal(list)  # emitted when the user changes the order.
-    on_changed = (
-        Signal()
-    )  # emitted when user changes whether plugin is enabled.
+    on_changed = Signal()  # when user changes whether plugin is enabled.
 
     def __init__(
         self,

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/defaults.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/defaults.py
@@ -7,7 +7,9 @@ def enum_defaults(schema):
 
 def object_defaults(schema):
     if "properties" in schema:
-        return {k: compute_defaults(s) for k, s in schema["properties"].items()}
+        return {
+            k: compute_defaults(s) for k, s in schema["properties"].items()
+        }
     else:
         return None
 

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/defaults.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/defaults.py
@@ -6,7 +6,10 @@ def enum_defaults(schema):
 
 
 def object_defaults(schema):
-    return {k: compute_defaults(s) for k, s in schema["properties"].items()}
+    if "properties" in schema:
+        return {k: compute_defaults(s) for k, s in schema["properties"].items()}
+    else:
+        return None
 
 
 def array_defaults(schema):
@@ -26,7 +29,6 @@ def compute_defaults(schema):
         return enum_defaults(schema)
 
     schema_type = schema["type"]
-
     if schema_type == "object":
         return object_defaults(schema)
 

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/form.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/form.py
@@ -25,6 +25,7 @@ class WidgetBuilder:
         "object": {
             "object": widgets.ObjectSchemaWidget,
             "enum": widgets.EnumSchemaWidget,
+            "plugins": widgets.PluginWidget
         },
         "number": {
             "spin": widgets.SpinDoubleSchemaWidget,
@@ -115,9 +116,7 @@ class WidgetBuilder:
 
         widget_variant = ui_schema.get('ui:widget', default_variant)
         widget_cls = self.widget_map[schema_type][widget_variant]
-
         widget = widget_cls(schema, ui_schema, self)
-
         default_state = get_widget_state(schema, state)
         if default_state is not None:
             widget.state = default_state

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/form.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/form.py
@@ -25,7 +25,7 @@ class WidgetBuilder:
         "object": {
             "object": widgets.ObjectSchemaWidget,
             "enum": widgets.EnumSchemaWidget,
-            "plugins": widgets.PluginWidget
+            "plugins": widgets.PluginWidget,
         },
         "number": {
             "spin": widgets.SpinDoubleSchemaWidget,
@@ -49,7 +49,7 @@ class WidgetBuilder:
         "array": {
             "array": widgets.ArraySchemaWidget,
             "enum": widgets.EnumSchemaWidget,
-            "plugins": widgets.PluginWidget
+            "plugins": widgets.PluginWidget,
         },
     }
 
@@ -80,17 +80,16 @@ class WidgetBuilder:
         validator_cls.check_schema(schema)
         validator = validator_cls(schema)
         schema_widget = self.create_widget(schema, ui_schema, state)
-       
+
         form = widgets.FormWidget(schema_widget)
 
         def validate(data):
             form.clear_errors()
-           
+
             errors = [*validator.iter_errors(data)]
 
             if errors:
                 form.display_errors(errors)
-               
 
             for err in errors:
                 schema_widget.handle_error(err.path, err)

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/form.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/form.py
@@ -25,7 +25,6 @@ class WidgetBuilder:
         "object": {
             "object": widgets.ObjectSchemaWidget,
             "enum": widgets.EnumSchemaWidget,
-            "plugins": widgets.PluginWidget
         },
         "number": {
             "spin": widgets.SpinDoubleSchemaWidget,

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/form.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/form.py
@@ -25,6 +25,7 @@ class WidgetBuilder:
         "object": {
             "object": widgets.ObjectSchemaWidget,
             "enum": widgets.EnumSchemaWidget,
+            "plugins": widgets.PluginWidget
         },
         "number": {
             "spin": widgets.SpinDoubleSchemaWidget,
@@ -48,6 +49,7 @@ class WidgetBuilder:
         "array": {
             "array": widgets.ArraySchemaWidget,
             "enum": widgets.EnumSchemaWidget,
+            "plugins": widgets.PluginWidget
         },
     }
 

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/form.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/form.py
@@ -49,7 +49,6 @@ class WidgetBuilder:
         "array": {
             "array": widgets.ArraySchemaWidget,
             "enum": widgets.EnumSchemaWidget,
-            "plugins": widgets.PluginWidget,
         },
     }
 

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
@@ -522,7 +522,7 @@ class ObjectSchemaWidget(SchemaWidgetMixin, QtWidgets.QGroupBox):
 
         # Populate rows
         widgets = {}
-
+        layout.setFieldGrowthPolicy(QtWidgets.QFormLayout.FieldGrowthPolicy(1))
         for name, sub_schema in schema['properties'].items():
             sub_ui_schema = ui_schema.get(name, {})
             widget = widget_builder.create_widget(

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
@@ -131,9 +131,8 @@ class PluginWidget(SchemaWidgetMixin, QtPluginSorter):
         return None
         # self.setValue(state)
 
-
-    # def configure(self):
-    #     self.valueChanged.connect(self.on_changed.emit)
+    def configure(self):
+        self.hook_list.order_changed.connect(self.on_changed.emit)
 
 
 class SpinSchemaWidget(SchemaWidgetMixin, QtWidgets.QSpinBox):

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
@@ -6,6 +6,8 @@ from qtpy import QtCore, QtGui, QtWidgets
 from .signal import Signal
 from .utils import is_concrete_schema, iter_layout_widgets, state_property
 
+from ...._qt.widgets.qt_plugin_sorter import QtPluginSorter
+
 
 class SchemaWidgetMixin:
     on_changed = Signal()
@@ -118,6 +120,20 @@ class SpinDoubleSchemaWidget(SchemaWidgetMixin, QtWidgets.QDoubleSpinBox):
 
     def configure(self):
         self.valueChanged.connect(self.on_changed.emit)
+
+class PluginWidget(SchemaWidgetMixin, QtPluginSorter):
+    @state_property
+    def state(self) -> int:
+        return self.value()
+
+    @state.setter
+    def state(self, state: int):
+        return None
+        # self.setValue(state)
+
+
+    # def configure(self):
+    #     self.valueChanged.connect(self.on_changed.emit)
 
 
 class SpinSchemaWidget(SchemaWidgetMixin, QtWidgets.QSpinBox):

--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -17,9 +17,9 @@ from typing import (
 from warnings import warn
 
 from magicgui import magicgui
-from numpy import isin
 from napari_plugin_engine import HookImplementation
 from napari_plugin_engine import PluginManager as _PM
+from numpy import isin
 from typing_extensions import TypedDict
 
 from ..types import AugmentedWidget, LayerData, SampleDict
@@ -380,6 +380,7 @@ def available_samples() -> Tuple[Tuple[str, str], ...]:
 
 
 discover_sample_data()
+
 
 def load_settings_plugin_defaults(SETTINGS):
     """Sets SETTINGS plugin defaults on start up from the defaults saved in

--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -71,13 +71,19 @@ class PluginManager(_PM):
 
         """
 
-        return {
-            spec_name: [
-                {'plugin': impl.plugin_name, 'enabled': impl.enabled}
-                for impl in reversed(caller.get_hookimpls())
-            ]
-            for spec_name, caller in self.hooks.items()
-        }
+        order = {}
+        for spec_name, caller in self.hooks.items():
+            # no need to save call order unless we only use first result
+            if not caller.is_firstresult:
+                continue
+            impls = caller.get_hookimpls()
+            # no need to save call order if there is only a single item
+            if len(impls) > 1:
+                order[spec_name] = [
+                    {'plugin': impl.plugin_name, 'enabled': impl.enabled}
+                    for impl in reversed(impls)
+                ]
+        return order
 
     def set_call_order(self, new_order: CallOrderDict):
         """Sets the plugin manager call order to match SETTINGS plugin values.

--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -113,9 +113,8 @@ class PluginManager(_PM):
         """
 
         for spec_name, hook_caller in self.hooks.items():
-            spec_order = new_order.get(spec_name)
             order = []
-            for p in spec_order:
+            for p in new_order.get(spec_name, []):
                 order.append(p['plugin'])
                 hook_caller._set_plugin_enabled(p['plugin'], p['enabled'])
             if order:

--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -299,6 +299,21 @@ def available_samples() -> Tuple[Tuple[str, str], ...]:
 
 
 discover_sample_data()
+def load_settings_plugin_defaults(SETTINGS):
+    plugins_call_order = []
+    for name, hook_caller in plugin_manager.hooks.items():
+        for hook_implementation in reversed(hook_caller._nonwrappers):
+            plugins_call_order.append(
+                (
+                    name,
+                    hook_implementation.plugin_name,
+                    hook_implementation.enabled,
+                )
+            )
+
+    SETTINGS._defaults['plugins'].plugins_call_order = plugins_call_order
+
+
 def load_plugin_manager_settings(plugins_call_order):
     """
     plugins_call_order : tuple of tuples
@@ -308,6 +323,7 @@ def load_plugin_manager_settings(plugins_call_order):
         )
     """
     # plugins_call_order = SETTINGS.plugins.plugins_call_order
+
     if plugins_call_order is not None:
         # (("get_write", "svg", True), ("get_writer", "builtins", True))
         for name, hook_caller in plugin_manager.hooks.items():

--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -300,6 +300,9 @@ def available_samples() -> Tuple[Tuple[str, str], ...]:
 
 discover_sample_data()
 def load_settings_plugin_defaults(SETTINGS):
+    """Sets SETTINGS plugin defaults on start up from the defaults saved in
+    the plugin manager.
+    """
     plugins_call_order = []
     for name, hook_caller in plugin_manager.hooks.items():
         for hook_implementation in reversed(hook_caller._nonwrappers):
@@ -315,12 +318,17 @@ def load_settings_plugin_defaults(SETTINGS):
 
 
 def load_plugin_manager_settings(plugins_call_order):
-    """
-    plugins_call_order : tuple of tuples
-        (
+    """Sets the plugin call order in the plugin in manger to match what is saved in
+    SETTINGS.
+
+    Note: Run this after load_settings_plugin_defaults, which sets the default values in
+    SETTINGS.
+
+    plugins_call_order : List of tuples
+        [
             (spec_name, plugin_name, enabled),
             (spec_name, plugin_name, enabled),
-        )
+        ]
     """
     # plugins_call_order = SETTINGS.plugins.plugins_call_order
 

--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -299,6 +299,32 @@ def available_samples() -> Tuple[Tuple[str, str], ...]:
 
 
 discover_sample_data()
+def load_plugin_manager_settings(plugins_call_order):
+    """
+    plugins_call_order : tuple of tuples
+        (
+            (spec_name, plugin_name, enabled),
+            (spec_name, plugin_name, enabled),
+        )
+    """
+    # plugins_call_order = SETTINGS.plugins.plugins_call_order
+    if plugins_call_order is not None:
+        # (("get_write", "svg", True), ("get_writer", "builtins", True))
+        for name, hook_caller in plugin_manager.hooks.items():
+            # order: List of hook implementations
+            order = []
+            for spec_name, plugin_name, enabled in plugins_call_order:
+                for hook_implementation in reversed(hook_caller._nonwrappers):
+                    if (
+                        spec_name == name
+                        and hook_implementation.plugin_name == plugin_name
+                    ):
+                        hook_implementation.enabled = enabled
+                        order.append(hook_implementation)
+                if order:
+                    hook_caller.bring_to_front(order)
+
+
 #: Template to use for namespacing a plugin item in the menu bar
 menu_item_template = '{}: {}'
 

--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -45,7 +45,6 @@ CallOrderDict = Dict[str, List[PluginHookOption]]
 
 
 class PluginManager(_PM):
-    # replaces QtPluginSorter.values
     def call_order(self) -> CallOrderDict:
         """Returns the call order from the plugin manager.
 
@@ -82,7 +81,7 @@ class PluginManager(_PM):
         """Sets the plugin manager call order to match SETTINGS plugin values.
 
         Note: Run this after load_settings_plugin_defaults, which
-        sets the default values inSETTINGS.
+        sets the default values in SETTINGS.
 
         Parameters
         ----------

--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -3,7 +3,6 @@ import sys
 from inspect import signature
 from pathlib import Path
 from types import FunctionType
-from typing_extensions import TypedDict
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -21,6 +20,7 @@ from magicgui import magicgui
 from numpy import isin
 from napari_plugin_engine import HookImplementation
 from napari_plugin_engine import PluginManager as _PM
+from typing_extensions import TypedDict
 
 from ..types import AugmentedWidget, LayerData, SampleDict
 from ..utils._appdirs import user_site_packages
@@ -34,6 +34,7 @@ if sys.platform.startswith('linux') and running_as_bundled_app():
 if TYPE_CHECKING:
     from magicgui.widgets import FunctionGui
     from qtpy.QtWidgets import QWidget
+
 
 class PluginHookOption(TypedDict):
     plugin: str
@@ -51,22 +52,22 @@ class PluginManager(_PM):
         Returns
         -------
         call_order : CallOrderDict
-        call_order = 
+        call_order =
             {
                         spec_name: [
                                 {
                                     name: plugin_name
-                                    enabled: enabled 
+                                    enabled: enabled
                                 },
                                 {
                                     name: plugin_name
-                                    enabled: enabled 
+                                    enabled: enabled
                                 },
                                 ...
                         ],
                         ...
             }
-        
+
         """
 
         return {
@@ -80,29 +81,29 @@ class PluginManager(_PM):
     def set_call_order(self, new_order: CallOrderDict):
         """Sets the plugin manager call order to match SETTINGS plugin values.
 
-            Note: Run this after load_settings_plugin_defaults, which 
-            sets the default values inSETTINGS.
+        Note: Run this after load_settings_plugin_defaults, which
+        sets the default values inSETTINGS.
 
-            Parameters
-            ----------
-            new_order : CallOrderDict
+        Parameters
+        ----------
+        new_order : CallOrderDict
 
-            new_order = 
-                    {
-                        spec_name: [
-                                {
-                                    name: plugin_name
-                                    enabled: enabled 
-                                },
-                                {
-                                    name: plugin_name
-                                    enabled: enabled 
-                                },
-                                ...
-                        ],
-                        ...
-                    }
-            """
+        new_order =
+                {
+                    spec_name: [
+                            {
+                                name: plugin_name
+                                enabled: enabled
+                            },
+                            {
+                                name: plugin_name
+                                enabled: enabled
+                            },
+                            ...
+                    ],
+                    ...
+                }
+        """
 
         for spec_name, hook_caller in self.hooks.items():
             spec_order = new_order.get(spec_name)

--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -37,6 +37,8 @@ if TYPE_CHECKING:
 
 
 class PluginHookOption(TypedDict):
+    """Custom type specifying plugin and enabled state."""
+
     plugin: str
     enabled: bool
 

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -2,7 +2,7 @@
 """
 
 from enum import Enum
-from typing import Tuple
+from typing import Tuple, Dict
 
 from pydantic import BaseSettings, Field
 
@@ -11,6 +11,7 @@ from ..events.evented_model import EventedModel
 from ..notifications import NotificationSeverity
 from ..theme import available_themes
 from ..translations import _load_language, get_language_packs, trans
+from ...plugins import CallOrderDict
 
 
 class Theme(str):
@@ -197,11 +198,11 @@ class PluginsSettings(BaseNapariSettings):
 
     schema_version = (0, 1, 0)
 
-    plugins_call_order: list = Field(
+    call_order: CallOrderDict = Field(
         None,
         title=trans._("Plugin sort order"),
         description=trans._(
-            "Sort plugins for each action in the order to be called."
+            "Sort plugins for each action in the order to be called.",
         ),
     )
 

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -197,7 +197,7 @@ class PluginsSettings(BaseNapariSettings):
 
     schema_version = (0, 1, 0)
 
-    plugins_call_order: dict = Field(
+    plugins_call_order: list = Field(
         None,
         title=trans._("Plugin sort order"),
         description=trans._(
@@ -211,7 +211,7 @@ class PluginsSettings(BaseNapariSettings):
 
     class NapariConfig:
         # Napari specific configuration
-        preferences_exclude = ['schema_version', 'plugins_call_order']
+        preferences_exclude = ['schema_version']
 
 
 CORE_SETTINGS = [AppearanceSettings, ApplicationSettings, PluginsSettings]

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -2,16 +2,16 @@
 """
 
 from enum import Enum
-from typing import Tuple, Dict
+from typing import Tuple
 
 from pydantic import BaseSettings, Field
 
+from ...plugins import CallOrderDict
 from .._base import _DEFAULT_LOCALE
 from ..events.evented_model import EventedModel
 from ..notifications import NotificationSeverity
 from ..theme import available_themes
 from ..translations import _load_language, get_language_packs, trans
-from ...plugins import CallOrderDict
 
 
 class Theme(str):

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -2,7 +2,7 @@
 """
 
 from enum import Enum
-from typing import List, Tuple
+from typing import Tuple
 
 from pydantic import BaseSettings, Field
 
@@ -196,10 +196,13 @@ class PluginsSettings(BaseNapariSettings):
     """Plugins Settings."""
 
     schema_version = (0, 1, 0)
-    plugins_call_order: List[str] = Field(
-        [],
-        title=trans._("Plugin call order"),
-        description=trans._("Sort plugins call order"),
+
+    plugins_call_order: dict = Field(
+        None,
+        title=trans._("Plugin sort order"),
+        description=trans._(
+            "Sort plugins for each action in the order to be called."
+        ),
     )
 
     class Config:


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
This PR will move the plugin sorter to the preferences dialog.  With this move, the plugin sort order will now be saved in the settings and remembered from session to session. 
The plugin sorter can still be launched from the install plugins UI.

<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousando words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
