### PR TITLE
Add double-click to finish shape

### DIFF
--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -503,3 +503,7 @@ def _move(layer, coordinates):
                 shapes = layer.selected_data
                 layer._selected_box = layer.interaction_box(shapes)
                 layer.refresh()
+
+
+def finish_drawing(layer, event):
+    layer._finish_drawing()

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -42,6 +42,7 @@ from ._shapes_mouse_bindings import (
     add_path_polygon,
     add_path_polygon_creating,
     add_rectangle,
+    finish_drawing,
     highlight,
     select,
     vertex_insert,
@@ -557,6 +558,7 @@ class Shapes(Layer):
 
         # Trigger generation of view slice and thumbnail
         self._update_dims()
+        self.mouse_double_click_callbacks.append(finish_drawing)
 
     def _initialize_current_color_for_empty_layer(
         self, color: ColorType, attribute: str

--- a/napari/utils/interactions.py
+++ b/napari/utils/interactions.py
@@ -206,6 +206,12 @@ def mouse_release_callbacks(obj, event):
         del obj._persisted_mouse_event[gen]
 
 
+def mouse_double_click_callbacks(obj, event):
+    # iterate through mouse_wheel_callbacks callback functions
+    for func in obj.mouse_double_click_callbacks:
+        func(obj, event)
+
+
 KEY_SYMBOLS = {
     'Control': 'Ctrl',
     'Shift': '⇧',

--- a/napari/utils/mouse_bindings.py
+++ b/napari/utils/mouse_bindings.py
@@ -19,6 +19,8 @@ class MousemapProvider:
         self.mouse_drag_callbacks = []
         # Hold callbacks for when mouse wheel is scrolled
         self.mouse_wheel_callbacks = []
+        # Hold callbacks for when mouse is double clicked
+        self.mouse_double_click_callbacks = []
 
         self._persisted_mouse_event = {}
         self._mouse_drag_gen = {}


### PR DESCRIPTION
# Description
This PR makes it so that drawing a shape (like a polygon) will finish when double clicking.  It's the same behavior as typing "escape" (that is, it doesn't close the polygon, it just make the double click the last point).

**note**: I realized only after posting this that #2907 is accomplishing the same thing.  let's do that one first


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
