### PR TITLE
Remove mentions of _mode_history (2987)

### DIFF
--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -253,7 +253,6 @@ class Labels(_ImageBase):
         self.color = color
 
         self._mode = Mode.PAN_ZOOM
-        self._mode_history = self._mode
         self._status = self.mode
         self._preserve_labels = False
         self._help = trans._('enter paint or fill mode to edit labels')

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -345,7 +345,6 @@ class Points(Layer):
         self._value = None
         self._value_stored = None
         self._mode = Mode.PAN_ZOOM
-        self._mode_history = self._mode
         self._status = self.mode
         self._highlight_index = []
         self._highlight_box = None

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -255,8 +255,6 @@ class Shapes(Layer):
         Dictionary containing all the shape data indexed by slice tuple
     _data_view : ShapeList
         Object containing the currently viewed shape data.
-    _mode_history : Mode
-        Interactive mode captured on press of <space>.
     _selected_data_history : set
         Set of currently selected captured on press of <space>.
     _selected_data_stored : set
@@ -516,7 +514,6 @@ class Shapes(Layer):
         # Mode setting logic
         self._mode = Mode.SELECT
         self.mode = Mode.PAN_ZOOM
-        self._mode_history = self._mode
         self._status = self.mode
 
         self._init_shapes(


### PR DESCRIPTION
# Description

Shapes, Points, and Label layers have a '_mode_history' attribute that seems to be unused. This PR removes this attribute and associated documentation.

The past intent behind _mode_history was to capture the interactive mode when the user pressed "space."

# References
closes #2987 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
