### PR TITLE
Add event for moving points

### DIFF
--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -288,6 +288,7 @@ class Points(Layer):
             symbol=Event,
             n_dimensional=Event,
             highlight=Event,
+            move=Event,
         )
 
         self._colors = get_color_namelist()
@@ -1470,6 +1471,8 @@ class Points(Layer):
                 self.data[np.ix_(index, disp)] + shift
             )
             self.refresh()
+            self.events.data(value=self.data)
+            self.events.move(idx=index, coord=coord)
 
     def _paste_data(self):
         """Paste any point from clipboard and select them."""


### PR DESCRIPTION
# Description
This PR adds a new event for moving points.

The event emits the index and coordinates of the point/s being moved.

@jni has mentioned that perhaps we would want to make this a subset of the data event e.g. 

```python
self.events.data(
    value=self.data,
    type='move',
    idx=index,
    coord=coord
)
```
For now I emit a data event alongside the move event. @sofroniewn I'm curious what you think and whether there's something you'd prefer.

I also wasn't sure where (if anywhere) to add tests for this event.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
