### PR TITLE
[WIP] Multi color text manager

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -302,3 +302,27 @@ def test_custom_layer(make_napari_viewer):
     # Make a viewer and add the custom layer
     viewer = make_napari_viewer(show=True)
     viewer.add_layer(NewLabels(np.zeros((10, 10, 10), dtype=np.uint8)))
+
+
+def test_add_points_with_multi_color_text(make_napari_viewer):
+    viewer = make_napari_viewer()
+    data = np.array([[100, 100], [200, 300], [333, 111]])
+    color = [
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+    ]
+    properties = {'number': [1, 2, 3]}
+    text = {
+        'text': '{number}',
+        'color': color,
+    }
+
+    layer = viewer.add_points(
+        data,
+        properties=properties,
+        text=text,
+    )
+
+    visual = viewer.window.qt_viewer.layer_to_visual[layer]
+    np.testing.assert_array_equal(visual._get_text_node().color.rgb, color)

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -326,3 +326,79 @@ def test_add_points_with_multi_color_text(make_napari_viewer):
 
     visual = viewer.window.qt_viewer.layer_to_visual[layer]
     np.testing.assert_array_equal(visual._get_text_node().color.rgb, color)
+
+
+def test_add_points_with_one_color(make_napari_viewer):
+    viewer = make_napari_viewer()
+    data = np.array([[100, 100], [200, 300], [333, 111]])
+    color = [[1, 0, 0]]
+    properties = {'number': [1, 2, 3]}
+    text = {
+        'text': '{number}',
+        'color': color,
+    }
+
+    layer = viewer.add_points(
+        data,
+        properties=properties,
+        text=text,
+    )
+
+    visual = viewer.window.qt_viewer.layer_to_visual[layer]
+    np.testing.assert_array_equal(
+        visual._get_text_node().color.rgb, np.tile(color, (3, 1))
+    )
+
+
+def test_add_points_with_two_colors(make_napari_viewer):
+    viewer = make_napari_viewer()
+    data = np.array([[100, 100], [200, 300], [333, 111]])
+    color = [
+        [1, 0, 0],
+        [0, 1, 0],
+    ]
+    properties = {'number': [1, 2, 3]}
+    text = {
+        'text': '{number}',
+        'color': color,
+    }
+
+    layer = viewer.add_points(
+        data,
+        properties=properties,
+        text=text,
+    )
+
+    visual = viewer.window.qt_viewer.layer_to_visual[layer]
+    np.testing.assert_array_equal(
+        visual._get_text_node().color.rgb, color + [color[0]]
+    )
+
+
+def test_add_points_with_multi_color_text_subselection(make_napari_viewer):
+    viewer = make_napari_viewer()
+    data = np.array([[100, 100], [200, 300], [333, 111]])
+    color = [
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+    ]
+    properties = {'number': [1, 2, 3]}
+    text = {
+        'text': '{number}',
+        'color': color,
+    }
+
+    layer = viewer.add_points(
+        data,
+        properties=properties,
+        text=text,
+    )
+    # TODO: find usage through public to cause these state changes.
+    layer._indices_view = np.array([0, 2])
+    visual = viewer.window.qt_viewer.layer_to_visual[layer]
+    visual._on_text_change(None)
+
+    np.testing.assert_array_equal(
+        visual._get_text_node().color.rgb, [color[0], color[2]]
+    )

--- a/napari/_vispy/vispy_points_layer.py
+++ b/napari/_vispy/vispy_points_layer.py
@@ -18,7 +18,7 @@ class VispyPointsLayer(VispyBaseLayer):
 
         # Create a compound visual with the following four subvisuals:
         # Lines: The lines of the interaction box used for highlights.
-        # Markers: The the outlines for each point used for highlights.
+        # Markers: The outlines for each point used for highlights.
         # Markers: The actual markers of each point.
         node = Compound([Markers(), Markers(), Line(), Text()])
 
@@ -49,7 +49,7 @@ class VispyPointsLayer(VispyBaseLayer):
 
         # Set vispy data, noting that the order of the points needs to be
         # reversed to make the most recently added point appear on top
-        # and the rows / columns need to be switch for vispys x / y ordering
+        # and the rows / columns need to be switch for vispy's x / y ordering
         if len(self.layer._indices_view) == 0:
             data = np.zeros((1, self.layer._ndisplay))
             size = [0]

--- a/napari/_vispy/vispy_points_layer.py
+++ b/napari/_vispy/vispy_points_layer.py
@@ -149,7 +149,7 @@ class VispyPointsLayer(VispyBaseLayer):
             coords=text_coords,
             anchor=(anchor_x, anchor_y),
             rotation=self.layer._text.rotation,
-            color=self.layer._text.color,
+            color=self.layer._view_text_colors,
             size=self.layer._text.size,
             ndisplay=ndisplay,
             text_node=text_node,

--- a/napari/_vispy/vispy_shapes_layer.py
+++ b/napari/_vispy/vispy_shapes_layer.py
@@ -36,7 +36,7 @@ class VispyShapesLayer(VispyBaseLayer):
         colors = self.layer._data_view._mesh.displayed_triangles_colors
         vertices = self.layer._data_view._mesh.vertices
 
-        # Note that the indices of the vertices need to be resversed to
+        # Note that the indices of the vertices need to be reversed to
         # go from numpy style to xyz
         if vertices is not None:
             vertices = vertices[:, ::-1]
@@ -138,7 +138,7 @@ class VispyShapesLayer(VispyBaseLayer):
             coords=text_coords,
             anchor=(anchor_x, anchor_y),
             rotation=self.layer._text.rotation,
-            color=self.layer._text.color,
+            color=self.layer._view_text_colors,
             size=self.layer._text.size,
             ndisplay=ndisplay,
             text_node=text_node,

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -9,7 +9,7 @@ from vispy.color import get_colormap
 from napari._tests.utils import check_layer_world_data_extent
 from napari.layers import Points
 from napari.layers.points._points_utils import points_to_squares
-from napari.layers.utils.color_manager import ColorProperties
+from napari.layers.utils.color_manager import ColorManager, ColorProperties
 from napari.utils.colormaps.standardize_color import transform_color
 
 
@@ -129,12 +129,12 @@ def test_empty_layer_with_text_properties():
         text=text_kwargs,
     )
     assert layer.text.values.size == 0
-    np.testing.assert_allclose(layer.text.color, [1, 0, 0, 1])
+    np.testing.assert_allclose(layer.text.color.colors, [[1, 0, 0, 1]])
 
     # add a point and check that the appropriate text value was added
     layer.add([1, 1])
     np.testing.assert_equal(layer.text.values, ['1.5'])
-    np.testing.assert_allclose(layer.text.color, [1, 0, 0, 1])
+    np.testing.assert_allclose(layer.text.color.colors, [[1, 0, 0, 1]])
 
 
 def test_empty_layer_with_text_formatted():
@@ -641,7 +641,7 @@ def test_text_from_property_fstring(properties):
 def test_set_text_with_kwarg_dict(properties):
     text_kwargs = {
         'text': 'type: {point_type}',
-        'color': [0, 0, 0, 1],
+        'color': ColorManager(colors=[0, 0, 0, 1]),
         'rotation': 10,
         'translation': [5, 5],
         'anchor': 'upper_left',

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1240,6 +1240,10 @@ class Points(Layer):
         return self.text.compute_text_coords(self._view_data, self._ndisplay)
 
     @property
+    def _view_text_colors(self) -> np.ndarray:
+        return self.text.view_colors(self._indices_view)
+
+    @property
     def _view_size(self) -> np.ndarray:
         """Get the sizes of the points in view
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1234,7 +1234,7 @@ class Points(Layer):
         Returns
         -------
         text_coords : (N x D) np.ndarray
-            Array of coordindates for the N text elements in view
+            Array of coordinates for the N text elements in view
         """
         # TODO check if it is used, as it has wrong signature and this not cause errors.
         return self.text.compute_text_coords(self._view_data, self._ndisplay)

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -8,6 +8,7 @@ import pytest
 from napari._tests.utils import check_layer_world_data_extent
 from napari.layers import Shapes
 from napari.layers.utils._text_constants import TextMode
+from napari.layers.utils.color_manager import ColorManager
 from napari.utils.colormaps.standardize_color import transform_color
 
 
@@ -170,12 +171,12 @@ def test_empty_layer_with_text_properties():
     )
     assert layer.text._mode == TextMode.PROPERTY
     assert layer.text.values.size == 0
-    np.testing.assert_allclose(layer.text.color, [1, 0, 0, 1])
+    np.testing.assert_allclose(layer.text.color.colors, [[1, 0, 0, 1]])
 
     # add a shape and check that the appropriate text value was added
     layer.add(np.random.random((1, 4, 2)))
     np.testing.assert_equal(layer.text.values, ['1.5'])
-    np.testing.assert_allclose(layer.text.color, [1, 0, 0, 1])
+    np.testing.assert_allclose(layer.text.color.colors, [[1, 0, 0, 1]])
 
 
 def test_empty_layer_with_text_formatted():
@@ -241,7 +242,7 @@ def test_text_from_property_fstring(properties):
 def test_set_text_with_kwarg_dict(properties):
     text_kwargs = {
         'text': 'type: {shape_type}',
-        'color': [0, 0, 0, 1],
+        'color': ColorManager(colors=[0, 0, 0, 1]),
         'rotation': 10,
         'translation': [5, 5],
         'anchor': 'upper_left',

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1427,7 +1427,7 @@ class Shapes(Layer):
         return self.text.view_text(self._indices_view)
 
     @property
-    def _view_text_coords(self) -> np.ndarray:
+    def _view_text_coords(self) -> Tuple[np.ndarray, str, str]:
         """Get the coordinates of the text elements in view
 
         Returns
@@ -1449,6 +1449,10 @@ class Shapes(Layer):
         return self.text.compute_text_coords(
             sliced_in_view_coords, self._ndisplay
         )
+
+    @property
+    def _view_text_colors(self) -> np.ndarray:
+        return self.text.view_colors(self._indices_view)
 
     @property
     def mode(self):

--- a/napari/layers/utils/color_manager.py
+++ b/napari/layers/utils/color_manager.py
@@ -114,7 +114,7 @@ class ColorManager(EventedModel):
         ColorMode.DIRECT: colors are set by passing color values to ColorManager.colors
         ColorMode.COLORMAP: colors are set via the continuous_colormap applied to the
                             color_properties
-        ColorMode.CYCLE: colors are set vie the categorical_colormap appied to the
+        ColorMode.CYCLE: colors are set via the categorical_colormap applied to the
                          color_properties. This should be used for categorical
                          properties only.
      color_properties : Optional[ColorProperties]

--- a/napari/layers/utils/text_manager.py
+++ b/napari/layers/utils/text_manager.py
@@ -205,7 +205,9 @@ class TextManager(EventedModel):
 
     @validator('color', pre=True, always=True)
     def _check_color(cls, color):
-        if not isinstance(color, ColorManager):
+        if isinstance(color, dict):
+            color = ColorManager(**color)
+        elif not isinstance(color, ColorManager):
             color = ColorManager(colors=color)
         return color
 

--- a/napari/layers/utils/text_manager.py
+++ b/napari/layers/utils/text_manager.py
@@ -196,6 +196,8 @@ class TextManager(EventedModel):
             TextMode.FORMATTED,
             TextMode.PROPERTY,
         ]:
+            # Resize the colors to match the number of text values, truncating
+            # or repeating colors as needed, then index them.
             colors = np.resize(self.color.colors, (len(self.values), 4))
             return colors[indices_view, :]
         # if no elements in this slice send dummy data


### PR DESCRIPTION
# Description
This allows text color to either be specified as a ColorManager, or as anything that can be coerced into ColorManager.colors (e.g. 'red', ['red', 'green'], [[1., 0., 0.], [0., 1., 0.]]), to support passing multiple colors as described in #2019. Here's a simple/minimal example.

```python
import numpy as np
import napari

viewer = napari.view_image(np.zeros((400, 400)))
points = np.array([[100, 100], [200, 300], [333, 111]])
properties = {
    'number': [1, 2, 3],
}
text = {
    'text': '{number}',
    'size': 20,
    'color': ['green', 'red', 'blue'],
}

points_layer = viewer.add_points(
    points,
    properties=properties,
    size=20,
    text=text,
)

napari.run()
```

![Screen Shot 2021-07-01 at 2 46 45 PM](https://user-images.githubusercontent.com/2608297/124193159-3631d480-da7b-11eb-9afc-0a72f5721978.png)

This is a WIP because I'm unsure of how TextMode and ColorMode should affect this behavior and if there are other usages I've missed (e.g. setting multiple text colors through properties). Currently, I've done something simple, which is to generate colors for text when needed and truncate/cycle ColorManager.colors to match the number of text values. But I suspect that's missing some intended use cases and maybe not taking advantage of ColorMode, so feedback on that would be really helpful!

## Type of change
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

This adds new functionality, but also breaks anyone relying on TextManager.color being a length-4 numpy array. I think it's fairly easy to make this a non-breaking change, so let me know if that's desired.

# References
This partly closes #2019, though does not cover adding borders around text, which should probably handled separately and another issue should be defined.

# How has this been tested?
- [ ] Newly added tests that cover the new functionality pass.
- [ ] All other affected tests pass.

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
