### PR TITLE
Cleanup console namespace in test to avoid leaking viewer.

### DIFF
--- a/napari/_tests/test_advanced.py
+++ b/napari/_tests/test_advanced.py
@@ -170,11 +170,14 @@ def test_update_console(make_napari_viewer):
 
     a = 4
     b = 5
-    viewer.update_console(locals())
+    locs = locals()
+    viewer.update_console(locs)
     assert 'a' in view.console.shell.user_ns
     assert view.console.shell.user_ns['a'] == a
     assert 'b' in view.console.shell.user_ns
     assert view.console.shell.user_ns['b'] == b
+    for k in locs.keys():
+        del viewer.window.qt_viewer.console.shell.user_ns[k]
 
 
 def test_changing_display_surface(make_napari_viewer):


### PR DESCRIPTION
Putting the locals in the console namespace put the qt viewer in an
immortal namespace linked to IPython singletons, and thus they will not
be collected later.

We prune the namespace of all reference which help freeing those extra
viewers.
