### PR TITLE
Reduce macos full testing.

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -56,12 +56,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        platform: [ubuntu-latest, windows-latest, macos]
         python: [3.7, 3.8, 3.9]
         include:
           # test big sur on 3.9.0
           - python: 3.9
-            platform: macos-11.0
+            platform: macos-11
             toxenv: py39-macos-pyqt
           # test with minimum specified requirements
           - python: 3.7

--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos]
+        platform: [ubuntu-latest, windows-latest]
         python: [3.7, 3.8, 3.9]
         include:
           # test big sur on 3.9.0


### PR DESCRIPTION
1) It has been failing for a long time.
2) failures are not particularly noticeable as they run only after
   merge.
3) this consume a huge number of build time and delay PRs testing (mac
   is often the limiting factor.

If we want to re-enable I would suggest a daily cron that auto-open an
issue.
