### PR TITLE
WIP: Layers sliders

### DIFF
--- a/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -79,8 +79,7 @@ class QtBaseImageControls(QtLayerControls):
         # gamma slider
 
         sld = QtLabeledSlider1(parent=self)
-        # sld = QSlider(Qt.Horizontal, parent=self)
-        # sld.setFocusPolicy(Qt.NoFocus)
+        sld.setFocusPolicy(Qt.NoFocus)
         sld.setMinimum(2)
         sld.setMaximum(200)
         sld.setSingleStep(2)

--- a/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -4,13 +4,14 @@ from functools import partial
 import numpy as np
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QImage, QPixmap
-from qtpy.QtWidgets import QLabel, QPushButton, QSlider
+from qtpy.QtWidgets import QLabel, QPushButton
 
 from ...utils.colormaps import AVAILABLE_COLORMAPS
 from ...utils.translations import trans
 from ..utils import qt_signals_blocked
 from ..widgets.qt_range_slider import QHRangeSlider
 from ..widgets.qt_range_slider_popup import QRangeSliderPopup
+from ..widgets.qt_sliders_with_labels import QtLabeledSlider1
 from .qt_colormap_combobox import QtColormapComboBox
 from .qt_layer_controls_base import QtLayerControls
 
@@ -76,8 +77,10 @@ class QtBaseImageControls(QtLayerControls):
         self.contrastLimitsSlider.rangeChanged.connect(set_climrange)
 
         # gamma slider
-        sld = QSlider(Qt.Horizontal, parent=self)
-        sld.setFocusPolicy(Qt.NoFocus)
+
+        sld = QtLabeledSlider1(parent=self)
+        # sld = QSlider(Qt.Horizontal, parent=self)
+        # sld.setFocusPolicy(Qt.NoFocus)
         sld.setMinimum(2)
         sld.setMaximum(200)
         sld.setSingleStep(2)

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -7,7 +7,6 @@ from qtpy.QtWidgets import (
     QComboBox,
     QHBoxLayout,
     QLabel,
-    QSlider,
     QSpinBox,
     QWidget,
 )
@@ -23,6 +22,7 @@ from ...utils.translations import trans
 from ..utils import disable_with_opacity
 from ..widgets.qt_large_int_spinbox import QtLargeIntSpinBox
 from ..widgets.qt_mode_buttons import QtModePushButton, QtModeRadioButton
+from ..widgets.qt_sliders_with_labels import QtLabeledSlider1
 from .qt_layer_controls_base import QtLayerControls
 
 INT32_MAX = 2 ** 31 - 1
@@ -100,7 +100,7 @@ class QtLabelsControls(QtLayerControls):
         self.selectionSpinBox.setAlignment(Qt.AlignCenter)
         self._on_selected_label_change()
 
-        sld = QSlider(Qt.Horizontal)
+        sld = QtLabeledSlider1()
         sld.setFocusPolicy(Qt.NoFocus)
         sld.setMinimum(1)
         sld.setMaximum(40)

--- a/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -1,8 +1,9 @@
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QComboBox, QFrame, QGridLayout, QSlider
+from qtpy.QtWidgets import QComboBox, QFrame, QGridLayout
 
 from ...layers.base._base_constants import BLENDING_TRANSLATIONS
 from ...utils.events import disconnect_events
+from ..widgets.qt_sliders_with_labels import QtLabeledSlider1
 
 
 class QtLayerControls(QFrame):
@@ -46,7 +47,7 @@ class QtLayerControls(QFrame):
         self.grid_layout.setColumnStretch(1, 1)
         self.setLayout(self.grid_layout)
 
-        sld = QSlider(Qt.Horizontal, parent=self)
+        sld = QtLabeledSlider1(parent=self)
         sld.setFocusPolicy(Qt.NoFocus)
         sld.setMinimum(0)
         sld.setMaximum(100)

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -6,7 +6,6 @@ from qtpy.QtWidgets import (
     QComboBox,
     QHBoxLayout,
     QLabel,
-    QSlider,
 )
 
 from ...layers.points._points_constants import SYMBOL_TRANSLATION, Mode
@@ -16,6 +15,7 @@ from ...utils.translations import trans
 from ..utils import disable_with_opacity, qt_signals_blocked
 from ..widgets.qt_color_swatch import QColorSwatchEdit
 from ..widgets.qt_mode_buttons import QtModePushButton, QtModeRadioButton
+from ..widgets.qt_sliders_with_labels import QtLabeledSlider1
 from .qt_layer_controls_base import QtLayerControls
 
 
@@ -87,7 +87,7 @@ class QtPointsControls(QtLayerControls):
         self.layer.events.editable.connect(self._on_editable_change)
         self.layer.text.events.visible.connect(self._on_text_visibility_change)
 
-        sld = QSlider(Qt.Horizontal)
+        sld = QtLabeledSlider1()
         sld.setFocusPolicy(Qt.NoFocus)
         sld.setMinimum(1)
         sld.setMaximum(100)

--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -2,13 +2,7 @@ from collections.abc import Iterable
 
 import numpy as np
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import (
-    QButtonGroup,
-    QCheckBox,
-    QGridLayout,
-    QLabel,
-    QSlider,
-)
+from qtpy.QtWidgets import QButtonGroup, QCheckBox, QGridLayout, QLabel
 
 from ...layers.shapes._shapes_constants import Mode
 from ...utils.events import disconnect_events
@@ -17,6 +11,7 @@ from ...utils.translations import trans
 from ..utils import disable_with_opacity, qt_signals_blocked
 from ..widgets.qt_color_swatch import QColorSwatchEdit
 from ..widgets.qt_mode_buttons import QtModePushButton, QtModeRadioButton
+from ..widgets.qt_sliders_with_labels import QtLabeledSlider1
 from .qt_layer_controls_base import QtLayerControls
 
 
@@ -95,7 +90,7 @@ class QtShapesControls(QtLayerControls):
         self.layer.events.editable.connect(self._on_editable_change)
         self.layer.text.events.visible.connect(self._on_text_visibility_change)
 
-        sld = QSlider(Qt.Horizontal)
+        sld = QtLabeledSlider1()
         sld.setFocusPolicy(Qt.NoFocus)
         sld.setMinimum(0)
         sld.setMaximum(40)

--- a/napari/_qt/widgets/qt_sliders_with_labels.py
+++ b/napari/_qt/widgets/qt_sliders_with_labels.py
@@ -1,4 +1,5 @@
 from qtpy.QtCore import Qt, Signal
+from qtpy.QtGui import QFont
 from qtpy.QtWidgets import QHBoxLayout, QLabel, QLineEdit, QSlider, QWidget
 
 from ...utils.translations import translator
@@ -44,7 +45,7 @@ class QtLabeledSlider1(QWidget):
     ):
         super().__init__(parent)
 
-        # self.setGeometry(300, 300, 125, 110)
+        # self.setGeometry(0, 0, 30, 100)
         self._value = value
         self._min_value = min_value
         self._max_value = max_value
@@ -52,7 +53,6 @@ class QtLabeledSlider1(QWidget):
 
         # Widget
         self._lineedit = QLineEdit()
-        self._unit = QLabel(self)
         self._slider = QSlider(Qt.Horizontal, parent=parent)
         self._slider_min_label = QLabel(self)
         self._slider_max_label = QLabel(self)
@@ -61,17 +61,45 @@ class QtLabeledSlider1(QWidget):
         # Widgets setup
         # self._lineedit.setValidator(self._validator)
         self._lineedit.setAlignment(Qt.AlignRight)
-        self._lineedit.setAlignment(Qt.AlignBottom)
+        self._lineedit.setAlignment(Qt.AlignHCenter)
+        self._lineedit.setFixedWidth(25)
         self._slider_min_label.setText(str(min_value))
-        self._slider_min_label.setAlignment(Qt.AlignBottom)
         self._slider_max_label.setText(str(max_value))
-        self._slider_max_label.setAlignment(Qt.AlignBottom)
         self._slider.setMinimum(min_value)
         self._slider.setMaximum(max_value)
+
+        font10 = QFont()
+        font10.setPointSize(10)
+        self._slider_min_label.setFont(font10)
+        self._slider_max_label.setFont(font10)
+        self._lineedit.setFont(font10)
+        # self._slider.setFixedWidth(60)
 
         # Signals
         self._slider.valueChanged.connect(self._update_value)
         self._lineedit.textChanged.connect(self._update_value)
+
+        # layout1 = QHBoxLayout()
+        # layout1.addWidget(self._slider_min_label)
+        # layout1.setContentsMargins(5,0,0,0)
+        # layout1.setSpacing(0)
+        # layout2 = QHBoxLayout()
+        # layout2.addWidget(self._slider_max_label)
+        # layout2.setContentsMargins(50,0, 0,0)
+        # layout2.setSpacing(0)
+
+        # layout3 = QHBoxLayout()
+        # layout3.addLayout(layout1)
+        # layout3.addLayout(layout2)
+
+        # layout4 = QHBoxLayout()
+        # layout4.addWidget(self._slider)
+        # layout4.setContentsMargins(0,0,0,0)
+        # layout4.setSpacing(0)
+
+        # layout = QVBoxLayout()
+        # layout.addLayout(layout4, 5)
+        # layout.addLayout(layout3)
 
         # layout
         layout = QHBoxLayout()
@@ -79,7 +107,10 @@ class QtLabeledSlider1(QWidget):
         layout.addWidget(self._slider_min_label)
         layout.addWidget(self._slider)
         layout.addWidget(self._slider_max_label)
-        layout.setAlignment(Qt.AlignBottom)
+        # layout.setAlignment(Qt.AlignBottom)
+        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setAlignment(Qt.AlignHCenter)
 
         self.setLayout(layout)
 

--- a/napari/_qt/widgets/qt_sliders_with_labels.py
+++ b/napari/_qt/widgets/qt_sliders_with_labels.py
@@ -1,0 +1,220 @@
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtWidgets import QHBoxLayout, QLabel, QLineEdit, QSlider, QWidget
+
+from ...utils.translations import translator
+
+trans = translator.load()
+
+
+# from qtpy.QtCore import QSize, Qt, Signal
+# from qtpy.QtGui import QColor, QIntValidator, QPainter, QPainterPath, QPen
+# from qtpy.QtWidgets import (
+#     QDialog,
+#     QFrame,
+#     QHBoxLayout,
+#     QLabel,
+#     QLineEdit,
+#     QSlider,
+#     QVBoxLayout,
+#     QWidget,
+# )
+
+# from ...utils.translations import translator
+
+# trans = translator.load()
+
+
+class QtLabeledSlider1(QWidget):
+    """Creates custom slider widget with 1 input text box.
+
+    Parameters
+    ----------
+
+    """
+
+    valueChanged = Signal(int)
+
+    def __init__(
+        self,
+        parent: QWidget = None,
+        value: int = 1,
+        min_value: int = 1,
+        max_value: int = 10,
+        single_step: int = 1,
+    ):
+        super().__init__(parent)
+
+        # self.setGeometry(300, 300, 125, 110)
+        self._value = value
+        self._min_value = min_value
+        self._max_value = max_value
+        self._single_step = single_step
+
+        # Widget
+        self._lineedit = QLineEdit()
+        self._unit = QLabel(self)
+        self._slider = QSlider(Qt.Horizontal, parent=parent)
+        self._slider_min_label = QLabel(self)
+        self._slider_max_label = QLabel(self)
+        # self._validator = QIntValidator(min_value, max_value, self)
+
+        # Widgets setup
+        # self._lineedit.setValidator(self._validator)
+        self._lineedit.setAlignment(Qt.AlignRight)
+        self._lineedit.setAlignment(Qt.AlignBottom)
+        self._slider_min_label.setText(str(min_value))
+        self._slider_min_label.setAlignment(Qt.AlignBottom)
+        self._slider_max_label.setText(str(max_value))
+        self._slider_max_label.setAlignment(Qt.AlignBottom)
+        self._slider.setMinimum(min_value)
+        self._slider.setMaximum(max_value)
+
+        # Signals
+        self._slider.valueChanged.connect(self._update_value)
+        self._lineedit.textChanged.connect(self._update_value)
+
+        # layout
+        layout = QHBoxLayout()
+        layout.addWidget(self._lineedit)
+        layout.addWidget(self._slider_min_label)
+        layout.addWidget(self._slider)
+        layout.addWidget(self._slider_max_label)
+        layout.setAlignment(Qt.AlignBottom)
+
+        self.setLayout(layout)
+
+        self._refresh()
+
+    def _update_value(self, value):
+        """Update slider widget value.
+
+        Parameters
+        ----------
+        value : int
+            Widget value.
+        """
+        if value == "":
+            value = int(self._value)
+
+        value = int(value)
+
+        if value > self._max_value:
+            value = self._max_value
+        elif value < self._min_value:
+            value = self._min_value
+
+        if value != self._value:
+            self.valueChanged.emit(value)
+
+        self._value = value
+        self._refresh()
+
+    def _refresh(self):
+        """Set every widget value to the new set value."""
+        self.blockSignals(True)
+        self._lineedit.setText(str(self._value))
+        self._slider.setValue(self._value)
+        self.blockSignals(False)
+        # self.valueChanged.emit(self._value)
+
+    def setSingleStep(self, value):
+        """sets the single step of the slider"""
+
+        self._slider.setSingleStep(value)
+
+    def value(self):
+        """Return current value.
+
+        Returns
+        -------
+        int
+            Current value of highlight widget.
+        """
+        return self._value
+
+    def setValue(self, value):
+        """Set new value and update widget.
+
+        Parameters
+        ----------
+        value : int
+            Highlight value.
+        """
+        self._update_value(value)
+        # self._refresh()
+
+    def setMinimum(self, value):
+        """Set minimum widget value for slider.
+
+        Parameters
+        ----------
+        value : int
+            Minimum widget value.
+        """
+        value = int(value)
+        if value < self._max_value:
+            self._min_value = value
+            self._slider_min_label.setText(str(value))
+            self._slider.setMinimum(value)
+            self._value = (
+                self._min_value
+                if self._value < self._min_value
+                else self._value
+            )
+            self._refresh()
+        else:
+            raise ValueError(
+                trans._(
+                    "Minimum value must be smaller than {max_value}",
+                    deferred=True,
+                    max_value=self._max_value,
+                )
+            )
+
+    def minimum(self):
+        """Return minimum widget value.
+
+        Returns
+        -------
+        int
+            Minimum value of widget widget.
+        """
+        return self._min_value
+
+    def setMaximum(self, value):
+        """Set maximum widget value.
+
+        Parameters
+        ----------
+        value : int
+            Maximum widget value.
+        """
+        value = int(value)
+        if value > self._min_value:
+            self._max_value = value
+            self._slider_max_label.setText(str(value))
+            self._slider.setMaximum(value)
+            self._value = (
+                self._max_value
+                if self._value > self._max_value
+                else self._value
+            )
+            self._refresh()
+        else:
+            raise ValueError(
+                trans._(
+                    "Maximum value must be larger than {min_value}",
+                    deferred=True,
+                    min_value=self._min_value,
+                )
+            )
+
+    def maximum(self):
+        """Return maximum widget value.
+
+        Returns
+        -------
+        int
+            Maximum value of highlight widget.
+        """
+        return self._max_value

--- a/napari/_qt/widgets/qt_sliders_with_labels.py
+++ b/napari/_qt/widgets/qt_sliders_with_labels.py
@@ -3,6 +3,7 @@ from qtpy.QtGui import QFont
 from qtpy.QtWidgets import QHBoxLayout, QLabel, QLineEdit, QSlider, QWidget
 
 from ...utils.translations import translator
+from ..widgets.qt_range_slider import QHRangeSlider
 
 trans = translator.load()
 
@@ -100,6 +101,230 @@ class QtLabeledSlider1(QWidget):
         # layout = QVBoxLayout()
         # layout.addLayout(layout4, 5)
         # layout.addLayout(layout3)
+
+        # layout
+        layout = QHBoxLayout()
+        layout.addWidget(self._lineedit)
+        layout.addWidget(self._slider_min_label)
+        layout.addWidget(self._slider)
+        layout.addWidget(self._slider_max_label)
+        # layout.setAlignment(Qt.AlignBottom)
+        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setAlignment(Qt.AlignHCenter)
+
+        self.setLayout(layout)
+
+        self._refresh()
+
+    def setFocusPolicy(self, policy):
+        """Set slider focus policy
+
+        Parameters
+        ----------
+        policy: Qt.focusPolicy (check this)
+        """
+        self._slider.setFocusPolicy(policy)
+
+    def _update_value(self, value):
+        """Update slider widget value.
+
+        Parameters
+        ----------
+        value : int
+            Widget value.
+        """
+        if value == "":
+            value = int(self._value)
+
+        value = int(value)
+
+        if value > self._max_value:
+            value = self._max_value
+        elif value < self._min_value:
+            value = self._min_value
+
+        if value != self._value:
+            self.valueChanged.emit(value)
+
+        self._value = value
+        self._refresh()
+
+    def _refresh(self):
+        """Set every widget value to the new set value."""
+        self.blockSignals(True)
+        self._lineedit.setText(str(self._value))
+        self._slider.setValue(self._value)
+        self.blockSignals(False)
+        # self.valueChanged.emit(self._value)
+
+    def setSingleStep(self, value):
+        """sets the single step of the slider"""
+
+        self._slider.setSingleStep(value)
+
+    def value(self):
+        """Return current value.
+
+        Returns
+        -------
+        int
+            Current value of highlight widget.
+        """
+        return self._value
+
+    def setValue(self, value):
+        """Set new value and update widget.
+
+        Parameters
+        ----------
+        value : int
+            Highlight value.
+        """
+        self._update_value(value)
+        # self._refresh()
+
+    def setMinimum(self, value):
+        """Set minimum widget value for slider.
+
+        Parameters
+        ----------
+        value : int
+            Minimum widget value.
+        """
+        value = int(value)
+        if value < self._max_value:
+            self._min_value = value
+            self._slider_min_label.setText(str(value))
+            self._slider.setMinimum(value)
+            self._value = (
+                self._min_value
+                if self._value < self._min_value
+                else self._value
+            )
+            self._refresh()
+        else:
+            raise ValueError(
+                trans._(
+                    "Minimum value must be smaller than {max_value}",
+                    deferred=True,
+                    max_value=self._max_value,
+                )
+            )
+
+    def minimum(self):
+        """Return minimum widget value.
+
+        Returns
+        -------
+        int
+            Minimum value of widget widget.
+        """
+        return self._min_value
+
+    def setMaximum(self, value):
+        """Set maximum widget value.
+
+        Parameters
+        ----------
+        value : int
+            Maximum widget value.
+        """
+        value = int(value)
+        if value > self._min_value:
+            self._max_value = value
+            self._slider_max_label.setText(str(value))
+            self._slider.setMaximum(value)
+            self._value = (
+                self._max_value
+                if self._value > self._max_value
+                else self._value
+            )
+            self._refresh()
+        else:
+            raise ValueError(
+                trans._(
+                    "Maximum value must be larger than {min_value}",
+                    deferred=True,
+                    min_value=self._min_value,
+                )
+            )
+
+    def maximum(self):
+        """Return maximum widget value.
+
+        Returns
+        -------
+        int
+            Maximum value of highlight widget.
+        """
+        return self._max_value
+
+
+class QtLabeledSlider2(QWidget):
+    """Creates custom slider widget with 2 input text box.
+
+    Parameters
+    ----------
+
+    """
+
+    valuesChanged = Signal(tuple)
+    rangeChanged = Signal(tuple)
+    # self.layer.contrast_limits,
+    #         self.layer.contrast_limits_range,
+    #         parent=self,
+
+    def __init__(
+        self,
+        initial_values=None,
+        data_range=None,
+        step_size=None,
+        collapsible=True,
+        collapsed=False,
+        parent=None,
+    ):
+        super().__init__(parent)
+
+        # self.setGeometry(0, 0, 30, 100)
+        self._initial_values = initial_values
+        self._data_range = data_range
+        self._step_size = step_size
+        # self._value = value
+        # self._min_value = min_value
+        # self._max_value = max_value
+        # self._single_step = single_step
+
+        # Widget
+        self._lineedit1 = QLineEdit()
+        self._lineedit2 = QLineEdit()
+        self._slider = QHRangeSlider(initial_values, data_range, parent=parent)
+        self._slider_min_label = QLabel(self)
+        self._slider_max_label = QLabel(self)
+        # self._validator = QIntValidator(min_value, max_value, self)
+
+        # Widgets setup
+        # self._lineedit.setValidator(self._validator)
+        self._lineedit1.setAlignment(Qt.AlignRight)
+        self._lineedit1.setAlignment(Qt.AlignHCenter)
+        self._lineedit1.setFixedWidth(25)
+        self._lineedit2.setAlignment(Qt.AlignRight)
+        self._lineedit2.setAlignment(Qt.AlignHCenter)
+        self._lineedit2.setFixedWidth(25)
+        self._slider_min_label.setText(str(data_range[0]))
+        self._slider_max_label.setText(str(data_range[1]))
+
+        font10 = QFont()
+        font10.setPointSize(10)
+        self._slider_min_label.setFont(font10)
+        self._slider_max_label.setFont(font10)
+        self._lineedit1.setFont(font10)
+        self._lineedit2.setFont(font10)
+        # self._slider.setFixedWidth(60)
+
+        # Signals
+        self._slider.valuesChanged.connect(self._update_value)
+        self._lineedit.textChanged.connect(self._update_value)
 
         # layout
         layout = QHBoxLayout()

--- a/napari/_qt/widgets/qt_sliders_with_labels.py
+++ b/napari/_qt/widgets/qt_sliders_with_labels.py
@@ -341,136 +341,136 @@ class QtLabeledSlider2(QWidget):
 
         self._refresh()
 
-    def _update_value(self, value):
-        """Update slider widget value.
+    # def _update_value(self, value):
+    #     """Update slider widget value.
 
-        Parameters
-        ----------
-        value : int
-            Widget value.
-        """
-        if value == "":
-            value = int(self._value)
+    #     Parameters
+    #     ----------
+    #     value : int
+    #         Widget value.
+    #     """
+    #     if value == "":
+    #         value = int(self._value)
 
-        value = int(value)
+    #     value = int(value)
 
-        if value > self._max_value:
-            value = self._max_value
-        elif value < self._min_value:
-            value = self._min_value
+    #     if value > self._max_value:
+    #         value = self._max_value
+    #     elif value < self._min_value:
+    #         value = self._min_value
 
-        if value != self._value:
-            self.valueChanged.emit(value)
+    #     if value != self._value:
+    #         self.valueChanged.emit(value)
 
-        self._value = value
-        self._refresh()
+    #     self._value = value
+    #     self._refresh()
 
-    def _refresh(self):
-        """Set every widget value to the new set value."""
-        self.blockSignals(True)
-        self._lineedit.setText(str(self._value))
-        self._slider.setValue(self._value)
-        self.blockSignals(False)
-        # self.valueChanged.emit(self._value)
+    # def _refresh(self):
+    #     """Set every widget value to the new set value."""
+    #     self.blockSignals(True)
+    #     self._lineedit.setText(str(self._value))
+    #     self._slider.setValue(self._value)
+    #     self.blockSignals(False)
+    #     # self.valueChanged.emit(self._value)
 
-    def setSingleStep(self, value):
-        """sets the single step of the slider"""
+    # def setSingleStep(self, value):
+    #     """sets the single step of the slider"""
 
-        self._slider.setSingleStep(value)
+    #     self._slider.setSingleStep(value)
 
-    def value(self):
-        """Return current value.
+    # def value(self):
+    #     """Return current value.
 
-        Returns
-        -------
-        int
-            Current value of highlight widget.
-        """
-        return self._value
+    #     Returns
+    #     -------
+    #     int
+    #         Current value of highlight widget.
+    #     """
+    #     return self._value
 
-    def setValue(self, value):
-        """Set new value and update widget.
+    # def setValue(self, value):
+    #     """Set new value and update widget.
 
-        Parameters
-        ----------
-        value : int
-            Highlight value.
-        """
-        self._update_value(value)
-        # self._refresh()
+    #     Parameters
+    #     ----------
+    #     value : int
+    #         Highlight value.
+    #     """
+    #     self._update_value(value)
+    #     # self._refresh()
 
-    def setMinimum(self, value):
-        """Set minimum widget value for slider.
+    # def setMinimum(self, value):
+    #     """Set minimum widget value for slider.
 
-        Parameters
-        ----------
-        value : int
-            Minimum widget value.
-        """
-        value = int(value)
-        if value < self._max_value:
-            self._min_value = value
-            self._slider_min_label.setText(str(value))
-            self._slider.setMinimum(value)
-            self._value = (
-                self._min_value
-                if self._value < self._min_value
-                else self._value
-            )
-            self._refresh()
-        else:
-            raise ValueError(
-                trans._(
-                    "Minimum value must be smaller than {max_value}",
-                    deferred=True,
-                    max_value=self._max_value,
-                )
-            )
+    #     Parameters
+    #     ----------
+    #     value : int
+    #         Minimum widget value.
+    #     """
+    #     value = int(value)
+    #     if value < self._max_value:
+    #         self._min_value = value
+    #         self._slider_min_label.setText(str(value))
+    #         self._slider.setMinimum(value)
+    #         self._value = (
+    #             self._min_value
+    #             if self._value < self._min_value
+    #             else self._value
+    #         )
+    #         self._refresh()
+    #     else:
+    #         raise ValueError(
+    #             trans._(
+    #                 "Minimum value must be smaller than {max_value}",
+    #                 deferred=True,
+    #                 max_value=self._max_value,
+    #             )
+    #         )
 
-    def minimum(self):
-        """Return minimum widget value.
+    # def minimum(self):
+    #     """Return minimum widget value.
 
-        Returns
-        -------
-        int
-            Minimum value of widget widget.
-        """
-        return self._min_value
+    #     Returns
+    #     -------
+    #     int
+    #         Minimum value of widget widget.
+    #     """
+    #     return self._min_value
 
-    def setMaximum(self, value):
-        """Set maximum widget value.
+    # def setMaximum(self, value):
+    #     """Set maximum widget value.
 
-        Parameters
-        ----------
-        value : int
-            Maximum widget value.
-        """
-        value = int(value)
-        if value > self._min_value:
-            self._max_value = value
-            self._slider_max_label.setText(str(value))
-            self._slider.setMaximum(value)
-            self._value = (
-                self._max_value
-                if self._value > self._max_value
-                else self._value
-            )
-            self._refresh()
-        else:
-            raise ValueError(
-                trans._(
-                    "Maximum value must be larger than {min_value}",
-                    deferred=True,
-                    min_value=self._min_value,
-                )
-            )
+    #     Parameters
+    #     ----------
+    #     value : int
+    #         Maximum widget value.
+    #     """
+    #     value = int(value)
+    #     if value > self._min_value:
+    #         self._max_value = value
+    #         self._slider_max_label.setText(str(value))
+    #         self._slider.setMaximum(value)
+    #         self._value = (
+    #             self._max_value
+    #             if self._value > self._max_value
+    #             else self._value
+    #         )
+    #         self._refresh()
+    #     else:
+    #         raise ValueError(
+    #             trans._(
+    #                 "Maximum value must be larger than {min_value}",
+    #                 deferred=True,
+    #                 min_value=self._min_value,
+    #             )
+    #         )
 
-    def maximum(self):
-        """Return maximum widget value.
+    # def maximum(self):
+    #     """Return maximum widget value.
 
-        Returns
-        -------
-        int
-            Maximum value of highlight widget.
-        """
-        return self._max_value
+    #     Returns
+    #     -------
+    #     int
+    #         Maximum value of highlight widget.
+    #     """
+    #     return self._max_value


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
Include a text box for sliders on the different layers that will allow a user to type in a value and adjust the slider.  Range limits are displayed as well.

This work is addresses this heuristic issue: https://github.com/napari/product-heuristics-2020/issues/24 .

Fixes https://github.com/napari/product-heuristics-2020/issues/24

TO DO: Still working on adding a text boxes for the contrast limit range slider (QHRangeSlider).  

Some previews of the new sliders in place.  I'd appreciate feedback!  Love it, hate it?  

Points:
<img width="288" alt="points" src="https://user-images.githubusercontent.com/54282105/118152255-1b77a380-b3da-11eb-8a25-ed48e24a91fa.png">

Shapes:
<img width="297" alt="shapes" src="https://user-images.githubusercontent.com/54282105/118152310-28949280-b3da-11eb-902b-2d402dfa0eae.png">

Labels:
<img width="282" alt="labels" src="https://user-images.githubusercontent.com/54282105/118152345-2f230a00-b3da-11eb-9a54-0914ab15e21e.png">

Images (Note: still working on slider for contrast limits): 
<img width="323" alt="image" src="https://user-images.githubusercontent.com/54282105/118152364-334f2780-b3da-11eb-9cba-a70cbf9baf68.png">


