### PR TITLE
Enforce layer.metadata as dict

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -300,10 +300,24 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         """str: Unique name of the layer."""
         return self._name
 
+    @name.setter
+    def name(self, name):
+        if name == self.name:
+            return
+        if not name:
+            name = self._basename()
+        self._name = name
+        self.events.name()
+
     @property
     def metadata(self) -> dict:
         """Key/value map for user-stored data."""
         return self._metadata
+
+    @metadata.setter
+    def metadata(self, value: dict) -> None:
+        self._metadata.clear()
+        self._metadata.update(value)
 
     @property
     def source(self):
@@ -317,15 +331,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         Derived classes that do asynchronous loading can override this.
         """
         return True
-
-    @name.setter
-    def name(self, name):
-        if name == self.name:
-            return
-        if not name:
-            name = self._basename()
-        self._name = name
-        self.events.name()
 
     @property
     def opacity(self):

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -181,7 +181,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
         self._source = current_source()
         self.dask_optimized_slicing = configure_dask(data)
-        self.metadata = metadata or {}
+        self._metadata = dict(metadata or {})
         self._opacity = opacity
         self._blending = Blending(blending)
         self._visible = visible
@@ -299,6 +299,11 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     def name(self):
         """str: Unique name of the layer."""
         return self._name
+
+    @property
+    def metadata(self) -> dict:
+        """Key/value map for user-stored data."""
+        return self._metadata
 
     @property
     def source(self):


### PR DESCRIPTION
# Description
closes #3017 by A) coercing `layer.metadata` input to a dict during `__init__`, and making it a read-only property.  (the dict-value itself is still mutable of course).


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
