### PR TITLE
Try to fix bundle building.

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Make Bundle (Linux)
         if: runner.os == 'Linux'
         run: |
+          sudo apt-get update
           sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 \
             libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
             libxcb-xinerama0 libxcb-xfixes0 libxcb-shape0 libqt5gui5


### PR DESCRIPTION
It might be that ubuntu has shifted the location of some packages in the
remote repository as most of the 404 files are in `pool/...` not in
`dist/<distname>`

The error message say to try to update or --fix-missing.

So let's try `update`
