### PR TITLE
Fix image display for plugin installation page.

### DIFF
--- a/docs/plugins/find-and-install-plugin.md
+++ b/docs/plugins/find-and-install-plugin.md
@@ -24,10 +24,10 @@ directly from within napari:
 
 1. From the “Plugins” menu, select “Install/Uninstall Plugins...”.
 
-   ![napari plugin menu](../images/plugin-menu.png)
+   ![napari plugin menu](/images/plugin-menu.png)
 
 2. In the resulting window that opens, where it says “Install by name/URL”, type the name of the plugin you want to install.
 
-   ![napari plugin installation dialog](../images/plugin-install-dialog.png)
+   ![napari plugin installation dialog](/images/plugin-install-dialog.png)
 
 3. Click the “Install” button next to the input bar.


### PR DESCRIPTION
# Description
This fixes the display of images in the "Finding and installing a napari plugin" page. Currently, these images are not shown in the rendered website.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Related: napari/napari.github.io#195

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
