### PR TITLE
Tiny: fix missing import in napari.__init__.pyi

### DIFF
--- a/napari/__init__.pyi
+++ b/napari/__init__.pyi
@@ -1,3 +1,5 @@
+from typing import Callable
+
 import napari._qt.qt_event_loop
 import napari.plugins.io
 import napari.utils.notifications


### PR DESCRIPTION
# Description
fixes a missing import in `napari.__init__.pyi` from #3149