### PR TITLE
PR: Enhance translation methods

### DIFF
--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -181,11 +181,13 @@ developers.
 
 For these case, all the `trans._*` methods provide an extra parameter
 `deferred`. When used and set to `True`, the methods will return an instance
-of a `TranslationString` which provides two methods, `TranslationString.translation()` and `TranslationString.value()`. The former provides the translation and the later
-provides the original string. Additionally, the `string` representation of this
-object will default to use the original string.
+of a `TranslationString` which provides two methods, `TranslationString.value()`
+and `TranslationString.translation()`. The former provides the original
+untranslated string and the later provides the translated string.
+Additionally, the `string` representation of this object will default to use
+the original string.
 
-Whit this, we can also provide the correct translations when using the napari
+With this, we can also provide the correct translations when using the napari
 application and displaying messages on the notifications manager in the
 language selected by the users.
 

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -27,14 +27,14 @@ from napari.utils.translations import trans
 standard library, which provides the l10n and i18n facilities in Python. To
 learn more about `gettext` visit the [Python documentation](https://docs.python.org/3/library/gettext.html).
 
-`trans` provides 3 helper methods that can be used to handle localization.
+`trans` provides 4 methods that can be used to handle localization.
 
 The following examples make use of a widget to illustrate the workflow, but
 this also applies to other strings that may be surfaced to the user, e.g.
 custom exceptions.
 
 `f-strings` do not work with localizable strings, so any strings that use them
-need to be converted to use `str.format` method. The [Plural strings section](#plural-strings)
+need to be converted. The [Plural strings section](#plural-strings)
 below explains this in more detail.
 
 ### Singular strings
@@ -75,7 +75,7 @@ For the `Spanish (Spain)` translation the options displayed would be:
   * verde
   * azul
 
-`trans._` is a wrapper on top of [gettext.gettext](https://docs.python.org/3/library/gettext.html#gettext.gettext).
+`trans._` is a wrapper on top of [gettext.gettext](https://docs.python.org/3/library/gettext.html#gettext.gettext) with enhanced functionality.
 
 ### Singular strings with context
 
@@ -121,7 +121,7 @@ For the `Spanish (Spain)` translation the options displayted would be:
   * tablatura
   * pestaña
 
-`trans._p` is a wrapper on top of [gettext.pgettext](https://docs.python.org/3/library/gettext.html#gettext.pgettext).
+`trans._p` is a wrapper on top of [gettext.pgettext](https://docs.python.org/3/library/gettext.html#gettext.pgettext) with enhanced functionality.
 
 ### Plural strings
 
@@ -138,17 +138,16 @@ from napari.utils.translations import trans
 class SomeWidget(QWidget):
 
     def __init__(self, amount):
-        string = trans._n(
-            "{amount} item", "{amount} items", amount
-        ).format(amount=amount)
+        string = trans._n("{n} item", "{n} items", n=amount)
         self.label = QLabel(string)
 ```
 
-On this example, the label string depends on the `amount` parameter. The
+On this example, the label string depends on the `n` parameter. The
 first argument of `trans._n` provides the singular version of the string.
 The second argument provides the plural version of the string. The third
 argument provides the quantity that will allow to know which string should
-be used, in this case `amount`.
+be used, in this case `amount`. Notice that by default `trans._n` will try to
+interpolate the value of `n` in the string, if found.
 
 For the `English (US)` translation the string displayed for different values
 of `amount` would be:
@@ -166,7 +165,59 @@ differently. Having clear variable names within strings (e.g. `{amount}`) of
 what the variable represents makes the internationalization process much
 easier and pleasant for translators.
 
-`trans._n` is a wrapper on top of [gettext.ngettext](https://docs.python.org/3/library/gettext.html#gettext.ngettext).
+`trans._n` is a wrapper on top of [gettext.ngettext](https://docs.python.org/3/library/gettext.html#gettext.ngettext) with enhanced functionality.
+
+### Plural strings with context
+
+This is similar to plural strings, but an additional context can be supplied
+as explained in the [Singular strings with context](#singular-strings-with-context) section.
+
+## Deferred translations
+
+For some strings we might not want to provide a translation right away. This
+could be the case of running napari in scripts, where providing the original
+english error messages might provide a better experience for users and
+developers.
+
+For these case, all the `trans._*` methods provide an extra parameter
+`deferred`. When used and set to `True`, the methods will return an instance
+of a `TranslationString` which provides two methods, `TranslationString.translation()` and `TranslationString.value()`. The former provides the translation and the later
+provides the original string. Additionally, the `string` representation of this
+object will default to use the original string.
+
+Whit this, we can also provide the correct translations when using the napari
+application and displaying messages on the notifications manager in the
+language selected by the users.
+
+## Additional arguments inside strings
+
+Since `f-strings` do not work with localizable strings, we loose their
+convenience and have to use `str.format`. However, when using deferred
+translations, we need to be able to use any variables the original string
+needs to be able to render itself. To handle this, the `trans` helpers
+provide the ability to receive any extra keyword arguments whcih will be
+used for rendering the deferred strings on demand.
+
+An example of how this works with Spanish and defered string yields:
+
+```python
+from napari.utils.translations import trans
+
+deferred_string = trans._("Hello {word}", deferred=True, word="world!")
+
+str(deferred_string) == "Hello world!"  # True
+deferred_string.value() == "Hello world!"  # True
+deferred_string.translation() == "¡Hola mundo!"  # True
+```
+
+An example of how this works for non-deferred string yields:
+
+```python
+from napari.utils.translations import trans
+
+normal_string = trans._("Hello {word}", word="world!")
+normal_string == "¡Hola mundo!"  # True
+```
 
 ## Contributing translations
 

--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -103,7 +103,7 @@ class NapariQtNotification(QDialog):
         self.message.setText(message)
         if source:
             self.source_label.setText(
-                trans._('Source: {source}').format(source=source)
+                trans._('Source: {source}', source=source)
             )
 
         self.close_button.clicked.connect(self.close)

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -280,7 +280,7 @@ class QPluginList(QListWidget):
             item.outdated = True
             widg = self.itemWidget(item)
             update_btn = QPushButton(
-                trans._("update (v{latest})").format(latest=latest), widg
+                trans._("update (v{latest})", latest=latest), widg
             )
             update_btn.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
             update_btn.clicked.connect(
@@ -446,7 +446,7 @@ class QtPluginDialog(QDialog):
     def _update_count_in_label(self):
         count = self.available_list.count()
         self.avail_label.setText(
-            trans._("Available Plugins ({count})").format(count=count)
+            trans._("Available Plugins ({count})", count=count)
         )
 
     def eventFilter(self, watched, event):

--- a/napari/_qt/dialogs/qt_plugin_report.py
+++ b/napari/_qt/dialogs/qt_plugin_report.py
@@ -157,8 +157,8 @@ class QtPluginErrReporter(QDialog):
 
         if not self.plugin_manager.get_errors(plugin):
             raise ValueError(
-                trans._("No errors reported for plugin '{plugin}'").format(
-                    plugin=plugin
+                trans._(
+                    "No errors reported for plugin '{plugin}'", plugin=plugin
                 )
             )
 

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -166,16 +166,18 @@ class QtLabelsControls(QtLayerControls):
             layer,
             'fill',
             Mode.FILL,
-            tooltip=trans._("Fill mode (F) \nToggle with {key}").format(
-                key=KEY_SYMBOLS['Control']
+            tooltip=trans._(
+                "Fill mode (F) \nToggle with {key}",
+                key=KEY_SYMBOLS['Control'],
             ),
         )
         self.erase_button = QtModeRadioButton(
             layer,
             'erase',
             Mode.ERASE,
-            tooltip=trans._("Erase mode (E) \nToggle with {key}").format(
-                key=KEY_SYMBOLS['Alt']
+            tooltip=trans._(
+                "Erase mode (E) \nToggle with {key}",
+                key=KEY_SYMBOLS['Alt'],
             ),
         )
 

--- a/napari/_qt/layer_controls/qt_layer_controls_container.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_container.py
@@ -49,8 +49,10 @@ def create_qt_layer_controls(layer):
             return controls(layer)
 
     raise TypeError(
-        trans._('Could not find QtControls for layer of type {type_}').format(
-            type_=type(layer)
+        trans._(
+            'Could not find QtControls for layer of type {type_}',
+            deferred=True,
+            type_=type(layer),
         )
     )
 

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -147,8 +147,8 @@ class QtPointsControls(QtLayerControls):
             layer,
             'delete_shape',
             slot=self.layer.remove_selected,
-            tooltip=trans._("Delete selected points ({key})").format(
-                key=KEY_SYMBOLS['Backspace']
+            tooltip=trans._(
+                "Delete selected points ({key})", key=KEY_SYMBOLS['Backspace']
             ),
         )
 

--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -178,8 +178,8 @@ class QtShapesControls(QtLayerControls):
             layer,
             'delete_shape',
             slot=self.layer.remove_selected,
-            tooltip=trans._("Delete selected shapes ({key})").format(
-                key=KEY_SYMBOLS['Backspace']
+            tooltip=trans._(
+                "Delete selected shapes ({key})", key=KEY_SYMBOLS['Backspace']
             ),
         )
 
@@ -293,7 +293,7 @@ class QtShapesControls(QtLayerControls):
             mode_buttons[event.mode].setChecked(True)
         else:
             raise ValueError(
-                trans._("Mode '{mode}'not recognized").format(mode=event.mode)
+                trans._("Mode '{mode}'not recognized", mode=event.mode)
             )
 
     def changeFaceColor(self, color: np.ndarray):

--- a/napari/_qt/perf/qt_event_tracing.py
+++ b/napari/_qt/perf/qt_event_tracing.py
@@ -98,7 +98,7 @@ class EventTypes:
         try:
             return self.string_name[event]
         except KeyError:
-            return trans._("UnknownEvent:{event}").format(event=event)
+            return trans._("UnknownEvent:{event}", event=event)
 
 
 EVENT_TYPES = EventTypes()

--- a/napari/_qt/perf/qt_performance.py
+++ b/napari/_qt/perf/qt_performance.py
@@ -39,9 +39,7 @@ class TextLog(QTextEdit):
         self.moveCursor(QTextCursor.End)
         self.setTextColor(Qt.red)
         self.insertPlainText(
-            trans._("{time_ms:5.0f}ms {name}\n").format(
-                time_ms=time_ms, name=name
-            )
+            trans._("{time_ms:5.0f}ms {name}\n", time_ms=time_ms, name=name)
         )
 
 
@@ -178,7 +176,7 @@ class QtPerformance(QWidget):
         # Update our timer label.
         elapsed = time.time() - self.start_time
         self.timer_label.setText(
-            trans._("Uptime: {elapsed:.2f}").format(elapsed=elapsed)
+            trans._("Uptime: {elapsed:.2f}", elapsed=elapsed)
         )
 
         average, long_events = self._get_timer_info()

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -448,7 +448,7 @@ class QtViewer(QSplitter):
         msg = trans._("selected") if selected else trans._("all")
         filename, _ = QFileDialog.getSaveFileName(
             parent=self,
-            caption=trans._('Save {msg} layers').format(msg=msg),
+            caption=trans._('Save {msg} layers', msg=msg),
             directory=self._last_visited_dir,  # home dir by default
         )
 
@@ -461,8 +461,11 @@ class QtViewer(QSplitter):
             if not saved:
                 raise OSError(
                     trans._(
-                        "File {filename} save failed.\n{error_messages}"
-                    ).format(filename=filename, error_messages=error_messages)
+                        "File {filename} save failed.\n{error_messages}",
+                        deferred=True,
+                        filename=filename,
+                        error_messages=error_messages,
+                    )
                 )
 
     def screenshot(self, path=None):

--- a/napari/_qt/widgets/qt_dims.py
+++ b/napari/_qt/widgets/qt_dims.py
@@ -293,8 +293,10 @@ class QtDims(QWidget):
             if loop_mode not in _modes:
                 raise ValueError(
                     trans._(
-                        'loop_mode must be one of {_modes}.  Got: {loop_mode}'
-                    ).format(_modes=_modes, loop_mode=loop_mode)
+                        'loop_mode must be one of {_modes}. Got: {loop_mode}',
+                        _modes=_modes,
+                        loop_mode=loop_mode,
+                    )
                 )
             loop_mode = LoopMode(loop_mode)
 

--- a/napari/_qt/widgets/qt_dims_slider.py
+++ b/napari/_qt/widgets/qt_dims_slider.py
@@ -49,7 +49,7 @@ class QtDimSliderWidget(QWidget):
         self.play_button = None
         self.curslice_label = QLineEdit(self)
         self.curslice_label.setToolTip(
-            trans._('Current slice for axis {axis}').format(axis=axis)
+            trans._('Current slice for axis {axis}', axis=axis)
         )
         # if we set the QIntValidator to actually reflect the range of the data
         # then an invalid (i.e. too large) index doesn't actually trigger the
@@ -62,7 +62,7 @@ class QtDimSliderWidget(QWidget):
         self.curslice_label.editingFinished.connect(self._set_slice_from_label)
         self.totslice_label = QLabel(self)
         self.totslice_label.setToolTip(
-            trans._('Total slices for axis {axis}').format(axis=axis)
+            trans._('Total slices for axis {axis}', axis=axis)
         )
         self.curslice_label.setObjectName('slice_label')
         self.totslice_label.setObjectName('slice_label')

--- a/napari/_qt/widgets/qt_size_preview.py
+++ b/napari/_qt/widgets/qt_size_preview.py
@@ -306,8 +306,9 @@ class QtSizeSliderPreviewWidget(QWidget):
             self._refresh()
         else:
             raise ValueError(
-                trans._("Minimum value must be smaller than {}").format(
-                    self._max_value
+                trans._(
+                    "Minimum value must be smaller than {max_value}",
+                    max_value=self._max_value,
                 )
             )
 
@@ -344,8 +345,9 @@ class QtSizeSliderPreviewWidget(QWidget):
             self._refresh()
         else:
             raise ValueError(
-                trans._("Maximum value must be larger than {}").format(
-                    self._min_value
+                trans._(
+                    "Maximum value must be larger than {min_value}",
+                    min_value=self._min_value,
                 )
             )
 

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -100,7 +100,8 @@ class QtViewerButtons(QFrame):
         self.consoleButton = QtViewerPushButton(
             self.viewer,
             'console',
-            trans._("Open IPython terminal ({key1}-{key2}-C)").format(
+            trans._(
+                "Open IPython terminal ({key1}-{key2}-C)",
                 key1=KEY_SYMBOLS['Control'],
                 key2=KEY_SYMBOLS['Shift'],
             ),
@@ -109,23 +110,25 @@ class QtViewerButtons(QFrame):
         self.rollDimsButton = QtViewerPushButton(
             self.viewer,
             'roll',
-            trans._("Roll dimensions order for display ({key}-E)").format(
-                key=KEY_SYMBOLS['Control']
+            trans._(
+                "Roll dimensions order for display ({key}-E)",
+                key=KEY_SYMBOLS['Control'],
             ),
             lambda: self.viewer.dims._roll(),
         )
         self.transposeDimsButton = QtViewerPushButton(
             self.viewer,
             'transpose',
-            trans._("Transpose displayed dimensions ({key}-T)").format(
-                key=KEY_SYMBOLS['Control']
+            trans._(
+                "Transpose displayed dimensions ({key}-T)",
+                key=KEY_SYMBOLS['Control'],
             ),
             lambda: self.viewer.dims._transpose(),
         )
         self.resetViewButton = QtViewerPushButton(
             self.viewer,
             'home',
-            trans._("Reset view ({key}-R)").format(key=KEY_SYMBOLS['Control']),
+            trans._("Reset view ({key}-R)", key=KEY_SYMBOLS['Control']),
             lambda: self.viewer.reset_view(),
         )
 
@@ -136,9 +139,7 @@ class QtViewerButtons(QFrame):
             self.viewer.grid.events,
         )
         self.gridViewButton.setToolTip(
-            trans._("Toggle grid view ({key}-G)").format(
-                key=KEY_SYMBOLS['Control']
-            )
+            trans._("Toggle grid view ({key}-G)", key=KEY_SYMBOLS['Control'])
         )
 
         self.ndisplayButton = QtStateButton(
@@ -150,8 +151,9 @@ class QtViewerButtons(QFrame):
             3,
         )
         self.ndisplayButton.setToolTip(
-            trans._("Toggle number of displayed dimensions ({key}-Y)").format(
-                key=KEY_SYMBOLS['Control']
+            trans._(
+                "Toggle number of displayed dimensions ({key}-Y)",
+                key=KEY_SYMBOLS['Control'],
             )
         )
 
@@ -188,8 +190,10 @@ class QtDeleteButton(QPushButton):
 
         self.viewer = viewer
         self.setToolTip(
-            trans._("Delete selected layers ({key1}-{key2})").format(
-                key1=KEY_SYMBOLS['Control'], key2=KEY_SYMBOLS['Backspace']
+            trans._(
+                "Delete selected layers ({key1}-{key2})",
+                key1=KEY_SYMBOLS['Control'],
+                key2=KEY_SYMBOLS['Backspace'],
             )
         )
         self.setAcceptDrops(True)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -706,8 +706,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
                 f"named {sample!r}. "
             )
             if samples:
-                msg += trans._('Available samples include: {samples}').format(
-                    samples=samples
+                msg += trans._(
+                    'Available samples include: {samples}', samples=samples
                 )
             else:
                 msg += trans._("No plugin samples have been registered.")

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -396,8 +396,9 @@ class Labels(_image_base_class):
             if np.issubdtype(data_level.dtype, np.floating):
                 raise TypeError(
                     trans._(
-                        "Only integer types are supported for Labels layers, but data contains {data_level_type}."
-                    ).format(data_level_type=data_level.dtype)
+                        "Only integer types are supported for Labels layers, but data contains {data_level_type}.",
+                        data_level_type=data_level.dtype,
+                    )
                 )
             if data_level.dtype == bool:
                 int_data.append(data_level.astype(np.int8))

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1359,8 +1359,9 @@ class Shapes(Layer):
             self.cursor = 'pointing'
             self.interactive = False
             self.help = trans._(
-                'hold <space> to pan/zoom, press <{BACKSPACE}> to remove selected'
-            ).format(BACKSPACE=BACKSPACE)
+                'hold <space> to pan/zoom, press <{BACKSPACE}> to remove selected',
+                BACKSPACE=BACKSPACE,
+            )
             self.mouse_drag_callbacks.append(select)
             self.mouse_move_callbacks.append(highlight)
         elif mode in [Mode.VERTEX_INSERT, Mode.VERTEX_REMOVE]:

--- a/napari/utils/_tests/test_translations.py
+++ b/napari/utils/_tests/test_translations.py
@@ -119,12 +119,16 @@ def test_is_valid_locale_invalid():
 def test_locale_valid_singular(trans):
     # Test singular method
     expected_result = "Más sobre napari"
-    result = trans.gettext("MORE ABOUT NAPARI")
-    assert result == expected_result
-
-    # Test singular method shorthand
     result = trans._("MORE ABOUT NAPARI")
     assert result == expected_result
+
+
+def test_locale_valid_deferred_singular(trans):
+    # Test singular method
+    expected_result = "Más sobre napari"
+    result = trans._("MORE ABOUT NAPARI", deferred=True)
+    assert result.translate() == expected_result
+    assert str(result) == expected_result
 
 
 def test_locale_invalid():
@@ -140,10 +144,6 @@ def test_locale_n_runs(trans):
     n = 2
     string = "MORE ABOUT NAPARI"
     plural = "MORE ABOUT NAPARIS"
-    result = trans.ngettext(string, plural, n)
-    assert result == plural
-
-    # Test plural method shorthand
     result = trans._n(string, plural, n)
     assert result == plural
 
@@ -153,19 +153,8 @@ def test_locale_p_runs(trans):
     context = "context"
     string = "MORE ABOUT NAPARI"
     py37_result = "Más sobre napari"
-    result = trans.pgettext(context, string)
-
-    # Python 3.7 or lower does not offer translations based on context
-    # so pgettext, or npgettext are not available. We fallback to the
-    # singular and plural versions without context. For these cases:
-    # `pgettext` falls back to `gettext` and `npgettext` to `gettext`
-    if PY37_OR_LOWER:
-        assert result == py37_result
-    else:
-        assert result == string
-
-    # Test context singular method shorthand
     result = trans._p(context, string)
+
     if PY37_OR_LOWER:
         assert result == py37_result
     else:
@@ -178,10 +167,6 @@ def test_locale_np_runs(trans):
     context = "context"
     string = "MORE ABOUT NAPARI"
     plural = "MORE ABOUT NAPARIS"
-    result = trans.npgettext(context, string, plural, n)
-    assert result == plural
-
-    # Test plural context method shorthand
     result = trans._np(context, string, plural, n)
     assert result == plural
 

--- a/napari/utils/_tests/test_translations.py
+++ b/napari/utils/_tests/test_translations.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from napari.utils.translations import (
+    TranslationString,
     _get_display_name,
     _is_valid_locale,
     _load_language,
@@ -127,7 +128,10 @@ def test_locale_valid_deferred_singular(trans):
     # Test singular method
     expected_result = "Más sobre napari"
     result = trans._("MORE ABOUT NAPARI", deferred=True)
-    assert result.translate() == expected_result
+    assert result.translation() == expected_result
+    assert str(result) == "MORE ABOUT NAPARI"
+
+    result = trans._("MORE ABOUT NAPARI", deferred=False)
     assert str(result) == expected_result
 
 
@@ -194,3 +198,15 @@ def test_load_language_invalid(tmp_path):
 
     with pytest.warns(UserWarning):
         _load_language(temp_config_path)
+
+
+def test_exception_string(trans):
+    expected_result = "Más sobre napari"
+    result = trans._("MORE ABOUT NAPARI", deferred=True)
+    assert str(result) != expected_result
+    assert str(result) == "MORE ABOUT NAPARI"
+
+    with pytest.raises(ValueError) as err:
+        raise ValueError(result)
+
+    assert isinstance(err.value.args[0], TranslationString)

--- a/napari/utils/_tests/test_translations.py
+++ b/napari/utils/_tests/test_translations.py
@@ -24,7 +24,7 @@ es_CO_po = r"""msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2021-02-18 19:00\n"
-"PO-Revision-Date:  2021-02-18 19:00\n"
+"PO-Revision-Date: 2021-04-08 08:14-0500\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -34,25 +34,52 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: es_CO\n"
 
-#: /
-msgid "MORE ABOUT NAPARI"
+#: Test for singular
+msgid "More about napari"
 msgstr "Más sobre napari"
+
+#: Test for singular with context
+msgctxt "singular-context"
+msgid "More about napari with context"
+msgstr "Más sobre napari con contexto"
+
+#: Test for singular with variables
+msgid "More about napari with {variable}"
+msgstr "Más sobre napari con {variable}"
+
+#: Test for singular with and context variables
+msgctxt "singular-context-variables"
+msgid "More about napari with context and {variable}"
+msgstr "Más sobre napari con contexto y {variable}"
+
+#: Test for plural
+msgid "I have napari"
+msgid_plural "I have naparis"
+msgstr[0] "Tengo napari"
+msgstr[1] "Tengo naparis"
+
+#: Test for singular with context
+msgctxt "plural-context"
+msgid "I have napari with context"
+msgid_plural "I have naparis with context"
+msgstr[0] "Tengo napari con contexto"
+msgstr[1] "Tengo naparis con contexto"
+
+#: Test for plural with variables
+msgid "I have {n} napari with {variable}"
+msgid_plural "I have {n} naparis with {variable}"
+msgstr[0] "Tengo {n} napari con {variable}"
+msgstr[1] "Tengo {n} naparis con {variable}"
+
+#: Test for singular with and context variables
+msgctxt "plural-context-variables"
+msgid "I have {n} napari with {variable} and context"
+msgid_plural "I have {n} naparis with {variable} and context"
+msgstr[0] "Tengo {n} napari con {variable} y contexto"
+msgstr[1] "Tengo {n} naparis con {variable} y contexto"
 """
 
-es_CO_mo = (
-    b"\xde\x12\x04\x95\x00\x00\x00\x00\x02\x00\x00\x00\x1c\x00\x00\x00,"
-    b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00<\x00"
-    b"\x00\x00\x11\x00\x00\x00=\x00\x00\x00[\x01\x00\x00O\x00\x00\x00\x11"
-    b"\x00\x00\x00\xab\x01\x00\x00\x00"
-    b"MORE ABOUT NAPARI\x00Project-Id-Version:  \n"
-    b"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-    b"POT-Creation-Date: 2021-02-18 19:00+0000\n"
-    b"PO-Revision-Date: 2021-02-18 19:00+0000\n"
-    b"Last-Translator: \nLanguage: es_CO\nLanguage-Team: \n"
-    b"Plural-Forms: nplurals=2; plural=(n != 1)\nMIME-Version: 1.0\n"
-    b"Content-Type: text/plain; charset=utf-8\nContent-Transfer-Encoding: 8bit"
-    b"\nGenerated-By: Babel 2.9.0\n\x00M\xc3\xa1s sobre napari\x00"
-)
+es_CO_mo = b'\xde\x12\x04\x95\x00\x00\x00\x00\t\x00\x00\x00\x1c\x00\x00\x00d\x00\x00\x00\r\x00\x00\x00\xac\x00\x00\x00\x00\x00\x00\x00\xe0\x00\x00\x00\x1c\x00\x00\x00\xe1\x00\x00\x00D\x00\x00\x00\xfe\x00\x00\x00\x11\x00\x00\x00C\x01\x00\x00!\x00\x00\x00U\x01\x00\x00E\x00\x00\x00w\x01\x00\x00u\x00\x00\x00\xbd\x01\x00\x00/\x00\x00\x003\x02\x00\x00H\x00\x00\x00c\x02\x00\x00\x0e\x01\x00\x00\xac\x02\x00\x00\x1a\x00\x00\x00\xbb\x03\x00\x00@\x00\x00\x00\xd6\x03\x00\x00\x11\x00\x00\x00\x17\x04\x00\x00 \x00\x00\x00)\x04\x00\x004\x00\x00\x00J\x04\x00\x00V\x00\x00\x00\x7f\x04\x00\x00\x1e\x00\x00\x00\xd6\x04\x00\x00+\x00\x00\x00\xf5\x04\x00\x00\x01\x00\x00\x00\t\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x08\x00\x00\x00\x06\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x02\x00\x00\x00\x00I have napari\x00I have naparis\x00I have {n} napari with {variable}\x00I have {n} naparis with {variable}\x00More about napari\x00More about napari with {variable}\x00plural-context\x04I have napari with context\x00I have naparis with context\x00plural-context-variables\x04I have {n} napari with {variable} and context\x00I have {n} naparis with {variable} and context\x00singular-context\x04More about napari with context\x00singular-context-variables\x04More about napari with context and {variable}\x00Project-Id-Version: \nPO-Revision-Date: 2021-04-08 08:14-0500\nLanguage-Team: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Generator: Poedit 2.4.2\nLast-Translator: \nPlural-Forms: nplurals=2; plural=(n != 1);\nLanguage: es_CO\n\x00Tengo napari\x00Tengo naparis\x00Tengo {n} napari con {variable}\x00Tengo {n} naparis con {variable}\x00M\xc3\xa1s sobre napari\x00M\xc3\xa1s sobre napari con {variable}\x00Tengo napari con contexto\x00Tengo naparis con contexto\x00Tengo {n} napari con {variable} y contexto\x00Tengo {n} naparis con {variable} y contexto\x00M\xc3\xa1s sobre napari con contexto\x00M\xc3\xa1s sobre napari con contexto y {variable}\x00'
 
 
 @pytest.fixture
@@ -117,64 +144,6 @@ def test_is_valid_locale_invalid():
     assert not _is_valid_locale("bar")
 
 
-def test_locale_valid_singular(trans):
-    # Test singular method
-    expected_result = "Más sobre napari"
-    result = trans._("MORE ABOUT NAPARI")
-    assert result == expected_result
-
-
-def test_locale_valid_deferred_singular(trans):
-    # Test singular method
-    expected_result = "Más sobre napari"
-    result = trans._("MORE ABOUT NAPARI", deferred=True)
-    assert result.translation() == expected_result
-    assert str(result) == "MORE ABOUT NAPARI"
-
-    result = trans._("MORE ABOUT NAPARI", deferred=False)
-    assert str(result) == expected_result
-
-
-def test_locale_invalid():
-    with pytest.warns(UserWarning):
-        translator._set_locale(TEST_LOCALE)
-        trans = translator.load()
-        result = trans._("BOO")
-        assert result == "BOO"
-
-
-def test_locale_n_runs(trans):
-    # Test plural method
-    n = 2
-    string = "MORE ABOUT NAPARI"
-    plural = "MORE ABOUT NAPARIS"
-    result = trans._n(string, plural, n)
-    assert result == plural
-
-
-def test_locale_p_runs(trans):
-    # Test context singular method
-    context = "context"
-    string = "MORE ABOUT NAPARI"
-    py37_result = "Más sobre napari"
-    result = trans._p(context, string)
-
-    if PY37_OR_LOWER:
-        assert result == py37_result
-    else:
-        assert result == string
-
-
-def test_locale_np_runs(trans):
-    # Test plural context method
-    n = 2
-    context = "context"
-    string = "MORE ABOUT NAPARI"
-    plural = "MORE ABOUT NAPARIS"
-    result = trans._np(context, string, plural, n)
-    assert result == plural
-
-
 def test_load_language_valid(tmp_path):
     # This is valid content
     data = """
@@ -200,6 +169,229 @@ def test_load_language_invalid(tmp_path):
         _load_language(temp_config_path)
 
 
+def test_locale_invalid():
+    with pytest.warns(UserWarning):
+        translator._set_locale(TEST_LOCALE)
+        trans = translator.load()
+        result = trans._("BOO")
+        assert result == "BOO"
+
+
+# Test trans methods
+# ------------------
+def test_locale_singular(trans):
+    expected_result = "Más sobre napari"
+    result = trans._("More about napari")
+    assert result == expected_result
+
+
+def test_locale_singular_with_format(trans):
+    variable = 1
+    singular = "More about napari with {variable}"
+    expected_result = f"Más sobre napari con {variable}"
+    result = trans._(singular, variable=variable)
+    assert result == expected_result
+
+
+def test_locale_singular_deferred_with_format(trans):
+    variable = 1
+    singular = "More about napari with {variable}"
+    original_result = f"More about napari with {variable}"
+    translated_result = f"Más sobre napari con {variable}"
+    result = trans._(singular, deferred=True, variable=variable)
+    assert isinstance(result, TranslationString)
+    assert result.translation() == translated_result
+    assert result.value() == original_result
+    assert str(result) == original_result
+
+
+def test_locale_singular_context(trans):
+    context = "singular-context"
+    singular = "More about napari with context"
+
+    if PY37_OR_LOWER:
+        # Context not supported on this version
+        expected_result = singular
+    else:
+        expected_result = "Más sobre napari con contexto"
+
+    result = trans._p(context, singular)
+    assert result == expected_result
+
+
+def test_locale_singular_context_with_format(trans):
+    context = "singular-context-variables"
+    variable = 1
+    singular = "More about napari with context and {variable}"
+
+    if PY37_OR_LOWER:
+        # Context not supported on this version
+        expected_result = singular.format(variable=variable)
+    else:
+        expected_result = f"Más sobre napari con contexto y {variable}"
+
+    result = trans._p(context, singular, variable=variable)
+    assert result == expected_result
+
+
+def test_locale_singular_context_deferred_with_format(trans):
+    context = "singular-context-variables"
+    variable = 1
+    singular = "More about napari with context and {variable}"
+    original_result = f"More about napari with context and {variable}"
+
+    if PY37_OR_LOWER:
+        # Context not supported on this version
+        translated_result = original_result
+    else:
+        translated_result = f"Más sobre napari con contexto y {variable}"
+
+    result = trans._p(context, singular, deferred=True, variable=variable)
+    assert isinstance(result, TranslationString)
+    assert result.translation() == translated_result
+    assert result.value() == original_result
+    assert str(result) == original_result
+
+
+def test_locale_plural(trans):
+    singular = "I have napari"
+    plural = "I have naparis"
+
+    n = 1
+    result = trans._n(singular, plural, n=n)
+    expected_result = "Tengo napari"
+    assert result == expected_result
+
+    n = 2
+    result_plural = trans._n(singular, plural, n=n)
+    expected_result_plural = "Tengo naparis"
+    assert result_plural == expected_result_plural
+
+
+def test_locale_plural_with_format(trans):
+    singular = "I have {n} napari with {variable}"
+    plural = "I have {n} naparis with {variable}"
+    variable = 1
+
+    n = 1
+    result = trans._n(singular, plural, n=n, variable=variable)
+    expected_result = f"Tengo {n} napari con {variable}"
+    assert result == expected_result
+
+    n = 2
+    result_plural = trans._n(singular, plural, n=n, variable=variable)
+    expected_result_plural = f"Tengo {n} naparis con {variable}"
+    assert result_plural == expected_result_plural
+
+
+def test_locale_plural_deferred_with_format(trans):
+    variable = 1
+    singular = "I have {n} napari with {variable}"
+    plural = "I have {n} naparis with {variable}"
+
+    n = 1
+    original_result = singular.format(n=n, variable=variable)
+    result = trans._n(singular, plural, n=n, deferred=True, variable=variable)
+    expected_result = f"Tengo {n} napari con {variable}"
+    assert isinstance(result, TranslationString)
+    assert result.translation() == expected_result
+    assert result.value() == original_result
+    assert str(result) == original_result
+
+    n = 2
+    original_result_plural = plural.format(n=n, variable=variable)
+    result_plural = trans._n(
+        singular, plural, n=n, deferred=True, variable=variable
+    )
+    expected_result_plural = f"Tengo {n} naparis con {variable}"
+    assert isinstance(result, TranslationString)
+    assert result_plural.translation() == expected_result_plural
+    assert result_plural.value() == original_result_plural
+    assert str(result_plural) == original_result_plural
+
+
+def test_locale_plural_context(trans):
+    context = "plural-context"
+    singular = "I have napari with context"
+    plural = "I have naparis with context"
+
+    n = 1
+    result = trans._np(context, singular, plural, n=n)
+    expected_res = singular if PY37_OR_LOWER else "Tengo napari con contexto"
+    assert result == expected_res
+
+    n = 2
+    result_plural = trans._np(context, singular, plural, n=n)
+    expected_res = plural if PY37_OR_LOWER else "Tengo naparis con contexto"
+    assert result_plural == expected_res
+
+
+def test_locale_plural_context_with_format(trans):
+    context = "plural-context-variables"
+    singular = "I have {n} napari with {variable} and context"
+    plural = "I have {n} naparis with {variable} and context"
+    variable = 1
+
+    n = 1
+    result = trans._np(context, singular, plural, n=n, variable=variable)
+    if PY37_OR_LOWER:
+        expected_result = singular.format(n=n, variable=variable)
+    else:
+        expected_result = f"Tengo {n} napari con {variable} y contexto"
+
+    assert result == expected_result
+
+    n = 2
+    result_plural = trans._np(
+        context, singular, plural, n=n, variable=variable
+    )
+    if PY37_OR_LOWER:
+        expected_result_plural = plural.format(n=n, variable=variable)
+    else:
+        expected_result_plural = f"Tengo {n} naparis con {variable} y contexto"
+
+    assert result_plural == expected_result_plural
+
+
+def test_locale_plural_context_deferred_with_format(trans):
+    context = "plural-context-variables"
+    variable = 1
+    singular = "I have {n} napari with {variable} and context"
+    plural = "I have {n} naparis with {variable} and context"
+
+    n = 1
+    original_result = singular.format(n=n, variable=variable)
+    result = trans._np(
+        context, singular, plural, n=n, deferred=True, variable=variable
+    )
+    if PY37_OR_LOWER:
+        expected_result = original_result
+    else:
+        expected_result = f"Tengo {n} napari con {variable} y contexto"
+
+    assert isinstance(result, TranslationString)
+    assert result.translation() == expected_result
+    assert result.value() == original_result
+    assert str(result) == original_result
+
+    n = 2
+    original_result_plural = plural.format(n=n, variable=variable)
+    result_plural = trans._np(
+        context, singular, plural, n=n, deferred=True, variable=variable
+    )
+    if PY37_OR_LOWER:
+        expected_result_plural = original_result_plural
+    else:
+        expected_result_plural = f"Tengo {n} naparis con {variable} y contexto"
+
+    assert isinstance(result, TranslationString)
+    assert result_plural.translation() == expected_result_plural
+    assert result_plural.value() == original_result_plural
+    assert str(result_plural) == original_result_plural
+
+
+# Deferred strings in exceptions
+# ------------------------------
 def test_exception_string(trans):
     expected_result = "Más sobre napari"
     result = trans._("MORE ABOUT NAPARI", deferred=True)

--- a/napari/utils/_tests/test_translations.py
+++ b/napari/utils/_tests/test_translations.py
@@ -402,3 +402,15 @@ def test_exception_string(trans):
         raise ValueError(result)
 
     assert isinstance(err.value.args[0], TranslationString)
+
+
+# Test TranslationString
+# ----------------------
+def test_translation_string_exceptions():
+    with pytest.raises(ValueError):
+        TranslationString()
+
+
+def test_bundle_exceptions(trans):
+    with pytest.raises(ValueError):
+        trans._dnpgettext()

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -33,7 +33,7 @@ class Theme(str):
     @classmethod
     def validate(cls, v):
         if not isinstance(v, str):
-            raise ValueError(trans._('must be a string'))
+            raise ValueError(trans._('must be a string', deferred=True))
 
         value = v.lower()
         themes = available_themes()

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -40,8 +40,11 @@ class Theme(str):
         if value not in available_themes():
             raise ValueError(
                 trans._(
-                    '"{value}" is not valid. It must be one of {themes}'
-                ).format(value=value, themes=", ".join(themes))
+                    '"{value}" is not valid. It must be one of {themes}',
+                    deferred=True,
+                    value=value,
+                    themes=", ".join(themes),
+                )
             )
 
         return value
@@ -74,8 +77,11 @@ class Language(str):
         if v not in language_packs:
             raise ValueError(
                 trans._(
-                    '"{value}" is not valid. It must be one of {language_packs}.'
-                ).format(value=v, language_packs=", ".join(language_packs))
+                    '"{value}" is not valid. It must be one of {language_packs}.',
+                    deferred=True,
+                    value=v,
+                    language_packs=", ".join(language_packs),
+                )
             )
 
         return v

--- a/napari/utils/translations.py
+++ b/napari/utils/translations.py
@@ -7,7 +7,7 @@ import gettext
 import os
 import sys
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 from yaml import safe_load
 
@@ -174,11 +174,11 @@ class TranslationString:
 
     def __init__(
         self,
-        domain: str = None,
-        msgctxt: str = None,
-        msgid: str = None,
-        msgid_plural: str = None,
-        n: str = None,
+        domain: Optional[str] = None,
+        msgctxt: Optional[str] = None,
+        msgid: Optional[str] = None,
+        msgid_plural: Optional[str] = None,
+        n: Optional[str] = None,
         deferred: bool = False,
         **kwargs,
     ):
@@ -307,10 +307,10 @@ class TranslationBundle:
 
     def _dnpgettext(
         self,
-        msgctxt: str = None,
+        msgctxt: Optional[str] = None,
         msgid: str = "",
         msgid_plural: str = "",
-        n: int = None,
+        n: Optional[int] = None,
         **kwargs,
     ):
         """
@@ -390,7 +390,7 @@ class TranslationBundle:
         msgid: str,
         msgid_plural: str,
         n: int,
-        deferred: bool = False,
+        deferred: Optional[bool] = False,
         **kwargs,
     ) -> Union[TranslationString, str]:
         """
@@ -433,7 +433,7 @@ class TranslationBundle:
         return translation
 
     def _p(
-        self, msgctxt: str, msgid: str, deferred: bool = False, **kwargs
+        self, msgctxt: str, msgid: str, deferred: Optional[bool] = False, **kwargs
     ) -> Union[TranslationString, str]:
         """
         Shorthand for `gettext.pgettext` with enhanced functionality.
@@ -477,7 +477,7 @@ class TranslationBundle:
         msgid: str,
         msgid_plural: str,
         n: str,
-        deferred: bool = False,
+        deferred: Optional[bool] = False,
         **kwargs,
     ) -> Union[TranslationString, str]:
         """

--- a/napari/utils/translations.py
+++ b/napari/utils/translations.py
@@ -195,14 +195,27 @@ class TranslationString:
 
     def __repr__(self):
         """"""
-        return repr(self.translate())
+        return repr(self.__str__())
 
     def __str__(self):
         """"""
-        return self.translate()
+        return self.value() if self._deferred else self.translation()
 
-    def translate(self):
-        """"""
+    def value(self):
+        """
+        Return the original string with interpolated kwargs, if provided.
+        """
+        if self._n is None or self._n == 1:
+            string = self._msgid
+        elif self._n != 1:
+            string = self._msgid_plural
+
+        return string.format(**self._kwargs)
+
+    def translation(self):
+        """
+        Return the translated string with interpolated kwargs, if provided.
+        """
         # Python 3.7 or lower does not offer translations based on context.
         # On these versions `gettext.npgettext` falls back to `gettext.ngettext`
         if PY37_OR_LOWER:

--- a/napari/utils/translations.py
+++ b/napari/utils/translations.py
@@ -182,6 +182,9 @@ class TranslationString:
         deferred: bool = False,
         **kwargs,
     ):
+        if msgid is None:
+            raise ValueError("Must provide at least a `msgid` parameter!")
+
         self._domain = domain
         self._msgctxt = msgctxt
         self._msgid = msgid


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousando words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->


Fixes #2513

Include format `kwargs` and a `deferred` option, for exceptions raised in modules not displaying a UI.

A subsequent PR will update the notifications UI to use deferred translations and translate before showing them on the UI.

Part of the docs thgat explain what this does.

<img width="953" alt="Screen Shot 2021-04-07 at 11 44 20 AM" src="https://user-images.githubusercontent.com/3627835/113903453-a095ea00-9796-11eb-8a2a-d0733386c01b.png">

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
