### PR TITLE
Add button to drop into debugger in the traceback viewer.

### DIFF
--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -82,15 +82,13 @@ class NapariQtNotification(QDialog):
 
         # FIXME: this does not work with multiple viewers.
         # we need a way to detect the viewer in which the error occured.
-        self.qt_viewer = None
         for wdg in QApplication.topLevelWidgets():
             if isinstance(wdg, QMainWindow):
                 try:
                     # TODO: making the canvas the parent makes it easier to
                     # move/resize, but also means that the notification can get
                     # clipped on the left if the canvas is too small.
-                    self.qt_viewer = wdg.centralWidget().children()[1]
-                    canvas = self.qt_viewer.canvas.native
+                    canvas = wdg.centralWidget().children()[1].canvas.native
                     self.setParent(canvas)
                     canvas.resized.connect(self.move_to_bottom_right)
                     break
@@ -335,9 +333,7 @@ class NapariQtNotification(QDialog):
                         'Now Debugging. Please quit debugger in console '
                         'to continue'
                     )
-                    QApplication.processEvents()
-                    QApplication.processEvents()
-                    debug_tb(notification.exception.__traceback__)
+                    _debug_tb(notification.exception.__traceback__)
                     btn.setText('Enter Debugger')
 
                 btn.clicked.connect(_enter_debug_mode)
@@ -372,11 +368,13 @@ class NapariQtNotification(QDialog):
             cls.from_notification(notification).show()
 
 
-def debug_tb(tb):
+def _debug_tb(tb):
     import pdb
 
     from ..utils import event_hook_removed
 
+    QApplication.processEvents()
+    QApplication.processEvents()
     with event_hook_removed():
         print("Entering debugger. Type 'q' to return to napari.\n")
         pdb.post_mortem(tb)

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -106,6 +106,20 @@ def qt_signals_blocked(obj):
     obj.blockSignals(False)
 
 
+@contextmanager
+def event_hook_removed():
+    """Context manager to temporarily remove the PyQt5 input hook"""
+    from qtpy import QtCore
+
+    if hasattr(QtCore, 'pyqtRemoveInputHook'):
+        QtCore.pyqtRemoveInputHook()
+    try:
+        yield
+    finally:
+        if hasattr(QtCore, 'pyqtRestoreInputHook'):
+            QtCore.pyqtRestoreInputHook()
+
+
 def disable_with_opacity(obj, widget_list, disabled):
     """Set enabled state on a list of widgets. If disabled, decrease opacity"""
     for wdg in widget_list:


### PR DESCRIPTION
# Description
This adds a button to the in-app traceback viewer that lets you drop into a post-mortem debugger.  While it's easy enough to just use `%debug` if you're in an ipython context, this makes it easier to debug certain issues that happen while the Qt event loop is running, or when IPython isn't controlling the loop ... (this will temporarily pause the qt event loop and resume when you quit the debugger).  This should also play nicely with #2290 ... letting you debug things that happened a couple exceptions back.

https://user-images.githubusercontent.com/1609449/114287490-364ea500-9a35-11eb-835a-d3e83fdb76c1.mov

note, it uses `pdb` by default, so nothing extra is needed, but if you have `pdbpp` installed, the experience is much nicer.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
