### PR TITLE
WIP: Allow more than one label to be selected in labels layer

### DIFF
--- a/examples/labels-2d.py
+++ b/examples/labels-2d.py
@@ -21,6 +21,7 @@ label_layer = viewer.add_labels(labels, name='segmentation')
 
 # Set the labels layer mode to picker with a string
 label_layer.mode = 'PICK'
-print(f'The color of label 5 is {label_layer.get_color(5)}')
+label_layer.selection = {4, 5, 6, 15}
+label_layer.show_selected_label = True
 
 napari.run()

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -77,9 +77,7 @@ class QtLabelsControls(QtLayerControls):
         super().__init__(layer)
 
         self.layer.events.mode.connect(self._on_mode_change)
-        self.layer.events.selected_label.connect(
-            self._on_selected_label_change
-        )
+        self.layer.events.active_label.connect(self._on_active_label_change)
         self.layer.events.brush_size.connect(self._on_brush_size_change)
         self.layer.events.contiguous.connect(self._on_contiguous_change)
         self.layer.events.n_edit_dimensions.connect(
@@ -99,7 +97,7 @@ class QtLabelsControls(QtLayerControls):
         self.selectionSpinBox.setKeyboardTracking(False)
         self.selectionSpinBox.valueChanged.connect(self.changeSelection)
         self.selectionSpinBox.setAlignment(Qt.AlignCenter)
-        self._on_selected_label_change()
+        self._on_active_label_change()
 
         sld = QSlider(Qt.Horizontal)
         sld.setFocusPolicy(Qt.NoFocus)
@@ -316,7 +314,7 @@ class QtLabelsControls(QtLayerControls):
         value : int
             Index of label to select.
         """
-        self.layer.selected_label = value
+        self.layer.active_label = value
         self.selectionSpinBox.clearFocus()
         self.setFocus()
 
@@ -409,7 +407,7 @@ class QtLabelsControls(QtLayerControls):
             value = self.layer.contour
             self.contourSpinBox.setValue(value)
 
-    def _on_selected_label_change(self, event=None):
+    def _on_active_label_change(self, event=None):
         """Receive layer model label selection change event and update spinbox.
 
         Parameters
@@ -417,8 +415,8 @@ class QtLabelsControls(QtLayerControls):
         event : napari.utils.event.Event, optional
             The napari event that triggered this method.
         """
-        with self.layer.events.selected_label.blocker():
-            value = self.layer.selected_label
+        with self.layer.events.active_label.blocker():
+            value = self.layer.active_label
             self.selectionSpinBox.setValue(value)
 
     def _on_brush_size_change(self, event=None):
@@ -511,9 +509,7 @@ class QtColorBox(QWidget):
         super().__init__()
 
         self.layer = layer
-        self.layer.events.selected_label.connect(
-            self._on_selected_label_change
-        )
+        self.layer.events.active_label.connect(self._on_active_label_change)
         self.layer.events.opacity.connect(self._on_opacity_change)
 
         self.setAttribute(Qt.WA_DeleteOnClose)
@@ -523,7 +519,7 @@ class QtColorBox(QWidget):
         self.setFixedHeight(self._height)
         self.setToolTip(trans._('Selected label color'))
 
-    def _on_selected_label_change(self, event):
+    def _on_active_label_change(self, event):
         """Receive layer model label selection change event & update colorbox.
 
         Parameters

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -552,7 +552,7 @@ class QtColorBox(QWidget):
             Event from the Qt context.
         """
         painter = QPainter(self)
-        if self.layer._selected_color is None:
+        if self.layer._active_color is None:
             for i in range(self._height // 4):
                 for j in range(self._height // 4):
                     if (i % 2 == 0 and j % 2 == 0) or (
@@ -565,7 +565,7 @@ class QtColorBox(QWidget):
                         painter.setBrush(QColor(25, 25, 25))
                     painter.drawRect(i * 4, j * 4, 5, 5)
         else:
-            color = np.multiply(self.layer._selected_color, self.layer.opacity)
+            color = np.multiply(self.layer._active_color, self.layer.opacity)
             color = np.round(255 * color).astype(int)
             painter.setPen(QColor(*list(color)))
             painter.setBrush(QColor(*list(color)))

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -49,27 +49,25 @@ def activate_label_erase_mode(layer):
 
 
 @register_label_action(
-    trans._(
-        "Set the currently selected label to the largest used label plus one."
-    ),
+    trans._("Set the active label to the largest used label plus one."),
 )
 def new_label(layer):
-    """Set the currently selected label to the largest used label plus one."""
-    layer.selected_label = layer.data.max() + 1
+    """Set the active label to the largest used label plus one."""
+    layer.active_label = layer.data.max() + 1
 
 
 @register_label_action(
-    trans._("Decrease the currently selected label by one."),
+    trans._("Decrease the active label by one."),
 )
 def decrease_label_id(layer):
-    layer.selected_label -= 1
+    layer.active_label -= 1
 
 
 @register_label_action(
-    trans._("Increase the currently selected label by one."),
+    trans._("Increase the active label by one."),
 )
 def increase_label_id(layer):
-    layer.selected_label += 1
+    layer.active_label += 1
 
 
 @Labels.bind_key('Control-Z')

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -3,21 +3,21 @@ from ._labels_utils import interpolate_coordinates
 
 
 def draw(layer, event):
-    """Draw with the currently selected label to a coordinate.
+    """Draw with the current active label to a coordinate.
 
     This method have different behavior when draw is called
     with different labeling layer mode.
 
     In PAINT mode the cursor functions like a paint brush changing any
     pixels it brushes over to the current label. If the background label
-    `0` is selected than any pixels will be changed to background and this
+    `0` is active than any pixels will be changed to background and this
     tool functions like an eraser. The size and shape of the cursor can be
     adjusted in the properties widget.
 
     In FILL mode the cursor functions like a fill bucket replacing pixels
     of the label clicked on with the current label. It can either replace
     all pixels of that label or just those that are contiguous with the
-    clicked on pixel. If the background label `0` is selected than any
+    clicked on pixel. If the background label `0` is active than any
     pixels will be changed to background and this tool functions like an
     eraser
     """
@@ -26,7 +26,7 @@ def draw(layer, event):
     if layer._mode == Mode.ERASE:
         new_label = layer._background_label
     else:
-        new_label = layer.selected_label
+        new_label = layer.active_label
 
     if layer._mode in [Mode.PAINT, Mode.ERASE]:
         layer.paint(coordinates, new_label)
@@ -57,6 +57,8 @@ def draw(layer, event):
 
 
 def pick(layer, event):
-    """Change the selected label to the same as the region clicked."""
+    """
+    Change the active label to the same as the region clicked.
+    """
     # on press
-    layer.selected_label = layer.get_value(event.position, world=True) or 0
+    layer.active_label = layer.get_value(event.position, world=True) or 0

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -540,6 +540,7 @@ class Labels(_ImageBase):
 
         self._active_label = label
         self._active_color = self.get_color(label)
+        self.selection = {label}
         self.events.active_label()
 
         # note: self.color_mode returns a string and this comparison fails,

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -126,8 +126,8 @@ class Labels(_ImageBase):
         with a thickness equal to its value.
     brush_size : float
         Size of the paint brush in data coordinates.
-    selected_label : int
-        Index of selected label. Can be greater than the current maximum label.
+    active_label : int
+        Index of active label. Can be greater than the current maximum label.
     mode : str
         Interactive mode. The normal, default mode is PAN_ZOOM, which
         allows for normal interactivity with the canvas.
@@ -364,7 +364,7 @@ class Labels(_ImageBase):
         # in _raw_to_displayed
         self._all_vals = np.array([])
         self.refresh()
-        self.events.selected_label()
+        self.events.active_label()
 
     @property
     def num_colors(self):
@@ -534,7 +534,7 @@ class Labels(_ImageBase):
     @active_label.setter
     def active_label(self, label):
         if label < 0:
-            raise ValueError(trans._('cannot reduce selected label below 0'))
+            raise ValueError(trans._('cannot reduce active label below 0'))
         if label == self._active_label:
             return
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -539,8 +539,8 @@ class Labels(_ImageBase):
             return
 
         self._active_label = label
-        self._active_color = self.get_color(label)
         self.selection = {label}
+        self._active_color = self.get_color(label)
         self.events.active_label()
 
         # note: self.color_mode returns a string and this comparison fails,

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -524,6 +524,10 @@ class Labels(_ImageBase):
             self._selected_labels.update(elements)
         else:
             self._selected_labels = set(elements)
+        # self.active_label should always be in self.selection
+        if self._active_label not in self._selected_labels:
+            self._active_label = np.min(list(self._selected_labels) or 0)
+            self.events.active_label()
         self.events.selection(value=self._selected_labels)
         self.refresh()
 
@@ -539,7 +543,8 @@ class Labels(_ImageBase):
             return
 
         self._active_label = label
-        self.selection = {label}
+        if label not in self.selection:
+            self.selection = {label}
         self._active_color = self.get_color(label)
         self.events.active_label()
 
@@ -750,7 +755,7 @@ class Labels(_ImageBase):
         selection : set of int, optional
             Value of selected labels to color, by default None
         """
-        if selection is not None:
+        if selection:
             selection_arr = np.asarray(list(selection))
             selected_pixels = np.isin(im, selection_arr)
             color_pixels = low_discrepancy_image(
@@ -771,7 +776,7 @@ class Labels(_ImageBase):
         selection : set of int, optional
             Value of selected labels to color, by default None
         """
-        if selection is not None:
+        if selection:
             selection_arr = np.asarray(list(selection))
             max_selected = np.max(selection_arr)
             if max_selected > len(self._all_vals):

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -377,7 +377,7 @@ class Labels(_ImageBase):
         self.colormap = label_colormap(num_colors)
         self.refresh()
         self._active_color = self.get_color(self.active_label)
-        self.events.selected_label()
+        self.events.active_label()
 
     @property
     def data(self):

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -156,8 +156,8 @@ class Labels(_ImageBase):
     -----
     _data_raw : array (N, M)
         2D labels data for the currently viewed slice.
-    _selected_color : 4-tuple or None
-        RGBA tuple of the color of the selected label, or None if the
+    _active_color : 4-tuple or None
+        RGBA tuple of the color of the active label, or None if the
         background label `0` is selected.
     """
 
@@ -523,7 +523,7 @@ class Labels(_ImageBase):
             return
 
         self._active_label = label
-        self._selected_color = self.get_color(label)
+        self._active_color = self.get_color(label)
         self.events.active_label()
 
         # note: self.color_mode returns a string and this comparison fails,
@@ -559,7 +559,7 @@ class Labels(_ImageBase):
             raise ValueError(trans._("Unsupported Color Mode"))
 
         self._color_mode = color_mode
-        self._selected_color = self.get_color(self.active_label)
+        self._active_color = self.get_color(self.active_label)
         self.events.color_mode()
         self.events.colormap()
         self.events.selected_label()
@@ -865,12 +865,12 @@ class Labels(_ImageBase):
             self.show_selected_label
             and self._color_mode == LabelColorMode.AUTO
         ):
-            image = self._color_lookup_func(raw, self._selected_label)
+            image = self._color_lookup_func(raw, self._active_label)
         elif (
             self.show_selected_label
             and self._color_mode == LabelColorMode.DIRECT
         ):
-            selected = self._selected_label
+            selected = self._active_label
             if selected not in self._label_color_index:
                 selected = None
             index = self._label_color_index


### PR DESCRIPTION
# Description

<img width="1590" alt="Screen Shot 2021-07-05 at 7 08 50 pm" src="https://user-images.githubusercontent.com/492549/124447156-728b6a80-ddc4-11eb-9246-828dbe8ac291.png">

This PR is WIP but the goal is to enable selecting multiple labels rather than a single one. The selection model would mirror the layer list, with an active label and a selection.

Currently the selection works but does not update the active label (that should change — active should always be "last selected"). Additionally, there are no GUI controls for making selections. One idea would be that holding Cmd with the picker would allow one to update the existing selection.

Joint work with @brisvag 😊 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
