### PR TITLE
pin furo version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 jupyter-book==0.10.2
 jupytext==1.10.3
 sphinx_autodoc_typehints==1.11.0
-furo
+furo==2021.6.18b36
 Jinja2


### PR DESCRIPTION
fixes #3312 

pins furo version, which should stop the bleeding for now

however, I believe eventually we'll want to adjust our pins in the docs requirements and upgrade to sphinx 4+, but I don't have the time to check that it's not breaking everything right now so someone else or I can do it later