### PR TITLE
drop pythonw patch in windows bundle

### DIFF
--- a/bundle.py
+++ b/bundle.py
@@ -263,9 +263,7 @@ def bundle():
 
         add_site_packages_to_path()
 
-        if WINDOWS:
-            patch_wxs()
-        elif MACOS:
+        if MACOS:
             patch_python_lib_location()
 
         # build


### PR DESCRIPTION
# Description
closes #1742 by dropping pythonw.exe replacement with python.exe

## Type of change
bundled app windows launcher change

# References
#1742 

# How has this been tested?
- tested build artifact on windows, confirmed works with prompt dropped (though it took a while to open, and nothing happens before it does, which might be a little confusing)

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
