### PR TITLE
Alternative to  #3407 migrate to pytest-timeouts

### DIFF
--- a/napari/_qt/_tests/test_app.py
+++ b/napari/_qt/_tests/test_app.py
@@ -30,7 +30,7 @@ def test_windows_grouping_overwrite(make_napari_viewer):
     assert get_app_id() == ""
 
 
-@slow(15)
+@slow(30)
 def test_run_outside_ipython(qapp, monkeypatch):
     """Test that we don't incorrectly give ipython the event loop."""
     assert not _ipython_has_eventloop()

--- a/napari/_qt/_tests/test_app.py
+++ b/napari/_qt/_tests/test_app.py
@@ -5,6 +5,7 @@ import pytest
 
 from napari import Viewer
 from napari._qt.qt_event_loop import _ipython_has_eventloop, run, set_app_id
+from napari._tests.utils import slow
 
 
 @pytest.mark.skipif(os.name != "Windows", reason="Windows specific")
@@ -29,6 +30,7 @@ def test_windows_grouping_overwrite(make_napari_viewer):
     assert get_app_id() == ""
 
 
+@slow(15)
 def test_run_outside_ipython(qapp, monkeypatch):
     """Test that we don't incorrectly give ipython the event loop."""
     assert not _ipython_has_eventloop()

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -15,6 +15,7 @@ from napari._tests.utils import (
     check_viewer_functioning,
     layer_test_data,
     skip_local_popups,
+    slow,
 )
 from napari.settings import get_settings
 from napari.utils.interactions import mouse_press_callbacks
@@ -195,6 +196,7 @@ def test_z_order_adding_removing_images(make_napari_viewer):
     np.testing.assert_almost_equal(order, list(range(len(viewer.layers))))
 
 
+@slow(15)
 def test_screenshot(make_napari_viewer):
     "Test taking a screenshot"
     viewer = make_napari_viewer()

--- a/napari/_qt/_tests/test_qt_window.py
+++ b/napari/_qt/_tests/test_qt_window.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from napari._qt.qt_main_window import Window, _QtMainWindow
+from napari._tests.utils import slow
 from napari.utils.theme import (
     _themes,
     get_theme,
@@ -9,6 +10,7 @@ from napari.utils.theme import (
 )
 
 
+@slow(10)
 def test_current_viewer(make_napari_viewer, qapp):
     """Test that we can retrieve the "current" viewer window easily.
 

--- a/napari/_qt/perf/_tests/test_perf.py
+++ b/napari/_qt/perf/_tests/test_perf.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from napari._tests.utils import skip_local_popups
+from napari._tests.utils import skip_local_popups, slow
 
 # NOTE:
 # for some reason, running this test fails in a subprocess with a segfault
@@ -31,6 +31,7 @@ CONFIG = {
 }
 
 
+@slow(20)
 @skip_local_popups
 def test_trace_on_start(tmp_path: Path):
     """Make sure napari can write a perfmon trace file."""

--- a/napari/_tests/test_adding_removing.py
+++ b/napari/_tests/test_adding_removing.py
@@ -6,7 +6,7 @@ from napari.layers import Image
 from napari.utils.events.event import WarningEmitter
 
 
-@slow(10)
+@slow(15)
 @skip_local_popups
 @pytest.mark.parametrize('Layer, data, _', layer_test_data)
 def test_add_all_layers(make_napari_viewer, Layer, data, _):

--- a/napari/_tests/test_adding_removing.py
+++ b/napari/_tests/test_adding_removing.py
@@ -1,11 +1,12 @@
 import numpy as np
 import pytest
 
-from napari._tests.utils import layer_test_data, skip_local_popups
+from napari._tests.utils import layer_test_data, skip_local_popups, slow
 from napari.layers import Image
 from napari.utils.events.event import WarningEmitter
 
 
+@slow(10)
 @skip_local_popups
 @pytest.mark.parametrize('Layer, data, _', layer_test_data)
 def test_add_all_layers(make_napari_viewer, Layer, data, _):

--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -1,11 +1,14 @@
 import os
 import runpy
 from pathlib import Path
-from qtpy import API_NAME
+
 import pytest
+from qtpy import API_NAME
 
 import napari
 from napari.utils.notifications import notification_manager
+
+from .utils import slow
 
 # not testing these examples
 skip = [
@@ -46,6 +49,7 @@ def qapp():
     yield app
 
 
+@slow(30)
 @pytest.mark.filterwarnings("ignore")
 @pytest.mark.skipif(not examples, reason="No examples were found.")
 @pytest.mark.parametrize("fname", examples)

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -141,7 +141,7 @@ def test_add_layer_magic_name(
     assert layer.name == "a_unique_name"
 
 
-@slow(10)
+@slow(20)
 def test_screenshot(make_napari_viewer):
     """Test taking a screenshot."""
     viewer = make_napari_viewer()

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -10,6 +10,7 @@ from napari._tests.utils import (
     check_viewer_functioning,
     layer_test_data,
     skip_local_popups,
+    slow,
 )
 from napari.utils._tests.test_naming import eval_with_filename
 from napari.utils.action_manager import action_manager
@@ -140,6 +141,7 @@ def test_add_layer_magic_name(
     assert layer.name == "a_unique_name"
 
 
+@slow(10)
 def test_screenshot(make_napari_viewer):
     """Test taking a screenshot."""
     viewer = make_napari_viewer()
@@ -292,6 +294,7 @@ def test_deleting_points(make_napari_viewer):
     assert len(pts_layer.data) == 3
 
 
+@slow(15)
 @skip_local_popups
 def test_custom_layer(make_napari_viewer):
     """Make sure that custom layers subclasses can be added to the viewer."""

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -3,7 +3,7 @@ import collections
 import numpy as np
 import pytest
 
-from napari._tests.utils import skip_local_popups, skip_on_win_ci
+from napari._tests.utils import skip_local_popups, skip_on_win_ci, slow
 from napari.utils.interactions import (
     ReadOnlyWrapper,
     mouse_move_callbacks,
@@ -77,6 +77,7 @@ def test_z_order_images(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
 
 
+@slow(10)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_image_points(make_napari_viewer):
@@ -98,6 +99,7 @@ def test_z_order_image_points(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
 
 
+@slow(10)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_images_after_ndisplay(make_napari_viewer):
@@ -127,6 +129,7 @@ def test_z_order_images_after_ndisplay(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
+@slow(10)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_image_points_after_ndisplay(make_napari_viewer):
@@ -156,6 +159,7 @@ def test_z_order_image_points_after_ndisplay(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
+@slow(10)
 @skip_on_win_ci
 @skip_local_popups
 def test_changing_image_colormap(make_napari_viewer):
@@ -216,6 +220,7 @@ def test_changing_image_gamma(make_napari_viewer):
     assert screenshot[center + (0,)] < 80
 
 
+@slow(10)
 @skip_on_win_ci
 @skip_local_popups
 def test_grid_mode(make_napari_viewer):

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -12,7 +12,7 @@ from napari.utils.interactions import (
 )
 
 
-@slow(15)
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_adding_removing_images(make_napari_viewer):
@@ -57,7 +57,7 @@ def test_z_order_adding_removing_images(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 255, 0, 255])
 
 
-@slow(15)
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_images(make_napari_viewer):
@@ -79,7 +79,7 @@ def test_z_order_images(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
 
 
-@slow(15)
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_image_points(make_napari_viewer):
@@ -101,7 +101,7 @@ def test_z_order_image_points(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
 
 
-@slow(15)
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_images_after_ndisplay(make_napari_viewer):
@@ -131,7 +131,7 @@ def test_z_order_images_after_ndisplay(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
-@slow(15)
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_image_points_after_ndisplay(make_napari_viewer):
@@ -161,7 +161,7 @@ def test_z_order_image_points_after_ndisplay(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
-@slow(15)
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_changing_image_colormap(make_napari_viewer):
@@ -192,7 +192,7 @@ def test_changing_image_colormap(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
-@slow(15)
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_changing_image_gamma(make_napari_viewer):
@@ -223,7 +223,7 @@ def test_changing_image_gamma(make_napari_viewer):
     assert screenshot[center + (0,)] < 80
 
 
-@slow(15)
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_grid_mode(make_napari_viewer):
@@ -324,7 +324,7 @@ def test_grid_mode(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 255, 255, 255])
 
 
-@slow(15)
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_changing_image_attenuation(make_napari_viewer):
@@ -350,7 +350,7 @@ def test_changing_image_attenuation(make_napari_viewer):
     assert screenshot[center + (0,)] < 60
 
 
-@slow(15)
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_labels_painting(make_napari_viewer):
@@ -424,7 +424,7 @@ def test_labels_painting(make_napari_viewer):
     assert screenshot[:, :, :2].max() > 0
 
 
-@slow(15)
+@slow(30)
 @pytest.mark.skip("Welcome visual temporarily disabled")
 @skip_on_win_ci
 @skip_local_popups
@@ -450,7 +450,7 @@ def test_welcome(make_napari_viewer):
     assert screenshot[..., :-1].max() > 0
 
 
-@slow(15)
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_axes_visible(make_napari_viewer):
@@ -475,7 +475,7 @@ def test_axes_visible(make_napari_viewer):
     np.testing.assert_almost_equal(launch_screenshot, off_screenshot)
 
 
-@slow(15)
+@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_scale_bar_visible(make_napari_viewer):

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -12,6 +12,7 @@ from napari.utils.interactions import (
 )
 
 
+@slow(15)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_adding_removing_images(make_napari_viewer):
@@ -56,6 +57,7 @@ def test_z_order_adding_removing_images(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 255, 0, 255])
 
 
+@slow(15)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_images(make_napari_viewer):
@@ -77,7 +79,7 @@ def test_z_order_images(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
 
 
-@slow(10)
+@slow(15)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_image_points(make_napari_viewer):
@@ -99,7 +101,7 @@ def test_z_order_image_points(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
 
 
-@slow(10)
+@slow(15)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_images_after_ndisplay(make_napari_viewer):
@@ -129,7 +131,7 @@ def test_z_order_images_after_ndisplay(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
-@slow(10)
+@slow(15)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_image_points_after_ndisplay(make_napari_viewer):
@@ -159,7 +161,7 @@ def test_z_order_image_points_after_ndisplay(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
-@slow(10)
+@slow(15)
 @skip_on_win_ci
 @skip_local_popups
 def test_changing_image_colormap(make_napari_viewer):
@@ -190,6 +192,7 @@ def test_changing_image_colormap(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
+@slow(15)
 @skip_on_win_ci
 @skip_local_popups
 def test_changing_image_gamma(make_napari_viewer):
@@ -220,7 +223,7 @@ def test_changing_image_gamma(make_napari_viewer):
     assert screenshot[center + (0,)] < 80
 
 
-@slow(10)
+@slow(15)
 @skip_on_win_ci
 @skip_local_popups
 def test_grid_mode(make_napari_viewer):
@@ -321,6 +324,7 @@ def test_grid_mode(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 255, 255, 255])
 
 
+@slow(15)
 @skip_on_win_ci
 @skip_local_popups
 def test_changing_image_attenuation(make_napari_viewer):
@@ -346,6 +350,7 @@ def test_changing_image_attenuation(make_napari_viewer):
     assert screenshot[center + (0,)] < 60
 
 
+@slow(15)
 @skip_on_win_ci
 @skip_local_popups
 def test_labels_painting(make_napari_viewer):
@@ -419,6 +424,7 @@ def test_labels_painting(make_napari_viewer):
     assert screenshot[:, :, :2].max() > 0
 
 
+@slow(15)
 @pytest.mark.skip("Welcome visual temporarily disabled")
 @skip_on_win_ci
 @skip_local_popups
@@ -444,6 +450,7 @@ def test_welcome(make_napari_viewer):
     assert screenshot[..., :-1].max() > 0
 
 
+@slow(15)
 @skip_on_win_ci
 @skip_local_popups
 def test_axes_visible(make_napari_viewer):
@@ -468,6 +475,7 @@ def test_axes_visible(make_napari_viewer):
     np.testing.assert_almost_equal(launch_screenshot, off_screenshot)
 
 
+@slow(15)
 @skip_on_win_ci
 @skip_local_popups
 def test_scale_bar_visible(make_napari_viewer):

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -205,7 +205,7 @@ def slow(timeout):
 
     def _slow(func):
 
-        func = pytest.mark.timeout(timeout * factor)(func)
+        func = pytest.mark.execution_timeout(timeout * factor)(func)
         func = pytest.mark.slow(func)
         return func
 

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -194,3 +194,19 @@ def check_layer_world_data_extent(layer, extent, scale, translate):
     translated_extent = np.add(scaled_extent, translate)
     np.testing.assert_almost_equal(layer.extent.data, extent)
     np.testing.assert_almost_equal(layer.extent.world, translated_extent)
+
+
+def slow(timeout):
+    """
+    Both mark a function as slow, and with a timeout which is easily scalable
+    via an env variable.
+    """
+    factor = int(os.getenv('NAPARI_TESTING_TIMEOUT_SCALING', '1'))
+
+    def _slow(func):
+
+        func = pytest.mark.timeout(timeout * factor)(func)
+        func = pytest.mark.slow(func)
+        return func
+
+    return _slow

--- a/napari/_vispy/_tests/test_vispy_big_images.py
+++ b/napari/_vispy/_tests/test_vispy_big_images.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from napari._tests.utils import slow
+
 
 def test_big_2D_image(make_napari_viewer):
     """Test big 2D image with axis exceeding max texture size."""
@@ -30,6 +32,7 @@ def test_big_3D_image(make_napari_viewer):
         assert np.all(layer._transforms['tile2data'].scale == s)
 
 
+@slow(10)
 @pytest.mark.parametrize(
     "shape",
     [(2, 4), (256, 4048), (4, 20_000), (20_000, 4)],

--- a/napari/layers/image/_tests/test_big_image_timing.py
+++ b/napari/layers/image/_tests/test_big_image_timing.py
@@ -11,35 +11,35 @@ data_zarr = zarr.zeros((100_000, 1000, 1000))
 data_dask_2D = da.random.random((100_000, 100_000))
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.execution_timeout(2)
 @pytest.mark.parametrize('data', [data_dask, data_zarr])
 def test_timing_fast_big_dask_all_specified_(data):
     layer = Image(data, multiscale=False, contrast_limits=[0, 1])
     assert layer.data.shape == data.shape
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.execution_timeout(2)
 @pytest.mark.parametrize('data', [data_dask, data_zarr])
 def test_timing_fast_big_dask_multiscale_specified(data):
     layer = Image(data, multiscale=False)
     assert layer.data.shape == data.shape
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.execution_timeout(2)
 @pytest.mark.parametrize('data', [data_dask, data_zarr])
 def test_timing_fast_big_dask_contrast_limits_specified(data):
     layer = Image(data, contrast_limits=[0, 1])
     assert layer.data.shape == data.shape
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.execution_timeout(2)
 @pytest.mark.parametrize('data', [data_dask, data_zarr])
 def test_timing_fast_big_dask_nothing_specified(data):
     layer = Image(data)
     assert layer.data.shape == data.shape
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.execution_timeout(2)
 def test_non_visible_images():
     """Test loading non-visible images doesn't trigger compute."""
     layer = Image(

--- a/napari/layers/image/_tests/test_image_utils.py
+++ b/napari/layers/image/_tests/test_image_utils.py
@@ -91,6 +91,6 @@ def test_guess_multiscale_incorrect_order():
         _, _ = guess_multiscale(data)
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.execution_timeout(2)
 def test_timing_multiscale_big():
     assert not guess_multiscale(data_dask)[0]

--- a/napari/layers/image/experimental/_tests/test_octree_import.py
+++ b/napari/layers/image/experimental/_tests/test_octree_import.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 import sys
 
+from napari._tests.utils import slow
+
 CREATE_VIEWER_SCRIPT = """
 import numpy as np
 import napari
@@ -9,6 +11,7 @@ v = napari.view_image(np.random.rand(512, 512))
 """
 
 
+@slow(15)
 def test_octree_import():
     """Test we can create a viewer with NAPARI_OCTREE."""
 

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -689,7 +689,7 @@ def test_paint_2d():
     assert np.sum(layer.data[5:26, 17:38] == 7) == 349
 
 
-@pytest.mark.timeout(1)
+@pytest.mark.execution_timeout(1)
 def test_paint_2d_xarray():
     """Test the memory usage of painting an xarray indirectly via timeout."""
     data = xr.DataArray(np.zeros((3, 3, 1024, 1024), dtype=np.uint32))

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -73,13 +73,13 @@ def test_calc_data_fast_uint8():
     assert calc_data_range(data) == [0, 255]
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.execution_timeout(2)
 def test_calc_data_range_fast_big():
     val = calc_data_range(data_dask)
     assert len(val) > 0
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.execution_timeout(2)
 def test_calc_data_range_fast_big_plane():
     val = calc_data_range(data_dask_plane)
     assert len(val) > 0

--- a/napari/plugins/_tests/test_plugins_manager.py
+++ b/napari/plugins/_tests/test_plugins_manager.py
@@ -8,7 +8,10 @@ from napari_plugin_engine import napari_hook_implementation
 if TYPE_CHECKING:
     from napari.plugins._plugin_manager import NapariPluginManager
 
+from napari._tests.utils import slow
 
+
+@slow(15)
 def test_plugin_discovery_is_delayed():
     """Test that plugins are not getting discovered at napari import time."""
     cmd = [

--- a/napari/utils/_tests/test_magicgui.py
+++ b/napari/utils/_tests/test_magicgui.py
@@ -8,7 +8,7 @@ import pytest
 from magicgui import magicgui
 
 from napari import Viewer, layers, types
-from napari._tests.utils import layer_test_data
+from napari._tests.utils import layer_test_data, slow
 from napari.layers import Image, Labels, Layer
 from napari.utils.misc import all_subclasses
 
@@ -67,6 +67,7 @@ def test_magicgui_add_data(make_napari_viewer, LayerType, data, ndim):
     assert viewer.layers[0].source.widget == add_data
 
 
+@slow(10)
 @pytest.mark.skipif(
     sys.version_info < (3, 9), reason='Futures not subscriptable before py3.9'
 )

--- a/napari/utils/_tests/test_magicgui.py
+++ b/napari/utils/_tests/test_magicgui.py
@@ -129,6 +129,7 @@ def test_magicgui_get_data(make_napari_viewer, LayerType, data, ndim):
     viewer.add_layer(layer)
 
 
+@slow(10)
 @pytest.mark.parametrize('LayerType, data, ndim', test_data)
 def test_magicgui_add_layer(make_napari_viewer, LayerType, data, ndim):
     viewer = make_napari_viewer()

--- a/napari/utils/_tests/test_theme.py
+++ b/napari/utils/_tests/test_theme.py
@@ -4,6 +4,7 @@ import sys
 import pytest
 from pydantic import ValidationError
 
+from napari._tests.utils import slow
 from napari.settings import get_settings
 from napari.utils.theme import (
     Theme,
@@ -101,6 +102,7 @@ def test_rebuild_theme_settings():
     settings.appearance.theme = "another-theme"
 
 
+@slow(15)
 @pytest.mark.skipif(
     os.getenv('CI') and sys.version_info < (3, 9),
     reason="Testing theme on CI is extremely slow ~ 15s per test."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ skip_glob = ["*examples/*", "*vendored*", "*_vendor*"]
 [tool.pytest.ini_options]
 # These follow standard library warnings filters syntax.  See more here:
 # https://docs.python.org/3/library/warnings.html#describing-warning-filters
-addopts = "--maxfail=5 --durations=10"
+addopts = "--maxfail=5 --durations=10 --timeout=5"
 
 # NOTE: only put things that will never change in here.
 # napari deprecation and future warnings should NOT go in here.
@@ -105,5 +105,6 @@ filterwarnings = [
 ]
 markers = [
     "sync_only: Test should only be run synchronously",
-    "async_only: Test should only be run asynchronously"
+    "async_only: Test should only be run asynchronously",
+    "slow: Slow test you can skip with `-m 'not slow'`, or adjust with the env varaible NAPARI_TESTING_TIMEOUT_SCALING"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ skip_glob = ["*examples/*", "*vendored*", "*_vendor*"]
 [tool.pytest.ini_options]
 # These follow standard library warnings filters syntax.  See more here:
 # https://docs.python.org/3/library/warnings.html#describing-warning-filters
-addopts = "--maxfail=5 --durations=10 --timeout=5"
+addopts = "--maxfail=5 --durations=10 --timeout=8"
 
 # NOTE: only put things that will never change in here.
 # napari deprecation and future warnings should NOT go in here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ skip_glob = ["*examples/*", "*vendored*", "*_vendor*"]
 [tool.pytest.ini_options]
 # These follow standard library warnings filters syntax.  See more here:
 # https://docs.python.org/3/library/warnings.html#describing-warning-filters
-addopts = "--maxfail=5 --durations=10 --timeout=8"
+addopts = "--maxfail=5 --durations=10"
 
 # NOTE: only put things that will never change in here.
 # napari deprecation and future warnings should NOT go in here.
@@ -108,3 +108,8 @@ markers = [
     "async_only: Test should only be run asynchronously",
     "slow: Slow test you can skip with `-m 'not slow'`, or adjust with the env varaible NAPARI_TESTING_TIMEOUT_SCALING"
 ]
+
+[pytest]
+setup_timeout = 60
+execution_timeout = 8
+teardown_timeout = 60

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,7 @@ testing =
     pytest-faulthandler
     pytest-order
     pytest-qt
-    pytest-timeout
+    pytest-timeouts
     hypothesis>=6.8.0
     pandas
     xarray


### PR DESCRIPTION
in #3407 I used pytest-timeout as it's already a dev dependency and is more actively maintained than pytests-timeouts (with a s).

Though pytest-timeouts does support different timeout from setup/exec/teardown, which is the main problem I encounter in #3407.