### PR TITLE
Include the message in notification REPR.

### DIFF
--- a/napari/utils/_tests/test_notification_manager.py
+++ b/napari/utils/_tests/test_notification_manager.py
@@ -28,6 +28,12 @@ class PurposefulException(Exception):
     pass
 
 
+def test_notification_repr_has_message():
+    assert "='this is the message'" in repr(
+        Notification("this is the message")
+    )
+
+
 def test_notification_manager_no_gui():
     """
     Direct test of the notification manager.

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -183,7 +183,7 @@ class Event:
                     continue
                 attr = getattr(self, name)
 
-                attrs.append(f"{name}={attr}")
+                attrs.append(f"{name}={attr!r}")
             return "<{} {}>".format(self.__class__.__name__, " ".join(attrs))
         finally:
             _event_repr_depth -= 1

--- a/napari/utils/notifications.py
+++ b/napari/utils/notifications.py
@@ -83,11 +83,19 @@ class Notification(Event):
     ):
         self.severity = NotificationSeverity(severity)
         super().__init__(type=str(self.severity).lower(), **kwargs)
-        self.message = message
+        self._message = message
         self.actions = actions
 
         # let's store when the object was created;
         self.date = datetime.now()
+
+    @property
+    def message(self):
+        return self._message
+
+    @message.setter
+    def message(self, value):
+        self._message = value
 
     @classmethod
     def from_exception(cls, exc: BaseException, **kwargs) -> Notification:


### PR DESCRIPTION
There are a couple times when test failures in pytest show
ErrorNotification problem in tests; unfortunately the repr does not show
the error message. This is dues to Events repr only including attributes
that are properties and Notification being a subclass of these.

I'm not sure why the repr only include properties and not other kind of
attributes – maybe to not include methods ? Or if attributes are
themselves to big ? So I turn the message attribute into a property.

Closes #2873

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
