### PR TITLE
add checked `QpushButton` qss

### DIFF
--- a/napari/_qt/qt_resources/styles/00_base.qss
+++ b/napari/_qt/qt_resources/styles/00_base.qss
@@ -78,6 +78,10 @@ QPushButton:pressed {
   background-color: {{ highlight }};
 }
 
+QPushButton:checked {
+  background-color: {{ highlight }};
+}
+
 QPushButton:disabled {
   background-color: {{ background }};
 }


### PR DESCRIPTION
# Description
This PR adds qss styling for checked `QPushButton`s - I came across this in the context of a plugin where checked buttons were not displaying properly

before:

https://user-images.githubusercontent.com/7307488/139467119-5cdf1d67-ef9f-4165-a1df-1273d31a26f8.mp4


after:

https://user-images.githubusercontent.com/7307488/139467132-81fd05bf-b92f-46fd-b5de-701f029f945e.mp4



## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)


# How has this been tested?
visually

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
