### PR TITLE
Fix Layer.affine assignment and broadcasting

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -446,6 +446,9 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
     @affine.setter
     def affine(self, affine):
+        # Assignment by transform name is not supported by TransformChain and
+        # EventedList, so use the integer index instead. For more details, see:
+        # https://github.com/napari/napari/issues/3058
         self._transforms[2] = coerce_affine(
             affine, ndim=self.ndim, name='physical2world'
         )

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -229,7 +229,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
                     ndim=ndim,
                     name='data2physical',
                 ),
-                coerce_affine(affine, ndim, name='physical2world'),
+                coerce_affine(affine, ndim=ndim, name='physical2world'),
                 Affine(np.ones(ndim), np.zeros(ndim), name='world2grid'),
             ]
         )
@@ -446,8 +446,8 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
     @affine.setter
     def affine(self, affine):
-        self._transforms['physical2world'] = coerce_affine(
-            affine, self.ndim, name='physical2world'
+        self._transforms[2] = coerce_affine(
+            affine, ndim=self.ndim, name='physical2world'
         )
         self._update_dims()
         self.events.affine()

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -670,3 +670,20 @@ def test_2d_image_with_channels_and_2d_scale_translate_then_scale_translate_padd
 
     np.testing.assert_array_equal(image.scale, (1, 1, 1))
     np.testing.assert_array_equal(image.translate, (0, 3, 4))
+
+
+@pytest.mark.parametrize('affine_size', range(3, 6))
+def test_2d_image_with_channels_and_affine_broadcasts(affine_size):
+    # For more details, see the GitHub issue:
+    # https://github.com/napari/napari/issues/3045
+    image = Image(np.ones((1, 1, 1, 100, 100)), affine=np.eye(affine_size))
+    np.testing.assert_array_equal(image.affine, np.eye(6))
+
+
+@pytest.mark.parametrize('affine_size', range(3, 6))
+def test_2d_image_with_channels_and_affine_assignment_broadcasts(affine_size):
+    # For more details, see the GitHub issue:
+    # https://github.com/napari/napari/issues/3045
+    image = Image(np.ones((1, 1, 1, 100, 100)))
+    image.affine = np.eye(affine_size)
+    np.testing.assert_array_equal(image.affine, np.eye(6))

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -461,19 +461,19 @@ def compute_multiscale_level_and_corners(
     return level, corners
 
 
-def coerce_affine(affine, ndim, name=None):
+def coerce_affine(affine, *, ndim, name=None):
     """Coerce a user input into an affine transform object.
 
     If the input is already an affine transform object, that same object is returned
     with a name change if the given name is not None. If the input is None, an identity
     affine transform object of the given dimensionality is returned.
 
-     Parameters
+    Parameters
     ----------
     affine : array-like or napari.utils.transforms.Affine
         An existing affine transform object or an array-like that is its transform matrix.
     ndim : int
-        The desired dimensionality of the transform. Ignored if implied by affine.
+        The desired dimensionality of the transform. Ignored is affine is an Affine transform object.
     name : str
         The desired name of the transform.
 
@@ -483,11 +483,11 @@ def coerce_affine(affine, ndim, name=None):
         The input coerced into an affine transform object.
     """
     if affine is None:
-        affine = Affine(affine_matrix=np.eye(ndim + 1))
+        affine = Affine(affine_matrix=np.eye(ndim + 1), ndim=ndim)
     elif isinstance(affine, np.ndarray):
-        affine = Affine(affine_matrix=affine)
+        affine = Affine(affine_matrix=affine, ndim=ndim)
     elif isinstance(affine, list):
-        affine = Affine(affine_matrix=np.array(affine))
+        affine = Affine(affine_matrix=np.array(affine), ndim=ndim)
     elif not isinstance(affine, Affine):
         raise TypeError(
             trans._(


### PR DESCRIPTION
# Description

This changes `Layer.affine.setter` to index the `TransformChain` by integer index rather than key/name, which does not seem to work for `TransformChain` and maybe for `EventedList` in general. It also makes `ndim` a required keyword argument of `coerce_affine` (to be consistent with the other transform coercion functions) and passes that to `Affine` in all cases to ensure that the matrix is broadcast to the same number of dimensions as the layer.

I'm not sure if `coerce_affine` should also apply `ndim` when the input `affine` argument is an `Affine` transform. I think it probably should, but I haven't made that change yet, and would appreciate some input.

## Type of change

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #3045 

# How has this been tested?
- [x] new tests added to cover assignment and construction.
- [x] existing related tests continue to pass.

The new tests just use an identity affine matrix, as the main concern here is that the matrix is broadcast in some legal way. I did start writing tests with random linear/translate components of that matrix, but that takes a little complex to setup correctly. Let me know if you think that's a better idea.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
