### PR TITLE
Make `EventedModel` compatible with `dask.Delayed` objects

### DIFF
--- a/napari/utils/events/_tests/test_evented_model.py
+++ b/napari/utils/events/_tests/test_evented_model.py
@@ -5,6 +5,8 @@ from unittest.mock import Mock
 import dask.array as da
 import numpy as np
 import pytest
+from dask import delayed
+from dask.delayed import Delayed
 from pydantic import Field
 
 from napari.utils.events import EmitterGroup, EventedModel
@@ -300,3 +302,19 @@ def test_nested_evented_model_serialization():
     assert raw == r'{"nest": {"obj": {"a": 1, "b": "hi"}}}'
     deserialized = Model.parse_raw(raw)
     assert deserialized == m
+
+
+def test_evented_model_dask_delayed():
+    """Test that evented models work with dask delayed objects"""
+
+    class MyObject(EventedModel):
+        attribute: Delayed
+
+    @delayed
+    def my_function():
+        pass
+
+    o1 = MyObject(attribute=my_function)
+
+    # check that equality checking works as expected
+    assert o1 == o1

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -435,6 +435,7 @@ def pick_equality_operator(obj) -> Callable[[Any, Any], bool]:
     _known_arrays = {
         'numpy.ndarray': np.array_equal,  # numpy.ndarray
         'dask.Array': operator.is_,  # dask.array.core.Array
+        'dask.Delayed': operator.is_,  # dask.delayed.Delayed
         'zarr.Array': operator.is_,  # zarr.core.Array
         'xarray.DataArray': np.array_equal,  # xarray.core.dataarray.DataArray
     }


### PR DESCRIPTION
# Description
This PR closes #2870 - `EventedModel` objects were previously incompatible with `dask.Delayed` objects. Including a specific equality operator for these objects (as suggested by @tlambert03) fixes the issue

