### PR TITLE
Fix notification manager threading test

### DIFF
--- a/napari/utils/_tests/test_notification_manager.py
+++ b/napari/utils/_tests/test_notification_manager.py
@@ -136,9 +136,16 @@ def test_notification_manager_no_gui_with_threading():
         assert warnings.showwarning == notification_manager.receive_warning
         warning_thread = threading.Thread(target=_warn)
         warning_thread.start()
-        time.sleep(0.02)
-        assert len(notification_manager.records) == 2
-        assert store[-1].type == 'warning'
+
+        for _ in range(100):
+            time.sleep(0.01)
+            if (
+                len(notification_manager.records) == 2
+                and store[-1].type == 'warning'
+            ):
+                break
+        else:
+            raise AssertionError("Thread notification not received in time")
 
     # make sure we've restored the threading except hook
     if PY38_OR_HIGHER:


### PR DESCRIPTION
Small fix (I hope) for this type of lingering error that we sometimes see in the threading test: 
https://github.com/napari/napari/runs/2842557235?check_suite_focus=true#step:7:283
