### PR TITLE
Provide manual deepcopy implementation for translations strings.

### DIFF
--- a/napari/utils/_tests/test_translations.py
+++ b/napari/utils/_tests/test_translations.py
@@ -1,6 +1,7 @@
 """Test the translations API."""
 
 import sys
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -414,3 +415,15 @@ def test_translation_string_exceptions():
 def test_bundle_exceptions(trans):
     with pytest.raises(ValueError):
         trans._dnpgettext()
+
+
+def test_deepcopy():
+    """see https://github.com/napari/napari/issues/2911
+
+    Object containing translation strings can't bee deep-copied.
+    """
+
+    t = TranslationString(msgid='huhu')
+    u = deepcopy(t)
+    assert t is not u
+    assert t == u

--- a/napari/utils/translations.py
+++ b/napari/utils/translations.py
@@ -166,6 +166,19 @@ class TranslationString(str):
     A class that allows to create a deferred translations.
     """
 
+    def __deepcopy__(self, memo):
+        from copy import deepcopy
+
+        return TranslationString(
+            domain=self._domain,
+            msgctxt=self._msgctxt,
+            msgid=self._msgid,
+            msgid_plural=self._msgid_plural,
+            n=self._n,
+            deferred=self._deferred,
+            kwargs=deepcopy(self._kwargs),
+        )
+
     def __new__(
         cls,
         domain: Optional[str] = None,


### PR DESCRIPTION
# Description

We can shallow copy most of the parameters as they are immutable,
except kwargs. Implementing __deepcopy__ mean that deepcopy() avoid
calling __new__ by itself which is problematic.

I can see similar issues with pickle or other magic serializers, in
which case we may want to let msgid stay None until __init__.

Closes #2911


## Type of change

- [x] Bug-fix (non-breaking change which fixes an issue)

# References
see https://docs.python.org/3/library/copy.html for the deepcopy protocol.

The one thing I did not look at is the `memo` object that could contain already copied object, this is typically used for data structure that do have shared references like a graph, to avoid breaking the graph. I don't think that our translation strings need to share ref with anything.

# How has this been tested?

- [x] original issue report snippet passes (not added to tests)
- [x] shorter snippet passes and added to test

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

I've also tested that added test fails if fix not implemented, the extra asserts in the test might be unnecessary
but as we mess with `__new__` and `__copy__` and want to make sure we actually end up with different objects.
