### PR TITLE
Add fix for large labels in new slices

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -884,3 +884,13 @@ def test_cursor_size_with_negative_scale():
     layer = Labels(np.zeros((5, 5), dtype=int), scale=[-1, -1])
     layer.mode = 'paint'
     assert layer.cursor_size > 0
+
+
+def test_switching_display_func_during_slicing():
+    label_array = (5e6 * np.ones((2, 2, 2))).astype(np.uint64)
+    label_array[0, :, :] = 0
+    layer = Labels(label_array)
+    layer._dims_point = (1, 0, 0)
+    layer._set_view_slice()
+    assert layer._color_lookup_func == layer._lookup_with_low_discrepancy_image
+    assert layer._all_vals.size < 1026

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -888,9 +888,20 @@ def test_cursor_size_with_negative_scale():
 
 def test_switching_display_func_during_slicing():
     label_array = (5e6 * np.ones((2, 2, 2))).astype(np.uint64)
-    label_array[0, :, :] = 0
+    label_array[0, :, :] = [[0, 1], [2, 3]]
     layer = Labels(label_array)
     layer._dims_point = (1, 0, 0)
     layer._set_view_slice()
     assert layer._color_lookup_func == layer._lookup_with_low_discrepancy_image
+    assert layer._all_vals.size < 1026
+
+
+def test_add_large_colors():
+    label_array = (5e6 * np.ones((2, 2, 2))).astype(np.uint64)
+    label_array[0, :, :] = [[0, 1], [2, 3]]
+    layer = Labels(label_array)
+    assert len(layer._all_vals) == layer.num_colors
+
+    layer.show_selected_label = True
+    layer.selected_label = int(5e6)
     assert layer._all_vals.size < 1026

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -754,9 +754,9 @@ class Labels(_ImageBase):
             Value of selected label to color, by default None
         """
         if selected_label:
-            if selected_label > len(self._all_vals) + 1:
+            if selected_label > len(self._all_vals):
                 self._color_lookup_func = self._get_color_lookup_func(
-                    im, np.max(im)
+                    im, max(np.max(im), selected_label)
                 )
             if (
                 self._color_lookup_func

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -772,7 +772,7 @@ class Labels(_ImageBase):
                 )
                 if (
                     self._color_lookup_func
-                    is self._lookup_with_low_discrepancy_image
+                    == self._lookup_with_low_discrepancy_image
                 ):
                     # revert to "classic" mode converting all pixels since we
                     # encountered a large value in the raw labels image


### PR DESCRIPTION
# Description

Fixes #2730

It turns out that `self.f = self.g` does not result in `self.f is self.g` for methods. This is in contrast to functions (`f = g` results in `f is g`). So our if-check in the method update was incorrect. This PR fixes it, and in addition addresses the issue for selected_label view mode.

