### PR TITLE
add napari module to console namespace

### DIFF
--- a/docs/release/release_0_4_8.md
+++ b/docs/release/release_0_4_8.md
@@ -106,6 +106,7 @@ and
 - Add Labels layer `get_dtype` utility to account for multiscale layers (#2679)
 - Display file format options when saving layers (#2650)
 - Add events to plugin manager (#2663)
+- Add napari module to console namespace (#2687)
 
 ## Bug Fixes
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -346,7 +346,10 @@ class QtViewer(QSplitter):
             try:
                 from napari_console import QtConsole
 
+                import napari
+
                 self.console = QtConsole(self.viewer)
+                self.console.push({'napari': napari})
             except ImportError:
                 warnings.warn(
                     trans._(


### PR DESCRIPTION
# Description
tiny PR that adds 'napari' to the namespace of the builtin console, so you don't need to use `import napari`