### PR TITLE
Catch and prune connections to stale Qt callbacks in events.py

### DIFF
--- a/napari/_qt/_tests/test_prune_qt_connections.py
+++ b/napari/_qt/_tests/test_prune_qt_connections.py
@@ -1,0 +1,37 @@
+from unittest.mock import Mock
+
+from qtpy.QtWidgets import QSpinBox
+
+from napari.utils.events import EmitterGroup
+
+
+def test_prune_dead_qt(qtbot):
+    qtcalls = 0
+
+    class W(QSpinBox):
+        def _set(self, event):
+            self.setValue(event.value)
+            nonlocal qtcalls
+            qtcalls += 1
+
+    wdg = W()
+
+    mock = Mock()
+    group = EmitterGroup(None, False, boom=None)
+    group.boom.connect(mock)
+    group.boom.connect(wdg._set)
+    assert len(group.boom.callbacks) == 2
+
+    group.boom(value=1)
+    assert qtcalls == 1
+    mock.assert_called_once()
+    mock.reset_mock()
+
+    with qtbot.waitSignal(wdg.destroyed):
+        wdg.close()
+        wdg.deleteLater()
+
+    group.boom(value=1)
+    mock.assert_called_once()
+    assert len(group.boom.callbacks) == 1  # we've lost the qt connection
+    assert qtcalls == 1  # qwidget didn't get called again

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -599,8 +599,8 @@ class EventEmitter:
             # here... but this error is consistent across backends
             if (
                 isinstance(e, RuntimeError)
-                and str(e).startswith('wrapped')
-                and 'has been deleted' in str(e)
+                and 'C++' in str(e)
+                and str(e).endswith(('has been deleted', 'already deleted.'))
             ):
                 self.disconnect(cb)
                 return


### PR DESCRIPTION
# Description
Curious to get peoples' feelings on this.  cc @goanpeca, @sofroniewn 

In working on #3184, it became clear that the biggest hurdle to reuse of our evented objects (after closing a Qt window), is the fact that python wrappers for "deleted" QtObjects stick around long after the QObject is deleted, causing the classic `RuntimeError: wrapped C/C++ object has been deleted` problem if an `EventEmitter` tries to call a method that belongs to a dead object.

`events.py` already _does_ try to catch whether a connected callback is no longer useful: it stores weakrefs to the object that owns the callback method, and if that object has been garbage collected, [simply refuses to call the callback and deletes it](https://github.com/napari/napari/blob/52c449a675ebf90540188c5a05b46638aca7bbac/napari/utils/events/event.py#L560-L565).  It seems to me that we should also have that behavior for connected Qt objects...  but it's a bit tricker since their python wrappers don't get garbage collected.  

This PR catches a call to a dead Qt object and quietly deletes the callback, just as it would for a dead non-Qt python object.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
