### PR TITLE
Bug fix for undo history in 3D painting

### DIFF
--- a/napari/_tests/test_advanced.py
+++ b/napari/_tests/test_advanced.py
@@ -247,6 +247,7 @@ def test_labels_undo_redo(make_napari_viewer):
 
     # history limit
     labels._history_limit = 1
+    labels._reset_history()
     labels.fill((0, 0), 3)
 
     l3 = labels.data.copy()

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -74,6 +74,9 @@ def draw(layer, event):
 
     # on release
     layer._block_saving = False
+    undo_item = layer._undo_history[-1]
+    if len(undo_item) == 1 and len(undo_item[0][0][0]) == 0:
+        layer._undo_history.pop()
 
 
 def pick(layer, event):

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -40,6 +40,12 @@ def draw(layer, event):
             layer.paint(coordinates, new_label)
         elif layer._mode == Mode.FILL:
             layer.fill(coordinates, new_label)
+    else:  # still add an item to undo queue
+        # when dragging, if we start a drag outside the layer, we will
+        # incorrectly append to the previous history item. We create a
+        # dummy history item to prevent this.
+        dummy_indices = (np.zeros(shape=0, dtype=int),) * layer.data.ndim
+        layer._undo_history.append([(dummy_indices, [], [])])
 
     last_cursor_coord = coordinates
     yield

--- a/napari/layers/labels/_tests/test_labels_mouse_bindings.py
+++ b/napari/layers/labels/_tests/test_labels_mouse_bindings.py
@@ -501,3 +501,43 @@ def test_paint_3d_undo(MouseEvent):
     assert ndi.label(layer.data)[1] == 2
     layer.undo()
     assert ndi.label(layer.data)[1] == 1
+
+
+def test_paint_3d_undo_empty(MouseEvent):
+    """Test painting labels with circle brush when scaled."""
+    data = np.zeros((20, 20, 20), dtype=np.int32)
+    data[10, :, :] = 1
+    layer = Labels(data)
+    layer.brush_size = 5
+    layer.mode = 'erase'
+    layer._slice_dims(point=(0, 0, 0), ndisplay=3)
+    layer.n_edit_dimensions = 3
+
+    # Simulate click, outside data
+    event = ReadOnlyWrapper(
+        MouseEvent(
+            type='mouse_press',
+            is_dragging=False,
+            position=(-1, -1, -1),
+            view_direction=(1, 0, 0),
+            dims_displayed=(0, 1, 2),
+            dims_point=(0, 0, 0),
+        )
+    )
+    mouse_press_callbacks(layer, event)
+
+    # Simulate release
+    event = ReadOnlyWrapper(
+        MouseEvent(
+            type='mouse_release',
+            is_dragging=False,
+            position=(-1, -1, -1),
+            view_direction=(1, 0, 0),
+            dims_displayed=(0, 1, 2),
+            dims_point=(0, 0, 0),
+        )
+    )
+    mouse_release_callbacks(layer, event)
+
+    # Undo queue should be empty
+    assert len(layer._undo_history) == 0

--- a/napari/layers/labels/_tests/test_labels_mouse_bindings.py
+++ b/napari/layers/labels/_tests/test_labels_mouse_bindings.py
@@ -434,8 +434,12 @@ def test_paint_3d(MouseEvent):
     assert new_num_filled < num_filled
 
 
-def test_paint_3d_undo(MouseEvent):
-    """Test painting labels with circle brush when scaled."""
+def test_erase_3d_undo(MouseEvent):
+    """Test erasing labels in 3D then undoing the erase.
+
+    Specifically, this test checks that undo is correctly filled even
+    when a click and drag starts outside of the data volume.
+    """
     data = np.zeros((20, 20, 20), dtype=np.int32)
     data[10, :, :] = 1
     layer = Labels(data)
@@ -503,8 +507,8 @@ def test_paint_3d_undo(MouseEvent):
     assert ndi.label(layer.data)[1] == 1
 
 
-def test_paint_3d_undo_empty(MouseEvent):
-    """Test painting labels with circle brush when scaled."""
+def test_erase_3d_undo_empty(MouseEvent):
+    """Nothing should be added to undo queue when clicks fall outside data."""
     data = np.zeros((20, 20, 20), dtype=np.int32)
     data[10, :, :] = 1
     layer = Labels(data)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -959,15 +959,8 @@ class Labels(_ImageBase):
         )
 
     def _reset_history(self, event=None):
-        self._undo_history = deque()
-        self._redo_history = deque()
-
-    def _trim_history(self):
-        while (
-            len(self._undo_history) + len(self._redo_history)
-            > self._history_limit
-        ):
-            self._undo_history.popleft()
+        self._undo_history = deque(maxlen=self._history_limit)
+        self._redo_history = deque(maxlen=self._history_limit)
 
     def _save_history(self, value):
         """Save a history "atom" to the undo history.
@@ -992,7 +985,6 @@ class Labels(_ImageBase):
         self._redo_history = deque()
         if not self._block_saving:
             self._undo_history.append([value])
-            self._trim_history()
         else:
             self._undo_history[-1].append(value)
 


### PR DESCRIPTION
# Description

There was a bug in the undo history when dragging in 3D, because no undo item was added if the drag started outside of the data volume, or even in a part of the volume with no nonzero data. This PR fixes it by ensuring a "no op" undo item gets created at the start of the drag even if it is outside the data.
