### PR TITLE
Fix tracks icons, and visibility icons

### DIFF
--- a/docs/release/release_0_4_8.md
+++ b/docs/release/release_0_4_8.md
@@ -143,6 +143,7 @@ and
 - Add get_default_shape_type utility introspecting current shape type (#2701)
 - Fix handling of exceptions and notifications of threading threads (#2703)
 - Fix vertical_stretch injection and kwargs passing on DockWidget (#2705)
+- Fix tracks icons, and visibility icons (#2708)
 
 ## API Changes
 

--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -684,7 +684,8 @@ QtLayerList::indicator {
 }
 
 QtLayerList::indicator:unchecked {
-  image: url(":/themes/{{ folder }}/2D.svg");
+  image: url(":/themes/{{ folder }}/visibility_off_50.svg");
+  
 }
 
 QtLayerList::indicator:checked {

--- a/napari/_tests/test_adding_removing.py
+++ b/napari/_tests/test_adding_removing.py
@@ -1,9 +1,19 @@
+import os
+
 import numpy as np
 import pytest
 
 from napari._tests.utils import layer_test_data
 from napari.layers import Image
 from napari.utils.events.event import WarningEmitter
+
+
+@pytest.mark.skipif(bool(not os.getenv("CI")), reason='shows viewer')
+@pytest.mark.parametrize('Layer, data, _', layer_test_data)
+def test_add_all_layers(make_napari_viewer, Layer, data, _):
+    """Make sure that all layers can show in the viewer."""
+    viewer = make_napari_viewer(show=True)
+    viewer.layers.append(Layer(data))
 
 
 def test_layers_removed_on_close(make_napari_viewer):

--- a/napari/resources/_icons.py
+++ b/napari/resources/_icons.py
@@ -17,7 +17,7 @@ def get_icon_path(name: str) -> str:
                 "unrecognized icon name: {name!r}. Known names: {icons}",
                 deferred=True,
                 name=name,
-                icons=ICONS,
+                icons=set(ICONS),
             )
         )
     return ICONS[name]

--- a/napari/resources/icons/new_tracks.svg
+++ b/napari/resources/icons/new_tracks.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.2.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
+<circle cx="80" cy="22.7" r="7.2"/>
+<circle cx="19.5" cy="17.6" r="7.2"/>
+<circle cx="72.8" cy="81.6" r="7.2"/>
+<g>
+	<path d="M39.8,43.8c-1.6-1.5-1.8-1.3-0.5,0.5l22.6,30.5c1.3,1.8,3.7,2,5.3,0.6s1.7-3.9,0.1-5.4L39.8,43.8z"/>
+</g>
+<g>
+	<path d="M41.9,32.4c-2.1,0.8-2,1.2,0.2,0.8l25.5-3.9c2.2-0.3,3.5-2.2,3-4.1S68,22.3,66,23.1L41.9,32.4z"/>
+</g>
+<g>
+	<path d="M27.7,88.5c0.4,2.2,0.6,2.1,0.5-0.1l-3.2-59c-0.1-2.2-2-3.8-4.2-3.5l-0.7,0.1c-2.2,0.3-3.6,2.2-3.2,4.4L27.7,88.5z"/>
+</g>
+</svg>


### PR DESCRIPTION
# Description

fixes #2706, adds a test that all layers can be added to a viewer with `show=True` (that was why this wasn't caught).
and brings back the "eye with a line through it" for invisible layers

here's the icon:

<img width="175" alt="Untitled" src="https://user-images.githubusercontent.com/1609449/118128394-d434e700-b3c8-11eb-9d6b-c2ad084b13ec.png">


![Untitled 3](https://user-images.githubusercontent.com/1609449/118128281-afd90a80-b3c8-11eb-9243-4f1f2d1c1d4d.png)


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
