### PR TITLE
Plugin dock widgets menu

### DIFF
--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -82,17 +82,18 @@ def test_plugin_widgets(monkeypatch, napari_plugin_manager):
 def test_plugin_widgets_menus(test_plugin_widgets, make_napari_viewer):
     """Test the plugin widgets get added to the window menu correctly."""
     viewer = make_napari_viewer()
-    actions = viewer.window._plugin_dock_widget_menu.actions()
+    # only take the plugin actions
+    actions = viewer.window.plugins_menu.actions()[3:]
     assert len(actions) == 3
     expected_text = ['TestP1', 'TestP2: Widg3', 'TestP3: magic']
     assert [a.text() for a in actions] == expected_text
 
-    # the first item in the menu is a submenu (for "Test plugin1")
+    # the first item of the plugins is a submenu (for "Test plugin1")
     assert actions[0].menu()
     subnames = ['Widg1', 'Widg2']
     assert [a.text() for a in actions[0].menu().actions()] == subnames
 
-    # the other items in the menu are not submenus
+    # the other items for the plugins are not submenus
     assert not actions[1].menu()
     assert not actions[2].menu()
 
@@ -100,7 +101,8 @@ def test_plugin_widgets_menus(test_plugin_widgets, make_napari_viewer):
 def test_making_plugin_dock_widgets(test_plugin_widgets, make_napari_viewer):
     """Test that we can create dock widgets, and they get the viewer."""
     viewer = make_napari_viewer()
-    actions = viewer.window._plugin_dock_widget_menu.actions()
+    # only take the plugin actions
+    actions = viewer.window.plugins_menu.actions()[3:]
 
     # trigger the 'TestP2: Widg3' action
     actions[1].trigger()
@@ -132,7 +134,8 @@ def test_making_function_dock_widgets(test_plugin_widgets, make_napari_viewer):
     import magicgui
 
     viewer = make_napari_viewer()
-    actions = viewer.window._plugin_dock_widget_menu.actions()
+    # only take the plugin actions
+    actions = viewer.window.plugins_menu.actions()[3:]
 
     # trigger the 'TestP3: magic' action
     actions[2].trigger()
@@ -157,7 +160,8 @@ def test_making_function_dock_widgets(test_plugin_widgets, make_napari_viewer):
 def test_clear_all_plugin_widgets(test_plugin_widgets, make_napari_viewer):
     """Test the the 'Remove Dock Widgets' menu item clears added widgets."""
     viewer = make_napari_viewer()
-    actions = viewer.window._plugin_dock_widget_menu.actions()
+    # only take the plugin actions
+    actions = viewer.window.plugins_menu.actions()[3:]
     actions[1].trigger()
     actions[0].menu().actions()[1].trigger()
     assert len(viewer.window._dock_widgets) == 2

--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -83,7 +83,12 @@ def test_plugin_widgets_menus(test_plugin_widgets, make_napari_viewer):
     """Test the plugin widgets get added to the window menu correctly."""
     viewer = make_napari_viewer()
     # only take the plugin actions
-    actions = viewer.window.plugins_menu.actions()[3:]
+    actions = viewer.window.plugins_menu.actions()
+    for cnt, action in enumerate(actions):
+        if action.text() == "":
+            # this is the separator
+            break
+    actions = actions[cnt + 1 :]
     assert len(actions) == 3
     expected_text = ['TestP1', 'TestP2: Widg3', 'TestP3: magic']
     assert [a.text() for a in actions] == expected_text
@@ -102,7 +107,12 @@ def test_making_plugin_dock_widgets(test_plugin_widgets, make_napari_viewer):
     """Test that we can create dock widgets, and they get the viewer."""
     viewer = make_napari_viewer()
     # only take the plugin actions
-    actions = viewer.window.plugins_menu.actions()[3:]
+    actions = viewer.window.plugins_menu.actions()
+    for cnt, action in enumerate(actions):
+        if action.text() == "":
+            # this is the separator
+            break
+    actions = actions[cnt + 1 :]
 
     # trigger the 'TestP2: Widg3' action
     actions[1].trigger()
@@ -135,7 +145,12 @@ def test_making_function_dock_widgets(test_plugin_widgets, make_napari_viewer):
 
     viewer = make_napari_viewer()
     # only take the plugin actions
-    actions = viewer.window.plugins_menu.actions()[3:]
+    actions = viewer.window.plugins_menu.actions()
+    for cnt, action in enumerate(actions):
+        if action.text() == "":
+            # this is the separator
+            break
+    actions = actions[cnt + 1 :]
 
     # trigger the 'TestP3: magic' action
     actions[2].trigger()
@@ -161,7 +176,12 @@ def test_clear_all_plugin_widgets(test_plugin_widgets, make_napari_viewer):
     """Test the the 'Remove Dock Widgets' menu item clears added widgets."""
     viewer = make_napari_viewer()
     # only take the plugin actions
-    actions = viewer.window.plugins_menu.actions()[3:]
+    actions = viewer.window.plugins_menu.actions()
+    for cnt, action in enumerate(actions):
+        if action.text() == "":
+            # this is the separator
+            break
+    actions = actions[cnt + 1 :]
     actions[1].trigger()
     actions[0].menu().actions()[1].trigger()
     assert len(viewer.window._dock_widgets) == 2

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -99,6 +99,9 @@ class Installer:
             self._output_widget.clear()
         self.process.start()
 
+        for pkg in pkg_list:
+            plugin_manager.unregister(pkg)
+
 
 class PluginListItem(QFrame):
     def __init__(

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -396,6 +396,10 @@ class Window:
             self._rebuild_dock_widget_menu
         )
         plugin_manager.events.registered.connect(self._rebuild_samples_menu)
+        plugin_manager.events.unregistered.connect(
+            self._rebuild_dock_widget_menu
+        )
+        plugin_manager.events.unregistered.connect(self._rebuild_samples_menu)
 
         viewer.events.status.connect(self._status_changed)
         viewer.events.help.connect(self._help_changed)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -781,6 +781,13 @@ class Window:
         """Add 'Plugins' menu to app menubar."""
         self.plugins_menu = self.main_menu.addMenu(trans._('&Plugins'))
 
+        plugin_manager.discover_widgets()
+        self._rebuild_dock_widget_menu()
+
+    def _rebuild_dock_widget_menu(self, event=None):
+
+        self.plugins_menu.clear()
+
         pip_install_action = QAction(
             trans._("Install/Uninstall Package(s)..."), self._qt_window
         )
@@ -796,29 +803,19 @@ class Window:
             )
         )
         report_plugin_action.triggered.connect(self._show_plugin_err_reporter)
+
         self.plugins_menu.addAction(report_plugin_action)
 
-        self._plugin_dock_widget_menu = QMenu(
-            trans._('Add Dock Widget'), self._qt_window
-        )
-
-        plugin_manager.discover_widgets()
-        self._rebuild_dock_widget_menu()
-
-        self.plugins_menu.addMenu(self._plugin_dock_widget_menu)
-
-    def _rebuild_dock_widget_menu(self, event=None):
-
-        self._plugin_dock_widget_menu.clear()
+        self.plugins_menu.addSeparator()
 
         # Add a menu item (QAction) for each available plugin widget
         for hook_type, (plugin_name, widgets) in plugin_manager.iter_widgets():
             multiprovider = len(widgets) > 1
             if multiprovider:
                 menu = QMenu(plugin_name, self._qt_window)
-                self._plugin_dock_widget_menu.addMenu(menu)
+                self.plugins_menu.addMenu(menu)
             else:
-                menu = self._plugin_dock_widget_menu
+                menu = self.plugins_menu
 
             for wdg_name in widgets:
                 key = (plugin_name, wdg_name)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -390,15 +390,11 @@ class Window:
 
         SETTINGS.appearance.events.theme.connect(self._update_theme)
 
-        plugin_manager.events.disabled.connect(self._rebuild_dock_widget_menu)
+        plugin_manager.events.disabled.connect(self._rebuild_plugins_menu)
         plugin_manager.events.disabled.connect(self._rebuild_samples_menu)
-        plugin_manager.events.registered.connect(
-            self._rebuild_dock_widget_menu
-        )
+        plugin_manager.events.registered.connect(self._rebuild_plugins_menu)
         plugin_manager.events.registered.connect(self._rebuild_samples_menu)
-        plugin_manager.events.unregistered.connect(
-            self._rebuild_dock_widget_menu
-        )
+        plugin_manager.events.unregistered.connect(self._rebuild_plugins_menu)
         plugin_manager.events.unregistered.connect(self._rebuild_samples_menu)
 
         viewer.events.status.connect(self._status_changed)
@@ -786,9 +782,9 @@ class Window:
         self.plugins_menu = self.main_menu.addMenu(trans._('&Plugins'))
 
         plugin_manager.discover_widgets()
-        self._rebuild_dock_widget_menu()
+        self._rebuild_plugins_menu()
 
-    def _rebuild_dock_widget_menu(self, event=None):
+    def _rebuild_plugins_menu(self, event=None):
 
         self.plugins_menu.clear()
 

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -41,6 +41,20 @@ CallOrderDict = Dict[str, List[PluginHookOption]]
 
 
 class NapariPluginManager(PluginManager):
+    """PluginManager subclass for napari-specific functionality.
+
+    Events
+    ------
+    registered (value: str)
+        Emitted after plugin named `value` has been registered.
+    unregistered (value: str)
+        Emitted after plugin named `value` has been unregistered.
+    enabled (value: str)
+        Emitted after plugin named `value` has been removed from the block list.
+    disabled (value: str)
+        Emitted after plugin named `value` has been added to the block list.
+    """
+
     ENTRY_POINT = 'napari.plugin'
 
     def __init__(self):

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -112,12 +112,6 @@ class NapariPluginManager(PluginManager):
     def _on_blocked_change(self, event):
         # things that are "added to the blocked list" become disabled
         for item in event.added:
-            for _dict in (
-                self._dock_widgets,
-                self._sample_data,
-                self._function_widgets,
-            ):
-                _dict.pop(item, None)
             self.events.disabled(value=item)
 
         # things that are "removed from the blocked list" become enabled

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -84,6 +84,27 @@ class NapariPluginManager(PluginManager):
             self.events.registered(value=name)
         return name
 
+    def unregister(
+        self,
+        name_or_object: Any,
+    ) -> Optional[Any]:
+        plugin = super().unregister(name_or_object)
+
+        # remove widgets, sample data
+
+        if type(name_or_object) is str:
+
+            for _dict in (
+                self._dock_widgets,
+                self._sample_data,
+                self._function_widgets,
+            ):
+                _dict.pop(name_or_object, None)
+
+        self.events.registered(value=name_or_object)
+
+        return plugin
+
     def _on_blocked_change(self, event):
         # things that are "added to the blocked list" become disabled
         for item in event.added:

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -47,7 +47,11 @@ class NapariPluginManager(PluginManager):
         super().__init__('napari', discover_entry_point=self.ENTRY_POINT)
 
         self.events = EmitterGroup(
-            source=self, registered=None, enabled=None, disabled=None
+            source=self,
+            registered=None,
+            unregistered=None,
+            enabled=None,
+            disabled=None,
         )
         self._blocked: EventedSet[str] = EventedSet()
         self._blocked.events.changed.connect(self._on_blocked_change)
@@ -101,7 +105,7 @@ class NapariPluginManager(PluginManager):
             ):
                 _dict.pop(name_or_object, None)
 
-        self.events.registered(value=name_or_object)
+        self.events.unregistered(value=None)
 
         return plugin
 

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -105,7 +105,7 @@ class NapariPluginManager(PluginManager):
             ):
                 _dict.pop(name_or_object, None)
 
-        self.events.unregistered(value=None)
+        self.events.unregistered(value=name_or_object)
 
         return plugin
 

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -106,20 +106,23 @@ class NapariPluginManager(PluginManager):
         self,
         name_or_object: Any,
     ) -> Optional[Any]:
+
+        if isinstance(name_or_object, str):
+            _name = name_or_object
+        else:
+            _name = self.get_name(name_or_object)
+
         plugin = super().unregister(name_or_object)
 
         # remove widgets, sample data
+        for _dict in (
+            self._dock_widgets,
+            self._sample_data,
+            self._function_widgets,
+        ):
+            _dict.pop(_name, None)
 
-        if type(name_or_object) is str:
-
-            for _dict in (
-                self._dock_widgets,
-                self._sample_data,
-                self._function_widgets,
-            ):
-                _dict.pop(name_or_object, None)
-
-        self.events.unregistered(value=name_or_object)
+        self.events.unregistered(value=_name)
 
         return plugin
 

--- a/napari/plugins/_tests/test_plugins_misc.py
+++ b/napari/plugins/_tests/test_plugins_misc.py
@@ -36,10 +36,12 @@ def test_plugin_events(napari_plugin_manager):
     tnpm: NapariPluginManager = napari_plugin_manager
 
     register_events = []
+    unregister_events = []
     enable_events = []
     disable_events = []
 
     tnpm.events.registered.connect(lambda e: register_events.append(e))
+    tnpm.events.unregistered.connect(lambda e: unregister_events.append(e))
     tnpm.events.enabled.connect(lambda e: enable_events.append(e))
     tnpm.events.disabled.connect(lambda e: disable_events.append(e))
 
@@ -52,6 +54,10 @@ def test_plugin_events(napari_plugin_manager):
     assert register_events[0].value == 'Plugin'
     assert not enable_events
     assert not disable_events
+
+    tnpm.unregister(Plugin)
+    assert len(unregister_events) == 1
+    assert unregister_events[0].value == Plugin
 
     tnpm.set_blocked('Plugin')
     assert len(disable_events) == 1

--- a/napari/plugins/_tests/test_plugins_misc.py
+++ b/napari/plugins/_tests/test_plugins_misc.py
@@ -57,7 +57,7 @@ def test_plugin_events(napari_plugin_manager):
 
     tnpm.unregister(Plugin)
     assert len(unregister_events) == 1
-    assert unregister_events[0].value == Plugin
+    assert unregister_events[0].value == 'Plugin'
 
     tnpm.set_blocked('Plugin')
     assert len(disable_events) == 1


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
Closes #2178 

The initial issue of updating the menu when a new plugin is installed was already fixed--the plugin would show up.  

I found that when a plugin was uninstalled, it was not removed from the list, so I changed that.  @tlambert03 I wanted to go through the plugin_manager events for this, so I tried to make this happen.  Please look over and let me know if this looks ok. 

Also, there was discussion in the past to move the plugins from the submenu and have them in the main plugins menu.  I made this change as well.  What do you think? 

<img width="560" alt="Screen Shot 2021-06-04 at 11 35 57 AM" src="https://user-images.githubusercontent.com/54282105/120834760-14e7d200-c529-11eb-8579-5a8f7c8b6c80.png">

