### PR TITLE
Move `get_color` call to after `all_vals` have been cleared

### DIFF
--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -385,10 +385,10 @@ class Labels(_ImageBase):
     @seed.setter
     def seed(self, seed):
         self._seed = seed
-        self._selected_color = self.get_color(self.selected_label)
         # invalidate _all_vals to trigger re-generation
         # in _raw_to_displayed
         self._all_vals = np.array([])
+        self._selected_color = self.get_color(self.selected_label)
         self.refresh()
         self.events.selected_label()
 


### PR DESCRIPTION
# Description

As described in #3135, shuffling labels doesn't correctly update the label spinbox color - in fact, it was always showing the previous colormap's color.

This PR addresses #3135 by moving the reassignment of `self._selected_color` in `@seed.setter` to after we've invalided `self._all_vals` for the layer. This ensures the new color is looked up rather than the previous colormap.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #3135 

# How has this been tested?
Visually confirmed the label color updates appropriately. @jni can you please confirm if this fixes it for you?

I'd like to add a test that the `QtColorBox` color matches `layer._selected_color` but I don't know how to get the color of the `QtColorBox`. It looks like we make a `QPainter` and give it the color we want [here](https://github.com/napari/napari/blob/756f51bba34beaf86f4294bf121aaefe689feb95/napari/_qt/qt_labels_layer.py#L115), but I'm not sure how to get that color back out of the widget once the `paintEvent` is finished. @sofroniewn @jni any ideas?

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
