### PR TITLE
Don't create a dask cache if it doesn't exist

### DIFF
--- a/napari/layers/_tests/test_dask_layers.py
+++ b/napari/layers/_tests/test_dask_layers.py
@@ -10,7 +10,7 @@ from napari import layers, utils, viewer
 
 
 def test_dask_array_doesnt_create_cache():
-    """Test that adding a dask array creates a dask cache and turns of fusion."""
+    """Test that dask arrays don't create cache but turns off fusion."""
     # by default we have no dask_cache and task fusion is active
     original = dask.config.get("optimization.fuse.active", None)
 

--- a/napari/layers/_tests/test_dask_layers.py
+++ b/napari/layers/_tests/test_dask_layers.py
@@ -36,9 +36,7 @@ def test_dask_array_doesnt_create_cache():
 
     # make sure we can resize the cache
     utils.resize_dask_cache(10000)
-    assert utils.dask_cache.cache.total_bytes > 1000
-    utils.resize_dask_cache(1000)
-    assert utils.dask_cache.cache.total_bytes <= 1000
+    assert utils.dask_cache.cache.available_bytes == 10000
 
     # This should only affect dask arrays, and not numpy data
     def mock_set_view_slice2():

--- a/napari/utils/dask_utils.py
+++ b/napari/utils/dask_utils.py
@@ -167,7 +167,6 @@ def configure_dask(data) -> Callable[[], ContextManager[dict]]:
     ...    data[0, 2].compute()
     """
     if _is_dask_data(data):
-        create_dask_cache()  # creates one if it doesn't exist
         if dask.__version__ < LooseVersion('2.15.0'):
             warnings.warn(
                 'For best performance with Dask arrays in napari, please '


### PR DESCRIPTION
# Description

I've mentioned before that our default handling of dask caching can be problematic, both when [debugging dask issues]() and when using the Play button (when the cache actually hinders performance). It [also seems](https://forum.image.sc/t/3d-point-cloud-with-changing-color-in-time/51635/8) like the dask cache is leaking memory.

So this PR simply does away with the automatic creation of the cache. Users still have the ability to create it with `napari.resize_dask_cache(mem_fraction=0.1)`. I'll add this point to the dask tutorial in a separate PR.

# References

Closes #2329

