### PR TITLE
Add note detailing current octree support

### DIFF
--- a/docs/guides/rendering.md
+++ b/docs/guides/rendering.md
@@ -73,6 +73,15 @@ class will use the same
 instead of the Vispy `ImageVisual` class that napari's
 {class}`~napari.layers.Image` class uses.
 
+---
+**NOTE**
+
+The current `OCTREE` implementation only fully supports 2D images and
+may not function with 3D and/or multiscale images. Improving support
+for 3D and multiscale images is part of future work on the `OCTREE`.
+
+---
+
 See {ref}`octree-config` for Octree configuration options.
 
 ### Octree Visuals

--- a/docs/guides/rendering.md
+++ b/docs/guides/rendering.md
@@ -74,9 +74,9 @@ instead of the Vispy `ImageVisual` class that napari's
 {class}`~napari.layers.Image` class uses.
 
 
->The current `OCTREE` implementation only fully supports 2D images and
->may not function with 3D and/or multiscale images. Improving support
->for 3D and multiscale images is part of future work on the `OCTREE`.
+>The current `OCTREE` implementation only fully supports a single 2D images and
+>may not function with 3D images or multiple images. Improving support
+>for 3D and multiple images is part of future work on the `OCTREE`.
 
 
 See {ref}`octree-config` for Octree configuration options.

--- a/docs/guides/rendering.md
+++ b/docs/guides/rendering.md
@@ -73,14 +73,11 @@ class will use the same
 instead of the Vispy `ImageVisual` class that napari's
 {class}`~napari.layers.Image` class uses.
 
----
-**NOTE**
 
-The current `OCTREE` implementation only fully supports 2D images and
-may not function with 3D and/or multiscale images. Improving support
-for 3D and multiscale images is part of future work on the `OCTREE`.
+>The current `OCTREE` implementation only fully supports 2D images and
+>may not function with 3D and/or multiscale images. Improving support
+>for 3D and multiscale images is part of future work on the `OCTREE`.
 
----
 
 See {ref}`octree-config` for Octree configuration options.
 


### PR DESCRIPTION
# Description
This PR clarifies that `OCTREE` currently only fully supports 2D images to avoid user confusion as in #3049.

I wasn't sure how to add a styled note to the markdown file, to match the styling we have in our rst documents like [here](https://napari.org/plugins/stable/for_plugin_developers.html#step-1-choose-a-hook-specification-to-implement). @kne42 is that even possible?
