### PR TITLE
handle npe2 dock widget return type

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -654,6 +654,8 @@ class Window:
                     and contrib.name == widget_name
                 ):
                     Widget = contrib.exec()
+                    if type(Widget) is tuple:
+                        Widget, _ = Widget
                     dock_kwargs = {}
 
         if Widget is None:


### PR DESCRIPTION
# Description
closes #3617

If you're trying to reproduce this, see the issue for instructions.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: the test suite for my feature covers cases x, y, and z

It's hard to tell, but here's activation of an npe2 dock widget:

https://user-images.githubusercontent.com/98295/141726245-377fdfb5-e73b-4352-aeff-c6c4fcf21ed6.mov



