### PR TITLE
Set upper limit of Vectors spinboxes to infinity

### DIFF
--- a/napari/_qt/layer_controls/qt_vectors_controls.py
+++ b/napari/_qt/layer_controls/qt_vectors_controls.py
@@ -84,6 +84,7 @@ class QtVectorsControls(QtLayerControls):
         self.widthSpinBox.setKeyboardTracking(False)
         self.widthSpinBox.setSingleStep(0.1)
         self.widthSpinBox.setMinimum(0.1)
+        self.widthSpinBox.setMaximum(np.inf)
         self.widthSpinBox.setValue(self.layer.edge_width)
         self.widthSpinBox.valueChanged.connect(self.change_width)
 
@@ -93,6 +94,7 @@ class QtVectorsControls(QtLayerControls):
         self.lengthSpinBox.setSingleStep(0.1)
         self.lengthSpinBox.setValue(self.layer.length)
         self.lengthSpinBox.setMinimum(0.1)
+        self.lengthSpinBox.setMaximum(np.inf)
         self.lengthSpinBox.valueChanged.connect(self.change_length)
 
         # grid_layout created in QtLayerControls


### PR DESCRIPTION
# Description
`Vectors` spinboxes to select length and width were capped at 100, but the value could be set programmatically to anything. This PR sets the upper limit of the spinbox to infinity.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
