### PR TITLE
Support varying number of dimensions during labels painting

### DIFF
--- a/examples/paint-nd.py
+++ b/examples/paint-nd.py
@@ -18,7 +18,7 @@ blobs = np.stack(
     ],
     axis=0,
 )
-viewer = napari.view_image(blobs.astype(float))
+viewer = napari.view_image(blobs.astype(float), rendering='attenuated_mip')
 labels = viewer.add_labels(np.zeros_like(blobs, dtype=np.int32))
 labels.n_edit_dimensions = 3
 labels.brush_size = 15

--- a/examples/paint-nd.py
+++ b/examples/paint-nd.py
@@ -23,5 +23,6 @@ labels = viewer.add_labels(np.zeros_like(blobs, dtype=np.int32))
 labels.n_edit_dimensions = 3
 labels.brush_size = 15
 labels.mode = 'paint'
+labels.n_dimensional = True
 
 napari.run()

--- a/examples/paint-nd.py
+++ b/examples/paint-nd.py
@@ -1,0 +1,27 @@
+"""
+Display a 4D labels layer and paint only in 3D.
+
+This is useful e.g. when proofreading segmentations within a time series.
+"""
+
+import numpy as np
+from skimage import data
+import napari
+
+
+blobs = np.stack(
+    [
+        data.binary_blobs(
+            length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=f
+        )
+        for f in np.linspace(0.05, 0.5, 10)
+    ],
+    axis=0,
+)
+viewer = napari.view_image(blobs.astype(float))
+labels = viewer.add_labels(np.zeros_like(blobs, dtype=np.int32))
+labels.n_edit_dimensions = 3
+labels.brush_size = 15
+labels.mode = 'paint'
+
+napari.run()

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -78,7 +78,9 @@ class QtLabelsControls(QtLayerControls):
         )
         self.layer.events.brush_size.connect(self._on_brush_size_change)
         self.layer.events.contiguous.connect(self._on_contiguous_change)
-        self.layer.events.n_dimensional.connect(self._on_n_dimensional_change)
+        self.layer.events.n_edit_dimensions.connect(
+            self._on_n_edit_dimensions_change
+        )
         self.layer.events.contour.connect(self._on_contour_change)
         self.layer.events.editable.connect(self._on_editable_change)
         self.layer.events.preserve_labels.connect(
@@ -115,11 +117,15 @@ class QtLabelsControls(QtLayerControls):
         self.contigCheckBox = contig_cb
         self._on_contiguous_change()
 
-        ndim_cb = QCheckBox()
-        ndim_cb.setToolTip(trans._('edit all dimensions'))
-        ndim_cb.stateChanged.connect(self.change_ndim)
-        self.ndimCheckBox = ndim_cb
-        self._on_n_dimensional_change()
+        ndim_sb = QSpinBox()
+        self.ndimSpinBox = ndim_sb
+        ndim_sb.setToolTip(trans._('number of dimensions for label editing'))
+        ndim_sb.valueChanged.connect(self.change_n_edit_dim)
+        ndim_sb.setMinimum(2)
+        ndim_sb.setMaximum(self.layer.ndim)
+        ndim_sb.setSingleStep(1)
+        ndim_sb.setAlignment(Qt.AlignCenter)
+        self._on_n_edit_dimensions_change()
 
         contour_sb = QSpinBox()
         contour_sb.setToolTip(trans._('display contours of labels'))
@@ -331,18 +337,17 @@ class QtLabelsControls(QtLayerControls):
         else:
             self.layer.contiguous = False
 
-    def change_ndim(self, state):
-        """Toggle n-dimensional state of label layer.
+    def change_n_edit_dim(self, value):
+        """Change the number of editable dimensions of label layer.
 
         Parameters
         ----------
-        state : QCheckBox
-            Checkbox indicating if label layer is n-dimensional.
+        value : int
+            The number of editable dimensions to set.
         """
-        if state == Qt.Checked:
-            self.layer.n_dimensional = True
-        else:
-            self.layer.n_dimensional = False
+        self.layer.n_edit_dimensions = value
+        self.ndimSpinBox.clearFocus()
+        self.setFocus()
 
     def change_contour(self, value):
         """Change contour thickness.
@@ -417,7 +422,7 @@ class QtLabelsControls(QtLayerControls):
             value = np.clip(int(value), 1, 40)
             self.brushSizeSlider.setValue(value)
 
-    def _on_n_dimensional_change(self, event=None):
+    def _on_n_edit_dimensions_change(self, event=None):
         """Receive layer model n-dim mode change event and update the checkbox.
 
         Parameters
@@ -425,8 +430,9 @@ class QtLabelsControls(QtLayerControls):
         event : napari.utils.event.Event, optional
             The napari event that triggered this method.
         """
-        with self.layer.events.n_dimensional.blocker():
-            self.ndimCheckBox.setChecked(self.layer.n_dimensional)
+        with self.layer.events.n_edit_dimensions.blocker():
+            value = self.layer.n_edit_dimensions
+            self.ndimSpinBox.setValue(int(value))
 
     def _on_contiguous_change(self, event=None):
         """Receive layer model contiguous change event and update the checkbox.

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -248,19 +248,19 @@ class QtLabelsControls(QtLayerControls):
         self.grid_layout.addWidget(self.colorModeComboBox, 6, 1, 1, 3)
         self.grid_layout.addWidget(QLabel(trans._('contour:')), 7, 0, 1, 1)
         self.grid_layout.addWidget(self.contourSpinBox, 7, 1, 1, 1)
-        self.grid_layout.addWidget(QLabel(trans._('contiguous:')), 8, 0, 1, 1)
-        self.grid_layout.addWidget(self.contigCheckBox, 8, 1, 1, 1)
-        self.grid_layout.addWidget(QLabel(trans._('n-dim:')), 8, 2, 1, 1)
-        self.grid_layout.addWidget(self.ndimCheckBox, 8, 3, 1, 1)
+        self.grid_layout.addWidget(QLabel(trans._('n edit dim:')), 8, 0, 1, 1)
+        self.grid_layout.addWidget(self.ndimSpinBox, 8, 1, 1, 1)
+        self.grid_layout.addWidget(QLabel(trans._('contiguous:')), 9, 0, 1, 1)
+        self.grid_layout.addWidget(self.contigCheckBox, 9, 1, 1, 1)
         self.grid_layout.addWidget(
-            QLabel(trans._('preserve labels:')), 9, 0, 1, 2
+            QLabel(trans._('preserve labels:')), 10, 0, 1, 2
         )
-        self.grid_layout.addWidget(self.preserveLabelsCheckBox, 9, 1, 1, 1)
+        self.grid_layout.addWidget(self.preserveLabelsCheckBox, 10, 1, 1, 1)
         self.grid_layout.addWidget(
-            QLabel(trans._('show selected:')), 9, 2, 1, 1
+            QLabel(trans._('show selected:')), 10, 2, 1, 1
         )
-        self.grid_layout.addWidget(self.selectedColorCheckbox, 9, 3, 1, 1)
-        self.grid_layout.setRowStretch(9, 1)
+        self.grid_layout.addWidget(self.selectedColorCheckbox, 10, 3, 1, 1)
+        self.grid_layout.setRowStretch(10, 1)
         self.grid_layout.setColumnStretch(1, 1)
         self.grid_layout.setSpacing(4)
 

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -701,11 +701,11 @@ def test_paint_3d(brush_shape, expected_sum):
     layer.paint((10, 10, 10), 3)
 
     # Paint in 3D
-    layer.n_dimensional = True
+    layer.n_edit_dimensions = 3
     layer.paint((10, 25, 10), 4)
 
     # Paint in 3D, preserve labels
-    layer.n_dimensional = True
+    layer.n_edit_dimensions = 3
     layer.preserve_labels = True
     layer.paint((10, 15, 15), 5)
 
@@ -795,7 +795,7 @@ def test_undo_redo(
     layer.mode = mode
     layer.selected_label = selected_label
     layer.preserve_labels = preserve_labels
-    layer.n_dimensional = n_dimensional
+    layer.n_edit_dimensions = 3 if n_dimensional else 2
     coord = np.random.random((3,)) * (np.array(blobs.shape) - 1)
     while layer.data[tuple(coord.astype(int))] == 0 and np.any(layer.data):
         coord = np.random.random((3,)) * (np.array(blobs.shape) - 1)

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -808,3 +808,24 @@ def test_undo_redo(
     np.testing.assert_array_equal(layer.data, data_history[0])
     layer.redo()
     np.testing.assert_array_equal(layer.data, data_history[1])
+
+
+def test_ndim_fill():
+    test_array = np.zeros((5, 5, 5, 5), dtype=int)
+
+    test_array[:, 1:3, 1:3, 1:3] = 1
+
+    layer = Labels(test_array)
+    layer.n_edit_dimensions = 3
+
+    layer.fill((0, 1, 1, 1), 2)
+
+    np.testing.assert_equal(layer.data[0, 1:3, 1:3, 1:3], 2)
+    np.testing.assert_equal(layer.data[1, 1:3, 1:3, 1:3], 1)
+
+    layer.n_edit_dimensions = 4
+
+    layer.fill((1, 1, 1, 1), 3)
+
+    np.testing.assert_equal(layer.data[0, 1:3, 1:3, 1:3], 2)
+    np.testing.assert_equal(layer.data[1:, 1:3, 1:3, 1:3], 3)

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -831,3 +831,32 @@ def test_ndim_fill():
 
     np.testing.assert_equal(layer.data[0, 1:3, 1:3, 1:3], 2)
     np.testing.assert_equal(layer.data[1:, 1:3, 1:3, 1:3], 3)
+
+
+def test_ndim_paint():
+    test_array = np.zeros((5, 6, 7, 8), dtype=int)
+    layer = Labels(test_array)
+    layer.n_edit_dimensions = 3
+    layer.brush_shape = 'circle'
+    layer.brush_size = 2  # equivalent to 18-connected 3D neighborhood
+    layer.paint((1, 1, 1, 1), 1)
+
+    assert np.sum(layer.data) == 19  # 18 + center
+    assert not np.any(layer.data[0]) and not np.any(layer.data[2:])
+
+    layer.n_edit_dimensions = 2  # 3x3 square
+    layer._dims_order = [1, 2, 0, 3]
+    layer.paint((4, 5, 6, 7), 8)
+    assert len(np.flatnonzero(layer.data == 8)) == 4  # 2D square is in corner
+    np.testing.assert_array_equal(
+        test_array[:, 5, 6, :],
+        np.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 8, 8],
+                [0, 0, 0, 0, 0, 0, 8, 8],
+            ]
+        ),
+    )

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -416,15 +416,17 @@ def test_contiguous():
     assert layer.contiguous is False
 
 
-def test_n_dimensional():
-    """Test changing n_dimensional."""
+def test_n_edit_dimensions():
+    """Test changing the number of editable dimensions."""
     np.random.seed(0)
-    data = np.random.randint(20, size=(10, 15))
+    data = np.random.randint(20, size=(5, 10, 15))
     layer = Labels(data)
-    assert layer.n_dimensional is False
-
-    layer.n_dimensional = True
-    assert layer.n_dimensional is True
+    layer.n_edit_dimensions = 2
+    with pytest.warns(FutureWarning):
+        assert layer.n_dimensional is False
+    layer.n_edit_dimensions = 3
+    with pytest.warns(FutureWarning):
+        assert layer.n_dimensional is True
 
 
 @pytest.mark.parametrize(

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -280,7 +280,7 @@ class Labels(_image_base_class):
             category=FutureWarning,
             stacklevel=2,
         )
-        return self._n_edit_dimensions == self.ndim
+        return self._n_edit_dimensions == self.ndim and self.ndim > 2
 
     @n_dimensional.setter
     def n_dimensional(self, n_dimensional):
@@ -992,7 +992,7 @@ class Labels(_image_base_class):
         shape = self.data.shape
         if str(self._brush_shape) == "square":
             brush_size_dims = [self.brush_size] * self.ndim
-            if not self.n_dimensional and self.ndim > 2:
+            if self.n_edit_dimensions == 2 and self.ndim > 2:
                 for i in self._dims_not_displayed:
                     brush_size_dims[i] = 1
 
@@ -1014,7 +1014,7 @@ class Labels(_image_base_class):
             slice_coord = indices_in_shape(slice_coord, shape)
         elif str(self._brush_shape) == "circle":
             slice_coord = [int(np.round(c)) for c in coord]
-            if not self.n_dimensional and self.ndim > 2:
+            if self.n_edit_dimensions == 2 and self.ndim > 2:
                 coord = [coord[i] for i in self._dims_displayed]
                 shape = [shape[i] for i in self._dims_displayed]
 
@@ -1032,7 +1032,7 @@ class Labels(_image_base_class):
             # Transfer valid coordinates to slice_coord,
             # or expand coordinate if 3rd dim in 2D image
             slice_coord_temp = [m for m in mask_indices.T]
-            if not self.n_dimensional and self.ndim > 2:
+            if self.n_edit_dimensions == 2 and self.ndim > 2:
                 for j, i in enumerate(self._dims_displayed):
                     slice_coord[i] = slice_coord_temp[j]
                 for i in self._dims_not_displayed:

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -11,6 +11,7 @@ from ...utils.colormaps import (
     low_discrepancy_image,
 )
 from ...utils.events import Event
+from ...utils.events.event import WarningEmitter
 from ...utils.translations import trans
 from ..image._image_utils import guess_multiscale
 from ..image.image import _get_image_base_class
@@ -228,7 +229,13 @@ class Labels(_image_base_class):
             mode=Event,
             preserve_labels=Event,
             properties=Event,
-            n_dimensional=Event,
+            n_dimensional=WarningEmitter(
+                trans._(
+                    "'Labels.events.n_dimensional' is deprecated and will be removed in napari v0.4.9. Use 'Labels.event.n_edit_dimensions' instead.",
+                    deferred=True,
+                ),
+                type='n_dimensional',
+            ),
             n_edit_dimensions=Event,
             contiguous=Event,
             brush_size=Event,

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -295,9 +295,9 @@ class Labels(_image_base_class):
             stacklevel=2,
         )
         if n_dimensional:
-            self._n_edit_dimensions = self.ndim
+            self.n_edit_dimensions = self.ndim
         else:
-            self._n_edit_dimensions = 2
+            self.n_edit_dimensions = 2
         self.events.n_dimensional()
 
     @property

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -281,8 +281,7 @@ class Labels(_image_base_class):
         """bool: paint and fill edits labels across all dimensions."""
         warnings.warn(
             trans._(
-                'Labels.n_dimensional is deprecated. '
-                'Use Labels.n_edit_dimensions instead.',
+                'Labels.n_dimensional is deprecated. Use Labels.n_edit_dimensions instead.',
                 deferred=True,
             ),
             category=FutureWarning,
@@ -294,8 +293,7 @@ class Labels(_image_base_class):
     def n_dimensional(self, n_dimensional):
         warnings.warn(
             trans._(
-                'Labels.n_dimensional is deprecated. '
-                'Use Labels.n_edit_dimensions instead.',
+                'Labels.n_dimensional is deprecated. Use Labels.n_edit_dimensions instead.',
                 deferred=True,
             ),
             category=FutureWarning,

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -229,6 +229,7 @@ class Labels(_image_base_class):
             preserve_labels=Event,
             properties=Event,
             n_dimensional=Event,
+            n_edit_dimensions=Event,
             contiguous=Event,
             brush_size=Event,
             selected_label=Event,
@@ -237,7 +238,7 @@ class Labels(_image_base_class):
             contour=Event,
         )
 
-        self._n_dimensional = False
+        self._n_edit_dimensions = 2
         self._contiguous = True
         self._brush_size = 10
 
@@ -271,12 +272,40 @@ class Labels(_image_base_class):
     @property
     def n_dimensional(self):
         """bool: paint and fill edits labels across all dimensions."""
-        return self._n_dimensional
+        warnings.warn(
+            trans._(
+                'Labels.n_dimensional is deprecated. '
+                'Use Labels.n_edit_dimensions instead.'
+            ),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        return self._n_edit_dimensions == self.ndim
 
     @n_dimensional.setter
     def n_dimensional(self, n_dimensional):
-        self._n_dimensional = n_dimensional
+        warnings.warn(
+            trans._(
+                'Labels.n_dimensional is deprecated. '
+                'Use Labels.n_edit_dimensions instead.'
+            ),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        if n_dimensional:
+            self._n_edit_dimensions = self.ndim
+        else:
+            self._n_edit_dimensions = 2
         self.events.n_dimensional()
+
+    @property
+    def n_edit_dimensions(self):
+        return self._n_edit_dimensions
+
+    @n_edit_dimensions.setter
+    def n_edit_dimensions(self, n_edit_dimensions):
+        self._n_edit_dimensions = n_edit_dimensions
+        self.events.n_edit_dimensions()
 
     @property
     def contour(self):

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -275,7 +275,8 @@ class Labels(_image_base_class):
         warnings.warn(
             trans._(
                 'Labels.n_dimensional is deprecated. '
-                'Use Labels.n_edit_dimensions instead.'
+                'Use Labels.n_edit_dimensions instead.',
+                deferred=True,
             ),
             category=FutureWarning,
             stacklevel=2,
@@ -287,7 +288,8 @@ class Labels(_image_base_class):
         warnings.warn(
             trans._(
                 'Labels.n_dimensional is deprecated. '
-                'Use Labels.n_edit_dimensions instead.'
+                'Use Labels.n_edit_dimensions instead.',
+                deferred=True,
             ),
             category=FutureWarning,
             stacklevel=2,

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -991,6 +991,7 @@ class Labels(_image_base_class):
         """
         shape = self.data.shape
         dims_to_paint = self._dims_order[-self.n_edit_dimensions :]
+        dims_not_painted = self._dims_order[: -self.n_edit_dimensions]
         if str(self._brush_shape) == "square":
             brush_size_dims = [self.brush_size] * self.ndim
             if self.n_edit_dimensions < self.ndim:
@@ -1039,9 +1040,9 @@ class Labels(_image_base_class):
             # or expand coordinate if 3rd dim in 2D image
             slice_coord_temp = [m for m in mask_indices.T]
             if self.n_edit_dimensions < self.ndim:
-                for j, i in enumerate(self._dims_displayed):
+                for j, i in enumerate(dims_to_paint):
                     slice_coord[i] = slice_coord_temp[j]
-                for i in self._dims_not_displayed:
+                for i in dims_not_painted:
                     slice_coord[i] = slice_coord[i] * np.ones(
                         mask_indices.shape[0], dtype=int
                     )


### PR DESCRIPTION
# Description

While proofreading segmentations of 3D+t data, @AbigailMcGovern and I realised that we wanted to be able to load a 4D dataset but proofread in 3D, since you typically don't want painting to propagate in time except for very slow-moving objects.

This PR changes the `n-dimensional` property of the labels layer in favour of `n_edit_dimensions`, the number of dimensions affected by edit operations (fill, paint, and by extension, erase).

A video of it in action. While recording it I thought it might be fun to paint in 4D over time, and I was right. 😃


https://user-images.githubusercontent.com/492549/115872167-d8827a00-a484-11eb-95be-9ba9f93a2e17.mov

