### PR TITLE
Fix off-by one error in Dims.range for non pixel-based layers

### DIFF
--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -119,6 +119,15 @@ def test_add_points():
     assert viewer.dims.ndim == 2
 
 
+def test_single_point_dims():
+    """Test dims of a Points layer with a single 3D point."""
+    viewer = ViewerModel()
+    shape = (1, 3)
+    data = np.zeros(shape)
+    viewer.add_points(data)
+    assert all(r == (0.0, 1.0, 1.0) for r in viewer.dims.range)
+
+
 def test_add_empty_points_to_empty_viewer():
     viewer = ViewerModel()
     layer = viewer.add_points(name='empty points')

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -1,11 +1,12 @@
 import itertools
 import warnings
 from collections import namedtuple
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import numpy as np
 
 from ..layers import Image, Labels, Layer
+from ..layers.image.image import _ImageBase
 from ..layers.utils._link_layers import get_linked_layers, layer_is_linked
 from ..utils._dtype import normalize_dtype
 from ..utils.events.containers import SelectableEventedList
@@ -123,6 +124,36 @@ class LayerList(SelectableEventedList[Layer]):
         """
         return self._get_extent_world([layer.extent for layer in self])
 
+    def _get_min_and_max(self, mins_list, maxes_list):
+
+        # Reverse dimensions since it is the last dimensions that are
+        # displayed.
+        mins_list = [mins[::-1] for mins in mins_list]
+        maxes_list = [maxes[::-1] for maxes in maxes_list]
+
+        with warnings.catch_warnings():
+            # Taking the nanmin and nanmax of an axis of all nan
+            # raises a warning and returns nan for that axis
+            # as we have do an explict nan_to_num below this
+            # behaviour is acceptable and we can filter the
+            # warning
+            warnings.filterwarnings(
+                'ignore',
+                message=str(
+                    trans._('All-NaN axis encountered', deferred=True)
+                ),
+            )
+            min_v = np.nanmin(
+                list(itertools.zip_longest(*mins_list, fillvalue=np.nan)),
+                axis=1,
+            )
+            max_v = np.nanmax(
+                list(itertools.zip_longest(*maxes_list, fillvalue=np.nan)),
+                axis=1,
+            )
+        # switch back to original order
+        return min_v[::-1], max_v[::-1]
+
     def _get_extent_world(self, layer_extent_list):
         """Extent of layers in world coordinates.
 
@@ -138,38 +169,18 @@ class LayerList(SelectableEventedList[Layer]):
             max_v = [np.nan] * self.ndim
         else:
             extrema = [extent.world for extent in layer_extent_list]
-            mins = [e[0][::-1] for e in extrema]
-            maxs = [e[1][::-1] for e in extrema]
-
-            with warnings.catch_warnings():
-                # Taking the nanmin and nanmax of an axis of all nan
-                # raises a warning and returns nan for that axis
-                # as we have do an explict nan_to_num below this
-                # behaviour is acceptable and we can filter the
-                # warning
-                warnings.filterwarnings(
-                    'ignore',
-                    message=str(
-                        trans._('All-NaN axis encountered', deferred=True)
-                    ),
-                )
-                min_v = np.nanmin(
-                    list(itertools.zip_longest(*mins, fillvalue=np.nan)),
-                    axis=1,
-                )
-                max_v = np.nanmax(
-                    list(itertools.zip_longest(*maxs, fillvalue=np.nan)),
-                    axis=1,
-                )
+            mins = [e[0] for e in extrema]
+            maxs = [e[1] for e in extrema]
+            min_v, max_v = self._get_min_and_max(mins, maxs)
 
         try:
-            min_vals = np.nan_to_num(min_v[::-1], nan=-0.5)
-            max_vals = np.nan_to_num(max_v[::-1], nan=511.5)
+            min_vals = np.nan_to_num(min_v, nan=-0.5)
+            max_vals = np.nan_to_num(max_v, nan=511.5)
         except TypeError:
             # In NumPy < 1.17, nan_to_num doesn't have a nan kwarg
-            min_vals = np.asarray(min_v[::-1])
+            min_vals = np.asarray(min_v)
             min_vals[np.isnan(min_vals)] = -0.5
-            max_vals = np.asarray(max_v[::-1])
+            max_vals = np.asarray(max_v)
             max_vals[np.isnan(max_vals)] = 511.5
 
         return np.vstack([min_vals, max_vals])
@@ -188,18 +199,22 @@ class LayerList(SelectableEventedList[Layer]):
         """
         return self._get_step_size([layer.extent for layer in self])
 
+    def _step_size_from_scales(self, scales):
+        # Reverse order so last axes of scale with different ndim are aligned
+        scales = [scale[::-1] for scale in scales]
+        full_scales = list(
+            np.array(list(itertools.zip_longest(*scales, fillvalue=np.nan)))
+        )
+        # restore original order
+        return np.nanmin(full_scales, axis=1)[::-1]
+
     def _get_step_size(self, layer_extent_list):
         if len(self) == 0:
             return np.ones(self.ndim)
         else:
-            scales = [extent.step[::-1] for extent in layer_extent_list]
-            full_scales = list(
-                np.array(
-                    list(itertools.zip_longest(*scales, fillvalue=np.nan))
-                ).T
-            )
-            min_scales = np.nanmin(full_scales, axis=0)
-            return min_scales[::-1]
+            scales = [extent.step for extent in layer_extent_list]
+            min_scales = self._step_size_from_scales(scales)
+            return min_scales
 
     @property
     def extent(self) -> Extent:
@@ -210,6 +225,58 @@ class LayerList(SelectableEventedList[Layer]):
             world=self._get_extent_world(extent_list),
             step=self._get_step_size(extent_list),
         )
+
+    @property
+    def _ranges(self) -> List[Tuple[float, float, float]]:
+        """Get ranges for Dims.range in world coordinates.
+
+        This shares some code in common with the `extent` property, but
+        determines Dims.range settings for each dimension such that each
+        range is aligned to pixel centers at the finest scale.
+        """
+        if len(self) == 0:
+            return [(0, 1, 1)] * self.ndim
+        else:
+            # Determine minimum step size across all layers
+            layer_extent_list = [layer.extent for layer in self]
+            scales = [extent.step for extent in layer_extent_list]
+            min_steps = self._step_size_from_scales(scales)
+
+            # Pixel-based layers need to be offset by 0.5 * min_steps to align
+            # Dims.range with pixel centers in world coordinates
+            pixel_offsets = [
+                0.5 * min_steps
+                if isinstance(layer, _ImageBase)
+                else [0] * len(min_steps)
+                for layer in self
+            ]
+
+            # Non-pixel layers need the an offset of the range stop by min_steps since the upper
+            # limit of Dims.range is non-inclusive.
+            point_offsets = [
+                [0] * len(min_steps)
+                if isinstance(layer, _ImageBase)
+                else min_steps
+                for layer in self
+            ]
+
+            # Determine world coordinate extents similarly to
+            # `_get_extent_world`, but including offsets calculated above.
+            extrema = [extent.world for extent in layer_extent_list]
+            mins = [
+                e[0] + o1[: len(e[0])] for e, o1 in zip(extrema, pixel_offsets)
+            ]
+            maxs = [
+                e[1] + o1[: len(e[0])] + o2[: len(e[0])]
+                for e, o1, o2 in zip(extrema, pixel_offsets, point_offsets)
+            ]
+            min_v, max_v = self._get_min_and_max(mins, maxs)
+
+            # form range tuples, switching back to original dimension order
+            return [
+                (start, stop, step)
+                for start, stop, step in zip(min_v, max_v, min_steps)
+            ]
 
     @property
     def ndim(self) -> int:

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -271,6 +271,11 @@ class LayerList(SelectableEventedList[Layer]):
                 for e, o1, o2 in zip(extrema, pixel_offsets, point_offsets)
             ]
             min_v, max_v = self._get_min_and_max(mins, maxs)
+            # same 512 element default extent as `_get_extent_world`
+            min_v = np.asarray(min_v)
+            min_v[np.isnan(min_v)] = -0.5
+            max_v = np.asarray(max_v)
+            max_v[np.isnan(max_v)] = 511.5
 
             # form range tuples, switching back to original dimension order
             return [

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -134,7 +134,7 @@ class LayerList(SelectableEventedList[Layer]):
         with warnings.catch_warnings():
             # Taking the nanmin and nanmax of an axis of all nan
             # raises a warning and returns nan for that axis
-            # as we have do an explict nan_to_num below this
+            # as we have do an explicit nan_to_num below this
             # behaviour is acceptable and we can filter the
             # warning
             warnings.filterwarnings(
@@ -251,7 +251,7 @@ class LayerList(SelectableEventedList[Layer]):
                 for layer in self
             ]
 
-            # Non-pixel layers need the an offset of the range stop by min_steps since the upper
+            # Non-pixel layers need an offset of the range stop by min_steps since the upper
             # limit of Dims.range is non-inclusive.
             point_offsets = [
                 [0] * len(min_steps)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -330,20 +330,11 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             self.dims.ndim = 2
             self.dims.reset()
         else:
-            extent = self.layers.extent
-            world = extent.world
-            ss = extent.step
-            ndim = world.shape[1]
+            ranges = self.layers._ranges
+            ndim = len(ranges)
             self.dims.ndim = ndim
-            for i in range(ndim):
-                self.dims.set_range(
-                    i,
-                    (
-                        world[0, i] + 0.5 * ss[i],
-                        world[1, i] + 0.5 * ss[i],
-                        ss[i],
-                    ),
-                )
+            for i, _range in enumerate(ranges):
+                self.dims.set_range(i, _range)
 
         new_dim = self.dims.ndim
         dim_diff = new_dim - len(self.cursor.position)

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -246,6 +246,16 @@ def test_3D_points():
     assert len(layer.data) == 10
 
 
+def test_single_point_extent():
+    """Test extent of a single 3D point at the origin."""
+    shape = (1, 3)
+    data = np.zeros(shape)
+    layer = Points(data)
+    assert np.all(layer.extent.data == 0)
+    assert np.all(layer.extent.world == 0)
+    assert np.all(layer.extent.step == 1)
+
+
 def test_4D_points():
     """Test instantiating Points layer with random 4D data."""
     shape = (10, 4)


### PR DESCRIPTION
# Description

This should fix the break in points layer behavior that was observed after the merge of #3381  

The primary change is a new `_ranges` property on LayerList that takes care of the proper logic. Much of this is adapted from the existing `extent` property, but the details are a little tricky to get right! Not sure if there is a better way to simplify it.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

closes #3428 (attn: @brisvag)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] existing tests and 2 new test cases pass with my change

The new `test_single_point_dims` test would have failed prior to the changes in this PR.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
