### PR TITLE
Update to openGL max texture size

### DIFF
--- a/napari/_vispy/utils_gl.py
+++ b/napari/_vispy/utils_gl.py
@@ -57,7 +57,9 @@ def get_max_texture_sizes() -> Tuple[int, int]:
     if max_size_2d == ():
         max_size_2d = None
 
-    # vispy doesn't expose GL_MAX_3D_TEXTURE_SIZE so hard coding for now.
+    # vispy/gloo doesn't provide the GL_MAX_3D_TEXTURE_SIZE constant value
+    # so we hard coded it from the documentation, section constants at the bottom
+    # http://pyopengl.sourceforge.net/documentation/pydoc/OpenGL.GL.html
     GL_MAX_3D_TEXTURE_SIZE = 32883
     max_size_3d = gl.glGetParameter(GL_MAX_3D_TEXTURE_SIZE)
     if max_size_3d == ():

--- a/napari/_vispy/utils_gl.py
+++ b/napari/_vispy/utils_gl.py
@@ -58,10 +58,10 @@ def get_max_texture_sizes() -> Tuple[int, int]:
         max_size_2d = None
 
     # vispy doesn't expose GL_MAX_3D_TEXTURE_SIZE so hard coding for now.
-    # MAX_TEXTURE_SIZE_3D = gl.glGetParameter(gl.GL_MAX_3D_TEXTURE_SIZE)
-    # if MAX_TEXTURE_SIZE_3D == ():
-    #    MAX_TEXTURE_SIZE_3D = None
-    max_size_3d = 2048
+    GL_MAX_3D_TEXTURE_SIZE = 32883
+    max_size_3d = gl.glGetParameter(GL_MAX_3D_TEXTURE_SIZE)
+    if max_size_3d == ():
+        max_size_3d = None
 
     return max_size_2d, max_size_3d
 


### PR DESCRIPTION
# Description
It updates OpenGL texture max size, it should improve performance on larger images. Requested by @royerloic .

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# References
It uses a constant value that can is not provided by Vispy.
It can be found [here](http://pyopengl.sourceforge.net/documentation/pydoc/OpenGL.GL.VERSION.GL_1_2.html)

# How has this been tested?
- [X] it passes most of the tests on my machine, the errors seem unrelated to OpenGL.

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas