### PR TITLE
[WIP] arbitrary clipping planes for volumes in the image layer

### DIFF
--- a/examples/clipping_planes.py
+++ b/examples/clipping_planes.py
@@ -12,9 +12,9 @@ blobs = data.binary_blobs(length=64, volume_fraction=0.1, n_dim=3).astype(
 )
 viewer = napari.Viewer(ndisplay=3)
 # add the volume
-layer = viewer.add_image(blobs, scale=[3, 1, 1])
+layer = viewer.add_image(blobs)
 
 
-layer.clipping_planes = np.random.rand(1, 2, 3)
+layer.clipping_planes = np.tile(0.5, (1, 2, 3))
 
 napari.run()

--- a/examples/clipping_planes.py
+++ b/examples/clipping_planes.py
@@ -1,0 +1,20 @@
+"""
+Display a 3D image and use a magic gui widget to control clipping planes
+"""
+
+from skimage import data
+import napari
+import numpy as np
+
+
+blobs = data.binary_blobs(length=64, volume_fraction=0.1, n_dim=3).astype(
+    float
+)
+viewer = napari.Viewer(ndisplay=3)
+# add the volume
+layer = viewer.add_image(blobs, scale=[3, 1, 1])
+
+
+layer.clipping_planes = np.random.rand(1, 2, 3)
+
+napari.run()

--- a/examples/clipping_planes.py
+++ b/examples/clipping_planes.py
@@ -7,7 +7,7 @@ import napari
 import numpy as np
 
 
-blobs = data.binary_blobs(length=64, volume_fraction=0.1, n_dim=3).astype(
+blobs = data.binary_blobs(length=64, volume_fraction=0.1, n_dim=4).astype(
     float
 )
 viewer = napari.Viewer(ndisplay=3)
@@ -15,6 +15,6 @@ viewer = napari.Viewer(ndisplay=3)
 layer = viewer.add_image(blobs)
 
 
-layer.clipping_planes = np.tile(0.5, (1, 2, 3))
+layer.clipping_planes = np.tile(0.5, (1, 2, 4))
 
 napari.run()

--- a/napari/_vispy/vendored/volume.py
+++ b/napari/_vispy/vendored/volume.py
@@ -280,7 +280,7 @@ void main() {{
 MIP_SNIPPETS = dict(
     before_loop="""
         float maxval = -99999.0; // The maximum encountered value
-        int maxi = 0;  // Where the maximum value was encountered
+        int maxi = -1;  // Where the maximum value was encountered
         """,
     in_loop="""
         if( val > maxval ) {
@@ -290,12 +290,14 @@ MIP_SNIPPETS = dict(
         """,
     after_loop="""
         // Refine search for max value
-        loc = start_loc + step * (float(maxi) - 0.5);
-        for (int i=0; i<10; i++) {
-            maxval = max(maxval, $sample(u_volumetex, loc).g);
-            loc += step * 0.1;
-        }
-        gl_FragColor = applyColormap(maxval);
+        if ( maxi > -1 ) {{
+            loc = start_loc + step * (float(maxi) - 0.5);
+            for (int i=0; i<10; i++) {
+                maxval = max(maxval, $sample(u_volumetex, loc).g);
+                loc += step * 0.1;
+            }
+            gl_FragColor = applyColormap(maxval);
+        }}
         """,
 )
 MIP_FRAG_SHADER = FRAG_SHADER.format(**MIP_SNIPPETS)

--- a/napari/_vispy/vendored/volume.py
+++ b/napari/_vispy/vendored/volume.py
@@ -7,19 +7,19 @@ About this technique
 --------------------
 
 In Python, we define the six faces of a cuboid to draw, as well as
-texture cooridnates corresponding with the vertices of the cuboid. 
+texture cooridnates corresponding with the vertices of the cuboid.
 The back faces of the cuboid are drawn (and front faces are culled)
-because only the back faces are visible when the camera is inside the 
+because only the back faces are visible when the camera is inside the
 volume.
 
-In the vertex shader, we intersect the view ray with the near and far 
+In the vertex shader, we intersect the view ray with the near and far
 clipping planes. In the fragment shader, we use these two points to
 compute the ray direction and then compute the position of the front
 cuboid surface (or near clipping plane) along the view ray.
 
 Next we calculate the number of steps to walk from the front surface
 to the back surface and iterate over these positions in a for-loop.
-At each iteration, the fragment color or other voxel information is 
+At each iteration, the fragment color or other voxel information is
 updated depending on the selected rendering method.
 
 It is important for the texture interpolation is 'linear' for most volumes,
@@ -396,14 +396,14 @@ frag_dict = {
 
 
 CLIPPING_PLANES_SETUP_SNIPPET = """
-    uniform vec3 clipping_plane_pos{idx};
-    uniform vec3 clipping_plane_norm{idx};
+    uniform vec3 u_clipping_plane_pos{idx};
+    uniform vec3 u_clipping_plane_norm{idx};
     """
 
 
 CLIPPING_PLANES_APPLY_SNIPPET = """
-    vec3 relative_vec{idx} = loc - clipping_plane_pos{idx};
-    float is_shown{idx} = dot(relative_vec{idx}, clipping_plane_norm{idx});
+    vec3 relative_vec{idx} = loc - u_clipping_plane_pos{idx};
+    float is_shown{idx} = dot(relative_vec{idx}, u_clipping_plane_norm{idx});
     is_shown = min(is_shown{idx}, is_shown);
     """
 
@@ -737,8 +737,8 @@ class VolumeVisual(Visual):
             frag = self.inject_clipping_planes(frag)
             self.set_frag(frag)
         for idx, plane in enumerate(self._clipping_planes):
-            self.shared_program[f'clipping_plane_pos{idx}'] = tuple(plane[0])
-            self.shared_program[f'clipping_plane_norm{idx}'] = tuple(plane[1])
+            self.shared_program[f'u_clipping_plane_pos{idx}'] = tuple(plane[0])
+            self.shared_program[f'u_clipping_plane_norm{idx}'] = tuple(plane[1])
         self.update()
 
     def inject_clipping_planes(self, frag):

--- a/napari/_vispy/vispy_image_layer.py
+++ b/napari/_vispy/vispy_image_layer.py
@@ -49,6 +49,9 @@ class VispyImageLayer(VispyBaseLayer):
         self.layer.events.gamma.connect(self._on_gamma_change)
         self.layer.events.iso_threshold.connect(self._on_iso_threshold_change)
         self.layer.events.attenuation.connect(self._on_attenuation_change)
+        self.layer.events.clipping_planes.connect(
+            self._on_clipping_planes_change
+        )
 
         self._on_display_change()
         self._on_data_change()
@@ -142,6 +145,10 @@ class VispyImageLayer(VispyBaseLayer):
     def _on_attenuation_change(self, event=None):
         if isinstance(self.node, VolumeNode):
             self.node.attenuation = self.layer.attenuation
+
+    def _on_clipping_planes_change(self, event=None):
+        if isinstance(self.node, VolumeNode):
+            self.node.clipping_planes = self.layer.clipping_planes
 
     def reset(self, event=None):
         self._reset_base()

--- a/napari/_vispy/volume.py
+++ b/napari/_vispy/volume.py
@@ -35,7 +35,7 @@ frag_dict['attenuated_mip'] = ATTENUATED_MIP_FRAG_SHADER
 MINIP_SNIPPETS = dict(
     before_loop="""
         float minval = 99999.0; // The minimum encountered value
-        int mini = 0;  // Where the minimum value was encountered
+        int mini = -1;  // Where the minimum value was encountered
         """,
     in_loop="""
         if( val < minval ) {
@@ -44,13 +44,15 @@ MINIP_SNIPPETS = dict(
         }
         """,
     after_loop="""
-        // Refine search for min value
-        loc = start_loc + step * (float(mini) - 0.5);
-        for (int i=0; i<10; i++) {
-            minval = min(minval, $sample(u_volumetex, loc).g);
-            loc += step * 0.1;
-        }
-        gl_FragColor = applyColormap(minval);
+        if (mini > -1) {{
+            // Refine search for min value
+            loc = start_loc + step * (float(mini) - 0.5);
+            for (int i=0; i<10; i++) {
+                minval = min(minval, $sample(u_volumetex, loc).g);
+                loc += step * 0.1;
+            }
+            gl_FragColor = applyColormap(minval);
+        }}
         """,
 )
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -422,15 +422,17 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
 
     @property
     def clipping_planes(self):
-        return self._clipping_planes
+        # slice according to displayed dims
+        return self._clipping_planes[..., self._dims_displayed]
 
     @clipping_planes.setter
     def clipping_planes(self, value):
         if value is not None:
             value = np.array(value)
-            if value.ndim != 3 and value.shape[-2:] != (2, 3):
+            if value.ndim != 3 and value.shape[-2:] != (2, self.data.ndim):
                 raise ValueError(
-                    f'clipping planes must have shape (n, 2, 3), not {value.shape}'
+                    f'clipping planes for a {self.data.ndim}D image must have '
+                    f'shape (n, 2, {self.data.ndim}), not {value.shape}'
                 )
         self._clipping_planes = value
         self.events.clipping_planes()

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -189,6 +189,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         blending='translucent',
         visible=True,
         multiscale=None,
+        clipping_planes=None,
     ):
         if isinstance(data, types.GeneratorType):
             data = list(data)
@@ -239,6 +240,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
             rendering=Event,
             iso_threshold=Event,
             attenuation=Event,
+            clipping_planes=Event,
         )
 
         # Set data
@@ -285,6 +287,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         }
         self.interpolation = interpolation
         self.rendering = rendering
+        self.clipping_planes = clipping_planes
 
         # Trigger generation of view slice and thumbnail
         self._update_dims()
@@ -416,6 +419,22 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         self._attenuation = value
         self._update_thumbnail()
         self.events.attenuation()
+
+    @property
+    def clipping_planes(self):
+        return self._clipping_planes
+
+    @clipping_planes.setter
+    def clipping_planes(self, value):
+        if value is not None:
+            value = np.array(value)
+            if value.ndim != 3 and value.shape[-2:] != (2, 3):
+                raise ValueError(
+                    f'clipping planes must have shape (n, 2, 3), not {value.shape}'
+                )
+        self._clipping_planes = value
+        self.events.clipping_planes()
+        self._update_thumbnail()
 
     @property
     def interpolation(self):
@@ -813,6 +832,7 @@ class Image(_ImageBase):
                 'rendering': self.rendering,
                 'iso_threshold': self.iso_threshold,
                 'attenuation': self.attenuation,
+                'clipping_planes': self.clipping_planes,
                 'gamma': self.gamma,
                 'data': self.data,
             }


### PR DESCRIPTION
# Description
This is a WIP attempt at arbitrary clipping planes. A lot of things are not yet hooked up or in a temporary state, but I'm starting the PR as a way to get some discussion and feedback going.

In short, this PR adds a `clipping_planes` attribute to image layers, which accepts an array of shape (n, 2, 3) (much like the vector layer). Each of these vectors define a clipping plane (position and normal vector), which is used to clip the volume (anything on the negative side of the normal vector is not shown).

Currently, the vector coordinates are normalized in (0, 1), but they should probably be in world coordinates.

I also added a little example to try it out. Here's what it looks like:

https://user-images.githubusercontent.com/23482191/123652944-068d8d00-d82d-11eb-8d5b-a7839bda91f0.mp4

I'd love to hear some thoughts, especially on the (very shady) code injection in the shader, and how it could be improved.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# References
This can also be a generalization of #2437, which could then simply be a special case with 6 clipping planes placed like a cuboid.

# How has this been tested?
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
