### PR TITLE
Minor refactor of get_active_layer_dtype

### DIFF
--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -313,12 +313,13 @@ class LayerList(SelectableEventedList[Layer]):
 
 
 def get_active_layer_dtype(layer):
+    dtype = None
     if layer.active:
-        return normalize_dtype(
-            getattr(layer.active.data, 'dtype', '')
-        ).__name__
-    else:
-        return None
+        try:
+            dtype = normalize_dtype(layer.active.data.dtype).__name__
+        except AttributeError:
+            pass
+    return dtype
 
 
 _CONTEXT_KEYS = {


### PR DESCRIPTION
I realised after reviewing #3402 that the getattr() fallback doesn't buy us anything in that function, because str objects don't have a __name__ attribute:

```
 $ python -c "print(''.__name__)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AttributeError: 'str' object has no attribute '__name__'
```

This refactors that function's flow to be more robust to unexpected values.
