### PR TITLE
fix for get_value() with mixed dims

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1024,14 +1024,15 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             if world:
                 ndim_world = len(position)
 
-                # convert the dims_displayed to the layer dims.This accounts
-                # for differences in the number of dimensions in the world
-                # dims versus the layer and for transpose and rolls.
-                dims_displayed = dims_displayed_world_to_layer(
-                    dims_displayed,
-                    ndim_world=ndim_world,
-                    ndim_layer=self.ndim,
-                )
+                if dims_displayed is not None:
+                    # convert the dims_displayed to the layer dims.This accounts
+                    # for differences in the number of dimensions in the world
+                    # dims versus the layer and for transpose and rolls.
+                    dims_displayed = dims_displayed_world_to_layer(
+                        dims_displayed,
+                        ndim_world=ndim_world,
+                        ndim_layer=self.ndim,
+                    )
                 position = self.world_to_data(position)
 
             if dims_displayed is not None:

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1023,6 +1023,10 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         if self.visible:
             if world:
                 ndim_world = len(position)
+
+                # convert the dims_displayed to the layer dims.This accounts
+                # for differences in the number of dimensions in the world
+                # dims versus the layer and for transpose and rolls.
                 dims_displayed = dims_displayed_world_to_layer(
                     dims_displayed,
                     ndim_world=ndim_world,

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1022,6 +1022,14 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         if self.visible:
             if world:
                 position = self.world_to_data(position)
+
+                if np.max(dims_displayed) > (self.ndim - 1):
+                    # if the world dims have more dimensions than the layers,
+                    # we need to map them properly
+                    dims_displayed = self._dims_displayed
+                elif len(dims_displayed) > self.ndim:
+                    dims_displayed = self._dims_displayed
+
             if dims_displayed is not None:
                 if len(dims_displayed) == 2:
                     value = self._get_value(position=tuple(position))

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -30,6 +30,7 @@ from ..utils.layer_utils import (
     coerce_affine,
     compute_multiscale_level_and_corners,
     convert_to_uint8,
+    dims_displayed_world_to_layer,
 )
 from ._base_constants import Blending
 
@@ -1021,14 +1022,13 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         """
         if self.visible:
             if world:
+                ndim_world = len(position)
+                dims_displayed = dims_displayed_world_to_layer(
+                    dims_displayed,
+                    ndim_world=ndim_world,
+                    ndim_layer=self.ndim,
+                )
                 position = self.world_to_data(position)
-
-                if np.max(dims_displayed) > (self.ndim - 1):
-                    # if the world dims have more dimensions than the layers,
-                    # we need to map them properly
-                    dims_displayed = self._dims_displayed
-                elif len(dims_displayed) > self.ndim:
-                    dims_displayed = self._dims_displayed
 
             if dims_displayed is not None:
                 if len(dims_displayed) == 2:

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -515,13 +515,25 @@ def test_value():
     assert value == data[0, 0]
 
 
-def test_value_3d():
+@pytest.mark.parametrize(
+    'position,view_direction,dims_displayed,world',
+    [
+        ((0, 0, 0), [1, 0, 0], [0, 1, 2], False),
+        ((0, 0, 0), [1, 0, 0], [0, 1, 2], True),
+        ((0, 0, 0, 0), [0, 1, 0, 0], [1, 2, 3], True),
+    ],
+)
+def test_value_3d(position, view_direction, dims_displayed, world):
     """Currently get_value should return None in 3D"""
     np.random.seed(0)
     data = np.random.random((10, 15, 15))
     layer = Image(data)
+    layer._slice_dims([0, 0, 0], ndisplay=3)
     value = layer.get_value(
-        (0, 0, 0), view_direction=[1, 0, 0], dims_displayed=[0, 1, 2]
+        position,
+        view_direction=view_direction,
+        dims_displayed=dims_displayed,
+        world=world,
     )
     assert value is None
 

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -754,6 +754,29 @@ def test_value():
     assert value == data[0, 0]
 
 
+@pytest.mark.parametrize(
+    'position,view_direction,dims_displayed,world',
+    [
+        ([10, 5, 5], [1, 0, 0], [0, 1, 2], False),
+        ([10, 5, 5], [1, 0, 0], [0, 1, 2], True),
+        ([0, 10, 5, 5], [0, 1, 0, 0], [1, 2, 3], True),
+    ],
+)
+def test_value_3d(position, view_direction, dims_displayed, world):
+    """Currently get_value should return None in 3D"""
+    data = np.zeros((20, 20, 20), dtype=int)
+    data[0:10, 0:10, 0:10] = 1
+    layer = Labels(data)
+    layer._slice_dims([0, 0, 0], ndisplay=3)
+    value = layer.get_value(
+        position,
+        view_direction=view_direction,
+        dims_displayed=dims_displayed,
+        world=world,
+    )
+    assert value == 1
+
+
 def test_message():
     """Test converting value and coords to message."""
     np.random.seed(0)

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -763,7 +763,7 @@ def test_value():
     ],
 )
 def test_value_3d(position, view_direction, dims_displayed, world):
-    """Currently get_value should return None in 3D"""
+    """get_value should return label value in 3D"""
     data = np.zeros((20, 20, 20), dtype=int)
     data[0:10, 0:10, 0:10] = 1
     layer = Labels(data)

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1449,13 +1449,25 @@ def test_value():
     assert value is None
 
 
-def test_value_3d():
+@pytest.mark.parametrize(
+    'position,view_direction,dims_displayed,world',
+    [
+        ((0, 0, 0), [1, 0, 0], [0, 1, 2], False),
+        ((0, 0, 0), [1, 0, 0], [0, 1, 2], True),
+        ((0, 0, 0, 0), [0, 1, 0, 0], [1, 2, 3], True),
+    ],
+)
+def test_value_3d(position, view_direction, dims_displayed, world):
     """Currently get_value should return None in 3D"""
     np.random.seed(0)
     data = np.random.random((10, 3))
     layer = Points(data)
+    layer._slice_dims([0, 0, 0], ndisplay=3)
     value = layer.get_value(
-        (0, 0, 0), view_direction=[1, 0, 0], dims_displayed=[0, 1, 2]
+        position,
+        view_direction=view_direction,
+        dims_displayed=dims_displayed,
+        world=world,
     )
     assert value is None
 

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -1933,14 +1933,26 @@ def test_value():
     assert value == (None, None)
 
 
-def test_value_3d():
+@pytest.mark.parametrize(
+    'position,view_direction,dims_displayed,world',
+    [
+        ((0, 0, 0), [1, 0, 0], [0, 1, 2], False),
+        ((0, 0, 0), [1, 0, 0], [0, 1, 2], True),
+        ((0, 0, 0, 0), [0, 1, 0, 0], [1, 2, 3], True),
+    ],
+)
+def test_value_3d(position, view_direction, dims_displayed, world):
     """Currently get_value should return None in 3D"""
     shape = (10, 4, 3)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
     layer = Shapes(data)
+    layer._slice_dims([0, 0, 0], ndisplay=3)
     value = layer.get_value(
-        (0, 0, 0), view_direction=[1, 0, 0], dims_displayed=[0, 1, 2]
+        position,
+        view_direction=view_direction,
+        dims_displayed=dims_displayed,
+        world=world,
     )
     assert value is None
 

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -7,6 +7,7 @@ from napari.layers.utils.layer_utils import (
     calc_data_range,
     coerce_current_properties,
     dataframe_to_properties,
+    dims_displayed_world_to_layer,
     get_current_properties,
     prepare_properties,
     segment_normal,
@@ -238,3 +239,25 @@ def test_coerce_current_properties_invalid_values():
 
     with pytest.raises(ValueError):
         _ = coerce_current_properties(current_properties)
+
+
+@pytest.mark.parametrize(
+    "dims_displayed,ndim_world,ndim_layer,expected",
+    [
+        ([1, 2, 3], 4, 4, [1, 2, 3]),
+        ([0, 1, 2], 4, 4, [0, 1, 2]),
+        ([1, 2, 3], 4, 3, [0, 1, 2]),
+        ([0, 1, 2], 4, 3, [2, 0, 1]),
+        ([1, 2, 3], 4, 2, [0, 1]),
+        ([0, 1, 2], 3, 3, [0, 1, 2]),
+        ([0, 1], 2, 2, [0, 1]),
+        ([1, 0], 2, 2, [1, 0]),
+    ],
+)
+def test_dims_displayed_world_to_layer(
+    dims_displayed, ndim_world, ndim_layer, expected
+):
+    dims_displayed_layer = dims_displayed_world_to_layer(
+        dims_displayed, ndim_world=ndim_world, ndim_layer=ndim_layer
+    )
+    np.testing.assert_array_equal(dims_displayed_layer, expected)

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import dask
 import numpy as np
@@ -550,3 +550,30 @@ def coerce_affine(affine, *, ndim, name=None):
     if name is not None:
         affine.name = name
     return affine
+
+
+def dims_displayed_world_to_layer(
+    dims_displayed_world: List[int], ndim_world: int, ndim_layer: int
+):
+    if ndim_world > len(dims_displayed_world):
+        all_dims = list(range(ndim_world))
+        not_in_dims_displayed = [
+            d for d in all_dims if d not in dims_displayed_world
+        ]
+        order = not_in_dims_displayed + dims_displayed_world
+    else:
+        order = dims_displayed_world
+    offset = ndim_world - ndim_layer
+    order = np.array(order)
+    if offset <= 0:
+        order = list(range(-offset)) + list(order - offset)
+    else:
+        order = list(order[order >= offset] - offset)
+    n_display_world = len(dims_displayed_world)
+    if n_display_world > ndim_layer:
+        n_display_layer = ndim_layer
+    else:
+        n_display_layer = n_display_world
+    dims_displayed = order[-n_display_layer:]
+
+    return dims_displayed

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -553,8 +553,24 @@ def coerce_affine(affine, *, ndim, name=None):
 
 
 def dims_displayed_world_to_layer(
-    dims_displayed_world: List[int], ndim_world: int, ndim_layer: int
-):
+    dims_displayed_world: List[int],
+    ndim_world: int,
+    ndim_layer: int,
+) -> List[int]:
+    """Convert the dims_displayed from world dims to the layer dims.
+
+    This accounts differences in the number of dimensions in the world
+    dims versus the layer and for transpose and rolls.
+
+    Parameters
+    ----------
+    dims_displayed_world : List[int]
+        The dims_displayed in world coordinates (i.e., from viewer.dims.displayed).
+    ndim_world : int
+        The number of dimensions in the world coordinates (i.e., viewer.dims.ndim)
+    ndim_layer : int
+        The number of dimensions in layer the layer (i.e., layer.ndim).
+    """
     if ndim_world > len(dims_displayed_world):
         all_dims = list(range(ndim_world))
         not_in_dims_displayed = [

--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -569,6 +569,29 @@ def test_value():
     assert value is None
 
 
+@pytest.mark.parametrize(
+    'position,view_direction,dims_displayed,world',
+    [
+        ((0, 0, 0), [1, 0, 0], [0, 1, 2], False),
+        ((0, 0, 0), [1, 0, 0], [0, 1, 2], True),
+        ((0, 0, 0, 0), [0, 1, 0, 0], [1, 2, 3], True),
+    ],
+)
+def test_value_3d(position, view_direction, dims_displayed, world):
+    np.random.seed(0)
+    data = np.random.random((10, 2, 3))
+    data[:, 0, :] = 20 * data[:, 0, :]
+    layer = Vectors(data)
+    layer._slice_dims([0, 0, 0], ndisplay=3)
+    value = layer.get_value(
+        position,
+        view_direction=view_direction,
+        dims_displayed=dims_displayed,
+        world=world,
+    )
+    assert value is None
+
+
 def test_message():
     """Test converting value and coords to message."""
     np.random.seed(0)

--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -578,6 +578,7 @@ def test_value():
     ],
 )
 def test_value_3d(position, view_direction, dims_displayed, world):
+    """Currently get_value should return None in 3D"""
     np.random.seed(0)
     data = np.random.random((10, 2, 3))
     data[:, 0, :] = 20 * data[:, 0, :]


### PR DESCRIPTION
# Description
This is a work in progress fix for get_value when the number of world dimensions is higher than the number of layer dimensions (#3118)

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
