### PR TITLE
Prevent highlight widget from emitting constant signals

### DIFF
--- a/napari/_qt/widgets/qt_highlight_preview.py
+++ b/napari/_qt/widgets/qt_highlight_preview.py
@@ -2,7 +2,6 @@ import numpy as np
 from qtpy.QtCore import QSize, Qt, Signal
 from qtpy.QtGui import QColor, QIntValidator, QPainter, QPainterPath, QPen
 from qtpy.QtWidgets import (
-    QDialog,
     QFrame,
     QHBoxLayout,
     QLabel,
@@ -294,7 +293,7 @@ class QtTriangle(QFrame):
         self.valueChanged.emit(self._value)
 
 
-class QtHighlightSizePreviewWidget(QDialog):
+class QtHighlightSizePreviewWidget(QWidget):
     """Creates custom widget to set highlight size.
 
     Parameters
@@ -422,19 +421,13 @@ class QtHighlightSizePreviewWidget(QDialog):
             Highlight value.
         """
         if value == "":
-            value = int(self._value)
-
+            return
         value = int(value)
-
-        if value > self._max_value:
-            value = self._max_value
-        elif value < self._min_value:
-            value = self._min_value
-
-        if value != self._value:
-            self.valueChanged.emit(value)
-
+        value = max(min(value, self._max_value), self._min_value)
+        if value == self._value:
+            return
         self._value = value
+        self.valueChanged.emit(self._value)
         self._refresh()
 
     def _refresh(self):
@@ -445,7 +438,6 @@ class QtHighlightSizePreviewWidget(QDialog):
         self._triangle.setValue(self._value)
         self._preview.setValue(self._value)
         self.blockSignals(False)
-        self.valueChanged.emit(self._value)
 
     def value(self):
         """Return current value.


### PR DESCRIPTION
# Description
If you go to the appearance tab in the preferences and watch the `on_changed` signal, it fires continuously, in the absence of input.  I tracked it down to the `QtHighlightSizePreviewWidget`

the following code shows an example (valueChanged is constantly emitted)
```py
from napari._qt.widgets.qt_highlight_preview import QtHighlightSizePreviewWidget
from qtpy.QtWidgets import QApplication

app = QApplication([])
w = QtHighlightSizePreviewWidget()
w.valueChanged.connect(lambda e: print('changed', e))
w.show()
app.exec_()
```

This PR fixes that.  @ppwadhwa, would appreciate a quick review to make sure I haven't broken anything.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

