### PR TITLE
Add `add_<shape_type>` method for each shape type

### DIFF
--- a/examples/add_shapes.py
+++ b/examples/add_shapes.py
@@ -65,6 +65,18 @@ layer = viewer.add_shapes(
     name='shapes',
 )
 
+# shapes of each type can also be added via their respective add_<shape_type> method 
+# e.g. for the polygons above:
+
+# layer = viewer.add_shapes(name='shapes') # create empty layer
+# layer.add_polygons(
+#     polygons,
+#     edge_width=1,
+#     edge_color='coral',
+#     face_color='royalblue',    
+# )
+
+
 # change some properties of the layer
 layer.selected_data = set(range(layer.nshapes))
 layer.current_edge_width = 5

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -1124,6 +1124,11 @@ def validate_num_vertices(
     ValueError
         Raised if a shape is found with invalid number of vertices
     """
+    n_shapes = number_of_shapes(data)
+    # single array of vertices
+    if n_shapes == 1 and len(np.array(data).shape) == 2:
+        # wrap in extra dimension so we can iterate through shape not vertices
+        data = [data]
     for shape in data:
         if (valid_vertices and len(shape) not in valid_vertices) or (
             min_vertices and len(shape) < min_vertices

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -1089,3 +1089,49 @@ def number_of_shapes(data):
         n_shapes = len(data)
 
     return n_shapes
+
+
+def validate_num_vertices(data, valid_vertices, shape_type):
+    """Raises error if not all shapes have num vertices in valid_vertices.
+
+    Parameters
+    ----------
+    data : Array | Tuple(Array,str) | List[Array | Tuple(Array, str)] | Tuple(List[Array], str)
+        List of shape data, where each element is either an (N, D) array of the
+        N vertices of a shape in D dimensions or a tuple containing an array of
+        the N vertices and the shape_type string. When a shape_type is present,
+        it overrides keyword arg shape_type. Can be an 3-dimensional array
+        if each shape has the same number of vertices.
+    valid_vertices : Tuple(int)
+        Valid number of vertices for
+    shape_type : str
+        Type of shape being validated (for detailed error message)
+
+    Raises
+    ------
+    ValueError
+        Raised if a shape is found with invalid number of vertices
+    """
+    n_shapes = number_of_shapes(data)
+
+    if n_shapes == 1:
+        # could be a 3D ndarray of shape (1, n vertices, D)
+        if isinstance(data, np.ndarray):
+            # squeeze to get rid of singleton dimension
+            data = np.squeeze(data)
+        if len(data) not in valid_vertices:
+            raise ValueError(
+                trans._(
+                    f"{shape_type.capitalize()} {data} has {len(data)} vertices, not one of {valid_vertices}.",
+                    deferred=True,
+                )
+            )
+    else:
+        for shpe in data:
+            if len(shpe) not in valid_vertices:
+                raise ValueError(
+                    trans._(
+                        f"{shape_type.capitalize()} {shpe} has {len(shpe)} vertices, not one of {valid_vertices}.",
+                        deferred=True,
+                    )
+                )

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -1091,47 +1091,46 @@ def number_of_shapes(data):
     return n_shapes
 
 
-def validate_num_vertices(data, valid_vertices, shape_type):
-    """Raises error if not all shapes have num vertices in valid_vertices.
+def validate_num_vertices(
+    data, shape_type, min_vertices=None, valid_vertices=None
+):
+    """Raises error if a shape in data has invalid number of vertices.
+
+    Checks whether all shapes in data have a valid number of vertices
+    for the given shape type and vertex information. Rectangles and
+    ellipses can have either 2 or 4 vertices per shape,
+    lines can have only 2, while paths and polygons have a minimum
+    number of vertices, but no maximum.
+
+    One of valid_vertices or min_vertices must be passed to the
+    function.
 
     Parameters
     ----------
     data : Array | Tuple(Array,str) | List[Array | Tuple(Array, str)] | Tuple(List[Array], str)
         List of shape data, where each element is either an (N, D) array of the
         N vertices of a shape in D dimensions or a tuple containing an array of
-        the N vertices and the shape_type string. When a shape_type is present,
-        it overrides keyword arg shape_type. Can be an 3-dimensional array
+        the N vertices and the shape_type string. Can be an 3-dimensional array
         if each shape has the same number of vertices.
-    valid_vertices : Tuple(int)
-        Valid number of vertices for
     shape_type : str
         Type of shape being validated (for detailed error message)
+    min_vertices : int or None
+        Minimum number of vertices for the shape type, by default None
+    valid_vertices : Tuple(int) or None
+        Valid number of vertices for the shape type in data, by default None
 
     Raises
     ------
     ValueError
         Raised if a shape is found with invalid number of vertices
     """
-    n_shapes = number_of_shapes(data)
-
-    if n_shapes == 1:
-        # could be a 3D ndarray of shape (1, n vertices, D)
-        if isinstance(data, np.ndarray):
-            # squeeze to get rid of singleton dimension
-            data = np.squeeze(data)
-        if len(data) not in valid_vertices:
+    for shpe in data:
+        if (valid_vertices and len(shpe) not in valid_vertices) or (
+            min_vertices and len(shpe) < min_vertices
+        ):
             raise ValueError(
                 trans._(
-                    f"{shape_type.capitalize()} {data} has {len(data)} vertices, not one of {valid_vertices}.",
+                    f"{shape_type.capitalize()} {shpe} has invalid number of vertices: {len(shpe)}.",
                     deferred=True,
                 )
             )
-    else:
-        for shpe in data:
-            if len(shpe) not in valid_vertices:
-                raise ValueError(
-                    trans._(
-                        f"{shape_type.capitalize()} {shpe} has {len(shpe)} vertices, not one of {valid_vertices}.",
-                        deferred=True,
-                    )
-                )

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -1124,13 +1124,13 @@ def validate_num_vertices(
     ValueError
         Raised if a shape is found with invalid number of vertices
     """
-    for shpe in data:
-        if (valid_vertices and len(shpe) not in valid_vertices) or (
-            min_vertices and len(shpe) < min_vertices
+    for shape in data:
+        if (valid_vertices and len(shape) not in valid_vertices) or (
+            min_vertices and len(shape) < min_vertices
         ):
             raise ValueError(
                 trans._(
-                    f"{shape_type.capitalize()} {shpe} has invalid number of vertices: {len(shpe)}.",
+                    f"{shape_type} {shape} has invalid number of vertices: {len(shape)}.",
                     deferred=True,
                 )
             )

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -632,7 +632,7 @@ def test_4D_ellispse():
     assert np.all([s == 'ellipse' for s in layer.shape_type])
 
     # test adding via add_ellipses
-    layer2 = Shapes()
+    layer2 = Shapes(ndim=4)
     layer2.add_ellipses(data)
     assert layer.nshapes == layer2.nshapes
     assert np.all(

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -345,8 +345,8 @@ def test_data_setter_with_text(properties):
 
 @pytest.mark.parametrize(
     "shape",
-    # single & multiple four corner rectangles
     [
+        # single & multiple four corner rectangles
         (1, 4, 2),
         (10, 4, 2),
         # single & multiple two corner rectangles
@@ -381,13 +381,12 @@ def test_add_rectangles_raises_errors():
     """Test input validation for add_rectangles method"""
     layer = Shapes()
 
-    # not the right number of vertices
     np.random.seed(0)
-    # single rectangle
+    # single rectangle, 3 vertices
     data = 20 * np.random.random((1, 3, 2))
     with pytest.raises(ValueError):
         layer.add_rectangles(data)
-    # multiple rectangles
+    # multiple rectangles, 5 vertices
     data = 20 * np.random.random((5, 5, 2))
     with pytest.raises(ValueError):
         layer.add_rectangles(data)
@@ -485,48 +484,54 @@ def test_3D_rectangles():
     assert np.all([s == 'rectangle' for s in layer.shape_type])
 
 
-def test_ellipses():
-    """Test instantiating Shapes layer with a random 2D ellipses."""
-    # Test a single four corner ellipses
-    shape = (1, 4, 2)
+@pytest.mark.parametrize(
+    "shape",
+    [
+        # single & multiple four corner ellipses
+        (1, 4, 2),
+        (10, 4, 2),
+        # single & multiple center, radii ellipses
+        (1, 2, 2),
+        (10, 2, 2),
+    ],
+)
+def test_ellipses(shape):
+    """Test instantiating Shapes layer with random 2D ellipses."""
+
+    # Test instantiating with data
     np.random.seed(0)
     data = 20 * np.random.random(shape)
     layer = Shapes(data, shape_type='ellipse')
     assert layer.nshapes == shape[0]
-    assert np.all(layer.data[0] == data[0])
+    # 4 corner bounding box passed, assert vertices the same
+    if shape[1] == 4:
+        assert np.all([layer.data[i] == data[i] for i in range(layer.nshapes)])
+    # (center, radii) passed, assert 4 vertices in layer
+    else:
+        assert [len(rect) == 4 for rect in layer.data]
     assert layer.ndim == shape[2]
     assert np.all([s == 'ellipse' for s in layer.shape_type])
 
-    # Test multiple four corner ellipses
-    shape = (10, 4, 2)
-    np.random.seed(0)
-    data = 20 * np.random.random(shape)
-    layer = Shapes(data, shape_type='ellipse')
-    assert layer.nshapes == shape[0]
-    assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data)])
-    assert layer.ndim == shape[2]
-    assert np.all([s == 'ellipse' for s in layer.shape_type])
+    # Test adding via add_ellipses method
+    layer2 = Shapes()
+    layer2.add_ellipses(data)
+    assert np.allclose(layer2.data, layer.data)
+    assert np.all([s == 'ellipse' for s in layer2.shape_type])
 
-    # Test a single ellipse center radii, which gets converted into four
-    # corner ellipse
-    shape = (1, 2, 2)
-    np.random.seed(0)
-    data = 20 * np.random.random(shape)
-    layer = Shapes(data, shape_type='ellipse')
-    assert layer.nshapes == 1
-    assert len(layer.data[0]) == 4
-    assert layer.ndim == shape[2]
-    assert np.all([s == 'ellipse' for s in layer.shape_type])
 
-    # Test multiple center radii ellipses
-    shape = (10, 2, 2)
+def test_add_ellipses_raises_error():
+    """Test input validation for add_ellipses method"""
+    layer = Shapes()
+
     np.random.seed(0)
-    data = 20 * np.random.random(shape)
-    layer = Shapes(data, shape_type='ellipse')
-    assert layer.nshapes == shape[0]
-    assert np.all([len(ld) == 4 for ld in layer.data])
-    assert layer.ndim == shape[2]
-    assert np.all([s == 'ellipse' for s in layer.shape_type])
+    # single ellipse, 3 vertices
+    data = 20 * np.random.random((1, 3, 2))
+    with pytest.raises(ValueError):
+        layer.add_ellipses(data)
+    # multiple ellipses, 5 vertices
+    data = 20 * np.random.random((5, 5, 2))
+    with pytest.raises(ValueError):
+        layer.add_ellipses(data)
 
 
 def test_ellipses_with_shape_type():

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1574,6 +1574,81 @@ class Shapes(Layer):
         if not self.editable:
             self.mode = Mode.PAN_ZOOM
 
+    def add_rectangles(
+        self,
+        data,
+        *,
+        edge_width=None,
+        edge_color=None,
+        face_color=None,
+        z_index=None,
+    ):
+        """Add rectangles to the current layer.
+
+        Parameters
+        ----------
+        data : Array | List[Array]
+            List of rectangle data where each element is a (4, D) array of 4 vertices
+            in D dimensions, or a (2, D) array of 2 vertices in D dimensions, where
+            the vertices are top-left and bottom-right corners.
+            Can be a 3-dimensional array.
+        edge_width : float | list
+            thickness of lines and edges. If a list is supplied it must be the
+            same length as the length of `data` and each element will be
+            applied to each shape otherwise the same value will be used for all
+            shapes.
+        edge_color : str | tuple | list
+            If string can be any color name recognized by vispy or hex value if
+            starting with `#`. If array-like must be 1-dimensional array with 3
+            or 4 elements. If a list is supplied it must be the same length as
+            the length of `data` and each element will be applied to each shape
+            otherwise the same value will be used for all shapes.
+        face_color : str | tuple | list
+            If string can be any color name recognized by vispy or hex value if
+            starting with `#`. If array-like must be 1-dimensional array with 3
+            or 4 elements. If a list is supplied it must be the same length as
+            the length of `data` and each element will be applied to each shape
+            otherwise the same value will be used for all shapes.
+        z_index : int | list
+            Specifier of z order priority. Shapes with higher z order are
+            displayed ontop of others. If a list is supplied it must be the
+            same length as the length of `data` and each element will be
+            applied to each shape otherwise the same value will be used for all
+            shapes.
+        """
+        n_shapes = number_of_shapes(data)
+        # this should be one rectangle with 2 or 4 vertices
+        if n_shapes == 1:
+            # could be a 3D ndarray of shape (1, n vertices, D)
+            if hasattr(data, 'shape') and len(data.shape) == 3:
+                data = data[0]
+            if len(data) != 2 and len(data) != 4:
+                raise ValueError(
+                    trans._(
+                        f"Data {data} does not define a valid rectangle",
+                        deferred=True,
+                    )
+                )
+        # multiple rectangles, each element should have 2 or 4 vertices
+        else:
+            for rect in data:
+                if len(rect) != 2 and len(rect) != 4:
+                    raise ValueError(
+                        trans._(
+                            f"Data {data} contains items which do not define a valid rectangle",
+                            deferred=True,
+                        )
+                    )
+
+        self.add(
+            data,
+            shape_type='rectangle',
+            edge_width=edge_width,
+            edge_color=edge_color,
+            face_color=face_color,
+            z_index=z_index,
+        )
+
     def add(
         self,
         data,

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1619,7 +1619,9 @@ class Shapes(Layer):
         """
         # rectangles can have either 4 vertices or (top left, bottom right)
         valid_vertices_per_shape = (2, 4)
-        validate_num_vertices(data, valid_vertices_per_shape, 'rectangle')
+        validate_num_vertices(
+            data, 'rectangle', valid_vertices=valid_vertices_per_shape
+        )
 
         self.add(
             data,
@@ -1674,11 +1676,176 @@ class Shapes(Layer):
         """
 
         valid_elem_per_shape = (2, 4)
-        validate_num_vertices(data, valid_elem_per_shape, 'ellipse')
+        validate_num_vertices(
+            data, 'ellipse', valid_vertices=valid_elem_per_shape
+        )
 
         self.add(
             data,
             shape_type='ellipse',
+            edge_width=edge_width,
+            edge_color=edge_color,
+            face_color=face_color,
+            z_index=z_index,
+        )
+
+    def add_polygons(
+        self,
+        data,
+        *,
+        edge_width=None,
+        edge_color=None,
+        face_color=None,
+        z_index=None,
+    ):
+        """Add polygons to the current layer.
+
+        Parameters
+        ----------
+        data : Array | List[Array]
+            List of polygon data where each element is a (V, D) array of V vertices
+            in D dimensions representing a polygon. Can be a 3-dimensional array if
+            polygons have same number of vertices.
+        edge_width : float | list
+            thickness of lines and edges. If a list is supplied it must be the
+            same length as the length of `data` and each element will be
+            applied to each shape otherwise the same value will be used for all
+            shapes.
+        edge_color : str | tuple | list
+            If string can be any color name recognized by vispy or hex value if
+            starting with `#`. If array-like must be 1-dimensional array with 3
+            or 4 elements. If a list is supplied it must be the same length as
+            the length of `data` and each element will be applied to each shape
+            otherwise the same value will be used for all shapes.
+        face_color : str | tuple | list
+            If string can be any color name recognized by vispy or hex value if
+            starting with `#`. If array-like must be 1-dimensional array with 3
+            or 4 elements. If a list is supplied it must be the same length as
+            the length of `data` and each element will be applied to each shape
+            otherwise the same value will be used for all shapes.
+        z_index : int | list
+            Specifier of z order priority. Shapes with higher z order are
+            displayed ontop of others. If a list is supplied it must be the
+            same length as the length of `data` and each element will be
+            applied to each shape otherwise the same value will be used for all
+            shapes.
+        """
+
+        min_vertices = 3
+        validate_num_vertices(data, 'polygon', min_vertices=min_vertices)
+
+        self.add(
+            data,
+            shape_type='polygon',
+            edge_width=edge_width,
+            edge_color=edge_color,
+            face_color=face_color,
+            z_index=z_index,
+        )
+
+    def add_lines(
+        self,
+        data,
+        *,
+        edge_width=None,
+        edge_color=None,
+        face_color=None,
+        z_index=None,
+    ):
+        """Add lines to the current layer.
+
+        Parameters
+        ----------
+        data : Array | List[Array]
+            List of line data where each element is a (2, D) array of 2 vertices
+            in D dimensions representing a line. Can be a 3-dimensional array.
+        edge_width : float | list
+            thickness of lines and edges. If a list is supplied it must be the
+            same length as the length of `data` and each element will be
+            applied to each shape otherwise the same value will be used for all
+            shapes.
+        edge_color : str | tuple | list
+            If string can be any color name recognized by vispy or hex value if
+            starting with `#`. If array-like must be 1-dimensional array with 3
+            or 4 elements. If a list is supplied it must be the same length as
+            the length of `data` and each element will be applied to each shape
+            otherwise the same value will be used for all shapes.
+        face_color : str | tuple | list
+            If string can be any color name recognized by vispy or hex value if
+            starting with `#`. If array-like must be 1-dimensional array with 3
+            or 4 elements. If a list is supplied it must be the same length as
+            the length of `data` and each element will be applied to each shape
+            otherwise the same value will be used for all shapes.
+        z_index : int | list
+            Specifier of z order priority. Shapes with higher z order are
+            displayed ontop of others. If a list is supplied it must be the
+            same length as the length of `data` and each element will be
+            applied to each shape otherwise the same value will be used for all
+            shapes.
+        """
+
+        valid_vertices_per_line = (2,)
+        validate_num_vertices(
+            data, 'line', valid_vertices=valid_vertices_per_line
+        )
+
+        self.add(
+            data,
+            shape_type='line',
+            edge_width=edge_width,
+            edge_color=edge_color,
+            face_color=face_color,
+            z_index=z_index,
+        )
+
+    def add_paths(
+        self,
+        data,
+        *,
+        edge_width=None,
+        edge_color=None,
+        face_color=None,
+        z_index=None,
+    ):
+        """Add paths to the current layer.
+
+        Parameters
+        ----------
+        data : Array | List[Array]
+            List of path data where each element is a (V, D) array of V vertices
+            in D dimensions representing a path. Can be a 3-dimensional array
+            if all paths have same number of vertices.
+        edge_width : float | list
+            thickness of lines and edges. If a list is supplied it must be the
+            same length as the length of `data` and each element will be
+            applied to each shape otherwise the same value will be used for all
+            shapes.
+        edge_color : str | tuple | list
+            If string can be any color name recognized by vispy or hex value if
+            starting with `#`. If array-like must be 1-dimensional array with 3
+            or 4 elements. If a list is supplied it must be the same length as
+            the length of `data` and each element will be applied to each shape
+            otherwise the same value will be used for all shapes.
+        face_color : str | tuple | list
+            If string can be any color name recognized by vispy or hex value if
+            starting with `#`. If array-like must be 1-dimensional array with 3
+            or 4 elements. If a list is supplied it must be the same length as
+            the length of `data` and each element will be applied to each shape
+            otherwise the same value will be used for all shapes.
+        z_index : int | list
+            Specifier of z order priority. Shapes with higher z order are
+            displayed ontop of others. If a list is supplied it must be the
+            same length as the length of `data` and each element will be
+            applied to each shape otherwise the same value will be used for all
+            shapes.
+        """
+
+        min_vertices_per_path = 2
+        validate_num_vertices(data, 'path', min_vertices=min_vertices_per_path)
+
+        self.add(
+            data,
+            shape_type='path',
             edge_width=edge_width,
             edge_color=edge_color,
             face_color=face_color,

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1625,7 +1625,7 @@ class Shapes(Layer):
             if len(data) != 2 and len(data) != 4:
                 raise ValueError(
                     trans._(
-                        f"Data {data} does not define a valid rectangle",
+                        f"Rectangle {data} has {len(data)} vertices, not 2 or 4.",
                         deferred=True,
                     )
                 )
@@ -1635,7 +1635,7 @@ class Shapes(Layer):
                 if len(rect) != 2 and len(rect) != 4:
                     raise ValueError(
                         trans._(
-                            f"Data {data} contains items which do not define a valid rectangle",
+                            f"Rectangle {rect} has {len(rect)} vertices, not 2 or 4.",
                             deferred=True,
                         )
                     )

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -53,6 +53,7 @@ from ._shapes_utils import (
     get_default_shape_type,
     get_shape_ndim,
     number_of_shapes,
+    validate_num_vertices,
 )
 
 DEFAULT_COLOR_CYCLE = np.array([[1, 0, 1, 1], [0, 1, 0, 1]])
@@ -1616,33 +1617,68 @@ class Shapes(Layer):
             applied to each shape otherwise the same value will be used for all
             shapes.
         """
-        n_shapes = number_of_shapes(data)
-        # this should be one rectangle with 2 or 4 vertices
-        if n_shapes == 1:
-            # could be a 3D ndarray of shape (1, n vertices, D)
-            if hasattr(data, 'shape') and len(data.shape) == 3:
-                data = data[0]
-            if len(data) != 2 and len(data) != 4:
-                raise ValueError(
-                    trans._(
-                        f"Rectangle {data} has {len(data)} vertices, not 2 or 4.",
-                        deferred=True,
-                    )
-                )
-        # multiple rectangles, each element should have 2 or 4 vertices
-        else:
-            for rect in data:
-                if len(rect) != 2 and len(rect) != 4:
-                    raise ValueError(
-                        trans._(
-                            f"Rectangle {rect} has {len(rect)} vertices, not 2 or 4.",
-                            deferred=True,
-                        )
-                    )
+        # rectangles can have either 4 vertices or (top left, bottom right)
+        valid_vertices_per_shape = (2, 4)
+        validate_num_vertices(data, valid_vertices_per_shape, 'rectangle')
 
         self.add(
             data,
             shape_type='rectangle',
+            edge_width=edge_width,
+            edge_color=edge_color,
+            face_color=face_color,
+            z_index=z_index,
+        )
+
+    def add_ellipses(
+        self,
+        data,
+        *,
+        edge_width=None,
+        edge_color=None,
+        face_color=None,
+        z_index=None,
+    ):
+        """Add ellipses to the current layer.
+
+        Parameters
+        ----------
+        data : Array | List[Array]
+            List of ellipse data where each element is a (4, D) array of 4 vertices
+            in D dimensions representing a bounding box, or a (2, D) array of
+            center position and radii magnitudes in D dimensions.
+            Can be a 3-dimensional array.
+        edge_width : float | list
+            thickness of lines and edges. If a list is supplied it must be the
+            same length as the length of `data` and each element will be
+            applied to each shape otherwise the same value will be used for all
+            shapes.
+        edge_color : str | tuple | list
+            If string can be any color name recognized by vispy or hex value if
+            starting with `#`. If array-like must be 1-dimensional array with 3
+            or 4 elements. If a list is supplied it must be the same length as
+            the length of `data` and each element will be applied to each shape
+            otherwise the same value will be used for all shapes.
+        face_color : str | tuple | list
+            If string can be any color name recognized by vispy or hex value if
+            starting with `#`. If array-like must be 1-dimensional array with 3
+            or 4 elements. If a list is supplied it must be the same length as
+            the length of `data` and each element will be applied to each shape
+            otherwise the same value will be used for all shapes.
+        z_index : int | list
+            Specifier of z order priority. Shapes with higher z order are
+            displayed ontop of others. If a list is supplied it must be the
+            same length as the length of `data` and each element will be
+            applied to each shape otherwise the same value will be used for all
+            shapes.
+        """
+
+        valid_elem_per_shape = (2, 4)
+        validate_num_vertices(data, valid_elem_per_shape, 'ellipse')
+
+        self.add(
+            data,
+            shape_type='ellipse',
             edge_width=edge_width,
             edge_color=edge_color,
             face_color=face_color,

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1592,7 +1592,8 @@ class Shapes(Layer):
             List of rectangle data where each element is a (4, D) array of 4 vertices
             in D dimensions, or a (2, D) array of 2 vertices in D dimensions, where
             the vertices are top-left and bottom-right corners.
-            Can be a 3-dimensional array.
+            Can be a 3-dimensional array for multiple shapes, or list of 2 or 4
+            vertices for a single shape.
         edge_width : float | list
             thickness of lines and edges. If a list is supplied it must be the
             same length as the length of `data` and each element will be
@@ -1649,7 +1650,8 @@ class Shapes(Layer):
             List of ellipse data where each element is a (4, D) array of 4 vertices
             in D dimensions representing a bounding box, or a (2, D) array of
             center position and radii magnitudes in D dimensions.
-            Can be a 3-dimensional array.
+            Can be a 3-dimensional array for multiple shapes, or list of 2 or 4
+            vertices for a single shape.
         edge_width : float | list
             thickness of lines and edges. If a list is supplied it must be the
             same length as the length of `data` and each element will be
@@ -1705,7 +1707,8 @@ class Shapes(Layer):
         data : Array | List[Array]
             List of polygon data where each element is a (V, D) array of V vertices
             in D dimensions representing a polygon. Can be a 3-dimensional array if
-            polygons have same number of vertices.
+            polygons have same number of vertices, or a list of V vertices for a
+            single polygon.
         edge_width : float | list
             thickness of lines and edges. If a list is supplied it must be the
             same length as the length of `data` and each element will be
@@ -1758,7 +1761,8 @@ class Shapes(Layer):
         ----------
         data : Array | List[Array]
             List of line data where each element is a (2, D) array of 2 vertices
-            in D dimensions representing a line. Can be a 3-dimensional array.
+            in D dimensions representing a line. Can be a 3-dimensional array for
+            multiple shapes, or list of 2 vertices for a single shape.
         edge_width : float | list
             thickness of lines and edges. If a list is supplied it must be the
             same length as the length of `data` and each element will be
@@ -1814,7 +1818,8 @@ class Shapes(Layer):
         data : Array | List[Array]
             List of path data where each element is a (V, D) array of V vertices
             in D dimensions representing a path. Can be a 3-dimensional array
-            if all paths have same number of vertices.
+            if all paths have same number of vertices, or a list of V vertices
+            for a single path.
         edge_width : float | list
             thickness of lines and edges. If a list is supplied it must be the
             same length as the length of `data` and each element will be


### PR DESCRIPTION
# Description
As proposed in #2956 this PR adds individual convenience methods for rectangles, ellipses, polygons, lines and paths.

The methods are all calling the existing `add()` method after validating the number of vertices for each shape in the given data. This validation seems to be sufficient even for nD shapes - although this is only because at the moment they are defined within planes. Once we move to cuboids and spheroids we would have to do a bit of arithmetic to compute valid number of vertices using the dimensions of the coordinates. This can be done per shape though, so I think the current validation method would be reusable in that case.

Valid vertices for each shape as currently defined:
- Rectangles: 2 or 4
- Ellipses: 2 or 4
- Polygons: 3+ (looking at the code this was 2, but I don't think a valid polygon has 2 vertices...)
- Lines: 2
- Paths: 2+

I've also added tests for each of the methods, including for nD where applicable.

**NB: I'm not currently doing any validation for the properties, as that is already done downstream. However, maybe there's more validation that could be done per shape?**

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# References
Closes #2956 

# How has this been tested?
I've added tests for each method for both 2D and 3D cases, and have parametrized each test with the same input we give to the existing tests.

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
