### PR TITLE
add alister burt to team page

### DIFF
--- a/docs/community/team.md
+++ b/docs/community/team.md
@@ -6,6 +6,7 @@ napari is a consensus-based community project. Anyone with an interest in the pr
 ## Current Core Developers
 
 - [Ahmet Can Solak](https://github.com/napari/napari/commits?author=AhmetCanSolak) - [@AhmetCanSolak](https://github.com/AhmetCanSolak)
+- [Alister Burt](https://github.com/napari/napari/commits?author=alisterburt) - [@alisterburt](https://github.com/alisterburt)
 - [Genevieve Buckley](https://github.com/napari/napari/commits?author=GenevieveBuckley) - [@GenevieveBuckley](https://github.com/GenevieveBuckley)
 - [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) - [@jni](https://github.com/jni) (SC)
 - [Justine Larsen](https://github.com/napari/napari/commits?author=justinelarsen) - [@justinelarsen](https://github.com/justinelarsen)


### PR DESCRIPTION
realized while looking at our docs that we hadn't updated them to reflect that @alisterburt is a core dev!