### PR TITLE
Fix nD anisotropic painting when scale is negative

### DIFF
--- a/napari/layers/labels/_labels_utils.py
+++ b/napari/layers/labels/_labels_utils.py
@@ -53,7 +53,8 @@ def sphere_indices(radius, scale):
         Centered indices within circle/sphere
     """
     ndim = len(scale)
-    scale_normalized = np.asarray(scale, dtype=float) / np.min(scale)
+    abs_scale = np.abs(scale)
+    scale_normalized = np.asarray(abs_scale, dtype=float) / np.min(abs_scale)
     # Create multi-dimensional grid to check for
     # circle/membership around center
     r_normalized = radius / scale_normalized + 0.5

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -958,3 +958,19 @@ def test_fill_tensorstore():
         layer.fill((1, 4, 6, 7), 4)
         modified_labels = np.where(labels == 2, 4, labels)
         np.testing.assert_array_equal(modified_labels, np.asarray(data))
+
+
+@pytest.mark.parametrize(
+    'scale', itertools.product([-2, 2], [-0.5, 0.5], [-0.5, 0.5])
+)
+def test_paint_3d_negative_scale(scale):
+    labels = np.zeros((3, 5, 11, 11), dtype=int)
+    labels_layer = Labels(
+        labels, scale=(1,) + scale, translate=(-200, 100, 100)
+    )
+    labels_layer.n_edit_dimensions = 3
+    labels_layer.brush_size = 8
+    labels_layer.paint((1, 2, 5, 5), 1)
+    np.testing.assert_array_equal(
+        np.sum(labels_layer.data, axis=(1, 2, 3)), [0, 95, 0]
+    )

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -961,7 +961,7 @@ def test_fill_tensorstore():
 
 
 @pytest.mark.parametrize(
-    'scale', itertools.product([-2, 2], [-0.5, 0.5], [-0.5, 0.5])
+    'scale', list(itertools.product([-2, 2], [-0.5, 0.5], [-0.5, 0.5]))
 )
 def test_paint_3d_negative_scale(scale):
     labels = np.zeros((3, 5, 11, 11), dtype=int)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -338,7 +338,7 @@ class Labels(_ImageBase):
         # Convert from brush size in data coordinates to
         # cursor size in world coordinates
         scale = self._data_to_world.scale
-        min_scale = np.min([scale[d] for d in self._dims_displayed])
+        min_scale = np.min([abs(scale[d]) for d in self._dims_displayed])
         return abs(self.brush_size * min_scale)
 
     @property


### PR DESCRIPTION
# Description

In #2962 I neglected to take negative scales into account, which broke painting in some cases. This PR contains a fix and a test.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
