### PR TITLE
Typo: test twice in 2D instead of 2D/3D.

### DIFF
--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -40,7 +40,7 @@ layer_test_data = [
     (Points, 20 * np.random.random((10, 3)), 3),
     (Vectors, 20 * np.random.random((10, 2, 2)), 2),
     (Shapes, 20 * np.random.random((10, 4, 2)), 2),
-    (Shapes, 20 * np.random.random((10, 4, 2)), 2),
+    (Shapes, 20 * np.random.random((10, 4, 2)), 3),
     (
         Surface,
         (


### PR DESCRIPTION
It seem weird to have the same data twice, my guess is this was meant to
test 2D/3D ?

It's unclear if ndim=3 will work in all cases, and I've tracked down the addition of this line to a refactor : https://github.com/napari/napari/pull/723/files#diff-a31c365ebeef582512fe77dda4d22958dff27a9a3fdc8177419e34fe76a08dd1R19