### PR TITLE
Patch plugin manager in `plugins.io` during test

### DIFF
--- a/napari/plugins/_tests/test_plugins_manager.py
+++ b/napari/plugins/_tests/test_plugins_manager.py
@@ -18,23 +18,11 @@ def test_plugin_discovery_is_delayed():
         sys.executable,
         '-c',
         'import sys; from napari.plugins import plugin_manager; '
-        'sys.exit(int("svg" in plugin_manager.plugins))',
+        'sys.exit(len(plugin_manager.plugins) != 2)',  # we have 2 'builtins'
     ]
     # will fail if plugin discovery happened at import
     proc = subprocess.run(cmd, capture_output=True)
     assert not proc.returncode, 'Plugins were discovered at import time!'
-
-    cmd = [
-        sys.executable,
-        '-c',
-        'import sys; '
-        'from napari.plugins import plugin_manager; '
-        'plugin_manager.discover(); '
-        'sys.exit(not int("svg" in plugin_manager.plugins))',
-    ]
-    # will fail if napari-svg is not in the environment and test needs fixing
-    proc = subprocess.run(cmd, capture_output=True)
-    assert not proc.returncode, 'napari-svg unavailable, this test is broken!'
 
 
 def test_plugin_events(napari_plugin_manager):

--- a/napari/plugins/_tests/test_reader_plugins.py
+++ b/napari/plugins/_tests/test_reader_plugins.py
@@ -17,7 +17,7 @@ def test_builtin_reader_plugin():
         data = np.random.rand(20, 20)
         utils.io.imsave(tmp.name, data)
         tmp.seek(0)
-        layer_data, _ = io.read_data_with_plugins(tmp.name)
+        layer_data, _ = io.read_data_with_plugins(tmp.name, 'builtins')
 
         assert layer_data is not None
         assert isinstance(layer_data, list)
@@ -38,7 +38,7 @@ def test_builtin_reader_plugin_npy():
         data = np.random.rand(20, 20)
         np.save(tmp.name, data)
         tmp.seek(0)
-        layer_data, _ = io.read_data_with_plugins(tmp.name)
+        layer_data, _ = io.read_data_with_plugins(tmp.name, 'builtins')
 
         assert layer_data is not None
         assert isinstance(layer_data, list)
@@ -60,7 +60,7 @@ def test_builtin_reader_plugin_csv(tmpdir):
     data = table[:, 1:]
     # Write csv file
     utils.io.write_csv(tmp, table, column_names=column_names)
-    layer_data, _ = io.read_data_with_plugins(tmp)
+    layer_data, _ = io.read_data_with_plugins(tmp, 'builtins')
 
     assert layer_data is not None
     assert isinstance(layer_data, list)

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -41,6 +41,7 @@ def napari_plugin_manager(monkeypatch):
     # make it so that internal requests for the plugin_manager
     # get this test version for the duration of the test.
     monkeypatch.setattr(napari.plugins, 'plugin_manager', pm)
+    monkeypatch.setattr(napari.plugins.io, 'plugin_manager', pm)
     try:
         monkeypatch.setattr(napari._qt.qt_main_window, 'plugin_manager', pm)
     except AttributeError:  # headless tests


### PR DESCRIPTION
# Description
small fix to make sure that the `napari_plugin_manager` fixture also patches the plugin manager  in `plugins.io`.  Otherwise: plugins installed in the environment may be used in various places during tests.


this also slightly speeds up `test_plugin_discovery_is_delayed`