### PR TITLE
test on macos-11, py39

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -88,8 +88,8 @@ jobs:
             platform: windows-latest
             backend: pyside
           # macOS py38
-          - python: 3.8
-            platform: macos-latest
+          - python: 3.9
+            platform: macos-11
             backend: pyqt # (only testing pyqt on mac in the interest of speed)
           # minimum specified requirements
           - python: 3.7

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ PLATFORM =
     ubuntu-20.04: linux
     windows-latest: windows
     macos-latest: macos
-    macos-11.0: macos
+    macos-11: macos
 BACKEND =
     pyqt: pyqt
     pyside: pyside


### PR DESCRIPTION
in a test on my own branch, macos-11 with py39 worked fine: https://github.com/tlambert03/napari/runs/4290965194?check_suite_focus=true

let's try it here.  cc @Carreau 

these also worked, but they were much slower (n=1):
macos-11 3.9 pyside2
macos-latest 3.8 pyside2