### PR TITLE
fix for too-late magicgui type registration

### DIFF
--- a/napari/components/experimental/chunk/_cache.py
+++ b/napari/components/experimental/chunk/_cache.py
@@ -11,22 +11,23 @@ if TYPE_CHECKING:
     from ....types import ArrayLike
     from ._request import ChunkRequest
 
+    # A ChunkRequest is just a dict of the arrays we need to load. We allow
+    # loading multiple arrays in one request so the caller does not have to
+    # deal with partial loads, where it has received some arrays but it cannot
+    # use them until other arrays have finished loading.
+    #
+    # The caller is free to use whatever names it wants to organize the arrays,
+    # for example "image" and "thumbnail", or spatially neighboring tiles like
+    # "tile.1.1", "tile1.2", "tile2.1", "tile2.2".
+    ChunkArrays = Dict[str, ArrayLike]
+
+
 LOGGER = logging.getLogger("napari.loader.cache")
 
 # ChunkCache size as a fraction of total RAM. Keep it small for now until
 # we figure out how ChunkCache will work with the Dask cache, and do
 # a lot more testing.
 CACHE_MEM_FRACTION = 0.1
-
-# A ChunkRequest is just a dict of the arrays we need to load. We allow
-# loading multiple arrays in one request so the caller does not have to
-# deal with partial loads, where it has received some arrays but it cannot
-# use them until other arrays have finished loading.
-#
-# The caller is free to use whatever names it wants to organize the arrays,
-# for example "image" and "thumbnail", or spatially neighboring tiles like
-# "tile.1.1", "tile1.2", "tile2.1", "tile2.2".
-ChunkArrays = Dict[str, ArrayLike]
 
 
 def _get_cache_size_bytes(mem_fraction: float) -> int:

--- a/napari/components/experimental/chunk/_cache.py
+++ b/napari/components/experimental/chunk/_cache.py
@@ -1,11 +1,15 @@
 """ChunkCache stores loaded chunks.
 """
+from __future__ import annotations
+
 import logging
-from typing import Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 from ...._vendor.experimental.cachetools import LRUCache
-from ....types import ArrayLike
-from ._request import ChunkRequest
+
+if TYPE_CHECKING:
+    from ....types import ArrayLike
+    from ._request import ChunkRequest
 
 LOGGER = logging.getLogger("napari.loader.cache")
 

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -26,7 +26,6 @@ from ..layers import Image, Layer
 from ..layers._source import layer_source
 from ..layers.image._image_utils import guess_labels
 from ..layers.utils.stack_utils import split_channels
-from ..types import PathOrPaths
 from ..utils._register import create_func as create_add_method
 from ..utils.colormaps import ensure_colormap
 from ..utils.events import Event, EventedModel, disconnect_events
@@ -61,7 +60,7 @@ EXCLUDE_DICT = {
 EXCLUDE_JSON = EXCLUDE_DICT.union({'layers', 'active_layer'})
 
 if TYPE_CHECKING:
-    from ..types import FullLayerData, LayerData
+    from ..types import FullLayerData, LayerData, PathOrPaths
 
 
 __all__ = ['ViewerModel', 'valid_add_kwargs']

--- a/napari/layers/image/_image_slice.py
+++ b/napari/layers/image/_image_slice.py
@@ -1,17 +1,21 @@
 """ImageSlice class.
 """
+from __future__ import annotations
+
 import logging
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import numpy as np
 
-from ...types import ArrayLike
 from ...utils import config
 from ._image_loader import ImageLoader
 from ._image_slice_data import ImageSliceData
 from ._image_view import ImageView
 
 LOGGER = logging.getLogger("napari.loader")
+
+if TYPE_CHECKING:
+    from ...types import ArrayLike
 
 
 def _create_loader_class() -> ImageLoader:

--- a/napari/layers/image/_image_slice_data.py
+++ b/napari/layers/image/_image_slice_data.py
@@ -1,11 +1,15 @@
 """ImageSliceData class.
 """
-from typing import Optional, Tuple
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import numpy as np
 
-from ...types import ArrayLike
 from ..base import Layer
+
+if TYPE_CHECKING:
+    from ...types import ArrayLike
 
 
 class ImageSliceData:

--- a/napari/layers/image/_image_view.py
+++ b/napari/layers/image/_image_view.py
@@ -1,6 +1,11 @@
 """ImageView class.
 """
-from ...types import ArrayLike, Callable
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ...types import ArrayLike, Callable
 
 
 class ImageView:

--- a/napari/layers/image/experimental/_chunked_slice_data.py
+++ b/napari/layers/image/experimental/_chunked_slice_data.py
@@ -2,16 +2,20 @@
 
 This is for pre-Octree Image class only.
 """
+from __future__ import annotations
+
 import logging
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from ....components.experimental.chunk import ChunkRequest, chunk_loader
-from ....types import ArrayLike
 from ...base import Layer
 from .._image_slice_data import ImageSliceData
 from ._image_location import ImageLocation
 
 LOGGER = logging.getLogger("napari.loader")
+
+if TYPE_CHECKING:
+    from ....types import ArrayLike
 
 
 class ChunkedSliceData(ImageSliceData):

--- a/napari/layers/image/experimental/octree_chunk.py
+++ b/napari/layers/image/experimental/octree_chunk.py
@@ -7,10 +7,9 @@ from typing import TYPE_CHECKING, List, NamedTuple
 
 import numpy as np
 
-from ....types import ArrayLike
-
 if TYPE_CHECKING:
     from ....components.experimental.chunk._request import OctreeLocation
+    from ....types import ArrayLike
 
 LOGGER = logging.getLogger("napari.octree")
 

--- a/napari/layers/image/experimental/octree_level.py
+++ b/napari/layers/image/experimental/octree_level.py
@@ -1,16 +1,20 @@
 """OctreeLevelInfo and OctreeLevel classes.
 """
+from __future__ import annotations
+
 import logging
 import math
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import numpy as np
 
-from ....types import ArrayLike
 from .octree_chunk import OctreeChunk, OctreeChunkGeom
 from .octree_util import OctreeMetadata
 
 LOGGER = logging.getLogger("napari.octree")
+
+if TYPE_CHECKING:
+    from ....types import ArrayLike
 
 
 class OctreeLevelInfo:

--- a/napari/layers/utils/stack_utils.py
+++ b/napari/layers/utils/stack_utils.py
@@ -1,14 +1,18 @@
+from __future__ import annotations
+
 import itertools
-from typing import Dict, List
+from typing import TYPE_CHECKING, Dict, List
 
 import numpy as np
 
 from ...layers import Image
 from ...layers.image._image_utils import guess_multiscale
-from ...types import FullLayerData
 from ...utils.colormaps import CYMRGB, MAGENTA_GREEN, Colormap
 from ...utils.misc import ensure_iterable, ensure_sequence_of_iterables
 from ...utils.translations import trans
+
+if TYPE_CHECKING:
+    from ...types import FullLayerData
 
 
 def slice_from_axis(array, *, axis, element):

--- a/napari/types.py
+++ b/napari/types.py
@@ -18,6 +18,8 @@ from typing import (
 import numpy as np
 from typing_extensions import TypedDict
 
+from .utils._magicgui import register_types_with_magicgui
+
 if TYPE_CHECKING:
     import dask.array
     import zarr
@@ -120,3 +122,6 @@ def image_reader_to_layerdata_reader(
         return [(result,)]
 
     return reader_function
+
+
+register_types_with_magicgui()

--- a/napari/utils/_tests/test_dtype.py
+++ b/napari/utils/_tests/test_dtype.py
@@ -2,12 +2,13 @@ import itertools
 
 import numpy as np
 import pytest
-import tensorstore as ts
-import torch
 import zarr
 from dask import array as da
 
 from napari.utils._dtype import normalize_dtype
+
+ts = pytest.importorskip('tensorstore')
+torch = pytest.importorskip('torch')
 
 bit_depths = [str(2 ** i) for i in range(3, 7)]
 uints = ['uint' + b for b in bit_depths]

--- a/napari/utils/_tests/test_magicgui.py
+++ b/napari/utils/_tests/test_magicgui.py
@@ -182,3 +182,24 @@ def test_magicgui_get_viewer(make_napari_viewer):
     assert func() is viewer
     # no widget should be shown
     assert not func.v.visible
+
+
+def test_magicgui_imports(tmp_path):
+    """Test that magicgui is registered in time"""
+    import subprocess
+    import sys
+    from textwrap import dedent
+
+    script = """
+    from napari.types import ImageData
+    from magicgui import magicgui
+
+    @magicgui()
+    def filter_widget(image: ImageData) -> ImageData:
+        return None
+
+    filter_widget()
+    """
+    script_path = tmp_path / 'script.py'
+    script_path.write_text(dedent(script))
+    subprocess.run([sys.executable, script_path], check=True)


### PR DESCRIPTION
# Description
The following script is currently failing since `register_types_with_magicgui`  gets called too late. 
```python
    from napari.types import ImageData
    from magicgui import magicgui

    @magicgui()
    def filter_widget(image: ImageData) -> ImageData:
        return None

    filter_widget()
```

This fixes that, but I'm still not 100% sure that the registration of types with magicgui is all being done in the best way possible.  In any case, the immediate issue is solved and we can reconsider going forward.


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
