### PR TITLE
Print warning if error formatting in the console fails instead of ignoring errors.

### DIFF
--- a/napari/_qt/widgets/qt_dims_slider.py
+++ b/napari/_qt/widgets/qt_dims_slider.py
@@ -292,7 +292,7 @@ class QtDimSliderWidget(QWidget):
                 reversing direction when the maximum or minimum frame
                 has been reached.
         """
-        assert value in LoopMode.keys()
+        value = LoopMode(value)
         self._loop_mode = value
         self.play_button.mode_combo.setCurrentText(
             str(value).replace('_', ' ')

--- a/napari/_qt/widgets/qt_dims_slider.py
+++ b/napari/_qt/widgets/qt_dims_slider.py
@@ -292,6 +292,7 @@ class QtDimSliderWidget(QWidget):
                 reversing direction when the maximum or minimum frame
                 has been reached.
         """
+        assert value in LoopMode.keys()
         self._loop_mode = value
         self.play_button.mode_combo.setCurrentText(
             str(value).replace('_', ' ')

--- a/napari/utils/notifications.py
+++ b/napari/utils/notifications.py
@@ -292,15 +292,24 @@ def show_info(message: str):
 
 
 def show_console_notification(notification: Notification):
-    from ..settings import get_settings
+    try:
+        from ..settings import get_settings
 
-    if (
-        notification.severity
-        < get_settings().application.console_notification_level
-    ):
-        return
+        if (
+            notification.severity
+            < get_settings().application.console_notification_level
+        ):
+            return
 
-    print(notification)
+        print(notification)
+    except Exception:
+        print(
+            "An error occurred while trying to format an error and show it in console.\n"
+            "You can try to uninstall IPython to disable rich traceback formatting\n"
+            "And/or report a bug to napari"
+        )
+        # this will likely get silenced by QT.
+        raise
 
 
 def _setup_thread_excepthook():


### PR DESCRIPTION
Found while reviewing #3178

This typo:

https://github.com/napari/napari/pull/3178/files#r689815054

Should have triggered a traceback somewhere, but did not.

I tracked that down to the IPython Verbose traceback formatter,
when trying to inspect some frames to display the local variables,
it triggers a SyntaxError when accessing a frame attribute.

More precisely:

    > frame_info.variables_in_executing_piece

raises a SyntaxError (i'm guessing this goes deeper into stackdata).

I'll add a workaround in IPython to not raise but show "Exception trying
to inspect frame. No more locals available." when we can't see locals,
but in the meantime this at least let napari users see that something is
wrong.

I'm also asserting the loops values are correct to help with #3178 

