### PR TITLE
DOC: Correct lenght for title underline.

### DIFF
--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -35,8 +35,8 @@ class VispyBaseLayer(ABC):
         Max texture size allowed by the vispy canvas during 2D rendering.
 
 
-    Extended Summary
-    ----------------
+    Notes
+    -----
     _master_transform : vispy.visuals.transforms.MatrixTransform
         Transform positioning the layer visual inside the scenecanvas.
     """

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -147,8 +147,8 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
     attenuation : float
         Attenuation rate for attenuated maximum intensity projection.
 
-    Extended Summary
-    ----------------
+    Notes
+    -----
     _data_view : array (N, M), (N, M, 3), or (N, M, 4)
         Image data for the currently viewed slice. Must be 2D image data, but
         can be multidimensional for RGB or RGBA images if multidimensional is

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -142,8 +142,8 @@ class Labels(_image_base_class):
         In ERASE mode the cursor functions similarly to PAINT mode, but to
         paint with background label, which effectively removes the label.
 
-    Extended Summary
-    ----------------
+    Notes
+    -----
     _data_raw : array (N, M)
         2D labels data for the currently viewed slice.
     _selected_color : 4-tuple or None

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -143,7 +143,7 @@ class Labels(_image_base_class):
         paint with background label, which effectively removes the label.
 
     Extended Summary
-    ----------
+    ----------------
     _data_raw : array (N, M)
         2D labels data for the currently viewed slice.
     _selected_color : 4-tuple or None

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -197,8 +197,8 @@ class Points(Layer):
 
         COLORMAP allows color to be set via a color map over an attribute
 
-    Extended Summary
-    ----------------
+    Notes
+    -----
     _property_choices : dict {str: array (N,)}
         Possible values for the properties in Points.properties.
         If properties is not provided, it will be {} (empty dictionary).

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -198,7 +198,7 @@ class Points(Layer):
         COLORMAP allows color to be set via a color map over an attribute
 
     Extended Summary
-    ----------
+    ----------------
     _property_choices : dict {str: array (N,)}
         Possible values for the properties in Points.properties.
         If properties is not provided, it will be {} (empty dictionary).

--- a/napari/layers/shapes/_mesh.py
+++ b/napari/layers/shapes/_mesh.py
@@ -43,7 +43,7 @@ class Mesh:
         of (0, ..., P-1)
 
     Extended Summary
-    ----------
+    ----------------
     _types : list
         Length two list of the different mesh types corresponding to faces and
         edges

--- a/napari/layers/shapes/_mesh.py
+++ b/napari/layers/shapes/_mesh.py
@@ -42,8 +42,8 @@ class Mesh:
         Length P array of the z order of each triangle. Must be a permutation
         of (0, ..., P-1)
 
-    Extended Summary
-    ----------------
+    Notes
+    -----
     _types : list
         Length two list of the different mesh types corresponding to faces and
         edges

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -42,7 +42,7 @@ class ShapeList:
         z-index for each shape.
 
     Extended Summary
-    ----------
+    ----------------
     _vertices : np.ndarray
         Mx2 array of all displayed vertices from all shapes
     _index : np.ndarray

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -41,8 +41,8 @@ class ShapeList:
     z_indices : (N, ) list of int
         z-index for each shape.
 
-    Extended Summary
-    ----------------
+    Notes
+    -----
     _vertices : np.ndarray
         Mx2 array of all displayed vertices from all shapes
     _index : np.ndarray

--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -57,7 +57,7 @@ class Shape(ABC):
         slicing multidimensional shapes.
 
     Extended Summary
-    ----------
+    ----------------
     _closed : bool
         Bool if shape edge is a closed path or not
     _box : np.ndarray

--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -56,8 +56,8 @@ class Shape(ABC):
         Min and max values of the M non-displayed dimensions, useful for
         slicing multidimensional shapes.
 
-    Extended Summary
-    ----------------
+    Notes
+    -----
     _closed : bool
         Bool if shape edge is a closed path or not
     _box : np.ndarray

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -207,8 +207,8 @@ class Shapes(Layer):
         The ADD_RECTANGLE, ADD_ELLIPSE, ADD_LINE, ADD_PATH, and ADD_POLYGON
         modes all allow for their corresponding shape type to be added.
 
-    Extended Summary
-    ----------------
+    Notes
+    -----
     _data_dict : Dict of ShapeList
         Dictionary containing all the shape data indexed by slice tuple
     _data_view : ShapeList

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -208,7 +208,7 @@ class Shapes(Layer):
         modes all allow for their corresponding shape type to be added.
 
     Extended Summary
-    ----------
+    ----------------
     _data_dict : Dict of ShapeList
         Dictionary containing all the shape data indexed by slice tuple
     _data_view : ShapeList

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -97,7 +97,7 @@ class Surface(IntensityVisualizationMixin, Layer):
         Gamma correction for determining colormap linearity.
 
     Extended Summary
-    ----------
+    ----------------
     _data_view : (M, 2) or (M, 3) array
         The coordinates of the vertices given the viewed dimensions.
     _view_faces : (P, 3) array

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -96,8 +96,8 @@ class Surface(IntensityVisualizationMixin, Layer):
     gamma : float
         Gamma correction for determining colormap linearity.
 
-    Extended Summary
-    ----------------
+    Notes
+    -----
     _data_view : (M, 2) or (M, 3) array
         The coordinates of the vertices given the viewed dimensions.
     _view_faces : (P, 3) array

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -102,7 +102,7 @@ class Vectors(Layer):
         (property.min(), property.max())
 
     Extended Summary
-    ----------
+    ----------------
     _view_data : (M, 2, 2) array
         The start point and projections of N vectors in 2D for vectors whose
         start point is in the currently viewed slice.

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -101,8 +101,8 @@ class Vectors(Layer):
         The default value is None. If set the none, the clims will be set to
         (property.min(), property.max())
 
-    Extended Summary
-    ----------------
+    Notes
+    -----
     _view_data : (M, 2, 2) array
         The start point and projections of N vectors in 2D for vectors whose
         start point is in the currently viewed slice.


### PR DESCRIPTION
Numpydoc triggers warning when parsing those;
which are made visible by pytest,
and for pytest seem to load napari plugins even in non-napari project.
Making those warnings appears in unexpected places.
