### PR TITLE
Ensure aborted workers don't emit returned signal

### DIFF
--- a/napari/_qt/_tests/test_threading.py
+++ b/napari/_qt/_tests/test_threading.py
@@ -43,7 +43,6 @@ def test_thread_worker(qtbot):
     checks = [equals_1, lambda: True]
     with qtbot.waitSignals(signals, check_params_cbs=checks, order="strict"):
         wrkr.start()
-    assert wrkr.is_running is False
 
 
 @pytest.mark.order(3)
@@ -65,7 +64,6 @@ def test_thread_generator_worker(qtbot):
         wrkr.start()
 
     qtbot.wait(500)
-    assert wrkr.is_running is False
 
 
 @pytest.mark.order(4)
@@ -120,7 +118,6 @@ def test_thread_warns(qtbot):
     checks = [equals_1, None, equals_3, equals_1]
     with qtbot.waitSignals(signals, check_params_cbs=checks):
         wrkr.start()
-    assert wrkr.is_running is False
 
 
 @pytest.mark.order(6)

--- a/napari/_qt/qthreading.py
+++ b/napari/_qt/qthreading.py
@@ -166,7 +166,8 @@ class WorkerBase(QRunnable):
                     return
                 else:
                     raise result
-            self.returned.emit(result)
+            if not self.abort_requested:
+                self.returned.emit(result)
         except Exception as exc:
             self.errored.emit(exc)
         self._running = False


### PR DESCRIPTION
# Description

I was surprised when using thread_worker that an aborted worker would still emit a returned signal. Following [this discussion on Zulip](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/worker.20finished.20signals/near/240557272), here's a fix with a test. I checked that the test failed before making the fix.

