### PR TITLE
Attempt to speedup tests around theme.

### DIFF
--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -17,6 +17,7 @@ skip = [
     'points-over-time.py',  # too resource hungry
     'embed_ipython.py',  # fails without monkeypatch
     'custom_key_bindings.py',  # breaks EXPECTED_NUMBER_OF_VIEWER_METHODS later
+    'new_theme.py',  # testing theme is extremely slow on CI
 ]
 EXAMPLE_DIR = Path(napari.__file__).parent.parent / 'examples'
 # using f.name here and re-joining at `run_path()` for test key presentation

--- a/napari/utils/_tests/test_theme.py
+++ b/napari/utils/_tests/test_theme.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 import pytest
 from pydantic import ValidationError
 
@@ -98,6 +101,11 @@ def test_rebuild_theme_settings():
     settings.appearance.theme = "another-theme"
 
 
+@pytest.mark.skipif(
+    os.getenv('CI') and sys.version_info < (3, 9),
+    reason="Testing theme on CI is extremely slow ~ 15s per test."
+    "Skip for now until we find the reason",
+)
 @pytest.mark.parametrize(
     "color",
     [
@@ -113,5 +121,8 @@ def test_theme(color):
     theme = get_theme("dark", False)
     theme.background = color
 
+
+def test_theme_syntax_highlight():
+    theme = get_theme("dark", False)
     with pytest.raises(ValidationError):
         theme.syntax_style = "invalid"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ skip_glob = ["*examples/*", "*vendored*", "*_vendor*"]
 [tool.pytest.ini_options]
 # These follow standard library warnings filters syntax.  See more here:
 # https://docs.python.org/3/library/warnings.html#describing-warning-filters
-addopts = "--maxfail=5 --durations=5"
+addopts = "--maxfail=5 --durations=10"
 
 # NOTE: only put things that will never change in here.
 # napari deprecation and future warnings should NOT go in here.


### PR DESCRIPTION
See #3404

Do 2 things:
  - Separate syntax highlight in its own test. My guess is that _might_
  be super slow because of Pygments listing all available style via
  entry point.

  - Skip theme switching on all but one matrix items.