### PR TITLE
Catch dockwidget layout modification error

### DIFF
--- a/docs/release/release_0_4_8.md
+++ b/docs/release/release_0_4_8.md
@@ -134,6 +134,7 @@ and
 - Use dtype.type when passing to downstream NumPy functions (#2632)
 - Fix notifications when something other than napari or ipython creates QApp (#2633)
 - Update missing translations for 0.4.8 (#2664)
+- Catch dockwidget layout modification error (#2671)
 
 ## API Changes
 

--- a/napari/_qt/widgets/_tests/test_qt_dock_widget.py
+++ b/napari/_qt/widgets/_tests/test_qt_dock_widget.py
@@ -102,5 +102,8 @@ def test_remove_dock_widget_by_widget_reference(make_napari_viewer):
 def test_adding_modified_widget(make_napari_viewer):
     viewer = make_napari_viewer()
     widg = QWidget()
+    # not uncommon to see people shadow the builtin layout()
+    # which breaks our ability to add vertical stretch... but shouldn't crash
     widg.layout = None
-    viewer.window.add_dock_widget(widg, name='test')
+    dw = viewer.window.add_dock_widget(widg, name='test', area='right')
+    assert dw.widget() is widg

--- a/napari/_qt/widgets/_tests/test_qt_dock_widget.py
+++ b/napari/_qt/widgets/_tests/test_qt_dock_widget.py
@@ -1,5 +1,11 @@
 import pytest
-from qtpy.QtWidgets import QDockWidget, QHBoxLayout, QPushButton, QVBoxLayout
+from qtpy.QtWidgets import (
+    QDockWidget,
+    QHBoxLayout,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
 
 
 def test_add_dock_widget(make_napari_viewer):
@@ -91,3 +97,10 @@ def test_remove_dock_widget_by_widget_reference(make_napari_viewer):
         # it's gone this time:
         viewer.window.remove_dock_widget(widg)
     assert not widg.parent()
+
+
+def test_adding_modified_widget(make_napari_viewer):
+    viewer = make_napari_viewer()
+    widg = QWidget()
+    widg.layout = None
+    viewer.window.add_dock_widget(widg, name='test')

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -134,14 +134,21 @@ class QtViewerDockWidget(QDockWidget):
             # add vertical stretch to the bottom of a vertical layout only
             # if there is not already a widget that wants vertical space
             # (like a textedit or something)
-            wlayout = widget.layout()
-            exp = QSizePolicy.Expanding
-            if hasattr(wlayout, 'addStretch') and all(
-                wlayout.itemAt(i).widget().sizePolicy().verticalPolicy() < exp
-                for i in range(wlayout.count())
-                if wlayout.itemAt(i).widget()
-            ):
-                wlayout.addStretch(next(counter))
+            try:
+                # not uncommon to see people shadow the builtin layout() method
+                # which breaks our ability to add vertical stretch...
+                # but shouldn't crash
+                wlayout = widget.layout()
+                exp = QSizePolicy.Expanding
+                if hasattr(wlayout, 'addStretch') and all(
+                    wlayout.itemAt(i).widget().sizePolicy().verticalPolicy()
+                    < exp
+                    for i in range(wlayout.count())
+                    if wlayout.itemAt(i).widget()
+                ):
+                    wlayout.addStretch(next(counter))
+            except TypeError:
+                pass
 
         self._features = self.features()
         self.dockLocationChanged.connect(self._set_title_orientation)


### PR DESCRIPTION
# Description
This PR puts a try/except block around the adding of vertical stretch to plugin dock widgets.  It's not terrible uncommon to see people shadow `QWidget.layout` by doing something like `widget.layout = QVBoxLayout()` ... after which `widget.layout()` becomes a `TypeError`
(See [zulip convo](https://napari.zulipchat.com/#narrow/stream/215289-release/topic/0.2E4.2E8/near/237857144))


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added test that breaks on master
