### PR TITLE
Split windows pyside/pyqt into own GitHub action check

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -76,9 +76,17 @@ jobs:
           # Windows py37
           - python: 3.7
             platform: windows-latest
+            backend: pyqt
+          - python: 3.7
+            platform: windows-latest
+            backend: pyside
           # Windows py38
           - python: 3.8
             platform: windows-latest
+            backend: pyqt
+          - python: 3.8
+            platform: windows-latest
+            backend: pyside
           # macOS py38
           - python: 3.8
             platform: macos-latest


### PR DESCRIPTION
I find it relatively confusing in the github action UI to find issues on
windows that happen only on Pyqt/pyside, I regularly forget that the
windows action run both, and I scroll to find the error for a minute or
so before figuring out that the I need to expand the other section.

I also find that having from the GitHub UI indication of which
variant(s) failed is a good way to guess wether we have a random failure
or an actual issue.

I'm hoping this may also reduce the "time to CI results" as we can now
run pytest/pyqt in parallel.

-- 

At least I hope that how we split the tox envs, I'm not too sure. It also look like there is no "headless" testing on windows, so I did not include it.
