### PR TITLE
Labels paintbrush now takes anisotropy into account

### DIFF
--- a/examples/nD_labels.py
+++ b/examples/nD_labels.py
@@ -9,8 +9,8 @@ import napari
 
 
 blobs = data.binary_blobs(length=128, volume_fraction=0.1, n_dim=3)
-viewer = napari.view_image(blobs.astype(float), name='blobs')
+viewer = napari.view_image(blobs[::2].astype(float), name='blobs', scale=(2, 1, 1))
 labeled = ndi.label(blobs)[0]
-viewer.add_labels(labeled, name='blob ID')
+viewer.add_labels(labeled[::2], name='blob ID', scale=(2, 1, 1))
 
 napari.run()

--- a/napari/layers/labels/_labels_utils.py
+++ b/napari/layers/labels/_labels_utils.py
@@ -56,7 +56,7 @@ def sphere_indices(radius, scale):
     scale_normalized = np.asarray(scale, dtype=float) / np.min(scale)
     # Create multi-dimensional grid to check for
     # circle/membership around center
-    r_normalized = (radius + 0.5) / scale_normalized
+    r_normalized = radius / scale_normalized + 0.5
     slices = [
         slice(-int(np.ceil(r)), int(np.floor(r)) + 1) for r in r_normalized
     ]

--- a/napari/layers/labels/_labels_utils.py
+++ b/napari/layers/labels/_labels_utils.py
@@ -37,28 +37,32 @@ def interpolate_coordinates(old_coord, new_coord, brush_size):
 
 
 @lru_cache(maxsize=64)
-def sphere_indices(radius, sphere_dims):
-    """Generate centered indices within circle or n-dim sphere.
+def sphere_indices(radius, scale):
+    """Generate centered indices within circle or n-dim ellipsoid.
 
     Parameters
     -------
     radius : float
         Radius of circle/sphere
-    sphere_dims : int
-        Number of circle/sphere dimensions
+    scale : tuple of float
+        The scaling to apply to the sphere along each axis
 
     Returns
     -------
     mask_indices : array
         Centered indices within circle/sphere
     """
+    ndim = len(scale)
+    scale_normalized = np.asarray(scale, dtype=float) / np.min(scale)
     # Create multi-dimensional grid to check for
     # circle/membership around center
-    vol_radius = radius + 0.5
+    r_normalized = (radius + 0.5) / scale_normalized
+    slices = [
+        slice(-int(np.ceil(r)), int(np.floor(r)) + 1) for r in r_normalized
+    ]
 
-    indices_slice = [slice(-vol_radius, vol_radius + 1)] * sphere_dims
-    indices = np.mgrid[indices_slice].T.reshape(-1, sphere_dims)
-    distances_sq = np.sum(indices ** 2, axis=1)
+    indices = np.mgrid[slices].T.reshape(-1, ndim)
+    distances_sq = np.sum((indices * scale_normalized) ** 2, axis=1)
     # Use distances within desired radius to mask indices in grid
     mask_indices = indices[distances_sq <= radius ** 2].astype(int)
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1114,6 +1114,9 @@ class Labels(_ImageBase):
         shape = self.data.shape
         dims_to_paint = self._dims_order[-self.n_edit_dimensions :]
         dims_not_painted = self._dims_order[: -self.n_edit_dimensions]
+        paint_scale = np.array(
+            [self.scale[i] for i in dims_to_paint], dtype=float
+        )
         if str(self._brush_shape) == "square":
             brush_size_dims = [self.brush_size] * self.ndim
             if self.n_edit_dimensions < self.ndim:
@@ -1145,11 +1148,10 @@ class Labels(_ImageBase):
             else:
                 coord_paint = coord
 
-            sphere_dims = len(coord_paint)
             # Ensure circle doesn't have spurious point
             # on edge by keeping radius as ##.5
             radius = np.floor(self.brush_size / 2) + 0.5
-            mask_indices = sphere_indices(radius, sphere_dims)
+            mask_indices = sphere_indices(radius, tuple(paint_scale))
 
             mask_indices = mask_indices + np.round(
                 np.array(coord_paint)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -338,8 +338,8 @@ class Labels(_ImageBase):
         # Convert from brush size in data coordinates to
         # cursor size in world coordinates
         scale = self._data_to_world.scale
-        average_scale = np.mean([scale[d] for d in self._dims_displayed])
-        return abs(self.brush_size * average_scale)
+        min_scale = np.min([scale[d] for d in self._dims_displayed])
+        return abs(self.brush_size * min_scale)
 
     @property
     def seed(self):


### PR DESCRIPTION
# Description

Before:

<img width="1202" alt="Screen Shot 2021-07-01 at 10 00 12 am" src="https://user-images.githubusercontent.com/492549/124045525-2c947680-da53-11eb-8fcc-0e6c7d569fd8.png">

After:

<img width="1202" alt="Screen Shot 2021-07-01 at 9 56 50 am" src="https://user-images.githubusercontent.com/492549/124045554-3cac5600-da53-11eb-9f27-84c1b8ad3665.png">
