### PR TITLE
Don't start gui qt event loop when building docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ docs:
 	find docs/api ! -name 'index.rst' -type f -exec rm -f {} +
 	pip install -qr docs/requirements.txt
 	python docs/update_docs.py
+	NAPARI_APPLICATION_IPY_INTERACTIVE=0
 	jb build docs
+	unset NAPARI_APPLICATION_IPY_INTERACTIVE
 
 typestubs:
 	python -m napari.utils.stubgen


### PR DESCRIPTION
# Description
This PR adds a flag which tells napari not to try to start an interactive "gui qt" event loop when building the docs, see discussion on [zulip](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/ipython.20issues.2C.20how.20was.20it.20done.20in.20our.20docs.3F/near/250164309)

cc @tlambert03 

