### PR TITLE
Use `ensure_main_thread` instead of custom thread propagation mechanism in NapariQtNotification

### DIFF
--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -2,11 +2,12 @@ import sys
 import threading
 import time
 import warnings
+from concurrent.futures import Future
 from unittest.mock import patch
 
 import dask.array as da
 import pytest
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, QThread
 from qtpy.QtWidgets import QPushButton
 
 from napari._qt.dialogs.qt_notification import NapariQtNotification
@@ -88,9 +89,38 @@ def test_notification_manager_via_gui(
             notification_manager.records = []
 
 
+@patch('napari._qt.dialogs.qt_notification.QDialog.show')
+def test_show_notification_from_thread(mock_show, monkeypatch, qtbot):
+    from napari.settings import get_settings
+
+    settings = get_settings()
+
+    monkeypatch.setattr(
+        settings.application,
+        'gui_notification_level',
+        NotificationSeverity.INFO,
+    )
+
+    class CustomThread(QThread):
+        def run(self):
+            notif = Notification(
+                'hi',
+                NotificationSeverity.INFO,
+                actions=[('click', lambda x: None)],
+            )
+            res = NapariQtNotification.show_notification(notif)
+            assert isinstance(res, Future)
+            assert res.result() is None
+            mock_show.assert_called_once()
+
+    thread = CustomThread()
+    with qtbot.waitSignal(thread.finished):
+        thread.start()
+
+
 @pytest.mark.parametrize('severity', NotificationSeverity.__members__)
 @patch('napari._qt.dialogs.qt_notification.QDialog.show')
-def test_notification_display(mock_show, severity, monkeypatch):
+def test_notification_display(mock_show, severity, monkeypatch, qtbot):
     """Test that NapariQtNotification can present a Notification event.
 
     NOTE: in napari.utils._tests.test_notification_manager, we already test
@@ -127,6 +157,7 @@ def test_notification_display(mock_show, severity, monkeypatch):
     dialog.toggle_expansion()
     assert not dialog.property('expanded')
     dialog.close()
+    dialog.deleteLater()
 
 
 @patch('napari._qt.dialogs.qt_notification.QDialog.show')

--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -4,15 +4,12 @@ from typing import Callable, Optional, Sequence, Tuple, Union
 
 from qtpy.QtCore import (
     QEasingCurve,
-    QObject,
     QPoint,
     QPropertyAnimation,
     QRect,
     QSize,
     Qt,
-    QThread,
     QTimer,
-    Signal,
 )
 from qtpy.QtWidgets import (
     QApplication,
@@ -26,21 +23,12 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from superqt import QElidingLabel
+from superqt import QElidingLabel, ensure_main_thread
 
 from ...utils.notifications import Notification, NotificationSeverity
 from ...utils.translations import trans
 
 ActionSequence = Sequence[Tuple[str, Callable[[], None]]]
-
-
-class NotificationDispatcher(QObject):
-    """
-    This is a helper class to allow the propagation of notifications
-    generated from exceptions or warnings inside threads.
-    """
-
-    sig_notified = Signal(Notification)
 
 
 class NapariQtNotification(QDialog):
@@ -365,6 +353,7 @@ class NapariQtNotification(QDialog):
         )
 
     @classmethod
+    @ensure_main_thread
     def show_notification(cls, notification: Notification):
         from ...settings import get_settings
 
@@ -376,17 +365,6 @@ class NapariQtNotification(QDialog):
             notification.severity
             >= settings.application.gui_notification_level
         ):
-            application_instance = QApplication.instance()
-            if (
-                application_instance
-                and application_instance.thread() != QThread.currentThread()
-            ):
-                dispatcher = getattr(application_instance, "_dispatcher", None)
-                if dispatcher:
-                    dispatcher.sig_notified.emit(notification)
-
-                return
-
             cls.from_notification(notification).show()
 
 

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -19,10 +19,7 @@ from ..utils.notifications import (
 )
 from ..utils.perf import perf_config
 from ..utils.translations import trans
-from .dialogs.qt_notification import (
-    NapariQtNotification,
-    NotificationDispatcher,
-)
+from .dialogs.qt_notification import NapariQtNotification
 from .qt_event_filters import QtToolTipEventFilter
 from .qt_resources import _register_napari_resources
 from .qthreading import wait_for_workers_to_quit
@@ -191,9 +188,6 @@ def get_app(
 
     # Add the dispatcher attribute to the application to be able to dispatch
     # notifications coming from threads
-    dispatcher = getattr(app, "_dispatcher", None)
-    if dispatcher is None:
-        app._dispatcher = NotificationDispatcher()
 
     return app
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -131,14 +131,6 @@ class _QtMainWindow(QMainWindow):
         else:
             self.qt_viewer.setToolTip("")
 
-        # Connect the notification dispacther to correctly propagate
-        # notifications from threads. See: `napari._qt.qt_event_loop::get_app`
-        application_instance = QApplication.instance()
-        if application_instance:
-            application_instance._dispatcher.sig_notified.connect(
-                self.show_notification
-            )
-
     @classmethod
     def current(cls):
         return cls._instances[-1] if cls._instances else None

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ install_requires =
     pydantic>=1.8.1
     qtpy>=1.7.0
     scipy>=1.2.0
-    superqt>=0.2.2
+    superqt>=0.2.4
     tifffile>=2020.2.16
     typing_extensions
     toolz>=0.10.0


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Change custom mechanism of change thread in `NapariQtNotification.show_notification` to `ensure_main_thread` from `superqt` 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

fix #3467

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).


@glyq It works on my computer, could You check it?