### PR TITLE
Handle "hold XX to" with action manager.

### DIFF
--- a/examples/action_manager.py
+++ b/examples/action_manager.py
@@ -32,13 +32,13 @@ def rotate45(viewer: napari.Viewer):
     layer.rotate = layer.rotate @ r
     return original_rotation
 
-
-
 def rotate_unrotate_45(viewer: napari.Viewer):
     """
     identical to rotate_45, but unrotate when keypress is released
+
     """
     layer = viewer.layers[0]
+    # we use the rotate 45º function here to not repeat code.
     original_rotation = rotate45(viewer)
     yield 
     layer.rotate = original_rotation

--- a/examples/action_manager.py
+++ b/examples/action_manager.py
@@ -28,7 +28,20 @@ def rotate45(viewer: napari.Viewer):
 
     r = np.array([[cos(angle), -sin(angle)], [sin(angle), cos(angle)]])
     layer = viewer.layers[0]
+    original_rotation = layer.rotate
     layer.rotate = layer.rotate @ r
+    return original_rotation
+
+
+
+def rotate_unrotate_45(viewer: napari.Viewer):
+    """
+    identical to rotate_45, but unrotate when keypress is released
+    """
+    layer = viewer.layers[0]
+    original_rotation = rotate45(viewer)
+    yield 
+    layer.rotate = original_rotation
 
 
 # create the viewer with an image
@@ -57,6 +70,7 @@ def register_action():
         command=rotate45,
         description='Rotate layer 0 by 45deg',
         keymapprovider=ViewerModel,
+        alternate_hold=rotate_unrotate_45
     )
 
 
@@ -65,6 +79,7 @@ def bind_shortcut():
     # remove the shortcut.
     action_manager.unbind_shortcut('napari:reset_view')  # Control-R
     action_manager.bind_shortcut('napari:rotate45', 'Control-R')
+    action_manager.bind_hold_shortcut('napari:rotate45', '7')
 
 
 def bind_button():

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -28,6 +28,7 @@ class PreferencesDialog(QDialog):
         "call_order": {"ui:widget": "plugins"},
         "highlight_thickness": {"ui:widget": "highlight"},
         "shortcuts": {"ui:widget": "shortcuts"},
+        "hold_shortcuts": {"ui:widget": "hold_shortcuts"},
     }
 
     resized = Signal(QSize)

--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -164,7 +164,7 @@ class QtShapesControls(QtLayerControls):
             layer,
             'zoom',
             Mode.PAN_ZOOM,
-            "napari:activate_shape_pan_zoom_mode",
+            "activate_shape_pan_zoom_mode",
             extra_tooltip_text=trans._('(or hold Space)'),
             checked=True,
         )

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -264,6 +264,15 @@ class QtViewer(QSplitter):
             for shortcut in shortcuts:
                 action_manager.bind_shortcut(action, shortcut)
 
+        for (
+            action,
+            shortcuts,
+        ) in get_settings().shortcuts.hold_shortcuts.items():
+            action_manager.unbind_shortcut(action)
+            for shortcut in shortcuts:
+                print('bind hold', action, 'to', shortcut)
+                action_manager.bind_hold_shortcut(action, shortcut)
+
     def _create_canvas(self) -> None:
         """Create the canvas and hook up events."""
         self.canvas = VispyCanvas(

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -34,6 +34,7 @@ from ..qt_resources import get_stylesheet
 KEY_SUBS = {'Ctrl': 'Control'}
 
 
+# TODO handle the yields versions.
 class ShortcutEditor(QWidget):
     """Widget to edit keybindings for napari."""
 

--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -15,7 +15,7 @@ skip = [
     'tiled-rendering-2d.py',  # too slow
     'live_tiffs_generator.py',
     'embed_ipython.py',  # fails without monkeypatch
-    'custom_key_bindings.py'  # breaks EXPECTED_NUMBER_OF_VIEWER_METHODS later
+    'custom_key_bindings.py',  # breaks EXPECTED_NUMBER_OF_VIEWER_METHODS later
 ]
 EXAMPLE_DIR = Path(napari.__file__).parent.parent / 'examples'
 # using f.name here and re-joining at `run_path()` for test key presentation

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -131,10 +131,13 @@ def test_add_layer(
     else:
         gen = func(layer)
         try:
-            next(gen)
+            next(gen)  # press button
+            next(
+                gen
+            )  # maybe release button (unless there is nothing to release)
             assert (
                 False
-            ), "We did not raise StopIteration, there is more than one yield"
+            ), f"We did not raise StopIteration, is there more than one yield in `{func=}` ?"
         except StopIteration:  # only one statement
             pass
 

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/form.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/form.py
@@ -27,6 +27,7 @@ class WidgetBuilder:
             "enum": widgets.EnumSchemaWidget,
             "plugins": widgets.PluginWidget,
             "shortcuts": widgets.ShortcutsWidget,
+            "hold_shortcuts": widgets.ShortcutsWidget,
         },
         "number": {
             "spin": widgets.SpinDoubleSchemaWidget,

--- a/napari/layers/points/_points_key_bindings.py
+++ b/napari/layers/points/_points_key_bindings.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from ...layers.utils.layer_utils import register_layer_action
+from ...layers.utils.layer_utils import (
+    register_layer_action,
+    register_layer_alternate_hold_action,
+)
 from ...utils.translations import trans
 from ._points_constants import Mode
 from .points import Points
@@ -10,7 +13,7 @@ def register_points_action(description):
     return register_layer_action(Points, description)
 
 
-@Points.bind_key('Space')
+@register_layer_alternate_hold_action('activate_points_pan_zoom_mode', 'Space')
 def hold_to_pan_zoom(layer):
     """Hold to pan and zoom in the viewer."""
     if layer._mode != Mode.PAN_ZOOM:

--- a/napari/layers/shapes/_shapes_key_bindings.py
+++ b/napari/layers/shapes/_shapes_key_bindings.py
@@ -1,18 +1,17 @@
 import numpy as np
 
-from ...layers.utils.layer_utils import (
-    register_layer_action,
-    register_layer_alternate_hold_action,
-)
+from ...layers.utils.layer_utils import register_layer_action
 from ...utils.translations import trans
 from ._shapes_constants import Box, Mode
 from ._shapes_mouse_bindings import _move
 from .shapes import Shapes
 
 
+def register_shapes_action(description):
+    return register_layer_action(Shapes, description)
 
 
-@Shapes.bind_key('Shift')
+@register_shapes_action(trans._('Hold to lock aspect ratio'))
 def hold_to_lock_aspect_ratio(layer):
     """Hold to lock aspect ratio when resizing a shape."""
     # on key press
@@ -35,10 +34,6 @@ def hold_to_lock_aspect_ratio(layer):
     layer._fixed_aspect = False
     if layer._is_moving:
         _move(layer, layer._moving_coordinates)
-
-
-def register_shapes_action(description):
-    return register_layer_action(Shapes, description)
 
 
 @register_shapes_action(trans._('Add rectangles'))

--- a/napari/layers/shapes/_shapes_key_bindings.py
+++ b/napari/layers/shapes/_shapes_key_bindings.py
@@ -1,27 +1,15 @@
 import numpy as np
 
-from ...layers.utils.layer_utils import register_layer_action
+from ...layers.utils.layer_utils import (
+    register_layer_action,
+    register_layer_alternate_hold_action,
+)
 from ...utils.translations import trans
 from ._shapes_constants import Box, Mode
 from ._shapes_mouse_bindings import _move
 from .shapes import Shapes
 
 
-@Shapes.bind_key('Space')
-def hold_to_pan_zoom(layer):
-    """Hold to pan and zoom in the viewer."""
-    if layer._mode != Mode.PAN_ZOOM:
-        # on key press
-        prev_mode = layer.mode
-        prev_selected = layer.selected_data.copy()
-        layer.mode = Mode.PAN_ZOOM
-
-        yield
-
-        # on key release
-        layer.mode = prev_mode
-        layer.selected_data = prev_selected
-        layer._set_highlight()
 
 
 @Shapes.bind_key('Shift')
@@ -99,6 +87,23 @@ def activate_select_mode(layer):
 def activate_shape_pan_zoom_mode(layer):
     """Activate pan and zoom mode."""
     layer.mode = Mode.PAN_ZOOM
+
+
+@activate_shape_pan_zoom_mode.hold('Space')
+def hold_to_pan_zoom(layer):
+    """Hold to pan and zoom in the viewer."""
+    if layer._mode != Mode.PAN_ZOOM:
+        # on key press
+        prev_mode = layer.mode
+        prev_selected = layer.selected_data.copy()
+        layer.mode = Mode.PAN_ZOOM
+
+        yield
+
+        # on key release
+        layer.mode = prev_mode
+        layer.selected_data = prev_selected
+        layer._set_highlight()
 
 
 @register_shapes_action(trans._('Insert vertex'))

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import warnings
 import inspect
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import dask
@@ -95,6 +95,7 @@ def register_layer_alternate_hold_action(name, shortcuts=None):
         function unmodified to allow decorator stacking.
 
     """
+
     def _inner(func):
         nonlocal shortcuts, name
         name_ = 'napari:' + name

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -39,7 +39,6 @@ def register_layer_action(keymapprovider, description: str, shortcuts=None):
     function:
         Actual decorator to apply to a function. Given decorator returns the
         function unmodified to allow decorator stacking.
-
     """
 
     def _inner(func):
@@ -57,6 +56,41 @@ def register_layer_action(keymapprovider, description: str, shortcuts=None):
 
             for shortcut in shortcuts:
                 action_manager.bind_shortcut(name, shortcut)
+        return func
+
+    return _inner
+
+
+def register_layer_alternate_hold_action(n, shortcuts=None):
+    """
+    Allow to register an action alternate that is undone when a key (button?) is
+    released
+
+    See `register_layer_action`
+
+    Parameters
+    ----------
+    n : str
+        name of the action this is an alternate for.
+    shortcuts : str | List[str]
+        Shortcut to bind by default to the action we are registering.
+
+    Returns
+    -------
+    function:
+        Actual decorator to apply to a function. Given decorator returns the
+        function unmodified to allow decorator stacking.
+
+    """
+
+    def _inner(func):
+        nonlocal shortcuts
+        name = 'napari:' + n
+        action_manager._hold_actions[name] = func
+        if isinstance(shortcuts, str):
+            shortcuts = [shortcuts]
+        for shortcut in shortcuts:
+            action_manager.bind_hold_shortcut(name, shortcut)
         return func
 
     return _inner

--- a/napari/settings/_shortcuts.py
+++ b/napari/settings/_shortcuts.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 from pydantic import Field
 
 from ..utils.events.evented_model import EventedModel
-from ..utils.shortcuts import default_shortcuts
+from ..utils.shortcuts import default_hold_shortcuts, default_shortcuts
 from ..utils.translations import trans
 
 
@@ -13,6 +13,14 @@ class ShortcutsSettings(EventedModel):
         title=trans._("shortcuts"),
         description=trans._(
             "Set keyboard shortcuts for actions.",
+        ),
+    )
+
+    hold_shortcuts: Dict[str, List[str]] = Field(
+        default_hold_shortcuts,
+        title=trans._("hold shortcuts"),
+        description=trans._(
+            "Set keyboard shortcuts for hold actions.",
         ),
     )
 

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -173,10 +173,10 @@ class ActionManager:
             self._update_gui_elements(name)
 
     def _validate_action_name(self, name):
-        if ":" not in name:
+        if len(name.split(':')) != 2:
             raise ValueError(
                 trans._(
-                    'Action names need to be in the form `package:name`, got {name}',
+                    'Action names need to be in the form `package:name`, got {name!r}',
                     name=name,
                     deferred=True,
                 )

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -3,8 +3,17 @@ from __future__ import annotations
 import warnings
 from collections import defaultdict
 from dataclasses import dataclass
-from inspect import signature
-from typing import TYPE_CHECKING, Callable, Dict, List, Set, Tuple, Union
+from inspect import isgeneratorfunction, signature
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 from .interactions import Shortcut
 from .key_bindings import KeymapProvider
@@ -240,9 +249,9 @@ class ActionManager:
         self._validate_action_name(name)
         self._actions[name] = Action(command, description, keymapprovider)
         if alternate_hold:
-            if inspect.isgeneratorfunction(alternate_hold):
+            if not isgeneratorfunction(alternate_hold):
                 raise ValueError(
-                    'alternate_hold needs to be a generator function with a single yield.'
+                    f'alternate_hold needs to be a generator function with a single yield. Got {alternate_hold}'
                 )
             self._hold_actions[name] = alternate_hold
         self._update_shortcut_bindings(name)

--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -448,6 +448,9 @@ class KeymapHandler:
         if inspect.isgeneratorfunction(func):
             try:
                 next(gen)  # call function
+                assert (
+                    False
+                ), "We did not raise StopIteration, there is more than one yield"
             except StopIteration:  # only one statement
                 pass
             else:

--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -448,9 +448,6 @@ class KeymapHandler:
         if inspect.isgeneratorfunction(func):
             try:
                 next(gen)  # call function
-                assert (
-                    False
-                ), "We did not raise StopIteration, there is more than one yield"
             except StopIteration:  # only one statement
                 pass
             else:
@@ -466,9 +463,15 @@ class KeymapHandler:
             Key combination.
         """
         key, _ = parse_key_combo(key_combo)
+        if key not in self._key_release_generators:
+            return
         try:
             next(self._key_release_generators[key])  # call function
-        except (KeyError, StopIteration):
+            assert (
+                False
+            ), f"We did not raise StopIteration, is there more than one yield in `{self._key_release_generators[key]}`"
+        except StopIteration:
+            del self._key_release_generators[key]
             pass
 
     def on_key_press(self, event):

--- a/napari/utils/shortcuts.py
+++ b/napari/utils/shortcuts.py
@@ -41,3 +41,7 @@ default_shortcuts = {
     'napari:delete_selected_shapes': ['Backspace', 'Delete', '3'],
     'napari:finish_drawing_shape': ['Escape'],
 }
+
+default_hold_shortcuts = {
+    'napari:hold_to_lock_aspect_ratio': ['Shift'],
+}


### PR DESCRIPTION
I'm unsure we want to go this route, I initially went the direction of
having isgeneratorfunction in `register_action` but realise we do not
really want to have two action with different names for the generator
and the non generator. Typically pan_zoom.

So I went the route of allowing an alternate implementation for when we
register an action.
 - the normal one
 - the one for "hold to XXX".

Thus there is now 2 bind_shortcut: bind_shortcut and bind_hold_shortcut.

Both interact with the tooltips so that a button that allow to toggle to
pan zoom, with get (XXX or YYY or hold ZZZZ) as a tooltip.

I'm stopping here as I realises that the "hold to XXX" action are of the
form:

    def ....(....):
         do_stuff
         yield
         undo_stuff.

So I'm wondering if this could also fit nicely in the "undo" framework
we want, and if having action being callable with and optional "undo"
callable might be something better.

I'm also thinking that maybe there is room from Qt Buttons  that have
effects only while pressed. Definitely not pan to zoom as you use the
mouse for something else, but maybe YAGNI.

I'm also wondering if generator based action can be used without calling
the second part of the generator, I'm afraid it would/could leak some
memory state; I need to look at the code of the keymapprovider.



https://user-images.githubusercontent.com/335567/121090900-89509880-c7e9-11eb-80ed-ff1991d0fffa.mov

I press U  in the above video and you can see how this new shortcut is taken into account and how the tooltip is updated to shat to press Z, hold space or hold U. 


# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
