### PR TITLE
Revert `Points` `remove_selected` always overwriting `self._value` to `None`

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -372,6 +372,26 @@ def test_removing_selected_points():
     assert len(layer.data) == shape[0] - 3
 
 
+def test_deleting_selected_value_changes():
+    """Test deleting selected points appropriately sets self._value"""
+    shape = (10, 2)
+    np.random.seed(0)
+    data = 20 * np.random.random(shape)
+    layer = Points(data)
+
+    # removing with self._value selected resets self._value to None
+    layer._value = 1
+    layer.selected_data = {1, 2}
+    layer.remove_selected()
+    assert layer._value is None
+
+    # removing with self._value outside selection doesn't change self._value
+    layer._value = 3
+    layer.selected_data = {4}
+    layer.remove_selected()
+    assert layer._value == 3
+
+
 def test_move():
     """Test moving points."""
     shape = (10, 2)

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1401,7 +1401,8 @@ class Points(Layer):
                     self.properties[k], index, axis=0
                 )
             self.text.remove(index)
-            self._value = None
+            if self._value in self.selected_data:
+                self._value = None
             self.selected_data = set()
             self.data = np.delete(self.data, index, axis=0)
 


### PR DESCRIPTION
# Description
Fixes #3160 by reverting always resetting `self._value` to `None` from #3119. 

Also verified that the points deletion bug reported in #3078 is still fixed by the changes to cursor position - `points._value` won't be changed by emitting `data` events from moving points as there will be no change in layer dimensionality.

Added test for `remove_selected` appropriately handling `self._value`.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #3160

# How has this been tested?
- Added test for `points._value` being changed appropriately by `remove_selected`
- Verified point deletion bug from #3078 hasn't been reintroduced

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
