### PR TITLE
fix set_call_order with missing plugin

### DIFF
--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -116,6 +116,8 @@ class PluginManager(_PM):
             order = []
             for p in new_order.get(spec_name, []):
                 try:
+                    # if the plugin was uninstalled in the meantime,
+                    # we should just move on to the next plugin
                     imp = hook_caller.get_plugin_implementation(p['plugin'])
                 except KeyError:
                     continue

--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -115,8 +115,12 @@ class PluginManager(_PM):
         for spec_name, hook_caller in self.hooks.items():
             order = []
             for p in new_order.get(spec_name, []):
+                try:
+                    imp = hook_caller.get_plugin_implementation(p['plugin'])
+                except KeyError:
+                    continue
+                imp.enabled = p['enabled']
                 order.append(p['plugin'])
-                hook_caller._set_plugin_enabled(p['plugin'], p['enabled'])
             if order:
                 hook_caller.bring_to_front(order)
 


### PR DESCRIPTION
# Description
Fixes a bug that I missed in #2501 that will cause napari to crash on startup if a plugin has been uninstalled in the meantime (when it tries to set the call order from settings)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
