### PR TITLE
Block connection to event if there is no positional argument

### DIFF
--- a/napari/utils/events/_tests/test_event_emitter.py
+++ b/napari/utils/events/_tests/test_event_emitter.py
@@ -17,3 +17,19 @@ def test_event_blocker_count():
         e()
         e()
     assert block.count == 3
+
+
+def test_no_event_arg():
+    class TestOb:
+        def __init__(self):
+            self.count = 0
+
+        def fun(self):
+            self.count += 1
+
+    t = TestOb()
+
+    e = EventEmitter(type="test")
+    e.connect(t.fun)
+    e()
+    assert t.count == 1

--- a/napari/utils/events/_tests/test_event_emitter.py
+++ b/napari/utils/events/_tests/test_event_emitter.py
@@ -1,3 +1,5 @@
+import pytest
+
 from napari.utils.events import EventEmitter
 
 
@@ -21,15 +23,11 @@ def test_event_blocker_count():
 
 def test_no_event_arg():
     class TestOb:
-        def __init__(self):
-            self.count = 0
-
         def fun(self):
-            self.count += 1
+            pass
 
     t = TestOb()
 
     e = EventEmitter(type="test")
-    e.connect(t.fun)
-    e()
-    assert t.count == 1
+    with pytest.raises(RuntimeError):
+        e.connect(t.fun)

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -615,7 +615,9 @@ class EventEmitter:
 
         return event
 
-    def _invoke_callback(self, cb: Callback, event: Optional[Event]):
+    def _invoke_callback(
+        self, cb: Union[Callback, Callable[[], None]], event: Optional[Event]
+    ):
         try:
             if event is not None:
                 cb(event)

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -522,9 +522,9 @@ class EventEmitter:
         if isinstance(callback, tuple) and not isinstance(
             callback[0], weakref.ref
         ):
-            callback = (weakref.ref(callback[0]), callback[1])
+            callback = (weakref.ref(callback[0]), *callback[1:])
 
-        if isinstance(callback, tuple):
+        if isinstance(callback, tuple) and len(callback) == 2:
             callback_fun = getattr(callback[0](), callback[1])
             signature = inspect.signature(callback_fun)
             allow_event = any(


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This PR blocks connecting class methods that do not take at least one positions parameter. 

My motivation is that too many times I got information about binding the wrong function (lacking event parameter) after the event happens, not when connecting the function to an event.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

This is a minimal version of #3449

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
