### PR TITLE
Check if proper function name is found when connect to EventEmmiter

### DIFF
--- a/napari/utils/events/_tests/test_event_emitter.py
+++ b/napari/utils/events/_tests/test_event_emitter.py
@@ -1,3 +1,5 @@
+import pytest
+
 from napari.utils.events import EventEmitter
 
 
@@ -26,6 +28,7 @@ def test_error_on_connect():
     will not be equal to getattr(obj, obj.method.__name__). We check here
     that event binding will be correct even in these situations.
     """
+
     def rename(newname):
         def decorator(f):
             f.__name__ = newname
@@ -45,6 +48,9 @@ def test_error_on_connect():
         def meth2(self, _event):
             self.m2 += 1
 
+        def meth3(self):
+            pass
+
     t = Test()
 
     e = EventEmitter(type="test")
@@ -56,3 +62,10 @@ def test_error_on_connect():
     e.connect(t.meth2)
     e()
     assert (t.m1, t.m2) == (2, 1)
+
+    meth = t.meth3
+
+    t.meth3 = "aaaa"
+
+    with pytest.raises(RuntimeError):
+        e.connect(meth)

--- a/napari/utils/events/_tests/test_event_emitter.py
+++ b/napari/utils/events/_tests/test_event_emitter.py
@@ -17,3 +17,36 @@ def test_event_blocker_count():
         e()
         e()
     assert block.count == 3
+
+
+def test_error_on_connect():
+    def rename(newname):
+        def decorator(f):
+            f.__name__ = newname
+            return f
+
+        return decorator
+
+    class Test:
+        def __init__(self):
+            self.m1, self.m2 = 0, 0
+
+        @rename("nonexist")
+        def meth1(self, _event):
+            self.m1 += 1
+
+        @rename("meth1")
+        def meth2(self, _event):
+            self.m2 += 1
+
+    t = Test()
+
+    e = EventEmitter(type="test")
+
+    e.connect(t.meth1)
+    e()
+    assert (t.m1, t.m2) == (1, 0)
+
+    e.connect(t.meth2)
+    e()
+    assert (t.m1, t.m2) == (2, 1)

--- a/napari/utils/events/_tests/test_event_emitter.py
+++ b/napari/utils/events/_tests/test_event_emitter.py
@@ -20,6 +20,12 @@ def test_event_blocker_count():
 
 
 def test_error_on_connect():
+    """Check that connections happen correctly even on decorated methods.
+
+    Some decorators will alter method.__name__, so that obj.method
+    will not be equal to getattr(obj, obj.method.__name__). We check here
+    that event binding will be correct even in these situations.
+    """
     def rename(newname):
         def decorator(f):
             f.__name__ = newname

--- a/napari/utils/events/_tests/test_event_emitter.py
+++ b/napari/utils/events/_tests/test_event_emitter.py
@@ -38,7 +38,7 @@ def test_error_on_connect():
 
     class Test:
         def __init__(self):
-            self.m1, self.m2 = 0, 0
+            self.m1, self.m2, self.m4 = 0, 0, 0
 
         @rename("nonexist")
         def meth1(self, _event):
@@ -50,6 +50,9 @@ def test_error_on_connect():
 
         def meth3(self):
             pass
+
+        def meth4(self, _event):
+            self.m4 += 1
 
     t = Test()
 
@@ -69,3 +72,12 @@ def test_error_on_connect():
 
     with pytest.raises(RuntimeError):
         e.connect(meth)
+
+    e.connect(t.meth4)
+    assert t.m4 == 0
+    e()
+    assert t.m4 == 1
+    t.meth4 = None
+    with pytest.warns(RuntimeWarning, match="Problem with function"):
+        e()
+    assert t.m4 == 1

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -517,6 +517,9 @@ class EventEmitter:
                 not hasattr(callback[0], callback[1])
                 or getattr(callback[0], callback[1]) != old_callback
             ):
+                # some decorators will alter method.__name__, so that obj.method
+                # will not be equal to getattr(obj, obj.method.__name__). We check
+                # for that case here and traverse to find the right method here.
                 for name in dir(callback[0]):
                     meth = getattr(callback[0], name)
                     if inspect.ismethod(meth) and meth == old_callback:

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -49,6 +49,7 @@ For more information see http://github.com/vispy/vispy/wiki/API_Events
 
 """
 import inspect
+import warnings
 import weakref
 from collections import Counter
 from typing import (
@@ -580,8 +581,14 @@ class EventEmitter:
                     if obj is None:
                         rem.append(cb)  # add dead weakref
                         continue
+                    old_cb = cb
                     cb = getattr(obj, cb[1], None)
                     if cb is None:
+                        warnings.warn(
+                            f"Problem with function {old_cb[1]} of {obj} connected to event {self}",
+                            stacklevel=2,
+                            category=RuntimeWarning,
+                        )
                         continue
                     cb = cast(Callback, cb)
 
@@ -883,7 +890,11 @@ class EmitterGroup(EventEmitter):
             setattr(self, name, emitter)  # this is a bummer for typing.
             self._emitters[name] = emitter
 
-            if auto_connect and self.source is not None:
+            if (
+                auto_connect
+                and self.source is not None
+                and hasattr(self.source, self.auto_connect_format % name)
+            ):
                 emitter.connect((self.source, self.auto_connect_format % name))
 
             # If emitters are connected to the group already, then this one

--- a/napari/utils/events/event_utils.py
+++ b/napari/utils/events/event_utils.py
@@ -47,7 +47,7 @@ def connect_setattr(emitter: Emitter, obj, attr: str):
 
     emitter.connect(_cb)
     # There are scenarios where emmiter is deleted before obj.
-    # Also there is no option to create weakref ot QT Signal
+    # Also there is no option to create weakref to QT Signal
     # but even if keep reference to base object and signal name it is possible to meet
     # problem with C++ "wrapped C/C++ object has been deleted"
     # weakref.finalize(obj, emitter.disconnect, _cb)


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->
If the decorator of the method does not inherit properly the name of the method (line `ensure_main_thread` in 0.2.4 version of `superqt`) then the connection function to event fails silently. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
