### PR TITLE
Fix __getattr__ in WorkerBase

### DIFF
--- a/napari/_qt/qthreading.py
+++ b/napari/_qt/qthreading.py
@@ -97,7 +97,9 @@ class WorkerBase(QRunnable):
             # (which is of type `SignalInstance` in PySide and
             # `pyqtBoundSignal` in PyQt)
             return getattr(self.signals, name)
-        return super().__getattr__(name)
+        raise AttributeError(
+            f"{self.__class__.__name__} has no attribute {name}"
+        )
 
     def quit(self) -> None:
         """Send a request to abort the worker.

--- a/napari/_qt/qthreading.py
+++ b/napari/_qt/qthreading.py
@@ -98,7 +98,7 @@ class WorkerBase(QRunnable):
             # `pyqtBoundSignal` in PyQt)
             return getattr(self.signals, name)
         raise AttributeError(
-            f"{self.__class__.__name__} has no attribute {name}"
+            f"{self.__class__.__name__!r} object has no attribute {name!r}"
         )
 
     def quit(self) -> None:


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

`QRunnable` does not contain `__getattr__` function.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

found in #3366

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
