### PR TITLE
Try to skip test on windows.

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -15,6 +15,7 @@ from napari._tests.utils import (
     check_viewer_functioning,
     layer_test_data,
     skip_local_popups,
+    skip_on_win_ci,
 )
 from napari.settings import get_settings
 from napari.utils.interactions import mouse_press_callbacks
@@ -195,6 +196,7 @@ def test_z_order_adding_removing_images(make_napari_viewer):
     np.testing.assert_almost_equal(order, list(range(len(viewer.layers))))
 
 
+@skip_on_win_ci
 def test_screenshot(make_napari_viewer):
     "Test taking a screenshot"
     viewer = make_napari_viewer()

--- a/napari/_qt/perf/_tests/test_perf.py
+++ b/napari/_qt/perf/_tests/test_perf.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from napari._tests.utils import skip_local_popups
+from napari._tests.utils import skip_local_popups, skip_on_win_ci
 
 # NOTE:
 # for some reason, running this test fails in a subprocess with a segfault
@@ -31,6 +31,7 @@ CONFIG = {
 }
 
 
+@skip_on_win_ci
 @skip_local_popups
 def test_trace_on_start(tmp_path: Path):
     """Make sure napari can write a perfmon trace file."""

--- a/napari/_tests/test_adding_removing.py
+++ b/napari/_tests/test_adding_removing.py
@@ -1,11 +1,16 @@
 import numpy as np
 import pytest
 
-from napari._tests.utils import layer_test_data, skip_local_popups
+from napari._tests.utils import (
+    layer_test_data,
+    skip_local_popups,
+    skip_on_win_ci,
+)
 from napari.layers import Image
 from napari.utils.events.event import WarningEmitter
 
 
+@skip_on_win_ci
 @skip_local_popups
 @pytest.mark.parametrize('Layer, data, _', layer_test_data)
 def test_add_all_layers(make_napari_viewer, Layer, data, _):

--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -28,6 +28,10 @@ examples = [f.name for f in EXAMPLE_DIR.glob("*.py") if f.name not in skip]
 if os.getenv("CI") and os.name == 'nt' and API_NAME == 'PyQt5':
     examples = []
 
+if os.getenv("CI") and os.name == 'nt':
+    if 'to_screenshot.py' in examples:
+        examples.remove('to_screenshot.py')
+
 
 @pytest.fixture
 def qapp():

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -10,6 +10,7 @@ from napari._tests.utils import (
     check_viewer_functioning,
     layer_test_data,
     skip_local_popups,
+    skip_on_win_ci,
 )
 from napari.utils._tests.test_naming import eval_with_filename
 from napari.utils.action_manager import action_manager
@@ -140,6 +141,7 @@ def test_add_layer_magic_name(
     assert layer.name == "a_unique_name"
 
 
+@skip_on_win_ci
 def test_screenshot(make_napari_viewer):
     """Test taking a screenshot."""
     viewer = make_napari_viewer()
@@ -174,6 +176,7 @@ def test_screenshot(make_napari_viewer):
     assert screenshot.ndim == 3
 
 
+@skip_on_win_ci
 def test_changing_theme(make_napari_viewer):
     """Test changing the theme updates the full window."""
     viewer = make_napari_viewer(show=False)


### PR DESCRIPTION
If my ability to count dots in CI is correct that should be (one of)
the test currently killing windows CI.

```
napari\_qt\_tests\test_qt_utils.py .......                               [  1%]
napari\_qt\_tests\test_qt_viewer.py .....................Windows fatal exception: access violation
```

I counted 21 dots, and the parametrized one has currently 14 variants
and thus this test_screenshot one is the 22cd
