### PR TITLE
[WIP] add depth_test flag

### DIFF
--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -58,7 +58,8 @@ class VispyBaseLayer(ABC):
         self.layer.events.set_data.connect(self._on_data_change)
         self.layer.events.visible.connect(self._on_visible_change)
         self.layer.events.opacity.connect(self._on_opacity_change)
-        self.layer.events.blending.connect(self._on_blending_change)
+        self.layer.events.blending.connect(self._on_gl_state_change)
+        self.layer.events.depth_test.connect(self._on_gl_state_change)
         self.layer.events.scale.connect(self._on_matrix_change)
         self.layer.events.translate.connect(self._on_matrix_change)
         self.layer.events.rotate.connect(self._on_matrix_change)
@@ -117,8 +118,10 @@ class VispyBaseLayer(ABC):
     def _on_opacity_change(self, event=None):
         self.node.opacity = self.layer.opacity
 
-    def _on_blending_change(self, event=None):
-        self.node.set_gl_state(self.layer.blending)
+    def _on_gl_state_change(self, event=None):
+        self.node.set_gl_state(
+            self.layer.blending, depth_test=self.layer.depth_test
+        )
         self.node.update()
 
     def _on_matrix_change(self, event=None):
@@ -161,7 +164,7 @@ class VispyBaseLayer(ABC):
     def _reset_base(self):
         self._on_visible_change()
         self._on_opacity_change()
-        self._on_blending_change()
+        self._on_gl_state_change()
         self._on_matrix_change()
         self._on_experimental_clipping_planes_change()
 


### PR DESCRIPTION
# Description
This PR adds a depth_test flag to the layers to turn of depth testing. I am not sure this is the best approach, as we already set depth_test via the blending modes. It may be better to add an additional blending mode (e.g., `translucent_no_depth`) that performs translucent blending without depth testing.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #3343 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
