### PR TITLE
add missing QSpinBox import in Labels layer controls

### DIFF
--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -8,6 +8,7 @@ from qtpy.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QSlider,
+    QSpinBox,
     QWidget,
 )
 


### PR DESCRIPTION
# Description
This PR adds back in a missing import in the Labels layer controls (issue described in #2618 )

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Fixes #2618 

# How has this been tested?
- [ ] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
