### PR TITLE
Prevent greedy dask array calculation when creating an Image layer

### DIFF
--- a/docs/release/release_0_4_11.md
+++ b/docs/release/release_0_4_11.md
@@ -130,7 +130,7 @@ Last but not least, some common operations are now much more accessible from the
 - Fix incorrect window position storage (#3196)
 - Fix incorrect use of dims_order when 3D painting (#3202)
 - Fix plugin settings restore and schema_version validation error in preferences dialog (#3215)
-
+- Prevent greedy dask array calculation when creating an Image layer #3248
 
 ## API Changes
 - Remove brush shape (#3047)

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -58,19 +58,6 @@ def clean_current(monkeypatch, qtbot):
     monkeypatch.setattr(NapariQtNotification, "show", store_widget)
 
 
-@pytest.mark.skipif(PY37_OR_LOWER, reason="Fails on py37")
-def test_notifications_error_with_threading(make_napari_viewer):
-    """Test notifications of `threading` threads, using a dask example."""
-    random_image = da.random.random(size=(50, 50))
-    with notification_manager:
-        viewer = make_napari_viewer()
-        viewer.add_image(random_image)
-        result = da.divide(random_image, da.zeros(50, 50))
-        viewer.add_image(result)
-        assert len(notification_manager.records) >= 1
-        notification_manager.records = []
-
-
 @pytest.mark.parametrize(
     "raise_func,warn_func",
     [(_raise, _warn), (_threading_raise, _threading_warn)],
@@ -165,3 +152,17 @@ def test_notification_error(mock_show, monkeypatch, clean_current):
     mock_show.assert_not_called()
     bttn.click()
     mock_show.assert_called_once()
+
+
+@pytest.mark.sync_only
+@pytest.mark.skipif(PY37_OR_LOWER, reason="Fails on py37")
+def test_notifications_error_with_threading(make_napari_viewer):
+    """Test notifications of `threading` threads, using a dask example."""
+    random_image = da.random.random(size=(50, 50))
+    with notification_manager:
+        viewer = make_napari_viewer()
+        viewer.add_image(random_image)
+        result = da.divide(random_image, da.zeros(50, 50))
+        viewer.add_image(result)
+        assert len(notification_manager.records) >= 1
+        notification_manager.records = []

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -58,6 +58,19 @@ def clean_current(monkeypatch, qtbot):
     monkeypatch.setattr(NapariQtNotification, "show", store_widget)
 
 
+@pytest.mark.skipif(PY37_OR_LOWER, reason="Fails on py37")
+def test_notifications_error_with_threading(make_napari_viewer):
+    """Test notifications of `threading` threads, using a dask example."""
+    random_image = da.random.random(size=(50, 50))
+    with notification_manager:
+        viewer = make_napari_viewer()
+        viewer.add_image(random_image)
+        result = da.divide(random_image, da.zeros(50, 50))
+        viewer.add_image(result)
+        assert len(notification_manager.records) >= 1
+        notification_manager.records = []
+
+
 @pytest.mark.parametrize(
     "raise_func,warn_func",
     [(_raise, _warn), (_threading_raise, _threading_warn)],
@@ -152,16 +165,3 @@ def test_notification_error(mock_show, monkeypatch, clean_current):
     mock_show.assert_not_called()
     bttn.click()
     mock_show.assert_called_once()
-
-
-@pytest.mark.skipif(PY37_OR_LOWER, reason="Fails on py37")
-def test_notifications_error_with_threading(make_napari_viewer):
-    """Test notifications of `threading` threads, using a dask example."""
-    random_image = da.random.random(size=(50, 50))
-    with notification_manager:
-        viewer = make_napari_viewer()
-        viewer.add_image(random_image)
-        result = da.divide(random_image, da.zeros(50, 50))
-        viewer.add_image(result)
-        assert len(notification_manager.records) >= 1
-        notification_manager.records = []

--- a/napari/layers/_tests/test_dask_layers.py
+++ b/napari/layers/_tests/test_dask_layers.py
@@ -13,8 +13,10 @@ from napari import layers, utils, viewer
 @pytest.mark.sync_only
 def test_dask_not_greedy():
     """Make sure that we don't immediately calculate dask arrays."""
-    # minreq seems to add one more fetch
-    FETCH_COUNT = int(bool(os.environ.get('MIN_REQ')))
+
+    FETCH_COUNT = 0
+    # the min requirements seems to add one more fetch
+    MINREQ = int(bool(os.environ.get('MIN_REQ')))
 
     def get_plane(block_id):
         if block_id:
@@ -28,7 +30,7 @@ def test_dask_not_greedy():
         dtype=float,
     )
     layer = layers.Image(arr)
-    assert FETCH_COUNT == 1
+    assert FETCH_COUNT == 1 + MINREQ
     assert tuple(layer.contrast_limits) == (0, 1)
 
     arr2 = da.map_blocks(
@@ -37,7 +39,7 @@ def test_dask_not_greedy():
         dtype='uint8',
     )
     layer = layers.Image(arr2)
-    assert FETCH_COUNT == 2
+    assert FETCH_COUNT == 2 + MINREQ
     assert tuple(layer.contrast_limits) == (0, 2 ** 8 - 1)
 
 

--- a/napari/layers/_tests/test_dask_layers.py
+++ b/napari/layers/_tests/test_dask_layers.py
@@ -9,6 +9,7 @@ import pytest
 from napari import layers, utils, viewer
 
 
+@pytest.mark.sync_only
 def test_dask_not_greedy():
     """Make sure that we don't immediately calculate dask arrays."""
     FETCH_COUNT = 0

--- a/napari/layers/_tests/test_dask_layers.py
+++ b/napari/layers/_tests/test_dask_layers.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import contextmanager
 from distutils.version import LooseVersion
 
@@ -12,7 +13,8 @@ from napari import layers, utils, viewer
 @pytest.mark.sync_only
 def test_dask_not_greedy():
     """Make sure that we don't immediately calculate dask arrays."""
-    FETCH_COUNT = 0
+    # minreq seems to add one more fetch
+    FETCH_COUNT = int(bool(os.environ.get('MIN_REQ')))
 
     def get_plane(block_id):
         if block_id:

--- a/napari/layers/_tests/test_dask_layers.py
+++ b/napari/layers/_tests/test_dask_layers.py
@@ -15,8 +15,8 @@ def test_dask_not_greedy():
     """Make sure that we don't immediately calculate dask arrays."""
 
     FETCH_COUNT = 0
-    # the min requirements seems to add one more fetch
-    MINREQ = int(bool(os.environ.get('MIN_REQ')))
+    # the min requirements seems to double the number of fetches
+    MINREQ = int(bool(os.environ.get('MIN_REQ'))) + 1
 
     def get_plane(block_id):
         if block_id:
@@ -30,7 +30,7 @@ def test_dask_not_greedy():
         dtype=float,
     )
     layer = layers.Image(arr)
-    assert FETCH_COUNT == 1 + MINREQ
+    assert FETCH_COUNT == 1 * MINREQ
     assert tuple(layer.contrast_limits) == (0, 1)
 
     arr2 = da.map_blocks(
@@ -39,7 +39,7 @@ def test_dask_not_greedy():
         dtype='uint8',
     )
     layer = layers.Image(arr2)
-    assert FETCH_COUNT == 2 + MINREQ
+    assert FETCH_COUNT == 2 * MINREQ
     assert tuple(layer.contrast_limits) == (0, 2 ** 8 - 1)
 
 

--- a/napari/layers/_tests/test_dask_layers.py
+++ b/napari/layers/_tests/test_dask_layers.py
@@ -10,7 +10,7 @@ from napari import layers, utils, viewer
 
 
 def test_dask_not_greedy():
-
+    """Make sure that we don't immediately calculate dask arrays."""
     FETCH_COUNT = 0
 
     def get_plane(block_id):

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -303,7 +303,6 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
                 self.contrast_limits_range = self._calc_data_range()
         else:
             self.contrast_limits_range = contrast_limits
-
         self._contrast_limits = tuple(self.contrast_limits_range)
         self.colormap = colormap
         self.contrast_limits = self._contrast_limits

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -6,7 +6,6 @@ import types
 import warnings
 from typing import TYPE_CHECKING, List, Union
 
-import dask.array as da
 import numpy as np
 from scipy import ndimage as ndi
 
@@ -294,9 +293,10 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         )
         self._experimental_clipping_planes = ClippingPlaneList()
         if contrast_limits is None:
-            if isinstance(data, da.Array):
-                if np.issubdtype(data.dtype, np.integer):
-                    self.contrast_limits_range = get_dtype_limits(data.dtype)
+            if not isinstance(data, np.ndarray):
+                dtype = getattr(data, 'dtype', None)
+                if np.issubdtype(dtype, np.integer):
+                    self.contrast_limits_range = get_dtype_limits(dtype)
                 else:
                     self.contrast_limits_range = (0, 1)
             else:


### PR DESCRIPTION
# Description
This PR makes sure that we don't greedily compute a dask array.  Together with #3022, this fixes #2888  (I think? @jni?)

would be nice to get this on for 0.4.11

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
test added
