### PR TITLE
Remove mode guards for selection interactions in points

### DIFF
--- a/napari/layers/points/_points_key_bindings.py
+++ b/napari/layers/points/_points_key_bindings.py
@@ -45,28 +45,24 @@ def activate_points_pan_zoom_mode(layer):
 @Points.bind_key('Control-C')
 def copy(layer):
     """Copy any selected points."""
-    if layer._mode == Mode.SELECT:
-        layer._copy_data()
+    layer._copy_data()
 
 
 @Points.bind_key('Control-V')
 def paste(layer):
     """Paste any copied points."""
-    if layer._mode == Mode.SELECT:
-        layer._paste_data()
+    layer._paste_data()
 
 
 @register_points_action(
     trans._("Select all points in the current view slice."),
 )
 def select_all(layer):
-    if layer._mode == Mode.SELECT:
-        layer.selected_data = set(layer._indices_view[: len(layer._view_data)])
-        layer._set_highlight()
+    layer.selected_data = set(layer._indices_view[: len(layer._view_data)])
+    layer._set_highlight()
 
 
 @register_points_action(trans._('Delete selected points'))
 def delete_selected_points(layer):
     """Delete all selected points."""
-    if layer._mode in (Mode.SELECT, Mode.ADD):
-        layer.remove_selected()
+    layer.remove_selected()


### PR DESCRIPTION
# Description

I think the mode guards for some of the selection actions in the points layer are there because we don't yet have interactive 3D picking. However, with plugins and code there are programmatic ways of getting selections, and it is good to be able to interact with those selections where it makes sense. In this case, I can select a bunch of points based on @brisvag's [napari-properties-plotter](https://github.com/brisvag/napari-properties-plotter), and delete them with Backspace/Delete. This is a very natural interaction that doesn't conflict with pan/zoom, so I don't think we should disallow it. (See screen share.) Similarly, selecting all points in a 3D slice of a 4D series would also be a useful interaction and it is enabled by this PR.

https://user-images.githubusercontent.com/492549/124555454-737ed380-de7a-11eb-9ca4-1f46e43f2f8a.mov
