### PR TITLE
test if history is not empty before accessing it

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -526,10 +526,14 @@ class QtViewer(QSplitter):
         hist = get_save_history()
         dlg.setHistory(hist)
 
+        default_directory = '.'
+        if len(hist) > 0:
+            default_directory = hist[0] # home dir by default
+        
         filename, _ = dlg.getSaveFileName(
             parent=self,
             caption=trans._('Save {msg} layers', msg=msg),
-            directory=hist[0],  # home dir by default,
+            directory=default_directory,  
             filter=ext_str,
         )
 


### PR DESCRIPTION
# Description
This change fixes an issue while saving layers. Opening the Save-File-Dialog fails in case the directory history is empty.

See also #2927 

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References

closes #2927

# How has this been tested?
I tested that by hand in the user interface

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
