### PR TITLE
Make maximum brush size flexible

### DIFF
--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -431,7 +431,9 @@ class QtLabelsControls(QtLayerControls):
         """
         with self.layer.events.brush_size.blocker():
             value = self.layer.brush_size
-            value = np.clip(int(value), 1, 40)
+            value = np.clip(int(value), 1, None)
+            if value > self.brushSizeSlider.maximum():
+                self.brushSizeSlider.setMaximum(value)
             self.brushSizeSlider.setValue(value)
 
     def _on_n_edit_dimensions_change(self, event=None):

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -431,9 +431,9 @@ class QtLabelsControls(QtLayerControls):
         """
         with self.layer.events.brush_size.blocker():
             value = self.layer.brush_size
-            value = np.clip(int(value), 1, None)
+            value = np.maximum(1, int(value))
             if value > self.brushSizeSlider.maximum():
-                self.brushSizeSlider.setMaximum(value)
+                self.brushSizeSlider.setMaximum(int(value))
             self.brushSizeSlider.setValue(value)
 
     def _on_n_edit_dimensions_change(self, event=None):

--- a/napari/_tests/test_advanced.py
+++ b/napari/_tests/test_advanced.py
@@ -259,3 +259,19 @@ def test_labels_undo_redo(make_napari_viewer):
     # cannot undo as limit exceeded
     labels.undo()
     assert np.array_equal(l2, labels.data)
+
+
+def test_labels_brush_size(make_napari_viewer):
+    """Test changing labels brush size."""
+    viewer = make_napari_viewer()
+
+    data = np.zeros((50, 50), dtype=np.uint8)
+    labels = viewer.add_labels(data)
+
+    # Make small change
+    labels.brush_size = 20
+    assert labels.brush_size == 20
+
+    # Make large change
+    labels.brush_size = 100
+    assert labels.brush_size == 100


### PR DESCRIPTION
# Description
Closes #2745 by updating maximum brush size when brush size value is set to a value larger than the current brush size. We might want to adopt this pattern more broadly following #2753 - curious what @tlambert03 thinks about that - but this will fix the immediate issue facing @pranathivemuri. Please let us know if this works for you.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #2745

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] test added

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
