### PR TITLE
Fix settings reset breaking connections (creating a new instance of nested sub-models)

### DIFF
--- a/napari/settings/_tests/test_settings.py
+++ b/napari/settings/_tests/test_settings.py
@@ -128,12 +128,15 @@ def test_settings_to_dict_no_env(monkeypatch):
 
 
 def test_settings_reset(test_settings):
+    appearance_id = id(test_settings.appearance)
     test_settings.reset()
+    assert id(test_settings.appearance) == appearance_id
     assert test_settings.appearance.theme == "dark"
     test_settings.appearance.theme = "light"
     assert test_settings.appearance.theme == "light"
     test_settings.reset()
     assert test_settings.appearance.theme == "dark"
+    assert id(test_settings.appearance) == appearance_id
 
 
 def test_settings_model(test_settings):

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -164,8 +164,12 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
         return get_defaults(self)
 
     def reset(self):
+        """Reset the state of the model to default values."""
         for name, value in self._defaults.items():
-            setattr(self, name, value)
+            if isinstance(value, EventedModel):
+                getattr(self, name).reset()
+            else:
+                setattr(self, name, value)
 
     def asdict(self):
         """Convert a model to a dictionary."""


### PR DESCRIPTION
# Description
This fixes the bug that @ppwadhwa observed with the new settings in https://github.com/napari/napari/pull/3120#issuecomment-891850219, and adds a test.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] the test suite for my feature covers cases x, y, and z
- [ ] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
