### PR TITLE
Deprecate gui qt

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,26 +96,28 @@ For more information or troubleshooting see our [installation tutorial](https://
 > ```
 
 ## simple example
+
 (The examples below require the `scikit-image` package to run. We just use data samples from this package for demonstration purposes. If you change the examples to use your own dataset, you may not need to install this package.)
 
-From inside an IPython shell (started with `ipython --gui=qt`) or jupyter notebook (after running a cell with magic command `%gui qt`) you can open up an interactive viewer by calling
+From inside an IPython shell, you can open up an interactive viewer by calling
 
 ```python
 from skimage import data
 import napari
+
 viewer = napari.view_image(data.astronaut(), rgb=True)
 ```
 
 ![image](resources/screenshot-add-image.png)
 
-To do the same thing inside a script call
+To use napari from inside a script, use `napari.run()`:
 
 ```python
 from skimage import data
 import napari
 
-with napari.gui_qt():
-    viewer = napari.view_image(data.astronaut(), rgb=True)
+viewer = napari.view_image(data.astronaut(), rgb=True)
+napari.run()  # start the "event loop" and show the viewer
 ```
 
 ## features

--- a/examples/3D_paths.py
+++ b/examples/3D_paths.py
@@ -10,21 +10,22 @@ from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    blobs = data.binary_blobs(
-                length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=0.05
-            )
+blobs = data.binary_blobs(
+            length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=0.05
+        )
 
-    viewer = napari.Viewer(ndisplay=3)
-    viewer.add_image(blobs.astype(float))
+viewer = napari.Viewer(ndisplay=3)
+viewer.add_image(blobs.astype(float))
 
-    # sample vector coord-like data
-    path = np.array([np.array([[0, 0, 0], [0, 10, 10], [0, 5, 15], [20, 5, 15],
-        [56, 70, 21], [127, 127, 127]]),
-        np.array([[0, 0, 0], [0, 10, 10], [0, 5, 15], [0, 5, 15],
-            [0, 70, 21], [0, 127, 127]])])
+# sample vector coord-like data
+path = np.array([np.array([[0, 0, 0], [0, 10, 10], [0, 5, 15], [20, 5, 15],
+    [56, 70, 21], [127, 127, 127]]),
+    np.array([[0, 0, 0], [0, 10, 10], [0, 5, 15], [0, 5, 15],
+        [0, 70, 21], [0, 127, 127]])])
 
-    print('Path', path.shape)
-    layer = viewer.add_shapes(
-        path, shape_type='path', edge_width=4, edge_color=['red', 'blue']
-    )
+print('Path', path.shape)
+layer = viewer.add_shapes(
+    path, shape_type='path', edge_width=4, edge_color=['red', 'blue']
+)
+
+napari.run()

--- a/examples/3d_kymograph.py
+++ b/examples/3d_kymograph.py
@@ -134,18 +134,19 @@ for s in samples:
     print(f"Description: {s['description']}")
     s["vol"] = np.squeeze(IDR_fetch_image(s["IDRid"]))
 
-with napari.gui_qt():
-    v = napari.Viewer(ndisplay=3)
-    scale = (5, 1, 1)  # "stretch" time domain
-    for s in samples:
-        v.add_image(
-            s["vol"], name=s['description'], scale=scale, blending="opaque"
-        )
+v = napari.Viewer(ndisplay=3)
+scale = (5, 1, 1)  # "stretch" time domain
+for s in samples:
+    v.add_image(
+        s["vol"], name=s['description'], scale=scale, blending="opaque"
+    )
 
-    v.grid.enabled = True  # show the volumes in grid mode
-    v.axes.visible = True  # magenta error shows time direction
+v.grid.enabled = True  # show the volumes in grid mode
+v.axes.visible = True  # magenta error shows time direction
 
-    # set an oblique view angle onto the kymograph grid
-    v.camera.center = (440, 880, 1490)
-    v.camera.angles = (-20, 23, -50)
-    v.camera.zoom = 0.17
+# set an oblique view angle onto the kymograph grid
+v.camera.center = (440, 880, 1490)
+v.camera.angles = (-20, 23, -50)
+v.camera.zoom = 0.17
+
+napari.run()

--- a/examples/add_grayscale_image.py
+++ b/examples/add_grayscale_image.py
@@ -7,8 +7,9 @@ import napari
 import numpy as np
 
 
-with napari.gui_qt():
-    # simulating a grayscale image here for testing contrast limits adjustments
-    image = data.astronaut().mean(-1) * 100 + 100
-    image += np.random.rand(*image.shape) * 3000
-    viewer = napari.view_image(image.astype(np.uint16))
+# simulating a grayscale image here for testing contrast limits adjustments
+image = data.astronaut().mean(-1) * 100 + 100
+image += np.random.rand(*image.shape) * 3000
+viewer = napari.view_image(image.astype(np.uint16))
+
+napari.run()

--- a/examples/add_image.py
+++ b/examples/add_image.py
@@ -6,6 +6,7 @@ from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    # create the viewer with an image
-    viewer = napari.view_image(data.astronaut(), rgb=True)
+# create the viewer with an image
+viewer = napari.view_image(data.astronaut(), rgb=True)
+
+napari.run()

--- a/examples/add_image_transformed.py
+++ b/examples/add_image_transformed.py
@@ -6,6 +6,7 @@ from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    # create the viewer with an image
-    viewer = napari.view_image(data.astronaut(), rgb=True, rotate=45)
+# create the viewer with an image
+viewer = napari.view_image(data.astronaut(), rgb=True, rotate=45)
+
+napari.run()

--- a/examples/add_labels.py
+++ b/examples/add_labels.py
@@ -11,21 +11,22 @@ from skimage.morphology import closing, square, remove_small_objects
 import napari
 
 
-with napari.gui_qt():
-    image = data.coins()[50:-50, 50:-50]
+image = data.coins()[50:-50, 50:-50]
 
-    # apply threshold
-    thresh = threshold_otsu(image)
-    bw = closing(image > thresh, square(4))
+# apply threshold
+thresh = threshold_otsu(image)
+bw = closing(image > thresh, square(4))
 
-    # remove artifacts connected to image border
-    cleared = remove_small_objects(clear_border(bw), 20)
+# remove artifacts connected to image border
+cleared = remove_small_objects(clear_border(bw), 20)
 
-    # label image regions
-    label_image = label(cleared)
+# label image regions
+label_image = label(cleared)
 
-    # initialise viewer with coins image
-    viewer = napari.view_image(image, name='coins', rgb=False)
+# initialise viewer with coins image
+viewer = napari.view_image(image, name='coins', rgb=False)
 
-    # add the labels
-    label_layer = viewer.add_labels(label_image, name='segmentation')
+# add the labels
+label_layer = viewer.add_labels(label_image, name='segmentation')
+
+napari.run()

--- a/examples/add_labels_with_properties.py
+++ b/examples/add_labels_with_properties.py
@@ -12,43 +12,44 @@ import numpy as np
 import napari
 
 
-with napari.gui_qt():
-    image = data.coins()[50:-50, 50:-50]
+image = data.coins()[50:-50, 50:-50]
 
-    # apply threshold
-    thresh = threshold_otsu(image)
-    bw = closing(image > thresh, square(4))
+# apply threshold
+thresh = threshold_otsu(image)
+bw = closing(image > thresh, square(4))
 
-    # remove artifacts connected to image border
-    cleared = remove_small_objects(clear_border(bw), 20)
+# remove artifacts connected to image border
+cleared = remove_small_objects(clear_border(bw), 20)
 
-    # label image regions
-    label_image = label(cleared)
+# label image regions
+label_image = label(cleared)
 
-    # initialise viewer with coins image
-    viewer = napari.view_image(image, name='coins', rgb=False)
+# initialise viewer with coins image
+viewer = napari.view_image(image, name='coins', rgb=False)
 
-    # get the size of each coin (first element is background area)
-    label_areas = np.bincount(label_image.ravel())[1:]
+# get the size of each coin (first element is background area)
+label_areas = np.bincount(label_image.ravel())[1:]
 
-    # split coins into small or large
-    size_range = max(label_areas) - min(label_areas)
-    small_threshold = min(label_areas) + (size_range / 2)
-    coin_sizes = np.where(label_areas > small_threshold, 'large', 'small')
+# split coins into small or large
+size_range = max(label_areas) - min(label_areas)
+small_threshold = min(label_areas) + (size_range / 2)
+coin_sizes = np.where(label_areas > small_threshold, 'large', 'small')
 
-    label_properties = {
-        'row': ['none']
-        + ['top'] * 4
-        + ['bottom'] * 4,  # background is row: none
-        'size': ['none'] + list(coin_sizes),  # background is size: none
-    }
+label_properties = {
+    'row': ['none']
+    + ['top'] * 4
+    + ['bottom'] * 4,  # background is row: none
+    'size': ['none'] + list(coin_sizes),  # background is size: none
+}
 
-    color = {1: 'white', 2: 'blue', 3: 'green', 4: 'red', 5: 'yellow'}
+color = {1: 'white', 2: 'blue', 3: 'green', 4: 'red', 5: 'yellow'}
 
-    # add the labels
-    label_layer = viewer.add_labels(
-        label_image,
-        name='segmentation',
-        properties=label_properties,
-        color=color,
-    )
+# add the labels
+label_layer = viewer.add_labels(
+    label_image,
+    name='segmentation',
+    properties=label_properties,
+    color=color,
+)
+
+napari.run()

--- a/examples/add_multiscale_image.py
+++ b/examples/add_multiscale_image.py
@@ -3,8 +3,6 @@ Displays a multiscale image
 """
 
 from skimage import data
-from skimage.util import img_as_ubyte
-from skimage.color import rgb2gray
 from skimage.transform import pyramid_gaussian
 import napari
 import numpy as np
@@ -17,6 +15,6 @@ multiscale = list(
 )
 print('multiscale level shapes: ', [p.shape[:2] for p in multiscale])
 
-with napari.gui_qt():
-    # add image multiscale
-    napari.view_image(multiscale, multiscale=True)
+# add image multiscale
+viewer = napari.view_image(multiscale, multiscale=True)
+napari.run()

--- a/examples/add_points.py
+++ b/examples/add_points.py
@@ -9,41 +9,42 @@ from skimage.color import rgb2gray
 import napari
 
 
-with napari.gui_qt():
-    # add the image
-    viewer = napari.view_image(rgb2gray(data.astronaut()))
-    # add the points
-    points = np.array([[100, 100], [200, 200], [333, 111]])
-    size = np.array([10, 20, 20])
-    viewer.add_points(points, size=size)
+# add the image
+viewer = napari.view_image(rgb2gray(data.astronaut()))
+# add the points
+points = np.array([[100, 100], [200, 200], [333, 111]])
+size = np.array([10, 20, 20])
+viewer.add_points(points, size=size)
 
-    # unselect the image layer
-    viewer.layers.selection.discard(viewer.layers[0])
+# unselect the image layer
+viewer.layers.selection.discard(viewer.layers[0])
 
-    # adjust some of the points layer properties
-    layer = viewer.layers[1]
+# adjust some of the points layer properties
+layer = viewer.layers[1]
 
-    # change the layer name
-    layer.name = 'points'
+# change the layer name
+layer.name = 'points'
 
-    # change the layer visibility
-    layer.visible = False
-    layer.visible = True
+# change the layer visibility
+layer.visible = False
+layer.visible = True
 
-    # select the layer
-    viewer.layers.selection.add(layer)
-    # deselect the layer
-    viewer.layers.selection.remove(layer)
-    # or: viewer.layers.selection.discard(layer)
+# select the layer
+viewer.layers.selection.add(layer)
+# deselect the layer
+viewer.layers.selection.remove(layer)
+# or: viewer.layers.selection.discard(layer)
 
-    # change the layer opacity
-    layer.opacity = 0.9
+# change the layer opacity
+layer.opacity = 0.9
 
-    # change the layer point symbol using an alias
-    layer.symbol = '+'
+# change the layer point symbol using an alias
+layer.symbol = '+'
 
-    # change the layer point n_dimensional status
-    layer.n_dimensional = True
+# change the layer point n_dimensional status
+layer.n_dimensional = True
 
-    # change the layer mode
-    layer.mode = 'add'
+# change the layer mode
+layer.mode = 'add'
+
+napari.run()

--- a/examples/add_points_with_properties.py
+++ b/examples/add_points_with_properties.py
@@ -9,47 +9,50 @@ from skimage.color import rgb2gray
 import napari
 
 
-with napari.gui_qt():
-    # add the image
-    viewer = napari.view_image(rgb2gray(data.astronaut()))
-    # add the points
-    points = np.array([[100, 100], [200, 200], [333, 111]])
+# add the image
+viewer = napari.view_image(rgb2gray(data.astronaut()))
+# add the points
+points = np.array([[100, 100], [200, 200], [333, 111]])
 
-    # create properties for each point
-    properties = {
-        'confidence': np.array([1, 0.5, 0]),
-        'good_point': np.array([True, False, False])
-    }
+# create properties for each point
+properties = {
+    'confidence': np.array([1, 0.5, 0]),
+    'good_point': np.array([True, False, False])
+}
 
-    # define the color cycle for the face_color annotation
-    face_color_cycle = ['blue', 'green']
+# define the color cycle for the face_color annotation
+face_color_cycle = ['blue', 'green']
 
-    # create a points layer where the face_color is set by the good_point property
-    # and the edge_color is set via a color map (grayscale) on the confidence property.
-    points_layer = viewer.add_points(
-        points,
-        properties=properties,
-        size=20,
-        edge_width=7,
-        edge_color='confidence',
-        edge_colormap='gray',
-        face_color='good_point',
-        face_color_cycle=face_color_cycle
-    )
+# create a points layer where the face_color is set by the good_point property
+# and the edge_color is set via a color map (grayscale) on the confidence property.
+points_layer = viewer.add_points(
+    points,
+    properties=properties,
+    size=20,
+    edge_width=7,
+    edge_color='confidence',
+    edge_colormap='gray',
+    face_color='good_point',
+    face_color_cycle=face_color_cycle
+)
 
-    # set the edge_color mode to colormap
-    points_layer.edge_color_mode = 'colormap'
+# set the edge_color mode to colormap
+points_layer.edge_color_mode = 'colormap'
 
-    # bind a function to toggle the good_point annotation of the selected points
-    @viewer.bind_key('t')
-    def toggle_point_annotation(viewer):
-        selected_points = list(points_layer.selected_data)
-        if len(selected_points) > 0:
-            good_point = points_layer.properties['good_point']
-            good_point[list(selected_points)] = ~good_point[list(selected_points)]
-            points_layer.properties['good_point'] = good_point
 
-            # we need to manually refresh since we did not use the Points.properties setter
-            # to avoid changing the color map if all points get toggled to the same class,
-            # we set update_colors=False (only re-colors the point using the previously-determined color mapping).
-            points_layer.refresh_colors(update_color_mapping=False)
+# bind a function to toggle the good_point annotation of the selected points
+@viewer.bind_key('t')
+def toggle_point_annotation(viewer):
+    selected_points = list(points_layer.selected_data)
+    if len(selected_points) > 0:
+        good_point = points_layer.properties['good_point']
+        good_point[list(selected_points)] = ~good_point[list(selected_points)]
+        points_layer.properties['good_point'] = good_point
+
+        # we need to manually refresh since we did not use the Points.properties setter
+        # to avoid changing the color map if all points get toggled to the same class,
+        # we set update_colors=False (only re-colors the point using the previously-determined color mapping).
+        points_layer.refresh_colors(update_color_mapping=False)
+
+
+napari.run()

--- a/examples/add_points_with_text.py
+++ b/examples/add_points_with_text.py
@@ -4,46 +4,45 @@ add_image APIs
 """
 
 import numpy as np
-from skimage import data
-from skimage.color import rgb2gray
 import napari
 
 
-with napari.gui_qt():
-    # add the image
-    viewer = napari.view_image(np.zeros((400, 400)))
-    # add the points
-    points = np.array([[100, 100], [200, 300], [333, 111]])
+# add the image
+viewer = napari.view_image(np.zeros((400, 400)))
+# add the points
+points = np.array([[100, 100], [200, 300], [333, 111]])
 
-    # create properties for each point
-    properties = {
-        'confidence': np.array([1, 0.5, 0]),
-        'good_point': np.array([True, False, False]),
-    }
+# create properties for each point
+properties = {
+    'confidence': np.array([1, 0.5, 0]),
+    'good_point': np.array([True, False, False]),
+}
 
-    # define the color cycle for the face_color annotation
-    face_color_cycle = ['blue', 'green']
+# define the color cycle for the face_color annotation
+face_color_cycle = ['blue', 'green']
 
-    text = {
-        'text': 'Confidence is {confidence:.2f}',
-        'size': 20,
-        'color': 'green',
-        'translation': np.array([-30, 0]),
-    }
+text = {
+    'text': 'Confidence is {confidence:.2f}',
+    'size': 20,
+    'color': 'green',
+    'translation': np.array([-30, 0]),
+}
 
-    # create a points layer where the face_color is set by the good_point property
-    # and the edge_color is set via a color map (grayscale) on the confidence property.
-    points_layer = viewer.add_points(
-        points,
-        properties=properties,
-        text=text,
-        size=20,
-        edge_width=7,
-        edge_color='confidence',
-        edge_colormap='gray',
-        face_color='good_point',
-        face_color_cycle=face_color_cycle,
-    )
+# create a points layer where the face_color is set by the good_point property
+# and the edge_color is set via a color map (grayscale) on the confidence property.
+points_layer = viewer.add_points(
+    points,
+    properties=properties,
+    text=text,
+    size=20,
+    edge_width=7,
+    edge_color='confidence',
+    edge_colormap='gray',
+    face_color='good_point',
+    face_color_cycle=face_color_cycle,
+)
 
-    # set the edge_color mode to colormap
-    points_layer.edge_color_mode = 'colormap'
+# set the edge_color mode to colormap
+points_layer.edge_color_mode = 'colormap'
+
+napari.run()

--- a/examples/add_shapes.py
+++ b/examples/add_shapes.py
@@ -9,77 +9,78 @@ from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    # add the image
-    viewer = napari.view_image(data.camera(), name='photographer')
+# add the image
+viewer = napari.view_image(data.camera(), name='photographer')
 
-    # create a list of polygons
-    polygons = [
-        np.array([[11, 13], [111, 113], [22, 246]]),
-        np.array(
-            [
-                [505, 60],
-                [402, 71],
-                [383, 42],
-                [251, 95],
-                [212, 59],
-                [131, 137],
-                [126, 187],
-                [191, 204],
-                [171, 248],
-                [211, 260],
-                [273, 243],
-                [264, 225],
-                [430, 173],
-                [512, 160],
-            ]
-        ),
-        np.array(
-            [
-                [310, 382],
-                [229, 381],
-                [209, 401],
-                [221, 411],
-                [258, 411],
-                [300, 412],
-                [306, 435],
-                [268, 434],
-                [265, 454],
-                [298, 461],
-                [307, 461],
-                [307, 507],
-                [349, 510],
-                [352, 369],
-                [330, 366],
-                [330, 366],
-            ]
-        ),
-    ]
+# create a list of polygons
+polygons = [
+    np.array([[11, 13], [111, 113], [22, 246]]),
+    np.array(
+        [
+            [505, 60],
+            [402, 71],
+            [383, 42],
+            [251, 95],
+            [212, 59],
+            [131, 137],
+            [126, 187],
+            [191, 204],
+            [171, 248],
+            [211, 260],
+            [273, 243],
+            [264, 225],
+            [430, 173],
+            [512, 160],
+        ]
+    ),
+    np.array(
+        [
+            [310, 382],
+            [229, 381],
+            [209, 401],
+            [221, 411],
+            [258, 411],
+            [300, 412],
+            [306, 435],
+            [268, 434],
+            [265, 454],
+            [298, 461],
+            [307, 461],
+            [307, 507],
+            [349, 510],
+            [352, 369],
+            [330, 366],
+            [330, 366],
+        ]
+    ),
+]
 
-    # add polygons
-    layer = viewer.add_shapes(
-        polygons,
-        shape_type='polygon',
-        edge_width=1,
-        edge_color='coral',
-        face_color='royalblue',
-        name='shapes',
-    )
+# add polygons
+layer = viewer.add_shapes(
+    polygons,
+    shape_type='polygon',
+    edge_width=1,
+    edge_color='coral',
+    face_color='royalblue',
+    name='shapes',
+)
 
-    # change some properties of the layer
-    layer.selected_data = set(range(layer.nshapes))
-    layer.current_edge_width = 5
-    layer.selected_data = set()
+# change some properties of the layer
+layer.selected_data = set(range(layer.nshapes))
+layer.current_edge_width = 5
+layer.selected_data = set()
 
-    # add an ellipse to the layer
-    ellipse = np.array([[59, 222], [110, 289], [170, 243], [119, 176]])
-    layer.add(
-        ellipse,
-        shape_type='ellipse',
-        edge_width=5,
-        edge_color='coral',
-        face_color='purple',
-    )
+# add an ellipse to the layer
+ellipse = np.array([[59, 222], [110, 289], [170, 243], [119, 176]])
+layer.add(
+    ellipse,
+    shape_type='ellipse',
+    edge_width=5,
+    edge_color='coral',
+    face_color='purple',
+)
 
-    # To save layers to svg:
-    # viewer.layers.save('viewer.svg', plugin='svg')
+# To save layers to svg:
+# viewer.layers.save('viewer.svg', plugin='svg')
+
+napari.run()

--- a/examples/add_shapes_with_properties.py
+++ b/examples/add_shapes_with_properties.py
@@ -9,77 +9,78 @@ from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    # add the image
-    viewer = napari.view_image(data.camera(), name='photographer')
+# add the image
+viewer = napari.view_image(data.camera(), name='photographer')
 
-    # create a list of polygons
-    polygons = [
-        np.array([[11, 13], [111, 113], [22, 246]]),
-        np.array(
-            [
-                [505, 60],
-                [402, 71],
-                [383, 42],
-                [251, 95],
-                [212, 59],
-                [131, 137],
-                [126, 187],
-                [191, 204],
-                [171, 248],
-                [211, 260],
-                [273, 243],
-                [264, 225],
-                [430, 173],
-                [512, 160],
-            ]
-        ),
-        np.array(
-            [
-                [310, 382],
-                [229, 381],
-                [209, 401],
-                [221, 411],
-                [258, 411],
-                [300, 412],
-                [306, 435],
-                [268, 434],
-                [265, 454],
-                [298, 461],
-                [307, 461],
-                [307, 507],
-                [349, 510],
-                [352, 369],
-                [330, 366],
-                [330, 366],
-            ]
-        ),
-    ]
+# create a list of polygons
+polygons = [
+    np.array([[11, 13], [111, 113], [22, 246]]),
+    np.array(
+        [
+            [505, 60],
+            [402, 71],
+            [383, 42],
+            [251, 95],
+            [212, 59],
+            [131, 137],
+            [126, 187],
+            [191, 204],
+            [171, 248],
+            [211, 260],
+            [273, 243],
+            [264, 225],
+            [430, 173],
+            [512, 160],
+        ]
+    ),
+    np.array(
+        [
+            [310, 382],
+            [229, 381],
+            [209, 401],
+            [221, 411],
+            [258, 411],
+            [300, 412],
+            [306, 435],
+            [268, 434],
+            [265, 454],
+            [298, 461],
+            [307, 461],
+            [307, 507],
+            [349, 510],
+            [352, 369],
+            [330, 366],
+            [330, 366],
+        ]
+    ),
+]
 
-    # create properties
-    properties = {
-        'likelihood': [0.2, 0.5, 1],
-        'class': ['sky', 'person', 'building'],
-    }
-    face_color_cycle = ['blue', 'magenta', 'green']
+# create properties
+properties = {
+    'likelihood': [0.2, 0.5, 1],
+    'class': ['sky', 'person', 'building'],
+}
+face_color_cycle = ['blue', 'magenta', 'green']
 
-    # add polygons
-    layer = viewer.add_shapes(
-        polygons,
-        properties=properties,
-        shape_type='polygon',
-        edge_width=1,
-        edge_color='likelihood',
-        edge_colormap='gray',
-        face_color='class',
-        face_color_cycle=face_color_cycle,
-        name='shapes',
-    )
+# add polygons
+layer = viewer.add_shapes(
+    polygons,
+    properties=properties,
+    shape_type='polygon',
+    edge_width=1,
+    edge_color='likelihood',
+    edge_colormap='gray',
+    face_color='class',
+    face_color_cycle=face_color_cycle,
+    name='shapes',
+)
 
-    # change some properties of the layer
-    layer.selected_data = set(range(layer.nshapes))
-    layer.current_edge_width = 5
-    layer.selected_data = set()
+# change some properties of the layer
+layer.selected_data = set(range(layer.nshapes))
+layer.current_edge_width = 5
+layer.selected_data = set()
 
-    # To save layers to svg:
-    # viewer.layers.save('viewer.svg', plugin='svg')
+# To save layers to svg:
+# viewer.layers.save('viewer.svg', plugin='svg')
+
+napari.run()

--- a/examples/add_shapes_with_text.py
+++ b/examples/add_shapes_with_text.py
@@ -9,47 +9,48 @@ from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    # add the image
-    viewer = napari.view_image(data.camera(), name='photographer')
+# add the image
+viewer = napari.view_image(data.camera(), name='photographer')
 
-    # create a list of polygons
-    polygons = [
-        np.array([[225, 146], [283, 146], [283, 211], [225, 211]]),
-        np.array([[67, 182], [167, 182], [167, 268], [67, 268]]),
-        np.array([[111, 336], [220, 336], [220, 240], [111, 240]]),
-    ]
+# create a list of polygons
+polygons = [
+    np.array([[225, 146], [283, 146], [283, 211], [225, 211]]),
+    np.array([[67, 182], [167, 182], [167, 268], [67, 268]]),
+    np.array([[111, 336], [220, 336], [220, 240], [111, 240]]),
+]
 
-    # create properties
-    properties = {
-        'likelihood': [21.23423, 51.2315, 100],
-        'class': ['hand', 'face', 'camera'],
-    }
-    edge_color_cycle = ['blue', 'magenta', 'green']
+# create properties
+properties = {
+    'likelihood': [21.23423, 51.2315, 100],
+    'class': ['hand', 'face', 'camera'],
+}
+edge_color_cycle = ['blue', 'magenta', 'green']
 
-    text_properties = {
-        'text': '{class}: {likelihood:0.1f}%',
-        'anchor': 'upper_left',
-        'translation': [-5, 0],
-        'size': 8,
-        'color': 'green',
-    }
+text_properties = {
+    'text': '{class}: {likelihood:0.1f}%',
+    'anchor': 'upper_left',
+    'translation': [-5, 0],
+    'size': 8,
+    'color': 'green',
+}
 
-    # add polygons
-    shapes_layer = viewer.add_shapes(
-        polygons,
-        properties=properties,
-        shape_type='polygon',
-        edge_width=3,
-        edge_color='class',
-        edge_color_cycle=edge_color_cycle,
-        face_color='transparent',
-        text=text_properties,
-        name='shapes',
-    )
+# add polygons
+shapes_layer = viewer.add_shapes(
+    polygons,
+    properties=properties,
+    shape_type='polygon',
+    edge_width=3,
+    edge_color='class',
+    edge_color_cycle=edge_color_cycle,
+    face_color='transparent',
+    text=text_properties,
+    name='shapes',
+)
 
-    # change some properties of the layer
-    shapes_layer.opacity = 1
+# change some properties of the layer
+shapes_layer.opacity = 1
 
-    # To save layers to svg:
-    # viewer.layers.save('viewer.svg', plugin='svg')
+# To save layers to svg:
+# viewer.layers.save('viewer.svg', plugin='svg')
+
+napari.run()

--- a/examples/add_surface_2D.py
+++ b/examples/add_surface_2D.py
@@ -3,14 +3,14 @@ Display a 2D surface
 """
 
 import numpy as np
-from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    data = np.array([[0, 0], [0, 20], [10, 0], [10, 10]])
-    faces = np.array([[0, 1, 2], [1, 2, 3]])
-    values = np.linspace(0, 1, len(data))
+data = np.array([[0, 0], [0, 20], [10, 0], [10, 10]])
+faces = np.array([[0, 1, 2], [1, 2, 3]])
+values = np.linspace(0, 1, len(data))
 
-    # add the surface
-    viewer = napari.view_surface((data, faces, values))
+# add the surface
+viewer = napari.view_surface((data, faces, values))
+
+napari.run()

--- a/examples/add_vectors.py
+++ b/examples/add_vectors.py
@@ -12,25 +12,26 @@ from skimage import data
 import numpy as np
 
 
-with napari.gui_qt():
-    # create the viewer and window
-    viewer = napari.Viewer()
+# create the viewer and window
+viewer = napari.Viewer()
 
-    layer = viewer.add_image(data.camera(), name='photographer')
+layer = viewer.add_image(data.camera(), name='photographer')
 
-    # sample vector coord-like data
-    n = 200
-    pos = np.zeros((n, 2, 2), dtype=np.float32)
-    phi_space = np.linspace(0, 4 * np.pi, n)
-    radius_space = np.linspace(0, 100, n)
+# sample vector coord-like data
+n = 200
+pos = np.zeros((n, 2, 2), dtype=np.float32)
+phi_space = np.linspace(0, 4 * np.pi, n)
+radius_space = np.linspace(0, 100, n)
 
-    # assign x-y position
-    pos[:, 0, 0] = radius_space * np.cos(phi_space) + 300
-    pos[:, 0, 1] = radius_space * np.sin(phi_space) + 256
+# assign x-y position
+pos[:, 0, 0] = radius_space * np.cos(phi_space) + 300
+pos[:, 0, 1] = radius_space * np.sin(phi_space) + 256
 
-    # assign x-y projection
-    pos[:, 1, 0] = 2 * radius_space * np.cos(phi_space)
-    pos[:, 1, 1] = 2 * radius_space * np.sin(phi_space)
+# assign x-y projection
+pos[:, 1, 0] = 2 * radius_space * np.cos(phi_space)
+pos[:, 1, 1] = 2 * radius_space * np.sin(phi_space)
 
-    # add the vectors
-    layer = viewer.add_vectors(pos, edge_width=3)
+# add the vectors
+layer = viewer.add_vectors(pos, edge_width=3)
+
+napari.run()

--- a/examples/add_vectors_color_by_angle.py
+++ b/examples/add_vectors_color_by_angle.py
@@ -9,47 +9,48 @@ from skimage import data
 import numpy as np
 
 
-with napari.gui_qt():
-    # create the viewer and window
-    viewer = napari.Viewer()
+# create the viewer and window
+viewer = napari.Viewer()
 
-    layer = viewer.add_image(data.camera(), name='photographer')
+layer = viewer.add_image(data.camera(), name='photographer')
 
-    # sample vector coord-like data
-    n = 300
-    pos = np.zeros((n, 2, 2), dtype=np.float32)
-    phi_space = np.linspace(0, 4 * np.pi, n)
-    radius_space = np.linspace(0, 100, n)
+# sample vector coord-like data
+n = 300
+pos = np.zeros((n, 2, 2), dtype=np.float32)
+phi_space = np.linspace(0, 4 * np.pi, n)
+radius_space = np.linspace(0, 100, n)
 
-    # assign x-y position
-    pos[:, 0, 0] = radius_space * np.cos(phi_space) + 300
-    pos[:, 0, 1] = radius_space * np.sin(phi_space) + 256
+# assign x-y position
+pos[:, 0, 0] = radius_space * np.cos(phi_space) + 300
+pos[:, 0, 1] = radius_space * np.sin(phi_space) + 256
 
-    # assign x-y projection
-    pos[:, 1, 0] = 2 * radius_space * np.cos(phi_space)
-    pos[:, 1, 1] = 2 * radius_space * np.sin(phi_space)
+# assign x-y projection
+pos[:, 1, 0] = 2 * radius_space * np.cos(phi_space)
+pos[:, 1, 1] = 2 * radius_space * np.sin(phi_space)
 
-    # make the angle property, range 0-2pi
-    angle = np.mod(phi_space, 2 * np.pi)
+# make the angle property, range 0-2pi
+angle = np.mod(phi_space, 2 * np.pi)
 
-    # create a property that is true for all angles  > pi
-    pos_angle = angle > np.pi
+# create a property that is true for all angles  > pi
+pos_angle = angle > np.pi
 
-    # create the properties dictionary.
-    properties = {
-        'angle': angle,
-        'pos_angle': pos_angle,
-    }
+# create the properties dictionary.
+properties = {
+    'angle': angle,
+    'pos_angle': pos_angle,
+}
 
-    # add the vectors
-    layer = viewer.add_vectors(
-        pos,
-        edge_width=3,
-        properties=properties,
-        edge_color='angle',
-        edge_colormap='husl',
-        name='vectors'
-    )
+# add the vectors
+layer = viewer.add_vectors(
+    pos,
+    edge_width=3,
+    properties=properties,
+    edge_color='angle',
+    edge_colormap='husl',
+    name='vectors'
+)
 
-    # set the edge color mode to colormap
-    layer.edge_color_mode = 'colormap'
+# set the edge color mode to colormap
+layer.edge_color_mode = 'colormap'
+
+napari.run()

--- a/examples/add_vectors_image.py
+++ b/examples/add_vectors_image.py
@@ -10,28 +10,29 @@ import napari
 import numpy as np
 
 
-with napari.gui_qt():
-    # create the viewer and window
-    viewer = napari.Viewer()
+# create the viewer and window
+viewer = napari.Viewer()
 
-    n = 20
-    m = 40
+n = 20
+m = 40
 
-    image = 0.2 * np.random.random((n, m)) + 0.5
-    layer = viewer.add_image(image, contrast_limits=[0, 1], name='background')
+image = 0.2 * np.random.random((n, m)) + 0.5
+layer = viewer.add_image(image, contrast_limits=[0, 1], name='background')
 
-    # sample vector image-like data
-    # n x m grid of slanted lines
-    # random data on the open interval (-1, 1)
-    pos = np.zeros(shape=(n, m, 2), dtype=np.float32)
-    rand1 = 2 * (np.random.random_sample(n * m) - 0.5)
-    rand2 = 2 * (np.random.random_sample(n * m) - 0.5)
+# sample vector image-like data
+# n x m grid of slanted lines
+# random data on the open interval (-1, 1)
+pos = np.zeros(shape=(n, m, 2), dtype=np.float32)
+rand1 = 2 * (np.random.random_sample(n * m) - 0.5)
+rand2 = 2 * (np.random.random_sample(n * m) - 0.5)
 
-    # assign projections for each vector
-    pos[:, :, 0] = rand1.reshape((n, m))
-    pos[:, :, 1] = rand2.reshape((n, m))
+# assign projections for each vector
+pos[:, :, 0] = rand1.reshape((n, m))
+pos[:, :, 1] = rand2.reshape((n, m))
 
-    # add the vectors
-    vect = viewer.add_vectors(pos, edge_width=0.2, length=2.5)
+# add the vectors
+vect = viewer.add_vectors(pos, edge_width=0.2, length=2.5)
 
-    print(image.shape, pos.shape)
+print(image.shape, pos.shape)
+
+napari.run()

--- a/examples/add_volume.py
+++ b/examples/add_volume.py
@@ -6,10 +6,11 @@ from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    blobs = data.binary_blobs(length=64, volume_fraction=0.1, n_dim=3).astype(
-        float
-    )
-    viewer = napari.Viewer(ndisplay=3)
-    # add the volume
-    viewer.add_image(blobs, scale=[3, 1, 1])
+blobs = data.binary_blobs(length=64, volume_fraction=0.1, n_dim=3).astype(
+    float
+)
+viewer = napari.Viewer(ndisplay=3)
+# add the volume
+viewer.add_image(blobs, scale=[3, 1, 1])
+
+napari.run()

--- a/examples/affine_transforms.py
+++ b/examples/affine_transforms.py
@@ -15,25 +15,27 @@ affine = np.array([[1, -1, 4], [2, 3, 2], [0, 0, 1]])
 corners = np.array([[0, 0], [4, 0], [0, 4], [4, 4]])
 corners_h = np.concatenate([corners, np.ones((4, 1))], axis=1)
 
-with napari.gui_qt():
-    viewer = napari.Viewer()
 
-    # Add the original image and its corners
-    viewer.add_image(image, name='background', colormap='red', opacity=.5)
-    viewer.add_points(corners_h[:, :-1], size=0.5, opacity=.5, face_color=[0.8, 0, 0, 0.8], name='bg corners')
+viewer = napari.Viewer()
 
-    # Add another copy of the image, now with a transform, and add its transformed corners
-    viewer.add_image(image, colormap='blue', opacity=.5, name='moving', affine=affine)
-    viewer.add_points((corners_h @ affine.T)[:, :-1], size=0.5, opacity=.5, face_color=[0, 0, 0.8, 0.8], name='mv corners')
+# Add the original image and its corners
+viewer.add_image(image, name='background', colormap='red', opacity=.5)
+viewer.add_points(corners_h[:, :-1], size=0.5, opacity=.5, face_color=[0.8, 0, 0, 0.8], name='bg corners')
 
-    # Note how the transformed corner points remain at the corners of the transformed image
+# Add another copy of the image, now with a transform, and add its transformed corners
+viewer.add_image(image, colormap='blue', opacity=.5, name='moving', affine=affine)
+viewer.add_points((corners_h @ affine.T)[:, :-1], size=0.5, opacity=.5, face_color=[0, 0, 0.8, 0.8], name='mv corners')
 
-    # Now add the a regridded version of the image transformed with scipy.ndimage.affine_transform
-    # Note that we have to use the inverse of the affine as scipy does ‘pull’ (or ‘backward’) resampling,
-    # transforming the output space to the input to locate data, but napari does ‘push’ (or ‘forward’) direction,
-    # transforming input to output.
-    scipy_affine = ndi.affine_transform(image, np.linalg.inv(affine), output_shape=(10, 25), order=5)
-    viewer.add_image(scipy_affine, colormap='green', opacity=.5, name='scipy')
+# Note how the transformed corner points remain at the corners of the transformed image
 
-    # Reset the view
-    viewer.reset_view()
+# Now add the a regridded version of the image transformed with scipy.ndimage.affine_transform
+# Note that we have to use the inverse of the affine as scipy does ‘pull’ (or ‘backward’) resampling,
+# transforming the output space to the input to locate data, but napari does ‘push’ (or ‘forward’) direction,
+# transforming input to output.
+scipy_affine = ndi.affine_transform(image, np.linalg.inv(affine), output_shape=(10, 25), order=5)
+viewer.add_image(scipy_affine, colormap='green', opacity=.5, name='scipy')
+
+# Reset the view
+viewer.reset_view()
+
+napari.run()

--- a/examples/annotate-2d.py
+++ b/examples/annotate-2d.py
@@ -10,10 +10,11 @@ import napari
 
 print("click to add points; close the window when finished.")
 
-with napari.gui_qt():
-    viewer = napari.view_image(data.astronaut(), rgb=True)
-    points = viewer.add_points(np.zeros((0, 2)))
-    points.mode = 'add'
+viewer = napari.view_image(data.astronaut(), rgb=True)
+points = viewer.add_points(np.zeros((0, 2)))
+points.mode = 'add'
+
+napari.run()
 
 print("you clicked on:")
 print(points.data)

--- a/examples/annotate_segmentation_with_text.py
+++ b/examples/annotate_segmentation_with_text.py
@@ -111,18 +111,19 @@ text_parameters = {
     'translation': [-3, 0],
 }
 
-with napari.gui_qt():
-    # initialise viewer with coins image
-    viewer = napari.view_image(image, name='coins', rgb=False)
+# initialise viewer with coins image
+viewer = napari.view_image(image, name='coins', rgb=False)
 
-    # add the labels
-    label_layer = viewer.add_labels(label_image, name='segmentation')
+# add the labels
+label_layer = viewer.add_labels(label_image, name='segmentation')
 
-    shapes_layer = viewer.add_shapes(
-        bbox_rects,
-        face_color='transparent',
-        edge_color='green',
-        properties=properties,
-        text=text_parameters,
-        name='bounding box',
-    )
+shapes_layer = viewer.add_shapes(
+    bbox_rects,
+    face_color='transparent',
+    edge_color='green',
+    properties=properties,
+    text=text_parameters,
+    name='bounding box',
+)
+
+napari.run()

--- a/examples/bbox_annotator.py
+++ b/examples/bbox_annotator.py
@@ -66,32 +66,33 @@ for slice_idx in range(n_slices):
     image[slice_idx, ...] = np.pad(base_image, ((0, 0), (shift, 0)), mode='constant')[:, :-shift]
 
 
-with napari.gui_qt():
-    # create a viewer with a fake t+2D image
-    viewer = napari.view_image(image)
+# create a viewer with a fake t+2D image
+viewer = napari.view_image(image)
 
-    # create an empty shapes layer initialized with
-    # text set to display the box label
-    text_kwargs = {
-        'text': text_property,
-        'size': text_size,
-        'color': text_color
-    }
-    shapes = viewer.add_shapes(
-        face_color='black',
-        properties={text_property: box_annotations},
-        text=text_kwargs,
-        ndim=3
-    )
+# create an empty shapes layer initialized with
+# text set to display the box label
+text_kwargs = {
+    'text': text_property,
+    'size': text_size,
+    'color': text_color
+}
+shapes = viewer.add_shapes(
+    face_color='black',
+    properties={text_property: box_annotations},
+    text=text_kwargs,
+    ndim=3
+)
 
-    # create the label section gui
-    label_widget = create_label_menu(
-        shapes_layer=shapes,
-        label_property=text_property,
-        labels=box_annotations
-    )
-    # add the label selection gui to the viewer as a dock widget
-    viewer.window.add_dock_widget(label_widget, area='right', name='label_widget')
+# create the label section gui
+label_widget = create_label_menu(
+    shapes_layer=shapes,
+    label_property=text_property,
+    labels=box_annotations
+)
+# add the label selection gui to the viewer as a dock widget
+viewer.window.add_dock_widget(label_widget, area='right', name='label_widget')
 
-    # set the shapes layer mode to adding rectangles
-    shapes.mode = 'add_rectangle'
+# set the shapes layer mode to adding rectangles
+shapes.mode = 'add_rectangle'
+
+napari.run()

--- a/examples/cursor_position.py
+++ b/examples/cursor_position.py
@@ -3,25 +3,24 @@ Add small data to examine cursor positions
 """
 
 import numpy as np
-from skimage import data
 import napari
 
 
-with napari.gui_qt():
+viewer = napari.Viewer()
+image = np.array([[1, 0, 0, 1],
+                  [0, 0, 1, 1],
+                  [1, 0, 3, 0],
+                  [0, 2, 0, 0]], dtype=int)
 
-    viewer = napari.Viewer()
-    image = np.array([[1, 0, 0, 1],
-                      [0, 0, 1, 1],
-                      [1, 0, 3, 0],
-                      [0, 2, 0, 0]], dtype=int)
+viewer.add_labels(image)
 
-    viewer.add_labels(image)
+points = np.array([[0, 0], [2, 0], [1, 3]])
+viewer.add_points(points, size=0.25)
 
-    points = np.array([[0, 0], [2, 0], [1, 3]])
-    viewer.add_points(points, size=0.25)
+rect = np.array([[0, 0], [3, 1]])
+viewer.add_shapes(rect, shape_type='rectangle', edge_width=0.1)
 
-    rect = np.array([[0, 0], [3, 1]])
-    viewer.add_shapes(rect, shape_type='rectangle', edge_width=0.1)
+vect = np.array([[[3, 2], [-1, 1]]])
+viewer.add_vectors(vect, edge_width=0.1)
 
-    vect = np.array([[[3, 2], [-1, 1]]])
-    viewer.add_vectors(vect, edge_width=0.1)
+napari.run()

--- a/examples/custom_key_bindings.py
+++ b/examples/custom_key_bindings.py
@@ -6,42 +6,48 @@ from skimage import data
 import napari
 
 
-with napari.gui_qt():
+blobs = data.binary_blobs(
+    length=128, blob_size_fraction=0.05, n_dim=2, volume_fraction=0.25
+).astype(float)
+
+viewer = napari.view_image(blobs, name='blobs')
+
+
+@viewer.bind_key('a')
+def accept_image(viewer):
+    msg = 'this is a good image'
+    viewer.status = msg
+    print(msg)
+    next(viewer)
+
+
+@viewer.bind_key('r')
+def reject_image(viewer):
+    msg = 'this is a bad image'
+    viewer.status = msg
+    print(msg)
+    next(viewer)
+
+
+def next(viewer):
     blobs = data.binary_blobs(
         length=128, blob_size_fraction=0.05, n_dim=2, volume_fraction=0.25
     ).astype(float)
+    viewer.layers[0].data = blobs
 
-    viewer = napari.view_image(blobs, name='blobs')
 
-    @viewer.bind_key('a')
-    def accept_image(viewer):
-        msg = 'this is a good image'
-        viewer.status = msg
-        print(msg)
-        next(viewer)
+@napari.Viewer.bind_key('w')
+def hello(viewer):
+    # on press
+    viewer.status = 'hello world!'
 
-    @viewer.bind_key('r')
-    def reject_image(viewer):
-        msg = 'this is a bad image'
-        viewer.status = msg
-        print(msg)
-        next(viewer)
+    yield
 
-    def next(viewer):
-        blobs = data.binary_blobs(
-            length=128, blob_size_fraction=0.05, n_dim=2, volume_fraction=0.25
-        ).astype(float)
-        viewer.layers[0].data = blobs
+    # on release
+    viewer.status = 'goodbye world :('
 
-    @napari.Viewer.bind_key('w')
-    def hello(viewer):
-        # on press
-        viewer.status = 'hello world!'
 
-        yield
+# change viewer title
+viewer.title = 'quality control images'
 
-        # on release
-        viewer.status = 'goodbye world :('
-
-    # change viewer title
-    viewer.title = 'quality control images'
+napari.run()

--- a/examples/custom_mouse_functions.py
+++ b/examples/custom_mouse_functions.py
@@ -9,61 +9,61 @@ import numpy as np
 import napari
 
 
-with napari.gui_qt():
-    np.random.seed(1)
-    viewer = napari.Viewer()
-    blobs = data.binary_blobs(length=128, volume_fraction=0.1, n_dim=2)
-    labeled = ndi.label(blobs)[0]
-    labels_layer = viewer.add_labels(labeled, name='blob ID')
+np.random.seed(1)
+viewer = napari.Viewer()
+blobs = data.binary_blobs(length=128, volume_fraction=0.1, n_dim=2)
+labeled = ndi.label(blobs)[0]
+labels_layer = viewer.add_labels(labeled, name='blob ID')
 
-    @viewer.mouse_drag_callbacks.append
-    def get_event(viewer, event):
-        print(event)
+@viewer.mouse_drag_callbacks.append
+def get_event(viewer, event):
+    print(event)
 
-    @viewer.mouse_drag_callbacks.append
-    def get_ndisplay(viewer, event):
-        if 'Alt' in event.modifiers:
-            print('viewer display ', viewer.dims.ndisplay)
+@viewer.mouse_drag_callbacks.append
+def get_ndisplay(viewer, event):
+    if 'Alt' in event.modifiers:
+        print('viewer display ', viewer.dims.ndisplay)
 
-    @labels_layer.mouse_drag_callbacks.append
-    def get_connected_component_shape(layer, event):
-        data_coordinates = layer.world_to_data(event.position)
-        cords = np.round(data_coordinates).astype(int)
-        val = layer.get_value(data_coordinates)
-        if val is None:
-            return
-        if val != 0:
-            data = layer.data
-            binary = data == val
-            if 'Shift' in event.modifiers:
-                binary_new = binary_erosion(binary)
-                data[binary] = 0
-                data[binary_new] = val
-            else:
-                binary_new = binary_dilation(binary)
-                data[binary_new] = val
-            size = np.sum(binary_new)
-            layer.data = data
-            msg = (
-                f'clicked at {cords} on blob {val} which is now {size} pixels'
-            )
+@labels_layer.mouse_drag_callbacks.append
+def get_connected_component_shape(layer, event):
+    data_coordinates = layer.world_to_data(event.position)
+    cords = np.round(data_coordinates).astype(int)
+    val = layer.get_value(data_coordinates)
+    if val is None:
+        return
+    if val != 0:
+        data = layer.data
+        binary = data == val
+        if 'Shift' in event.modifiers:
+            binary_new = binary_erosion(binary)
+            data[binary] = 0
         else:
-            msg = f'clicked at {cords} on background which is ignored'
-        print(msg)
+            binary_new = binary_dilation(binary)
+        data[binary_new] = val
+        size = np.sum(binary_new)
+        layer.data = data
+        msg = (
+            f'clicked at {cords} on blob {val} which is now {size} pixels'
+        )
+    else:
+        msg = f'clicked at {cords} on background which is ignored'
+    print(msg)
 
-    # Handle click or drag events separately
-    @labels_layer.mouse_drag_callbacks.append
-    def click_drag(layer, event):
-        print('mouse down')
-        dragged = False
+# Handle click or drag events separately
+@labels_layer.mouse_drag_callbacks.append
+def click_drag(layer, event):
+    print('mouse down')
+    dragged = False
+    yield
+    # on move
+    while event.type == 'mouse_move':
+        print(event.position)
+        dragged = True
         yield
-        # on move
-        while event.type == 'mouse_move':
-            print(event.position)
-            dragged = True
-            yield
-        # on release
-        if dragged:
-            print('drag end')
-        else:
-            print('clicked!')
+    # on release
+    if dragged:
+        print('drag end')
+    else:
+        print('clicked!')
+
+napari.run()

--- a/examples/dask_nD_image.py
+++ b/examples/dask_nD_image.py
@@ -13,14 +13,15 @@ from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    blobs = da.stack(
-        [
-            data.binary_blobs(
-                length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=f
-            )
-            for f in np.linspace(0.05, 0.5, 10)
-        ],
-        axis=0,
-    )
-    viewer = napari.view_image(blobs.astype(float))
+blobs = da.stack(
+    [
+        data.binary_blobs(
+            length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=f
+        )
+        for f in np.linspace(0.05, 0.5, 10)
+    ],
+    axis=0,
+)
+viewer = napari.view_image(blobs.astype(float))
+
+napari.run()

--- a/examples/interactive_scripting.py
+++ b/examples/interactive_scripting.py
@@ -4,20 +4,21 @@ from napari.qt import thread_worker
 import time
 
 
-with napari.gui_qt():
-    # create the viewer with an image
-    data = np.random.random((512, 512))
-    viewer = napari.Viewer()
-    layer = viewer.add_image(data)
+# create the viewer with an image
+data = np.random.random((512, 512))
+viewer = napari.Viewer()
+layer = viewer.add_image(data)
 
-    def update_layer(data):
-        layer.data = data
+def update_layer(data):
+    layer.data = data
 
-    @thread_worker(connect={'yielded': update_layer})
-    def create_data(*, update_period, num_updates):
-        # number of times to update
-        for k in range(num_updates):
-            yield np.random.random((512, 512))
-            time.sleep(update_period)
+@thread_worker(connect={'yielded': update_layer})
+def create_data(*, update_period, num_updates):
+    # number of times to update
+    for k in range(num_updates):
+        yield np.random.random((512, 512))
+        time.sleep(update_period)
 
-    create_data(update_period=0.05, num_updates=50)
+create_data(update_period=0.05, num_updates=50)
+
+napari.run()

--- a/examples/labels-2d.py
+++ b/examples/labels-2d.py
@@ -9,17 +9,18 @@ from skimage.segmentation import slic
 import napari
 
 
-with napari.gui_qt():
-    astro = data.astronaut()
+astro = data.astronaut()
 
-    # initialise viewer with astro image
-    viewer = napari.view_image(rgb2gray(astro), name='astronaut', rgb=False)
+# initialise viewer with astro image
+viewer = napari.view_image(rgb2gray(astro), name='astronaut', rgb=False)
 
-    # add the labels
-    # we add 1 because SLIC returns labels from 0, which we consider background
-    labels = slic(astro, multichannel=True, compactness=20) + 1
-    label_layer = viewer.add_labels(labels, name='segmentation')
+# add the labels
+# we add 1 because SLIC returns labels from 0, which we consider background
+labels = slic(astro, multichannel=True, compactness=20) + 1
+label_layer = viewer.add_labels(labels, name='segmentation')
 
-    # Set the labels layer mode to picker with a string
-    label_layer.mode = 'PICK'
-    print(f'The color of label 5 is {label_layer.get_color(5)}')
+# Set the labels layer mode to picker with a string
+label_layer.mode = 'PICK'
+print(f'The color of label 5 is {label_layer.get_color(5)}')
+
+napari.run()

--- a/examples/layers.py
+++ b/examples/layers.py
@@ -9,12 +9,13 @@ import numpy as np
 import napari
 
 
-with napari.gui_qt():
-    # create the viewer with several image layers
-    viewer = napari.view_image(rgb2gray(data.astronaut()), name='astronaut')
-    viewer.add_image(data.camera(), name='photographer')
-    viewer.add_image(data.coins(), name='coins')
-    viewer.add_image(data.moon(), name='moon')
-    viewer.add_image(np.random.random((512, 512)), name='random')
-    viewer.add_image(data.binary_blobs(length=512, volume_fraction=0.2, n_dim=2), name='blobs')
-    viewer.grid.enabled = True
+# create the viewer with several image layers
+viewer = napari.view_image(rgb2gray(data.astronaut()), name='astronaut')
+viewer.add_image(data.camera(), name='photographer')
+viewer.add_image(data.coins(), name='coins')
+viewer.add_image(data.moon(), name='moon')
+viewer.add_image(np.random.random((512, 512)), name='random')
+viewer.add_image(data.binary_blobs(length=512, volume_fraction=0.2, n_dim=2), name='blobs')
+viewer.grid.enabled = True
+
+napari.run()

--- a/examples/live_tiffs.py
+++ b/examples/live_tiffs.py
@@ -6,7 +6,6 @@ This script should be run together with live_tiffs_generator.py
 import os
 import sys
 import time
-import numpy as np
 from skimage.io.collection import alphanumeric_key
 from dask import delayed
 import dask.array as da
@@ -15,107 +14,102 @@ import napari
 from napari.qt import thread_worker
 
 
-with napari.gui_qt():
-    """Starts Napari viewer with in which to display the tiffs.
+viewer = napari.Viewer(ndisplay=3)
+# pass a directory to monitor or it will monitor current directory.
+path = sys.argv[1] if len(sys.argv) > 1 else '.'
+path = os.path.abspath(path)
+end_of_experiment = 'final.log'
+
+
+def append(delayed_image):
+    """Appends the image to viewer.
 
     Parameters
     ----------
-    input_dir : str, optional
-        directory to monitor and load tiffs as they start appearing.
-        If no argument is given the then it starts monitoring currect dir.
+    delayed_image : dask.delayed function object
     """
-    viewer = napari.Viewer(ndisplay=3)
-    # pass a directory to monitor or it will monitor current directory.
-    path = sys.argv[1] if len(sys.argv) > 1 else '.'
-    path = os.path.abspath(path)
-    end_of_experiment = 'final.log'
+    if delayed_image is None:
+        return
 
-    def append(delayed_image):
-        """Appends the image to viewer.
+    if viewer.layers:
+        # layer is present, append to its data
+        layer = viewer.layers[0]
+        image_shape = layer.data.shape[1:]
+        image_dtype = layer.data.dtype
+        image = da.from_delayed(
+            delayed_image, shape=image_shape, dtype=image_dtype,
+        ).reshape((1,) + image_shape)
+        layer.data = da.concatenate((layer.data, image), axis=0)
+    else:
+        # first run, no layer added yet
+        image = delayed_image.compute()
+        image = da.from_delayed(
+            delayed_image, shape=image.shape, dtype=image.dtype,
+        ).reshape((1,) + image.shape)
+        layer = viewer.add_image(image, rendering='attenuated_mip')
 
-        Parameters
-        ----------
-        delayed_image : dask.delayed function object
-        """
-        if delayed_image is None:
-            return
+    # we want to show the last file added in the viewer to do so we want to
+    # put the slider at the very end. But, sometimes when user is scrolling
+    # through the previous slide then it is annoying to jump to last
+    # stack as it gets added. To avoid that jump we 1st check where
+    # the scroll is and if its not at the last slide then don't move the slider.
+    if viewer.dims.point[0] >= layer.data.shape[0] - 2:
+        viewer.dims.set_point(0, layer.data.shape[0] - 1)
 
-        if viewer.layers:
-            # layer is present, append to its data
-            layer = viewer.layers[0]
-            image_shape = layer.data.shape[1:]
-            image_dtype = layer.data.dtype
-            image = da.from_delayed(
-                delayed_image, shape=image_shape, dtype=image_dtype,
-            ).reshape((1,) + image_shape)
-            layer.data = da.concatenate((layer.data, image), axis=0)
+
+@thread_worker(connect={'yielded': append})
+def watch_path(path):
+    """Watches the path for new files and yields it once file is ready.
+
+    Notes
+    -----
+    Currently, there is no proper way to know if the file has written 
+    entirely. So the workaround is we assume that files are generating 
+    serially (in most microscopes it common), and files are name in 
+    alphanumeric sequence We start loading the total number of minus the 
+    last file (`total__files - last`). In other words, once we see the new 
+    file in the directory, it means the file before it has completed so load
+    that file. For this example, we also assume that the microscope is 
+    generating a `final.log` file at the end of the acquisition, this file 
+    is an indicator to stop monitoring the directory.
+
+    Parameters
+    ----------
+    path : str
+    directory to monitor and load tiffs as they start appearing.
+    """
+    current_files = set()
+    processed_files = set()
+    end_of_acquisition = False
+    while not end_of_acquisition:
+        files_to_process = set()
+        # Get the all files in the directory at this time
+        current_files = set(os.listdir(path))
+
+        # Check if the end of acquisition has reached
+        # if yes then remove it from the files_to_process set
+        # and send it to display
+        if end_of_experiment in current_files:
+            files_to_process = current_files - processed_files
+            files_to_process.remove(end_of_experiment)
+            end_of_acquisition = True
+
+        elif len(current_files):
+            # get the last file from the current files based on the file names
+            last_file = sorted(current_files, key=alphanumeric_key)[-1]
+            current_files.remove(last_file)
+            files_to_process = current_files - processed_files
+
+        # yield every file to process as a dask.delayed function object.
+        for p in sorted(files_to_process, key=alphanumeric_key):
+            yield delayed(imread)(os.path.join(path, p))
         else:
-            # first run, no layer added yet
-            image = delayed_image.compute()
-            image = da.from_delayed(
-                delayed_image, shape=image.shape, dtype=image.dtype,
-            ).reshape((1,) + image.shape)
-            layer = viewer.add_image(image, rendering='attenuated_mip')
+            yield
 
-        # we want to show the last file added in the viewer to do so we want to
-        # put the slider at the very end. But, sometimes when user is scrolling
-        # through the previous slide then it is annoying to jump to last
-        # stack as it gets added. To avoid that jump we 1st check where
-        # the scroll is and if its not at the last slide then don't move the slider.
-        if viewer.dims.point[0] >= layer.data.shape[0] - 2:
-            viewer.dims.set_point(0, layer.data.shape[0] - 1)
+        # add the files which we have yield to the processed list.
+        processed_files.update(files_to_process)
+        time.sleep(0.1)
 
-    @thread_worker(connect={'yielded': append})
-    def watch_path(path):
-        """Watches the path for new files and yields it once file is ready.
 
-        Notes
-        -----
-        Currently, there is no proper way to know if the file has written 
-        entirely. So the workaround is we assume that files are generating 
-        serially (in most microscopes it common), and files are name in 
-        alphanumeric sequence We start loading the total number of minus the 
-        last file (`total__files - last`). In other words, once we see the new 
-        file in the directory, it means the file before it has completed so load
-        that file. For this example, we also assume that the microscope is 
-        generating a `final.log` file at the end of the acquisition, this file 
-        is an indicator to stop monitoring the directory.
-
-        Parameters
-        ----------
-        path : str
-        directory to monitor and load tiffs as they start appearing.
-        """
-        current_files = set()
-        processed_files = set()
-        end_of_acquisition = False
-        while not end_of_acquisition:
-            files_to_process = set()
-            # Get the all files in the directory at this time
-            current_files = set(os.listdir(path))
-
-            # Check if the end of acquisition has reached
-            # if yes then remove it from the files_to_process set
-            # and send it to display
-            if end_of_experiment in current_files:
-                files_to_process = current_files - processed_files
-                files_to_process.remove(end_of_experiment)
-                end_of_acquisition = True
-
-            elif len(current_files):
-                # get the last file from the current files based on the file names
-                last_file = sorted(current_files, key=alphanumeric_key)[-1]
-                current_files.remove(last_file)
-                files_to_process = current_files - processed_files
-
-            # yield every file to process as a dask.delayed function object.
-            for p in sorted(files_to_process, key=alphanumeric_key):
-                yield delayed(imread)(os.path.join(path, p))
-            else:
-                yield
-
-            # add the files which we have yield to the processed list.
-            processed_files.update(files_to_process)
-            time.sleep(0.1)
-
-    worker = watch_path(path)
+worker = watch_path(path)
+napari.run()

--- a/examples/magic_image_arithmetic.py
+++ b/examples/magic_image_arithmetic.py
@@ -22,7 +22,7 @@ class Operation(enum.Enum):
 # really matter. But this syntax would let you specify that a parameter is a
 # napari object type without actually importing or depending on napari.
 # Note: here we use `napari.types.ImageData` as our parameter annotations,
-# which means our function will be passed layer.data instead of 
+# which means our function will be passed layer.data instead of
 # the full layer instance
 def image_arithmetic(
     layerA: 'napari.types.ImageData',
@@ -34,11 +34,12 @@ def image_arithmetic(
         return operation.value(layerA, layerB)
 
 
-with napari.gui_qt():
-    # create a new viewer with a couple image layers
-    viewer = napari.Viewer()
-    viewer.add_image(np.random.rand(20, 20), name="Layer 1")
-    viewer.add_image(np.random.rand(20, 20), name="Layer 2")
+# create a new viewer with a couple image layers
+viewer = napari.Viewer()
+viewer.add_image(np.random.rand(20, 20), name="Layer 1")
+viewer.add_image(np.random.rand(20, 20), name="Layer 2")
 
-    # Add our magic function to napari
-    viewer.window.add_function_widget(image_arithmetic)
+# Add our magic function to napari
+viewer.window.add_function_widget(image_arithmetic)
+
+napari.run()

--- a/examples/magic_parameter_sweep.py
+++ b/examples/magic_parameter_sweep.py
@@ -30,11 +30,12 @@ def gaussian_blur(
         return skimage.filters.gaussian(layer.data, sigma=sigma, mode=mode)
 
 
-with napari.gui_qt():
-    # create a viewer and add some images
-    viewer = napari.Viewer()
-    viewer.add_image(skimage.data.astronaut().mean(-1), name="astronaut")
-    viewer.add_image(skimage.data.grass().astype("float"), name="grass")
+# create a viewer and add some images
+viewer = napari.Viewer()
+viewer.add_image(skimage.data.astronaut().mean(-1), name="astronaut")
+viewer.add_image(skimage.data.grass().astype("float"), name="grass")
 
-    # Add our magic function to napari
-    viewer.window.add_function_widget(gaussian_blur)
+# Add our magic function to napari
+viewer.window.add_function_widget(gaussian_blur)
+
+napari.run()

--- a/examples/mouse_drag_callback.py
+++ b/examples/mouse_drag_callback.py
@@ -10,37 +10,39 @@ import napari
 
 
 def profile_lines(image, shape_layer):
-    profile_data = []
-    for line in shape_layer.data:
-        profile_data.append(
-            measure.profile_line(
-                image, line[0], line[1], mode='reflect'
-            ).mean()
-        )
-    msg = ('profile means: ['
-            + ', '.join([f'{d:.2f}' for d in profile_data])
-            + ']')
-    print(msg)
+    profile_data = [
+        measure.profile_line(image, line[0], line[1], mode='reflect').mean()
+        for line in shape_layer.data
+    ]
+    print(f"profile means: [{', '.join(f'{d:.2f}' for d in profile_data)}]")
 
 
-with napari.gui_qt():
-    np.random.seed(1)
-    viewer = napari.Viewer()
-    blobs = data.binary_blobs(length=512, volume_fraction=0.1, n_dim=2)
-    viewer.add_image(blobs, name='blobs')
-    line1 = np.array([[11, 13], [111, 113]])
-    line2 = np.array([[200, 200], [400, 300]])
-    lines = [line1, line2]
-    shapes_layer = viewer.add_shapes(lines, shape_type='line',
-            edge_width=5, edge_color='coral', face_color='royalblue')
-    shapes_layer.mode = 'select'
+np.random.seed(1)
+viewer = napari.Viewer()
+blobs = data.binary_blobs(length=512, volume_fraction=0.1, n_dim=2)
+viewer.add_image(blobs, name='blobs')
+line1 = np.array([[11, 13], [111, 113]])
+line2 = np.array([[200, 200], [400, 300]])
+lines = [line1, line2]
+shapes_layer = viewer.add_shapes(
+    lines,
+    shape_type='line',
+    edge_width=5,
+    edge_color='coral',
+    face_color='royalblue',
+)
+shapes_layer.mode = 'select'
 
-    @shapes_layer.mouse_drag_callbacks.append
-    def profile_lines_drag(layer, event):
+
+@shapes_layer.mouse_drag_callbacks.append
+def profile_lines_drag(layer, event):
+    profile_lines(blobs, layer)
+    yield
+    while event.type == 'mouse_move':
         profile_lines(blobs, layer)
+        # the yield statement allows the mouse UI to keep working while
+        # this loop is executed repeatedly
         yield
-        while event.type == 'mouse_move':
-            profile_lines(blobs, layer)
-            # the yield statement allows the mouse UI to keep working while
-            # this loop is executed repeatedly
-            yield
+
+
+napari.run()

--- a/examples/multiple_viewers.py
+++ b/examples/multiple_viewers.py
@@ -2,17 +2,17 @@
 Create multiple viewers from the same script
 """
 
-import numpy as np
 from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    # add the image
-    photographer = data.camera()
-    viewer_a = napari.view_image(photographer, name='photographer')
+# add the image
+photographer = data.camera()
+viewer_a = napari.view_image(photographer, name='photographer')
 
-    # add the image in a new viewer window
-    astronaut = data.astronaut()
-    # Also view_path, view_shapes, view_points, view_labels etc.
-    viewer_b = napari.view_image(astronaut, name='astronaut')
+# add the image in a new viewer window
+astronaut = data.astronaut()
+# Also view_path, view_shapes, view_points, view_labels etc.
+viewer_b = napari.view_image(astronaut, name='astronaut')
+
+napari.run()

--- a/examples/multithreading_two_way.py
+++ b/examples/multithreading_two_way.py
@@ -112,7 +112,8 @@ def create_connected_widget():
 
 if __name__ == "__main__":
 
-    with napari.gui_qt():
-        viewer = napari.view_image(np.random.rand(512, 512))
-        w = create_connected_widget()
-        viewer.window.add_dock_widget(w)
+    viewer = napari.view_image(np.random.rand(512, 512))
+    w = create_connected_widget()
+    viewer.window.add_dock_widget(w)
+
+    napari.run()

--- a/examples/nD_image.py
+++ b/examples/nD_image.py
@@ -7,14 +7,15 @@ from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    blobs = np.stack(
-        [
-            data.binary_blobs(
-                length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=f
-            )
-            for f in np.linspace(0.05, 0.5, 10)
-        ],
-        axis=0,
-    )
-    viewer = napari.view_image(blobs.astype(float))
+blobs = np.stack(
+    [
+        data.binary_blobs(
+            length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=f
+        )
+        for f in np.linspace(0.05, 0.5, 10)
+    ],
+    axis=0,
+)
+viewer = napari.view_image(blobs.astype(float))
+
+napari.run()

--- a/examples/nD_labels.py
+++ b/examples/nD_labels.py
@@ -8,8 +8,9 @@ from scipy import ndimage as ndi
 import napari
 
 
-with napari.gui_qt():
-    blobs = data.binary_blobs(length=128, volume_fraction=0.1, n_dim=3)
-    viewer = napari.view_image(blobs.astype(float), name='blobs')
-    labeled = ndi.label(blobs)[0]
-    viewer.add_labels(labeled, name='blob ID')
+blobs = data.binary_blobs(length=128, volume_fraction=0.1, n_dim=3)
+viewer = napari.view_image(blobs.astype(float), name='blobs')
+labeled = ndi.label(blobs)[0]
+viewer.add_labels(labeled, name='blob ID')
+
+napari.run()

--- a/examples/nD_multiscale_image.py
+++ b/examples/nD_multiscale_image.py
@@ -16,6 +16,7 @@ multiscale = list(
 )
 print('multiscale level shapes: ', [p.shape for p in multiscale])
 
-with napari.gui_qt():
-    # add image multiscale
-    napari.view_image(multiscale, contrast_limits=[0, 1], multiscale=True)
+# add image multiscale
+viewer = napari.view_image(multiscale, contrast_limits=[0, 1], multiscale=True)
+
+napari.run()

--- a/examples/nD_multiscale_image_non_uniform.py
+++ b/examples/nD_multiscale_image_non_uniform.py
@@ -3,8 +3,6 @@ Displays an nD multiscale image
 """
 
 from skimage import data
-from skimage.util import img_as_ubyte
-from skimage.color import rgb2gray
 from skimage.transform import pyramid_gaussian
 import napari
 import numpy as np
@@ -21,6 +19,7 @@ multiscale = [
 ]
 print('multiscale level shapes: ', [p.shape for p in multiscale])
 
-with napari.gui_qt():
-    # add image multiscale
-    napari.view_image(multiscale, multiscale=True)
+# add image multiscale
+viewer = napari.view_image(multiscale, multiscale=True)
+
+napari.run()

--- a/examples/nD_points.py
+++ b/examples/nD_points.py
@@ -9,28 +9,29 @@ from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    blobs = np.stack(
-        [
-            data.binary_blobs(
-                length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=f
-            )
-            for f in np.linspace(0.05, 0.5, 10)
-        ],
-        axis=0,
-    )
-    viewer = napari.view_image(blobs.astype(float))
+blobs = np.stack(
+    [
+        data.binary_blobs(
+            length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=f
+        )
+        for f in np.linspace(0.05, 0.5, 10)
+    ],
+    axis=0,
+)
+viewer = napari.view_image(blobs.astype(float))
 
-    # add the points
-    points = np.array(
-        [
-            [0, 0, 100, 100],
-            [0, 0, 50, 120],
-            [1, 0, 100, 40],
-            [2, 10, 110, 100],
-            [9, 8, 80, 100],
-        ]
-    )
-    viewer.add_points(
-        points, size=[0, 6, 10, 10], face_color='blue', n_dimensional=True
-    )
+# add the points
+points = np.array(
+    [
+        [0, 0, 100, 100],
+        [0, 0, 50, 120],
+        [1, 0, 100, 40],
+        [2, 10, 110, 100],
+        [9, 8, 80, 100],
+    ]
+)
+viewer.add_points(
+    points, size=[0, 6, 10, 10], face_color='blue', n_dimensional=True
+)
+
+napari.run()

--- a/examples/nD_points_with_properties.py
+++ b/examples/nD_points_with_properties.py
@@ -4,49 +4,48 @@ add_points and add_image APIs, where the markes are visible as nD objects
 across the dimensions, specified by their size
 """
 
-from math import ceil
-
 import numpy as np
 from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    blobs = data.binary_blobs(
-        length=100, blob_size_fraction=0.05, n_dim=3, volume_fraction=0.05
-    )
-    viewer = napari.view_image(blobs.astype(float))
+blobs = data.binary_blobs(
+    length=100, blob_size_fraction=0.05, n_dim=3, volume_fraction=0.05
+)
+viewer = napari.view_image(blobs.astype(float))
 
-    # create the points
-    points = []
-    for z in range(blobs.shape[0]):
-        points += [[z, 25, 25], [z, 25, 75], [z, 75, 25], [z, 75, 75]]
+# create the points
+points = []
+for z in range(blobs.shape[0]):
+    points += [[z, 25, 25], [z, 25, 75], [z, 75, 25], [z, 75, 75]]
 
-    # create the property for setting the face and edge color.
-    face_property = np.array(
-        [True, True, True, True, False, False, False, False]
-        * int((blobs.shape[0] / 2))
-    )
-    edge_property = np.array(['A', 'B', 'C', 'D', 'E'] * int(len(points) / 5))
+# create the property for setting the face and edge color.
+face_property = np.array(
+    [True, True, True, True, False, False, False, False]
+    * int((blobs.shape[0] / 2))
+)
+edge_property = np.array(['A', 'B', 'C', 'D', 'E'] * int(len(points) / 5))
 
-    properties = {
-        'face_property': face_property,
-        'edge_property': edge_property,
-    }
+properties = {
+    'face_property': face_property,
+    'edge_property': edge_property,
+}
 
-    points_layer = viewer.add_points(
-        points,
-        properties=properties,
-        size=3,
-        edge_width=5,
-        edge_color='edge_property',
-        face_color='face_property',
-        n_dimensional=False,
-    )
+points_layer = viewer.add_points(
+    points,
+    properties=properties,
+    size=3,
+    edge_width=5,
+    edge_color='edge_property',
+    face_color='face_property',
+    n_dimensional=False,
+)
 
-    # change the face color cycle
-    points_layer.face_color_cycle = ['white', 'black']
+# change the face color cycle
+points_layer.face_color_cycle = ['white', 'black']
 
-    # change the edge_color cycle.
-    # there are 4 colors for 5 categories, so 'c' will be recycled
-    points_layer.edge_color_cycle = ['c', 'm', 'y', 'k']
+# change the edge_color cycle.
+# there are 4 colors for 5 categories, so 'c' will be recycled
+points_layer.edge_color_cycle = ['c', 'm', 'y', 'k']
+
+napari.run()

--- a/examples/nD_shapes.py
+++ b/examples/nD_shapes.py
@@ -7,48 +7,47 @@ from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    blobs = data.binary_blobs(
-        length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=0.1
-    ).astype(float)
+blobs = data.binary_blobs(
+    length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=0.1
+).astype(float)
 
-    viewer = napari.view_image(blobs.astype(float))
+viewer = napari.view_image(blobs.astype(float))
 
-    # create one random polygon per "plane"
-    planes = np.tile(np.arange(128).reshape((128, 1, 1)), (1, 5, 1))
-    np.random.seed(0)
-    corners = np.random.uniform(0, 128, size=(128, 5, 2))
-    shapes = np.concatenate((planes, corners), axis=2)
+# create one random polygon per "plane"
+planes = np.tile(np.arange(128).reshape((128, 1, 1)), (1, 5, 1))
+np.random.seed(0)
+corners = np.random.uniform(0, 128, size=(128, 5, 2))
+shapes = np.concatenate((planes, corners), axis=2)
 
-    base_cols = ['red', 'green', 'blue', 'white', 'yellow', 'magenta', 'cyan']
-    colors = np.random.choice(base_cols, size=128)
+base_cols = ['red', 'green', 'blue', 'white', 'yellow', 'magenta', 'cyan']
+colors = np.random.choice(base_cols, size=128)
 
-    layer = viewer.add_shapes(
-        np.array(shapes),
-        shape_type='polygon',
-        face_color=colors,
-        name='sliced',
-    )
+layer = viewer.add_shapes(
+    np.array(shapes),
+    shape_type='polygon',
+    face_color=colors,
+    name='sliced',
+)
 
-    masks = layer.to_masks(mask_shape=(128, 128, 128))
-    labels = layer.to_labels(labels_shape=(128, 128, 128))
-    shape_array = np.array(layer.data)
+masks = layer.to_masks(mask_shape=(128, 128, 128))
+labels = layer.to_labels(labels_shape=(128, 128, 128))
+shape_array = np.array(layer.data)
 
-    print(
-        f'sliced: nshapes {layer.nshapes}, mask shape {masks.shape}, '
-        f'labels_shape {labels.shape}, array_shape, {shape_array.shape}'
-    )
+print(
+    f'sliced: nshapes {layer.nshapes}, mask shape {masks.shape}, '
+    f'labels_shape {labels.shape}, array_shape, {shape_array.shape}'
+)
 
-    corners = np.random.uniform(0, 128, size=(2, 2))
-    layer = viewer.add_shapes(
-        corners, shape_type='rectangle', name='broadcasted'
-    )
+corners = np.random.uniform(0, 128, size=(2, 2))
+layer = viewer.add_shapes(corners, shape_type='rectangle', name='broadcasted')
 
-    masks = layer.to_masks(mask_shape=(128, 128))
-    labels = layer.to_labels(labels_shape=(128, 128))
-    shape_array = np.array(layer.data)
+masks = layer.to_masks(mask_shape=(128, 128))
+labels = layer.to_labels(labels_shape=(128, 128))
+shape_array = np.array(layer.data)
 
-    print(
-        f'broadcast: nshapes {layer.nshapes}, mask shape {masks.shape}, '
-        f'labels_shape {labels.shape}, array_shape, {shape_array.shape}'
-    )
+print(
+    f'broadcast: nshapes {layer.nshapes}, mask shape {masks.shape}, '
+    f'labels_shape {labels.shape}, array_shape, {shape_array.shape}'
+)
+
+napari.run()

--- a/examples/nD_shapes_with_text.py
+++ b/examples/nD_shapes_with_text.py
@@ -1,25 +1,25 @@
-import numpy as np
 from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    blobs = data.binary_blobs(
-        length=100, blob_size_fraction=0.05, n_dim=3, volume_fraction=0.03
-    ).astype(float)
+blobs = data.binary_blobs(
+    length=100, blob_size_fraction=0.05, n_dim=3, volume_fraction=0.03
+).astype(float)
 
-    viewer = napari.view_image(blobs.astype(float), ndisplay=3)
+viewer = napari.view_image(blobs.astype(float), ndisplay=3)
 
-    n = 50
-    shape = [[[n, 40, 40], [n, 40, 60], [n + 20, 60, 60], [n + 20, 60, 40]]]
+n = 50
+shape = [[[n, 40, 40], [n, 40, 60], [n + 20, 60, 60], [n + 20, 60, 40]]]
 
-    properties = {'z_index': [n]}
-    text = {'text': 'z_index', 'color': 'green', 'anchor': 'upper_left'}
+properties = {'z_index': [n]}
+text = {'text': 'z_index', 'color': 'green', 'anchor': 'upper_left'}
 
-    shapes_layer = viewer.add_shapes(
-        shape,
-        edge_color=[0, 1, 0, 1],
-        face_color='transparent',
-        properties=properties,
-        text=text,
-    )
+shapes_layer = viewer.add_shapes(
+    shape,
+    edge_color=[0, 1, 0, 1],
+    face_color='transparent',
+    properties=properties,
+    text=text,
+)
+
+napari.run()

--- a/examples/nD_surface.py
+++ b/examples/nD_surface.py
@@ -3,17 +3,17 @@ Display a 3D surface
 """
 
 import numpy as np
-from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    # create the viewer and window
-    viewer = napari.Viewer(ndisplay=3)
+# create the viewer and window
+viewer = napari.Viewer(ndisplay=3)
 
-    data = np.array([[0, 0, 0], [0, 20, 10], [10, 0, -10], [10, 10, -10]])
-    faces = np.array([[0, 1, 2], [1, 2, 3]])
-    values = np.linspace(0, 1, len(data))
+data = np.array([[0, 0, 0], [0, 20, 10], [10, 0, -10], [10, 10, -10]])
+faces = np.array([[0, 1, 2], [1, 2, 3]])
+values = np.linspace(0, 1, len(data))
 
-    # add the surface
-    layer = viewer.add_surface((data, faces, values))
+# add the surface
+layer = viewer.add_surface((data, faces, values))
+
+napari.run()

--- a/examples/nD_vectors.py
+++ b/examples/nD_vectors.py
@@ -10,41 +10,42 @@ from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    blobs = np.stack(
-        [
-            data.binary_blobs(
-                length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=f
-            )
-            for f in np.linspace(0.05, 0.5, 10)
-        ],
-        axis=0,
-    )
-    viewer = napari.view_image(blobs.astype(float))
+blobs = np.stack(
+    [
+        data.binary_blobs(
+            length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=f
+        )
+        for f in np.linspace(0.05, 0.5, 10)
+    ],
+    axis=0,
+)
+viewer = napari.view_image(blobs.astype(float))
 
-    # sample vector coord-like data
-    n = 200
-    pos = np.zeros((n, 2, 2), dtype=np.float32)
-    phi_space = np.linspace(0, 4 * np.pi, n)
-    radius_space = np.linspace(0, 20, n)
+# sample vector coord-like data
+n = 200
+pos = np.zeros((n, 2, 2), dtype=np.float32)
+phi_space = np.linspace(0, 4 * np.pi, n)
+radius_space = np.linspace(0, 20, n)
 
-    # assign x-y position
-    pos[:, 0, 0] = radius_space * np.cos(phi_space) + 64
-    pos[:, 0, 1] = radius_space * np.sin(phi_space) + 64
+# assign x-y position
+pos[:, 0, 0] = radius_space * np.cos(phi_space) + 64
+pos[:, 0, 1] = radius_space * np.sin(phi_space) + 64
 
-    # assign x-y projection
-    pos[:, 1, 0] = 2 * radius_space * np.cos(phi_space)
-    pos[:, 1, 1] = 2 * radius_space * np.sin(phi_space)
+# assign x-y projection
+pos[:, 1, 0] = 2 * radius_space * np.cos(phi_space)
+pos[:, 1, 1] = 2 * radius_space * np.sin(phi_space)
 
-    planes = np.round(np.linspace(0, 128, n)).astype(int)
-    planes = np.concatenate(
-        (planes.reshape((n, 1, 1)), np.zeros((n, 1, 1))), axis=1
-    )
-    vectors = np.concatenate((planes, pos), axis=2)
+planes = np.round(np.linspace(0, 128, n)).astype(int)
+planes = np.concatenate(
+    (planes.reshape((n, 1, 1)), np.zeros((n, 1, 1))), axis=1
+)
+vectors = np.concatenate((planes, pos), axis=2)
 
-    # add the sliced vectors
-    layer = viewer.add_vectors(
-        vectors, edge_width=0.4, name='sliced vectors', edge_color='blue'
-    )
+# add the sliced vectors
+layer = viewer.add_vectors(
+    vectors, edge_width=0.4, name='sliced vectors', edge_color='blue'
+)
 
-    viewer.dims.ndisplay = 3
+viewer.dims.ndisplay = 3
+
+napari.run()

--- a/examples/nD_vectors_image.py
+++ b/examples/nD_vectors_image.py
@@ -9,22 +9,23 @@ import napari
 import numpy as np
 
 
-with napari.gui_qt():
-    # create the viewer and window
-    viewer = napari.Viewer()
+# create the viewer and window
+viewer = napari.Viewer()
 
-    m = 10
-    n = 20
-    p = 40
+m = 10
+n = 20
+p = 40
 
-    image = 0.2 * np.random.random((m, n, p)) + 0.5
-    layer = viewer.add_image(image, contrast_limits=[0, 1], name='background')
+image = 0.2 * np.random.random((m, n, p)) + 0.5
+layer = viewer.add_image(image, contrast_limits=[0, 1], name='background')
 
-    # sample vector image-like data
-    # n x m grid of slanted lines
-    # random data on the open interval (-1, 1)
-    pos = np.random.uniform(-1, 1, size=(m, n, p, 3))
-    print(image.shape, pos.shape)
+# sample vector image-like data
+# n x m grid of slanted lines
+# random data on the open interval (-1, 1)
+pos = np.random.uniform(-1, 1, size=(m, n, p, 3))
+print(image.shape, pos.shape)
 
-    # add the vectors
-    vect = viewer.add_vectors(pos, edge_width=0.2, length=2.5)
+# add the vectors
+vect = viewer.add_vectors(pos, edge_width=0.2, length=2.5)
+
+napari.run()

--- a/examples/nD_volume.py
+++ b/examples/nD_volume.py
@@ -2,21 +2,20 @@
 Slide through 3D Volume series in 4D data using the add_volume API
 """
 
-from skimage import data
+from skimage.data import binary_blobs
 import numpy as np
 import napari
 
 
-with napari.gui_qt():
-    blobs = np.asarray(
-        [
-            data.binary_blobs(length=64, volume_fraction=0.1, n_dim=3).astype(
-                float
-            )
-            for i in range(10)
-        ]
-    )
-    viewer = napari.Viewer(ndisplay=3)
+blobs = np.asarray(
+    [
+        binary_blobs(length=64, volume_fraction=0.1, n_dim=3).astype(float)
+        for i in range(10)
+    ]
+)
+viewer = napari.Viewer(ndisplay=3)
 
-    # add the volume
-    layer = viewer.add_image(blobs)
+# add the volume
+layer = viewer.add_image(blobs)
+
+napari.run()

--- a/examples/new_theme.py
+++ b/examples/new_theme.py
@@ -6,27 +6,27 @@ from skimage import data
 import napari
 from napari.utils.theme import available_themes, get_theme, register_theme
 
-with napari.gui_qt():
-    # create the viewer with an image
-    viewer = napari.view_image(
-        data.astronaut(), rgb=True, name='astronaut'
-    )
 
-    # List themes
-    print('Originally themes', available_themes())
+# create the viewer with an image
+viewer = napari.view_image(data.astronaut(), rgb=True, name='astronaut')
 
-    blue_theme = get_theme('dark')
-    blue_theme.update(
-        background='rgb(28, 31, 48)',
-        foreground='rgb(45, 52, 71)',
-        primary='rgb(80, 88, 108)',
-        current='rgb(184, 112, 0)',
-    )
+# List themes
+print('Originally themes', available_themes())
 
-    register_theme('blue', blue_theme)
+blue_theme = get_theme('dark')
+blue_theme.update(
+    background='rgb(28, 31, 48)',
+    foreground='rgb(45, 52, 71)',
+    primary='rgb(80, 88, 108)',
+    current='rgb(184, 112, 0)',
+)
 
-    # List themes
-    print('New themes', available_themes())
+register_theme('blue', blue_theme)
 
-    # Set theme
-    viewer.theme = 'blue'
+# List themes
+print('New themes', available_themes())
+
+# Set theme
+viewer.theme = 'blue'
+
+napari.run()

--- a/examples/notebook.ipynb
+++ b/examples/notebook.ipynb
@@ -20,12 +20,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%gui qt5\n",
-    "# Note that this Magics command needs to be run in a cell\n",
-    "# before any of the Napari objects are instantiated to\n",
-    "# ensure it has time to finish executing before they are\n",
-    "# called\n",
-    "\n",
     "from skimage import data\n",
     "import napari"
    ]

--- a/examples/pass_colormaps.py
+++ b/examples/pass_colormaps.py
@@ -3,7 +3,6 @@ Add named or unnamed vispy colormaps to existing layers.
 """
 
 import numpy as np
-import vispy.color
 from skimage import data
 import napari
 
@@ -11,15 +10,16 @@ import napari
 histo = data.astronaut() / 255
 rch, gch, bch = np.transpose(histo, (2, 0, 1))
 
-with napari.gui_qt():
-    v = napari.Viewer()
+v = napari.Viewer()
 
-    rlayer = v.add_image(
-        rch, name='red channel', colormap='red', blending='additive'
-    )
-    glayer = v.add_image(
-        gch, name='green channel', colormap='green', blending='additive'
-    )
-    blayer = v.add_image(
-        bch, name='blue channel', colormap='blue', blending='additive'
-    )
+rlayer = v.add_image(
+    rch, name='red channel', colormap='red', blending='additive'
+)
+glayer = v.add_image(
+    gch, name='green channel', colormap='green', blending='additive'
+)
+blayer = v.add_image(
+    bch, name='blue channel', colormap='blue', blending='additive'
+)
+
+napari.run()

--- a/examples/scale_bar.py
+++ b/examples/scale_bar.py
@@ -5,8 +5,8 @@ import numpy as np
 import napari
 
 
-with napari.gui_qt():
-    np.random.seed(0)
-    viewer = napari.Viewer()
-    viewer.add_image(np.random.random((5, 5, 5)), colormap='red', opacity=0.8)
-    viewer.scale_bar.visible = True
+viewer = napari.Viewer()
+viewer.add_image(np.random.random((5, 5, 5)), colormap='red', opacity=0.8)
+viewer.scale_bar.visible = True
+
+napari.run()

--- a/examples/set_colormaps.py
+++ b/examples/set_colormaps.py
@@ -14,15 +14,16 @@ red = vispy.color.Colormap([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
 green = vispy.color.Colormap([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
 blue = vispy.color.Colormap([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
 
-with napari.gui_qt():
-    v = napari.Viewer()
+v = napari.Viewer()
 
-    rlayer = v.add_image(rch, name='red channel')
-    rlayer.blending = 'additive'
-    rlayer.colormap = 'red', red
-    glayer = v.add_image(gch, name='green channel')
-    glayer.blending = 'additive'
-    glayer.colormap = green  # this will appear as [unnamed colormap]
-    blayer = v.add_image(bch, name='blue channel')
-    blayer.blending = 'additive'
-    blayer.colormap = {'blue': blue}
+rlayer = v.add_image(rch, name='red channel')
+rlayer.blending = 'additive'
+rlayer.colormap = 'red', red
+glayer = v.add_image(gch, name='green channel')
+glayer.blending = 'additive'
+glayer.colormap = green  # this will appear as [unnamed colormap]
+blayer = v.add_image(bch, name='blue channel')
+blayer.blending = 'additive'
+blayer.colormap = {'blue': blue}
+
+napari.run()

--- a/examples/set_theme.py
+++ b/examples/set_theme.py
@@ -6,11 +6,10 @@ from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    # create the viewer with an image
-    viewer = napari.view_image(
-        data.astronaut(), rgb=True, name='astronaut'
-    )
+# create the viewer with an image
+viewer = napari.view_image(data.astronaut(), rgb=True, name='astronaut')
 
-    # set the theme to 'light'
-    viewer.theme = 'light'
+# set the theme to 'light'
+viewer.theme = 'light'
+
+napari.run()

--- a/examples/shapes_to_labels.py
+++ b/examples/shapes_to_labels.py
@@ -10,89 +10,88 @@ import napari
 from vispy.color import Colormap
 
 
-with napari.gui_qt():
-    # create the viewer and window
-    viewer = napari.Viewer()
+# create the viewer and window
+viewer = napari.Viewer()
 
-    # add the image
-    img_layer = viewer.add_image(data.camera(), name='photographer')
+# add the image
+img_layer = viewer.add_image(data.camera(), name='photographer')
 
-    # create a list of polygons
-    polygons = [
-        np.array([[11, 13], [111, 113], [22, 246]]),
-        np.array(
-            [
-                [505, 60],
-                [402, 71],
-                [383, 42],
-                [251, 95],
-                [212, 59],
-                [131, 137],
-                [126, 187],
-                [191, 204],
-                [171, 248],
-                [211, 260],
-                [273, 243],
-                [264, 225],
-                [430, 173],
-                [512, 160],
-            ]
-        ),
-        np.array(
-            [
-                [310, 382],
-                [229, 381],
-                [209, 401],
-                [221, 411],
-                [258, 411],
-                [300, 412],
-                [306, 435],
-                [268, 434],
-                [265, 454],
-                [298, 461],
-                [307, 461],
-                [307, 507],
-                [349, 510],
-                [352, 369],
-                [330, 366],
-                [330, 366],
-            ]
-        ),
-    ]
+# create a list of polygons
+polygons = [
+    np.array([[11, 13], [111, 113], [22, 246]]),
+    np.array(
+        [
+            [505, 60],
+            [402, 71],
+            [383, 42],
+            [251, 95],
+            [212, 59],
+            [131, 137],
+            [126, 187],
+            [191, 204],
+            [171, 248],
+            [211, 260],
+            [273, 243],
+            [264, 225],
+            [430, 173],
+            [512, 160],
+        ]
+    ),
+    np.array(
+        [
+            [310, 382],
+            [229, 381],
+            [209, 401],
+            [221, 411],
+            [258, 411],
+            [300, 412],
+            [306, 435],
+            [268, 434],
+            [265, 454],
+            [298, 461],
+            [307, 461],
+            [307, 507],
+            [349, 510],
+            [352, 369],
+            [330, 366],
+            [330, 366],
+        ]
+    ),
+]
 
-    # add polygons
-    layer = viewer.add_shapes(
-        polygons,
-        shape_type='polygon',
-        edge_width=1,
-        edge_color='coral',
-        face_color='royalblue',
-        name='shapes',
-    )
+# add polygons
+layer = viewer.add_shapes(
+    polygons,
+    shape_type='polygon',
+    edge_width=1,
+    edge_color='coral',
+    face_color='royalblue',
+    name='shapes',
+)
 
-    # change some properties of the layer
-    layer.selected_data = set(range(layer.nshapes))
-    layer.current_edge_width = 5
-    layer.current_opacity = 0.75
-    layer.selected_data = set()
+# change some properties of the layer
+layer.selected_data = set(range(layer.nshapes))
+layer.current_edge_width = 5
+layer.current_opacity = 0.75
+layer.selected_data = set()
 
-    # add an ellipse to the layer
-    ellipse = np.array([[59, 222], [110, 289], [170, 243], [119, 176]])
-    layer.add(
-        ellipse,
-        shape_type='ellipse',
-        edge_width=5,
-        edge_color='coral',
-        face_color='purple',
-    )
+# add an ellipse to the layer
+ellipse = np.array([[59, 222], [110, 289], [170, 243], [119, 176]])
+layer.add(
+    ellipse,
+    shape_type='ellipse',
+    edge_width=5,
+    edge_color='coral',
+    face_color='purple',
+)
 
-    masks = layer.to_masks([512, 512])
-    masks_layer = viewer.add_image(masks.astype(float), name='masks')
-    masks_layer.opacity = 0.7
-    masks_layer.colormap = Colormap(
-        [[0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 1.0]]
-    )
+masks = layer.to_masks([512, 512])
+masks_layer = viewer.add_image(masks.astype(float), name='masks')
+masks_layer.opacity = 0.7
+masks_layer.colormap = Colormap([[0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 1.0]])
 
-    labels = layer.to_labels([512, 512])
-    labels_layer = viewer.add_labels(labels, name='labels')
-    labels_layer.visible = False
+labels = layer.to_labels([512, 512])
+labels_layer = viewer.add_labels(labels, name='labels')
+labels_layer.visible = False
+
+napari.run()

--- a/examples/surface_timeseries.py
+++ b/examples/surface_timeseries.py
@@ -26,12 +26,13 @@ timeseries = surface.load_surf_data(nki_dataset['func_left'][0])
 # vertices axis to be placed last to match NumPy broadcasting rules
 timeseries = timeseries.transpose((1, 0))
 
-with napari.gui_qt():
-    # create an empty viewer
-    viewer = napari.Viewer(ndisplay=3)
+# create an empty viewer
+viewer = napari.Viewer(ndisplay=3)
 
-    # add the mri
-    viewer.add_surface((brain_vertices, brain_faces, brain_vertex_depth), name='base')
-    viewer.add_surface((brain_vertices, brain_faces, timeseries),
-                       colormap='turbo', opacity=0.9,
-                       contrast_limits=[-1.5, 3.5], name='timeseries')
+# add the mri
+viewer.add_surface((brain_vertices, brain_faces, brain_vertex_depth), name='base')
+viewer.add_surface((brain_vertices, brain_faces, timeseries),
+                    colormap='turbo', opacity=0.9,
+                    contrast_limits=[-1.5, 3.5], name='timeseries')
+
+napari.run()

--- a/examples/swap_dims.py
+++ b/examples/swap_dims.py
@@ -7,30 +7,31 @@ from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    blobs = np.stack(
-        [
-            data.binary_blobs(
-                length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=f
-            )
-            for f in np.linspace(0.05, 0.5, 10)
-        ],
-        axis=0,
-    )
-    viewer = napari.view_image(blobs.astype(float))
+blobs = np.stack(
+    [
+        data.binary_blobs(
+            length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=f
+        )
+        for f in np.linspace(0.05, 0.5, 10)
+    ],
+    axis=0,
+)
+viewer = napari.view_image(blobs.astype(float))
 
-    # add the points
-    points = np.array(
-        [
-            [0, 0, 0, 100],
-            [0, 0, 50, 120],
-            [1, 0, 100, 40],
-            [2, 10, 110, 100],
-            [9, 8, 80, 100],
-        ]
-    )
-    viewer.add_points(
-        points, size=[0, 6, 10, 10], face_color='blue', n_dimensional=True
-    )
+# add the points
+points = np.array(
+    [
+        [0, 0, 0, 100],
+        [0, 0, 50, 120],
+        [1, 0, 100, 40],
+        [2, 10, 110, 100],
+        [9, 8, 80, 100],
+    ]
+)
+viewer.add_points(
+    points, size=[0, 6, 10, 10], face_color='blue', n_dimensional=True
+)
 
-    viewer.dims.order = (0, 2, 1, 3)
+viewer.dims.order = (0, 2, 1, 3)
+
+napari.run()

--- a/examples/to_screenshot.py
+++ b/examples/to_screenshot.py
@@ -6,120 +6,120 @@ your shapes.
 
 import numpy as np
 from skimage import data
-from skimage.io import imsave
 import napari
 from vispy.color import Colormap
 
 
-with napari.gui_qt():
-    # create the viewer and window
-    viewer = napari.Viewer()
+# create the viewer and window
+viewer = napari.Viewer()
 
-    # add the image
-    img_layer = viewer.add_image(data.camera(), name='photographer')
-    img_layer.colormap = 'gray'
+# add the image
+img_layer = viewer.add_image(data.camera(), name='photographer')
+img_layer.colormap = 'gray'
 
-    # create a list of polygons
-    polygons = [
-        np.array([[11, 13], [111, 113], [22, 246]]),
-        np.array(
-            [
-                [505, 60],
-                [402, 71],
-                [383, 42],
-                [251, 95],
-                [212, 59],
-                [131, 137],
-                [126, 187],
-                [191, 204],
-                [171, 248],
-                [211, 260],
-                [273, 243],
-                [264, 225],
-                [430, 173],
-                [512, 160],
-            ]
-        ),
-        np.array(
-            [
-                [310, 382],
-                [229, 381],
-                [209, 401],
-                [221, 411],
-                [258, 411],
-                [300, 412],
-                [306, 435],
-                [268, 434],
-                [265, 454],
-                [298, 461],
-                [307, 461],
-                [307, 507],
-                [349, 510],
-                [352, 369],
-                [330, 366],
-                [330, 366],
-            ]
-        ),
-    ]
+# create a list of polygons
+polygons = [
+    np.array([[11, 13], [111, 113], [22, 246]]),
+    np.array(
+        [
+            [505, 60],
+            [402, 71],
+            [383, 42],
+            [251, 95],
+            [212, 59],
+            [131, 137],
+            [126, 187],
+            [191, 204],
+            [171, 248],
+            [211, 260],
+            [273, 243],
+            [264, 225],
+            [430, 173],
+            [512, 160],
+        ]
+    ),
+    np.array(
+        [
+            [310, 382],
+            [229, 381],
+            [209, 401],
+            [221, 411],
+            [258, 411],
+            [300, 412],
+            [306, 435],
+            [268, 434],
+            [265, 454],
+            [298, 461],
+            [307, 461],
+            [307, 507],
+            [349, 510],
+            [352, 369],
+            [330, 366],
+            [330, 366],
+        ]
+    ),
+]
 
-    # add polygons
-    layer = viewer.add_shapes(
-        polygons,
-        shape_type='polygon',
-        edge_width=1,
-        edge_color='coral',
-        face_color='royalblue',
-        name='shapes',
-    )
+# add polygons
+layer = viewer.add_shapes(
+    polygons,
+    shape_type='polygon',
+    edge_width=1,
+    edge_color='coral',
+    face_color='royalblue',
+    name='shapes',
+)
 
-    # change some properties of the layer
-    layer.selected_data = set(range(layer.nshapes))
-    layer.current_edge_width = 5
-    layer.current_opacity = 0.75
-    layer.selected_data = set()
+# change some properties of the layer
+layer.selected_data = set(range(layer.nshapes))
+layer.current_edge_width = 5
+layer.current_opacity = 0.75
+layer.selected_data = set()
 
-    # add an ellipse to the layer
-    ellipse = np.array([[59, 222], [110, 289], [170, 243], [119, 176]])
-    layer.add(
-        ellipse,
-        shape_type='ellipse',
-        edge_width=5,
-        edge_color='coral',
-        face_color='purple',
-    )
+# add an ellipse to the layer
+ellipse = np.array([[59, 222], [110, 289], [170, 243], [119, 176]])
+layer.add(
+    ellipse,
+    shape_type='ellipse',
+    edge_width=5,
+    edge_color='coral',
+    face_color='purple',
+)
 
-    masks = layer.to_masks([512, 512])
-    masks_layer = viewer.add_image(masks.astype(float), name='masks')
-    masks_layer.opacity = 0.7
-    masks_layer.colormap = Colormap(
-        [[0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 1.0]]
-    )
+masks = layer.to_masks([512, 512])
+masks_layer = viewer.add_image(masks.astype(float), name='masks')
+masks_layer.opacity = 0.7
+masks_layer.colormap = Colormap([[0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 1.0]])
 
-    labels = layer.to_labels([512, 512])
-    labels_layer = viewer.add_labels(labels, name='labels')
+labels = layer.to_labels([512, 512])
+labels_layer = viewer.add_labels(labels, name='labels')
 
-    points = np.array([[100, 100], [200, 200], [333, 111]])
-    size = np.array([10, 20, 20])
-    viewer.add_points(points, size=size)
+points = np.array([[100, 100], [200, 200], [333, 111]])
+size = np.array([10, 20, 20])
+viewer.add_points(points, size=size)
 
-    # sample vector coord-like data
-    n = 100
-    pos = np.zeros((n, 2, 2), dtype=np.float32)
-    phi_space = np.linspace(0, 4 * np.pi, n)
-    radius_space = np.linspace(0, 100, n)
+# sample vector coord-like data
+n = 100
+pos = np.zeros((n, 2, 2), dtype=np.float32)
+phi_space = np.linspace(0, 4 * np.pi, n)
+radius_space = np.linspace(0, 100, n)
 
-    # assign x-y position
-    pos[:, 0, 0] = radius_space * np.cos(phi_space) + 350
-    pos[:, 0, 1] = radius_space * np.sin(phi_space) + 256
+# assign x-y position
+pos[:, 0, 0] = radius_space * np.cos(phi_space) + 350
+pos[:, 0, 1] = radius_space * np.sin(phi_space) + 256
 
-    # assign x-y projection
-    pos[:, 1, 0] = 2 * radius_space * np.cos(phi_space)
-    pos[:, 1, 1] = 2 * radius_space * np.sin(phi_space)
+# assign x-y projection
+pos[:, 1, 0] = 2 * radius_space * np.cos(phi_space)
+pos[:, 1, 1] = 2 * radius_space * np.sin(phi_space)
 
-    # add the vectors
-    layer = viewer.add_vectors(pos, edge_width=2)
+# add the vectors
+layer = viewer.add_vectors(pos, edge_width=2)
 
-    # take screenshot
-    screenshot = viewer.screenshot()
-    viewer.add_image(screenshot, rgb=True, name='screenshot')
-    # imsave('screenshot.png', screenshot)
+# take screenshot
+screenshot = viewer.screenshot()
+viewer.add_image(screenshot, rgb=True, name='screenshot')
+
+# from skimage.io import imsave
+# imsave('screenshot.png', screenshot)
+
+napari.run()

--- a/examples/tracks_2d.py
+++ b/examples/tracks_2d.py
@@ -1,13 +1,14 @@
 import napari
 import numpy as np
 
+
 def _circle(r, theta):
-    x = r*np.cos(theta)
-    y = r*np.sin(theta)
+    x = r * np.cos(theta)
+    y = r * np.sin(theta)
     return x, y
 
 
-def tracks_2d(num_tracks = 10):
+def tracks_2d(num_tracks=10):
     """ create 2d+t track data """
     tracks = []
 
@@ -19,26 +20,27 @@ def tracks_2d(num_tracks = 10):
         # time
         timestamps = np.arange(track.shape[0])
 
-        radius = 20+30*np.random.random()
-        theta = timestamps*0.1 + np.random.random()*np.pi
+        radius = 20 + 30 * np.random.random()
+        theta = timestamps * 0.1 + np.random.random() * np.pi
         x, y = _circle(radius, theta)
 
         track[:, 0] = track_id
         track[:, 1] = timestamps
-        track[:, 2] = 50. + y
-        track[:, 3] = 50. + x
+        track[:, 2] = 50.0 + y
+        track[:, 3] = 50.0 + x
         track[:, 4] = theta
         track[:, 5] = radius
 
         tracks.append(track)
 
-
     tracks = np.concatenate(tracks, axis=0)
-    data = tracks[:, :4] # just the coordinate data
+    data = tracks[:, :4]  # just the coordinate data
 
-    properties = {'time': tracks[:, 1],
-                  'theta': tracks[:, 4],
-                  'radius': tracks[:, 5]}
+    properties = {
+        'time': tracks[:, 1],
+        'theta': tracks[:, 4],
+        'radius': tracks[:, 5],
+    }
 
     graph = {}
     return data, properties, graph
@@ -47,7 +49,8 @@ def tracks_2d(num_tracks = 10):
 tracks, properties, graph = tracks_2d(num_tracks=10)
 vertices = tracks[:, 1:]
 
-with napari.gui_qt():
-    viewer = napari.Viewer()
-    viewer.add_points(vertices, size=1, name='points', opacity=0.3)
-    viewer.add_tracks(tracks, properties=properties, name='tracks')
+viewer = napari.Viewer()
+viewer.add_points(vertices, size=1, name='points', opacity=0.3)
+viewer.add_tracks(tracks, properties=properties, name='tracks')
+
+napari.run()

--- a/examples/tracks_3d.py
+++ b/examples/tracks_3d.py
@@ -1,14 +1,15 @@
 import napari
 import numpy as np
 
+
 def lissajous(t):
-    a = np.random.random(size=(3,))*80. - 40.
-    b = np.random.random(size=(3,))*0.05
-    c = np.random.random(size=(3,))*0.1
-    return (a[i]*np.cos(b[i]*t+c[i]) for i in range(3))
+    a = np.random.random(size=(3,)) * 80.0 - 40.0
+    b = np.random.random(size=(3,)) * 0.05
+    c = np.random.random(size=(3,)) * 0.1
+    return (a[i] * np.cos(b[i] * t + c[i]) for i in range(3))
 
 
-def tracks_3d(num_tracks = 10):
+def tracks_3d(num_tracks=10):
     """ create 3d+t track data """
     tracks = []
 
@@ -23,17 +24,17 @@ def tracks_3d(num_tracks = 10):
 
         track[:, 0] = track_id
         track[:, 1] = timestamps
-        track[:, 2] = 50. + z
-        track[:, 3] = 50. + y
-        track[:, 4] = 50. + x
+        track[:, 2] = 50.0 + z
+        track[:, 3] = 50.0 + y
+        track[:, 4] = 50.0 + x
 
         # calculate the speed as a property
         gz = np.gradient(track[:, 2])
         gy = np.gradient(track[:, 3])
         gx = np.gradient(track[:, 4])
 
-        speed = np.sqrt(gx**2 + gy**2 + gz**2)
-        distance = np.sqrt(x**2 + y**2 + z**2)
+        speed = np.sqrt(gx ** 2 + gy ** 2 + gz ** 2)
+        distance = np.sqrt(x ** 2 + y ** 2 + z ** 2)
 
         track[:, 5] = gz
         track[:, 6] = gy
@@ -43,24 +44,27 @@ def tracks_3d(num_tracks = 10):
 
         tracks.append(track)
 
-
     tracks = np.concatenate(tracks, axis=0)
-    data = tracks[:, :5] # just the coordinate data
+    data = tracks[:, :5]  # just the coordinate data
 
-    properties = {'time': tracks[:, 1],
-                  'gradient_z': tracks[:, 5],
-                  'gradient_y': tracks[:, 6],
-                  'gradient_x': tracks[:, 7],
-                  'speed': tracks[:, 8],
-                  'distance': tracks[:, 9]}
+    properties = {
+        'time': tracks[:, 1],
+        'gradient_z': tracks[:, 5],
+        'gradient_y': tracks[:, 6],
+        'gradient_x': tracks[:, 7],
+        'speed': tracks[:, 8],
+        'distance': tracks[:, 9],
+    }
 
     graph = {}
     return data, properties, graph
 
+
 tracks, properties, graph = tracks_3d(num_tracks=100)
 vertices = tracks[:, 1:]
 
-with napari.gui_qt():
-    viewer = napari.Viewer()
-    viewer.add_points(vertices, size=1, name='points', opacity=0.3)
-    viewer.add_tracks(tracks, properties=properties, name='tracks')
+viewer = napari.Viewer()
+viewer.add_points(vertices, size=1, name='points', opacity=0.3)
+viewer.add_tracks(tracks, properties=properties, name='tracks')
+
+napari.run()

--- a/examples/tracks_3d_with_graph.py
+++ b/examples/tracks_3d_with_graph.py
@@ -1,9 +1,10 @@
 import napari
 import numpy as np
 
+
 def _circle(r, theta):
-    x = r*np.cos(theta)
-    y = r*np.sin(theta)
+    x = r * np.cos(theta)
+    y = r * np.sin(theta)
     return x, y
 
 
@@ -12,35 +13,34 @@ def tracks_3d_merge_split():
 
     timestamps = np.arange(300)
 
-
     def _trajectory(t, r, track_id):
-        theta = t*0.1
+        theta = t * 0.1
         x, y = _circle(r, theta)
         z = np.zeros(x.shape)
         tid = np.ones(x.shape) * track_id
         return np.stack([tid, t, z, y, x], axis=1)
 
-    trackA = _trajectory(timestamps[:100], 30., 0)
-    trackB = _trajectory(timestamps[100:200], 10., 1)
-    trackC = _trajectory(timestamps[100:200], 50., 2)
-    trackD = _trajectory(timestamps[200:], 30., 3)
+    trackA = _trajectory(timestamps[:100], 30.0, 0)
+    trackB = _trajectory(timestamps[100:200], 10.0, 1)
+    trackC = _trajectory(timestamps[100:200], 50.0, 2)
+    trackD = _trajectory(timestamps[200:], 30.0, 3)
 
     data = [trackA, trackB, trackC, trackD]
     tracks = np.concatenate(data, axis=0)
-    tracks[:, 2:] += 50. # centre the track at (50, 50, 50)
+    tracks[:, 2:] += 50.0  # centre the track at (50, 50, 50)
 
-    graph = {1:0, 2:[0], 3:[1,2]}
+    graph = {1: 0, 2: [0], 3: [1, 2]}
 
     properties = {'time': tracks[:, 1]}
 
     return tracks, properties, graph
 
 
-
 tracks, properties, graph = tracks_3d_merge_split()
 vertices = tracks[:, 1:]
 
-with napari.gui_qt():
-    viewer = napari.Viewer()
-    viewer.add_points(vertices, size=1, name='points', opacity=0.3)
-    viewer.add_tracks(tracks, properties=properties, graph=graph, name='tracks')
+viewer = napari.Viewer()
+viewer.add_points(vertices, size=1, name='points', opacity=0.3)
+viewer.add_tracks(tracks, properties=properties, graph=graph, name='tracks')
+
+napari.run()

--- a/examples/update_console.py
+++ b/examples/update_console.py
@@ -9,66 +9,67 @@ from skimage import data
 import napari
 
 
-with napari.gui_qt():
-    # create the viewer and window
-    viewer = napari.Viewer()
+# create the viewer and window
+viewer = napari.Viewer()
 
-    # add the image
-    photographer = data.camera()
-    image_layer = napari.view_image(photographer, name='photographer')
+# add the image
+photographer = data.camera()
+image_layer = napari.view_image(photographer, name='photographer')
 
-    # create a list of polygons
-    polygons = [
-        np.array([[11, 13], [111, 113], [22, 246]]),
-        np.array(
-            [
-                [505, 60],
-                [402, 71],
-                [383, 42],
-                [251, 95],
-                [212, 59],
-                [131, 137],
-                [126, 187],
-                [191, 204],
-                [171, 248],
-                [211, 260],
-                [273, 243],
-                [264, 225],
-                [430, 173],
-                [512, 160],
-            ]
-        ),
-        np.array(
-            [
-                [310, 382],
-                [229, 381],
-                [209, 401],
-                [221, 411],
-                [258, 411],
-                [300, 412],
-                [306, 435],
-                [268, 434],
-                [265, 454],
-                [298, 461],
-                [307, 461],
-                [307, 507],
-                [349, 510],
-                [352, 369],
-                [330, 366],
-                [330, 366],
-            ]
-        ),
-    ]
+# create a list of polygons
+polygons = [
+    np.array([[11, 13], [111, 113], [22, 246]]),
+    np.array(
+        [
+            [505, 60],
+            [402, 71],
+            [383, 42],
+            [251, 95],
+            [212, 59],
+            [131, 137],
+            [126, 187],
+            [191, 204],
+            [171, 248],
+            [211, 260],
+            [273, 243],
+            [264, 225],
+            [430, 173],
+            [512, 160],
+        ]
+    ),
+    np.array(
+        [
+            [310, 382],
+            [229, 381],
+            [209, 401],
+            [221, 411],
+            [258, 411],
+            [300, 412],
+            [306, 435],
+            [268, 434],
+            [265, 454],
+            [298, 461],
+            [307, 461],
+            [307, 507],
+            [349, 510],
+            [352, 369],
+            [330, 366],
+            [330, 366],
+        ]
+    ),
+]
 
-    # add polygons
-    shapes_layer = viewer.add_shapes(
-        polygons,
-        shape_type='polygon',
-        edge_width=5,
-        edge_color='coral',
-        face_color='royalblue',
-        name='shapes',
-    )
+# add polygons
+shapes_layer = viewer.add_shapes(
+    polygons,
+    shape_type='polygon',
+    edge_width=5,
+    edge_color='coral',
+    face_color='royalblue',
+    name='shapes',
+)
 
-    # Send local variables to the console
-    viewer.update_console(locals())
+# Send local variables to the console
+viewer.update_console(locals())
+
+napari.run()

--- a/examples/without_gui_qt.py
+++ b/examples/without_gui_qt.py
@@ -1,4 +1,8 @@
-"""Alternative to using napari.gui_qt() context manager."""
+"""Alternative to using napari.gui_qt() context manager.
+
+This is here for historical purposes, to the transition away from 
+the "gui_qt()" context manager.
+"""
 
 from skimage import data
 import napari

--- a/examples/xarray_nD_image.py
+++ b/examples/xarray_nD_image.py
@@ -14,9 +14,10 @@ import napari
 data = np.random.random((20, 40, 50))
 xdata = xr.DataArray(data, dims=['z', 'y', 'x'])
 
-with napari.gui_qt():
-    # create an empty viewer
-    viewer = napari.Viewer()
+# create an empty viewer
+viewer = napari.Viewer()
 
-    # add the xarray
-    layer = viewer.add_image(xdata, name='xarray')
+# add the xarray
+layer = viewer.add_image(xdata, name='xarray')
+
+napari.run()

--- a/examples/zarr_nD_image.py
+++ b/examples/zarr_nD_image.py
@@ -11,11 +11,12 @@ except ImportError:
 import napari
 
 
-with napari.gui_qt():
-    data = zarr.zeros((102_0, 200, 210), chunks=(100, 200, 210))
-    data[53_0:53_1, 100:110, 110:120] = 1
+data = zarr.zeros((102_0, 200, 210), chunks=(100, 200, 210))
+data[53_0:53_1, 100:110, 110:120] = 1
 
-    print(data.shape)
-    # For big data, we should specify the contrast_limits range, or napari will try
-    # to find the min and max of the full image.
-    viewer = napari.view_image(data, contrast_limits=[0, 1], rgb=False)
+print(data.shape)
+# For big data, we should specify the contrast_limits range, or napari will try
+# to find the min and max of the full image.
+viewer = napari.view_image(data, contrast_limits=[0, 1], rgb=False)
+
+napari.run()

--- a/napari/_qt/perf/qt_event_tracing.py
+++ b/napari/_qt/perf/qt_event_tracing.py
@@ -27,7 +27,7 @@ def convert_app_for_tracing(app: QApplication) -> QApplication:
     if isinstance(app, QApplicationWithTracing):
         # We're already using QApplicationWithTracing so there is nothing
         # to do. This happens when napari is launched from the command
-        # line because we create a QApplicationWithTracing in gui_qt.
+        # line because we create a QApplicationWithTracing in get_app.
         return app
 
     if app is not None:

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -238,6 +238,19 @@ def gui_qt(*, startup_logo=False, gui_exceptions=False, force=False):
     IPython with the Qt GUI event loop enabled by default by using
     ``ipython --gui=qt``.
     """
+    warn(
+        "\nThe 'gui_qt()' context manager is deprecated.\nIf you are running "
+        "napari from a script, please use 'napari.run()' as follows:\n\n"
+        "    import napari\n\n"
+        "    viewer = napari.Viewer()  # no prior setup needed\n"
+        "    # other code using the viewer...\n"
+        "    napari.run()\n\n"
+        "In IPython or Jupyter, 'napari.run()' is not necessary. napari will "
+        "automatically\nstart an interactive event loop for you: \n\n"
+        "    import napari\n"
+        "    viewer = napari.Viewer()  # that's it!\n",
+        FutureWarning,
+    )
 
     app = get_app()
     splash = None

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -217,8 +217,7 @@ def quit_app():
 def gui_qt(*, startup_logo=False, gui_exceptions=False, force=False):
     """Start a Qt event loop in which to run the application.
 
-    NOTE: This context manager may be deprecated in the future. Prefer using
-    :func:`napari.run` instead.
+    NOTE: This context manager is deprecated!. Prefer using :func:`napari.run`.
 
     Parameters
     ----------

--- a/napari/_tests/test_cli.py
+++ b/napari/_tests/test_cli.py
@@ -1,6 +1,5 @@
 import gc
 import sys
-from contextlib import contextmanager
 from unittest import mock
 
 import pytest
@@ -41,10 +40,6 @@ def test_cli_parses_unknowns(mock_run, monkeypatch):
     def assert_kwargs(*args, **kwargs):
         assert args == (["file"],)
         assert kwargs['contrast_limits'] == (0, 1)
-
-    @contextmanager
-    def gui_qt(**kwargs):
-        yield
 
     # testing all the variants of literal_evals
     monkeypatch.setattr(napari.__main__, 'view_path', assert_kwargs)

--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -50,11 +50,11 @@ def test_examples(qapp, fname, monkeypatch, capsys):
     # hide viewer window
     monkeypatch.setattr(Window, 'show', lambda *a: None)
 
-    # make sure our sys.excepthook override in gui_qt doesn't hide errors
+    # make sure our sys.excepthook override doesn't hide errors
     def raise_errors(etype, value, tb):
         raise value
 
     monkeypatch.setattr(notification_manager, 'receive_error', raise_errors)
 
     # run the example!
-    assert runpy.run_path(str(EXAMPLE_DIR / fname))
+    runpy.run_path(str(EXAMPLE_DIR / fname))


### PR DESCRIPTION
# Description
I think it's time to deprecate gui_qt 😱
Most people new to napari are still learning it with `gui_qt`... and I don't see much reason to keep that up.  This doesn't break anything... just formally deprecates it and updates all of the examples.

I'll follow up with an updated event_loop docs, and some PRs to napari tutorials / aka napari.github.io


## Type of change
<!-- Please delete options that are not relevant. -->
- [x]  Deprecation

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
