### PR TITLE
add _QtMainWindow.current

### DIFF
--- a/napari/_qt/_tests/test_qt_window.py
+++ b/napari/_qt/_tests/test_qt_window.py
@@ -2,8 +2,8 @@ from napari import Viewer
 from napari._qt.qt_main_window import _QtMainWindow
 
 
-def test_active_viewer(make_napari_viewer, qapp):
-    """Test that we can retrieve the "active" viewer instance easily.
+def test_current_viewer(make_napari_viewer, qapp):
+    """Test that we can retrieve the "current" viewer instance easily.
 
     ... where "current" means it was the last viewer the user interacted with.
     """

--- a/napari/_qt/_tests/test_qt_window.py
+++ b/napari/_qt/_tests/test_qt_window.py
@@ -2,7 +2,7 @@ from napari._qt.qt_main_window import _QtMainWindow
 
 
 def test_current_viewer(make_napari_viewer, qapp):
-    """Test that we can retrieve the "current" viewer instance easily.
+    """Test that we can retrieve the "current" viewer window easily.
 
     ... where "current" means it was the last viewer the user interacted with.
     """

--- a/napari/_qt/_tests/test_qt_window.py
+++ b/napari/_qt/_tests/test_qt_window.py
@@ -1,0 +1,41 @@
+from napari import Viewer
+from napari._qt.qt_main_window import _QtMainWindow
+
+
+def test_active_viewer(make_napari_viewer, qapp):
+    """Test that we can retrieve the "active" viewer instance easily.
+
+    ... where "active" means it was the last viewer the user interacted with.
+    """
+    assert Viewer.active() is None
+    assert _QtMainWindow.current() is None
+
+    # when we create a new viewer it becomes accessible at Viewer.active()
+    v1 = make_napari_viewer(title='v1')
+    assert Viewer.active() == v1
+    assert _QtMainWindow._instances == [v1.window._qt_window]
+    assert _QtMainWindow.current() == v1.window._qt_window
+
+    v2 = make_napari_viewer(title='v2')
+    assert Viewer.active() == v2
+    assert _QtMainWindow._instances == [
+        v1.window._qt_window,
+        v2.window._qt_window,
+    ]
+
+    # Viewer.active() will always give the most recently activated viewer.
+    v1.window.activate()
+    assert Viewer.active() == v1
+    v2.window.activate()
+    assert Viewer.active() == v2
+
+    # The list remembers the z-order of previous viewers ...
+    v2.close()
+    assert Viewer.active() == v1
+    assert _QtMainWindow._instances == [v1.window._qt_window]
+
+    # and when none are left, Viewer.active() becomes None again
+    v1.close()
+    assert Viewer.active() is None
+    assert _QtMainWindow._instances == []
+    assert _QtMainWindow.current() is None

--- a/napari/_qt/_tests/test_qt_window.py
+++ b/napari/_qt/_tests/test_qt_window.py
@@ -5,7 +5,7 @@ from napari._qt.qt_main_window import _QtMainWindow
 def test_active_viewer(make_napari_viewer, qapp):
     """Test that we can retrieve the "active" viewer instance easily.
 
-    ... where "active" means it was the last viewer the user interacted with.
+    ... where "current" means it was the last viewer the user interacted with.
     """
     assert Viewer.current() is None
     assert _QtMainWindow.current() is None

--- a/napari/_qt/_tests/test_qt_window.py
+++ b/napari/_qt/_tests/test_qt_window.py
@@ -7,35 +7,35 @@ def test_active_viewer(make_napari_viewer, qapp):
 
     ... where "active" means it was the last viewer the user interacted with.
     """
-    assert Viewer.active() is None
+    assert Viewer.current() is None
     assert _QtMainWindow.current() is None
 
-    # when we create a new viewer it becomes accessible at Viewer.active()
+    # when we create a new viewer it becomes accessible at Viewer.current()
     v1 = make_napari_viewer(title='v1')
-    assert Viewer.active() == v1
+    assert Viewer.current() == v1
     assert _QtMainWindow._instances == [v1.window._qt_window]
     assert _QtMainWindow.current() == v1.window._qt_window
 
     v2 = make_napari_viewer(title='v2')
-    assert Viewer.active() == v2
+    assert Viewer.current() == v2
     assert _QtMainWindow._instances == [
         v1.window._qt_window,
         v2.window._qt_window,
     ]
 
-    # Viewer.active() will always give the most recently activated viewer.
+    # Viewer.current() will always give the most recently activated viewer.
     v1.window.activate()
-    assert Viewer.active() == v1
+    assert Viewer.current() == v1
     v2.window.activate()
-    assert Viewer.active() == v2
+    assert Viewer.current() == v2
 
     # The list remembers the z-order of previous viewers ...
     v2.close()
-    assert Viewer.active() == v1
+    assert Viewer.current() == v1
     assert _QtMainWindow._instances == [v1.window._qt_window]
 
-    # and when none are left, Viewer.active() becomes None again
+    # and when none are left, Viewer.current() becomes None again
     v1.close()
-    assert Viewer.active() is None
+    assert Viewer.current() is None
     assert _QtMainWindow._instances == []
     assert _QtMainWindow.current() is None

--- a/napari/_qt/_tests/test_qt_window.py
+++ b/napari/_qt/_tests/test_qt_window.py
@@ -1,4 +1,3 @@
-from napari import Viewer
 from napari._qt.qt_main_window import _QtMainWindow
 
 
@@ -7,35 +6,32 @@ def test_current_viewer(make_napari_viewer, qapp):
 
     ... where "current" means it was the last viewer the user interacted with.
     """
-    assert Viewer.current() is None
     assert _QtMainWindow.current() is None
 
     # when we create a new viewer it becomes accessible at Viewer.current()
     v1 = make_napari_viewer(title='v1')
-    assert Viewer.current() == v1
     assert _QtMainWindow._instances == [v1.window._qt_window]
     assert _QtMainWindow.current() == v1.window._qt_window
 
     v2 = make_napari_viewer(title='v2')
-    assert Viewer.current() == v2
     assert _QtMainWindow._instances == [
         v1.window._qt_window,
         v2.window._qt_window,
     ]
+    assert _QtMainWindow.current() == v2.window._qt_window
 
     # Viewer.current() will always give the most recently activated viewer.
     v1.window.activate()
-    assert Viewer.current() == v1
+    assert _QtMainWindow.current() == v1.window._qt_window
     v2.window.activate()
-    assert Viewer.current() == v2
+    assert _QtMainWindow.current() == v2.window._qt_window
 
     # The list remembers the z-order of previous viewers ...
     v2.close()
-    assert Viewer.current() == v1
+    assert _QtMainWindow.current() == v1.window._qt_window
     assert _QtMainWindow._instances == [v1.window._qt_window]
 
     # and when none are left, Viewer.current() becomes None again
     v1.close()
-    assert Viewer.current() is None
     assert _QtMainWindow._instances == []
     assert _QtMainWindow.current() is None

--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -18,7 +18,6 @@ from qtpy.QtWidgets import (
     QGraphicsOpacityEffect,
     QHBoxLayout,
     QLabel,
-    QMainWindow,
     QPushButton,
     QSizePolicy,
     QTextEdit,
@@ -77,25 +76,16 @@ class NapariQtNotification(QDialog):
         source: Optional[str] = None,
         actions: ActionSequence = (),
     ):
-        """[summary]"""
-        super().__init__(None)
+        super().__init__()
 
-        # FIXME: this does not work with multiple viewers.
-        # we need a way to detect the viewer in which the error occured.
-        for wdg in QApplication.topLevelWidgets():
-            if isinstance(wdg, QMainWindow):
-                try:
-                    # TODO: making the canvas the parent makes it easier to
-                    # move/resize, but also means that the notification can get
-                    # clipped on the left if the canvas is too small.
-                    qt_viewer = wdg.centralWidget().children()[1]
-                    self.setParent(qt_viewer._canvas_overlay)
-                    qt_viewer._canvas_overlay.resized.connect(
-                        self.move_to_bottom_right
-                    )
-                    break
-                except Exception:
-                    pass
+        from ..qt_main_window import _QtMainWindow
+
+        current_window = _QtMainWindow.current()
+        if current_window is not None:
+            canvas = current_window.qt_viewer._canvas_overlay
+            self.setParent(canvas)
+            canvas.resized.connect(self.move_to_bottom_right)
+
         self.setupUi()
         self.setAttribute(Qt.WA_DeleteOnClose)
         self.setup_buttons(actions)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1235,10 +1235,8 @@ class Window:
 
     def activate(self):
         """Make the viewer the currently active window."""
-        print("activationg")
         self._qt_window.activateWindow()  # for Windows
         self._qt_window.raise_()  # for macOS
-        print("activation222")
 
     def _update_theme(self, event=None):
         """Update widget color theme."""

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1247,8 +1247,8 @@ class Window:
 
     def activate(self):
         """Make the viewer the currently active window."""
-        self._qt_window.activateWindow()  # for Windows
         self._qt_window.raise_()  # for macOS
+        self._qt_window.activateWindow()  # for Windows
 
     def _update_theme(self, event=None):
         """Update widget color theme."""

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -93,8 +93,8 @@ class _QtMainWindow(QMainWindow):
                 _QtMainWindow._instances.remove(self)
             except ValueError:
                 pass
-        if e.type() == QEvent.WindowActivate:
-            # upon activation, put window at the end of the instances list
+        if e.type() in {QEvent.WindowActivate, QEvent.ZOrderChange}:
+            # upon activation or raise_, put window at the end of _instances
             try:
                 inst = _QtMainWindow._instances
                 inst.append(inst.pop(inst.index(self)))
@@ -1234,8 +1234,10 @@ class Window:
 
     def activate(self):
         """Make the viewer the currently active window."""
-        self._qt_window.raise_()  # for macOS
+        print("activationg")
         self._qt_window.activateWindow()  # for Windows
+        self._qt_window.raise_()  # for macOS
+        print("activation222")
 
     def _update_theme(self, event=None):
         """Update widget color theme."""

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -55,9 +55,9 @@ class _QtMainWindow(QMainWindow):
     # *no* active windows, so we want to track the most recently active windows
     _instances: ClassVar[List['_QtMainWindow']] = []
 
-    def __init__(self, viewer, parent=None) -> None:
+    def __init__(self, qt_viewer: QtViewer, parent=None) -> None:
         super().__init__(parent)
-        self._viewer = viewer
+        self.qt_viewer = qt_viewer
 
         self._quit_app = False
         self.setWindowIcon(QIcon(self._window_icon))
@@ -65,8 +65,11 @@ class _QtMainWindow(QMainWindow):
         self.setUnifiedTitleAndToolBarOnMac(True)
         center = QWidget(self)
         center.setLayout(QHBoxLayout())
+        center.layout().addWidget(qt_viewer)
         center.layout().setContentsMargins(4, 0, 4, 0)
         self.setCentralWidget(center)
+
+        self.setWindowTitle(qt_viewer.viewer.title)
 
         self._maximized_flag = False
         self._preferences_dialog = None
@@ -314,10 +317,8 @@ class Window:
         self._unnamed_dockwidget_count = 1
 
         # Connect the Viewer and create the Main Window
-        self._qt_window = _QtMainWindow(viewer)
         self.qt_viewer = QtViewer(viewer, show_welcome_screen=True)
-        self._qt_window.centralWidget().layout().addWidget(self.qt_viewer)
-        self._qt_window.setWindowTitle(viewer.title)
+        self._qt_window = _QtMainWindow(self.qt_viewer)
         self._status_bar = self._qt_window.statusBar()
 
         # Dictionary holding dock widgets

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from .components import ViewerModel
 from .utils import config
@@ -118,3 +118,11 @@ class Viewer(ViewerModel):
             # https://github.com/napari/napari/issues/1500
             for layer in self.layers:
                 chunk_loader.on_layer_deleted(layer)
+
+    @classmethod
+    def active(cls) -> Optional['Viewer']:
+        """Return the currently active viewer instance, if there is one."""
+        from ._qt.qt_main_window import _QtMainWindow
+
+        current_window = _QtMainWindow.current()
+        return current_window._viewer if current_window else None

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -120,8 +120,12 @@ class Viewer(ViewerModel):
                 chunk_loader.on_layer_deleted(layer)
 
     @classmethod
-    def active(cls) -> Optional['Viewer']:
-        """Return the currently active viewer instance, if there is one."""
+    def current(cls) -> Optional['Viewer']:
+        """Return the current ("active") viewer instance, if there is one.
+
+        In the case where the Qt app is in the background (i.e. all inactive),
+        this will be the last viewer that the user interacted with.
+        """
         from ._qt.qt_main_window import _QtMainWindow
 
         current_window = _QtMainWindow.current()

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from .components import ViewerModel
 from .utils import config
@@ -118,15 +118,3 @@ class Viewer(ViewerModel):
             # https://github.com/napari/napari/issues/1500
             for layer in self.layers:
                 chunk_loader.on_layer_deleted(layer)
-
-    @classmethod
-    def current(cls) -> Optional['Viewer']:
-        """Return the current ("active") viewer instance, if there is one.
-
-        In the case where the Qt app is in the background (i.e. all inactive),
-        this will be the last viewer that the user interacted with.
-        """
-        from ._qt.qt_main_window import _QtMainWindow
-
-        current_window = _QtMainWindow.current()
-        return current_window.qt_viewer.viewer if current_window else None

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -125,4 +125,4 @@ class Viewer(ViewerModel):
         from ._qt.qt_main_window import _QtMainWindow
 
         current_window = _QtMainWindow.current()
-        return current_window._viewer if current_window else None
+        return current_window.qt_viewer.viewer if current_window else None


### PR DESCRIPTION
# Description
Addresses the increasingly common issue of needing to know what the currently active viewer is.

As a reminder, it's slightly trickier than just calling `QApplication.activeWindow()`, because when you tab away from a QApp (for instance, to go to IPython...) then all windows become inactive.  This stores the last active QMainWindow in a class variable on `_QtMainWindow`... and reshuffles that list on events like window activation and close.

the classmethod `Viewer.active()` will give you the "most recent" active `viewer` instance (or `None`), and `_QtMainWindow.current()` will give you the "most recent" active `QMainWindow` instance (or None).

the changes in `qt_notification.py` show how it could be used.  (Internally, I think we'll want to use `_QtMainWindow.current()` more

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
