### PR TITLE
display file format options when saving layers

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -50,6 +50,8 @@ from .._vispy import (  # isort:skip
 if TYPE_CHECKING:
     from ..viewer import Viewer
 
+from ..utils.io import imsave_extensions
+
 
 class QtViewer(QSplitter):
     """Qt view for the napari Viewer model.
@@ -449,14 +451,26 @@ class QtViewer(QSplitter):
         if msg:
             raise OSError(trans._("Nothing to save"))
 
+        # prepare list of extensions for drop down menu.
+        ext = imsave_extensions()
+        ext_list = []
+
+        for val in ext:
+            ext_list.append("*" + val)
+
+        ext_str = ';;'.join(ext_list)
+        ext_str = "All Files (*);;" + ext_str
+
         msg = trans._("selected") if selected else trans._("all")
         dlg = QFileDialog()
         hist = get_save_history()
         dlg.setHistory(hist)
+
         filename, _ = dlg.getSaveFileName(
             parent=self,
             caption=trans._('Save {msg} layers', msg=msg),
-            directory=hist[0],  # home dir by default
+            directory=hist[0],  # home dir by default,
+            filter=ext_str,
         )
 
         if filename:

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -452,14 +452,29 @@ class QtViewer(QSplitter):
             raise OSError(trans._("Nothing to save"))
 
         # prepare list of extensions for drop down menu.
-        ext = imsave_extensions()
-        ext_list = []
+        if selected and len(self.viewer.layers.selection) == 1:
+            selected_layer = list(self.viewer.layers.selection)[0]
+            # single selected layer.
+            if selected_layer._type_string == 'image':
 
-        for val in ext:
-            ext_list.append("*" + val)
+                ext = imsave_extensions()
+                ext_list = []
 
-        ext_str = ';;'.join(ext_list)
-        ext_str = "All Files (*);;" + ext_str
+                for val in ext:
+                    ext_list.append("*" + val)
+
+                ext_str = ';;'.join(ext_list)
+                ext_str = "All Files (*);; Image file types:;;" + ext_str
+
+            elif selected_layer._type_string == 'points':
+                ext_str = "All Files (*);; *.csv;;"
+            else:
+                # layer other than image or points
+                ext_str = "All Files(*);;"
+
+        else:
+            # multiple layers.
+            ext_str = "All Files(*);;"
 
         msg = trans._("selected") if selected else trans._("all")
         dlg = QFileDialog()

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -458,16 +458,22 @@ class QtViewer(QSplitter):
             if selected_layer._type_string == 'image':
 
                 ext = imsave_extensions()
-                ext_list = []
 
+                ext_list = []
                 for val in ext:
                     ext_list.append("*" + val)
 
                 ext_str = ';;'.join(ext_list)
-                ext_str = trans._("All Files (*);; Image file types:;;{ext_str}", ext_str=ext_str) 
+
+                ext_str = trans._(
+                    "All Files (*);; Image file types:;;{ext_str}",
+                    ext_str=ext_str,
+                )
 
             elif selected_layer._type_string == 'points':
+
                 ext_str = trans._("All Files (*);; *.csv;;")
+
             else:
                 # layer other than image or points
                 ext_str = trans._("All Files (*);;")

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -474,7 +474,7 @@ class QtViewer(QSplitter):
 
         else:
             # multiple layers.
-            ext_str = "All Files(*);;"
+            ext_str = trans._("All Files (*);;")
 
         msg = trans._("selected") if selected else trans._("all")
         dlg = QFileDialog()

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -470,7 +470,7 @@ class QtViewer(QSplitter):
                 ext_str = trans._("All Files (*);; *.csv;;")
             else:
                 # layer other than image or points
-                ext_str = "All Files(*);;"
+                ext_str = trans._("All Files (*);;")
 
         else:
             # multiple layers.

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -464,7 +464,7 @@ class QtViewer(QSplitter):
                     ext_list.append("*" + val)
 
                 ext_str = ';;'.join(ext_list)
-                ext_str = "All Files (*);; Image file types:;;" + ext_str
+                ext_str = trans._("All Files (*);; Image file types:;;{ext_str}", ext_str=ext_str) 
 
             elif selected_layer._type_string == 'points':
                 ext_str = "All Files (*);; *.csv;;"

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -467,7 +467,7 @@ class QtViewer(QSplitter):
                 ext_str = trans._("All Files (*);; Image file types:;;{ext_str}", ext_str=ext_str) 
 
             elif selected_layer._type_string == 'points':
-                ext_str = "All Files (*);; *.csv;;"
+                ext_str = trans._("All Files (*);; *.csv;;")
             else:
                 # layer other than image or points
                 ext_str = "All Files(*);;"


### PR DESCRIPTION

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
Previously, there was no indication of what kind of file formats were available for saving layers.  This PR will add a drop down menu at the bottom of the QFileDialog that displays file format options.   Currently, I have just included image options and a points layer option (this one only includes csv and *).

If there are multiple layers, I just defaulted to *, because it saves it as a folder.  I need to decide how to handle each individual file type for multiple layers being saved.  



<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousando words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).


<img width="864" alt="Screen Shot 2021-05-03 at 3 51 46 PM" src="https://user-images.githubusercontent.com/54282105/116936106-f1c9ba00-ac2c-11eb-9d19-fc2e98d6fcb0.png">