### PR TITLE
Fix typo, add proper note markdown

### DIFF
--- a/docs/guides/rendering.md
+++ b/docs/guides/rendering.md
@@ -73,11 +73,11 @@ class will use the same
 instead of the Vispy `ImageVisual` class that napari's
 {class}`~napari.layers.Image` class uses.
 
-
->The current `OCTREE` implementation only fully supports a single 2D images and
->may not function with 3D images or multiple images. Improving support
->for 3D and multiple images is part of future work on the `OCTREE`.
-
+```{note}
+The current `OCTREE` implementation only fully supports a single 2D image and
+may not function with 3D images or multiple images. Improving support
+for 3D and multiple images is part of future work on the `OCTREE`.
+```
 
 See {ref}`octree-config` for Octree configuration options.
 


### PR DESCRIPTION
# Description
Tiny PR fixing typo in note about octree and making it proper markdown note.
