### PR TITLE
Misc Doc format fixing

### DIFF
--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -85,8 +85,8 @@ class PreferencesDialog(QDialog):
     def _restart_dialog(self, event=None, extra_str=""):
         """Displays the dialog informing user a restart is required.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         event : Event
         extra_str : str
             Extra information to add to the message about needing a restart.
@@ -204,16 +204,7 @@ class PreferencesDialog(QDialog):
             self._reset_widgets()
 
     def _reset_widgets(self):
-        """Deletes the widgets and rebuilds with defaults.
-
-        Parameter
-        ---------
-        event: bool
-            Indicates whether to restore the defaults.  When a user clicks "Restore", the signal
-            event emitted will be True.  If "Cancel" is selected, event will be False and nothing
-            is done.
-
-        """
+        """Deletes the widgets and rebuilds with defaults."""
 
         get_settings().reset()
         self.accept()

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -131,13 +131,7 @@ class ShortcutEditor(QWidget):
             self._reset_shortcuts()
 
     def _reset_shortcuts(self):
-        """Reset shortcuts to default settings.
-
-        Parameters
-        ----------
-        event: Bool
-            Event will indicate whether user confirmed resetting shortcuts.
-        """
+        """Reset shortcuts to default settings."""
 
         get_settings().shortcuts.reset()
         for (
@@ -150,12 +144,12 @@ class ShortcutEditor(QWidget):
 
         self._set_table(layer_str=self.layer_combo_box.currentText())
 
-    def _set_table(self, layer_str=''):
+    def _set_table(self, layer_str: str = ''):
         """Builds and populates keybindings table.
 
         Parameters
         ----------
-        layer_str = str
+        layer_str : str
             If layer_str is not empty, then show the specified layers'
             keybinding shortcut table.
         """
@@ -261,9 +255,9 @@ class ShortcutEditor(QWidget):
 
         Parameters
         ----------
-        row: int
+        row : int
             Row in keybindings table that is being edited.
-        col: int
+        col : int
             Column being edited (shortcut column).
         """
 
@@ -425,7 +419,7 @@ class ShortcutEditor(QWidget):
 
         Parameters
         ----------
-        rows: list[int]
+        rows : list[int]
             List of row numbers that should have the icon.
         """
 
@@ -440,9 +434,9 @@ class ShortcutEditor(QWidget):
     def _cleanup_warning_icons(self, rows):
         """Remove the warning icons from the shortcut table.
 
-        Paramters
-        ---------
-        rows: list[int]
+        Parameters
+        ----------
+        rows : list[int]
             List of row numbers to remove warning icon from.
 
         """
@@ -454,13 +448,13 @@ class ShortcutEditor(QWidget):
 
         Parameters
         ----------
-        new_shortcut: str
+        new_shortcut : str
             The new shortcut attempting to be set.
-        action: Action
+        action : Action
             Action that is already assigned with the shortcut.
-        row: int
+        row : int
             Row in table where the shortcut is attempting to be set.
-        message: str
+        message : str
             Message to be displayed in warning pop up.
         """
 
@@ -496,7 +490,6 @@ class ShortcutEditor(QWidget):
         Returns
         -------
         value: dict
-
             Dictionary of action names and shortcuts assigned to them.
         """
 

--- a/napari/_qt/widgets/qt_range_slider_popup.py
+++ b/napari/_qt/widgets/qt_range_slider_popup.py
@@ -14,8 +14,6 @@ class QRangeSliderPopup(QtPopup):
         parent : QWidget, optional
             Will like be an instance of QtLayerControls.  Note, providing
             parent can be useful to inherit stylesheets.
-        decimals : int, optional
-            Number of decimal values in the labels, by default 0
 
         Attributes
         ----------

--- a/napari/_qt/widgets/qt_spinbox.py
+++ b/napari/_qt/widgets/qt_spinbox.py
@@ -11,9 +11,9 @@ class QtSpinBox(QSpinBox):
     def setProhibitValue(self, value: int):
         """Set value that should not be used in QSpinBox.
 
-        Parameter
-        ---------
-        value: int
+        Parameters
+        ----------
+        value : int
             Value to be excluded from QSpinBox.
         """
         self.prohibit = value

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -316,9 +316,9 @@ class QtViewerButtons(QFrame):
     def _update_grid_width(self, value):
         """Update the width value in grid shape.
 
-        Parameter
-        ---------
-        value: int
+        Parameters
+        ----------
+        value : int
             New grid width value.
         """
 
@@ -327,9 +327,9 @@ class QtViewerButtons(QFrame):
     def _update_grid_stride(self, value):
         """Update stride in grid settings.
 
-        Parameter
-        ---------
-        value: int
+        Parameters
+        ----------
+        value : int
             New grid stride value.
         """
 
@@ -338,9 +338,9 @@ class QtViewerButtons(QFrame):
     def _update_grid_height(self, value):
         """Update height value in grid shape.
 
-        Parameter
-        ---------
-        value: int
+        Parameters
+        ----------
+        value : int
             New grid height value.
         """
 

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1168,9 +1168,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         ----------
         vector : tuple, list, 1D array
             A vector in world coordinates.
-        dims_displayed: List[int]
-            The indices of the displayed dimensions. This is used to slice the
-            affine transform parameters.
 
         Returns
         -------
@@ -1199,13 +1196,13 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
         Parameters
         ----------
-        position :
+        position
             the position of the point in nD coordinates. World vs. data
             is set by the world keyword argument.
         view_direction : np.ndarray
             a unit vector giving the direction of the ray in nD coordinates.
             World vs. data is set by the world keyword argument.
-        dims_displayed :
+        dims_displayed
             a list of the dimensions currently being displayed in the viewer.
         world : bool
             True if the provided coordinates are in world coordinates.

--- a/napari/layers/image/experimental/_octree_loader.py
+++ b/napari/layers/image/experimental/_octree_loader.py
@@ -138,7 +138,7 @@ class OctreeLoader:
 
         Parameters
         ----------
-        drawn_chunk_set : Set[OctreeChunk]
+        drawn_set : Set[OctreeChunk]
             The chunks which the visual is currently drawing.
         ideal_chunks : List[OctreeChunk]
             The chunks which are visible to the current view.

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -756,7 +756,7 @@ class Labels(_ImageBase):
             maximum label value in data
 
         Returns
-        ----------
+        -------
         lookup_func : function
             function to use for mapping label values to colors
         """

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -998,7 +998,7 @@ def get_default_shape_type(current_type):
         list of current shape types
 
     Returns
-    ----------
+    -------
     default_type : str
         default shape type
     """

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -224,11 +224,11 @@ def prepare_properties(
     ----------
     properties : dict[str, Array] or DataFrame
         The property values.
-    choices: dict[str, Array]
+    choices : dict[str, Array]
         The property value choices.
-    num_data: int
+    num_data : int
         The length of data that the properties represent (e.g. number of points).
-    save_choices: bool
+    save_choices : bool
         If true, always return all of the properties in choices.
 
     Returns
@@ -298,9 +298,9 @@ def get_current_properties(
     ----------
     properties : dict[str, np.ndarray]
         The property values.
-    choices: dict[str, np.ndarray]
+    choices : dict[str, np.ndarray]
         The property value choices.
-    num_data: int
+    num_data : int
         The length of data that the properties represent (e.g. number of points).
 
     Returns

--- a/napari/settings/__init__.py
+++ b/napari/settings/__init__.py
@@ -29,7 +29,7 @@ def get_settings(path=_NOT_SET) -> NapariSettings:
 
     Parameters
     ----------
-    path: Path, optional
+    path : Path, optional
         The path to read/write the settings from.
 
     Returns

--- a/napari/utils/geometry.py
+++ b/napari/utils/geometry.py
@@ -61,13 +61,13 @@ def project_point_onto_plane(
 def rotation_matrix_from_vectors(vec_1, vec_2):
     """Calculate the rotation matrix that aligns vec1 to vec2.
 
-
     Parameters
     ----------
     vec_1 : np.ndarray
         The vector you want to rotate
     vec_2 : np.ndarray
         The vector you would like to align to.
+
     Returns
     -------
     rotation_matrix : np.ndarray
@@ -111,7 +111,7 @@ def clamp_point_to_bounding_box(point: np.ndarray, bounding_box: np.ndarray):
     point : np.ndarray
         n-dimensional point as an (n,) ndarray. Multiple points can
         be passed as an (n, D) array.
-    bounding_box: np.ndarray
+    bounding_box : np.ndarray
         n-dimensional bounding box as a (n, 2) ndarray
 
     Returns
@@ -133,7 +133,7 @@ def face_coordinate_from_bounding_box(
 
     Parameters
     ----------
-    bounding_box: np.ndarray
+    bounding_box : np.ndarray
         n-dimensional bounding box as a (n, 2) ndarray.
         Each row should contain the [min, max] extents for the
         axis.
@@ -168,7 +168,7 @@ def intersect_line_with_axis_aligned_plane(
 
     Parameters
     ----------
-    plane_intercept: float
+    plane_intercept : float
         The coordinate that the plane intersects on the axis to which plane is
         normal.
         For example, if the plane is described by y=42, plane_intercept is 42.


### PR DESCRIPTION
# Description

Misc doc formatting fixes, it look like more recent version of numpydoc don't like parameter names in the form `name`,`<space>`,`:`,`<nothing>` as they they think the parameter name include the space and colon.

Also a couple of renaming to match actual parameters names, and removal of non existing ones.
    
