### PR TITLE
Fix CI failure from example

### DIFF
--- a/examples/mgui_with_threading.py
+++ b/examples/mgui_with_threading.py
@@ -6,7 +6,7 @@ import sys
 
 if sys.version_info < (3, 9):
     print('This example requires python >= 3.9')
-    sys.exit()
+    sys.exit(0)
 
 from magicgui import magic_factory, widgets
 from skimage import feature

--- a/examples/mgui_with_threading.py
+++ b/examples/mgui_with_threading.py
@@ -1,6 +1,13 @@
 """An example of calling a threaded function from a magicgui dock_widget.
 Note: this example requires python >= 3.9
 """
+
+import sys
+
+if sys.version_info < (3, 9):
+    print('This example requires python >= 3.9')
+    sys.exit()
+
 from magicgui import magic_factory, widgets
 from skimage import feature
 from typing_extensions import Annotated

--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -63,4 +63,9 @@ def test_examples(qapp, fname, monkeypatch, capsys):
     monkeypatch.setattr(notification_manager, 'receive_error', raise_errors)
 
     # run the example!
-    runpy.run_path(str(EXAMPLE_DIR / fname))
+    try:
+        runpy.run_path(str(EXAMPLE_DIR / fname))
+    except SystemExit as e:
+        # we use sys.exit(0) to gracefully exit from examples
+        if e.code != 0:
+            raise


### PR DESCRIPTION
# Description
[This example](examples/mgui_with_threading.py) causes a CI failure since testing of examples was re-enabled. This is simply due to version incompatibility. I added a line to check for this, but I'm not sure this is the cleanest way to do it.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
