### PR TITLE
Disconnect some event on Canvas destruction.

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -282,7 +282,15 @@ class QtViewer(QSplitter):
         self.canvas.connect(self.on_draw)
         self.canvas.connect(self.on_resize)
         self.canvas.bgcolor = get_theme(self.viewer.theme)['canvas']
-        self.viewer.events.theme.connect(self.canvas._on_theme_change)
+        theme = self.viewer.events.theme
+
+        on_theme_change = self.canvas._on_theme_change
+        theme.connect(on_theme_change)
+
+        def disconnect():
+            theme.disconnect(on_theme_change)
+
+        self.canvas.destroyed.connect(disconnect)
 
     def _add_visuals(self) -> None:
         """Add visuals for axes, scale bar, and welcome text."""

--- a/napari/_vispy/vispy_axes_visual.py
+++ b/napari/_vispy/vispy_axes_visual.py
@@ -204,6 +204,16 @@ class VispyAxesVisual:
         self.text_node.anchors = ('center', 'center')
         self.text_node.text = f'{1}'
 
+        # Note:
+        # There are issues on MacOS + GitHub action about destroyed
+        # C/C++ object during test if those don't get disconnected.
+        def set_none():
+            self.node._set_canvas(None)
+            self.text_node._set_canvas(None)
+
+        self.node.canvas._backend.destroyed.connect(set_none)
+        # End Note
+
         self._viewer.events.theme.connect(self._on_data_change)
         self._viewer.axes.events.visible.connect(self._on_visible_change)
         self._viewer.axes.events.colored.connect(self._on_data_change)

--- a/napari/_vispy/vispy_canvas.py
+++ b/napari/_vispy/vispy_canvas.py
@@ -39,6 +39,10 @@ class VispyCanvas(SceneCanvas):
         self.context.set_depth_func('lequal')
 
     @property
+    def destroyed(self):
+        return self._backend.destroyed
+
+    @property
     def background_color_override(self):
         return self._background_color_override
 

--- a/napari/_vispy/vispy_scale_bar_visual.py
+++ b/napari/_vispy/vispy_scale_bar_visual.py
@@ -49,6 +49,19 @@ class VispyScaleBarVisual:
         self.text_node.anchors = ("center", "center")
         self.text_node.text = f"{1}px"
 
+        # Note:
+        # There are issues on MacOS + GitHub action about destroyed
+        # C/C++ object during test if those don't get disconnected.
+        def set_none():
+            self.node._set_canvas(None)
+            self.text_node._set_canvas(None)
+
+        # the two canvas are not the same object, better be safe.
+        self.node.canvas._backend.destroyed.connect(set_none)
+        self.text_node.canvas._backend.destroyed.connect(set_none)
+        assert self.node.canvas is self.text_node.canvas
+        # End Note
+
         self._viewer.events.theme.connect(self._on_data_change)
         self._viewer.scale_bar.events.visible.connect(self._on_visible_change)
         self._viewer.scale_bar.events.colored.connect(self._on_data_change)


### PR DESCRIPTION
Extracted from https://github.com/napari/napari/pull/2612,
see some of the failing tests from the previous commits in above PRs.

Vispy seem to internally use weakrefs so that once the canvas is destroyed, event are not sent,
my guess is in above PR is likely keeping extra references around, leading to typical
error warnings that the C++ object have already been destroyed.

This seem to fix the errors on the action manager PRs, I'm unsure if
that would be the right fixes, but at least that should help to start
the discussion if something else keep those around.

In the Qt viewer I guess we could also set self.canvas to None is that's
desirable. I don't like accessing vispy private API either but have not
found any other ways.

I'm unsure how to test; as I'm unsure what does keep a reference
around in #2612.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


----  

<details>
    <summary>Error 1 (and 2 with self.node_text instead of self.node) see https://github.com/napari/napari/runs/2424001664 </summary>

          =================================== FAILURES ===================================
          ______________________ test_viewer_methods[toggle_theme] _______________________
          
          make_napari_viewer = <function make_napari_viewer.<locals>.actual_factory at 0x156a17a60>
          func = <function toggle_theme at 0x12398c280>
          
              @pytest.mark.parametrize('func', viewer_methods)
              def test_viewer_methods(make_napari_viewer, func):
                  """Test instantiating viewer."""
                  viewer = make_napari_viewer()
              
                  if func.__name__ == 'toggle_fullscreen' and not os.getenv("CI"):
                      pytest.skip("Fullscreen cannot be tested in CI")
                  if func.__name__ == 'play':
                      pytest.skip("Play cannot be tested with Pytest")
          >       func(viewer)
          
          napari/_tests/test_viewer.py:52: 
          _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
          napari/components/_viewer_key_bindings.py:63: in toggle_theme
              SETTINGS.appearance.theme = themes[idx]
          napari/utils/events/evented_model.py:155: in __setattr__
              getattr(self.events, name)(value=after)  # emit event
          napari/utils/events/event.py:573: in __call__
              self._invoke_callback(cb, event)
          napari/utils/events/event.py:595: in _invoke_callback
              _handle_exception(
          napari/utils/events/event.py:593: in _invoke_callback
              cb(event)
          napari/_qt/qt_main_window.py:1254: in _update_theme
              self.qt_viewer.viewer.theme = value
          napari/components/viewer_model.py:307: in __setattr__
              return super().__setattr__(name, value)
          napari/utils/events/evented_model.py:155: in __setattr__
              getattr(self.events, name)(value=after)  # emit event
          napari/utils/events/event.py:573: in __call__
              self._invoke_callback(cb, event)
          napari/utils/events/event.py:595: in _invoke_callback
              _handle_exception(
          napari/utils/events/event.py:593: in _invoke_callback
              cb(event)
          napari/_vispy/vispy_scale_bar_visual.py:118: in _on_data_change
              self.node.set_data(data, color)
          /tmp/.tox/py38-macos-pyqt/lib/python3.8/site-packages/vispy/visuals/line/line.py:192: in set_data
              self.update()
          /tmp/.tox/py38-macos-pyqt/lib/python3.8/site-packages/vispy/scene/node.py:333: in update
              c.update(node=self)
          /tmp/.tox/py38-macos-pyqt/lib/python3.8/site-packages/vispy/scene/canvas.py:200: in update
              super(SceneCanvas, self).update()
          /tmp/.tox/py38-macos-pyqt/lib/python3.8/site-packages/vispy/app/canvas.py:442: in update
              self._backend._vispy_update()
          _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
          
          self = <vispy.app.backends._qt.CanvasBackendDesktop object at 0x14c860940>
          
              def _vispy_update(self):
                  if self._vispy_canvas is None:
                      return
                  # Invoke a redraw
          >       self.update()
          E       RuntimeError: wrapped C/C++ object of type CanvasBackendDesktop has been deleted
          
          /tmp/.tox/py38-macos-pyqt/lib/python3.8/site-packages/vispy/app/backends/_qt.py:427: RuntimeError

</details>

<details>
    <summary>Error 3 see https://github.com/napari/napari/runs/2433265462 </summary>
        _____________________________ test_changing_theme ______________________________
          
          make_napari_viewer = <function make_napari_viewer.<locals>.actual_factory at 0x17740f820>
          
              def test_changing_theme(make_napari_viewer):
                  """Test changing the theme updates the full window."""
                  viewer = make_napari_viewer(show=False)
                  viewer.window.qt_viewer.set_welcome_visible(False)
                  viewer.add_points(data=None)
                  size = viewer.window.qt_viewer.size()
                  viewer.window.qt_viewer.setFixedSize(size)
              
                  assert viewer.theme == 'dark'
                  screenshot_dark = viewer.screenshot(canvas_only=False)
              
          >       viewer.theme = 'light'
          
          napari/_tests/test_viewer.py:180: 
          _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
          napari/components/viewer_model.py:307: in __setattr__
              return super().__setattr__(name, value)
          napari/utils/events/evented_model.py:155: in __setattr__
              getattr(self.events, name)(value=after)  # emit event
          napari/utils/events/event.py:573: in __call__
              self._invoke_callback(cb, event)
          napari/utils/events/event.py:595: in _invoke_callback
              _handle_exception(
          napari/utils/events/event.py:593: in _invoke_callback
              cb(event)
          napari/_qt/qt_main_window.py:1253: in _update_theme
              SETTINGS.appearance.theme = value
          napari/utils/events/evented_model.py:155: in __setattr__
              getattr(self.events, name)(value=after)  # emit event
          napari/utils/events/event.py:573: in __call__
              self._invoke_callback(cb, event)
          napari/utils/events/event.py:595: in _invoke_callback
              _handle_exception(
          napari/utils/events/event.py:593: in _invoke_callback
              cb(event)
          napari/_qt/qt_main_window.py:1254: in _update_theme
              self.qt_viewer.viewer.theme = value
          napari/components/viewer_model.py:307: in __setattr__
              return super().__setattr__(name, value)
          napari/utils/events/evented_model.py:155: in __setattr__
              getattr(self.events, name)(value=after)  # emit event
          napari/utils/events/event.py:573: in __call__
              self._invoke_callback(cb, event)
          napari/utils/events/event.py:595: in _invoke_callback
              _handle_exception(
          napari/utils/events/event.py:593: in _invoke_callback
              cb(event)
          napari/_vispy/vispy_scale_bar_visual.py:118: in _on_data_change
              self.node.set_data(data, color)
          /tmp/.tox/py38-macos-pyqt/lib/python3.8/site-packages/vispy/visuals/line/line.py:192: in set_data
              self.update()
          /tmp/.tox/py38-macos-pyqt/lib/python3.8/site-packages/vispy/scene/node.py:333: in update
              c.update(node=self)
          /tmp/.tox/py38-macos-pyqt/lib/python3.8/site-packages/vispy/scene/canvas.py:200: in update
              super(SceneCanvas, self).update()
          /tmp/.tox/py38-macos-pyqt/lib/python3.8/site-packages/vispy/app/canvas.py:442: in update
              self._backend._vispy_update()
          _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
          
          self = <vispy.app.backends._qt.CanvasBackendDesktop object at 0x1533d5280>
          
              def _vispy_update(self):
                  if self._vispy_canvas is None:
                      return
                  # Invoke a redraw
          >       self.update()
          E       RuntimeError: wrapped C/C++ object of type CanvasBackendDesktop has been deleted
          
          /tmp/.tox/py38-macos-pyqt/lib/python3.8/site-packages/vispy/app/backends/_qt.py:427: RuntimeError
</details>




