### PR TITLE
Added float16 support to dtype normalization

### DIFF
--- a/napari/utils/_dtype.py
+++ b/napari/utils/_dtype.py
@@ -17,6 +17,7 @@ _np_ints = {
 }
 
 _np_floats = {
+    16: np.float16,
     32: np.float32,
     64: np.float64,
 }


### PR DESCRIPTION
# Description
This change fixes some minor issues when loading float 16 data.
Its contrast limits are now between 0 and 1, before it was from 0 and 65535 for float16.
It fixes loading float16 data that wasn't in NumPy format, like TensorStore.

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)

# References

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] It passes the CI tests.

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
