### PR TITLE
Revert "drop pythonw patch (#3479)"

### DIFF
--- a/bundle.py
+++ b/bundle.py
@@ -263,7 +263,9 @@ def bundle():
 
         add_site_packages_to_path()
 
-        if MACOS:
+        if WINDOWS:
+            patch_wxs()
+        elif MACOS:
             patch_python_lib_location()
 
         # build

--- a/docs/release/release_0_4_12.md
+++ b/docs/release/release_0_4_12.md
@@ -16,8 +16,8 @@ This is a bug fix release with many minor improvements and bug fixes. The user
 experience for users of dask arrays might be significantly improved by a new
 approach to setting the contrast limits based on the current slice (#3425).
 
-A progress bar will now display when opening multiple files (#3355). 
-Thanks to first-time contributor @tibuch the data type of labels layers can now 
+A progress bar will now display when opening multiple files (#3355).
+Thanks to first-time contributor @tibuch the data type of labels layers can now
 be converted from a context menu on the layer list (#3402).
 
 See the full list of merged pull requests below for further delails!

--- a/docs/release/release_0_4_12.md
+++ b/docs/release/release_0_4_12.md
@@ -57,6 +57,7 @@ See the full list of merged pull requests below for further delails!
 - Finds layer_controls based on layer's MRO (#3471)
 - Use `ensure_main_thread` instead of custom thread propagation mechanism in NapariQtNotification (#3473)
 - Drop pythonw patch in windows bundle (#3479)
+- Revert "drop pythonw patch (#3479)" (#3501)
 
 
 ## Bug Fixes


### PR DESCRIPTION
This reverts commit bcc3d00ee847f65b72acb73be3f3d4c2fdbb7db3.

Fixes #3500.

Discussion in Zulip:

https://napari.zulipchat.com/#narrow/stream/215289-release/topic/0.2E4.2E12.20bugfix.20release/near/258460195

@Czaki says:

> As I check it looks like when launching napari without console then
> sys.stdout and sys.stderr are set to None which cause failure of
> creating console object

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
