### PR TITLE
Developer guide cleanup (typo and link fixes)

### DIFF
--- a/docs/guides/3D_interactivity.md
+++ b/docs/guides/3D_interactivity.md
@@ -1,7 +1,7 @@
 # 3D interactivity
 
 ## Coordinate systems in napari
-In napari, there are three main coordinate systems: (1) canvas, (2) world, and (3) layer. The canvas coordinates system is the 2D coordinate system of the canvas on which the scene is rendered. World coordinates are the nD coordinates of the entire scene. As the name suggests, layer coordinates are the nD coordinate system of the data in a given layer. Layer coordinates are specific the each layer's data and are related to the world coordinate system via the layer transforms.
+In napari, there are three main coordinate systems: (1) canvas, (2) world, and (3) layer. The canvas coordinates system is the 2D coordinate system of the canvas on which the scene is rendered. World coordinates are the nD coordinates of the entire scene. As the name suggests, layer coordinates are the nD coordinate system of the data in a given layer. Layer coordinates are specific to each layer's data and are related to the world coordinate system via the layer transforms.
 
 ![coordinate-systems](images/3d_interaction_coordianates.png)
 

--- a/docs/guides/magicgui.md
+++ b/docs/guides/magicgui.md
@@ -60,7 +60,7 @@ when using `magicgui` with napari-specific type annotations.
 `magicgui` uses [type hints](https://www.python.org/dev/peps/pep-0484/) to infer
 the appropriate widget type for a given function parameter, and to indicate a
 context-dependent action for the object returned from the function (in the
-absense of a type hint, the type of the default value will be used).  Third
+absence of a type hint, the type of the default value will be used).  Third
 party packages (like `napari` in this case) may provide support for their types
 using
 [`magicgui.register_type`](https://napari.org/magicgui/usage/types_widgets.html#register-type).

--- a/docs/guides/perfmon.md
+++ b/docs/guides/perfmon.md
@@ -2,7 +2,7 @@
 
 # Performance Monitoring
 
-If napari is not performing well, you can use the
+If napari is not performing well, you can use
 {mod}`napari.utils.perf<napari.utils.perf>` to help
 diagnose the problem.
 
@@ -119,8 +119,8 @@ This is an example showing how you might use the
 ### Add a Sleep
 
 To simulate a performance problem in napari, add a `sleep()` call to the
-:meth:`Labels.paint<napari.layer.labels.Label.paint>` method, this 
-will make the method take at least 100ms:
+{meth}`Labels.paint<napari.layer.labels.Label.paint>` method, this
+will make the method take at least 100 ms:
 
 ```{code-block} python
 ---
@@ -187,10 +187,10 @@ the lower pane the `Wall Duration` field says it took over 100ms:
 ![example chrome output](https://user-images.githubusercontent.com/4163446/94200256-1fc17180-fe88-11ea-9935-bef4f818407d.png)
 
 So we can see that some events are running slow. The next questions is
-why are `MouseButtonPress` or `MouseMove` is running slow? To answer this
+why are `MouseButtonPress` and `MouseMove` running slow? To answer this
 question we can add more timers. In this case we know the answer, but often
 you will have to guess or experiment. You might add some timers and then
-find out they actually runs fast, so you can remove them.
+find out they actually run fast, so you can remove them.
 
 ### Add Paint Method
 
@@ -227,7 +227,7 @@ Drop `/tmp/latest.json` into Chrome again. Now we can see that
 {meth}`Labels.paint<napari.layers.Labels.paint>` is really responsible
 for most of the time. After clicking on the event press the `m` key, that
 will highlight the event duration with arrows and print the duration right
-on the timeline, in this case it says the even took  106.597ms:
+on the timeline, in this case it says the event took 106.597ms:
 
 ![highlighted event duration showing Labels.paint took 106.597ms to run](https://user-images.githubusercontent.com/4163446/94201049-66fc3200-fe89-11ea-9720-6a7ff3c7361a.png)
 

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -6,9 +6,9 @@ more critical. Therefore performance is a core feature of napari.
 
 Inadequate performance will leave the user frustrated and discouraged and they
 will migrate to other tools or simply give up on interactive exploration of
-their data all together. In contrast excellent performance will create a joyful
-experience that encourages longer and more intensive exploration yielding better
-scientific results.
+their data altogether. In contrast, excellent performance will create a joyful
+experience that encourages longer and more intensive exploration, yielding
+better scientific results.
 
 There are two main types of performance:
 

--- a/docs/guides/rendering-explanation.md
+++ b/docs/guides/rendering-explanation.md
@@ -78,7 +78,7 @@ Issues that napari has without asynchronous rendering include
 ## RAM and VRAM
 
 There is a two step process to prepare data for rendering. First the data
-needs to be loaded it RAM, then it needs to be transferred from RAM to
+needs to be loaded in RAM, then it needs to be transferred from RAM to
 VRAM. Some hardware has "unified memory" where there is no actual VRAM, but
 there is still a change of status when data goes from raw bytes in RAM to a
 graphics "resource" like a texture or geometry that can be drawn.

--- a/docs/guides/rendering.md
+++ b/docs/guides/rendering.md
@@ -169,7 +169,7 @@ The loader will load lower resolution chunks in some cases. Although this
 can slightly delay when the ideal chunks are loaded, it's a very quick way
 to get reasonable looking "coverage" of the area of interest. Often data
 from one or two levels up isn't even that noticeably degraded. This table
-shows how many ideal chunks are "covered" a chunk at a higher level:
+shows how many ideal chunks are "covered" by a chunk at a higher level:
 
 | Levels Above Ideal | Coverage |
 | -----------------: | -------: |
@@ -260,7 +260,7 @@ of view. The
 {class}`~napari.components.experimental.chunk._delay_queue.DelayQueue` was
 created to help with this problem.
 
-While we can't cancel a load if a worker as started working on it, we can
+While we can't cancel a load if a worker has started working on it, we can
 trivially cancel loads that are still in our delay queue. If the chunk goes
 out of view, we cancel the load. If the user pauses for a bit, we initiate
 the loads.
@@ -324,7 +324,7 @@ works today is the
 potentially passes the visual tiles of various sizes, from different levels
 of the Octree. The tiles are rendered on top of each other from largest
 (coarsest level) to smallest (finest level). This is a nice trick so that
-bigger tiles to provide "coverage" for an area, while the smaller tiles add
+bigger tiles provide "coverage" for an area, while the smaller tiles add
 detail only where that data has been loaded.
 
 However, this breaks blending and opacity. We draw multiple tiles on top of
@@ -337,9 +337,9 @@ larger tiles to make sure we do not render anything on top of anything
 else.
 
 Until we do that, we could punt on making things look correct while loads
-are in progress. We could even highly the fact that a tile has not been
-fully loaded. Purposely make them look different until the data is fully
-loaded. Aside from blending this would address a common complaint with
+are in progress. We could even highlight the fact that a tile has not been
+fully loaded (purposely making it look different until the data is fully
+loaded). Aside from blending, this would address a common complaint with
 tiled image viewers: you often can't tell if the data is still being
 loaded. This could be a big issue for scientific uses, you don't want
 people drawing the wrong conclusions from the data.
@@ -426,12 +426,12 @@ framerate would not tank, and you could switch slices at any time.
 
 ### Future Work: Caching
 
-Basically no work as gone into caching or memory management for Octree
+Basically no work has gone into caching or memory management for Octree
 data. It's very likely there are leaks and extended usage will run out of
 memory. This hasn't been addressed because using Octree for long periods of
 time is just now becoming possible.
 
-One caching issue is figuring how to combine the `ChunkCache` with
+One caching issue is figuring out how to combine the `ChunkCache` with
 Dasks's built-in caching. We probably want to keep the `ChunkCache` for
 rendering non-Dask arrays? But when using Dask, we defer to its cache? We
 certainly don't want to cache the data in both places.

--- a/docs/guides/threading.md
+++ b/docs/guides/threading.md
@@ -57,9 +57,9 @@ methods in another thread.
 ## Threading in napari with `@thread_worker`
 
 The simplest way to run a function in another thread in napari is to decorate
-your function with the {func}`@thread_worker
-<napari.qt.threading.thread_worker>` decorator. Continuing with the example
-above:
+your function with the
+{func}`@thread_worker <napari.qt.threading.thread_worker>` decorator.
+Continuing with the example above:
 
 ```{code-block} python
 ---
@@ -232,10 +232,10 @@ napari.run()
 
 Note how we periodically (every 16 iterations) `yield` the image result in
 the `large_random_images` function.  We also connected the
-`yielded` event in the {func}`@thread_worker
-<napari.qt.threading.thread_worker>` decorator to the previously-defined
-`update_layer` function.  The result is that the image in the viewer
-is updated every time a new image is yielded.
+`yielded` event in the
+{func}`@thread_worker <napari.qt.threading.thread_worker>`
+decorator to the previously-defined `update_layer` function.  The result is
+that the image in the viewer is updated every time a new image is yielded.
 
 Any time you can break up a long-running function into a stream of
 shorter-running yield statements like this, you not only benefit from the
@@ -247,11 +247,11 @@ resources.
 
 A perhaps even more useful aspect of yielding periodically in our long running
 function is that we provide a "hook" for the main thread to control the flow of
-our long running function.  When you use the {func}`@thread_worker
-<napari.qt.threading.thread_worker>` decorator on a generator function, the
-ability to stop, start, and quit a thread comes for free.  In the example below
-we decorate what would normally be an infinitely yielding generator, but add a
-button that aborts the worker when clicked:
+our long running function.  When you use the
+{func}`@thread_worker <napari.qt.threading.thread_worker>` decorator on a
+generator function, the ability to stop, start, and quit a thread comes for
+free.  In the example below we decorate what would normally be an infinitely
+yielding generator, but add a button that aborts the worker when clicked:
 
 ```{code-block} python
 ---
@@ -283,7 +283,7 @@ def yield_random_images_forever():
 worker = yield_random_images_forever()
 worker.yielded.connect(update_layer)
 
-# add a button to the viewew that, when clicked, stops the worker
+# add a button to the viewer that, when clicked, stops the worker
 button = QPushButton("STOP!")
 button.clicked.connect(worker.quit)
 worker.finished.connect(button.clicked.disconnect)
@@ -304,9 +304,9 @@ and then closes without leaving any orphaned threads.
 Now go back to the first example with the pure (non-generator) function, and
 try quitting before the function has returned (i.e. before the image appears).
 You'll notice that it takes a while to quit: it has to wait for the background
-thread to finish because there is no good way to communicate equest that it
-quit!  If you had a *very* long function, you'd be left with no choice but to
-force quit your program.
+thread to finish because there is no good way to communicate the request that
+it quit!  If you had a *very* long function, you'd be left with no choice but
+to force quit your program.
 
 So whenever possible, sprinkle your long-running functions with `yield`.
 
@@ -386,9 +386,9 @@ napari.run()
 
 Let's break it down:
 
-1. As usual, we decorate our generator function with {func}`@thread_worker
-   <napari.qt.threading.thread_worker>` and instantiate it to create a
-   `worker`.
+1. As usual, we decorate our generator function with
+   {func}`@thread_worker <napari.qt.threading.thread_worker>` and instantiate
+   it to create a `worker`.
 
 2. The most interesting line in this example is where we both
    `yield` the current ``total`` to the main thread (`yield total`), *and*
@@ -403,8 +403,7 @@ Let's break it down:
 
 5. However, before that `resume()` command gets sent, we use
    `worker.send()` to send the current value of the `line_edit` widget
-   into the thread which the thread will multiple by the existing
-   total.
+   into the thread for multiplication by the existing total.
 
 6. Lastly, if the thread total ever goes to "0", we stop the thread by
    returning the string ``"Game Over"``.  In the main thread, the
@@ -474,11 +473,11 @@ keep in mind the following guidelines:
    {meth}`~napari.qt.threading.WorkerBase.work` method (preferred), or in
    extreme cases, may directly reimplement the
    {meth}`~napari.qt.threading.WorkerBase.run` method.  (When a worker "start"
-   is started with :meth:`~napari.qt.threading.WorkerBase.start`, the call
-   order is always :meth:`worker.start()
-   <napari.qt.threading.WorkerBase.start>` → {meth}`worker.run()
-   <napari.qt.threading.WorkerBase.run>` → {meth}`worker.work()
-   <napari.qt.threading.WorkerBase.work>`.
+   is started with {meth}`~napari.qt.threading.WorkerBase.start`, the call
+   order is always
+   {meth}`worker.start() <napari.qt.threading.WorkerBase.start>` →
+   {meth}`worker.run() <napari.qt.threading.WorkerBase.run>` →
+   {meth}`worker.work() <napari.qt.threading.WorkerBase.work>`.
 
 2. When implementing the {meth}`~napari.qt.threading.WorkerBase.work` method,
    it is important that you periodically check `self.abort_requested` in your
@@ -488,10 +487,10 @@ keep in mind the following guidelines:
    def work(self):
        i = 0
        while True:
-       if self.abort_requested:
-           self.aborted.emit()
-           break
-           time.sleep(0.5)
+           if self.abort_requested:
+               self.aborted.emit()
+               break
+               time.sleep(0.5)
     ```
 
 3. It is also important to be mindful of the fact that the


### PR DESCRIPTION
# Description

This PR fixes a number of typos across the developer guides that I noticed while going through most of the guide.

It also fixes indentation in one code block and fixes a number of function and method links in `threading.md`.

For example the following broken links in the current docs:
![docs_broken](https://user-images.githubusercontent.com/6528957/131420971-deefd515-8e88-47ba-8f8a-0524ba2e6df0.png)

Now render properly as:
![docs_fixed](https://user-images.githubusercontent.com/6528957/131420981-fff86d70-4381-4504-89da-43b5d6c0785c.png)


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->

I built the docs locally to check the rendering of method/function links as in the screenshot above.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
