### PR TITLE
Fixing `add_dock_widget` compatibility with `magicgui v0.2`

### DIFF
--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -245,7 +245,7 @@ def combine_widgets(
             container = QWidget()
             container.setLayout(QVBoxLayout() if vertical else QHBoxLayout())
             for widget in widgets:
-                container.layout.addWidget(widget)
+                container.layout().addWidget(widget)
             return container
     raise TypeError(
         trans._('"widget" must be a QWidget or a sequence of QWidgets')

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -11,7 +11,6 @@ from qtpy.QtWidgets import (
     QGraphicsOpacityEffect,
     QHBoxLayout,
     QListWidget,
-    QSizePolicy,
     QVBoxLayout,
     QWidget,
 )
@@ -244,17 +243,9 @@ def combine_widgets(
         ]
         if all(isinstance(i, QWidget) for i in widgets):
             container = QWidget()
-            container.layout = QVBoxLayout() if vertical else QHBoxLayout()
-            container.setLayout(container.layout)
+            container.setLayout(QVBoxLayout() if vertical else QHBoxLayout())
             for widget in widgets:
                 container.layout.addWidget(widget)
-            # if this is a vertical layout, and none of the widgets declare a size
-            # policy of "expanding", add our own stretch.
-            if vertical and not any(
-                w.sizePolicy().verticalPolicy() == QSizePolicy.Expanding
-                for w in widgets
-            ):
-                container.layout.addStretch()
             return container
     raise TypeError(
         trans._('"widget" must be a QWidget or a sequence of QWidgets')


### PR DESCRIPTION
# Description
With these changes, the combine widgets function can combine multiple `magicgui` objects (`FunctionGui`).

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #2733 .

# How has this been tested?
- [X] The code from #2733 executes on my machine after this update.

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).

I forgot to run the pre-commit before committing. The CI might complain about that and I can fix it.
