### PR TITLE
Skip labeled sliders for <5.14

### DIFF
--- a/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -8,11 +8,11 @@ from qtpy.QtCore import Qt
 from qtpy.QtGui import QImage, QPixmap
 from qtpy.QtWidgets import QHBoxLayout, QLabel, QPushButton, QWidget
 from superqt import QDoubleRangeSlider
-from superqt import QLabeledDoubleSlider as QSlider
 
 from ...utils.colormaps import AVAILABLE_COLORMAPS
 from ...utils.translations import trans
 from ..utils import qt_signals_blocked
+from ..widgets._slider_compat import QDoubleSlider
 from ..widgets.qt_range_slider_popup import QRangeSliderPopup
 from .qt_colormap_combobox import QtColormapComboBox
 from .qt_layer_controls_base import QtLayerControls
@@ -90,7 +90,7 @@ class QtBaseImageControls(QtLayerControls):
         self.autoScaleBar = AutoScaleButtons(layer, self)
 
         # gamma slider
-        sld = QSlider(Qt.Horizontal, parent=self)
+        sld = QDoubleSlider(Qt.Horizontal, parent=self)
         sld.setMinimum(0.2)
         sld.setMaximum(2)
         sld.setSingleStep(0.02)

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -1,5 +1,4 @@
 import numpy as np
-from qtpy import QT_VERSION
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor, QPainter
 from qtpy.QtWidgets import (
@@ -8,14 +7,9 @@ from qtpy.QtWidgets import (
     QComboBox,
     QHBoxLayout,
     QLabel,
-    QSlider,
     QSpinBox,
     QWidget,
 )
-
-if tuple(int(x) for x in QT_VERSION.split(".")) >= (5, 13):
-    from superqt import QLabeledSlider as QSlider  # noqa
-
 from superqt import QLargeIntSpinBox
 
 from ...layers.image._image_constants import Rendering
@@ -30,6 +24,7 @@ from ...utils.events import disconnect_events
 from ...utils.interactions import Shortcut
 from ...utils.translations import trans
 from ..utils import disable_with_opacity
+from ..widgets._slider_compat import QSlider
 from ..widgets.qt_mode_buttons import QtModePushButton, QtModeRadioButton
 from .qt_layer_controls_base import QtLayerControls
 

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -1,4 +1,5 @@
 import numpy as np
+from qtpy import QT_VERSION
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor, QPainter
 from qtpy.QtWidgets import (
@@ -7,10 +8,14 @@ from qtpy.QtWidgets import (
     QComboBox,
     QHBoxLayout,
     QLabel,
+    QSlider,
     QSpinBox,
     QWidget,
 )
-from superqt import QLabeledSlider as QSlider
+
+if tuple(int(x) for x in QT_VERSION.split(".")) >= (5, 13):
+    from superqt import QLabeledSlider as QSlider  # noqa
+
 from superqt import QLargeIntSpinBox
 
 from ...layers.image._image_constants import Rendering

--- a/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -1,9 +1,9 @@
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QComboBox, QFrame, QGridLayout
-from superqt import QLabeledDoubleSlider
 
 from ...layers.base._base_constants import BLENDING_TRANSLATIONS
 from ...utils.events import disconnect_events
+from ..widgets._slider_compat import QDoubleSlider
 
 
 class QtLayerControls(QFrame):
@@ -47,7 +47,7 @@ class QtLayerControls(QFrame):
         self.grid_layout.setColumnStretch(1, 1)
         self.setLayout(self.grid_layout)
 
-        sld = QLabeledDoubleSlider(Qt.Horizontal, parent=self)
+        sld = QDoubleSlider(Qt.Horizontal, parent=self)
         sld.setFocusPolicy(Qt.NoFocus)
         sld.setMinimum(0)
         sld.setMaximum(1)

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -1,5 +1,4 @@
 import numpy as np
-from qtpy import QT_VERSION
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import (
     QButtonGroup,
@@ -7,17 +6,14 @@ from qtpy.QtWidgets import (
     QComboBox,
     QHBoxLayout,
     QLabel,
-    QSlider,
 )
-
-if tuple(int(x) for x in QT_VERSION.split(".")) >= (5, 13):
-    from superqt import QLabeledSlider as QSlider  # noqa
 
 from ...layers.points._points_constants import SYMBOL_TRANSLATION, Mode
 from ...utils.action_manager import action_manager
 from ...utils.events import disconnect_events
 from ...utils.translations import trans
 from ..utils import disable_with_opacity, qt_signals_blocked
+from ..widgets._slider_compat import QSlider
 from ..widgets.qt_color_swatch import QColorSwatchEdit
 from ..widgets.qt_mode_buttons import QtModePushButton, QtModeRadioButton
 from .qt_layer_controls_base import QtLayerControls

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -1,4 +1,5 @@
 import numpy as np
+from qtpy import QT_VERSION
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import (
     QButtonGroup,
@@ -6,8 +7,11 @@ from qtpy.QtWidgets import (
     QComboBox,
     QHBoxLayout,
     QLabel,
+    QSlider,
 )
-from superqt import QLabeledSlider as QSlider
+
+if tuple(int(x) for x in QT_VERSION.split(".")) >= (5, 13):
+    from superqt import QLabeledSlider as QSlider  # noqa
 
 from ...layers.points._points_constants import SYMBOL_TRANSLATION, Mode
 from ...utils.action_manager import action_manager

--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -1,9 +1,18 @@
 from collections.abc import Iterable
 
 import numpy as np
+from qtpy import QT_VERSION
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QButtonGroup, QCheckBox, QGridLayout, QLabel
-from superqt import QLabeledSlider as QSlider
+from qtpy.QtWidgets import (
+    QButtonGroup,
+    QCheckBox,
+    QGridLayout,
+    QLabel,
+    QSlider,
+)
+
+if tuple(int(x) for x in QT_VERSION.split(".")) >= (5, 13):
+    from superqt import QLabeledSlider as QSlider  # noqa
 
 from ...layers.shapes._shapes_constants import Mode
 from ...utils.action_manager import action_manager

--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -1,18 +1,8 @@
 from collections.abc import Iterable
 
 import numpy as np
-from qtpy import QT_VERSION
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import (
-    QButtonGroup,
-    QCheckBox,
-    QGridLayout,
-    QLabel,
-    QSlider,
-)
-
-if tuple(int(x) for x in QT_VERSION.split(".")) >= (5, 13):
-    from superqt import QLabeledSlider as QSlider  # noqa
+from qtpy.QtWidgets import QButtonGroup, QCheckBox, QGridLayout, QLabel
 
 from ...layers.shapes._shapes_constants import Mode
 from ...utils.action_manager import action_manager
@@ -20,6 +10,7 @@ from ...utils.events import disconnect_events
 from ...utils.interactions import Shortcut
 from ...utils.translations import trans
 from ..utils import disable_with_opacity, qt_signals_blocked
+from ..widgets._slider_compat import QSlider
 from ..widgets.qt_color_swatch import QColorSwatchEdit
 from ..widgets.qt_mode_buttons import QtModePushButton, QtModeRadioButton
 from .qt_layer_controls_base import QtLayerControls

--- a/napari/_qt/widgets/_slider_compat.py
+++ b/napari/_qt/widgets/_slider_compat.py
@@ -3,6 +3,6 @@ from qtpy.QtWidgets import QSlider  # noqa
 from superqt import QDoubleSlider
 
 # here until we can debug why labeled sliders render differently on 5.12
-if tuple(int(x) for x in QT_VERSION.split(".")) >= (5, 13):
+if tuple(int(x) for x in QT_VERSION.split(".")) >= (5, 14):
     from superqt import QLabeledDoubleSlider as QDoubleSlider  # noqa
     from superqt import QLabeledSlider as QSlider  # noqa

--- a/napari/_qt/widgets/_slider_compat.py
+++ b/napari/_qt/widgets/_slider_compat.py
@@ -1,0 +1,8 @@
+from qtpy import QT_VERSION
+from qtpy.QtWidgets import QSlider  # noqa
+from superqt import QDoubleSlider
+
+# here until we can debug why labeled sliders render differently on 5.12
+if tuple(int(x) for x in QT_VERSION.split(".")) >= (5, 13):
+    from superqt import QLabeledDoubleSlider as QDoubleSlider  # noqa
+    from superqt import QLabeledSlider as QSlider  # noqa


### PR DESCRIPTION
# Description
This is a temporary workaround to #3221...
After some tinkering,I'm still not sure why I can't get a QDoubleSpinbox to have very minimal padding on 5.12.  (QLabeledSliders use Spinboxes as their labels)... I tried all the standard tricks I could think of (padding, margings, contentsmargins, etc), but a good amount of dead space remains such that when I make the widget itself a smaller width, the text gets clipped.

This PR uses labeled sliders from #2753 only if we're running Qt 5.14 or later... this might be enough for 0.4.11 release, and we can circle back around to the stylings for earlier qt in a followup PR.


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
