### PR TITLE
POC for 1D images (e.g. line plots)

### DIFF
--- a/napari/_vispy/vispy_camera.py
+++ b/napari/_vispy/vispy_camera.py
@@ -143,7 +143,8 @@ class VispyCamera:
         self._on_angles_change(None)
 
     def _on_center_change(self, event):
-        self.center = self._camera.center[-self._dims.ndisplay :]
+        ncords = max(self._dims.ndisplay, 2)
+        self.center = self._camera.center[-ncords:]
 
     def _on_zoom_change(self, event):
         self.zoom = self._camera.zoom

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -66,7 +66,7 @@ class Dims(EventedModel):
 
     # fields
     ndim: int = 2
-    ndisplay: Literal[2, 3] = 2
+    ndisplay: Literal[1, 2, 3] = 2
     last_used: int = 0
     range: Tuple[Tuple[float, float, float], ...] = ()
     current_step: Tuple[int, ...] = ()

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -430,7 +430,10 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         str
             The current interpolation mode
         """
-        return str(self._interpolation[self._ndisplay])
+        if self._ndisplay > 1:
+            return str(self._interpolation[self._ndisplay])
+        else:
+            return 'nearest'
 
     @interpolation.setter
     def interpolation(self, interpolation):
@@ -658,8 +661,10 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
 
         image = self._slice.thumbnail.view
 
-        if self._ndisplay == 3 and self.ndim > 2:
+        if self._ndisplay == 3 and image.ndim > 2:
             image = np.max(image, axis=0)
+        elif self._ndisplay == 1 and image.ndim == 1:
+            image = np.expand_dims(image, axis=0)
 
         # float16 not supported by ndi.zoom
         dtype = np.dtype(image.dtype)


### PR DESCRIPTION
# Description
Following up on some of the discussion around 1D images from last weeks dev meeting, I put together this very rough and ready PR that does the bare minimum to support 1D plots for the image layer.

The idea is that we'd now allow `viewer.dims.ndisplay=1` and we'd then do 1D slicing on all our layers and 1D rendering. For now I just hacked it together so that the image layer works. It also ignores a lot of additional possible settings, but it is pretty cool.

We can discuss whether we like this direction or not, but I'm already planning to make use of this branch with some 1D wave equations simulations I've been playing with where I have a time axis and a 1D plot (so a 2D dataset) but I want to look at 1D plots of it. I also want to use napari-animation to make movies of the wave propagation, so having this include in napari instead of something like matplotlib is very helpful.

Here's a movie of 1D slicing through a 2D image of a cell:

```python
viewer.open_sample(plugin='scikit-image', sample='cell')
viewer.dims.ndisplay = 1
```


https://user-images.githubusercontent.com/6531703/119244514-5ab69a80-bb26-11eb-99d1-8c60fb792bb4.mov

Curious what others think cc @tlambert03 @jni @andy-sweet 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
