### PR TITLE
Fix octree imports

### DIFF
--- a/napari/_lazy.py
+++ b/napari/_lazy.py
@@ -1,5 +1,4 @@
-import importlib
-import importlib.util
+from importlib import import_module
 
 
 def install_lazy(module_name, submodules=None, submod_attrs=None):
@@ -42,21 +41,10 @@ def install_lazy(module_name, submodules=None, submod_attrs=None):
         # see: https://github.com/napari/napari/issues/1347
         from scipy import stats  # noqa: F401
 
-        # This must come before .plugins
-        from .utils import _magicgui
-
-        _magicgui.register_types_with_magicgui()
-        del _magicgui
-
         if name in submodules:
-            module = importlib.import_module(f'{module_name}.{name}')
-            del stats
-            return module
+            return import_module(f'{module_name}.{name}')
         elif name in attr_to_modules:
-            submod = importlib.import_module(
-                f'{module_name}.{attr_to_modules[name]}'
-            )
-            del stats
+            submod = import_module(f'{module_name}.{attr_to_modules[name]}')
             return getattr(submod, name)
         else:
             raise AttributeError(f'No {module_name} attribute {name}')

--- a/napari/components/experimental/chunk/__init__.py
+++ b/napari/components/experimental/chunk/__init__.py
@@ -1,3 +1,13 @@
 """chunk module"""
 from ._loader import chunk_loader, synchronous_loading, wait_for_async
-from ._request import ChunkLocation, ChunkRequest, LayerRef
+from ._request import ChunkLocation, ChunkRequest, LayerRef, OctreeLocation
+
+__all__ = [
+    'ChunkLocation',
+    'OctreeLocation',
+    'ChunkRequest',
+    'LayerRef',
+    'chunk_loader',
+    'wait_for_async',
+    'synchronous_loading',
+]

--- a/napari/components/experimental/chunk/_request.py
+++ b/napari/components/experimental/chunk/_request.py
@@ -66,6 +66,52 @@ class ChunkLocation:
         return cls(LayerRef.from_layer(layer))
 
 
+class OctreeLocation(ChunkLocation):
+    """Location of one chunk within the octree.
+
+    Parameters
+    ----------
+    layer_ref : LayerRef
+        Referen to the layer this location is in.
+    slice_id : int
+        The id of the OctreeSlice we are in.
+    level_index : int
+        The octree level index.
+    row : int
+        The chunk row.
+    col : int
+        The chunk col.
+    """
+
+    def __init__(
+        self,
+        layer_ref: LayerRef,
+        slice_id: int,
+        level_index: int,
+        row: int,
+        col: int,
+    ):
+        super().__init__(layer_ref)
+        self.slice_id: int = slice_id
+        self.level_index: int = level_index
+        self.row: int = row
+        self.col: int = col
+
+    def __str__(self):
+        return f"location=({self.level_index}, {self.row}, {self.col}) "
+
+    def __eq__(self, other) -> bool:
+        return (
+            self.slice_id == other.slice_id
+            and self.level_index == other.level_index
+            and self.row == other.row
+            and self.col == other.col
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.slice_id, self.level_index, self.row, self.col))
+
+
 class ChunkRequest:
     """A request asking the ChunkLoader to load data.
 

--- a/napari/layers/image/experimental/__init__.py
+++ b/napari/layers/image/experimental/__init__.py
@@ -1,5 +1,5 @@
 """layers.image.experimental
 """
-from .octree_chunk import OctreeChunk, OctreeChunkGeom, OctreeLocation
+from .octree_chunk import OctreeChunk, OctreeChunkGeom
 from .octree_intersection import OctreeIntersection
 from .octree_level import OctreeLevel

--- a/napari/layers/image/experimental/_chunk_set.py
+++ b/napari/layers/image/experimental/_chunk_set.py
@@ -2,9 +2,13 @@
 
 Used by the OctreeLoader.
 """
-from typing import Dict, List, Set
+from __future__ import annotations
 
-from .octree_chunk import OctreeChunk, OctreeLocation
+from typing import TYPE_CHECKING, Dict, List, Set
+
+if TYPE_CHECKING:
+    from ....components.experimental.chunk._request import OctreeLocation
+    from .octree_chunk import OctreeChunk
 
 
 class ChunkSet:

--- a/napari/layers/image/experimental/_octree_loader.py
+++ b/napari/layers/image/experimental/_octree_loader.py
@@ -2,17 +2,22 @@
 
 Uses ChunkLoader to load data into OctreeChunks in the octree.
 """
-import logging
-from typing import List, Set
+from __future__ import annotations
 
-from ....components.experimental.chunk import (
-    ChunkRequest,
-    LayerRef,
-    chunk_loader,
-)
+import logging
+from typing import TYPE_CHECKING, List, Set
+
 from ._chunk_set import ChunkSet
 from .octree import Octree
-from .octree_chunk import OctreeChunk, OctreeLocation
+
+if TYPE_CHECKING:
+    from ....components.experimental.chunk import (
+        ChunkRequest,
+        LayerRef,
+        OctreeLocation,
+    )
+    from .octree_chunk import OctreeChunk
+
 
 LOGGER = logging.getLogger("napari.octree.loader")
 LOADER = logging.getLogger("napari.loader.futures")
@@ -371,6 +376,11 @@ class OctreeLoader:
         # Mark that this chunk is being loaded.
         octree_chunk.loading = True
 
+        from ....components.experimental.chunk import (
+            ChunkRequest,
+            chunk_loader,
+        )
+
         # Create the ChunkRequest and load it with the ChunkLoader.
         request = ChunkRequest(octree_chunk.location, chunks, priority)
         satisfied_request = chunk_loader.load_request(request)
@@ -407,6 +417,8 @@ class OctreeLoader:
         seen : ChunkSet
             The set of chunks the loader can see.
         """
+
+        from ....components.experimental.chunk import chunk_loader
 
         def _should_cancel(chunk_request: ChunkRequest) -> bool:
             """Cancel if we are no longer seeing this location."""

--- a/napari/layers/image/experimental/_octree_slice.py
+++ b/napari/layers/image/experimental/_octree_slice.py
@@ -2,22 +2,30 @@
 
 For viewing one slice of a multiscale image using an octree.
 """
+from __future__ import annotations
+
 import logging
 import math
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 
-from ....components.experimental.chunk import ChunkRequest, LayerRef
 from ....utils.translations import trans
 from ._octree_loader import OctreeLoader
 from .octree import Octree
-from .octree_chunk import OctreeChunk, OctreeLocation
 from .octree_intersection import OctreeIntersection, OctreeView
 from .octree_level import OctreeLevel, OctreeLevelInfo
 from .octree_util import OctreeMetadata
 
 LOGGER = logging.getLogger("napari.octree.slice")
+
+if TYPE_CHECKING:
+    from ....components.experimental.chunk import (
+        ChunkRequest,
+        LayerRef,
+        OctreeLocation,
+    )
+    from .octree_chunk import OctreeChunk
 
 
 class OctreeSlice:

--- a/napari/layers/image/experimental/_tests/test_octree_import.py
+++ b/napari/layers/image/experimental/_tests/test_octree_import.py
@@ -1,0 +1,7 @@
+import subprocess
+import sys
+
+
+def test_octree_import():
+    cmd = [sys.executable, '-c', 'import napari; v = napari.Viewer()']
+    subprocess.run(cmd, check=True, env={'NAPARI_OCTREE': '1'})

--- a/napari/layers/image/experimental/_tests/test_octree_import.py
+++ b/napari/layers/image/experimental/_tests/test_octree_import.py
@@ -1,7 +1,16 @@
 import subprocess
 import sys
 
+CREATE_VIEWER_SCRIPT = """
+import numpy as np
+import napari
+v = napari.view_image(np.random.rand(512, 512))
+"""
+
 
 def test_octree_import():
-    cmd = [sys.executable, '-c', 'import napari; v = napari.Viewer()']
+    """Test we can create a viewer with NAPARI_OCTREE."""
+
+    cmd = [sys.executable, '-c', CREATE_VIEWER_SCRIPT]
+
     subprocess.run(cmd, check=True, env={'NAPARI_OCTREE': '1'})

--- a/napari/layers/image/experimental/_tests/test_octree_import.py
+++ b/napari/layers/image/experimental/_tests/test_octree_import.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 
@@ -13,4 +14,6 @@ def test_octree_import():
 
     cmd = [sys.executable, '-c', CREATE_VIEWER_SCRIPT]
 
-    subprocess.run(cmd, check=True, env={'NAPARI_OCTREE': '1'})
+    env = os.environ.copy()
+    env['NAPARI_OCTREE'] = '1'
+    subprocess.run(cmd, check=True, env=env)

--- a/napari/layers/image/experimental/octree.py
+++ b/napari/layers/image/experimental/octree.py
@@ -1,17 +1,22 @@
 """Octree class.
 """
+from __future__ import annotations
+
 import logging
 import math
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from ....utils.perf import block_timer
 from ....utils.translations import trans
-from .octree_chunk import OctreeChunk, OctreeLocation
 from .octree_level import OctreeLevel, log_levels
 from .octree_tile_builder import create_downsampled_levels
 from .octree_util import OctreeMetadata
 
 LOGGER = logging.getLogger("napari.octree")
+
+if TYPE_CHECKING:
+    from ....components.experimental.chunk._request import OctreeLocation
+    from .octree_chunk import OctreeChunk
 
 
 class Octree:

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -1,12 +1,16 @@
 """OctreeChunkGeom, OctreeLocation and OctreeChunk classes.
 """
+from __future__ import annotations
+
 import logging
-from typing import List, NamedTuple
+from typing import TYPE_CHECKING, List, NamedTuple
 
 import numpy as np
 
-from ....components.experimental.chunk import ChunkLocation, LayerRef
 from ....types import ArrayLike
+
+if TYPE_CHECKING:
+    from ....components.experimental.chunk._request import OctreeLocation
 
 LOGGER = logging.getLogger("napari.octree")
 
@@ -16,52 +20,6 @@ class OctreeChunkGeom(NamedTuple):
 
     pos: np.ndarray
     size: np.ndarray
-
-
-class OctreeLocation(ChunkLocation):
-    """Location of one chunk within the octree.
-
-    Parameters
-    ----------
-    layer_ref : LayerRef
-        Referen to the layer this location is in.
-    slice_id : int
-        The id of the OctreeSlice we are in.
-    level_index : int
-        The octree level index.
-    row : int
-        The chunk row.
-    col : int
-        The chunk col.
-    """
-
-    def __init__(
-        self,
-        layer_ref: LayerRef,
-        slice_id: int,
-        level_index: int,
-        row: int,
-        col: int,
-    ):
-        super().__init__(layer_ref)
-        self.slice_id: int = slice_id
-        self.level_index: int = level_index
-        self.row: int = row
-        self.col: int = col
-
-    def __str__(self):
-        return f"location=({self.level_index}, {self.row}, {self.col}) "
-
-    def __eq__(self, other) -> bool:
-        return (
-            self.slice_id == other.slice_id
-            and self.level_index == other.level_index
-            and self.row == other.row
-            and self.col == other.col
-        )
-
-    def __hash__(self) -> int:
-        return hash((self.slice_id, self.level_index, self.row, self.col))
 
 
 class OctreeChunk:

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -3,12 +3,13 @@
 An eventual replacement for Image that combines single-scale and
 chunked (tiled) multi-scale into one implementation.
 """
+from __future__ import annotations
+
 import logging
-from typing import List, Set
+from typing import TYPE_CHECKING, List, Set
 
 import numpy as np
 
-from ....components.experimental.chunk import ChunkRequest, LayerRef
 from ....utils.events import Event
 from ....utils.translations import trans
 from ..image import _ImageBase
@@ -17,6 +18,9 @@ from .octree_chunk import OctreeChunk
 from .octree_intersection import OctreeIntersection
 from .octree_level import OctreeLevelInfo
 from .octree_util import OctreeDisplayOptions, OctreeMetadata
+
+if TYPE_CHECKING:
+    from ....components.experimental.chunk import ChunkRequest
 
 LOGGER = logging.getLogger("napari.octree.image")
 
@@ -410,10 +414,9 @@ class _OctreeImageBase(_ImageBase):
         logic in Image._set_view_slice goes away entirely.
         """
         # Consider non-multiscale data as just having a single level
-        if self.multiscale:
-            multilevel_data = self.data
-        else:
-            multilevel_data = [self.data]
+        from ....components.experimental.chunk import LayerRef
+
+        multilevel_data = self.data if self.multiscale else [self.data]
 
         if self._slice is not None:
             # For now bail out so we don't nuke an existing slice which

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional
 import numpy as np
 
 from ....types import ArrayLike
-from .octree_chunk import OctreeChunk, OctreeChunkGeom, OctreeLocation
+from .octree_chunk import OctreeChunk, OctreeChunkGeom
 from .octree_util import OctreeMetadata
 
 LOGGER = logging.getLogger("napari.octree")
@@ -151,6 +151,8 @@ class OctreeLevel:
 
         meta = self.info.meta
         layer_ref = meta.layer_ref
+
+        from ....components.experimental.chunk._request import OctreeLocation
 
         location = OctreeLocation(
             layer_ref, self.slice_id, level_index, row, col

--- a/napari/layers/image/experimental/octree_util.py
+++ b/napari/layers/image/experimental/octree_util.py
@@ -1,12 +1,16 @@
 """OctreeDisplayOptions, NormalNoise and OctreeMetadata classes.
 """
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 
-from ....components.experimental.chunk import LayerRef
 from ....utils.config import octree_config
+
+if TYPE_CHECKING:
+    from ....components.experimental.chunk import LayerRef
 
 
 def _get_tile_size() -> int:

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -1,7 +1,10 @@
 """Image class.
 """
+from __future__ import annotations
+
 import types
 import warnings
+from typing import TYPE_CHECKING
 
 import numpy as np
 from scipy import ndimage as ndi
@@ -18,13 +21,8 @@ from ._image_slice import ImageSlice
 from ._image_slice_data import ImageSliceData
 from ._image_utils import guess_multiscale, guess_rgb
 
-# Use special ChunkedSlideData for async.
-if config.async_loading:
-    from .experimental._chunked_slice_data import ChunkedSliceData
-
-    SliceDataClass = ChunkedSliceData
-else:
-    SliceDataClass = ImageSliceData
+if TYPE_CHECKING:
+    from ...components.experimental.chunk import ChunkRequest
 
 
 # It is important to contain at least one abstractmethod to properly exclude this class
@@ -592,10 +590,21 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
             thumbnail_source = None
 
         # Load our images, might be sync or async.
-        data = SliceDataClass(self, image_indices, image, thumbnail_source)
+        data = self._SliceDataClass(
+            self, image_indices, image, thumbnail_source
+        )
         self._load_slice(data)
 
-    def _load_slice(self, data: SliceDataClass):
+    @property
+    def _SliceDataClass(self):
+        # Use special ChunkedSlideData for async.
+        if config.async_loading:
+            from .experimental._chunked_slice_data import ChunkedSliceData
+
+            return ChunkedSliceData
+        return ImageSliceData
+
+    def _load_slice(self, data: ImageSliceData):
         """Load the image and maybe thumbnail source.
 
         Parameters
@@ -610,7 +619,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
             # property is now false, since the load is in progress.
             self.events.loaded()
 
-    def _on_data_loaded(self, data: SliceDataClass, sync: bool) -> None:
+    def _on_data_loaded(self, data: ImageSliceData, sync: bool) -> None:
         """The given data a was loaded, use it now.
 
         This routine is called synchronously from _load_async() above, or
@@ -755,7 +764,6 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
 
     # For async we add an on_chunk_loaded() method.
     if config.async_loading:
-        from ...components.experimental.chunk import ChunkRequest
 
         def on_chunk_loaded(self, request: ChunkRequest) -> None:
             """An asynchronous ChunkRequest was loaded.
@@ -766,7 +774,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
                 This request was loaded.
             """
             # Convert the ChunkRequest to SliceData and use it.
-            data = SliceDataClass.from_request(self, request)
+            data = self._SliceDataClass.from_request(self, request)
             self._on_data_loaded(data, sync=False)
 
 

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -21,6 +21,7 @@ from napari_plugin_engine import PluginManager as PluginManager
 from typing_extensions import TypedDict
 
 from ..types import AugmentedWidget, LayerData, SampleDict, WidgetCallable
+from ..utils import _magicgui
 from ..utils._appdirs import user_site_packages
 from ..utils.events import EmitterGroup, EventedSet
 from ..utils.misc import camel_to_spaces, running_as_bundled_app
@@ -64,6 +65,8 @@ class NapariPluginManager(PluginManager):
 
         if sys.platform.startswith('linux') and running_as_bundled_app():
             sys.path.append(user_site_packages())
+
+        _magicgui.register_types_with_magicgui()
 
     def _initialize(self):
         with self.discovery_blocked():


### PR DESCRIPTION
# Description
This fixes #2834 and closes #2835, and adds a test

Octree imports are a disastrous house of cards.  Classes are defined all over the place, exported all over the place in top level `__init__`, and most problematically, re-imported all over the place mostly just for the sake of type hinting.  As a result, one generally has to go on a wild goose chase to fix anything. 

The problem here ultimately stemmed from the fact that the import of `_OctreeImageBase` in `image.py` _indirectly_ was importing `OctreeLocation` which then needed to inherit from `ChunkLocation` that existed over in `components.experimental` rather than `image.experimental` ... so there's no isolation of these things.

Most importantly, they are imported _everywhere_ for the purpose of type annotations.  So a major lesson here is, type hints are great, but please put things behind `if TYPE_CHECKING` if you are only importing them for the sake of type hints.  


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
