### PR TITLE
addressing case wher argument to get_default_shape_type is empty list, addresses issue #2960

### DIFF
--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -1015,7 +1015,9 @@ def extract_shape_type(data, shape_type=None):
 
 
 def get_default_shape_type(current_type):
-    """Returns current shape type if current_type is one shape, else "polygon".
+    """If all shapes in current_type are of identical shape type,
+       return this shape type, else "polygon" as lowest common 
+       denominator type.
 
     Parameters
     ----------
@@ -1027,10 +1029,13 @@ def get_default_shape_type(current_type):
     default_type : str
         default shape type
     """
+    default = "polygon"
+    if not current_type:
+        return default
     first_type = current_type[0]
     if all(shape_type == first_type for shape_type in current_type):
         return first_type
-    return "rectangle"
+    return default
 
 
 def get_shape_ndim(data):

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -1016,7 +1016,7 @@ def extract_shape_type(data, shape_type=None):
 
 def get_default_shape_type(current_type):
     """If all shapes in current_type are of identical shape type,
-       return this shape type, else "polygon" as lowest common 
+       return this shape type, else "polygon" as lowest common
        denominator type.
 
     Parameters

--- a/napari/layers/shapes/_tests/test_shapes_utils.py
+++ b/napari/layers/shapes/_tests/test_shapes_utils.py
@@ -27,8 +27,17 @@ def test_get_default_shape_type():
     shape_type = ['polygon', 'polygon']
     assert get_default_shape_type(shape_type) == 'polygon'
 
+    shape_type = []
+    assert get_default_shape_type(shape_type) == 'polygon'
+
     shape_type = ['ellipse', 'rectangle']
+    assert get_default_shape_type(shape_type) == 'polygon'
+
+    shape_type = ['rectangle', 'rectangle']
     assert get_default_shape_type(shape_type) == 'rectangle'
+
+    shape_type = ['ellipse', 'ellipse']
+    assert get_default_shape_type(shape_type) == 'polygon'
 
     shape_type = ['polygon']
     assert get_default_shape_type(shape_type) == 'polygon'

--- a/napari/layers/shapes/_tests/test_shapes_utils.py
+++ b/napari/layers/shapes/_tests/test_shapes_utils.py
@@ -37,7 +37,7 @@ def test_get_default_shape_type():
     assert get_default_shape_type(shape_type) == 'rectangle'
 
     shape_type = ['ellipse', 'ellipse']
-    assert get_default_shape_type(shape_type) == 'polygon'
+    assert get_default_shape_type(shape_type) == 'ellipse'
 
     shape_type = ['polygon']
     assert get_default_shape_type(shape_type) == 'polygon'


### PR DESCRIPTION
# Description

## Type of change

bugfix, see #2960

checks for empty list.

I also changed the docstring to be more accurate and changed the default type that is returned
to the type "polygon" that was mentioned in the docstring.

# How has this been tested?

manually checked whether #2960 has been fixed.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
