### PR TITLE
Patch horizontalAdvance for older Qt versions

### DIFF
--- a/docs/release/release_0_4_8.md
+++ b/docs/release/release_0_4_8.md
@@ -145,6 +145,7 @@ and
 - Fix handling of exceptions and notifications of threading threads (#2703)
 - Fix vertical_stretch injection and kwargs passing on DockWidget (#2705)
 - Fix tracks icons, and visibility icons (#2708)
+- Patch horizontalAdvance for older Qt versions (#2711)
 
 ## API Changes
 

--- a/napari/_qt/widgets/qt_large_int_spinbox.py
+++ b/napari/_qt/widgets/qt_large_int_spinbox.py
@@ -156,7 +156,11 @@ class QtLargeIntSpinBox(QAbstractSpinBox):
         self.ensurePolished()
         fm = QFontMetrics(self.font())
         h = self.lineEdit().sizeHint().height()
-        w = fm.horizontalAdvance(str(self._value)) + 3
+        if hasattr(fm, 'horizontalAdvance'):
+            # Qt >= 5.11
+            w = fm.horizontalAdvance(str(self._value)) + 3
+        else:
+            w = fm.width(str(self._value)) + 3
         w = max(36, w)
         opt = QStyleOptionSpinBox()
         self.initStyleOption(opt)

--- a/napari/_qt/widgets/qt_size_preview.py
+++ b/napari/_qt/widgets/qt_size_preview.py
@@ -174,9 +174,14 @@ class QtSizeSliderPreviewWidget(QWidget):
 
     def _update_line_width(self):
         """Update width ofg line text edit."""
-        size = self._lineedit.fontMetrics().horizontalAdvance(
-            "m" * (1 + len(str(self._max_value)))
-        )
+        txt = "m" * (1 + len(str(self._max_value)))
+        fm = self._lineedit.fontMetrics()
+        if hasattr(fm, 'horizontalAdvance'):
+            # Qt >= 5.11
+            size = fm.horizontalAdvance(txt)
+        else:
+            size = fm.width(txt)
+
         self._lineedit.setMaximumWidth(size)
         self._lineedit.setMinimumWidth(size)
 


### PR DESCRIPTION
# Description
This PR let's us hobble along with accidental support for Qt <5.11 for a little longer, by preventing an [attribute error](https://github.com/napari/napari/issues/2710).