### PR TITLE
Replace custom signals to accept/reject

### DIFF
--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -15,7 +15,6 @@ from qtpy.QtWidgets import (
 from ..._vendor.qt_json_builder.qt_jsonschema_form import WidgetBuilder
 from ...settings import get_settings
 from ...utils.translations import trans
-from ..qt_resources import get_stylesheet
 from .qt_message_dialogs import ResetNapariInfoDialog
 
 if TYPE_CHECKING:
@@ -193,19 +192,15 @@ class PreferencesDialog(QDialog):
     def restore_defaults(self):
         """Launches dialog to confirm restore settings choice."""
 
-        restore_box = QMessageBox()
-
-        settings = get_settings()
-        restore_box.setStyleSheet(get_stylesheet(settings.appearance.theme))
-        restore_box.setText(
-            trans._("Are you sure you want to restore default settings?")
+        response = QMessageBox.question(
+            self,
+            trans._("Restore Settings"),
+            trans._("Are you sure you want to restore default settings?"),
+            QMessageBox.RestoreDefaults | QMessageBox.Cancel,
+            QMessageBox.RestoreDefaults,
         )
-        restore_box.setStandardButtons(
-            QMessageBox.Cancel | QMessageBox.RestoreDefaults
-        )
-        restore = restore_box.exec()
 
-        if restore == QMessageBox.RestoreDefaults:
+        if response == QMessageBox.RestoreDefaults:
             self._reset_widgets()
 
     def _reset_widgets(self):

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -6,6 +6,7 @@ from qtpy.QtWidgets import (
     QDialog,
     QHBoxLayout,
     QListWidget,
+    QMessageBox,
     QPushButton,
     QStackedWidget,
     QVBoxLayout,
@@ -14,7 +15,8 @@ from qtpy.QtWidgets import (
 from ..._vendor.qt_json_builder.qt_jsonschema_form import WidgetBuilder
 from ...settings import get_settings
 from ...utils.translations import trans
-from .qt_message_dialogs import ConfirmDialog, ResetNapariInfoDialog
+from ..qt_resources import get_stylesheet
+from .qt_message_dialogs import ResetNapariInfoDialog
 
 if TYPE_CHECKING:
     from pydantic.fields import ModelField
@@ -190,14 +192,23 @@ class PreferencesDialog(QDialog):
 
     def restore_defaults(self):
         """Launches dialog to confirm restore settings choice."""
-        self._reset_dialog = ConfirmDialog(
-            parent=self,
-            text=trans._("Are you sure you want to restore default settings?"),
-        )
-        self._reset_dialog.valueChanged.connect(self._reset_widgets)
-        self._reset_dialog.exec_()
 
-    def _reset_widgets(self, event=None):
+        restore_box = QMessageBox()
+
+        settings = get_settings()
+        restore_box.setStyleSheet(get_stylesheet(settings.appearance.theme))
+        restore_box.setText(
+            trans._("Are you sure you want to restore default settings?")
+        )
+        restore_box.setStandardButtons(
+            QMessageBox.Cancel | QMessageBox.RestoreDefaults
+        )
+        restore = restore_box.exec()
+
+        if restore == QMessageBox.RestoreDefaults:
+            self._reset_widgets()
+
+    def _reset_widgets(self):
         """Deletes the widgets and rebuilds with defaults.
 
         Parameter
@@ -209,21 +220,20 @@ class PreferencesDialog(QDialog):
 
         """
 
-        if event is True:
-            get_settings().reset()
-            self.accept()
-            self.valueChanged.emit()
-            self._list.clear()
+        get_settings().reset()
+        self.accept()
+        self._list.clear()
 
-            for n in range(self._stack.count()):
-                widget = self._stack.removeWidget(  # noqa: F841
-                    self._stack.currentWidget()
-                )
-                del widget
+        for n in range(self._stack.count()):
+            widget = self._stack.removeWidget(  # noqa: F841
+                self._stack.currentWidget()
+            )
+            del widget
 
-            self.make_dialog()
-            self._list.setCurrentRow(0)
-            self.show()
+        self.make_dialog()
+        self._list.setCurrentRow(0)
+        self.valueChanged.emit()
+        self.show()
 
     def on_click_ok(self):
         """Keeps the selected preferences saved to settings."""

--- a/napari/_qt/dialogs/qt_message_dialogs.py
+++ b/napari/_qt/dialogs/qt_message_dialogs.py
@@ -2,7 +2,6 @@ from qtpy.QtCore import Signal
 from qtpy.QtWidgets import (
     QDialog,
     QGridLayout,
-    QHBoxLayout,
     QLabel,
     QPushButton,
     QVBoxLayout,
@@ -10,53 +9,6 @@ from qtpy.QtWidgets import (
 )
 
 from ...utils.translations import trans
-
-
-class ConfirmDialog(QDialog):
-    """Dialog to confirms a user's choice to restore default settings."""
-
-    valueChanged = Signal(bool)
-
-    def __init__(
-        self,
-        parent: QWidget = None,
-        text: str = "",
-    ):
-        super().__init__(parent)
-
-        # Set up components
-        self._question = QLabel(self)
-        self._button_restore = QPushButton(trans._("Restore"))
-        self._button_cancel = QPushButton(trans._("Cancel"))
-        self._button_restore.setDefault(True)
-
-        # Widget set up
-        self._question.setText(text)
-
-        # Layout
-        button_layout = QHBoxLayout()
-        button_layout.addWidget(self._button_cancel)
-        button_layout.addWidget(self._button_restore)
-
-        main_layout = QVBoxLayout()
-        main_layout.addWidget(self._question)
-        main_layout.addLayout(button_layout)
-
-        self.setLayout(main_layout)
-
-        # Signals
-        self._button_cancel.clicked.connect(self.on_click_cancel)
-        self._button_restore.clicked.connect(self.on_click_restore)
-
-    def on_click_cancel(self):
-        """Do not restore defaults and close window."""
-        self.valueChanged.emit(False)
-        self.close()
-
-    def on_click_restore(self):
-        """Emit signal to restore defaults and close window."""
-        self.valueChanged.emit(True)
-        self.close()
 
 
 class ResetNapariInfoDialog(QDialog):

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -72,7 +72,7 @@ class ShortcutEditor(QWidget):
         self._table.setSelectionBehavior(QAbstractItemView.SelectItems)
         self._table.setSelectionMode(QAbstractItemView.SingleSelection)
         self._table.setShowGrid(False)
-        self._restore_button = QPushButton(trans._("Reset All Keybindings"))
+        self._restore_button = QPushButton(trans._("Restore All Keybindings"))
 
         # Set up dictionary for layers and associated actions.
         all_actions = action_manager._actions.copy()
@@ -119,19 +119,15 @@ class ShortcutEditor(QWidget):
     def restore_defaults(self):
         """Launches dialog to confirm restore choice."""
 
-        restore_box = QMessageBox()
-
-        settings = get_settings()
-        restore_box.setStyleSheet(get_stylesheet(settings.appearance.theme))
-        restore_box.setText(
-            trans._("Are you sure you want to restore default shortcuts?")
+        response = QMessageBox.question(
+            self,
+            trans._("Restore Shortcuts"),
+            trans._("Are you sure you want to restore default shortcuts?"),
+            QMessageBox.RestoreDefaults | QMessageBox.Cancel,
+            QMessageBox.RestoreDefaults,
         )
-        restore_box.setStandardButtons(
-            QMessageBox.Cancel | QMessageBox.RestoreDefaults
-        )
-        restore = restore_box.exec()
 
-        if restore == QMessageBox.RestoreDefaults:
+        if response == QMessageBox.RestoreDefaults:
             self._reset_shortcuts()
 
     def _reset_shortcuts(self):


### PR DESCRIPTION
I have replaced the custom ConfirmDialog with QMessageBox.  This will use functionality already provided by Qt.  

Closes #3086