### PR TITLE
Add back support for big-endian NumPy dtypes in get_dtype_limits

### DIFF
--- a/napari/utils/_dtype.py
+++ b/napari/utils/_dtype.py
@@ -79,6 +79,11 @@ def normalize_dtype(dtype_spec):
         return _normalize_str_by_bit_depth(dtype_str, 'complex')
     if 'bool' in dtype_str:
         return np.bool_
+    # If we don't find one of the named dtypes, return the dtype_spec
+    # unchanged. This allows NumPy big endian types to work. See
+    # https://github.com/napari/napari/issues/3421
+    else:
+        return dtype_spec
 
 
 def get_dtype_limits(dtype_spec) -> Tuple[float, float]:

--- a/napari/utils/_tests/test_dtype.py
+++ b/napari/utils/_tests/test_dtype.py
@@ -74,7 +74,10 @@ def test_pure_python_types(dtype_str):
         float,
         'float32',
         'float64',
-    ],
+        '>f4',
+        '>f8',
+    ]
+    + [''.join(t) for t in itertools.product('<>', 'iu', '1248')],
 )
 def test_dtype_lims(dtype):
     lims = get_dtype_limits(dtype)


### PR DESCRIPTION
# Description

Fixes #3421

See also [this Zulip conversation](https://napari.zulipchat.com/#narrow/stream/215289-release/topic/0.2E4.2E12.20bugfix.20release/near/255124596)

