### PR TITLE
Center data within points thumbnail

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1553,6 +1553,9 @@ def test_thumbnail_non_square_data():
     np.testing.assert_array_equal(
         layer.thumbnail[: mid_row - 1, :, :3], expected_zeros
     )
+    assert (
+        np.count_nonzero(layer.thumbnail[mid_row - 1 : mid_row + 1, :, :3]) > 0
+    )
     np.testing.assert_array_equal(
         layer.thumbnail[mid_row + 1 :, :, :3], expected_zeros
     )

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1530,6 +1530,29 @@ def test_thumbnail():
     assert layer.thumbnail.shape == layer._thumbnail_shape
 
 
+def test_thumbnail_non_square_data():
+    """Test the image thumbnail for non-square data.
+
+    See: https://github.com/napari/napari/issues/1450
+    """
+    # Make the x coordinate range 16x the y range so that the points
+    # should be drawn on two rows of the 32x32 thumbnail.
+    data_range = [1, 32]
+    np.random.seed(0)
+    data = np.random.random((10, 2)) * data_range
+    # Make sure the random points span the range.
+    data[0, :] = [0, 0]
+    data[-1, :] = data_range
+    layer = Points(data)
+
+    layer._update_thumbnail()
+
+    assert layer.thumbnail.shape == (32, 32, 4)
+    expected_zeros = np.zeros(shape=(15, 32, 3), dtype=np.uint8)
+    np.testing.assert_array_equal(layer.thumbnail[:15, :, :3], expected_zeros)
+    np.testing.assert_array_equal(layer.thumbnail[17:, :, :3], expected_zeros)
+
+
 def test_thumbnail_with_n_points_greater_than_max():
     """Test thumbnail generation with n_points > _max_points_thumbnail
 

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1535,8 +1535,7 @@ def test_thumbnail_non_square_data():
 
     See: https://github.com/napari/napari/issues/1450
     """
-    # Make the x coordinate range 16x the y range so that the points
-    # should be drawn on two rows of the 32x32 thumbnail.
+    # The points coordinates are in a short and wide range.
     data_range = [1, 32]
     np.random.seed(0)
     data = np.random.random((10, 2)) * data_range
@@ -1547,10 +1546,16 @@ def test_thumbnail_non_square_data():
 
     layer._update_thumbnail()
 
-    assert layer.thumbnail.shape == (32, 32, 4)
-    expected_zeros = np.zeros(shape=(15, 32, 3), dtype=np.uint8)
-    np.testing.assert_array_equal(layer.thumbnail[:15, :, :3], expected_zeros)
-    np.testing.assert_array_equal(layer.thumbnail[17:, :, :3], expected_zeros)
+    assert layer.thumbnail.shape == layer._thumbnail_shape
+    # Check that the thumbnail only contains non-zero RGB values in the middle two rows.
+    mid_row = layer.thumbnail.shape[0] // 2
+    expected_zeros = np.zeros(shape=(mid_row - 1, 32, 3), dtype=np.uint8)
+    np.testing.assert_array_equal(
+        layer.thumbnail[: mid_row - 1, :, :3], expected_zeros
+    )
+    np.testing.assert_array_equal(
+        layer.thumbnail[mid_row + 1 :, :, :3], expected_zeros
+    )
 
 
 def test_thumbnail_with_n_points_greater_than_max():

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -126,6 +126,9 @@ class Points(Layer):
         {'opaque', 'translucent', and 'additive'}.
     visible : bool
         Whether the layer visual is currently being displayed.
+    cache : bool
+        Whether slices of out-of-core datasets should be cached upon retrieval.
+        Currently, this only applies to dask arrays.
 
     Attributes
     ----------
@@ -267,6 +270,7 @@ class Points(Layer):
         opacity=1,
         blending='translucent',
         visible=True,
+        cache=True,
         property_choices=None,
         experimental_clipping_planes=None,
     ):
@@ -288,6 +292,7 @@ class Points(Layer):
             opacity=opacity,
             blending=blending,
             visible=visible,
+            cache=cache,
             experimental_clipping_planes=experimental_clipping_planes,
         )
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1379,13 +1379,11 @@ class Points(Layer):
                 thumbnail_indices = self._indices_view
 
             # Calculate the point coordinates in the thumbnail data space.
-            thumbnail_shape = np.round(
-                np.clip(
-                    zoom_factor * np.array(shape[:2]),
-                    1,  # smallest side should be 1 pixel wide
-                    self._thumbnail_shape[:2],
-                )
-            ).astype(int)
+            thumbnail_shape = np.clip(
+                np.ceil(zoom_factor * np.array(shape[:2])).astype(int),
+                1,  # smallest side should be 1 pixel wide
+                self._thumbnail_shape[:2],
+            )
             coords = np.floor(
                 (points[:, -2:] - min_vals[-2:] + 0.5) * zoom_factor
             ).astype(int)

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -126,9 +126,6 @@ class Points(Layer):
         {'opaque', 'translucent', and 'additive'}.
     visible : bool
         Whether the layer visual is currently being displayed.
-    cache : bool
-        Whether slices of out-of-core datasets should be cached upon retrieval.
-        Currently, this only applies to dask arrays.
 
     Attributes
     ----------
@@ -270,7 +267,6 @@ class Points(Layer):
         opacity=1,
         blending='translucent',
         visible=True,
-        cache=True,
         property_choices=None,
         experimental_clipping_planes=None,
     ):
@@ -292,7 +288,6 @@ class Points(Layer):
             opacity=opacity,
             blending=blending,
             visible=visible,
-            cache=cache,
             experimental_clipping_planes=experimental_clipping_planes,
         )
 
@@ -1358,6 +1353,7 @@ class Points(Layer):
         colormapped[..., 3] = 1
         view_data = self._view_data
         if len(view_data) > 0:
+            # Get the zoom factor required to fit all data in the thumbnail.
             de = self._extent_data
             min_vals = [de[0, i] for i in self._dims_displayed]
             shape = np.ceil(
@@ -1366,6 +1362,8 @@ class Points(Layer):
             zoom_factor = np.divide(
                 self._thumbnail_shape[:2], shape[-2:]
             ).min()
+
+            # Maybe subsample the points.
             if len(view_data) > self._max_points_thumbnail:
                 thumbnail_indices = np.random.randint(
                     0, len(view_data), self._max_points_thumbnail
@@ -1374,12 +1372,23 @@ class Points(Layer):
             else:
                 points = view_data
                 thumbnail_indices = self._indices_view
+
+            # Calculate the point coordinates in the thumbnail data space.
+            thumbnail_shape = np.round(
+                np.clip(
+                    zoom_factor * np.array(shape[:2]),
+                    1,  # smallest side should be 1 pixel wide
+                    self._thumbnail_shape[:2],
+                )
+            ).astype(int)
             coords = np.floor(
                 (points[:, -2:] - min_vals[-2:] + 0.5) * zoom_factor
             ).astype(int)
-            coords = np.clip(
-                coords, 0, np.subtract(self._thumbnail_shape[:2], 1)
-            )
+            coords = np.clip(coords, 0, thumbnail_shape - 1)
+
+            # Draw single pixel points in the colormapped thumbnail.
+            colormapped = np.zeros(tuple(thumbnail_shape) + (4,))
+            colormapped[..., 3] = 1
             colors = self._face.colors[thumbnail_indices]
             colormapped[coords[:, 0], coords[:, 1]] = colors
 


### PR DESCRIPTION
# Description
This is the minimum amount of work I could do to fix the bug described in #1450, where the points thumbnail did not center the data as desired/expected.

The bug existed because `Points._update_thumbnail` fills out a 32x32 image regardless of the shape of the points layer's data extent. By contrast, `ImageBase._update_thumbnail` returns an image where one of the dimensions should be 32 and the other will be in [1, 32] depending on the anisotropy of the shape of the image.

The fix calculates the non-isotropic `thumbnail_shape` in `Points._update_thumbnail` in the same way that `Image._update_thumbnail` does. Padding and centering happens in `Layer.thumbnail.setter`. Using the same example in the bug description, this seems to work.

![Screen Shot 2021-09-21 at 1 15 14 PM](https://user-images.githubusercontent.com/2608297/134241178-c44f40bd-517d-4b3b-954f-eb3213d69e9c.png)

There is some opportunity for code sharing between the different implementations of `update_thumbnail`, though I haven't attempted that here yet. I also believe there are similar bugs to this one for `Vectors`, `Tracks`, and maybe `Shapes` (note that `Surface` does not have a thumbnail).

**Do we want to expand this fix to handle those, or should I open a separate issue(s) with examples?**

In the long term, I'm wondering if we can reuse vispy to render thumbnails (e.g. using [offscreen rendering](https://github.com/vispy/vispy/blob/main/examples/demo/gloo/offscreen.py)) to avoid maintaining different rendering pipelines in `Layer._update_thumbnail`. I think that might be an overall easier and more maintainable solution.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Based on the code added, I think this should be a safe bug fix because the coordinate/thumbnail indexing is clipped to be in bounds.

# References
Closes #1450.

# How has this been tested?
- [x] example: added a test to `test_points.py` to cover this case.
- [ ] example: all existing tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
