### PR TITLE
Fix use of `default_factory` in settings

### DIFF
--- a/napari/utils/settings/_manager.py
+++ b/napari/utils/settings/_manager.py
@@ -179,11 +179,9 @@ class SettingsManager(_SettingsMixin):
                     )
                 )
 
-            _section_defaults = {}
-            for option, option_data in setting.schema()["properties"].items():
-                _section_defaults[option] = option_data.get("default", None)
-
-            self._defaults[section] = setting(**_section_defaults)
+            self._defaults[section] = setting(
+                **{k: v.get_default() for k, v in setting.__fields__.items()}
+            )
             model = setting()
             model.events.connect(lambda x: self._save())
             self._settings[section] = model

--- a/napari/utils/settings/_tests/test_settings.py
+++ b/napari/utils/settings/_tests/test_settings.py
@@ -241,10 +241,12 @@ def test_default_factory(monkeypatch):
     from napari.utils.settings._defaults import BaseNapariSettings
 
     class MockSettings(BaseNapariSettings):
-        test: list = Field(default_factory=list)
+        test_field: list = Field(default_factory=list)
 
         class Config:
-            schema_extra = {"section": "test"}
+            schema_extra = {"section": "test_section"}
 
     monkeypatch.setattr(_manager, "CORE_SETTINGS", (MockSettings,))
-    _manager.SettingsManager()
+    mng = _manager.SettingsManager()
+    assert mng.test_section.test_field == []
+    assert mng._defaults['test_section'].test_field == []

--- a/napari/utils/settings/_tests/test_settings.py
+++ b/napari/utils/settings/_tests/test_settings.py
@@ -3,6 +3,7 @@
 
 import pydantic
 import pytest
+from pydantic.fields import Field
 from yaml import safe_dump, safe_load
 
 import napari.utils.settings._manager as _manager
@@ -234,3 +235,16 @@ def test_get_settings_fails(monkeypatch, tmp_path):
     _manager.get_settings(tmp_path)
     with pytest.raises(Exception):
         _manager.get_settings(tmp_path)
+
+
+def test_default_factory(monkeypatch):
+    from napari.utils.settings._defaults import BaseNapariSettings
+
+    class MockSettings(BaseNapariSettings):
+        test: list = Field(default_factory=list)
+
+        class Config:
+            schema_extra = {"section": "test"}
+
+    monkeypatch.setattr(_manager, "CORE_SETTINGS", (MockSettings,))
+    _manager.SettingsManager()


### PR DESCRIPTION
# Description
This fixes #2929 and unblocks #2695

In general, I'm a little concerned that we're not really using pydantic "to it's fullest" in our Settings.  I see a fair amount of conversion to `model.schema()` (json) and then back to python, when there are probably pydantic provided conveniences that are less error prone.  will follow up in a later PR.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
