### PR TITLE
rename autoscale to auto-contrast

### DIFF
--- a/napari/_qt/layer_controls/qt_image_controls.py
+++ b/napari/_qt/layer_controls/qt_image_controls.py
@@ -103,7 +103,7 @@ class QtImageControls(QtBaseImageControls):
         self.grid_layout.addWidget(self.opacitySlider, 0, 1)
         self.grid_layout.addWidget(QLabel(trans._('contrast limits:')), 1, 0)
         self.grid_layout.addWidget(self.contrastLimitsSlider, 1, 1)
-        self.grid_layout.addWidget(QLabel(trans._('autoscale:')), 2, 0)
+        self.grid_layout.addWidget(QLabel(trans._('auto-contrast:')), 2, 0)
         self.grid_layout.addWidget(self.autoScaleBar, 2, 1)
         self.grid_layout.addWidget(QLabel(trans._('gamma:')), 3, 0)
         self.grid_layout.addWidget(self.gammaSlider, 3, 1)

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -394,7 +394,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         self._data = data
         self._update_dims()
         self.events.data(value=self.data)
-        if self._keep_autoscale:
+        if self._keep_auto_contrast:
             self.reset_contrast_limits()
         self._set_editable()
 
@@ -698,7 +698,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
             self, image_indices, image, thumbnail_source
         )
         self._load_slice(data)
-        if self._keep_autoscale or self._should_calc_clims:
+        if self._keep_auto_contrast or self._should_calc_clims:
             self.reset_contrast_limits()
             self._should_calc_clims = False
 

--- a/napari/layers/intensity_mixin.py
+++ b/napari/layers/intensity_mixin.py
@@ -32,12 +32,12 @@ class IntensityVisualizationMixin:
         self._contrast_limits_msg = ''
         self._contrast_limits = [None, None]
         self._contrast_limits_range = [None, None]
-        self._autoscale_source = 'slice'
-        self._keep_autoscale = False
+        self._auto_contrast_source = 'slice'
+        self._keep_auto_contrast = False
 
     def reset_contrast_limits(self: 'Image', mode=None):
         """Scale contrast limits to data range"""
-        mode = mode or self._autoscale_source
+        mode = mode or self._auto_contrast_source
         self.contrast_limits = self._calc_data_range(mode)
 
     def reset_contrast_limits_range(self):

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -239,7 +239,7 @@ class Surface(IntensityVisualizationMixin, Layer):
 
         self._update_dims()
         self.events.data(value=self.data)
-        if self._keep_autoscale:
+        if self._keep_auto_contrast:
             self.reset_contrast_limits()
 
     @property
@@ -403,7 +403,7 @@ class Surface(IntensityVisualizationMixin, Layer):
         else:
             self._view_faces = self.faces
 
-        if self._keep_autoscale:
+        if self._keep_auto_contrast:
             self.reset_contrast_limits()
 
     def _update_thumbnail(self):


### PR DESCRIPTION
# Description
Hi all, hi @jni ,

this is a followup-PR to a short [discussion on twitter.](https://twitter.com/haesleinhuepf/status/1451443421449760772?s=20): I'm suggesting to rename "autoscale" in the brightness-contrast config panel to "auto-contrast" to make it more accessible for a broader audience.
![image](https://user-images.githubusercontent.com/12660498/138453687-45ba42e7-0f8d-47ac-88f6-713cb5b13b65.png)


## Type of change
- [ ] This change requires a documentation update: I guess some screenshots in the documentation should be updated with time.

# References
I only changed the name in the user interface. However, if there is a locale-specific (settings.yaml?) file somewhere, where translations should be adapted as well, I'm happy also do this.

# How has this been tested?
- [ ] I tested it manually (See screenshot above)

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
