### PR TITLE
Change shapes default edge color to middle gray

### DIFF
--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -385,7 +385,7 @@ class Shapes(Layer):
         text=None,
         shape_type='rectangle',
         edge_width=1,
-        edge_color='black',
+        edge_color='#777777',
         edge_color_cycle=None,
         edge_colormap='viridis',
         edge_contrast_limits=None,


### PR DESCRIPTION
# Description
changes the default shapes edge color to middle gray (`"#777"`)

<img width="1125" alt="Untitled 2" src="https://user-images.githubusercontent.com/1609449/127756086-69bfd989-6e58-42cd-8f4b-d4193dce8986.png">

closes #3106 