### PR TITLE
Skip dask example test

### DIFF
--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -21,6 +21,7 @@ skip = [
     'embed_ipython.py',  # fails without monkeypatch
     'custom_key_bindings.py',  # breaks EXPECTED_NUMBER_OF_VIEWER_METHODS later
     'new_theme.py',  # testing theme is extremely slow on CI
+    'dynamic-projections-dask.py',  # extremely slow / does not finish
 ]
 
 


### PR DESCRIPTION
# Description
Skips the dask example added in #3604 which seems to cause CI to hang. cc @tlambert03 @jni 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
