### PR TITLE
Remove 1-pixel border from vispy widgets

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -347,7 +347,7 @@ class QtViewer(QSplitter):
         for layer in self.viewer.layers:
             self._add_layer(layer)
 
-        self.view = self.canvas.central_widget.add_view()
+        self.view = self.canvas.central_widget.add_view(border_width=0)
         self.camera = VispyCamera(
             self.view, self.viewer.camera, self.viewer.dims
         )

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -503,3 +503,20 @@ def test_scale_bar_visible(make_napari_viewer):
     off_screenshot = viewer.screenshot(canvas_only=True, flash=False)
     assert not viewer.scale_bar.visible
     np.testing.assert_almost_equal(launch_screenshot, off_screenshot)
+
+
+@slow(30)
+@skip_on_win_ci
+@skip_local_popups
+def test_screenshot_has_no_border(make_napari_viewer):
+    """See https://github.com/napari/napari/issues/3357"""
+    viewer = make_napari_viewer(show=True)
+    image_data = np.ones((60, 80))
+    viewer.add_image(image_data, colormap='red')
+    # Zoom in dramatically to make the screenshot all red.
+    viewer.camera.zoom = 1000
+
+    screenshot = viewer.screenshot(canvas_only=True, flash=False)
+
+    expected = np.broadcast_to([255, 0, 0, 255], screenshot.shape)
+    np.testing.assert_array_equal(screenshot, expected)

--- a/napari/_vispy/canvas.py
+++ b/napari/_vispy/canvas.py
@@ -1,7 +1,7 @@
 """VispyCanvas class.
 """
 from qtpy.QtCore import QSize
-from vispy.scene import SceneCanvas
+from vispy.scene import SceneCanvas, Widget
 
 from ..utils.colormaps.standardize_color import transform_color
 from .utils.gl import get_max_texture_sizes
@@ -76,6 +76,15 @@ class VispyCanvas(SceneCanvas):
     def bgcolor(self, value):
         _value = self._background_color_override or value
         SceneCanvas.bgcolor.fset(self, _value)
+
+    @property
+    def central_widget(self):
+        """Overrides SceneCanvas.central_widget to make border_width=0"""
+        if self._central_widget is None:
+            self._central_widget = Widget(
+                size=self.size, parent=self.scene, border_width=0
+            )
+        return self._central_widget
 
     def _process_mouse_event(self, event):
         """Ignore mouse wheel events which have modifiers."""


### PR DESCRIPTION
# Description

This removes the 1-pixel border from all the current widgets (i.e. the central widget and the view box) in our `VispyCanvas`.

Before
![Screen Shot 2021-11-15 at 11 45 23 AM](https://user-images.githubusercontent.com/2608297/141844553-381db519-de3b-4e2f-a887-98bce90e55b4.png)

After
![Screen Shot 2021-11-15 at 11 45 59 AM](https://user-images.githubusercontent.com/2608297/141844590-c0d387d7-8c0f-4c72-a3e2-572469487aae.png)

By default vispy widgets have a transparent 1-pixel wide border. This causes the `bgcolor` of the vispy canvas to show even when zoomed in to the image when you wouldn't expect to see the background.

The fix here ensures that `VispyCanvas.central_widget` has a border width of 0 and also ensures that the only `ViewBox` widget we add to that also has a border width of 0. I don't think there are any other vispy widgets we have to think about - but please correct me on that if I'm wrong.

See https://gitter.im/vispy/vispy for some discussion on this issue and other alternative fixes considered.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #3357 

# How has this been tested?
- [ ] example: the new test added to cover the bug passes
- [ ] example: all existing tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
