### PR TITLE
Extract shortcut into their own object.

### DIFF
--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -17,7 +17,7 @@ from ...layers.labels._labels_constants import (
     Mode,
 )
 from ...utils.events import disconnect_events
-from ...utils.interactions import KEY_SYMBOLS
+from ...utils.interactions import Shortcut
 from ...utils.translations import trans
 from ..utils import disable_with_opacity
 from ..widgets.qt_mode_buttons import QtModePushButton, QtModeRadioButton
@@ -167,8 +167,8 @@ class QtLabelsControls(QtLayerControls):
             'fill',
             Mode.FILL,
             tooltip=trans._(
-                "Fill mode (F) \nToggle with {key}",
-                key=KEY_SYMBOLS['Control'],
+                "Fill mode (F) \nToggle with {shortcut}",
+                shortcut=Shortcut("Control"),
             ),
         )
         self.erase_button = QtModeRadioButton(
@@ -176,8 +176,8 @@ class QtLabelsControls(QtLayerControls):
             'erase',
             Mode.ERASE,
             tooltip=trans._(
-                "Erase mode (E) \nToggle with {key}",
-                key=KEY_SYMBOLS['Alt'],
+                "Erase mode (E) \nToggle with {shortcut}",
+                shortcut=Shortcut("Alt"),
             ),
         )
 

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -11,7 +11,7 @@ from qtpy.QtWidgets import (
 
 from ...layers.points._points_constants import SYMBOL_TRANSLATION, Mode
 from ...utils.events import disconnect_events
-from ...utils.interactions import KEY_SYMBOLS
+from ...utils.interactions import Shortcut
 from ...utils.translations import trans
 from ..utils import disable_with_opacity, qt_signals_blocked
 from ..widgets.qt_color_swatch import QColorSwatchEdit
@@ -148,7 +148,8 @@ class QtPointsControls(QtLayerControls):
             'delete_shape',
             slot=self.layer.remove_selected,
             tooltip=trans._(
-                "Delete selected points ({key})", key=KEY_SYMBOLS['Backspace']
+                "Delete selected points ({shortcut})",
+                shortcut=Shortcut('Backspace').platform,
             ),
         )
 

--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -12,7 +12,7 @@ from qtpy.QtWidgets import (
 
 from ...layers.shapes._shapes_constants import Mode
 from ...utils.events import disconnect_events
-from ...utils.interactions import KEY_SYMBOLS
+from ...utils.interactions import Shortcut
 from ...utils.translations import trans
 from ..utils import disable_with_opacity, qt_signals_blocked
 from ..widgets.qt_color_swatch import QColorSwatchEdit
@@ -179,7 +179,8 @@ class QtShapesControls(QtLayerControls):
             'delete_shape',
             slot=self.layer.remove_selected,
             tooltip=trans._(
-                "Delete selected shapes ({key})", key=KEY_SYMBOLS['Backspace']
+                "Delete selected shapes ({shortcut})",
+                shortcut=Shortcut('Backspace').platform,
             ),
         )
 

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -1,6 +1,6 @@
 from qtpy.QtWidgets import QFrame, QHBoxLayout, QPushButton
 
-from ...utils.interactions import KEY_SYMBOLS
+from ...utils.interactions import Shortcut
 from ...utils.translations import trans
 
 
@@ -101,9 +101,8 @@ class QtViewerButtons(QFrame):
             self.viewer,
             'console',
             trans._(
-                "Open IPython terminal ({key1}-{key2}-C)",
-                key1=KEY_SYMBOLS['Control'],
-                key2=KEY_SYMBOLS['Shift'],
+                "Open IPython terminal ({shortcut})",
+                shortcut=Shortcut('Control-Shift-C').platform,
             ),
         )
         self.consoleButton.setProperty('expanded', False)
@@ -111,8 +110,8 @@ class QtViewerButtons(QFrame):
             self.viewer,
             'roll',
             trans._(
-                "Roll dimensions order for display ({key}-E)",
-                key=KEY_SYMBOLS['Control'],
+                "Roll dimensions order for display ({shortcut})",
+                shortcut=Shortcut('Control-E').platform,
             ),
             lambda: self.viewer.dims._roll(),
         )
@@ -120,15 +119,18 @@ class QtViewerButtons(QFrame):
             self.viewer,
             'transpose',
             trans._(
-                "Transpose displayed dimensions ({key}-T)",
-                key=KEY_SYMBOLS['Control'],
+                "Transpose displayed dimensions ({shortcut})",
+                shortcut=Shortcut('Control-T').platform,
             ),
             lambda: self.viewer.dims._transpose(),
         )
         self.resetViewButton = QtViewerPushButton(
             self.viewer,
             'home',
-            trans._("Reset view ({key}-R)", key=KEY_SYMBOLS['Control']),
+            trans._(
+                "Reset view ({shortcut})",
+                shortcut=Shortcut('Control-R').platform,
+            ),
             lambda: self.viewer.reset_view(),
         )
 
@@ -139,7 +141,9 @@ class QtViewerButtons(QFrame):
             self.viewer.grid.events,
         )
         self.gridViewButton.setToolTip(
-            trans._("Toggle grid view ({key}-G)", key=KEY_SYMBOLS['Control'])
+            trans._(
+                "Toggle grid view ({shortcut})", shortcut=Shortcut("Control-R")
+            )
         )
 
         self.ndisplayButton = QtStateButton(
@@ -152,8 +156,8 @@ class QtViewerButtons(QFrame):
         )
         self.ndisplayButton.setToolTip(
             trans._(
-                "Toggle number of displayed dimensions ({key}-Y)",
-                key=KEY_SYMBOLS['Control'],
+                "Toggle number of displayed dimensions ({shortcut})",
+                shortcut=Shortcut("Control-Y"),
             )
         )
 
@@ -191,9 +195,8 @@ class QtDeleteButton(QPushButton):
         self.viewer = viewer
         self.setToolTip(
             trans._(
-                "Delete selected layers ({key1}-{key2})",
-                key1=KEY_SYMBOLS['Control'],
-                key2=KEY_SYMBOLS['Backspace'],
+                "Delete selected layers ({shortcut})",
+                shortcut=Shortcut("Control-Backspace"),
             )
         )
         self.setAcceptDrops(True)

--- a/napari/utils/_tests/test_interactions.py
+++ b/napari/utils/_tests/test_interactions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..interactions import ReadOnlyWrapper
+from ..interactions import ReadOnlyWrapper, Shortcut
 
 
 def test_ReadOnlyWrapper_setitem():
@@ -23,3 +23,23 @@ def test_ReadOnlyWrapper_setattr():
 
     with pytest.raises(TypeError):
         tc_read_only.x = 5
+
+
+@pytest.mark.parametrize(
+    'shortcut,reason',
+    [
+        ('Ctrl-A', 'Ctrl instead of Control'),
+        ('Ctrl+A', '+ instead of -'),
+        ('Ctrl-AA', 'AA make no sens'),
+        ('BB', 'BB make no sens'),
+    ],
+)
+def test_shortcut_invalid(shortcut, reason):
+
+    with pytest.raises(AssertionError):
+        Shortcut(shortcut)  # Should be Control-A
+
+
+def test_shortcut_qt():
+
+    assert Shortcut('Control-A').qt == 'Control+A'

--- a/napari/utils/interactions.py
+++ b/napari/utils/interactions.py
@@ -211,12 +211,63 @@ KEY_SYMBOLS = {
 }
 
 
+joinchar = '-'
 if sys.platform.startswith('darwin'):
     KEY_SYMBOLS.update(
         {'Control': '⌘', 'Alt': '⌥', 'Option': '⌥', 'Meta': '⌃'}
     )
+    joinchar = ''
 elif sys.platform.startswith('linux'):
     KEY_SYMBOLS.update({'Meta': 'Super'})
+
+
+class Shortcut:
+    """
+    Wrapper object around shortcuts,
+
+    Mostly help to handle cross platform differences in UI:
+      - whether the joiner is -,'' or something else.
+      - replace the corresponding modifier with their equivalents.
+
+    As well as integration with qt which uses a different convention with +
+    instead of -.
+    """
+
+    def __init__(self, shortcut: str):
+        """
+        Parameters
+        ----------
+        shortcut : string
+            shortcut to format in the form of dash separated keys to press
+
+        """
+        self._values = shortcut.split('-')
+        for v in self._values:
+            if len(v) > 1:
+                assert v in KEY_SYMBOLS.keys()
+
+    @property
+    def qt(self) -> str:
+        return '+'.join(self._values)
+
+    @property
+    def platform(self) -> str:
+        """
+        Format the given shortcut for the current platform.
+
+        Replace Cmd, Ctrl, Meta...etc by appropriate symbols if relevant for the
+        given platform.
+
+        Returns
+        -------
+        string
+            Shortcut formatted to be displayed on current paltform.
+        """
+
+        return joinchar.join(KEY_SYMBOLS.get(x, x) for x in self._values)
+
+    def __str__(self):
+        return self.platform
 
 
 def get_key_bindings_summary(keymap, col='rgb(134, 142, 147)'):


### PR DESCRIPTION
Spawn out of Action manager; Shortcut formatting is not limited to
swapping the right symbols for Control, Alt and alike.
The join character is not the same on platform.

It will also be useful for interoperability with QT which uses the +
symbol for joining values.

I've implemented the __str__ method to be platform specific, but I'm not
100% certain, so I'm happy with changing the impl

This also make basic checks that the shortcut looks alright when
instantiating it.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
