### PR TITLE
Pass opening files to a reader `thread_worker` when opening list of paths

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1243,24 +1243,38 @@ def valid_add_kwargs() -> Dict[str, Set[str]]:
     return valid
 
 
-def prep_layers(_path, plugin):
+def prep_layers(path, plugin):
+    """Read path into data using plugin and decide filename.
+
+    Parameters
+    ----------
+    path : str
+        the path to file or URL to open
+    plugin : str
+        plugin to use to open path
+
+    Returns
+    -------
+    tuple
+        tuple of (filenames, layer_data, hookimpl) layer info
+    """
     from ..plugins.io import read_data_with_plugins
 
-    layer_data, hookimpl = read_data_with_plugins(_path, plugin=plugin)
+    layer_data, hookimpl = read_data_with_plugins(path, plugin=plugin)
 
     # glean layer names from filename. These will be used as *fallback*
     # names, if the plugin does not return a name kwarg in their meta dict.
     filenames = []
-    if isinstance(_path, str):
-        filenames = itertools.repeat(_path)
-    elif is_sequence(_path):
-        if len(_path) == len(layer_data):
-            filenames = iter(_path)
+    if isinstance(path, str):
+        filenames = itertools.repeat(path)
+    elif is_sequence(path):
+        if len(path) == len(layer_data):
+            filenames = iter(path)
         else:
             # if a list of paths has been returned as a list of layer data
             # without a 1:1 relationship between the two lists we iterate
             # over the first name
-            filenames = itertools.repeat(_path[0])
+            filenames = itertools.repeat(path[0])
 
     return filenames, layer_data, hookimpl
 


### PR DESCRIPTION
# Description

This PR would be one option for addressing the second part of #3125 by handing off reading of layers to a `thread_worker` when the user has a large list of files to open, using the current mechanisms we have in place.

I've refactored `_add_layers_with_plugins` so that we can use it for adding stacks (which I'm not passing off to a `thread_worker`, though we could) and so we can compare the difference in the opening methods.

The `thread_worker` gets created by `get_reader_worker` which parameterizes the worker with its total number of files (for the progress bar) and a `yield` callback (to add the layer to the viewer on `yield`). This could also just be an inner declaration in `viewer.open` though.

The major issue with this approach (and I think any approach we could take with the mechanisms we have currently available, though @tlambert03 might be able to correct me on this), is that we can no longer have `viewer.open` return the list of layers it has added, which is a pretty big API change and not something I think we should necessarily move forward with?

However, if we had some form of `Futures` object as proposed in #2581 and #2593, we would be able to populate our returned list with these objects instead. I don't think this PR in its current form should be merged necessarily, but I think it's good to open a discussion about how we could support threaded layer reads. I'd appreciate any thoughts people have (@jni, @sofroniewn) - maybe we can pick up the idea of a `Futures` object again?

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
