### PR TITLE
WIP: Add a POC for side bars

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -17,6 +17,7 @@ from qtpy.QtWidgets import (
     QDockWidget,
     QHBoxLayout,
     QLabel,
+    QListWidget,
     QMainWindow,
     QMenu,
     QShortcut,
@@ -40,6 +41,7 @@ from .qt_event_loop import NAPARI_ICON_PATH, get_app, quit_app
 from .qt_resources import get_stylesheet
 from .qt_viewer import QtViewer
 from .utils import QImg2array, qbytearray_to_str, str_to_qbytearray
+from .widgets.qt_sidebar import QtSideBar
 from .widgets.qt_viewer_dock_widget import QtViewerDockWidget
 
 
@@ -300,6 +302,7 @@ class Window:
         self._add_window_menu()
         self._add_plugins_menu()
         self._add_help_menu()
+        self._add_sidebars()
 
         self._status_bar.showMessage(trans._('Ready'))
         self._help = QLabel('')
@@ -1239,3 +1242,30 @@ class Window:
             self.qt_viewer.close()
             self._qt_window.close()
             del self._qt_window
+
+    def _add_sidebars(self):
+        self._left_sidebar = QtSideBar(self._qt_window, "left")
+        self._right_sidebar = QtSideBar(self._qt_window, "right")
+        self._qt_window.addToolBar(Qt.LeftToolBarArea, self._left_sidebar)
+        self._qt_window.addToolBar(Qt.RightToolBarArea, self._right_sidebar)
+
+        list_1 = QListWidget(self._qt_window)
+        list_1.addItem("Hello World!")
+        list_1.addItem("Hello World!")
+        list_2 = QListWidget(self._qt_window)
+        list_2.addItem("List 2!")
+        list_2.addItem("List 2!")
+        list_2.addItem("List 2!")
+        list_3 = QListWidget(self._qt_window)
+        list_3.addItem("List 3!")
+        list_3.addItem("List 3!")
+        list_3.addItem("List 3!")
+        list_3.addItem("List 3!")
+
+        self._left_sidebar.add_widget(
+            "sidebar_plugins", trans._("Plugins"), list_1
+        )
+        self._left_sidebar.add_widget(
+            "sidebar_other", trans._("Other"), list_2
+        )
+        self._right_sidebar.add_widget("sidebar_help", trans._("Help"), list_3)

--- a/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -239,47 +239,47 @@ QtPlayButton[playing=True] {
 
 
 /* Testing */
-QtStateButton[mode="sidebar_plugins"] {
+QtSideBarButton[mode="sidebar_plugins"] {
   background: {{ background }};
   image: url(":/themes/{{ folder }}/3D.svg");
 }
 
-QtStateButton[mode="sidebar_plugins"]:hover {
+QtSideBarButton[mode="sidebar_plugins"]:hover {
   background: {{ highlight }};
   image: url(":/themes/{{ folder }}/3D.svg");
 }
 
-QtStateButton[mode="sidebar_plugins"]:checked {
+QtSideBarButton[mode="sidebar_plugins"]:checked {
   background: {{ highlight }};
   image: url(":/themes/{{ folder }}/3D.svg");
 }
 
-QtStateButton[mode="sidebar_help"] {
+QtSideBarButton[mode="sidebar_help"] {
   background: {{ background }};
   image: url(":/themes/{{ folder }}/2D.svg");
 }
 
-QtStateButton[mode="sidebar_help"]:hover {
+QtSideBarButton[mode="sidebar_help"]:hover {
   background: {{ highlight }};
   image: url(":/themes/{{ folder }}/2D.svg");
 }
 
-QtStateButton[mode="sidebar_help"]:checked {
+QtSideBarButton[mode="sidebar_help"]:checked {
   background: {{ highlight }};
   image: url(":/themes/{{ folder }}/2D.svg");
 }
 
-QtStateButton[mode="sidebar_other"] {
+QtSideBarButton[mode="sidebar_other"] {
   background: {{ background }};
   image: url(":/themes/{{ folder }}/copy_to_clipboard.svg");
 }
 
-QtStateButton[mode="sidebar_other"]:hover {
+QtSideBarButton[mode="sidebar_other"]:hover {
   background: {{ highlight }};
   image: url(":/themes/{{ folder }}/copy_to_clipboard.svg");
 }
 
-QtStateButton[mode="sidebar_other"]:checked {
+QtSideBarButton[mode="sidebar_other"]:checked {
   background: {{ highlight }};
   image: url(":/themes/{{ folder }}/copy_to_clipboard.svg");
 }

--- a/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -236,3 +236,50 @@ QtPlayButton[playing=True] {
     width: 12px;
     padding: 2px;
 }
+
+
+/* Testing */
+QtStateButton[mode="sidebar_plugins"] {
+  background: {{ background }};
+  image: url(":/themes/{{ folder }}/3D.svg");
+}
+
+QtStateButton[mode="sidebar_plugins"]:hover {
+  background: {{ highlight }};
+  image: url(":/themes/{{ folder }}/3D.svg");
+}
+
+QtStateButton[mode="sidebar_plugins"]:checked {
+  background: {{ highlight }};
+  image: url(":/themes/{{ folder }}/3D.svg");
+}
+
+QtStateButton[mode="sidebar_help"] {
+  background: {{ background }};
+  image: url(":/themes/{{ folder }}/2D.svg");
+}
+
+QtStateButton[mode="sidebar_help"]:hover {
+  background: {{ highlight }};
+  image: url(":/themes/{{ folder }}/2D.svg");
+}
+
+QtStateButton[mode="sidebar_help"]:checked {
+  background: {{ highlight }};
+  image: url(":/themes/{{ folder }}/2D.svg");
+}
+
+QtStateButton[mode="sidebar_other"] {
+  background: {{ background }};
+  image: url(":/themes/{{ folder }}/copy_to_clipboard.svg");
+}
+
+QtStateButton[mode="sidebar_other"]:hover {
+  background: {{ highlight }};
+  image: url(":/themes/{{ folder }}/copy_to_clipboard.svg");
+}
+
+QtStateButton[mode="sidebar_other"]:checked {
+  background: {{ highlight }};
+  image: url(":/themes/{{ folder }}/copy_to_clipboard.svg");
+}

--- a/napari/_qt/widgets/qt_sidebar.py
+++ b/napari/_qt/widgets/qt_sidebar.py
@@ -1,26 +1,20 @@
-from qtpy.QtCore import QSize, Qt, Signal, QObject
-from qtpy.QtGui import QFont, QIntValidator
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
-    QToolBar,
-    QWidget,
-    QToolButton,
-    QVBoxLayout,
+    QButtonGroup,
     QHBoxLayout,
     QStackedWidget,
-    QAction,
-    QButtonGroup,
+    QToolBar,
+    QWidget,
 )
 
-from ...utils.translations import trans
 from .qt_viewer_buttons import QtStateButton
 
 
-class QtSideBarButton(QToolButton):
+class QtSideBarButton(QtStateButton):
     pass
 
 
 class QtSideBarWidget(QWidget):
-
     def __init__(self, parent: QWidget = None, name: str = None):
         super().__init__(parent)
 
@@ -32,11 +26,10 @@ class QtSideBarWidget(QWidget):
         # Widget setup
         self.setObjectName(name)
         self._buttons.setOrientation(Qt.Vertical)
-        # self._buttons.setVisible(False)
+        self._buttons.setVisible(False)
         self._stack.setVisible(False)
         self._group.setExclusive(False)
         self._group.buttonToggled.connect(self._toggle_widget)
-
 
         self._layout = QHBoxLayout()
         if name == "left":
@@ -53,10 +46,9 @@ class QtSideBarWidget(QWidget):
         self._buttons.setContentsMargins(0, 0, 0, 0)
         self.setLayout(self._layout)
 
-    def add_widget(self, name, text, widget, location = "top"):
-        """
-        """
-        button = QtStateButton(name, self, "_test", None)
+    def add_widget(self, name, text, widget, location="top"):
+        """"""
+        button = QtSideBarButton(name, self, "_test", None)
         button.setToolTip(text)
         button._widget = widget
         self._button_list.append(button)
@@ -66,8 +58,7 @@ class QtSideBarWidget(QWidget):
         self._stack.addWidget(widget)
 
     def _toggle_widget(self, button, value):
-        """
-        """
+        """"""
         for btn in self._button_list:
             if btn != button:
                 btn.blockSignals(True)
@@ -83,8 +74,7 @@ class QtSideBarWidget(QWidget):
 
 
 class QtSideBar(QToolBar):
-    """
-    """
+    """"""
 
     def __init__(self, parent: QWidget = None, name: str = None):
         super().__init__(parent)
@@ -96,5 +86,5 @@ class QtSideBar(QToolBar):
         self.addWidget(self._widget)
         self.setContentsMargins(0, 0, 0, 0)
 
-    def add_widget(self, name, text, widget, location = "top"):
+    def add_widget(self, name, text, widget, location="top"):
         self._widget.add_widget(name, text, widget, location=location)

--- a/napari/_qt/widgets/qt_sidebar.py
+++ b/napari/_qt/widgets/qt_sidebar.py
@@ -1,0 +1,100 @@
+from qtpy.QtCore import QSize, Qt, Signal, QObject
+from qtpy.QtGui import QFont, QIntValidator
+from qtpy.QtWidgets import (
+    QToolBar,
+    QWidget,
+    QToolButton,
+    QVBoxLayout,
+    QHBoxLayout,
+    QStackedWidget,
+    QAction,
+    QButtonGroup,
+)
+
+from ...utils.translations import trans
+from .qt_viewer_buttons import QtStateButton
+
+
+class QtSideBarButton(QToolButton):
+    pass
+
+
+class QtSideBarWidget(QWidget):
+
+    def __init__(self, parent: QWidget = None, name: str = None):
+        super().__init__(parent)
+
+        self._stack = QStackedWidget(self)
+        self._buttons = QToolBar(self)
+        self._group = QButtonGroup(self)
+        self._button_list = []
+
+        # Widget setup
+        self.setObjectName(name)
+        self._buttons.setOrientation(Qt.Vertical)
+        # self._buttons.setVisible(False)
+        self._stack.setVisible(False)
+        self._group.setExclusive(False)
+        self._group.buttonToggled.connect(self._toggle_widget)
+
+
+        self._layout = QHBoxLayout()
+        if name == "left":
+            self._layout.addWidget(self._buttons)
+            self._layout.addWidget(self._stack)
+        else:
+            self._layout.addWidget(self._stack)
+            self._layout.addWidget(self._buttons)
+
+        self._stack.setContentsMargins(0, 0, 0, 0)
+        self.setContentsMargins(0, 0, 0, 0)
+        self._layout.setContentsMargins(0, 0, 0, 0)
+        self._layout.setSpacing(0)
+        self._buttons.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(self._layout)
+
+    def add_widget(self, name, text, widget, location = "top"):
+        """
+        """
+        button = QtStateButton(name, self, "_test", None)
+        button.setToolTip(text)
+        button._widget = widget
+        self._button_list.append(button)
+        self._buttons.addWidget(button)
+        self._group.addButton(button)
+        self._buttons.setVisible(True)
+        self._stack.addWidget(widget)
+
+    def _toggle_widget(self, button, value):
+        """
+        """
+        for btn in self._button_list:
+            if btn != button:
+                btn.blockSignals(True)
+                btn.setChecked(False)
+                btn.blockSignals(False)
+
+        button.setChecked(value)
+        widget = button._widget
+        if value:
+            self._stack.setCurrentWidget(widget)
+
+        self._stack.setVisible(value)
+
+
+class QtSideBar(QToolBar):
+    """
+    """
+
+    def __init__(self, parent: QWidget = None, name: str = None):
+        super().__init__(parent)
+
+        self._widget = QtSideBarWidget(self, name=name)
+
+        self.setMovable(False)
+        self.setObjectName(name)
+        self.addWidget(self._widget)
+        self.setContentsMargins(0, 0, 0, 0)
+
+    def add_widget(self, name, text, widget, location = "top"):
+        self._widget.add_widget(name, text, widget, location=location)

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -310,7 +310,9 @@ class QtStateButton(QtViewerPushButton):
         self._onstate = onstate
         self._offstate = offstate
         self._events = events
-        self._events.connect(self._on_change)
+        if events:
+            self._events.connect(self._on_change)
+
         self.clicked.connect(self.change)
         self._on_change()
 
@@ -320,6 +322,7 @@ class QtStateButton(QtViewerPushButton):
             newstate = self._onstate
         else:
             newstate = self._offstate
+
         setattr(self._target, self._attribute, newstate)
 
     def _on_change(self, event=None):
@@ -330,8 +333,9 @@ class QtStateButton(QtViewerPushButton):
         event : qtpy.QtCore.QEvent
             Event from the Qt context.
         """
-        with self._events.blocker():
-            if self.isChecked() != (
-                getattr(self._target, self._attribute) == self._onstate
-            ):
-                self.toggle()
+        if self._events:
+            with self._events.blocker():
+                if self.isChecked() != (
+                    getattr(self._target, self._attribute) == self._onstate
+                ):
+                    self.toggle()


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousando words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Related to https://github.com/napari/napari/issues/3653

Add an initial POC for sidebar implementation. This could be used for a couple of things:
- Add the help viewer to either side
- Move the plugin install/uninstall dialog to this place.

![sidebars](https://user-images.githubusercontent.com/3627835/115819448-73ffe600-a3c4-11eb-8492-bae05cde58ef.gif)

Any feedback is appreciated @napari/core-devs 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)


## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
