### PR TITLE
add missing libraries in docker file and entrypoint

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -8,7 +8,10 @@ ENV TZ America/Los_Angeles
 ENV DEBIAN_FRONTEND noninteractive
 
 # install graphical libraries used by qt and vispy
-RUN apt-get install -qqy libxi6 libglib2.0-0 fontconfig libgl1-mesa-glx libfontconfig1 libxrender1 libdbus-1-3
+RUN apt-get install -qqy mesa-utils libgl1-mesa-glx  libglib2.0-0
+RUN apt-get install -qqy libfontconfig1 libxrender1 libdbus-1-3 libxkbcommon-x11-0 libxi6
+RUN apt-get install -qqy libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0
+RUN apt-get install -qqy libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0
 
 # install napari release version
 RUN pip3 install napari[all]
@@ -16,3 +19,5 @@ RUN pip3 install napari[all]
 # install scikit image for examples
 RUN pip3 install scikit-image
 COPY examples /tmp/examples
+
+ENTRYPOINT ["python3", "-m", "napari"]


### PR DESCRIPTION
# Description
added missing libraries for qt per #1457 and #3024 
added a default entry point so that the docker run napari when no command is given

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# References
https://github.com/napari/napari/issues/1457#issuecomment-752667286
#3024 

# How has this been tested?
Manually tested the docker image with x11 server, the image itself is good to go but I could not get it to run on my MacBook pro because of the ATI driver don't work along with xquartz. But this works fine on my windows 11 machine with vcXsrv

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
