### PR TITLE
Extend the action manager to support multiple shortcuts

### DIFF
--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -12,7 +12,6 @@ from qtpy.QtWidgets import (
 from ...layers.points._points_constants import SYMBOL_TRANSLATION, Mode
 from ...utils.action_manager import action_manager
 from ...utils.events import disconnect_events
-from ...utils.interactions import Shortcut
 from ...utils.translations import trans
 from ..utils import disable_with_opacity, qt_signals_blocked
 from ..widgets.qt_color_swatch import QColorSwatchEdit
@@ -144,17 +143,17 @@ class QtPointsControls(QtLayerControls):
             layer,
             'pan_zoom',
             Mode.PAN_ZOOM,
-            tooltip=trans._('Pan/zoom (Z)'),
             checked=True,
+        )
+        action_manager.bind_button(
+            'napari:activate_points_pan_zoom_mode', self.panzoom_button
         )
         self.delete_button = QtModePushButton(
             layer,
             'delete_shape',
-            slot=self.layer.remove_selected,
-            tooltip=trans._(
-                "Delete selected points ({shortcut})",
-                shortcut=Shortcut('Backspace').platform,
-            ),
+        )
+        action_manager.bind_button(
+            'napari:delete_selected_points', self.delete_button
         )
 
         text_disp_cb = QCheckBox()

--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -218,12 +218,21 @@ class QtShapesControls(QtLayerControls):
             slot=self.layer.move_to_front,
             tooltip=trans._('Move to front'),
         )
+
+        action_manager.bind_button(
+            'napari:move_shapes_selection_to_front', self.move_front_button
+        )
+
         self.move_back_button = QtModePushButton(
             layer,
             'move_back',
             slot=self.layer.move_to_back,
             tooltip=trans._('Move to back'),
         )
+        action_manager.bind_button(
+            'napari:move_shapes_selection_to_back', self.move_back_button
+        )
+
         self.delete_button = QtModePushButton(
             layer,
             'delete_shape',

--- a/napari/layers/points/_points_key_bindings.py
+++ b/napari/layers/points/_points_key_bindings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ...layers.utils.layer_utils import register_layer_action
 from ...utils.translations import trans
 from ._points_constants import Mode
@@ -35,9 +37,8 @@ def activate_points_select_mode(layer):
     layer.mode = Mode.SELECT
 
 
-@Points.bind_key('Z')
-def activate_pan_zoom_mode(layer):
-    """Activate pan and zoom mode."""
+@register_points_action(trans._('Pan/zoom'), 'Z')
+def activate_points_pan_zoom_mode(layer):
     layer.mode = Mode.PAN_ZOOM
 
 
@@ -55,17 +56,19 @@ def paste(layer):
         layer._paste_data()
 
 
-@Points.bind_key('A')
+@register_points_action(
+    trans._("Select all points in the current view slice."), "A"
+)
 def select_all(layer):
-    """Select all points in the current view slice."""
     if layer._mode == Mode.SELECT:
         layer.selected_data = set(layer._indices_view[: len(layer._view_data)])
         layer._set_highlight()
 
 
-@Points.bind_key('Backspace')
-@Points.bind_key('Delete')
-def delete_selected(layer):
+@register_points_action(
+    trans._('Delete selected points'), ['Backspace', 'Delete']
+)
+def delete_selected_points(layer):
     """Delete all selected points."""
     if layer._mode in (Mode.SELECT, Mode.ADD):
         layer.remove_selected()

--- a/napari/layers/shapes/_shapes_key_bindings.py
+++ b/napari/layers/shapes/_shapes_key_bindings.py
@@ -49,7 +49,7 @@ def hold_to_lock_aspect_ratio(layer):
         _move(layer, layer._moving_coordinates)
 
 
-def register_shapes_action(description, shortcuts):
+def register_shapes_action(description, shortcuts=()):
     return register_layer_action(Shapes, description, shortcuts)
 
 
@@ -137,10 +137,22 @@ def select_all_shapes(layer):
         layer._set_highlight()
 
 
-@register_shapes_action(trans._('Delete any selected shapes'), "Backspace")
+@register_shapes_action(
+    trans._('Delete any selected shapes'), ("Backspace", "Delete")
+)
 def delete_selected_shapes(layer):
     """."""
     layer.remove_selected()
+
+
+@register_shapes_action(trans._('Move to front'))
+def move_shapes_selection_to_front(layer):
+    layer.move_to_front()
+
+
+@register_shapes_action(trans._('Move to back'))
+def move_shapes_selection_to_back(layer):
+    layer.move_to_back()
 
 
 @register_shapes_action(

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, Optional, Tuple
 
 import dask
@@ -6,12 +8,32 @@ import numpy as np
 from ...utils.action_manager import action_manager
 
 
-def register_layer_action(keymapprovider, description, shortcuts):
+def register_layer_action(keymapprovider, description: str, shortcuts=None):
     """
     Convenient decorator to register an action with the current Layers
 
     It will use the function name as the action name. We force the description
     to be given instead of function docstring for translation purpose.
+
+
+    Parameters
+    ----------
+
+    keymapprovider : KeymapProvider
+        class on which to register the keybindings – this will typically be
+        the instance in focus that will handle the keyboard shortcut.
+    description : str
+        The description of the action, this will typically be translated and
+        will be what will be used in tooltips.
+    shortcuts : str | List[str]
+        Shortcut to bind by default to the action we are registering.
+
+    Returns
+    -------
+    function:
+        Actual decorator to apply to a function. Given decorator returns the
+        function unmodified to allow decorator stacking.
+
     """
 
     def _inner(func):

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -159,7 +159,7 @@ class ActionManager:
         self._buttons: Dict[
             str, Set[Tuple(Union[QPushButton, QtStateButton], str)]
         ] = defaultdict(lambda: set())
-        self._shortcuts: Dict[str, list[str]] = defaultdict(lambda: set())
+        self._shortcuts: Dict[str, set[str]] = defaultdict(lambda: set())
         self.context = Context()  # Dict[str, Any] = {}
         self._stack: List[str] = []
         self._tooltip_include_action_name = False
@@ -248,9 +248,14 @@ class ActionManager:
         # update buttons with shortcut and description
         if name in self._shortcuts:
             shortcuts = self._shortcuts[name]
+            joinstr = (
+                ' '
+                + trans._('or', msgctxt='<keysequence> or <keysequence>')
+                + ' '
+            )
             shortcut_str = (
                 '('
-                + ','.join(
+                + joinstr.join(
                     f"{Shortcut(shortcut).platform}" for shortcut in shortcuts
                 )
                 + ')'

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -159,7 +159,7 @@ class ActionManager:
         self._buttons: Dict[
             str, Set[Tuple(Union[QPushButton, QtStateButton], str)]
         ] = defaultdict(lambda: set())
-        self._shortcuts: Dict[str, str] = {}
+        self._shortcuts: Dict[str, list[str]] = defaultdict(lambda: set())
         self.context = Context()  # Dict[str, Any] = {}
         self._stack: List[str] = []
         self._tooltip_include_action_name = False
@@ -247,8 +247,14 @@ class ActionManager:
 
         # update buttons with shortcut and description
         if name in self._shortcuts:
-            shortcut = self._shortcuts[name]
-            shortcut_str = f' ({Shortcut(shortcut).platform})'
+            shortcuts = self._shortcuts[name]
+            shortcut_str = (
+                '('
+                + ','.join(
+                    f"{Shortcut(shortcut).platform}" for shortcut in shortcuts
+                )
+                + ')'
+            )
         else:
             shortcut_str = ''
 
@@ -269,10 +275,13 @@ class ActionManager:
         action = self._actions[name]
         if name not in self._shortcuts:
             return
-        shortcut = self._shortcuts.get(name)
+        shortcuts = self._shortcuts.get(name)
         keymapprovider = action.keymapprovider
         if hasattr(keymapprovider, 'bind_key'):
-            keymapprovider.bind_key(shortcut, overwrite=True)(action.command)
+            for shortcut in shortcuts:
+                keymapprovider.bind_key(shortcut, overwrite=True)(
+                    action.command
+                )
 
     def bind_button(self, name: str, button, extra_tooltip_text='') -> None:
         """
@@ -327,7 +336,7 @@ class ActionManager:
         delayed until the corresponding action is registered.
         """
         self._validate_action_name(name)
-        self._shortcuts[name] = shortcut
+        self._shortcuts[name].add(shortcut)
         self._update_shortcut_bindings(name)
         self._update_gui_elements(name)
 
@@ -347,10 +356,11 @@ class ActionManager:
             previously bound shortcut.
         """
         action = self._actions[name]
-        shortcut = self._shortcuts.get(name)
-        if shortcut is not None:
+        shortcuts = self._shortcuts.get(name)
+        if shortcuts:
             if hasattr(action.keymapprovider, 'bind_key'):
-                action.keymapprovider.bind_key(shortcut)(None)
+                for shortcut in shortcuts:
+                    action.keymapprovider.bind_key(shortcut)(None)
             del self._shortcuts[name]
         self._update_gui_elements(name)
         return shortcut

--- a/napari/utils/translations.py
+++ b/napari/utils/translations.py
@@ -432,7 +432,7 @@ class TranslationBundle:
             Define if the string translation should be deferred or executed
             in place. Default is False.
         **kwargs : dict, optional
-            Any additional arguments to use when formating the string.
+            Any additional arguments to use when formatting the string.
 
         Returns
         -------


### PR DESCRIPTION
And add a few actions.



When multiple shortcuts are bound they will now be show in tooltips
comma separated.

unbind_shortcut unbind all the existing shortcuts for a given action,
that seem the most reasonable thing to do, though maybe it should
pluralized ? Though as most actions have only one shortcut, I'm not sure
that make sens.

This also use the action manager for a couple more actions, in
particular on the shapes layers the move to front and move to back
now have an assigned actions, even if they do not have shortcuts.
This will let users add keybindings to those if they wish to.


<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousands words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Manually tested to make sure the UI still have the target buttons and in particular that calling `action_manager._debug(True)` insert the action name in the button tooltip.

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
