### PR TITLE
Modified quaternion2euler function to cap the arcsin's argument by +-1

### DIFF
--- a/napari/_vispy/_tests/test_utils.py
+++ b/napari/_vispy/_tests/test_utils.py
@@ -12,8 +12,8 @@ angles_param = [(x, True) for x in angles]
 angles_param.extend([(x, False) for x in np.radians(angles)])
 
 
-@pytest.mark.parametrize('angles_param', angles_param)
-def test_quaternion2euler(angles_param):
+@pytest.mark.parametrize('angles,degrees', angles_param)
+def test_quaternion2euler(angles, degress):
     """Test quaternion to euler angle conversion."""
 
     # Test for degrees

--- a/napari/_vispy/_tests/test_utils.py
+++ b/napari/_vispy/_tests/test_utils.py
@@ -4,32 +4,22 @@ from vispy.util.quaternion import Quaternion
 
 from napari._vispy.quaternion import quaternion2euler
 
+# Euler angles to be tested, in degrees
+angles = [[12, 53, 92], [180, -90, 0], [16, 90, 0]]
 
-@pytest.mark.parametrize('angles', [[12, 53, 92], [180, -90, 0], [16, 90, 0]])
-def test_quaternion2euler(angles):
+# Prepare for input and add corresponding values in radians
+angles_param = [(x, True) for x in angles]
+angles_param.extend([(x, False) for x in np.radians(angles)])
+
+
+@pytest.mark.parametrize('angles_param', angles_param)
+def test_quaternion2euler(angles_param):
     """Test quaternion to euler angle conversion."""
 
     # Test for degrees
-    q = Quaternion.create_from_euler_angles(*angles, degrees=True)
-    ea = quaternion2euler(q, degrees=True)
-    q_p = Quaternion.create_from_euler_angles(*ea, degrees=True)
-
-    # We now compare the corresponding quaternions ; they should be equals or opposites (as they're already unit ones)
-    q_values = np.array([q.w, q.x, q.y, q.z])
-    q_p_values = np.array([q_p.w, q_p.x, q_p.y, q_p.z])
-
-    nn_zero_ind = np.argmax((q_values != 0) & (q_p_values != 0))
-
-    q_values *= np.sign(q_values[nn_zero_ind])
-    q_p_values *= np.sign(q_p_values[nn_zero_ind])
-
-    np.testing.assert_allclose(q_values, q_p_values)
-
-    # Test for radians
-    angles_rad = np.radians(angles)
-    q = Quaternion.create_from_euler_angles(*angles_rad)
-    ea = quaternion2euler(q)
-    q_p = Quaternion.create_from_euler_angles(*ea)
+    q = Quaternion.create_from_euler_angles(*angles_param[0], angles_param[1])
+    ea = quaternion2euler(q, degrees=angles_param[1])
+    q_p = Quaternion.create_from_euler_angles(*ea, degrees=angles_param[1])
 
     # We now compare the corresponding quaternions ; they should be equals or opposites (as they're already unit ones)
     q_values = np.array([q.w, q.x, q.y, q.z])

--- a/napari/_vispy/_tests/test_utils.py
+++ b/napari/_vispy/_tests/test_utils.py
@@ -12,10 +12,16 @@ def test_quaternion2euler():
     for angles in angles_test:
         q = Quaternion.create_from_euler_angles(*angles, degrees=True)
         ea = quaternion2euler(q, degrees=True)
-        np.testing.assert_allclose(ea, angles)
+        q_p = Quaternion.create_from_euler_angles(*ea, degrees=True)
+        np.testing.assert_allclose(
+            list(q.__dict__.values()), list(q_p.__dict__.values())
+        )
 
         # Test roundtrip radians
         angles_rad = np.radians(angles)
         q = Quaternion.create_from_euler_angles(*angles_rad)
         ea = quaternion2euler(q)
-        np.testing.assert_allclose(ea, angles_rad)
+        q_p = Quaternion.create_from_euler_angles(*ea)
+        np.testing.assert_allclose(
+            list(q.__dict__.values()), list(q_p.__dict__.values())
+        )

--- a/napari/_vispy/_tests/test_utils.py
+++ b/napari/_vispy/_tests/test_utils.py
@@ -17,7 +17,7 @@ def test_quaternion2euler(angles, degress):
     """Test quaternion to euler angle conversion."""
 
     # Test for degrees
-    q = Quaternion.create_from_euler_angles(*angles_param[0], angles_param[1])
+    q = Quaternion.create_from_euler_angles(*angles, degrees)
     ea = quaternion2euler(q, degrees=angles_param[1])
     q_p = Quaternion.create_from_euler_angles(*ea, degrees=angles_param[1])
 

--- a/napari/_vispy/_tests/test_utils.py
+++ b/napari/_vispy/_tests/test_utils.py
@@ -13,7 +13,7 @@ angles_param.extend([(x, False) for x in np.radians(angles)])
 
 
 @pytest.mark.parametrize('angles,degrees', angles_param)
-def test_quaternion2euler(angles, degress):
+def test_quaternion2euler(angles, degrees):
     """Test quaternion to euler angle conversion."""
 
     # Test for degrees

--- a/napari/_vispy/_tests/test_utils.py
+++ b/napari/_vispy/_tests/test_utils.py
@@ -1,27 +1,43 @@
 import numpy as np
+import pytest
 from vispy.util.quaternion import Quaternion
 
 from napari._vispy.quaternion import quaternion2euler
 
 
-def test_quaternion2euler():
+@pytest.mark.parametrize('angles', [[12, 53, 92], [180, -90, 0], [16, 90, 0]])
+def test_quaternion2euler(angles):
     """Test quaternion to euler angle conversion."""
-    # Test some sets of angles
-    angles_test = [[12, 53, 92], [180, -90, 0]]
 
-    for angles in angles_test:
-        q = Quaternion.create_from_euler_angles(*angles, degrees=True)
-        ea = quaternion2euler(q, degrees=True)
-        q_p = Quaternion.create_from_euler_angles(*ea, degrees=True)
-        np.testing.assert_allclose(
-            list(q.__dict__.values()), list(q_p.__dict__.values())
-        )
+    # Test for degrees
+    q = Quaternion.create_from_euler_angles(*angles, degrees=True)
+    ea = quaternion2euler(q, degrees=True)
+    q_p = Quaternion.create_from_euler_angles(*ea, degrees=True)
 
-        # Test roundtrip radians
-        angles_rad = np.radians(angles)
-        q = Quaternion.create_from_euler_angles(*angles_rad)
-        ea = quaternion2euler(q)
-        q_p = Quaternion.create_from_euler_angles(*ea)
-        np.testing.assert_allclose(
-            list(q.__dict__.values()), list(q_p.__dict__.values())
-        )
+    # We now compare the corresponding quaternions ; they should be equals or opposites (as they're already unit ones)
+    q_values = np.array([q.w, q.x, q.y, q.z])
+    q_p_values = np.array([q_p.w, q_p.x, q_p.y, q_p.z])
+
+    nn_zero_ind = np.argmax((q_values != 0) & (q_p_values != 0))
+
+    q_values *= np.sign(q_values[nn_zero_ind])
+    q_p_values *= np.sign(q_p_values[nn_zero_ind])
+
+    np.testing.assert_allclose(q_values, q_p_values)
+
+    # Test for radians
+    angles_rad = np.radians(angles)
+    q = Quaternion.create_from_euler_angles(*angles_rad)
+    ea = quaternion2euler(q)
+    q_p = Quaternion.create_from_euler_angles(*ea)
+
+    # We now compare the corresponding quaternions ; they should be equals or opposites (as they're already unit ones)
+    q_values = np.array([q.w, q.x, q.y, q.z])
+    q_p_values = np.array([q_p.w, q_p.x, q_p.y, q_p.z])
+
+    nn_zero_ind = np.argmax((q_values != 0) & (q_p_values != 0))
+
+    q_values *= np.sign(q_values[nn_zero_ind])
+    q_p_values *= np.sign(q_p_values[nn_zero_ind])
+
+    np.testing.assert_allclose(q_values, q_p_values)

--- a/napari/_vispy/_tests/test_utils.py
+++ b/napari/_vispy/_tests/test_utils.py
@@ -18,8 +18,8 @@ def test_quaternion2euler(angles, degress):
 
     # Test for degrees
     q = Quaternion.create_from_euler_angles(*angles, degrees)
-    ea = quaternion2euler(q, degrees=angles_param[1])
-    q_p = Quaternion.create_from_euler_angles(*ea, degrees=angles_param[1])
+    ea = quaternion2euler(q, degrees=degrees)
+    q_p = Quaternion.create_from_euler_angles(*ea, degrees=degrees)
 
     # We now compare the corresponding quaternions ; they should be equals or opposites (as they're already unit ones)
     q_values = np.array([q.w, q.x, q.y, q.z])

--- a/napari/_vispy/quaternion.py
+++ b/napari/_vispy/quaternion.py
@@ -24,14 +24,14 @@ def quaternion2euler(quaternion, degrees=False):
     angles : 3-tuple
         Euler angles in (rx, ry, rz) order.
     """
-    epsilon = 1e-7
+    epsilon = 1e-10
 
     q = quaternion
 
     sin_theta_2 = 2 * (q.w * q.y - q.z * q.x)
     sin_theta_2 = np.sign(sin_theta_2) * min(abs(sin_theta_2), 1)
 
-    if abs(sin_theta_2) - 1 < epsilon:
+    if abs(sin_theta_2) > 1 - epsilon:
         theta_1 = -np.sign(sin_theta_2) * 2 * np.arctan2(q.x, q.w)
         theta_2 = np.arcsin(sin_theta_2)
         theta_3 = 0

--- a/napari/_vispy/quaternion.py
+++ b/napari/_vispy/quaternion.py
@@ -4,6 +4,14 @@ import numpy as np
 def quaternion2euler(quaternion, degrees=False):
     """Converts VisPy quaternion into euler angle representation.
 
+    Euler angles have degeneracies, so the output might different
+    from the Euler angles that might have been used to generate
+    the input quaternion.
+
+    Euler angles representation also has a singularity
+    near pitch = Pi/2 ; to avoid this, we set to Pi/2 pitch angles
+     that are closer than the chosen epsilon from it.
+
     Parameters
     ----------
     quaternion : vispy.util.Quaternion
@@ -16,25 +24,30 @@ def quaternion2euler(quaternion, degrees=False):
     angles : 3-tuple
         Euler angles in (rx, ry, rz) order.
     """
+    epsilon = 1e-7
 
     q = quaternion
 
-    theta_1 = np.arctan2(
-        2 * (q.w * q.z + q.y * q.x),
-        1 - 2 * (q.y * q.y + q.z * q.z),
-    )
+    sin_theta_2 = 2 * (q.w * q.y - q.z * q.x)
+    sin_theta_2 = np.sign(sin_theta_2) * min(abs(sin_theta_2), 1)
 
-    theta_2 = 2 * (q.w * q.y - q.z * q.x)
-    theta_2 = (
-        np.arcsin(theta_2)
-        if abs(theta_2) < 1
-        else np.sign(theta_2) * np.pi / 2
-    )
+    if abs(sin_theta_2) - 1 < epsilon:
+        theta_1 = -np.sign(sin_theta_2) * 2 * np.arctan2(q.x, q.w)
+        theta_2 = np.arcsin(sin_theta_2)
+        theta_3 = 0
 
-    theta_3 = np.arctan2(
-        2 * (q.w * q.x + q.y * q.z),
-        1 - 2 * (q.x * q.x + q.y * q.y),
-    )
+    else:
+        theta_1 = np.arctan2(
+            2 * (q.w * q.z + q.y * q.x),
+            1 - 2 * (q.y * q.y + q.z * q.z),
+        )
+
+        theta_2 = np.arcsin(sin_theta_2)
+
+        theta_3 = np.arctan2(
+            2 * (q.w * q.x + q.y * q.z),
+            1 - 2 * (q.x * q.x + q.y * q.y),
+        )
 
     angles = (theta_1, theta_2, theta_3)
 

--- a/napari/_vispy/quaternion.py
+++ b/napari/_vispy/quaternion.py
@@ -16,25 +16,24 @@ def quaternion2euler(quaternion, degrees=False):
     angles : 3-tuple
         Euler angles in (rx, ry, rz) order.
     """
-    
-    def capper(value):
-        # Cap the value to +1 or -1
-        value_capped = value if abs(value) < 1 else np.sign(value)
-        return value_capped
-    
-    
+
     q = quaternion
-    angles = (
-        np.arctan2(
+
+    theta_1 = np.arctan2(
             2 * (q.w * q.z + q.y * q.x),
             1 - 2 * (q.y * q.y + q.z * q.z),
-        ),
-        np.arcsin(capper(2 * (q.w * q.y - q.z * q.x))),
-        np.arctan2(
+        )
+
+    theta_2 = 2 * (q.w * q.y - q.z * q.x)
+    theta_2 = np.arcsin(theta_2) if abs(theta_2) < 1 else np.sign(theta_2)*np.pi/2
+
+    theta_3 = np.arctan2(
             2 * (q.w * q.x + q.y * q.z),
             1 - 2 * (q.x * q.x + q.y * q.y),
-        ),
-    )
+        )
+
+    angles = (theta_1, theta_2, theta_3)
+
     if degrees:
         return tuple(np.degrees(angles))
     else:

--- a/napari/_vispy/quaternion.py
+++ b/napari/_vispy/quaternion.py
@@ -16,13 +16,20 @@ def quaternion2euler(quaternion, degrees=False):
     angles : 3-tuple
         Euler angles in (rx, ry, rz) order.
     """
+    
+    def capper(value):
+        # Cap the value to +1 or -1
+        value_capped = value if abs(value) < 1 else np.sign(value)
+        return value_capped
+    
+    
     q = quaternion
     angles = (
         np.arctan2(
             2 * (q.w * q.z + q.y * q.x),
             1 - 2 * (q.y * q.y + q.z * q.z),
         ),
-        np.arcsin(2 * (q.w * q.y - q.z * q.x)),
+        np.arcsin(capper(2 * (q.w * q.y - q.z * q.x))),
         np.arctan2(
             2 * (q.w * q.x + q.y * q.z),
             1 - 2 * (q.x * q.x + q.y * q.y),

--- a/napari/_vispy/quaternion.py
+++ b/napari/_vispy/quaternion.py
@@ -10,7 +10,7 @@ def quaternion2euler(quaternion, degrees=False):
 
     Euler angles representation also has a singularity
     near pitch = Pi/2 ; to avoid this, we set to Pi/2 pitch angles
-     that are closer than the chosen epsilon from it.
+    that are closer than the chosen epsilon from it.
 
     Parameters
     ----------

--- a/napari/_vispy/quaternion.py
+++ b/napari/_vispy/quaternion.py
@@ -16,25 +16,24 @@ def quaternion2euler(quaternion, degrees=False):
     angles : 3-tuple
         Euler angles in (rx, ry, rz) order.
     """
-    
-    def capper(value):
-        # Cap the value to +1 or -1
-        value_capped = value if abs(value) < 1 else np.sign(value)
-        return value_capped
-    
-    
+
     q = quaternion
-    angles = (
-        np.arctan2(
-            2 * (q.w * q.z + q.y * q.x),
-            1 - 2 * (q.y * q.y + q.z * q.z),
-        ),
-        np.arcsin(capper(2 * (q.w * q.y - q.z * q.x))),
-        np.arctan2(
-            2 * (q.w * q.x + q.y * q.z),
-            1 - 2 * (q.x * q.x + q.y * q.y),
-        ),
+
+    theta_1 = np.arctan2(
+        2 * (q.w * q.z + q.y * q.x),
+        1 - 2 * (q.y * q.y + q.z * q.z),
     )
+
+    theta_2 = 2 * (q.w * q.y - q.z * q.x)
+    theta_2 = np.arcsin(theta_2) if abs(theta_2) < 1 else np.sign(theta_2) * np.pi / 2
+
+    theta_3 = np.arctan2(
+        2 * (q.w * q.x + q.y * q.z),
+        1 - 2 * (q.x * q.x + q.y * q.y),
+    )
+
+    angles = (theta_1, theta_2, theta_3)
+
     if degrees:
         return tuple(np.degrees(angles))
     else:

--- a/napari/_vispy/vispy_camera.py
+++ b/napari/_vispy/vispy_camera.py
@@ -44,7 +44,10 @@ class VispyCamera:
 
     @property
     def angles(self):
-        """3-tuple: Euler angles of camera in 3D viewing, in degrees."""
+        """3-tuple: Euler angles of camera in 3D viewing, in degrees.
+        Note that angles might be different than the ones that might have generated the quaternion.
+        """
+
         if self._view.camera == self._3D_camera:
             # Do conversion from quaternion representation to euler angles
             angles = quaternion2euler(

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -18,6 +18,8 @@ class Camera(EventedModel):
     angles : 3-tuple
         Euler angles of camera in 3D viewing (rx, ry, rz), in degrees.
         Only used during 3D viewing.
+        Note that Euler angles's intrinsic degeneracy means different
+        sets of Euler angles may lead to the same view.
     interactive : bool
         If the camera interactivity is enabled or not.
     """


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousando words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
Adresses #2525 .

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
Checked that returned tuple of angles doesn't contain `nan`, and doesn't return a warning anymore.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas

