### PR TITLE
Remove make_napari_viewer in vispy tests.

### DIFF
--- a/napari/_vispy/_tests/test_vispy_points_layer.py
+++ b/napari/_vispy/_tests/test_vispy_points_layer.py
@@ -1,26 +1,26 @@
 import numpy as np
 import pytest
 
+from napari._vispy.layers.points import VispyPointsLayer
+from napari.layers import Points
 
-@pytest.mark.parametrize("opacity", [(0), (0.3), (0.7), (1)])
-def test_VispyPointsLayer(make_napari_viewer, opacity):
-    """Test on the VispyPointsLayer object."""
-    viewer = make_napari_viewer()
+
+@pytest.mark.parametrize("opacity", [0, 0.3, 0.7, 1])
+def test_VispyPointsLayer(opacity):
     points = np.array([[100, 100], [200, 200], [300, 100]])
-    layer = viewer.add_points(points, size=30, opacity=opacity)
-    visual = viewer.window.qt_viewer.layer_to_visual[layer]
+    layer = Points(points, size=30, opacity=opacity)
+    visual = VispyPointsLayer(layer)
     assert visual.node.opacity == opacity
 
 
-def test_change_text_updates_node_string(make_napari_viewer):
-    viewer = make_napari_viewer()
+def test_change_text_updates_node_string():
     points = np.random.rand(3, 2)
     properties = {
         'class': np.array(['A', 'B', 'C']),
         'name': np.array(['D', 'E', 'F']),
     }
-    layer = viewer.add_points(points, text='class', properties=properties)
-    vispy_layer = viewer.window.qt_viewer.layer_to_visual[layer]
+    layer = Points(points, text='class', properties=properties)
+    vispy_layer = VispyPointsLayer(layer)
     text_node = vispy_layer._get_text_node()
     np.testing.assert_array_equal(text_node.text, properties['class'])
 
@@ -29,13 +29,12 @@ def test_change_text_updates_node_string(make_napari_viewer):
     np.testing.assert_array_equal(text_node.text, properties['name'])
 
 
-def test_change_text_color_updates_node_color(make_napari_viewer):
-    viewer = make_napari_viewer()
+def test_change_text_color_updates_node_color():
     points = np.random.rand(3, 2)
     properties = {'class': np.array(['A', 'B', 'C'])}
     text = {'text': 'class', 'color': [1, 0, 0]}
-    layer = viewer.add_points(points, text=text, properties=properties)
-    vispy_layer = viewer.window.qt_viewer.layer_to_visual[layer]
+    layer = Points(points, text=text, properties=properties)
+    vispy_layer = VispyPointsLayer(layer)
     text_node = vispy_layer._get_text_node()
     np.testing.assert_array_equal(text_node.color.rgb, [[1, 0, 0]])
 
@@ -45,11 +44,10 @@ def test_change_text_color_updates_node_color(make_napari_viewer):
 
 
 def test_change_properties_updates_node_strings(make_napari_viewer):
-    viewer = make_napari_viewer()
     points = np.random.rand(3, 2)
     properties = {'class': np.array(['A', 'B', 'C'])}
-    layer = viewer.add_points(points, properties=properties, text='class')
-    vispy_layer = viewer.window.qt_viewer.layer_to_visual[layer]
+    layer = Points(points, properties=properties, text='class')
+    vispy_layer = VispyPointsLayer(layer)
     text_node = vispy_layer._get_text_node()
     np.testing.assert_array_equal(text_node.text, ['A', 'B', 'C'])
 
@@ -58,14 +56,11 @@ def test_change_properties_updates_node_strings(make_napari_viewer):
     np.testing.assert_array_equal(text_node.text, ['D', 'E', 'F'])
 
 
-def test_update_property_value_then_refresh_text_updates_node_strings(
-    make_napari_viewer,
-):
-    viewer = make_napari_viewer()
+def test_update_property_value_then_refresh_text_updates_node_strings():
     points = np.random.rand(3, 2)
     properties = {'class': np.array(['A', 'B', 'C'])}
-    layer = viewer.add_points(points, properties=properties, text='class')
-    vispy_layer = viewer.window.qt_viewer.layer_to_visual[layer]
+    layer = Points(points, properties=properties, text='class')
+    vispy_layer = VispyPointsLayer(layer)
     text_node = vispy_layer._get_text_node()
     np.testing.assert_array_equal(text_node.text, ['A', 'B', 'C'])
 

--- a/napari/_vispy/_tests/test_vispy_shapes_layer.py
+++ b/napari/_vispy/_tests/test_vispy_shapes_layer.py
@@ -1,15 +1,17 @@
 import numpy as np
 
+from napari._vispy.layers.shapes import VispyShapesLayer
+from napari.layers import Shapes
 
-def test_change_text_updates_node_string(make_napari_viewer):
-    viewer = make_napari_viewer()
+
+def test_change_text_updates_node_string():
     shapes = np.random.rand(3, 4, 2)
     properties = {
         'class': np.array(['A', 'B', 'C']),
         'name': np.array(['D', 'E', 'F']),
     }
-    layer = viewer.add_shapes(shapes, properties=properties, text='class')
-    vispy_layer = viewer.window.qt_viewer.layer_to_visual[layer]
+    layer = Shapes(shapes, properties=properties, text='class')
+    vispy_layer = VispyShapesLayer(layer)
     text_node = vispy_layer._get_text_node()
     np.testing.assert_array_equal(text_node.text, properties['class'])
 
@@ -18,13 +20,12 @@ def test_change_text_updates_node_string(make_napari_viewer):
     np.testing.assert_array_equal(text_node.text, properties['name'])
 
 
-def test_change_text_color_updates_node_color(make_napari_viewer):
-    viewer = make_napari_viewer()
+def test_change_text_color_updates_node_color():
     shapes = np.random.rand(3, 4, 2)
     properties = {'class': np.array(['A', 'B', 'C'])}
     text = {'text': 'class', 'color': [1, 0, 0]}
-    layer = viewer.add_shapes(shapes, properties=properties, text=text)
-    vispy_layer = viewer.window.qt_viewer.layer_to_visual[layer]
+    layer = Shapes(shapes, properties=properties, text=text)
+    vispy_layer = VispyShapesLayer(layer)
     text_node = vispy_layer._get_text_node()
     np.testing.assert_array_equal(text_node.color.rgb, [[1, 0, 0]])
 
@@ -33,12 +34,11 @@ def test_change_text_color_updates_node_color(make_napari_viewer):
     np.testing.assert_array_equal(text_node.color.rgb, [[0, 0, 1]])
 
 
-def test_change_properties_updates_node_strings(make_napari_viewer):
-    viewer = make_napari_viewer()
+def test_change_properties_updates_node_strings():
     shapes = np.random.rand(3, 4, 2)
     properties = {'class': np.array(['A', 'B', 'C'])}
-    layer = viewer.add_shapes(shapes, properties=properties, text='class')
-    vispy_layer = viewer.window.qt_viewer.layer_to_visual[layer]
+    layer = Shapes(shapes, properties=properties, text='class')
+    vispy_layer = VispyShapesLayer(layer)
     text_node = vispy_layer._get_text_node()
     np.testing.assert_array_equal(text_node.text, ['A', 'B', 'C'])
 
@@ -47,14 +47,11 @@ def test_change_properties_updates_node_strings(make_napari_viewer):
     np.testing.assert_array_equal(text_node.text, ['D', 'E', 'F'])
 
 
-def test_update_property_value_then_refresh_text_updates_node_strings(
-    make_napari_viewer,
-):
-    viewer = make_napari_viewer()
+def test_update_property_value_then_refresh_text_updates_node_strings():
     shapes = np.random.rand(3, 4, 2)
     properties = {'class': np.array(['A', 'B', 'C'])}
-    layer = viewer.add_shapes(shapes, properties=properties, text='class')
-    vispy_layer = viewer.window.qt_viewer.layer_to_visual[layer]
+    layer = Shapes(shapes, properties=properties, text='class')
+    vispy_layer = VispyShapesLayer(layer)
     text_node = vispy_layer._get_text_node()
     np.testing.assert_array_equal(text_node.text, ['A', 'B', 'C'])
 


### PR DESCRIPTION
# Description
This removes the `make_napari_viewer` fixture as a dependency of the vispy points/shapes tests. Instead of using the viewer's methods, we construct `Points` and `VispyPointsLayer` instances directly.

On my machine that decreased the total test time of `test_vispy_points_layer.py` from 4.30 seconds to 1.17 seconds, which seems worth having.

I don't think we lose anything by not creating an instance of `Viewer`, but it would be good for someone more informed to double check that (e.g. in terms of the correct/safe setup/teardown of any vispy related stuff).

## Type of change
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Performance improvement.

# References
Follow-up on Zulip message: https://napari.zulipchat.com/#narrow/stream/212875-general/topic/test_vispy_*_layer.20can't.20find.20fixture/near/257584854

# How has this been tested?
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
