### PR TITLE
Add octree and async to preferences

### DIFF
--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -34,7 +34,7 @@ class PreferencesDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        SETTINGS.experimental.events.octree.connect(self._octree_restart_info)
+        SETTINGS.experimental.events.octree.connect(self._restart_dialog)
         SETTINGS.experimental.events.async_.connect(self._restart_dialog)
 
         self._list = QListWidget(self)
@@ -78,18 +78,6 @@ class PreferencesDialog(QDialog):
         self.make_dialog()
         self._list.setCurrentRow(0)
 
-    def _octree_restart_info(self, event):
-        """Sets extra string to display if octree enabled."""
-
-        if SETTINGS.experimental.octree is True:
-            extra_str = (
-                "Asynchronous rendering cannot be changed with this setting."
-            )
-        else:
-            extra_str = ""
-
-        self._restart_dialog(extra_str=extra_str)
-
     def _restart_dialog(self, event=None, extra_str=""):
         """Displays the dialog informing user a restart is required.
 
@@ -101,8 +89,7 @@ class PreferencesDialog(QDialog):
         """
 
         text_str = trans._(
-            "Napari requires a restart for this setting to apply.\n"
-            + extra_str
+            "Napari requires a restart for image rendering changes to apply."
         )
 
         widget = ResetNapariInfoDialog(

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -86,7 +86,7 @@ class PreferencesDialog(QDialog):
         """
 
         text_str = trans._(
-            "Napari requires a restart for image rendering changes to apply."
+            "napari requires a restart for image rendering changes to apply."
         )
 
         widget = ResetNapariInfoDialog(
@@ -287,6 +287,7 @@ class PreferencesDialog(QDialog):
         idx = list(values.keys()).index('async_')
         form_layout = form.widget.layout()
         widget = form_layout.itemAt(idx, form_layout.FieldRole).widget()
+        widget.opacity.setOpacity(0.3 if disable else 1)
         widget.setDisabled(disable)
 
         return form

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -260,9 +260,11 @@ class PreferencesDialog(QDialog):
         for row in range(form.widget.layout().rowCount()):
             widget = form_layout.itemAt(row, form_layout.FieldRole).widget()
             name = widget._name
-            widget.setDisabled(
-                bool(SETTINGS._env_settings.get(section, {}).get(name, None))
+            disable = bool(
+                SETTINGS._env_settings.get(section, {}).get(name, None)
             )
+            widget.setDisabled(disable)
+            widget.opacity.setOpacity(0.3 if disable else 1)
 
         # set state values for widget
         form.widget.state = values
@@ -283,6 +285,14 @@ class PreferencesDialog(QDialog):
 
     def _disable_async(self, form, values, disable=True, state=True):
         """Disable async if octree is True."""
+
+        # need to make sure that if async_ is an environment setting, that we don't
+        # enable it here.
+        if (
+            SETTINGS._env_settings['experimental'].get('async_', None)
+            is not None
+        ):
+            disable = True
 
         idx = list(values.keys()).index('async_')
         form_layout = form.widget.layout()

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -267,7 +267,6 @@ class PreferencesDialog(QDialog):
         form_layout = form.widget.layout()
         widget = form_layout.itemAt(idx, form_layout.FieldRole).widget()
         widget.setDisabled(disable)
-        widget.state = state
 
         return form
 
@@ -315,18 +314,11 @@ class PreferencesDialog(QDialog):
                     self._values_dict[page] = new_dict
 
                     if page == 'experimental' and setting_name == 'octree':
-                        # if octree is changed, need to rebuild this page so that
-                        # async_ is set properly and enable/disabled.  If the value of
-                        # the widget is changed the the changed dictionary grows while
-                        # in this function and you get an error.
-                        setting = SETTINGS.schemas()[page]
-                        schema, new_values, properties = self.get_page_dict(
-                            setting
-                        )
-                        widget = self.build_page_dialog(schema, new_dict)
-                        self._stack.addWidget(widget)
-                        self._stack.removeWidget(self._stack.currentWidget())
-                        self._stack.setCurrentWidget(widget)
+
+                        # disable/enable async checkbox
+                        widget = self._stack.currentWidget()
+                        cstate = True if value is True else False
+                        self._disable_async(widget, new_dict, disable=cstate)
 
                 except:  # noqa: E722
                     continue

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -261,7 +261,7 @@ class PreferencesDialog(QDialog):
         return form
 
     def _disable_async(self, form, values, disable=True, state=True):
-        """ "Set async checkbox to True if octree is True.  Disable is octree is True."""
+        """Disable async if octree is True."""
 
         idx = list(values.keys()).index('async_')
         form_layout = form.widget.layout()

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -34,9 +34,6 @@ class PreferencesDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        SETTINGS.experimental.events.octree.connect(self._restart_dialog)
-        SETTINGS.experimental.events.async_.connect(self._restart_dialog)
-
         self._list = QListWidget(self)
         self._stack = QStackedWidget(self)
 
@@ -337,12 +334,23 @@ class PreferencesDialog(QDialog):
                     setattr(SETTINGS._settings[page], setting_name, value)
                     self._values_dict[page] = new_dict
 
-                    if page == 'experimental' and setting_name == 'octree':
+                    if page == 'experimental':
 
-                        # disable/enable async checkbox
-                        widget = self._stack.currentWidget()
-                        cstate = True if value is True else False
-                        self._disable_async(widget, new_dict, disable=cstate)
+                        if setting_name == 'octree':
+
+                            # disable/enable async checkbox
+                            widget = self._stack.currentWidget()
+                            cstate = True if value is True else False
+                            self._disable_async(
+                                widget, new_dict, disable=cstate
+                            )
+
+                            # need to inform user that napari restart needed.
+                            self._restart_dialog()
+
+                        elif setting_name == 'async_':
+                            # need to inform user that napari restart needed.
+                            self._restart_dialog()
 
                 except:  # noqa: E722
                     continue

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
@@ -117,6 +117,9 @@ class CheckboxSchemaWidget(SchemaWidgetMixin, QtWidgets.QCheckBox):
 
     def configure(self):
         self.stateChanged.connect(lambda _: self.on_changed.emit(self.state))
+        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
 
     def setDescription(self, description: str):
         self.description = description

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
@@ -67,6 +67,9 @@ class SchemaWidgetMixin:
 class TextSchemaWidget(SchemaWidgetMixin, QtWidgets.QLineEdit):
     def configure(self):
         self.textChanged.connect(self.on_changed.emit)
+        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
 
     @state_property
     def state(self) -> str:
@@ -101,6 +104,9 @@ class TextAreaSchemaWidget(SchemaWidgetMixin, QtWidgets.QTextEdit):
 
     def configure(self):
         self.textChanged.connect(lambda: self.on_changed.emit(self.state))
+        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
 
     def setDescription(self, description: str):
         self.description = description
@@ -120,6 +126,7 @@ class CheckboxSchemaWidget(SchemaWidgetMixin, QtWidgets.QCheckBox):
         self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
         self.setGraphicsEffect(self.opacity)
         self.opacity.setOpacity(1)
+        
 
     def setDescription(self, description: str):
         self.description = description
@@ -136,6 +143,9 @@ class SpinDoubleSchemaWidget(SchemaWidgetMixin, QtWidgets.QDoubleSpinBox):
 
     def configure(self):
         self.valueChanged.connect(self.on_changed.emit)
+        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
 
     def setDescription(self, description: str):
         self.description = description
@@ -153,6 +163,9 @@ class PluginWidget(SchemaWidgetMixin, QtPluginSorter):
 
     def configure(self):
         self.hook_list.order_changed.connect(self.on_changed.emit)
+        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
 
     def setDescription(self, description: str):
         self.description = description
@@ -169,6 +182,9 @@ class SpinSchemaWidget(SchemaWidgetMixin, QtWidgets.QSpinBox):
 
     def configure(self):
         self.valueChanged.connect(self.on_changed.emit)
+        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
 
     def setDescription(self, description: str):
         self.description = description
@@ -195,6 +211,9 @@ class IntegerRangeSchemaWidget(SchemaWidgetMixin, QtWidgets.QSlider):
 
     def configure(self):
         self.valueChanged.connect(self.on_changed.emit)
+        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
 
         minimum = 0
         if "minimum" in self.schema:
@@ -232,6 +251,9 @@ class QColorButton(QtWidgets.QPushButton):
 
         self._color = None
         self.pressed.connect(self.onColorPicker)
+        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
 
     def color(self):
         return self._color
@@ -269,6 +291,9 @@ class ColorSchemaWidget(SchemaWidgetMixin, QColorButton):
 
     def configure(self):
         self.colorChanged.connect(lambda: self.on_changed.emit(self.state))
+        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
 
     @state_property
     def state(self) -> str:
@@ -290,6 +315,10 @@ class FilepathSchemaWidget(SchemaWidgetMixin, QtWidgets.QWidget):
         widget_builder: 'WidgetBuilder',  # noqa: F821
     ):
         super().__init__(schema, ui_schema, widget_builder)
+
+        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
 
         layout = QtWidgets.QHBoxLayout()
         self.setLayout(layout)
@@ -332,6 +361,10 @@ class ArrayControlsWidget(QtWidgets.QWidget):
         self.up_button.setIcon(style.standardIcon(QtWidgets.QStyle.SP_ArrowUp))
         self.up_button.clicked.connect(lambda _: self.on_move_up.emit())
 
+        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
+
         self.delete_button = QtWidgets.QPushButton()
         self.delete_button.setIcon(
             style.standardIcon(QtWidgets.QStyle.SP_DialogCancelButton)
@@ -367,6 +400,10 @@ class ArrayRowWidget(QtWidgets.QWidget):
         layout.addWidget(controls)
         self.setLayout(layout)
 
+        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
+
         self.widget = widget
         self.controls = controls
 
@@ -400,6 +437,10 @@ class ArraySchemaWidget(SchemaWidgetMixin, QtWidgets.QWidget):
     def configure(self):
         layout = QtWidgets.QVBoxLayout()
         style = self.style()
+
+        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
 
         self.add_button = QtWidgets.QPushButton()
         self.add_button.setIcon(
@@ -531,6 +572,9 @@ class HighlightSizePreviewWidget(SchemaWidgetMixin, QtHighlightSizePreviewWidget
 
     def configure(self):
         self.valueChanged.connect(self.on_changed.emit)
+        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
 
 
 class ObjectSchemaWidget(SchemaWidgetMixin, QtWidgets.QGroupBox):
@@ -626,6 +670,10 @@ class EnumSchemaWidget(SchemaWidgetMixin, QtWidgets.QComboBox):
         self.currentIndexChanged.connect(
             lambda _: self.on_changed.emit(self.state)
         )
+
+        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
 
     def _index_changed(self, index: int):
         self.on_changed.emit(self.state)

--- a/napari/utils/_octree.py
+++ b/napari/utils/_octree.py
@@ -43,7 +43,7 @@ def _get_async_config() -> Optional[dict]:
         The async config to use or None if async not specified.
     """
 
-    async_var = str(int(SETTINGS.experimental.NAPARI_ASYNC))
+    async_var = str(int(SETTINGS.experimental.async_))
 
     print('async_var', async_var)
 
@@ -70,7 +70,7 @@ def get_octree_config() -> dict:
         The config data we should use.
     """
 
-    octree_var = str(int(SETTINGS.experimental.NAPARI_OCTREE))
+    octree_var = str(int(SETTINGS.experimental.octree))
 
     print('octree_var', octree_var)
 

--- a/napari/utils/_octree.py
+++ b/napari/utils/_octree.py
@@ -45,8 +45,6 @@ def _get_async_config() -> Optional[dict]:
 
     async_var = str(int(SETTINGS.experimental.async_))
 
-    print('async_var', async_var)
-
     # NAPARI_ASYNC can now only be "0" or "1".
     if async_var not in [None, "0", "1"]:
         raise ValueError('NAPARI_ASYNC can only be "0" or "1"')
@@ -72,10 +70,8 @@ def get_octree_config() -> dict:
 
     octree_var = str(int(SETTINGS.experimental.octree))
 
-    print('octree_var', octree_var)
 
     octree_env = os.getenv("NAPARI_OCTREE")
-    print('octree_env', octree_env)
 
     # If NAPARI_OCTREE is not enabled, defer to NAPARI_ASYNC
     if octree_var in [None, "0"]:

--- a/napari/utils/_octree.py
+++ b/napari/utils/_octree.py
@@ -42,7 +42,10 @@ def _get_async_config() -> Optional[dict]:
         The async config to use or None if async not specified.
     """
 
-    async_var = str(int(SETTINGS.experimental.async_))
+    async_var = SETTINGS.experimental.async_
+
+    if async_var in [True, False]:
+        async_var = str(int(async_var))
 
     # NAPARI_ASYNC can now only be "0" or "1".
     if async_var not in [None, "0", "1"]:
@@ -67,7 +70,10 @@ def get_octree_config() -> dict:
         The config data we should use.
     """
 
-    octree_var = str(int(SETTINGS.experimental.octree))
+    octree_var = SETTINGS.experimental.octree
+
+    if octree_var in [True, False]:
+        octree_var = str(int(octree_var))
 
     # If NAPARI_OCTREE is not enabled, defer to NAPARI_ASYNC
     if octree_var in [None, "0"]:
@@ -81,4 +87,9 @@ def get_octree_config() -> dict:
     # NAPARI_OCTREE should be a config file path
     path = Path(octree_var).expanduser()
     with path.open() as infile:
-        return json.load(infile)
+        json_config = json.load(infile)
+
+    # Need to set this for the preferences dialog to build.
+    SETTINGS.experimental.octree = True
+
+    return json_config

--- a/napari/utils/_octree.py
+++ b/napari/utils/_octree.py
@@ -9,6 +9,8 @@ import os
 from pathlib import Path
 from typing import Optional
 
+from ..utils.settings import SETTINGS
+
 LOGGER = logging.getLogger("napari.loader")
 
 DEFAULT_OCTREE_CONFIG = {
@@ -40,7 +42,10 @@ def _get_async_config() -> Optional[dict]:
     Optional[dict]
         The async config to use or None if async not specified.
     """
-    async_var = os.getenv("NAPARI_ASYNC")
+
+    async_var = str(int(SETTINGS.experimental.NAPARI_ASYNC))
+
+    print('async_var', async_var)
 
     # NAPARI_ASYNC can now only be "0" or "1".
     if async_var not in [None, "0", "1"]:
@@ -64,7 +69,13 @@ def get_octree_config() -> dict:
     dict
         The config data we should use.
     """
-    octree_var = os.getenv("NAPARI_OCTREE")
+
+    octree_var = str(int(SETTINGS.experimental.NAPARI_OCTREE))
+
+    print('octree_var', octree_var)
+
+    octree_env = os.getenv("NAPARI_OCTREE")
+    print('octree_env', octree_env)
 
     # If NAPARI_OCTREE is not enabled, defer to NAPARI_ASYNC
     if octree_var in [None, "0"]:

--- a/napari/utils/_octree.py
+++ b/napari/utils/_octree.py
@@ -5,7 +5,6 @@ until napari has a system-wide one.
 """
 import json
 import logging
-import os
 from pathlib import Path
 from typing import Optional
 
@@ -69,9 +68,6 @@ def get_octree_config() -> dict:
     """
 
     octree_var = str(int(SETTINGS.experimental.octree))
-
-
-    octree_env = os.getenv("NAPARI_OCTREE")
 
     # If NAPARI_OCTREE is not enabled, defer to NAPARI_ASYNC
     if octree_var in [None, "0"]:

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -426,7 +426,6 @@ class PluginsSettings(BaseNapariSettings):
 
 
 class ExperimentalSettings(BaseNapariSettings):
-
     schema_version: SchemaVersion = (0, 1, 1)
 
     octree: bool = Field(

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -426,20 +426,20 @@ class PluginsSettings(BaseNapariSettings):
 
 
 class ExperimentalSettings(BaseNapariSettings):
-    """Developer/Experimental Settings."""
 
     schema_version: SchemaVersion = (0, 1, 1)
 
-    NAPARI_OCTREE: bool = Field(
+    octree: bool = Field(
         True,
         title=trans._("NAPARI_OCTREE"),
         description=trans._("Use OctreeImage instead of Image."),
     )
 
-    NAPARI_ASYNC: bool = Field(
+    async_: bool = Field(
         True,
         title=trans._("NAPARI_ASYNC"),
         description=trans._("Asynchronous rendering with Image class."),
+        env="napari_async",
     )
 
     class Config:

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -425,9 +425,24 @@ class PluginsSettings(BaseNapariSettings):
         preferences_exclude = ['schema_version', 'disabled_plugins']
 
 
+class DeveloperSettings(BaseNapariSettings):
+    """Developer/Experimental Settings."""
+
+    schema_version: SchemaVersion = (0, 1, 1)
+
+    class Config:
+        # Pydantic specific configuration
+        title = trans._("developer")
+
+    class NapariConfig:
+        # Napari specific configuration
+        preferences_exclude = ['schema_version']
+
+
 CORE_SETTINGS = [
     AppearanceSettings,
     ApplicationSettings,
     PluginsSettings,
     ShortcutsSettings,
+    DeveloperSettings,
 ]

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -425,14 +425,30 @@ class PluginsSettings(BaseNapariSettings):
         preferences_exclude = ['schema_version', 'disabled_plugins']
 
 
-class DeveloperSettings(BaseNapariSettings):
+class ExperimentalSettings(BaseNapariSettings):
     """Developer/Experimental Settings."""
 
     schema_version: SchemaVersion = (0, 1, 1)
 
+    NAPARI_OCTREE: bool = Field(
+        True,
+        title=trans._("NAPARI_OCTREE"),
+        description=trans._("Use OctreeImage instead of Image."),
+    )
+
+    NAPARI_ASYNC: bool = Field(
+        True,
+        title=trans._("NAPARI_ASYNC"),
+        description=trans._("Asynchronous rendering with Image class."),
+    )
+
     class Config:
         # Pydantic specific configuration
-        title = trans._("developer")
+        schema_extra = {
+            "title": trans._("Experimental"),
+            "description": trans._("Experimental settings."),
+            "section": "experimental",
+        }
 
     class NapariConfig:
         # Napari specific configuration
@@ -444,5 +460,5 @@ CORE_SETTINGS = [
     ApplicationSettings,
     PluginsSettings,
     ShortcutsSettings,
-    DeveloperSettings,
+    ExperimentalSettings,
 ]

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple, Union
 
 from pydantic import BaseSettings, Field, ValidationError
 from typing_extensions import TypedDict
@@ -428,17 +428,18 @@ class PluginsSettings(BaseNapariSettings):
 class ExperimentalSettings(BaseNapariSettings):
     schema_version: SchemaVersion = (0, 1, 1)
 
-    octree: bool = Field(
-        True,
+    octree: Union[bool, str] = Field(
+        False,
         title=trans._("Enable Asynchronous Tiling of Images"),
         description=trans._(
             "Renders images asynchronously using tiles. \nYou must restart napari for "
             + "changes of this setting to apply."
         ),
+        type='boolean',  # need to specify to build checkbox in preferences.
     )
 
     async_: bool = Field(
-        True,
+        False,
         title=trans._("Render Images Asynchronously"),
         description=trans._(
             "Asynchronous loading of image data. \nThis setting partially "

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -432,16 +432,20 @@ class ExperimentalSettings(BaseNapariSettings):
     octree: bool = Field(
         True,
         title=trans._("Enable Tiling of Images"),
-        description=trans._("Renders images using tiles. \nYou must restart napari for "+ 
-        "changes of this setting to apply."),
+        description=trans._(
+            "Renders images using tiles. \nYou must restart napari for "
+            + "changes of this setting to apply."
+        ),
     )
 
     async_: bool = Field(
         True,
         title=trans._("Render Images Asynchronously"),
-        description=trans._("Asynchronous loading of image data.  \nThis setting partially "+
-        "loads data while viewing. \nYou must restart napari for changes of this setting "+ 
-        "to apply."),
+        description=trans._(
+            "Asynchronous loading of image data. \nThis setting partially "
+            + "loads data while viewing. \nYou must restart napari for changes of this setting "
+            + "to apply."
+        ),
         env="napari_async",
     )
 

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -431,14 +431,17 @@ class ExperimentalSettings(BaseNapariSettings):
 
     octree: bool = Field(
         True,
-        title=trans._("NAPARI_OCTREE"),
-        description=trans._("Use OctreeImage instead of Image."),
+        title=trans._("Enable Tiling of Images"),
+        description=trans._("Renders images using tiles. \nYou must restart napari for "+ 
+        "changes of this setting to apply."),
     )
 
     async_: bool = Field(
         True,
-        title=trans._("NAPARI_ASYNC"),
-        description=trans._("Asynchronous rendering with Image class."),
+        title=trans._("Render Images Asynchronously"),
+        description=trans._("Asynchronous loading of image data.  \nThis setting partially "+
+        "loads data while viewing. \nYou must restart napari for changes of this setting "+ 
+        "to apply."),
         env="napari_async",
     )
 

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -431,9 +431,9 @@ class ExperimentalSettings(BaseNapariSettings):
 
     octree: bool = Field(
         True,
-        title=trans._("Enable Tiling of Images"),
+        title=trans._("Enable Asynchronous Tiling of Images"),
         description=trans._(
-            "Renders images using tiles. \nYou must restart napari for "
+            "Renders images asynchronously using tiles. \nYou must restart napari for "
             + "changes of this setting to apply."
         ),
     )

--- a/napari/utils/settings/_manager.py
+++ b/napari/utils/settings/_manager.py
@@ -16,6 +16,7 @@ from ._defaults import (
     AppearanceSettings,
     ApplicationSettings,
     BaseNapariSettings,
+    ExperimentalSettings,
     PluginsSettings,
     ShortcutsSettings,
 )
@@ -61,6 +62,7 @@ class SettingsManager:
     application: ApplicationSettings
     plugins: PluginsSettings
     shortcuts: ShortcutsSettings
+    experimental: ExperimentalSettings
 
     def __init__(self, config_path: str = None, save_to_disk: bool = True):
         self._config_path = (


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
Add checkboxes to the preferences menu for NAPARI_ASYNC and NAPARI_OCTREE settings.  


<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousando words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
closes #2712

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
