### PR TITLE
Delay importing plugins during settings registration

### DIFF
--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import sys
 from inspect import signature
@@ -35,15 +37,7 @@ if TYPE_CHECKING:
     from magicgui.widgets import FunctionGui
     from qtpy.QtWidgets import QWidget
 
-
-class PluginHookOption(TypedDict):
-    """Custom type specifying plugin and enabled state."""
-
-    plugin: str
-    enabled: bool
-
-
-CallOrderDict = Dict[str, List[PluginHookOption]]
+    from ..utils.settings._defaults import CallOrderDict
 
 
 class PluginManager(_PM):

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import os
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Tuple, TypedDict
+from typing import Dict, List, Tuple
 
 from pydantic import BaseSettings, Field
+from typing_extensions import TypedDict
 
 from .._base import _DEFAULT_LOCALE
 from ..events.evented_model import EventedModel

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -1,14 +1,14 @@
 """Settings management.
 """
+from __future__ import annotations
 
 import os
 from enum import Enum
 from pathlib import Path
-from typing import List, Tuple
+from typing import Dict, List, Tuple, TypedDict
 
 from pydantic import BaseSettings, Field
 
-from ...plugins import CallOrderDict
 from .._base import _DEFAULT_LOCALE
 from ..events.evented_model import EventedModel
 from ..notifications import NotificationSeverity
@@ -273,6 +273,16 @@ class ApplicationSettings(BaseNapariSettings):
             "open_history",
             "save_history",
         ]
+
+
+class PluginHookOption(TypedDict):
+    """Custom type specifying plugin and enabled state."""
+
+    plugin: str
+    enabled: bool
+
+
+CallOrderDict = Dict[str, List[PluginHookOption]]
 
 
 class PluginsSettings(BaseNapariSettings):


### PR DESCRIPTION
# Description
fixes #2574
This is a quick patch that fixes a regression in #2501 where importing a type annotation from `plugins.__init__` inside `settings._defaults` triggered plugin discovery.  As such, if a plugin imported from napari and tried to directly access something like `napari.viewer.Viewer`, they would get an attribute error (because napari isn't ready yet).

This is tricky to test, since it's harder to replicate import orders in pytest (where napari has usually fully imported before a test starts).  This PR is not intended to be a robust fix for this, but more needs to be done to prevent plugin discovery during napari initialization in the future.  I'd like for #2535 to merge first, after which that will be a lot easier.


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
