### PR TITLE
don't raise exception when failing to save qt resources.

### DIFF
--- a/napari/_qt/qt_resources/_icons.py
+++ b/napari/_qt/qt_resources/_icons.py
@@ -37,6 +37,8 @@ from typing import Dict, Iterable, Iterator, Optional, Tuple, Union
 
 import qtpy
 
+from ...utils.translations import trans
+
 __all__ = [
     '_register_napari_resources',
     'compile_qt_svgs',
@@ -318,7 +320,18 @@ def _compile_napari_resources(
     with _temporary_qrc_file(svgs, prefix='themes') as qrc:
         output = compile_qrc(qrc)
         if save_path:
-            Path(save_path).write_bytes(output)
+            try:
+                Path(save_path).write_bytes(output)
+            except OSError as e:
+                import warnings
+
+                msg = trans._(
+                    "Unable to save qt-resources: {err}",
+                    err=str(e),
+                    deferred=True,
+                )
+                warnings.warn(msg)
+
         return output.decode()
 
 


### PR DESCRIPTION
# Description

fixes #2918
If someone has napari installed in a non-writeable location, it will fail to start when trying to save resources.  This PR just makes the failure to save resources a warning.  It will still compile and import the resources, it will just have to do it on every load.