### PR TITLE
Add pytest-order and move threading tests to the top of the suite

### DIFF
--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -26,7 +26,7 @@ def _threading_warn():
 
 
 def _warn():
-    time.sleep(0.01)
+    time.sleep(0.1)
     warnings.warn('warning!')
 
 
@@ -36,7 +36,7 @@ def _threading_raise():
 
 
 def _raise():
-    time.sleep(0.01)
+    time.sleep(0.1)
     raise ValueError("error!")
 
 
@@ -62,6 +62,7 @@ def clean_current(monkeypatch, qtbot):
     "raise_func,warn_func",
     [(_raise, _warn), (_threading_raise, _threading_warn)],
 )
+@pytest.mark.order(11)
 def test_notification_manager_via_gui(
     qtbot, raise_func, warn_func, clean_current
 ):
@@ -79,9 +80,9 @@ def test_notification_manager_via_gui(
             (errButton, 'error!'),
             (warnButton, 'warning!'),
         ]:
-            assert len(notification_manager.records) == 0
+            notification_manager.records = []
             qtbot.mouseClick(btt, Qt.LeftButton)
-            qtbot.wait(300)
+            qtbot.wait(500)
             assert len(notification_manager.records) == 1
             assert notification_manager.records[0].message == expected_message
             notification_manager.records = []

--- a/napari/_qt/_tests/test_threading.py
+++ b/napari/_qt/_tests/test_threading.py
@@ -9,8 +9,10 @@ from napari._qt import qthreading
 
 equals_1 = partial(eq, 1)
 equals_3 = partial(eq, 3)
+skip = pytest.mark.skipif(True, reason="testing")
 
 
+@pytest.mark.order(1)
 def test_as_generator_function():
     """Test we can convert a regular function to a generator function."""
 
@@ -26,6 +28,7 @@ def test_as_generator_function():
 
 # qtbot is necessary for qthreading here.
 # note: pytest-cov cannot check coverage of code run in the other thread.
+@pytest.mark.order(2)
 def test_thread_worker(qtbot):
     """Test basic threadworker on a function"""
 
@@ -43,6 +46,7 @@ def test_thread_worker(qtbot):
     assert wrkr.is_running is False
 
 
+@pytest.mark.order(3)
 def test_thread_generator_worker(qtbot):
     """Test basic threadworker on a generator"""
 
@@ -59,9 +63,12 @@ def test_thread_generator_worker(qtbot):
     checks = [equals_1, equals_1, equals_3, lambda: True]
     with qtbot.waitSignals(signals, check_params_cbs=checks, order="strict"):
         wrkr.start()
+
+    qtbot.wait(500)
     assert wrkr.is_running is False
 
 
+@pytest.mark.order(4)
 def test_thread_raises2(qtbot):
     handle_val = [0]
 
@@ -88,6 +95,7 @@ def test_thread_raises2(qtbot):
     assert handle_val[0] == 1
 
 
+@pytest.mark.order(5)
 def test_thread_warns(qtbot):
     """Test warnings get returned to main thread"""
     import warnings
@@ -115,6 +123,7 @@ def test_thread_warns(qtbot):
     assert wrkr.is_running is False
 
 
+@pytest.mark.order(6)
 def test_multiple_connections(qtbot):
     """Test the connect dict accepts a list of functions, and type checks"""
 
@@ -154,6 +163,7 @@ def test_multiple_connections(qtbot):
         qthreading.thread_worker(func, connect=test1)()
 
 
+@pytest.mark.order(7)
 def test_create_worker():
     """Test directly calling create_worker."""
 
@@ -169,6 +179,7 @@ def test_create_worker():
 
 # note: pytest-cov cannot check coverage of code run in the other thread.
 # this is just for the sake of coverage
+@pytest.mark.order(8)
 def test_thread_worker_in_main_thread():
     """Test basic threadworker on a function"""
 
@@ -185,6 +196,7 @@ def test_thread_worker_in_main_thread():
 
 # note: pytest-cov cannot check coverage of code run in the other thread.
 # this is just for the sake of coverage
+@pytest.mark.order(9)
 def test_thread_generator_worker_in_main_thread():
     """Test basic threadworker on a generator in the main thread with methods."""
 
@@ -234,6 +246,7 @@ def test_thread_generator_worker_in_main_thread():
     assert worker2.work() == 3
 
 
+@pytest.mark.order(10)
 def test_worker_base_attribute():
     obj = qthreading.WorkerBase()
     assert obj.started is not None

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,6 +89,7 @@ testing =
     babel>=2.9.0
     pytest
     pytest-faulthandler
+    pytest-order
     pytest-qt
     pytest-timeout
     hypothesis>=6.8.0


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousando words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This seems to avoid the persistent errors by moving all "flaky" tests to the start of the test suite. Seems to help :)
 
## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Taks: CI stuff
