### PR TITLE
Fix screenshot test on hi dpi screen.

### DIFF
--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -22,7 +22,7 @@ from napari.utils.interactions import (
 @skip_local_popups
 def test_z_order_adding_removing_images(make_napari_viewer):
     """Test z order is correct after adding/ removing images."""
-    data = np.ones((10, 10))
+    data = np.ones((11, 11))
 
     viewer = make_napari_viewer(show=True)
     viewer.add_image(data, colormap='red', name='red')
@@ -67,7 +67,7 @@ def test_z_order_adding_removing_images(make_napari_viewer):
 @skip_local_popups
 def test_z_order_images(make_napari_viewer):
     """Test changing order of images changes z order in display."""
-    data = np.ones((10, 10))
+    data = np.ones((11, 11))
 
     viewer = make_napari_viewer(show=True)
     viewer.add_image(data, colormap='red')
@@ -89,7 +89,7 @@ def test_z_order_images(make_napari_viewer):
 @skip_local_popups
 def test_z_order_image_points(make_napari_viewer):
     """Test changing order of image and points changes z order in display."""
-    data = np.ones((10, 10))
+    data = np.ones((11, 11))
 
     viewer = make_napari_viewer(show=True)
     viewer.add_image(data, colormap='red')
@@ -111,7 +111,7 @@ def test_z_order_image_points(make_napari_viewer):
 @skip_local_popups
 def test_z_order_images_after_ndisplay(make_napari_viewer):
     """Test z order of images remanins constant after chaning ndisplay."""
-    data = np.ones((10, 10))
+    data = np.ones((11, 11))
 
     viewer = make_napari_viewer(show=True)
     viewer.add_image(data, colormap='red')
@@ -141,11 +141,11 @@ def test_z_order_images_after_ndisplay(make_napari_viewer):
 @skip_local_popups
 def test_z_order_image_points_after_ndisplay(make_napari_viewer):
     """Test z order of image and points remanins constant after chaning ndisplay."""
-    data = np.ones((10, 10))
+    data = np.ones((11, 11))
 
     viewer = make_napari_viewer(show=True)
     viewer.add_image(data, colormap='red')
-    viewer.add_points([5, 5], face_color='blue', size=10)
+    viewer.add_points([5, 5], face_color='blue', size=5)
     screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
     # Check that blue is visible


### PR DESCRIPTION
The problem with data array with even rows/columns is that there is no
exact center. So (5,5) is slightly to to the lower-right of the grid.

On hi DPI/large enough screen, that means that the radius of the point
is not enough to overlap with the center of the screenshot as the point
is virtually smaller. At least that's my understanding in using
plt.imshow to look at the screenshot.

This fixes it locally on my recent M1 macbook pro, it does not affects
CI or my other laptop.

Another approach would be to compute the number of blue pixels and make
sure that they are roughly in a circular shape and central location, but
this is an easier fix.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

I'm not sure how to test the fix or make sure it does not regress, but I think that might be a small enough changes that it's acceptable? It may be related to some other things about 1/2 pixel alignments I vaguely remember of.
