### PR TITLE
PR: Unify plugin wording and installer dialog to display only package/plugins

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -864,7 +864,7 @@ class Window:
         self.plugins_menu.clear()
 
         pip_install_action = QAction(
-            trans._("Install/Uninstall Package(s)..."), self._qt_window
+            trans._("Install/Uninstall Plugins..."), self._qt_window
         )
         pip_install_action.triggered.connect(self._show_plugin_install_dialog)
         self.plugins_menu.addAction(pip_install_action)


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Unify the plugin so install and uninstall listings are only displaying packages



## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

See https://github.com/napari/napari/issues/3035#issuecomment-882748103

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).


---



<img width="848" alt="Screen Shot 2021-07-19 at 6 48 52 PM" src="https://user-images.githubusercontent.com/3627835/126241643-13160b3c-910c-44d1-9701-a30006a66fb6.png">

I also updated the wording in the Plugins menu to Plugins instead of packages. Or we could just remove the word and leave `Install/Uninstall` 

<img width="437" alt="Screen Shot 2021-07-19 at 6 49 00 PM" src="https://user-images.githubusercontent.com/3627835/126241650-e0680018-743a-4ecb-87f0-07358415e0fa.png">

---

I kept this PR simple this so that merging/rebasing with the other PRs is easier.
I will make a single list and clean up the code in a separate PR.


