### PR TITLE
Mesh depth

### DIFF
--- a/examples/spheres.py
+++ b/examples/spheres.py
@@ -2,8 +2,12 @@
 Display two spheres with Surface layers
 """
 
+try:
+    from meshzoo import icosa_sphere
+except ImportError:
+    raise ImportError("This example uses a meshzoo but meshzoo is not installed. "
+                      "To install try 'pip install meshzoo'.")
 import napari
-from meshzoo import icosa_sphere
 
 
 vert, faces = icosa_sphere(10)

--- a/examples/spheres.py
+++ b/examples/spheres.py
@@ -1,0 +1,21 @@
+"""
+Display two spheres with Surface layers
+"""
+
+import napari
+from meshzoo import icosa_sphere
+
+
+vert, faces = icosa_sphere(10)
+
+vert *= 100
+
+sphere1 = (vert + 30, faces)
+sphere2 = (vert - 30, faces)
+
+viewer = napari.Viewer(ndisplay=3)
+surface1 = viewer.add_surface(sphere1)
+surface2 = viewer.add_surface(sphere2)
+viewer.reset_view()
+
+napari.run()

--- a/napari/_vispy/vendored/mesh.py
+++ b/napari/_vispy/vendored/mesh.py
@@ -29,8 +29,10 @@ void main() {
 
 fragment_template = """
 varying vec4 v_base_color;
+
 void main() {
     gl_FragColor = v_base_color;
+    gl_FragDepth = gl_FragCoord.z;
 }
 """
 


### PR DESCRIPTION
# Description

This tiny change sets the right value for the mesh depth buffer. I'm not sure why `gl_FragCoord` is not already checked in depth thesting, but here we are.

https://user-images.githubusercontent.com/23482191/131103772-222be311-944e-4f4b-85ed-55fac4042227.mp4

This should move along things like [getting some form of molecular visualization](https://github.com/vispy/vispy/pull/2008#issuecomment-798829246) as well as many other complex mesh work.

This might hit performance, especially on big complex meshes... need to test, and maybe make it togglable?

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
