### PR TITLE
Use compression=('zlib', 1) for new tifffile

### DIFF
--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -44,7 +44,9 @@ def imsave(filename: str, data: np.ndarray):
             )
 
         if compression_instead_of_compress:
-            tifffile.imsave(filename, data, compression=1)
+            # 'compression' scheme is more complex. See:
+            # https://forum.image.sc/t/problem-saving-generated-labels-in-cellpose-napari/54892/8
+            tifffile.imsave(filename, data, compression=('zlib', 1))
         else:  # older version of tifffile since 2021.6.6  this is deprecated
             tifffile.imsave(filename, data, compress=1)
     else:


### PR DESCRIPTION
# Description

Turns out that #2872 was not the correct way to deal the deprecation of the `compress=` keyword argument for `tifffile.imsave`. As @cgohlke explains (🙏) [on image.sc](https://forum.image.sc/t/problem-saving-generated-labels-in-cellpose-napari/54892/8), the correct approach is `compression=('zlib', 1)`. This PR contains that fix.

