### PR TITLE
Add class method to viewers to simplify closing all of them.

### DIFF
--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -61,6 +61,7 @@ def test_examples(qapp, fname, monkeypatch, capsys):
     """Test that all of our examples are still working without warnings."""
 
     from napari._qt.qt_main_window import Window
+    from napari import Viewer
 
     # hide viewer window
     monkeypatch.setattr(Window, 'show', lambda *a: None)
@@ -78,3 +79,5 @@ def test_examples(qapp, fname, monkeypatch, capsys):
         # we use sys.exit(0) to gracefully exit from examples
         if e.code != 0:
             raise
+    finally:
+        Viewer.close_all()

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,4 +1,6 @@
+import typing
 from typing import TYPE_CHECKING
+from weakref import WeakSet
 
 import magicgui as mgui
 
@@ -31,6 +33,7 @@ class Viewer(ViewerModel):
     """
 
     _window: 'Window' = None  # type: ignore
+    _instances: typing.ClassVar[WeakSet] = WeakSet()
 
     def __init__(
         self,
@@ -52,6 +55,7 @@ class Viewer(ViewerModel):
         from .window import Window
 
         self._window = Window(self, show=show)
+        self._instances.add(self)
 
     # Expose private window publically. This is needed to keep window off pydantic model
     @property
@@ -124,6 +128,30 @@ class Viewer(ViewerModel):
             # https://github.com/napari/napari/issues/1500
             for layer in self.layers:
                 chunk_loader.on_layer_deleted(layer)
+        self._instances.discard(self)
+
+    @classmethod
+    def close_all(cls) -> int:
+        """
+        Class metod, Close all existing viewer instances.
+
+        This is mostly exposed to avoid leaking of viewers when running tests.
+        As having many non-closed viewer can adversely affect performances.
+
+        It will return the number of viewer closed.
+
+        Returns
+        -------
+        int :
+            number of viewer closed.
+
+        """
+        # copy to not iterate while changing.
+        viewers = [v for v in cls._instances]
+        ret = len(viewers)
+        for viewer in viewers:
+            viewer.close()
+        return ret
 
 
 def current_viewer() -> Viewer:


### PR DESCRIPTION
Use this to close all viewer started when running all the examples,
to make sure that is has no further effects on test duration.

In particular this makes the theme tests go from multiple seconds to <
0.1 sec on my machine.



## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References

See #3472, #3407, #3457.

# How has this been tested?
Locally : python -We -m pytest   --durations=100 napari/_tests/test_examples.py napari/utils/_tests/test_theme.py

## Final checklist:

- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
