### PR TITLE
Allow disconnect from EventEmiter using object

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -203,7 +203,6 @@ def test_changing_theme(make_napari_viewer):
         viewer.theme = 'nonexistent_theme'
 
 
-
 # TODO: revisit the need for sync_only here.
 # An async failure was observed here on CI, but was not reproduced locally
 @pytest.mark.sync_only

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -203,6 +203,7 @@ def test_changing_theme(make_napari_viewer):
         viewer.theme = 'nonexistent_theme'
 
 
+@pytest.mark.sync_only
 @pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)
 def test_roll_transpose_update(make_napari_viewer, layer_class, data, ndim):
     """Check that transpose and roll preserve correct transform sequence."""

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -34,6 +34,7 @@ def napari_plugin_manager(monkeypatch):
     from unittest.mock import patch
 
     import napari
+    import napari.plugins.io
     from napari.plugins._plugin_manager import NapariPluginManager
 
     pm = NapariPluginManager()

--- a/napari/utils/events/_tests/test_event_emitter.py
+++ b/napari/utils/events/_tests/test_event_emitter.py
@@ -1,3 +1,5 @@
+import weakref
+
 import pytest
 
 from napari.utils.events import EventEmitter
@@ -149,3 +151,22 @@ def test_disconnect_object():
 
     assert t.call_list_1 == [1]
     assert t.call_list_2 == [1]
+
+
+def test_weakref_disconnect():
+    class TestOb:
+        call_list_1 = []
+
+        def fun1(self):
+            self.call_list_1.append(1)
+
+    t = TestOb()
+
+    e = EventEmitter(type="test")
+    e.connect(t.fun1)
+    e()
+
+    assert t.call_list_1 == [1]
+    e.disconnect((weakref.ref(t), "fun1"))
+    e()
+    assert t.call_list_1 == [1]

--- a/napari/utils/events/_tests/test_event_emitter.py
+++ b/napari/utils/events/_tests/test_event_emitter.py
@@ -121,3 +121,31 @@ def test_to_many_positional():
         e.connect(t.fun)
     with pytest.raises(RuntimeError):
         e.connect(simple_fun)
+
+
+def test_disconnect_object():
+    class TestOb:
+        call_list_1 = []
+        call_list_2 = []
+
+        def fun1(self):
+            self.call_list_1.append(1)
+
+        def fun2(self):
+            self.call_list_2.append(1)
+
+    t = TestOb()
+
+    e = EventEmitter(type="test")
+    e.connect(t.fun1)
+    e.connect(t.fun2)
+    e()
+
+    assert t.call_list_1 == [1]
+    assert t.call_list_2 == [1]
+
+    e.disconnect(t)
+    e()
+
+    assert t.call_list_1 == [1]
+    assert t.call_list_2 == [1]

--- a/napari/utils/events/_tests/test_event_emitter.py
+++ b/napari/utils/events/_tests/test_event_emitter.py
@@ -126,6 +126,11 @@ def test_to_many_positional():
 
 
 def test_disconnect_object():
+    count_list = []
+
+    def fun1():
+        count_list.append(1)
+
     class TestOb:
         call_list_1 = []
         call_list_2 = []
@@ -141,16 +146,19 @@ def test_disconnect_object():
     e = EventEmitter(type="test")
     e.connect(t.fun1)
     e.connect(t.fun2)
+    e.connect(fun1)
     e()
 
     assert t.call_list_1 == [1]
     assert t.call_list_2 == [1]
+    assert count_list == [1]
 
     e.disconnect(t)
     e()
 
     assert t.call_list_1 == [1]
     assert t.call_list_2 == [1]
+    assert count_list == [1, 1]
 
 
 def test_weakref_disconnect():
@@ -170,3 +178,18 @@ def test_weakref_disconnect():
     e.disconnect((weakref.ref(t), "fun1"))
     e()
     assert t.call_list_1 == [1]
+
+
+def test_none_disconnect():
+    count_list = []
+
+    def fun1():
+        count_list.append(1)
+
+    e = EventEmitter(type="test")
+    e.connect(fun1)
+    e()
+    assert count_list == [1]
+    e.disconnect(None)
+    e()
+    assert count_list == [1]

--- a/napari/utils/events/_tests/test_event_emitter.py
+++ b/napari/utils/events/_tests/test_event_emitter.py
@@ -168,6 +168,9 @@ def test_weakref_disconnect():
         def fun1(self):
             self.call_list_1.append(1)
 
+        def fun2(self, event):
+            self.call_list_1.append(2)
+
     t = TestOb()
 
     e = EventEmitter(type="test")
@@ -178,6 +181,9 @@ def test_weakref_disconnect():
     e.disconnect((weakref.ref(t), "fun1"))
     e()
     assert t.call_list_1 == [1]
+    e.connect(t.fun2)
+    e()
+    assert t.call_list_1 == [1, 2]
 
 
 def test_none_disconnect():
@@ -186,6 +192,9 @@ def test_none_disconnect():
     def fun1():
         count_list.append(1)
 
+    def fun2(event):
+        count_list.append(2)
+
     e = EventEmitter(type="test")
     e.connect(fun1)
     e()
@@ -193,3 +202,6 @@ def test_none_disconnect():
     e.disconnect(None)
     e()
     assert count_list == [1]
+    e.connect(fun2)
+    e()
+    assert count_list == [1, 2]

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -506,7 +506,7 @@ class EventEmitter:
             self._callbacks = []
             self._callback_refs = []
             self._callback_pass_event = []
-        elif isinstance(callback, Callable):
+        elif isinstance(callback, (Callable, tuple)):
             callback, _pass_event = self._normalize_cb(callback)
             if callback in self._callbacks:
                 idx = self._callbacks.index(callback)
@@ -521,7 +521,10 @@ class EventEmitter:
                     and isinstance(local_callback[0], weakref.ref)
                 ):
                     continue
-                if local_callback[0]() is callback:
+                if (
+                    local_callback[0]() is callback
+                    or local_callback[0]() is None
+                ):
                     index_list.append(idx)
             for idx in index_list[::-1]:
                 self._callbacks.pop(idx)

--- a/napari/utils/events/event_utils.py
+++ b/napari/utils/events/event_utils.py
@@ -26,17 +26,8 @@ def disconnect_events(emitter, listener):
     listener : Object
         Any object that has been connected to.
     """
-    weak_listener = weakref.ref(listener)
     for em in emitter.emitters.values():
-        for callback in em.callbacks:
-            # *callback* may be either a callable object or a tuple
-            # (object, attr_name) where object.attr_name will point to a
-            # callable object. Note that only a weak reference to ``object``
-            # will be kept. If *callback* is a callable object then it is
-            # not attached to the listener and does not need to be
-            # disconnected
-            if isinstance(callback, tuple) and callback[0] is weak_listener:
-                em.disconnect(callback)
+        em.disconnect(listener)
 
 
 def connect_setattr(emitter: Emitter, obj, attr: str):


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This PR adds options to disconnect all events using the object itself. After reading the code changed in #3449 it looks like disconnecting using objects is not working, but fails silently. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

close 33565

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).


@tlambert03 