### PR TITLE
Ensure we save a *copy* of existing value for undo

### DIFF
--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1093,7 +1093,11 @@ class Labels(_ImageBase):
             match_indices = match_indices_local
 
         self._save_history(
-            (match_indices, self.data[match_indices], new_label)
+            (
+                match_indices,
+                np.array(self.data[match_indices], copy=True),
+                new_label,
+            )
         )
 
         # Replace target pixels with new_label
@@ -1180,7 +1184,13 @@ class Labels(_ImageBase):
             slice_coord = tuple(sc[keep_coords] for sc in slice_coord)
 
         # save the existing values to the history
-        self._save_history((slice_coord, self.data[slice_coord], new_label))
+        self._save_history(
+            (
+                slice_coord,
+                np.array(self.data[slice_coord], copy=True),
+                new_label,
+            )
+        )
 
         # update the labels image
         self.data[slice_coord] = new_label


### PR DESCRIPTION
# Description

When adding a value to the undo history, we need to make sure it's a copy. If it's a reference, undoing will fail, because it will point to the already-edited values within the array. With NumPy, all fancy indexing returns a copy, but with other arrays (specifically, tensorstore arrays), we get a reference, so undoing reduces to "set layer.data[index] to layer.data[index]", which goes about as well as can be expected. :joy:

This only affects a relatively small niche of users I think, so can probably wait till after I'm back from holidays/next release to merge. But I won't stop anyone! :joy:
