### PR TITLE
Add global test timeout to avoid regression.

### DIFF
--- a/napari/_qt/_tests/test_app.py
+++ b/napari/_qt/_tests/test_app.py
@@ -5,6 +5,7 @@ import pytest
 
 from napari import Viewer
 from napari._qt.qt_event_loop import _ipython_has_eventloop, run, set_app_id
+from napari._tests.utils import slow
 
 
 @pytest.mark.skipif(os.name != "Windows", reason="Windows specific")
@@ -29,6 +30,7 @@ def test_windows_grouping_overwrite(make_napari_viewer):
     assert get_app_id() == ""
 
 
+@slow(30)
 def test_run_outside_ipython(qapp, monkeypatch):
     """Test that we don't incorrectly give ipython the event loop."""
     assert not _ipython_has_eventloop()

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -16,6 +16,7 @@ from napari._tests.utils import (
     layer_test_data,
     skip_local_popups,
     skip_on_win_ci,
+    slow,
 )
 from napari.settings import get_settings
 from napari.utils.interactions import mouse_press_callbacks
@@ -197,6 +198,7 @@ def test_z_order_adding_removing_images(make_napari_viewer):
 
 
 @skip_on_win_ci
+@slow(15)
 def test_screenshot(make_napari_viewer):
     "Test taking a screenshot"
     viewer = make_napari_viewer()

--- a/napari/_qt/_tests/test_qt_window.py
+++ b/napari/_qt/_tests/test_qt_window.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from napari._qt.qt_main_window import Window, _QtMainWindow
+from napari._tests.utils import slow
 from napari.utils.theme import (
     _themes,
     get_theme,
@@ -9,6 +10,7 @@ from napari.utils.theme import (
 )
 
 
+@slow(10)
 def test_current_viewer(make_napari_viewer, qapp):
     """Test that we can retrieve the "current" viewer window easily.
 

--- a/napari/_qt/perf/_tests/test_perf.py
+++ b/napari/_qt/perf/_tests/test_perf.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from napari._tests.utils import skip_local_popups, skip_on_win_ci
+from napari._tests.utils import skip_local_popups, skip_on_win_ci, slow
 
 # NOTE:
 # for some reason, running this test fails in a subprocess with a segfault
@@ -32,6 +32,7 @@ CONFIG = {
 
 
 @skip_on_win_ci
+@slow(20)
 @skip_local_popups
 def test_trace_on_start(tmp_path: Path):
     """Make sure napari can write a perfmon trace file."""

--- a/napari/_tests/test_adding_removing.py
+++ b/napari/_tests/test_adding_removing.py
@@ -5,12 +5,14 @@ from napari._tests.utils import (
     layer_test_data,
     skip_local_popups,
     skip_on_win_ci,
+    slow,
 )
 from napari.layers import Image
 from napari.utils.events.event import WarningEmitter
 
 
 @skip_on_win_ci
+@slow(15)
 @skip_local_popups
 @pytest.mark.parametrize('Layer, data, _', layer_test_data)
 def test_add_all_layers(make_napari_viewer, Layer, data, _):

--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -8,7 +8,7 @@ from qtpy import API_NAME
 import napari
 from napari.utils.notifications import notification_manager
 
-from .utils import slow
+from napari._tests.utils import slow
 
 # not testing these examples
 skip = [

--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -1,11 +1,14 @@
 import os
 import runpy
 from pathlib import Path
-from qtpy import API_NAME
+
 import pytest
+from qtpy import API_NAME
 
 import napari
 from napari.utils.notifications import notification_manager
+
+from .utils import slow
 
 # not testing these examples
 skip = [
@@ -50,6 +53,7 @@ def qapp():
     yield app
 
 
+@slow(30)
 @pytest.mark.filterwarnings("ignore")
 @pytest.mark.skipif(not examples, reason="No examples were found.")
 @pytest.mark.parametrize("fname", examples)

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -11,6 +11,7 @@ from napari._tests.utils import (
     layer_test_data,
     skip_local_popups,
     skip_on_win_ci,
+    slow,
 )
 from napari.utils._tests.test_naming import eval_with_filename
 from napari.utils.action_manager import action_manager
@@ -142,6 +143,7 @@ def test_add_layer_magic_name(
 
 
 @skip_on_win_ci
+@slow(20)
 def test_screenshot(make_napari_viewer):
     """Test taking a screenshot."""
     viewer = make_napari_viewer()
@@ -295,6 +297,7 @@ def test_deleting_points(make_napari_viewer):
     assert len(pts_layer.data) == 3
 
 
+@slow(15)
 @skip_local_popups
 def test_custom_layer(make_napari_viewer):
     """Make sure that custom layers subclasses can be added to the viewer."""

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -3,7 +3,12 @@ import collections
 import numpy as np
 import pytest
 
-from napari._tests.utils import skip_local_popups, skip_on_win_ci, slow
+from napari._tests.utils import (
+    skip_local_popups,
+    skip_on_mac_ci,
+    skip_on_win_ci,
+    slow,
+)
 from napari.utils.interactions import (
     ReadOnlyWrapper,
     mouse_move_callbacks,
@@ -12,8 +17,8 @@ from napari.utils.interactions import (
 )
 
 
-@slow(30)
 @skip_on_win_ci
+@skip_on_mac_ci
 @skip_local_popups
 def test_z_order_adding_removing_images(make_napari_viewer):
     """Test z order is correct after adding/ removing images."""

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -3,7 +3,7 @@ import collections
 import numpy as np
 import pytest
 
-from napari._tests.utils import skip_local_popups, skip_on_win_ci
+from napari._tests.utils import skip_local_popups, skip_on_win_ci, slow
 from napari.utils.interactions import (
     ReadOnlyWrapper,
     mouse_move_callbacks,
@@ -12,6 +12,7 @@ from napari.utils.interactions import (
 )
 
 
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_adding_removing_images(make_napari_viewer):
@@ -56,6 +57,7 @@ def test_z_order_adding_removing_images(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 255, 0, 255])
 
 
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_images(make_napari_viewer):
@@ -77,6 +79,7 @@ def test_z_order_images(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
 
 
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_image_points(make_napari_viewer):
@@ -98,6 +101,7 @@ def test_z_order_image_points(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
 
 
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_images_after_ndisplay(make_napari_viewer):
@@ -127,6 +131,7 @@ def test_z_order_images_after_ndisplay(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_image_points_after_ndisplay(make_napari_viewer):
@@ -156,6 +161,7 @@ def test_z_order_image_points_after_ndisplay(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_changing_image_colormap(make_napari_viewer):
@@ -186,6 +192,7 @@ def test_changing_image_colormap(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_changing_image_gamma(make_napari_viewer):
@@ -216,6 +223,7 @@ def test_changing_image_gamma(make_napari_viewer):
     assert screenshot[center + (0,)] < 80
 
 
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_grid_mode(make_napari_viewer):
@@ -316,6 +324,7 @@ def test_grid_mode(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 255, 255, 255])
 
 
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_changing_image_attenuation(make_napari_viewer):
@@ -341,6 +350,7 @@ def test_changing_image_attenuation(make_napari_viewer):
     assert screenshot[center + (0,)] < 60
 
 
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_labels_painting(make_napari_viewer):
@@ -414,6 +424,7 @@ def test_labels_painting(make_napari_viewer):
     assert screenshot[:, :, :2].max() > 0
 
 
+@slow(30)
 @pytest.mark.skip("Welcome visual temporarily disabled")
 @skip_on_win_ci
 @skip_local_popups
@@ -439,6 +450,7 @@ def test_welcome(make_napari_viewer):
     assert screenshot[..., :-1].max() > 0
 
 
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_axes_visible(make_napari_viewer):
@@ -463,6 +475,7 @@ def test_axes_visible(make_napari_viewer):
     np.testing.assert_almost_equal(launch_screenshot, off_screenshot)
 
 
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_scale_bar_visible(make_napari_viewer):

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -197,3 +197,19 @@ def check_layer_world_data_extent(
     translated_world_extent = np.add(scaled_world_extent, translate)
     np.testing.assert_almost_equal(layer.extent.data, extent)
     np.testing.assert_almost_equal(layer.extent.world, translated_world_extent)
+
+
+def slow(timeout):
+    """
+    Both mark a function as slow, and with a timeout which is easily scalable
+    via an env variable.
+    """
+    factor = int(os.getenv('NAPARI_TESTING_TIMEOUT_SCALING', '1'))
+
+    def _slow(func):
+
+        func = pytest.mark.timeout(timeout * factor)(func)
+        func = pytest.mark.slow(func)
+        return func
+
+    return _slow

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -20,6 +20,11 @@ skip_on_win_ci = pytest.mark.skipif(
     reason='Screenshot tests are not supported on windows CI.',
 )
 
+skip_on_mac_ci = pytest.mark.skipif(
+    sys.platform.startswith('darwin') and os.getenv('CI', '0') != '0',
+    reason='This test seem to be problematic on mac.',
+)
+
 skip_local_popups = pytest.mark.skipif(
     not os.getenv('CI') and os.getenv('NAPARI_POPUP_TESTS', '0') == '0',
     reason='Tests requiring GUI windows are skipped locally by default.',

--- a/napari/_vispy/_tests/test_image_rendering.py
+++ b/napari/_vispy/_tests/test_image_rendering.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from napari._tests.utils import skip_on_win_ci
+from napari._tests.utils import skip_on_win_ci, slow
 
 
 def test_image_rendering(make_napari_viewer):
@@ -39,6 +39,7 @@ def test_image_rendering(make_napari_viewer):
     assert layer.rendering == 'additive'
 
 
+@slow(15)
 @skip_on_win_ci
 def test_visibility_consistency(qtbot, make_napari_viewer):
     """Make sure toggling visibility maintains image contrast.

--- a/napari/_vispy/_tests/test_vispy_big_images.py
+++ b/napari/_vispy/_tests/test_vispy_big_images.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from napari._tests.utils import slow
+
 
 def test_big_2D_image(make_napari_viewer):
     """Test big 2D image with axis exceeding max texture size."""
@@ -30,6 +32,7 @@ def test_big_3D_image(make_napari_viewer):
         assert np.all(layer._transforms['tile2data'].scale == s)
 
 
+@slow(10)
 @pytest.mark.parametrize(
     "shape",
     [(2, 4), (256, 4048), (4, 20_000), (20_000, 4)],

--- a/napari/layers/image/experimental/_tests/test_octree_import.py
+++ b/napari/layers/image/experimental/_tests/test_octree_import.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 import sys
 
+from napari._tests.utils import slow
+
 CREATE_VIEWER_SCRIPT = """
 import numpy as np
 import napari
@@ -9,6 +11,7 @@ v = napari.view_image(np.random.rand(512, 512))
 """
 
 
+@slow(15)
 def test_octree_import():
     """Test we can create a viewer with NAPARI_OCTREE."""
 

--- a/napari/plugins/_tests/test_plugins_manager.py
+++ b/napari/plugins/_tests/test_plugins_manager.py
@@ -8,7 +8,10 @@ from napari_plugin_engine import napari_hook_implementation
 if TYPE_CHECKING:
     from napari.plugins._plugin_manager import NapariPluginManager
 
+from napari._tests.utils import slow
 
+
+@slow(15)
 def test_plugin_discovery_is_delayed():
     """Test that plugins are not getting discovered at napari import time."""
     cmd = [

--- a/napari/utils/_tests/test_magicgui.py
+++ b/napari/utils/_tests/test_magicgui.py
@@ -8,7 +8,7 @@ import pytest
 from magicgui import magicgui
 
 from napari import Viewer, layers, types
-from napari._tests.utils import layer_test_data
+from napari._tests.utils import layer_test_data, slow
 from napari.layers import Image, Labels, Layer
 from napari.utils.misc import all_subclasses
 
@@ -67,6 +67,7 @@ def test_magicgui_add_data(make_napari_viewer, LayerType, data, ndim):
     assert viewer.layers[0].source.widget == add_data
 
 
+@slow(10)
 @pytest.mark.skipif(
     sys.version_info < (3, 9), reason='Futures not subscriptable before py3.9'
 )
@@ -128,6 +129,7 @@ def test_magicgui_get_data(make_napari_viewer, LayerType, data, ndim):
     viewer.add_layer(layer)
 
 
+@slow(10)
 @pytest.mark.parametrize('LayerType, data, ndim', test_data)
 def test_magicgui_add_layer(make_napari_viewer, LayerType, data, ndim):
     viewer = make_napari_viewer()

--- a/napari/utils/_tests/test_theme.py
+++ b/napari/utils/_tests/test_theme.py
@@ -4,6 +4,7 @@ import sys
 import pytest
 from pydantic import ValidationError
 
+from napari._tests.utils import slow
 from napari.settings import get_settings
 from napari.utils.theme import (
     Theme,
@@ -101,6 +102,7 @@ def test_rebuild_theme_settings():
     settings.appearance.theme = "another-theme"
 
 
+@slow(15)
 @pytest.mark.skipif(
     os.getenv('CI') and sys.version_info < (3, 9),
     reason="Testing theme on CI is extremely slow ~ 15s per test."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ skip_glob = ["*examples/*", "*vendored*", "*_vendor*"]
 [tool.pytest.ini_options]
 # These follow standard library warnings filters syntax.  See more here:
 # https://docs.python.org/3/library/warnings.html#describing-warning-filters
-addopts = "--maxfail=5 --durations=10"
+addopts = "--maxfail=5 --durations=10 --timeout=8"
 
 # NOTE: only put things that will never change in here.
 # napari deprecation and future warnings should NOT go in here.
@@ -105,5 +105,6 @@ filterwarnings = [
 ]
 markers = [
     "sync_only: Test should only be run synchronously",
-    "async_only: Test should only be run asynchronously"
+    "async_only: Test should only be run asynchronously",
+    "slow: Slow test you can skip with `-m 'not slow'`, or adjust with the env variable NAPARI_TESTING_TIMEOUT_SCALING"
 ]


### PR DESCRIPTION
This set a global timeout for each test to 5s, Individual test can be
marked with a longer timeout instead of marking with with
`@pytest.mark.timeout(new_value)`, I introduce a `@slow` decorator and
marker.

1) it makes test easy to disable with "-m 'not slow'" on pytest CLI,
and
2) introduce the NAPARI_TESTING_TIMEOUT_SCALING env variable, so if you
want to double all timeouts as you are on a slower machine, you can set
it to '2'.

I expect for example to set it on macos and windows which on CI may be
quite slow.


Old description: 

~~This set a global timeout for each test to 5s,
Individual test can be marked with a longer timeout with
`@pytest.mark.timeout(new_value)`, but this should ensure that there is
no surprised regression of test ballooning to 15 to 30s like the theme
ones.~~

See #3404 for example.


