### PR TITLE
Add link to top level project roadmap page

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ For more details on how to use `napari` checkout our [tutorials](https://napari.
 ## mission, values, and roadmap
 
 For more information about our plans for `napari` you can read our [mission and values statement](https://napari.org/docs/dev/developers/mission_and_values.html), which includes more details on our vision for supporting a plugin ecosystem around napari.
+You can see details of [the project roadmap here](https://napari.org/roadmaps/index.html).
 
 ## contributing
 


### PR DESCRIPTION
# Description
Closes https://github.com/napari/napari/issues/2277

This PR adds a link to the README, pointing to the top level project roadmap page (so the link won't keep going out of date) https://napari.org/roadmaps/index.html

## Type of change
- [x] This change is a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
