### PR TITLE
Finds layer_controls based on layer's MRO

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
@@ -1,15 +1,11 @@
-import pytest
 import numpy as np
+import pytest
 
 from napari._qt.layer_controls.qt_layer_controls_container import (
     create_qt_layer_controls,
     layer_to_controls,
 )
 from napari._qt.layer_controls.qt_shapes_controls import QtShapesControls
-
-from napari._qt.layer_controls.qt_shapes_controls import QtShapesControls
-from napari._qt.layer_controls.qt_layer_controls_container import layer_to_controls
-
 from napari.layers import Shapes
 
 _SHAPES = np.random.random((10, 4, 2))
@@ -32,7 +28,7 @@ def test_unknown_raises(qtbot):
 
 def test_inheritance(qtbot):
     class QtLinesControls(QtShapesControls):
-        """Yes I'm the same """
+        """Yes I'm the same"""
 
     class Lines(Shapes):
         """Here too"""

--- a/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
@@ -1,43 +1,43 @@
-import numpy as np
-import pytest
+# import numpy as np
+# import pytest
 
-from napari._qt.layer_controls.qt_layer_controls_container import (
-    create_qt_layer_controls,
-    layer_to_controls,
-)
-from napari._qt.layer_controls.qt_shapes_controls import QtShapesControls
-from napari.layers import Shapes
+# from napari._qt.layer_controls.qt_layer_controls_container import (
+#     create_qt_layer_controls,
+#     layer_to_controls,
+# )
+# from napari._qt.layer_controls.qt_shapes_controls import QtShapesControls
+# from napari.layers import Shapes
 
-_SHAPES = np.random.random((10, 4, 2))
-_LINES = np.random.random((6, 2, 2))
-
-
-def test_create_shape(qtbot):
-    shapes = Shapes(_SHAPES)
-
-    ctrl = create_qt_layer_controls(shapes)
-    qtbot.addWidget(ctrl)
-
-    assert isinstance(ctrl, QtShapesControls)
+# _SHAPES = np.random.random((10, 4, 2))
+# _LINES = np.random.random((6, 2, 2))
 
 
-def test_unknown_raises(qtbot):
-    class Test:
-        """Unmatched class"""
+# def test_create_shape(qtbot):
+#     shapes = Shapes(_SHAPES)
 
-    with pytest.raises(TypeError):
-        create_qt_layer_controls(Test())
+#     ctrl = create_qt_layer_controls(shapes)
+#     qtbot.addWidget(ctrl)
+
+#     assert isinstance(ctrl, QtShapesControls)
 
 
-def test_inheritance(qtbot):
-    class QtLinesControls(QtShapesControls):
-        """Yes I'm the same"""
+# def test_unknown_raises(qtbot):
+#     class Test:
+#         """Unmatched class"""
 
-    class Lines(Shapes):
-        """Here too"""
+#     with pytest.raises(TypeError):
+#         create_qt_layer_controls(Test())
 
-    lines = Lines(_LINES)
-    layer_to_controls[Lines] = QtLinesControls
-    ctrl = create_qt_layer_controls(lines)
-    qtbot.addWidget(ctrl)
-    assert isinstance(ctrl, QtLinesControls)
+
+# def test_inheritance(qtbot):
+#     class QtLinesControls(QtShapesControls):
+#         """Yes I'm the same"""
+
+#     class Lines(Shapes):
+#         """Here too"""
+
+#     lines = Lines(_LINES)
+#     layer_to_controls[Lines] = QtLinesControls
+#     ctrl = create_qt_layer_controls(lines)
+#     qtbot.addWidget(ctrl)
+#     assert isinstance(ctrl, QtLinesControls)

--- a/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
@@ -1,43 +1,43 @@
-# import numpy as np
-# import pytest
+import numpy as np
+import pytest
 
-# from napari._qt.layer_controls.qt_layer_controls_container import (
-#     create_qt_layer_controls,
-#     layer_to_controls,
-# )
-# from napari._qt.layer_controls.qt_shapes_controls import QtShapesControls
-# from napari.layers import Shapes
+from napari._qt.layer_controls.qt_layer_controls_container import (
+    create_qt_layer_controls,
+    layer_to_controls,
+)
+from napari._qt.layer_controls.qt_shapes_controls import QtShapesControls
+from napari.layers import Shapes
 
-# _SHAPES = np.random.random((10, 4, 2))
-# _LINES = np.random.random((6, 2, 2))
-
-
-# def test_create_shape(qtbot):
-#     shapes = Shapes(_SHAPES)
-
-#     ctrl = create_qt_layer_controls(shapes)
-#     qtbot.addWidget(ctrl)
-
-#     assert isinstance(ctrl, QtShapesControls)
+_SHAPES = np.random.random((10, 4, 2))
+_LINES = np.random.random((6, 2, 2))
 
 
-# def test_unknown_raises(qtbot):
-#     class Test:
-#         """Unmatched class"""
+def test_create_shape(qtbot):
+    shapes = Shapes(_SHAPES)
 
-#     with pytest.raises(TypeError):
-#         create_qt_layer_controls(Test())
+    ctrl = create_qt_layer_controls(shapes)
+    qtbot.addWidget(ctrl)
+
+    assert isinstance(ctrl, QtShapesControls)
 
 
-# def test_inheritance(qtbot):
-#     class QtLinesControls(QtShapesControls):
-#         """Yes I'm the same"""
+def test_unknown_raises(qtbot):
+    class Test:
+        """Unmatched class"""
 
-#     class Lines(Shapes):
-#         """Here too"""
+    with pytest.raises(TypeError):
+        create_qt_layer_controls(Test())
 
-#     lines = Lines(_LINES)
-#     layer_to_controls[Lines] = QtLinesControls
-#     ctrl = create_qt_layer_controls(lines)
-#     qtbot.addWidget(ctrl)
-#     assert isinstance(ctrl, QtLinesControls)
+
+def test_inheritance(qtbot):
+    class QtLinesControls(QtShapesControls):
+        """Yes I'm the same"""
+
+    class Lines(Shapes):
+        """Here too"""
+
+    lines = Lines(_LINES)
+    layer_to_controls[Lines] = QtLinesControls
+    ctrl = create_qt_layer_controls(lines)
+    qtbot.addWidget(ctrl)
+    assert isinstance(ctrl, QtLinesControls)

--- a/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
@@ -14,7 +14,10 @@ _LINES = np.random.random((6, 2, 2))
 
 def test_create_shape(qtbot):
     shapes = Shapes(_SHAPES)
+
     ctrl = create_qt_layer_controls(shapes)
+    qtbot.addWidget(ctrl)
+
     assert isinstance(ctrl, QtShapesControls)
 
 
@@ -36,4 +39,5 @@ def test_inheritance(qtbot):
     lines = Lines(_LINES)
     layer_to_controls[Lines] = QtLinesControls
     ctrl = create_qt_layer_controls(lines)
+    qtbot.addWidget(ctrl)
     assert isinstance(ctrl, QtLinesControls)

--- a/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
@@ -1,0 +1,43 @@
+import pytest
+import numpy as np
+
+from napari._qt.layer_controls.qt_layer_controls_container import (
+    create_qt_layer_controls,
+    layer_to_controls,
+)
+from napari._qt.layer_controls.qt_shapes_controls import QtShapesControls
+
+from napari._qt.layer_controls.qt_shapes_controls import QtShapesControls
+from napari._qt.layer_controls.qt_layer_controls_container import layer_to_controls
+
+from napari.layers import Shapes
+
+_SHAPES = np.random.random((10, 4, 2))
+_LINES = np.random.random((6, 2, 2))
+
+
+def test_create_shape(qtbot):
+    shapes = Shapes(_SHAPES)
+    ctrl = create_qt_layer_controls(shapes)
+    assert isinstance(ctrl, QtShapesControls)
+
+
+def test_unknown_raises(qtbot):
+    class Test:
+        """Unmatched class"""
+
+    with pytest.raises(TypeError):
+        create_qt_layer_controls(Test())
+
+
+def test_inheritance(qtbot):
+    class QtLinesControls(QtShapesControls):
+        """Yes I'm the same """
+
+    class Lines(Shapes):
+        """Here too"""
+
+    lines = Lines(_LINES)
+    layer_to_controls[Lines] = QtLinesControls
+    ctrl = create_qt_layer_controls(lines)
+    assert isinstance(ctrl, QtLinesControls)

--- a/napari/_qt/layer_controls/qt_layer_controls_container.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_container.py
@@ -33,6 +33,9 @@ def create_qt_layer_controls(layer):
     """
     Create a qt controls widget for a layer based on its layer type.
 
+    In case of a subclass, the type higher in the layer's method resolution
+    order will be used.
+
     Parameters
     ----------
     layer : napari.layers._base_layer.Layer
@@ -43,18 +46,24 @@ def create_qt_layer_controls(layer):
     controls : napari.layers.base.QtLayerControls
         Qt controls widget
     """
-
-    for layer_type, controls in layer_to_controls.items():
+    candidates = []
+    for layer_type in layer_to_controls:
         if isinstance(layer, layer_type):
-            return controls(layer)
+            candidates.append(layer_type)
 
-    raise TypeError(
-        trans._(
-            'Could not find QtControls for layer of type {type_}',
-            deferred=True,
-            type_=type(layer),
+    if not candidates:
+        raise TypeError(
+            trans._(
+                'Could not find QtControls for layer of type {type_}',
+                deferred=True,
+                type_=type(layer),
+            )
         )
-    )
+
+    layer_cls = layer.__class__
+    candidates.sort(key=lambda layer_type: layer_cls.mro().index(layer_type))
+    controls = layer_to_controls[candidates[0]]
+    return controls(layer)
 
 
 class QtLayerControlsContainer(QStackedWidget):

--- a/napari/_qt/layer_controls/qt_layer_controls_container.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_container.py
@@ -61,6 +61,7 @@ def create_qt_layer_controls(layer):
         )
 
     layer_cls = layer.__class__
+    # Sort the list of candidates by 'lineage'
     candidates.sort(key=lambda layer_type: layer_cls.mro().index(layer_type))
     controls = layer_to_controls[candidates[0]]
     return controls(layer)


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->
See discussion on image.sc [here](https://forum.image.sc/t/custom-layer-control/58727)

This PR should allow to use inheritance for the QtLayerControls widgets (which is not possible right now due to the way the `layer_to_controls` dictionary is parsed


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
https://forum.image.sc/t/custom-layer-control/58727

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
I added `test_qt_layer_controls.py` to assert that the class higher in the layer's MRO was used. The test fails with the current implementation and passes with the proposed changes.

- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
_As this is not part of the public API, I'm not sure what I have to modify_ (I still updated the docstring)
- [ ] I have made corresponding changes to the documentation

- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
