### PR TITLE
Use more weakrefs in test.

### DIFF
--- a/napari/_qt/widgets/_tests/test_qt_play.py
+++ b/napari/_qt/widgets/_tests/test_qt_play.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from weakref import ref
 
 import numpy as np
 import pytest
@@ -97,18 +98,27 @@ def test_animation_thread_once(qtbot):
 
 
 @pytest.fixture()
-def view(make_napari_viewer):
-    """basic viewer with data that we will use a few times"""
+def ref_view(make_napari_viewer):
+    """basic viewer with data that we will use a few times
+
+    It is problematic to yield the qt_viewer directly as it will stick
+    around in the generator frames and causes issues if we want to make sure
+    there is only a single instance of QtViewer instantiated at all times during
+    the test suite. Thus we yield a weak reference that we resolve immediately
+    in the test suite.
+    """
+
     viewer = make_napari_viewer()
 
     np.random.seed(0)
     data = np.random.random((10, 10, 15))
     viewer.add_image(data)
+    yield ref(viewer.window.qt_viewer)
+    viewer.close()
 
-    return viewer.window.qt_viewer
 
-
-def test_play_raises_index_errors(qtbot, view):
+def test_play_raises_index_errors(qtbot, ref_view):
+    view = ref_view()
     # play axis is out of range
     with pytest.raises(IndexError):
         view.dims.play(4, 20)
@@ -122,7 +132,8 @@ def test_play_raises_index_errors(qtbot, view):
         view.dims.stop()
 
 
-def test_play_raises_value_errors(qtbot, view):
+def test_play_raises_value_errors(qtbot, ref_view):
+    view = ref_view()
     # frame_range[1] not > frame_range[0]
     with pytest.raises(ValueError):
         view.dims.play(0, 20, frame_range=[2, 2])
@@ -137,8 +148,9 @@ def test_play_raises_value_errors(qtbot, view):
 
 
 @pytest.mark.skip(reason="fails too often... tested indirectly elsewhere")
-def test_play_api(qtbot, view):
+def test_play_api(qtbot, ref_view):
     """Test that the QtDims.play() function advances a few frames"""
+    view = ref_view()
     view.dims._frame = 0
 
     def increment():
@@ -162,8 +174,10 @@ def test_play_api(qtbot, view):
     assert A == view.dims._frame
 
 
-def test_playing_hidden_slider_does_nothing(view):
+def test_playing_hidden_slider_does_nothing(ref_view):
     """Make sure playing a dimension without a slider does nothing"""
+
+    view = ref_view()
 
     def increment(e):
         view.dims._frame = e.value  # this is provided by the step event
@@ -174,4 +188,5 @@ def test_playing_hidden_slider_does_nothing(view):
 
     with pytest.warns(UserWarning):
         view.dims.play(2, 20)
+    view.dims.dims.events.current_step.disconnect(increment)
     assert not view.dims.is_playing


### PR DESCRIPTION
This is still related to trying to find the root cause of the mac
failures where tests teardown are taking forever, and having lingering
instances of objects like the VisPyCanvas / QtViewer.

It updates a couple of test to make sure there are no more references
to the qt viewer after each test during teardown.

This requires having one fixture return a weakref, and properly
disconnecting some closure keeping a ref on the qtviewers.
