### PR TITLE
Try to handle multiple viewer

### DIFF
--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -100,7 +100,6 @@ class QtViewerButtons(QFrame):
         super().__init__()
 
         self.viewer = viewer
-        action_manager.context['viewer'] = viewer
 
         def active_layer():
             if len(self.viewer.layers.selection) == 1:

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from .components.viewer_model import ViewerModel
-from .utils import _magicgui, config
+from .utils import _magicgui, action_manager, config
 
 if TYPE_CHECKING:
     # helpful for IDE support
@@ -30,6 +30,14 @@ class Viewer(ViewerModel):
 
     # Create private variable for window
     _window: 'Window'
+
+    @classmethod
+    def active_instance(self):
+        import napari
+
+        return (
+            napari._qt.qt_main_window._QtMainWindow.current().qt_viewer.viewer
+        )
 
     def __init__(
         self,
@@ -123,3 +131,6 @@ class Viewer(ViewerModel):
             # https://github.com/napari/napari/issues/1500
             for layer in self.layers:
                 chunk_loader.on_layer_deleted(layer)
+
+
+action_manager.action_manager.context['viewer'] = Viewer.active_instance


### PR DESCRIPTION
handle multiple (qt)viewer in multiple windows.

I'm trying to introduce the notion of active viewer, it's not perfect but help
for #2977, so it does not for #2897, though discussing with Juan, we are not
sure it's worth fixing when both are in the same window.

Which viewer should be targeted by actions when there are many is
inherently ambiguous with the concept of action and menu - especially on mac
where there is a single menu, while there are often one menu per window on other
platform.

This also update the toggle console visibility action even if regardless, we
don't support multiple console and only the first one open will show the prompt.

Original Text:

~~I'm trying to introduce the notion of active viewer, it's not perfect
for #2897 but should help, though I'm unsure how to determine what is
the active viewer. I was thinking last in focus, but I"m not sure how to
do that.~~

~~Which viewer should be targeted by actions when there are many is
inherently ambiguous with the concept of action and menu. While in #2897
we have local proximity of buttons and viewer and it would make sens to
have them act on the closer viewer keep in mind that action are also
used for menu, and that we want them in an undo-re or command palette
– napari makes no distinction depending on what triggered an action.
This is why for layer we trigger on the currently active.~~

~~We can see this issue with the menus that only let us toggle a single
docked panel, or a single qtconsole.~~

~~We could try to refactor the action manager context everything to
support multiple instance and when multiple are present provide the
ability to choose which instance(s), even for menu and have button have
an option to diambiguate.~~

~~For example each viewer instance have a title and we could ask "for
which one".~~

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
