### PR TITLE
Fix magicgui registration and circular imports

### DIFF
--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -16,6 +16,8 @@ _proto_all_ = [
     'experimental',
     'layers',
     'qt',
+    'types',
+    'viewer',
     'utils',
 ]
 

--- a/napari/components/__init__.py
+++ b/napari/components/__init__.py
@@ -25,3 +25,5 @@ from . import _viewer_key_bindings  # isort:skip
 from .viewer_model import ViewerModel  # isort:skip
 
 del _viewer_key_bindings
+
+__all__ = ['ViewerModel', 'Camera', 'Dims', 'LayerList']

--- a/napari/layers/__init__.py
+++ b/napari/layers/__init__.py
@@ -4,9 +4,10 @@ Custom layers must inherit from Layer and pass along the
 `visual node <http://vispy.org/scene.html#module-vispy.scene.visuals>`_
 to the super constructor.
 """
-from inspect import isabstract
+import inspect as _inspect
+from importlib import import_module as _imp
 
-from ..utils.misc import all_subclasses
+from ..utils.misc import all_subclasses as _all_subcls
 from .base import Layer
 from .image import Image
 from .labels import Labels
@@ -19,7 +20,20 @@ from .vectors import Vectors
 # isabstact check is to exclude _ImageBase class
 NAMES = {
     subclass.__name__.lower()
-    for subclass in all_subclasses(Layer)
-    if not isabstract(subclass)
+    for subclass in _all_subcls(Layer)
+    if not _inspect.isabstract(subclass)
 }
-del all_subclasses
+
+__all__ = [
+    'Layer',
+    'Image',
+    'Labels',
+    'Points',
+    'Shapes',
+    'Surface',
+    'Tracks',
+    'Vectors',
+    'NAMES',
+]
+
+_imp('napari.utils._magicgui').register_layers_with_magicgui()

--- a/napari/layers/__init__.py
+++ b/napari/layers/__init__.py
@@ -35,5 +35,3 @@ __all__ = [
     'Vectors',
     'NAMES',
 ]
-
-_imp('napari.utils._magicgui').register_layers_with_magicgui()

--- a/napari/layers/_source.py
+++ b/napari/layers/_source.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import Optional, Tuple
 
+from magicgui.widgets import FunctionGui
 from pydantic import BaseModel
-
-if TYPE_CHECKING:
-    from magicgui.widgets import FunctionGui
 
 
 class Source(BaseModel):

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -6,6 +6,8 @@ from typing import List, Optional
 
 import numpy as np
 
+from ...utils import _magicgui as _mgui
+from ...utils._magicgui import add_layer_to_viewer, get_layers
 from ...utils.dask_utils import configure_dask
 from ...utils.events import EmitterGroup, Event
 from ...utils.events.event import WarningEmitter
@@ -27,6 +29,7 @@ from ._base_constants import Blending
 Extent = namedtuple('Extent', 'data world step')
 
 
+@_mgui.register_type(choices=get_layers, return_callback=add_layer_to_viewer)
 class Layer(KeymapProvider, MousemapProvider, ABC):
     """Base layer class.
 

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -1,7 +1,6 @@
 import importlib
 import sys
 from functools import partial
-from importlib import import_module as _imp
 from pathlib import Path
 from types import FunctionType
 from typing import (
@@ -83,8 +82,6 @@ class NapariPluginManager(PluginManager):
 
         if sys.platform.startswith('linux') and running_as_bundled_app():
             sys.path.append(user_site_packages())
-
-        _imp('napari.utils._magicgui').register_types_with_magicgui()
 
     def _initialize(self):
         with self.discovery_blocked():

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 from functools import partial
+from importlib import import_module as _imp
 from pathlib import Path
 from types import FunctionType
 from typing import (
@@ -21,7 +22,6 @@ from napari_plugin_engine import PluginManager as PluginManager
 from typing_extensions import TypedDict
 
 from ..types import AugmentedWidget, LayerData, SampleDict, WidgetCallable
-from ..utils import _magicgui
 from ..utils._appdirs import user_site_packages
 from ..utils.events import EmitterGroup, EventedSet
 from ..utils.misc import camel_to_spaces, running_as_bundled_app
@@ -84,7 +84,7 @@ class NapariPluginManager(PluginManager):
         if sys.platform.startswith('linux') and running_as_bundled_app():
             sys.path.append(user_site_packages())
 
-        _magicgui.register_types_with_magicgui()
+        _imp('napari.utils._magicgui').register_types_with_magicgui()
 
     def _initialize(self):
         with self.discovery_blocked():

--- a/napari/types.py
+++ b/napari/types.py
@@ -18,8 +18,6 @@ from typing import (
 import numpy as np
 from typing_extensions import TypedDict
 
-from .utils._magicgui import register_types_with_magicgui
-
 if TYPE_CHECKING:
     import dask.array
     import zarr
@@ -124,4 +122,25 @@ def image_reader_to_layerdata_reader(
     return reader_function
 
 
-register_types_with_magicgui()
+def _register_types_with_magicgui():
+    """Register napari.types objects with magicgui."""
+    from . import layers
+    from .utils import _magicgui as _mgui
+
+    _mgui.register_type(
+        LayerDataTuple,
+        return_callback=_mgui.add_layer_data_tuples_to_viewer,
+    )
+    _mgui.register_type(
+        List[LayerDataTuple],
+        return_callback=_mgui.add_layer_data_tuples_to_viewer,
+    )
+    for layer_name in layers.NAMES:
+        _mgui.register_type(
+            globals().get(f'{layer_name.title()}Data'),
+            choices=_mgui.get_layers_data,
+            return_callback=_mgui.add_layer_data_to_viewer,
+        )
+
+
+_register_types_with_magicgui()

--- a/napari/utils/_tests/test_magicgui.py
+++ b/napari/utils/_tests/test_magicgui.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from magicgui import magicgui
 
-from napari import Viewer, types
+from napari import Viewer, layers, types
 from napari._tests.utils import layer_test_data
 from napari.layers import Image, Labels, Layer
 from napari.utils.misc import all_subclasses
@@ -184,22 +184,32 @@ def test_magicgui_get_viewer(make_napari_viewer):
     assert not func.v.visible
 
 
-def test_magicgui_imports(tmp_path):
-    """Test that magicgui is registered in time"""
+MGUI_EXPORTS = ['napari.layers.Layer', 'napari.Viewer']
+MGUI_EXPORTS += [f'napari.types.{nm.title()}Data' for nm in layers.NAMES]
+
+
+@pytest.mark.parametrize('name', MGUI_EXPORTS)
+def test_mgui_forward_refs(tmp_path, name):
+    """Test magicgui forward ref annotations
+
+    In a 'fresh' process, make sure that calling
+    `magicgui.type_map.pick_widget_type` with the string version of a napari
+    object triggers the appropriate imports to resolve the class in time.
+    """
     import subprocess
-    import sys
-    from textwrap import dedent
+    import textwrap
 
     script = """
-    from napari.types import ImageData
-    from magicgui import magicgui
-
-    @magicgui()
-    def filter_widget(image: ImageData) -> ImageData:
-        return None
-
-    filter_widget()
+    import magicgui
+    assert magicgui.type_map._TYPE_DEFS == {{}}
+    name = {0!r}
+    wdg, options = magicgui.type_map.pick_widget_type(annotation=name)
+    if name == 'napari.Viewer':
+        assert wdg == magicgui.widgets.EmptyWidget and 'bind' in options
+    else:
+        assert wdg == magicgui.widgets.Combobox
     """
+
     script_path = tmp_path / 'script.py'
-    script_path.write_text(dedent(script))
+    script_path.write_text(textwrap.dedent(script.format(name)))
     subprocess.run([sys.executable, str(script_path)], check=True)

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,14 +1,14 @@
-from importlib import import_module as _imp
 from typing import TYPE_CHECKING
 
 from .components.viewer_model import ViewerModel
-from .utils import config
+from .utils import _magicgui, config
 
 if TYPE_CHECKING:
     # helpful for IDE support
     from ._qt.qt_main_window import Window
 
 
+@_magicgui.register_type(bind=_magicgui.find_viewer_ancestor)
 class Viewer(ViewerModel):
     """Napari ndarray viewer.
 
@@ -123,6 +123,3 @@ class Viewer(ViewerModel):
             # https://github.com/napari/napari/issues/1500
             for layer in self.layers:
                 chunk_loader.on_layer_deleted(layer)
-
-
-_imp('napari.utils._magicgui').register_viewer_with_magicgui()

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,6 +1,7 @@
+from importlib import import_module as _imp
 from typing import TYPE_CHECKING
 
-from .components import ViewerModel
+from .components.viewer_model import ViewerModel
 from .utils import config
 
 if TYPE_CHECKING:
@@ -122,3 +123,6 @@ class Viewer(ViewerModel):
             # https://github.com/napari/napari/issues/1500
             for layer in self.layers:
                 chunk_loader.on_layer_deleted(layer)
+
+
+_imp('napari.utils._magicgui').register_viewer_with_magicgui()


### PR DESCRIPTION
# Description
fixes https://github.com/napari/napari/issues/2944

I think there's still lots of room for improvements here.  Generally, supporting forward refs has turned out to be quite challenging.   There's just a lot of room for "too late" imports... that was the case here, where our new lazy imports in #2662 made it so that `napari.layers` hadn't yet been imported by the time @ViktorvdValk's magicgui decorated function was evaluated, _and_ when magicgui attempted to resolve the name `'napari.layers.Image'`, it worked, but the "register_types_with_magicgui" function hadn't yet been called.  

So, what I've done here is to split each "register_x_with_magicgui" function into it's own function so that they don't need to import _all_ of the types that we want to register with magicgui at once (which was otherwise causing circular imports).

In other words, these types should really be registered with magicgui _where_ they are declared, and not in one big `_magicgui` module that tries to import everything.  in a followup PR, I can imagine a slightly better pattern using a decorator:

```python
@register_with_magicgui(...)
class Layer:
    ...
```
 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
