### PR TITLE
Add a method for setting `Camera.view_direction` and `Camera.up_direction`

### DIFF
--- a/napari/components/_tests/test_camera.py
+++ b/napari/components/_tests/test_camera.py
@@ -39,6 +39,22 @@ def test_calculate_view_direction_3d():
     assert np.allclose(camera.view_direction, (0, 1, 0))
 
 
+def test_set_view_direction_3d():
+    """Check that view direction can be set properly."""
+    # simple case
+    camera = Camera(center=(0, 0, 0), angles=(0, 0, 0), zoom=1)
+    camera.view_direction = (1, 0, 0)
+    assert np.allclose(camera.view_direction, (1, 0, 0))
+    assert np.allclose(camera.angles, (0, 0, 90))
+
+    # case with ordering and up direction setting
+    view_direction = np.array([1, 2, 3], dtype=float)
+    view_direction /= np.linalg.norm(view_direction)
+    camera.view_direction = view_direction
+    assert np.allclose(camera.view_direction, view_direction)
+    assert np.allclose(camera.angles, (58.1, -53.3, 26.6), atol=0.1)
+
+
 def test_calculate_view_direction_nd():
     """Check that nD view direction is calculated properly."""
     camera = Camera(center=(0, 0, 0), angles=(90, 0, 0), zoom=1)

--- a/napari/components/_tests/test_camera.py
+++ b/napari/components/_tests/test_camera.py
@@ -62,14 +62,14 @@ def test_set_view_direction_3d():
     """Check that view direction can be set properly."""
     # simple case
     camera = Camera(center=(0, 0, 0), angles=(0, 0, 0), zoom=1)
-    camera.view_direction = (1, 0, 0)
+    camera.set_view_direction(view_direction=(1, 0, 0))
     assert np.allclose(camera.view_direction, (1, 0, 0))
     assert np.allclose(camera.angles, (0, 0, 90))
 
     # case with ordering and up direction setting
     view_direction = np.array([1, 2, 3], dtype=float)
     view_direction /= np.linalg.norm(view_direction)
-    camera.view_direction = view_direction
+    camera.set_view_direction(view_direction=view_direction)
     assert np.allclose(camera.view_direction, view_direction)
     assert np.allclose(camera.angles, (58.1, -53.3, 26.6), atol=0.1)
 

--- a/napari/components/_tests/test_camera.py
+++ b/napari/components/_tests/test_camera.py
@@ -39,6 +39,25 @@ def test_calculate_view_direction_3d():
     assert np.allclose(camera.view_direction, (0, 1, 0))
 
 
+def test_calculate_up_direction_3d():
+    """Check that up direction is calculated properly from camera angles."""
+    # simple case
+    camera = Camera(center=(0, 0, 0), angles=(0, 0, 90), zoom=1)
+    assert np.allclose(camera.up_direction, (0, -1, 0))
+
+    # shouldn't change with zoom
+    camera = Camera(center=(0, 0, 0), angles=(0, 0, 90), zoom=10)
+    assert np.allclose(camera.up_direction, (0, -1, 0))
+
+    # shouldn't change with center
+    camera = Camera(center=(15, 15, 15), angles=(0, 0, 90), zoom=1)
+    assert np.allclose(camera.up_direction, (0, -1, 0))
+
+    # more complex case with order dependent Euler angles
+    camera = Camera(center=(0, 0, 0), angles=(10, 20, 30), zoom=1)
+    assert np.allclose(camera.up_direction, (0.88, -0.44, 0.16), atol=0.01)
+
+
 def test_set_view_direction_3d():
     """Check that view direction can be set properly."""
     # simple case

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     PyYAML>=5.1
     pydantic>=1.8.1
     qtpy>=1.7.0
-    scipy>=1.2.0
+    scipy>=1.4.0
     superqt>=0.2.4
     tifffile>=2020.2.16
     typing_extensions


### PR DESCRIPTION
# Description
This PR adds a setter on the `view_direction` attribute of our `Camera` model. This is useful because we often have a vector describing a direction in our data and might not know how to convert this to the Euler angle representation used by our camera model.

https://user-images.githubusercontent.com/7307488/140627857-c5171135-1858-4433-9f5a-2bee1ee42ecd.mp4

The view direction alone does not uniquely describe the camera orientation. I have provided sane defaults which I think match expectations if only a view direction is provided. I have also added the slightly more verbose method `Camera.set_view_direction(view_direction, up_direction)` which additionally specifies a vector which should point upwards on the canvas. These two attributes uniquely define the camera orientation.

cc @kevinyamauchi @brisvag 

Also cc @tlambert03 and @andy-sweet because I had to override `__setattr__` on the `Camera` to achieve the `Camera.view_direction = ` API [as discussed on zulip](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/pydantic.20model.20with.20settable.20property) and you might find this icky 🤮

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
- [x] simple tests added to test suite

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
