### PR TITLE
set default highlight thickness to 2

### DIFF
--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -163,7 +163,7 @@ class Language(str):
 class HighlightThickness(int):
     """Highlight thickness to use when hovering over shapes/points."""
 
-    highlight_thickness = 1
+    highlight_thickness = 2
     minimum = 1
     maximum = 10
 
@@ -202,7 +202,7 @@ class AppearanceSettings(BaseNapariSettings):
     )
 
     highlight_thickness: HighlightThickness = Field(
-        1,
+        2,
         description=trans._(
             "Customize the highlight weight indicating selected shapes and points."
         ),

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -202,7 +202,7 @@ class AppearanceSettings(BaseNapariSettings):
     )
 
     highlight_thickness: HighlightThickness = Field(
-        2,
+        HighlightThickness.highlight_thickness,
         description=trans._(
             "Customize the highlight weight indicating selected shapes and points."
         ),


### PR DESCRIPTION
Increasing the default highlight thickness per this discussion: 
https://forum.image.sc/t/cellfinder-napari-crashes-with-segmentation-fault-on-macos-when-saving-training-data-in-curation/52978/5
