### PR TITLE
Use in-memory IPython history during testing

### DIFF
--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -11,6 +11,7 @@ import dask.threaded
 import numpy as np
 import pooch
 import pytest
+from IPython.core.history import HistoryManager
 
 from napari.components import LayerList
 from napari.layers import Image, Labels, Points, Shapes, Vectors
@@ -381,3 +382,11 @@ if sys.version_info > (
             if dask.threaded.default_pool is not None:
                 dask.threaded.default_pool.shutdown()
                 dask.threaded.default_pool = None
+
+
+# this is not the proper way to configure IPython, but it's an easy one.
+# This will prevent IPython to try to write history on its sql file and do
+# everything in memory.
+# 1) it saves a thread and
+# 2) it can prevent issues with slow or read-only file systems in CI.
+HistoryManager.enabled = False


### PR DESCRIPTION
This make IPython history saving in-memory. 

It should be slightly faster in test suite, avoid polluting history when running locally and use one less thread in test (so we can start ensuring in some test that there is never more than one thread)