### PR TITLE
Gracefully handle properties with `object` dtype

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -674,6 +674,16 @@ def test_text_error(properties):
         Points(data, properties=copy(properties), text=123)
 
 
+def test_select_properties_object_dtype():
+    """selecting points when they have a property of object dtype should not fail"""
+    # pandas uses object as dtype for strings by default
+    properties = pd.DataFrame({'color': ['red', 'green']})
+    pl = Points(np.ones((2, 2)), properties=properties)
+    selection = {0, 1}
+    pl.selected_data = selection
+    assert pl.selected_data == selection
+
+
 def test_refresh_text():
     """Test refreshing the text after setting new properties"""
     shape = (10, 2)

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1011,7 +1011,8 @@ class Points(Layer):
 
         properties = {}
         for k, v in self.properties.items():
-            # only use axis argument if strictly necessary
+            # pandas uses `object` as dtype for strings by default, which
+            # combined with the axis argument breaks np.unique
             axis = 0 if v.ndim > 1 else None
             properties[k] = np.unique(v[index], axis=axis)
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1009,9 +1009,12 @@ class Points(Layer):
             with self.block_update_properties():
                 self.current_size = size
 
-        properties = {
-            k: np.unique(v[index], axis=0) for k, v in self.properties.items()
-        }
+        properties = {}
+        for k, v in self.properties.items():
+            # only use axis argument if strictly necessary
+            axis = 0 if v.ndim > 1 else None
+            properties[k] = np.unique(v[index], axis=axis)
+
         n_unique_properties = np.array([len(v) for v in properties.values()])
         if np.all(n_unique_properties == 1):
             with self.block_update_properties():

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -274,6 +274,16 @@ def test_text_error(properties):
         Shapes(data, properties=copy(properties), text=123)
 
 
+def test_select_properties_object_dtype():
+    """selecting points when they have a property of object dtype should not fail"""
+    # pandas uses object as dtype for strings by default
+    properties = pd.DataFrame({'color': ['red', 'green']})
+    pl = Shapes(np.ones((2, 2, 2)), properties=properties)
+    selection = {0, 1}
+    pl.selected_data = selection
+    assert pl.selected_data == selection
+
+
 def test_refresh_text():
     """Test refreshing the text after setting new properties"""
     shape = (10, 4, 2)

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1071,10 +1071,13 @@ class Shapes(Layer):
                 edge_width = edge_width[0]
                 with self.block_update_properties():
                     self.current_edge_width = edge_width
-            properties = {
-                k: np.unique(v[selected_data_indices], axis=0)
-                for k, v in self.properties.items()
-            }
+
+            properties = {}
+            for k, v in self.properties.items():
+                # only use axis argument if strictly necessary
+                axis = 0 if v.ndim > 1 else None
+                properties[k] = np.unique(v[selected_data_indices], axis=axis)
+
             n_unique_properties = np.array(
                 [len(v) for v in properties.values()]
             )

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1074,7 +1074,8 @@ class Shapes(Layer):
 
             properties = {}
             for k, v in self.properties.items():
-                # only use axis argument if strictly necessary
+                # pandas uses `object` as dtype for strings by default, which
+                # combined with the axis argument breaks np.unique
                 axis = 0 if v.ndim > 1 else None
                 properties[k] = np.unique(v[selected_data_indices], axis=axis)
 


### PR DESCRIPTION
# Description
In #2756 I noticed that properties with `object` dtype break the selection methods in the points layer due to an `np.unique` with the axis argument ([see this comment by @andy-sweet](https://github.com/napari/napari/pull/2957#discussion_r661618991)).

To preserve the ability of having multidimensional arrays as properties, this fix intriduces a little check so that the axis argument is used only when the dimensionality requires it. It's not super elegant, but it works, and it will hopefully be superseded once we unify the properties as per #2866.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #2756.

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas