### PR TITLE
add provide sample data hook to docs

### DIFF
--- a/docs/plugins/hook_specifications.rst
+++ b/docs/plugins/hook_specifications.rst
@@ -11,6 +11,7 @@ napari hook specification reference
 IO hooks
 --------
 
+.. autofunction:: napari_provide_sample_data
 .. autofunction:: napari_get_reader
 .. autofunction:: napari_get_writer
 

--- a/docs/release/release_0_4_8.md
+++ b/docs/release/release_0_4_8.md
@@ -192,6 +192,7 @@ and
 - Remove `raw_stylesheet` (#2643)
 - Add link to top level project roadmap page (#2652)
 - Replace pypa/pep517 with pypa/build (#2684)
+- Add provide sample data hook to docs (#2689)
 
 ## Other Pull Requests
 


### PR DESCRIPTION
simple one-liner that adds a missing function to the docs