### PR TITLE
Fix z-index of notifications (hidden by welcome window)

### DIFF
--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -88,9 +88,11 @@ class NapariQtNotification(QDialog):
                     # TODO: making the canvas the parent makes it easier to
                     # move/resize, but also means that the notification can get
                     # clipped on the left if the canvas is too small.
-                    canvas = wdg.centralWidget().children()[1].canvas.native
-                    self.setParent(canvas)
-                    canvas.resized.connect(self.move_to_bottom_right)
+                    qt_viewer = wdg.centralWidget().children()[1]
+                    self.setParent(qt_viewer._canvas_overlay)
+                    qt_viewer._canvas_overlay.resized.connect(
+                        self.move_to_bottom_right
+                    )
                     break
                 except Exception:
                     pass

--- a/napari/_qt/widgets/qt_welcome.py
+++ b/napari/_qt/widgets/qt_welcome.py
@@ -150,6 +150,7 @@ class QtWidgetOverlay(QStackedWidget):
     """
 
     sig_dropped = Signal("QEvent")
+    resized = Signal()
 
     def __init__(self, parent, widget):
         super().__init__(parent)
@@ -167,3 +168,7 @@ class QtWidgetOverlay(QStackedWidget):
     def set_welcome_visible(self, visible=True):
         """Show welcome screen widget on stack."""
         self.setCurrentIndex(int(visible))
+
+    def resizeEvent(self, event):
+        self.resized.emit()
+        return super().resizeEvent(event)


### PR DESCRIPTION
# Description
Because notifications were parented on the vispy canvas object, since #2542, notifications are now no longer showing unless a layer has been added, and the stacked widget is flipped.

This is a small PR that reparents the notification popups so that they show even when the welcome window is in front.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
