### PR TITLE
Shortcuts: Render properly shortcuts with minus and space.

### DIFF
--- a/napari/utils/_tests/test_interactions.py
+++ b/napari/utils/_tests/test_interactions.py
@@ -40,6 +40,15 @@ def test_shortcut_invalid(shortcut, reason):
         Shortcut(shortcut)  # Should be Control-A
 
 
+def test_minus_shortcut():
+    """
+    Misc tests minus is properly handled as it is the delimiter
+    """
+    assert str(Shortcut('-')) == '-'
+    assert str(Shortcut('Control--')).endswith('-')
+    assert str(Shortcut('Shift--')).endswith('-')
+
+
 def test_shortcut_qt():
 
     assert Shortcut('Control-A').qt == 'Control+A'

--- a/napari/utils/interactions.py
+++ b/napari/utils/interactions.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 import sys
 import warnings
 
@@ -221,6 +222,7 @@ KEY_SYMBOLS = {
     'Escape': 'Esc',
     'Return': '⏎',
     'Enter': '↵',
+    'Space': '␣',
 }
 
 
@@ -254,7 +256,7 @@ class Shortcut:
             shortcut to format in the form of dash separated keys to press
 
         """
-        self._values = shortcut.split('-')
+        self._values = re.split('-(?=.+)', shortcut)
         for shortcut_key in self._values:
             if (
                 len(shortcut_key) > 1


### PR DESCRIPTION
The splitting was incorrect is the bound key was minus (only in UI).
also replace Space with it's corresponding Unicode "blank" symbol

