### PR TITLE
Add ActionManager tests

### DIFF
--- a/napari/utils/_tests/test_action_manager.py
+++ b/napari/utils/_tests/test_action_manager.py
@@ -1,0 +1,51 @@
+"""
+This module test some of the behavior of action manager.
+"""
+import pytest
+
+from ..action_manager import ActionManager
+
+
+@pytest.fixture
+def action_manager():
+    """
+    Unlike normal napari we use a different instance we have complete control
+    over and can throw away this makes it easier.
+    """
+    return ActionManager()
+
+
+def test_unbind_non_existing_action(action_manager):
+    """
+    We test that unbinding an non existing action is ok, this can happen due to
+    keybindings in settings while some plugins are deactivated or upgraded.
+
+    We emit a warning but should not fail.
+    """
+    with pytest.warns(UserWarning):
+        assert action_manager.unbind_shortcut('napari:foo_bar') is None
+
+
+def test_bind_multiple_action(action_manager):
+    """
+    Test we can have multiple bindings per action
+    """
+
+    action_manager.register_action(
+        'napari:test_action_2', lambda: None, 'this is a test action', None
+    )
+
+    action_manager.bind_shortcut('napari:test_action_2', 'X')
+    action_manager.bind_shortcut('napari:test_action_2', 'Y')
+    assert action_manager._shortcuts['napari:test_action_2'] == {'X', 'Y'}
+
+
+def test_bind_unbind_existing_action(action_manager):
+
+    action_manager.register_action(
+        'napari:test_action_1', lambda: None, 'this is a test action', None
+    )
+
+    assert action_manager.bind_shortcut('napari:test_action_1', 'X') is None
+    assert action_manager.unbind_shortcut('napari:test_action_1') == {'X'}
+    assert action_manager._shortcuts['napari:test_action_1'] == set()

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -346,9 +346,9 @@ class ActionManager:
         self._update_shortcut_bindings(name)
         self._update_gui_elements(name)
 
-    def unbind_shortcut(self, name: str):
+    def unbind_shortcut(self, name: str) -> Union[Set[str], None]:
         """
-        unbind shortcut for action name
+        Unbind all shortcuts for a given action name.
 
         Parameters
         ----------
@@ -357,9 +357,9 @@ class ActionManager:
 
         Returns
         -------
-        shortcut: str | None
-            Previously bound shortcut or None if not such shortcuts was bound,
-            or  no such action exists.
+        shortcuts: set of str | None
+            Previously bound shortcuts or None if not such shortcuts was bound,
+            or no such action exists.
 
         Warns
         -----


### PR DESCRIPTION
Add tests for some of the recent changes that were made to
action_manager. Mostly:

    #2861 – Be more robust for non-existant keybindings in settings.

That makes sure unbind shortcut does not fail, in particular when
non-sensical action rebinding are in settings.

And

    #2830 – Extend the action manager to support multiple shortcuts

This also includes a couple of type annotation updates and docstrings
corrections.

