### PR TITLE
fix warnings in thread_worker, relay messages to gui

### DIFF
--- a/docs/release/release_0_4_8.md
+++ b/docs/release/release_0_4_8.md
@@ -137,6 +137,7 @@ and
 - Fix notifications when something other than napari or ipython creates QApp (#2633)
 - Update missing translations for 0.4.8 (#2664)
 - Catch dockwidget layout modification error (#2671)
+- Fix warnings in thread_worker, relay messages to gui (#2688)
 
 ## API Changes
 

--- a/examples/dev/gui_notifications_threaded.py
+++ b/examples/dev/gui_notifications_threaded.py
@@ -1,0 +1,29 @@
+import time
+import warnings
+
+import napari
+from napari._qt.widgets.qt_viewer_buttons import QtViewerPushButton
+from napari.qt import thread_worker
+
+
+@thread_worker(start_thread=True)
+def make_warning(*_):
+    time.sleep(0.05)
+    warnings.warn('Warning in another thread')
+
+
+@thread_worker(start_thread=True)
+def make_error(*_):
+    time.sleep(0.05)
+    raise ValueError("Error in another thread")
+
+
+viewer = napari.Viewer()
+layer_buttons = viewer.window.qt_viewer.layerButtons
+err_btn = QtViewerPushButton(None, 'warning', 'new Error', make_error)
+warn_btn = QtViewerPushButton(None, 'warning', 'new Warn', make_warning)
+layer_buttons.layout().insertWidget(3, warn_btn)
+layer_buttons.layout().insertWidget(3, err_btn)
+
+
+napari.run()

--- a/napari/_qt/qthreading.py
+++ b/napari/_qt/qthreading.py
@@ -62,12 +62,12 @@ class WorkerBase(QRunnable):
         self.signals.warned.connect(self._relay_warning)
 
     def _relay_error(self, exc):
-        from napari.utils.notifications import notification_manager
+        from ..utils.notifications import notification_manager
 
         notification_manager.receive_error(type(exc), exc, exc.__traceback__)
 
     def _relay_warning(self, show_warn_args):
-        from napari.utils.notifications import notification_manager
+        from ..utils.notifications import notification_manager
 
         notification_manager.receive_warning(*show_warn_args)
 

--- a/napari/_qt/qthreading.py
+++ b/napari/_qt/qthreading.py
@@ -1,11 +1,19 @@
 import inspect
 import time
 import warnings
-from functools import wraps
+from functools import partial, wraps
 from typing import Any, Callable, Dict, Optional, Sequence, Set, Type, Union
 
 import toolz as tz
-from qtpy.QtCore import QObject, QRunnable, QThread, QThreadPool, Signal, Slot
+from qtpy.QtCore import (
+    QObject,
+    QRunnable,
+    QThread,
+    QThreadPool,
+    QTimer,
+    Signal,
+    Slot,
+)
 
 from ..utils.translations import trans
 
@@ -224,7 +232,8 @@ class WorkerBase(QRunnable):
 
         WorkerBase._worker_set.add(self)
         self.finished.connect(lambda: WorkerBase._worker_set.discard(self))
-        QThreadPool.globalInstance().start(self)
+        start_ = partial(QThreadPool.globalInstance().start, self)
+        QTimer.singleShot(10, start_)
 
 
 class FunctionWorker(WorkerBase):

--- a/napari/_qt/qthreading.py
+++ b/napari/_qt/qthreading.py
@@ -147,6 +147,7 @@ class WorkerBase(QRunnable):
         self._running = True
         try:
             with warnings.catch_warnings():
+                warnings.filterwarnings("always")
                 warnings.showwarning = lambda *w: self.warned.emit(w)
                 result = self.work()
             if isinstance(result, Exception):

--- a/napari/utils/_tests/test_notification_manager.py
+++ b/napari/utils/_tests/test_notification_manager.py
@@ -30,6 +30,7 @@ def test_notification_manager_no_gui():
 
     previous_exhook = sys.excepthook
     with notification_manager:
+        notification_manager.records.clear()
         # save all of the events that get emitted
         store: List[Notification] = []
         _append = lambda e: store.append(e)  # lambda needed on py3.7  # noqa


### PR DESCRIPTION
# Description
fixes #2681 
just needed to intercept `notification_manager.showwarnings` receiving the warning from the other thread (with warnings.catch_warnings), and transmit via signals instead.

I also added up `notification_manager.receive_` slots to the warning and error signals, so warnings and exceptions in another thread will show up in the gui.


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
