### PR TITLE
Restore all mac-ci-skipped tests.

### DIFF
--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -3,11 +3,7 @@ import collections
 import numpy as np
 import pytest
 
-from napari._tests.utils import (
-    skip_local_popups,
-    skip_on_mac_ci,
-    skip_on_win_ci,
-)
+from napari._tests.utils import skip_local_popups, skip_on_win_ci
 from napari.utils._proxies import ReadOnlyWrapper
 from napari.utils.interactions import (
     mouse_move_callbacks,
@@ -17,7 +13,6 @@ from napari.utils.interactions import (
 
 
 @skip_on_win_ci
-@skip_on_mac_ci
 @skip_local_popups
 def test_z_order_adding_removing_images(make_napari_viewer):
     """Test z order is correct after adding/ removing images."""

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -23,11 +23,6 @@ skip_on_win_ci = pytest.mark.skipif(
     reason='Screenshot tests are not supported on windows CI.',
 )
 
-skip_on_mac_ci = pytest.mark.skipif(
-    sys.platform.startswith('darwin') and os.getenv('CI', '0') != '0',
-    reason='This test seem to be problematic on mac.',
-)
-
 skip_local_popups = pytest.mark.skipif(
     not os.getenv('CI') and os.getenv('NAPARI_POPUP_TESTS', '0') == '0',
     reason='Tests requiring GUI windows are skipped locally by default.',


### PR DESCRIPTION
Those were skipped/marked as slow as they were failing/hanging on mac.

Talley updates to python 3.9 macos-latest, and test seem to be passing.

From the last passing test they should not take more than 15s, so using
20 s timeout.
