### PR TITLE
Reverse order in grid view

### DIFF
--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -274,6 +274,7 @@ def test_grid_mode(make_napari_viewer):
         [255, 255, 0, 255],
         [0, 255, 255, 255],
     ]
+    color = color[::-1]
     for c, p in zip(color, pos):
         coord = tuple(
             np.round(np.multiply(screenshot.shape[:2], p)).astype(int)

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -296,6 +296,7 @@ def test_grid_mode(make_napari_viewer):
         [255, 255, 0, 255],
         [0, 0, 255, 255],
     ]
+    color = color[::-1]
     for c, p in zip(color, pos):
         coord = tuple(
             np.round(np.multiply(screenshot.shape[:2], p)).astype(int)

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -252,7 +252,7 @@ def test_grid_mode(make_napari_viewer):
         [15, 15],
         [15, 30],
     ]
-    np.testing.assert_allclose(translations, expected_translations[::-1])
+    np.testing.assert_allclose(translations, expected_translations)
 
     # check screenshot
     screenshot = viewer.screenshot(canvas_only=True, flash=False)

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -380,14 +380,14 @@ def test_grid():
     assert viewer.grid.stride == -2
     translations = [layer.translate_grid for layer in viewer.layers]
     expected_translations = [
-        [0, 0],
-        [0, 0],
-        [0, 15],
-        [0, 15],
         [15, 0],
         [15, 0],
+        [0, 15],
+        [0, 15],
+        [0, 0],
+        [0, 0],
     ]
-    np.testing.assert_allclose(translations, expected_translations)
+    np.testing.assert_allclose(translations, expected_translations[::-1])
 
 
 def test_add_remove_layer_dims_change():

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -387,7 +387,7 @@ def test_grid():
         [0, 0],
         [0, 0],
     ]
-    np.testing.assert_allclose(translations, expected_translations[::-1])
+    np.testing.assert_allclose(translations, expected_translations)
 
 
 def test_add_remove_layer_dims_change():

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -361,7 +361,7 @@ def test_grid():
         [15, 15],
         [15, 30],
     ]
-    np.testing.assert_allclose(translations, expected_translations[::-1])
+    np.testing.assert_allclose(translations, expected_translations)
 
     # return to stack view
     viewer.grid.enabled = False

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -387,7 +387,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         extent = self._sliced_extent_world
         n_layers = len(self.layers)
         for i, layer in enumerate(self.layers):
-            i_row, i_column = self.grid.position(n_layers - 1 - i, n_layers)
+            i_row, i_column = self.grid.position(i, n_layers)
             self._subplot(layer, (i_row, i_column), extent)
 
     def _subplot(self, layer, position, extent):


### PR DESCRIPTION
Hi all,

this is a small change in how the grid view is drawn. I know a major revamp of the grid view is in planning. In the meantime this change would help to make it more intuitive.

# Description
This PR changes the order how layers are drawn. Before this PR it looked like this (note the order is bottom->up, right->left):
![image](https://user-images.githubusercontent.com/12660498/124386206-9cb42e00-dcd9-11eb-9bdf-4841d95d5842.png)

After this PR is merged it will look like this (top->bottom, left->right)
![image](https://user-images.githubusercontent.com/12660498/124386218-b190c180-dcd9-11eb-99f6-95d3e7dfbc51.png)

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

I'm not sure if this change can break other functionality. I'm also not sure if tests and/or documentation need to be updated. Let me know if I should do any of those.

# References

# How has this been tested?
I tested this manually.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

Let me know what you think!

Cheers,
Robert