### PR TITLE
Speedup one of the slowest test.

### DIFF
--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -64,8 +64,8 @@ def test_calc_data_fast_uint8():
     data = da.random.randint(
         0,
         100,
-        size=(100_000, 1000, 1000),
-        chunks=(1, 1000, 1000),
+        size=(1_000, 10, 10),
+        chunks=(1, 10, 10),
         dtype=np.uint8,
     )
     assert calc_data_range(data) == [0, 255]


### PR DESCRIPTION
Creating a 100B random values takes most of the time in this test (5 to
6 sec), which is unnecessary. calc_data_range return [0,255] if the type
is uint8 anyway w/o looking at the data.

I guess we could reduce even further, but maybe those large values are
to test that da actually chunks the array, but at that point this is
quasi-instantaneous anyway.
