### PR TITLE
Add support for passing `shape_type` through `data` attribute for `Shapes` layers

### DIFF
--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -982,8 +982,7 @@ def points_in_poly(points, vertices):
 
 
 def extract_shape_type(data, shape_type=None):
-    """Checks whether data contains shape type information and extracts it if so, returning
-    data and shape_type separately.
+    """Separates shape_type from data if present, and returns both.
 
     Parameters
     ----------

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -981,7 +981,7 @@ def points_in_poly(points, vertices):
     return inside
 
 
-def extract_shape_type(data, shape_type):
+def extract_shape_type(data, shape_type=None):
     """Checks whether data contains shape type information and extracts it if so, returning
     data and shape_type separately.
 
@@ -996,7 +996,7 @@ def extract_shape_type(data, shape_type):
     -------
     data : Array | List[Array]
         list or array of vertices belonging to each shape
-    shape_type : str | List[str] | None
+    shape_type : List[str] | None
         type of each shape in data, or None if none was passed
     """
     # Tuple for one shape or list of shapes with shape_type

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import numpy as np
 from vispy.geometry import PolygonData
 from vispy.visuals.tube import _frenet_frames
@@ -977,6 +979,35 @@ def points_in_poly(points, vertices):
     # if the number of crossings is odd then the point is inside the polygon
 
     return inside
+
+
+def extract_shape_type(data, shape_type):
+    """Checks whether data contains shape type information and extracts it if so, returning
+    data and shape_type separately.
+
+    Parameters
+    ----------
+    data : Array | Tuple(Array,str) | List[Array | Tuple(Array, str)] | Tuple(List[Array], str)
+        list or array of vertices belonging to each shape, optionally containing shape type strings
+    shape_type : str | None
+        metadata shape type string, or None if none was passed
+
+    Returns
+    -------
+    data : Array | List[Array]
+        list or array of vertices belonging to each shape
+    shape_type : str | List[str] | None
+        type of each shape in data, or None if none was passed
+    """
+    # Tuple for one shape or list of shapes with shape_type
+    if isinstance(data, Tuple):
+        shape_type = data[1]
+        data = data[0]
+    # List of (vertices, shape_type) tuples
+    elif len(data) != 0 and all(isinstance(datum, Tuple) for datum in data):
+        shape_type = [datum[1] for datum in data]
+        data = [datum[0] for datum in data]
+    return data, shape_type
 
 
 def get_shape_ndim(data):

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -863,12 +863,41 @@ def test_changing_shapes():
     assert layer.ndim == shape_b[2]
     assert np.all([s == 'rectangle' for s in layer.shape_type])
 
+    # setting data with shape type
     data_a = (vertices_a, "ellipse")
     layer.data = data_a
     assert layer.nshapes == shape_a[0]
     assert np.all([np.all(ld == d) for ld, d in zip(layer.data, vertices_a)])
     assert layer.ndim == shape_a[2]
     assert np.all([s == 'ellipse' for s in layer.shape_type])
+
+    # setting data with fewer shapes
+    smaller_data = vertices_a[:5]
+    current_edge_color = layer._data_view.edge_color
+    current_edge_width = layer._data_view.edge_widths
+    current_face_color = layer._data_view.face_color
+    current_z = layer._data_view.z_indices
+
+    layer.data = smaller_data
+    assert layer.nshapes == smaller_data.shape[0]
+    assert np.allclose(layer._data_view.edge_color, current_edge_color[:5])
+    assert np.allclose(layer._data_view.face_color, current_face_color[:5])
+    assert np.allclose(layer._data_view.edge_widths, current_edge_width[:5])
+    assert np.allclose(layer._data_view.z_indices, current_z[:5])
+
+    # setting data with added shapes
+    current_edge_color = layer._data_view.edge_color
+    current_edge_width = layer._data_view.edge_widths
+    current_face_color = layer._data_view.face_color
+    current_z = layer._data_view.z_indices
+
+    bigger_data = vertices_b
+    layer.data = bigger_data
+    assert layer.nshapes == bigger_data.shape[0]
+    assert np.allclose(layer._data_view.edge_color[:5], current_edge_color)
+    assert np.allclose(layer._data_view.face_color[:5], current_face_color)
+    assert np.allclose(layer._data_view.edge_widths[:5], current_edge_width)
+    assert np.allclose(layer._data_view.z_indices[:5], current_z)
 
 
 def test_changing_shape_type():

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -622,6 +622,39 @@ def test_lines():
     assert layer.ndim == shape[2]
     assert np.all([s == 'line' for s in layer.shape_type])
 
+    # Test (single line, shape_type) tuple
+    shape = (1, 2, 2)
+    np.random.seed(0)
+    end_points = 20 * np.random.random(shape)
+    data = (end_points, 'line')
+    layer = Shapes(data)
+    assert layer.nshapes == shape[0]
+    assert np.all(layer.data[0] == end_points[0])
+    assert layer.ndim == shape[2]
+    assert np.all([s == 'line' for s in layer.shape_type])
+
+    # Test (multiple lines, shape_type) tuple
+    shape = (10, 2, 2)
+    np.random.seed(0)
+    end_points = 20 * np.random.random(shape)
+    data = (end_points, "line")
+    layer = Shapes(data)
+    assert layer.nshapes == shape[0]
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, end_points)])
+    assert layer.ndim == shape[2]
+    assert np.all([s == 'line' for s in layer.shape_type])
+
+    # Test list of (line, shape_type) tuples
+    shape = (10, 2, 2)
+    np.random.seed(0)
+    end_points = 20 * np.random.random(shape)
+    data = [(end_points[i], "line") for i in range(shape[0])]
+    layer = Shapes(data)
+    assert layer.nshapes == shape[0]
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, end_points)])
+    assert layer.ndim == shape[2]
+    assert np.all([s == 'line' for s in layer.shape_type])
+
 
 def test_lines_roundtrip():
     """Test a full roundtrip with line data."""
@@ -652,6 +685,36 @@ def test_paths():
     layer = Shapes(data, shape_type='path')
     assert layer.nshapes == len(data)
     assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data)])
+    assert layer.ndim == 2
+    assert np.all([s == 'path' for s in layer.shape_type])
+
+    # Test (single path, shape_type) tuple
+    shape = (1, 6, 2)
+    np.random.seed(0)
+    path_points = 20 * np.random.random(shape)
+    data = (path_points, "path")
+    layer = Shapes(data)
+    assert layer.nshapes == shape[0]
+    assert np.all(layer.data[0] == path_points[0])
+    assert layer.ndim == shape[2]
+    assert np.all([s == 'path' for s in layer.shape_type])
+
+    # Test (list of paths, shape_type) tuple
+    path_points = [
+        20 * np.random.random((np.random.randint(2, 12), 2)) for i in range(10)
+    ]
+    data = (path_points, "path")
+    layer = Shapes(data)
+    assert layer.nshapes == len(path_points)
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, path_points)])
+    assert layer.ndim == 2
+    assert np.all([s == 'path' for s in layer.shape_type])
+
+    # Test list of  (path, shape_type) tuples
+    data = [(path_points[i], "path") for i in range(len(path_points))]
+    layer = Shapes(data)
+    assert layer.nshapes == len(data)
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, path_points)])
     assert layer.ndim == 2
     assert np.all([s == 'path' for s in layer.shape_type])
 
@@ -691,6 +754,36 @@ def test_polygons():
     assert layer.ndim == 2
     assert np.all([s == 'polygon' for s in layer.shape_type])
 
+    # Test single (polygon, shape_type) tuple
+    shape = (1, 6, 2)
+    np.random.seed(0)
+    vertices = 20 * np.random.random(shape)
+    data = (vertices, 'polygon')
+    layer = Shapes(data)
+    assert layer.nshapes == shape[0]
+    assert np.all(layer.data[0] == vertices[0])
+    assert layer.ndim == shape[2]
+    assert np.all([s == 'polygon' for s in layer.shape_type])
+
+    # Test (list of polygons, shape_type) tuple
+    polygons = [
+        20 * np.random.random((np.random.randint(2, 12), 2)) for i in range(10)
+    ]
+    data = (polygons, 'polygon')
+    layer = Shapes(data)
+    assert layer.nshapes == len(polygons)
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, polygons)])
+    assert layer.ndim == 2
+    assert np.all([s == 'polygon' for s in layer.shape_type])
+
+    # Test list of (polygon, shape_type) tuples
+    data = [(polygons[i], 'polygon') for i in range(len(polygons))]
+    layer = Shapes(data)
+    assert layer.nshapes == len(polygons)
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, polygons)])
+    assert layer.ndim == 2
+    assert np.all([s == 'polygon' for s in layer.shape_type])
+
 
 def test_polygon_roundtrip():
     """Test a full roundtrip with polygon data."""
@@ -709,13 +802,15 @@ def test_mixed_shapes():
     """Test instantiating Shapes layer with a mix of random 2D shapes."""
     # Test multiple polygons with different numbers of points
     np.random.seed(0)
-    data = [
+    shape_vertices = [
         20 * np.random.random((np.random.randint(2, 12), 2)) for i in range(5)
     ] + list(np.random.random((5, 4, 2)))
     shape_type = ['polygon'] * 5 + ['rectangle'] * 3 + ['ellipse'] * 2
-    layer = Shapes(data, shape_type=shape_type)
-    assert layer.nshapes == len(data)
-    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data)])
+    layer = Shapes(shape_vertices, shape_type=shape_type)
+    assert layer.nshapes == len(shape_vertices)
+    assert np.all(
+        [np.all(ld == d) for ld, d in zip(layer.data, shape_vertices)]
+    )
     assert layer.ndim == 2
     assert np.all([s == so for s, so in zip(layer.shape_type, shape_type)])
 
@@ -727,6 +822,16 @@ def test_mixed_shapes():
     assert np.all(
         [ns == s for ns, s in zip(new_layer.shape_type, layer.shape_type)]
     )
+
+    # Test multiple (shape, shape_type) tuples
+    data = list(zip(shape_vertices, shape_type))
+    layer = Shapes(data)
+    assert layer.nshapes == len(shape_vertices)
+    assert np.all(
+        [np.all(ld == d) for ld, d in zip(layer.data, shape_vertices)]
+    )
+    assert layer.ndim == 2
+    assert np.all([s == so for s, so in zip(layer.shape_type, shape_type)])
 
 
 def test_changing_shapes():

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -871,6 +871,15 @@ def test_changing_shapes():
     assert np.all([s == 'ellipse' for s in layer.shape_type])
 
 
+def test_changing_shape_type():
+    """Test changing shape type"""
+    np.random.seed(0)
+    rectangles = 20 * np.random.random((10, 4, 2))
+    layer = Shapes(rectangles, shape_type='rectangle')
+    layer.shape_type = "ellipse"
+    assert np.all([s == 'ellipse' for s in layer.shape_type])
+
+
 def test_adding_shapes():
     """Test adding shapes."""
     # Start with polygons with different numbers of points

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -853,15 +853,22 @@ def test_changing_shapes():
     shape_a = (10, 4, 2)
     shape_b = (20, 4, 2)
     np.random.seed(0)
-    data_a = 20 * np.random.random(shape_a)
-    data_b = 20 * np.random.random(shape_b)
-    layer = Shapes(data_a)
+    vertices_a = 20 * np.random.random(shape_a)
+    vertices_b = 20 * np.random.random(shape_b)
+    layer = Shapes(vertices_a)
     assert layer.nshapes == shape_a[0]
-    layer.data = data_b
+    layer.data = vertices_b
     assert layer.nshapes == shape_b[0]
-    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data_b)])
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, vertices_b)])
     assert layer.ndim == shape_b[2]
     assert np.all([s == 'rectangle' for s in layer.shape_type])
+
+    data_a = (vertices_a, "ellipse")
+    layer.data = data_a
+    assert layer.nshapes == shape_a[0]
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, vertices_a)])
+    assert layer.ndim == shape_a[2]
+    assert np.all([s == 'ellipse' for s in layer.shape_type])
 
 
 def test_adding_shapes():
@@ -880,6 +887,18 @@ def test_adding_shapes():
     all_shape_type = ['polygon'] * 5 + new_shape_type
     assert layer.nshapes == len(all_data)
     assert np.all([np.all(ld == d) for ld, d in zip(layer.data, all_data)])
+    assert layer.ndim == 2
+    assert np.all([s == so for s, so in zip(layer.shape_type, all_shape_type)])
+
+    # test adding data with shape_type
+    new_vertices = np.random.random((5, 4, 2))
+    new_shape_type2 = ['ellipse'] * 3 + ['rectangle'] * 2
+    new_data2 = list(zip(new_vertices, new_shape_type2))
+    layer.add(new_data2)
+    all_vertices = all_data + list(new_vertices)
+    all_shape_type = all_shape_type + new_shape_type2
+    assert layer.nshapes == len(all_vertices)
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, all_vertices)])
     assert layer.ndim == 2
     assert np.all([s == so for s, so in zip(layer.shape_type, all_shape_type)])
 

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -834,6 +834,20 @@ def test_mixed_shapes():
     assert np.all([s == so for s, so in zip(layer.shape_type, shape_type)])
 
 
+def test_data_shape_type_overwrites_meta():
+    """Test shape type passed through data property overwrites metadata shape type"""
+    shape = (10, 4, 2)
+    np.random.seed(0)
+    vertices = 20 * np.random.random(shape)
+    data = (vertices, "ellipse")
+    layer = Shapes(data, shape_type='rectangle')
+    assert np.all([s == 'ellipse' for s in layer.shape_type])
+
+    data = [(vertices[i], "ellipse") for i in range(shape[0])]
+    layer = Shapes(data, shape_type='rectangle')
+    assert np.all([s == 'ellipse' for s in layer.shape_type])
+
+
 def test_changing_shapes():
     """Test changing Shapes data."""
     shape_a = (10, 4, 2)

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -372,6 +372,35 @@ def test_rectangles():
     assert layer.ndim == shape[2]
     assert np.all([s == 'rectangle' for s in layer.shape_type])
 
+    # Test (rectangle, shape_type) tuple
+    shape = (1, 4, 2)
+    np.random.seed(0)
+    vertices = 20 * np.random.random(shape)
+    data = (vertices, "rectangle")
+    layer = Shapes(data)
+    assert layer.nshapes == shape[0]
+    assert np.all(layer.data[0] == data[0])
+    assert layer.ndim == shape[2]
+    assert np.all([s == 'rectangle' for s in layer.shape_type])
+
+    # Test (list of rectangles, shape_type) tuple
+    shape = (10, 4, 2)
+    vertices = 20 * np.random.random(shape)
+    data = (vertices, "rectangle")
+    layer = Shapes(data)
+    assert layer.nshapes == shape[0]
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, vertices)])
+    assert layer.ndim == shape[2]
+    assert np.all([s == 'rectangle' for s in layer.shape_type])
+
+    # Test list of (rectangle, shape_type) tuples
+    data = [(vertices[i], "rectangle") for i in range(shape[0])]
+    layer = Shapes(data)
+    assert layer.nshapes == shape[0]
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, vertices)])
+    assert layer.ndim == shape[2]
+    assert np.all([s == 'rectangle' for s in layer.shape_type])
+
 
 def test_rectangles_roundtrip():
     """Test a full roundtrip with rectangles data."""
@@ -471,6 +500,71 @@ def test_ellipses():
     np.random.seed(0)
     data = 20 * np.random.random(shape)
     layer = Shapes(data, shape_type='ellipse')
+    assert layer.nshapes == shape[0]
+    assert np.all([len(ld) == 4 for ld in layer.data])
+    assert layer.ndim == shape[2]
+    assert np.all([s == 'ellipse' for s in layer.shape_type])
+
+    # Test single four corner (vertices, shape_type) tuple
+    shape = (1, 4, 2)
+    np.random.seed(0)
+    vertices = 20 * np.random.random(shape)
+    data = (vertices, "ellipse")
+    layer = Shapes(data)
+    assert layer.nshapes == shape[0]
+    assert np.all(layer.data[0] == data[0])
+    assert layer.ndim == shape[2]
+    assert np.all([s == 'ellipse' for s in layer.shape_type])
+
+    # Test multiple four corner (list of vertices, shape_type) tuple
+    shape = (10, 4, 2)
+    np.random.seed(0)
+    vertices = 20 * np.random.random(shape)
+    data = (vertices, "ellipse")
+    layer = Shapes(data)
+    assert layer.nshapes == shape[0]
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, vertices)])
+    assert layer.ndim == shape[2]
+    assert np.all([s == 'ellipse' for s in layer.shape_type])
+
+    # Test list of four corner (vertices, shape_type) tuples
+    shape = (10, 4, 2)
+    np.random.seed(0)
+    vertices = 20 * np.random.random(shape)
+    data = [(vertices[i], "ellipse") for i in range(shape[0])]
+    layer = Shapes(data)
+    assert layer.nshapes == shape[0]
+    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, vertices)])
+    assert layer.ndim == shape[2]
+    assert np.all([s == 'ellipse' for s in layer.shape_type])
+
+    # Test single (center-radii, shape_type) ellipse
+    shape = (1, 2, 2)
+    np.random.seed(0)
+    data = (20 * np.random.random(shape), "ellipse")
+    layer = Shapes(data)
+    assert layer.nshapes == 1
+    assert len(layer.data[0]) == 4
+    assert layer.ndim == shape[2]
+    assert np.all([s == 'ellipse' for s in layer.shape_type])
+
+    # Test (list of center-radii, shape_type) tuple
+    shape = (10, 2, 2)
+    np.random.seed(0)
+    center_radii = 20 * np.random.random(shape)
+    data = (center_radii, "ellipse")
+    layer = Shapes(data)
+    assert layer.nshapes == shape[0]
+    assert np.all([len(ld) == 4 for ld in layer.data])
+    assert layer.ndim == shape[2]
+    assert np.all([s == 'ellipse' for s in layer.shape_type])
+
+    # Test list of (center-radii, shape_type) tuples
+    shape = (10, 2, 2)
+    np.random.seed(0)
+    center_radii = 20 * np.random.random(shape)
+    data = [(center_radii[i], "ellipse") for i in range(shape[0])]
+    layer = Shapes(data)
     assert layer.nshapes == shape[0]
     assert np.all([len(ld) == 4 for ld in layer.data])
     assert layer.ndim == shape[2]

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -372,6 +372,9 @@ def test_rectangles():
     assert layer.ndim == shape[2]
     assert np.all([s == 'rectangle' for s in layer.shape_type])
 
+
+def test_rectangles_with_shape_type():
+    """Test instantiating rectangles with shape_type in data"""
     # Test (rectangle, shape_type) tuple
     shape = (1, 4, 2)
     np.random.seed(0)
@@ -505,6 +508,9 @@ def test_ellipses():
     assert layer.ndim == shape[2]
     assert np.all([s == 'ellipse' for s in layer.shape_type])
 
+
+def test_ellipses_with_shape_type():
+    """Test instantiating ellipses with shape_type in data"""
     # Test single four corner (vertices, shape_type) tuple
     shape = (1, 4, 2)
     np.random.seed(0)
@@ -622,6 +628,9 @@ def test_lines():
     assert layer.ndim == shape[2]
     assert np.all([s == 'line' for s in layer.shape_type])
 
+
+def test_lines_with_shape_type():
+    """Test instantiating lines with shape_type"""
     # Test (single line, shape_type) tuple
     shape = (1, 2, 2)
     np.random.seed(0)
@@ -688,6 +697,9 @@ def test_paths():
     assert layer.ndim == 2
     assert np.all([s == 'path' for s in layer.shape_type])
 
+
+def test_paths_with_shape_type():
+    """Test instantiating paths with shape_type in data"""
     # Test (single path, shape_type) tuple
     shape = (1, 6, 2)
     np.random.seed(0)
@@ -753,6 +765,10 @@ def test_polygons():
     assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data)])
     assert layer.ndim == 2
     assert np.all([s == 'polygon' for s in layer.shape_type])
+
+
+def test_polygons_with_shape_type():
+    """Test 2D polygons with shape_type in data"""
 
     # Test single (polygon, shape_type) tuple
     shape = (1, 6, 2)
@@ -822,6 +838,15 @@ def test_mixed_shapes():
     assert np.all(
         [ns == s for ns, s in zip(new_layer.shape_type, layer.shape_type)]
     )
+
+
+def test_mixed_shapes_with_shape_type():
+    """Test adding mixed shapes with shape_type in data"""
+    np.random.seed(0)
+    shape_vertices = [
+        20 * np.random.random((np.random.randint(2, 12), 2)) for i in range(5)
+    ] + list(np.random.random((5, 4, 2)))
+    shape_type = ['polygon'] * 5 + ['rectangle'] * 3 + ['ellipse'] * 2
 
     # Test multiple (shape, shape_type) tuples
     data = list(zip(shape_vertices, shape_type))

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -760,8 +760,6 @@ class Shapes(Layer):
         self._add_shapes_to_view(shape_inputs, new_data_view)
 
         self._data_view = new_data_view
-        self._display_order_stored = copy(self._dims_order)
-        self._ndisplay_stored = copy(self._ndisplay)
         self._update_dims()
 
     @property
@@ -1829,7 +1827,8 @@ class Shapes(Layer):
             )
 
             # Add shape
-            data_view.add(shape, edge_color=ec, face_color=fc, z_refresh=True)
+            data_view.add(shape, edge_color=ec, face_color=fc, z_refresh=False)
+        data_view._update_z_order()
 
     def _validate_properties(
         self, properties: Dict[str, np.ndarray], n_shapes: Optional[int] = None

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -325,6 +325,16 @@ class Shapes(Layer):
                 ndim = 2
             data = np.empty((0, 0, ndim))
         else:
+            # Tuple for one shape or list of shapes with shape_type
+            if isinstance(data, Tuple):
+                shape_type = data[1]
+                data = data[0]
+            # List of (vertices, shape_type) tuples
+            elif len(data) != 0 and all(
+                isinstance(datum, Tuple) for datum in data
+            ):
+                data = [datum[0] for datum in data]
+                shape_type = [datum[1] for datum in data]
             data_ndim = get_shape_ndim(data)
             if ndim is not None and ndim != data_ndim:
                 raise ValueError(

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -757,21 +757,7 @@ class Shapes(Layer):
             self._data_view.z_indices,
         )
 
-        for d, st, ew, ec, fc, z in shape_inputs:
-
-            shape_cls = shape_classes[ShapeType(st)]
-            shape = shape_cls(
-                d,
-                edge_width=ew,
-                z_index=z,
-                dims_order=self._dims_order,
-                ndisplay=self._ndisplay,
-            )
-
-            # Add shape
-            new_data_view.add(
-                shape, edge_color=ec, face_color=fc, z_refresh=True
-            )
+        self._add_shapes_to_view(shape_inputs, new_data_view)
 
         self._data_view = new_data_view
         self._display_order_stored = copy(self._dims_order)
@@ -1823,27 +1809,27 @@ class Shapes(Layer):
                 ensure_iterable(z_index),
             )
 
-            for d, st, ew, ec, fc, z in shape_inputs:
-
-                # A False slice_key means the shape is invalid as it is not
-                # confined to a single plane
-                shape_cls = shape_classes[ShapeType(st)]
-                shape = shape_cls(
-                    d,
-                    edge_width=ew,
-                    z_index=z,
-                    dims_order=self._dims_order,
-                    ndisplay=self._ndisplay,
-                )
-
-                # Add shape
-                self._data_view.add(
-                    shape, edge_color=ec, face_color=fc, z_refresh=z_refresh
-                )
+            self._add_shapes_to_view(shape_inputs, self._data_view)
 
         self._display_order_stored = copy(self._dims_order)
         self._ndisplay_stored = copy(self._ndisplay)
         self._update_dims()
+
+    def _add_shapes_to_view(self, shape_inputs, data_view):
+        """Build new shapes and add them to the _data_view"""
+        for d, st, ew, ec, fc, z in shape_inputs:
+
+            shape_cls = shape_classes[ShapeType(st)]
+            shape = shape_cls(
+                d,
+                edge_width=ew,
+                z_index=z,
+                dims_order=self._dims_order,
+                ndisplay=self._ndisplay,
+            )
+
+            # Add shape
+            data_view.add(shape, edge_color=ec, face_color=fc, z_refresh=True)
 
     def _validate_properties(
         self, properties: Dict[str, np.ndarray], n_shapes: Optional[int] = None

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -46,7 +46,12 @@ from ._shapes_mouse_bindings import (
     vertex_insert,
     vertex_remove,
 )
-from ._shapes_utils import create_box, get_shape_ndim, number_of_shapes
+from ._shapes_utils import (
+    create_box,
+    extract_shape_type,
+    get_shape_ndim,
+    number_of_shapes,
+)
 
 DEFAULT_COLOR_CYCLE = np.array([[1, 0, 1, 1], [0, 1, 0, 1]])
 
@@ -325,16 +330,7 @@ class Shapes(Layer):
                 ndim = 2
             data = np.empty((0, 0, ndim))
         else:
-            # Tuple for one shape or list of shapes with shape_type
-            if isinstance(data, Tuple):
-                shape_type = data[1]
-                data = data[0]
-            # List of (vertices, shape_type) tuples
-            elif len(data) != 0 and all(
-                isinstance(datum, Tuple) for datum in data
-            ):
-                shape_type = [datum[1] for datum in data]
-                data = [datum[0] for datum in data]
+            data, shape_type = extract_shape_type(data, shape_type)
             data_ndim = get_shape_ndim(data)
             if ndim is not None and ndim != data_ndim:
                 raise ValueError(
@@ -1493,6 +1489,8 @@ class Shapes(Layer):
             applied to each shape otherwise the same value will be used for all
             shapes.
         """
+        data, shape_type = extract_shape_type(data, shape_type)
+
         if edge_width is None:
             edge_width = self.current_edge_width
 

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1456,15 +1456,17 @@ class Shapes(Layer):
         Parameters
         ----------
         data : Array | Tuple(Array,str) | List[Array | Tuple(Array, str)] | Tuple(List[Array], str)
-            List of shape data, where each element is an (N, D) array of the
-            N vertices of a shape in D dimensions. Each element can optionally be a tuple containing an array of the N vertices and the shape_type string. Can be an 3-dimensional
-            array if each shape has the same number of vertices.
+            List of shape data, where each element is either an (N, D) array of the
+            N vertices of a shape in D dimensions or a tuple containing an array of
+            the N vertices and the shape_type string. When a shape_type is present,
+            it overrides keyword arg shape_type. Can be an 3-dimensional array
+            if each shape has the same number of vertices.
         shape_type : string | list
             String of shape shape_type, must be one of "{'line', 'rectangle',
             'ellipse', 'path', 'polygon'}". If a list is supplied it must be
             the same length as the length of `data` and each element will be
             applied to each shape otherwise the same value will be used for all
-            shapes.
+            shapes. Overriden by data shape_type, if present.
         edge_width : float | list
             thickness of lines and edges. If a list is supplied it must be the
             same length as the length of `data` and each element will be
@@ -1565,15 +1567,17 @@ class Shapes(Layer):
         Parameters
         ----------
         data : Array | Tuple(Array,str) | List[Array | Tuple(Array, str)] | Tuple(List[Array], str)
-            List of shape data, where each element is an (N, D) array of the
-            N vertices of a shape in D dimensions. Each element can optionally be a tuple containing an array of the N vertices and the shape_type string. Can be an 3-dimensional
-            array if each shape has the same number of vertices.
+            List of shape data, where each element is either an (N, D) array of the
+            N vertices of a shape in D dimensions or a tuple containing an array of
+            the N vertices and the shape_type string. When a shape_type is present,
+            it overrides keyword arg shape_type. Can be an 3-dimensional array
+            if each shape has the same number of vertices.
         shape_type : string | list
             String of shape shape_type, must be one of "{'line', 'rectangle',
             'ellipse', 'path', 'polygon'}". If a list is supplied it must be
             the same length as the length of `data` and each element will be
             applied to each shape otherwise the same value will be used for all
-            shapes.
+            shapes. Overriden by data shape_type, if present.
         edge_width : float | list
             thickness of lines and edges. If a list is supplied it must be the
             same length as the length of `data` and each element will be
@@ -1652,15 +1656,17 @@ class Shapes(Layer):
         Parameters
         ----------
         data : Array | Tuple(Array,str) | List[Array | Tuple(Array, str)] | Tuple(List[Array], str)
-            List of shape data, where each element is an (N, D) array of the
-            N vertices of a shape in D dimensions. Each element can optionally be a tuple containing an array of the N vertices and the shape_type string. Can be an 3-dimensional
-            array if each shape has the same number of vertices.
+            List of shape data, where each element is either an (N, D) array of the
+            N vertices of a shape in D dimensions or a tuple containing an array of
+            the N vertices and the shape_type string. When a shape_type is present,
+            it overrides keyword arg shape_type. Can be an 3-dimensional array
+            if each shape has the same number of vertices.
         shape_type : string | list
             String of shape shape_type, must be one of "{'line', 'rectangle',
             'ellipse', 'path', 'polygon'}". If a list is supplied it must be
             the same length as the length of `data` and each element will be
             applied to each shape otherwise the same value will be used for all
-            shapes.
+            shapes. Overriden by data shape_type, if present.
         edge_width : float | list
             thickness of lines and edges. If a list is supplied it must be the
             same length as the length of `data` and each element will be

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -541,10 +541,11 @@ class Shapes(Layer):
         return self._data_view.data
 
     @data.setter
-    def data(self, data, shape_type='rectangle'):
+    def data(self, data):
         self._finish_drawing()
+
         self._data_view = ShapeList()
-        self.add(data, shape_type=shape_type)
+        self.add(data, shape_type=None)
 
         self._update_dims()
         self.events.data(value=self.data)
@@ -1492,6 +1493,20 @@ class Shapes(Layer):
             shapes.
         """
         data, shape_type = extract_shape_type(data, shape_type)
+
+        # not given a shape_type through data
+        if shape_type is None:
+            # if same number of shapes assume shape type unchanged
+            if self.nshapes == len(data):
+                shape_type = self.shape_type
+            # fewer shapes, trim shape type
+            elif self.nshapes > len(data):
+                shape_type = self.shape_type[: len(data)]
+            # more shapes, default to rectangle for new shapes
+            else:
+                shape_type = self.shape_type + ["rectangle"] * (
+                    len(data) - self.nshapes
+                )
 
         if edge_width is None:
             edge_width = self.current_edge_width

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -333,8 +333,8 @@ class Shapes(Layer):
             elif len(data) != 0 and all(
                 isinstance(datum, Tuple) for datum in data
             ):
-                data = [datum[0] for datum in data]
                 shape_type = [datum[1] for datum in data]
+                data = [datum[0] for datum in data]
             data_ndim = get_shape_ndim(data)
             if ndim is not None and ndim != data_ndim:
                 raise ValueError(

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -731,8 +731,6 @@ class Shapes(Layer):
 
         for d, st, ew, ec, fc, z in shape_inputs:
 
-            # A False slice_key means the shape is invalid as it is not
-            # confined to a single plane
             shape_cls = shape_classes[ShapeType(st)]
             shape = shape_cls(
                 d,
@@ -744,9 +742,12 @@ class Shapes(Layer):
 
             # Add shape
             new_data_view.add(
-                shape, edge_color=ec, face_color=fc, z_refresh=False
+                shape, edge_color=ec, face_color=fc, z_refresh=True
             )
+
         self._data_view = new_data_view
+        self._display_order_stored = copy(self._dims_order)
+        self._ndisplay_stored = copy(self._ndisplay)
         self._update_dims()
 
     @property

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1455,9 +1455,9 @@ class Shapes(Layer):
 
         Parameters
         ----------
-        data : list or array
+        data : Array | Tuple(Array,str) | List[Array | Tuple(Array, str)] | Tuple(List[Array], str)
             List of shape data, where each element is an (N, D) array of the
-            N vertices of a shape in D dimensions. Can be an 3-dimensional
+            N vertices of a shape in D dimensions. Each element can optionally be a tuple containing an array of the N vertices and the shape_type string. Can be an 3-dimensional
             array if each shape has the same number of vertices.
         shape_type : string | list
             String of shape shape_type, must be one of "{'line', 'rectangle',
@@ -1564,9 +1564,9 @@ class Shapes(Layer):
 
         Parameters
         ----------
-        data : list or array
+        data : Array | Tuple(Array,str) | List[Array | Tuple(Array, str)] | Tuple(List[Array], str)
             List of shape data, where each element is an (N, D) array of the
-            N vertices of a shape in D dimensions. Can be an 3-dimensional
+            N vertices of a shape in D dimensions. Each element can optionally be a tuple containing an array of the N vertices and the shape_type string. Can be an 3-dimensional
             array if each shape has the same number of vertices.
         shape_type : string | list
             String of shape shape_type, must be one of "{'line', 'rectangle',
@@ -1651,9 +1651,9 @@ class Shapes(Layer):
 
         Parameters
         ----------
-        data : list or array
+        data : Array | Tuple(Array,str) | List[Array | Tuple(Array, str)] | Tuple(List[Array], str)
             List of shape data, where each element is an (N, D) array of the
-            N vertices of a shape in D dimensions. Can be an 3-dimensional
+            N vertices of a shape in D dimensions. Each element can optionally be a tuple containing an array of the N vertices and the shape_type string. Can be an 3-dimensional
             array if each shape has the same number of vertices.
         shape_type : string | list
             String of shape shape_type, must be one of "{'line', 'rectangle',

--- a/napari/utils/_magicgui.py
+++ b/napari/utils/_magicgui.py
@@ -177,9 +177,9 @@ def add_layer_data_tuples_to_viewer(gui, result, return_type):
             # then try to update the viewer layer with that name.
             try:
                 layer = viewer.layers[layer_datum[1].get('name')]
-                layer.data = layer_datum[0]
                 for k, v in layer_datum[1].items():
                     setattr(layer, k, v)
+                layer.data = layer_datum[0]
                 continue
             except KeyError:  # layer not in the viewer
                 pass


### PR DESCRIPTION
# Description
Add support for passing `tuples` of `(shapes, shape_type)` to `Shapes.data`.

Shapes layers should now support the following for its `data` attribute:
`Array | Tuple(Array,str) | List[Array | Tuple(Array, str)] | Tuple(List[Array], str)`

This is fully compatible with previous behaviour of `Shapes` layers while adding flexibility. Where `shape_type` is passed both through `data` and through `metadata kwargs`, the `data` `shape_type` will take priority.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# References
Partially addresses #2354 

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/guides/stable/translations.html).
