### PR TITLE
Fix contrast_limit artefacts for images with large data range

### DIFF
--- a/napari/_vispy/vendored/image.py
+++ b/napari/_vispy/vendored/image.py
@@ -317,10 +317,7 @@ class ImageVisual(Visual):
             clim = np.array(clim, float)
             if clim.shape != (2,):
                 raise ValueError('clim must have two elements')
-            if self._texture_limits is not None and (
-                (clim[0] < self._texture_limits[0])
-                or (clim[1] > self._texture_limits[1])
-            ):
+            if self._texture_limits is not None:
                 self._need_texture_upload = True
         self._clim = clim
         if self._texture_limits is not None:


### PR DESCRIPTION


# Description

For images with large data ranges (e.g. hot pixels) the manual changing of contrast limits towards lower values doesn't update the texture limits thus leading to image quantization artefacts. 

Example:

```python
import numpy as np
import napari
from skimage.data import camera

x = camera().astype(np.uint16)
x[100,100] = 2**16-1

napari.view_image(x)

```
Manually changing the contrasts limits to values like `(0,217)` leads to this:

<img width="994" alt="Screenshot 2021-10-27 at 02 24 27" src="https://user-images.githubusercontent.com/11042162/138980331-02fc3c1f-0561-4ada-a334-9eeb23e6832f.png">

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

Every pixel is sacred, every pixel is great.
If a pixel is wasted, god gets quite irate.

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

(N.B. `napari/_tests` depends on `tensorstore` which seems not available for Apple Silicon arm64)

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
