### PR TITLE
Fix missing class annotations from stubgen

### DIFF
--- a/napari/utils/stubgen.py
+++ b/napari/utils/stubgen.py
@@ -153,9 +153,6 @@ def generate_class_stubs(cls: Type) -> Tuple[Set[str], str]:
     return imports, stub
 
 
-List
-
-
 def generate_module_stub(module: Union[str, ModuleType], save=True) -> str:
     """Generate a pyi stub for a module.
 

--- a/napari/utils/stubgen.py
+++ b/napari/utils/stubgen.py
@@ -115,13 +115,18 @@ def _get_subclass_methods(cls: Type[Any]) -> Set[str]:
     return all_methods.difference(*base_methods)
 
 
-def generate_class_stubs(cls) -> Tuple[Set[str], str]:
+def generate_class_stubs(cls: Type) -> Tuple[Set[str], str]:
     """Generate a stub and imports for a class."""
-
     bases = ", ".join(f'{b.__module__}.{b.__name__}' for b in cls.__bases__)
 
     methods = []
+    attrs = []
     imports = set()
+
+    local_names = set(cls.__dict__).union(set(cls.__annotations__))
+    for sup in cls.mro()[1:]:
+        local_names.difference_update(set(sup.__dict__))
+
     for methname in sorted(_get_subclass_methods(cls)):
         method = getattr(cls, methname)
         if not callable(method):
@@ -129,12 +134,26 @@ def generate_class_stubs(cls) -> Tuple[Set[str], str]:
         _imports, stub = generate_function_stub(method)
         imports.update(_imports)
         methods.append(stub)
+    hints = get_type_hints(cls)
+    for name, type_ in hints.items():
+        if name not in local_names:
+            continue
+        if hasattr(type_, '__name__'):
+            hint = f'{type_.__module__}.{type_.__name__}'
+        else:
+            hint = repr(type_).replace('typing.', '')
+        attrs.append(f'{name}: {hint.replace("builtins.", "")}')
+        imports.update(set(_iter_imports(type_)))
 
     doc = f'"""{cls.__doc__.lstrip()}"""' if cls.__doc__ else '...'
     stub = f'class {cls.__name__}({bases}):\n    {doc}\n'
-    stub += textwrap.indent("\n".join(methods), '    ')
+    stub += textwrap.indent("\n".join(attrs), '    ')
+    stub += "\n" + textwrap.indent("\n".join(methods), '    ')
 
     return imports, stub
+
+
+List
 
 
 def generate_module_stub(module: Union[str, ModuleType], save=True) -> str:


### PR DESCRIPTION
The stubgen script that creates .pyi files for a couple classes is missing logic to add stubs for annotations defined on the class itself (like pydantic annotations on ViewerModel).  So all the methods were working, but it looks like things like `viewer.camera` etc. wasn't ...

This fixes that
(devs may want to run `make typestubs` after merging this if you want that locally... it will get into the next release)