### PR TITLE
Refactor the Point, Label and Shape Layer Mode logic.

### DIFF
--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -225,7 +225,7 @@ class QtPointsControls(QtLayerControls):
         elif mode == Mode.PAN_ZOOM:
             self.panzoom_button.setChecked(True)
         else:
-            raise ValueError(trans._("Mode not recognized"))
+            raise ValueError(trans._("Mode not recognized {mode}", mode=mode))
 
     def changeSymbol(self, text):
         """Change marker symbol of the points on the layer model.

--- a/napari/layers/base/__init__.py
+++ b/napari/layers/base/__init__.py
@@ -1,1 +1,1 @@
-from .base import Layer
+from .base import Layer, no_op

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 from abc import ABC, abstractmethod
 from collections import namedtuple
@@ -29,12 +31,24 @@ from ._base_constants import Blending
 Extent = namedtuple('Extent', 'data world step')
 
 
-def no_op(layer, even):
+def no_op(layer: Layer, event: Event) -> None:
     """
     A convenient no-op event for the layer mouse binding.
 
     This makes it easier to handle many cases by inserting this as
     as place holder
+
+    Parameters
+    ----------
+    layer : Layer
+        Current layer on which this will be bound as a callback
+    event : Event
+        event that triggered this mouse callback.
+
+    Returns
+    -------
+    None
+
     """
     return None
 
@@ -306,13 +320,25 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         """
         Helper to manage callbacks in multiple layers
 
+        Parameters
+        ----------
+        mode : Modeclass | str
+            New mode for the current layer.
+        Modeclass : Enum
+            Enum for the current class representing the modes it can takes,
+            this is usually specific on each subclass.
+
+        Returns
+        -------
+        tuple (new Mode, mode changed)
+
         """
         mode = Modeclass(mode)
         assert mode is not None
         if not self.editable:
             mode = Modeclass.PAN_ZOOM
         if mode == self._mode:
-            return mode
+            return mode, False
         if mode.value not in Modeclass.keys():
             raise ValueError(
                 trans._(
@@ -335,7 +361,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             self.interactive = True
         else:
             self.interactive = False
-        return mode
+        return mode, True
 
     @classmethod
     def _basename(cls):
@@ -1190,7 +1216,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     @classmethod
     def create(
         cls, data, meta: dict = None, layer_type: Optional[str] = None
-    ) -> 'Layer':
+    ) -> Layer:
         """Create layer from `data` of type `layer_type`.
 
         Primarily intended for usage by reader plugin hooks and creating a

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -628,7 +628,9 @@ class Labels(_ImageBase):
 
     @mode.setter
     def mode(self, mode: Union[str, Mode]):
-        mode = self._mode_setter_helper(mode, Mode)
+        mode, changed = self._mode_setter_helper(mode, Mode)
+        if not changed:
+            return
 
         self.help = _FWD_SHAPE_HELP[mode]
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -16,6 +16,7 @@ from ...utils.events import Event
 from ...utils.events.custom_types import Array
 from ...utils.events.event import WarningEmitter
 from ...utils.translations import trans
+from ..base import no_op
 from ..image._image_utils import guess_multiscale
 from ..image.image import _ImageBase
 from ..utils.color_transformations import transform_color
@@ -23,6 +24,28 @@ from ..utils.layer_utils import validate_properties
 from ._labels_constants import LabelColorMode, Mode
 from ._labels_mouse_bindings import draw, pick
 from ._labels_utils import indices_in_shape, sphere_indices
+
+_REV_SHAPE_HELP = {
+    trans._('enter paint or fill mode to edit labels'): {Mode.PAN_ZOOM},
+    trans._('hold <space> to pan/zoom, click to pick a label'): {
+        Mode.PICK,
+        Mode.FILL,
+    },
+    trans._(
+        'hold <space> to pan/zoom, hold <shift> to toggle preserve_labels, hold <control> to fill, hold <alt> to erase, drag to paint a label'
+    ): {Mode.PAINT},
+    trans._('hold <space> to pan/zoom, drag to erase a label'): {Mode.ERASE},
+}
+
+
+# This avoid duplicating the trans._ help messages above
+# as some modes have the same help.
+# while most tooling will recognise identical messages,
+# this can lead to human error.
+_FWD_SHAPE_HELP = {}
+for t, modes in _REV_SHAPE_HELP.items():
+    for m in modes:
+        _FWD_SHAPE_HELP[m] = t
 
 
 class Labels(_ImageBase):
@@ -580,59 +603,37 @@ class Labels(_ImageBase):
         """
         return str(self._mode)
 
+    _drag_modes = {
+        Mode.PAN_ZOOM: no_op,
+        Mode.PICK: pick,
+        Mode.PAINT: draw,
+        Mode.FILL: draw,
+        Mode.ERASE: draw,
+    }
+
+    _move_modes = {
+        Mode.PAN_ZOOM: no_op,
+        Mode.PICK: no_op,
+        Mode.PAINT: no_op,
+        Mode.FILL: no_op,
+        Mode.ERASE: no_op,
+    }
+    _cursor_modes = {
+        Mode.PAN_ZOOM: 'standard',
+        Mode.PICK: 'cross',
+        Mode.PAINT: 'circle',
+        Mode.FILL: 'cross',
+        Mode.ERASE: 'circle',
+    }
+
     @mode.setter
     def mode(self, mode: Union[str, Mode]):
-        mode = Mode(mode)
+        mode = self._mode_setter_helper(mode, Mode)
 
-        if not self.editable:
-            mode = Mode.PAN_ZOOM
+        self.help = _FWD_SHAPE_HELP[mode]
 
-        if mode == self._mode:
-            return
-
-        if self._mode == Mode.PICK:
-            self.mouse_drag_callbacks.remove(pick)
-        elif self._mode in [Mode.PAINT, Mode.FILL, Mode.ERASE]:
-            self.mouse_drag_callbacks.remove(draw)
-
-        if mode == Mode.PAN_ZOOM:
-            self.cursor = 'standard'
-            self.interactive = True
-            self.help = trans._('enter paint or fill mode to edit labels')
-        elif mode == Mode.PICK:
-            self.cursor = 'cross'
-            self.interactive = False
-            self.help = trans._(
-                'hold <space> to pan/zoom, click to pick a label'
-            )
-            self.mouse_drag_callbacks.append(pick)
-        elif mode == Mode.PAINT:
-            self.cursor = 'circle'
+        if mode in (Mode.PAINT, Mode.ERASE):
             self.cursor_size = self._calculate_cursor_size()
-            self.interactive = False
-            self.help = trans._(
-                'hold <space> to pan/zoom, hold <shift> to toggle preserve_labels, hold <control> to fill, hold <alt> to erase, drag to paint a label'
-            )
-            self.mouse_drag_callbacks.append(draw)
-        elif mode == Mode.FILL:
-            self.cursor = 'cross'
-            self.interactive = False
-            self.help = trans._(
-                'hold <space> to pan/zoom, click to fill a label'
-            )
-            self.mouse_drag_callbacks.append(draw)
-        elif mode == Mode.ERASE:
-            self.cursor = 'circle'
-            self.cursor_size = self._calculate_cursor_size()
-            self.interactive = False
-            self.help = trans._(
-                'hold <space> to pan/zoom, drag to erase a label'
-            )
-            self.mouse_drag_callbacks.append(draw)
-        else:
-            raise ValueError(trans._("Mode not recognized"))
-
-        self._mode = mode
 
         self.events.mode(mode=mode)
         self.refresh()

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -14,7 +14,7 @@ from ...utils.colormaps.standardize_color import (
 from ...utils.events import Event
 from ...utils.events.custom_types import Array
 from ...utils.translations import trans
-from ..base import Layer
+from ..base import Layer, no_op
 from ..utils._color_manager_constants import ColorMode
 from ..utils.color_manager import ColorManager
 from ..utils.color_transformations import ColorType
@@ -26,7 +26,6 @@ from ._points_utils import create_box, fix_data_points, points_to_squares
 
 if TYPE_CHECKING:
     from pandas import DataFrame
-
 
 DEFAULT_COLOR_CYCLE = np.array([[1, 0, 1, 1], [0, 1, 0, 1]])
 
@@ -1057,56 +1056,39 @@ class Points(Layer):
         """
         return str(self._mode)
 
+    _drag_modes = {Mode.ADD: add, Mode.SELECT: select, Mode.PAN_ZOOM: no_op}
+
+    _move_modes = {
+        Mode.ADD: no_op,
+        Mode.SELECT: highlight,
+        Mode.PAN_ZOOM: no_op,
+    }
+    _cursor_modes = {
+        Mode.ADD: 'pointing',
+        Mode.SELECT: 'standard',
+        Mode.PAN_ZOOM: 'standard',
+    }
+
     @mode.setter
     def mode(self, mode):
-        mode = Mode(mode)
-
-        if not self.editable:
-            mode = Mode.PAN_ZOOM
-
-        if mode == self._mode:
-            return
+        mode = self._mode_setter_helper(mode, Mode)
+        assert mode is not None, mode
         old_mode = self._mode
 
-        if old_mode == Mode.ADD:
-            self.mouse_drag_callbacks.remove(add)
-        elif old_mode == Mode.SELECT:
-            # add mouse drag and move callbacks
-            self.mouse_drag_callbacks.remove(select)
-            self.mouse_move_callbacks.remove(highlight)
-
         if mode == Mode.ADD:
-            self.cursor = 'pointing'
-            self.interactive = True
-            self.help = trans._('hold <space> to pan/zoom')
             self.selected_data = set()
-            self._set_highlight()
-            self.mouse_drag_callbacks.append(add)
-        elif mode == Mode.SELECT:
-            self.cursor = 'standard'
-            self.interactive = False
-            self.help = trans._('hold <space> to pan/zoom')
-            # add mouse drag and move callbacks
-            self.mouse_drag_callbacks.append(select)
-            self.mouse_move_callbacks.append(highlight)
-        elif mode == Mode.PAN_ZOOM:
-            self.cursor = 'standard'
             self.interactive = True
+
+        if mode == Mode.PAN_ZOOM:
             self.help = ''
+            self.interactive = True
         else:
-            raise ValueError(
-                trans._(
-                    "Mode not recognized",
-                    deferred=True,
-                )
-            )
+            self.help = trans._('hold <space> to pan/zoom')
 
         if mode != Mode.SELECT or old_mode != Mode.SELECT:
             self._selected_data_stored = set()
 
-        self._mode = mode
         self._set_highlight()
-
         self.events.mode(mode=mode)
 
     @property

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1071,7 +1071,9 @@ class Points(Layer):
 
     @mode.setter
     def mode(self, mode):
-        mode = self._mode_setter_helper(mode, Mode)
+        mode, changed = self._mode_setter_helper(mode, Mode)
+        if not changed:
+            return
         assert mode is not None, mode
         old_mode = self._mode
 

--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -7,16 +7,6 @@ from ._shapes_models import Ellipse, Line, Path, Polygon, Rectangle
 from ._shapes_utils import point_to_lines
 
 
-def no_op(layer, even):
-    """
-    A convenient no-op event for the shape mouse binding.
-
-    This makes it easier to handle many cases by inserting this as
-    as place holder
-    """
-    return None
-
-
 def highlight(layer, event):
     """Highlight hovered shapes."""
     layer._set_highlight()

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1540,7 +1540,9 @@ class Shapes(Layer):
     @mode.setter
     def mode(self, mode: Union[str, Mode]):
         old_mode = self._mode
-        mode = self._mode_setter_helper(mode, Mode)
+        mode, changed = self._mode_setter_helper(mode, Mode)
+        if not changed:
+            return
 
         self.help = _FWD_SHAPE_HELP[mode]
 

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -17,7 +17,7 @@ from ...utils.events import Event
 from ...utils.events.custom_types import Array
 from ...utils.misc import ensure_iterable
 from ...utils.translations import trans
-from ..base import Layer
+from ..base import Layer, no_op
 from ..utils.color_manager_utils import guess_continuous, map_property
 from ..utils.color_transformations import (
     ColorType,
@@ -43,7 +43,6 @@ from ._shapes_mouse_bindings import (
     add_path_polygon_creating,
     add_rectangle,
     highlight,
-    no_op,
     select,
     vertex_insert,
     vertex_remove,
@@ -1539,38 +1538,9 @@ class Shapes(Layer):
         return str(self._mode)
 
     @mode.setter
-    def mode(self, mode):
-        mode = Mode(mode)
-
-        if not self.editable:
-            mode = Mode.PAN_ZOOM
-
-        if mode == self._mode:
-            return
-        if mode.value not in Mode.keys():
-            raise ValueError(
-                trans._(
-                    "Mode not recognized: {mode}", deferred=True, mode=mode
-                )
-            )
-
+    def mode(self, mode: Union[str, Mode]):
         old_mode = self._mode
-        self._mode = mode
-
-        for callback_list, mode_dict in [
-            (self.mouse_drag_callbacks, self._drag_modes),
-            (self.mouse_move_callbacks, self._move_modes),
-        ]:
-            if mode_dict[old_mode] in callback_list:
-                callback_list.remove(mode_dict[old_mode])
-            callback_list.append(mode_dict[mode])
-
-        self.cursor = self._cursor_modes[mode]
-
-        if mode == Mode.PAN_ZOOM:
-            self.interactive = True
-        else:
-            self.interactive = False
+        mode = self._mode_setter_helper(mode, Mode)
 
         self.help = _FWD_SHAPE_HELP[mode]
 


### PR DESCRIPTION
The Shape was already refactor, this does the same refactoring in the
Points and Label Layer, and move the common logic to a helper in the
base Layer.

This should make it slightly easier to make new layers with modes
and different mouse callbacks depending on which mode is active.

This make it also a tiny bit less error-prone to edit what is active in
which mode.

There is still a bit of repetition to keep things readable, and I erred
on the side of expliciteness (having a no_op callback) instead of of
checking whether a callback is present.

There is a hint of complexity with cursor because of square brush, which
is deprecated and should have been removed.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor

# References

Closes #3030 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
