### PR TITLE
Bump minimum NumPy requirement to 1.18 (as per NEP29)

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -15,7 +15,7 @@ dependencies:
 - napari-console >=0.0.4
 - napari-plugin-engine >=0.1.9
 - napari-svg >=0.1.4
-- numpy >=1.16.5
+- numpy >=1.18.5
 - numpydoc >=0.9.2
 - pillow
 - pint >=0.17

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
     napari-console>=0.0.4
     napari-plugin-engine>=0.1.9
     napari-svg>=0.1.4
-    numpy>=1.16.5
+    numpy>=1.18.5
     numpydoc>=0.9.2
     Pillow!=7.1.0,!=7.1.1  # not a direct dependency, but 7.1.0 and 7.1.1 broke imageio
     pint>=0.17


### PR DESCRIPTION
# Description

Updates the minimum supported NumPy version as recommended by [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table)

A specific case where dropping 1.17 support would avoid a `try`/`except` came up in recently: https://github.com/napari/napari/pull/3444#discussion_r720608467

Some CI tests run on the minimum versions specified in `setup.cfg`. The binder environment file was the only other place I could find an explicit reference to "1.16".

## Type of change
dependency version update

# How has this been tested?

will be verified by tests continuing to pass on CI

## Final checklist:
- [ x ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
  