### PR TITLE
Add `strict_qt` and `block_plugin_discovery` parameters to `make_napari_viewer`

### DIFF
--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -37,11 +37,11 @@ dwidget_args = {
 }
 
 
-# test_napari_plugin_manager from conftest.py
+# napari_plugin_manager from _testsupport.py
 # monkeypatch, request, recwarn fixtures are from pytest
 @pytest.mark.parametrize('arg', dwidget_args.values(), ids=dwidget_args.keys())
 def test_dock_widget_registration(
-    arg, test_napari_plugin_manager, request, recwarn
+    arg, napari_plugin_manager, request, recwarn
 ):
     """Test that dock widgets get validated and registerd correctly."""
 
@@ -50,9 +50,9 @@ def test_dock_widget_registration(
         def napari_experimental_provide_dock_widget():
             return arg
 
-    test_napari_plugin_manager.register(Plugin, name='Plugin')
-    test_napari_plugin_manager.discover_widgets()
-    widgets = test_napari_plugin_manager._dock_widgets
+    napari_plugin_manager.register(Plugin, name='Plugin')
+    napari_plugin_manager.discover_widgets()
+    widgets = napari_plugin_manager._dock_widgets
 
     if '[bad_' in request.node.name:
         assert len(recwarn) == 1
@@ -65,9 +65,9 @@ def test_dock_widget_registration(
 
 
 @pytest.fixture
-def test_plugin_widgets(monkeypatch, test_napari_plugin_manager):
+def test_plugin_widgets(monkeypatch, napari_plugin_manager):
     """A smattering of example registered dock widgets and function widgets."""
-    tnpm = test_napari_plugin_manager
+    tnpm = napari_plugin_manager
     dock_widgets = {
         "TestP1": {"Widg1": (Widg1, {}), "Widg2": (Widg2, {})},
         "TestP2": {"Widg3": (Widg3, {})},

--- a/napari/_tests/test_cli.py
+++ b/napari/_tests/test_cli.py
@@ -24,7 +24,7 @@ def test_cli_works(monkeypatch, capsys):
     assert 'napari command line viewer.' in str(capsys.readouterr())
 
 
-def test_cli_shows_plugins(test_napari_plugin_manager, monkeypatch, capsys):
+def test_cli_shows_plugins(napari_plugin_manager, monkeypatch, capsys):
     """Test the cli --info runs and shows plugins"""
     monkeypatch.setattr(sys, 'argv', ['napari', '--info'])
     with pytest.raises(SystemExit):

--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -12,6 +12,7 @@ skip = [
     'surface_timeseries.py',  # needs nilearn
     '3d_kymograph.py',  # needs tqdm
     'live_tiffs.py',  # requires files
+    'tiled-rendering-2d.py',  # too slow
     'live_tiffs_generator.py',
     'embed_ipython.py',  # fails without monkeypatch
 ]

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -332,28 +332,3 @@ def pytest_collection_modifyitems(session, config, items):
             at_end.append(items.pop(i))
 
     items.extend([x for _, x in sorted(zip(put_at_end, at_end))])
-
-
-@pytest.fixture
-def test_napari_plugin_manager(monkeypatch):
-    from unittest.mock import patch
-
-    import napari
-    from napari.plugins import NapariPluginManager
-
-    pm = NapariPluginManager()
-
-    # make it so that internal requests for the plugin_manager
-    # get this test version for the duration of the test.
-    monkeypatch.setattr(napari.plugins, 'plugin_manager', pm)
-    monkeypatch.setattr(napari.plugins.io, 'plugin_manager', pm)
-    try:
-        monkeypatch.setattr(napari._qt.qt_main_window, 'plugin_manager', pm)
-    except AttributeError:  # headless tests
-        pass
-
-    # prevent discovery of plugins in the environment
-    # you can still use `pm.register` to explicitly register something.
-    with patch.object(pm, 'discover'):
-        pm._initialize()  # register our builtins
-        yield pm

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -130,8 +130,11 @@ class NapariPluginManager(PluginManager):
         for spec_name, hook_caller in self.hooks.items():
             order = []
             for p in new_order.get(spec_name, []):
-                order.append(p['plugin'])
-                hook_caller._set_plugin_enabled(p['plugin'], p['enabled'])
+                try:
+                    hook_caller._set_plugin_enabled(p['plugin'], p['enabled'])
+                    order.append(p['plugin'])
+                except KeyError:
+                    pass
             if order:
                 hook_caller.bring_to_front(order)
 

--- a/napari/plugins/_tests/test_builtin_get_writer.py
+++ b/napari/plugins/_tests/test_builtin_get_writer.py
@@ -8,14 +8,14 @@ from napari.plugins import _builtins
 
 # test_plugin_manager fixture is provided by napari_plugin_engine._testsupport
 def test_get_writer_succeeds(
-    test_napari_plugin_manager, tmpdir, layer_data_and_types
+    napari_plugin_manager, tmpdir, layer_data_and_types
 ):
     """Test writing layers data."""
 
     _, layer_data, layer_types, filenames = layer_data_and_types
     path = os.path.join(tmpdir, 'layers_folder')
 
-    writer = test_napari_plugin_manager.hook.napari_get_writer(
+    writer = napari_plugin_manager.hook.napari_get_writer(
         path=path, layer_types=layer_types
     )
 
@@ -35,7 +35,7 @@ def test_get_writer_succeeds(
 # the layer_data_and_types fixture is defined in napari/conftest.py
 # test_plugin_manager fixture is provided by napari_plugin_engine._testsupport
 def test_get_writer_bad_plugin(
-    test_napari_plugin_manager, tmpdir, layer_data_and_types
+    napari_plugin_manager, tmpdir, layer_data_and_types
 ):
     """Test cleanup when get_writer has an exception."""
     from napari_plugin_engine import napari_hook_implementation
@@ -47,7 +47,7 @@ def test_get_writer_bad_plugin(
 
     _, layer_data, layer_types, filenames = layer_data_and_types
 
-    test_napari_plugin_manager.register(bad_plugin)
+    napari_plugin_manager.register(bad_plugin)
     # this time we try writing directly to the tmpdir (which already exists)
     writer = _builtins.napari_get_writer(tmpdir, layer_types)
 

--- a/napari/plugins/_tests/test_plugin_widgets.py
+++ b/napari/plugins/_tests/test_plugin_widgets.py
@@ -26,11 +26,11 @@ fwidget_args = {
 }
 
 
-# test_napari_plugin_manager fixture from napari.conftest
+# napari_plugin_manager fixture from napari.conftest
 # request, recwarn fixtures are from pytest
 @pytest.mark.parametrize('arg', fwidget_args.values(), ids=fwidget_args.keys())
 def test_function_widget_registration(
-    arg, test_napari_plugin_manager, request, recwarn
+    arg, napari_plugin_manager, request, recwarn
 ):
     """Test that function widgets get validated and registerd correctly."""
 
@@ -39,10 +39,10 @@ def test_function_widget_registration(
         def napari_experimental_provide_function():
             return arg
 
-    test_napari_plugin_manager.discover_widgets()
-    test_napari_plugin_manager.register(Plugin, name='Plugin')
+    napari_plugin_manager.discover_widgets()
+    napari_plugin_manager.register(Plugin, name='Plugin')
 
-    f_widgets = test_napari_plugin_manager._function_widgets
+    f_widgets = napari_plugin_manager._function_widgets
 
     if 'bad_' in request.node.name:
         assert not f_widgets

--- a/napari/plugins/_tests/test_plugins_misc.py
+++ b/napari/plugins/_tests/test_plugins_misc.py
@@ -31,9 +31,9 @@ def test_plugin_discovery_is_delayed():
     assert not proc.returncode, 'napari-svg unavailable, this test is broken!'
 
 
-def test_plugin_events(test_napari_plugin_manager):
+def test_plugin_events(napari_plugin_manager):
     """Test event emission by plugin manager."""
-    tnpm: NapariPluginManager = test_napari_plugin_manager
+    tnpm: NapariPluginManager = napari_plugin_manager
 
     register_events = []
     enable_events = []

--- a/napari/plugins/_tests/test_reader_plugins.py
+++ b/napari/plugins/_tests/test_reader_plugins.py
@@ -77,7 +77,7 @@ def test_builtin_reader_plugin_stacks():
 
 
 def test_reader_plugin_can_return_null_layer_sentinel(
-    test_napari_plugin_manager,
+    napari_plugin_manager,
 ):
     from napari_plugin_engine import napari_hook_implementation
 
@@ -93,7 +93,7 @@ def test_reader_plugin_can_return_null_layer_sentinel(
 
             return _reader
 
-    test_napari_plugin_manager.register(sample_plugin)
+    napari_plugin_manager.register(sample_plugin)
     layer_data, _ = read_data_with_plugins('')
     assert layer_data is not None
     assert len(layer_data) == 0

--- a/napari/plugins/_tests/test_reader_plugins.py
+++ b/napari/plugins/_tests/test_reader_plugins.py
@@ -82,7 +82,7 @@ def test_reader_plugin_can_return_null_layer_sentinel(
     from napari_plugin_engine import napari_hook_implementation
 
     with pytest.raises(ValueError) as e:
-        read_data_with_plugins('')
+        read_data_with_plugins('/')
     assert 'No plugin found capable of reading' in str(e)
 
     class sample_plugin:

--- a/napari/plugins/_tests/test_sample_data.py
+++ b/napari/plugins/_tests/test_sample_data.py
@@ -9,10 +9,10 @@ from napari.layers._source import Source
 from napari.viewer import ViewerModel
 
 
-def test_sample_hook(test_napari_plugin_manager):
+def test_sample_hook(napari_plugin_manager):
 
     viewer = ViewerModel()
-    test_napari_plugin_manager.discover_sample_data()
+    napari_plugin_manager.discover_sample_data()
 
     with pytest.raises(KeyError) as e:
         viewer.open_sample('test_plugin', 'random data')
@@ -41,9 +41,9 @@ def test_sample_hook(test_napari_plugin_manager):
                 },
             }
 
-    test_napari_plugin_manager.register(test_plugin)
+    napari_plugin_manager.register(test_plugin)
 
-    reg = test_napari_plugin_manager._sample_data['test_plugin']
+    reg = napari_plugin_manager._sample_data['test_plugin']
     assert reg['random data']['data'] == _generate_random_data
     assert reg['random data']['display_name'] == 'random data'
     assert reg['napari logo']['data'] == LOGO

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -20,7 +20,7 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture
-def test_napari_plugin_manager(monkeypatch):
+def napari_plugin_manager(monkeypatch):
     from unittest.mock import patch
 
     import napari
@@ -48,7 +48,7 @@ def test_napari_plugin_manager(monkeypatch):
 
 @pytest.fixture
 def make_napari_viewer(
-    qtbot, request: 'FixtureRequest', test_napari_plugin_manager
+    qtbot, request: 'FixtureRequest', napari_plugin_manager
 ):
     """A fixture function that creates a napari viewer for use in testing.
 
@@ -88,7 +88,7 @@ def make_napari_viewer(
         _strict = strict
 
         if not block_plugin_discovery:
-            test_napari_plugin_manager._discover_patcher.stop()
+            napari_plugin_manager._discover_patcher.stop()
 
         should_show = request.config.getoption("--show-napari-viewer")
         model_kwargs['show'] = model_kwargs.pop('show', should_show)

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -1,8 +1,11 @@
 import sys
 import warnings
-from typing import List
+from typing import TYPE_CHECKING, List
 
 import pytest
+
+if TYPE_CHECKING:
+    from pytest import FixtureRequest
 
 
 def pytest_addoption(parser):
@@ -15,32 +18,7 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture
-def _strict_qtbot(qtbot):
-    """A modified qtbot fixture that makes sure no widgets have been leaked."""
-    from qtpy.QtWidgets import QApplication
-
-    initial = QApplication.topLevelWidgets()
-    prior_exception = getattr(sys, 'last_value', None)
-
-    yield qtbot
-
-    # if an exception was raised during the test, we should just quit now and
-    # skip looking for leaked widgets.
-    if getattr(sys, 'last_value', None) is not prior_exception:
-        return
-
-    QApplication.processEvents()
-    leaks = set(QApplication.topLevelWidgets()).difference(initial)
-    # still not sure how to clean up some of the remaining vispy
-    # vispy.app.backends._qt.CanvasBackendDesktop widgets...
-    if any([n.__class__.__name__ != 'CanvasBackendDesktop' for n in leaks]):
-        raise AssertionError(f'Widgets leaked!: {leaks}')
-    if leaks:
-        warnings.warn(f'Widgets leaked!: {leaks}')
-
-
-@pytest.fixture(scope="function")
-def make_napari_viewer(_strict_qtbot, request):
+def make_napari_viewer(qtbot, request: 'FixtureRequest'):
     """A fixture function that creates a napari viewer for use in testing.
 
     This uses a strict qtbot variant that asserts that no widgets are left over
@@ -57,20 +35,33 @@ def make_napari_viewer(_strict_qtbot, request):
     from napari.utils.settings import SETTINGS
 
     SETTINGS.reset()
-
     viewers: List[Viewer] = []
+    _strict = False
 
-    def actual_factory(*model_args, viewer_class=Viewer, **model_kwargs):
-        model_kwargs['show'] = model_kwargs.pop(
-            'show', request.config.getoption("--show-napari-viewer")
-        )
-        viewer = viewer_class(*model_args, **model_kwargs)
+    from qtpy.QtWidgets import QApplication
+
+    initial = QApplication.topLevelWidgets()
+    prior_exception = getattr(sys, 'last_value', None)
+    internal_test = request.module.__name__.startswith("napari.")
+
+    def actual_factory(
+        *model_args, ViewerClass=Viewer, strict=internal_test, **model_kwargs
+    ):
+        nonlocal _strict
+        _strict = strict
+
+        should_show = request.config.getoption("--show-napari-viewer")
+        model_kwargs['show'] = model_kwargs.pop('show', should_show)
+
+        viewer = ViewerClass(*model_args, **model_kwargs)
         viewers.append(viewer)
+
         return viewer
 
     yield actual_factory
 
-    # Some tests might have the viewer closed, so this call will not be able to access the window.
+    # Some tests might have the viewer closed, so this call will not be able
+    # to access the window.
     try:
         SETTINGS.reset()
     except AttributeError:
@@ -78,3 +69,15 @@ def make_napari_viewer(_strict_qtbot, request):
 
     for viewer in viewers:
         viewer.close()
+
+    # only check for leaked widgets if an exception was raised during the test,
+    # or "strict" mode was not used.
+    if _strict and getattr(sys, 'last_value', None) is prior_exception:
+        QApplication.processEvents()
+        leak = set(QApplication.topLevelWidgets()).difference(initial)
+        # still not sure how to clean up some of the remaining vispy
+        # vispy.app.backends._qt.CanvasBackendDesktop widgets...
+        if any([n.__class__.__name__ != 'CanvasBackendDesktop' for n in leak]):
+            # just a warning... but this can be converted to test errors
+            # in pytest with `-W error`
+            warnings.warn(f'Widgets leaked!: {leak}')

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -1,6 +1,8 @@
 import sys
 import warnings
+from contextlib import suppress
 from typing import TYPE_CHECKING, List
+from unittest.mock import patch
 
 import pytest
 
@@ -18,7 +20,36 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture
-def make_napari_viewer(qtbot, request: 'FixtureRequest'):
+def test_napari_plugin_manager(monkeypatch):
+    from unittest.mock import patch
+
+    import napari
+    from napari.plugins._plugin_manager import NapariPluginManager
+
+    pm = NapariPluginManager()
+
+    # make it so that internal requests for the plugin_manager
+    # get this test version for the duration of the test.
+    monkeypatch.setattr(napari.plugins, 'plugin_manager', pm)
+    monkeypatch.setattr(napari.plugins.io, 'plugin_manager', pm)
+    try:
+        monkeypatch.setattr(napari._qt.qt_main_window, 'plugin_manager', pm)
+    except AttributeError:  # headless tests
+        pass
+
+    # prevent discovery of plugins in the environment
+    # you can still use `pm.register` to explicitly register something.
+    pm._discover_patcher = patch.object(pm, 'discover')
+    pm._discover_patcher.start()
+    pm._initialize()  # register our builtins
+    yield pm
+    pm._discover_patcher.stop()
+
+
+@pytest.fixture
+def make_napari_viewer(
+    qtbot, request: 'FixtureRequest', test_napari_plugin_manager
+):
     """A fixture function that creates a napari viewer for use in testing.
 
     This uses a strict qtbot variant that asserts that no widgets are left over
@@ -31,28 +62,36 @@ def make_napari_viewer(qtbot, request: 'FixtureRequest'):
     ...     viewer.add_shapes()
     ...     assert len(viewer.layers) == 1
     """
+    from qtpy.QtWidgets import QApplication
+
     from napari import Viewer
     from napari.utils.settings import SETTINGS
 
     SETTINGS.reset()
     viewers: List[Viewer] = []
-    _strict = False
 
-    from qtpy.QtWidgets import QApplication
+    # may be overridden by using `make_napari_viewer(strict=True)`
+    _strict = False
 
     initial = QApplication.topLevelWidgets()
     prior_exception = getattr(sys, 'last_value', None)
-    internal_test = request.module.__name__.startswith("napari.")
+    is_internal_test = request.module.__name__.startswith("napari.")
 
     def actual_factory(
-        *model_args, ViewerClass=Viewer, strict=internal_test, **model_kwargs
+        *model_args,
+        ViewerClass=Viewer,
+        strict=is_internal_test,
+        block_plugin_discovery=True,
+        **model_kwargs,
     ):
         nonlocal _strict
         _strict = strict
 
+        if not block_plugin_discovery:
+            test_napari_plugin_manager._discover_patcher.stop()
+
         should_show = request.config.getoption("--show-napari-viewer")
         model_kwargs['show'] = model_kwargs.pop('show', should_show)
-
         viewer = ViewerClass(*model_args, **model_kwargs)
         viewers.append(viewer)
 
@@ -62,16 +101,21 @@ def make_napari_viewer(qtbot, request: 'FixtureRequest'):
 
     # Some tests might have the viewer closed, so this call will not be able
     # to access the window.
-    try:
+    with suppress(AttributeError):
         SETTINGS.reset()
-    except AttributeError:
-        pass
 
+    # close viewers, but don't saving window settings while closing
     for viewer in viewers:
-        viewer.close()
+        if hasattr(viewer.window, '_qt_window'):
+            with patch.object(
+                viewer.window._qt_window, '_save_current_window_settings'
+            ):
+                viewer.close()
+        else:
+            viewer.close()
 
     # only check for leaked widgets if an exception was raised during the test,
-    # or "strict" mode was not used.
+    # or "strict" mode was used.
     if _strict and getattr(sys, 'last_value', None) is prior_exception:
         QApplication.processEvents()
         leak = set(QApplication.topLevelWidgets()).difference(initial)

--- a/napari/utils/settings/__init__.py
+++ b/napari/utils/settings/__init__.py
@@ -3,3 +3,5 @@
 
 from ._defaults import CORE_SETTINGS
 from ._manager import SETTINGS
+
+__all__ = ['SETTINGS', 'CORE_SETTINGS']


### PR DESCRIPTION
# Description
closes #2676 
This PR adds a public `napari_plugin_manager` test fixture and updates `make_napari_viewer` to use it, and adds some additional configuration options.   here's the summar:

1. `make_napari_viewer` will now _block_ discovery of non-builtin plugins by default.  To register external plugins for testing hook specs, use one of the following options:

    - `make_napari_viewer(block_plugin_discovery=False)`
    - use `napari_plugin_manager` fixture and manually register a plugin with `napari_plugin_manager.register()`
    - use `napari_plugin_manager` fixture and call `napari_plugin_manager.discovery_blocker.stop()`
    
2. The check for "leaked widgets" is now `False` by default for third party packages (it's too confusing), but `True` when testing inside of napari.  Anyone using `make_napari_viewer` can opt-in to strict Qt widgets checks with:

    - `make_napari_viewer(strict_qt=True)`
    - setting the `NAPARI_STRICT_QT` variable
    
   It's also a warning now, instead of an error, unless `strict_qt='raise'` .  (and internally, it will be an error anyway because napari test warnings are converted into errors.
