### PR TITLE
Add setter for modifying multiple dims.range elements

### DIFF
--- a/napari/components/_tests/test_dims.py
+++ b/napari/components/_tests/test_dims.py
@@ -90,6 +90,32 @@ def test_range():
     assert dims.range == ((0, 2, 1),) * 3 + ((0, 4, 2),)
 
 
+def test_range_set_multiple():
+    """
+    Tests bulk range setting.
+    """
+    dims = Dims(ndim=4)
+    assert dims.range == ((0, 2, 1),) * 4
+
+    dims._set_ranges([(0, 6, 3), (0, 9, 3)], axes=(0, 3))
+    assert dims.range == ((0, 6, 3),) + ((0, 2, 1),) * 2 + ((0, 9, 3),)
+
+    # default without axes specified is to set the first len(ranges) axes
+    dims._set_ranges(((0, 5, 1),) * 4)
+    assert dims.range == ((0, 5, 1),) * 4
+    assert dims.last_used == 3
+
+    dims._set_ranges([(0.0, 4.0, 1.0)])
+    assert dims.range == ((0, 4, 1),) + ((0, 5, 1),) * 3
+    assert dims.last_used == 0
+
+    # When the range matches the current range last_used is not modified.
+    current_range = list(dims.range)
+    dims._set_ranges(current_range)
+    assert dims.range == tuple(current_range)
+    assert dims.last_used == 0
+
+
 def test_axis_labels():
     dims = Dims(ndim=4)
     assert dims.axis_labels == ('0', '1', '2', '3')

--- a/napari/components/_tests/test_dims.py
+++ b/napari/components/_tests/test_dims.py
@@ -103,18 +103,10 @@ def test_range_set_multiple():
     # last_used will be set to the smallest axis in range
     dims.set_range(range(1, 4), ((0, 5, 1),) * 3)
     assert dims.range == ((0, 6, 3),) + ((0, 5, 1),) * 3
-    assert dims.last_used == 1
-
-    # setting to an identical range doesn't modify last_used or range
-    current_range = list(dims.range)
-    dims.set_range(range(dims.ndim), current_range)
-    assert dims.range == tuple(current_range)
-    assert dims.last_used == 1
 
     # test with descending axis order
     dims.set_range(axis=(3, 0), _range=[(0, 4, 1), (0, 6, 1)])
     assert dims.range == ((0, 6, 1),) + ((0, 5, 1),) * 2 + ((0, 4, 1),)
-    assert dims.last_used == 0
 
     # out of range axis raises a ValueError
     with pytest.raises(ValueError):

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -211,7 +211,6 @@ class Dims(EventedModel):
                 full_range = list(self.range)
                 full_range[axis] = _range
                 self.range = full_range
-            self.last_used = axis
         else:
             full_range = list(self.range)
             _range = list(_range)  # type: ignore
@@ -221,15 +220,10 @@ class Dims(EventedModel):
                     "axis and _range sequences must have equal length"
                 )
             if _range != full_range:
-                changed_axes = []
                 for ax, r in zip(axis, _range):
                     ax = assert_axis_in_bounds(int(ax), self.ndim)
-                    if r != full_range[ax]:
-                        full_range[ax] = r
-                        changed_axes.append(ax)
+                    full_range[ax] = r
                 self.range = full_range
-                # set last_used to the smallest of the changed axes
-                self.last_used = min(changed_axes)
 
     def set_point(self, axis: int, value: Union[int, float]):
         """Sets point to slice dimension in world coordinates.

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -204,6 +204,31 @@ class Dims(EventedModel):
             self.range = full_range
         self.last_used = axis
 
+    def _set_ranges(
+        self,
+        _ranges: Sequence[Sequence[Union[int, float]]],
+        axes: Sequence[int] = None,
+    ):
+        """Sets the ranges (min, max, step) along the specified axes
+
+        Parameters
+        ----------
+        _ranges : tuple
+            Ranges specified as a sequence of (min, max, step).
+        axes : sequence of int or None
+            Axes whos range will be set. Default is ``range(len(_ranges))``.
+        """
+        full_range = list(self.range)
+        _ranges = list(_ranges)
+        if axes is None:
+            axes = range(len(_ranges))
+        if _ranges != full_range:
+            for axis, _range in zip(axes, _ranges):
+                axis = assert_axis_in_bounds(axis, self.ndim)
+                full_range[axis] = _range
+            self.range = full_range
+            self.last_used = axis
+
     def set_point(self, axis: int, value: Union[int, float]):
         """Sets point to slice dimension in world coordinates.
 

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -339,8 +339,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             ranges = self.layers._ranges
             ndim = len(ranges)
             self.dims.ndim = ndim
-            for i, _range in enumerate(ranges):
-                self.dims.set_range(i, _range)
+            self.dims._set_ranges(ranges)
 
         new_dim = self.dims.ndim
         dim_diff = new_dim - len(self.cursor.position)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -339,7 +339,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             ranges = self.layers._ranges
             ndim = len(ranges)
             self.dims.ndim = ndim
-            self.dims._set_ranges(ranges)
+            self.dims.set_range(range(ndim), ranges)
 
         new_dim = self.dims.ndim
         dim_diff = new_dim - len(self.cursor.position)


### PR DESCRIPTION
# Description

This PR adds a `dims._set_ranges` method that will emit only one `dims.events.range` event and one `dims.events.last_used` event regardless of how many elements of `dims.range` are being updated. It emits 0 events if the values being set match the current range. 

Calling the current `dims.set_range` over all axes in a loop, as is currently done in `ViewerModel._on_layers_change`,  results in ndim range events and ndim or (ndim - 1) last_used events being emitted. All of these individual events are unnecessary and add performance overhead.

Two questions:
1.) Can we just omit the `last_used` event altogether for `_set_ranges`? (I need to look what that actually gets used for)
2.) should `_set_ranges` be renamed without an underscore for use as public API? One issue is that the attribute containing the sequence of ranges is just called `dims.range` so it would ideally just be named `set_range` rather than `set_ranges` but that overlaps with the existing `set_range` which only allows setting a single element of `dims.range`. I suppose we could potentially have one function handle both cases, but that would make the type hinting harder to parse.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References

This is a partial fix to #3636 reducing the total events in the scenario outlined there from 6 to 3. With the changes in this PR the events that occur there are:
1.) dims.ndim is changed from 2 to 3
2.) dims.range is set
3.) dims.last_used is set  (but we can possibly remove this too?)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] new tests specific to _set_range were added
- [x] existing tests involving the `ViewerModel` should continue to pass

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
