### PR TITLE
Fix button binding tooltip.

### DIFF
--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -164,7 +164,7 @@ class QtShapesControls(QtLayerControls):
             layer,
             'zoom',
             Mode.PAN_ZOOM,
-            "napari:activate_shape_pan_zoom_mode",
+            "activate_shape_pan_zoom_mode",
             extra_tooltip_text=trans._('(or hold Space)'),
             checked=True,
         )

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -171,10 +171,10 @@ class ActionManager:
             self._update_gui_elements(name)
 
     def _validate_action_name(self, name):
-        if ":" not in name:
+        if len(name.split(':')) != 2:
             raise ValueError(
                 trans._(
-                    'Action names need to be in the form `package:name`, got {name}',
+                    'Action names need to be in the form `package:name`, got {name!r}',
                     name=name,
                     deferred=True,
                 )


### PR DESCRIPTION
The extra `napari:` meant the tooltip of the Shapes pan zoom button would
not be updated as the radio_button utility would also prepend `napari:`,
I now check that `:` is present only once when registering an action,
and the shape tooltip should now be properly updated.

