### PR TITLE
Improve error message when legacy Qt installed from conda over pip

### DIFF
--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from distutils.version import StrictVersion
 from pathlib import Path
 from warnings import warn
@@ -30,11 +31,26 @@ if API_NAME == 'PySide2':
 
 # When QT is not the specific version, we raise a warning:
 if StrictVersion(QtCore.__version__) < StrictVersion('5.12.3'):
-    warn_message = trans._(
-        "napari was tested with QT library `>=5.12.3`.\nThe version installed is {version}. Please report any issues with this specific QT version at https://github.com/Napari/napari/issues.",
-        deferred=True,
-        version=QtCore.__version__,
-    )
+    if sys.version_info >= (3, 8):
+        from importlib import metadata as importlib_metadata
+    else:
+        import importlib_metadata
+
+    try:
+        dist_info_version = importlib_metadata.version(API_NAME)
+        if dist_info_version != QtCore.__version__:
+            warn_message = trans._(
+                "\nYou are using QT version {version}, but version {dversion} was also found in your environment.\nThis usually happens when you 'conda install' something that also uses Qt (like\njupyter notebook), *after* you have pip installed napari.\nYou will likely run into problems. If you want to install conda packages into the same\nenvironment as napari, please add conda-forge to your channels: https://conda-forge.org/",
+                deferred=True,
+                version=QtCore.__version__,
+                dversion=dist_info_version,
+            )
+    except ModuleNotFoundError:
+        warn_message = trans._(
+            "\nnapari was tested with QT library `>=5.12.3`.\nThe version installed is {version}. Please report any issues with\nthis specific QT version at https://github.com/Napari/napari/issues.",
+            deferred=True,
+            version=QtCore.__version__,
+        )
     warn(message=warn_message)
 
 

--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -40,14 +40,14 @@ if StrictVersion(QtCore.__version__) < StrictVersion('5.12.3'):
         dist_info_version = importlib_metadata.version(API_NAME)
         if dist_info_version != QtCore.__version__:
             warn_message = trans._(
-                "\nYou are using QT version {version}, but version {dversion} was also found in your environment.\nThis usually happens when you 'conda install' something that also uses Qt (like\njupyter notebook), *after* you have pip installed napari.\nYou will likely run into problems. If you want to install conda packages into the same\nenvironment as napari, please add conda-forge to your channels: https://conda-forge.org/",
+                "\n\nIMPORTANT:\nYou are using QT version {version}, but version {dversion} was also found in your environment.\nThis usually happens when you 'conda install' something that also depends on PyQt\n*after* you have pip installed napari (such as jupyter notebook).\nYou will likely run into problems and should create a fresh environment.\nIf you want to install conda packages into the same environment as napari,\nplease add conda-forge to your channels: https://conda-forge.org\n",
                 deferred=True,
                 version=QtCore.__version__,
                 dversion=dist_info_version,
             )
     except ModuleNotFoundError:
         warn_message = trans._(
-            "\nnapari was tested with QT library `>=5.12.3`.\nThe version installed is {version}. Please report any issues with\nthis specific QT version at https://github.com/Napari/napari/issues.",
+            "\n\nnapari was tested with QT library `>=5.12.3`.\nThe version installed is {version}. Please report any issues with\nthis specific QT version at https://github.com/Napari/napari/issues.",
             deferred=True,
             version=QtCore.__version__,
         )


### PR DESCRIPTION
# Description
We're seeing a lot of Windows users (without conda-forge in their channels) reporting issues that are caused by an outdated Qt library, without realizing that they may have unintentionally installed it via another package (see and #2710 and #2771).   This usually happens if you `conda install` something that requires `PyQt` _after_ you have pip installed napari... if you don't have conda-forge in your conda config, then you'll end up with 5.9.2.  Furthermore, this only happens on windows, since the posix Qt distributions on pypi use `abi3.so` libraries, which come alphabetically before the plain `.so` libraries that are in Qt distributions on anaconda cloud.  So, by happy chance, the pip install takes priority on posix.

This PR will try to detect if a user has ended up with a legacy Qt version, even if they had installed a newer one.  It relies on the fact that `importlib.metadata.version()` can detect the `dist-info` package from pip even if conda has overwritten the actual shared libraries:

```
IMPORTANT:
You are using QT version 5.9.6, but version 5.15.4 was also found in your environment.
This usually happens when you 'conda install' something that also depends on PyQt
*after* you have pip installed napari (such as jupyter notebook).
You will likely run into problems and should create a fresh environment.
If you want to install conda packages into the same environment as napari,
please add conda-forge to your channels: https://conda-forge.org
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
