### PR TITLE
Make points add mode cursor a crosshair

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -808,7 +808,7 @@ class QtViewer(QSplitter):
         elif cursor == 'circle':
             q_cursor = QCursor(circle_pixmap(size))
         elif cursor == 'crosshair':
-            q_cursor = QCursor(crosshair_pixmap(25))
+            q_cursor = QCursor(crosshair_pixmap(81))
         else:
             q_cursor = self._cursors[cursor]
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -807,7 +807,7 @@ class QtViewer(QSplitter):
         elif cursor == 'circle':
             q_cursor = QCursor(circle_pixmap(size))
         elif cursor == 'crosshair':
-            q_cursor = QCursor(crosshair_pixmap(size))
+            q_cursor = QCursor(crosshair_pixmap())
         else:
             q_cursor = self._cursors[cursor]
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -41,7 +41,7 @@ from ..utils.translations import trans
 from .containers import QtLayerList
 from .dialogs.screenshot_dialog import ScreenshotDialog
 from .perf.qt_performance import QtPerformance
-from .utils import QImg2array, circle_pixmap, square_pixmap
+from .utils import QImg2array, circle_pixmap, crosshair_pixmap, square_pixmap
 from .widgets.qt_dims import QtDims
 from .widgets.qt_viewer_buttons import QtLayerButtons, QtViewerButtons
 from .widgets.qt_viewer_dock_widget import QtViewerDockWidget
@@ -796,6 +796,7 @@ class QtViewer(QSplitter):
         else:
             size = self.viewer.cursor.size
 
+        print(cursor)
         if cursor == 'square':
             # make sure the square fits within the current canvas
             if size < 8 or size > (
@@ -806,6 +807,8 @@ class QtViewer(QSplitter):
                 q_cursor = QCursor(square_pixmap(size))
         elif cursor == 'circle':
             q_cursor = QCursor(circle_pixmap(size))
+        elif cursor == 'crosshair':
+            q_cursor = QCursor(crosshair_pixmap(size))
         else:
             q_cursor = self._cursors[cursor]
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -796,7 +796,6 @@ class QtViewer(QSplitter):
         else:
             size = self.viewer.cursor.size
 
-        print(cursor)
         if cursor == 'square':
             # make sure the square fits within the current canvas
             if size < 8 or size > (

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -808,7 +808,7 @@ class QtViewer(QSplitter):
         elif cursor == 'circle':
             q_cursor = QCursor(circle_pixmap(size))
         elif cursor == 'crosshair':
-            q_cursor = QCursor(crosshair_pixmap(81))
+            q_cursor = QCursor(crosshair_pixmap(size))
         else:
             q_cursor = self._cursors[cursor]
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -808,7 +808,7 @@ class QtViewer(QSplitter):
         elif cursor == 'circle':
             q_cursor = QCursor(circle_pixmap(size))
         elif cursor == 'crosshair':
-            q_cursor = QCursor(crosshair_pixmap(size))
+            q_cursor = QCursor(crosshair_pixmap(25))
         else:
             q_cursor = self._cursors[cursor]
 

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -167,14 +167,11 @@ def square_pixmap(size):
 
 
 @lru_cache(maxsize=64)
-def crosshair_pixmap(size):
+def crosshair_pixmap():
     """Create a cross cursor with white/black hollow square pixmap in the middle.
     For use as points cursor."""
 
-    size = max(int(size), 1)
-    size = 25 * size
-    if size % 2 == 0:
-        size += 1
+    size = 25
 
     pixmap = QPixmap(QSize(size, size))
     pixmap.fill(Qt.transparent)

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -20,7 +20,7 @@ from qtpy.QtCore import (
     Qt,
     Signal,
 )
-from qtpy.QtGui import QColor, QCursor, QDrag, QImage, QPainter, QPixmap
+from qtpy.QtGui import QColor, QCursor, QDrag, QImage, QPainter, QPen, QPixmap
 from qtpy.QtWidgets import (
     QGraphicsColorizeEffect,
     QGraphicsOpacityEffect,
@@ -171,6 +171,17 @@ def crosshair_pixmap(size):
     """Create a cross cursor with white/black hollow square pixmap in the middle.
     For use as points cursor."""
 
+    # size = max(int(size), 1)
+    # pixmap = QPixmap(QSize(size, size))
+    # pixmap.fill(Qt.transparent)
+    # painter = QPainter(pixmap)
+    # painter.setPen(Qt.white)
+    # painter.drawRect(0, 0, size - 1, size - 1)
+    # painter.setPen(Qt.black)
+    # painter.drawRect(1, 1, size - 3, size - 3)
+    # painter.end()
+    # return pixmap
+
     # painter.drawLine(QPointF(0, size/2), QPointF(size/2-gap,size/2))
     # painter.drawLine(QPointF(size/2+gap, size/2), QPointF(size, size/2))
     # painter.drawLine(QPointF(size/2, 0), QPointF(size/2,size/2-gap))
@@ -179,14 +190,43 @@ def crosshair_pixmap(size):
     pixmap = QPixmap(QSize(size, size))
     pixmap.fill(Qt.transparent)
     painter = QPainter(pixmap)
-    painter.setPen(Qt.white)
-    painter.drawRect(0, 0, size - 1, size - 1)
-    painter.setPen(Qt.black)
-    painter.drawRect(1, 1, size - 2, size - 2)
-    painter.drawLine(QPoint(0, size - 2), QPoint(0, size - 3))
-    painter.drawLine(QPoint(0, size + 2), QPoint(0, size + 3))
-    painter.drawLine(QPoint(size - 2, 0), QPoint(size - 3, 0))
-    painter.drawLine(QPoint(size + 2, 0), QPoint(size + 3, 0))
+    # painter.setPen(Qt.black)
+    # painter.drawRect(0, 0, size-1, size-1)
+
+    # p.setPen(QPen(Qt::white, 3));
+    pen = QPen(Qt.white, 3)
+    pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
+    painter.setPen(pen)
+    # painter.setPen(Qt.white)
+    val = 0.12
+    loc = (size / 2) - (val * size)
+    # painter.drawRect(0, 0, size-1, size-1)
+    painter.drawRect(
+        loc, loc, val * 2 * size, val * 2 * size
+    )  # white rectangle
+    pen = QPen(Qt.white, 4)
+    pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
+    painter.setPen(pen)
+    painter.drawLine(QPoint(size / 2, loc), QPoint(size / 2, 0))
+    painter.drawLine(QPoint(size / 2, size - loc), QPoint(size / 2, size))
+    painter.drawLine(QPoint(loc, size / 2), QPoint(0, size / 2))
+    painter.drawLine(QPoint(size - loc, size / 2), QPoint(size, size / 2))
+
+    val = 0.1
+    loc = (size / 2) - (val * size)
+    pen = QPen(Qt.black, 2)
+    pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
+    painter.setPen(pen)
+    painter.drawRect(loc, loc, val * 2 * size, val * 2 * size)
+    painter.drawLine(QPoint(size / 2, loc - 2), QPoint(size / 2, 2))
+    painter.drawLine(
+        QPoint(size / 2, size - loc + 2), QPoint(size / 2, size - 2)
+    )
+    painter.drawLine(QPoint(loc - 2, size / 2), QPoint(2, size / 2))
+    painter.drawLine(
+        QPoint(size - loc + 2, size / 2), QPoint(size - 2, size / 2)
+    )
+
     painter.end()
     return pixmap
 

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -172,49 +172,75 @@ def crosshair_pixmap(size):
     For use as points cursor."""
 
     size = max(int(size), 1)
+    size = 25 * size
+    if size % 2 == 0:
+        size += 1
+
     pixmap = QPixmap(QSize(size, size))
     pixmap.fill(Qt.transparent)
     painter = QPainter(pixmap)
 
-    pval = (3 / 27) * size
-    pen = QPen(Qt.white, pval)
+    # Base measures
+    width = 1
+    center = 3  # Must be odd!
+    rect_size = center + 2 * width
+    square = rect_size + width * 4
+
+    pen = QPen(Qt.white, 1)
     pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
     painter.setPen(pen)
 
-    loc = (9 / 27) * size
-    hw = (10 / 27) * size
-    painter.drawRect(loc - 1, loc - 1, hw, hw)
-    loc = (11 / 27) * size
-    pval = (2 / 27) * size
-    hw = (7 / 27) * size
-    pen = QPen(Qt.black, pval)
-    pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
-    painter.setPen(pen)
-    painter.drawRect(loc - 1, loc - 1, hw, hw)
+    # # Horizontal rectangle
+    painter.drawRect(0, (size - rect_size) // 2, size - 1, rect_size - 1)
 
-    pval = (4 / 27) * size
-    pen = QPen(Qt.white, pval)
-    pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
-    painter.setPen(pen)
-    mid = size / 2
-    val1 = (7 / 27) * size
-    val2 = (20 / 27) * size
-    painter.drawLine(QPoint(mid, 7), QPoint(mid, 0))
-    painter.drawLine(QPoint(7, mid), QPoint(0, mid))
-    painter.drawLine(QPoint(mid, val2), QPoint(mid, size))
-    painter.drawLine(QPoint(val2, mid), QPoint(size, mid))
+    # Vertical rectangle
+    painter.drawRect((size - rect_size) // 2, 0, rect_size - 1, size - 1)
 
-    pen = QPen(Qt.black, pval / 2)
+    # Square
+    painter.drawRect(
+        (size - square) // 2, (size - square) // 2, square - 1, square - 1
+    )
+
+    pen = QPen(Qt.blue, 1)
     pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
     painter.setPen(pen)
-    val1 = (8 / 27) * size
-    val2 = (2 / 27) * size
-    val3 = (19 / 27) * size
-    val4 = size - 2
-    painter.drawLine(QPoint(mid, val1), QPoint(mid, val2))
-    painter.drawLine(QPoint(val1, mid), QPoint(val2, mid))
-    painter.drawLine(QPoint(mid, val3), QPoint(mid, val4))
-    painter.drawLine(QPoint(val3, mid), QPoint(val4, mid))
+    painter.drawPoint(size // 2, size // 2)
+
+    pen = QPen(Qt.black, 2)
+    pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
+    painter.setPen(pen)
+
+    # # Square
+    painter.drawRect(
+        (size - square) // 2 + 2,
+        (size - square) // 2 + 2,
+        square - 4,
+        square - 4,
+    )
+
+    pen = QPen(Qt.black, 3)
+    pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
+    painter.setPen(pen)
+
+    # # # Horizontal lines
+    mid_vpoint = QPoint(2, size // 2)
+    painter.drawLine(
+        mid_vpoint, QPoint(((size - center) // 2) - center + 1, size // 2)
+    )
+    mid_vpoint = QPoint(size - 3, size // 2)
+    painter.drawLine(
+        mid_vpoint, QPoint(((size - center) // 2) + center + 1, size // 2)
+    )
+
+    # # # Vertical lines
+    mid_hpoint = QPoint(size // 2, 2)
+    painter.drawLine(
+        QPoint(size // 2, ((size - center) // 2) - center + 1), mid_hpoint
+    )
+    mid_hpoint = QPoint(size // 2, size - 3)
+    painter.drawLine(
+        QPoint(size // 2, ((size - center) // 2) + center + 1), mid_hpoint
+    )
 
     painter.end()
     return pixmap

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -171,61 +171,50 @@ def crosshair_pixmap(size):
     """Create a cross cursor with white/black hollow square pixmap in the middle.
     For use as points cursor."""
 
-    # size = max(int(size), 1)
-    # pixmap = QPixmap(QSize(size, size))
-    # pixmap.fill(Qt.transparent)
-    # painter = QPainter(pixmap)
-    # painter.setPen(Qt.white)
-    # painter.drawRect(0, 0, size - 1, size - 1)
-    # painter.setPen(Qt.black)
-    # painter.drawRect(1, 1, size - 3, size - 3)
-    # painter.end()
-    # return pixmap
-
-    # painter.drawLine(QPointF(0, size/2), QPointF(size/2-gap,size/2))
-    # painter.drawLine(QPointF(size/2+gap, size/2), QPointF(size, size/2))
-    # painter.drawLine(QPointF(size/2, 0), QPointF(size/2,size/2-gap))
-    # painter.drawLine(QPointF(size/2, size/2+gap), QPointF(size/2, size))
     size = max(int(size), 1)
     pixmap = QPixmap(QSize(size, size))
     pixmap.fill(Qt.transparent)
     painter = QPainter(pixmap)
-    # painter.setPen(Qt.black)
-    # painter.drawRect(0, 0, size-1, size-1)
 
-    # p.setPen(QPen(Qt::white, 3));
-    pen = QPen(Qt.white, 3)
+    pval = (3 / 27) * size
+    pen = QPen(Qt.white, pval)
     pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
     painter.setPen(pen)
-    # painter.setPen(Qt.white)
-    val = 0.12
-    loc = (size / 2) - (val * size)
-    # painter.drawRect(0, 0, size-1, size-1)
-    painter.drawRect(
-        loc, loc, val * 2 * size, val * 2 * size
-    )  # white rectangle
-    pen = QPen(Qt.white, 4)
-    pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
-    painter.setPen(pen)
-    painter.drawLine(QPoint(size / 2, loc), QPoint(size / 2, 0))
-    painter.drawLine(QPoint(size / 2, size - loc), QPoint(size / 2, size))
-    painter.drawLine(QPoint(loc, size / 2), QPoint(0, size / 2))
-    painter.drawLine(QPoint(size - loc, size / 2), QPoint(size, size / 2))
 
-    val = 0.1
-    loc = (size / 2) - (val * size)
-    pen = QPen(Qt.black, 2)
+    loc = (9 / 27) * size
+    hw = (10 / 27) * size
+    painter.drawRect(loc - 1, loc - 1, hw, hw)
+    loc = (11 / 27) * size
+    pval = (2 / 27) * size
+    hw = (7 / 27) * size
+    pen = QPen(Qt.black, pval)
     pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
     painter.setPen(pen)
-    painter.drawRect(loc, loc, val * 2 * size, val * 2 * size)
-    painter.drawLine(QPoint(size / 2, loc - 2), QPoint(size / 2, 2))
-    painter.drawLine(
-        QPoint(size / 2, size - loc + 2), QPoint(size / 2, size - 2)
-    )
-    painter.drawLine(QPoint(loc - 2, size / 2), QPoint(2, size / 2))
-    painter.drawLine(
-        QPoint(size - loc + 2, size / 2), QPoint(size - 2, size / 2)
-    )
+    painter.drawRect(loc - 1, loc - 1, hw, hw)
+
+    pval = (4 / 27) * size
+    pen = QPen(Qt.white, pval)
+    pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
+    painter.setPen(pen)
+    mid = size / 2
+    val1 = (7 / 27) * size
+    val2 = (20 / 27) * size
+    painter.drawLine(QPoint(mid, 7), QPoint(mid, 0))
+    painter.drawLine(QPoint(7, mid), QPoint(0, mid))
+    painter.drawLine(QPoint(mid, val2), QPoint(mid, size))
+    painter.drawLine(QPoint(val2, mid), QPoint(size, mid))
+
+    pen = QPen(Qt.black, pval / 2)
+    pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
+    painter.setPen(pen)
+    val1 = (8 / 27) * size
+    val2 = (2 / 27) * size
+    val3 = (19 / 27) * size
+    val4 = size - 2
+    painter.drawLine(QPoint(mid, val1), QPoint(mid, val2))
+    painter.drawLine(QPoint(val1, mid), QPoint(val2, mid))
+    painter.drawLine(QPoint(mid, val3), QPoint(mid, val4))
+    painter.drawLine(QPoint(val3, mid), QPoint(val4, mid))
 
     painter.end()
     return pixmap

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -201,11 +201,6 @@ def crosshair_pixmap(size):
         (size - square) // 2, (size - square) // 2, square - 1, square - 1
     )
 
-    pen = QPen(Qt.blue, 1)
-    pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
-    painter.setPen(pen)
-    painter.drawPoint(size // 2, size // 2)
-
     pen = QPen(Qt.black, 2)
     pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
     painter.setPen(pen)

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -13,6 +13,7 @@ import qtpy
 from qtpy.QtCore import (
     QByteArray,
     QObject,
+    QPoint,
     QPropertyAnimation,
     QSize,
     QSocketNotifier,
@@ -161,6 +162,31 @@ def square_pixmap(size):
     painter.drawRect(0, 0, size - 1, size - 1)
     painter.setPen(Qt.black)
     painter.drawRect(1, 1, size - 3, size - 3)
+    painter.end()
+    return pixmap
+
+
+@lru_cache(maxsize=64)
+def crosshair_pixmap(size):
+    """Create a cross cursor with white/black hollow square pixmap in the middle.
+    For use as points cursor."""
+
+    # painter.drawLine(QPointF(0, size/2), QPointF(size/2-gap,size/2))
+    # painter.drawLine(QPointF(size/2+gap, size/2), QPointF(size, size/2))
+    # painter.drawLine(QPointF(size/2, 0), QPointF(size/2,size/2-gap))
+    # painter.drawLine(QPointF(size/2, size/2+gap), QPointF(size/2, size))
+    size = max(int(size), 1)
+    pixmap = QPixmap(QSize(size, size))
+    pixmap.fill(Qt.transparent)
+    painter = QPainter(pixmap)
+    painter.setPen(Qt.white)
+    painter.drawRect(0, 0, size - 1, size - 1)
+    painter.setPen(Qt.black)
+    painter.drawRect(1, 1, size - 2, size - 2)
+    painter.drawLine(QPoint(0, size - 2), QPoint(0, size - 3))
+    painter.drawLine(QPoint(0, size + 2), QPoint(0, size + 3))
+    painter.drawLine(QPoint(size - 2, 0), QPoint(size - 3, 0))
+    painter.drawLine(QPoint(size + 2, 0), QPoint(size + 3, 0))
     painter.end()
     return pixmap
 

--- a/napari/components/_viewer_constants.py
+++ b/napari/components/_viewer_constants.py
@@ -47,6 +47,7 @@ class CursorStyle(str, Enum):
             * forbidden: A forbidden symbol
             * pointing: A finger for pointing
             * standard: The standard cursor
+            # crosshair: A crosshair
     """
 
     SQUARE = 'square'
@@ -55,3 +56,4 @@ class CursorStyle(str, Enum):
     FORBIDDEN = 'forbidden'
     POINTING = 'pointing'
     STANDARD = 'standard'
+    CROSSHAIR = 'crosshair'

--- a/napari/components/cursor.py
+++ b/napari/components/cursor.py
@@ -27,6 +27,7 @@ class Cursor(EventedModel):
             * forbidden: A forbidden symbol
             * pointing: A finger for pointing
             * standard: The standard cursor
+            # crosshair: A crosshair
     _view_direction : Optional[Tuple[float, ...]]
         The vector describing the direction of the camera in the scene.
         This is None when viewing in 2D.

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -358,6 +358,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
     def _update_cursor(self, event):
         """Set the viewer cursor with the `event.cursor` string."""
+        print(event.cursor)
         self.cursor.style = event.cursor
 
     def _update_cursor_size(self, event):

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -358,7 +358,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
     def _update_cursor(self, event):
         """Set the viewer cursor with the `event.cursor` string."""
-        print(event.cursor)
         self.cursor.style = event.cursor
 
     def _update_cursor_size(self, event):

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1071,7 +1071,7 @@ class Points(Layer):
         Mode.PAN_ZOOM: no_op,
     }
     _cursor_modes = {
-        Mode.ADD: 'pointing',
+        Mode.ADD: 'crosshair',
         Mode.SELECT: 'standard',
         Mode.PAN_ZOOM: 'standard',
     }


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
This PR changes the cursor for points add mode to a crosshair cursor instead of a hand.  The cursor is based on the design by Isabela in issue #2142 .  

There was some discussion over not using the Qt crosshair cursor, but instead create our own.  

Huge thanks to @goanpeca for the help implementing this.  It ended up being a bit of a challenge to scale the cursor properly. 

One question about the behavior of the cursor---  should it change based on the zooming?  If you zoom it, it gets large, zoom out it gets smaller?   Right now, it has this behavior to do that but only updates if you click on and off of points add mode.  I need to change this, but wanted to make sure its the behavior we want. 


https://user-images.githubusercontent.com/54282105/141356049-d02c4153-d342-4770-93b4-fbc14a2c553a.mov

