### PR TITLE
Only use index lookup based on max label value when it would improve performance

### DIFF
--- a/docs/release/release_0_4_8.md
+++ b/docs/release/release_0_4_8.md
@@ -146,6 +146,7 @@ and
 - Fix vertical_stretch injection and kwargs passing on DockWidget (#2705)
 - Fix tracks icons, and visibility icons (#2708)
 - Patch horizontalAdvance for older Qt versions (#2711)
+- Fix labels with large maximum value (#2723)
 
 ## API Changes
 

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -868,3 +868,13 @@ def test_ndim_paint():
             ]
         ),
     )
+
+
+def test_switching_display_func():
+    label_data = np.random.randint(int(1e10), int(1e10 + 5), size=(50, 50))
+    layer = Labels(label_data)
+    assert layer._color_lookup_func == layer._lookup_with_low_discrepancy_image
+
+    label_data = np.random.randint(0, 5, size=(50, 50))
+    layer = Labels(label_data)
+    assert layer._color_lookup_func == layer._lookup_with_index

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -371,7 +371,7 @@ def test_custom_color_dict():
 
 def test_add_colors():
     """Test adding new colors"""
-    data = np.random.randint(20, size=(10, 15))
+    data = np.random.randint(20, size=(40, 40))
     layer = Labels(data)
     assert len(layer._all_vals) == layer.num_colors
 
@@ -379,8 +379,8 @@ def test_add_colors():
     assert len(layer._all_vals) == 52
 
     layer.show_selected_label = True
-    layer.selected_label = 60
-    assert len(layer._all_vals) == 61
+    layer.selected_label = 53
+    assert len(layer._all_vals) == 54
 
 
 def test_metadata():

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -871,7 +871,7 @@ def test_ndim_paint():
 
 
 def test_switching_display_func():
-    label_data = np.random.randint(2 ** 30, 2 ** 30 + 5, size=(50, 50))
+    label_data = np.random.randint(2 ** 25, 2 ** 25 + 5, size=(50, 50))
     layer = Labels(label_data)
     assert layer._color_lookup_func == layer._lookup_with_low_discrepancy_image
 

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -871,7 +871,7 @@ def test_ndim_paint():
 
 
 def test_switching_display_func():
-    label_data = np.random.randint(int(1e10), int(1e10 + 5), size=(50, 50))
+    label_data = np.random.randint(2 ** 30, 2 ** 30 + 5, size=(50, 50))
     layer = Labels(label_data)
     assert layer._color_lookup_func == layer._lookup_with_low_discrepancy_image
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -380,6 +380,9 @@ class Labels(_ImageBase):
     @data.setter
     def data(self, data):
         data = self._ensure_int_labels(data)
+        self._color_lookup_func = self._get_color_lookup_func(
+            data[0] if isinstance(data, list) else data
+        )
         self._data = data
         self._update_dims()
         self.events.data(value=self.data)


### PR DESCRIPTION
# Description
As a result of #2415 we've seen a lot of issues when users have large label values, as we try to compute an array of length `max_label_value` in order to perform a fast color lookup. See this [image.sc](https://forum.image.sc/t/brainreg-tutorial-error-in-napari/52702/10) post for an example.

This PR improves this logic by adding a check for whether initialising such an array would be more costly than passing the whole image through `low_discrepancy_image` as we used to before #2415.

This check is then re-performed when the data is set - note that this check is not re-performed when we choose a `selected_label` but we may wish to consider this - I didn't add it because I judged it too costly to compute max each time we select a label, but we could probably get around this.

PS - I really struggled with naming these functions so if anyone has any suggestions please don't hold back

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
