### PR TITLE
[draft] remove action_manager context

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -68,6 +68,7 @@ class _QtMainWindow(QMainWindow):
         super().__init__(parent)
         self._ev = None
         self.qt_viewer = qt_viewer
+        self.viewer = qt_viewer.viewer
 
         self._quit_app = False
         self.setWindowIcon(QIcon(self._window_icon))
@@ -79,7 +80,7 @@ class _QtMainWindow(QMainWindow):
         center.layout().setContentsMargins(4, 0, 4, 0)
         self.setCentralWidget(center)
 
-        self.setWindowTitle(qt_viewer.viewer.title)
+        self.setWindowTitle(self.viewer.title)
 
         self._maximized_flag = False
         self._preferences_dialog = None
@@ -96,10 +97,10 @@ class _QtMainWindow(QMainWindow):
             plugin_manager.set_call_order(settings.plugins.call_order)
 
         _QtMainWindow._instances.append(self)
-        self.qt_viewer.viewer.tooltip.events.text.connect(self.update_tooltip)
+        self.viewer.tooltip.events.text.connect(self.update_tooltip)
 
     def update_tooltip(self, event):
-        if self.qt_viewer.viewer.tooltip.visible:
+        if self.viewer.tooltip.visible:
             self.qt_viewer.setToolTip(event.value)
         else:
             self.qt_viewer.setToolTip("")

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -170,17 +170,6 @@ class QtViewer(QSplitter):
 
         # This dictionary holds the corresponding vispy visual for each layer
         self.layer_to_visual = {}
-        action_manager.register_action(
-            "napari:toggle_console_visibility",
-            self.toggle_console_visibility,
-            trans._("Show/Hide IPython console"),
-            self.viewer,
-        )
-        action_manager.bind_button(
-            'napari:toggle_console_visibility',
-            self.viewerButtons.consoleButton,
-        )
-
         self._create_canvas()
 
         # Stacked widget to provide a welcome page

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -100,42 +100,25 @@ class QtViewerButtons(QFrame):
         super().__init__()
 
         self.viewer = viewer
-        action_manager.context['viewer'] = viewer
-
-        def active_layer():
-            if len(self.viewer.layers.selection) == 1:
-                return next(iter(self.viewer.layers.selection))
-            else:
-                return None
-
-        action_manager.context['layer'] = active_layer
-
         self.consoleButton = QtViewerPushButton(
             self.viewer,
             'console',
-            trans._(
-                "Open IPython terminal",
-            ),
+            trans._("Open IPython terminal"),
+            bind='napari:toggle_console_visibility',
         )
         self.consoleButton.setProperty('expanded', False)
-        self.rollDimsButton = QtViewerPushButton(
-            self.viewer,
-            'roll',
-        )
 
-        action_manager.bind_button('napari:roll_axes', self.rollDimsButton)
+        self.rollDimsButton = QtViewerPushButton(
+            self.viewer, 'roll', bind='napari:roll_axes'
+        )
 
         self.transposeDimsButton = QtViewerPushButton(
-            self.viewer,
-            'transpose',
+            self.viewer, 'transpose', bind='napari:transpose_axes'
         )
 
-        action_manager.bind_button(
-            'napari:transpose_axes', self.transposeDimsButton
+        self.resetViewButton = QtViewerPushButton(
+            self.viewer, 'home', bind='napari:reset_view'
         )
-
-        self.resetViewButton = QtViewerPushButton(self.viewer, 'home')
-        action_manager.bind_button('napari:reset_view', self.resetViewButton)
 
         self.gridViewButton = QtStateButton(
             'grid_view_button',
@@ -284,7 +267,9 @@ class QtViewerPushButton(QPushButton):
         Napari viewer containing the rendered scene, layers, and controls.
     """
 
-    def __init__(self, viewer, button_name, tooltip=None, slot=None):
+    def __init__(
+        self, viewer, button_name, tooltip=None, slot=None, *, bind=None
+    ):
         super().__init__()
 
         self.viewer = viewer
@@ -292,6 +277,8 @@ class QtViewerPushButton(QPushButton):
         self.setProperty('mode', button_name)
         if slot is not None:
             self.clicked.connect(slot)
+        if bind is not None:
+            action_manager.bind_button(bind, self)
 
 
 class QtStateButton(QtViewerPushButton):

--- a/napari/components/_viewer_key_bindings.py
+++ b/napari/components/_viewer_key_bindings.py
@@ -19,12 +19,13 @@ def register_viewer_action(description):
         # convert these functions to argument-free functions
         # that act on the current viewer
         @wraps(func)
-        def _func():
-            from ..viewer import Viewer
+        def _func(viewer=None):
+            if viewer is None:
+                from ..viewer import Viewer
 
-            v = Viewer.current()
-            if v is not None:
-                return func(v)
+                viewer = Viewer.current()
+            if viewer is not None:
+                return func(viewer)
 
         action_manager.register_action(
             name='napari:' + func.__name__,

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -53,7 +53,9 @@ class ButtonWrapper:
         from qtpy.QtCore import Qt
 
         with suppress(TypeError):
-            self._button.clicked.connect(callback, Qt.UniqueConnection)
+            self._button.clicked.connect(
+                lambda e: callback(), Qt.UniqueConnection
+            )
 
     @property
     def destroyed(self):

--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -445,7 +445,7 @@ class KeymapHandler:
 
         gen = func()
 
-        if inspect.isgeneratorfunction(func):
+        if inspect.isgenerator(gen):
             try:
                 next(gen)  # call function
             except StopIteration:  # only one statement

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from .components.viewer_model import ViewerModel
 from .utils import _magicgui, config
@@ -123,3 +123,12 @@ class Viewer(ViewerModel):
             # https://github.com/napari/napari/issues/1500
             for layer in self.layers:
                 chunk_loader.on_layer_deleted(layer)
+
+    @classmethod
+    def current(cls) -> Optional['Viewer']:
+        try:
+            from ._qt.qt_main_window import _QtMainWindow
+        except ImportError:
+            return None
+        curwin = _QtMainWindow.current()
+        return curwin.viewer if curwin else None


### PR DESCRIPTION
this is more of a PR to get some feedback from @Carreau, but provides an alternative to #2914.

@Carreau, I'm playing here with the removal of the context object on the action manager, which I'm still kind struggling with Please let me know if I've overlooked something big here, particularly with the active_layer context... 

The primary difference here is that the `register_viewer_action` decorator is [doing the job](https://github.com/napari/napari/compare/master...tlambert03:no-action-context?expand=1#diff-bba32f24d9521c1fd114e940534c88a661d3f3400db6c153ba296cc4f2a866b3R22-R27) of converting all of the one-argument functions to zero-arg functions that operate on the current viewer, rather than trying to encode that in the action_manager context.