### PR TITLE
pin docs dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-jupyter-book
-jupytext
-sphinx_autodoc_typehints
+jupyter-book==0.10.2
+jupytext==1.10.3
+sphinx_autodoc_typehints==1.11.0
 furo


### PR DESCRIPTION
# Description
fixes #2558 by pinning sphinx_autodoc_typehints to 1.11.0 (can't tell yet from the changelog why 1.12.0 broke the build).

I'm pinning the other dependencies here too.  Building docs is something that doesn't need to be "compatible" with anything else, it needs to just work.  So updating dependencies should be a periodic manual process (update deps, build locally, push if it works).