### PR TITLE
Exclude vispy 0.8.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ install_requires =
     typing_extensions
     toolz>=0.10.0
     tqdm>=4.56.0
-    vispy>=0.6.4
+    vispy>=0.6.4, !=0.8.0
     wrapt>=1.11.1
 
 [options.package_data]


### PR DESCRIPTION
# Description
In vispy 0.8.0, there was a small bug in the handling of the pinch gesture event that led to an `AttributeError` being emitted when interacting with 3D scenes (#3263). Since this bug was fixed in vispy 0.8.1, I propose that we exclude vispy 0.8.0 just in case a user has it installed.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
This closes https://github.com/napari/napari/issues/3263 and uses the fix in https://github.com/vispy/vispy/pull/2202

# How has this been tested?
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
