### PR TITLE
Update vendored modules.

### DIFF
--- a/napari/_vendor/darkdetect/__init__.py
+++ b/napari/_vendor/darkdetect/__init__.py
@@ -4,7 +4,7 @@
 #  Distributed under the terms of the 3-clause BSD License.
 #-----------------------------------------------------------------------------
 
-__version__ = '0.5.0'
+__version__ = '0.5.2'
 
 import sys
 import platform
@@ -16,10 +16,10 @@ if sys.platform == "darwin":
     else:
         from ._mac_detect import *
     del V
-elif sys.platform == "win32" and platform.release() == "10":
-    # Checks if running Windows 10 version 10.0.14393 (Anniversary Update) or higher. The getwindowsversion method returns a tuple.
+elif sys.platform == "win32" and int(platform.release()) >= 10:
+    # Checks if running Windows 10 version 10.0.14393 (Anniversary Update) OR HIGHER. The getwindowsversion method returns a tuple.
     # The third item is the build number that we can use to check if the user has a new enough version of Windows.
-    winver = int(sys.getwindowsversion()[2])
+    winver = int(platform.version().split('.')[2])
     if winver >= 14393:
         from ._windows_detect import *
     else:

--- a/napari/_vendor/darkdetect/_mac_detect.py
+++ b/napari/_vendor/darkdetect/_mac_detect.py
@@ -6,17 +6,15 @@
 
 import ctypes
 import ctypes.util
-import platform
 
-from distutils.version import LooseVersion as V
-
-if V(platform.mac_ver()[0]) < V("10.16") or platform.python_version_tuple()[0] == '2':
-    appkit = ctypes.cdll.LoadLibrary(ctypes.util.find_library('AppKit'))
-    objc = ctypes.cdll.LoadLibrary(ctypes.util.find_library('objc'))
-else:
+try:
+    # macOS Big Sur+ use "a built-in dynamic linker cache of all system-provided libraries"
     appkit = ctypes.cdll.LoadLibrary('AppKit.framework/AppKit')
     objc = ctypes.cdll.LoadLibrary('libobjc.dylib')
-del V
+except OSError:
+    # revert to full path for older OS versions and hardened programs
+    appkit = ctypes.cdll.LoadLibrary(ctypes.util.find_library('AppKit'))
+    objc = ctypes.cdll.LoadLibrary(ctypes.util.find_library('objc'))
 
 void_p = ctypes.c_void_p
 ull = ctypes.c_uint64

--- a/napari/_vendor/darkdetect/_windows_detect.py
+++ b/napari/_vendor/darkdetect/_windows_detect.py
@@ -5,14 +5,20 @@ def theme():
     # Registry will return 0 if Windows is in Dark Mode and 1 if Windows is in Light Mode. This dictionary converts that output into the text that the program is expecting.
     valueMeaning = {0: "Dark", 1: "Light"}
     # In HKEY_CURRENT_USER, get the Personalisation Key.
-    key = getKey(hkey, "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize")
-    # In the Personalisation Key, get the AppsUseLightTheme subkey. This returns a tuple. 
-    # The first item in the tuple is the result we want (0 or 1 indicating Dark Mode or Light Mode); the other value is the type of subkey e.g. DWORD, QWORD, String, etc.
-    subkey = getSubkeyValue(key, "AppsUseLightTheme")[0]
+    try:
+        key = getKey(hkey, "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize")
+        # In the Personalisation Key, get the AppsUseLightTheme subkey. This returns a tuple.
+        # The first item in the tuple is the result we want (0 or 1 indicating Dark Mode or Light Mode); the other value is the type of subkey e.g. DWORD, QWORD, String, etc.
+        subkey = getSubkeyValue(key, "AppsUseLightTheme")[0]
+    except FileNotFoundError:
+        # some headless Windows instances (e.g. GitHub Actions or Docker images) do not have this key
+        return None
     return valueMeaning[subkey]
 
 def isDark():
-    return theme() == 'Dark'
+    if theme() is not None:
+        return theme() == 'Dark'
 
 def isLight():
-    return theme() == 'Light'
+    if theme() is not None:
+        return theme() == 'Light'


### PR DESCRIPTION
Same as #3644, except that when triggered by an actual human* it should start the test suite.