### PR TITLE
Override stepBy to emit valueChanged signal

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
@@ -19,3 +19,33 @@ def test_changing_layer_color_mode_updates_combo_box(qtbot):
 
     layer.color_mode = 'auto'
     assert layer.color_mode == qtctrl.colorModeComboBox.currentText()
+
+
+def test_changing_layer_selected_updates_spinbox(qtbot):
+    layer = Labels(_LABELS, color=_COLOR)
+    qtctrl = QtLabelsControls(layer)
+    qtbot.addWidget(qtctrl)
+
+    original_selected = layer.selected_label
+    assert original_selected == qtctrl.selectionSpinBox.value()
+
+    layer.selected_label == 5
+    assert layer.selected_label == qtctrl.selectionSpinBox.value()
+
+
+def test_changing_spinbox_updates_layer_selected(qtbot):
+    layer = Labels(_LABELS, color=_COLOR)
+    qtctrl = QtLabelsControls(layer)
+    qtbot.addWidget(qtctrl)
+
+    qtctrl.selectionSpinBox.setValue(2)
+    assert layer.selected_label == 2
+
+    qtctrl.selectionSpinBox.stepUp()
+    assert layer.selected_label == 3
+
+    qtctrl.selectionSpinBox.stepDown()
+    assert layer.selected_label == 2
+
+    qtctrl.selectionSpinBox.stepBy(2)
+    assert layer.selected_label == 4

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -91,7 +91,7 @@ class QtLabelsControls(QtLayerControls):
         self.layer.events.color_mode.connect(self._on_color_mode_change)
 
         # selection spinbox
-        self.selectionSpinBox = QtLargeIntSpinBox(self.layer.data.dtype)
+        self.selectionSpinBox = QtLargeIntSpinBox()
         self.selectionSpinBox.setKeyboardTracking(False)
         self.selectionSpinBox.setMinimum(0)
         self.selectionSpinBox.valueChanged.connect(self.changeSelection)
@@ -123,7 +123,7 @@ class QtLabelsControls(QtLayerControls):
         ndim_sb.setAlignment(Qt.AlignCenter)
         self._on_n_edit_dimensions_change()
 
-        contour_sb = QtLargeIntSpinBox(self.layer.data.dtype)
+        contour_sb = QtLargeIntSpinBox()
         contour_sb.setToolTip(trans._('display contours of labels'))
         contour_sb.valueChanged.connect(self.change_contour)
         self.contourSpinBox = contour_sb

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -91,7 +91,7 @@ class QtLabelsControls(QtLayerControls):
         self.layer.events.color_mode.connect(self._on_color_mode_change)
 
         # selection spinbox
-        self.selectionSpinBox = QtLargeIntSpinBox()
+        self.selectionSpinBox = QtLargeIntSpinBox(self.layer.data.dtype)
         self.selectionSpinBox.setKeyboardTracking(False)
         self.selectionSpinBox.setMinimum(0)
         self.selectionSpinBox.valueChanged.connect(self.changeSelection)
@@ -123,7 +123,7 @@ class QtLabelsControls(QtLayerControls):
         ndim_sb.setAlignment(Qt.AlignCenter)
         self._on_n_edit_dimensions_change()
 
-        contour_sb = QtLargeIntSpinBox()
+        contour_sb = QtLargeIntSpinBox(self.layer.data.dtype)
         contour_sb.setToolTip(trans._('display contours of labels'))
         contour_sb.valueChanged.connect(self.change_contour)
         self.contourSpinBox = contour_sb

--- a/napari/_qt/widgets/_tests/test_qt_large_int_spinbox.py
+++ b/napari/_qt/widgets/_tests/test_qt_large_int_spinbox.py
@@ -51,7 +51,7 @@ def test_event_emits_int(qtbot):
     dtype = np.dtype(np.int32)
 
     def fn(value):
-        assert isinstance(value, dtype.type)
+        assert np.issubdtype(type(value), np.integer)
 
     spinbox = QtLargeIntSpinBox(dtype)
     spinbox.valueChanged.connect(fn)

--- a/napari/_qt/widgets/_tests/test_qt_large_int_spinbox.py
+++ b/napari/_qt/widgets/_tests/test_qt_large_int_spinbox.py
@@ -51,7 +51,7 @@ def test_event_emits_int(qtbot):
     dtype = np.dtype(np.int32)
 
     def fn(value):
-        assert np.issubdtype(type(value), int)
+        assert isinstance(value, int)
 
     spinbox = QtLargeIntSpinBox(dtype)
     spinbox.valueChanged.connect(fn)

--- a/napari/_qt/widgets/_tests/test_qt_large_int_spinbox.py
+++ b/napari/_qt/widgets/_tests/test_qt_large_int_spinbox.py
@@ -1,58 +1,36 @@
-import numpy as np
-import pytest
-
 from ..qt_large_int_spinbox import QtLargeIntSpinBox
 
 
-@pytest.mark.parametrize(
-    ["dtype"],
-    [
-        (np.uint8,),
-        (np.int8,),
-        (np.uint16,),
-        (np.int16,),
-        (np.uint32,),
-        (np.int32,),
-        ("uint8",),
-        (np.dtype("uint8"),),
-    ],
-)
-def test_clamp_dtype(qtbot, dtype):
-    spinbox = QtLargeIntSpinBox(dtype)
-    iinfo = np.iinfo(dtype)
-    assert spinbox.minimum() == iinfo.min
-    assert spinbox.maximum() == iinfo.max
+def test_large_ints(qtbot):
+    spinbox = QtLargeIntSpinBox()
 
+    spinbox.setValue(1e34)
+    assert spinbox.value() == spinbox.maximum()
 
-def test_clamp_float(qtbot):
-    dtype = np.uint64
-    spinbox = QtLargeIntSpinBox(dtype)
-    iinfo = np.iinfo(dtype)
-    assert spinbox.minimum() == iinfo.min
-    assert spinbox.maximum() < iinfo.max
+    spinbox.setValue(1e29)
+    assert spinbox.value() == spinbox.maximum()
+
+    spinbox.setValue(1e13)
+    assert spinbox.value() == int(1e13)
+
+    spinbox.setValue(2 ** 64 - 1)
+    assert spinbox.value() == spinbox.maximum()
 
 
 def test_digitize_value(qtbot):
-    dtype = np.dtype(np.uint32)
-    spinbox = QtLargeIntSpinBox(dtype)
-
-    assert isinstance(spinbox.value(), dtype.type)
+    spinbox = QtLargeIntSpinBox()
 
     spinbox.setValue(1.1)
-    assert isinstance(spinbox.value(), dtype.type)
     assert spinbox.value() == 1
 
     spinbox.setValue(1.9)
-    assert isinstance(spinbox.value(), dtype.type)
     assert spinbox.value() == 1
 
 
 def test_event_emits_int(qtbot):
-    dtype = np.dtype(np.int32)
-
     def fn(value):
         assert isinstance(value, int)
 
-    spinbox = QtLargeIntSpinBox(dtype)
+    spinbox = QtLargeIntSpinBox()
     spinbox.valueChanged.connect(fn)
     spinbox.setValue(1)

--- a/napari/_qt/widgets/_tests/test_qt_large_int_spinbox.py
+++ b/napari/_qt/widgets/_tests/test_qt_large_int_spinbox.py
@@ -51,7 +51,7 @@ def test_event_emits_int(qtbot):
     dtype = np.dtype(np.int32)
 
     def fn(value):
-        assert np.issubdtype(type(value), np.integer)
+        assert np.issubdtype(type(value), int)
 
     spinbox = QtLargeIntSpinBox(dtype)
     spinbox.valueChanged.connect(fn)

--- a/napari/_qt/widgets/_tests/test_qt_large_int_spinbox.py
+++ b/napari/_qt/widgets/_tests/test_qt_large_int_spinbox.py
@@ -1,36 +1,58 @@
+import numpy as np
+import pytest
+
 from ..qt_large_int_spinbox import QtLargeIntSpinBox
 
 
-def test_large_ints(qtbot):
-    spinbox = QtLargeIntSpinBox()
+@pytest.mark.parametrize(
+    ["dtype"],
+    [
+        (np.uint8,),
+        (np.int8,),
+        (np.uint16,),
+        (np.int16,),
+        (np.uint32,),
+        (np.int32,),
+        ("uint8",),
+        (np.dtype("uint8"),),
+    ],
+)
+def test_clamp_dtype(qtbot, dtype):
+    spinbox = QtLargeIntSpinBox(dtype)
+    iinfo = np.iinfo(dtype)
+    assert spinbox.minimum() == iinfo.min
+    assert spinbox.maximum() == iinfo.max
 
-    spinbox.setValue(1e34)
-    assert spinbox.value() == spinbox.maximum()
 
-    spinbox.setValue(1e29)
-    assert spinbox.value() == spinbox.maximum()
-
-    spinbox.setValue(1e13)
-    assert spinbox.value() == int(1e13)
-
-    spinbox.setValue(2 ** 64 - 1)
-    assert spinbox.value() == spinbox.maximum()
+def test_clamp_float(qtbot):
+    dtype = np.uint64
+    spinbox = QtLargeIntSpinBox(dtype)
+    iinfo = np.iinfo(dtype)
+    assert spinbox.minimum() == iinfo.min
+    assert spinbox.maximum() < iinfo.max
 
 
 def test_digitize_value(qtbot):
-    spinbox = QtLargeIntSpinBox()
+    dtype = np.dtype(np.uint32)
+    spinbox = QtLargeIntSpinBox(dtype)
+
+    assert isinstance(spinbox.value(), dtype.type)
 
     spinbox.setValue(1.1)
+    assert isinstance(spinbox.value(), dtype.type)
     assert spinbox.value() == 1
 
     spinbox.setValue(1.9)
+    assert isinstance(spinbox.value(), dtype.type)
     assert spinbox.value() == 1
 
 
 def test_event_emits_int(qtbot):
+    dtype = np.dtype(np.int32)
+
     def fn(value):
         assert isinstance(value, int)
 
-    spinbox = QtLargeIntSpinBox()
+    spinbox = QtLargeIntSpinBox(dtype)
     spinbox.valueChanged.connect(fn)
     spinbox.setValue(1)

--- a/napari/_qt/widgets/qt_large_int_spinbox.py
+++ b/napari/_qt/widgets/qt_large_int_spinbox.py
@@ -66,7 +66,9 @@ class QtLargeIntSpinBox(QDoubleSpinBox):
         raise NotImplementedError
 
     def setValue(self, value):
-        super().setValue(self._cast(value))
+        val = self._cast(value)
+        super().setValue(val)
+        self.valueChanged.emit(val)
 
     def value(self):
         return self._cast(super().value())

--- a/napari/_qt/widgets/qt_large_int_spinbox.py
+++ b/napari/_qt/widgets/qt_large_int_spinbox.py
@@ -58,6 +58,10 @@ class QtLargeIntSpinBox(QDoubleSpinBox):
     def singleStep(self):
         return int(super().singleStep())
 
+    def stepBy(self, steps: int) -> None:
+        super().stepBy(steps)
+        self.valueChanged.emit(self.value())
+
     def setDecimals(self):
         raise NotImplementedError
 

--- a/napari/_qt/widgets/qt_large_int_spinbox.py
+++ b/napari/_qt/widgets/qt_large_int_spinbox.py
@@ -1,113 +1,90 @@
-from qtpy.QtCore import QSize, Signal
-from qtpy.QtGui import QFontMetrics, QValidator
-from qtpy.QtWidgets import QAbstractSpinBox, QStyle, QStyleOptionSpinBox
+import logging
+
+import numpy as np
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import QDoubleSpinBox
+
+logger = logging.getLogger(__name__)
 
 
-class AnyIntValidator(QValidator):
-    def __init__(self, parent=None) -> None:
-        super().__init__(parent)
-
-    def validate(self, input: str, pos: int):
-        if input.isnumeric():
-            return 2, input, len(input)
-        else:
-            return 0, input, len(input)
-
-
-class QtLargeIntSpinBox(QAbstractSpinBox):
-    """An integer spinboxes backed by unbound python integer
+class QtLargeIntSpinBox(QDoubleSpinBox):
+    """
+    A class for integer spinboxes backed by a double (i.e. float64).
 
     Qt's built-in ``QSpinBox`` is backed by a signed 32-bit integer.
     This could become limiting, particularly in large dense segmentations.
-    This class behaves like a ``QSpinBox`` backed by an unbound python int.
+    This class behaves like a ``QSpinBox`` backed by a signed 54-bit integer.
 
-    Does not yet support "prefix", "suffix" or "specialValue" like QSpinBox.
+    Instances are associated with a ``numpy.dtype``
+    which can further constrain their maximum range,
+    and ensures that values are clamped and cast correctly
+    when using setter and getter methods.
     """
 
-    textChanged = Signal(str)
+    MAX_FLOAT64_INT = 2 ** 53
+    MIN_FLOAT64_INT = -MAX_FLOAT64_INT
+
     valueChanged = Signal(int)
 
-    def __init__(self, parent=None) -> None:
+    def __init__(self, dtype=int, parent=None):
         super().__init__(parent)
-        self._value: int = 0
-        self._minimum: int = 0
-        self._maximum: int = 2 ** 64 - 1
-        self._single_step: int = 1
-        validator = AnyIntValidator(self)
-        self.lineEdit().setValidator(validator)
-        self.lineEdit().textChanged.connect(self._editor_text_changed)
-        self.setValue(0)
+        self._dtype = np.dtype(dtype)
+        if not np.issubdtype(self._dtype, np.integer):
+            raise ValueError(f"Spinbox dtype must be integral, got {dtype}")
+        iinfo = np.iinfo(self._dtype)
 
-    def value(self):
-        return self._value
+        self.setSingleStep(1)
+        super().setDecimals(0)
 
-    def setValue(self, value):
-        self._value, old = self._bound(int(value)), self._value
-        self._updateEdit()
-        self.update()
-        if self._value != old:
-            self.textChanged.emit(self.lineEdit().displayText())
-            self.valueChanged.emit(self._value)
+        self._min = self._dtype.type(max(iinfo.min, self.MIN_FLOAT64_INT))
+        self._max = self._dtype.type(min(iinfo.max, self.MAX_FLOAT64_INT))
+        self.setRange(self._min, self._max)
 
-    def _updateEdit(self):
-        new_text = str(self._value)
-        if self.lineEdit().text() == new_text:
-            return
-        self.lineEdit().setText(new_text)
+    def _cast(self, value):
+        actual_val = max(self._min, min(self._max, self._dtype.type(value)))
+        if actual_val != value:
+            logger.warning(
+                "Value %s is not representable by %s(%s); using %s",
+                value,
+                type(self).__qualname__,
+                self._dtype,
+                actual_val,
+            )
+        return actual_val
+
+    def setSingleStep(self, val):
+        return super().setSingleStep(int(val))
 
     def singleStep(self):
-        return self._single_step
-
-    def setSingleStep(self, step):
-        self._single_step = int(step)
-
-    def minimum(self):
-        return self._minimum
-
-    def setMinimum(self, min):
-        self._minimum = int(min)
-
-    def maximum(self):
-        return self._maximum
-
-    def setMaximum(self, max):
-        self._maximum = int(max)
-
-    def setRange(self, minimum, maximum):
-        self.setMinimum(minimum)
-        self.setMaximum(maximum)
+        return int(super().singleStep())
 
     def stepBy(self, steps: int) -> None:
-        step = self._single_step
-        self.setValue(self._bound(self._value + (step * steps)))
+        super().stepBy(steps)
+        self.valueChanged.emit(self.value())
 
-    def _editor_text_changed(self, t):
-        state, *_ = self.validate(t, self.lineEdit().cursorPosition())
-        if state == QValidator.Acceptable:
-            self.setValue(int(t))
+    def setDecimals(self):
+        raise NotImplementedError
 
-    def _bound(self, value):
-        return max(self._minimum, min(self._maximum, value))
+    def setValue(self, value):
+        val = self._cast(value)
+        super().setValue(val)
+        self.valueChanged.emit(val)
 
-    def stepEnabled(self):
-        flags = QAbstractSpinBox.StepNone
-        if self.isReadOnly():
-            return flags
-        if self._value < self._maximum:
-            flags |= QAbstractSpinBox.StepUpEnabled
-        if self._value > self._minimum:
-            flags |= QAbstractSpinBox.StepDownEnabled
-        return flags
+    def value(self):
+        return self._cast(super().value())
 
-    def sizeHint(self):
-        self.ensurePolished()
-        fm = QFontMetrics(self.font())
-        h = self.lineEdit().sizeHint().height()
-        w = fm.horizontalAdvance(str(self._value)) + 3
-        w = max(36, w)
-        opt = QStyleOptionSpinBox()
-        self.initStyleOption(opt)
-        hint = QSize(w, h)
-        return self.style().sizeFromContents(
-            QStyle.CT_SpinBox, opt, hint, self
-        )
+    def setMinimum(self, value):
+        super().setMinimum(self._cast(value))
+
+    def minimum(self):
+        return self._cast(super().minimum())
+
+    def setMaximum(self, value):
+        super().setMaximum(self._cast(value))
+
+    def maximum(self):
+        return self._cast(super().maximum())
+
+    def setRange(self, min_, max_):
+        self.setMinimum(min_)
+        self.setMaximum(max_)

--- a/napari/_qt/widgets/qt_large_int_spinbox.py
+++ b/napari/_qt/widgets/qt_large_int_spinbox.py
@@ -1,90 +1,113 @@
-import logging
-
-import numpy as np
-from qtpy.QtCore import Signal
-from qtpy.QtWidgets import QDoubleSpinBox
-
-logger = logging.getLogger(__name__)
+from qtpy.QtCore import QSize, Signal
+from qtpy.QtGui import QFontMetrics, QValidator
+from qtpy.QtWidgets import QAbstractSpinBox, QStyle, QStyleOptionSpinBox
 
 
-class QtLargeIntSpinBox(QDoubleSpinBox):
-    """
-    A class for integer spinboxes backed by a double (i.e. float64).
+class AnyIntValidator(QValidator):
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+
+    def validate(self, input: str, pos: int):
+        if input.isnumeric():
+            return 2, input, len(input)
+        else:
+            return 0, input, len(input)
+
+
+class QtLargeIntSpinBox(QAbstractSpinBox):
+    """An integer spinboxes backed by unbound python integer
 
     Qt's built-in ``QSpinBox`` is backed by a signed 32-bit integer.
     This could become limiting, particularly in large dense segmentations.
-    This class behaves like a ``QSpinBox`` backed by a signed 54-bit integer.
+    This class behaves like a ``QSpinBox`` backed by an unbound python int.
 
-    Instances are associated with a ``numpy.dtype``
-    which can further constrain their maximum range,
-    and ensures that values are clamped and cast correctly
-    when using setter and getter methods.
+    Does not yet support "prefix", "suffix" or "specialValue" like QSpinBox.
     """
 
-    MAX_FLOAT64_INT = 2 ** 53
-    MIN_FLOAT64_INT = -MAX_FLOAT64_INT
-
+    textChanged = Signal(str)
     valueChanged = Signal(int)
 
-    def __init__(self, dtype=int, parent=None):
+    def __init__(self, parent=None) -> None:
         super().__init__(parent)
-        self._dtype = np.dtype(dtype)
-        if not np.issubdtype(self._dtype, np.integer):
-            raise ValueError(f"Spinbox dtype must be integral, got {dtype}")
-        iinfo = np.iinfo(self._dtype)
-
-        self.setSingleStep(1)
-        super().setDecimals(0)
-
-        self._min = self._dtype.type(max(iinfo.min, self.MIN_FLOAT64_INT))
-        self._max = self._dtype.type(min(iinfo.max, self.MAX_FLOAT64_INT))
-        self.setRange(self._min, self._max)
-
-    def _cast(self, value):
-        actual_val = max(self._min, min(self._max, self._dtype.type(value)))
-        if actual_val != value:
-            logger.warning(
-                "Value %s is not representable by %s(%s); using %s",
-                value,
-                type(self).__qualname__,
-                self._dtype,
-                actual_val,
-            )
-        return actual_val
-
-    def setSingleStep(self, val):
-        return super().setSingleStep(int(val))
-
-    def singleStep(self):
-        return int(super().singleStep())
-
-    def stepBy(self, steps: int) -> None:
-        super().stepBy(steps)
-        self.valueChanged.emit(self.value())
-
-    def setDecimals(self):
-        raise NotImplementedError
-
-    def setValue(self, value):
-        val = self._cast(value)
-        super().setValue(val)
-        self.valueChanged.emit(val)
+        self._value: int = 0
+        self._minimum: int = 0
+        self._maximum: int = 2 ** 64 - 1
+        self._single_step: int = 1
+        validator = AnyIntValidator(self)
+        self.lineEdit().setValidator(validator)
+        self.lineEdit().textChanged.connect(self._editor_text_changed)
+        self.setValue(0)
 
     def value(self):
-        return self._cast(super().value())
+        return self._value
 
-    def setMinimum(self, value):
-        super().setMinimum(self._cast(value))
+    def setValue(self, value):
+        self._value, old = self._bound(int(value)), self._value
+        self._updateEdit()
+        self.update()
+        if self._value != old:
+            self.textChanged.emit(self.lineEdit().displayText())
+            self.valueChanged.emit(self._value)
+
+    def _updateEdit(self):
+        new_text = str(self._value)
+        if self.lineEdit().text() == new_text:
+            return
+        self.lineEdit().setText(new_text)
+
+    def singleStep(self):
+        return self._single_step
+
+    def setSingleStep(self, step):
+        self._single_step = int(step)
 
     def minimum(self):
-        return self._cast(super().minimum())
+        return self._minimum
 
-    def setMaximum(self, value):
-        super().setMaximum(self._cast(value))
+    def setMinimum(self, min):
+        self._minimum = int(min)
 
     def maximum(self):
-        return self._cast(super().maximum())
+        return self._maximum
 
-    def setRange(self, min_, max_):
-        self.setMinimum(min_)
-        self.setMaximum(max_)
+    def setMaximum(self, max):
+        self._maximum = int(max)
+
+    def setRange(self, minimum, maximum):
+        self.setMinimum(minimum)
+        self.setMaximum(maximum)
+
+    def stepBy(self, steps: int) -> None:
+        step = self._single_step
+        self.setValue(self._bound(self._value + (step * steps)))
+
+    def _editor_text_changed(self, t):
+        state, *_ = self.validate(t, self.lineEdit().cursorPosition())
+        if state == QValidator.Acceptable:
+            self.setValue(int(t))
+
+    def _bound(self, value):
+        return max(self._minimum, min(self._maximum, value))
+
+    def stepEnabled(self):
+        flags = QAbstractSpinBox.StepNone
+        if self.isReadOnly():
+            return flags
+        if self._value < self._maximum:
+            flags |= QAbstractSpinBox.StepUpEnabled
+        if self._value > self._minimum:
+            flags |= QAbstractSpinBox.StepDownEnabled
+        return flags
+
+    def sizeHint(self):
+        self.ensurePolished()
+        fm = QFontMetrics(self.font())
+        h = self.lineEdit().sizeHint().height()
+        w = fm.horizontalAdvance(str(self._value)) + 3
+        w = max(36, w)
+        opt = QStyleOptionSpinBox()
+        self.initStyleOption(opt)
+        hint = QSize(w, h)
+        return self.style().sizeFromContents(
+            QStyle.CT_SpinBox, opt, hint, self
+        )


### PR DESCRIPTION
# Description
Closes #2625 by overridting `stepBy` to make sure it emits the new `valueChanged()`.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
