### PR TITLE
Add TypedMutableMapping and EventedDict

### DIFF
--- a/napari/utils/events/__init__.py
+++ b/napari/utils/events/__init__.py
@@ -1,4 +1,5 @@
 from .event import EmitterGroup, Event, EventEmitter  # isort:skip
+from .containers._evented_dict import EventedDict
 from .containers._evented_list import EventedList
 from .containers._nested_list import NestableEventedList
 from .containers._selectable_list import SelectableEventedList

--- a/napari/utils/events/_tests/test_evented_dict.py
+++ b/napari/utils/events/_tests/test_evented_dict.py
@@ -1,0 +1,99 @@
+from unittest.mock import Mock
+
+import pytest
+
+from napari.utils.events import EmitterGroup
+from napari.utils.events.containers import EventedDict
+
+
+@pytest.fixture
+def regular_dict():
+    return {"A": 0, "B": 1, "C": 2}
+
+
+@pytest.fixture(params=[EventedDict])
+def test_dict(request, regular_dict):
+    test_dict = request.param(regular_dict)
+    test_dict.events = Mock(wraps=test_dict.events)
+    return test_dict
+
+
+@pytest.mark.parametrize(
+    'meth',
+    [
+        # METHOD, ARGS, EXPECTED EVENTS
+        # primary interface
+        ('__getitem__', ("A",), ()),  # read
+        ('__setitem__', ("A", 3), ('changed',)),  # update
+        ('__setitem__', ("D", 3), ('adding', 'added')),  # add new entry
+        ('__delitem__', ("A",), ('removing', 'removed')),  # delete
+        # inherited interface
+        ('key', (3,), ()),
+        ('clear', (), ('removing', 'removed') * 3),
+        ('pop', ("B",), ('removing', 'removed')),
+    ],
+    ids=lambda x: x[0],
+)
+def test_dict_interface_parity(test_dict, regular_dict, meth):
+    method_name, args, expected = meth
+    test_dict_method = getattr(test_dict, method_name)
+    assert test_dict == regular_dict
+    if hasattr(regular_dict, method_name):
+        regular_dict_method = getattr(regular_dict, method_name)
+        assert test_dict_method(*args) == regular_dict_method(*args)
+        assert test_dict == regular_dict
+    else:
+        test_dict_method(*args)  # smoke test
+
+    for c, expect in zip(test_dict.events.call_args_list, expected):
+        event = c.args[0]
+        assert event.type == expect
+
+
+def test_copy(test_dict, regular_dict):
+    """Copying an evented dict should return a same-class evented dict."""
+    new_test = test_dict.copy()
+    new_reg = regular_dict.copy()
+    assert id(new_test) != id(test_dict)
+    assert new_test == test_dict
+    assert tuple(new_test) == tuple(test_dict) == tuple(new_reg)
+    test_dict.events.assert_not_called()
+
+
+class E:
+    def __init__(self):
+        self.events = EmitterGroup(test=None)
+
+
+def test_child_events():
+    """Test that evented dicts bubble child events."""
+    # create a random object that emits events
+    e_obj = E()
+    root = EventedDict()
+    observed = []
+    root.events.connect(lambda e: observed.append(e))
+    root["A"] = e_obj
+    e_obj.events.test(value="hi")
+    obs = [(e.type, e.key, getattr(e, 'value', None)) for e in observed]
+    expected = [
+        ('adding', "A", None),  # before we adding b into root
+        ('added', "A", e_obj),  # after b was added into root
+        ('test', "A", 'hi'),  # when e_obj emitted an event called "test"
+    ]
+    for o, e in zip(obs, expected):
+        assert o == e
+
+
+def test_evented_dict_subclass():
+    """Test that multiple inheritance maintains events from superclass."""
+
+    class A:
+        events = EmitterGroup(boom=None)
+
+    class B(A, EventedDict):
+        pass
+
+    dct = B({"A": 1, "B": 2})
+    assert hasattr(dct, 'events')
+    assert 'boom' in dct.events.emitters
+    assert dct == {"A": 1, "B": 2}

--- a/napari/utils/events/_tests/test_typed_dict.py
+++ b/napari/utils/events/_tests/test_typed_dict.py
@@ -1,0 +1,35 @@
+import pytest
+
+from napari.utils.events.containers import EventedDict, TypedMutableMapping
+
+
+# this is a parametrized fixture, all tests using ``dict_type`` will be run
+# once using each of the items in params
+# https://docs.pytest.org/en/stable/fixture.html#parametrizing-fixtures
+@pytest.fixture(params=[TypedMutableMapping, EventedDict])
+def dict_type(request):
+    return request.param
+
+
+def test_type_enforcement(dict_type):
+    """Test that TypedDicts enforce type during mutation events."""
+    a = dict_type({"A": 1, "B": 3, "C": 5}, basetype=int)
+    assert tuple(a.values()) == (1, 3, 5)
+    with pytest.raises(TypeError):
+        a["D"] = "string"
+    with pytest.raises(TypeError):
+        a.update({"E": 3.5})
+
+    # also on instantiation
+    with pytest.raises(TypeError):
+        dict_type({"A": 1, "B": 3.3, "C": "5"}, basetype=int)
+
+
+def test_multitype_enforcement(dict_type):
+    """Test that basetype also accepts/enforces a sequence of types."""
+    a = dict_type({"A": 1, "B": 3, "C": 5.5}, basetype=(int, float))
+    assert tuple(a.values()) == (1, 3, 5.5)
+    with pytest.raises(TypeError):
+        a["D"] = "string"
+    a["D"] = 2.4
+    a.update({"E": 3.5})

--- a/napari/utils/events/containers/__init__.py
+++ b/napari/utils/events/containers/__init__.py
@@ -1,3 +1,5 @@
+from ._dict import TypedMutableMapping
+from ._evented_dict import EventedDict
 from ._evented_list import EventedList
 from ._nested_list import NestableEventedList
 from ._selectable_list import (
@@ -12,9 +14,11 @@ __all__ = [
     'EventedList',
     'EventedSet',
     'NestableEventedList',
+    'EventedDict',
     'Selectable',
     'SelectableEventedList',
     'SelectableNestableEventedList',
     'Selection',
     'TypedMutableSequence',
+    'TypedMutableMapping',
 ]

--- a/napari/utils/events/containers/_dict.py
+++ b/napari/utils/events/containers/_dict.py
@@ -1,0 +1,72 @@
+"""Evented dictionary"""
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    Mapping,
+    MutableMapping,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+)
+
+_K = TypeVar("_K")
+_T = TypeVar("_T")
+
+
+class TypedMutableMapping(MutableMapping[_K, _T]):
+    """Dictionary mixin that enforces item type."""
+
+    def __init__(
+        self,
+        data: Mapping[_K, _T] = None,
+        basetype: Union[Type[_T], Sequence[Type[_T]]] = (),
+    ):
+        if data is None:
+            data = {}
+        self._dict: Dict[_K, _T] = dict()
+        self._basetypes = (
+            basetype if isinstance(basetype, Sequence) else (basetype,)
+        )
+        self.update(data)
+
+    # #### START Required Abstract Methods
+
+    def __setitem__(self, key: int, value: _T):  # noqa: F811
+        self._dict[key] = self._type_check(value)
+
+    def __delitem__(self, key: _K) -> None:
+        del self._dict[key]
+
+    def __getitem__(self, key: _K) -> _T:
+        return self._dict[key]
+
+    def __len__(self) -> int:
+        return len(self._dict)
+
+    def __iter__(self) -> Iterator[_T]:
+        return iter(self._dict)
+
+    def __repr__(self):
+        return str(self._dict)
+
+    def _type_check(self, e: Any) -> _T:
+        if self._basetypes and not any(
+            isinstance(e, t) for t in self._basetypes
+        ):
+            raise TypeError(
+                f"Cannot add object with type {type(e)} to TypedDict expecting type {self._basetypes}",
+            )
+        return e
+
+    def __newlike__(self, iterable: MutableMapping[_K, _T]):
+        new = self.__class__()
+        # separating this allows subclasses to omit these from their `__init__`
+        new._basetypes = self._basetypes
+        new.update(**iterable)
+        return new
+
+    def copy(self) -> "TypedMutableMapping[_T]":
+        """Return a shallow copy of the dictionary."""
+        return self.__newlike__(self)

--- a/napari/utils/events/containers/_evented_dict.py
+++ b/napari/utils/events/containers/_evented_dict.py
@@ -32,9 +32,11 @@ class EventedDict(TypedMutableMapping[_K, _T]):
         emitted before ``key`` is removed from the dictionary
     removed (key: K, value: T)
         emitted after ``key`` was removed from the dictionary
-    refresh (key, K, value: T)
-        emitted after ``value`` of ``key`` was changed. Only implemented by subclasses to give them an option
-        to trigger some update after ``value`` was changed and this class did not register it.
+    updated (key, K, value: T)
+        emitted after ``value`` of ``key`` was changed. Only implemented by
+        subclasses to give them an option to trigger some update after ``value``
+        was changed and this class did not register it. This can be useful if
+        the ``basetype`` is not an evented object.
     """
 
     events: EmitterGroup
@@ -51,7 +53,7 @@ class EventedDict(TypedMutableMapping[_K, _T]):
             "added": None,
             "removing": None,
             "removed": None,
-            "refresh": None,
+            "updated": None,
         }
         # For inheritance: If the mro already provides an EmitterGroup, add...
         if hasattr(self, "events") and isinstance(self.events, EmitterGroup):

--- a/napari/utils/events/containers/_evented_dict.py
+++ b/napari/utils/events/containers/_evented_dict.py
@@ -1,0 +1,108 @@
+"""MutableMapping that emits events when altered."""
+from typing import Mapping, Sequence, Type, Union
+
+from ..event import EmitterGroup, Event
+from ..types import SupportsEvents
+from ._dict import _K, _T, TypedMutableMapping
+
+
+class EventedDict(TypedMutableMapping[_K, _T]):
+    """Mutable dictionary that emits events when altered.
+
+    This class is designed to behave exactly like builting ``dict``, but
+    will emit events before and after all mutations (addition, removal, and
+    changing).
+
+    Parameters
+    ----------
+    data : Mapping, optional
+        Dictionary to initialize the class with.
+    basetype : type of sequence of types, optional
+        Type of the element in the dictionary.
+
+    Events
+    ------
+    changed (key: K, old_value: T, value: T)
+        emitted when ``key`` is set from ``old_value`` to ``value``
+    adding (key: K)
+        emitted before an item is added to the dictionary with ``key``
+    added (key: K, value: T)
+        emitted after ``value`` was added to the dictionary with ``key``
+    removing (key: K)
+        emitted before ``key`` is removed from the dictionary
+    removed (key: K, value: T)
+        emitted after ``key`` was removed from the dictionary
+    refresh (key, K, value: T)
+        emitted after ``value`` of ``key`` was changed. Only implemented by subclasses to give them an option
+        to trigger some update after ``value`` was changed and this class did not register it.
+    """
+
+    events: EmitterGroup
+
+    def __init__(
+        self,
+        data: Mapping[_K, _T] = None,
+        basetype: Union[Type[_T], Sequence[Type[_T]]] = (),
+    ):
+        _events = {
+            "changing": None,
+            "changed": None,
+            "adding": None,
+            "added": None,
+            "removing": None,
+            "removed": None,
+            "refresh": None,
+        }
+        # For inheritance: If the mro already provides an EmitterGroup, add...
+        if hasattr(self, "events") and isinstance(self.events, EmitterGroup):
+            self.events.add(**_events)
+        else:
+            # otherwise create a new one
+            self.events = EmitterGroup(source=self, **_events)
+        super().__init__(data, basetype)
+
+    def __setitem__(self, key: _K, value: _T):
+        old = self._dict.get(key, None)
+        if value is old or value == old:
+            return
+        if old is None:
+            self.events.adding(key=key)
+            super().__setitem__(key, value)
+            self.events.added(key=key, value=value)
+            self._connect_child_emitters(value)
+        else:
+            super().__setitem__(key, value)
+            self.events.changed(key=key, old_value=old, value=value)
+
+    def __delitem__(self, key: _K):
+        self.events.removing(key=key)
+        self._disconnect_child_emitters(self[key])
+        item = self._dict.pop(key)
+        self.events.removed(key=key, value=item)
+
+    def _reemit_child_event(self, event: Event):
+        """An item in the dict emitted an event.  Re-emit with key"""
+        if not hasattr(event, "key"):
+            setattr(event, "key", self.key(event.source))
+        # re-emit with this object's EventEmitter of the same type if present
+        # otherwise just emit with the EmitterGroup itself
+        getattr(self.events, event.type, self.events)(event)
+
+    def _disconnect_child_emitters(self, child: _T):
+        """Disconnect all events from the child from the re-emitter."""
+        if isinstance(child, SupportsEvents):
+            child.events.disconnect(self._reemit_child_event)
+
+    def _connect_child_emitters(self, child: _T):
+        """Connect all events from the child to be re-emitted."""
+        if isinstance(child, SupportsEvents):
+            # make sure the event source has been set on the child
+            if child.events.source is None:
+                child.events.source = child
+            child.events.connect(self._reemit_child_event)
+
+    def key(self, value: _T):
+        """Return first instance of value."""
+        for k, v in self._dict.items():
+            if v is value or v == value:
+                return k


### PR DESCRIPTION
This PR adds two new container classes, namely `TypedMutableMapping` and `EventedDict` which are very similar to the `list` and `set` containers. 

These were implemented as part of #2900  which still requires a bit of work. Since there are others like @alisterburt who might benefit from an `EventedDict` it makes sense to split it up.

# Changelog
- added `TypedMutableMapping` and `EventedDict` to the available containers
- added interface tests

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
