### PR TITLE
Fix setting label selection spinbox dtype

### DIFF
--- a/docs/release/release_0_4_8.md
+++ b/docs/release/release_0_4_8.md
@@ -103,6 +103,7 @@ and
 - Relax dask test (#2641)
 - Add table header style (#2645)
 - QLargeIntSpinbox with QAbstractSpinbox and python model (#2648)
+- Add Labels layer `get_dtype` utility to account for multiscale layers (#2679)
 - Display file format options when saving layers (#2650)
 - Add events to plugin manager (#2663)
 

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -16,6 +16,7 @@ from ...layers.labels._labels_constants import (
     LABEL_COLOR_MODE_TRANSLATIONS,
     Mode,
 )
+from ...layers.labels._labels_utils import get_dtype
 from ...utils.events import disconnect_events
 from ...utils.interactions import Shortcut
 from ...utils.translations import trans
@@ -92,7 +93,8 @@ class QtLabelsControls(QtLayerControls):
 
         # selection spinbox
         self.selectionSpinBox = QtLargeIntSpinBox()
-        self.selectionSpinBox.set_dtype(self.layer.data.dtype)
+        layer_dtype = get_dtype(layer)
+        self.selectionSpinBox.set_dtype(layer_dtype)
         self.selectionSpinBox.setKeyboardTracking(False)
         self.selectionSpinBox.valueChanged.connect(self.changeSelection)
         self.selectionSpinBox.setAlignment(Qt.AlignCenter)
@@ -124,7 +126,7 @@ class QtLabelsControls(QtLayerControls):
         self._on_n_edit_dimensions_change()
 
         self.contourSpinBox = QtLargeIntSpinBox()
-        self.contourSpinBox.set_dtype(self.layer.data.dtype)
+        self.contourSpinBox.set_dtype(layer_dtype)
         self.contourSpinBox.setToolTip(trans._('display contours of labels'))
         self.contourSpinBox.valueChanged.connect(self.change_contour)
         self.contourSpinBox.setKeyboardTracking(False)

--- a/napari/layers/labels/_labels_utils.py
+++ b/napari/layers/labels/_labels_utils.py
@@ -121,9 +121,10 @@ def get_dtype(layer):
     layer_data = layer.data
     if not isinstance(layer_data, list):
         layer_data = [layer_data]
-    if hasattr(layer_data, 'dtype'):
-        layer_dtype = layer_data[0].dtype
+    layer_data_level = layer_data[0]
+    if hasattr(layer_data_level, 'dtype'):
+        layer_dtype = layer_data_level[0].dtype
     else:
-        layer_dtype = type(layer_data[0])
+        layer_dtype = type(layer_data_level)
 
     return layer_dtype

--- a/napari/layers/labels/_labels_utils.py
+++ b/napari/layers/labels/_labels_utils.py
@@ -106,9 +106,24 @@ def indices_in_shape(idxs, shape):
 
 
 def get_dtype(layer):
+    """Returns dtype of layer data
+
+    Parameters
+    ----------
+    layer : Labels
+        Labels layer (may be multiscale)
+
+    Returns
+    -------
+    dtype
+        dtype of Layer data
+    """
     layer_data = layer.data
     if not isinstance(layer_data, list):
         layer_data = [layer_data]
-    layer_dtype = layer_data[0].dtype
+    if hasattr(layer_data, 'dtype'):
+        layer_dtype = layer_data[0].dtype
+    else:
+        layer_dtype = type(layer_data[0])
 
     return layer_dtype

--- a/napari/layers/labels/_labels_utils.py
+++ b/napari/layers/labels/_labels_utils.py
@@ -103,3 +103,12 @@ def indices_in_shape(idxs, shape):
     if np_index:  # convert back to original format
         filtered = tuple(filtered.T)
     return filtered
+
+
+def get_dtype(layer):
+    layer_data = layer.data
+    if not isinstance(layer_data, list):
+        layer_data = [layer_data]
+    layer_dtype = layer_data[0].dtype
+
+    return layer_dtype

--- a/napari/layers/labels/_tests/test_labels_utils.py
+++ b/napari/layers/labels/_tests/test_labels_utils.py
@@ -1,6 +1,10 @@
 import numpy as np
 
-from napari.layers.labels._labels_utils import interpolate_coordinates
+from napari.layers.labels import Labels
+from napari.layers.labels._labels_utils import (
+    get_dtype,
+    interpolate_coordinates,
+)
 
 
 def test_interpolate_coordinates():
@@ -25,3 +29,20 @@ def test_interpolate_coordinates():
         ]
     )
     assert np.all(coords == expected_coords)
+
+
+def test_get_dtype():
+    np.random.seed(0)
+    data = np.random.randint(20, size=(50, 50))
+    layer = Labels(data)
+
+    assert get_dtype(layer) == data.dtype
+
+    data2 = data[::2, ::2]
+    layer_data = [data, data2]
+    multiscale_layer = Labels(layer_data)
+    assert get_dtype(multiscale_layer) == layer_data[0].dtype
+
+    data = data.astype(int)
+    int_layer = Labels(data)
+    assert get_dtype(int_layer) == int


### PR DESCRIPTION
# Description
- Add `get_dtype` label utility to get `dtype` of labels data, accounting for multiscale labels
- Fix setting `QtLargeIntSpinbox` `dtype` in `QtLabelsControls`

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #2678 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
