### PR TITLE
Fix mpl colormaps

### DIFF
--- a/napari/utils/colormaps/_tests/test_colormaps.py
+++ b/napari/utils/colormaps/_tests/test_colormaps.py
@@ -141,3 +141,10 @@ def test_mpl_colormap_exists():
     """Test that all localized mpl colormap names exist."""
     for name in _MATPLOTLIB_COLORMAP_NAMES:
         assert getattr(cm, name, None) is not None
+
+
+def test_unnamed_colormap():
+    """Test we can grab an unnamed MPL colormap"""
+    cmap_name = 'RdYlGn'
+    cmap = ensure_colormap(cmap_name)
+    assert isinstance(cmap, Colormap)

--- a/napari/utils/colormaps/_tests/test_colormaps.py
+++ b/napari/utils/colormaps/_tests/test_colormaps.py
@@ -94,6 +94,14 @@ def test_can_accept_named_vispy_colormaps():
     assert cmap.name == 'red'
 
 
+def test_can_accept_named_mpl_colormap():
+    """Test we can accept named mpl colormap"""
+    cmap_name = 'RdYlGn'
+    cmap = ensure_colormap(cmap_name)
+    assert isinstance(cmap, Colormap)
+    assert cmap.name == cmap_name
+
+
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_can_accept_vispy_colormaps_in_dict():
     """Test that we can accept vispy colormaps in a dictionary."""
@@ -141,10 +149,3 @@ def test_mpl_colormap_exists():
     """Test that all localized mpl colormap names exist."""
     for name in _MATPLOTLIB_COLORMAP_NAMES:
         assert getattr(cm, name, None) is not None
-
-
-def test_unnamed_colormap():
-    """Test we can grab an unnamed MPL colormap"""
-    cmap_name = 'RdYlGn'
-    cmap = ensure_colormap(cmap_name)
-    assert isinstance(cmap, Colormap)

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -388,7 +388,7 @@ def vispy_or_mpl_colormap(name):
             if name in _MATPLOTLIB_COLORMAP_NAMES:
                 display_name = _MATPLOTLIB_COLORMAP_NAMES[name]
             else:
-                display_name = trans._(name)
+                display_name = name
         except AttributeError:
             raise KeyError(
                 trans._(

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -385,7 +385,10 @@ def vispy_or_mpl_colormap(name):
     else:
         try:
             mpl_cmap = getattr(cm, name)
-            display_name = _MATPLOTLIB_COLORMAP_NAMES[name]
+            if name in _MATPLOTLIB_COLORMAP_NAMES:
+                display_name = _MATPLOTLIB_COLORMAP_NAMES[name]
+            else:
+                display_name = trans._(name)
         except AttributeError:
             raise KeyError(
                 trans._(


### PR DESCRIPTION
# Description
Noticed named MPL colormaps were broken as a result of #2498. Added fix and explicit test for it.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
