### PR TITLE
Followup to #2485 to add opengl context

### DIFF
--- a/napari/_vispy/utils_gl.py
+++ b/napari/_vispy/utils_gl.py
@@ -57,11 +57,13 @@ def get_max_texture_sizes() -> Tuple[int, int]:
     if max_size_2d == ():
         max_size_2d = None
 
-    # vispy/gloo doesn't provide the GL_MAX_3D_TEXTURE_SIZE constant value
-    # so we hard coded it from the documentation, section constants at the bottom
+    # vispy/gloo doesn't provide the GL_MAX_3D_TEXTURE_SIZE location,
+    # but it can be found in this list of constants
     # http://pyopengl.sourceforge.net/documentation/pydoc/OpenGL.GL.html
-    GL_MAX_3D_TEXTURE_SIZE = 32883
-    max_size_3d = gl.glGetParameter(GL_MAX_3D_TEXTURE_SIZE)
+    with _opengl_context():
+        GL_MAX_3D_TEXTURE_SIZE = 32883
+        max_size_3d = gl.glGetParameter(GL_MAX_3D_TEXTURE_SIZE)
+
     if max_size_3d == ():
         max_size_3d = None
 


### PR DESCRIPTION
# Description
PR puts call inside opengl context, which can be needed if done on startup before canvas is created. Also makes comment more clear. cc @JoOkuma @jni 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
