### PR TITLE
PR: Allow for multiple installs and update buttons to reflect state

### DIFF
--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -112,7 +112,6 @@ class Installer(QObject):
     def set_output_widget(self, output_widget: QTextEdit):
         if output_widget:
             self._output_widget = output_widget
-            # self.process.setParent(output_widget)
 
     def _on_process_finished(self, process, exit_code, exit_status):
         if exit_code != 0:
@@ -435,11 +434,7 @@ class QPluginList(QListWidget):
             enabled=enabled,
         )
         item.widget = widg
-        # method = getattr(
-        #     self.installer, 'uninstall' if plugin_name else 'install'
-        # )
         action_name = 'uninstall' if plugin_name else 'install'
-        # widg.action_button.clicked.connect(lambda: method([project_info.name]))
         widg.action_button.clicked.connect(
             lambda: self.handle_action(item, project_info.name, action_name)
         )

--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -523,15 +523,15 @@ PluginListItem {
   border-radius: 3px;
 }
 
-PluginListItem > QPushButton {
+PluginListItem > QPushButton#install_button {
   background-color: {{ current }}
 }
 
-PluginListItem > QPushButton:hover {
+PluginListItem > QPushButton#install_button:hover {
   background-color: {{ lighten(current, 10) }}
 }
 
-PluginListItem > QPushButton:pressed {
+PluginListItem > QPushButton#install_button:pressed {
   background-color: {{ darken(current, 10) }}
 }
 
@@ -545,6 +545,22 @@ PluginListItem > QPushButton#remove_button:hover {
 
 PluginListItem > QPushButton#remove_button:pressed {
   background-color: {{ darken(warning, 10) }}
+}
+
+PluginListItem > QPushButton#busy_button:pressed {
+  background-color: {{ darken(secondary, 10) }}
+}
+
+PluginListItem > QPushButton#busy_button {
+  background-color: {{ secondary }}
+}
+
+PluginListItem > QPushButton#busy_button:hover {
+  background-color: {{ lighten(secondary, 10) }}
+}
+
+PluginListItem > QPushButton#busy_button:pressed {
+  background-color: {{ darken(secondary, 10) }}
 }
 
 #small_text {


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

- This now allows to install and uninstall multiple packages at the same time.
- The final refresh will only happen when all the queued processes have finished.
- Updates text and color when clicking on buttons.
- Removes showind the output by default (this is an advanced user feature)


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).

![napari](https://user-images.githubusercontent.com/3627835/126209846-1de96f5d-030a-4e1b-b7d6-c7a990475aea.gif)
