### PR TITLE
Fix window geometry loading bug, and make `ApplicationSettings` types more accurate

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -149,52 +149,38 @@ class _QtMainWindow(QMainWindow):
         Load window layout settings from configuration.
         """
         settings = get_settings()
-        window_size = settings.application.window_size
-        window_state = settings.application.window_state
-        preferences_dialog_size = settings.application.preferences_size
         window_position = settings.application.window_position
 
-        # It's necessary to verify if the window/position value is valid with the current screen.
-        width, height = window_position
-        screen_shape = QApplication.desktop().geometry()
-        current_width = screen_shape.width()
-        current_height = screen_shape.height()
-        if current_width < width or current_height < height:
+        # It's necessary to verify if the window/position value is valid with
+        # the current screen.
+        if not window_position:
             window_position = (self.x(), self.y())
+        else:
+            width, height = window_position
+            screen_geo = QApplication.desktop().geometry()
+            if screen_geo.width() < width or screen_geo.height() < height:
+                window_position = (self.x(), self.y())
 
-        window_maximized = settings.application.window_maximized
-        window_fullscreen = settings.application.window_fullscreen
         return (
-            window_state,
-            window_size,
+            settings.application.window_state,
+            settings.application.window_size,
             window_position,
-            window_maximized,
-            window_fullscreen,
-            preferences_dialog_size,
+            settings.application.window_maximized,
+            settings.application.window_fullscreen,
+            settings.application.preferences_size,
         )
 
     def _get_window_settings(self):
-        """
-        Return current window settings.
+        """Return current window settings.
 
         Symmetric to the 'set_window_settings' setter.
         """
-        if self._window_size is None:
-            window_size = (self.width(), self.height())
-        else:
-            window_size = self._window_size
 
         window_fullscreen = self.isFullScreen()
-
         if window_fullscreen:
             window_maximized = self._maximized_flag
         else:
             window_maximized = self.isMaximized()
-
-        if self._window_pos is None:
-            window_position = (self.x(), self.y())
-        else:
-            window_position = self._window_pos
 
         preferences_dialog_size = (
             self._preferences_dialog_size.width(),
@@ -203,8 +189,8 @@ class _QtMainWindow(QMainWindow):
         window_state = qbytearray_to_str(self.saveState())
         return (
             window_state,
-            window_size,
-            window_position,
+            self._window_size or (self.width(), self.height()),
+            self._window_pos or (self.x(), self.y()),
             window_maximized,
             window_fullscreen,
             preferences_dialog_size,

--- a/napari/settings/_application.py
+++ b/napari/settings/_application.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from pydantic import Field, validator
 
@@ -59,14 +59,14 @@ class ApplicationSettings(EventedModel):
         title=trans._("Save window state"),
         description=trans._("Toggle saving the main window state of widgets."),
     )
-    window_position: Tuple[int, int] = Field(
+    window_position: Optional[Tuple[int, int]] = Field(
         None,
         title=trans._("Window position"),
         description=trans._(
             "Last saved x and y coordinates for the main window. This setting is managed by the application."
         ),
     )
-    window_size: Tuple[int, int] = Field(
+    window_size: Optional[Tuple[int, int]] = Field(
         None,
         title=trans._("Window size"),
         description=trans._(
@@ -87,7 +87,7 @@ class ApplicationSettings(EventedModel):
             "Last saved fullscreen state for the main window. This setting is managed by the application."
         ),
     )
-    window_state: str = Field(
+    window_state: Optional[str] = Field(
         None,
         title=trans._("Window state"),
         description=trans._(
@@ -101,7 +101,7 @@ class ApplicationSettings(EventedModel):
             "Toggle diplaying the status bar for the main window."
         ),
     )
-    preferences_size: Tuple[int, int] = Field(
+    preferences_size: Optional[Tuple[int, int]] = Field(
         None,
         title=trans._("Preferences size"),
         description=trans._(


### PR DESCRIPTION
# Description
Fixes a potential bug loading window geometry:

```
/Users/talley/Dropbox (HMS)/Python/forks/napari/napari/viewer.py:110: RuntimeWarning: The window geometry settings could not be loaded due to the following error: cannot unpack non-iterable NoneType object
  self.window.show(block=block)
```

And fixes the underlying settings schema that caused it: a few fields are marked as type `Tuple[int, int]` but give a default of None, so trying to unpack the iterable failed, but the type hints didn't indicate it.

... minimizing the code a bit in the process

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
