### PR TITLE
Exclude new buggy version of imageio.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     cachey>=0.2.1
     certifi>=2018.1.18
     dask[array]>=2.15.0,!=2.28.0  # https://github.com/napari/napari/issues/1656
-    imageio>=2.5.0
+    imageio>=2.5.0,!=2.11.0
     importlib-metadata>=1.5.0 ; python_version < '3.8'
     jsonschema>=3.2.0
     magicgui>=0.3.3


### PR DESCRIPTION
See https://github.com/imageio/imageio/issues/687,
BytesIO no longer work due to omission in refactor.
