### PR TITLE
Update python version in install instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ napari into a clean virtual environment using an environment manager like
 [venv](https://docs.python.org/3/library/venv.html).  For example, with `conda`:
 
 ```sh
-conda create -y -n napari-env python=3.8
+conda create -y -n napari-env -c conda-forge python=3.9
 conda activate napari-env
 pip install "napari[all]"
 ```


### PR DESCRIPTION
updates the conda environment creation advice in our readme to use python-3.9 ... and be explicit about -c conda forge (which has bitten us a few times)

```py
conda create -y -n napari-env -c conda-forge python=3.9
conda activate napari-env
pip install "napari[all]"
```