### PR TITLE
bundle: add arch suffix to zip name

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: napari-${{ env.version }}-${{ runner.os }}.zip
-          path: napari-${{ env.version }}-${{ runner.os }}.zip
+          name: napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.zip
+          path: napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.zip
       - name: Get Release
         if: startsWith(github.ref, 'refs/tags/v')
         id: get_release
@@ -76,8 +76,8 @@ jobs:
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: napari-${{ env.version }}-${{ runner.os }}.zip
-          asset_name: napari-${{ env.version }}-${{ runner.os }}.zip
+          asset_path: napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.zip
+          asset_name: napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.zip
           asset_content_type: application/zip
       - name: Upload Nightly Build Asset
         if: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -51,12 +51,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e '.[bundle_build]'
-      - name: get tag
+      - name: get tag / arch-suffix
         shell: bash
         run: |
           VER=`python bundle.py --version`
           echo "version=${VER}" >> $GITHUB_ENV
-          echo $VER
+          echo "Version: $VER"
+          ARCH_SUFFIX=`python -c "import platform; print(platform.machine())"`
+          echo "arch-suffix=${ARCH_SUFFIX}" >> $GITHUB_ENV
+          echo "Machine: ${ARCH_SUFFIX}"
       - name: Make Bundle
         run: python bundle.py
       - name: Upload Artifact
@@ -85,8 +88,8 @@ jobs:
           # nightly build release from https://api.github.com/repos/napari/napari/releases
           upload_url: https://uploads.github.com/repos/napari/napari/releases/34273071/assets{?name,label}
           release_id: 34273071
-          asset_path: napari-${{ env.version }}-${{ runner.os }}.zip
-          asset_name: napari-${{ runner.os }}.zip
+          asset_path: napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.zip
+          asset_name: napari-${{ runner.os }}-${{ env.arch-suffix }}.zip
           asset_content_type: application/zip
           max_releases: 1
       - name: Update latest tag

--- a/bundle.py
+++ b/bundle.py
@@ -1,5 +1,6 @@
 import configparser
 import os
+import platform
 import re
 import shutil
 import subprocess
@@ -28,6 +29,8 @@ LINUX = sys.platform.startswith("linux")
 HERE = os.path.abspath(os.path.dirname(__file__))
 PYPROJECT_TOML = os.path.join(HERE, 'pyproject.toml')
 SETUP_CFG = os.path.join(HERE, 'setup.cfg')
+ARCH = platform.machine() or "generic"
+
 
 if WINDOWS:
     BUILD_DIR = os.path.join(HERE, 'windows')
@@ -204,7 +207,7 @@ def patch_python_lib_location():
 
 
 def patch_environment_variables():
-    os.environ["ARCH"] = os.uname().machine
+    os.environ["ARCH"] = ARCH
 
 
 def make_zip():
@@ -218,7 +221,7 @@ def make_zip():
     elif MACOS:
         ext, OS = '*.dmg', 'macOS'
     artifact = glob.glob(os.path.join(BUILD_DIR, ext))[0]
-    dest = f'napari-{VERSION}-{OS}.zip'
+    dest = f'napari-{VERSION}-{OS}-{ARCH}.zip'
 
     with zipfile.ZipFile(dest, 'w', zipfile.ZIP_DEFLATED) as zf:
         zf.write(artifact, arcname=os.path.basename(artifact))


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

Comes from https://github.com/napari/napari/issues/2898#issuecomment-867522044, later expanded in https://github.com/napari/napari/pull/2991 's description. This will finish closing #2898. 

* Note: I changed `ARCH` from `uname().machine` to `platform.machine()` to handle Windows as well.

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] Zip file name in CI Bundle contains arch name `x86_64`.

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
