### PR TITLE
Fix plugin settings restore and schema_version validation error in preferences dialog

### DIFF
--- a/docs/release/release_0_4_11.md
+++ b/docs/release/release_0_4_11.md
@@ -127,6 +127,7 @@ Last but not least, some common operations are now much more accessible from the
 - Fix missing import in napari.__init__.pyi (#3183)
 - Fix incorrect window position storage (#3196)
 - Fix incorrect use of dims_order when 3D painting (#3202)
+- Fix plugin settings restore and schema_version validation error in preferences dialog (#3215)
 
 
 ## API Changes

--- a/napari/_qt/dialogs/_tests/test_preferences_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_preferences_dialog.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import pytest
 from qtpy.QtCore import Qt
 
@@ -6,6 +8,9 @@ from napari._qt.dialogs.preferences_dialog import (
     QMessageBox,
 )
 from napari.settings import get_settings
+
+if TYPE_CHECKING:
+    from napari.plugins import NapariPluginManager
 
 
 @pytest.fixture
@@ -56,3 +61,10 @@ def test_preferences_dialog_restore(qtbot, pref, monkeypatch):
     )
     pref._restore_default_dialog()
     assert get_settings().appearance.theme == 'dark'
+
+
+def test_cancel_plugins(qtbot, pref, napari_plugin_manager):
+    pm: NapariPluginManager = napari_plugin_manager
+    print(pm.call_order())
+    with qtbot.waitSignal(pref.finished):
+        pref._button_cancel.click()

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -66,7 +66,6 @@ class PreferencesDialog(QDialog):
         self.layout().addWidget(self._stack, 3)
 
         # Build dialog from settings
-        self._starting_values = {}
         self._rebuild_dialog()
 
     def keyPressEvent(self, e: 'QKeyEvent'):
@@ -85,7 +84,10 @@ class PreferencesDialog(QDialog):
 
     def _rebuild_dialog(self):
         """Removes settings not to be exposed to user and creates dialog pages."""
+        # FIXME: this dialog should not need to know about the plugin manager
+        from ...plugins import plugin_manager
 
+        self._starting_pm_order = plugin_manager.call_order()
         self._starting_values = self._settings.dict(exclude={'schema_version'})
 
         self._list.clear()
@@ -93,7 +95,9 @@ class PreferencesDialog(QDialog):
             self._stack.removeWidget(self._stack.currentWidget())
 
         for field in self._settings.__fields__.values():
-            if isinstance(field.type_, BaseModel):
+            if isinstance(field.type_, type) and issubclass(
+                field.type_, BaseModel
+            ):
                 self._add_page(field)
 
         self._list.setCurrentRow(0)
@@ -161,8 +165,8 @@ class PreferencesDialog(QDialog):
         napari_config = getattr(setting, "NapariConfig", None)
         if hasattr(napari_config, 'preferences_exclude'):
             for val in napari_config.preferences_exclude:
-                schema['properties'].pop(val)
-                values.pop(val)
+                schema['properties'].pop(val, None)
+                values.pop(val, None)
 
         return schema, values
 
@@ -195,6 +199,11 @@ class PreferencesDialog(QDialog):
 
     def reject(self):
         """Restores the settings in place when dialog was launched."""
-        print(self._starting_values)
         self._settings.update(self._starting_values)
+
+        # FIXME: this dialog should not need to know about the plugin manager
+        if self._starting_pm_order:
+            from ...plugins import plugin_manager
+
+            plugin_manager.set_call_order(self._starting_pm_order)
         super().reject()

--- a/napari/settings/_appearance.py
+++ b/napari/settings/_appearance.py
@@ -1,14 +1,11 @@
-from typing import Tuple, Union
-
 from pydantic import Field
 
 from ..utils.events.evented_model import EventedModel
 from ..utils.translations import trans
-from ._fields import SchemaVersion, Theme
+from ._fields import Theme
 
 
 class AppearanceSettings(EventedModel):
-    schema_version: Union[SchemaVersion, Tuple[int, int, int]] = (0, 1, 1)
     theme: Theme = Field(
         "dark",
         title=trans._("Theme"),

--- a/napari/settings/_appearance.py
+++ b/napari/settings/_appearance.py
@@ -8,21 +8,13 @@ from ._fields import SchemaVersion, Theme
 
 
 class AppearanceSettings(EventedModel):
-    # 1. If you want to *change* the default value of a current option, you need to
-    #    do a MINOR update in config version, e.g. from 3.0.0 to 3.1.0
-    # 2. If you want to *remove* options that are no longer needed in the codebase,
-    #    or if you want to *rename* options, then you need to do a MAJOR update in
-    #    version, e.g. from 3.0.0 to 4.0.0
-    # 3. You don't need to touch this value if you're just adding a new option
     schema_version: Union[SchemaVersion, Tuple[int, int, int]] = (0, 1, 1)
-
     theme: Theme = Field(
         "dark",
         title=trans._("Theme"),
         description=trans._("Select the user interface theme."),
         env="napari_theme",
     )
-
     highlight_thickness: int = Field(
         1,
         title=trans._("Highlight thickness"),
@@ -32,7 +24,6 @@ class AppearanceSettings(EventedModel):
         ge=1,
         le=10,
     )
-
     layer_tooltip_visibility: bool = Field(
         False,
         title=trans._("Show layer tooltips"),

--- a/napari/settings/_application.py
+++ b/napari/settings/_application.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 
 from pydantic import Field, validator
 
@@ -10,7 +10,7 @@ from ..utils.events.evented_model import EventedModel
 from ..utils.notifications import NotificationSeverity
 from ..utils.translations import trans
 from ._constants import LoopMode
-from ._fields import Language, SchemaVersion
+from ._fields import Language
 
 GridStride = conint(ge=-50, le=50, ne=0)
 GridWidth = conint(ge=-1, ne=0)
@@ -18,13 +18,6 @@ GridHeight = conint(ge=-1, ne=0)
 
 
 class ApplicationSettings(EventedModel):
-    # 1. If you want to *change* the default value of a current option, you need to
-    #    do a MINOR update in config version, e.g. from 3.0.0 to 3.1.0
-    # 2. If you want to *remove* options that are no longer needed in the codebase,
-    #    or if you want to *rename* options, then you need to do a MAJOR update in
-    #    version, e.g. from 3.0.0 to 4.0.0
-    # 3. You don't need to touch this value if you're just adding a new option
-    schema_version: Union[SchemaVersion, Tuple[int, int, int]] = (0, 2, 1)
     first_time: bool = Field(
         True,
         title=trans._('First time'),

--- a/napari/settings/_experimental.py
+++ b/napari/settings/_experimental.py
@@ -1,23 +1,14 @@
-from typing import Tuple, Union
+from typing import Union
 
 from pydantic import Field
 
 from ..utils.translations import trans
 from ._base import EventedSettings
-from ._fields import SchemaVersion
+
 
 # this class inherits from EventedSettings instead of EventedModel because
 # it uses Field(env=...) for one of its attributes
-
-
 class ExperimentalSettings(EventedSettings):
-    # 1. If you want to *change* the default value of a current option, you need to
-    #    do a MINOR update in config version, e.g. from 3.0.0 to 3.1.0
-    # 2. If you want to *remove* options that are no longer needed in the codebase,
-    #    or if you want to *rename* options, then you need to do a MAJOR update in
-    #    version, e.g. from 3.0.0 to 4.0.0
-    # 3. You don't need to touch this value if you're just adding a new option
-    schema_version: Union[SchemaVersion, Tuple[int, int, int]] = (0, 1, 0)
     octree: Union[bool, str] = Field(
         False,
         title=trans._("Enable Asynchronous Tiling of Images"),
@@ -27,7 +18,6 @@ class ExperimentalSettings(EventedSettings):
         type='boolean',  # need to specify to build checkbox in preferences.
         requires_restart=True,
     )
-
     async_: bool = Field(
         False,
         title=trans._("Render Images Asynchronously"),

--- a/napari/settings/_napari_settings.py
+++ b/napari/settings/_napari_settings.py
@@ -29,6 +29,7 @@ class NapariSettings(EventedConfigFileSettings):
     schema_version: Tuple[int, int, int] = Field(
         (0, 3, 0),
         description=trans._("Napari settings schema version."),
+        allow_mutation=False,
     )
     application: ApplicationSettings = Field(
         default_factory=ApplicationSettings,

--- a/napari/settings/_napari_settings.py
+++ b/napari/settings/_napari_settings.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 from pydantic import Field
 
@@ -20,6 +20,16 @@ _DEFAULT_CFG_PATH = Path(_DEFAULT_CFG_PATH) if _DEFAULT_CFG_PATH else None
 class NapariSettings(EventedConfigFileSettings):
     """Schema for napari settings."""
 
+    # 1. If you want to *change* the default value of a current option, you need to
+    #    do a MINOR update in config version, e.g. from 3.0.0 to 3.1.0
+    # 2. If you want to *remove* options that are no longer needed in the codebase,
+    #    or if you want to *rename* options, then you need to do a MAJOR update in
+    #    version, e.g. from 3.0.0 to 4.0.0
+    # 3. You don't need to touch this value if you're just adding a new option
+    schema_version: Tuple[int, int, int] = Field(
+        (0, 3, 0),
+        description=trans._("Napari settings schema version."),
+    )
     application: ApplicationSettings = Field(
         default_factory=ApplicationSettings,
         title=trans._("Application"),

--- a/napari/settings/_plugins.py
+++ b/napari/settings/_plugins.py
@@ -1,11 +1,10 @@
-from typing import Dict, List, Set, Tuple, Union
+from typing import Dict, List, Set
 
 from pydantic import Field
 from typing_extensions import TypedDict
 
 from ..utils.events.evented_model import EventedModel
 from ..utils.translations import trans
-from ._fields import SchemaVersion
 
 
 class PluginHookOption(TypedDict):
@@ -19,13 +18,6 @@ CallOrderDict = Dict[str, List[PluginHookOption]]
 
 
 class PluginsSettings(EventedModel):
-    # 1. If you want to *change* the default value of a current option, you need to
-    #    do a MINOR update in config version, e.g. from 3.0.0 to 3.1.0
-    # 2. If you want to *remove* options that are no longer needed in the codebase,
-    #    or if you want to *rename* options, then you need to do a MAJOR update in
-    #    version, e.g. from 3.0.0 to 4.0.0
-    # 3. You don't need to touch this value if you're just adding a new option
-    schema_version: Union[SchemaVersion, Tuple[int, int, int]] = (0, 1, 1)
     call_order: CallOrderDict = Field(
         default_factory=dict,
         title=trans._("Plugin sort order"),

--- a/napari/settings/_shortcuts.py
+++ b/napari/settings/_shortcuts.py
@@ -1,21 +1,13 @@
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List
 
 from pydantic import Field
 
 from ..utils.events.evented_model import EventedModel
 from ..utils.shortcuts import default_shortcuts
 from ..utils.translations import trans
-from ._fields import SchemaVersion
 
 
 class ShortcutsSettings(EventedModel):
-    # 1. If you want to *change* the default value of a current option, you need to
-    #    do a MINOR update in config version, e.g. from 3.0.0 to 3.1.0
-    # 2. If you want to *remove* options that are no longer needed in the codebase,
-    #    or if you want to *rename* options, then you need to do a MAJOR update in
-    #    version, e.g. from 3.0.0 to 4.0.0
-    # 3. You don't need to touch this value if you're just adding a new option
-    schema_version: Union[SchemaVersion, Tuple[int, int, int]] = (0, 1, 1)
     shortcuts: Dict[str, List[str]] = Field(
         default_shortcuts,
         title=trans._("shortcuts"),

--- a/napari/settings/_tests/test_settings.py
+++ b/napari/settings/_tests/test_settings.py
@@ -181,6 +181,8 @@ def test_model_fields_are_annotated(test_settings):
     errors = []
     for field in test_settings.__fields__.values():
         model = field.type_
+        if not hasattr(model, '__fields__'):
+            continue
         difference = set(model.__fields__) - set(model.__annotations__)
         if difference:
             errors.append(

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -164,7 +164,10 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
         for name, value in self._defaults.items():
             if isinstance(value, EventedModel):
                 getattr(self, name).reset()
-            else:
+            elif (
+                self.__config__.allow_mutation
+                and self.__fields__[name].field_info.allow_mutation
+            ):
                 setattr(self, name, value)
 
     def asdict(self):


### PR DESCRIPTION
# Description
This fixes items 3 and 4 from #3206 ... probably want to get this in for 0.4.11

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
