### PR TITLE
enable two different grid views

### DIFF
--- a/napari/components/_viewer_key_bindings.py
+++ b/napari/components/_viewer_key_bindings.py
@@ -111,10 +111,13 @@ def transpose_axes(viewer):
 @register_viewer_action(trans._("Toggle grid mode."))
 def toggle_grid(viewer):
     if not viewer.grid.enabled:
+        # activate grid view
         viewer.grid.enabled = True
     elif viewer.grid.enabled and viewer.grid.stride == 1:
+        # switch from right-left to left-right grid order
         viewer.grid.stride = -1
     elif viewer.grid.enabled and viewer.grid.stride == -1:
+        # turn grid of and reset grid order
         viewer.grid.enabled = False
         viewer.grid.stride = 1
 

--- a/napari/components/_viewer_key_bindings.py
+++ b/napari/components/_viewer_key_bindings.py
@@ -110,8 +110,13 @@ def transpose_axes(viewer):
 
 @register_viewer_action(trans._("Toggle grid mode."))
 def toggle_grid(viewer):
-    viewer.grid.enabled = not viewer.grid.enabled
-
+    if not viewer.grid.enabled:
+        viewer.grid.enabled = True
+    elif viewer.grid.enabled and viewer.grid.stride == 1:
+        viewer.grid.stride = -1
+    elif viewer.grid.enabled and viewer.grid.stride == -1:
+        viewer.grid.enabled = False
+        viewer.grid.stride = 1
 
 @register_viewer_action(trans._("Toggle visibility of selected layers"))
 def toggle_selected_visibility(viewer):


### PR DESCRIPTION
Hi all,
hi @sofroniewn @tlambert03 @jni 

This is an alternative PR to #2974 . 

# Description
In short: I change what happens when the user toggles grid view. There are now three states:
1. No grid view
2. Grid view with stride = 1
3. Grid view with stride = -1

This is how it looks in action:
![triple-grid-state](https://user-images.githubusercontent.com/12660498/125087688-f8f9c200-e0cc-11eb-99fb-dbc12b8bf064.gif)


## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# References
closes #2974 

# How has this been tested?
manually

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
