### PR TITLE
Add `unregistering` event to the NapariPluginManager

### DIFF
--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -46,6 +46,8 @@ class NapariPluginManager(PluginManager):
     ------
     registered (value: str)
         Emitted after plugin named `value` has been registered.
+    unregistering (value: str)
+        Emitted before plugin named `value` is unregistered.
     unregistered (value: str)
         Emitted after plugin named `value` has been unregistered.
     enabled (value: str)
@@ -62,6 +64,7 @@ class NapariPluginManager(PluginManager):
         self.events = EmitterGroup(
             source=self,
             registered=None,
+            unregistering=None,
             unregistered=None,
             enabled=None,
             disabled=None,
@@ -108,6 +111,8 @@ class NapariPluginManager(PluginManager):
             _name = name_or_object
         else:
             _name = self.get_name(name_or_object)
+
+        self.events.unregistering(value=_name)
 
         plugin = super().unregister(name_or_object)
 

--- a/napari/plugins/_tests/test_plugins_misc.py
+++ b/napari/plugins/_tests/test_plugins_misc.py
@@ -36,11 +36,13 @@ def test_plugin_events(napari_plugin_manager):
     tnpm: NapariPluginManager = napari_plugin_manager
 
     register_events = []
+    unregistering_events = []
     unregister_events = []
     enable_events = []
     disable_events = []
 
     tnpm.events.registered.connect(lambda e: register_events.append(e))
+    tnpm.events.unregistering.connect(lambda e: unregistering_events.append(e))
     tnpm.events.unregistered.connect(lambda e: unregister_events.append(e))
     tnpm.events.enabled.connect(lambda e: enable_events.append(e))
     tnpm.events.disabled.connect(lambda e: disable_events.append(e))
@@ -56,7 +58,9 @@ def test_plugin_events(napari_plugin_manager):
     assert not disable_events
 
     tnpm.unregister(Plugin)
+    assert len(unregistering_events) == 1
     assert len(unregister_events) == 1
+    assert unregistering_events[0].value == 'Plugin'
     assert unregister_events[0].value == 'Plugin'
 
     tnpm.set_blocked('Plugin')


### PR DESCRIPTION
This PR adds the `unregistering` event to the `NapariPluginManager`. 

Currently when a plugin is being unregistered, a single event `unregistered` is emitted after the plugin has been removed and any of it's metadata (e.g. what's in `_dock_widgets`, `_sample_data`, etc) has been cleared. This PR adds the `unregistering` event to the `NapariPluginManager` so that if we rely on the metadata somewhere else in the application, we can act on it before it is removed.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
