### PR TITLE
Range of label spinbox is more dtype-aware

### DIFF
--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -24,7 +24,6 @@ from ..widgets.qt_mode_buttons import QtModePushButton, QtModeRadioButton
 from .qt_layer_controls_base import QtLayerControls
 
 INT32_MAX = 2 ** 31 - 1
-INT32_MIN = -INT32_MAX
 
 
 class QtLabelsControls(QtLayerControls):
@@ -95,7 +94,7 @@ class QtLabelsControls(QtLayerControls):
         self.selectionSpinBox.setSingleStep(1)
         # spinboxes use i32 internally
         # use the smaller range of i32 and label dtype
-        self.selectionSpinBox.setMinimum(max(iinfo.min, INT32_MIN))
+        self.selectionSpinBox.setMinimum(0)
         self.selectionSpinBox.setMaximum(min(iinfo.max, INT32_MAX))
         self.selectionSpinBox.valueChanged.connect(self.changeSelection)
         self.selectionSpinBox.setAlignment(Qt.AlignCenter)
@@ -130,7 +129,7 @@ class QtLabelsControls(QtLayerControls):
         self.contourSpinBox.setSingleStep(1)
         # spinboxes use i32 internally
         # use the smaller range of i32 and label dtype
-        self.contourSpinBox.setMinimum(max(iinfo.min, INT32_MIN))
+        self.contourSpinBox.setMinimum(0)
         self.contourSpinBox.setMaximum(min(iinfo.max, INT32_MAX))
         self.contourSpinBox.setAlignment(Qt.AlignCenter)
         self._on_contour_change()

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -23,6 +23,9 @@ from ..utils import disable_with_opacity
 from ..widgets.qt_mode_buttons import QtModePushButton, QtModeRadioButton
 from .qt_layer_controls_base import QtLayerControls
 
+INT32_MAX = 2 ** 31 - 1
+INT32_MIN = -INT32_MAX
+
 
 class QtLabelsControls(QtLayerControls):
     """Qt view and controls for the napari Labels layer.
@@ -84,12 +87,16 @@ class QtLabelsControls(QtLayerControls):
         )
         self.layer.events.color_mode.connect(self._on_color_mode_change)
 
+        iinfo = np.iinfo(self.layer.data.dtype)
+
         # selection spinbox
         self.selectionSpinBox = QSpinBox()
         self.selectionSpinBox.setKeyboardTracking(False)
         self.selectionSpinBox.setSingleStep(1)
-        self.selectionSpinBox.setMinimum(0)
-        self.selectionSpinBox.setMaximum(1024)
+        # spinboxes use i32 internally
+        # use the smaller range of i32 and label dtype
+        self.selectionSpinBox.setMinimum(max(iinfo.min, INT32_MIN))
+        self.selectionSpinBox.setMaximum(min(iinfo.max, INT32_MAX))
         self.selectionSpinBox.valueChanged.connect(self.changeSelection)
         self.selectionSpinBox.setAlignment(Qt.AlignCenter)
         self._on_selected_label_change()
@@ -121,8 +128,10 @@ class QtLabelsControls(QtLayerControls):
         self.contourSpinBox = contour_sb
         self.contourSpinBox.setKeyboardTracking(False)
         self.contourSpinBox.setSingleStep(1)
-        self.contourSpinBox.setMinimum(0)
-        self.contourSpinBox.setMaximum(2147483647)
+        # spinboxes use i32 internally
+        # use the smaller range of i32 and label dtype
+        self.contourSpinBox.setMinimum(max(iinfo.min, INT32_MIN))
+        self.contourSpinBox.setMaximum(min(iinfo.max, INT32_MAX))
         self.contourSpinBox.setAlignment(Qt.AlignCenter)
         self._on_contour_change()
 


### PR DESCRIPTION
# Description

This is an interim improvement relating to #2587 . Disconnects between the bounds of the label selection spinner and the label data itself led to surprising behaviour, so the spinner is now restricted to the intersection of the non-negative values representable by the label array and the spinbox (i32).

The issue still exists for label values not representable by i32, but labels `>=2**31` are at least less common than `>=1024`.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?

- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
