### PR TITLE
Added copy-to-clipboard functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: docs
+.PHONY: docs pre
 
 docs:
 	rm -rf docs/_build/
 	find docs/api ! -name 'index.rst' -type f -exec rm -f {} +
 	pip install -qr docs/requirements.txt
 	jb build docs
+
+pre:
+	pre-commit run -a

--- a/examples/clipboard.py
+++ b/examples/clipboard.py
@@ -1,0 +1,24 @@
+"""Copy canvas or whole viewer to clipboard."""
+from skimage import data
+
+import napari
+from napari._qt.widgets.qt_viewer_buttons import QtViewerPushButton
+
+
+# create the viewer with an image
+viewer = napari.view_image(data.astronaut(), rgb=True)
+
+layer_buttons = viewer.window.qt_viewer.layerButtons
+
+# Add button to copy image of the canvas to clipboard.
+copy_canvas_button = QtViewerPushButton(None, 'warning')
+copy_canvas_button.setToolTip("Copy screenshot of the canvas to clipboard.")
+copy_canvas_button.clicked.connect(viewer.window.qt_viewer.clipboard)
+layer_buttons.layout().insertWidget(3, copy_canvas_button)
+
+copy_canvas_button = QtViewerPushButton(None, 'warning')
+copy_canvas_button.setToolTip("Copy screenshot of the entire viewer to clipboard.")
+copy_canvas_button.clicked.connect(viewer.window.clipboard)
+layer_buttons.layout().insertWidget(3, copy_canvas_button)
+
+napari.run()

--- a/examples/clipboard.py
+++ b/examples/clipboard.py
@@ -1,24 +1,40 @@
-"""Copy canvas or whole viewer to clipboard."""
+"""Copy screenshot of the canvas or the whole viewer to clipboard."""
 from skimage import data
 
+from qtpy.QtWidgets import QVBoxLayout, QPushButton, QWidget
+
 import napari
-from napari._qt.widgets.qt_viewer_buttons import QtViewerPushButton
 
 
 # create the viewer with an image
-viewer = napari.view_image(data.cells3d())
+viewer = napari.view_image(data.moon())
 
-layer_buttons = viewer.window.qt_viewer.layerButtons
 
-# Add button to copy image of the canvas to clipboard.
-copy_canvas_button = QtViewerPushButton(None, 'warning')
-copy_canvas_button.setToolTip("Copy screenshot of the canvas to clipboard.")
-copy_canvas_button.clicked.connect(viewer.window.qt_viewer.clipboard)
-layer_buttons.layout().insertWidget(3, copy_canvas_button)
+class Grabber(QWidget):
+    def __init__(self):
+        super().__init__()
 
-copy_canvas_button = QtViewerPushButton(None, 'warning')
-copy_canvas_button.setToolTip("Copy screenshot of the entire viewer to clipboard.")
-copy_canvas_button.clicked.connect(viewer.window.clipboard)
-layer_buttons.layout().insertWidget(3, copy_canvas_button)
+        self.copy_canvas_btn = QPushButton("Copy Canvas to Clipboard", self)
+        self.copy_canvas_btn.setToolTip("Copy screenshot of the canvas to clipboard.")
+        self.copy_viewer_btn = QPushButton("Copy Viewer to Clipboard", self)
+        self.copy_viewer_btn.setToolTip("Copy screenshot of the entire viewer to clipboard.")
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.copy_canvas_btn)
+        layout.addWidget(self.copy_viewer_btn)
+
+
+def create_grabber_widget():
+    """Create widget"""
+    widget = Grabber()
+
+    # connect buttons
+    widget.copy_canvas_btn.clicked.connect(lambda: viewer.window.qt_viewer.clipboard())
+    widget.copy_viewer_btn.clicked.connect(lambda: viewer.window.clipboard())
+    return widget
+
+
+widget = create_grabber_widget()
+viewer.window.add_dock_widget(widget)
 
 napari.run()

--- a/examples/clipboard.py
+++ b/examples/clipboard.py
@@ -6,7 +6,7 @@ from napari._qt.widgets.qt_viewer_buttons import QtViewerPushButton
 
 
 # create the viewer with an image
-viewer = napari.view_image(data.astronaut(), rgb=True)
+viewer = napari.view_image(data.cells3d())
 
 layer_buttons = viewer.window.qt_viewer.layerButtons
 

--- a/napari/_qt/_tests/test_qt_utils.py
+++ b/napari/_qt/_tests/test_qt_utils.py
@@ -92,6 +92,6 @@ def test_add_flash_animation(qtbot):
     add_flash_animation(widget)
     assert widget.graphicsEffect() is not None
     assert hasattr(widget, "_flash_animation")
-    qtbot.wait(300)
+    qtbot.wait(350)
     assert widget.graphicsEffect() is None
     assert not hasattr(widget, "_flash_animation")

--- a/napari/_qt/_tests/test_qt_utils.py
+++ b/napari/_qt/_tests/test_qt_utils.py
@@ -2,8 +2,9 @@ import pytest
 from qtpy.QtCore import QObject, Signal
 from qtpy.QtWidgets import QMainWindow
 
-from ..utils import (
+from napari._qt.utils import (
     QBYTE_FLAG,
+    add_flash_animation,
     is_qbyte,
     qbytearray_to_str,
     qt_signals_blocked,
@@ -82,3 +83,15 @@ def test_qbytearray_to_str_and_back(qtbot):
 
     qbyte = widget.saveState()
     assert str_to_qbytearray(qbytearray_to_str(qbyte)) == qbyte
+
+
+def test_add_flash_animation(qtbot):
+    widget = QMainWindow()
+    qtbot.addWidget(widget)
+    assert widget.graphicsEffect() is None
+    add_flash_animation(widget)
+    assert widget.graphicsEffect() is not None
+    assert hasattr(widget, "_flash_animation")
+    qtbot.wait(300)
+    assert widget.graphicsEffect() is None
+    assert not hasattr(widget, "_flash_animation")

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -4,6 +4,7 @@ from unittest import mock
 import numpy as np
 import pytest
 from qtpy.QtWidgets import QMessageBox
+from qtpy.QtGui import QGuiApplication
 
 from napari._tests.utils import (
     add_layer_by_type,
@@ -301,3 +302,21 @@ def test_points_layer_display_correct_slice_on_scale(make_napari_viewer):
     layer = viewer.layers[1]
     indices, scale = layer._slice_data(layer._slice_indices)
     np.testing.assert_equal(indices, [0])
+
+
+def test_qt_viewer_clipboard(make_napari_viewer):
+    viewer = make_napari_viewer()
+    # copy to clipboard
+    clipboard_image = QGuiApplication.clipboard().image()
+    assert clipboard_image.isNull()
+    viewer.window.qt_viewer.clipboard()
+    clipboard_image = QGuiApplication.clipboard().image()
+    assert not clipboard_image.isNull()
+
+    # clear clipboard and grab image from application view
+    QGuiApplication.clipboard().clear()
+    clipboard_image = QGuiApplication.clipboard().image()
+    assert clipboard_image.isNull()
+    viewer.window.clipboard()
+    clipboard_image = QGuiApplication.clipboard().image()
+    assert not clipboard_image.isNull()

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -349,4 +349,3 @@ def test_active_keybindings(make_napari_viewer):
     assert viewer.layers.selection.active == layer_image
     assert len(view._key_map_handler.keymap_providers) == 2
     assert view._key_map_handler.keymap_providers[0] == layer_image
-

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -304,22 +304,76 @@ def test_points_layer_display_correct_slice_on_scale(make_napari_viewer):
     np.testing.assert_equal(indices, [0])
 
 
-def test_qt_viewer_clipboard(make_napari_viewer):
+def test_qt_viewer_clipboard_with_flash(make_napari_viewer, qtbot):
     viewer = make_napari_viewer()
-    # copy to clipboard
+    # make sure clipboard is empty
+    QGuiApplication.clipboard().clear()
     clipboard_image = QGuiApplication.clipboard().image()
     assert clipboard_image.isNull()
-    viewer.window.qt_viewer.clipboard()
+
+    # capture screenshot
+    viewer.window.qt_viewer.clipboard(flash=True)
     clipboard_image = QGuiApplication.clipboard().image()
     assert not clipboard_image.isNull()
+
+    # ensure the flash effect is applied
+    assert viewer.window.qt_viewer._canvas_overlay.graphicsEffect() is not None
+    assert hasattr(viewer.window.qt_viewer._canvas_overlay, "_flash_animation")
+    qtbot.wait(350)  # wait for the animation to finish
+    assert viewer.window.qt_viewer._canvas_overlay.graphicsEffect() is None
+    assert not hasattr(
+        viewer.window.qt_viewer._canvas_overlay, "_flash_animation"
+    )
 
     # clear clipboard and grab image from application view
     QGuiApplication.clipboard().clear()
     clipboard_image = QGuiApplication.clipboard().image()
     assert clipboard_image.isNull()
-    viewer.window.clipboard()
+
+    # capture screenshot of the entire window
+    viewer.window.clipboard(flash=True)
     clipboard_image = QGuiApplication.clipboard().image()
     assert not clipboard_image.isNull()
+
+    # ensure the flash effect is applied
+    assert viewer.window._qt_window.graphicsEffect() is not None
+    assert hasattr(viewer.window._qt_window, "_flash_animation")
+    qtbot.wait(350)  # wait for the animation to finish
+    assert viewer.window._qt_window.graphicsEffect() is None
+    assert not hasattr(viewer.window._qt_window, "_flash_animation")
+
+
+def test_qt_viewer_clipboard_without_flash(make_napari_viewer):
+    viewer = make_napari_viewer()
+    # make sure clipboard is empty
+    QGuiApplication.clipboard().clear()
+    clipboard_image = QGuiApplication.clipboard().image()
+    assert clipboard_image.isNull()
+
+    # capture screenshot
+    viewer.window.qt_viewer.clipboard(flash=False)
+    clipboard_image = QGuiApplication.clipboard().image()
+    assert not clipboard_image.isNull()
+
+    # ensure the flash effect is not applied
+    assert viewer.window.qt_viewer._canvas_overlay.graphicsEffect() is None
+    assert not hasattr(
+        viewer.window.qt_viewer._canvas_overlay, "_flash_animation"
+    )
+
+    # clear clipboard and grab image from application view
+    QGuiApplication.clipboard().clear()
+    clipboard_image = QGuiApplication.clipboard().image()
+    assert clipboard_image.isNull()
+
+    # capture screenshot of the entire window
+    viewer.window.clipboard(flash=False)
+    clipboard_image = QGuiApplication.clipboard().image()
+    assert not clipboard_image.isNull()
+
+    # ensure the flash effect is not applied
+    assert viewer.window._qt_window.graphicsEffect() is None
+    assert not hasattr(viewer.window._qt_window, "_flash_animation")
 
 
 def test_active_keybindings(make_napari_viewer):

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -219,7 +219,7 @@ def test_screenshot(make_napari_viewer):
     viewer.add_shapes(data)
 
     # Take screenshot
-    screenshot = viewer.window.qt_viewer.screenshot()
+    screenshot = viewer.window.qt_viewer.screenshot(flash=False)
     assert screenshot.ndim == 3
 
 
@@ -262,7 +262,7 @@ def test_screenshot_dialog(make_napari_viewer, tmpdir):
     expected_filepath = input_filepath + '.png'  # add default file extension
     assert os.path.exists(expected_filepath)
     output_data = imread(expected_filepath)
-    expected_data = viewer.window.qt_viewer.screenshot()
+    expected_data = viewer.window.qt_viewer.screenshot(flash=False)
     assert np.allclose(output_data, expected_data)
 
 
@@ -319,7 +319,7 @@ def test_qt_viewer_clipboard_with_flash(make_napari_viewer, qtbot):
     # ensure the flash effect is applied
     assert viewer.window.qt_viewer._canvas_overlay.graphicsEffect() is not None
     assert hasattr(viewer.window.qt_viewer._canvas_overlay, "_flash_animation")
-    qtbot.wait(350)  # wait for the animation to finish
+    qtbot.wait(500)  # wait for the animation to finish
     assert viewer.window.qt_viewer._canvas_overlay.graphicsEffect() is None
     assert not hasattr(
         viewer.window.qt_viewer._canvas_overlay, "_flash_animation"
@@ -338,7 +338,7 @@ def test_qt_viewer_clipboard_with_flash(make_napari_viewer, qtbot):
     # ensure the flash effect is applied
     assert viewer.window._qt_window.graphicsEffect() is not None
     assert hasattr(viewer.window._qt_window, "_flash_animation")
-    qtbot.wait(350)  # wait for the animation to finish
+    qtbot.wait(500)  # wait for the animation to finish
     assert viewer.window._qt_window.graphicsEffect() is None
     assert not hasattr(viewer.window._qt_window, "_flash_animation")
 

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -3,8 +3,8 @@ from unittest import mock
 
 import numpy as np
 import pytest
-from qtpy.QtWidgets import QMessageBox
 from qtpy.QtGui import QGuiApplication
+from qtpy.QtWidgets import QMessageBox
 
 from napari._tests.utils import (
     add_layer_by_type,

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -488,6 +488,14 @@ class Window:
         )
         screenshot_wv.triggered.connect(self._screenshot_dialog)
 
+        clipboard = QAction(
+            trans._('Copy Screenshot to Clipboard...'), self._qt_window
+        )
+        clipboard.setStatusTip(
+            trans._('Copy screenshot of current display to the clipboard')
+        )
+        clipboard.triggered.connect(self.qt_viewer.clipboard)
+
         # OS X will rename this to Quit and put it in the app menu.
         # This quits the entire QApplication and all windows that may be open.
         quitAction = QAction(trans._('Exit'), self._qt_window)
@@ -543,6 +551,7 @@ class Window:
         self.file_menu.addAction(save_all_layers)
         self.file_menu.addAction(screenshot)
         self.file_menu.addAction(screenshot_wv)
+        self.file_menu.addAction(clipboard)
         self.file_menu.addSeparator()
         self.file_menu.addAction(closeAction)
 
@@ -1352,6 +1361,14 @@ class Window:
         if path is not None:
             imsave(path, QImg2array(img))  # scikit-image imsave method
         return QImg2array(img)
+
+    def clipboard(self):
+        """Take a screenshot of the currently displayed viewer and copy the image to the clipboard."""
+        from qtpy.QtGui import QGuiApplication
+
+        img = self._qt_window.grab().toImage()
+        cb = QGuiApplication.clipboard()
+        cb.setImage(img)
 
     def close(self):
         """Close the viewer window and cleanup sub-widgets."""

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -496,12 +496,23 @@ class Window:
         screenshot_wv.triggered.connect(self._screenshot_dialog)
 
         clipboard = QAction(
-            trans._('Copy Screenshot to Clipboard...'), self._qt_window
+            trans._('Copy Screenshot to Clipboard'), self._qt_window
         )
         clipboard.setStatusTip(
             trans._('Copy screenshot of current display to the clipboard')
         )
         clipboard.triggered.connect(self.qt_viewer.clipboard)
+
+        clipboard_wv = QAction(
+            trans._('Copy Screenshot with Viewer to Clipboard'),
+            self._qt_window,
+        )
+        clipboard_wv.setStatusTip(
+            trans._(
+                'Copy screenshot of current display with the viewer to the clipboard'
+            )
+        )
+        clipboard_wv.triggered.connect(self.clipboard)
 
         # OS X will rename this to Quit and put it in the app menu.
         # This quits the entire QApplication and all windows that may be open.
@@ -529,7 +540,7 @@ class Window:
         self.file_menu.addAction(open_images)
         self.file_menu.addAction(open_stack)
         self.file_menu.addAction(open_folder)
-        self.file_menu.addMenu(open_sample_menu)
+        self.file_menu.addMenu(self.open_sample_menu)
         self.file_menu.addSeparator()
         self.file_menu.addAction(preferences)
         self.file_menu.addSeparator()
@@ -538,6 +549,7 @@ class Window:
         self.file_menu.addAction(screenshot)
         self.file_menu.addAction(screenshot_wv)
         self.file_menu.addAction(clipboard)
+        self.file_menu.addAction(clipboard_wv)
         self.file_menu.addSeparator()
         self.file_menu.addAction(closeAction)
 
@@ -1398,9 +1410,12 @@ class Window:
         """Take a screenshot of the currently displayed viewer and copy the image to the clipboard."""
         from qtpy.QtGui import QGuiApplication
 
+        from .utils import add_flash_animation
+
         img = self._qt_window.grab().toImage()
         cb = QGuiApplication.clipboard()
         cb.setImage(img)
+        add_flash_animation(self._qt_window)
 
     def close(self):
         """Close the viewer window and cleanup sub-widgets."""

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -501,7 +501,7 @@ class Window:
         clipboard.setStatusTip(
             trans._('Copy screenshot of current display to the clipboard')
         )
-        clipboard.triggered.connect(self.qt_viewer.clipboard)
+        clipboard.triggered.connect(lambda: self.qt_viewer.clipboard())
 
         clipboard_wv = QAction(
             trans._('Copy Screenshot with Viewer to Clipboard'),
@@ -512,7 +512,7 @@ class Window:
                 'Copy screenshot of current display with the viewer to the clipboard'
             )
         )
-        clipboard_wv.triggered.connect(self.clipboard)
+        clipboard_wv.triggered.connect(lambda: self.clipboard())
 
         # OS X will rename this to Quit and put it in the app menu.
         # This quits the entire QApplication and all windows that may be open.
@@ -1387,13 +1387,32 @@ class Window:
         """Restart the napari application."""
         self._qt_window.restart()
 
-    def screenshot(self, path=None):
+    def _screenshot(self, flash=True):
+        """Capture screenshot of the currently displayed viewer.
+
+        Parameters
+        ----------
+        flash : bool
+            Flag to indicate whether flash animation should be shown after
+            the screenshot was captured.
+        """
+        img = self._qt_window.grab().toImage()
+        if flash:
+            from .utils import add_flash_animation
+
+            add_flash_animation(self._qt_window)
+        return img
+
+    def screenshot(self, path=None, flash=True):
         """Take currently displayed viewer and convert to an image array.
 
         Parameters
         ----------
         path : str
             Filename for saving screenshot image.
+        flash : bool
+            Flag to indicate whether flash animation should be shown after
+            the screenshot was captured.
 
         Returns
         -------
@@ -1401,21 +1420,25 @@ class Window:
             Numpy array of type ubyte and shape (h, w, 4). Index [0, 0] is the
             upper-left corner of the rendered region.
         """
-        img = self._qt_window.grab().toImage()
+        img = self._screenshot(flash)
         if path is not None:
             imsave(path, QImg2array(img))  # scikit-image imsave method
         return QImg2array(img)
 
-    def clipboard(self):
-        """Take a screenshot of the currently displayed viewer and copy the image to the clipboard."""
+    def clipboard(self, flash=True):
+        """Take a screenshot of the currently displayed viewer and copy the image to the clipboard.
+
+        Parameters
+        ----------
+        flash : bool
+            Flag to indicate whether flash animation should be shown after
+            the screenshot was captured.
+        """
         from qtpy.QtGui import QGuiApplication
 
-        from .utils import add_flash_animation
-
-        img = self._qt_window.grab().toImage()
+        img = self._screenshot(flash)
         cb = QGuiApplication.clipboard()
         cb.setImage(img)
-        add_flash_animation(self._qt_window)
 
     def close(self):
         """Close the viewer window and cleanup sub-widgets."""

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -582,9 +582,10 @@ class QtViewer(QSplitter):
         cb = QGuiApplication.clipboard()
         cb.setImage(img)
 
-        # here we are actually applying the effect to the `QSplitter` and not
-        # the `native` widget because for some reason it does not work.
-        add_flash_animation(self)
+        # Here we are actually applying the effect to the `_canvas_overlay` and not
+        # the `native` widget because it does not work on the `native` widget. It's
+        # probably because the widget is in a stack with the `QtWelcomeWidget`.
+        add_flash_animation(self._canvas_overlay)
 
     def _screenshot_dialog(self):
         """Save screenshot of current display, default .png"""

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -572,11 +572,19 @@ class QtViewer(QSplitter):
         return img
 
     def clipboard(self):
-        """Take a screenshot of the currently displayed screen and copy the image to the clipboard."""
+        """Take a screenshot of the currently displayed screen and copy the
+        image to the clipboard.
+        """
+        from .utils import add_flash_animation
+
         img = self.canvas.native.grabFramebuffer()
 
         cb = QGuiApplication.clipboard()
         cb.setImage(img)
+
+        # here we are actually applying the effect to the `QSplitter` and not
+        # the `native` widget because for some reason it does not work.
+        add_flash_animation(self)
 
     def _screenshot_dialog(self):
         """Save screenshot of current display, default .png"""

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -552,13 +552,36 @@ class QtViewer(QSplitter):
         if self._show_welcome_screen:
             self._canvas_overlay.set_welcome_visible(not self.viewer.layers)
 
-    def screenshot(self, path=None):
+    def _screenshot(self, flash=True):
+        """Capture a screenshot of the Vispy canvas.
+
+        Parameters
+        ----------
+        flash : bool
+            Flag to indicate whether flash animation should be shown after
+            the screenshot was captured.
+        """
+        img = self.canvas.native.grabFramebuffer()
+        if flash:
+            from .utils import add_flash_animation
+
+            # Here we are actually applying the effect to the `_canvas_overlay`
+            # and not # the `native` widget because it does not work on the
+            # `native` widget. It's probably because the widget is in a stack
+            # with the `QtWelcomeWidget`.
+            add_flash_animation(self._canvas_overlay)
+        return img
+
+    def screenshot(self, path=None, flash=True):
         """Take currently displayed screen and convert to an image array.
 
         Parameters
         ----------
         path : str
             Filename for saving screenshot image.
+        flash : bool
+            Flag to indicate whether flash animation should be shown after
+            the screenshot was captured.
 
         Returns
         -------
@@ -566,26 +589,23 @@ class QtViewer(QSplitter):
             Numpy array of type ubyte and shape (h, w, 4). Index [0, 0] is the
             upper-left corner of the rendered region.
         """
-        img = QImg2array(self.canvas.native.grabFramebuffer())
+        img = QImg2array(self._screenshot(flash))
         if path is not None:
             imsave(path, img)  # scikit-image imsave method
         return img
 
-    def clipboard(self):
+    def clipboard(self, flash=True):
         """Take a screenshot of the currently displayed screen and copy the
         image to the clipboard.
+
+        Parameters
+        ----------
+        flash : bool
+            Flag to indicate whether flash animation should be shown after
+            the screenshot was captured.
         """
-        from .utils import add_flash_animation
-
-        img = self.canvas.native.grabFramebuffer()
-
         cb = QGuiApplication.clipboard()
-        cb.setImage(img)
-
-        # Here we are actually applying the effect to the `_canvas_overlay` and not
-        # the `native` widget because it does not work on the `native` widget. It's
-        # probably because the widget is in a stack with the `QtWelcomeWidget`.
-        add_flash_animation(self._canvas_overlay)
+        cb.setImage(self._screenshot(flash))
 
     def _screenshot_dialog(self):
         """Save screenshot of current display, default .png"""

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -575,6 +575,13 @@ class QtViewer(QSplitter):
             imsave(path, img)  # scikit-image imsave method
         return img
 
+    def clipboard(self):
+        """Take a screenshot of the currently displayed screen and copy the image to the clipboard."""
+        img = self.canvas.native.grabFramebuffer()
+
+        cb = QGuiApplication.clipboard()
+        cb.setImage(img)
+
     def _screenshot_dialog(self):
         """Save screenshot of current display, default .png"""
         hist = get_save_history()

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -16,6 +16,8 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from ..utils.colormaps.standardize_color import transform_color
+from ..utils.events.custom_types import Array
 from ..utils.misc import is_sequence
 from ..utils.translations import trans
 
@@ -253,14 +255,23 @@ def combine_widgets(
     )
 
 
-def add_flash_animation(widget: QWidget):
+def add_flash_animation(
+    widget: QWidget, duration: int = 300, color: Array = (0.5, 0.5, 0.5, 0.5)
+):
     """Add flash animation to widget to highlight certain action (e.g. taking a screenshot).
 
     Parameters
     ----------
     widget : QWidget
         Any Qt widget.
+    duration : int
+        Duration of the flash animation.
+    color : Array
+        Color of the flash animation. By default, we use light gray.
     """
+    color = transform_color(color)[0]
+    color = (255 * color).astype("int")
+
     effect = QGraphicsColorizeEffect(widget)
     widget.setGraphicsEffect(effect)
 
@@ -278,8 +289,8 @@ def add_flash_animation(widget: QWidget):
     widget._flash_animation.start()
 
     # now  set an actual time for the flashing and an intermediate color
-    widget._flash_animation.setDuration(250)
-    widget._flash_animation.setKeyValueAt(0.5, QColor(255, 255, 255, 255))
+    widget._flash_animation.setDuration(duration)
+    widget._flash_animation.setKeyValueAt(0.5, QColor(*color))
 
 
 def remove_flash_animation(widget: QWidget):

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -157,11 +157,11 @@ def test_screenshot(make_napari_viewer):
     viewer.add_shapes(data)
 
     # Take screenshot of the image canvas only
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     assert screenshot.ndim == 3
 
     # Take screenshot with the viewer included
-    screenshot = viewer.screenshot(canvas_only=False)
+    screenshot = viewer.screenshot(canvas_only=False, flash=False)
     assert screenshot.ndim == 3
 
 
@@ -174,11 +174,11 @@ def test_changing_theme(make_napari_viewer):
     viewer.window.qt_viewer.setFixedSize(size)
 
     assert viewer.theme == 'dark'
-    screenshot_dark = viewer.screenshot(canvas_only=False)
+    screenshot_dark = viewer.screenshot(canvas_only=False, flash=False)
 
     viewer.theme = 'light'
     assert viewer.theme == 'light'
-    screenshot_light = viewer.screenshot(canvas_only=False)
+    screenshot_light = viewer.screenshot(canvas_only=False, flash=False)
 
     equal = (screenshot_dark == screenshot_light).min(-1)
 

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -24,7 +24,7 @@ def test_z_order_adding_removing_images(make_napari_viewer):
     viewer.add_image(data, colormap='blue', name='blue')
 
     # Check that blue is visible
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
@@ -32,27 +32,27 @@ def test_z_order_adding_removing_images(make_napari_viewer):
     viewer.layers.remove('red')
     viewer.add_image(data, colormap='red', name='red')
     # Check that red is visible
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
 
     # Remove two other images
     viewer.layers.remove('green')
     viewer.layers.remove('blue')
     # Check that red is still visible
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
 
     # Add two other layers back
     viewer.add_image(data, colormap='green', name='green')
     viewer.add_image(data, colormap='blue', name='blue')
     # Check that blue is visible
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
     # Hide blue
     viewer.layers['blue'].visible = False
     # Check that green is visible. Note this assert was failing before #1463
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     np.testing.assert_almost_equal(screenshot[center], [0, 255, 0, 255])
 
 
@@ -65,13 +65,13 @@ def test_z_order_images(make_napari_viewer):
     viewer = make_napari_viewer(show=True)
     viewer.add_image(data, colormap='red')
     viewer.add_image(data, colormap='blue')
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that blue is visible
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
     viewer.layers.move(1, 0)
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that red is now visible
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
@@ -86,13 +86,13 @@ def test_z_order_image_points(make_napari_viewer):
     viewer = make_napari_viewer(show=True)
     viewer.add_image(data, colormap='red')
     viewer.add_points([5, 5], face_color='blue', size=10)
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that blue is visible
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
     viewer.layers.move(1, 0)
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that red is now visible
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
@@ -107,21 +107,21 @@ def test_z_order_images_after_ndisplay(make_napari_viewer):
     viewer = make_napari_viewer(show=True)
     viewer.add_image(data, colormap='red')
     viewer.add_image(data, colormap='blue')
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that blue is visible
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
     # Switch to 3D rendering
     viewer.dims.ndisplay = 3
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that blue is still visible
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
     # Switch back to 2D rendering
     viewer.dims.ndisplay = 2
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that blue is still visible
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
@@ -136,21 +136,21 @@ def test_z_order_image_points_after_ndisplay(make_napari_viewer):
     viewer = make_napari_viewer(show=True)
     viewer.add_image(data, colormap='red')
     viewer.add_points([5, 5], face_color='blue', size=10)
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that blue is visible
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
     # Switch to 3D rendering
     viewer.dims.ndisplay = 3
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that blue is still visible
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
     # Switch back to 2D rendering
     viewer.dims.ndisplay = 2
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that blue is still visible
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
@@ -165,24 +165,24 @@ def test_changing_image_colormap(make_napari_viewer):
     data = np.ones((20, 20, 20))
     layer = viewer.add_image(data, contrast_limits=[0, 1])
 
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     np.testing.assert_almost_equal(screenshot[center], [255, 255, 255, 255])
 
     layer.colormap = 'red'
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
 
     viewer.dims.ndisplay = 3
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
 
     layer.colormap = 'blue'
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
     viewer.dims.ndisplay = 2
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
@@ -195,24 +195,24 @@ def test_changing_image_gamma(make_napari_viewer):
     data = np.ones((20, 20, 20))
     layer = viewer.add_image(data, contrast_limits=[0, 2])
 
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     assert screenshot[center + (0,)] == 128
 
     layer.gamma = 0.1
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     assert screenshot[center + (0,)] > 230
 
     viewer.dims.ndisplay = 3
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     assert screenshot[center + (0,)] > 230
 
     layer.gamma = 1.9
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     assert screenshot[center + (0,)] < 80
 
     viewer.dims.ndisplay = 2
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     assert screenshot[center + (0,)] < 80
 
 
@@ -234,7 +234,7 @@ def test_grid_mode(make_napari_viewer):
     np.testing.assert_allclose(translations, expected_translations)
 
     # check screenshot
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
@@ -255,7 +255,7 @@ def test_grid_mode(make_napari_viewer):
     np.testing.assert_allclose(translations, expected_translations[::-1])
 
     # check screenshot
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     # sample 6 squares of the grid and check they have right colors
     pos = [
         (1 / 3, 1 / 3),
@@ -285,7 +285,7 @@ def test_grid_mode(make_napari_viewer):
     viewer.layers.move(1, 6)
 
     # check screenshot
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     # CGRMYB color order
     color = [
         [0, 255, 255, 255],
@@ -311,7 +311,7 @@ def test_grid_mode(make_napari_viewer):
     np.testing.assert_allclose(translations, expected_translations)
 
     # check screenshot
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     np.testing.assert_almost_equal(screenshot[center], [0, 255, 255, 255])
 
@@ -329,13 +329,13 @@ def test_changing_image_attenuation(make_napari_viewer):
     viewer.layers[0].rendering = 'attenuated_mip'
 
     viewer.layers[0].attenuation = 0.5
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that rendering has not been attenuated
     assert screenshot[center + (0,)] > 80
 
     viewer.layers[0].attenuation = 0.02
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that rendering has been attenuated
     assert screenshot[center + (0,)] < 60
@@ -351,7 +351,7 @@ def test_labels_painting(make_napari_viewer):
     viewer.add_labels(data)
     layer = viewer.layers[0]
 
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
 
     # Check that no painting has occurred
     assert layer.data.max() == 0
@@ -408,7 +408,7 @@ def test_labels_painting(make_napari_viewer):
     )
     mouse_press_callbacks(layer, event)
 
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     # Check that painting has now occurred
     assert layer.data.max() > 0
     assert screenshot[:, :, :2].max() > 0
@@ -422,19 +422,19 @@ def test_welcome(make_napari_viewer):
     viewer = make_napari_viewer(show=True)
 
     # Check something is visible
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     assert len(viewer.layers) == 0
     assert screenshot[..., :-1].max() > 0
 
     # Check adding zeros image makes it go away
     viewer.add_image(np.zeros((1, 1)))
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     assert len(viewer.layers) == 1
     assert screenshot[..., :-1].max() == 0
 
     # Remove layer and check something is visible again
     viewer.layers.pop(0)
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     assert len(viewer.layers) == 0
     assert screenshot[..., :-1].max() > 0
 
@@ -447,18 +447,18 @@ def test_axes_visible(make_napari_viewer):
     viewer.window.qt_viewer.set_welcome_visible(False)
 
     # Check axes are not visible
-    launch_screenshot = viewer.screenshot(canvas_only=True)
+    launch_screenshot = viewer.screenshot(canvas_only=True, flash=False)
     assert not viewer.axes.visible
 
     # Make axes visible and check something is seen
     viewer.axes.visible = True
-    on_screenshot = viewer.screenshot(canvas_only=True)
+    on_screenshot = viewer.screenshot(canvas_only=True, flash=False)
     assert viewer.axes.visible
     assert abs(on_screenshot - launch_screenshot).max() > 0
 
     # Make axes not visible and check they are gone
     viewer.axes.visible = False
-    off_screenshot = viewer.screenshot(canvas_only=True)
+    off_screenshot = viewer.screenshot(canvas_only=True, flash=False)
     assert not viewer.axes.visible
     np.testing.assert_almost_equal(launch_screenshot, off_screenshot)
 
@@ -471,17 +471,17 @@ def test_scale_bar_visible(make_napari_viewer):
     viewer.window.qt_viewer.set_welcome_visible(False)
 
     # Check scale bar is not visible
-    launch_screenshot = viewer.screenshot(canvas_only=True)
+    launch_screenshot = viewer.screenshot(canvas_only=True, flash=False)
     assert not viewer.scale_bar.visible
 
     # Make scale bar visible and check something is seen
     viewer.scale_bar.visible = True
-    on_screenshot = viewer.screenshot(canvas_only=True)
+    on_screenshot = viewer.screenshot(canvas_only=True, flash=False)
     assert viewer.scale_bar.visible
     assert abs(on_screenshot - launch_screenshot).max() > 0
 
     # Make scale bar not visible and check it is gone
     viewer.scale_bar.visible = False
-    off_screenshot = viewer.screenshot(canvas_only=True)
+    off_screenshot = viewer.screenshot(canvas_only=True, flash=False)
     assert not viewer.scale_bar.visible
     np.testing.assert_almost_equal(launch_screenshot, off_screenshot)

--- a/napari/_vispy/_tests/test_image_rendering.py
+++ b/napari/_vispy/_tests/test_image_rendering.py
@@ -52,7 +52,7 @@ def test_visibility_consistency(qtbot, make_napari_viewer):
     )
     qtbot.wait(10)
     layer.contrast_limits = (0, 2)
-    screen1 = viewer.screenshot().astype('float')
+    screen1 = viewer.screenshot(flash=False).astype('float')
     layer.visible = True
-    screen2 = viewer.screenshot().astype('float')
+    screen2 = viewer.screenshot(flash=False).astype('float')
     assert np.max(np.abs(screen2 - screen1)) < 5

--- a/napari/_vispy/_tests/test_vispy_multiscale.py
+++ b/napari/_vispy/_tests/test_vispy_multiscale.py
@@ -71,7 +71,7 @@ def test_multiscale_screenshot(make_napari_viewer):
     # Set canvas size to target amount
     viewer.window.qt_viewer.view.canvas.size = (800, 600)
 
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(int)
     target_center = np.array([255, 255, 255, 255], dtype='uint8')
     target_edge = np.array([0, 0, 0, 255], dtype='uint8')
@@ -107,7 +107,7 @@ def test_multiscale_screenshot_zoomed(make_napari_viewer):
     # Check that current level is bottom level of multiscale
     assert viewer.layers[0].data_level == 0
 
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(int)
     target_center = np.array([255, 255, 255, 255], dtype='uint8')
     screen_offset = 3  # Offset is needed as our screenshots have black borders
@@ -138,7 +138,7 @@ def test_image_screenshot_zoomed(make_napari_viewer):
     view.view.camera.rect = [1000, 1000, 200, 150]
     viewer.window.qt_viewer.on_draw(None)
 
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(int)
     target_center = np.array([255, 255, 255, 255], dtype='uint8')
     screen_offset = 3  # Offset is needed as our screenshots have black borders

--- a/napari/_vispy/experimental/_tests/test_vispy_tiled_image.py
+++ b/napari/_vispy/experimental/_tests/test_vispy_tiled_image.py
@@ -56,7 +56,7 @@ def test_tiled_screenshot(qtbot, monkeypatch, make_napari_viewer, dtype):
     qtbot.wait(SHORT_LOADING_DELAY)
 
     # Take the screenshot
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)
     target_center = np.array([0, 0, 128, 255], dtype='uint8')
     target_edge = np.array([0, 0, 0, 255], dtype='uint8')
@@ -97,7 +97,7 @@ def test_tiled_rgb(qtbot, monkeypatch, make_napari_viewer):
     qtbot.wait(SHORT_LOADING_DELAY)
 
     # Take the screenshot
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)
     target_center = np.array([128, 128, 128, 255], dtype='uint8')
     target_edge = np.array([0, 0, 0, 255], dtype='uint8')
@@ -143,7 +143,7 @@ def test_tiled_changing_contrast_limits(
     qtbot.wait(SHORT_LOADING_DELAY)
 
     # Take the screenshot
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)
     target_center = np.array([0, 0, 255, 255], dtype='uint8')
     target_edge = np.array([0, 0, 0, 255], dtype='uint8')
@@ -164,7 +164,7 @@ def test_tiled_changing_contrast_limits(
     # Required wait is longer, ToDo change this to a qtbot.waitSignal
     qtbot.wait(LONG_LOADING_DELAY)
 
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     np.testing.assert_allclose(screenshot[tuple(center_coord)], target_center)
 
 
@@ -197,7 +197,7 @@ def test_tiled_single_scale(qtbot, monkeypatch, make_napari_viewer):
     qtbot.wait(10 * LONG_LOADING_DELAY)
 
     # Take the screenshot
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)
     target_center = np.array([128, 128, 128, 255], dtype='uint8')
     screen_offset = 3  # Offset is needed as our screenshots have black borders
@@ -238,7 +238,7 @@ def test_tiled_labels(qtbot, monkeypatch, make_napari_viewer):
     qtbot.wait(SHORT_LOADING_DELAY)
 
     # Take the screenshot
-    screenshot = viewer.screenshot(canvas_only=True)
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)
     col = layer.get_color(1)
     target_center = np.array([c * 255 for c in col], dtype='uint8')

--- a/napari/utils/colormaps/standardize_color.py
+++ b/napari/utils/colormaps/standardize_color.py
@@ -131,7 +131,7 @@ def _handle_list_like(colors: Sequence) -> np.ndarray:
     except ValueError:
         warnings.warn(
             trans._(
-                "Coudln't convert input color array to a proper numpy array. Please make sure that your input data is in a parsable format. Converting input to a white color array.",
+                "Couldn't convert input color array to a proper numpy array. Please make sure that your input data is in a parsable format. Converting input to a white color array.",
                 deferred=True,
             )
         )

--- a/napari/utils/notebook_display.py
+++ b/napari/utils/notebook_display.py
@@ -63,7 +63,9 @@ class NotebookScreenshot:
         from .._qt.qt_event_loop import get_app
 
         get_app().processEvents()
-        self.image = self.viewer.screenshot(canvas_only=self.canvas_only)
+        self.image = self.viewer.screenshot(
+            canvas_only=self.canvas_only, flash=False
+        )
         with BytesIO() as file_obj:
             imsave(file_obj, self.image, format='png')
             file_obj.seek(0)

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -74,7 +74,7 @@ class Viewer(ViewerModel):
         else:
             self.window.qt_viewer.console.push(variables)
 
-    def screenshot(self, path=None, *, canvas_only=True):
+    def screenshot(self, path=None, *, canvas_only=True, flash: bool = True):
         """Take currently displayed screen and convert to an image array.
 
         Parameters
@@ -85,6 +85,10 @@ class Viewer(ViewerModel):
             If True, screenshot shows only the image display canvas, and
             if False include the napari viewer frame in the screenshot,
             By default, True.
+        flash : bool
+            Flag to indicate whether flash animation should be shown after
+            the screenshot was captured.
+            By default, True.
 
         Returns
         -------
@@ -93,9 +97,9 @@ class Viewer(ViewerModel):
             upper-left corner of the rendered region.
         """
         if canvas_only:
-            image = self.window.qt_viewer.screenshot(path=path)
+            image = self.window.qt_viewer.screenshot(path=path, flash=flash)
         else:
-            image = self.window.screenshot(path=path)
+            image = self.window.screenshot(path=path, flash=flash)
         return image
 
     def show(self):


### PR DESCRIPTION
- added copy screenshot of viewer/window to the clipboard
- fixed unrelated typo

# Description
This PR adds the funcionality to copy screenshot of the viewer (or window) to the user's clipboard. This is accessible via `Menu -> File -> Copy Screenshot to Clipboard` or via `viewer.window.clipboard()` to capture screenshot of the entire window or `viewer.window.qt_viewer.clipboard()` to only capture the canvas.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
Added extra test to make sure an iamge is copied into the user's clipboard.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
