### PR TITLE
Try to close dask threads after usage.

### DIFF
--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -1,6 +1,8 @@
 import os
+import sys
 from functools import partial
 
+import dask.threaded
 import numpy as np
 import pooch
 import pytest
@@ -350,3 +352,27 @@ def fresh_settings(monkeypatch):
     # this makes sure that we start with fresh settings for every test.
     settings._SETTINGS = None
     yield
+
+
+if sys.version_info > (
+    3,
+    8,
+):
+    # There seem to be on issue on 3.7 where ThreadPool has not shutdown method.
+    # just do nothing. No need to define it on 3.7 as we are not requesting the
+    # fixture explicitely ever.
+    @pytest.fixture(autouse=True)
+    def auto_shutdown_dask_threadworkers():
+        """
+        This automatically shutdown dask thread workers.
+
+        We don't assert the number of threads in unchanged as other things
+        modify the number of threads.
+        """
+        assert dask.threaded.default_pool is None
+        try:
+            yield
+        finally:
+            if dask.threaded.default_pool is not None:
+                dask.threaded.default_pool.shutdown()
+                dask.threaded.default_pool = None

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -164,10 +164,22 @@ def make_napari_viewer(
         if any([n.__class__.__name__ != 'CanvasBackendDesktop' for n in leak]):
             # just a warning... but this can be converted to test errors
             # in pytest with `-W error`
+            msg = f"""The following Widgets leaked!: {leak}.
+
+            Note: If other tests are failing it is likely that widgets will leak
+            as they will be (indirectly) attached to the tracebacks of previous failures.
+            Please only consider this an error if all other tests are passing.
+            """
+            # Explanation notes on the above: While we are indeed looking at the
+            # difference in sets of widgets between before and after, new object can
+            # still not be garbage collected because of it.
+            # in particular with VisPyCanvas, it looks like if a traceback keeps
+            # contains the type, then instances are still attached to the type.
+            # I'm not too sure why this is the case though.
             if _strict == 'raise':
-                raise AssertionError(f'Widgets leaked!: {leak}')
+                raise AssertionError(msg)
             else:
-                warnings.warn(f'Widgets leaked!: {leak}')
+                warnings.warn(msg)
 
 
 @pytest.fixture


### PR DESCRIPTION
Try to close dask threads after usage.

This tries to make sure that dask thread worker is closed after each test.
This is not in it's own an issue, but from some of the mac failures I
have the impression there there are thread problems (one of the recent
failure was in IPython's history saving thread), so one of the things
I'd like to enable in pytest fixture is that the number of thread
before/after tests has not changed, unless the test if flagged
specifically.

This ensure that the above is true – at least from the dask scheduler.
We make sure the threaded scheduler is not setup.

Later, once other threads have been cleaned up as well,
we can make sure that the number of thread before/after is unchanged.

In addition this also make IPython history saving in-memory to save a
thread on having to write to disk, and put a reminder that widgets leaks
detection has strong false positive if some other errors happen, and I
caught myself forgetting this several times.
