### PR TITLE
Add support for setting the settings configuration path via CLI and import

### DIFF
--- a/docs/guides/event_loop.md
+++ b/docs/guides/event_loop.md
@@ -29,9 +29,9 @@ If you would prefer that napari did *not* start the interactive
 event loop for you in IPython, then you can disable it with:
 
 ```python
-from napari.utils import SETTINGS
+from napari.utils import get_settings
 
-SETTINGS.application.ipy_interactive = False
+get_settings().application.ipy_interactive = False
 ```
 
 ... but then you will have to start the program yourself as described [below](#in-a-script).

--- a/docs/release/release_0_4_8.md
+++ b/docs/release/release_0_4_8.md
@@ -188,7 +188,7 @@ and
   been reduced. (#2552)
 - The ipy interactive setting has been removed from the preferences panel.
   (#2605) You can still turn it off from the API with
-  `napari.utils.settings.SETTINGS.ipy_interactive = False`, but this is not
+  `napari.utils.settings.get_settings().ipy_interactive = False`, but this is not
   recommended.
 - The `n-dimensional` tick box in the Labels layer controls has been removed.
   (#2609) Use "n edit dims" instead.

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -209,6 +209,11 @@ def parse_sys_argv():
         action='store_true',
         help='reset settings to default values.',
     )
+    parser.add_argument(
+        '--settings-path',
+        type=Path,
+        help='use specific path to store and load settings.',
+    )
 
     args, unknown = parser.parse_known_args()
     # this is a hack to allow using "=" as a key=value separator while also
@@ -223,7 +228,7 @@ def parse_sys_argv():
 
 def _run():
     from napari import run, view_path
-    from napari.utils.settings import SETTINGS
+    from napari.utils.settings import get_settings
 
     """Main program."""
     args, kwargs = parse_sys_argv()
@@ -237,8 +242,9 @@ def _run():
         datefmt='%H:%M:%S',
     )
 
+    settings = get_settings(path=args.settings_path)
     if args.reset:
-        SETTINGS.reset()
+        settings.reset()
         sys.exit("Resetting settings to default values.\n")
 
     if args.plugin:

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -103,10 +103,12 @@ def test_notification_display(mock_show, severity, monkeypatch):
     that show_notification is capable of receiving various event types.
     (we don't need to test that )
     """
-    from napari.utils.settings import SETTINGS
+    from napari.utils.settings import get_settings
+
+    settings = get_settings()
 
     monkeypatch.delenv('NAPARI_CATCH_ERRORS', raising=False)
-    monkeypatch.setattr(SETTINGS.application, 'gui_notification_level', 'info')
+    monkeypatch.setattr(settings.application, 'gui_notification_level', 'info')
     notif = Notification('hi', severity, actions=[('click', lambda x: None)])
     NapariQtNotification.show_notification(notif)
     if NotificationSeverity(severity) >= NotificationSeverity.INFO:
@@ -125,10 +127,12 @@ def test_notification_display(mock_show, severity, monkeypatch):
 
 @patch('napari._qt.dialogs.qt_notification.QDialog.show')
 def test_notification_error(mock_show, monkeypatch, clean_current):
-    from napari.utils.settings import SETTINGS
+    from napari.utils.settings import get_settings
+
+    settings = get_settings()
 
     monkeypatch.delenv('NAPARI_CATCH_ERRORS', raising=False)
-    monkeypatch.setattr(SETTINGS.application, 'gui_notification_level', 'info')
+    monkeypatch.setattr(settings.application, 'gui_notification_level', 'info')
     try:
         raise ValueError('error!')
     except ValueError as e:

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -251,6 +251,7 @@ class PreferencesDialog(QDialog):
         values : dict
             Dictionary of current values set in preferences.
         """
+        settings = get_settings()
         builder = WidgetBuilder()
         form = builder.create_form(schema, self.ui_schema)
 
@@ -261,7 +262,7 @@ class PreferencesDialog(QDialog):
             widget = form_layout.itemAt(row, form_layout.FieldRole).widget()
             name = widget._name
             disable = bool(
-                SETTINGS._env_settings.get(section, {}).get(name, None)
+                get_settings()._env_settings.get(section, {}).get(name, None)
             )
             widget.setDisabled(disable)
             try:

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -14,7 +14,7 @@ from qtpy.QtWidgets import (
 )
 
 from ..._vendor.qt_json_builder.qt_jsonschema_form import WidgetBuilder
-from ...utils.settings import SETTINGS
+from ...utils.settings import get_settings
 from ...utils.translations import trans
 
 
@@ -112,7 +112,7 @@ class PreferencesDialog(QDialog):
 
     def make_dialog(self):
         """Removes settings not to be exposed to user and creates dialog pages."""
-
+        settings = get_settings()
         # Because there are multiple pages, need to keep a dictionary of values dicts.
         # One set of keywords are for each page, then in each entry for a page, there are dicts
         # of setting and its value.
@@ -120,7 +120,7 @@ class PreferencesDialog(QDialog):
         self._values_dict = {}
         self._setting_changed_dict = {}
 
-        for page, setting in SETTINGS.schemas().items():
+        for page, setting in settings.schemas().items():
             schema, values, properties = self.get_page_dict(setting)
 
             self._setting_changed_dict[page] = {}
@@ -202,12 +202,13 @@ class PreferencesDialog(QDialog):
         self.show()
 
     def on_click_ok(self):
-        """Keeps the selected preferences saved to SETTINGS."""
+        """Keeps the selected preferences saved to settings."""
         self.close()
 
     def on_click_cancel(self):
         """Restores the settings in place when dialog was launched."""
         # Need to check differences for each page.
+        settings = get_settings()
         for n in range(self._stack.count()):
             # Must set the current row so that the proper list is updated
             # in check differences.
@@ -217,7 +218,7 @@ class PreferencesDialog(QDialog):
             # of preference dialog session, change them back.
             # Using the settings value seems to be the best way to get the checkboxes right
             # on the plugin call order widget.
-            setting = SETTINGS.schemas()[page]
+            setting = settings.schemas()[page]
             schema, new_values, properties = self.get_page_dict(setting)
             self.check_differences(self._values_orig_dict[page], new_values)
 
@@ -348,15 +349,16 @@ class PreferencesDialog(QDialog):
         old_dict : dict
             Dict wtih values set at the beginning of the preferences dialog session.
         """
+        settings = get_settings()
         page = self._list.currentItem().text().split(" ")[0].lower()
         self._values_changed(page, new_dict, old_dict)
         different_values = self._setting_changed_dict[page]
 
         if len(different_values) > 0:
-            # change the values in SETTINGS
+            # change the values in settings
             for setting_name, value in different_values.items():
                 try:
-                    setattr(SETTINGS._settings[page], setting_name, value)
+                    setattr(settings._settings[page], setting_name, value)
                     self._values_dict[page] = new_dict
 
                     if page == 'experimental':
@@ -422,7 +424,7 @@ class ConfirmDialog(QDialog):
 
     def on_click_restore(self):
         """Restore defaults and close window."""
-        SETTINGS.reset()
+        get_settings().reset()
         self.valueChanged.emit()
         self.close()
 

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -262,7 +262,7 @@ class PreferencesDialog(QDialog):
             widget = form_layout.itemAt(row, form_layout.FieldRole).widget()
             name = widget._name
             disable = bool(
-                get_settings()._env_settings.get(section, {}).get(name, None)
+                settings._env_settings.get(section, {}).get(name, None)
             )
             widget.setDisabled(disable)
             try:
@@ -290,11 +290,11 @@ class PreferencesDialog(QDialog):
 
     def _disable_async(self, form, values, disable=True, state=True):
         """Disable async if octree is True."""
-
+        settings = get_settings()
         # need to make sure that if async_ is an environment setting, that we don't
         # enable it here.
         if (
-            SETTINGS._env_settings['experimental'].get('async_', None)
+            settings._env_settings['experimental'].get('async_', None)
             is not None
         ):
             disable = True

--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -361,14 +361,16 @@ class NapariQtNotification(QDialog):
 
     @classmethod
     def show_notification(cls, notification: Notification):
-        from ...utils.settings import SETTINGS
+        from ...utils.settings import get_settings
+
+        settings = get_settings()
 
         # after https://github.com/napari/napari/issues/2370,
         # the os.getenv can be removed (and NAPARI_CATCH_ERRORS retired)
         if (
             os.getenv("NAPARI_CATCH_ERRORS") not in ('0', 'False')
             and notification.severity
-            >= SETTINGS.application.gui_notification_level
+            >= settings.application.gui_notification_level
         ):
             application_instance = QApplication.instance()
             if application_instance:

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -17,7 +17,7 @@ from ..utils.notifications import (
     show_console_notification,
 )
 from ..utils.perf import perf_config
-from ..utils.settings import SETTINGS
+from ..utils.settings import get_settings
 from ..utils.translations import trans
 from .dialogs.qt_notification import (
     NapariQtNotification,
@@ -165,7 +165,7 @@ def get_app(
         app.setWindowIcon(QIcon(kwargs.get('icon')))
 
     if ipy_interactive is None:
-        ipy_interactive = SETTINGS.application.ipy_interactive
+        ipy_interactive = get_settings().application.ipy_interactive
     _try_enable_ipython_gui('qt' if ipy_interactive else None)
 
     if perf_config and not perf_config.patched:

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -642,6 +642,7 @@ class Window:
 
     def _add_view_menu(self):
         """Add 'View' menu to app menubar."""
+        settings = get_settings()
         toggle_visible = QAction(
             trans._('Toggle Menubar Visibility'), self._qt_window
         )
@@ -772,10 +773,10 @@ class Window:
             trans._('Layer Tooltip visibility'),
             parent=self._qt_window,
             checkable=True,
-            checked=SETTINGS.appearance.layer_tooltip_visibility,
+            checked=settings.appearance.layer_tooltip_visibility,
         )
         self.tooltip_menu.triggered.connect(self._tooltip_visibility_toggle)
-        SETTINGS.appearance.events.layer_tooltip_visibility.connect(
+        settings.appearance.events.layer_tooltip_visibility.connect(
             self._tooltip_visibility_toggled
         )
         self.view_menu.addAction(self.tooltip_menu)
@@ -783,11 +784,11 @@ class Window:
         self.view_menu.addSeparator()
 
     def _tooltip_visibility_toggle(self, value):
-        SETTINGS.appearance.layer_tooltip_visibility = value
+        get_settings().appearance.layer_tooltip_visibility = value
 
     def _tooltip_visibility_toggled(self, event):
         self.tooltip_menu.setChecked(
-            SETTINGS.appearance.layer_tooltip_visibility
+            get_settings().appearance.layer_tooltip_visibility
         )
 
     def _event_to_action(self, action, event):

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -30,7 +30,7 @@ from ..utils.history import get_save_history, update_save_history
 from ..utils.io import imsave
 from ..utils.misc import in_jupyter, running_as_bundled_app
 from ..utils.notifications import Notification
-from ..utils.settings import SETTINGS
+from ..utils.settings import get_settings
 from ..utils.translations import trans
 from .dialogs.preferences_dialog import PreferencesDialog
 from .dialogs.qt_about import QtAbout
@@ -85,12 +85,12 @@ class _QtMainWindow(QMainWindow):
         self._preferences_dialog_size = QSize()
         self._status_bar = self.statusBar()
 
-        # set SETTINGS plugin defaults.
-        SETTINGS._defaults['plugins'].call_order = plugin_manager.call_order()
+        settings = get_settings()
+        settings._defaults['plugins'].call_order = plugin_manager.call_order()
 
-        # set the values in plugins to match the ones saved in SETTINGS
-        if SETTINGS.plugins.call_order is not None:
-            plugin_manager.set_call_order(SETTINGS.plugins.call_order)
+        # set the values in plugins to match the ones saved in settings
+        if settings.plugins.call_order is not None:
+            plugin_manager.set_call_order(settings.plugins.call_order)
 
         _QtMainWindow._instances.append(self)
         self.qt_viewer.viewer.tooltip.events.text.connect(self.update_tooltip)
@@ -133,10 +133,11 @@ class _QtMainWindow(QMainWindow):
         """
         Load window layout settings from configuration.
         """
-        window_size = SETTINGS.application.window_size
-        window_state = SETTINGS.application.window_state
-        preferences_dialog_size = SETTINGS.application.preferences_size
-        window_position = SETTINGS.application.window_position
+        settings = get_settings()
+        window_size = settings.application.window_size
+        window_state = settings.application.window_state
+        preferences_dialog_size = settings.application.preferences_size
+        window_position = settings.application.window_position
 
         # It's necessary to verify if the window/position value is valid with the current screen.
         width, height = window_position
@@ -146,8 +147,8 @@ class _QtMainWindow(QMainWindow):
         if current_width < width or current_height < height:
             window_position = (self.x(), self.y())
 
-        window_maximized = SETTINGS.application.window_maximized
-        window_fullscreen = SETTINGS.application.window_fullscreen
+        window_maximized = settings.application.window_maximized
+        window_fullscreen = settings.application.window_fullscreen
         return (
             window_state,
             window_size,
@@ -236,18 +237,19 @@ class _QtMainWindow(QMainWindow):
             preferences_dialog_size,
         ) = self._get_window_settings()
 
-        if SETTINGS.application.save_window_geometry:
-            SETTINGS.application.window_maximized = window_maximized
-            SETTINGS.application.window_fullscreen = window_fullscreen
-            SETTINGS.application.window_position = window_position
-            SETTINGS.application.window_size = window_size
-            SETTINGS.application.window_statusbar = (
+        settings = get_settings()
+        if settings.application.save_window_geometry:
+            settings.application.window_maximized = window_maximized
+            settings.application.window_fullscreen = window_fullscreen
+            settings.application.window_position = window_position
+            settings.application.window_size = window_size
+            settings.application.window_statusbar = (
                 not self._status_bar.isHidden()
             )
-            SETTINGS.application.preferences_size = preferences_dialog_size
+            settings.application.preferences_size = preferences_dialog_size
 
-        if SETTINGS.application.save_window_state:
-            SETTINGS.application.window_state = window_state
+        if settings.application.save_window_state:
+            settings.application.window_state = window_state
 
     def _update_preferences_dialog_size(self, size):
         """Save preferences dialog size."""
@@ -352,6 +354,8 @@ class Window:
     """
 
     def __init__(self, viewer, *, show: bool = True):
+        settings = get_settings()
+
         # create QApplication if it doesn't already exist
         get_app()
 
@@ -382,7 +386,7 @@ class Window:
         self._help = QLabel('')
         self._status_bar.addPermanentWidget(self._help)
 
-        self.qt_viewer.viewer.theme = SETTINGS.appearance.theme
+        self.qt_viewer.viewer.theme = settings.appearance.theme
         self._update_theme()
 
         self._add_viewer_dock_widget(self.qt_viewer.dockConsole, tabify=False)
@@ -395,7 +399,7 @@ class Window:
         self._add_viewer_dock_widget(self.qt_viewer.activityDock, tabify=False)
         self.window_menu.addSeparator()
 
-        SETTINGS.appearance.events.theme.connect(self._update_theme)
+        settings.appearance.events.theme.connect(self._update_theme)
 
         plugin_manager.events.disabled.connect(self._rebuild_plugins_menu)
         plugin_manager.events.disabled.connect(self._rebuild_samples_menu)
@@ -630,7 +634,7 @@ class Window:
 
         # need to reset call order to defaults
 
-        plugin_manager.set_call_order(SETTINGS.plugins.call_order)
+        plugin_manager.set_call_order(get_settings().plugins.call_order)
 
     def _on_preferences_closed(self):
         """Reset preferences dialog variable."""
@@ -1301,6 +1305,7 @@ class Window:
         RuntimeError
             If the viewer.window has already been closed and deleted.
         """
+        settings = get_settings()
         try:
             self._qt_window.show(block=block)
         except (AttributeError, RuntimeError):
@@ -1311,8 +1316,8 @@ class Window:
                 )
             )
 
-        if SETTINGS.application.first_time:
-            SETTINGS.application.first_time = False
+        if settings.application.first_time:
+            settings.application.first_time = False
             try:
                 self._qt_window.resize(self._qt_window.layout().sizeHint())
             except (AttributeError, RuntimeError):
@@ -1324,7 +1329,7 @@ class Window:
                 )
         else:
             try:
-                if SETTINGS.application.save_window_geometry:
+                if settings.application.save_window_geometry:
                     self._qt_window._set_window_settings(
                         *self._qt_window._load_window_settings()
                     )
@@ -1365,9 +1370,10 @@ class Window:
 
     def _update_theme(self, event=None):
         """Update widget color theme."""
+        settings = get_settings()
         if event:
             value = event.value
-            SETTINGS.appearance.theme = value
+            settings.appearance.theme = value
             self.qt_viewer.viewer.theme = value
         else:
             value = self.qt_viewer.viewer.theme

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
     from ..viewer import Viewer
 
 from ..utils.io import imsave_extensions
-from ..utils.settings import SETTINGS
+from ..utils.settings import get_settings
 
 
 class QtViewer(QSplitter):
@@ -267,13 +267,12 @@ class QtViewer(QSplitter):
         else:
             self.chunk_receiver = None
 
-        # bind shortcuts stored in SETTINGS last.
+        # bind shortcuts stored in settings last.
         self._bind_shortcuts()
 
     def _bind_shortcuts(self):
         """Bind shortcuts stored in SETTINGS to actions."""
-
-        for action, shortcuts in SETTINGS.shortcuts.shortcuts.items():
+        for action, shortcuts in get_settings().shortcuts.shortcuts.items():
             action_manager.unbind_shortcut(action)
             for shortcut in shortcuts:
                 action_manager.bind_shortcut(action, shortcut)

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -22,7 +22,7 @@ from qtpy.QtWidgets import (
 )
 
 from ...plugins import plugin_manager as napari_plugin_manager
-from ...utils.settings import SETTINGS
+from ...utils.settings import get_settings
 from ...utils.translations import trans
 from ..utils import drag_with_pixmap
 from ..widgets.qt_eliding_label import ElidingLabel
@@ -362,7 +362,8 @@ class QtPluginSorter(QWidget):
 
     def _change_settings_plugins(self):
         """Update settings if plugin call order changes."""
-        SETTINGS.plugins.call_order = self.plugin_manager.call_order()
+        settings = get_settings()
+        settings.plugins.call_order = self.plugin_manager.call_order()
 
     def set_hookname(self, hook: str):
         """Change the hook specification shown in the list widget.

--- a/napari/_vispy/vispy_points_layer.py
+++ b/napari/_vispy/vispy_points_layer.py
@@ -3,7 +3,7 @@ from vispy.scene.visuals import Compound, Line, Text
 
 from ..utils.colormaps.standardize_color import transform_color
 from ..utils.events import disconnect_events
-from ..utils.settings import SETTINGS
+from ..utils.settings import get_settings
 from ._text_utils import update_text
 from .markers import Markers
 from .vispy_base_layer import VispyBaseLayer
@@ -11,9 +11,11 @@ from .vispy_base_layer import VispyBaseLayer
 
 class VispyPointsLayer(VispyBaseLayer):
     _highlight_color = (0, 0.6, 1)
-    _highlight_width = SETTINGS.appearance.highlight_thickness
+    _highlight_width = None
 
     def __init__(self, layer):
+        self._highlight_width = get_settings().appearance.highlight_thickness
+
         # Create a compound visual with the following four subvisuals:
         # Lines: The lines of the interaction box used for highlights.
         # Markers: The the outlines for each point used for highlights.
@@ -74,6 +76,7 @@ class VispyPointsLayer(VispyBaseLayer):
         self._on_matrix_change()
 
     def _on_highlight_change(self, event=None):
+        settings = get_settings()
         if len(self.layer._highlight_index) > 0:
             # Color the hovered or selected points
             data = self.layer._view_data[self.layer._highlight_index]
@@ -87,7 +90,7 @@ class VispyPointsLayer(VispyBaseLayer):
         self.node._subvisuals[1].set_data(
             data[:, ::-1],
             size=size,
-            edge_width=SETTINGS.appearance.highlight_thickness,
+            edge_width=settings.appearance.highlight_thickness,
             symbol=self.layer.symbol,
             edge_color=self._highlight_color,
             face_color=transform_color('transparent'),
@@ -104,7 +107,7 @@ class VispyPointsLayer(VispyBaseLayer):
                 width = 0
             else:
                 pos = self.layer._highlight_box
-                width = SETTINGS.appearance.highlight_thickness
+                width = settings.appearance.highlight_thickness
 
             self.node._subvisuals[2].set_data(
                 pos=pos[:, ::-1],

--- a/napari/_vispy/vispy_shapes_layer.py
+++ b/napari/_vispy/vispy_shapes_layer.py
@@ -2,7 +2,7 @@ import numpy as np
 from vispy.scene.visuals import Compound, Line, Markers, Mesh, Text
 
 from ..utils.events import disconnect_events
-from ..utils.settings import SETTINGS
+from ..utils.settings import get_settings
 from ._text_utils import update_text
 from .vispy_base_layer import VispyBaseLayer
 
@@ -59,8 +59,8 @@ class VispyShapesLayer(VispyBaseLayer):
         self.node.update()
 
     def _on_highlight_change(self, event=None):
-
-        self.layer._highlight_width = SETTINGS.appearance.highlight_thickness
+        settings = get_settings()
+        self.layer._highlight_width = settings.appearance.highlight_thickness
 
         # Compute the vertices and faces of any shape outlines
         vertices, faces = self.layer._outline_shapes()
@@ -85,7 +85,7 @@ class VispyShapesLayer(VispyBaseLayer):
             width,
         ) = self.layer._compute_vertices_and_box()
 
-        width = SETTINGS.appearance.highlight_thickness
+        width = settings.appearance.highlight_thickness
 
         if vertices is None or len(vertices) == 0:
             vertices = np.zeros((1, self.layer._ndisplay))

--- a/napari/components/_viewer_key_bindings.py
+++ b/napari/components/_viewer_key_bindings.py
@@ -1,5 +1,5 @@
 from ..utils.action_manager import action_manager
-from ..utils.settings import SETTINGS
+from ..utils.settings import get_settings
 from ..utils.theme import available_themes
 from ..utils.translations import trans
 from .viewer_model import ViewerModel
@@ -56,14 +56,15 @@ def toggle_ndisplay(viewer):
 @register_viewer_action(trans._("Toggle theme."))
 def toggle_theme(viewer):
     """Toggle theme for viewer"""
+    settings = get_settings()
     themes = available_themes()
-    current_theme = SETTINGS.appearance.theme
+    current_theme = settings.appearance.theme
     idx = themes.index(current_theme)
     idx += 1
     if idx == len(themes):
         idx = 0
 
-    SETTINGS.appearance.theme = themes[idx]
+    settings.appearance.theme = themes[idx]
 
 
 @register_viewer_action(trans._("Reset view to original state."))

--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -1,4 +1,4 @@
-from ..utils.settings import SETTINGS
+from ..utils.settings import get_settings
 from ._plugin_manager import NapariPluginManager
 
 __all__ = ["plugin_manager", "menu_item_template"]
@@ -7,8 +7,8 @@ __all__ = ["plugin_manager", "menu_item_template"]
 # the main plugin manager instance for the `napari` plugin namespace.
 plugin_manager = NapariPluginManager()
 plugin_manager._initialize()
-# Disable plugins listed as disabled in SETTINGS.
-plugin_manager._blocked.update(SETTINGS.plugins.disabled_plugins)
+# Disable plugins listed as disabled in settings.
+plugin_manager._blocked.update(get_settings().plugins.disabled_plugins)
 
 #: Template to use for namespacing a plugin item in the menu bar
 menu_item_template = '{}: {}'

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -25,7 +25,7 @@ from ..utils import _magicgui
 from ..utils._appdirs import user_site_packages
 from ..utils.events import EmitterGroup, EventedSet
 from ..utils.misc import camel_to_spaces, running_as_bundled_app
-from ..utils.settings import SETTINGS
+from ..utils.settings import get_settings
 from ..utils.translations import trans
 from . import _builtins, hook_specifications
 
@@ -140,7 +140,7 @@ class NapariPluginManager(PluginManager):
             # let's reregister.  # TODO: might be able to be more direct here.
             self.discover()
 
-        SETTINGS.plugins.disabled_plugins = set(self._blocked)
+        get_settings().plugins.disabled_plugins = set(self._blocked)
 
     def call_order(self, first_result_only=True) -> CallOrderDict:
         """Returns the call order from the plugin manager.
@@ -168,10 +168,10 @@ class NapariPluginManager(PluginManager):
         return order
 
     def set_call_order(self, new_order: CallOrderDict):
-        """Sets the plugin manager call order to match SETTINGS plugin values.
+        """Sets the plugin manager call order to match settings plugin values.
 
         Note: Run this after load_settings_plugin_defaults, which
-        sets the default values in SETTINGS.
+        sets the default values in settings.
 
         Parameters
         ----------

--- a/napari/utils/_octree.py
+++ b/napari/utils/_octree.py
@@ -8,7 +8,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from ..utils.settings import SETTINGS
+from ..utils.settings import get_settings
 from ..utils.translations import trans
 
 LOGGER = logging.getLogger("napari.loader")
@@ -42,7 +42,7 @@ def _get_async_config() -> Optional[dict]:
         The async config to use or None if async not specified.
     """
 
-    async_var = SETTINGS.experimental.async_
+    async_var = get_settings().experimental.async_
 
     if async_var in [True, False]:
         async_var = str(int(async_var))
@@ -74,8 +74,8 @@ def get_octree_config() -> dict:
     dict
         The config data we should use.
     """
-
-    octree_var = SETTINGS.experimental.octree
+    settings = get_settings()
+    octree_var = settings.experimental.octree
 
     if octree_var in [True, False]:
         octree_var = str(int(octree_var))
@@ -95,6 +95,6 @@ def get_octree_config() -> dict:
         json_config = json.load(infile)
 
     # Need to set this for the preferences dialog to build.
-    SETTINGS.experimental.octree = True
+    settings.experimental.octree = True
 
     return json_config

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -100,9 +100,11 @@ def make_napari_viewer(
     from qtpy.QtWidgets import QApplication
 
     from napari import Viewer
-    from napari.utils.settings import SETTINGS
+    from napari.utils.settings import get_settings
 
-    SETTINGS.reset()
+    settings = get_settings()
+    settings.reset()
+
     viewers: List[Viewer] = []
 
     # may be overridden by using `make_napari_viewer(strict=True)`
@@ -137,7 +139,7 @@ def make_napari_viewer(
     # Some tests might have the viewer closed, so this call will not be able
     # to access the window.
     with suppress(AttributeError):
-        SETTINGS.reset()
+        get_settings().reset()
 
     # close viewers, but don't saving window settings while closing
     for viewer in viewers:

--- a/napari/utils/history.py
+++ b/napari/utils/history.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-from ..utils.settings import SETTINGS
+from ..utils.settings import get_settings
 
 
 def update_open_history(filename):
@@ -12,14 +12,15 @@ def update_open_history(filename):
     filename : str
         New file being added to open history.
     """
-    folders = SETTINGS.application.open_history
+    settings = get_settings()
+    folders = settings.application.open_history
     new_loc = os.path.dirname(filename)
     if new_loc in folders:
         folders.insert(0, folders.pop(folders.index(new_loc)))
     else:
         folders.insert(0, new_loc)
     folders = folders[0:10]
-    SETTINGS.application.open_history = folders
+    settings.application.open_history = folders
 
 
 def update_save_history(filename):
@@ -30,26 +31,29 @@ def update_save_history(filename):
     filename : str
         New file being added to save history.
     """
-    folders = SETTINGS.application.save_history
+    settings = get_settings()
+    folders = settings.application.save_history
     new_loc = os.path.dirname(filename)
     if new_loc in folders:
         folders.insert(0, folders.pop(folders.index(new_loc)))
     else:
         folders.insert(0, new_loc)
     folders = folders[0:10]
-    SETTINGS.application.save_history = folders
+    settings.application.save_history = folders
 
 
 def get_open_history():
     """A helper for history handling."""
-    folders = SETTINGS.application.open_history
+    settings = get_settings()
+    folders = settings.application.open_history
     folders = [f for f in folders if os.path.isdir(f)]
     return folders or [str(Path.home())]
 
 
 def get_save_history():
     """A helper for history handling."""
-    folders = SETTINGS.application.save_history
+    settings = get_settings()
+    folders = settings.application.save_history
     folders = [f for f in folders if os.path.isdir(f)]
 
     return folders

--- a/napari/utils/notifications.py
+++ b/napari/utils/notifications.py
@@ -272,9 +272,12 @@ def show_info(message: str):
 
 
 def show_console_notification(notification: Notification):
-    from .settings import SETTINGS
+    from .settings import get_settings
 
-    if notification.severity < SETTINGS.application.console_notification_level:
+    if (
+        notification.severity
+        < get_settings().application.console_notification_level
+    ):
         return
 
     print(notification)

--- a/napari/utils/settings/__init__.py
+++ b/napari/utils/settings/__init__.py
@@ -2,6 +2,6 @@
 """
 
 from ._defaults import CORE_SETTINGS
-from ._manager import SETTINGS
+from ._manager import get_settings
 
-__all__ = ['SETTINGS', 'CORE_SETTINGS']
+__all__ = ['CORE_SETTINGS', 'get_settings']

--- a/napari/utils/settings/__init__.py
+++ b/napari/utils/settings/__init__.py
@@ -2,6 +2,6 @@
 """
 
 from ._defaults import CORE_SETTINGS
-from ._manager import get_settings
+from ._manager import SETTINGS, get_settings
 
-__all__ = ['CORE_SETTINGS', 'get_settings']
+__all__ = ['CORE_SETTINGS', 'get_settings', 'SETTINGS']

--- a/napari/utils/settings/_manager.py
+++ b/napari/utils/settings/_manager.py
@@ -5,7 +5,7 @@ import json
 import os
 import warnings
 from pathlib import Path
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, List, Optional
 
 from appdirs import user_config_dir
 from yaml import safe_dump, safe_load
@@ -235,7 +235,7 @@ class SettingsManager:
         self._plugins.append(plugin)
 
 
-_SETTINGS: Optional[SettingsManager] = None
+SETTINGS: Optional[SettingsManager] = None
 
 
 def get_settings(path: Optional[Path] = None) -> SettingsManager:
@@ -256,11 +256,11 @@ def get_settings(path: Optional[Path] = None) -> SettingsManager:
     -----
     The path can only be set once per session.
     """
-    global _SETTINGS
+    global SETTINGS
 
-    if _SETTINGS is None:
+    if SETTINGS is None:
         config_path = path.resolve() if path else None
-        _SETTINGS = SettingsManager(config_path=config_path)
+        SETTINGS = SettingsManager(config_path=config_path)
     elif path is not None:
         import inspect
 
@@ -274,4 +274,4 @@ def get_settings(path: Optional[Path] = None) -> SettingsManager:
             )
         )
 
-    return _SETTINGS
+    return SETTINGS

--- a/napari/utils/settings/_tests/test_settings.py
+++ b/napari/utils/settings/_tests/test_settings.py
@@ -5,6 +5,7 @@ import pydantic
 import pytest
 from yaml import safe_load
 
+import napari.utils.settings._manager as _manager
 from napari.utils.settings._manager import CORE_SETTINGS, SettingsManager
 from napari.utils.theme import get_theme, register_theme
 
@@ -207,3 +208,16 @@ def test_core_settings_are_class_variables_in_settings_manager():
         section = schema["section"]
         assert section in SettingsManager.__annotations__
         assert setting == SettingsManager.__annotations__[section]
+
+
+def test_get_settings(monkeypatch, tmp_path):
+    monkeypatch.setattr(_manager, "_SETTINGS", None)
+    settings = _manager.get_settings(tmp_path)
+    assert settings._config_path == tmp_path
+
+
+def test_get_settings_fails(monkeypatch, tmp_path):
+    monkeypatch.setattr(_manager, "_SETTINGS", None)
+    _manager.get_settings(tmp_path)
+    with pytest.raises(Exception):
+        _manager.get_settings(tmp_path)

--- a/napari/utils/settings/_tests/test_settings.py
+++ b/napari/utils/settings/_tests/test_settings.py
@@ -6,7 +6,11 @@ import pytest
 from yaml import safe_load
 
 import napari.utils.settings._manager as _manager
-from napari.utils.settings._manager import CORE_SETTINGS, SettingsManager
+from napari.utils.settings._manager import (
+    CORE_SETTINGS,
+    SettingsManager,
+    _SettingsProxy,
+)
 from napari.utils.theme import get_theme, register_theme
 
 
@@ -211,13 +215,13 @@ def test_core_settings_are_class_variables_in_settings_manager():
 
 
 def test_get_settings(monkeypatch, tmp_path):
-    monkeypatch.setattr(_manager, "SETTINGS", None)
+    monkeypatch.setattr(_manager, "SETTINGS", _SettingsProxy())
     settings = _manager.get_settings(tmp_path)
     assert settings._config_path == tmp_path
 
 
 def test_get_settings_fails(monkeypatch, tmp_path):
-    monkeypatch.setattr(_manager, "SETTINGS", None)
+    monkeypatch.setattr(_manager, "SETTINGS", _SettingsProxy())
     _manager.get_settings(tmp_path)
     with pytest.raises(Exception):
         _manager.get_settings(tmp_path)

--- a/napari/utils/settings/_tests/test_settings.py
+++ b/napari/utils/settings/_tests/test_settings.py
@@ -211,13 +211,13 @@ def test_core_settings_are_class_variables_in_settings_manager():
 
 
 def test_get_settings(monkeypatch, tmp_path):
-    monkeypatch.setattr(_manager, "_SETTINGS", None)
+    monkeypatch.setattr(_manager, "SETTINGS", None)
     settings = _manager.get_settings(tmp_path)
     assert settings._config_path == tmp_path
 
 
 def test_get_settings_fails(monkeypatch, tmp_path):
-    monkeypatch.setattr(_manager, "_SETTINGS", None)
+    monkeypatch.setattr(_manager, "SETTINGS", None)
     _manager.get_settings(tmp_path)
     with pytest.raises(Exception):
         _manager.get_settings(tmp_path)


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousando words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Add support for loading settings from a different path. Replaces `SETTINGS` by a `get_settings` function.

Related to https://github.com/napari/napari/issues/2336

Specifically it fixes:

>Does not use global settings object.
>Why: When using napari from notebook user may open more than one napari Viewer instance. They should not share state so should not share settings object. Open multiple Viewer may be useful when preparing to meet and like to prepare few different views (without a wait for calculations on meeting).

>?Allow to simply provide a path to the directory where settings should be stored.
>Why: I embed napari in my own application This application provides its own set of plugins etc. To avoid settings collision (especially when store plugins-related things in napari) I would like to store settings for the embedded instance application-specific directory. I think that it also will be useful for other persons who develop rich plugins.

Pinging @Czaki for testing :) 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
