### PR TITLE
Fix Labels.fill for tensorstore data

### DIFF
--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1055,7 +1055,7 @@ class Labels(_ImageBase):
             return
 
         # If requested new label doesn't change old label then return
-        old_label = self.data[int_coord]
+        old_label = np.asarray(self.data[int_coord]).item()
         if old_label == new_label or (
             self.preserve_labels and old_label != self._background_label
         ):
@@ -1066,7 +1066,7 @@ class Labels(_ImageBase):
         for dim in dims_to_fill:
             data_slice_list[dim] = slice(None)
         data_slice = tuple(data_slice_list)
-        labels = self.data[data_slice]
+        labels = np.asarray(self.data[data_slice])
         slice_coord = tuple(int_coord[d] for d in dims_to_fill)
 
         matches = labels == old_label

--- a/setup.cfg
+++ b/setup.cfg
@@ -102,7 +102,7 @@ testing =
     scikit-image>=0.18.1
     pooch>=1.3.0
     semgrep
-    tensorstore>=0.1.10
+    tensorstore>=0.1.10,!=0.1.11
     torch>=1.7
 release = 
     PyGithub>=1.44.1


### PR DESCRIPTION
# Description

It turns out that tensorstore filling was broken, I'm not sure for how long, maybe forever. It's a simple matter of making sure that particular parts of the code deal with NumPy arrays rather than lazy tensorstore objects. These commits make those changes and add a test.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
