### PR TITLE
remove opacity from plugin sorter widget

### DIFF
--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -263,7 +263,11 @@ class PreferencesDialog(QDialog):
                 SETTINGS._env_settings.get(section, {}).get(name, None)
             )
             widget.setDisabled(disable)
-            widget.opacity.setOpacity(0.3 if disable else 1)
+            try:
+                widget.opacity.setOpacity(0.3 if disable else 1)
+            except AttributeError:
+                # some widgets may not have opacity (such as the QtPluginSorter)
+                pass
 
         # set state values for widget
         form.widget.state = values

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
@@ -163,10 +163,7 @@ class PluginWidget(SchemaWidgetMixin, QtPluginSorter):
 
     def configure(self):
         self.hook_list.order_changed.connect(self.on_changed.emit)
-        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
-        self.setGraphicsEffect(self.opacity)
-        self.opacity.setOpacity(1)
-
+        
     def setDescription(self, description: str):
         self.description = description
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
Fixes #2839 

The plugin sorter widget doesn't really need opacity, and it doesn't work well as it is.   That particular widget is already doing its own thing with opacity, which may be not working well with using opacity for the plugin sorter widget as a whole.  I removed opacity for that particular widget.  The whole idea was to reduce the opacity for any widget in the preferences dialog if it had been disabled because it was set by an environment variable.  It is unlikely someone will set the call order for the plugins through an environment variable.  If they do, the plugin sorter widget should still be disabled in the preferences dialog, it just won't be dimmed.


<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
