### PR TITLE
fix naming inconsistency for windows bundle

### DIFF
--- a/bundle.py
+++ b/bundle.py
@@ -29,7 +29,6 @@ LINUX = sys.platform.startswith("linux")
 HERE = os.path.abspath(os.path.dirname(__file__))
 PYPROJECT_TOML = os.path.join(HERE, 'pyproject.toml')
 SETUP_CFG = os.path.join(HERE, 'setup.cfg')
-ARCH = platform.machine() or "generic"
 
 
 if WINDOWS:
@@ -230,7 +229,7 @@ def make_zip():
     elif MACOS:
         ext, OS = '*.dmg', 'macOS'
     artifact = glob.glob(os.path.join(BUILD_DIR, ext))[0]
-    dest = f'napari-{VERSION}-{OS}-{ARCH}.zip'
+    dest = f'napari-{VERSION}-{OS}-{architecture()}.zip'
 
     with zipfile.ZipFile(dest, 'w', zipfile.ZIP_DEFLATED) as zf:
         zf.write(artifact, arcname=os.path.basename(artifact))


### PR DESCRIPTION
# Description
Fix windows bundle upload failure, the upload is looking for arch x86_64 while the built file is using AMD64

## Type of change
- Bug-fix (non-breaking change which fixes an issue)

# References
failure run: https://github.com/napari/napari/actions/runs/1335363411
success run after this patch: https://github.com/napari/napari/runs/3887081544


## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
