### PR TITLE
Fix point deletion bug

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -302,3 +302,19 @@ def test_custom_layer(make_napari_viewer):
     # Make a viewer and add the custom layer
     viewer = make_napari_viewer(show=True)
     viewer.add_layer(NewLabels(np.zeros((10, 10, 10), dtype=np.uint8)))
+
+
+def test_emitting_data_doesnt_change_points_value(make_napari_viewer):
+    """Test emitting data with no change doesn't change the layer _value."""
+    viewer = make_napari_viewer()
+
+    data = np.array([[0, 0], [10, 10], [20, 20]])
+    layer = viewer.add_points(data, size=2)
+    viewer.layers.selection.active = layer
+
+    assert layer._value is None
+    viewer.cursor.position = tuple(layer.data[1])
+    assert layer._value == 1
+
+    layer.events.data(value=layer.data)
+    assert layer._value == 1

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -318,3 +318,19 @@ def test_emitting_data_doesnt_change_points_value(make_napari_viewer):
 
     layer.events.data(value=layer.data)
     assert layer._value == 1
+
+
+@pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)
+def test_emitting_data_doesnt_change_cursor_position(
+    make_napari_viewer, layer_class, data, ndim
+):
+    """Test emitting data event from layer doesn't change cursor position"""
+    viewer = make_napari_viewer()
+    layer = layer_class(data)
+    viewer.add_layer(layer)
+
+    new_position = (5,) * ndim
+    viewer.cursor.position = new_position
+    layer.events.data(value=layer.data)
+
+    assert viewer.cursor.position == new_position

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -562,6 +562,23 @@ def test_active_layer_cursor_size():
     assert viewer.cursor.size == 10
 
 
+def test_cursor_ndim_matches_layer():
+    """Test cursor position ndim matches viewer ndim after update."""
+    viewer = ViewerModel()
+    np.random.seed(0)
+    im = viewer.add_image(np.random.random((10, 10)))
+    assert viewer.dims.ndim == 2
+    assert len(viewer.cursor.position) == 2
+
+    im.data = np.random.random((10, 10, 10))
+    assert viewer.dims.ndim == 3
+    assert len(viewer.cursor.position) == 3
+
+    im.data = np.random.random((10, 10))
+    assert viewer.dims.ndim == 2
+    assert len(viewer.cursor.position) == 2
+
+
 def test_sliced_world_extent():
     """Test world extent after adding layers and slicing."""
     np.random.seed(0)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -344,7 +344,15 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             self.dims.ndim = ndim
             for i in range(ndim):
                 self.dims.set_range(i, (world[0, i], world[1, i], ss[i]))
-        self.cursor.position = (0,) * self.dims.ndim
+
+        new_dim = self.dims.ndim
+        dim_diff = new_dim - len(self.cursor.position)
+        if dim_diff < 0:
+            self.cursor.position = self.cursor.position[:new_dim]
+        elif dim_diff > 0:
+            self.cursor.position = tuple(
+                list(self.cursor.position) + [0] * dim_diff
+            )
         self.events.layers_change()
 
     def _update_interactive(self, event):

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -330,6 +330,7 @@ def test_removing_selected_points():
     assert len(layer.selected_data) == 0
     keep = [1, 2] + list(range(4, 10))
     assert np.all(layer.data == data[keep])
+    assert layer._value is None
 
     # Select another point and remove it
     layer.selected_data = {4}

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1395,8 +1395,7 @@ class Points(Layer):
                     self.properties[k], index, axis=0
                 )
             self.text.remove(index)
-            if self._value in self.selected_data:
-                self._value = None
+            self._value = None
             self.selected_data = set()
             self.data = np.delete(self.data, index, axis=0)
 


### PR DESCRIPTION
# Description
This PR fixes the bug reported in #3078 by 
- updating `viewer.on_layers_change` to pad or trim `self.cursor.position` dimensions based on `self.dims.ndim` rather than just set to 0
- updating `points.remove_selected` to always overwrite `self._value` to `None` when any points are deleted

I've also added a test which failed before this bug fix but now passes which checks that emitting a data event from a points layer doesn't change the `points._value`. I wasn't really sure where to put this test because it needs the viewer and it's a highly specific test, but I've put it alongside other `viewer` tests for now.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #3078

# How has this been tested?
Manually confirmed the bug no longer occurs with the sample code provided in #3078 and added test.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
