### PR TITLE
Make flash effect feel more instant

### DIFF
--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -290,7 +290,7 @@ def add_flash_animation(
 
     # now  set an actual time for the flashing and an intermediate color
     widget._flash_animation.setDuration(duration)
-    widget._flash_animation.setKeyValueAt(0.5, QColor(*color))
+    widget._flash_animation.setKeyValueAt(0.1, QColor(*color))
 
 
 def remove_flash_animation(widget: QWidget):


### PR DESCRIPTION

This PR is a fix for issue #3000 by moving the peak of the flash closer to the beginning of the animation. 
This PR was worked on during the SciPy2021 sprints with @alisterburt 