### PR TITLE
Fix problem with assigning affine with negative entries to  pyramids

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -872,8 +872,8 @@ class QtViewer(QSplitter):
             if layer.ndim <= self.viewer.dims.ndim:
                 layer._update_draw(
                     scale_factor=1 / self.viewer.camera.zoom,
-                    corner_pixels=self._canvas_corners_in_world[
-                        :, -layer.ndim :
+                    corner_pixels_displayed=self._canvas_corners_in_world[
+                        :, layer._displayed_axes
                     ],
                     shape_threshold=self.canvas.size,
                 )

--- a/napari/_vispy/_tests/test_vispy_multiscale.py
+++ b/napari/_vispy/_tests/test_vispy_multiscale.py
@@ -171,8 +171,11 @@ def test_5D_multiscale(make_napari_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
-def test_multiscale_negative_affine(make_napari_viewer):
-    """Crash on affine transforms that contain negative values?"""
+def test_multiscale_flipped_axes(make_napari_viewer):
+    """Check rendering of multiscale images with negative scale values.
+
+    See https://github.com/napari/napari/issues/3057
+    """
     viewer = make_napari_viewer(show=True)
 
     shapes = [(4000, 3000), (2000, 1500), (1000, 750), (500, 375)]

--- a/napari/_vispy/_tests/test_vispy_multiscale.py
+++ b/napari/_vispy/_tests/test_vispy_multiscale.py
@@ -184,3 +184,21 @@ def test_multiscale_flipped_axes(make_napari_viewer):
     _ = viewer.add_image(
         data, multiscale=True, contrast_limits=[0, 1], scale=(-1, 1)
     )
+
+
+@skip_on_win_ci
+@skip_local_popups
+def test_multiscale_rotated_image(make_napari_viewer):
+    viewer = make_napari_viewer(show=True)
+    sizes = [4000 // i for i in range(1, 5)]
+    arrays = [np.zeros((size, size), dtype=np.uint8) for size in sizes]
+    for arr in arrays:
+        arr[:10, :10] = 255
+        arr[-10:, -10:] = 255
+
+    viewer.add_image(arrays, multiscale=True, rotate=44)
+    screenshot_rgba = viewer.screenshot(canvas_only=True, flash=False)
+    screenshot_rgb = screenshot_rgba[..., :3]
+    assert np.any(
+        screenshot_rgb
+    )  # make sure there is at least one white pixel

--- a/napari/_vispy/_tests/test_vispy_multiscale.py
+++ b/napari/_vispy/_tests/test_vispy_multiscale.py
@@ -167,3 +167,17 @@ def test_5D_multiscale(make_napari_viewer):
     assert layer.data == data
     assert layer.multiscale is True
     assert layer.ndim == len(shapes[0])
+
+
+@skip_on_win_ci
+@skip_local_popups
+def test_multiscale_negative_affine(make_napari_viewer):
+    """Crash on affine transforms that contain negative values?"""
+    viewer = make_napari_viewer(show=True)
+
+    shapes = [(4000, 3000), (2000, 1500), (1000, 750), (500, 375)]
+    data = [np.ones(s) for s in shapes]
+    # this used to crash, see issue #3057
+    _ = viewer.add_image(
+        data, multiscale=True, contrast_limits=[0, 1], scale=(-1, 1)
+    )

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1221,7 +1221,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         # Note that we ignore the first transform which is tile2data
         data_corners = (
             self._transforms[1:]
-            .simplified.set_slice(self._dims_displayed)
+            .simplified.set_slice(displayed_axes)
             .inverse(all_corners)
         )
 

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -265,7 +265,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
         self._position = (0,) * ndim
         self._dims_point = [0] * ndim
-        self.corner_pixels = np.zeros((2, ndim), dtype=int)
+        self.corner_pixels = np.zeros((2, 2), dtype=int)
         self._editable = True
 
         self._thumbnail_shape = (32, 32, 4)
@@ -1240,19 +1240,16 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         )
 
         if self._ndisplay == 2 and self.multiscale:
-            level, displayed_corners = compute_multiscale_level_and_corners(
-                data_bbox_clipped[:, self._dims_displayed],
+            level, scaled_corners = compute_multiscale_level_and_corners(
+                data_bbox_clipped,
                 shape_threshold,
-                self.downsample_factors[:, self._dims_displayed],
+                self.downsample_factors[:, displayed_axes],
             )
-            corners = np.zeros((2, self.ndim))
-            corners[:, self._dims_displayed] = displayed_corners
-            corners = corners.astype(int)
             if self.data_level != level or not np.all(
-                self.corner_pixels == corners
+                self.corner_pixels == scaled_corners
             ):
+                self.corner_pixels = scaled_corners
                 self._data_level = level
-                self.corner_pixels = corners
                 self.refresh()
 
         else:

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -265,7 +265,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
         self._position = (0,) * ndim
         self._dims_point = [0] * ndim
-        self.corner_pixels = np.zeros((2, 2), dtype=int)
+        self.corner_pixels = np.zeros((2, ndim), dtype=int)
         self._editable = True
 
         self._thumbnail_shape = (32, 32, 4)
@@ -1240,16 +1240,19 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         )
 
         if self._ndisplay == 2 and self.multiscale:
-            level, scaled_corners = compute_multiscale_level_and_corners(
-                data_bbox_clipped,
+            level, displayed_corners = compute_multiscale_level_and_corners(
+                data_bbox_clipped[:, self._dims_displayed],
                 shape_threshold,
-                self.downsample_factors[:, displayed_axes],
+                self.downsample_factors[:, self._dims_displayed],
             )
+            corners = np.zeros((2, self.ndim))
+            corners[:, self._dims_displayed] = displayed_corners
+            corners = corners.astype(int)
             if self.data_level != level or not np.all(
-                self.corner_pixels == scaled_corners
+                self.corner_pixels == corners
             ):
-                self.corner_pixels = scaled_corners
                 self._data_level = level
+                self.corner_pixels = corners
                 self.refresh()
 
         else:

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1210,7 +1210,11 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
         self.scale_factor = scale_factor
 
-        # Round and clip data corners
+        # Sort, because negative affines can lead to
+        # top-left and bottom-right corners not actually
+        # being top-left and bottom-right
+        data_corners = np.sort(data_corners, axis=0)
+        # round and clip data corners
         data_corners = np.array(
             [np.floor(data_corners[0]), np.ceil(data_corners[1])]
         ).astype(int)

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -340,7 +340,7 @@ class _OctreeImageBase(_ImageBase):
         )
 
     def _update_draw(
-        self, scale_factor, corner_pixels, shape_threshold
+        self, scale_factor, corner_pixels_displayed, shape_threshold
     ) -> None:
         """Override Layer._update_draw completely.
 
@@ -353,21 +353,24 @@ class _OctreeImageBase(_ImageBase):
         ----------
         scale_factor : float
             Scale factor going from canvas to world coordinates.
-        corner_pixels : array
-            Coordinates of the top-left and bottom-right canvas pixels in the
+        corner_pixels_displayed : array
+            Coordinates of the top-left and bottom-right canvas pixels in
             world coordinates.
         shape_threshold : tuple
             Requested shape of field of view in data coordinates.
 
         """
         # Compute our 2D corners from the incoming n-d corner_pixels
-        data_corners = self._transforms[1:].simplified.inverse(corner_pixels)
-        corners = data_corners[:, self._dims_displayed]
+        data_corners = (
+            self._transforms[1:]
+            .simplified.set_slice(self._displayed_axes)
+            .inverse(corner_pixels_displayed)
+        )
 
         # Update our self._view to to capture the state of things right
         # before we are drawn. Our self._view will used by our
         # drawable_chunks() method.
-        self._view = OctreeView(corners, shape_threshold, self.display)
+        self._view = OctreeView(data_corners, shape_threshold, self.display)
 
     def get_intersection(self) -> OctreeIntersection:
         """The the interesection between the current view and the octree.

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -354,25 +354,20 @@ class _OctreeImageBase(_ImageBase):
         scale_factor : float
             Scale factor going from canvas to world coordinates.
         corner_pixels : array
-            Coordinates of the top-left and bottom-right canvas pixels in
+            Coordinates of the top-left and bottom-right canvas pixels in the
             world coordinates.
         shape_threshold : tuple
             Requested shape of field of view in data coordinates.
 
         """
-        displayed_axes = [
-            self._dims_displayed[i] for i in self._dims_displayed_order
-        ]
-        data_corners = (
-            self._transforms[1:]
-            .simplified.set_slice(displayed_axes)
-            .inverse(corner_pixels)
-        )
+        # Compute our 2D corners from the incoming n-d corner_pixels
+        data_corners = self._transforms[1:].simplified.inverse(corner_pixels)
+        corners = data_corners[:, self._dims_displayed]
 
         # Update our self._view to to capture the state of things right
         # before we are drawn. Our self._view will used by our
         # drawable_chunks() method.
-        self._view = OctreeView(data_corners, shape_threshold, self.display)
+        self._view = OctreeView(corners, shape_threshold, self.display)
 
     def get_intersection(self) -> OctreeIntersection:
         """The the interesection between the current view and the octree.

--- a/napari/layers/image/experimental/octree_image.py
+++ b/napari/layers/image/experimental/octree_image.py
@@ -354,20 +354,25 @@ class _OctreeImageBase(_ImageBase):
         scale_factor : float
             Scale factor going from canvas to world coordinates.
         corner_pixels : array
-            Coordinates of the top-left and bottom-right canvas pixels in the
+            Coordinates of the top-left and bottom-right canvas pixels in
             world coordinates.
         shape_threshold : tuple
             Requested shape of field of view in data coordinates.
 
         """
-        # Compute our 2D corners from the incoming n-d corner_pixels
-        data_corners = self._transforms[1:].simplified.inverse(corner_pixels)
-        corners = data_corners[:, self._dims_displayed]
+        displayed_axes = [
+            self._dims_displayed[i] for i in self._dims_displayed_order
+        ]
+        data_corners = (
+            self._transforms[1:]
+            .simplified.set_slice(displayed_axes)
+            .inverse(corner_pixels)
+        )
 
         # Update our self._view to to capture the state of things right
         # before we are drawn. Our self._view will used by our
         # drawable_chunks() method.
-        self._view = OctreeView(corners, shape_threshold, self.display)
+        self._view = OctreeView(data_corners, shape_threshold, self.display)
 
     def get_intersection(self) -> OctreeIntersection:
         """The the interesection between the current view and the octree.

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -260,12 +260,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         else:
             self._data_level = 0
             self._thumbnail_level = 0
-        displayed_axes = [
-            self._dims_displayed[i] for i in self._dims_displayed_order
-        ]
-        self.corner_pixels[1] = self.level_shapes[self._data_level][
-            displayed_axes
-        ]
+        self.corner_pixels[1] = self.level_shapes[self._data_level]
 
         self._new_empty_slice()
 
@@ -569,25 +564,15 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
             self._transforms['tile2data'].scale = scale
 
             if self._ndisplay == 2:
-                displayed_axes = [
-                    self._dims_displayed[i] for i in self._dims_displayed_order
-                ]
-                for i, d in enumerate(displayed_axes):
+                for d in self._dims_displayed:
                     indices[d] = slice(
-                        self.corner_pixels[0, i],
-                        self.corner_pixels[1, i] + 1,
+                        self.corner_pixels[0, d],
+                        self.corner_pixels[1, d] + 1,
                         1,
                     )
-                displayed_scale = np.asarray(
-                    self._transforms['tile2data'].scale
-                )[displayed_axes]
-                new_translate = np.copy(
-                    self._transforms['tile2data'].translate
+                self._transforms['tile2data'].translate = (
+                    self.corner_pixels[0] * self._transforms['tile2data'].scale
                 )
-                new_translate[displayed_axes] = (
-                    self.corner_pixels[0] * displayed_scale
-                )
-                self._transforms['tile2data'].translate = new_translate
             image = self.data[level][tuple(indices)]
             image_indices = indices
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -260,7 +260,10 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         else:
             self._data_level = 0
             self._thumbnail_level = 0
-        self.corner_pixels[1] = self.level_shapes[self._data_level]
+        displayed_axes = self._displayed_axes
+        self.corner_pixels[1][displayed_axes] = self.level_shapes[
+            self._data_level
+        ][displayed_axes]
 
         self._new_empty_slice()
 
@@ -564,7 +567,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
             self._transforms['tile2data'].scale = scale
 
             if self._ndisplay == 2:
-                for d in self._dims_displayed:
+                for d in self._displayed_axes:
                     indices[d] = slice(
                         self.corner_pixels[0, d],
                         self.corner_pixels[1, d] + 1,

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -435,7 +435,7 @@ def compute_multiscale_level_and_corners(
 
     Parameters
     ----------
-    corner_pixels : array (2, D)
+    corner_pixels : array (2, 2)
         Requested corner pixels at full resolution.
     shape_threshold : tuple
         Maximum size of a displayed tile in pixels.
@@ -447,7 +447,7 @@ def compute_multiscale_level_and_corners(
     -------
     level : int
         Level of the multiscale to be viewing.
-    corners : array (2, D)
+    corners : array (2, 2)
         Needed corner pixels at target resolution.
     """
     requested_shape = corner_pixels[1] - corner_pixels[0]

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -435,7 +435,7 @@ def compute_multiscale_level_and_corners(
 
     Parameters
     ----------
-    corner_pixels : array (2, 2)
+    corner_pixels : array (2, D)
         Requested corner pixels at full resolution.
     shape_threshold : tuple
         Maximum size of a displayed tile in pixels.
@@ -447,7 +447,7 @@ def compute_multiscale_level_and_corners(
     -------
     level : int
         Level of the multiscale to be viewing.
-    corners : array (2, 2)
+    corners : array (2, D)
         Needed corner pixels at target resolution.
     """
     requested_shape = corner_pixels[1] - corner_pixels[0]


### PR DESCRIPTION
# Description

This PR fixes #3057.
The problem was caused by bounding box coordinates being calculated in a way that top-left and bottom-right coordinates were incorrect if a negative entry in an affine transform flipped a coordinate axis direction.
Credit goes to @jni who helped narrow this down in a [pair programming session](https://twitter.com/jnuneziglesias/status/1385754529639985152). 

## Type of change
Bugfix

# References
closes #3057

# How has this been tested?
Added a specific test for this.
All other tests still pass.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
