### PR TITLE
Fix vertical_stretch injection and kwargs passing on DockWidget

### DIFF
--- a/docs/release/release_0_4_8.md
+++ b/docs/release/release_0_4_8.md
@@ -141,6 +141,7 @@ and
 - Fix warnings in thread_worker, relay messages to gui (#2688)
 - Add missing setters for shape attributes (#2696)
 - Add get_default_shape_type utility introspecting current shape type (#2701)
+- Fix vertical_stretch injection and kwargs passing on DockWidget (#2705)
 
 ## API Changes
 
@@ -150,6 +151,18 @@ and
   the previous behaviour with
   `napari.utils.resize_dask_cache(memory_fraction=0.1)`. You can of course also
   experiment with other values!
+- The default `area` for `add_dock_widget` is not `right`.
+- To avoid oddly spaced sparse widgets, #2154 adds vertical stretch to the
+  bottom of all dock widgets added (via plugins or manually) with an `area`
+  of `left` or `right`, *unless:*
+
+    1) the widget, or any widget in its primary layout, has a vertical 
+       [`QSizePolicy`](https://doc.qt.io/qt-5/qsizepolicy.html#Policy-enum)
+       of `Expanding`, `MinimumExpanding`, or `Ignored`
+  
+    1) `add_vertical_stretch=False` is provided to `add_dock_widget`,
+       or in the widget options provided with plugin dock widgets.
+
 
 ## Deprecations
 

--- a/docs/release/release_0_4_8.md
+++ b/docs/release/release_0_4_8.md
@@ -151,7 +151,7 @@ and
   the previous behaviour with
   `napari.utils.resize_dask_cache(memory_fraction=0.1)`. You can of course also
   experiment with other values!
-- The default `area` for `add_dock_widget` is not `right`.
+- The default `area` for `add_dock_widget` is now `right`, and no longer `bottom`.
 - To avoid oddly spaced sparse widgets, #2154 adds vertical stretch to the
   bottom of all dock widgets added (via plugins or manually) with an `area`
   of `left` or `right`, *unless:*
@@ -261,4 +261,3 @@ and
 - [Pam](https://github.com/napari/napari/commits?author=ppwadhwa) - @ppwadhwa
 - [Robert Haase](https://github.com/napari/napari/commits?author=haesleinhuepf) - @haesleinhuepf
 - [Talley Lambert](https://github.com/napari/napari/commits?author=tlambert03) - @tlambert03
-

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -885,14 +885,12 @@ class Window:
         # instantiate the widget
         wdg = Widget(**kwargs)
 
-        # Add dock widget
-        dock_widget = self.add_dock_widget(
-            wdg,
-            name=full_name,
-            area=dock_kwargs.get('area', 'right'),
-            allowed_areas=dock_kwargs.get('allowed_areas', None),
-        )
+        dock_kwargs.setdefault('area', 'right')
+        dock_kwargs.setdefault('allowed_areas', None)
+        dock_kwargs.pop('name', None)
 
+        # Add dock widget
+        dock_widget = self.add_dock_widget(wdg, name=full_name, **dock_kwargs)
         return dock_widget, wdg
 
     def _add_plugin_function_widget(self, plugin_name: str, widget_name: str):

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -6,7 +6,7 @@ import inspect
 import sys
 import time
 import warnings
-from typing import Any, ClassVar, Dict, List, Tuple
+from typing import Any, ClassVar, Dict, List, Optional, Sequence, Tuple
 
 from qtpy.QtCore import QEvent, QPoint, QProcess, QSize, Qt
 from qtpy.QtGui import QIcon, QKeySequence
@@ -920,7 +920,7 @@ class Window:
         *,
         name: str = '',
         area: str = 'right',
-        allowed_areas=None,
+        allowed_areas: Optional[Sequence[str]] = None,
         shortcut=_sentinel,
         add_vertical_stretch=True,
     ):

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -885,11 +885,8 @@ class Window:
         # instantiate the widget
         wdg = Widget(**kwargs)
 
-        dock_kwargs.setdefault('area', 'right')
-        dock_kwargs.setdefault('allowed_areas', None)
-        dock_kwargs.pop('name', None)
-
         # Add dock widget
+        dock_kwargs.pop('name', None)
         dock_widget = self.add_dock_widget(wdg, name=full_name, **dock_kwargs)
         return dock_widget, wdg
 
@@ -922,7 +919,7 @@ class Window:
         widget: QWidget,
         *,
         name: str = '',
-        area: str = 'bottom',
+        area: str = 'right',
         allowed_areas=None,
         shortcut=_sentinel,
         add_vertical_stretch=True,

--- a/napari/_qt/widgets/_tests/test_qt_dock_widget.py
+++ b/napari/_qt/widgets/_tests/test_qt_dock_widget.py
@@ -13,7 +13,7 @@ def test_add_dock_widget(make_napari_viewer):
     """Test basic add_dock_widget functionality"""
     viewer = make_napari_viewer()
     widg = QPushButton('button')
-    dwidg = viewer.window.add_dock_widget(widg, name='test')
+    dwidg = viewer.window.add_dock_widget(widg, name='test', area='bottom')
     assert not dwidg.is_vertical
     assert viewer.window._qt_window.findChild(QDockWidget, 'test')
     assert dwidg.widget() == widg

--- a/napari/_qt/widgets/_tests/test_qt_dock_widget.py
+++ b/napari/_qt/widgets/_tests/test_qt_dock_widget.py
@@ -1,9 +1,9 @@
 import pytest
-from PyQt5.QtWidgets import QTextEdit
 from qtpy.QtWidgets import (
     QDockWidget,
     QHBoxLayout,
     QPushButton,
+    QTextEdit,
     QVBoxLayout,
     QWidget,
 )

--- a/napari/_qt/widgets/_tests/test_qt_dock_widget.py
+++ b/napari/_qt/widgets/_tests/test_qt_dock_widget.py
@@ -1,4 +1,5 @@
 import pytest
+from PyQt5.QtWidgets import QTextEdit
 from qtpy.QtWidgets import (
     QDockWidget,
     QHBoxLayout,
@@ -107,3 +108,35 @@ def test_adding_modified_widget(make_napari_viewer):
     widg.layout = None
     dw = viewer.window.add_dock_widget(widg, name='test', area='right')
     assert dw.widget() is widg
+
+
+def test_adding_stretch(make_napari_viewer):
+    """Make sure that vertical stretch only gets added when appropriate."""
+    viewer = make_napari_viewer()
+
+    # adding a widget to the left/right will usually addStretch to the layout
+    widg = QWidget()
+    widg.setLayout(QVBoxLayout())
+    widg.layout().addWidget(QPushButton())
+    assert widg.layout().count() == 1
+    dw = viewer.window.add_dock_widget(widg, area='right')
+    assert widg.layout().count() == 2
+    dw.close()
+
+    # ... unless the widget has a widget with a large vertical sizePolicy
+    widg = QWidget()
+    widg.setLayout(QVBoxLayout())
+    widg.layout().addWidget(QTextEdit())
+    assert widg.layout().count() == 1
+    dw = viewer.window.add_dock_widget(widg, area='right')
+    assert widg.layout().count() == 1
+    dw.close()
+
+    # ... widgets on the bottom do not get stretch
+    widg = QWidget()
+    widg.setLayout(QHBoxLayout())
+    widg.layout().addWidget(QPushButton())
+    assert widg.layout().count() == 1
+    dw = viewer.window.add_dock_widget(widg, area='bottom')
+    assert widg.layout().count() == 1
+    dw.close()

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -66,7 +66,7 @@ class QtViewerDockWidget(QDockWidget):
         widget: QWidget,
         *,
         name: str = '',
-        area: str = 'bottom',
+        area: str = 'right',
         allowed_areas: Optional[List[str]] = None,
         shortcut=_sentinel,
         object_name: str = '',

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -159,6 +159,8 @@ class QtViewerDockWidget(QDockWidget):
         # which breaks our ability to add vertical stretch...
         try:
             wlayout = widget.layout()
+            if wlayout is None:
+                return
         except TypeError:
             return
 


### PR DESCRIPTION
# Description
This PR fixes two issues with dock_widgets

1) not all of the keys from the widget options dict was making to the `add_dock_widget` method (preventing plugins from using `{'add_vertical_stretch': False}`
2) widgets that have sub-widgets with expanding QSizePolicies were _still_ having layouts added.  this fixes that and adds a test.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
test added,  checked manually on napari-animation ... testing now with AICS