### PR TITLE
Alternate "Hold xxx for action" + action invert.

### DIFF
--- a/examples/action_manager.py
+++ b/examples/action_manager.py
@@ -28,8 +28,15 @@ def rotate45(viewer: napari.Viewer):
 
     r = np.array([[cos(angle), -sin(angle)], [sin(angle), cos(angle)]])
     layer = viewer.layers[0]
+    original_rotation = layer.rotate
     layer.rotate = layer.rotate @ r
+    return original_rotation
 
+
+
+def unrotate_45(viewer: napari.Viewer, state):
+    layer = viewer.layers[0]
+    layer.rotate = state
 
 # create the viewer with an image
 viewer = napari.view_image(data.astronaut(), rgb=True)
@@ -57,6 +64,7 @@ def register_action():
         command=rotate45,
         description='Rotate layer 0 by 45deg',
         keymapprovider=ViewerModel,
+        invert=unrotate_45
     )
 
 
@@ -65,6 +73,7 @@ def bind_shortcut():
     # remove the shortcut.
     action_manager.unbind_shortcut('napari:reset_view')  # Control-R
     action_manager.bind_shortcut('napari:rotate45', 'Control-R')
+    action_manager.bind_hold_shortcut('napari:rotate45', '7') # key `&`
 
 
 def bind_button():
@@ -105,5 +114,7 @@ settings = {
 for action, key in settings.items():
    _old_shortcut = action_manager.unbind_shortcut(action)
    action_manager.bind_shortcut(action, key)
+
+action_manager.bind_hold_shortcut('napari:activate_points_pan_zoom_mode', 'Space')
 
 napari.run()

--- a/napari/layers/points/_points_key_bindings.py
+++ b/napari/layers/points/_points_key_bindings.py
@@ -6,25 +6,8 @@ from ._points_constants import Mode
 from .points import Points
 
 
-def register_points_action(description):
-    return register_layer_action(Points, description)
-
-
-@Points.bind_key('Space')
-def hold_to_pan_zoom(layer):
-    """Hold to pan and zoom in the viewer."""
-    if layer._mode != Mode.PAN_ZOOM:
-        # on key press
-        prev_mode = layer.mode
-        prev_selected = layer.selected_data.copy()
-        layer.mode = Mode.PAN_ZOOM
-
-        yield
-
-        # on key release
-        layer.mode = prev_mode
-        layer.selected_data = prev_selected
-        layer._set_highlight()
+def register_points_action(description, invert=None):
+    return register_layer_action(Points, description, invert=invert)
 
 
 @register_points_action(trans._('Add points'))
@@ -37,9 +20,22 @@ def activate_points_select_mode(layer):
     layer.mode = Mode.SELECT
 
 
-@register_points_action(trans._('Pan/zoom'))
+def _pan_zoom_invert(layer, state):
+    """Hold to pan and zoom in the viewer."""
+    prev_selected, prev_mode = state
+    layer.mode = prev_mode
+    layer.selected_data = prev_selected
+    layer._set_highlight()
+
+
+@register_points_action(trans._('Pan/zoom'), invert=_pan_zoom_invert)
 def activate_points_pan_zoom_mode(layer):
-    layer.mode = Mode.PAN_ZOOM
+    if layer._mode != Mode.PAN_ZOOM:
+        # on key press
+        prev_mode = layer.mode
+        prev_selected = layer.selected_data.copy()
+        layer.mode = Mode.PAN_ZOOM
+        return prev_selected, prev_mode
 
 
 @Points.bind_key('Control-C')

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -10,7 +10,9 @@ from ...utils.transforms import Affine
 from ...utils.translations import trans
 
 
-def register_layer_action(keymapprovider, description: str, shortcuts=None):
+def register_layer_action(
+    keymapprovider, description: str, shortcuts=None, invert=None
+):
     """
     Convenient decorator to register an action with the current Layers
 
@@ -46,6 +48,7 @@ def register_layer_action(keymapprovider, description: str, shortcuts=None):
             command=func,
             description=description,
             keymapprovider=keymapprovider,
+            invert=invert,
         )
         if shortcuts:
             if isinstance(shortcuts, str):


### PR DESCRIPTION
Unlike #2854 which let user define action that are either functions, or
generator this allows to register an "invert" for an action.

The invert takes the same parameter as the original action plus a state
object (what is returned from an action).

In the action manager as we are still relying on KeymapProvider,
we turn this into a generator and bind that on a key (so we can get hold
space to pan zoom for example), but we could store the intermediate
state and keep a stack of actions we can undo.

We _could_ likely also let users simply register a generator with both
side of the yield being the action and its invert,

and then either bind the generator for "hold to xxx", or lambda:
next(gen()) to only do the forward step, though with this we have no way
of recording a stack and have undo/redo; unless we keep the generator
instances arround, which I'm not a fan of.

Thoughts on wether you have preference for this approach or the one in
gh-2854 are welcome.

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
