### PR TITLE
replace pypa/pep517 with pypa/build

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -21,11 +21,11 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install check-manifest pep517
+          python -m pip install check-manifest build
       - name: Build Distribution
         run: |
           check-manifest  # https://github.com/mgedmin/check-manifest
-          python -m pep517.build .
+          python -m build  # https://pypa-build.readthedocs.io/en/latest/
       - name: Find Release Notes
         id: release_notes
         run: |

--- a/docs/release/release_0_4_8.md
+++ b/docs/release/release_0_4_8.md
@@ -189,6 +189,7 @@ and
 - Remove test warnings again, minimize output, hide more async stuff (#2642)
 - Remove `raw_stylesheet` (#2643)
 - Add link to top level project roadmap page (#2652)
+- Replace pypa/pep517 with pypa/build (#2684)
 
 ## Other Pull Requests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ ignore = [
   "napari/_version.py",  # added during build by setuptools_scm
   "tools/minreq.py",
   "tox.ini",
+  "napari/_qt/qt_resources/_qt_resources_*.py"
 ]
 
 [tool.isort]

--- a/tox.ini
+++ b/tox.ini
@@ -115,8 +115,8 @@ deps =
     check_manifest
     wheel
     twine
-    pep517
+    build
 commands =
     check-manifest
-    python -m pep517.build .
+    python -m build
     python -m twine check dist/*


### PR DESCRIPTION
# Description
The the high level API of https://github.com/pypa/pep517 (which we use when building releases) is deprecated in favor of https://github.com/pypa/build

This PR swaps them out

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
