### PR TITLE
fix some divide-by-zeros (#3318)

### DIFF
--- a/napari/_vispy/vispy_camera.py
+++ b/napari/_vispy/vispy_camera.py
@@ -106,8 +106,7 @@ class VispyCamera:
             scale = np.array(
                 [self._view.camera.rect.width, self._view.camera.rect.height]
             )
-            if np.allclose(scale, [0, 0]):  # fix for #2875
-                scale = [1, 1]
+            scale[np.isclose(scale, 0)] = 1  # fix for #2875
         zoom = np.min(canvas_size / scale)
         return zoom
 

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -281,8 +281,10 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         if np.max(size) == 0:
             self.camera.zoom = 0.95 * np.min(self._canvas_size)
         else:
+            scale = np.array(size[-2:])
+            scale[np.isclose(scale, 0)] = 1
             self.camera.zoom = 0.95 * np.min(
-                np.array(self._canvas_size) / np.array(size[-2:])
+                np.array(self._canvas_size) / scale
             )
         self.camera.angles = (0, 0, 90)
 


### PR DESCRIPTION
# Description
Closes #3318. May fix part of #3159.

There were a few areas of the code susceptible to divide-by-zero issues. Some checks were present that would handle when all scale dimensions were near zero, but they need to handle when any dimension is near zero.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
I ran the reproducer identified by @DragaDoncila in #3159 and verified the divide-by-zero error did not present itself. 

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
