### PR TITLE
Fix min_req text matrix (skip test)

### DIFF
--- a/examples/clipping_planes_interactive.py
+++ b/examples/clipping_planes_interactive.py
@@ -6,7 +6,15 @@ import napari
 import numpy as np
 from skimage import data
 from scipy import ndimage
-from meshzoo import icosa_sphere
+
+try:
+    from meshzoo import icosa_sphere
+except ImportError as e:
+    raise ImportError(
+        "This example uses a meshzoo but meshzoo is not installed. "
+        "To install try 'pip install meshzoo'."
+    ) from e
+
 
 viewer = napari.Viewer(ndisplay=3)
 

--- a/examples/spheres.py
+++ b/examples/spheres.py
@@ -4,9 +4,11 @@ Display two spheres with Surface layers
 
 try:
     from meshzoo import icosa_sphere
-except ImportError:
-    raise ImportError("This example uses a meshzoo but meshzoo is not installed. "
-                      "To install try 'pip install meshzoo'.")
+except ImportError as e:
+    raise ImportError(
+        "This example uses a meshzoo but meshzoo is not installed. "
+        "To install try 'pip install meshzoo'."
+    ) from e
 import napari
 
 

--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -22,6 +22,11 @@ skip = [
     'custom_key_bindings.py',  # breaks EXPECTED_NUMBER_OF_VIEWER_METHODS later
     'new_theme.py',  # testing theme is extremely slow on CI
 ]
+
+
+if os.environ.get('MIN_REQ', '') == '1':
+    skip.extend(['spheres.py', 'clipping_planes_interactive.py'])
+
 EXAMPLE_DIR = Path(napari.__file__).parent.parent / 'examples'
 # using f.name here and re-joining at `run_path()` for test key presentation
 # (works even if the examples list is empty, as opposed to using an ids lambda)


### PR DESCRIPTION
meshzoo cannot import and numpy.typing is not available.