### PR TITLE
Add ability to run file as plugin

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from textwrap import wrap
 from typing import Any, Dict, List
 
-from . import __version__, layers, run, view_path
+from . import Viewer, __version__, layers, run, view_path
 from .components.viewer_model import valid_add_kwargs
 from .utils import citation_text, sys_info
 from .utils.settings import SETTINGS
@@ -33,7 +33,7 @@ class InfoAction(argparse.Action):
             names = {e.plugin_name for e in errors}
             print("\n‼️  Errors were detected in the following plugins:")
             print("(Run 'napari --plugin-info -v' for more details)")
-            print("\n".join([f"  - {n}" for n in names]))
+            print("\n".join(f"  - {n}" for n in names))
         sys.exit()
 
 
@@ -46,10 +46,10 @@ class PluginInfoAction(argparse.Action):
         discover_dock_widgets()
         print(plugin_manager)
 
-        verbose = '-v' in sys.argv or '--verbose' in sys.argv
         errors = plugin_manager.get_errors()
         if errors:
             print("‼️  Some errors occurred:")
+            verbose = '-v' in sys.argv or '--verbose' in sys.argv
             if not verbose:
                 print("   (use '-v') to show full tracebacks")
             print("-" * 38)
@@ -125,7 +125,8 @@ def validate_unknown_args(unknown: List[str]) -> Dict[str, Any]:
     return out
 
 
-def _run():
+def parse_sys_argv():
+    """Parse command line arguments."""
     kwarg_options = []
     for layer_type, keys in valid_add_kwargs().items():
         kwarg_options.append(f"  {layer_type.title()}:")
@@ -214,6 +215,13 @@ def _run():
             unknown.append(args.paths.pop(len(args.paths) - idx - 1))
     kwargs = validate_unknown_args(unknown) if unknown else {}
 
+    return args, kwargs
+
+
+def _run():
+    """Main program."""
+    args, kwargs = parse_sys_argv()
+
     # parse -v flags and set the appropriate logging level
     levels = [logging.WARNING, logging.INFO, logging.DEBUG]
     level = levels[min(2, args.verbose)]  # prevent index error
@@ -240,12 +248,21 @@ def _run():
         sys.argv.remove('--plugin')
 
     if any(p.endswith('.py') for p in args.paths):
+        # we're running a script
         if len(args.paths) > 1:
             sys.exit(
                 'When providing a python script, only a '
                 'single positional argument may be provided'
             )
-        runpy.run_path(args.paths[0])
+
+        # run the file
+        mod = runpy.run_path(args.paths[0])
+
+        from napari_plugin_engine.markers import HookImplementationMarker
+
+        # if this file had any hook implementations, register and run as plugin
+        if any(isinstance(i, HookImplementationMarker) for i in mod.values()):
+            _run_plugin_module(mod, os.path.basename(args.paths[0]))
 
     else:
         if args.with_:
@@ -289,6 +306,36 @@ def _run():
                 viewer.window.add_plugin_dock_widget(pname)
 
         run(gui_exceptions=True)
+
+
+def _run_plugin_module(mod, plugin_name):
+    """Register `mod` as a plugin, find/create viewer, and run napari."""
+    from .plugins import plugin_manager
+
+    plugin_manager.register(mod, name=plugin_name)
+
+    # now, check if a viewer was created, and if not, create one.
+    for obj in mod.values():
+        if isinstance(obj, Viewer):
+            _v = obj
+            break
+    else:
+        _v = Viewer()
+
+    try:
+        _v.window._qt_window.parent()
+    except RuntimeError:
+        # this script had a napari.run() in it, and the viewer has already been
+        # used and cleaned up... if we eventually have "reusable viewers", we
+        # can continue here
+        return
+
+    # finally, if the file declared a dock widget, add it to the viewer.
+    dws = plugin_manager.hooks.napari_experimental_provide_dock_widget
+    if any(i.plugin_name == plugin_name for i in dws.get_hookimpls()):
+        _v.window.add_plugin_dock_widget(plugin_name)
+
+    run()
 
 
 def _run_pythonw(python_path):


### PR DESCRIPTION
# Description
This PR adds the ability to quickly "test out" a plugin using `napari some_file.py`.  The motivation for this comes from three places:

1. I have been noticing that developers often (quite reasonably) provide an example of their plugin by copying the `@napari_hook_implementation` that they would use.  However, it's a bit hard to test that quickly without either pip-installing something with an `entry_point`, or creating a quick wrapper class and registering it.  See for example, https://github.com/napari/magicgui/issues/187 ... where it takes a bit of extra boilerplate to quickly test the code.
2. In addition to core devs, plugin devs may want to quickly prototype a plugin without using the full cookiecutter boilerplate, and using `pip install -e` (this came up on [image.sc](https://forum.image.sc/t/alpha-release-of-pyclesperanto-graphical-user-interface-for-napari/46863/10))  And they should not be expected to know how to register the plugin module directly.
3. I noticed a conversation (starting [here](https://github.com/napari/napari-plugin-devtools/pull/14#issuecomment-810542539)) between @ziyangczi and @justinelarsen the other day, proposing potentially creating a new temporary environment to test out a plugin that isn't installed.

It may be lost in all this that it's really rather easy to register a plugin without installing it with entry points using `napari.plugins.plugin_manager.register()`... which accepts _any_ namespace, whether it be a module, class, or even just a plain `dict`.  So, this PR tacks on a little more functionality when running `napari my_file.py`.  Currently that command is very nearly an alias for `python my_file.py`.  Here, I inspect the namespace of the file and, if a hook implementation is declared: register the file as a plugin, create a viewer (if one isn't already created in the file), add any dock widgets to the viewer, and run it.  This means you could just put something like this in a script and run it as `napari my_file.py`:

```python
# my_file.py
from napari_plugin_engine import napari_hook_implementation
from qtpy.QtWidgets import QPushButton
from functools import partial

@napari_hook_implementation
def napari_experimental_provide_dock_widget():
    return partial(QPushButton, "HI"), {"name": "TEST"}
```

 
<img width="629" alt="Untitled" src="https://user-images.githubusercontent.com/1609449/113509183-2a894d00-9522-11eb-96d3-ddf37f3c2cae.png">


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
