### PR TITLE
Use enum values internally for settings.

### DIFF
--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -108,7 +108,11 @@ def test_notification_display(mock_show, severity, monkeypatch):
     settings = get_settings()
 
     monkeypatch.delenv('NAPARI_CATCH_ERRORS', raising=False)
-    monkeypatch.setattr(settings.application, 'gui_notification_level', 'info')
+    monkeypatch.setattr(
+        settings.application,
+        'gui_notification_level',
+        NotificationSeverity.INFO,
+    )
     notif = Notification('hi', severity, actions=[('click', lambda x: None)])
     NapariQtNotification.show_notification(notif)
     if NotificationSeverity(severity) >= NotificationSeverity.INFO:
@@ -132,7 +136,11 @@ def test_notification_error(mock_show, monkeypatch, clean_current):
     settings = get_settings()
 
     monkeypatch.delenv('NAPARI_CATCH_ERRORS', raising=False)
-    monkeypatch.setattr(settings.application, 'gui_notification_level', 'info')
+    monkeypatch.setattr(
+        settings.application,
+        'gui_notification_level',
+        NotificationSeverity.INFO,
+    )
     try:
         raise ValueError('error!')
     except ValueError as e:

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -174,7 +174,8 @@ class PreferencesDialog(QDialog):
         # Need to remove certain properties that will not be displayed on the GUI
         properties = schema.pop('properties')
         model = setting['model']
-        values = model.dict()
+        with model.enums_as_values():
+            values = model.dict()
         napari_config = getattr(model, "NapariConfig", None)
         if napari_config is not None:
             for val in napari_config.preferences_exclude:

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -31,7 +31,6 @@ from ..utils.io import imsave
 from ..utils.misc import in_jupyter, running_as_bundled_app
 from ..utils.notifications import Notification
 from ..utils.settings import get_settings
-from ..utils.settings._constants import LoopMode
 from ..utils.translations import trans
 from .dialogs.activity_dialog import ActivityDialog, ActivityToggleItem
 from .dialogs.preferences_dialog import PreferencesDialog
@@ -655,7 +654,7 @@ class Window:
                 widget, settings.application.playback_fps
             )
             widget.__class__.loop_mode.fset(
-                widget, LoopMode(settings.application.playback_mode)
+                widget, settings.application.playback_mode
             )
 
     def _reset_preference_states(self):

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -650,12 +650,8 @@ class Window:
         settings = get_settings()
 
         for widget in self.qt_viewer.dims.slider_widgets:
-            widget.__class__.fps.fset(
-                widget, settings.application.playback_fps
-            )
-            widget.__class__.loop_mode.fset(
-                widget, settings.application.playback_mode
-            )
+            setattr(widget, 'fps', settings.application.playback_fps)
+            setattr(widget, 'loop_mode', settings.application.playback_mode)
 
     def _reset_preference_states(self):
         # resetting plugin states in plugin manager

--- a/napari/_qt/widgets/qt_dims_slider.py
+++ b/napari/_qt/widgets/qt_dims_slider.py
@@ -76,7 +76,7 @@ class QtDimSliderWidget(QWidget):
         self._fps = settings.application.playback_fps
         self._minframe = None
         self._maxframe = None
-        self._loop_mode = LoopMode(settings.application.playback_mode)
+        self._loop_mode = settings.application.playback_mode
 
         layout = QHBoxLayout()
         self._create_axis_label_widget()

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -218,10 +218,10 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             return self.dict() == other
 
     @contextmanager
-    def enums_as_values(self, b: bool = True):
+    def enums_as_values(self, asval: bool = True):
         """Temporarily override how enums are retrieved."""
         before = getattr(self.Config, 'use_enum_values', None)
-        self.Config.use_enum_values = b
+        self.Config.use_enum_values = asval
         try:
             yield
         finally:

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -216,3 +216,16 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             return True
         else:
             return self.dict() == other
+
+    @contextmanager
+    def enums_as_values(self, b: bool = True):
+        """Temporarily override how enums are retrieved."""
+        before = getattr(self.Config, 'use_enum_values', None)
+        self.Config.use_enum_values = b
+        try:
+            yield
+        finally:
+            if before:
+                self.Config.use_enum_values = before
+            else:
+                delattr(self.Config, 'use_enum_values')

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -218,10 +218,17 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             return self.dict() == other
 
     @contextmanager
-    def enums_as_values(self, asval: bool = True):
-        """Temporarily override how enums are retrieved."""
+    def enums_as_values(self, as_values: bool = True):
+        """Temporarily override how enums are retrieved.
+
+        Parameters
+        ----------
+        as_values : bool, optional
+            Whether enums should be shown as values (or as enum objects),
+            by default `True`
+        """
         before = getattr(self.Config, 'use_enum_values', None)
-        self.Config.use_enum_values = asval
+        self.Config.use_enum_values = as_values
         try:
             yield
         finally:

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -220,8 +220,7 @@ class BaseNapariSettings(BaseSettings, EventedModel, ManagerMixin):
     class Config:
         # Pydantic specific configuration
         env_prefix = 'napari_'
-        use_enum_values = True
-        validate_all = True
+        use_enum_values = False  # override eventedmodel
         _env_settings: Optional[SettingsSourceCallable] = None
 
         @classmethod
@@ -416,7 +415,6 @@ class ApplicationSettings(BaseNapariSettings):
 
     class Config:
         # Pydantic specific configuration
-        use_enum_values = False
         schema_extra = {
             "title": trans._("Application"),
             "description": trans._("Main application settings."),

--- a/napari/utils/settings/_defaults.py
+++ b/napari/utils/settings/_defaults.py
@@ -416,6 +416,7 @@ class ApplicationSettings(BaseNapariSettings):
 
     class Config:
         # Pydantic specific configuration
+        use_enum_values = False
         schema_extra = {
             "title": trans._("Application"),
             "description": trans._("Main application settings."),


### PR DESCRIPTION
# Description
Part of #3062, this uses `use_enum_values = False` for our Settings model.  So that we don't need to convert to the back to the appropriate enum type everywhere when using the setting internally.

our schema-based widget generation was implicitly requiring `use_enum_values=True`, so I added a `enums_as_values` context manager to EventedModel so that you can (for example) get a dict with all values as enums without affecting the model overall.  (i looked, but pydantic doesn't offer this)

I pulled this out of #2932  for ease of review.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
