### PR TITLE
relax dask test

### DIFF
--- a/napari/layers/_tests/test_dask_layers.py
+++ b/napari/layers/_tests/test_dask_layers.py
@@ -166,8 +166,9 @@ def test_dask_unoptimized_slicing(delayed_dask_stack, monkeypatch):
     v.dims.set_point(0, 1)
     v.dims.set_point(0, 0)
     v.dims.set_point(0, 3)
-    # all told, we have 2x as many calls as the optimized version above.
-    assert delayed_dask_stack['calls'] == 8
+    # all told, we have ~2x as many calls as the optimized version above.
+    # (should be exactly 8 calls, but for some reason, sometimes less on CI)
+    assert delayed_dask_stack['calls'] >= 7
 
 
 @pytest.mark.sync_only


### PR DESCRIPTION
# Description
This PR relaxes a dask test that has been failing randomly [a couple times](https://github.com/napari/napari/pull/2639/checks?check_run_id=2478905597).  All it was doing it was testing that things *don't* work that well when dask cache is turned off, and we were getting an off-by-one assertion, that doesn't really matter.
