### PR TITLE
Fix incorrect use of dims_order when 3D painting

### DIFF
--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1059,7 +1059,7 @@ class Labels(_ImageBase):
         ):
             return
 
-        dims_to_fill = self._dims_order[-self.n_edit_dimensions :]
+        dims_to_fill = sorted(self._dims_order[-self.n_edit_dimensions :])
         data_slice_list = list(int_coord)
         for dim in dims_to_fill:
             data_slice_list[dim] = slice(None)
@@ -1118,8 +1118,8 @@ class Labels(_ImageBase):
             calls.
         """
         shape = self.data.shape
-        dims_to_paint = self._dims_order[-self.n_edit_dimensions :]
-        dims_not_painted = self._dims_order[: -self.n_edit_dimensions]
+        dims_to_paint = sorted(self._dims_order[-self.n_edit_dimensions :])
+        dims_not_painted = sorted(self._dims_order[: -self.n_edit_dimensions])
         paint_scale = np.array(
             [self.scale[i] for i in dims_to_paint], dtype=float
         )


### PR DESCRIPTION
# Description

`layer._dims_order` contains the displayed dimensions, but on the data array the axes remain in sorted order. Therefore, painting and filling was happening along the incorrect axes with the current code. With this PR, the data order is maintained correctly when painting and filling in the Labels layer.

I'm gonna use the "I'm on holiday card" and not write a test for this yet 😂. I think it should merge before the next release though or I would just leave the whole thing till after I'm back. @sofroniewn, if you want to merge and create an issue for adding tests here assigned to me, that would be 👌.

Obviously I'm ok with waiting to merge till I'm back and can add tests, but it's a pretty significant bug if editing non-contiguous dims.

