### PR TITLE
Ensure new height of expanded notification is larger than current height

### DIFF
--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -76,6 +76,7 @@ class NapariQtNotification(QDialog):
     FADE_OUT_RATE = 120
     DISMISS_AFTER = 4000
     MIN_WIDTH = 400
+    MIN_EXPANSION = 18
 
     message: MultilineElidedLabel
     source_label: QLabel
@@ -178,6 +179,9 @@ class NapariQtNotification(QDialog):
         self.geom_anim.setDuration(100)
         self.geom_anim.setStartValue(curr)
         new_height = self.sizeHint().height()
+        if new_height < curr.height():
+            # new height would shift notification down, ensure some expansion
+            new_height = curr.height() + self.MIN_EXPANSION
         delta = new_height - curr.height()
         self.geom_anim.setEndValue(
             QRect(curr.x(), curr.y() - delta, curr.width(), new_height)


### PR DESCRIPTION
# Description
Addresses #2938 by checking whether the new height of the notification would be smaller than the existing height, and adding a nominal 18px to the current height if so.

This ensures the y-delta of the new position is smaller (higher up the window) than the current position and therefore avoids shifting the notification down.

https://user-images.githubusercontent.com/17995243/124527377-d35c8680-de48-11eb-9688-8976714acc15.mp4

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #2938

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
