### PR TITLE
minor LayerList refactor to remove unneeded NumPy<=1.17 fallback code

### DIFF
--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -153,15 +153,8 @@ class LayerList(SelectableEventedList[Layer]):
             )
 
         # 512 element default extent as documented in `_get_extent_world`
-        try:
-            min_v = np.nan_to_num(min_v, nan=-0.5)
-            max_v = np.nan_to_num(max_v, nan=511.5)
-        except TypeError:
-            # In NumPy < 1.17, nan_to_num doesn't have a nan kwarg
-            min_v = np.asarray(min_v)
-            min_v[np.isnan(min_v)] = -0.5
-            max_v = np.asarray(max_v)
-            max_v[np.isnan(max_v)] = 511.5
+        min_v = np.nan_to_num(min_v, nan=-0.5)
+        max_v = np.nan_to_num(max_v, nan=511.5)
 
         # switch back to original order
         return min_v[::-1], max_v[::-1]


### PR DESCRIPTION

# Description

This is a tiny follow-up to #3444 making a change suggested here https://github.com/napari/napari/pull/3444#discussion_r720608467, now that we no longer support NumPy < 1.18.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

minor maintenance change (no change in behavior)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

no change in behavior, so covered by existing tests 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
