### PR TITLE
trigger label colormap generation on seed change to fix shuffle bug, addresses #2523

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from numpy.core.numerictypes import issubdtype
+from numpy.testing import assert_array_almost_equal, assert_raises
 from skimage import data
 
 from napari._tests.utils import check_layer_world_data_extent
@@ -229,6 +230,15 @@ def test_seed():
 
     layer = Labels(data, seed=0.7)
     assert layer.seed == 0.7
+
+    # ensure setting seed triggers
+    # recalculation of _all_vals
+    _all_vals_07 = layer._all_vals.copy()
+    layer.seed = 0.4
+    _all_vals_04 = layer._all_vals.copy()
+    assert_raises(
+        AssertionError, assert_array_almost_equal, _all_vals_04, _all_vals_07
+    )
 
 
 def test_num_colors():

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -316,7 +316,7 @@ class Labels(_image_base_class):
         self._selected_color = self.get_color(self.selected_label)
         # invalidate _all_vals to trigger re-generation
         # in _raw_to_displayed
-        self._all_vals = None
+        self._all_vals = np.array([])
         self.refresh()
         self.events.selected_label()
 
@@ -718,7 +718,7 @@ class Labels(_image_base_class):
         ):
             try:
                 image = self._all_vals[raw]
-            except (IndexError, TypeError):
+            except IndexError:
                 max_val = np.max(raw)
                 self._all_vals = low_discrepancy_image(
                     np.arange(max_val + 1), self._seed

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -314,8 +314,12 @@ class Labels(_image_base_class):
     def seed(self, seed):
         self._seed = seed
         self._selected_color = self.get_color(self.selected_label)
+        # invalidate _all_vals to trigger re-generation
+        # in _raw_to_displayed
+        self._all_vals = None
         self.refresh()
         self.events.selected_label()
+
 
     @property
     def num_colors(self):
@@ -715,7 +719,7 @@ class Labels(_image_base_class):
         ):
             try:
                 image = self._all_vals[raw]
-            except IndexError:
+            except (IndexError, TypeError):
                 max_val = np.max(raw)
                 self._all_vals = low_discrepancy_image(
                     np.arange(max_val + 1), self._seed

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -320,7 +320,6 @@ class Labels(_image_base_class):
         self.refresh()
         self.events.selected_label()
 
-
     @property
     def num_colors(self):
         """int: Number of unique colors to use in colormap."""


### PR DESCRIPTION
# Description

For discussion see #2523


## Type of change

- [x ] Bug-fix (non-breaking change which fixes an issue)

# References
closes #2523

# How has this been tested?
manually verified that shuffling is restored

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).


For discussion: not sure whether it is clean style to trigger an update through causing an Exception somewhere else (debatable). 
Probably, there should be an automated test to see whether shuffle does what it should. I don't have time for this in the near future though. Feel free to add to this branch (or use a completely different approach).

@DragaDoncila  @jni @sofroniewn 