### PR TITLE
Always raise PluginErrors

### DIFF
--- a/napari/_qt/dialogs/_tests/test_qt_plugin_report.py
+++ b/napari/_qt/dialogs/_tests/test_qt_plugin_report.py
@@ -21,7 +21,13 @@ def test_error_reporter(qtbot, monkeypatch):
     )
 
     error_message = 'my special error'
-    _ = PluginError(error_message, plugin_name='test_plugin', plugin="mock")
+    try:
+        # we need to raise to make sure a __traceback__ is attached to the error.
+        raise PluginError(
+            error_message, plugin_name='test_plugin', plugin="mock"
+        )
+    except PluginError:
+        pass
     report_widget = qt_plugin_report.QtPluginErrReporter()
     qtbot.addWidget(report_widget)
 


### PR DESCRIPTION
Fixes #3156, this make sure the PluginError have an attached
__traceback__ attribute. I'm honestly unsure why the error started to
appear on my machine and not on CI, but that fixes it.

