### PR TITLE
Fix custom layer subclasses (don't require layer icon)

### DIFF
--- a/napari/_qt/containers/_layer_delegate.py
+++ b/napari/_qt/containers/_layer_delegate.py
@@ -93,7 +93,10 @@ class LayerDelegate(QStyledItemDelegate):
         else:
             icon_name = f'new_{layer._type_string}'
 
-        icon = QColoredSVGIcon.from_resources(icon_name)
+        try:
+            icon = QColoredSVGIcon.from_resources(icon_name)
+        except ValueError:
+            return
         # guessing theme rather than passing it through.
         bg = option.palette.color(option.palette.Background).red()
         option.icon = icon.colored(theme='dark' if bg < 128 else 'light')

--- a/napari/_tests/test_adding_removing.py
+++ b/napari/_tests/test_adding_removing.py
@@ -1,14 +1,12 @@
-import os
-
 import numpy as np
 import pytest
 
-from napari._tests.utils import layer_test_data
+from napari._tests.utils import layer_test_data, skip_local_popups
 from napari.layers import Image
 from napari.utils.events.event import WarningEmitter
 
 
-@pytest.mark.skipif(bool(not os.getenv("CI")), reason='shows viewer')
+@skip_local_popups
 @pytest.mark.parametrize('Layer, data, _', layer_test_data)
 def test_add_all_layers(make_napari_viewer, Layer, data, _):
     """Make sure that all layers can show in the viewer."""

--- a/napari/_tests/test_draw.py
+++ b/napari/_tests/test_draw.py
@@ -1,13 +1,9 @@
-import os
 import sys
 
 import numpy as np
 import pytest
 
-skip_local_popups = pytest.mark.skipif(
-    not os.getenv('CI') and os.getenv('NAPARI_POPUP_TESTS', '0') == '0',
-    reason='Tests requiring GUI windows are skipped locally by default.',
-)
+from napari._tests.utils import skip_local_popups
 
 
 @skip_local_popups

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -9,6 +9,7 @@ from napari._tests.utils import (
     check_view_transform_consistency,
     check_viewer_functioning,
     layer_test_data,
+    skip_local_popups,
 )
 from napari.utils._tests.test_naming import eval_with_filename
 
@@ -280,3 +281,15 @@ def test_deleting_points(make_napari_viewer):
     pts_layer.remove_selected()
 
     assert len(pts_layer.data) == 3
+
+
+@skip_local_popups
+def test_custom_layer(make_napari_viewer):
+    """Make sure that custom layers subclasses can be added to the viewer."""
+
+    class NewLabels(layers.Labels):
+        """'Empty' extension of napari Labels layer."""
+
+    # Make a viewer and add the custom layer
+    viewer = make_napari_viewer(show=True)
+    viewer.add_layer(NewLabels(np.zeros((10, 10, 10), dtype=np.uint8)))

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -1,24 +1,14 @@
 import collections
-import os
-import sys
 
 import numpy as np
 import pytest
 
+from napari._tests.utils import skip_local_popups, skip_on_win_ci
 from napari.utils.interactions import (
     ReadOnlyWrapper,
     mouse_move_callbacks,
     mouse_press_callbacks,
     mouse_release_callbacks,
-)
-
-skip_on_win_ci = pytest.mark.skipif(
-    sys.platform.startswith('win') and os.getenv('CI', '0') != '0',
-    reason='Screenshot tests are not supported on windows CI.',
-)
-skip_local_popups = pytest.mark.skipif(
-    not os.getenv('CI') and os.getenv('NAPARI_POPUP_TESTS', '0') == '0',
-    reason='Tests requiring GUI windows are skipped locally by default.',
 )
 
 

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -1,4 +1,8 @@
+import os
+import sys
+
 import numpy as np
+import pytest
 
 from napari import Viewer
 from napari.layers import (
@@ -10,6 +14,17 @@ from napari.layers import (
     Tracks,
     Vectors,
 )
+
+skip_on_win_ci = pytest.mark.skipif(
+    sys.platform.startswith('win') and os.getenv('CI', '0') != '0',
+    reason='Screenshot tests are not supported on windows CI.',
+)
+
+skip_local_popups = pytest.mark.skipif(
+    not os.getenv('CI') and os.getenv('NAPARI_POPUP_TESTS', '0') == '0',
+    reason='Tests requiring GUI windows are skipped locally by default.',
+)
+
 
 """
 Used as pytest params for testing layer add and view functionality (Layer class, data, ndim)

--- a/napari/_vispy/_tests/test_image_rendering.py
+++ b/napari/_vispy/_tests/test_image_rendering.py
@@ -1,8 +1,6 @@
-import os
-import sys
-
 import numpy as np
-import pytest
+
+from napari._tests.utils import skip_on_win_ci
 
 
 def test_image_rendering(make_napari_viewer):
@@ -41,10 +39,7 @@ def test_image_rendering(make_napari_viewer):
     assert layer.rendering == 'additive'
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith('win') or not os.getenv("CI"),
-    reason='Screenshot tests are not supported on napari windows CI.',
-)
+@skip_on_win_ci
 def test_visibility_consistency(qtbot, make_napari_viewer):
     """Make sure toggling visibility maintains image contrast.
 

--- a/napari/_vispy/_tests/test_vispy_multiscale.py
+++ b/napari/_vispy/_tests/test_vispy_multiscale.py
@@ -1,17 +1,6 @@
-import os
-import sys
-
 import numpy as np
-import pytest
 
-skip_on_win_ci = pytest.mark.skipif(
-    sys.platform.startswith('win') and os.getenv('CI', '0') != '0',
-    reason='Screenshot tests are not supported on windows CI.',
-)
-skip_local_popups = pytest.mark.skipif(
-    not os.getenv('CI') and os.getenv('NAPARI_POPUP_TESTS', '0') == '0',
-    reason='Tests requiring GUI windows are skipped locally by default.',
-)
+from napari._tests.utils import skip_local_popups, skip_on_win_ci
 
 
 def test_multiscale(make_napari_viewer):

--- a/napari/_vispy/experimental/_tests/test_vispy_tiled_image.py
+++ b/napari/_vispy/experimental/_tests/test_vispy_tiled_image.py
@@ -1,20 +1,9 @@
-import os
-import sys
-
 import numpy as np
 import pytest
 
+from napari._tests.utils import skip_local_popups, skip_on_win_ci
 from napari._vispy.experimental.vispy_tiled_image_layer import (
     VispyTiledImageLayer,
-)
-
-skip_on_win_ci = pytest.mark.skipif(
-    sys.platform.startswith('win') and os.getenv('CI', '0') != '0',
-    reason='Screenshot tests are not supported on windows CI.',
-)
-skip_local_popups = pytest.mark.skipif(
-    not os.getenv('CI') and os.getenv('NAPARI_POPUP_TESTS', '0') == '0',
-    reason='Tests requiring GUI windows are skipped locally by default.',
 )
 
 # Add a loading delay in ms.


### PR DESCRIPTION
# Description
Fixes #2757 
This was the same issue that broke tracks in #2706, so I'm adding a try/catch around fetching the icon for a given layer in the layerlist.

I'm also reducing moving some of our `@skip_local_popups` code to `napari._tests.utils` to reduce code duplication.


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added a test
- [x] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
