### PR TITLE
Minimal update to plan for qtpy 2.0 and pyqt6.

### DIFF
--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from warnings import warn
 
+from qtpy import PYQT5
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QApplication
@@ -134,7 +135,8 @@ def get_app(
     else:
         # automatically determine monitor DPI.
         # Note: this MUST be set before the QApplication is instantiated
-        QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
+        if PYQT5:
+            QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
 
         if perf_config and perf_config.trace_qt_events:
             from .perf.qt_event_tracing import QApplicationWithTracing

--- a/napari/_qt/qt_resources/_icons.py
+++ b/napari/_qt/qt_resources/_icons.py
@@ -190,6 +190,17 @@ def _compile_qrc_pyqt5(qrc) -> bytes:
     return out
 
 
+def _compile_qrc_pyqt6(qrc) -> bytes:
+    """
+    We can't do that with PyQt6,
+
+    The maintainer has discontinued pyrcc for PyQt6
+
+    """
+
+    raise NotImplementedError('pyrcc discontinued on Pyqt6')
+
+
 def _compile_qrc_pyside2(qrc) -> bytes:
     """Compile qrc file using the PySide2 method.
 
@@ -225,7 +236,9 @@ def _compile_qrc_pyside2(qrc) -> bytes:
 
 def compile_qrc(qrc) -> bytes:
     """Compile a qrc file into a resources.py bytes"""
-    if qtpy.API_NAME == 'PyQt5':
+    if qtpy.API_NAME == 'PyQt6':
+        return _compile_qrc_pyqt6(qrc).replace(b'PyQt6', b'qtpy')
+    elif qtpy.API_NAME == 'PyQt5':
         return _compile_qrc_pyqt5(qrc).replace(b'PyQt5', b'qtpy')
     elif qtpy.API_NAME == 'PySide2':
         return _compile_qrc_pyside2(qrc).replace(b'PySide2', b'qtpy')


### PR DESCRIPTION
That does requires spyder-ide/qtpy#271

This in itself does not make napari work, but at least the next person trying will have less questions.
pyqt6 will be necessary for running natively on the new macs. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
