### PR TITLE
Move dock widgets

### DIFF
--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -170,25 +170,3 @@ def test_making_function_dock_widgets(test_plugin_widgets, make_napari_viewer):
     assert isinstance(magic_widget(), napari.Viewer)
     # Add twice is ok, only does a show
     actions[2].trigger()
-
-
-def test_clear_all_plugin_widgets(test_plugin_widgets, make_napari_viewer):
-    """Test the the 'Remove Dock Widgets' menu item clears added widgets."""
-    viewer = make_napari_viewer()
-    # only take the plugin actions
-    actions = viewer.window.plugins_menu.actions()
-    for cnt, action in enumerate(actions):
-        if action.text() == "":
-            # this is the separator
-            break
-    actions = actions[cnt + 1 :]
-    actions[1].trigger()
-    actions[0].menu().actions()[1].trigger()
-    assert len(viewer.window._dock_widgets) == 2
-    clear_action = next(
-        a
-        for a in viewer.window.window_menu.actions()
-        if a.text().startswith("Remove Dock Widgets")
-    )
-    clear_action.trigger()
-    assert len(viewer.window._dock_widgets) == 0

--- a/napari/_qt/menus/plugins_menu.py
+++ b/napari/_qt/menus/plugins_menu.py
@@ -18,12 +18,16 @@ class PluginsMenu(QMenu):
         from ...plugins import plugin_manager
 
         plugin_manager.discover_widgets()
-        plugin_manager.events.disabled.connect(self._rebuild)
-        plugin_manager.events.registered.connect(self._rebuild)
-        plugin_manager.events.unregistered.connect(self._rebuild)
-        self._rebuild()
+        plugin_manager.events.disabled.connect(
+            self._remove_unregistered_widget
+        )
+        plugin_manager.events.registered.connect(self._add_registered_widget)
+        plugin_manager.events.unregistered.connect(
+            self._remove_unregistered_widget
+        )
+        self._build()
 
-    def _rebuild(self, event=None):
+    def _build(self, event=None):
         from ...plugins import menu_item_template, plugin_manager
 
         self.clear()
@@ -61,8 +65,52 @@ class PluginsMenu(QMenu):
                     else:
                         self._win._add_plugin_function_widget(*key)
 
-                menu.addAction(action)
+                action.setCheckable(True)
+                # check that this wasn't added to the menu already
+                actions = [a.text() for a in menu.actions()]
+                if action.text() not in actions:
+                    menu.addAction(action)
                 action.triggered.connect(_add_widget)
+
+    def _remove_unregistered_widget(self, event=None):
+
+        for idx, action in enumerate(self.actions()):
+            if event.value in action.text():
+                self.removeAction(action)
+                self._win._remove_dock_widget(event=event)
+
+    def _add_registered_widget(self, event=None):
+        from ...plugins import menu_item_template, plugin_manager
+
+        for hook_type, (plugin_name, widgets) in plugin_manager.iter_widgets():
+            if event.value == plugin_name:
+                multiprovider = len(widgets) > 1
+                if multiprovider:
+                    menu = QMenu(plugin_name, self)
+                    self.addMenu(menu)
+                else:
+                    menu = self
+
+                for wdg_name in widgets:
+                    key = (plugin_name, wdg_name)
+                    if multiprovider:
+                        action = QAction(wdg_name, parent=self)
+                    else:
+                        full_name = menu_item_template.format(*key)
+                        action = QAction(full_name, parent=self)
+
+                    def _add_widget(*args, key=key, hook_type=hook_type):
+                        if hook_type == 'dock':
+                            self._win.add_plugin_dock_widget(*key)
+                        else:
+                            self._win._add_plugin_function_widget(*key)
+
+                    action.setCheckable(True)
+                    # check that this wasn't added to the menu already
+                    actions = [a.text() for a in menu.actions()]
+                    if action.text() not in actions:
+                        menu.addAction(action)
+                    action.triggered.connect(_add_widget)
 
     def _show_plugin_install_dialog(self):
         """Show dialog that allows users to sort the call order of plugins."""

--- a/napari/_qt/menus/window_menu.py
+++ b/napari/_qt/menus/window_menu.py
@@ -12,12 +12,5 @@ if TYPE_CHECKING:
 class WindowMenu(QMenu):
     def __init__(self, window: 'Window'):
         super().__init__(trans._('&Window'), window._qt_window)
-        ACTIONS = [
-            {
-                'text': trans._('Remove Dock Widgets'),
-                'slot': lambda e: window.remove_dock_widget('all'),
-                'statusTip': 'Remove all dock widgets',
-            },
-            {},
-        ]
+        ACTIONS = []
         populate_menu(self, ACTIONS)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -745,9 +745,56 @@ class Window:
             shortcut = dock_widget.shortcut
         if shortcut is not None:
             action.setShortcut(shortcut)
+
+        # dock widgets can have a menu item on the window menu or the plugin menu.
+
+        # check for plugins menu first.  Need to check submenus too.  If the action in the
+        # plugin menu is toggled for the first time, it will be replaced with the toggleViewAction
+        # directly in the plugins menu.
+        actions = [a.text() for a in self.plugins_menu.actions()]
+        if dock_widget.name in actions:
+            idx = actions.index(dock_widget.name)
+            old_action = self.plugins_menu.actions()[idx]
+            dock_widget.setVisible(True)
+            self.plugins_menu.insertAction(old_action, action)
+            self.plugins_menu.removeAction(old_action)
+            return
+        else:
+            # if the action is not here, it may be in a submenu
+            for cnt, current_action in enumerate(self.plugins_menu.actions()):
+                if current_action.menu() is not None:
+                    sub_actions = [
+                        plugin_menu_item_template.format(
+                            current_action.text(), a.text()
+                        )
+                        for a in current_action.menu().actions()
+                    ]
+                    if dock_widget.name in sub_actions:
+                        idx = sub_actions.index(dock_widget.name)
+                        old_action = (
+                            self.plugins_menu.actions()[cnt]
+                            .menu()
+                            .actions()[idx]
+                        )
+                        self.plugins_menu.actions()[cnt].menu().insertAction(
+                            old_action, action
+                        )
+                        self.plugins_menu.actions()[cnt].menu().removeAction(
+                            old_action
+                        )
+                        return
+
         self.window_menu.addAction(action)
 
-    def remove_dock_widget(self, widget: QWidget):
+    def _remove_dock_widget(self, event=None):
+        names = list(self._dock_widgets.keys())
+        for widget_name in names:
+            if event.value in widget_name:
+                # remove this widget
+                widget = self._dock_widgets[widget_name]
+                self.remove_dock_widget(widget)
+
+    def remove_dock_widget(self, widget: QWidget, menu=None):
         """Removes specified dock widget.
 
         If a QDockWidget is not provided, the existing QDockWidgets will be
@@ -783,7 +830,8 @@ class Window:
         if _dw.widget():
             _dw.widget().setParent(None)
         self._qt_window.removeDockWidget(_dw)
-        self.window_menu.removeAction(_dw.toggleViewAction())
+        if menu is not None:
+            menu.removeAction(_dw.toggleViewAction())
 
         # Remove dock widget from dictionary
         del self._dock_widgets[_dw.name]

--- a/napari/_qt/widgets/_tests/test_qt_dock_widget.py
+++ b/napari/_qt/widgets/_tests/test_qt_dock_widget.py
@@ -79,7 +79,7 @@ def test_remove_dock_widget_orphans_widget(make_napari_viewer):
     dw = viewer.window.add_dock_widget(widg, name='test')
     assert widg.parent() is dw
     assert dw.toggleViewAction() in viewer.window.window_menu.actions()
-    viewer.window.remove_dock_widget(dw)
+    viewer.window.remove_dock_widget(dw, menu=viewer.window.window_menu)
     assert dw.toggleViewAction() not in viewer.window.window_menu.actions()
     del dw
     # if dw didn't release widg, we'd get an exception when next accessing widg


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->

This PR will take plugin dock widgets off the window menu and only show them on the plugins menu.  When a plugin is installed, it will appear on the plugins drop down menu, and you can toggle its visibility from there.  
I also added a value to the application settings to remember which dock widgets were left opened on the viewer for both the plugins menu and the window menu.  So, if you re-open napari, it will open with same dock widgets in place.  If you uninstall a plugin, it will remove it from settings as well as from the plugins menu.

I need to add a few docstrings, but I'd appreciate a look at the code.  :)

Note:  this is part 1 of a few steps for #3101 

https://user-images.githubusercontent.com/54282105/129751316-69dfd916-d789-4e55-9646-9929c9fce95e.mov


