### PR TITLE
Add napari_write_tracks to hook spec reference

### DIFF
--- a/docs/plugins/hook_specifications.rst
+++ b/docs/plugins/hook_specifications.rst
@@ -34,6 +34,7 @@ from ``Layer.data``, and a ``meta`` dict that will correspond to the layer's
 .. autofunction:: napari_write_points
 .. autofunction:: napari_write_shapes
 .. autofunction:: napari_write_surface
+.. autofunction:: napari_write_tracks
 .. autofunction:: napari_write_vectors
 
 Analysis hooks


### PR DESCRIPTION
# Description
Based on the diagram @kne42 posted [here](https://github.com/napari/napari.github.io/pull/144#issuecomment-901316137), I believe this is the change required to close out #2859 and add `napari_write_tracks` to our hook spec reference. This change should then be reflected on napari.org with our next release, as I understand it.

## Type of change
Documentation update.

# References
Closes #2859
