### PR TITLE
DOC: Minor reformatting.

### DIFF
--- a/napari/_qt/qthreading.py
+++ b/napari/_qt/qthreading.py
@@ -724,10 +724,10 @@ def _new_worker_qthread(
     Worker : QObject
         QObject type that implements a work() method.  The Worker should also
         emit a finished signal when the work is done.
-    start_thread : bool
+    _start_thread : bool
         If True, thread will be started immediately, otherwise, thread must
         be manually started with thread.start().
-    connections : dict, optional
+    _connect : dict, optional
         Optional dictionary of {signal: function} to connect to the new worker.
         for instance:  connections = {'incremented': myfunc} will result in:
         worker.incremented.connect(myfunc)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -684,8 +684,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         reader_plugin : str, optional
             reader plugin to pass to viewer.open (only used if the sample data
             is a string).  by default None.
-
-        **kwargs:
+        **kwargs
             additional kwargs will be passed to the sample data loader provided
             by `plugin`.  Use of **kwargs may raise an error if the kwargs do
             not match the sample data loader.

--- a/napari/layers/utils/stack_utils.py
+++ b/napari/layers/utils/stack_utils.py
@@ -34,7 +34,7 @@ def split_channels(
     data : array or list of array
     channel_axis : int
         Axis to split the image along.
-    kwargs : dict
+    **kwargs : dict
         Keyword arguments will override the default image meta keys
         returned in each layer data tuple.
 
@@ -208,7 +208,7 @@ def images_to_stack(
         List of Image Layers
     axis : int
         Index to to insert the new axis
-    kwargs : dict
+    **kwargs : dict
         Dictionary of parameters values to override parameters
         from the first image in images list.
 

--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -95,21 +95,24 @@ class PluginManager(_PM):
         ----------
         new_order : CallOrderDict
 
-        new_order =
-                {
-                    spec_name: [
-                            {
-                                name: plugin_name
-                                enabled: enabled
-                            },
-                            {
-                                name: plugin_name
-                                enabled: enabled
-                            },
-                            ...
-                    ],
-                    ...
-                }
+        Examples
+        --------
+        >>> new_order =
+        ...         {
+        ...             spec_name: [
+        ...                     {
+        ...                         name: plugin_name
+        ...                         enabled: enabled
+        ...                     },
+        ...                     {
+        ...                         name: plugin_name
+        ...                         enabled: enabled
+        ...                     },
+        ...                     ...
+        ...             ],
+        ...             ...
+        ...         }
+        ... plugin_manager.set_call_order(new_order)
         """
 
         for spec_name, hook_caller in self.hooks.items():
@@ -378,7 +381,6 @@ def available_samples() -> Tuple[Tuple[str, str], ...]:
 
     Examples
     --------
-
     .. code-block:: python
 
         from napari.plugins import available_samples

--- a/napari/utils/perf/_timers.py
+++ b/napari/utils/perf/_timers.py
@@ -80,7 +80,7 @@ class PerfTimers:
         ----------
         name : PerfEvent
             Add this event.
-        kwargs
+        **kwargs
             Arguments to display in the Args section of the Tracing GUI.
         """
         now = perf_counter_ns()
@@ -93,7 +93,7 @@ class PerfTimers:
         ----------
         name : str
             The name of this event like "draw".
-        kwargs : Dict[str, float]
+        **kwargs : Dict[str, float]
             The individual counters for this event.
 
         Notes
@@ -191,7 +191,7 @@ def _create_timer():
         ----------
         name : PerfEvent
             Add this event.
-        kwargs
+        **kwargs
             Arguments to display in the Args section of the Chrome Tracing GUI.
         """
         timers.add_instant_event(name, **kwargs)
@@ -203,7 +203,7 @@ def _create_timer():
         ----------
         name : str
             The name of this event like "draw".
-        kwargs : Dict[str, float]
+        **kwargs : Dict[str, float]
             The individual counters for this event.
 
         Notes

--- a/napari/utils/translations.py
+++ b/napari/utils/translations.py
@@ -328,7 +328,7 @@ class TranslationBundle:
             The plural string to translate.
         n : int, optional
             The number for pluralization.
-        kwargs : dict, optional
+        **kwargs : dict, optional
             Any additional arguments to use when formating the string.
         """
         if msgid is None:
@@ -377,7 +377,7 @@ class TranslationBundle:
         deferred : bool, optional
             Define if the string translation should be deferred or executed
             in place. Default is False.
-        kwargs : dict, optional
+        **kwargs : dict, optional
             Any additional arguments to use when formating the string.
 
         Returns
@@ -416,7 +416,7 @@ class TranslationBundle:
         deferred : bool, optional
             Define if the string translation should be deferred or executed
             in place. Default is False.
-        kwargs : dict, optional
+        **kwargs : dict, optional
             Any additional arguments to use when formating the string.
 
         Returns
@@ -459,7 +459,7 @@ class TranslationBundle:
         deferred : bool, optional
             Define if the string translation should be deferred or executed
             in place. Default is False.
-        kwargs : dict, optional
+        **kwargs : dict, optional
             Any additional arguments to use when formating the string.
 
         Returns
@@ -505,7 +505,7 @@ class TranslationBundle:
         deferred : bool, optional
             Define if the string translation should be deferred or executed
             in place. Default is False.
-        kwargs : dict, optional
+        **kwargs : dict, optional
             Any additional arguments to use when formating the string.
 
         Returns


### PR DESCRIPTION
Standardize *args, and **kwargs to have leading stars, which does not
seem to be a problem for sphinx.

Move one thing to  Examples, as otherwise it is interpreted as
an actual parameter by Numpydoc.
