### PR TITLE
Fix saving preferences

### DIFF
--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -69,7 +69,6 @@ class PreferencesDialog(QDialog):
         self._button_cancel.clicked.connect(self.on_click_cancel)
         self._button_ok.clicked.connect(self.on_click_ok)
         self._default_restore.clicked.connect(self.restore_defaults)
-        self.rejected.connect(self.on_click_cancel)
 
         # Make widget
 

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -69,6 +69,7 @@ class PreferencesDialog(QDialog):
         self._button_cancel.clicked.connect(self.on_click_cancel)
         self._button_ok.clicked.connect(self.on_click_ok)
         self._default_restore.clicked.connect(self.restore_defaults)
+        self.rejected.connect(self.on_click_cancel)
 
         # Make widget
 
@@ -94,6 +95,11 @@ class PreferencesDialog(QDialog):
             text=text_str,
         )
         widget.exec_()
+
+    def accept(self):
+        """Override to emit signal."""
+        self.closed.emit()
+        super().accept()
 
     def closeEvent(self, event):
         """Override to emit signal."""
@@ -201,7 +207,7 @@ class PreferencesDialog(QDialog):
 
         if event is True:
             get_settings().reset()
-            self.close()
+            self.accept()
             self.valueChanged.emit()
             self._list.clear()
 
@@ -217,7 +223,7 @@ class PreferencesDialog(QDialog):
 
     def on_click_ok(self):
         """Keeps the selected preferences saved to settings."""
-        self.close()
+        self.accept()
 
     def on_click_cancel(self):
         """Restores the settings in place when dialog was launched."""

--- a/napari/_qt/dialogs/qt_message_dialogs.py
+++ b/napari/_qt/dialogs/qt_message_dialogs.py
@@ -28,6 +28,7 @@ class ConfirmDialog(QDialog):
         self._question = QLabel(self)
         self._button_restore = QPushButton(trans._("Restore"))
         self._button_cancel = QPushButton(trans._("Cancel"))
+        self._button_restore.setDefault(True)
 
         # Widget set up
         self._question.setText(text)


### PR DESCRIPTION
A recent bug was introduced where the preferences were not being saved if `Return` or "ok" was clicked in the preferences dialog.  This PR fixes so that preferences are saved if `Return` or "ok" are clicked.  The escape function still works to cancel any changes made in the dialog.  