### PR TITLE
Fix formatting of Layers docstrings

### DIFF
--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -46,14 +46,12 @@ def _merge_docstrings(add_method, layer_string):
     import textwrap
 
     add_method_doc = _NumpyDocString(add_method.__doc__)
-    params = (
-        "\n".join(add_method_doc._str_param_list('Parameters')) + _VIEW_PARAMS
-    )
+
     # this ugliness is because the indentation of the parsed numpydocstring
     # is different for the first parameter :(
-    lines = params.splitlines()
+    lines = add_method_doc._str_param_list('Parameters')
     lines = lines[:3] + textwrap.dedent("\n".join(lines[3:])).splitlines()
-    params = "\n".join(lines)
+    params = "\n".join(lines) + "\n" + textwrap.dedent(_VIEW_PARAMS)
     n = 'n' if layer_string.startswith(tuple('aeiou')) else ''
     return _doc_template.format(n=n, layer_string=layer_string, params=params)
 


### PR DESCRIPTION
# Description

Currently, the [napari.view_layers](https://napari.org/api/stable/napari.view_layers.html) page shows ill-formatted docstrings:

![Screenshot_20211014_223104](https://user-images.githubusercontent.com/3949932/137418157-e481b0c1-f1c5-4254-aab0-b5c8c90e3c7b.png)

This PR fixes this problem.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
