### PR TITLE
Update new label action to work with tensorstore arrays

### DIFF
--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from ...layers.utils.layer_utils import register_layer_action
 from ...utils.translations import trans
 from ._labels_constants import Mode
@@ -55,7 +57,7 @@ def activate_label_erase_mode(layer):
 )
 def new_label(layer):
     """Set the currently selected label to the largest used label plus one."""
-    layer.selected_label = layer.data.max() + 1
+    layer.selected_label = np.max(layer.data) + 1
 
 
 @register_label_action(

--- a/napari/layers/labels/_tests/test_labels_key_bindings.py
+++ b/napari/layers/labels/_tests/test_labels_key_bindings.py
@@ -1,0 +1,50 @@
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import pytest
+import tensorstore as ts
+import zarr
+
+from napari.layers import Labels
+from napari.layers.labels._labels_key_bindings import new_label
+
+
+@pytest.fixture
+def labels_data_4d():
+    labels = np.zeros((5, 7, 8, 9), dtype=int)
+    labels[1, 2:4, 4:6, 4:6] = 1
+    labels[1, 3:5, 5:7, 6:8] = 2
+    labels[2, 3:5, 5:7, 6:8] = 3
+    return labels
+
+
+def test_max_label(labels_data_4d):
+    labels = Labels(labels_data_4d)
+    new_label(labels)
+    assert labels.selected_label == 4
+
+
+def test_max_label_tensorstore(labels_data_4d):
+    with TemporaryDirectory(suffix='.zarr') as fout:
+        labels_temp = zarr.open(
+            fout,
+            mode='w',
+            shape=labels_data_4d.shape,
+            dtype=np.uint32,
+            chunks=(1, 1, 8, 9),
+        )
+        labels_temp[:] = labels_data_4d
+        labels_ts_spec = {
+            'driver': 'zarr',
+            'kvstore': {'driver': 'file', 'path': fout},
+            'path': '',
+            'metadata': {
+                'dtype': labels_temp.dtype.str,
+                'order': labels_temp.order,
+                'shape': labels_data_4d.shape,
+            },
+        }
+        data = ts.open(labels_ts_spec, create=False, open=True).result()
+        layer = Labels(data)
+        new_label(layer)
+        assert layer.selected_label == 4


### PR DESCRIPTION
# Description

Not all arrays have a `.max()` method, but `np.max()` is guaranteed to work with arrays that use the `__array__` protocol. This simple change allows the new_label shortcut to work with both NumPy and tensorstore arrays backing Labels layers.

