### PR TITLE
only copy the autosummary templates

### DIFF
--- a/docs/copy-docs.py
+++ b/docs/copy-docs.py
@@ -28,7 +28,7 @@ TO_COPY = [
     'release',
     'roadmaps',
     'images',
-    '_templates',
+    osp.join('_templates', 'autosummary'),
     *[
         (dire, osp.join(dire, 'stable'))
         for dire in ('api', 'guides', 'plugins')


### PR DESCRIPTION
I was erroneously copying the entire templates folder, which can overwrite things in the entire directory (see [here](https://github.com/napari/napari.github.io/commit/d020777291b994413ddc75d0cade40be46a99732)). This narrows the copy down to just the autosummary templates.