### PR TITLE
fix 3D image interpolation breaking remove-and-add layer

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -556,3 +556,16 @@ def test_mixed_2d_and_3d_layers(make_napari_viewer, multiscale):
     viewer.dims.order = (1, 2, 0)
     viewer.window.qt_viewer.on_draw(None)
     assert np.all(img_multi_layer.corner_pixels == expected_corner_pixels)
+
+
+def test_remove_add_image_3D(make_napari_viewer):
+    """
+    Test that adding, removing and readding an image layer in 3D does not cause issues
+    due to the vispy node change. See https://github.com/napari/napari/pull/3670
+    """
+    viewer = make_napari_viewer(ndisplay=3)
+    img = np.ones((10, 10, 10))
+
+    layer = viewer.add_image(img)
+    viewer.layers.remove(layer)
+    viewer.layers.append(layer)

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -64,6 +64,9 @@ class VispyImageLayer(VispyBaseLayer):
             self._on_experimental_slicing_plane_normal_change
         )
 
+        # display_change is special (like data_change) because it requires a self.reset()
+        # this means that we have to call it manually. Also, it must be called before reset
+        # in order to set the appropriate node first
         self._on_display_change()
         self.reset()
         self._on_data_change()

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -64,18 +64,18 @@ class VispyImageLayer(VispyBaseLayer):
             self._on_experimental_slicing_plane_normal_change
         )
 
+        self._on_display_change()
         self.reset()
         self._on_data_change()
 
     def _on_display_change(self, data=None):
-
         parent = self.node.parent
         self.node.parent = None
 
         self.node = self._layer_node.get_node(self.layer._ndisplay)
 
         if data is None:
-            data = np.zeros((1,) * self.layer._ndisplay)
+            data = np.zeros((1,) * self.layer._ndisplay, dtype=np.float32)
 
         if self.layer._empty:
             self.node.visible = False
@@ -87,7 +87,6 @@ class VispyImageLayer(VispyBaseLayer):
 
         self.node.parent = parent
         self.node.order = self.order
-        self.reset()
 
     def _on_data_change(self):
         if not self.layer.loaded:

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -87,6 +87,7 @@ class VispyImageLayer(VispyBaseLayer):
 
         self.node.parent = parent
         self.node.order = self.order
+        self.reset()
 
     def _on_data_change(self):
         if not self.layer.loaded:


### PR DESCRIPTION
# Description

Fixes #3667 by calling `_on_display_changed` on init to make sure layer and vispylayer are in sync. As far as I can tell, that `reset()` call is not needed. Also added a `dtype` parameter so calling `_on_display_changed` with empty data does not trigger the following warning:

```
UserWarning: GPUs can't support floating point data with more than 32-bits, precision will be lost due to downcasting to 32-bit float.
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
fixes #3667 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality