### PR TITLE
Fix napari.run aborting due to IPython being imported during script

### DIFF
--- a/napari/_qt/_tests/test_app.py
+++ b/napari/_qt/_tests/test_app.py
@@ -1,8 +1,10 @@
 import os
+from unittest.mock import Mock
 
 import pytest
 
-from napari._qt.qt_event_loop import set_app_id
+from napari import Viewer
+from napari._qt.qt_event_loop import _ipython_has_eventloop, run, set_app_id
 
 
 @pytest.mark.skipif(os.name != "Windows", reason="Windows specific")
@@ -25,3 +27,21 @@ def test_windows_grouping_overwrite(make_napari_viewer):
     assert get_app_id() == "custom_string"
     set_app_id("")
     assert get_app_id() == ""
+
+
+def test_run_outside_ipython(qapp, monkeypatch):
+    """Test that we don't incorrectly give ipython the event loop."""
+    assert not _ipython_has_eventloop()
+    v1 = Viewer(show=False)
+    assert not _ipython_has_eventloop()
+    v2 = Viewer(show=False)
+    assert not _ipython_has_eventloop()
+
+    with monkeypatch.context() as m:
+        mock_exec = Mock()
+        m.setattr(qapp, 'exec_', mock_exec)
+        run()
+        mock_exec.assert_called_once()
+
+    v1.close()
+    v2.close()

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -55,6 +55,7 @@ _defaults = {
 
 # store reference to QApplication to prevent garbage collection
 _app_ref = None
+_IPYTHON_WAS_HERE_FIRST = "IPython" in sys.modules
 
 
 def get_app(
@@ -165,7 +166,8 @@ def get_app(
 
     if ipy_interactive is None:
         ipy_interactive = get_settings().application.ipy_interactive
-    _try_enable_ipython_gui('qt' if ipy_interactive else None)
+    if _IPYTHON_WAS_HERE_FIRST:
+        _try_enable_ipython_gui('qt' if ipy_interactive else None)
 
     if perf_config and not perf_config.patched:
         # Will patch based on config file.


### PR DESCRIPTION
# Description
a simple fix for now to avoid the call to `_try_enable_ipython_gui` in the first viewer fooling `napari.run` into thinking it's running in an ipython environment (and bailing)

fixes #2925, fixes #3033, fixes #3322

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
