### PR TITLE
normalize_dtype() when setting contrast limits.

### DIFF
--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -787,6 +787,8 @@ def test_instantiate_with_experimental_clipping_planes_dict():
 
 def test_tensorstore_image():
     """Test an image coming from a tensorstore array."""
-    data = ts.array(np.full(shape=(1024, 1024), fill_value=255, dtype=np.uint8))
+    data = ts.array(
+        np.full(shape=(1024, 1024), fill_value=255, dtype=np.uint8)
+    )
     layer = Image(data)
     assert np.all(layer.data == data)

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -1,6 +1,7 @@
 import dask.array as da
 import numpy as np
 import pytest
+import tensorstore as ts
 import xarray as xr
 
 from napari._tests.utils import check_layer_world_data_extent
@@ -782,3 +783,9 @@ def test_instantiate_with_experimental_clipping_planes_dict():
         assert (
             image.experimental_clipping_planes[i].normal == planes[i]['normal']
         )
+
+def test_tensorstore_image():
+    """Test an image coming from a tensorstore array."""
+    data = ts.array(np.full(shape=(1024,1024), fill_value=255, dtype=np.uint8))
+    layer = Image(data)
+    assert np.all(layer.data == data)

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -784,8 +784,9 @@ def test_instantiate_with_experimental_clipping_planes_dict():
             image.experimental_clipping_planes[i].normal == planes[i]['normal']
         )
 
+
 def test_tensorstore_image():
     """Test an image coming from a tensorstore array."""
-    data = ts.array(np.full(shape=(1024,1024), fill_value=255, dtype=np.uint8))
+    data = ts.array(np.full(shape=(1024, 1024), fill_value=255, dtype=np.uint8))
     layer = Image(data)
     assert np.all(layer.data == data)

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -10,6 +10,7 @@ import numpy as np
 from scipy import ndimage as ndi
 
 from ...utils import config
+from ...utils._dtype import normalize_dtype
 from ...utils._dtype import get_dtype_limits
 from ...utils.colormaps import AVAILABLE_COLORMAPS
 from ...utils.events import Event
@@ -295,7 +296,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         if contrast_limits is None:
             if not isinstance(data, np.ndarray):
                 dtype = getattr(data, 'dtype', None)
-                if np.issubdtype(dtype, np.integer):
+                if np.issubdtype(normalize_dtype(dtype), np.integer):
                     self.contrast_limits_range = get_dtype_limits(dtype)
                 else:
                     self.contrast_limits_range = (0, 1)

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -10,8 +10,7 @@ import numpy as np
 from scipy import ndimage as ndi
 
 from ...utils import config
-from ...utils._dtype import normalize_dtype
-from ...utils._dtype import get_dtype_limits
+from ...utils._dtype import get_dtype_limits, normalize_dtype
 from ...utils.colormaps import AVAILABLE_COLORMAPS
 from ...utils.events import Event
 from ...utils.translations import trans


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This PR adds a call to `normalize_dtype` when setting the contrast limits on a new layer.
This allows tensorstore objects to used without throwing an exception.

`normalize_dtype` comes from #2632 as a generalized function function to clean up strange dtypes.
 
## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

#2632

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

This is a complete program to show the bug and to test the fix:
```
import tensorstore as ts
import napari
import numpy as np
data = ts.array(np.full(shape=(1024,1024), fill_value=255, dtype=np.uint8))
viewer = napari.view_image(data)
```

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
