### PR TITLE
Proposition of save as_dict in get_theme but with change default behaviour in future

### DIFF
--- a/napari/_qt/qt_resources/__init__.py
+++ b/napari/_qt/qt_resources/__init__.py
@@ -56,8 +56,6 @@ def get_stylesheet(
     if theme:
         from ...utils.theme import get_theme, template
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            return template(stylesheet, **get_theme(theme))
+        return template(stylesheet, **get_theme(theme, as_dict=True))
 
     return stylesheet

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -213,7 +213,7 @@ def get_theme(name, as_dict=None):
         warnings.warn(
             trans._(
                 "Themes were changed to use evented model with Pydantic's color type rather than the `rgb(x, y, z)`."
-                "The `as_dict=True` option will be changed to `as_dict=False` in 0.X.X",
+                "The `as_dict=True` option will be changed to `as_dict=False` in 0.4.15",
                 deferred=True,
             ),
             category=FutureWarning,

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -173,7 +173,7 @@ def get_system_theme():
     return name
 
 
-def get_theme(name, as_dict=True):
+def get_theme(name, as_dict=None):
     """Get a copy of theme based on it's name.
 
     If you get a copy of the theme, changes to the theme model will not be
@@ -198,26 +198,7 @@ def get_theme(name, as_dict=True):
     if name == "system":
         name = get_system_theme()
 
-    if name in _themes:
-        theme = _themes[name]
-        _theme = theme.copy()
-        if as_dict:
-            warnings.warn(
-                trans._(
-                    "Themes were changed to use evented model with Pydantic's color type rather than the `rgb(x, y, z)`. You can get the old color by calling `color.as_rgb()`. The `as_dict=True` option will be removed in 0.X.X",
-                    deferred=True,
-                ),
-                category=FutureWarning,
-                stacklevel=2,
-            )
-            _theme = _theme.dict()
-            _theme = {
-                k: v if not isinstance(v, Color) else v.as_rgb()
-                for (k, v) in _theme.items()
-            }
-            return _theme
-        return _theme
-    else:
+    if name not in _themes:
         raise ValueError(
             trans._(
                 "Unrecognized theme {name}. Available themes are {themes}",
@@ -226,6 +207,27 @@ def get_theme(name, as_dict=True):
                 themes=available_themes(),
             )
         )
+    theme = _themes[name]
+    _theme = theme.copy()
+    if as_dict is None:
+        warnings.warn(
+            trans._(
+                "Themes were changed to use evented model with Pydantic's color type rather than the `rgb(x, y, z)`."
+                "The `as_dict=True` option will be changed to `as_dict=False` in 0.X.X",
+                deferred=True,
+            ),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        as_dict = True
+    if as_dict:
+        _theme = _theme.dict()
+        _theme = {
+            k: v if not isinstance(v, Color) else v.as_rgb()
+            for (k, v) in _theme.items()
+        }
+        return _theme
+    return _theme
 
 
 def register_theme(name, theme):


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

As qss needs colors in `rgb(x,y,z)` then saving option to convert Theme to old-style dictionary is necessary. It could be done in `get_theme` function, in a separate function or as method of `Theme`class. To reduce changes in depending codebase I suggest keeping `as_dict` option in the code, and only change its default value in a future release. 

I also use `None` to distinguish user-provided value and the default one.  

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
