### PR TITLE
Add imagecodecs to the bundle to open additional tiffs

### DIFF
--- a/bundle.py
+++ b/bundle.py
@@ -20,6 +20,7 @@ APP = 'napari'
 # python bundle.py --add 'PySide2==5.15.0' 'ome-zarr'
 
 EXTRA_REQS = [
+    "imagecodecs",
     "pip",
     "PySide2==5.15.2",
     "scikit-image",


### PR DESCRIPTION
# Description

Motivated by https://forum.image.sc/t/segmentation-pipeline-from-ilastik-to-napari/53986 .  It turns out that we can't open uint32 tiffs exported by Ilastik using our default plugin. Installing imagecodecs fixes the problem and allows them to be opened correctly as labels.
