### PR TITLE
Do not store default values in preference files.

### DIFF
--- a/napari/utils/settings/_manager.py
+++ b/napari/utils/settings/_manager.py
@@ -95,6 +95,22 @@ class SettingsManager:
     def __str__(self):
         return safe_dump(self._to_dict(safe=True))
 
+    def _remove_default(self, settings_data):
+        """
+        Attempt to convert self to dict and to remove any default values from the configuration
+        """
+
+        for section, values in settings_data.items():
+            if section not in self._defaults:
+                continue
+
+            default_values = self._defaults[section].dict()
+            for k, v in list(values.items()):
+                if default_values.get(k, None) == v:
+                    del values[k]
+
+        return settings_data
+
     def _to_dict(self, safe: bool = False) -> dict:
         """Convert the settings to a dictionary."""
         data = {}
@@ -128,9 +144,11 @@ class SettingsManager:
                         except KeyError:
                             pass
 
-                data_str = safe_dump(data)
+                data_str = safe_dump(self._remove_default(data))
             else:
-                data_str = str(self)
+                data_str = safe_dump(
+                    self._remove_default(self._to_dict(safe=True))
+                )
 
             with open(path, "w") as fh:
                 fh.write(data_str)

--- a/napari/utils/settings/_tests/test_settings.py
+++ b/napari/utils/settings/_tests/test_settings.py
@@ -168,7 +168,7 @@ def test_settings_env_variables(tmp_path, monkeypatch):
 def test_settings_env_variables_do_not_write_to_disk(tmp_path, monkeypatch):
     data = """
 appearance:
-  theme: dark
+  theme: pink
 """
     with open(tmp_path / SettingsManager._FILENAME, "w") as fh:
         fh.write(data)
@@ -181,11 +181,13 @@ appearance:
     with open(tmp_path / SettingsManager._FILENAME) as fh:
         saved_data = fh.read()
 
-    model_values = settings._to_dict(safe=True)
+    model_values = settings._remove_default(settings._to_dict(safe=True))
     saved_values = safe_load(saved_data)
 
     assert model_values["appearance"]["theme"] == value
-    assert saved_values["appearance"]["theme"] == "dark"
+    # Note: Pink is currently not a valid theme, but if we use dark as it is the
+    # default it is not saved in the saved_values. We can't use "Light" either
+    assert saved_values["appearance"]["theme"] == "pink"
 
     model_values["appearance"].pop("theme")
     saved_values["appearance"].pop("theme")


### PR DESCRIPTION
When a value match the default value from napari in settings; do not
store it.

This is useful as this let us change the default values across napari
versions and  leads to much smaller settings.

This should also address #2847 which was driving me crazy as changing
default_values of shortcuts had no effects.

Still a few things to do, like adding tests, and we should also discuss if reset should also save an empty configuration file instead of trying to go through this cleaning process. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [?] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).



