### PR TITLE
Move 8s tiemout to github actions only

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -25,7 +25,7 @@ jobs:
           pip install --upgrade pip
           pip install tox
       - name: Run task
-        run: tox -e ${{ matrix.task }}
+        run: tox -e ${{ matrix.task }} -- --timeout=8
 
   vendor:
     name: Vendored

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ skip_glob = ["*examples/*", "*vendored*", "*_vendor*"]
 [tool.pytest.ini_options]
 # These follow standard library warnings filters syntax.  See more here:
 # https://docs.python.org/3/library/warnings.html#describing-warning-filters
-addopts = "--maxfail=5 --durations=10 --timeout=8"
+addopts = "--maxfail=5 --durations=10"
 
 # NOTE: only put things that will never change in here.
 # napari deprecation and future warnings should NOT go in here.


### PR DESCRIPTION
@andy-sweet realized that the 8 s timeout apply locally as well which is annoying when you debug locally. 

This should make it apply only when testing PRs.
