### PR TITLE
Proposal: override Labels.data.__setitem__ to support undo

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1264,3 +1264,12 @@ def test_labels_state_update():
     state = layer._get_state()
     for k, v in state.items():
         setattr(layer, k, v)
+
+
+def test_labels_set_data_undo():
+    data = np.zeros((10, 10), dtype=np.int32)
+    layer = Labels(data)
+    layer.data[([5, 5, 5], [1, 2, 3])] = 1
+    np.testing.assert_array_equal(layer.data[5, :5], [0, 1, 1, 1, 0])
+    layer.undo()
+    np.testing.assert_array_equal(layer.data, 0)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1028,6 +1028,12 @@ class Labels(_ImageBase):
             self._redo_history, self._undo_history, undoing=False
         )
 
+    def data_setitem(self, key, value):
+        """Edit data in-place while adding to the undo queue."""
+        self._save_history((key, self.data[key], value))
+        # Replace target pixels with new_label
+        self.data[key] = value
+
     def fill(self, coord, new_label, refresh=True):
         """Replace an existing label with a new label, either just at the
         connected component if the `contiguous` flag is `True` or everywhere

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1103,10 +1103,6 @@ class Labels(_ImageBase):
         else:
             match_indices = match_indices_local
 
-        self._save_history(
-            (match_indices, self.data[match_indices], new_label)
-        )
-
         # Replace target pixels with new_label
         self.data[match_indices] = new_label
 
@@ -1189,9 +1185,6 @@ class Labels(_ImageBase):
             else:
                 keep_coords = self.data[slice_coord] == self._background_label
             slice_coord = tuple(sc[keep_coords] for sc in slice_coord)
-
-        # save the existing values to the history
-        self._save_history((slice_coord, self.data[slice_coord], new_label))
 
         # update the labels image
         self.data[slice_coord] = new_label

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1025,7 +1025,7 @@ class Labels(_ImageBase):
         after.append(list(reversed(history_item)))
         for prev_indices, prev_values, next_values in reversed(history_item):
             values = prev_values if undoing else next_values
-            self.data[prev_indices] = values
+            self._data[prev_indices] = values
 
         self.refresh()
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -416,7 +416,9 @@ class Labels(_ImageBase):
 
             def __setitem__(self, key, value):
                 """Edit data in-place while adding to the undo queue."""
-                layer._save_history((key, self[key], value))
+                layer._save_history(
+                    (key, np.array(self[key]), np.array(value))
+                )
                 self.__class__.__setitem__(layer._data, key, value)
 
         return ArrayWithUndo(self._data)


### PR DESCRIPTION
# Description

This proposal is a bit out there so I am creating this PR to generate a discussion.  To see the less-controversial approach, see f2c45e265620b702da82468de45fd130685faacf.

In this PR, I replace the Labels.data property getter with a *wrapper* around the original array. The wrapper should preserve every property of the existing array, while overriding the array's __setitem__ to add elements to the undo queue. This means that plugins using `layer.data[indices] = whatever`, for example in plugins implementing a watershed split function, will be able to benefit from our undo/redo functionality.

The safer alternative is shown in f2c45e265620b702da82468de45fd130685faacf: add a `data_setitem` method to the layer that works like setitem but also saves to the undo queue. We would then encourage plugins to use this API. *But*, the problem with that is that it expands the API footprint of the layer.

It has not escaped our notice ;) that we could also take advantage of this to emit a `layer.events.data` event on setitem.
