### PR TITLE
Only change `labels` color mode in `color` setter if new `colors` are not default

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1264,3 +1264,24 @@ def test_labels_state_update():
     state = layer._get_state()
     for k, v in state.items():
         setattr(layer, k, v)
+
+
+def test_is_default_color():
+    """Test labels layer default color for None and background"""
+    data = np.random.randint(20, size=(10, 15))
+    layer = Labels(data)
+
+    # layer gets instantiated with defaults
+    current_color = layer.color
+    assert layer._is_default_colors(current_color)
+
+    # setting color to default colors doesn't update color mode
+    layer.color = current_color
+    assert layer.color_mode == 'auto'
+
+    # new colors are not default
+    new_color = {0: 'white', 1: 'red', 3: 'green'}
+    assert not layer._is_default_colors(new_color)
+    # setting the color with non-default colors updates color mode
+    layer.color = new_color
+    assert layer.color_mode == 'direct'

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1267,7 +1267,18 @@ def test_labels_state_update():
 
 
 def test_is_default_color():
-    """Test labels layer default color for None and background"""
+    """Test labels layer default color for None and background
+
+    Previously, setting color to just default values would
+    change color mode to DIRECT and display a black layer.
+    This test ensures `is_default_color` is
+    correctly checking against layer defaults, and `color_mode`
+    is only changed when appropriate.
+
+    See
+        - https://github.com/napari/napari/issues/2479
+        - https://github.com/napari/napari/issues/2953
+    """
     data = np.random.randint(20, size=(10, 15))
     layer = Labels(data)
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -474,16 +474,14 @@ class Labels(_ImageBase):
         }
         self._color = colors
 
-        """
-        `colors` may contain just the default None and background label
-        colors, in which case we need to be in AUTO color mode. Otherwise,
-        `colors` contains colors for all labels, and we should be in DIRECT
-        mode.
+        # `colors` may contain just the default None and background label
+        # colors, in which case we need to be in AUTO color mode. Otherwise,
+        # `colors` contains colors for all labels, and we should be in DIRECT
+        # mode.
 
-        For more information
-        - https://github.com/napari/napari/issues/2479
-        - https://github.com/napari/napari/issues/2953
-        """
+        # For more information
+        # - https://github.com/napari/napari/issues/2479
+        # - https://github.com/napari/napari/issues/2953
         if self._is_default_colors(colors):
             color_mode = LabelColorMode.AUTO
         else:

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -475,14 +475,14 @@ class Labels(_ImageBase):
         self._color = colors
 
         # if colors just contains default colors for None and background
-        if self.is_default_colors(colors):
+        if self._is_default_colors(colors):
             color_mode = LabelColorMode.AUTO
         else:
             color_mode = LabelColorMode.DIRECT
 
         self.color_mode = color_mode
 
-    def is_default_colors(self, color):
+    def _is_default_colors(self, color):
         """Returns True if color contains only default colors, otherwise False.
 
         Default colors are black for `None` and transparent for

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -474,7 +474,16 @@ class Labels(_ImageBase):
         }
         self._color = colors
 
-        # if colors just contains default colors for None and background
+        """
+        `colors` may contain just the default None and background label
+        colors, in which case we need to be in AUTO color mode. Otherwise,
+        `colors` contains colors for all labels, and we should be in DIRECT
+        mode.
+
+        For more information
+        - https://github.com/napari/napari/issues/2479
+        - https://github.com/napari/napari/issues/2953
+        """
         if self._is_default_colors(colors):
             color_mode = LabelColorMode.AUTO
         else:


### PR DESCRIPTION
# Description
Similarly to #2968, this PR addresses #2479 and #2953 by checking whether the new colors are just the default colors for `None` and `self._background_label`. This PR avoids making a new layer attribute by checking the two keys manually and rearranging the flow of the `color` setter a little.

I'm hoping this is a slightly less complicated approach to address @sofroniewn's concerns [here](https://github.com/napari/napari/pull/2968#issuecomment-876130926) without splitting the `color_mode` setter and therefore requiring separate calls. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #2953 and #2479. 

# How has this been tested?
- added test for `is_valid_color` and changing `color_mode`
- confirmed fixes for #2479 and #2953 manually

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
