### PR TITLE
Fix `_old_size` attribute error in main window

### DIFF
--- a/docs/release/release_0_4_11.md
+++ b/docs/release/release_0_4_11.md
@@ -182,6 +182,7 @@ more! Thanks to our incredible user and contributor community.
 - Fix connect_setattr to handle single arguments better (#3324)
 - Fix objectName being an empty string (#3326)
 - Fix napari.run aborting due to IPython being imported during script (#3328)
+- Fix _old_size attribute error in main window (#3329)
 
 ## API Changes
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -306,7 +306,7 @@ class _QtMainWindow(QMainWindow):
             condition = (
                 self.isMaximized() if os.name == "nt" else self.isFullScreen()
             )
-            if condition:
+            if condition and self._old_size is not None:
                 if self._positions and len(self._positions) > 1:
                     self._window_pos = self._positions[-2]
 


### PR DESCRIPTION
# Description
Fixes the bug reported here:
https://forum.image.sc/t/napari-crash-after-installing-cellpose/57154

cc @goanpeca ... can you double check that this is the correct intention?

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
