### PR TITLE
Add right-click context menu to convert label data type.

### DIFF
--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from ..layers import Image, Labels, Layer
 from ..layers.utils._link_layers import get_linked_layers, layer_is_linked
+from ..utils._dtype import normalize_dtype
 from ..utils.events.containers import SelectableEventedList
 from ..utils.naming import inc_name_count
 from ..utils.translations import trans
@@ -302,6 +303,16 @@ class LayerList(SelectableEventedList[Layer]):
 # `qt_action_context_menu.QtActionContextMenu` method to update the enabled
 # and/or visible items based on the state of the layerlist.
 
+
+def get_active_layer_dtype(layer):
+    if layer.active:
+        return normalize_dtype(
+            getattr(layer.active.data, 'dtype', '')
+        ).__name__
+    else:
+        return None
+
+
 _CONTEXT_KEYS = {
     'selection_count': lambda s: len(s),
     'all_layers_linked': lambda s: all(layer_is_linked(x) for x in s),
@@ -321,6 +332,5 @@ _CONTEXT_KEYS = {
     'same_shape': (
         lambda s: len({getattr(x.data, 'shape', ()) for x in s}) == 1
     ),
-    'active_layer_dtype': lambda s: s.active
-    and str(getattr(s.active.data, 'dtype', '')),
+    'active_layer_dtype': get_active_layer_dtype,
 }

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -321,4 +321,36 @@ _CONTEXT_KEYS = {
     'same_shape': (
         lambda s: len({getattr(x.data, 'shape', ()) for x in s}) == 1
     ),
+    'int64_label': (
+        lambda s: s.active
+        and getattr(s.active.data, 'dtype', None) == np.dtype('int64')
+    ),
+    'int32_label': (
+        lambda s: s.active
+        and getattr(s.active.data, 'dtype', None) == np.dtype('int32')
+    ),
+    'int16_label': (
+        lambda s: s.active
+        and getattr(s.active.data, 'dtype', None) == np.dtype('int16')
+    ),
+    'int8_label': (
+        lambda s: s.active
+        and getattr(s.active.data, 'dtype', None) == np.dtype('int8')
+    ),
+    'uint64_label': (
+        lambda s: s.active
+        and getattr(s.active.data, 'dtype', None) == np.dtype('uint64')
+    ),
+    'uint32_label': (
+        lambda s: s.active
+        and getattr(s.active.data, 'dtype', None) == np.dtype('uint32')
+    ),
+    'uint16_label': (
+        lambda s: s.active
+        and getattr(s.active.data, 'dtype', None) == np.dtype('uint16')
+    ),
+    'uint8_label': (
+        lambda s: s.active
+        and getattr(s.active.data, 'dtype', None) == np.dtype('uint8')
+    ),
 }

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -321,36 +321,6 @@ _CONTEXT_KEYS = {
     'same_shape': (
         lambda s: len({getattr(x.data, 'shape', ()) for x in s}) == 1
     ),
-    'int64_label': (
-        lambda s: s.active
-        and getattr(s.active.data, 'dtype', None) == np.dtype('int64')
-    ),
-    'int32_label': (
-        lambda s: s.active
-        and getattr(s.active.data, 'dtype', None) == np.dtype('int32')
-    ),
-    'int16_label': (
-        lambda s: s.active
-        and getattr(s.active.data, 'dtype', None) == np.dtype('int16')
-    ),
-    'int8_label': (
-        lambda s: s.active
-        and getattr(s.active.data, 'dtype', None) == np.dtype('int8')
-    ),
-    'uint64_label': (
-        lambda s: s.active
-        and getattr(s.active.data, 'dtype', None) == np.dtype('uint64')
-    ),
-    'uint32_label': (
-        lambda s: s.active
-        and getattr(s.active.data, 'dtype', None) == np.dtype('uint32')
-    ),
-    'uint16_label': (
-        lambda s: s.active
-        and getattr(s.active.data, 'dtype', None) == np.dtype('uint16')
-    ),
-    'uint8_label': (
-        lambda s: s.active
-        and getattr(s.active.data, 'dtype', None) == np.dtype('uint8')
-    ),
+    'active_layer_dtype': lambda s: s.active
+    and str(getattr(s.active.data, 'dtype', '')),
 }

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -197,7 +197,7 @@ def _labeltypedict(key) -> ContextAction:
     return {
         'description': key,
         'action': partial(_convert_dtype, mode=key),
-        'enable_when': f'not {key}_label',
+        'enable_when': f'only_labels_selected and active_layer_dtype != {key!r}',
         'show_when': 'True',
     }
 

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -77,6 +77,27 @@ def _project(ll: LayerList, axis: int = 0, mode='max'):
     ll.append(new)
 
 
+def _convert_dtype(ll: LayerList, mode='int64'):
+    layer = ll.selection.active
+    if not layer:
+        return
+    if layer._type_string != 'labels':
+        raise NotImplementedError(
+            "Data type conversion only implemented for labels"
+        )
+
+    target_dtype = np.dtype(mode)
+    if (
+        layer.data.min() < np.iinfo(target_dtype).min
+        or layer.data.max() > np.iinfo(target_dtype).max
+    ):
+        raise AssertionError(
+            "Labeling contains values outside of the target data type range."
+        )
+    else:
+        layer.data = layer.data.astype(np.dtype(mode))
+
+
 def _convert(ll: LayerList, type_: str):
 
     for lay in list(ll.selection):
@@ -172,6 +193,15 @@ def _projdict(key) -> ContextAction:
     }
 
 
+def _labeltypedict(key) -> ContextAction:
+    return {
+        'description': key,
+        'action': partial(_convert_dtype, mode=key),
+        'enable_when': f'not {key}_label',
+        'show_when': 'True',
+    }
+
+
 _LAYER_ACTIONS: Sequence[MenuItem] = [
     {
         'napari:duplicate_layer': {
@@ -200,6 +230,23 @@ _LAYER_ACTIONS: Sequence[MenuItem] = [
         },
     },
     # (each new dict creates a seperated section in the menu)
+    {
+        'napari:group:convert_type': {
+            'description': trans._('Convert datatype'),
+            'enable_when': 'only_labels_selected',
+            'show_when': 'True',
+            'action_group': {
+                'napari:to_int8': _labeltypedict('int8'),
+                'napari:to_int16': _labeltypedict('int16'),
+                'napari:to_int32': _labeltypedict('int32'),
+                'napari:to_int64': _labeltypedict('int64'),
+                'napari:to_uint8': _labeltypedict('uint8'),
+                'napari:to_uint16': _labeltypedict('uint16'),
+                'napari:to_uint32': _labeltypedict('uint32'),
+                'napari:to_uint64': _labeltypedict('uint64'),
+            },
+        }
+    },
     {
         'napari:group:projections': {
             'description': trans._('Make Projection'),

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -88,8 +88,8 @@ def _convert_dtype(ll: LayerList, mode='int64'):
 
     target_dtype = np.dtype(mode)
     if (
-        layer.data.min() < np.iinfo(target_dtype).min
-        or layer.data.max() > np.iinfo(target_dtype).max
+        np.min(layer.data) < np.iinfo(target_dtype).min
+        or np.max(layer.data) > np.iinfo(target_dtype).max
     ):
         raise AssertionError(
             "Labeling contains values outside of the target data type range."


### PR DESCRIPTION
# Description
This PR adds a context menu which allows users to change the data type of a label layer. This is useful if one wants to save a labeling in a different data type. However, conversion is only possible if min and max value of the current data is in the target data type range.

![napari_label_dtype_conversion](https://user-images.githubusercontent.com/5450869/134197188-43950b71-7026-4ed2-b4cd-7eb7eeeea29a.gif)


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
I could not find a related issue or PR. Please fix if I missed something related.

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] Added conversion test to `layers/_tests/test_layer_actions:test_convert_dtype`.
The test checks if the label values stay the same and checks if the `AssertionError` is raised if a conversion is attempted of a label which contains values outside of the target data type.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
