### PR TITLE
Set text consistent 1833

### DIFF
--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -258,7 +258,7 @@ class QtPointsControls(QtLayerControls):
         self.layer.n_dimensional = state == Qt.Checked
 
     def change_text_visibility(self, state):
-        """Toggle the visibiltiy of the text.
+        """Toggle the visibility of the text.
 
         Parameters
         ----------
@@ -268,7 +268,7 @@ class QtPointsControls(QtLayerControls):
         self.layer.text.visible = state == Qt.Checked
 
     def _on_text_visibility_change(self, event):
-        """Receive layer model text visibiltiy change change event and update checkbox.
+        """Receive layer model text visibility change change event and update checkbox.
 
         Parameters
         ----------

--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -386,7 +386,7 @@ class QtShapesControls(QtLayerControls):
         self.layer.current_edge_width = float(value) / 2
 
     def change_text_visibility(self, state):
-        """Toggle the visibiltiy of the text.
+        """Toggle the visibility of the text.
 
         Parameters
         ----------
@@ -399,7 +399,7 @@ class QtShapesControls(QtLayerControls):
             self.layer.text.visible = False
 
     def _on_text_visibility_change(self, event):
-        """Receive layer model text visibiltiy change change event and update checkbox.
+        """Receive layer model text visibility change change event and update checkbox.
 
         Parameters
         ----------

--- a/napari/_vispy/layers/points.py
+++ b/napari/_vispy/layers/points.py
@@ -27,13 +27,17 @@ class VispyPointsLayer(VispyBaseLayer):
         self.layer.events.face_color.connect(self._on_data_change)
         self.layer._face.events.colors.connect(self._on_data_change)
         self.layer._face.events.color_properties.connect(self._on_data_change)
-        self.layer.text._connect_update_events(
-            self._on_text_change, self._on_blending_change
-        )
+        self.layer.events.text.connect(self._on_layer_text_change)
         self.layer.events.highlight.connect(self._on_highlight_change)
 
         self.reset()
+        self._on_layer_text_change()
         self._on_data_change()
+
+    def _on_layer_text_change(self, event=None):
+        self.layer.text.events.data_update.connect(self._on_text_change)
+        self.layer.text.events.blending.connect(self._on_blending_change)
+        self._on_text_change()
 
     def _on_data_change(self, event=None):
         if len(self.layer._indices_view) > 0:
@@ -45,7 +49,7 @@ class VispyPointsLayer(VispyBaseLayer):
 
         # Set vispy data, noting that the order of the points needs to be
         # reversed to make the most recently added point appear on top
-        # and the rows / columns need to be switch for vispys x / y ordering
+        # and the rows / columns need to be switched for vispy's x / y ordering
         if len(self.layer._indices_view) == 0:
             data = np.zeros((1, self.layer._ndisplay))
             size = [0]
@@ -65,6 +69,7 @@ class VispyPointsLayer(VispyBaseLayer):
             scaling=True,
         )
 
+        self._on_text_change(update_node=False)
         self.node.update()
 
         # Call to update order of translation values with new dims:

--- a/napari/_vispy/layers/points.py
+++ b/napari/_vispy/layers/points.py
@@ -27,16 +27,10 @@ class VispyPointsLayer(VispyBaseLayer):
         self.layer.events.face_color.connect(self._on_data_change)
         self.layer._face.events.colors.connect(self._on_data_change)
         self.layer._face.events.color_properties.connect(self._on_data_change)
-        self.layer.events.text.connect(self._on_text_instance_change)
         self.layer.events.highlight.connect(self._on_highlight_change)
         self.layer.text.events.connect(self._on_text_change)
 
         self._on_data_change()
-
-    def _on_text_instance_change(self, event=None):
-        self.layer.text.events.connect(self._on_text_change)
-        self._update_text(update_node=False)
-        self._on_blending_change(None)
 
     def _on_data_change(self, event=None):
         if len(self.layer._indices_view) > 0:

--- a/napari/_vispy/layers/shapes.py
+++ b/napari/_vispy/layers/shapes.py
@@ -16,13 +16,17 @@ class VispyShapesLayer(VispyBaseLayer):
         self.layer.events.edge_width.connect(self._on_data_change)
         self.layer.events.edge_color.connect(self._on_data_change)
         self.layer.events.face_color.connect(self._on_data_change)
-        self.layer.text._connect_update_events(
-            self._on_text_change, self._on_blending_change
-        )
+        self.layer.events.text.connect(self._on_layer_text_change)
         self.layer.events.highlight.connect(self._on_highlight_change)
 
         self.reset()
+        self._on_layer_text_change()
         self._on_data_change()
+
+    def _on_layer_text_change(self, event=None):
+        self.layer.text.events.data_update.connect(self._on_text_change)
+        self.layer.text.events.blending.connect(self._on_blending_change)
+        self._on_text_change()
 
     def _on_data_change(self, event=None):
         faces = self.layer._data_view._mesh.displayed_triangles

--- a/napari/_vispy/layers/shapes.py
+++ b/napari/_vispy/layers/shapes.py
@@ -16,7 +16,6 @@ class VispyShapesLayer(VispyBaseLayer):
         self.layer.events.edge_width.connect(self._on_data_change)
         self.layer.events.edge_color.connect(self._on_data_change)
         self.layer.events.face_color.connect(self._on_data_change)
-        self.layer.events.text.connect(self._on_text_instance_change)
         self.layer.events.highlight.connect(self._on_highlight_change)
         self.layer.text.events.connect(self._on_text_change)
 
@@ -103,12 +102,7 @@ class VispyShapesLayer(VispyBaseLayer):
             pos=pos, color=edge_color, width=width
         )
 
-    def _on_text_instance_change(self, event=None):
-        self.layer.text.events.connect(self._on_text_change)
-        self._update_text(update_node=False)
-        self._on_blending_change(None)
-
-    def _update_text(self, update_node=True):
+    def _update_text(self, *, update_node=True):
         """Function to update the text node properties
 
         Parameters

--- a/napari/_vispy/layers/shapes.py
+++ b/napari/_vispy/layers/shapes.py
@@ -16,17 +16,12 @@ class VispyShapesLayer(VispyBaseLayer):
         self.layer.events.edge_width.connect(self._on_data_change)
         self.layer.events.edge_color.connect(self._on_data_change)
         self.layer.events.face_color.connect(self._on_data_change)
-        self.layer.events.text.connect(self._on_layer_text_change)
+        self.layer.events.text.connect(self._on_text_instance_change)
         self.layer.events.highlight.connect(self._on_highlight_change)
+        self.layer.text.events.connect(self._on_text_change)
 
         self.reset()
-        self._on_layer_text_change()
         self._on_data_change()
-
-    def _on_layer_text_change(self, event=None):
-        self.layer.text.events.data_update.connect(self._on_text_change)
-        self.layer.text.events.blending.connect(self._on_blending_change)
-        self._on_text_change()
 
     def _on_data_change(self, event=None):
         faces = self.layer._data_view._mesh.displayed_triangles
@@ -52,7 +47,7 @@ class VispyShapesLayer(VispyBaseLayer):
 
         # Call to update order of translation values with new dims:
         self._on_matrix_change()
-        self._on_text_change(update_node=False)
+        self._update_text(update_node=False)
         self.node.update()
 
     def _on_highlight_change(self, event=None):
@@ -108,7 +103,12 @@ class VispyShapesLayer(VispyBaseLayer):
             pos=pos, color=edge_color, width=width
         )
 
-    def _on_text_change(self, update_node=True):
+    def _on_text_instance_change(self, event=None):
+        self.layer.text.events.connect(self._on_text_change)
+        self._update_text(update_node=False)
+        self._on_blending_change(None)
+
+    def _update_text(self, update_node=True):
         """Function to update the text node properties
 
         Parameters
@@ -147,6 +147,12 @@ class VispyShapesLayer(VispyBaseLayer):
         """Function to get the text node from the Compound visual"""
         text_node = self.node._subvisuals[-1]
         return text_node
+
+    def _on_text_change(self, event=None):
+        if event is not None and event.type == 'blending':
+            self._on_blending_change(event)
+        else:
+            self._update_text()
 
     def _on_blending_change(self, event=None):
         """Function to set the blending mode"""

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2154,3 +2154,25 @@ def test_set_properties_with_missing_text_property_text_becomes_constant():
     np.testing.assert_array_equal(
         points.text.values, ['class', 'class', 'class']
     )
+
+
+def test_text_param_and_setter_are_consistent():
+    """See https://github.com/napari/napari/issues/1833"""
+    data = np.random.rand(5, 3) * 100
+    properties = {
+        'accepted': np.random.choice([True, False], (5,)),
+    }
+    text = {'text': 'accepted', 'color': 'black'}
+
+    points_init = Points(data, properties=properties, text=text)
+
+    points_set = Points(data, properties=properties)
+    points_set.text = text
+
+    np.testing.assert_array_equal(
+        points_init.text.values,
+        points_set.text.values,
+    )
+    np.testing.assert_array_equal(
+        points_init.text.color, points_set.text.color
+    )

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -309,6 +309,7 @@ class Points(Layer):
             symbol=Event,
             n_dimensional=Event,
             highlight=Event,
+            text=Event,
         )
 
         self._colors = get_color_namelist()
@@ -321,21 +322,7 @@ class Points(Layer):
             properties, property_choices, len(self.data), save_choices=True
         )
 
-        # make the text
-        if text is None or isinstance(text, (list, np.ndarray, str)):
-            self._text = TextManager(text, len(data), self.properties)
-        elif isinstance(text, dict):
-            copied_text = deepcopy(text)
-            copied_text['properties'] = self.properties
-            copied_text['n_text'] = len(data)
-            self._text = TextManager(**copied_text)
-        else:
-            raise TypeError(
-                trans._(
-                    'text should be a string, array, or dict',
-                    deferred=True,
-                )
-            )
+        self.text = text
 
         # Save the point style params
         self.symbol = symbol
@@ -414,7 +401,7 @@ class Points(Layer):
         cur_npoints = len(self._data)
         self._data = data
 
-        # Adjust the size array when the number of points has changed
+        # Add/remove property and style values based on the number of new points.
         with self.events.blocker_all():
             with self._edge.events.blocker_all():
                 with self._face.events.blocker_all():
@@ -577,9 +564,12 @@ class Points(Layer):
 
     @text.setter
     def text(self, text):
-        self._text._set_text(
-            text, n_text=len(self.data), properties=self.properties
+        self._text = TextManager._from_layer(
+            text=text,
+            n_text=len(self.data),
+            properties=self.properties,
         )
+        self.events.text()
 
     def refresh_text(self):
         """Refresh the text values.
@@ -610,7 +600,7 @@ class Points(Layer):
 
     @property
     def n_dimensional(self) -> bool:
-        """bool: renders points as n-dimensionsal."""
+        """bool: renders points as n-dimensional."""
         return self._n_dimensional
 
     @n_dimensional.setter
@@ -1144,8 +1134,11 @@ class Points(Layer):
         -------
         text_coords : (N x D) np.ndarray
             Array of coordinates for the N text elements in view
+        anchor_x : str
+            The vispy text anchor for the x axis
+        anchor_y : str
+            The vispy text anchor for the y axis
         """
-        # TODO check if it is used, as it has wrong signature and this not cause errors.
         return self.text.compute_text_coords(self._view_data, self._ndisplay)
 
     @property

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -568,8 +568,11 @@ class Points(Layer):
             text=text,
             n_text=len(self.data),
             properties=self.properties,
+            current_manager=getattr(self, '_text', None),
         )
-        self.events.text()
+        # TODO: should we use TextManager's EmitterGroup's main event, or should we
+        # add a text event to the Points layer?
+        self._text.events(Event('TODO: what should this be?'))
 
     def refresh_text(self):
         """Refresh the text values.

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -474,7 +474,6 @@ class Shapes(Layer):
             current_face_color=Event,
             current_properties=Event,
             highlight=Event,
-            text=Event,
         )
 
         # Flag set to false to block thumbnail refresh
@@ -2227,10 +2226,11 @@ class Shapes(Layer):
     def text(self, text):
         self._text = TextManager._from_layer(
             text=text,
-            n_text=self.nshapes,
+            n_text=len(self.data),
             properties=self.properties,
+            current_manager=getattr(self, '_text', None),
         )
-        self.events.text()
+        self._text.events(Event('TODO: what should this be?'))
 
     def refresh_text(self):
         """Refresh the text values.

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -474,6 +474,7 @@ class Shapes(Layer):
             current_face_color=Event,
             current_properties=Event,
             highlight=Event,
+            text=Event,
         )
 
         # Flag set to false to block thumbnail refresh
@@ -485,22 +486,6 @@ class Shapes(Layer):
         self._properties, self._property_choices = prepare_properties(
             properties, property_choices, num_data=len(data)
         )
-
-        # make the text
-        if text is None or isinstance(text, (list, np.ndarray, str)):
-            self._text = TextManager(text, len(data), self.properties)
-        elif isinstance(text, dict):
-            copied_text = deepcopy(text)
-            copied_text['properties'] = self.properties
-            copied_text['n_text'] = len(data)
-            self._text = TextManager(**copied_text)
-        else:
-            raise TypeError(
-                trans._(
-                    'text should be a string, array, or dict',
-                    deferred=True,
-                )
-            )
 
         # The following shape properties are for the new shapes that will
         # be drawn. Each shape has a corresponding property with the
@@ -586,6 +571,8 @@ class Shapes(Layer):
         self.current_properties = get_current_properties(
             self._properties, self._property_choices, len(data)
         )
+
+        self.text = text
 
         # Trigger generation of view slice and thumbnail
         self._update_dims()
@@ -1529,13 +1516,17 @@ class Shapes(Layer):
         return self.text.view_text(self._indices_view)
 
     @property
-    def _view_text_coords(self) -> np.ndarray:
+    def _view_text_coords(self) -> Tuple[np.ndarray, str, str]:
         """Get the coordinates of the text elements in view
 
         Returns
         -------
         text_coords : (N x D) np.ndarray
             Array of coordinates for the N text elements in view
+        anchor_x : str
+            The vispy text anchor for the x axis
+        anchor_y : str
+            The vispy text anchor for the y axis
         """
         # get the coordinates of the vertices for the shapes in view
         in_view_shapes_coords = [
@@ -2234,9 +2225,12 @@ class Shapes(Layer):
 
     @text.setter
     def text(self, text):
-        self._text._set_text(
-            text, n_text=len(self.data), properties=self.properties
+        self._text = TextManager._from_layer(
+            text=text,
+            n_text=self.nshapes,
+            properties=self.properties,
         )
+        self.events.text()
 
     def refresh_text(self):
         """Refresh the text values.

--- a/napari/layers/utils/text_manager.py
+++ b/napari/layers/utils/text_manager.py
@@ -20,16 +20,15 @@ class TextManager(EventedModel):
     Parameters
     ----------
     text : str
-        The string that may be a constant, a property name, or a format string
-        containing property names. The property name and format string will be
-        used to fill out strings n_text times using the data in properties. Any
-        constant will be repeated n_text times.
+        A a property name or a format string containing property names.
+        This will be used to fill out string values n_text times using the
+        data in properties.
     n_text : int
         The number of text elements to initially display, which should match
         the number of elements (e.g. points) in a layer.
     properties: dict
-        Stores properties data that will be used to generate strings when text
-        is a property name or format string. Typically comes from a layer.
+        Stores properties data that will be used to generate strings from the
+        given text. Typically comes from a layer.
 
     Attributes
     ----------
@@ -218,7 +217,7 @@ class TextManager(EventedModel):
         ----------
         text : Union[TextManager, dict, str, None]
             An instance of TextManager, a dict that contains some of its state,
-            a string that may be a constant, a property name, or a format string.
+            a string that should be a property name, or a format string.
         n_text : int
             The number of text elements to initially display, which should match
             the number of elements (e.g. points) in a layer.

--- a/napari/layers/utils/text_manager.py
+++ b/napari/layers/utils/text_manager.py
@@ -6,7 +6,7 @@ import numpy as np
 from pydantic import PositiveInt, validator
 
 from ...utils.colormaps.standardize_color import transform_color
-from ...utils.events import Event, EventedModel
+from ...utils.events import EventedModel
 from ...utils.events.custom_types import Array
 from ...utils.translations import trans
 from ..base._base_constants import Blending
@@ -73,16 +73,6 @@ class TextManager(EventedModel):
             text = kwargs['values']
             n_text = len(text)
         self._set_text(text, n_text, properties=properties)
-        # When all the fields except blending change, listeners typically
-        # respond in the same way, so create an event that they all emit.
-        self.events.add(data_update=Event)
-        self.events.values.connect(self.events.data_update)
-        self.events.visible.connect(self.events.data_update)
-        self.events.size.connect(self.events.data_update)
-        self.events.color.connect(self.events.data_update)
-        self.events.anchor.connect(self.events.data_update)
-        self.events.translation.connect(self.events.data_update)
-        self.events.rotation.connect(self.events.data_update)
 
     def _set_text(
         self,

--- a/napari/utils/events/_tests/test_event_utils.py
+++ b/napari/utils/events/_tests/test_event_utils.py
@@ -1,0 +1,55 @@
+from copy import copy
+
+from napari.utils.events import EmitterGroup, Event
+from napari.utils.events.event_utils import transfer_connections
+
+
+def _event_callback(event: Event):
+    pass
+
+
+class EventedObject:
+    def __init__(self):
+        self.events = EmitterGroup(self, a=Event, b=Event, c=Event)
+        # Event a is auto-connected to on_a, but setup the connection
+        # from b to _on_b_changed manually.
+        self.events.b.connect(self._on_b_changed)
+        # Event c is an event that is triggered by a and b.
+        self.events.a.connect(self.events.c)
+        self.events.b.connect(self.events.c)
+
+    def on_a(self, event: Event):
+        pass
+
+    def _on_b_changed(self, event: Event):
+        pass
+
+
+def test_transfer_connections_with_no_external_connections_then_no_change():
+    old_object = EventedObject()
+    new_object = EventedObject()
+    a_cbs_before = copy(new_object.events.a.callbacks)
+    b_cbs_before = copy(new_object.events.b.callbacks)
+    c_cbs_before = copy(new_object.events.c.callbacks)
+
+    transfer_connections(old_object, new_object)
+
+    assert new_object.events.a.callbacks == a_cbs_before
+    assert new_object.events.b.callbacks == b_cbs_before
+    assert new_object.events.c.callbacks == c_cbs_before
+
+
+def test_transfer_connection_with_external_connections_then_added():
+    old_object = EventedObject()
+    old_object.events.a.connect(_event_callback)
+    old_object.events.c.connect(_event_callback)
+    new_object = EventedObject()
+    a_cbs_before = copy(new_object.events.a.callbacks)
+    b_cbs_before = copy(new_object.events.b.callbacks)
+    c_cbs_before = copy(new_object.events.c.callbacks)
+
+    transfer_connections(old_object, new_object)
+
+    assert new_object.events.a.callbacks == (_event_callback,) + a_cbs_before
+    assert new_object.events.b.callbacks == b_cbs_before
+    assert new_object.events.c.callbacks == (_event_callback,) + c_cbs_before

--- a/napari/utils/events/_tests/test_event_utils.py
+++ b/napari/utils/events/_tests/test_event_utils.py
@@ -32,14 +32,14 @@ def test_transfer_connections_with_no_external_connections_then_no_change():
     b_cbs_before = copy(new_object.events.b.callbacks)
     c_cbs_before = copy(new_object.events.c.callbacks)
 
-    transfer_connections(old_object, new_object)
+    transfer_connections(old_object.events, new_object.events)
 
     assert new_object.events.a.callbacks == a_cbs_before
     assert new_object.events.b.callbacks == b_cbs_before
     assert new_object.events.c.callbacks == c_cbs_before
 
 
-def test_transfer_connection_with_external_connections_then_added():
+def test_transfer_connections_with_external_connections_then_added():
     old_object = EventedObject()
     old_object.events.a.connect(_event_callback)
     old_object.events.c.connect(_event_callback)
@@ -48,8 +48,19 @@ def test_transfer_connection_with_external_connections_then_added():
     b_cbs_before = copy(new_object.events.b.callbacks)
     c_cbs_before = copy(new_object.events.c.callbacks)
 
-    transfer_connections(old_object, new_object)
+    transfer_connections(old_object.events, new_object.events)
 
     assert new_object.events.a.callbacks == (_event_callback,) + a_cbs_before
     assert new_object.events.b.callbacks == b_cbs_before
     assert new_object.events.c.callbacks == (_event_callback,) + c_cbs_before
+
+
+def test_transfer_connections_from_emitter_group_then_added():
+    old_object = EventedObject()
+    old_object.events.connect(_event_callback)
+    new_object = EventedObject()
+    cbs_before = new_object.events.callbacks
+
+    transfer_connections(old_object.events, new_object.events)
+
+    assert new_object.events.callbacks == (_event_callback,) + cbs_before


### PR DESCRIPTION
# Description
As part of the `TextManager` part of the properties related work (e.g. see #3327, #3493), I found it natural to change how the layers create and mutate their instance of `TextManager`. In order to make those PRs smaller, and to fix issue #1833 in a separate place, I decided to create this PR.

As described in #1833, the `text` parameter in `Points.__init__` behaves differently to `Points.text.setter`, which is unnecessarily confusing and can cause unexpected errors. We see similar behavior in the `Shapes` layer.

This PR takes the approach of making the `Points.text` setter always recreate the `TextManager` instance and assign it to the `Points._text` attribute. This has the benefit of clear syntax and semantics, but has the downside that anything that was connected to any of the events of the old instance of `Points.text` needs to reconnect to those of the new instance.

Alternatively, we could use `EventedModel.update` to update the one instance of `TextManager` associated with a `Points` layer. I dislike this for a few reasons.
- The update can partially succeed (i.e. one of the fields cannot be validated), leaving `TextManager` in a possibly inconsistent state.
- The semantics of passing the parameter as a `dict` is different to setting the property as a `dict` because the setter will only update the fields that are keys in the `dict` (i.e. existing field values that are not specified will stay the same). This behavior might be nice, but if users want it, they can just call `Points.text.update()`. 
- The implementation of setting text in `Points.__init__` and `Points.text.setter` have to be slightly different.

I also made a few other changes in this PR that are less important. In particular, I removed `TextManager._connect_update_events` and added an extra super/custom event to `TextManager` instead. I don't feel strongly about this change, so am happy to revert or consider other ideas.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #1833.
Fixes the documentation issues related to #3053.

# How has this been tested?
- [ ] example: new test that covers original issue passes
- [ ] example: all existing tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
