### PR TITLE
Fix empty points layer with color cycle

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -120,6 +120,33 @@ def test_empty_layer_with_edge_colormap():
     np.testing.assert_allclose(layer._edge.current_color, edge_color)
 
 
+@pytest.mark.parametrize('feature_name', ('edge', 'face'))
+def test_empty_layer_with_edge_color_cycle(feature_name):
+    """Test creating an empty layer where the edge color is a color cycle"""
+    default_properties = {'annotation': np.array(['tail', 'nose', 'paw'])}
+    color_cycle = [[0, 1, 0, 1], [1, 0, 1, 1]]
+    color_parameters = {
+        'colors': 'annotation',
+        'categorical_colormap': color_cycle,
+        'mode': 'cycle',
+    }
+    color_name = f'{feature_name}_color'
+    points_kwargs = {
+        'property_choices': default_properties,
+        color_name: color_parameters,
+    }
+    layer = Points(**points_kwargs)
+
+    color_mode = getattr(layer, f'{feature_name}_color_mode')
+    assert color_mode == 'cycle'
+    layer.current_properties = {'annotation': 'paw'}
+
+    layer.add([10, 10])
+    colors = getattr(layer, color_name)
+    np.testing.assert_allclose(colors, [color_cycle[1]])
+    assert len(layer.data == 1)
+
+
 def test_empty_layer_with_text_properties():
     """Test initializing an empty layer with text defined"""
     default_properties = {'point_type': np.array([1.5], dtype=float)}

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -121,8 +121,11 @@ def test_empty_layer_with_edge_colormap():
 
 
 @pytest.mark.parametrize('feature_name', ('edge', 'face'))
-def test_empty_layer_with_edge_color_cycle(feature_name):
-    """Test creating an empty layer where the face/edge color is a color cycle"""
+def test_set_current_properties_on_empty_layer_with_color_cycle(feature_name):
+    """Test creating an empty layer where the face/edge color is a color cycle
+
+    See: https://github.com/napari/napari/pull/3110
+    """
     default_properties = {'annotation': np.array(['tail', 'nose', 'paw'])}
     color_cycle = [[0, 1, 0, 1], [1, 0, 1, 1]]
     color_parameters = {
@@ -139,12 +142,14 @@ def test_empty_layer_with_edge_color_cycle(feature_name):
 
     color_mode = getattr(layer, f'{feature_name}_color_mode')
     assert color_mode == 'cycle'
-    layer.current_properties = {'annotation': 'paw'}
+    layer.current_properties = {'annotation': np.array(['paw'])}
 
     layer.add([10, 10])
     colors = getattr(layer, color_name)
     np.testing.assert_allclose(colors, [color_cycle[1]])
-    assert len(layer.data == 1)
+    assert len(layer.data) == 1
+    cm = getattr(layer, f'_{feature_name}')
+    assert cm.color_properties.current_value == 'paw'
 
 
 def test_empty_layer_with_text_properties():

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -122,7 +122,7 @@ def test_empty_layer_with_edge_colormap():
 
 @pytest.mark.parametrize('feature_name', ('edge', 'face'))
 def test_empty_layer_with_edge_color_cycle(feature_name):
-    """Test creating an empty layer where the edge color is a color cycle"""
+    """Test creating an empty layer where the face/edge color is a color cycle"""
     default_properties = {'annotation': np.array(['tail', 'nose', 'paw'])}
     color_cycle = [[0, 1, 0, 1], [1, 0, 1, 1]]
     color_parameters = {

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -122,7 +122,8 @@ def test_empty_layer_with_edge_colormap():
 
 @pytest.mark.parametrize('feature_name', ('edge', 'face'))
 def test_set_current_properties_on_empty_layer_with_color_cycle(feature_name):
-    """Test creating an empty layer where the face/edge color is a color cycle
+    """Test setting current_properties an empty layer where the face/edge color
+    is a color cycle.
 
     See: https://github.com/napari/napari/pull/3110
     """

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -622,6 +622,39 @@ def test_updating_points_properties():
     np.testing.assert_equal(layer.properties, updated_properties)
 
 
+def test_setting_current_properties():
+    shape = (2, 2)
+    np.random.seed(0)
+    data = 20 * np.random.random(shape)
+    properties = {
+        'annotation': ['paw', 'leg'],
+        'confidence': [0.5, 0.75],
+        'annotator': ['jane', 'ash'],
+        'model': ['worst', 'best'],
+    }
+    layer = Points(data, properties=copy(properties))
+    current_properties = {
+        'annotation': ['leg'],
+        'confidence': 1,
+        'annotator': 'ash',
+        'model': np.array(['best']),
+    }
+    layer.current_properties = current_properties
+
+    expected_current_properties = {
+        'annotation': np.array(['leg']),
+        'confidence': np.array([1]),
+        'annotator': np.array(['ash']),
+        'model': np.array(['best']),
+    }
+
+    coerced_current_properties = layer.current_properties
+    for k, v in coerced_current_properties.items():
+        value = coerced_current_properties[k]
+        assert isinstance(value, np.ndarray)
+        np.testing.assert_equal(value, expected_current_properties[k])
+
+
 properties_array = {'point_type': _make_cycled_properties(['A', 'B'], 10)}
 properties_list = {'point_type': list(_make_cycled_properties(['A', 'B'], 10))}
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -18,7 +18,11 @@ from ..base import Layer, no_op
 from ..utils._color_manager_constants import ColorMode
 from ..utils.color_manager import ColorManager
 from ..utils.color_transformations import ColorType
-from ..utils.layer_utils import get_current_properties, prepare_properties
+from ..utils.layer_utils import (
+    coerce_current_properties,
+    get_current_properties,
+    prepare_properties,
+)
 from ..utils.text_manager import TextManager
 from ._points_constants import SYMBOL_ALIAS, Mode, Symbol
 from ._points_mouse_bindings import add, highlight, select
@@ -539,7 +543,9 @@ class Points(Layer):
 
     @current_properties.setter
     def current_properties(self, current_properties):
-        self._current_properties = current_properties
+        self._current_properties = coerce_current_properties(
+            current_properties
+        )
 
         if (
             self._update_properties

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -160,6 +160,39 @@ def test_properties_dataframe():
     np.testing.assert_equal(layer.properties, properties)
 
 
+def test_setting_current_properties():
+    shape = (2, 4, 2)
+    np.random.seed(0)
+    data = 20 * np.random.random(shape)
+    properties = {
+        'annotation': ['paw', 'leg'],
+        'confidence': [0.5, 0.75],
+        'annotator': ['jane', 'ash'],
+        'model': ['worst', 'best'],
+    }
+    layer = Shapes(data, properties=copy(properties))
+    current_properties = {
+        'annotation': ['leg'],
+        'confidence': 1,
+        'annotator': 'ash',
+        'model': np.array(['best']),
+    }
+    layer.current_properties = current_properties
+
+    expected_current_properties = {
+        'annotation': np.array(['leg']),
+        'confidence': np.array([1]),
+        'annotator': np.array(['ash']),
+        'model': np.array(['best']),
+    }
+
+    coerced_current_properties = layer.current_properties
+    for k, v in coerced_current_properties.items():
+        value = coerced_current_properties[k]
+        assert isinstance(value, np.ndarray)
+        np.testing.assert_equal(value, expected_current_properties[k])
+
+
 def test_empty_layer_with_text_property_choices():
     """Test initializing an empty layer with text defined"""
     default_properties = {'shape_type': np.array([1.5], dtype=float)}

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -25,7 +25,11 @@ from ..utils.color_transformations import (
     transform_color_cycle,
     transform_color_with_defaults,
 )
-from ..utils.layer_utils import get_current_properties, prepare_properties
+from ..utils.layer_utils import (
+    coerce_current_properties,
+    get_current_properties,
+    prepare_properties,
+)
 from ..utils.text_manager import TextManager
 from ._shape_list import ShapeList
 from ._shapes_constants import (
@@ -793,7 +797,9 @@ class Shapes(Layer):
 
     @current_properties.setter
     def current_properties(self, current_properties):
-        self._current_properties = current_properties
+        self._current_properties = coerce_current_properties(
+            current_properties
+        )
 
         if (
             self._update_properties

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -5,6 +5,7 @@ from dask import array as da
 
 from napari.layers.utils.layer_utils import (
     calc_data_range,
+    coerce_current_properties,
     dataframe_to_properties,
     get_current_properties,
     prepare_properties,
@@ -204,3 +205,36 @@ def test_get_current_properties_with_property_choices_then_first_values():
         "face_color": "cyan",
         "angle": 0.5,
     }
+
+
+def test_coerce_current_properties_valid_values():
+    current_properties = {
+        'annotation': ['leg'],
+        'confidence': 1,
+        'annotator': 'ash',
+        'model': np.array(['best']),
+    }
+    expected_current_properties = {
+        'annotation': np.array(['leg']),
+        'confidence': np.array([1]),
+        'annotator': np.array(['ash']),
+        'model': np.array(['best']),
+    }
+    coerced_current_properties = coerce_current_properties(current_properties)
+
+    for k, v in coerced_current_properties.items():
+        value = coerced_current_properties[k]
+        assert isinstance(value, np.ndarray)
+        np.testing.assert_equal(value, expected_current_properties[k])
+
+
+def test_coerce_current_properties_invalid_values():
+    current_properties = {
+        'annotation': ['leg'],
+        'confidence': 1,
+        'annotator': 'ash',
+        'model': np.array(['best', 'best_v2_final']),
+    }
+
+    with pytest.raises(ValueError):
+        _ = coerce_current_properties(current_properties)

--- a/napari/layers/utils/color_manager.py
+++ b/napari/layers/utils/color_manager.py
@@ -409,6 +409,10 @@ class ColorManager(EventedModel):
             current_property_name = self.color_properties.name
             current_property_values = self.color_properties.values
             if current_property_name in current_properties:
+                # note that we set ColorProperties.current_value by indexing rather than
+                # np.squeeze since the current_property values have shape (1,) and
+                # np.squeeze would return an array with shape ().
+                # see https://github.com/napari/napari/pull/3110#discussion_r680680779
                 new_current_value = current_properties[current_property_name][
                     0
                 ]

--- a/napari/layers/utils/color_manager.py
+++ b/napari/layers/utils/color_manager.py
@@ -221,6 +221,10 @@ class ColorManager(EventedModel):
         # if the provided color is a string, first check if it is a key in the properties.
         # otherwise, assume it is the name of a color
         if is_color_mapped(color, properties):
+            # note that we set ColorProperties.current_value by indexing rather than
+            # np.squeeze since the current_property values have shape (1,) and
+            # np.squeeze would return an array with shape ().
+            # see https://github.com/napari/napari/pull/3110#discussion_r680680779
             self.color_properties = ColorProperties(
                 name=color,
                 values=properties[color],

--- a/napari/layers/utils/color_manager.py
+++ b/napari/layers/utils/color_manager.py
@@ -224,7 +224,7 @@ class ColorManager(EventedModel):
             self.color_properties = ColorProperties(
                 name=color,
                 values=properties[color],
-                current_value=np.squeeze(current_properties[color]),
+                current_value=current_properties[color][0],
             )
             if guess_continuous(properties[color]):
                 self.color_mode = ColorMode.COLORMAP
@@ -405,9 +405,10 @@ class ColorManager(EventedModel):
             current_property_name = self.color_properties.name
             current_property_values = self.color_properties.values
             if current_property_name in current_properties:
-                new_current_value = np.squeeze(
-                    current_properties[current_property_name]
-                )
+                new_current_value = current_properties[current_property_name][
+                    0
+                ]
+
                 if new_current_value != self.color_properties.current_value:
                     self.color_properties = ColorProperties(
                         name=current_property_name,

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -321,6 +321,57 @@ def get_current_properties(
     return current_properties
 
 
+def _coerce_current_properties_value(
+    value: Union[float, str, int, bool, list, tuple, np.ndarray]
+) -> np.ndarray:
+    """Coerce a value in a current_properties dictionary into the correct type.
+
+    Parameters
+    ----------
+    value : Union[float, str, int, bool, list, tuple, np.ndarray]
+        The value to be coerced.
+
+    Returns
+    -------
+    coerced_value : np.ndarray
+        The value in a 1D numpy array with length 1.
+    """
+    if isinstance(value, (np.ndarray, list, tuple)):
+        if len(value) != 1:
+            raise ValueError('current_properties values should have length 1.')
+        coerced_value = np.asarray(value)
+    else:
+        coerced_value = np.array([value])
+
+    return coerced_value
+
+
+def coerce_current_properties(
+    current_properties: Dict[
+        str, Union[float, str, int, bool, list, tuple, np.ndarray]
+    ]
+) -> Dict[str, np.ndarray]:
+    """Coerce a current_properties dictionary into the correct type.
+
+
+    Parameters
+    ----------
+    current_properties : Dict[str, Union[float, str, int, bool, list, tuple, np.ndarray]]
+        The current_properties dictionary to be coerced.
+
+    Returns
+    -------
+    coerced_current_properties : Dict[str, np.ndarray]
+        The current_properties dictionary with string keys and 1D numpy array with length 1 values.
+    """
+    coerced_current_properties = {
+        k: _coerce_current_properties_value(v)
+        for k, v in current_properties.items()
+    }
+
+    return coerced_current_properties
+
+
 def dataframe_to_properties(
     dataframe: DataFrame,
 ) -> Dict[str, np.ndarray]:


### PR DESCRIPTION
# Description
Fixes the bug described by @andy-sweet and @quantumjot in #3039 where adding Points to an empty layer would cause an indexing error.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)


# References
Closes #3039, https://github.com/napari/napari.github.io/issues/133

# How has this been tested?
- [x] added a test
- [x] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
