### PR TITLE
Bug fix for individual shape selection with shift modifier

### DIFF
--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -29,7 +29,12 @@ def select(layer, event):
             if shape_under_cursor in layer.selected_data:
                 layer.selected_data.remove(shape_under_cursor)
             else:
-                layer.selected_data.add(shape_under_cursor)
+                if len(layer.selected_data):
+                    # one or more shapes already selected
+                    layer.selected_data.add(shape_under_cursor)
+                else:
+                    # first shape being selected
+                    layer.selected_data = {shape_under_cursor}
         elif shape_under_cursor is not None:
             if shape_under_cursor not in layer.selected_data:
                 layer.selected_data = {shape_under_cursor}


### PR DESCRIPTION
# Description
This PR addresses a minor bug in the canvas selection tool. When selecting shapes with the shift modifier, if no previous shapes have been selected, the `mouse_press` event throws a TypeError related to the layer selection box attribute. This error is repeatedly thrown with each `mouse_move` until a subsequent `mouse_press` event. Before this correcting `mouse_press`, the TypeError blocks certain viewer functionality.

This fix targets the `layer.selected_data` assignment when an individual shape is selected with the shift modifier.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
None :slightly_smiling_face:

# How has this been tested?
- [x] Tested manually on shape layer
- [x] The test suite failed given a fresh installation of the Napari code base...it also produced the same failures for my branch with changes; however, because the changes are so minor&mdash;four lines of code in a function that only relates to specific events (mouse press plus shift modifier) on shapes layer&mdash;I am confident that it will not interfere with other core functionality

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.