### PR TITLE
Be more robust for non-existant keybindings in settings.

### DIFF
--- a/docs/release/release_0_4_9.md
+++ b/docs/release/release_0_4_9.md
@@ -82,6 +82,7 @@ It also contains a variety of bug fixes and improvements.
 - Remove opacity from plugin sorter widget (#2840)
 - Fix Labels.fill for tensorstore data (#2856)
 - Be more robust for non-existant keybindings in settings (#2861)
+- trans NameError bugfix (#2865)
 
 
 ## Tasks

--- a/docs/release/release_0_4_9.md
+++ b/docs/release/release_0_4_9.md
@@ -80,6 +80,8 @@ It also contains a variety of bug fixes and improvements.
 - Fix keypress skipping layers in layerlist (#2837)
 - Fix octree imports (#2838)
 - Remove opacity from plugin sorter widget (#2840)
+- Fix Labels.fill for tensorstore data (#2856)
+- Be more robust for non-existant keybindings in settings (#2861)
 
 
 ## Tasks

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -274,8 +274,7 @@ class QtViewer(QSplitter):
         """Bind shortcuts stored in SETTINGS to actions."""
 
         for action, shortcuts in SETTINGS.shortcuts.shortcuts.items():
-            if action in action_manager._shortcuts:
-                action_manager.unbind_shortcut(action)
+            action_manager.unbind_shortcut(action)
             for shortcut in shortcuts:
                 action_manager.bind_shortcut(action, shortcut)
 


### PR DESCRIPTION
Non-existant keybindings configuration can arise from many places,
this includes but not limited to update of napari or plugins,
deactivation of plugins, typos ...

We try to be more conservative as to when we fail and emit a warning for
users which should help to catch typos.



<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How has this been tested?
created an invalid shortcut settings:

```
shortcuts:
  shortcuts:
    napari:activate_points_pan_zoom_mode:
    - U
    napari:i_do_not-exists:
    - Alt-Shift-X
 ```

Napari properly starts and warns:

```
UserWarning: Attempting to unbind an action which does not exists (napari:i_do_not_exists), this may have no effects. This can happen if your settings are out of date, if you upgraded napari, upgraded or deactivated a plugin, or made a typo in in your custom keybinding.
```
