### PR TITLE
Tifffile compress' kwargs deprecated. Update to compression.

### DIFF
--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -1,6 +1,7 @@
 import csv
 import os
 import re
+import warnings
 from glob import glob
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
@@ -28,7 +29,24 @@ def imsave(filename: str, data: np.ndarray):
     if ext in [".tif", ".tiff"]:
         import tifffile
 
-        tifffile.imsave(filename, data, compress=1)
+        compression_instead_of_compress = False
+        try:
+            current_version = tuple(
+                int(x) for x in tifffile.__version__.split('.')[:3]
+            )
+            compression_instead_of_compress = current_version >= (2021, 6, 6)
+        except Exception:
+            # Just in case anything goes wrong in parsing version number
+            # like repackaging on linux or anything else we fallback to
+            # using compress
+            warnings.warn(
+                f'Error parsing tiffile version number {tifffile.__version__:!r}'
+            )
+
+        if compression_instead_of_compress:
+            tifffile.imsave(filename, data, compression=1)
+        else:  # older version of tifffile since 2021.6.6  this is deprecated
+            tifffile.imsave(filename, data, compress=1)
     else:
         import imageio
 


### PR DESCRIPTION
This is since version 2021 6 6, I've also sent a patch to tifffile
itself to set the proper stacklevel for the deprecation warnings, see
`cgohlke/tifffile#89`.

I'm comparing the version numbers and LBYL instead of EAFP as I find it
much easier to cleanup and find dead code due to change in version
number when those are explicit.

Closes #2871