### PR TITLE
Move some hard references to weak references.

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -17,6 +17,7 @@ from typing import (
     Sequence,
     Tuple,
 )
+from weakref import WeakValueDictionary
 
 from qtpy.QtCore import QEvent, QEventLoop, QPoint, QProcess, QSize, Qt, Slot
 from qtpy.QtGui import QIcon
@@ -404,7 +405,9 @@ class Window:
         get_app()
 
         # Dictionary holding dock widgets
-        self._dock_widgets: Dict[str, QtViewerDockWidget] = {}
+        self._dock_widgets: Dict[
+            str, QtViewerDockWidget
+        ] = WeakValueDictionary()
         self._unnamed_dockwidget_count = 1
 
         # Connect the Viewer and create the Main Window

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -28,7 +28,7 @@ skip_on_mac_ci = pytest.mark.skipif(
 
 skip_local_popups = pytest.mark.skipif(
     not os.getenv('CI') and os.getenv('NAPARI_POPUP_TESTS', '0') == '0',
-    reason='Tests requiring GUI windows are skipped locally by default.',
+    reason='Tests requiring GUI windows are skipped locally by default. Set run with NAPARI_POPUP_TESTS=1 to enable',
 )
 
 
@@ -215,7 +215,7 @@ def slow(timeout):
     Both mark a function as slow, and with a timeout which is easily scalable
     via an env variable.
     """
-    factor = int(os.getenv('NAPARI_TESTING_TIMEOUT_SCALING', '1'))
+    factor = float(os.getenv('NAPARI_TESTING_TIMEOUT_SCALING', '1.0'))
 
     def _slow(func):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ skip_glob = ["*examples/*", "*vendored*", "*_vendor*"]
 [tool.pytest.ini_options]
 # These follow standard library warnings filters syntax.  See more here:
 # https://docs.python.org/3/library/warnings.html#describing-warning-filters
-addopts = "--maxfail=5 --durations=10"
+addopts = "--maxfail=5 --durations=10 -rXxs"
 
 # NOTE: only put things that will never change in here.
 # napari deprecation and future warnings should NOT go in here.


### PR DESCRIPTION
This is itself a step toward #3629, in which during the test suite we
try to make sure there is not more than one instance of the QtViewer,
VisPyCanvas and a few other things.

It seem that there are a couple of hard references between things that
can make it hard for object to be GC'd. In particular docwidgets can be
directly referenced from the main window, and QtViewer from certain
dockwidgets.

Also minimal update to testing to show more informations (if xpass, or  xfail , and reason if skip), and how to enable some skip tests if skipped, because I keep looking it up and never remembering.



## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
