### PR TITLE
Ignore opening 1D image layers in the viewer model.

### DIFF
--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -719,6 +719,21 @@ def test_not_mutable_fields(field):
 
 
 @pytest.mark.skipif(not zarr_available, reason='zarr not installed')
+def test_open_zarr_multiscale_image():
+    # For more details: https://github.com/napari/napari/issues/1471
+    viewer = ViewerModel()
+    with TemporaryDirectory(suffix='.zarr') as zarr_dir:
+        z = zarr.open(zarr_dir, 'w')
+        z['hires'] = np.ones((6, 8))
+        z['lores'] = np.ones((3, 4))
+
+        viewer.open(zarr_dir)
+
+        assert len(viewer.layers) == 1
+        assert viewer.layers[0].multiscale
+
+
+@pytest.mark.skipif(not zarr_available, reason='zarr not installed')
 def test_open_zarr_1d_array_is_ignored():
     # For more details: https://github.com/napari/napari/issues/1471
     viewer = ViewerModel()

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -3,13 +3,7 @@ from tempfile import TemporaryDirectory
 
 import numpy as np
 import pytest
-
-try:
-    import zarr
-
-    zarr_available = True
-except ImportError:
-    zarr_available = False
+import zarr
 
 from napari._tests.utils import good_layer_data, layer_test_data
 from napari.components import ViewerModel
@@ -718,7 +712,6 @@ def test_not_mutable_fields(field):
     )
 
 
-@pytest.mark.skipif(not zarr_available, reason='zarr not installed')
 def test_open_zarr_multiscale_image():
     # For more details: https://github.com/napari/napari/issues/1471
     viewer = ViewerModel()
@@ -733,7 +726,6 @@ def test_open_zarr_multiscale_image():
         assert viewer.layers[0].multiscale
 
 
-@pytest.mark.skipif(not zarr_available, reason='zarr not installed')
 def test_open_zarr_1d_array_is_ignored():
     # For more details: https://github.com/napari/napari/issues/1471
     viewer = ViewerModel()
@@ -741,12 +733,12 @@ def test_open_zarr_1d_array_is_ignored():
         z = zarr.open(zarr_dir, 'w')
         z['1d'] = np.zeros(3)
 
-        viewer.open(os.path.join(zarr_dir, '1d'))
+        with pytest.warns(UserWarning):
+            viewer.open(os.path.join(zarr_dir, '1d'))
 
         assert len(viewer.layers) == 0
 
 
-@pytest.mark.skipif(not zarr_available, reason='zarr not installed')
 def test_open_many_zarr_files_1d_array_is_ignored():
     # For more details: https://github.com/napari/napari/issues/1471
     viewer = ViewerModel()
@@ -756,6 +748,9 @@ def test_open_many_zarr_files_1d_array_is_ignored():
         z['2d'] = np.zeros((3, 4))
         z['3d'] = np.zeros((3, 4, 5))
 
-        viewer.open([os.path.join(zarr_dir, name) for name in z.array_keys()])
+        with pytest.warns(UserWarning):
+            viewer.open(
+                [os.path.join(zarr_dir, name) for name in z.array_keys()]
+            )
 
         assert [layer.name for layer in viewer.layers] == ['2d', '3d']

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -908,12 +908,11 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
                 data, kwargs, layer_type, fallback_name=basename
             )
 
-            if layer_type is None and getattr(_data[0], 'ndim', None) == 1:
-                LOGGER.warning(
-                    'Skipping 1D data with unspecified layer_type: {}'.format(
-                        filename
-                    )
-                )
+            if getattr(_data[0], 'ndim', None) == 1 and _data[2] in (
+                'image',
+                'labels',
+            ):
+                LOGGER.warning(f'Skipping 1D image: {filename}')
                 continue
 
             # actually add the layer

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -900,25 +900,10 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         added: List[Layer] = []  # for layers that get added
         plugin = hookimpl.plugin_name if hookimpl else None
         for data, filename in zip(layer_data, filenames):
-            basename = os.path.basename(filename)
-            fallback_name, _ext = os.path.splitext(basename)
+            basename, _ext = os.path.splitext(os.path.basename(filename))
             _data = _unify_data_and_user_kwargs(
-                data, kwargs, layer_type, fallback_name=fallback_name
+                data, kwargs, layer_type, fallback_name=basename
             )
-
-            if getattr(_data[0], 'ndim', None) == 1 and _data[2] in (
-                'image',
-                'labels',
-            ):
-                warnings.warn(
-                    trans._(
-                        "Skipped 1D image: {basename}",
-                        deferred=True,
-                        basename=basename,
-                    )
-                )
-                continue
-
             # actually add the layer
             with layer_source(path=filename, reader_plugin=plugin):
                 added.extend(self._add_layer_from_data(*_data))

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -507,7 +507,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         Parameters
         ----------
         data : array or list of array
-            Image data. Can be N dimensional. If the last dimension has length
+            Image data. Can be N >= 2 dimensional. If the last dimension has length
             3 or 4 can be interpreted as RGB or RGBA if rgb is `True`. If a
             list and arrays are decreasing in shape then the data is treated as
             a multiscale image.

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -9,6 +9,7 @@ from scipy import ndimage as ndi
 from ...utils import config
 from ...utils.colormaps import AVAILABLE_COLORMAPS
 from ...utils.events import Event
+from ...utils.translations import trans
 from ..base import Layer
 from ..intensity_mixin import IntensityVisualizationMixin
 from ..utils.layer_utils import calc_data_range
@@ -35,7 +36,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
     Parameters
     ----------
     data : array or list of array
-        Image data. Can be N dimensional. If the last dimension has length
+        Image data. Can be N >= 2 dimensional. If the last dimension has length
         3 or 4 can be interpreted as RGB or RGBA if rgb is `True`. If a
         list and arrays are decreasing in shape then the data is treated as
         a multiscale image.
@@ -86,7 +87,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
     affine : n-D array or napari.utils.transforms.Affine
         (N+1, N+1) affine transformation matrix in homogeneous coordinates.
         The first (N, N) entries correspond to a linear transform and
-        the final column is a lenght N translation vector and a 1 or a napari
+        the final column is a length N translation vector and a 1 or a napari
         AffineTransform object. If provided then translate, scale, rotate, and
         shear values are ignored.
     opacity : float
@@ -185,6 +186,11 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
     ):
         if isinstance(data, types.GeneratorType):
             data = list(data)
+
+        if getattr(data, 'ndim', 2) < 2:
+            raise ValueError(
+                trans._('Image data must have at least 2 dimensions.')
+            )
 
         # Determine if data is a multiscale
         if multiscale is None:

--- a/napari/utils/_tests/test_io.py
+++ b/napari/utils/_tests/test_io.py
@@ -5,17 +5,10 @@ from tempfile import TemporaryDirectory
 
 import numpy as np
 import pytest
+import zarr
 from dask import array as da
 
 from napari.utils import io
-
-try:
-    import zarr
-
-    zarr_available = True
-except ImportError:
-    zarr_available = False
-
 
 # the following fixtures are defined in napari/conftest.py
 # single_png, two_pngs, irregular_images, single_tiff
@@ -119,7 +112,6 @@ def test_guess_zarr_path():
     assert not io.guess_zarr_path('no_zarr_suffix/data.png')
 
 
-@pytest.mark.skipif(not zarr_available, reason='zarr not installed')
 def test_zarr():
     image = np.random.random((10, 20, 20))
     with TemporaryDirectory(suffix='.zarr') as fout:
@@ -131,7 +123,6 @@ def test_zarr():
         np.testing.assert_array_equal(image, image_in)
 
 
-@pytest.mark.skipif(not zarr_available, reason='zarr not installed')
 def test_zarr_nested(tmp_path):
     image = np.random.random((10, 20, 20))
     image_name = 'my_image'
@@ -143,7 +134,6 @@ def test_zarr_nested(tmp_path):
     np.testing.assert_array_equal(image, image_in)
 
 
-@pytest.mark.skipif(not zarr_available, reason='zarr not installed')
 def test_zarr_multiscale():
     multiscale = [
         np.random.random((20, 20)),

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -1,5 +1,4 @@
 import csv
-import logging
 import os
 import re
 from glob import glob
@@ -13,8 +12,6 @@ from dask import delayed
 from ..types import FullLayerData
 from ..utils.misc import abspath_or_url
 from ..utils.translations import trans
-
-LOGGER = logging.getLogger(__name__)
 
 
 def imsave(filename: str, data: np.ndarray):
@@ -209,8 +206,8 @@ def magic_imread(filenames, *, use_dask=None, stack=True):
     for filename in filenames_expanded:
         if guess_zarr_path(filename):
             image, zarr_shape = read_zarr_dataset(filename)
+            # 1D images are currently unsupported, so skip them.
             if len(zarr_shape) == 1:
-                LOGGER.warning(f'Skipped 1D zarr image: {filename}')
                 continue
             if shape is None:
                 shape = zarr_shape

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -1,6 +1,7 @@
 import csv
 import os
 import re
+import warnings
 from glob import glob
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
@@ -206,6 +207,15 @@ def magic_imread(filenames, *, use_dask=None, stack=True):
     for filename in filenames_expanded:
         if guess_zarr_path(filename):
             image, zarr_shape = read_zarr_dataset(filename)
+            if len(zarr_shape) == 1:
+                warnings.warn(
+                    trans._(
+                        'Skipped 1D zarr dataset: {basename}',
+                        deferred=True,
+                        basename=os.path.basename(filename),
+                    )
+                )
+                continue
             if shape is None:
                 shape = zarr_shape
         else:
@@ -220,6 +230,8 @@ def magic_imread(filenames, *, use_dask=None, stack=True):
             elif len(images) > 0:  # not read by shape clause
                 image = imread(filename)
         images.append(image)
+    if len(images) == 0:
+        return None
     if len(images) == 1:
         image = images[0]
     else:

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -1,7 +1,7 @@
 import csv
+import logging
 import os
 import re
-import warnings
 from glob import glob
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
@@ -13,6 +13,8 @@ from dask import delayed
 from ..types import FullLayerData
 from ..utils.misc import abspath_or_url
 from ..utils.translations import trans
+
+LOGGER = logging.getLogger(__name__)
 
 
 def imsave(filename: str, data: np.ndarray):
@@ -208,13 +210,7 @@ def magic_imread(filenames, *, use_dask=None, stack=True):
         if guess_zarr_path(filename):
             image, zarr_shape = read_zarr_dataset(filename)
             if len(zarr_shape) == 1:
-                warnings.warn(
-                    trans._(
-                        'Skipped 1D zarr dataset: {basename}',
-                        deferred=True,
-                        basename=os.path.basename(filename),
-                    )
-                )
+                LOGGER.warning(f'Skipped 1D zarr image: {filename}')
                 continue
             if shape is None:
                 shape = zarr_shape
@@ -230,8 +226,10 @@ def magic_imread(filenames, *, use_dask=None, stack=True):
             elif len(images) > 0:  # not read by shape clause
                 image = imread(filename)
         images.append(image)
+
     if len(images) == 0:
         return None
+
     if len(images) == 1:
         image = images[0]
     else:


### PR DESCRIPTION
# Description

This ignores any 1D image/labels found by `ViewerModel::open`, which fixes the associated crash. If the top level zarr directory is opened, we get the same crash, but I think that's OK because the error message more clearly states the problem (though we might want to present it more cleanly in an error notification rather than crashing).

I chose to filter these in `ViewerModel` mostly for two reasons.

1. Semantics: the data can be successfully read, but cannot be used as a layer that the viewer supports.
2. There is a clear place in `ViewerModel::_add_layers_with_plugins` where there is one layer/file pair. In many other parts of related code (e.g. magic_imread), I'm unsure if there are multiple files or layers, so I don't know whether to continue, return, and how to handle any return values appropriately.

Other ideas are welcome though, especially if there's something easy I missed.

I logged the skipped files as warnings, but I could also imagine that we might want to surface those to the user, so let me know if that's desired and the best way to do that.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

I don't think this is a breaking change, but I'm still unsure of how multi-scale images are represented and if these might be skipped as a result of this change. I added to test to cover opening a zarr multiscale image, but I'd appreciate if a more season contributor could check that and any other potential breakages this might cause.

# References
closes #1471

# How has this been tested?
- [x] I added two tests that create zarr arrays and try to open them, which reflects the described usage in the bug.
- [x] I manually tested napari to check that other layers are opened correctly.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).

Unsure if the log message should be translated, though this likely depends on how the message is delivered.