### PR TITLE
Shortcuts UI

### DIFF
--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -187,8 +187,18 @@ class PreferencesDialog(QDialog):
         self._reset_dialog.exec_()
 
     def _reset_widgets(self, event=None):
-        """Deletes the widgets and rebuilds with defaults."""
+        """Deletes the widgets and rebuilds with defaults.
 
+        Parameter
+        ---------
+        event: bool
+            Indicates whether to restore the defaults.  When a user clicks "Restore", the signal
+            event emitted will be True.  If "Cancel" is selected, event will be False and nothing
+            is done.
+
+        """
+
+        print(event)
         if event is True:
             get_settings().reset()
             self.close()

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -3,19 +3,17 @@ import json
 from qtpy.QtCore import QSize, Signal
 from qtpy.QtWidgets import (
     QDialog,
-    QGridLayout,
     QHBoxLayout,
-    QLabel,
     QListWidget,
     QPushButton,
     QStackedWidget,
     QVBoxLayout,
-    QWidget,
 )
 
 from ..._vendor.qt_json_builder.qt_jsonschema_form import WidgetBuilder
 from ...utils.settings import get_settings
 from ...utils.translations import trans
+from .qt_message_dialogs import ConfirmDialog, ResetNapariInfoDialog
 
 
 class PreferencesDialog(QDialog):
@@ -188,19 +186,24 @@ class PreferencesDialog(QDialog):
         self._reset_dialog.valueChanged.connect(self._reset_widgets)
         self._reset_dialog.exec_()
 
-    def _reset_widgets(self):
+    def _reset_widgets(self, event=None):
         """Deletes the widgets and rebuilds with defaults."""
-        self.close()
-        self.valueChanged.emit()
-        self._list.clear()
 
-        for n in range(self._stack.count()):
-            widget = self._stack.removeWidget(self._stack.currentWidget())
-            del widget
+        if event is True:
+            get_settings().reset()
+            self.close()
+            self.valueChanged.emit()
+            self._list.clear()
 
-        self.make_dialog()
-        self._list.setCurrentRow(0)
-        self.show()
+            for n in range(self._stack.count()):
+                widget = self._stack.removeWidget(  # noqa: F841
+                    self._stack.currentWidget()
+                )
+                del widget
+
+            self.make_dialog()
+            self._list.setCurrentRow(0)
+            self.show()
 
     def on_click_ok(self):
         """Keeps the selected preferences saved to settings."""
@@ -383,86 +386,3 @@ class PreferencesDialog(QDialog):
 
                 except:  # noqa: E722
                     continue
-
-
-class ConfirmDialog(QDialog):
-    """Dialog to confirms a user's choice to restore default settings."""
-
-    valueChanged = Signal()
-
-    def __init__(
-        self,
-        parent: QWidget = None,
-        text: str = "",
-    ):
-        super().__init__(parent)
-
-        # Set up components
-        self._question = QLabel(self)
-        self._button_restore = QPushButton(trans._("Restore"))
-        self._button_cancel = QPushButton(trans._("Cancel"))
-
-        # Widget set up
-        self._question.setText(text)
-
-        # Layout
-        button_layout = QHBoxLayout()
-        button_layout.addWidget(self._button_cancel)
-        button_layout.addWidget(self._button_restore)
-
-        main_layout = QVBoxLayout()
-        main_layout.addWidget(self._question)
-        main_layout.addLayout(button_layout)
-
-        self.setLayout(main_layout)
-
-        # Signals
-        self._button_cancel.clicked.connect(self.on_click_cancel)
-        self._button_restore.clicked.connect(self.on_click_restore)
-
-    def on_click_cancel(self):
-        """Do not restore defaults and close window."""
-        self.close()
-
-    def on_click_restore(self):
-        """Restore defaults and close window."""
-        get_settings().reset()
-        self.valueChanged.emit()
-        self.close()
-
-
-class ResetNapariInfoDialog(QDialog):
-    """Dialog to inform the user that restart of Napari is necessary to enable setting."""
-
-    valueChanged = Signal()
-
-    def __init__(
-        self,
-        parent: QWidget = None,
-        text: str = "",
-    ):
-        super().__init__(parent)
-        # Set up components
-        self._info_str = QLabel(self)
-        self._button_ok = QPushButton(trans._("OK"))
-        # Widget set up
-        self._info_str.setText(text)
-
-        # Layout
-        button_layout = QGridLayout()
-        button_layout.addWidget(self._button_ok, 0, 1)
-        button_layout.setColumnStretch(0, 1)
-        button_layout.setColumnStretch(1, 1)
-
-        main_layout = QVBoxLayout()
-        main_layout.addWidget(self._info_str)
-        main_layout.addLayout(button_layout)
-
-        self.setLayout(main_layout)
-
-        # Signals
-        self._button_ok.clicked.connect(self._close_dialog)
-
-    def _close_dialog(self):
-        """Close window."""
-        self.close()

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -198,7 +198,6 @@ class PreferencesDialog(QDialog):
 
         """
 
-        print(event)
         if event is True:
             get_settings().reset()
             self.close()

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -26,6 +26,7 @@ class PreferencesDialog(QDialog):
     ui_schema = {
         "call_order": {"ui:widget": "plugins"},
         "highlight_thickness": {"ui:widget": "highlight"},
+        "shortcuts": {"ui:widget": "shortcuts"},
     }
 
     resized = Signal(QSize)

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -226,6 +226,10 @@ class PreferencesDialog(QDialog):
             schema, new_values, properties = self.get_page_dict(setting)
             self.check_differences(self._values_orig_dict[page], new_values)
 
+        # need to reset plugin_manager to defaults and change keybindings in action_manager.
+        # Emit signal to do this in main window.
+        self.valueChanged.emit()
+
         self._list.setCurrentRow(0)
         self.close()
 

--- a/napari/_qt/dialogs/qt_message_dialogs.py
+++ b/napari/_qt/dialogs/qt_message_dialogs.py
@@ -1,0 +1,96 @@
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import (
+    QDialog,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ...utils.translations import trans
+
+
+class ConfirmDialog(QDialog):
+    """Dialog to confirms a user's choice to restore default settings."""
+
+    valueChanged = Signal(bool)
+
+    def __init__(
+        self,
+        parent: QWidget = None,
+        text: str = "",
+    ):
+        super().__init__(parent)
+
+        # Set up components
+        self._question = QLabel(self)
+        self._button_restore = QPushButton(trans._("Restore"))
+        self._button_cancel = QPushButton(trans._("Cancel"))
+
+        # Widget set up
+        self._question.setText(text)
+
+        # Layout
+        button_layout = QHBoxLayout()
+        button_layout.addWidget(self._button_cancel)
+        button_layout.addWidget(self._button_restore)
+
+        main_layout = QVBoxLayout()
+        main_layout.addWidget(self._question)
+        main_layout.addLayout(button_layout)
+
+        self.setLayout(main_layout)
+
+        # Signals
+        self._button_cancel.clicked.connect(self.on_click_cancel)
+        self._button_restore.clicked.connect(self.on_click_restore)
+
+    def on_click_cancel(self):
+        """Do not restore defaults and close window."""
+        self.valueChanged.emit(False)
+        self.close()
+
+    def on_click_restore(self):
+        """Restore defaults and close window."""
+        # get_settings().reset()
+        self.valueChanged.emit(True)
+        self.close()
+
+
+class ResetNapariInfoDialog(QDialog):
+    """Dialog to inform the user that restart of Napari is necessary to enable setting."""
+
+    valueChanged = Signal()
+
+    def __init__(
+        self,
+        parent: QWidget = None,
+        text: str = "",
+    ):
+        super().__init__(parent)
+        # Set up components
+        self._info_str = QLabel(self)
+        self._button_ok = QPushButton(trans._("OK"))
+        # Widget set up
+        self._info_str.setText(text)
+
+        # Layout
+        button_layout = QGridLayout()
+        button_layout.addWidget(self._button_ok, 0, 1)
+        button_layout.setColumnStretch(0, 1)
+        button_layout.setColumnStretch(1, 1)
+
+        main_layout = QVBoxLayout()
+        main_layout.addWidget(self._info_str)
+        main_layout.addLayout(button_layout)
+
+        self.setLayout(main_layout)
+
+        # Signals
+        self._button_ok.clicked.connect(self._close_dialog)
+
+    def _close_dialog(self):
+        """Close window."""
+        self.close()

--- a/napari/_qt/dialogs/qt_message_dialogs.py
+++ b/napari/_qt/dialogs/qt_message_dialogs.py
@@ -53,8 +53,7 @@ class ConfirmDialog(QDialog):
         self.close()
 
     def on_click_restore(self):
-        """Restore defaults and close window."""
-        # get_settings().reset()
+        """Emit signal to restore defaults and close window."""
         self.valueChanged.emit(True)
         self.close()
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -620,21 +620,29 @@ class Window:
                 win.resize(self._qt_window._preferences_dialog_size)
 
             self._qt_window._preferences_dialog = win
-            win.valueChanged.connect(self._reset_plugin_state)
+            win.valueChanged.connect(self._reset_preference_states)
             win.closed.connect(self._on_preferences_closed)
             win.show()
         else:
             self._qt_window._preferences_dialog.raise_()
 
-    def _reset_plugin_state(self):
+    def _reset_preference_states(self):
         # resetting plugin states in plugin manager
         plugin_manager._blocked.clear()
 
         plugin_manager.discover()
 
+        settings = get_settings()
         # need to reset call order to defaults
+        if settings.plugins.call_order is not None:
+            plugin_manager.set_call_order(get_settings().plugins.call_order)
+        else:
+            plugin_manager.set_call_order(
+                settings._defaults['plugins'].call_order
+            )
 
-        plugin_manager.set_call_order(get_settings().plugins.call_order)
+        # reset the keybindings in action manager
+        self.qt_viewer._bind_shortcuts()
 
     def _on_preferences_closed(self):
         """Reset preferences dialog variable."""

--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -409,6 +409,14 @@ QtAbout > QTextEdit{
   padding: 2px;
 }
 
+/* ------------ Shortcut Editor ------------ */
+
+ShortcutEditor QHeaderView::section {
+  padding: 2px;
+  border: None;
+}
+
+
 /* ------------ Plugin Sorter ------------ */
 
 ImplementationListItem {

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -1,0 +1,21 @@
+import pytest
+
+from napari._qt.widgets.qt_keyboard_settings import ShortcutEditor
+
+
+@pytest.fixture
+def shortcut_editor_widget(qtbot):
+    def _shortcut_editor_widget(**kwargs):
+        widget = ShortcutEditor(**kwargs)
+        widget.show()
+        qtbot.addWidget(widget)
+
+        return widget
+
+    return _shortcut_editor_widget
+
+
+def test_shortcut_editor_defaults(
+    shortcut_editor_widget,
+):
+    shortcut_editor_widget()

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -247,7 +247,6 @@ class ShortcutEditor(QWidget):
             item1 = self._table.currentItem()
             new_shortcut = item1.text()
             new_shortcut = new_shortcut[0].upper() + new_shortcut[1:]
-            print('right after get item', new_shortcut)
 
             # get the action name
             current_action = self._table.item(row, self._action_col).text()
@@ -272,10 +271,7 @@ class ShortcutEditor(QWidget):
                         current_shortcuts = list(
                             action_manager._shortcuts.get(current_action, {})
                         )
-                        print('current', current_shortcuts)
-                        print(len(current_shortcuts))
                         if len(current_shortcuts) > 0:
-                            print('check 3', current_shortcuts[0])
                             self._skip = True
                             item1.setText(
                                 Shortcut(current_shortcuts[0]).platform
@@ -291,6 +287,7 @@ class ShortcutEditor(QWidget):
                     else:
                         # this one was here, need to re-format in case its not done
                         csc = Shortcut(new_shortcut).platform
+                        self._skip = True
                         item1.setText(csc)
 
             if replace is True:
@@ -300,11 +297,9 @@ class ShortcutEditor(QWidget):
                 # all the other widgets.
 
                 #  Bind new shortcut to the action manager
-                print('current action', current_action)
                 action_manager.unbind_shortcut(current_action)
 
                 if new_shortcut != "":
-                    print(new_shortcut)
                     # look for special symbols
 
                     action_manager.bind_shortcut(current_action, new_shortcut)
@@ -460,11 +455,9 @@ class EditorWidget(QLineEdit):
     def event(self, event):
         """Qt method override."""
         if event.type() == QEvent.ShortcutOverride:
-            print('check 1')
             self.keyPressEvent(event)
             return True
         elif event.type() in [QEvent.KeyPress, QEvent.Shortcut]:
-            print('check 2', event.key())
             return True
         else:
             return super().event(event)
@@ -487,11 +480,7 @@ class EditorWidget(QLineEdit):
 
         translator = ShortcutTranslator()
         event_keyseq = translator.keyevent_to_keyseq(event)
-        # print('event_keyseq', event_keyseq)
-        # print('event to string', event_keyseq.toString())
         event_keystr = event_keyseq.toString(QKeySequence.PortableText)
-        # print(len(event_keystr))
-        # print('event_keystr', event_keystr)
 
         self._shortcut = event_keystr
 
@@ -504,9 +493,7 @@ class EditorWidget(QLineEdit):
                 keys.append(val)
 
         keys = '-'.join(keys)
-        print('setting key', keys)
         self.setText(keys)
-        print('done setting')
 
         # super().keyPressEvent(event)
 
@@ -527,10 +514,8 @@ class ShortcutTranslator(QKeySequenceEdit):
 
     def keyevent_to_keyseq(self, event):
         """Return a QKeySequence representation of the provided QKeyEvent."""
-        print(event)
         self.keyPressEvent(event)
         event.accept()
-        print('keyseq!!!!', self.keySequence().toString())
         return self.keySequence()
 
     def keyReleaseEvent(self, event):

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -1,4 +1,6 @@
-from qtpy.QtCore import Qt
+from collections import OrderedDict
+
+from qtpy.QtCore import Qt  # Signal
 from qtpy.QtWidgets import (
     QComboBox,
     QDialog,
@@ -12,6 +14,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from ...layers import Image, Labels, Points, Shapes, Surface, Vectors
 from ...utils.action_manager import action_manager
 from ...utils.settings import SETTINGS
 from ...utils.translations import trans
@@ -22,14 +25,36 @@ from ...utils.translations import trans
 class ShortcutEditor(QDialog):
     """ """
 
+    # onChanged = Signal(list[str, str])
+
     def __init__(
         self,
+        # viewer,
+        # key_map_handler,
         parent: QWidget = None,
         description: str = "",
         value: dict = None,
     ):
 
-        super().__init__(parent)
+        super().__init__(parent=parent)
+
+        #  for name, shortcut in self._shortcuts.items():
+        #         action = self._actions.get(name, None)
+        #         if action and layer == action.keymapprovider:
+        #             layer_shortcuts[layer][str(shortcut)] = action.description
+
+        # col = theme['secondary']
+        layers = [
+            Image,
+            Labels,
+            Points,
+            Shapes,
+            Surface,
+            Vectors,
+        ]
+
+        self.key_bindings_strs = OrderedDict()
+        self.key_bindings_strs[trans._('All active key bindings')] = 'base'
 
         # widgets
         self.layer_combo_box = QComboBox(self)
@@ -40,39 +65,23 @@ class ShortcutEditor(QDialog):
         self._restore_button = QPushButton(trans._("Reset All Keybindings"))
 
         # set up
-        self.layer_combo_box.addItems(['All Active Keybindings'])
+        for layer in layers:
+            self.key_bindings_strs[f"{layer.__name__} layer"] = layer
+
+        self.layer_combo_box.addItems(list(self.key_bindings_strs))
         self._label.setText("Layer")
 
-        self._table.horizontalHeader().setStretchLastSection(True)
-        self._table.horizontalHeader().setSectionResizeMode(
-            QHeaderView.Stretch
-        )
-        self._table.setRowCount(len(SETTINGS.shortcuts.shortcuts))
-        self._table.setColumnCount(2)
-        self._table.setHorizontalHeaderLabels(['Action', 'Keybinding'])
-        self._table.verticalHeader().setVisible(False)
-        # myTableWidget->verticalHeader()->setVisible(false);
+        # layer_shortcuts = action_manager._get_layer_shortcuts(layers)
+        # print(layer_shortcuts)
 
-        for row, (action_name, action) in enumerate(
-            action_manager._actions.items()
-        ):
-            shortcuts = action_manager._shortcuts.get(action_name, [])
-            # for row, (action_name, shortcuts) in enumerate(SETTINGS.shortcuts.shortcuts.items()):
-            # shortcuts = action_manager._shortcuts.get(action_name, [])
-            item = QTableWidgetItem(action_name)
-            item = QTableWidgetItem(action.description)
+        #     if len(layer.class_keymap) == 0:
+        #         text = trans._('No key bindings')
+        #     else:
+        #         text = get_key_bindings_summary(
+        #             layer_shortcuts[layer], col=col
+        #         )
 
-            item.setFlags(item.flags() & ~Qt.ItemIsEditable)
-
-            self._table.setItem(row, 0, item)
-            item_shortcut = QTableWidgetItem(
-                list(shortcuts)[0] if shortcuts else ""
-            )
-
-            self._table.setItem(row, 1, item_shortcut)
-
-        self._table.itemChanged.connect(self._set_keybinding)
-        self._table.cellChanged.connect(self._set_keybinding2)
+        self._set_table()
 
         # layout
 
@@ -94,29 +103,169 @@ class ShortcutEditor(QDialog):
 
         self.setLayout(layout)
 
-    def _set_keybinding(self, event):
-        # print(event)
-        print(event.text())
+    def _set_table(self, layer=None):
 
-    def _set_keybinding2(self, event):
+        self._table.horizontalHeader().setStretchLastSection(True)
+        self._table.horizontalHeader().setSectionResizeMode(
+            QHeaderView.Stretch
+        )
+        self._table.setRowCount(len(action_manager._actions))
+        self._table.setColumnCount(3)
+        self._table.setHorizontalHeaderLabels(['Action', 'Keybinding'])
+        self._table.verticalHeader().setVisible(False)
+
+        self._table.setColumnHidden(2, True)
+
+        for row, (action_name, action) in enumerate(
+            action_manager._actions.items()
+        ):
+            shortcuts = action_manager._shortcuts.get(action_name, [])
+            # for row, (action_name, shortcuts) in enumerate(SETTINGS.shortcuts.shortcuts.items()):
+            # shortcuts = action_manager._shortcuts.get(action_name, [])
+            item = QTableWidgetItem(action.description)
+
+            item.setFlags(item.flags() & ~Qt.ItemIsEditable)
+
+            self._table.setItem(row, 0, item)
+            item_shortcut = QTableWidgetItem(
+                list(shortcuts)[0] if shortcuts else ""
+            )
+
+            self._table.setItem(row, 1, item_shortcut)
+
+            item_action = QTableWidgetItem(action_name)
+            # action_name is stored in the table to use later, but is not shown on dialog.
+            self._table.setItem(row, 2, item_action)
+
+        # self._table.itemChanged.connect(self._set_keybinding)
+        self._table.cellChanged.connect(self._set_keybinding)
+
+    def _set_keybinding(self, event):
         # event is the index of the event.
 
-        # get the current item (keyboard shortcut)
-        shortcut = self._table.currentItem()
-        # get the current action for the keyboard shortcut
-        item2 = self._table.item(event, 0).text()
-        print(item2)
+        # get the current item from shortcuts column
+        item1 = self._table.currentItem()
+        new_shortcut = item1.text()
+        # get the current action description
+        # action_description = self._table.item(event, 0).text()
+
+        # get the action name
+        current_action = self._table.item(event, 2).text()
         # print(action_manager._actions.items()[event]._description)
         # print(event.text())
-
+        #
         # check if shortcut is in use in layer or globally
-        print(action_manager._shortcuts)
+        # current_shortcut = list(
+        #     action_manager._shortcuts.get(current_action, [])
+        # )[0]
+
+        replace = True
         for row, (action_name, action) in enumerate(
             action_manager._actions.items()
         ):
             shortcuts = action_manager._shortcuts.get(action_name, [])
 
-            if shortcut in shortcuts:
-                # this is here, give warning
-                # pop up window for warning.
-                pass
+            if new_shortcut in shortcuts:
+                # shortcut is here (either same action or not), don't replace in settings.
+                replace = False
+                if action_name != current_action:
+                    # the shortcut is saved to a different action, show message.
+                    # pop up window for warning.
+                    message = trans._(
+                        f"The keybinding <b>{new_shortcut}</b> "
+                        + f"is already assigned to <b>{action.description}</b>; change or clear "
+                        + f"that shortcut before assigning <b>{new_shortcut}</b> to this one."
+                    )
+
+                    print(message)
+
+                    self._warn_dialog = KeyBindWarnPopup(
+                        parent=self,
+                        text=message,
+                    )
+                    # self._reset_dialog.valueChanged.connect(print('works!'))
+                    self._warn_dialog.exec_()
+
+                    # get the original shortcut
+                    current_shortcuts = list(
+                        action_manager._shortcuts.get(current_action, {})
+                    )
+                    # reset value in table to value stored in action manager.
+                    item1.setText(current_shortcuts[0])
+
+                    print('done!')
+
+                    break
+
+            # else:
+
+        print('replace', replace)
+        if replace is True:
+
+            # this shortcut is not taken, can set it and save in settings
+            # how are we doing this? saving in settings and then that triggers to update the action manager?
+            # right now I'm updating the action manager, and settings will be saved after a trigger as with
+            # all the other widgets.
+
+            #  Bind new shortcut to the action manager
+            print('unbind', current_action)
+            action_manager.unbind_shortcut(current_action)
+            print('bind', new_shortcut)
+            action_manager.bind_shortcut(current_action, new_shortcut)
+
+            #     break
+            # Save to settings here temporarily
+            if current_action in SETTINGS.shortcuts.shortcuts:
+                # This one was here, need to save the new shortcut
+                SETTINGS.shortcuts.shortcuts[current_action][0] = new_shortcut
+            else:
+                # this action not currently set in SETTINGS, need to save it.
+                SETTINGS.shortcuts.shortcuts[current_action] = [new_shortcut]
+
+                # self.onChanged.emit([action, new_shortcut])
+
+    def value(self):
+        # need to return value from widget.
+        pass
+
+
+class KeyBindWarnPopup(QDialog):
+    """Dialog to inform user that shortcut is already assigned."""
+
+    # valueChanged = Signal()
+
+    def __init__(
+        self,
+        parent: QWidget = None,
+        text: str = "",
+    ):
+        super().__init__(parent)
+
+        # self.setWindowFlags(Qt.FramelessWindowHint)
+
+        # Set up components
+        self._message = QLabel(self)
+
+        # Widget set up
+        self._message.setText(text)
+        self._message.setWordWrap(True)
+
+        # Layout
+        main_layout = QVBoxLayout()
+        main_layout.addWidget(self._message)
+
+        self.setLayout(main_layout)
+
+        # # Signals
+        # self._button_cancel.clicked.connect(self.on_click_cancel)
+        # self._button_restore.clicked.connect(self.on_click_restore)
+
+    #     QDialog *popup = new QDialog(0, Qt::Popup | Qt::FramelessWindowHint);
+    # QVBoxLayout *layout = new QVBoxLayout;
+    # QLabel *popupLabel = new QLabel(data_.value(rowIndex).displayHtml(), 0);
+    # layout->addWidget(popupLabel);
+    # popupLabel->setTextFormat(Qt::RichText);
+    # popupLabel->setOpenExternalLinks(true);
+    # popup->setLayout(layout);
+    # popup->move(location);
+    # popup->exec();

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -237,8 +237,6 @@ class ShortcutEditor(QDialog):
                             + f"that shortcut before assigning <b>{new_shortcut}</b> to this one."
                         )
 
-                        # style = self.style()
-
                         delta_y = 105
                         delta_x = 10
                         global_point = self.mapToGlobal(
@@ -275,7 +273,10 @@ class ShortcutEditor(QDialog):
                             action_manager._shortcuts.get(current_action, {})
                         )
                         # reset value in table to value stored in action manager.
-                        item1.setText(current_shortcuts[0])
+                        if len(current_shortcuts) > 0:
+                            item1.setText(current_shortcuts[0])
+                        else:
+                            item1.setText("")
 
                         self._table.setCellWidget(
                             row, self._icon_col, QLabel("")
@@ -299,7 +300,8 @@ class ShortcutEditor(QDialog):
 
                 #  Bind new shortcut to the action manager
                 action_manager.unbind_shortcut(current_action)
-                action_manager.bind_shortcut(current_action, new_shortcut)
+                if new_shortcut != "":
+                    action_manager.bind_shortcut(current_action, new_shortcut)
 
                 # Save to settings here temporarily (probably won't do this here)
                 if current_action in SETTINGS.shortcuts.shortcuts:

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -176,6 +176,10 @@ class ShortcutEditor(QWidget):
         try:
             self._table.cellChanged.disconnect(self._set_keybinding)
         except TypeError:
+            # if building the first time, the cells are not yet connected so this would fail.
+            pass
+        except RuntimeError:
+            # Needed to pass some tests.
             pass
 
         self._table.clearContents()

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -1,0 +1,122 @@
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ...utils.action_manager import action_manager
+from ...utils.settings import SETTINGS
+from ...utils.translations import trans
+
+# from qtpy.QtCore import Qt.ItemIsEditable
+
+
+class ShortcutEditor(QDialog):
+    """ """
+
+    def __init__(
+        self,
+        parent: QWidget = None,
+        description: str = "",
+        value: dict = None,
+    ):
+
+        super().__init__(parent)
+
+        # widgets
+        self.layer_combo_box = QComboBox(self)
+        self._label = QLabel(self)
+        self._table = QTableWidget(self)
+
+        # Set up buttons
+        self._restore_button = QPushButton(trans._("Reset All Keybindings"))
+
+        # set up
+        self.layer_combo_box.addItems(['All Active Keybindings'])
+        self._label.setText("Layer")
+
+        self._table.horizontalHeader().setStretchLastSection(True)
+        self._table.horizontalHeader().setSectionResizeMode(
+            QHeaderView.Stretch
+        )
+        self._table.setRowCount(len(SETTINGS.shortcuts.shortcuts))
+        self._table.setColumnCount(2)
+        self._table.setHorizontalHeaderLabels(['Action', 'Keybinding'])
+        self._table.verticalHeader().setVisible(False)
+        # myTableWidget->verticalHeader()->setVisible(false);
+
+        for row, (action_name, action) in enumerate(
+            action_manager._actions.items()
+        ):
+            shortcuts = action_manager._shortcuts.get(action_name, [])
+            # for row, (action_name, shortcuts) in enumerate(SETTINGS.shortcuts.shortcuts.items()):
+            # shortcuts = action_manager._shortcuts.get(action_name, [])
+            item = QTableWidgetItem(action_name)
+            item = QTableWidgetItem(action.description)
+
+            item.setFlags(item.flags() & ~Qt.ItemIsEditable)
+
+            self._table.setItem(row, 0, item)
+            item_shortcut = QTableWidgetItem(
+                list(shortcuts)[0] if shortcuts else ""
+            )
+
+            self._table.setItem(row, 1, item_shortcut)
+
+        self._table.itemChanged.connect(self._set_keybinding)
+        self._table.cellChanged.connect(self._set_keybinding2)
+
+        # layout
+
+        hlayout1 = QHBoxLayout()
+
+        hlayout1.addWidget(self._label)
+        hlayout1.addWidget(self.layer_combo_box)
+        hlayout1.setContentsMargins(0, 0, 0, 0)
+        hlayout1.setSpacing(20)
+        hlayout1.addStretch(0)
+
+        hlayout2 = QHBoxLayout()
+        hlayout2.addLayout(hlayout1)
+        hlayout2.addWidget(self._restore_button)
+
+        layout = QVBoxLayout()
+        layout.addLayout(hlayout2)
+        layout.addWidget(self._table)
+
+        self.setLayout(layout)
+
+    def _set_keybinding(self, event):
+        # print(event)
+        print(event.text())
+
+    def _set_keybinding2(self, event):
+        # event is the index of the event.
+
+        # get the current item (keyboard shortcut)
+        shortcut = self._table.currentItem()
+        # get the current action for the keyboard shortcut
+        item2 = self._table.item(event, 0).text()
+        print(item2)
+        # print(action_manager._actions.items()[event]._description)
+        # print(event.text())
+
+        # check if shortcut is in use in layer or globally
+        print(action_manager._shortcuts)
+        for row, (action_name, action) in enumerate(
+            action_manager._actions.items()
+        ):
+            shortcuts = action_manager._shortcuts.get(action_name, [])
+
+            if shortcut in shortcuts:
+                # this is here, give warning
+                # pop up window for warning.
+                pass

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -275,7 +275,7 @@ class ShortcutEditor(QWidget):
 
         if col == self._shortcut_col:
             # Get all layer actions and viewer actions in order to determine
-            # the new shortcut is not already set.
+            # the new shortcut is not already set to an action.
 
             current_layer_text = self.layer_combo_box.currentText()
             layer_actions = self.key_bindings_strs[current_layer_text]
@@ -292,7 +292,7 @@ class ShortcutEditor(QWidget):
             new_shortcut = current_item.text()
             new_shortcut = new_shortcut[0].upper() + new_shortcut[1:]
 
-            # get the action name
+            # get the current action name
             current_action = self._table.item(row, self._action_col).text()
 
             # get the original shortcutS
@@ -326,7 +326,7 @@ class ShortcutEditor(QWidget):
                         self._show_warning(new_shortcut, action, row, message)
 
                         if len(current_shortcuts) > 0:
-                            # If there was a shortcut set, then format it and reset the text.
+                            # If there was a shortcut set originally, then format it and reset the text.
                             format_shortcut = Shortcut(
                                 current_shortcuts[0]
                             ).platform
@@ -355,7 +355,7 @@ class ShortcutEditor(QWidget):
                         current_item.setText(format_shortcut)
 
             if replace is True:
-                # This shortcut is not taken, so can be set in settings.
+                # This shortcut is not taken.
 
                 #  Unbind current action from shortcuts in action manager.
                 action_manager.unbind_shortcut(current_action)
@@ -367,6 +367,7 @@ class ShortcutEditor(QWidget):
                             current_action, new_shortcut
                         )
                     except TypeError:
+                        # Shortcut is not valid.
                         action_manager._shortcuts[current_action] = set()
                         # need to rebind the old shortcut
                         action_manager.unbind_shortcut(current_action)
@@ -374,7 +375,9 @@ class ShortcutEditor(QWidget):
                             current_action, current_shortcuts[0]
                         )
 
+                        # Show warning message to let user know this shortcut is invalid.
                         self._show_warning_icons([row])
+
                         message = trans._(
                             "<b>{new_shortcut}</b> is not a valid keybinding.",
                             new_shortcut=new_shortcut,
@@ -394,13 +397,15 @@ class ShortcutEditor(QWidget):
                         current_item.setText(format_shortcut)
                         return
 
+                    # The new shortcut is valid and can be displayed in widget.
+
                     # Keep track of what changed.
                     new_value_dict = {current_action: [new_shortcut]}
 
-                    # Format shortcut before setting.
+                    # Format new shortcut.
                     format_shortcut = Shortcut(new_shortcut).platform
                     if format_shortcut != new_shortcut:
-                        # Skip the next round if there are special symbols.
+                        # Skip the next round because there are special symbols.
                         self._skip = True
 
                     # Update text to formated shortcut.
@@ -455,6 +460,8 @@ class ShortcutEditor(QWidget):
             Action that is already assigned with the shortcut.
         row: int
             Row in table where the shortcut is attempting to be set.
+        message: str
+            Message to be displayed in warning pop up.
         """
 
         # Determine placement of warning message.

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -49,6 +49,10 @@ class ShortcutEditor(QDialog):
         self._qsequences = list()
         self._new_keys = ''
 
+        print('ShortcutOverride', QEvent.ShortcutOverride)
+        print('keypress', QEvent.KeyPress)
+        print('shortcut', QEvent.Shortcut)
+
         layers = [
             Image,
             Labels,
@@ -114,22 +118,24 @@ class ShortcutEditor(QDialog):
 
         self.setLayout(layout)
 
-    def event(self, event):
-        """Qt method override."""
-        # We reroute all ShortcutOverride events to our keyPressEvent and block
-        # any KeyPress and Shortcut event. This allows to register default
-        # Qt shortcuts for which no key press event are emitted.
-        # See spyder-ide/spyder/issues/10786.
-        # spyder code
-        if event.type() == QEvent.ShortcutOverride:
-            print('check 1')
-            self.keyPressEvent(event)
-            return True
-        elif event.type() in [QEvent.KeyPress, QEvent.Shortcut]:
-            print('check 2')
-            return True
-        else:
-            return super().event(event)
+    # def event(self, event):
+    #     """Qt method override."""
+    #     # We reroute all ShortcutOverride events to our keyPressEvent and block
+    #     # any KeyPress and Shortcut event. This allows to register default
+    #     # Qt shortcuts for which no key press event are emitted.
+    #     # See spyder-ide/spyder/issues/10786.
+    #     # spyder code
+
+    #     if event.type() == QEvent.ShortcutOverride:
+    #         print('check 1')
+    #         self.keyPressEvent(event)
+    #         return True
+    #     elif event.type() in [QEvent.KeyPress, QEvent.Shortcut]:
+    #         print('check 2', event.key())
+    #         return True
+    #     else:
+    #         print('check 2b')
+    #         return super().event(event)
 
     def keyPressEvent(self, event):
         """Qt method override."""

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -27,6 +27,10 @@ from ...utils.translations import trans
 from ..dialogs.qt_message_dialogs import ConfirmDialog
 from ..qt_resources import get_stylesheet
 
+# Dict used to format strings returned from converted key press events.
+# For example, the ShortcutTranslator returns 'Ctrl' instead of 'Control'.
+# In order to be consistent with the code base, the values in KEY_SUBS will
+# be subsituted.
 KEY_SUBS = {'Ctrl': 'Control'}
 
 

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from qtpy.QtCore import QEvent, QPoint, Qt, Signal
 from qtpy.QtGui import QKeySequence
 from qtpy.QtWidgets import (
+    QAbstractItemView,
     QComboBox,
     QDialog,
     QHBoxLayout,
@@ -29,7 +30,7 @@ from ..qt_resources import get_stylesheet
 KEY_SUBS = {'Ctrl': 'Control'}
 
 
-class ShortcutEditor(QDialog):
+class ShortcutEditor(QWidget):
     """ """
 
     valueChanged = Signal(dict)
@@ -48,6 +49,7 @@ class ShortcutEditor(QDialog):
 
         self._qsequences = list()
         self._new_keys = ''
+        self._skip = False
 
         print('ShortcutOverride', QEvent.ShortcutOverride)
         print('keypress', QEvent.KeyPress)
@@ -68,7 +70,8 @@ class ShortcutEditor(QDialog):
         self.layer_combo_box = QComboBox(self)
         self._label = QLabel(self)
         self._table = QTableWidget(self)
-
+        self._table.setSelectionBehavior(QAbstractItemView.SelectItems)
+        self._table.setSelectionMode(QAbstractItemView.SingleSelection)
         self._table.setShowGrid(False)
 
         # Set up buttons
@@ -118,73 +121,6 @@ class ShortcutEditor(QDialog):
 
         self.setLayout(layout)
 
-    # def event(self, event):
-    #     """Qt method override."""
-    #     # We reroute all ShortcutOverride events to our keyPressEvent and block
-    #     # any KeyPress and Shortcut event. This allows to register default
-    #     # Qt shortcuts for which no key press event are emitted.
-    #     # See spyder-ide/spyder/issues/10786.
-    #     # spyder code
-
-    #     if event.type() == QEvent.ShortcutOverride:
-    #         print('check 1')
-    #         self.keyPressEvent(event)
-    #         return True
-    #     elif event.type() in [QEvent.KeyPress, QEvent.Shortcut]:
-    #         print('check 2', event.key())
-    #         return True
-    #     else:
-    #         print('check 2b')
-    #         return super().event(event)
-
-    def keyPressEvent(self, event):
-        """Qt method override."""
-
-        event_key = event.key()
-        if not event_key or event_key == Qt.Key_unknown:
-            return
-        if len(self._qsequences) == 4:
-            # QKeySequence accepts a maximum of 3 different sequences.
-            return
-        if event_key in [
-            Qt.Key_Control,
-            Qt.Key_Shift,
-            Qt.Key_Alt,
-            Qt.Key_Meta,
-            Qt.Key_Return,
-            Qt.Key_Tab,
-        ]:
-            # do we want to be able to set these?
-            return
-
-        translator = ShortcutTranslator()
-        event_keyseq = translator.keyevent_to_keyseq(event)
-        # print('event_keyseq', event_keyseq)
-        # print('event to string', event_keyseq.toString())
-        event_keystr = event_keyseq.toString(QKeySequence.PortableText)
-        # print(len(event_keystr))
-        # print('event_keystr', event_keystr)
-
-        self._qsequences.append(event_keystr)
-
-        if len(self._qsequences[-1]) > 0:
-            item1 = self._table.currentItem()
-
-            parsed = re.split('[-(?=.+)]', self._qsequences[-1])
-            keys = []
-            for val in parsed:
-                if val in KEY_SUBS.keys():
-                    keys.append(KEY_SUBS[val])
-                else:
-                    keys.append(val)
-
-            keys = '-'.join(keys)
-            self._new_keys = keys
-            print('setting key')
-            item1.setText(Shortcut(keys).platform)
-            print('done setting')
-            return
-
     def restore_defaults(self):
         """Launches dialog to confirm restore choice."""
         self._reset_dialog = ConfirmDialog(
@@ -216,8 +152,8 @@ class ShortcutEditor(QDialog):
         self._action_col = 3
 
         header_strs = ['', '', '', '']
-        header_strs[self._action_name_col] = 'Action'
-        header_strs[self._shortcut_col] = 'Keybinding'
+        header_strs[self._action_name_col] = trans._('Action')
+        header_strs[self._shortcut_col] = trans._('Keybinding')
 
         if layer_str == '':
             layer_str = self.ALL_ACTIVE_KEYBINDINGS
@@ -259,11 +195,15 @@ class ShortcutEditor(QDialog):
             for row, (action_name, action) in enumerate(actions.items()):
                 shortcuts = action_manager._shortcuts.get(action_name, [])
                 item = QTableWidgetItem(action.description)
-
-                item.setFlags(item.flags() & ~Qt.ItemIsEditable)
+                item.setFlags(Qt.NoItemFlags)
                 # item.setStyleSheet('border-top: 1px solid white; border-bottom: 1px solid white;')
 
                 self._table.setItem(row, self._action_name_col, item)
+
+                item = QTableWidgetItem("")
+                item.setFlags(Qt.NoItemFlags)
+                self._table.setItem(row, self._icon_col, item)
+
                 item_shortcut = QTableWidgetItem(
                     Shortcut(list(shortcuts)[0]).platform if shortcuts else ""
                 )
@@ -289,6 +229,12 @@ class ShortcutEditor(QDialog):
 
     def _set_keybinding(self, row, col):
 
+        if self._skip is True:
+            # this will skip everything if the text is setting to a symbol.
+            # Its already been handled.
+            self._skip = False
+            return
+
         if col == self._shortcut_col:
             # event is the index of the event.
             current_layer_text = self.layer_combo_box.currentText()
@@ -305,6 +251,7 @@ class ShortcutEditor(QDialog):
             item1 = self._table.currentItem()
             new_shortcut = item1.text()
             new_shortcut = new_shortcut[0].upper() + new_shortcut[1:]
+            print('right after get item', new_shortcut)
 
             # get the action name
             current_action = self._table.item(row, self._action_col).text()
@@ -312,8 +259,6 @@ class ShortcutEditor(QDialog):
             replace = True
             for row1, (action_name, action) in enumerate(actions_all.items()):
                 shortcuts = action_manager._shortcuts.get(action_name, [])
-
-                # shortcuts = [kb.lower() for kb in shortcuts]
 
                 if self._new_keys != '':
                     new_shortcut = self._new_keys
@@ -365,6 +310,7 @@ class ShortcutEditor(QDialog):
                         self._table.setCellWidget(
                             row, self._icon_col, self.warning_indicator
                         )
+
                         self._table.setCellWidget(
                             row1, self._icon_col, self.warning_indicator2
                         )
@@ -398,24 +344,32 @@ class ShortcutEditor(QDialog):
                         csc = Shortcut(new_shortcut).platform
                         self._new_keys = new_shortcut
                         item1.setText(csc)
-            if replace is True:
 
+            if replace is True:
                 # this shortcut is not taken, can set it and save in settings
                 # how are we doing this? saving in settings and then that triggers to update the action manager?
                 # right now I'm updating the action manager, and settings will be saved after a trigger as with
                 # all the other widgets.
 
                 #  Bind new shortcut to the action manager
+                print('current action', current_action)
                 action_manager.unbind_shortcut(current_action)
 
                 if new_shortcut != "":
+                    print(new_shortcut)
+                    # look for special symbols
+
                     action_manager.bind_shortcut(current_action, new_shortcut)
 
                     new_value_dict = {current_action: [new_shortcut]}
 
+                    # skip this method when setting the symbol
+                    self._skip = True
+
                     # update the symbols in the text
                     sc = Shortcut(new_shortcut).platform
                     item1.setText(sc)
+
                 else:
 
                     if action_manager._shortcuts[current_action] != "":
@@ -486,18 +440,13 @@ class KeyBindWarnPopup(QDialog):
 
 
 class ShortcutDelegate(QItemDelegate):
-    def __init__(self, parent=None):
-        super().__init__(parent)
-
     def createEditor(self, QWidget, QStyleOptionViewItem, QModelIndex):
         self._editor = EditorWidget(QWidget)
-        self._editor.setFocusProxy(self._editor._edit)
         return self._editor
 
     def setEditorData(self, widget, QModelIndex):
         text = QModelIndex.model().data(QModelIndex, Qt.EditRole)
         widget.setText(str(text) if text else "")
-        widget._edit.setFocus()
 
     def updateEditorGeometry(self, QWidget, QStyleOptionViewItem, QModelIndex):
         QWidget.setGeometry(QStyleOptionViewItem.rect)
@@ -507,24 +456,67 @@ class ShortcutDelegate(QItemDelegate):
         QAbstractItemModel.setData(QModelIndex, text, Qt.EditRole)
 
 
-class EditorWidget(QWidget):
+class EditorWidget(QLineEdit):
     def __init__(self, parent=None):
         super().__init__(parent)
-        self._edit = QLineEdit()
-        # remove_button = QToolButton()
-        # add_button = QToolButton()
-        layout = QHBoxLayout()
-        layout.addWidget(self._edit, 5)
-        # layout.addWidget(add_button, 1)
-        # layout.addWidget(remove_button, 1)
-        self.setLayout(layout)
-        layout.setContentsMargins(0, 0, 0, 0)
+        self._shortcut = None
 
-    def setText(self, text):
-        self._edit.setText(text)
+    def event(self, event):
+        """Qt method override."""
+        if event.type() == QEvent.ShortcutOverride:
+            print('check 1')
+            self.keyPressEvent(event)
+            return True
+        elif event.type() in [QEvent.KeyPress, QEvent.Shortcut]:
+            print('check 2', event.key())
+            return True
+        else:
+            print('check 2b')
+            return super().event(event)
 
-    def text(self):
-        return self._edit.text() or ""
+    def keyPressEvent(self, event):
+        """Qt method override."""
+        event_key = event.key()
+        if not event_key or event_key == Qt.Key_unknown:
+            return
+
+        if event_key in [
+            Qt.Key_Control,
+            Qt.Key_Shift,
+            Qt.Key_Alt,
+            Qt.Key_Meta,
+            Qt.Key_Return,
+            Qt.Key_Tab,
+        ]:
+            # do we want to be able to set these?
+            return
+
+        translator = ShortcutTranslator()
+        event_keyseq = translator.keyevent_to_keyseq(event)
+        # print('event_keyseq', event_keyseq)
+        # print('event to string', event_keyseq.toString())
+        event_keystr = event_keyseq.toString(QKeySequence.PortableText)
+        # print(len(event_keystr))
+        # print('event_keystr', event_keystr)
+
+        self._shortcut = event_keystr
+
+        parsed = re.split('[-(?=.+)]', self._shortcut)
+        keys = []
+        for val in parsed:
+            if val in KEY_SUBS.keys():
+                keys.append(KEY_SUBS[val])
+            else:
+                keys.append(val)
+
+        keys = '-'.join(keys)
+        self._new_keys = keys
+        print('setting key', keys)
+        self.setText(keys)
+        # self.setText(Shortcut(keys).platform)
+        print('done setting')
+
+        # super().keyPressEvent(event)
 
 
 class ShortcutTranslator(QKeySequenceEdit):

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -15,6 +15,7 @@ from qtpy.QtWidgets import (
 
 from ...layers import Image, Labels, Points, Shapes, Surface, Vectors
 from ...utils.action_manager import action_manager
+from ...utils.interactions import Shortcut
 from ...utils.settings import SETTINGS
 from ...utils.translations import trans
 from ..dialogs.qt_message_dialogs import ConfirmDialog
@@ -182,7 +183,7 @@ class ShortcutEditor(QDialog):
 
                 self._table.setItem(row, self._action_name_col, item)
                 item_shortcut = QTableWidgetItem(
-                    list(shortcuts)[0] if shortcuts else ""
+                    Shortcut(list(shortcuts)[0]).platform if shortcuts else ""
                 )
 
                 self._table.setItem(row, self._shortcut_col, item_shortcut)
@@ -233,9 +234,11 @@ class ShortcutEditor(QDialog):
                         # the shortcut is saved to a different action, show message.
                         # pop up window for warning.
                         message = trans._(
-                            f"The keybinding <b>{new_shortcut}</b> "
-                            + f"is already assigned to <b>{action.description}</b>; change or clear "
-                            + f"that shortcut before assigning <b>{new_shortcut}</b> to this one."
+                            "The keybinding <b>{new_shortcut}</b>  "
+                            + "is already assigned to <b>{action_description}</b>; change or clear "
+                            + "that shortcut before assigning <b>{new_shortcut}</b> to this one.",
+                            new_shortcut=new_shortcut,
+                            action_description=action.description,
                         )
 
                         delta_y = 105
@@ -252,6 +255,17 @@ class ShortcutEditor(QDialog):
                             text=message,
                         )
                         self._warn_dialog.move(global_point)
+
+                        print(self._warn_dialog.sizeHint().width())
+                        self._warn_dialog.resize(
+                            250, self._warn_dialog.sizeHint().height()
+                        )
+
+                        print(self._warn_dialog._message.sizeHint())
+                        self._warn_dialog._message.resize(
+                            200, self._warn_dialog._message.sizeHint().height()
+                        )
+                        # self._warn_dialog.setSizeHint()
 
                         self.warning_indicator = QLabel(self)
                         self.warning_indicator.setObjectName("error_label")

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/form.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/form.py
@@ -26,6 +26,7 @@ class WidgetBuilder:
             "object": widgets.ObjectSchemaWidget,
             "enum": widgets.EnumSchemaWidget,
             "plugins": widgets.PluginWidget,
+            "shortcuts": widgets.ShortcutsWidget,
         },
         "number": {
             "spin": widgets.SpinDoubleSchemaWidget,

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
@@ -577,19 +577,19 @@ class HighlightSizePreviewWidget(SchemaWidgetMixin, QtHighlightSizePreviewWidget
 
 class ShortcutsWidget(SchemaWidgetMixin, ShortcutEditor):
     @state_property
-    def state(self) -> int:
+    def state(self) -> dict:
         return self.value()
 
     def setDescription(self, description: str):
         self.description = description
 
     @state.setter
-    def state(self, state: int):
+    def state(self, state: dict):
         # self.setValue(state)
         return None
 
     def configure(self):
-        # self.valueChanged.connect(self.on_changed.emit)
+        self.valueChanged.connect(self.on_changed.emit)
         self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
         self.setGraphicsEffect(self.opacity)
         self.opacity.setOpacity(1)

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional, Tuple
 
 from qtpy import QtCore, QtGui, QtWidgets
 from ...._qt.widgets.qt_highlight_preview import QtHighlightSizePreviewWidget
+from ...._qt.widgets.qt_keyboard_settings import ShortcutEditor
 
 from .signal import Signal
 from .utils import is_concrete_schema, iter_layout_widgets, state_property
@@ -573,6 +574,25 @@ class HighlightSizePreviewWidget(SchemaWidgetMixin, QtHighlightSizePreviewWidget
         self.setGraphicsEffect(self.opacity)
         self.opacity.setOpacity(1)
 
+
+class ShortcutsWidget(SchemaWidgetMixin, ShortcutEditor):
+    @state_property
+    def state(self) -> int:
+        return self.value()
+
+    def setDescription(self, description: str):
+        self.description = description
+
+    @state.setter
+    def state(self, state: int):
+        # self.setValue(state)
+        return None
+
+    def configure(self):
+        # self.valueChanged.connect(self.on_changed.emit)
+        self.opacity = QtWidgets.QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
 
 class ObjectSchemaWidget(SchemaWidgetMixin, QtWidgets.QGroupBox):
     def __init__(

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -395,15 +395,6 @@ class ActionManager:
         self._update_gui_elements(name)
         return shortcuts
 
-    def _get_layer_actions(self, layer):
-        """ """
-        layer_actions = {}
-        for name, action in self._actions.items():
-            if action and layer == action.keymapprovider:
-                layer_actions[name] = action
-
-        return layer_actions
-
     def _get_layer_shortcuts(self, layers):
         """
         Get shortcuts filtered by the given layers.

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -395,6 +395,15 @@ class ActionManager:
         self._update_gui_elements(name)
         return shortcuts
 
+    def _get_layer_actions(self, layer):
+        """ """
+        layer_actions = {}
+        for name, action in self._actions.items():
+            if action and layer == action.keymapprovider:
+                layer_actions[name] = action
+
+        return layer_actions
+
     def _get_layer_shortcuts(self, layers):
         """
         Get shortcuts filtered by the given layers.

--- a/napari/utils/interactions.py
+++ b/napari/utils/interactions.py
@@ -223,6 +223,7 @@ KEY_SYMBOLS = {
     'Return': '⏎',
     'Enter': '↵',
     'Space': '␣',
+    'Ctrl': 'Ctrl',
 }
 
 
@@ -256,12 +257,14 @@ class Shortcut:
             shortcut to format in the form of dash separated keys to press
 
         """
-        self._values = re.split('-(?=.+)', shortcut)
+        self._values = re.split('[-(?=.+)]', shortcut)
         for shortcut_key in self._values:
             if (
                 len(shortcut_key) > 1
                 and shortcut_key not in KEY_SYMBOLS.keys()
+                and shortcut_key not in KEY_SYMBOLS.values()
             ):
+
                 warnings.warn(
                     trans._(
                         "{shortcut_key} does not seem to be a valid shortcut Key.",

--- a/napari/utils/interactions.py
+++ b/napari/utils/interactions.py
@@ -261,7 +261,6 @@ class Shortcut:
             if (
                 len(shortcut_key) > 1
                 and shortcut_key not in KEY_SYMBOLS.keys()
-                and shortcut_key not in KEY_SYMBOLS.values()
             ):
 
                 warnings.warn(

--- a/napari/utils/interactions.py
+++ b/napari/utils/interactions.py
@@ -223,7 +223,6 @@ KEY_SYMBOLS = {
     'Return': '⏎',
     'Enter': '↵',
     'Space': '␣',
-    'Ctrl': 'Ctrl',
 }
 
 

--- a/napari/utils/interactions.py
+++ b/napari/utils/interactions.py
@@ -256,7 +256,7 @@ class Shortcut:
             shortcut to format in the form of dash separated keys to press
 
         """
-        self._values = re.split('[-(?=.+)]', shortcut)
+        self._values = re.split('-(?=.+)', shortcut)
         for shortcut_key in self._values:
             if (
                 len(shortcut_key) > 1

--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -95,7 +95,7 @@ def parse_key_combo(key_combo):
     modifiers : set of str
         Modifier keys of the combination.
     """
-    parsed = re.split('[-(?=.+)]', key_combo)
+    parsed = re.split('-(?=.+)', key_combo)
     *modifiers, key = parsed
 
     return key, set(modifiers)

--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -77,6 +77,8 @@ SPECIAL_KEYS = [
 
 MODIFIER_KEYS = [keys.CONTROL, keys.ALT, keys.SHIFT, keys.META]
 
+KEY_SUBS = {'Ctrl': 'Control'}
+
 
 def parse_key_combo(key_combo):
     """Parse a key combination into its components in a comparable format.
@@ -93,7 +95,7 @@ def parse_key_combo(key_combo):
     modifiers : set of str
         Modifier keys of the combination.
     """
-    parsed = re.split('-(?=.+)', key_combo)
+    parsed = re.split('[-(?=.+)]', key_combo)
     *modifiers, key = parsed
 
     return key, set(modifiers)
@@ -143,7 +145,6 @@ def components_to_key_combo(key, modifiers):
             lambda key: key in modifiers and cond(key), MODIFIER_KEYS
         )
     )
-
     return '-'.join(modifiers + (key,))
 
 
@@ -181,6 +182,11 @@ def normalize_key_combo(key_combo):
         )
 
     for modifier in modifiers:
+        if modifier in KEY_SUBS.keys():
+            modifiers.remove(modifier)
+            modifier = KEY_SUBS[modifier]
+
+            modifiers.add(modifier)
         if modifier not in MODIFIER_KEYS:
             raise TypeError(
                 trans._(

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -445,11 +445,12 @@ class ShortcutsSettings(BaseNapariSettings):
     #    version, e.g. from 3.0.0 to 4.0.0
     # 3. You don't need to touch this value if you're just adding a new option
     schema_version: Union[SchemaVersion, Tuple[int, int, int]] = (0, 1, 1)
+
     shortcuts: Dict[str, List[str]] = Field(
         default_shortcuts,
         title=trans._("shortcuts"),
         description=trans._(
-            "Sort plugins for each action in the order to be called.",
+            "Set keyboard shortcuts for actions.",
         ),
     )
 
@@ -463,7 +464,7 @@ class ShortcutsSettings(BaseNapariSettings):
 
     class NapariConfig:
         # Napari specific configuration
-        preferences_exclude = ['schema_version', 'shortcuts']
+        preferences_exclude = ['schema_version']
 
 
 class PluginsSettings(BaseNapariSettings):

--- a/napari/utils/settings/_manager.py
+++ b/napari/utils/settings/_manager.py
@@ -195,9 +195,20 @@ class SettingsManager(_SettingsMixin):
     def path(self):
         return self._config_path
 
-    def reset(self):
-        """Reset settings to default values."""
-        for section in self._settings:
+    def reset(self, sections=None):
+        """Reset settings to default values.
+
+        Parameters
+        ----------
+        sections: list[str]
+            List of settings sections to reset.
+            If None specified, will reset all.
+        """
+        if not sections:
+            # sections to reset are not specified, so reset all.
+            sections = self._settings.keys()
+
+        for section in sections:
             for key, default_value in self._defaults[section].dict().items():
                 setattr(self._settings[section], key, default_value)
 


### PR DESCRIPTION
This PR will add a widget to the preferences dialog to allow a user to edit keyboard shortcuts.   
In its current state, you can edit a shortcut, and it will update the action manager and save the new shortcut to settings.  It will also not allow you to use a shortcut if its assigned to another action on that layer.  

The restore to defaults button does not work yet.  I also know that I will probably move where the settings are actually saved.  For now, I am trying to get things in place and then will make improvements.  

Still need docstrings, tests, and general clean up...

Comments and suggestions are appreciated!  

Closes #2819 

https://user-images.githubusercontent.com/54282105/121475004-7f19d000-c98a-11eb-88e0-bc12617a68b8.mov

