### PR TITLE
Ommit RuntimeError during `remove_flash_animation`

### DIFF
--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -318,8 +318,12 @@ def remove_flash_animation(widget_ref: weakref.ref[QWidget]):
     if widget_ref() is None:
         return
     widget = widget_ref()
-    widget.setGraphicsEffect(None)
-    del widget._flash_animation
+    try:
+        widget.setGraphicsEffect(None)
+        del widget._flash_animation
+    except RuntimeError:
+        # RuntimeError: wrapped C/C++ object of type QtWidgetOverlay has been deleted
+        pass
 
 
 @contextmanager


### PR DESCRIPTION
 wrapped C/C++ object of type QtWidgetOverlay has been deleted

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

I observe that during test sessions (of my code) I got time to time test failure because of partially deleted object:
```
    File "/tmp/tox/py38-PyQt5-all/lib/python3.8/site-packages/napari/_qt/utils.py", line 321, in remove_flash_animation
      widget.setGraphicsEffect(None)
  RuntimeError: wrapped C/C++ object of type QtWidgetOverlay has been deleted
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

 #3437 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
