### PR TITLE
Use slicing rather than np.take in add_image

### DIFF
--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -30,6 +30,14 @@ def test_add_image():
     assert viewer.dims.ndim == 2
 
 
+def test_add_image_multichannel_share_memory():
+    viewer = ViewerModel()
+    image = np.random.random((10, 5, 64, 64))
+    layers = viewer.add_image(image, channel_axis=1)
+    for layer in layers:
+        assert np.may_share_memory(image, layer.data)
+
+
 def test_add_image_colormap_variants():
     """Test adding image with all valid colormap argument types."""
     viewer = ViewerModel()

--- a/napari/layers/utils/stack_utils.py
+++ b/napari/layers/utils/stack_utils.py
@@ -11,6 +11,31 @@ from ...utils.misc import ensure_iterable, ensure_sequence_of_iterables
 from ...utils.translations import trans
 
 
+def slice_from_axis(array, *, axis, element):
+    """Take a single index slice from array using slicing.
+
+    Equivalent to :func:`np.take`, but using slicing, which ensures that the
+    output is a view of the original array.
+
+    Parameters
+    ----------
+    array : NumPy or other array
+        Input array to be sliced.
+    axis : int
+        The axis along which to slice.
+    element : int
+        The element along that axis to grab.
+
+    Returns
+    -------
+    sliced : NumPy or other array
+        The sliced output array, which has one less dimension than the input.
+    """
+    slices = [slice(None) for i in range(array.ndim)]
+    slices[axis] = element
+    return array[tuple(slices)]
+
+
 def split_channels(
     data: np.ndarray,
     channel_axis: int,
@@ -88,11 +113,11 @@ def split_channels(
     for i in range(n_channels):
         if multiscale:
             image = [
-                np.take(data[j], i, axis=channel_axis)
+                slice_from_axis(data[j], axis=channel_axis, element=i)
                 for j in range(len(data))
             ]
         else:
-            image = np.take(data, i, axis=channel_axis)
+            image = slice_from_axis(data, axis=channel_axis, element=i)
         i_kwargs = {}
         for key, val in kwargs.items():
             try:


### PR DESCRIPTION
# Description

In many (most? all?) cases of add_image/add_labels, the input array and the layer.data array are one and the same. When channel_axis is given, however, this breaks because np.take() doesn't create views into the original array, but rather makes copies.

This PR ensures that the layer.data arrays are views of the original NumPy array passed to add_image. The use of simple slicing should ensure that this also works fine for other array types.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
