### PR TITLE
add `make watch` command for hot reload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,29 @@
-.PHONY: docs
+.PHONY: docs watch
 
 docs:
 	rm -rf docs/_build/
 	find docs/api ! -name 'index.rst' -type f -exec rm -f {} +
 	pip install -qr docs/requirements.txt
 	jb build docs
+
+
+# If the first argument is "watch"...
+ifeq (watch,$(firstword $(MAKECMDGOALS)))
+  # use the rest as arguments for "watch"
+  WATCH_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(WATCH_ARGS):;@:)
+endif
+
+# examples:
+# make watch ~/Desktop/Untitled.png
+# make watch -- -w animation  # -- is required for passing flags to napari
+
+watch:
+	@echo "running: napari $(WATCH_ARGS)"
+	@echo "Save any file to restart napari\nCtrl-C to stop..\n" && \
+		watchmedo auto-restart -R \
+			--ignore-patterns="*.pyc*" -D \
+			--signal SIGKILL \
+			napari -- $(WATCH_ARGS) || \
+		echo "please run 'pip install watchdog[watchmedo]'"


### PR DESCRIPTION
# Description
in [this thread](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/Hot.20reloading) on zulip, @0x00b1 inquired about hot reloading for napari development.  this PR adds a new command to our makefile that will start a [watchmedo](https://github.com/gorakhargosh/watchdog) process to monitor files in the napari directory and restart napari if they change (if watchdog isn't installed, you get a helpful message).

examples:

```sh
# start napari and restart if anything changes
make watch

# start napari with argument
make watch  ~/some_file.tiff

# start napari with additional flags
# note: `--` is required for passing flags to napari
make watch -- -w animation  
# also note: this won't restart if you change a file outside
# of the napari directory
```

