### PR TITLE
Add 3D fill, "mill", and "print" on top of #3074

### DIFF
--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -530,14 +530,14 @@ class QtLabelsControls(QtLayerControls):
         # (only picking works in 3D)
         widget_list = [
             'pick_button',
-            'paint_button',
             'fill_button',
+            'paint_button',
             'erase_button',
         ]
         widgets_to_toggle = {
             (2, True): widget_list,
             (2, False): widget_list,
-            (3, True): widget_list[:1],
+            (3, True): widget_list,
             (3, False): widget_list,
         }
 
@@ -546,9 +546,6 @@ class QtLabelsControls(QtLayerControls):
             widgets_to_toggle[(self.layer._ndisplay, self.layer.editable)],
             self.layer.editable,
         )
-
-        if self.layer.editable and self.layer._ndisplay == 3:
-            disable_with_opacity(self, widget_list[1:], False)
 
     def _on_rendering_change(self, event):
         """Receive layer model rendering change event and update dropdown menu.

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from ._labels_constants import Mode
 from ._labels_utils import get_action_coordinate, interpolate_coordinates
 
@@ -21,6 +23,7 @@ def draw(layer, event):
     pixels will be changed to background and this tool functions like an
     eraser
     """
+    ndisplay = len(layer._dims_displayed)
     coordinates = get_action_coordinate(layer, event)
 
     # on press
@@ -47,6 +50,11 @@ def draw(layer, event):
                 last_cursor_coord, coordinates, layer.brush_size
             )
             for c in interp_coord:
+                if (
+                    ndisplay == 3
+                    and layer.data[tuple(np.round(c).astype(int))] == 0
+                ):
+                    continue
                 if layer._mode in [Mode.PAINT, Mode.ERASE]:
                     layer.paint(c, new_label, refresh=False)
                 elif layer._mode == Mode.FILL:

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -1,7 +1,10 @@
 import numpy as np
 
 from ._labels_constants import Mode
-from ._labels_utils import get_action_coordinate, interpolate_coordinates
+from ._labels_utils import (
+    interpolate_coordinates,
+    mouse_event_to_labels_coordinate,
+)
 
 
 def draw(layer, event):
@@ -24,7 +27,7 @@ def draw(layer, event):
     eraser
     """
     ndisplay = len(layer._dims_displayed)
-    coordinates = get_action_coordinate(layer, event)
+    coordinates = mouse_event_to_labels_coordinate(layer, event)
 
     # on press
     if layer._mode == Mode.ERASE:
@@ -44,7 +47,7 @@ def draw(layer, event):
     layer._block_saving = True
     # on move
     while event.type == 'mouse_move':
-        coordinates = get_action_coordinate(layer, event)
+        coordinates = mouse_event_to_labels_coordinate(layer, event)
         if coordinates is not None or last_cursor_coord is not None:
             interp_coord = interpolate_coordinates(
                 last_cursor_coord, coordinates, layer.brush_size

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -1,5 +1,5 @@
 from ._labels_constants import Mode
-from ._labels_utils import interpolate_coordinates
+from ._labels_utils import get_action_coordinate, interpolate_coordinates
 
 
 def draw(layer, event):
@@ -21,17 +21,19 @@ def draw(layer, event):
     pixels will be changed to background and this tool functions like an
     eraser
     """
-    coordinates = layer.world_to_data(event.position)
+    coordinates = get_action_coordinate(layer, event)
+
     # on press
     if layer._mode == Mode.ERASE:
         new_label = layer._background_label
     else:
         new_label = layer.selected_label
 
-    if layer._mode in [Mode.PAINT, Mode.ERASE]:
-        layer.paint(coordinates, new_label)
-    elif layer._mode == Mode.FILL:
-        layer.fill(coordinates, new_label)
+    if coordinates is not None:
+        if layer._mode in [Mode.PAINT, Mode.ERASE]:
+            layer.paint(coordinates, new_label)
+        elif layer._mode == Mode.FILL:
+            layer.fill(coordinates, new_label)
 
     last_cursor_coord = coordinates
     yield
@@ -39,16 +41,17 @@ def draw(layer, event):
     layer._block_saving = True
     # on move
     while event.type == 'mouse_move':
-        coordinates = layer.world_to_data(event.position)
-        interp_coord = interpolate_coordinates(
-            last_cursor_coord, coordinates, layer.brush_size
-        )
-        for c in interp_coord:
-            if layer._mode in [Mode.PAINT, Mode.ERASE]:
-                layer.paint(c, new_label, refresh=False)
-            elif layer._mode == Mode.FILL:
-                layer.fill(c, new_label, refresh=False)
-        layer.refresh()
+        coordinates = get_action_coordinate(layer, event)
+        if coordinates is not None or last_cursor_coord is not None:
+            interp_coord = interpolate_coordinates(
+                last_cursor_coord, coordinates, layer.brush_size
+            )
+            for c in interp_coord:
+                if layer._mode in [Mode.PAINT, Mode.ERASE]:
+                    layer.paint(c, new_label, refresh=False)
+                elif layer._mode == Mode.FILL:
+                    layer.fill(c, new_label, refresh=False)
+            layer.refresh()
         last_cursor_coord = coordinates
         yield
 

--- a/napari/layers/labels/_labels_utils.py
+++ b/napari/layers/labels/_labels_utils.py
@@ -160,7 +160,7 @@ def first_nonzero_coordinate(data, start_point, end_point):
     length = np.linalg.norm(end_point - start_point)
     length_int = np.round(length).astype(int)
     coords = np.linspace(start_point, end_point, length_int + 1, endpoint=True)
-    clipped_coords = np.clip(coords, 0, shape - 1).astype(int)
+    clipped_coords = np.clip(np.round(coords), 0, shape - 1).astype(int)
     nonzero = np.flatnonzero(data[tuple(clipped_coords.T)])
     if len(nonzero) == 0:
         return None

--- a/napari/layers/labels/_labels_utils.py
+++ b/napari/layers/labels/_labels_utils.py
@@ -168,7 +168,7 @@ def first_nonzero_coordinate(data, start_point, end_point):
         return clipped_coords[nonzero[0]]
 
 
-def get_action_coordinate(layer, event):
+def mouse_event_to_labels_coordinate(layer, event):
     """Return the data coordinate of a Labels layer mouse event in 2D or 3D.
 
     In 2D, this is just the event's position transformed by the layer's

--- a/napari/layers/labels/_labels_utils.py
+++ b/napari/layers/labels/_labels_utils.py
@@ -140,6 +140,22 @@ def get_dtype(layer):
 
 
 def first_nonzero_coordinate(data, start_point, end_point):
+    """Coordinate of the first nonzero element between start and end points.
+
+    Parameters
+    ----------
+    data : nD array, shape (N1, N2, ..., ND)
+        A data volume.
+    start_point : array, shape (D,)
+        The start coordinate to check.
+    end_point : array, shape (D,)
+        The end coordinate to check.
+
+    Returns
+    -------
+    coordinates : array of int, shape (D,)
+        The coordinates of the first nonzero element along the ray, or None.
+    """
     shape = np.asarray(data.shape)
     length = np.linalg.norm(end_point - start_point)
     length_int = np.round(length).astype(int)
@@ -153,6 +169,27 @@ def first_nonzero_coordinate(data, start_point, end_point):
 
 
 def get_action_coordinate(layer, event):
+    """Return the data coordinate of a Labels layer mouse event in 2D or 3D.
+
+    In 2D, this is just the event's position transformed by the layer's
+    world_to_data transform.
+
+    In 3D, a ray is cast in data coordinates, and the coordinate of the first
+    nonzero value along that ray is returned. If the ray only contains zeros,
+    None is returned.
+
+    Parameters
+    ----------
+    layer : napari.layers.Labels
+        The Labels layer.
+    event : vispy MouseEvent
+        The mouse event, containing position and view direction attributes.
+
+    Returns
+    -------
+    coordinates : array of int
+        The data coordinates for the mouse event.
+    """
     ndim = len(layer._dims_displayed)
     if ndim == 2:
         coordinates = layer.world_to_data(event.position)

--- a/napari/layers/labels/_tests/test_labels_mouse_bindings.py
+++ b/napari/layers/labels/_tests/test_labels_mouse_bindings.py
@@ -1,7 +1,4 @@
-import collections
-
 import numpy as np
-import pytest
 
 from napari.layers import Labels
 from napari.utils.interactions import (
@@ -12,30 +9,7 @@ from napari.utils.interactions import (
 )
 
 
-@pytest.fixture
-def Event():
-    """Create a subclass for simulating vispy mouse events.
-
-    Returns
-    -------
-    Event : Type
-        A new tuple subclass named Event that can be used to create a
-        NamedTuple object with fields "type" and "is_dragging".
-    """
-    return collections.namedtuple(
-        'Event',
-        field_names=[
-            'type',
-            'is_dragging',
-            'position',
-            'view_direction',
-            'dims_displayed',
-            'dims_point',
-        ],
-    )
-
-
-def test_paint(Event):
+def test_paint(MouseEvent):
     """Test painting labels with circle brush."""
     data = np.ones((20, 20), dtype=np.int32)
     layer = Labels(data)
@@ -47,7 +21,7 @@ def test_paint(Event):
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_press',
             is_dragging=False,
             position=(0, 0),
@@ -60,7 +34,7 @@ def test_paint(Event):
 
     # Simulate drag
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_move',
             is_dragging=True,
             position=(19, 19),
@@ -73,7 +47,7 @@ def test_paint(Event):
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_release',
             is_dragging=False,
             position=(19, 19),
@@ -93,7 +67,7 @@ def test_paint(Event):
     assert np.sum(layer.data == 3) == 244
 
 
-def test_paint_scale(Event):
+def test_paint_scale(MouseEvent):
     """Test painting labels with circle brush when scaled."""
     data = np.ones((20, 20), dtype=np.int32)
     layer = Labels(data, scale=(2, 2))
@@ -104,7 +78,7 @@ def test_paint_scale(Event):
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_press',
             is_dragging=False,
             position=(0, 0),
@@ -117,7 +91,7 @@ def test_paint_scale(Event):
 
     # Simulate drag
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_move',
             is_dragging=True,
             position=(39, 39),
@@ -130,7 +104,7 @@ def test_paint_scale(Event):
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_release',
             is_dragging=False,
             position=(39, 39),
@@ -150,7 +124,7 @@ def test_paint_scale(Event):
     assert np.sum(layer.data == 3) == 244
 
 
-def test_erase(Event):
+def test_erase(MouseEvent):
     """Test erasing labels with different brush shapes."""
     data = np.ones((20, 20), dtype=np.int32)
     layer = Labels(data)
@@ -161,7 +135,7 @@ def test_erase(Event):
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_press',
             is_dragging=False,
             position=(0, 0),
@@ -174,7 +148,7 @@ def test_erase(Event):
 
     # Simulate drag
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_move',
             is_dragging=True,
             position=(19, 19),
@@ -187,7 +161,7 @@ def test_erase(Event):
 
     # Simulate release
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_release',
             is_dragging=False,
             position=(19, 19),
@@ -207,7 +181,7 @@ def test_erase(Event):
     assert np.sum(layer.data == 1) == 156
 
 
-def test_pick(Event):
+def test_pick(MouseEvent):
     """Test picking label."""
     data = np.ones((20, 20), dtype=np.int32)
     data[:5, :5] = 2
@@ -219,7 +193,7 @@ def test_pick(Event):
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_press',
             is_dragging=False,
             position=(0, 0),
@@ -233,7 +207,7 @@ def test_pick(Event):
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_press',
             is_dragging=False,
             position=(19, 19),
@@ -246,7 +220,7 @@ def test_pick(Event):
     assert layer.selected_label == 3
 
 
-def test_fill(Event):
+def test_fill(MouseEvent):
     """Test filling label."""
     data = np.ones((20, 20), dtype=np.int32)
     data[:5, :5] = 2
@@ -262,7 +236,7 @@ def test_fill(Event):
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_press',
             is_dragging=False,
             position=(0, 0),
@@ -281,7 +255,7 @@ def test_fill(Event):
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_press',
             is_dragging=False,
             position=(19, 19),
@@ -297,7 +271,7 @@ def test_fill(Event):
     assert np.unique(layer.data[-5:, :5]) == 1
 
 
-def test_fill_nD_plane(Event):
+def test_fill_nD_plane(MouseEvent):
     """Test filling label nD plane."""
     data = np.ones((20, 20, 20), dtype=np.int32)
     data[:5, :5, :5] = 2
@@ -315,7 +289,7 @@ def test_fill_nD_plane(Event):
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_press',
             is_dragging=False,
             position=(0, 0, 0),
@@ -336,7 +310,7 @@ def test_fill_nD_plane(Event):
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_press',
             is_dragging=False,
             position=(0, 19, 19),
@@ -356,7 +330,7 @@ def test_fill_nD_plane(Event):
     assert np.unique(layer.data[0, 8:10, 8:10]) == 2
 
 
-def test_fill_nD_all(Event):
+def test_fill_nD_all(MouseEvent):
     """Test filling label nD."""
     data = np.ones((20, 20, 20), dtype=np.int32)
     data[:5, :5, :5] = 2
@@ -375,7 +349,7 @@ def test_fill_nD_all(Event):
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_press',
             is_dragging=False,
             position=(0, 0, 0),
@@ -395,7 +369,7 @@ def test_fill_nD_all(Event):
 
     # Simulate click
     event = ReadOnlyWrapper(
-        Event(
+        MouseEvent(
             type='mouse_press',
             is_dragging=False,
             position=(0, 19, 19),

--- a/napari/layers/labels/_tests/test_labels_utils.py
+++ b/napari/layers/labels/_tests/test_labels_utils.py
@@ -5,7 +5,9 @@ from napari.layers.labels._labels_utils import (
     first_nonzero_coordinate,
     get_dtype,
     interpolate_coordinates,
+    mouse_event_to_labels_coordinate,
 )
+from napari.utils.interactions import ReadOnlyWrapper
 
 
 def test_interpolate_coordinates():
@@ -80,3 +82,43 @@ def test_first_nonzero_coordinate():
         ),
         [4, 6, 6],
     )
+
+
+def test_mouse_event_to_labels_coordinate_2d(MouseEvent):
+    pass
+
+
+def test_mouse_event_to_labels_coordinate_3d(MouseEvent):
+    data = np.zeros((11, 11, 11), dtype=int)
+    data[4:7, 4:7, 4:7] = 1
+    layer = Labels(data, scale=(2, 2, 2))
+    layer._slice_dims(point=(0, 0, 0), ndisplay=3)
+
+    # click straight down from the top
+    # (note the scale on the layer!)
+    event = ReadOnlyWrapper(
+        MouseEvent(
+            type='mouse_press',
+            is_dragging=False,
+            position=(0, 10, 10),
+            view_direction=(1, 0, 0),
+            dims_displayed=(0, 1, 2),
+            dims_point=(10, 10, 10),
+        )
+    )
+    coord = mouse_event_to_labels_coordinate(layer, event)
+    np.testing.assert_array_equal(coord, [4, 5, 5])
+
+    # click diagonally from the top left corner
+    event = ReadOnlyWrapper(
+        MouseEvent(
+            type='mouse_press',
+            is_dragging=False,
+            position=(0, 0, 0),
+            view_direction=np.full(3, 1 / np.sqrt(3)),
+            dims_displayed=(0, 1, 2),
+            dims_point=(10, 10, 10),
+        )
+    )
+    coord = mouse_event_to_labels_coordinate(layer, event)
+    np.testing.assert_array_equal(coord, [4, 4, 4])

--- a/napari/layers/labels/_tests/test_labels_utils.py
+++ b/napari/layers/labels/_tests/test_labels_utils.py
@@ -31,6 +31,16 @@ def test_interpolate_coordinates():
     assert np.all(coords == expected_coords)
 
 
+def test_interpolate_with_none():
+    """Test that interpolating with one None coordinate returns original."""
+    coord = np.array([5, 5])
+    expected = coord[np.newaxis, :]
+    actual = interpolate_coordinates(coord, None, brush_size=1)
+    np.testing.assert_array_equal(actual, expected)
+    actual2 = interpolate_coordinates(None, coord, brush_size=5)
+    np.testing.assert_array_equal(actual2, expected)
+
+
 def test_get_dtype():
     np.random.seed(0)
     data = np.random.randint(20, size=(50, 50))

--- a/napari/layers/labels/_tests/test_labels_utils.py
+++ b/napari/layers/labels/_tests/test_labels_utils.py
@@ -85,7 +85,22 @@ def test_first_nonzero_coordinate():
 
 
 def test_mouse_event_to_labels_coordinate_2d(MouseEvent):
-    pass
+    data = np.zeros((11, 11), dtype=int)
+    data[4:7, 4:7] = 1
+    layer = Labels(data, scale=(2, 2))
+
+    event = ReadOnlyWrapper(
+        MouseEvent(
+            type='mouse_press',
+            is_dragging=False,
+            position=(10, 10),
+            view_direction=None,
+            dims_displayed=(1, 2),
+            dims_point=(0, 0),
+        )
+    )
+    coord = mouse_event_to_labels_coordinate(layer, event)
+    np.testing.assert_array_equal(coord, [5, 5])
 
 
 def test_mouse_event_to_labels_coordinate_3d(MouseEvent):

--- a/napari/layers/labels/_tests/test_labels_utils.py
+++ b/napari/layers/labels/_tests/test_labels_utils.py
@@ -114,7 +114,7 @@ def test_mouse_event_to_labels_coordinate_3d(MouseEvent):
         MouseEvent(
             type='mouse_press',
             is_dragging=False,
-            position=(0, 0, 0),
+            position=(0.1, 0, 0),
             view_direction=np.full(3, 1 / np.sqrt(3)),
             dims_displayed=(0, 1, 2),
             dims_point=(10, 10, 10),

--- a/napari/layers/labels/_tests/test_labels_utils.py
+++ b/napari/layers/labels/_tests/test_labels_utils.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from napari.layers.labels import Labels
 from napari.layers.labels._labels_utils import (
+    first_nonzero_coordinate,
     get_dtype,
     interpolate_coordinates,
 )
@@ -56,3 +57,26 @@ def test_get_dtype():
     data = data.astype(int)
     int_layer = Labels(data)
     assert get_dtype(int_layer) == int
+
+
+def test_first_nonzero_coordinate():
+    data = np.zeros((11, 11, 11))
+    data[4:7, 4:7, 4:7] = 1
+    np.testing.assert_array_equal(
+        first_nonzero_coordinate(data, np.zeros(3), np.full(3, 10)),
+        [4, 4, 4],
+    )
+    np.testing.assert_array_equal(
+        first_nonzero_coordinate(data, np.full(3, 10), np.zeros(3)),
+        [6, 6, 6],
+    )
+    assert (
+        first_nonzero_coordinate(data, np.zeros(3), np.array([0, 1, 1]))
+        is None
+    )
+    np.testing.assert_array_equal(
+        first_nonzero_coordinate(
+            data, np.array([0, 6, 6]), np.array([10, 5, 5])
+        ),
+        [4, 6, 6],
+    )

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -1,3 +1,4 @@
+import collections
 import os
 import sys
 import warnings
@@ -165,3 +166,26 @@ def make_napari_viewer(
                 raise AssertionError(f'Widgets leaked!: {leak}')
             else:
                 warnings.warn(f'Widgets leaked!: {leak}')
+
+
+@pytest.fixture
+def MouseEvent():
+    """Create a subclass for simulating vispy mouse events.
+
+    Returns
+    -------
+    Event : Type
+        A new tuple subclass named Event that can be used to create a
+        NamedTuple object with fields "type" and "is_dragging".
+    """
+    return collections.namedtuple(
+        'Event',
+        field_names=[
+            'type',
+            'is_dragging',
+            'position',
+            'view_direction',
+            'dims_displayed',
+            'dims_point',
+        ],
+    )


### PR DESCRIPTION
# Description

This adds our first 3D "write" interactivity! 🎉 Currently this PR is on top of #3074, it should be rebased after that merges, but I couldn't wait to play with it. Short video below.

Not everything is perfect yet but it's a brilliant start. The biggest issue I've noticed playing with it is that interpolating in 3D while filling is dangerous. 😂 Perhaps filling label 0 should be disabled in 3D?

Here's a video of it in action:

https://user-images.githubusercontent.com/492549/127662770-d765c8b7-92b2-4b8f-971b-73df67ab0753.mov

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
