### PR TITLE
trans NameError bugfix

### DIFF
--- a/napari/window.py
+++ b/napari/window.py
@@ -8,9 +8,10 @@ to server as a graphical user interface for napari.
 
 __all__ = ['Window']
 
+from .utils.translations import trans
+
 try:
     from ._qt import Window
-    from .utils.translations import trans
 
 except ImportError:
 


### PR DESCRIPTION
This PR fixes a bug @jni and I came across this morning - I don't have a stacktrace so here is a brief description

If you modify something in napari which makes the `napari._qt.Window` import fail here
https://github.com/napari/napari/blob/a279594e677f913067ce65c8fc62943d1819900c/napari/window.py#L12-L13

then the translated string in the except block fails due to a `NameError` when trying to use `trans`
https://github.com/napari/napari/blob/a279594e677f913067ce65c8fc62943d1819900c/napari/window.py#L15-L27

Moving the import of `trans` outside the try/except block solves the issue
