### PR TITLE
Hide or Destroy dock widgets

### DIFF
--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -137,6 +137,14 @@ def test_making_plugin_dock_widgets(test_plugin_widgets, make_napari_viewer):
     assert isinstance(dw.widget().viewer, napari.Viewer)
     # Add twice is ok, only does a show
     action.trigger()
+    # Check that widget is still there when closed.
+    widg = dw.widget()
+    dw.title.hide_button.click()
+    assert widg
+    # Check that widget is destroyed when closed.
+    dw.destroyOnClose()
+    assert action not in viewer.window.plugins_menu.actions()
+    assert not widg.parent()
 
 
 def test_making_function_dock_widgets(test_plugin_widgets, make_napari_viewer):

--- a/napari/_qt/menus/plugins_menu.py
+++ b/napari/_qt/menus/plugins_menu.py
@@ -71,9 +71,7 @@ class PluginsMenu(NapariMenu):
                         full_name = menu_item_template.format(*key)
                         action = QAction(full_name, parent=self)
 
-                    def _add_toggle_widget(
-                        *args, key=key, hook_type=hook_type
-                    ):
+                    def _add_toggle_widget(*, key=key, hook_type=hook_type):
 
                         full_name = menu_item_template.format(*key)
                         if full_name in self._win._dock_widgets.keys():

--- a/napari/_qt/menus/plugins_menu.py
+++ b/napari/_qt/menus/plugins_menu.py
@@ -60,7 +60,15 @@ class PluginsMenu(NapariMenu):
                     full_name = menu_item_template.format(*key)
                     action = QAction(full_name, parent=self)
 
-                def _add_widget(*args, key=key, hook_type=hook_type):
+                def _add_toggle_widget(*args, key=key, hook_type=hook_type):
+                    full_name = menu_item_template.format(*key)
+                    if full_name in self._win._dock_widgets.keys():
+                        dock_widget = self._win._dock_widgets[full_name]
+                        if dock_widget.isVisible():
+                            dock_widget.hide()
+                        else:
+                            dock_widget.show()
+                        return
                     if hook_type == 'dock':
                         self._win.add_plugin_dock_widget(*key)
                     else:
@@ -71,7 +79,7 @@ class PluginsMenu(NapariMenu):
                 actions = [a.text() for a in menu.actions()]
                 if action.text() not in actions:
                     menu.addAction(action)
-                action.triggered.connect(_add_widget)
+                action.triggered.connect(_add_toggle_widget)
 
     def _remove_unregistered_widget(self, event=None):
 
@@ -100,7 +108,19 @@ class PluginsMenu(NapariMenu):
                         full_name = menu_item_template.format(*key)
                         action = QAction(full_name, parent=self)
 
-                    def _add_widget(*args, key=key, hook_type=hook_type):
+                    def _add_toggle_widget(
+                        *args, key=key, hook_type=hook_type
+                    ):
+
+                        full_name = menu_item_template.format(*key)
+                        if full_name in self._win._dock_widgets.keys():
+                            dock_widget = self._win._dock_widgets[full_name]
+                            if dock_widget.isVisible():
+                                dock_widget.hide()
+                            else:
+                                dock_widget.show()
+                            return
+
                         if hook_type == 'dock':
                             self._win.add_plugin_dock_widget(*key)
                         else:
@@ -111,7 +131,7 @@ class PluginsMenu(NapariMenu):
                     actions = [a.text() for a in menu.actions()]
                     if action.text() not in actions:
                         menu.addAction(action)
-                    action.triggered.connect(_add_widget)
+                    action.triggered.connect(_add_toggle_widget)
 
     def _show_plugin_install_dialog(self):
         """Show dialog that allows users to sort the call order of plugins."""

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -727,6 +727,7 @@ class Window:
         allowed_areas: Optional[Sequence[str]] = None,
         shortcut=_sentinel,
         add_vertical_stretch=True,
+        menu=None,
     ):
         """Convenience method to add a QDockWidget to the main window.
 
@@ -802,7 +803,7 @@ class Window:
                 add_vertical_stretch=add_vertical_stretch,
             )
 
-        self._add_viewer_dock_widget(dock_widget)
+        self._add_viewer_dock_widget(dock_widget, menu=menu)
 
         if hasattr(widget, 'reset_choices'):
             # Keep the dropdown menus in the widget in sync with the layer model
@@ -867,7 +868,7 @@ class Window:
             if shortcut is not None:
                 action.setShortcut(shortcut)
 
-                menu.addAction(action)
+            menu.addAction(action)
         # self.window_menu.addAction(action)
 
     def _remove_dock_widget(self, event=None):

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -867,10 +867,11 @@ class Window:
             dock_widget.closed.connect(
                 lambda: current_action.setChecked(False)
             )
+            dock_widget.opened.connect(lambda: current_action.setChecked(True))
             dock_widget.setVisible(True)
             return
         else:
-            # if the action is not here, it may be in a submenu
+            # if the action was not already here, it may be in a submenu
             for cnt, current_action in enumerate(self.plugins_menu.actions()):
                 if current_action.menu() is not None:
                     sub_actions = [
@@ -893,31 +894,15 @@ class Window:
 
                         return
 
+        # it the action was not in the plugins menu, add it to the window menu.
         self.window_menu.addAction(action)
 
     def _toggle_dock_visibility(self, dock_widget=None):
-        try:
-            if dock_widget.isVisible():
-                dock_widget.hide()
-            else:
-                dock_widget.show()
-        except RuntimeError:
-            # this widget was deleted
-            if dock_widget.name == 'console':
-                self.qt_viewer._add_dockConsole()
-                self._add_viewer_dock_widget(
-                    self.qt_viewer.dockConsole, tabify=False
-                )
-            elif dock_widget.name == 'layer controls':
-                self.qt_viewer._add_dockLayerControls()
-                self._add_viewer_dock_widget(
-                    self.qt_viewer.dockLayerControls, tabify=False
-                )
-            else:
-                self.qt_viewer._add_dockLayerList()
-                self._add_viewer_dock_widget(
-                    self.qt_viewer.dockLayerList, tabify=False
-                )
+
+        if dock_widget.isVisible():
+            dock_widget.hide()
+        else:
+            dock_widget.show()
 
     def _remove_dock_widget(self, event=None):
         names = list(self._dock_widgets.keys())
@@ -967,8 +952,6 @@ class Window:
             menu.removeAction(_dw.toggleViewAction())
 
         # Remove dock widget from dictionary
-        for widg in self._dock_widgets:
-            print('wid', widg)
         del self._dock_widgets[_dw.name]
 
         # Deleting the dock widget means any references to it will no longer

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -660,10 +660,6 @@ class Window:
         full_name = plugin_menu_item_template.format(plugin_name, widget_name)
         if full_name in self._dock_widgets:
             dock_widget = self._dock_widgets[full_name]
-            if dock_widget.isVisible():
-                dock_widget.hide()
-            else:
-                dock_widget.show()
             wdg = dock_widget.widget()
             if hasattr(wdg, '_magic_widget'):
                 wdg = wdg._magic_widget
@@ -703,12 +699,6 @@ class Window:
         """
         full_name = plugin_menu_item_template.format(plugin_name, widget_name)
         if full_name in self._dock_widgets:
-            dock_widget = self._dock_widgets[full_name]
-            if dock_widget.isVisible():
-                self._dock_widgets[full_name].hide()
-            else:
-                self._dock_widgets[full_name].show()
-            # self._dock_widgets[full_name].show()
             return
 
         func = plugin_manager._function_widgets[plugin_name][widget_name]

--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -86,6 +86,13 @@ QStatusBar {
     padding: 2 1 2 1;
 }
 
+#QTitleBarHideButton{
+    image: url(":/themes/{{ name }}/visibility_off.svg");
+    width: 10px;
+    height: 8px;
+    padding: 2 1 2 1;
+}
+
 /* ----------------- Console ------------------ */
 
 QtConsole {

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -141,7 +141,6 @@ class QtViewer(QSplitter):
             allowed_areas=['left', 'right'],
             object_name='layer list',
         )
-
         self.dockLayerControls = QtViewerDockWidget(
             self,
             self.controls,

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -141,6 +141,7 @@ class QtViewer(QSplitter):
             allowed_areas=['left', 'right'],
             object_name='layer list',
         )
+
         self.dockLayerControls = QtViewerDockWidget(
             self,
             self.controls,

--- a/napari/_qt/widgets/_tests/test_qt_dock_widget.py
+++ b/napari/_qt/widgets/_tests/test_qt_dock_widget.py
@@ -76,7 +76,9 @@ def test_remove_dock_widget_orphans_widget(make_napari_viewer):
     widg = QPushButton('button')
 
     assert not widg.parent()
-    dw = viewer.window.add_dock_widget(widg, name='test')
+    dw = viewer.window.add_dock_widget(
+        widg, name='test', menu=viewer.window.window_menu
+    )
     assert widg.parent() is dw
     assert dw.toggleViewAction() in viewer.window.window_menu.actions()
     viewer.window.remove_dock_widget(dw, menu=viewer.window.window_menu)

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -143,7 +143,7 @@ class QtViewerDockWidget(QDockWidget):
         self.visibilityChanged.connect(self._on_visibility_changed)
 
     def destroyOnClose(self):
-        """ "Destroys dock plugin dock widget when 'x' is clicked."""
+        """Destroys dock plugin dock widget when 'x' is clicked."""
         self.qt_viewer.viewer.window.remove_dock_widget(self)
 
     def _maybe_add_vertical_stretch(self, widget):

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -269,6 +269,8 @@ class QtCustomTitleBar(QLabel):
 
         add_close = False
         try:
+            # if the plugins menu is already created, check to see if this is a plugin
+            # dock widget.  If it is, then add the close button option to the title bar.
             actions = [
                 action.text()
                 for action in self.parent().qt_viewer.viewer.window.plugins_menu.actions()

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -146,12 +146,8 @@ class QtViewerDockWidget(QDockWidget):
         self.visibilityChanged.connect(self._on_visibility_changed)
 
     def destroyOnClose(self):
-        if self.name in self.qt_viewer.viewer.window._dock_widgets.keys():
-            self.qt_viewer.viewer.window.remove_dock_widget(self)
-        else:
-            # need to handle console, layer controls, etc.
-            self.setAttribute(Qt.WA_DeleteOnClose)
-            self.close()
+        """ "Destroys dock plugin dock widget when 'x' is clicked."""
+        self.qt_viewer.viewer.window.remove_dock_widget(self)
 
     def _maybe_add_vertical_stretch(self, widget):
         """Add vertical stretch to the bottom of a vertical layout only

--- a/tools/strings_list.py
+++ b/tools/strings_list.py
@@ -515,6 +515,7 @@ SKIP_WORDS = {
     'napari/_qt/widgets/qt_viewer_dock_widget.py': [
         'QTitleBarCloseButton',
         'QTitleBarFloatButton',
+        'QTitleBarHideButton',
         'QtCustomTitleBar',
         'QtCustomTitleBarLine',
         'bottom',


### PR DESCRIPTION
This PR adds the options to hide or destroy a dock widget from the title bar.  

See #3101 


https://user-images.githubusercontent.com/54282105/131959804-257f4e4e-05d4-4d3b-93d4-463db18389a8.mov

