### PR TITLE
Degrade gracefully to default when colormap is not recognized

### DIFF
--- a/napari/utils/colormaps/_tests/test_colormaps.py
+++ b/napari/utils/colormaps/_tests/test_colormaps.py
@@ -138,10 +138,10 @@ def test_can_accept_colormap_dict():
     assert cmap.name == 'special_name'
 
 
-@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_can_degrade_gracefully():
     """Test that we can degrade gracefully is given something not recognized."""
-    cmap = ensure_colormap(object)
+    with pytest.warns(UserWarning):
+        cmap = ensure_colormap(object)
     assert isinstance(cmap, Colormap)
     assert cmap.name == 'gray'
 

--- a/napari/utils/colormaps/_tests/test_colormaps.py
+++ b/napari/utils/colormaps/_tests/test_colormaps.py
@@ -139,7 +139,7 @@ def test_can_accept_colormap_dict():
 
 
 def test_can_degrade_gracefully():
-    """Test that we can degrade gracefully is given something not recognized."""
+    """Test that we can degrade gracefully if given something not recognized."""
     with pytest.warns(UserWarning):
         cmap = ensure_colormap(object)
     assert isinstance(cmap, Colormap)

--- a/napari/utils/colormaps/_tests/test_colormaps.py
+++ b/napari/utils/colormaps/_tests/test_colormaps.py
@@ -138,6 +138,14 @@ def test_can_accept_colormap_dict():
     assert cmap.name == 'special_name'
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_can_degrade_gracefully():
+    """Test that we can degrade gracefully is given something not recognized."""
+    cmap = ensure_colormap(object)
+    assert isinstance(cmap, Colormap)
+    assert cmap.name == 'gray'
+
+
 def test_vispy_colormap_amount():
     """
     Test that the amount of localized vispy colormap names matches available colormaps.

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -610,13 +610,18 @@ def ensure_colormap(colormap: ValidColormapArg) -> Colormap:
                         )
                     )
         else:
-            raise TypeError(
+            import warnings
+
+            warnings.warn(
                 trans._(
-                    'invalid type for colormap: {cm_type}. Must be a {{str, tuple, dict, napari.utils.Colormap, vispy.colors.Colormap}}',
+                    'invalid type for colormap: {cm_type}. Must be a {{str, tuple, dict, napari.utils.Colormap, vispy.colors.Colormap}}. Reverting to default',
                     deferred=True,
                     cm_type=type(colormap),
                 )
             )
+
+            # Use default colormap
+            name = 'gray'
 
     return AVAILABLE_COLORMAPS[name]
 


### PR DESCRIPTION
# Description
Not completely sure we want to do this, but this would fix https://github.com/tlambert03/napari-bioformats/issues/4. It could just make things a little smoother for plugins proving colormaps - if we don't recognize colormap we just go with default option.

Thoughts @tlambert03? We might also want to let `[1.0, 0.0, 0.0]` be recognized as valid, but it's a little tricky as you really do need two colors to specify to colormap (or we just assume it always goes from black to that color, which isn't unreasonable).

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
