### PR TITLE
Fix behavior of return/escape on preferences dialog to accept/cancel

### DIFF
--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -45,6 +45,7 @@ class PreferencesDialog(QDialog):
 
         # Setup
         self.setWindowTitle(trans._("Preferences"))
+        self._button_ok.setDefault(True)
 
         # Layout
         left_layout = QVBoxLayout()
@@ -68,6 +69,7 @@ class PreferencesDialog(QDialog):
         self._button_cancel.clicked.connect(self.on_click_cancel)
         self._button_ok.clicked.connect(self.on_click_ok)
         self._default_restore.clicked.connect(self.restore_defaults)
+        self.rejected.connect(self.on_click_cancel)
 
         # Make widget
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Correctly handle escape and return presses to reject or accept preferences changes.

Fixes https://github.com/napari/napari/issues/2993

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
