### PR TITLE
Raise AttributeError when labels.contrast_limits are set to anything other than (0, 1)

### DIFF
--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -672,9 +672,10 @@ class Labels(_image_base_class):
     @property
     def contrast_limits(self):
         return self._contrast_limits
-        
+
     @contrast_limits.setter
     def contrast_limits(self, value):
+        # Setting contrast_limits of labels layers leads to wrong visualization of the layer
         raise AttributeError("Setting contrast_limits on labels layers is not allowed.")
 
     def _set_editable(self, editable=None):

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -676,7 +676,11 @@ class Labels(_image_base_class):
     @contrast_limits.setter
     def contrast_limits(self, value):
         # Setting contrast_limits of labels layers leads to wrong visualization of the layer
-        raise AttributeError("Setting contrast_limits on labels layers is not allowed.")
+        if tuple(value) != (0, 1):
+            raise AttributeError(
+                "Setting contrast_limits on labels layers is not allowed."
+            )
+        self._contrast_limits = (0, 1)
 
     def _set_editable(self, editable=None):
         """Set editable mode based on layer properties."""

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -668,6 +668,10 @@ class Labels(_image_base_class):
     def preserve_labels(self, preserve_labels: bool):
         self._preserve_labels = preserve_labels
         self.events.preserve_labels(preserve_labels=preserve_labels)
+        
+    @contrast_limits.setter
+    def contrast_limits(self, value):
+        raise AttributeError("Setting contrast_limits on labels layers is not allowed.")
 
     def _set_editable(self, editable=None):
         """Set editable mode based on layer properties."""

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -668,6 +668,10 @@ class Labels(_image_base_class):
     def preserve_labels(self, preserve_labels: bool):
         self._preserve_labels = preserve_labels
         self.events.preserve_labels(preserve_labels=preserve_labels)
+
+    @property
+    def contrast_limits(self):
+        return self._contrast_limits
         
     @contrast_limits.setter
     def contrast_limits(self, value):


### PR DESCRIPTION
# Description
Instead of setting `contrast_limits` of `Labels` layers, an `AttributeError` is raised.

## Type of change
I'm not sure if this is a breaking change. I would hope nobody was setting `contrast_limits` of `Labels` layers before...
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

Let me know if I should add a remark to the documentation somewhere. 

# References
closes #2570 

# How has this been tested?

- [x] I tested it by hand using the example code provided in #2570 

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
