### PR TITLE
Make Points construction with properties consistent with setting properties

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1600,20 +1600,23 @@ def test_set_face_color_mode_after_set_properties():
     # See GitHub issue for more details:
     # https://github.com/napari/napari/issues/2755
     rng = np.random.default_rng(0)
-    points = Points(rng.random((5, 2)) * 3)
+    num_points = 3
+    points = Points(rng.random((num_points, 2)))
 
     points.properties = {
-        'cat': rng.integers(low=0, high=5, size=5),
-        'cont': rng.random(5),
+        'cat': rng.integers(low=0, high=num_points, size=num_points),
+        'cont': rng.random(num_points),
     }
 
     with pytest.warns(UserWarning):
         points.face_color_mode = 'cycle'
 
-    property_key, property_values = next(iter(points.properties.items()))
+    first_property_key, first_property_values = next(
+        iter(points.properties.items())
+    )
     expected_properties = ColorProperties(
-        name=property_key,
-        values=property_values,
-        current_value=property_values[-1],
+        name=first_property_key,
+        values=first_property_values,
+        current_value=first_property_values[-1],
     )
     assert points._face.color_properties == expected_properties

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1599,13 +1599,13 @@ def test_prepare_properties():
 def test_set_face_color_mode_after_set_properties():
     # See GitHub issue for more details:
     # https://github.com/napari/napari/issues/2755
-    rng = np.random.default_rng(0)
+    np.random.seed(0)
     num_points = 3
-    points = Points(rng.random((num_points, 2)))
+    points = Points(np.random.random((num_points, 2)))
 
     points.properties = {
-        'cat': rng.integers(low=0, high=num_points, size=num_points),
-        'cont': rng.random(num_points),
+        'cat': np.random.randint(low=0, high=num_points, size=num_points),
+        'cont': np.random.random(num_points),
     }
 
     # Initially the color_mode is DIRECT, which means that the face ColorManager

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1608,6 +1608,8 @@ def test_set_face_color_mode_after_set_properties():
         'cont': rng.random(num_points),
     }
 
+    # Initially the color_mode is DIRECT, which means that the face ColorManager
+    # has no color_properties, so the first property is used with a warning.
     with pytest.warns(UserWarning):
         points.face_color_mode = 'cycle'
 

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1593,3 +1593,28 @@ def test_prepare_properties():
     properties, choices = layer._prepare_properties({"aa": [1, 2, 1]})
     assert np.array_equal(properties["aa"], [1, 2, 1])
     assert np.array_equal(choices["aa"], [1, 2])
+
+
+def test_bug_2755_works():
+    rng = np.random.default_rng()
+    points = Points(
+        rng.random((5, 2)) * 512,
+        properties={
+            'cat': rng.integers(low=0, high=5, size=5),
+            'cont': rng.random(5),
+        },
+    )
+
+    points.face_color_mode = 'cycle'
+
+
+def test_bug_2755():
+    rng = np.random.default_rng()
+    points = Points(rng.random((5, 2)) * 512)
+
+    points.properties = {
+        'cat': rng.integers(low=0, high=5, size=5),
+        'cont': rng.random(5),
+    }
+
+    points.face_color_mode = 'cycle'

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -401,17 +401,10 @@ class Points(Layer):
         self._update_dims()
 
     def _update_current_properties(self):
-        if len(self._data) > 0:
-            self.current_properties = {
-                k: np.asarray([v[-1]]) for k, v in self.properties.items()
-            }
-        elif len(self._data) == 0 and self.properties:
-            self.current_properties = {
-                k: np.asarray([v[0]])
-                for k, v in self._property_choices.items()
-            }
-        else:
-            self.current_properties = {}
+        index = 0 if len(self._data) == 0 else -1
+        self.current_properties = {
+            k: np.asarray([v[index]]) for k, v in self.properties.items()
+        }
 
     @property
     def data(self) -> np.ndarray:

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -107,7 +107,7 @@ class Points(Layer):
     affine : n-D array or napari.utils.transforms.Affine
         (N+1, N+1) affine transformation matrix in homogeneous coordinates.
         The first (N, N) entries correspond to a linear transform and
-        the final column is a lenght N translation vector and a 1 or a napari
+        the final column is a length N translation vector and a 1 or a napari
         AffineTransform object. If provided then translate, scale, rotate, and
         shear values are ignored.
     opacity : float
@@ -395,21 +395,23 @@ class Points(Layer):
 
         self.size = size
 
-        # set the current_properties
-        if len(data) > 0:
+        self._update_current_properties()
+
+        # Trigger generation of view slice and thumbnail
+        self._update_dims()
+
+    def _update_current_properties(self):
+        if len(self._data) > 0:
             self.current_properties = {
                 k: np.asarray([v[-1]]) for k, v in self.properties.items()
             }
-        elif len(data) == 0 and self.properties:
+        elif len(self._data) == 0 and self.properties:
             self.current_properties = {
                 k: np.asarray([v[0]])
                 for k, v in self._property_choices.items()
             }
         else:
             self.current_properties = {}
-
-        # Trigger generation of view slice and thumbnail
-        self._update_dims()
 
     @property
     def data(self) -> np.ndarray:
@@ -530,6 +532,7 @@ class Points(Layer):
         self._properties, self._property_choices = self._prepare_properties(
             properties, self._property_choices
         )
+        self._update_current_properties()
         self._update_color_manager(
             self._face,
             self._properties,

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -532,6 +532,8 @@ class Points(Layer):
         self._properties, self._property_choices = self._prepare_properties(
             properties, self._property_choices
         )
+        # Updating current_properties can modify properties, so block to avoid
+        # infinite recursion when explicitly setting the properties.
         with self.block_update_properties():
             self._update_current_properties()
         self._update_color_manager(
@@ -961,7 +963,7 @@ class Points(Layer):
             it should be one of: 'direct', 'cycle', or 'colormap'
         attribute : str in {'edge', 'face'}
             The name of the attribute to set the color of.
-            Should be 'edge' for edge_colo_moder or 'face' for face_color_mode.
+            Should be 'edge' for edge_color_mode or 'face' for face_color_mode.
         """
         color_mode = ColorMode(color_mode)
         color_manager = getattr(self, f'_{attribute}')

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -532,7 +532,8 @@ class Points(Layer):
         self._properties, self._property_choices = self._prepare_properties(
             properties, self._property_choices
         )
-        self._update_current_properties()
+        with self.block_update_properties():
+            self._update_current_properties()
         self._update_color_manager(
             self._face,
             self._properties,

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -401,10 +401,17 @@ class Points(Layer):
         self._update_dims()
 
     def _update_current_properties(self):
-        index = 0 if len(self._data) == 0 else -1
-        self.current_properties = {
-            k: np.asarray([v[index]]) for k, v in self.properties.items()
-        }
+        if len(self._data) > 0:
+            self.current_properties = {
+                k: np.asarray([v[-1]]) for k, v in self.properties.items()
+            }
+        elif len(self._data) == 0 and self.properties:
+            self.current_properties = {
+                k: np.asarray([v[0]])
+                for k, v in self._property_choices.items()
+            }
+        else:
+            self.current_properties = {}
 
     @property
     def data(self) -> np.ndarray:


### PR DESCRIPTION
# Description
This makes the behavior of constructing a Points layer with properties and setting those properties consistent. Specifically, when the properties are set and thus clobbered, we now update the current properties in the same way the constructor does.

Even though the change is small, I marked it as WIP for a few reasons.
- I'm also working on the larger issue #2866, which may make this PR redundant.
- I'm unsure if the test represents a clear/common use of properties.
- I'm unsure how to avoid the warning in the test usage through the Points public API, and if that's something we should think about here.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #2755.

# How has this been tested?
- [x] All the tests in test_points.py continue to pass.
- [x] A new test that reproduces the buggy behavior also passes.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
