### PR TITLE
add table header style

### DIFF
--- a/napari/_qt/qt_resources/styles/00_base.qss
+++ b/napari/_qt/qt_resources/styles/00_base.qss
@@ -639,3 +639,14 @@ QLCDNumber {
 QStatusBar::item{
   border: None;
 }
+
+/* ----------------- QHeaderView ----------------- */
+QHeaderView::section {
+  background-color: {{ background }};
+  border: 1px solid {{ foreground }};
+  border-bottom: 0px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  padding: 3px 6px;
+  background: vgradient({{ lighten(background, 15) }} - {{ background }});
+}

--- a/napari/_qt/qt_resources/styles/00_base.qss
+++ b/napari/_qt/qt_resources/styles/00_base.qss
@@ -643,10 +643,5 @@ QStatusBar::item{
 /* ----------------- QHeaderView ----------------- */
 QHeaderView::section {
   background-color: {{ background }};
-  border: 1px solid {{ foreground }};
-  border-bottom: 0px;
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-  padding: 3px 6px;
-  background: vgradient({{ lighten(background, 15) }} - {{ background }});
+  padding: 2px;
 }


### PR DESCRIPTION
# Description

This change in the style sheet fixed visualization of table headers in Windows. It now looks like shown below. Would be cool if others could check this on Mac / Linux.

Dark Theme:
![image](https://user-images.githubusercontent.com/12660498/116824148-ef158900-ab88-11eb-909c-89f6c6c7b80f.png)

Ligh Theme:
![image](https://user-images.githubusercontent.com/12660498/116824154-f6d52d80-ab88-11eb-96ab-c0b252504759.png)

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
closes #2644 

# How has this been tested?
- [x] I tested manually on Windows 1
- [ ] Tested on Linux
- [ ] Tested on Mac

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
