### PR TITLE
Global plugin setting

### DIFF
--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -20,6 +20,8 @@ from ...utils.translations import trans
 class PreferencesDialog(QDialog):
     """Preferences Dialog for Napari user settings."""
 
+    valueChanged = Signal()
+
     ui_schema = {
         "call_order": {"ui:widget": "plugins"},
         "highlight_thickness": {"ui:widget": "highlight"},
@@ -157,6 +159,7 @@ class PreferencesDialog(QDialog):
     def _reset_widgets(self):
         """Deletes the widgets and rebuilds with defaults."""
         self.close()
+        self.valueChanged.emit()
         self._list.clear()
 
         for n in range(self._stack.count()):
@@ -279,7 +282,7 @@ class PreferencesDialog(QDialog):
 class ConfirmDialog(QDialog):
     """Dialog to confirms a user's choice to restore default settings."""
 
-    valueChanged = Signal(bool)
+    valueChanged = Signal()
 
     def __init__(
         self,
@@ -318,5 +321,5 @@ class ConfirmDialog(QDialog):
     def on_click_restore(self):
         """Restore defaults and close window."""
         SETTINGS.reset()
-        self.valueChanged.emit(True)
+        self.valueChanged.emit()
         self.close()

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -264,7 +264,6 @@ class QPluginList(QListWidget):
             plugin_name=plugin_name,
             enabled=enabled,
         )
-
         method = getattr(
             self.installer, 'uninstall' if plugin_name else 'install'
         )
@@ -339,7 +338,6 @@ class QtPluginDialog(QDialog):
                 meta = standard_metadata(distname)
             else:
                 meta = {}
-
             self.installed_list.addItem(
                 ProjectInfo(
                     normalized_name(distname or ''),

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -237,9 +237,6 @@ class PluginListItem(QFrame):
     def _on_enabled_checkbox(self, state: int):
         """Called with `state` when checkbox is clicked."""
         plugin_manager.set_blocked(self.plugin_name.text(), not state)
-        if state:
-            print('discover!')
-            plugin_manager.discover()
 
 
 class QPluginList(QListWidget):

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -1,4 +1,3 @@
-import copy
 import os
 import sys
 from pathlib import Path
@@ -398,7 +397,7 @@ class QtPluginDialog(QDialog):
         self.worker.start()
 
     def update_state(self, plugin_state):
-        """Emit plugin state whecn checkbox is triggered.
+        """Emit plugin state when checkbox is triggered.
         Parameters
         ----------
         new_state: dict
@@ -407,40 +406,14 @@ class QtPluginDialog(QDialog):
                 'state': bool
             }
         """
-        disabled_plugins = copy.deepcopy(SETTINGS.plugins.disabled_plugins)
-        if plugin_state['plugin'] in disabled_plugins:
-            # already here, need to remove it, because now it is enabled again.
-            if plugin_state['state'] is True:
-                disabled_plugins.remove(plugin_state['plugin'])
 
-                plugin_manager.set_blocked(plugin_state['plugin'], False)
-                plugin_manager.discover()
-
+        if plugin_state['state'] is False:
+            plugin_manager.set_blocked(plugin_state['plugin'], True)
         else:
-            # this plugin is not in the disabled plugins, and is now disabled, needs to be added.
-            if plugin_state['state'] is False:
-                disabled_plugins.add(plugin_state['plugin'])
-
-                plugin_manager.set_blocked(plugin_state['plugin'], True)
-
-                # remove plugin from various lists in plugins
-                if plugin_state['plugin'] in plugin_manager._dock_widgets:
-
-                    del plugin_manager._dock_widgets[plugin_state['plugin']]
-
-                if plugin_state['plugin'] in plugin_manager._function_widgets:
-                    del plugin_manager._function_widgets[
-                        plugin_state['plugin']
-                    ]
-
-                if plugin_state['plugin'] in plugin_manager._sample_data:
-                    del plugin_manager._sample_data[plugin_state['plugin']]
-
-        SETTINGS.plugins.disabled_plugins = disabled_plugins
+            plugin_manager.set_blocked(plugin_state['plugin'], False)
 
         # need to reset call order
         plugin_manager.set_call_order(SETTINGS.plugins.call_order)
-
         self.plugin_sorter.refresh()
 
     def setup_ui(self):

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -321,6 +321,9 @@ class QPluginList(QListWidget):
 
 
 class QtPluginDialog(QDialog):
+
+    on_changed = Signal()
+
     def __init__(self, parent=None, disabled_list=None):
         super().__init__(parent)
         self.installer = Installer()
@@ -415,6 +418,8 @@ class QtPluginDialog(QDialog):
         # need to reset call order
         plugin_manager.set_call_order(SETTINGS.plugins.call_order)
         self.plugin_sorter.refresh()
+
+        self.on_changed.emit()
 
     def setup_ui(self):
         self.resize(1080, 640)

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -111,7 +111,7 @@ class Installer:
 
 class PluginListItem(QFrame):
 
-    on_changed = Signal(dict)
+    on_changed = Signal()
 
     def __init__(
         self,
@@ -254,14 +254,20 @@ class PluginListItem(QFrame):
             Value from the checkbox indicating whether its checked or not.
         """
 
-        plugin = self.plugin_name.text()
-        edict = {'plugin': plugin, 'state': bool(state)}
-        self.on_changed.emit(edict)
+        plugin_name = self.plugin_name.text()
+        plugin_state = bool(state)
+
+        if plugin_state is False:
+            plugin_manager.set_blocked(plugin_name, True)
+        else:
+            plugin_manager.set_blocked(plugin_name, False)
+
+        self.on_changed.emit()
 
 
 class QPluginList(QListWidget):
 
-    on_changed = Signal(dict)
+    on_changed = Signal()
 
     def __init__(self, parent: QWidget, installer: Installer):
         super().__init__(parent)
@@ -399,21 +405,10 @@ class QtPluginDialog(QDialog):
         self.worker.finished.connect(self._update_count_in_label)
         self.worker.start()
 
-    def update_state(self, plugin_state):
-        """Emit plugin state when checkbox is triggered.
-        Parameters
-        ----------
-        new_state: dict
-            new_state = {
-                'plugin': str
-                'state': bool
-            }
-        """
+    def update_state(self):
+        """Emit plugin state when checkbox is triggered."""
 
-        if plugin_state['state'] is False:
-            plugin_manager.set_blocked(plugin_state['plugin'], True)
-        else:
-            plugin_manager.set_blocked(plugin_state['plugin'], False)
+        # NOTE: the plugin sorter refresh works from here...
 
         # need to reset call order
         plugin_manager.set_call_order(SETTINGS.plugins.call_order)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -817,9 +817,8 @@ class Window:
     def _update_menus(self, event):
         """"Update dock widget and sample menus when plugins are enabled/disabled."""
 
-        print(
-            'does not update menus properly.  not sure how to get the same plugin manager values'
-        )
+        # does not update menus properly.  not sure how to get the same plugin manager
+        print('supposed to update menu')
         self._plugin_dock_widget_menu.clear()
         self._fill_dock_widget_menu()
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -385,6 +385,9 @@ class Window:
 
         SETTINGS.appearance.events.theme.connect(self._update_theme)
 
+        plugin_manager.events.disabled.connect(self._update_menus)
+        plugin_manager.events.enabled.connect(self._update_menus)
+
         viewer.events.status.connect(self._status_changed)
         viewer.events.help.connect(self._help_changed)
         viewer.events.title.connect(self._title_changed)
@@ -777,6 +780,7 @@ class Window:
 
         # Add a menu item (QAction) for each available plugin widget
         for hook_type, (plugin_name, widgets) in plugin_manager.iter_widgets():
+            print(plugin_name)
             multiprovider = len(widgets) > 1
             if multiprovider:
                 menu = QMenu(plugin_name, self._qt_window)
@@ -807,12 +811,15 @@ class Window:
         self.plugin_dialog = QtPluginDialog(
             self._qt_window, copy.deepcopy(SETTINGS.plugins.disabled_plugins)
         )
-        self.plugin_dialog.on_changed.connect(self._update_menus)
+        # self.plugin_dialog.on_changed.connect(self._update_menus)
         self.plugin_dialog.exec_()
 
-    def _update_menus(self):
+    def _update_menus(self, event):
         """"Update dock widget and sample menus when plugins are enabled/disabled."""
 
+        print(
+            'does not update menus properly.  not sure how to get the same plugin manager values'
+        )
         self._plugin_dock_widget_menu.clear()
         self._fill_dock_widget_menu()
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -786,21 +786,20 @@ class Window:
 
             for wdg_name in widgets:
                 key = (plugin_name, wdg_name)
-                if plugin_name not in SETTINGS.plugins.disabled_plugins:
-                    if multiprovider:
-                        action = QAction(wdg_name, parent=self._qt_window)
+                if multiprovider:
+                    action = QAction(wdg_name, parent=self._qt_window)
+                else:
+                    full_name = plugin_menu_item_template.format(*key)
+                    action = QAction(full_name, parent=self._qt_window)
+
+                def _add_widget(*args, key=key, hook_type=hook_type):
+                    if hook_type == 'dock':
+                        self.add_plugin_dock_widget(*key)
                     else:
-                        full_name = plugin_menu_item_template.format(*key)
-                        action = QAction(full_name, parent=self._qt_window)
+                        self._add_plugin_function_widget(*key)
 
-                    def _add_widget(*args, key=key, hook_type=hook_type):
-                        if hook_type == 'dock':
-                            self.add_plugin_dock_widget(*key)
-                        else:
-                            self._add_plugin_function_widget(*key)
-
-                    menu.addAction(action)
-                    action.triggered.connect(_add_widget)
+                menu.addAction(action)
+                action.triggered.connect(_add_widget)
 
     def _show_plugin_install_dialog(self):
         """Show dialog that allows users to sort the call order of plugins."""

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -2,7 +2,6 @@
 Custom Qt widgets that serve as native objects that the public-facing elements
 wrap.
 """
-import copy
 import inspect
 import sys
 import time
@@ -91,12 +90,6 @@ class _QtMainWindow(QMainWindow):
         # set the values in plugins to match the ones saved in SETTINGS
         if SETTINGS.plugins.call_order is not None:
             plugin_manager.set_call_order(SETTINGS.plugins.call_order)
-
-        else:
-            # need to set the call_order for plugin_dialog to work
-            SETTINGS.plugins.call_order = copy.deepcopy(
-                SETTINGS._defaults['plugins'].call_order
-            )
 
         _QtMainWindow._instances.append(self)
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -786,20 +786,21 @@ class Window:
 
             for wdg_name in widgets:
                 key = (plugin_name, wdg_name)
-                if multiprovider:
-                    action = QAction(wdg_name, parent=self._qt_window)
-                else:
-                    full_name = plugin_menu_item_template.format(*key)
-                    action = QAction(full_name, parent=self._qt_window)
-
-                def _add_widget(*args, key=key, hook_type=hook_type):
-                    if hook_type == 'dock':
-                        self.add_plugin_dock_widget(*key)
+                if plugin_name not in SETTINGS.plugins.disabled_plugins:
+                    if multiprovider:
+                        action = QAction(wdg_name, parent=self._qt_window)
                     else:
-                        self._add_plugin_function_widget(*key)
+                        full_name = plugin_menu_item_template.format(*key)
+                        action = QAction(full_name, parent=self._qt_window)
 
-                menu.addAction(action)
-                action.triggered.connect(_add_widget)
+                    def _add_widget(*args, key=key, hook_type=hook_type):
+                        if hook_type == 'dock':
+                            self.add_plugin_dock_widget(*key)
+                        else:
+                            self._add_plugin_function_widget(*key)
+
+                    menu.addAction(action)
+                    action.triggered.connect(_add_widget)
 
     def _show_plugin_install_dialog(self):
         """Show dialog that allows users to sort the call order of plugins."""
@@ -811,12 +812,11 @@ class Window:
         self.plugin_dialog.exec_()
 
     def _update_menus(self):
+        """"Update dock widget and sample menus when plugins are enabled/disabled."""
 
-        plugin_manager.discover_widgets()
         self._plugin_dock_widget_menu.clear()
         self._fill_dock_widget_menu()
 
-        # to do -- finish sample menu update
         self.open_sample_menu.clear()
         self._fill_sample_menu()
 

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -394,17 +394,6 @@ class QtPluginSorter(QWidget):
     def refresh(self):
         self._on_hook_change(self.hook_combo_box.currentIndex())
 
-    def set_setting_default_value(self):
-        """On start up, this function is used to set the defaults in settings.
-        Note: use before loading in the saved settings.
-        """
-        if SETTINGS._defaults["plugins"].call_order is None:
-            setattr(
-                SETTINGS._defaults['plugins'],
-                'call_order',
-                self.plugin_manager.call_order(),
-            )
-
     def value(self):
         """Returns the call order from the plugin manager.
 

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -300,9 +300,8 @@ class QtPluginSorter(QWidget):
         self.hook_combo_box = QComboBox()
         self.hook_combo_box.addItem(self.NULL_OPTION, None)
 
-        # Included this, because I believe we want the plugin sorter to update from listening.
         self.plugin_manager.events.disabled.connect(self._on_disabled)
-        # self.plugin_manager.events.enabled.connect(self._update)
+        self.plugin_manager.events.registered.connect(self.refresh)
 
         # populate comboBox with all of the hooks known by the plugin manager
 
@@ -395,11 +394,12 @@ class QtPluginSorter(QWidget):
             self.info.hide()
             self.docstring.setToolTip('')
 
-    def refresh(self, event=None):
+    def refresh(self):
+        print("refresh", self.hook_combo_box.currentIndex())
         self._on_hook_change(self.hook_combo_box.currentIndex())
 
     def _on_disabled(self, event):
-        for i in range(self.hook_list.count()):
+        for i in range(self.hook_list.count() - 1):
             item = self.hook_list.item(i)
             if item.hook_implementation.plugin_name == event.value:
                 self.hook_list.takeItem(i)

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -300,6 +300,10 @@ class QtPluginSorter(QWidget):
         self.hook_combo_box = QComboBox()
         self.hook_combo_box.addItem(self.NULL_OPTION, None)
 
+        # Included this, because I believe we want the plugin sorter to update from listening.
+        self.plugin_manager.events.disabled.connect(self._update)
+        self.plugin_manager.events.enabled.connect(self._update)
+
         # populate comboBox with all of the hooks known by the plugin manager
 
         for name, hook_caller in plugin_manager.hooks.items():
@@ -404,3 +408,8 @@ class QtPluginSorter(QWidget):
         """
 
         return plugins.plugin_manager.call_order()
+
+    def _update(self, event):
+        # this refresh doesn't update right away.
+        print(event.value)
+        # self.refresh()

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -394,14 +394,13 @@ class QtPluginSorter(QWidget):
             self.info.hide()
             self.docstring.setToolTip('')
 
-    def refresh(self):
-        print("refresh", self.hook_combo_box.currentIndex())
+    def refresh(self, event=None):
         self._on_hook_change(self.hook_combo_box.currentIndex())
 
     def _on_disabled(self, event):
-        for i in range(self.hook_list.count() - 1):
+        for i in range(self.hook_list.count()):
             item = self.hook_list.item(i)
-            if item.hook_implementation.plugin_name == event.value:
+            if item and item.hook_implementation.plugin_name == event.value:
                 self.hook_list.takeItem(i)
 
     def value(self):

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -300,9 +300,6 @@ class QtPluginSorter(QWidget):
         self.hook_combo_box = QComboBox()
         self.hook_combo_box.addItem(self.NULL_OPTION, None)
 
-        self.plugin_manager.events.disabled.connect(self._on_disabled)
-        self.plugin_manager.events.registered.connect(self.refresh)
-
         # populate comboBox with all of the hooks known by the plugin manager
 
         for name, hook_caller in plugin_manager.hooks.items():
@@ -319,6 +316,9 @@ class QtPluginSorter(QWidget):
             self.hook_combo_box.addItem(
                 name.replace("napari_", ""), hook_caller
             )
+
+        self.plugin_manager.events.disabled.connect(self._on_disabled)
+        self.plugin_manager.events.registered.connect(self.refresh)
 
         self.hook_combo_box.setToolTip(
             trans._("select the hook specification to reorder")

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -301,8 +301,8 @@ class QtPluginSorter(QWidget):
         self.hook_combo_box.addItem(self.NULL_OPTION, None)
 
         # Included this, because I believe we want the plugin sorter to update from listening.
-        self.plugin_manager.events.disabled.connect(self._update)
-        self.plugin_manager.events.enabled.connect(self._update)
+        self.plugin_manager.events.disabled.connect(self._on_disabled)
+        # self.plugin_manager.events.enabled.connect(self._update)
 
         # populate comboBox with all of the hooks known by the plugin manager
 
@@ -395,8 +395,14 @@ class QtPluginSorter(QWidget):
             self.info.hide()
             self.docstring.setToolTip('')
 
-    def refresh(self):
+    def refresh(self, event=None):
         self._on_hook_change(self.hook_combo_box.currentIndex())
+
+    def _on_disabled(self, event):
+        for i in range(self.hook_list.count()):
+            item = self.hook_list.item(i)
+            if item.hook_implementation.plugin_name == event.value:
+                self.hook_list.takeItem(i)
 
     def value(self):
         """Returns the call order from the plugin manager.
@@ -408,8 +414,3 @@ class QtPluginSorter(QWidget):
         """
 
         return plugins.plugin_manager.call_order()
-
-    def _update(self, event):
-        # this refresh doesn't update right away.
-        print(event.value)
-        # self.refresh()

--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -1,3 +1,4 @@
+from ..utils.settings import SETTINGS
 from ._plugin_manager import NapariPluginManager
 
 __all__ = ["plugin_manager", "menu_item_template"]
@@ -6,6 +7,8 @@ __all__ = ["plugin_manager", "menu_item_template"]
 # the main plugin manager instance for the `napari` plugin namespace.
 plugin_manager = NapariPluginManager()
 plugin_manager._initialize()
+# Disable plugins listed as disabled in SETTINGS.
+plugin_manager._blocked.update(SETTINGS.plugins.disabled_plugins)
 
 #: Template to use for namespacing a plugin item in the menu bar
 menu_item_template = '{}: {}'

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -128,15 +128,13 @@ class NapariPluginManager(PluginManager):
             sooner.
         """
         for spec_name, hook_caller in self.hooks.items():
-            order = []
-            for p in new_order.get(spec_name, []):
-                try:
-                    hook_caller._set_plugin_enabled(p['plugin'], p['enabled'])
+            if spec_name in new_order:
+                order = []
+                for p in new_order.get(spec_name, []):
                     order.append(p['plugin'])
-                except KeyError:
-                    pass
-            if order:
-                hook_caller.bring_to_front(order)
+                    hook_caller._set_plugin_enabled(p['plugin'], p['enabled'])
+                if order:
+                    hook_caller.bring_to_front(order)
 
     # SAMPLE DATA ---------------------------
 

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -95,16 +95,19 @@ class NapariPluginManager(PluginManager):
         return name
 
     def _update_settings_enable(self, event):
-        """Removes plugin name from disabled plugins set"""
+        """Removes plugin name from disabled plugins set."""
+
         disabled_plugins = copy.deepcopy(SETTINGS.plugins.disabled_plugins)
+
         if event.value in disabled_plugins:
             disabled_plugins.remove(event.value)
 
         SETTINGS.plugins.disabled_plugins = disabled_plugins
+
         self.discover()
 
     def _update_settings_disable(self, event):
-        """Adds plugin name to disabled plugins set """
+        """Adds plugin name to disabled plugins set."""
 
         disabled_plugins = copy.deepcopy(SETTINGS.plugins.disabled_plugins)
 
@@ -112,12 +115,14 @@ class NapariPluginManager(PluginManager):
 
         SETTINGS.plugins.disabled_plugins = disabled_plugins
 
-        self._dock_widgets = {}
-        self._function_widgets = {}
-        self._sample_data = {}
+        if event.value in self._dock_widgets:
+            del self._dock_widgets[event.value]
 
-        # do I need discover widgets here?   Having it here doesn't update the qt_main_window widgets properly.
-        # self.discover_widgets()
+        if event.value in self._sample_data:
+            del self._sample_data[event.value]
+
+        if event.value in self._function_widgets:
+            del self._function_widgets[event.value]
 
     def call_order(self, first_result_only=True) -> CallOrderDict:
         """Returns the call order from the plugin manager.
@@ -400,6 +405,7 @@ class NapariPluginManager(PluginManager):
         (historic here means that even plugins that are discovered after this
         is called will be added.)
         """
+
         if self._dock_widgets:
             return
         self.hook.napari_experimental_provide_dock_widget.call_historic(

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -1,3 +1,4 @@
+import copy
 import importlib
 import sys
 from functools import partial
@@ -95,25 +96,28 @@ class NapariPluginManager(PluginManager):
 
     def _update_settings_enable(self, event):
         """Removes plugin name from disabled plugins set"""
+        disabled_plugins = copy.deepcopy(SETTINGS.plugins.disabled_plugins)
+        if event.value in disabled_plugins:
+            disabled_plugins.remove(event.value)
 
-        if event.value in SETTINGS.plugins.disabled_plugins:
-            SETTINGS.plugins.disabled_plugins.remove(event.value)
-
+        SETTINGS.plugins.disabled_plugins = disabled_plugins
         self.discover()
 
     def _update_settings_disable(self, event):
         """Adds plugin name to disabled plugins set """
 
-        SETTINGS.plugins.disabled_plugins.add(event.value)
+        disabled_plugins = copy.deepcopy(SETTINGS.plugins.disabled_plugins)
 
-        if event.value in self._dock_widgets:
-            del self._dock_widgets[event.value]
+        disabled_plugins.add(event.value)
 
-        if event.value in self._function_widgets:
-            del self._function_widgets[event.value]
+        SETTINGS.plugins.disabled_plugins = disabled_plugins
 
-        if event.value in self._sample_data:
-            del self._sample_data[event.value]
+        self._dock_widgets = {}
+        self._function_widgets = {}
+        self._sample_data = {}
+
+        # do I need discover widgets here?   Having it here doesn't update the qt_main_window widgets properly.
+        # self.discover_widgets()
 
     def call_order(self, first_result_only=True) -> CallOrderDict:
         """Returns the call order from the plugin manager.

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Set, Tuple
 
 from pydantic import BaseSettings, Field
 from typing_extensions import TypedDict
@@ -318,13 +318,15 @@ class PluginsSettings(BaseNapariSettings):
         ),
     )
 
+    disabled_plugins: Set[str] = set()
+
     class Config:
         # Pydantic specific configuration
         title = trans._("Plugins")
 
     class NapariConfig:
         # Napari specific configuration
-        preferences_exclude = ['schema_version']
+        preferences_exclude = ['schema_version', 'disabled_plugins']
 
 
 CORE_SETTINGS = [AppearanceSettings, ApplicationSettings, PluginsSettings]


### PR DESCRIPTION
In the plugin installation dialog, you can select to enable/disable a plugin globally.  This PR will save this setting and propagate that setting to all the hooks.  

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousando words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
