### PR TITLE
fix Labels layer controls checkbox labels

### DIFF
--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -282,14 +282,14 @@ class QtLabelsControls(QtLayerControls):
         self.grid_layout.addWidget(QLabel(trans._('contiguous:')), 10, 0, 1, 1)
         self.grid_layout.addWidget(self.contigCheckBox, 10, 1, 1, 1)
         self.grid_layout.addWidget(
-            QLabel(trans._('preserve\nlabels:')), 10, 0, 1, 2
+            QLabel(trans._('preserve\nlabels:')), 11, 0, 1, 2
         )
         self.grid_layout.addWidget(self.preserveLabelsCheckBox, 11, 1, 1, 1)
         self.grid_layout.addWidget(
-            QLabel(trans._('show\nselected:')), 10, 2, 1, 1
+            QLabel(trans._('show\nselected:')), 11, 2, 1, 1
         )
         self.grid_layout.addWidget(self.selectedColorCheckbox, 11, 3, 1, 1)
-        self.grid_layout.setRowStretch(11, 1)
+        self.grid_layout.setRowStretch(12, 1)
         self.grid_layout.setColumnStretch(1, 1)
         self.grid_layout.setSpacing(4)
 

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -265,11 +265,11 @@ class QtLabelsControls(QtLayerControls):
         self.grid_layout.addWidget(QLabel(trans._('contiguous:')), 9, 0, 1, 1)
         self.grid_layout.addWidget(self.contigCheckBox, 9, 1, 1, 1)
         self.grid_layout.addWidget(
-            QLabel(trans._('preserve labels:')), 10, 0, 1, 2
+            QLabel(trans._('preserve\nlabels:')), 10, 0, 1, 2
         )
         self.grid_layout.addWidget(self.preserveLabelsCheckBox, 10, 1, 1, 1)
         self.grid_layout.addWidget(
-            QLabel(trans._('show selected:')), 10, 2, 1, 1
+            QLabel(trans._('show\nselected:')), 10, 2, 1, 1
         )
         self.grid_layout.addWidget(self.selectedColorCheckbox, 10, 3, 1, 1)
         self.grid_layout.setRowStretch(10, 1)


### PR DESCRIPTION
# Description
This PR fixes #3044 (labels for the Labels layer checkboxes being cut off) by splitting the label text into two lines.

![Screenshot 2021-07-14 at 18 03 59](https://user-images.githubusercontent.com/1120672/125676604-b93da52b-b527-459c-b568-c2adc8676088.png)


## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #3044

# How has this been tested?
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
