### PR TITLE
Improve behavior when holding "shift" while editing shapes

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -589,6 +589,17 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         self._position = _position
 
     @property
+    def _is_moving(self):
+        return self._private_is_moving
+
+    @_is_moving.setter
+    def _is_moving(self, value):
+        assert value in (True, False)
+        if value:
+            assert self._moving_coordinates is not None
+        self._private_is_moving = value
+
+    @property
     def _dims_displayed(self):
         """To be removed displayed dimensions."""
         # Ultimately we aim to remove all slicing information from the layer

--- a/napari/layers/shapes/_shapes_key_bindings.py
+++ b/napari/layers/shapes/_shapes_key_bindings.py
@@ -39,6 +39,7 @@ def hold_to_lock_aspect_ratio(layer):
     else:
         layer._aspect_ratio = 1
     if layer._is_moving:
+        assert layer._moving_coordinates is not None, layer
         _move(layer, layer._moving_coordinates)
 
     yield

--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -93,6 +93,8 @@ def add_line(layer, event):
         full_size[i] = size
 
     coordinates = layer.world_to_data(event.position)
+    layer._moving_coordinates = coordinates
+
     corner = np.array(coordinates)
     data = np.array([corner, corner + full_size])
     yield from _add_line_rectangle_ellipse(
@@ -153,6 +155,7 @@ def _add_line_rectangle_ellipse(layer, event, data, shape_type):
     while event.type == 'mouse_move':
         # Drag any selected shapes
         coordinates = layer.world_to_data(event.position)
+        layer._moving_coordinates = coordinates
         _move(layer, coordinates)
         yield
 
@@ -371,6 +374,7 @@ def _move(layer, coordinates):
         [Mode.SELECT, Mode.ADD_RECTANGLE, Mode.ADD_ELLIPSE, Mode.ADD_LINE]
     ):
         coord = [coordinates[i] for i in layer._dims_displayed]
+        layer._moving_coordinates = coordinates
         layer._is_moving = True
         if vertex is None:
             # Check where dragging box from to move whole object

--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -140,7 +140,7 @@ def add_rectangle(layer, event):
 
 
 def _add_line_rectangle_ellipse(layer, event, data, shape_type):
-    """Helper function for adding a a line, rectangle or ellipse."""
+    """Helper function for adding a line, rectangle or ellipse."""
 
     # on press
     # Start drawing rectangle / ellipse / line
@@ -497,6 +497,7 @@ def _move(layer, coordinates):
             layer.refresh()
     elif layer._mode in [Mode.DIRECT, Mode.ADD_PATH, Mode.ADD_POLYGON]:
         if vertex is not None:
+            layer._moving_coordinates = coordinates
             layer._is_moving = True
             index = layer._moving_value[0]
             shape_type = type(layer._data_view.shapes[index])

--- a/napari/layers/shapes/_tests/test_shapes_key_bindings.py
+++ b/napari/layers/shapes/_tests/test_shapes_key_bindings.py
@@ -7,6 +7,7 @@ from napari.layers.shapes import _shapes_key_bindings as key_bindings
 def test_lock_aspect_ratio():
     # Test a single four corner rectangle
     layer = Shapes(20 * np.random.random((1, 4, 2)))
+    layer._moving_coordinates = (0, 0, 0)
     layer._is_moving = True
     # need to go through the generator
     _ = list(key_bindings.hold_to_lock_aspect_ratio(layer))
@@ -17,6 +18,7 @@ def test_lock_aspect_ratio_selected_box():
     layer = Shapes(20 * np.random.random((1, 4, 2)))
     # select a shape
     layer._selected_box = layer.interaction_box(0)
+    layer._moving_coordinates = (0, 0, 0)
     layer._is_moving = True
     # need to go through the generator
     _ = list(key_bindings.hold_to_lock_aspect_ratio(layer))
@@ -27,6 +29,7 @@ def test_lock_aspect_ratio_selected_box_zeros():
     layer = Shapes(20 * np.zeros((1, 4, 2)))
     # select a shape
     layer._selected_box = layer.interaction_box(0)
+    layer._moving_coordinates = (0, 0, 0)
     layer._is_moving = True
     # need to go through the generator
     _ = list(key_bindings.hold_to_lock_aspect_ratio(layer))

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -521,9 +521,13 @@ class Shapes(Layer):
         self._fixed_aspect = False
         self._aspect_ratio = 1
         self._is_moving = False
+
         # _moving_coordinates are needed for fixing aspect ratio during
-        # a resize
+        # a resize, it stores the last pointer coordinate value that happened
+        # during a mouse move to that pressing/releasing shift
+        # can trigger a redraw of the shape with a fixed aspect ratio.
         self._moving_coordinates = None
+
         self._fixed_index = 0
         self._is_selecting = False
         self._drag_box = None


### PR DESCRIPTION
This remove the crash/exception that makes things behave a bit better,
but not quite.

I think we should consolidate the _is_moving and _moving_coordinates
into a single item to not have inconsistency when manipulating those
values.

It's still unclear to me how this behave exactly, but it seem the loginc
is a anyway a bit wrong as pressing shift before drawing forces 45º,
but not after drawing the first point.

note that with lines we likely want to allow all multiple of 45º and not only
45º+k*90º.
