### PR TITLE
Fix corner_pixels set from QtViewer.on_draw when layers have mixed numbers of dimensions

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -923,9 +923,11 @@ class QtViewer(QSplitter):
         """
         for layer in self.viewer.layers:
             if layer.ndim <= self.viewer.dims.ndim:
-                displayed_axes = self.viewer.dims.displayed[
-                    -len(layer._displayed_axes) :
-                ]
+                nd = len(layer._displayed_axes)
+                if nd > self.viewer.dims.ndisplay:
+                    displayed_axes = layer._displayed_axes
+                else:
+                    displayed_axes = self.viewer.dims.displayed[-nd:]
                 layer._update_draw(
                     scale_factor=1 / self.viewer.camera.zoom,
                     corner_pixels_displayed=self._canvas_corners_in_world[

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -923,10 +923,14 @@ class QtViewer(QSplitter):
         """
         for layer in self.viewer.layers:
             if layer.ndim <= self.viewer.dims.ndim:
+                axes_offset = self.viewer.dims.ndim - layer.ndim
+                displayed_axes = tuple(
+                    ax + axes_offset for ax in layer._displayed_axes
+                )
                 layer._update_draw(
                     scale_factor=1 / self.viewer.camera.zoom,
                     corner_pixels_displayed=self._canvas_corners_in_world[
-                        :, layer._displayed_axes
+                        :, displayed_axes
                     ],
                     shape_threshold=self.canvas.size,
                 )

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -923,10 +923,9 @@ class QtViewer(QSplitter):
         """
         for layer in self.viewer.layers:
             if layer.ndim <= self.viewer.dims.ndim:
-                axes_offset = self.viewer.dims.ndim - layer.ndim
-                displayed_axes = tuple(
-                    ax + axes_offset for ax in layer._displayed_axes
-                )
+                displayed_axes = self.viewer.dims.displayed[
+                    -len(layer._displayed_axes) :
+                ]
                 layer._update_draw(
                     scale_factor=1 / self.viewer.camera.zoom,
                     corner_pixels_displayed=self._canvas_corners_in_world[

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -203,6 +203,9 @@ def test_changing_theme(make_napari_viewer):
         viewer.theme = 'nonexistent_theme'
 
 
+# TODO: revisit the need for sync_only here.
+# An async failure was observed here on CI, but was not reproduced locally
+@pytest.mark.sync_only
 @pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)
 def test_roll_transpose_update(make_napari_viewer, layer_class, data, ndim):
     """Check that transpose and roll preserve correct transform sequence."""

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1342,7 +1342,9 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
                 self.refresh()
 
         else:
-            self.corner_pixels = data_bbox_clipped
+            corners = np.zeros((2, self.ndim))
+            corners[:, displayed_axes] = data_bbox_clipped
+            self.corner_pixels = corners
 
     def get_status(
         self,

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1300,6 +1300,10 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         self.scale_factor = scale_factor
 
         displayed_axes = self._displayed_axes
+        # must adjust displayed_axes according to _dims_order
+        displayed_axes = np.asarray(
+            [self._dims_order[d] for d in displayed_axes]
+        )
         # we need to compute all four corners to compute a complete,
         # data-aligned bounding box, because top-left/bottom-right may not
         # remain top-left and bottom-right after transformations.

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1342,7 +1342,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
                 self.refresh()
 
         else:
-            corners = np.zeros((2, self.ndim))
+            corners = np.zeros((2, self.ndim), dtype=int)
             corners[:, displayed_axes] = data_bbox_clipped
             self.corner_pixels = corners
 


### PR DESCRIPTION
# Description

This PR is related to #2487.  I don't think it fully closes the issue, but it fixes the problem pointed out by @VolkerH https://github.com/napari/napari/issues/2487#issuecomment-932076245. 

The source of the issue was that `QtViewer`'s `on_draw` method was using the wrong axes when sending the corner pixels to the Layer's `_update_draw` method. 

A separate bug was related to the shape of `corner_pixels` for non-multiscale layers. In `__init__` it is shape `(2, ndim)`:
https://github.com/napari/napari/blob/2f6c4377a3435ac68ed79b9a2e7c7bd0f1730070/napari/layers/base/base.py#L281
, but for non-multiscale images this was getting truncated to shape `(2, 2)` in `_update_draw`:
https://github.com/napari/napari/blob/2f6c4377a3435ac68ed79b9a2e7c7bd0f1730070/napari/layers/base/base.py#L1389

The change here preserves the original `(2, ndim)` shape, making the multiscale and non-multiscale cases consistent.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

I checked that the example case given in https://github.com/napari/napari/issues/2487#issuecomment-932076245 works after this change. 

This still needs a unit test, but I could use some help on how best to write it.  I initially tried writing a unit test using a Viewer created via the `make_napari_viewer` fixture. This did not replicate the issue, though, because when running the test there is no `QtViewer` who's `on_draw` method gets called. 


## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
