### PR TITLE
Skip progress indicator test when viewer is not shown

### DIFF
--- a/napari/_qt/_tests/test_progress.py
+++ b/napari/_qt/_tests/test_progress.py
@@ -151,14 +151,18 @@ def test_progress_update(make_napari_viewer):
     pbr.close()
 
 
+@pytest.mark.skipif(
+    not SHOW,
+    reason='viewer needs to be shown to test indicator',
+)
 def test_progress_indicator(make_napari_viewer):
     viewer = make_napari_viewer(show=SHOW)
     activity_dialog = viewer.window.qt_viewer.window()._activity_dialog
-    if SHOW:
-        assert not qt_viewer_has_pbar(viewer)
-        with progress(range(10)):
-            assert qt_viewer_has_pbar(viewer)
-            assert activity_button_shows_indicator(activity_dialog)
+
+    assert not qt_viewer_has_pbar(viewer)
+    with progress(range(10)):
+        assert qt_viewer_has_pbar(viewer)
+        assert activity_button_shows_indicator(activity_dialog)
 
 
 @pytest.mark.skipif(

--- a/napari/_qt/_tests/test_progress.py
+++ b/napari/_qt/_tests/test_progress.py
@@ -154,11 +154,11 @@ def test_progress_update(make_napari_viewer):
 def test_progress_indicator(make_napari_viewer):
     viewer = make_napari_viewer(show=SHOW)
     activity_dialog = viewer.window.qt_viewer.window()._activity_dialog
-
-    assert not qt_viewer_has_pbar(viewer)
-    with progress(range(10)):
-        assert qt_viewer_has_pbar(viewer)
-        assert activity_button_shows_indicator(activity_dialog)
+    if SHOW:
+        assert not qt_viewer_has_pbar(viewer)
+        with progress(range(10)):
+            assert qt_viewer_has_pbar(viewer)
+            assert activity_button_shows_indicator(activity_dialog)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
# Description
This PR skips the test checking whether the progress indicator is shown if the viewer is currently not being shown.

The test relies on checking whether the progress indicator is visible, which will always be false if the viewer is not visible.
This should fix local tests for non-linux distributions. @tlambert03 can you confirm if this is the right approach?

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #3061

# How has this been tested?
All tests still pass with my change but will need someone to confirm who's not running on linux. 

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
