### PR TITLE
Add tranlucent no depth blending mode

### DIFF
--- a/napari/_vispy/utils_gl.py
+++ b/napari/_vispy/utils_gl.py
@@ -104,3 +104,26 @@ def fix_data_dtype(data):
                 )
             )
         return data.astype(dtype)
+
+
+BLENDING_MODES = {
+    'opaque': dict(depth_test=True, cull_face=False, blend=False),
+    'translucent': dict(
+        depth_test=True,
+        cull_face=False,
+        blend=True,
+        blend_func=('src_alpha', 'one_minus_src_alpha', 'zero', 'one'),
+    ),
+    'translucent_no_depth': dict(
+        depth_test=False,
+        cull_face=False,
+        blend=True,
+        blend_func=('src_alpha', 'one_minus_src_alpha', 'zero', 'one'),
+    ),
+    'additive': dict(
+        depth_test=False,
+        cull_face=False,
+        blend=True,
+        blend_func=('src_alpha', 'one'),
+    ),
+}

--- a/napari/_vispy/utils_gl.py
+++ b/napari/_vispy/utils_gl.py
@@ -107,23 +107,35 @@ def fix_data_dtype(data):
 
 
 BLENDING_MODES = {
-    'opaque': dict(depth_test=True, cull_face=False, blend=False),
-    'translucent': dict(
-        depth_test=True,
-        cull_face=False,
-        blend=True,
-        blend_func=('src_alpha', 'one_minus_src_alpha', 'zero', 'one'),
-    ),
+    'opaque': dict(preset='opaque'),
+    'translucent': dict(preset='translucent'),
     'translucent_no_depth': dict(
         depth_test=False,
         cull_face=False,
         blend=True,
         blend_func=('src_alpha', 'one_minus_src_alpha', 'zero', 'one'),
     ),
-    'additive': dict(
-        depth_test=False,
-        cull_face=False,
-        blend=True,
-        blend_func=('src_alpha', 'one'),
-    ),
+    'additive': dict(preset='additive'),
 }
+
+# BLENDING_MODES = {
+#     'opaque': dict(depth_test=True, cull_face=False, blend=False),
+#     'translucent': dict(
+#         depth_test=True,
+#         cull_face=False,
+#         blend=True,
+#         blend_func=('src_alpha', 'one_minus_src_alpha', 'zero', 'one'),
+#     ),
+#     'translucent_no_depth': dict(
+#         depth_test=False,
+#         cull_face=False,
+#         blend=True,
+#         blend_func=('src_alpha', 'one_minus_src_alpha', 'zero', 'one'),
+#     ),
+#     'additive': dict(
+#         depth_test=False,
+#         cull_face=False,
+#         blend=True,
+#         blend_func=('src_alpha', 'one'),
+#     ),
+# }

--- a/napari/_vispy/utils_gl.py
+++ b/napari/_vispy/utils_gl.py
@@ -117,4 +117,3 @@ BLENDING_MODES = {
     ),
     'additive': dict(preset='additive'),
 }
-

--- a/napari/_vispy/utils_gl.py
+++ b/napari/_vispy/utils_gl.py
@@ -118,24 +118,3 @@ BLENDING_MODES = {
     'additive': dict(preset='additive'),
 }
 
-# BLENDING_MODES = {
-#     'opaque': dict(depth_test=True, cull_face=False, blend=False),
-#     'translucent': dict(
-#         depth_test=True,
-#         cull_face=False,
-#         blend=True,
-#         blend_func=('src_alpha', 'one_minus_src_alpha', 'zero', 'one'),
-#     ),
-#     'translucent_no_depth': dict(
-#         depth_test=False,
-#         cull_face=False,
-#         blend=True,
-#         blend_func=('src_alpha', 'one_minus_src_alpha', 'zero', 'one'),
-#     ),
-#     'additive': dict(
-#         depth_test=False,
-#         cull_face=False,
-#         blend=True,
-#         blend_func=('src_alpha', 'one'),
-#     ),
-# }

--- a/napari/_vispy/vispy_base_layer.py
+++ b/napari/_vispy/vispy_base_layer.py
@@ -4,7 +4,7 @@ import numpy as np
 from vispy.visuals.transforms import MatrixTransform
 
 from ..utils.events import disconnect_events
-from .utils_gl import get_max_texture_sizes
+from .utils_gl import BLENDING_MODES, get_max_texture_sizes
 
 
 class VispyBaseLayer(ABC):
@@ -118,7 +118,8 @@ class VispyBaseLayer(ABC):
         self.node.opacity = self.layer.opacity
 
     def _on_blending_change(self, event=None):
-        self.node.set_gl_state(self.layer.blending)
+        blending_kwargs = BLENDING_MODES[self.layer.blending]
+        self.node.set_gl_state(**blending_kwargs)
         self.node.update()
 
     def _on_matrix_change(self, event=None):

--- a/napari/_vispy/vispy_points_layer.py
+++ b/napari/_vispy/vispy_points_layer.py
@@ -4,6 +4,7 @@ from ..settings import get_settings
 from ..utils.colormaps.standardize_color import transform_color
 from ..utils.events import disconnect_events
 from ._text_utils import update_text
+from .utils_gl import BLENDING_MODES
 from .vispy_base_layer import VispyBaseLayer
 from .vispy_points_visual import PointsVisual
 
@@ -163,10 +164,12 @@ class VispyPointsLayer(VispyBaseLayer):
 
     def _on_blending_change(self, event=None):
         """Function to set the blending mode"""
-        self.node.set_gl_state(self.layer.blending)
+        points_blending_kwargs = BLENDING_MODES[self.layer.blending]
+        self.node.set_gl_state(**points_blending_kwargs)
 
         text_node = self._get_text_node()
-        text_node.set_gl_state(str(self.layer.text.blending))
+        text_blending_kwargs = BLENDING_MODES[self.layer.text.blending]
+        text_node.set_gl_state(**text_blending_kwargs)
         self.node.update()
 
     def reset(self, event=None):

--- a/napari/_vispy/vispy_shapes_layer.py
+++ b/napari/_vispy/vispy_shapes_layer.py
@@ -3,6 +3,7 @@ import numpy as np
 from ..settings import get_settings
 from ..utils.events import disconnect_events
 from ._text_utils import update_text
+from .utils_gl import BLENDING_MODES
 from .vispy_base_layer import VispyBaseLayer
 from .vispy_shapes_visual import ShapesVisual
 
@@ -152,10 +153,12 @@ class VispyShapesLayer(VispyBaseLayer):
 
     def _on_blending_change(self, event=None):
         """Function to set the blending mode"""
-        self.node.set_gl_state(self.layer.blending)
+        shapes_blending_kwargs = BLENDING_MODES[self.layer.blending]
+        self.node.set_gl_state(**shapes_blending_kwargs)
 
         text_node = self._get_text_node()
-        text_node.set_gl_state(str(self.layer.text.blending))
+        text_blending_kwargs = BLENDING_MODES[self.layer.text.blending]
+        text_node.set_gl_state(**text_blending_kwargs)
         self.node.update()
 
     def reset(self):

--- a/napari/layers/base/_base_constants.py
+++ b/napari/layers/base/_base_constants.py
@@ -17,6 +17,11 @@ class Blending(StringEnum):
                 Allows for multiple layers to be blended with different opacity
                 and corresponds to depth_test=True, cull_face=False,
                 blend=True, blend_func=('src_alpha', 'one_minus_src_alpha').
+            Blending.TRANSLUCENT_NO_DEPTH
+                Allows for multiple layers to be blended with different opacity,
+                but no depth testing is performed.
+                and corresponds to depth_test=False, cull_face=False,
+                blend=True, blend_func=('src_alpha', 'one_minus_src_alpha').
             Blending.ADDITIVE
                 Allows for multiple layers to be blended together with
                 different colors and opacity. Useful for creating overlays. It
@@ -25,6 +30,7 @@ class Blending(StringEnum):
     """
 
     TRANSLUCENT = auto()
+    TRANSLUCENT_NO_DEPTH = auto()
     ADDITIVE = auto()
     OPAQUE = auto()
 
@@ -32,6 +38,7 @@ class Blending(StringEnum):
 BLENDING_TRANSLATIONS = OrderedDict(
     [
         (Blending.TRANSLUCENT, trans._("translucent")),
+        (Blending.TRANSLUCENT_NO_DEPTH, trans._("translucent_no_depth")),
         (Blending.ADDITIVE, trans._("additive")),
         (Blending.OPAQUE, trans._("opaque")),
     ]

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -94,7 +94,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     blending : str
         One of a list of preset blending modes that determines how RGB and
         alpha values of the layer visual get mixed. Allowed values are
-        {'opaque', 'translucent', and 'additive'}.
+        {'opaque', 'translucent', 'translucent_no_depth', and 'additive'}.
     visible : bool
         Whether the layer visual is currently being displayed.
     multiscale : bool
@@ -118,6 +118,11 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             Blending.TRANSLUCENT
                 Allows for multiple layers to be blended with different opacity
                 and corresponds to depth_test=True, cull_face=False,
+                blend=True, blend_func=('src_alpha', 'one_minus_src_alpha').
+            Blending.TRANSLUCENT_NO_DEPTH
+                Allows for multiple layers to be blended with different opacity,
+                but no depth testing is performed.
+                and corresponds to depth_test=False, cull_face=False,
                 blend=True, blend_func=('src_alpha', 'one_minus_src_alpha').
             Blending.ADDITIVE
                 Allows for multiple layers to be blended together with


### PR DESCRIPTION
# Description
This PR adds a blending mode that is the same as translucent, but without depth checking.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)


# References
Closes #3343 , supercedes #3395 

# How has this been tested?

- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
