### PR TITLE
Fix removing selected points with derived text

### DIFF
--- a/napari/_vispy/_tests/test_vispy_points_layer.py
+++ b/napari/_vispy/_tests/test_vispy_points_layer.py
@@ -13,6 +13,21 @@ def test_VispyPointsLayer(opacity):
     assert visual.node.opacity == opacity
 
 
+def test_remove_selected_with_derived_text():
+    """See https://github.com/napari/napari/issues/3504"""
+    points = np.random.rand(3, 2)
+    properties = {'class': np.array(['A', 'B', 'C'])}
+    layer = Points(points, text='class', properties=properties)
+    vispy_layer = VispyPointsLayer(layer)
+    text_node = vispy_layer._get_text_node()
+    np.testing.assert_array_equal(text_node.text, ['A', 'B', 'C'])
+
+    layer.selected_data = {1}
+    layer.remove_selected()
+
+    np.testing.assert_array_equal(text_node.text, ['A', 'C'])
+
+
 def test_change_text_updates_node_string():
     points = np.random.rand(3, 2)
     properties = {

--- a/napari/_vispy/_tests/test_vispy_shapes_layer.py
+++ b/napari/_vispy/_tests/test_vispy_shapes_layer.py
@@ -4,6 +4,21 @@ from napari._vispy.layers.shapes import VispyShapesLayer
 from napari.layers import Shapes
 
 
+def test_remove_selected_with_derived_text():
+    """See https://github.com/napari/napari/issues/3504"""
+    shapes = np.random.rand(3, 4, 2)
+    properties = {'class': np.array(['A', 'B', 'C'])}
+    layer = Shapes(shapes, properties=properties, text='class')
+    vispy_layer = VispyShapesLayer(layer)
+    text_node = vispy_layer._get_text_node()
+    np.testing.assert_array_equal(text_node.text, ['A', 'B', 'C'])
+
+    layer.selected_data = {1}
+    layer.remove_selected()
+
+    np.testing.assert_array_equal(text_node.text, ['A', 'C'])
+
+
 def test_change_text_updates_node_string():
     shapes = np.random.rand(3, 4, 2)
     properties = {

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2154,21 +2154,3 @@ def test_set_properties_with_missing_text_property_text_becomes_constant():
     np.testing.assert_array_equal(
         points.text.values, ['class', 'class', 'class']
     )
-
-
-def test_remove_selected_with_derived_text():
-    data = np.array([[100, 100], [200, 300], [333, 111]])
-    properties = {
-        'confidence': np.array([1, 0.5, 0]),
-    }
-    points = Points(
-        data=data,
-        properties=properties,
-        text='confidence',
-    )
-    np.testing.assert_array_equal(points.text.values, ['1.0', '0.5', '0.0'])
-
-    points.selected_data = {1}
-    points.remove_selected()
-
-    np.testing.assert_array_equal(points.text.values, ['1.0', '0.0'])

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2154,3 +2154,21 @@ def test_set_properties_with_missing_text_property_text_becomes_constant():
     np.testing.assert_array_equal(
         points.text.values, ['class', 'class', 'class']
     )
+
+
+def test_remove_selected_with_derived_text():
+    data = np.array([[100, 100], [200, 300], [333, 111]])
+    properties = {
+        'confidence': np.array([1, 0.5, 0]),
+    }
+    points = Points(
+        data=data,
+        properties=properties,
+        text='confidence',
+    )
+    np.testing.assert_array_equal(points.text.values, ['1.0', '0.5', '0.0'])
+
+    points.selected_data = {1}
+    points.remove_selected()
+
+    np.testing.assert_array_equal(points.text.values, ['1.0', '0.0'])

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1421,7 +1421,8 @@ class Points(Layer):
                 self.properties[k] = np.delete(
                     self.properties[k], index, axis=0
                 )
-            self.text.remove(index)
+            with self.text.events.blocker_all():
+                self.text.remove(index)
             if self._value in self.selected_data:
                 self._value = None
             self.selected_data = set()


### PR DESCRIPTION
# Description
This is a simple fix for #3504 that blocks the event associated with the change to `TextManager.values` in `Points.remove_selected`. If that's not blocked the vispy layer tries to refresh before the data has been updated, because it is listening to text string value changes. The change to data at the end of `remove_selected` will cause the refresh to occur, at which point it should be safe.

I'm not aware of any recent changes that would have broken this. And I haven't run `git bisect` to find out how long it's been around, but can if desired.

I added vispy layer tests for points (where the error was occurring), and a similar one for shapes (where it is not failing, but to protect us in the future.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #3504 

# How has this been tested?
- [ ] example: I added tests to cover the bug and potential similar one for shapes.
- [ ] example: all existing tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
