### PR TITLE
Add hint how to stop a worker when napari closed

### DIFF
--- a/docs/guides/threading.md
+++ b/docs/guides/threading.md
@@ -315,7 +315,7 @@ So whenever possible, sprinkle your long-running functions with `yield`.
 
 If you want your thread to quit when the napari viewer closes, you can connect
 the `destroyed` signal to `worker.quit`. This is recommended to prevent the 
-loop to contiue after napari being closed:
+loop to continue after napari being closed:
 
 ```
 # Start the loop

--- a/docs/guides/threading.md
+++ b/docs/guides/threading.md
@@ -313,6 +313,17 @@ force quit your program.
 
 So whenever possible, sprinkle your long-running functions with `yield`.
 
+If you want your thread to quit when the napari viewer closes, you can connect
+the `destroyed` signal to `worker.quit`. This is recommended to prevent the 
+loop to contiue after napari being closed:
+
+```
+# Start the loop
+worker = loop_run()
+viewer.window._qt_window.destroyed.connect(worker.quit)
+worker.start()
+```
+
 ## Full Two-way Communication
 
 So far we've mostly been *receiving* results from the threaded function, but we

--- a/docs/guides/threading.md
+++ b/docs/guides/threading.md
@@ -315,7 +315,7 @@ So whenever possible, sprinkle your long-running functions with `yield`.
 
 If you want your thread to quit when the napari viewer closes, you can connect
 the `destroyed` signal to `worker.quit`. This is recommended to prevent the 
-loop to continue after napari being closed:
+loop from continuing after napari is closed:
 
 ```
 # Start the loop


### PR DESCRIPTION
# Description

this is a follow up discussion on #2688 . As @tlambert03 pointed out, I should probably not do `while viewer.window.qt_viewer` within a `thread_worker` for thread-safety reasons. I think it would be great to have an example showing how to terminate a worker once the viewer is closed. Thus, I'm adding this example to the documentation. 

I assume it's not great to access the private `viewer.window._qt_window` here. Thus, maybe there should be a publicly accessible field / signal for this. I could add it to the API (e.g. `viewer.destroyed`) as part of this PR or shall I create another issue for that?

## Type of change
- [x] This change is a documentation update

# References

#2688

# How has this been tested?

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
