### PR TITLE
Add missing rendering documentation

### DIFF
--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -499,18 +499,22 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         volume is displayed.  Options include:
 
         * ``translucent``: voxel colors are blended along the view ray until
-          the result is opaque.
+              the result is opaque.
         * ``mip``: maximum intensity projection. Cast a ray and display the
-          maximum value that was encountered.
-        * ``additive``: voxel colors are added along the view ray until the
-          result is saturated.
-        * ``iso``: isosurface. Cast a ray until a certain threshold is
-          encountered. At that location, lighning calculations are performed to
-          give the visual appearance of a surface.
+            maximum value that was encountered.
+        * ``minip``: minimum intensity projection. Cast a ray and display the
+            minimum value that was encountered.
         * ``attenuated_mip``: attenuated maximum intensity projection. Cast a
-          ray and attenuate values based on integral of encountered values,
-          display the maximum value that was encountered after attenuation.
-          This will make nearer objects appear more prominent.
+            ray and attenuate values based on integral of encountered values,
+            display the maximum value that was encountered after attenuation.
+            This will make nearer objects appear more prominent.
+        * ``additive``: voxel colors are added along the view ray until
+            the result is saturated.
+        * ``iso``: isosurface. Cast a ray until a certain threshold is
+            encountered. At that location, lighning calculations are
+            performed to give the visual appearance of a surface.
+        * ``average``: average intensity projection. Cast a ray and display the
+            average of values that were encountered.
 
         Returns
         -------

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -499,7 +499,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         volume is displayed.  Options include:
 
         * ``translucent``: voxel colors are blended along the view ray until
-              the result is opaque.
+            the result is opaque.
         * ``mip``: maximum intensity projection. Cast a ray and display the
             maximum value that was encountered.
         * ``minip``: minimum intensity projection. Cast a ray and display the


### PR DESCRIPTION
Solves issue https://github.com/napari/napari/issues/3423.
It is possible to set the rendering to average programmatically:
viewer.layers[0].rendering= 'average'
But it was not shown in the API.
After this pr it is.

