### PR TITLE
Add `get_default_shape_type` utility introspecting current shape type

### DIFF
--- a/docs/release/release_0_4_8.md
+++ b/docs/release/release_0_4_8.md
@@ -140,6 +140,7 @@ and
 - Catch dockwidget layout modification error (#2671)
 - Fix warnings in thread_worker, relay messages to gui (#2688)
 - Add missing setters for shape attributes (#2696)
+- Add get_default_shape_type utility introspecting current shape type (#2701)
 
 ## API Changes
 

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -1030,7 +1030,7 @@ def get_default_shape_type(current_type):
     first_type = current_type[0]
     if all(shape_type == first_type for shape_type in current_type):
         return first_type
-    return "polygon"
+    return "rectangle"
 
 
 def get_shape_ndim(data):

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -1014,6 +1014,25 @@ def extract_shape_type(data, shape_type=None):
     return data, shape_type
 
 
+def get_default_shape_type(current_type):
+    """Returns current shape type if current_type is one shape, else "polygon".
+
+    Parameters
+    ----------
+    current_type : list of str
+        list of current shape types
+
+    Returns
+    ----------
+    default_type : str
+        default shape type
+    """
+    first_type = current_type[0]
+    if all(shape_type == first_type for shape_type in current_type):
+        return first_type
+    return "polygon"
+
+
 def get_shape_ndim(data):
     """Checks whether data is a list of the same type of shape, one shape, or
     a list of different shapes and returns the dimensionality of the shape/s.

--- a/napari/layers/shapes/_tests/test_shapes_utils.py
+++ b/napari/layers/shapes/_tests/test_shapes_utils.py
@@ -1,6 +1,9 @@
 import numpy as np
 
-from napari.layers.shapes._shapes_utils import number_of_shapes
+from napari.layers.shapes._shapes_utils import (
+    get_default_shape_type,
+    number_of_shapes,
+)
 
 
 def test_no_shapes():
@@ -17,3 +20,15 @@ def test_one_shape():
 def test_many_shapes():
     """Test many shapes."""
     assert number_of_shapes(np.random.random((8, 4, 2))) == 8
+
+
+def test_get_default_shape_type():
+    """Test getting default shape type"""
+    shape_type = ['rectangle', 'rectangle']
+    assert get_default_shape_type(shape_type) == 'rectangle'
+
+    shape_type = ['ellipse', 'rectangle']
+    assert get_default_shape_type(shape_type) == 'polygon'
+
+    shape_type = ['polygon']
+    assert get_default_shape_type(shape_type) == 'polygon'

--- a/napari/layers/shapes/_tests/test_shapes_utils.py
+++ b/napari/layers/shapes/_tests/test_shapes_utils.py
@@ -24,11 +24,11 @@ def test_many_shapes():
 
 def test_get_default_shape_type():
     """Test getting default shape type"""
-    shape_type = ['rectangle', 'rectangle']
-    assert get_default_shape_type(shape_type) == 'rectangle'
+    shape_type = ['polygon', 'polygon']
+    assert get_default_shape_type(shape_type) == 'polygon'
 
     shape_type = ['ellipse', 'rectangle']
-    assert get_default_shape_type(shape_type) == 'polygon'
+    assert get_default_shape_type(shape_type) == 'rectangle'
 
     shape_type = ['polygon']
     assert get_default_shape_type(shape_type) == 'polygon'

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -576,7 +576,7 @@ class Shapes(Layer):
             n_shapes_difference = n_new_shapes - self.nshapes
             shape_type = (
                 shape_type
-                + get_default_shape_type(shape_type) * n_shapes_difference
+                + [get_default_shape_type(shape_type)] * n_shapes_difference
             )
             edge_widths = edge_widths + [1] * n_shapes_difference
             z_indices = z_indices + [0] * n_shapes_difference

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -49,6 +49,7 @@ from ._shapes_mouse_bindings import (
 from ._shapes_utils import (
     create_box,
     extract_shape_type,
+    get_default_shape_type,
     get_shape_ndim,
     number_of_shapes,
 )
@@ -573,7 +574,10 @@ class Shapes(Layer):
         # more shapes, add attributes
         elif self.nshapes < n_new_shapes:
             n_shapes_difference = n_new_shapes - self.nshapes
-            shape_type = shape_type + ["rectangle"] * n_shapes_difference
+            shape_type = (
+                shape_type
+                + get_default_shape_type(shape_type) * n_shapes_difference
+            )
             edge_widths = edge_widths + [1] * n_shapes_difference
             z_indices = z_indices + [0] * n_shapes_difference
             edge_color = np.concatenate(


### PR DESCRIPTION
# Description
We've run into some issues when assuming the default shape type is a `rectangle`. 

This PR adds
- a utility method that takes a list of `shape_type` and returns the current `shape_type` if all shapes have the same type, and otherwise the default - **this could be slow with lots of shapes** However it only gets called in the data setter so maybe this is not such a big deal?
- I've changed this default to `polygon`, as it is a more flexible `shape_type` than `rectangle`, and `rectangles` are `polygons` anyway.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Hopefully this will adress #2354 in full...

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
