### PR TITLE
Add example tying slider change to point properties change

### DIFF
--- a/examples/points-over-time.py
+++ b/examples/points-over-time.py
@@ -1,0 +1,34 @@
+import napari
+import numpy as np
+import dask.array as da
+from skimage import data
+
+
+image4d = da.random.random((20, 32, 256, 256))
+pts_coordinates = np.random.random((300, 3)) * image4d.shape[1:]
+pts_values = np.random.random((300, 20))
+
+viewer = napari.Viewer(ndisplay=3)
+image_layer = viewer.add_image(
+        image4d, opacity=0.5
+        )
+pts_layer = viewer.add_points(
+        pts_coordinates,
+        properties={'value': pts_values[:, 0]},
+        face_color='value',
+        )
+
+
+def set_pts_properties(pts_layer, values_table, step):
+    # step is a 4D coordinate with the current slider position for each dim
+    column = step[0]  # grab the leading ("time") coordinate
+    pts_layer.properties['value'] = values_table[:, column]
+    pts_layer.face_color = 'value'  # force properties refresh
+
+
+viewer.dims.events.current_step.connect(
+        lambda event: set_pts_properties(pts_layer, pts_values, event.value)
+        )
+
+
+napari.run()

--- a/examples/points-over-time.py
+++ b/examples/points-over-time.py
@@ -4,9 +4,12 @@ import dask.array as da
 from skimage import data
 
 
-image4d = da.random.random((20, 32, 256, 256))
-pts_coordinates = np.random.random((300, 3)) * image4d.shape[1:]
-pts_values = np.random.random((300, 20))
+image4d = da.random.random(
+        (4000, 32, 256, 256),
+        chunks=(1, 32, 256, 256),
+        )
+pts_coordinates = np.random.random((50000, 3)) * image4d.shape[1:]
+pts_values = da.random.random((50000, 4000), chunks=(50000, 1))
 
 viewer = napari.Viewer(ndisplay=3)
 image_layer = viewer.add_image(
@@ -14,15 +17,16 @@ image_layer = viewer.add_image(
         )
 pts_layer = viewer.add_points(
         pts_coordinates,
-        properties={'value': pts_values[:, 0]},
+        properties={'value': np.asarray(pts_values[:, 0])},
         face_color='value',
+        size=2,
         )
 
 
 def set_pts_properties(pts_layer, values_table, step):
     # step is a 4D coordinate with the current slider position for each dim
     column = step[0]  # grab the leading ("time") coordinate
-    pts_layer.properties['value'] = values_table[:, column]
+    pts_layer.properties['value'] = np.asarray(values_table[:, column])
     pts_layer.face_color = 'value'  # force properties refresh
 
 


### PR DESCRIPTION
# Description

This PR adds an example demonstrating how to tie points properties to slider state. This allows us to display static point coordinates with time varying properties without having to duplicate the points. See [1] for motivation.

# References

[1]: https://forum.image.sc/t/3d-point-cloud-with-changing-color-in-time/51635

