### PR TITLE
Save files after launch from ipython

### DIFF
--- a/napari/_qt/dialogs/screenshot_dialog.py
+++ b/napari/_qt/dialogs/screenshot_dialog.py
@@ -4,6 +4,7 @@ from typing import Any, Callable
 
 from qtpy.QtWidgets import QFileDialog, QMessageBox
 
+from ...utils.misc import in_ipython
 from ...utils.translations import trans
 
 
@@ -37,6 +38,9 @@ class ScreenshotDialog(QFileDialog):
         )
         self.setDirectory(directory)
         self.setHistory(history)
+
+        if in_ipython():
+            self.setOptions(QFileDialog.DontUseNativeDialog)
 
         self.save_function = save_function
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -508,21 +508,15 @@ class QtViewer(QSplitter):
         hist = get_save_history()
         dlg.setHistory(hist)
 
-        if in_ipython():
-            filename, _ = dlg.getSaveFileName(
-                parent=self,
-                caption=trans._('Save {msg} layers', msg=msg),
-                directory=hist[0],  # home dir by default,
-                filter=ext_str,
-                options=QFileDialog.DontUseNativeDialog,
-            )
-        else:
-            filename, _ = dlg.getSaveFileName(
-                parent=self,
-                caption=trans._('Save {msg} layers', msg=msg),
-                directory=hist[0],  # home dir by default,
-                filter=ext_str,
-            )
+        filename, _ = dlg.getSaveFileName(
+            parent=self,
+            caption=trans._('Save {msg} layers', msg=msg),
+            directory=hist[0],  # home dir by default,
+            filter=ext_str,
+            options=(
+                QFileDialog.DontUseNativeDialog if in_ipython() else QFileDialog.Options()
+            ),
+        )
 
         if filename:
             with warnings.catch_warnings(record=True) as wa:

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -514,7 +514,9 @@ class QtViewer(QSplitter):
             directory=hist[0],  # home dir by default,
             filter=ext_str,
             options=(
-                QFileDialog.DontUseNativeDialog if in_ipython() else QFileDialog.Options()
+                QFileDialog.DontUseNativeDialog
+                if in_ipython()
+                else QFileDialog.Options()
             ),
         )
 
@@ -616,19 +618,16 @@ class QtViewer(QSplitter):
         hist = get_open_history()
         dlg.setHistory(hist)
 
-        if in_ipython():
-            filenames, _ = dlg.getOpenFileNames(
-                parent=self,
-                caption=trans._('Select file(s)...'),
-                directory=hist[0],
-                options=QFileDialog.DontUseNativeDialog,
-            )
-        else:
-            filenames, _ = dlg.getOpenFileNames(
-                parent=self,
-                caption=trans._('Select file(s)...'),
-                directory=hist[0],
-            )
+        filenames, _ = dlg.getOpenFileNames(
+            parent=self,
+            caption=trans._('Select file(s)...'),
+            directory=hist[0],
+            options=(
+                QFileDialog.DontUseNativeDialog
+                if in_ipython()
+                else QFileDialog.Options()
+            ),
+        )
 
         if (filenames != []) and (filenames is not None):
             self.viewer.open(filenames)
@@ -640,19 +639,17 @@ class QtViewer(QSplitter):
         hist = get_open_history()
         dlg.setHistory(hist)
 
-        if in_ipython():
-            filenames, _ = dlg.getOpenFileNames(
-                parent=self,
-                caption=trans._('Select files...'),
-                directory=hist[0],  # home dir by default
-                options=QFileDialog.DontUseNativeDialog,
-            )
-        else:
-            filenames, _ = dlg.getOpenFileNames(
-                parent=self,
-                caption=trans._('Select files...'),
-                directory=hist[0],  # home dir by default
-            )
+        filenames, _ = dlg.getOpenFileNames(
+            parent=self,
+            caption=trans._('Select files...'),
+            directory=hist[0],  # home dir by default
+            options=(
+                QFileDialog.DontUseNativeDialog
+                if in_ipython()
+                else QFileDialog.Options()
+            ),
+        )
+
         if (filenames != []) and (filenames is not None):
             self.viewer.open(filenames, stack=True)
             update_open_history(filenames[0])
@@ -663,19 +660,16 @@ class QtViewer(QSplitter):
         hist = get_open_history()
         dlg.setHistory(hist)
 
-        if in_ipython():
-            folder = dlg.getExistingDirectory(
-                parent=self,
-                caption=trans._('Select folder...'),
-                directory=hist[0],  # home dir by default
-                options=QFileDialog.DontUseNativeDialog,
-            )
-        else:
-            folder = dlg.getExistingDirectory(
-                parent=self,
-                caption=trans._('Select folder...'),
-                directory=hist[0],  # home dir by default
-            )
+        folder = dlg.getExistingDirectory(
+            parent=self,
+            caption=trans._('Select folder...'),
+            directory=hist[0],  # home dir by default
+            options=(
+                QFileDialog.DontUseNativeDialog
+                if in_ipython()
+                else QFileDialog.Options()
+            ),
+        )
 
         if folder not in {'', None}:
             self.viewer.open([folder])

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -28,6 +28,7 @@ from ..utils.interactions import (
 )
 from ..utils.io import imsave
 from ..utils.key_bindings import KeymapHandler
+from ..utils.misc import in_ipython
 from ..utils.theme import get_theme
 from ..utils.translations import trans
 from .containers import QtLayerList
@@ -47,6 +48,7 @@ from .._vispy import (  # isort:skip
     VispyTextVisual,
     create_vispy_visual,
 )
+
 
 if TYPE_CHECKING:
     from ..viewer import Viewer
@@ -506,12 +508,21 @@ class QtViewer(QSplitter):
         hist = get_save_history()
         dlg.setHistory(hist)
 
-        filename, _ = dlg.getSaveFileName(
-            parent=self,
-            caption=trans._('Save {msg} layers', msg=msg),
-            directory=hist[0],  # home dir by default,
-            filter=ext_str,
-        )
+        if in_ipython():
+            filename, _ = dlg.getSaveFileName(
+                parent=self,
+                caption=trans._('Save {msg} layers', msg=msg),
+                directory=hist[0],  # home dir by default,
+                filter=ext_str,
+                options=QFileDialog.DontUseNativeDialog,
+            )
+        else:
+            filename, _ = dlg.getSaveFileName(
+                parent=self,
+                caption=trans._('Save {msg} layers', msg=msg),
+                directory=hist[0],  # home dir by default,
+                filter=ext_str,
+            )
 
         if filename:
             with warnings.catch_warnings(record=True) as wa:
@@ -610,11 +621,20 @@ class QtViewer(QSplitter):
         dlg = QFileDialog()
         hist = get_open_history()
         dlg.setHistory(hist)
-        filenames, _ = dlg.getOpenFileNames(
-            parent=self,
-            caption=trans._('Select file(s)...'),
-            directory=hist[0],
-        )
+
+        if in_ipython():
+            filenames, _ = dlg.getOpenFileNames(
+                parent=self,
+                caption=trans._('Select file(s)...'),
+                directory=hist[0],
+                options=QFileDialog.DontUseNativeDialog,
+            )
+        else:
+            filenames, _ = dlg.getOpenFileNames(
+                parent=self,
+                caption=trans._('Select file(s)...'),
+                directory=hist[0],
+            )
 
         if (filenames != []) and (filenames is not None):
             self.viewer.open(filenames)
@@ -625,11 +645,20 @@ class QtViewer(QSplitter):
         dlg = QFileDialog()
         hist = get_open_history()
         dlg.setHistory(hist)
-        filenames, _ = dlg.getOpenFileNames(
-            parent=self,
-            caption=trans._('Select files...'),
-            directory=hist[0],  # home dir by default
-        )
+
+        if in_ipython():
+            filenames, _ = dlg.getOpenFileNames(
+                parent=self,
+                caption=trans._('Select files...'),
+                directory=hist[0],  # home dir by default
+                options=QFileDialog.DontUseNativeDialog,
+            )
+        else:
+            filenames, _ = dlg.getOpenFileNames(
+                parent=self,
+                caption=trans._('Select files...'),
+                directory=hist[0],  # home dir by default
+            )
         if (filenames != []) and (filenames is not None):
             self.viewer.open(filenames, stack=True)
             update_open_history(filenames[0])
@@ -639,11 +668,21 @@ class QtViewer(QSplitter):
         dlg = QFileDialog()
         hist = get_open_history()
         dlg.setHistory(hist)
-        folder = dlg.getExistingDirectory(
-            parent=self,
-            caption=trans._('Select folder...'),
-            directory=hist[0],  # home dir by default
-        )
+
+        if in_ipython():
+            folder = dlg.getExistingDirectory(
+                parent=self,
+                caption=trans._('Select folder...'),
+                directory=hist[0],  # home dir by default
+                options=QFileDialog.DontUseNativeDialog,
+            )
+        else:
+            folder = dlg.getExistingDirectory(
+                parent=self,
+                caption=trans._('Select folder...'),
+                directory=hist[0],  # home dir by default
+            )
+
         if folder not in {'', None}:
             self.viewer.open([folder])
             update_open_history(folder)


### PR DESCRIPTION
For whatever reason, the native QFileDialog will not open properly when napari has been launched from ipython.  If you use the non-native dialog in these cases, everything works.  

Temp fix for #3080 