### PR TITLE
Pycharm blocking fix

### DIFF
--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -294,7 +294,8 @@ def _ipython_has_eventloop() -> bool:
 
 
 def _pycharm_has_eventloop(app: QApplication) -> bool:
-    """Return true if running in PyCharm and eventloop is active
+    """Return true if running in PyCharm and eventloop is active.
+    
     PyCharm runs a custom interactive shell which overrides
     `InteractiveShell.enable_gui()`, breaking some superclass behaviour.
     """

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -293,6 +293,16 @@ def _ipython_has_eventloop() -> bool:
     return shell.active_eventloop == 'qt'
 
 
+def _pycharm_has_eventloop(app: QApplication) -> bool:
+    """Return true if running in PyCharm and eventloop is active
+    PyCharm runs a custom interactive shell which overrides
+    `InteractiveShell.enable_gui()`, breaking some superclass behaviour.
+    """
+    in_pycharm = 'PYCHARM_HOSTED' in os.environ
+    in_event_loop = getattr(app, '_in_event_loop', False)
+    return in_pycharm and in_event_loop
+
+
 def _try_enable_ipython_gui(gui='qt'):
     """Start %gui qt the eventloop."""
     ipy_module = sys.modules.get("IPython")
@@ -341,6 +351,10 @@ def run(
         return
 
     app = QApplication.instance()
+    if _pycharm_has_eventloop(app):
+        # explicit check for PyCharm pydev console
+        return
+
     if not app:
         raise RuntimeError(
             trans._(

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -295,9 +295,10 @@ def _ipython_has_eventloop() -> bool:
 
 def _pycharm_has_eventloop(app: QApplication) -> bool:
     """Return true if running in PyCharm and eventloop is active.
-    
-    PyCharm runs a custom interactive shell which overrides
-    `InteractiveShell.enable_gui()`, breaking some superclass behaviour.
+
+    Explicit checking is necessary because PyCharm runs a custom interactive
+    shell which overrides `InteractiveShell.enable_gui()`, breaking some
+    superclass behaviour.
     """
     in_pycharm = 'PYCHARM_HOSTED' in os.environ
     in_event_loop = getattr(app, '_in_event_loop', False)


### PR DESCRIPTION
# Description
Fix for problem discussed in #2904. This PR adds an explicit check for whether napari is being run inside PyCharm to `napari.run()` to stop blocking if napari is run in the [custom PyCharm iPython 'pydev' console](https://github.com/JetBrains/intellij-community/tree/b2cbfec46a49b6415973ae6dded692ff65ce77c5/python/helpers/pydev)

Their custom console overrides the `InteractiveShell.enable_gui()` method in a way that makes it not work when we use it here to ensure that things are set properly in the `InteractiveShell`.
https://github.com/napari/napari/blob/08bc6166c42b10ac0bd71e7c12598ccae61d8124/napari/_qt/qt_event_loop.py#L305-L306

this is the cause of our issue (and should probably be fixed on their pydev console)