### PR TITLE
`mask_axis` property (WIP)

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -906,21 +906,6 @@ def masks_3d(masks_2d: np.array) -> (np.array, np.array):
     )
 
 
-def test_mask_axis(masks_2d, masks_3d):
-    masks_2d_front_axis, masks_2d_back_axis = masks_2d
-    masks_3d_front_axis, masks_3d_back_axis = masks_3d
-
-    assert Labels(masks_2d_front_axis, mask_axis=0).mask_axis == 0
-    assert Labels(masks_3d_front_axis, mask_axis=0).mask_axis == 0
-
-    assert Labels(masks_2d_back_axis, mask_axis=2).mask_axis == 2
-
-    assert Labels(masks_3d_back_axis, mask_axis=3).mask_axis == 3
-
-    assert Labels(masks_2d_back_axis, mask_axis=-1).mask_axis == -1
-    assert Labels(masks_3d_back_axis, mask_axis=-1).mask_axis == -1
-
-
 def test_mask_raw_to_displayed(masks_2d, masks_3d):
     masks_2d_front_axis, masks_2d_back_axis = masks_2d
     masks_3d_front_axis, masks_3d_back_axis = masks_3d

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1,6 +1,5 @@
 import itertools
 
-import numpy
 import numpy as np
 import pytest
 import xarray as xr
@@ -13,7 +12,6 @@ from napari._tests.utils import check_layer_world_data_extent
 from napari.layers import Labels
 from napari.utils import Colormap
 from napari.utils.colormaps import low_discrepancy_image
-import napari.layers.labels
 
 
 def test_random_labels():
@@ -436,68 +434,68 @@ def test_n_edit_dimensions():
     "input_data, expected_data_view",
     [
         (
-                np.array(
-                    [
-                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 5, 5, 5, 0, 0],
-                        [0, 0, 1, 1, 1, 5, 5, 5, 0, 0],
-                        [0, 0, 1, 1, 1, 5, 5, 5, 0, 0],
-                        [0, 0, 1, 1, 1, 5, 5, 5, 0, 0],
-                        [0, 0, 0, 0, 0, 5, 5, 5, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                    ],
-                    dtype=np.int_,
-                ),
-                np.array(
-                    [
-                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 5, 5, 5, 0, 0],
-                        [0, 0, 1, 1, 1, 5, 0, 5, 0, 0],
-                        [0, 0, 1, 0, 1, 5, 0, 5, 0, 0],
-                        [0, 0, 1, 1, 1, 5, 0, 5, 0, 0],
-                        [0, 0, 0, 0, 0, 5, 5, 5, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                    ],
-                    dtype=np.int_,
-                ),
+            np.array(
+                [
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 5, 5, 5, 0, 0],
+                    [0, 0, 1, 1, 1, 5, 5, 5, 0, 0],
+                    [0, 0, 1, 1, 1, 5, 5, 5, 0, 0],
+                    [0, 0, 1, 1, 1, 5, 5, 5, 0, 0],
+                    [0, 0, 0, 0, 0, 5, 5, 5, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                ],
+                dtype=np.int_,
+            ),
+            np.array(
+                [
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 5, 5, 5, 0, 0],
+                    [0, 0, 1, 1, 1, 5, 0, 5, 0, 0],
+                    [0, 0, 1, 0, 1, 5, 0, 5, 0, 0],
+                    [0, 0, 1, 1, 1, 5, 0, 5, 0, 0],
+                    [0, 0, 0, 0, 0, 5, 5, 5, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                ],
+                dtype=np.int_,
+            ),
         ),
         (
-                np.array(
-                    [
-                        [1, 1, 0, 0, 0, 0, 0, 2, 2, 2],
-                        [1, 1, 0, 0, 0, 0, 0, 2, 2, 2],
-                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 4, 4, 4, 4],
-                        [3, 3, 3, 0, 0, 0, 4, 4, 4, 4],
-                        [3, 3, 3, 0, 0, 0, 4, 4, 4, 4],
-                        [3, 3, 3, 0, 0, 0, 4, 4, 4, 4],
-                    ],
-                    dtype=np.int_,
-                ),
-                np.array(
-                    [
-                        [0, 1, 0, 0, 0, 0, 0, 2, 0, 0],
-                        [1, 1, 0, 0, 0, 0, 0, 2, 2, 2],
-                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 4, 4, 4, 4],
-                        [3, 3, 3, 0, 0, 0, 4, 0, 0, 0],
-                        [0, 0, 3, 0, 0, 0, 4, 0, 0, 0],
-                        [0, 0, 3, 0, 0, 0, 4, 0, 0, 0],
-                    ],
-                    dtype=np.int_,
-                ),
+            np.array(
+                [
+                    [1, 1, 0, 0, 0, 0, 0, 2, 2, 2],
+                    [1, 1, 0, 0, 0, 0, 0, 2, 2, 2],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 4, 4, 4, 4],
+                    [3, 3, 3, 0, 0, 0, 4, 4, 4, 4],
+                    [3, 3, 3, 0, 0, 0, 4, 4, 4, 4],
+                    [3, 3, 3, 0, 0, 0, 4, 4, 4, 4],
+                ],
+                dtype=np.int_,
+            ),
+            np.array(
+                [
+                    [0, 1, 0, 0, 0, 0, 0, 2, 0, 0],
+                    [1, 1, 0, 0, 0, 0, 0, 2, 2, 2],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 4, 4, 4, 4],
+                    [3, 3, 3, 0, 0, 0, 4, 0, 0, 0],
+                    [0, 0, 3, 0, 0, 0, 4, 0, 0, 0],
+                    [0, 0, 3, 0, 0, 0, 4, 0, 0, 0],
+                ],
+                dtype=np.int_,
+            ),
         ),
         (
-                5 * np.ones((9, 10), dtype=np.uint32),
-                np.zeros((9, 10), dtype=np.uint32),
+            5 * np.ones((9, 10), dtype=np.uint32),
+            np.zeros((9, 10), dtype=np.uint32),
         ),
     ],
 )
@@ -789,12 +787,12 @@ def test_world_data_extent():
     ),
 )
 def test_undo_redo(
-        brush_shape,
-        brush_size,
-        mode,
-        selected_label,
-        preserve_labels,
-        n_dimensional,
+    brush_shape,
+    brush_size,
+    mode,
+    selected_label,
+    preserve_labels,
+    n_dimensional,
 ):
     blobs = data.binary_blobs(length=64, volume_fraction=0.3, n_dim=3)
     layer = Labels(blobs)
@@ -912,15 +910,15 @@ def test_mask_axis(masks_2d, masks_3d):
     masks_2d_front_axis, masks_2d_back_axis = masks_2d
     masks_3d_front_axis, masks_3d_back_axis = masks_3d
 
-    assert napari.layers.labels.Labels(masks_2d_front_axis, mask_axis=0).mask_axis == 0
-    assert napari.layers.labels.Labels(masks_3d_front_axis, mask_axis=0).mask_axis == 0
+    assert Labels(masks_2d_front_axis, mask_axis=0).mask_axis == 0
+    assert Labels(masks_3d_front_axis, mask_axis=0).mask_axis == 0
 
-    assert napari.layers.labels.Labels(masks_2d_back_axis, mask_axis=2).mask_axis == 2
+    assert Labels(masks_2d_back_axis, mask_axis=2).mask_axis == 2
 
-    assert napari.layers.labels.Labels(masks_3d_back_axis, mask_axis=3).mask_axis == 3
+    assert Labels(masks_3d_back_axis, mask_axis=3).mask_axis == 3
 
-    assert napari.layers.labels.Labels(masks_2d_back_axis, mask_axis=-1).mask_axis == -1
-    assert napari.layers.labels.Labels(masks_3d_back_axis, mask_axis=-1).mask_axis == -1
+    assert Labels(masks_2d_back_axis, mask_axis=-1).mask_axis == -1
+    assert Labels(masks_3d_back_axis, mask_axis=-1).mask_axis == -1
 
 
 def test_mask_raw_to_displayed(masks_2d, masks_3d):

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -907,11 +907,6 @@ class Labels(_ImageBase):
             )
 
         if self.mask_axis is not None:
-            image = np.zeros(self.data.shape[1:], np.uint8)
-
-            for mask in self.data:
-                image[mask != 0] = np.unique(mask)[-1]
-
             image = skimage.color.label2rgb(image, bg_label=0)
 
         return image


### PR DESCRIPTION
# Description

Adds a `mask_axis` property to `napari.layers.Labels` for labels with shapes like `(16, 224, 224)` or `(224, 224, 16)`. This feature is, intentionally, not exposed anywhere in the application.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
- [x] example: 2D and 3D mask fixtures
- [x] example: unit tests for `label_masks` utility function
- [ ] example: unit tests for `_raw_to_displayed` that use the 2D and 3D mask fixtures

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.