### PR TITLE
add about team page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: docs
 
 docs:
-	rm -rf docs/_build/html
+	rm -rf docs/_build/
 	find docs/api ! -name 'index.rst' -type f -exec rm -f {} +
 	pip install -qr docs/requirements.txt
 	jb build docs

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -19,6 +19,7 @@
 
 - file: developers/index
   sections:
+    - file: developers/team
     - file: developers/benchmarks
     - file: developers/code_of_conduct
     - file: developers/code_of_conduct_reporting

--- a/docs/community/team.md
+++ b/docs/community/team.md
@@ -1,0 +1,25 @@
+# About Team
+
+napari is a consensus-based community project. Anyone with an interest in the project can join the community, contribute to the project design, and participate in the decision making process. You can learn more about how the project is run by reading our [governance model](https://napari.org/community/governance.html). This page lists our current and emeritus [core developers](https://napari.org/community/governance.html#core-developers). Core developers are community members that have demonstrated a sustained commitment to the project through ongoing contributions and that they can maintain napari with care.
+
+
+## Current Core Developers
+
+- [Ahmet Can Solak](https://github.com/napari/napari/commits?author=AhmetCanSolak) - @AhmetCanSolak
+- [Genevieve Buckley](https://github.com/napari/napari/commits?author=GenevieveBuckley) - @GenevieveBuckley
+- [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) - @jni (SC)
+- [Justine Larsen](https://github.com/napari/napari/commits?author=justinelarsen) - @justinelarsen
+- [Kevin Yamauchi](https://github.com/napari/napari/commits?author=kevinyamauchi) - @kevinyamauchi
+- [Kira Evans](https://github.com/napari/napari/commits?author=kne42) - @kne42
+- [Loic Royer](https://github.com/napari/napari/commits?author=royerloic) - @royerloic (SC)
+- [Nicholas Sofroniew](https://github.com/napari/napari/commits?author=sofroniewn) - @sofroniewn (SC)
+- [Talley Lambert](https://github.com/napari/napari/commits?author=tlambert03) - @tlambert03
+- [Ziyang Liu](https://github.com/napari/napari/commits?author=ziyangczi) - @ziyangczi
+
+
+## Emeritus Core Developers
+
+- [Shannon Axelrod](https://github.com/napari/napari/commits?author=shanaxel42) - @shanaxel42
+
+
+<sub>*SC — currently on the napari [steering council](https://napari.org/community/governance.html#steering-council).</sub>

--- a/docs/community/team.md
+++ b/docs/community/team.md
@@ -5,21 +5,21 @@ napari is a consensus-based community project. Anyone with an interest in the pr
 
 ## Current Core Developers
 
-- [Ahmet Can Solak](https://github.com/napari/napari/commits?author=AhmetCanSolak) - @AhmetCanSolak
-- [Genevieve Buckley](https://github.com/napari/napari/commits?author=GenevieveBuckley) - @GenevieveBuckley
-- [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) - @jni (SC)
-- [Justine Larsen](https://github.com/napari/napari/commits?author=justinelarsen) - @justinelarsen
-- [Kevin Yamauchi](https://github.com/napari/napari/commits?author=kevinyamauchi) - @kevinyamauchi
-- [Kira Evans](https://github.com/napari/napari/commits?author=kne42) - @kne42
-- [Loic Royer](https://github.com/napari/napari/commits?author=royerloic) - @royerloic (SC)
-- [Nicholas Sofroniew](https://github.com/napari/napari/commits?author=sofroniewn) - @sofroniewn (SC)
-- [Talley Lambert](https://github.com/napari/napari/commits?author=tlambert03) - @tlambert03
-- [Ziyang Liu](https://github.com/napari/napari/commits?author=ziyangczi) - @ziyangczi
+- [Ahmet Can Solak](https://github.com/napari/napari/commits?author=AhmetCanSolak) - [@AhmetCanSolak](https://github.com/AhmetCanSolak)
+- [Genevieve Buckley](https://github.com/napari/napari/commits?author=GenevieveBuckley) - [@GenevieveBuckley](https://github.com/GenevieveBuckley)
+- [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) - [@jni](https://github.com/jni) (SC)
+- [Justine Larsen](https://github.com/napari/napari/commits?author=justinelarsen) - [@justinelarsen](https://github.com/justinelarsen)
+- [Kevin Yamauchi](https://github.com/napari/napari/commits?author=kevinyamauchi) - [@kevinyamauchi](https://github.com/kevinyamauchi)
+- [Kira Evans](https://github.com/napari/napari/commits?author=kne42) - [@kne42](https://github.com/kne42)
+- [Loic Royer](https://github.com/napari/napari/commits?author=royerloic) - [@royerloic](https://github.com/royerloic) (SC)
+- [Nicholas Sofroniew](https://github.com/napari/napari/commits?author=sofroniewn) - [@sofroniewn](https://github.com/sofroniewn) (SC)
+- [Talley Lambert](https://github.com/napari/napari/commits?author=tlambert03) - [@tlambert03](https://github.com/tlambert03)
+- [Ziyang Liu](https://github.com/napari/napari/commits?author=ziyangczi) - [@ziyangczi](https://github.com/ziyangczi)
 
 
 ## Emeritus Core Developers
 
-- [Shannon Axelrod](https://github.com/napari/napari/commits?author=shanaxel42) - @shanaxel42
+- [Shannon Axelrod](https://github.com/napari/napari/commits?author=shanaxel42) - [@shanaxel42](https://github.com/shanaxel42)
 
 
 <sub>***SC** currently on the napari [steering council](https://napari.org/community/governance.html#steering-council).</sub>

--- a/docs/community/team.md
+++ b/docs/community/team.md
@@ -22,4 +22,4 @@ napari is a consensus-based community project. Anyone with an interest in the pr
 - [Shannon Axelrod](https://github.com/napari/napari/commits?author=shanaxel42) - @shanaxel42
 
 
-<sub>*SC — currently on the napari [steering council](https://napari.org/community/governance.html#steering-council).</sub>
+<sub>***SC** currently on the napari [steering council](https://napari.org/community/governance.html#steering-council).</sub>

--- a/docs/developers/team.md
+++ b/docs/developers/team.md
@@ -1,0 +1,2 @@
+```{include} ../community/team.md
+```


### PR DESCRIPTION
# Description

Add an about team page based on [this](https://docs.google.com/document/d/1MDijuDJyTAn3tu2dA7mdzA9NJ7-_JMtRMJtGzpXoAno/edit) copy.

![preview of page](https://user-images.githubusercontent.com/29165011/113759719-42033a00-96ca-11eb-899d-76fb7d6f2232.png)

