### PR TITLE
Emit data event when moving, adding or removing shapes or points

### DIFF
--- a/napari/layers/points/_points_mouse_bindings.py
+++ b/napari/layers/points/_points_mouse_bindings.py
@@ -59,8 +59,13 @@ def select(layer, event):
             layer._set_highlight()
         yield
 
+    # only emit data once dragging has finished
+    if layer._is_moving:
+        layer.events.data(value=layer.data)
+
     # on release
     layer._drag_start = None
+    layer._is_moving = False
     if layer._is_selecting:
         layer._is_selecting = False
         if len(layer._view_data) > 0:

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -225,6 +225,8 @@ class Points(Layer):
     _drag_start : list or None
         Coordinates of first cursor click during a drag action. Gets reset to
         None after dragging is done.
+    _is_moving : bool
+        Bool indicating if any points are currently being moved.
     """
 
     # TODO  write better documentation for edge_color and face_color
@@ -359,6 +361,7 @@ class Points(Layer):
         self._drag_box = None
         self._drag_box_stored = None
         self._is_selecting = False
+        self._is_moving = False
         self._clipboard = {}
         self._round_index = False
 
@@ -1424,6 +1427,7 @@ class Points(Layer):
             Coordinates to move points to
         """
         if len(index) > 0:
+            self._is_moving = True
             index = list(index)
             disp = list(self._dims_displayed)
             if self._drag_start is None:

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -225,8 +225,6 @@ class Points(Layer):
     _drag_start : list or None
         Coordinates of first cursor click during a drag action. Gets reset to
         None after dragging is done.
-    _is_moving : bool
-        Bool indicating if any points are currently being moved.
     """
 
     # TODO  write better documentation for edge_color and face_color
@@ -361,7 +359,6 @@ class Points(Layer):
         self._drag_box = None
         self._drag_box_stored = None
         self._is_selecting = False
-        self._is_moving = False
         self._clipboard = {}
         self._round_index = False
 
@@ -1427,7 +1424,6 @@ class Points(Layer):
             Coordinates to move points to
         """
         if len(index) > 0:
-            self._is_moving = True
             index = list(index)
             disp = list(self._dims_displayed)
             if self._drag_start is None:
@@ -1439,6 +1435,7 @@ class Points(Layer):
                 self.data[np.ix_(index, disp)] + shift
             )
             self.refresh()
+        self.events.data(value=self.data)
 
     def _paste_data(self):
         """Paste any point from clipboard and select them."""

--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -58,6 +58,10 @@ def select(layer, event):
             update_thumbnail = True
         yield
 
+    # only emit data once dragging has finished
+    if layer._is_moving:
+        layer.events.data(value=layer.data)
+
     # on release
     shift = 'Shift' in event.modifiers
     if not layer._is_moving and not layer._is_selecting and not shift:

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1674,6 +1674,7 @@ class Shapes(Layer):
                 face_color=face_color,
                 z_index=z_index,
             )
+            self.events.data(value=self.data)
 
     def _init_shapes(
         self,
@@ -2218,6 +2219,7 @@ class Shapes(Layer):
             )
         self.selected_data = set()
         self._finish_drawing()
+        self.events.data(value=self.data)
 
     def _rotate_box(self, angle, center=[0, 0]):
         """Perform a rotation on the selected box.


### PR DESCRIPTION
# Description
This PR addresses the first part of the discussion in #2809 - emitting `data` events when a shape or point is added, removed or moved.

Points addition and removal is already handled by emitting in the `data` setter, as each of these methods assign the new data. I've added an event emitted on mouse release after a dragging event that involved moving, to ensure we only emit once per move. This required adding an `_is_moving` attribute (already present in the `Shapes` layer) to exclude emission on non-point-moving dragging events.  

`Shapes` layers only emitted `data` in the `data` setter. We now emit in the `add` and `remove_selected` methods, as well as on mouse release after a dragging event that involved moving. This is identical to the emissions in `Points`.

I was not able to find any tests checking events are emitted as expected, so I haven't added any. Is there a best approach for this? My only thought was simulating the events with `qtbot` and having implicit tests using `qtbot.waitSignal` with a timeout. @sofroniewn @jni does that seem useful?

I still think we should emit more information alongside the `data` event e.g. the type of event (add, remove or move) and the affected indices.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# References
Partially addresses #2809. 
Supersedes #2720.

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
