### PR TITLE
Fix notifications when something other than napari or ipython creates QApp

### DIFF
--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -150,6 +150,7 @@ def get_app(
         app.setOrganizationDomain(kwargs.get('org_domain'))
         set_app_id(kwargs.get('app_id'))
 
+    if not _ipython_has_eventloop():
         notification_manager.notification_ready.connect(
             NapariQtNotification.show_notification
         )


### PR DESCRIPTION
# Description
fixes #2631 
This PR makes it so that notifications are shown in the GUI/console (according to settings), if _anything but_ IPython has the event loop (whereas the previous behavior was to _hide_ notifications if anything but napari itself created the app ... which created problems in certain magicgui cases)

While both of these connections are configurable via `SETTINGS.application.gui_notification_level` and `SETTINGS.application.console_notification_level`... we can't yet expose them in the preferences window because Enum's aren't working in the preferences window yet.  cc @goanpeca @ppwadhwa  (I'll make a new issue for that: #2634 )