### PR TITLE
Fix progressbar and notifications segfaults in test

### DIFF
--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -47,8 +47,11 @@ def clean_current(monkeypatch, qtbot):
     def none_return(*_, **__):
         return None
 
-    def store_widget(self, *_, **__):
+    base_show = NapariQtNotification.show
+
+    def store_widget(self, *args, **kwargs):
         qtbot.addWidget(self)
+        base_show(self, *args, **kwargs)
 
     # monkeypatch.setattr(qt_notification.QPropertyAnimation, "start", none_return)
     monkeypatch.setattr(_QtMainWindow, "current", none_return)

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import dask.array as da
 import pytest
+import qtpy
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QPushButton
 
@@ -42,6 +43,8 @@ def _raise():
 
 @pytest.fixture
 def clean_current(monkeypatch):
+    if not qtpy.PYSIDE2:
+        return
     from napari._qt.qt_main_window import _QtMainWindow
 
     def none_return(*_, **__):

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 
 import dask.array as da
 import pytest
-import qtpy
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QPushButton
 
@@ -43,8 +42,6 @@ def _raise():
 
 @pytest.fixture
 def clean_current(monkeypatch):
-    if not qtpy.PYSIDE2:
-        return
     from napari._qt.qt_main_window import _QtMainWindow
 
     def none_return(*_, **__):

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -41,15 +41,18 @@ def _raise():
 
 
 @pytest.fixture
-def clean_current(monkeypatch):
+def clean_current(monkeypatch, qtbot):
     from napari._qt.qt_main_window import _QtMainWindow
 
     def none_return(*_, **__):
         return None
 
+    def store_widget(self, *_, **__):
+        qtbot.addWidget(self)
+
     # monkeypatch.setattr(qt_notification.QPropertyAnimation, "start", none_return)
     monkeypatch.setattr(_QtMainWindow, "current", none_return)
-    monkeypatch.setattr(NapariQtNotification, "show", none_return)
+    monkeypatch.setattr(NapariQtNotification, "show", store_widget)
 
 
 @pytest.mark.parametrize(

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import dask.array as da
 import pytest
-from qtpy.QtCore import QCoreApplication, Qt
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QPushButton
 
 from napari._qt.dialogs.qt_notification import NapariQtNotification
@@ -49,14 +49,7 @@ def clean_current(monkeypatch):
 
     # monkeypatch.setattr(qt_notification.QPropertyAnimation, "start", none_return)
     monkeypatch.setattr(_QtMainWindow, "current", none_return)
-    monkeypatch.setattr(NapariQtNotification, "FADE_OUT_RATE", 0)
-    monkeypatch.setattr(NapariQtNotification, "DISMISS_AFTER", 0)
-    yield
-    for el in NapariQtNotification._instances:
-        # el.close()
-        el.deleteLater()
-    NapariQtNotification._instances = []
-    QCoreApplication.processEvents()
+    monkeypatch.setattr(NapariQtNotification, "show", none_return)
 
 
 @pytest.mark.parametrize(
@@ -90,7 +83,7 @@ def test_notification_manager_via_gui(
 
 @pytest.mark.parametrize('severity', NotificationSeverity.__members__)
 @patch('napari._qt.dialogs.qt_notification.QDialog.show')
-def test_notification_display(mock_show, severity, monkeypatch, clean_current):
+def test_notification_display(mock_show, severity, monkeypatch):
     """Test that NapariQtNotification can present a Notification event.
 
     NOTE: in napari.utils._tests.test_notification_manager, we already test

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import dask.array as da
 import pytest
-from qtpy.QtCore import Qt
+from qtpy.QtCore import QCoreApplication, Qt
 from qtpy.QtWidgets import QPushButton
 
 from napari._qt.dialogs.qt_notification import NapariQtNotification
@@ -42,16 +42,21 @@ def _raise():
 
 @pytest.fixture
 def clean_current(monkeypatch):
-    from ..qt_main_window import _QtMainWindow
+    from napari._qt.qt_main_window import _QtMainWindow
 
-    def none_return():
+    def none_return(*_, **__):
         return None
 
+    # monkeypatch.setattr(qt_notification.QPropertyAnimation, "start", none_return)
     monkeypatch.setattr(_QtMainWindow, "current", none_return)
+    monkeypatch.setattr(NapariQtNotification, "FADE_OUT_RATE", 0)
+    monkeypatch.setattr(NapariQtNotification, "DISMISS_AFTER", 0)
     yield
     for el in NapariQtNotification._instances:
+        # el.close()
         el.deleteLater()
     NapariQtNotification._instances = []
+    QCoreApplication.processEvents()
 
 
 @pytest.mark.parametrize(

--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -80,6 +80,7 @@ class NapariQtNotification(QDialog):
     message: MultilineElidedLabel
     source_label: QLabel
     severity_icon: QLabel
+    _instances = []
 
     def __init__(
         self,
@@ -89,6 +90,7 @@ class NapariQtNotification(QDialog):
         actions: ActionSequence = (),
     ):
         super().__init__()
+        self._instances.append(self)
 
         from ..qt_main_window import _QtMainWindow
 
@@ -307,6 +309,12 @@ class NapariQtNotification(QDialog):
             super().sizeHint().width(),
             self.row2_widget.height() + self.message.sizeHint().height(),
         )
+
+    def __del__(self):
+        try:
+            self._instances.remove(self)
+        except ValueError:
+            pass
 
     @classmethod
     def from_notification(

--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -165,7 +165,6 @@ class NapariQtNotification(QDialog):
         self.opacity_anim.setStartValue(self.MAX_OPACITY)
         self.opacity_anim.setEndValue(0)
         self.opacity_anim.start()
-
         self.opacity_anim.finished.connect(super().close)
 
     def toggle_expansion(self):

--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -80,7 +80,6 @@ class NapariQtNotification(QDialog):
     message: MultilineElidedLabel
     source_label: QLabel
     severity_icon: QLabel
-    _instances = []
 
     def __init__(
         self,
@@ -90,7 +89,6 @@ class NapariQtNotification(QDialog):
         actions: ActionSequence = (),
     ):
         super().__init__()
-        self._instances.append(self)
 
         from ..qt_main_window import _QtMainWindow
 
@@ -167,10 +165,7 @@ class NapariQtNotification(QDialog):
         self.opacity_anim.setStartValue(self.MAX_OPACITY)
         self.opacity_anim.setEndValue(0)
         self.opacity_anim.start()
-        try:
-            self._instances.remove(self)
-        except ValueError:
-            pass
+
         self.opacity_anim.finished.connect(super().close)
 
     def toggle_expansion(self):

--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -167,6 +167,10 @@ class NapariQtNotification(QDialog):
         self.opacity_anim.setStartValue(self.MAX_OPACITY)
         self.opacity_anim.setEndValue(0)
         self.opacity_anim.start()
+        try:
+            self._instances.remove(self)
+        except ValueError:
+            pass
         self.opacity_anim.finished.connect(super().close)
 
     def toggle_expansion(self):
@@ -309,12 +313,6 @@ class NapariQtNotification(QDialog):
             super().sizeHint().width(),
             self.row2_widget.height() + self.message.sizeHint().height(),
         )
-
-    def __del__(self):
-        try:
-            self._instances.remove(self)
-        except ValueError:
-            pass
 
     @classmethod
     def from_notification(


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousando words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->
Today morning I notice that every time tests fail I see black "plugin.py" windows which are closed exactly at the same time when StopIteration was printed to console. When running tests without `test_progress` these windows do not show. 

![Zrzut ekranu z 2021-05-17 08-51-15](https://user-images.githubusercontent.com/3826210/118446914-710cc280-b6f0-11eb-8f7f-0dd8dd751502.png)

Then in this PR, I try to force its closing. And it works locally. 

So it looks like segfault in `MIN_REQ` is connected with the pending notification dialog.
I think that it could be connected with the same reason why the last test was disabled on python 3.7. 

https://github.com/napari/napari/blob/419cfe0a759ae1d3c7fb2747f9ab149390a43ee8/napari/_qt/_tests/test_qt_notifications.py#L125-L135

This PR is a little brutal but may be an inspiration for a person who better understands notification code or may be used as a temporary workaround for release 0.4.8 if no one has some idea for a better solution.  If using please check the mechanism of cleaning the`_instances` class attribute of `NapariQtNotification` 

cc: @tlambert03 @sofroniewn 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
