### PR TITLE
single line change to track recoloring function

### DIFF
--- a/napari/_qt/layer_controls/qt_tracks_controls.py
+++ b/napari/_qt/layer_controls/qt_tracks_controls.py
@@ -4,6 +4,7 @@ from qtpy.QtWidgets import QCheckBox, QComboBox, QLabel, QSlider
 
 from ...utils.colormaps import AVAILABLE_COLORMAPS
 from ...utils.translations import trans
+from ..utils import qt_signals_blocked
 from .qt_layer_controls_base import QtLayerControls
 
 MAX_TAIL_LENGTH = 300
@@ -133,7 +134,9 @@ class QtTracksControls(QtLayerControls):
     def _on_properties_change(self, event=None):
         """Change the properties that can be used to color the tracks."""
         with self.layer.events.properties.blocker():
-            self.color_by_combobox.clear()
+
+            with qt_signals_blocked(self.color_by_combobox):
+                self.color_by_combobox.clear()
             self.color_by_combobox.addItems(self.layer.properties_to_color_by)
 
     def _on_colormap_change(self, event=None):

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -496,7 +496,7 @@ class Tracks(Layer):
         # updated before the properties are. properties should always contain
         # a track_id key
         if self.color_by not in self.properties_to_color_by:
-            self.color_by = 'track_id'
+            self._color_by = 'track_id'
 
         # if we change the coloring, rebuild the vertex colors array
         vertex_properties = self._manager.vertex_properties(self.color_by)

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -497,6 +497,7 @@ class Tracks(Layer):
         # a track_id key
         if self.color_by not in self.properties_to_color_by:
             self._color_by = 'track_id'
+            self.events.color_by()
 
         # if we change the coloring, rebuild the vertex colors array
         vertex_properties = self._manager.vertex_properties(self.color_by)


### PR DESCRIPTION
# Description

It fixes #2531, but it leads to another error. I would like to discuss this here.

The `_recolor_track` method was setting the `color_by` value using its setter, executing `_recolor_track` twice and leading to an error when it was called from the data setter method because it had just cleaned the `properties` dictionary, such that `color_by` would never be available.

```python3
    @data.setter
    def data(self, data: np.ndarray):
        """ set the data and build the vispy arrays for display """
        # set the data and build the tracks
        self._manager.data = data
        self._manager.build_tracks()

        # reset the properties and recolor the tracks
        self.properties = {}
        self._recolor_tracks()  # <- HERE
        ...

    @color_by.setter
    def color_by(self, color_by: str):
        """ set the property to color vertices by """
        if color_by not in self.properties_to_color_by:
            raise ValueError(f'{color_by} is not a valid property key')
        self._color_by = color_by
        self._recolor_tracks()
        self.events.color_by()

        ...

    def _recolor_tracks(self):
        """ recolor the tracks """

        # this catch prevents a problem coloring the tracks if the data is
        # updated before the properties are. properties should always contain
        # a track_id key
        if self.color_by not in self.properties_to_color_by:
            # self.color_by = 'track_id'  # BEFORE
            self._color_by = 'track_id'  # after this PR
        ...
```

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# References
Issue #2531 

# How has this been tested?

Now it leads to an error from a qt signal, it is sending an empty string to the `change_color_by` slot. I'm not sure why this is happening.

It can be reproduced with the same example from the original issue.
I have to fix this before merging this PR.

```python3
WARNING: Traceback (most recent call last):
  File "~/napari/napari/_qt/layer_controls/qt_tracks_controls.py", line 201, in change_color_by
    self.layer.color_by = value
  File "~/napari/napari/layers/tracks/tracks.py", line 465, in color_by
    raise ValueError(f'{color_by} is not a valid property key')
ValueError:  is not a valid property key
Aborted (core dumped)
```

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
