### PR TITLE
Added default color dict check when automatically selecting the color mode

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -981,7 +981,7 @@ def test_paint_3d_negative_scale(scale):
 
 
 def test_is_default_color():
-    """Test that Labels._is_default_color() returns True for the default color 
+    """Test that Labels._is_default_color() returns True for the default color
     value of the Labels layer.
     """
     data = np.random.randint(20, size=(30, 30))

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -981,6 +981,9 @@ def test_paint_3d_negative_scale(scale):
 
 
 def test_is_default_color():
+    """Test that Labels._is_default_color() returns True for the default color 
+    value of the Labels layer.
+    """
     data = np.random.randint(20, size=(30, 30))
     layer = Labels(data)
     assert layer._is_default_color(layer.color)

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -978,3 +978,9 @@ def test_paint_3d_negative_scale(scale):
     np.testing.assert_array_equal(
         np.sum(labels_layer.data, axis=(1, 2, 3)), [0, 95, 0]
     )
+
+
+def test_is_default_color():
+    data = np.random.randint(20, size=(30, 30))
+    layer = Labels(data)
+    assert layer._is_default_color(layer.color)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -416,7 +416,8 @@ class Labels(_ImageBase):
     @color.setter
     def color(self, color):
 
-        if not color or self._is_default_color(color):  # default check fixes #2479 and #2953 
+        # default check fixes #2479 and #2953
+        if not color or self._is_default_color(color):
             color = {}
             color_mode = LabelColorMode.AUTO
         else:

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -432,7 +432,7 @@ class Labels(_ImageBase):
             for label, color_str in color.items()
         }
 
-        for label, color_rgba in self._default_color:
+        for label, color_rgba in self._default_color.items():
             if label not in colors:
                 colors[label] = color_rgba
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -446,7 +446,6 @@ class Labels(_ImageBase):
             None: transform_color('black')[0],
             self._background_label: transform_color('transparent')[0],
         }
-        print(color)
 
         for key, value in color.items():
             default_value = default_color.get(key)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -416,7 +416,7 @@ class Labels(_ImageBase):
     @color.setter
     def color(self, color):
 
-        if not color:
+        if not color or self._is_default_color(color):
             color = {}
             color_mode = LabelColorMode.AUTO
         else:
@@ -435,6 +435,25 @@ class Labels(_ImageBase):
 
         self._color = colors
         self.color_mode = color_mode
+
+    def _is_default_color(
+        self, color: Dict[Optional[int], np.ndarray]
+    ) -> bool:
+        if len(color) != 2:
+            return False
+
+        default_color = {
+            None: transform_color('black')[0],
+            self._background_label: transform_color('transparent')[0],
+        }
+        print(color)
+
+        for key, value in color.items():
+            default_value = default_color.get(key)
+            if not np.array_equal(value, default_value):
+                return False
+
+        return True
 
     def _ensure_int_labels(self, data):
         """Ensure data is integer by converting from bool if required, raising an error otherwise."""

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -251,6 +251,10 @@ class Labels(_ImageBase):
         self._selected_label = 1
         self._selected_color = self.get_color(self._selected_label)
         self.color = color
+        self._default_color = {
+            None: transform_color('black')[0],
+            self._background_label: transform_color('transparent')[0],
+        }
 
         self._mode = Mode.PAN_ZOOM
         self._mode_history = self._mode
@@ -423,16 +427,14 @@ class Labels(_ImageBase):
         else:
             color_mode = LabelColorMode.DIRECT
 
-        if self._background_label not in color:
-            color[self._background_label] = 'transparent'
-
-        if None not in color:
-            color[None] = 'black'
-
         colors = {
             label: transform_color(color_str)[0]
             for label, color_str in color.items()
         }
+
+        for label, color_rgba in self._default_color:
+            if label not in colors:
+                colors[label] = color_rgba
 
         self._color = colors
         self.color_mode = color_mode
@@ -444,13 +446,8 @@ class Labels(_ImageBase):
         if len(color) != 2:
             return False
 
-        default_color = {
-            None: transform_color('black')[0],
-            self._background_label: transform_color('transparent')[0],
-        }
-
         for key, value in color.items():
-            default_value = default_color.get(key)
+            default_value = self._default_color.get(key)
             if not np.array_equal(value, default_value):
                 return False
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -416,7 +416,7 @@ class Labels(_ImageBase):
     @color.setter
     def color(self, color):
 
-        if not color or self._is_default_color(color):
+        if not color or self._is_default_color(color):  # default check fixes #2479 and #2953 
             color = {}
             color_mode = LabelColorMode.AUTO
         else:
@@ -439,6 +439,7 @@ class Labels(_ImageBase):
     def _is_default_color(
         self, color: Dict[Optional[int], np.ndarray]
     ) -> bool:
+        """Checks whether a color is equal to the default color value of the layer."""
         if len(color) != 2:
             return False
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -250,11 +250,11 @@ class Labels(_ImageBase):
 
         self._selected_label = 1
         self._selected_color = self.get_color(self._selected_label)
-        self.color = color
         self._default_color = {
             None: transform_color('black')[0],
             self._background_label: transform_color('transparent')[0],
         }
+        self.color = color
 
         self._mode = Mode.PAN_ZOOM
         self._mode_history = self._mode


### PR DESCRIPTION
# Description
The `Labels` layer color setter selected the `color_mode` according to the `color` dict content, but it did not take into account that it could contain only the default values, resulting in undesired behaviors when using the layers' `data_tuple` API.

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #2953.

# How has this been tested?
- [X] the example from the issue results in the expected behavior.
- [X] passes the labels layer test suite.

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
