### PR TITLE
Be cautious when checking a module's __package__ attribute

### DIFF
--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -49,7 +49,11 @@ def running_as_bundled_app() -> bool:
     """Infer whether we are running as a briefcase bundle"""
     # https://github.com/beeware/briefcase/issues/412
     # https://github.com/beeware/briefcase/pull/425
-    app_module = sys.modules['__main__'].__package__
+    # note that a module may not have a __package__ attribute
+    try:
+        app_module = sys.modules['__main__'].__package__
+    except AttributeError:
+        return False
     try:
         metadata = importlib_metadata.metadata(app_module)
     except importlib_metadata.PackageNotFoundError:


### PR DESCRIPTION
# Description

When running `python -m pdb script.py` and the script contains a napari import, I was getting this error:

```pytb
(torch) jni@super80:~/projects/platelet-segmentation$ python -m pdb local_train.py
> /home/jni/projects/platelet-segmentation/local_train.py(1)<module>()
-> import napari
(Pdb) c
Traceback (most recent call last):
  File "/home/jni/micromamba/envs/torch/lib/python3.8/pdb.py", line 1705, in main
    pdb._runscript(mainpyfile)
  File "/home/jni/micromamba/envs/torch/lib/python3.8/pdb.py", line 1573, in _runscript
    self.run(statement)
  File "/home/jni/micromamba/envs/torch/lib/python3.8/bdb.py", line 580, in run
    exec(cmd, globals, locals)
  File "<string>", line 1, in <module>
  File "/home/jni/projects/platelet-segmentation/local_train.py", line 1, in <module>
    import napari
  File "/home/jni/micromamba/envs/torch/lib/python3.8/site-packages/napari/__init__.py", line 22, in <module>
    from ._event_loop import gui_qt, run
  File "/home/jni/micromamba/envs/torch/lib/python3.8/site-packages/napari/_event_loop.py", line 2, in <module>
    from ._qt.qt_event_loop import gui_qt, run
  File "/home/jni/micromamba/envs/torch/lib/python3.8/site-packages/napari/_qt/__init__.py", line 41, in <module>
    from .qt_main_window import Window
  File "/home/jni/micromamba/envs/torch/lib/python3.8/site-packages/napari/_qt/qt_main_window.py", line 26, in <module>
    from .. import plugins
  File "/home/jni/micromamba/envs/torch/lib/python3.8/site-packages/napari/plugins/__init__.py", line 25, in <module>
    if sys.platform.startswith('linux') and running_as_bundled_app():
  File "/home/jni/micromamba/envs/torch/lib/python3.8/site-packages/napari/utils/misc.py", line 52, in running_as_bundled_app
    app_module = sys.modules['__main__'].__package__
AttributeError: module '__main__' has no attribute '__package__'
Uncaught exception. Entering post mortem debugging
Running 'cont' or 'step' will restart the program
> /home/jni/micromamba/envs/torch/lib/python3.8/site-packages/napari/utils/misc.py(52)running_as_bundled_app()
-> app_module = sys.modules['__main__'].__package__
```

This change ensures that we don't crash when the main module is not part of a package.
