### PR TITLE
Fix calc_data_range for large, 1D data

### DIFF
--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -17,6 +17,10 @@ data_dask = da.random.random(
     size=(100_000, 1000, 1000), chunks=(1, 1000, 1000)
 )
 
+data_dask_1d = da.random.random(size=(20_000_000,), chunks=(5000,))
+
+data_dask_1d_rgb = da.random.random(size=(5_000_000, 3), chunks=(50_000, 3))
+
 data_dask_plane = da.random.random(
     size=(100_000, 100_000), chunks=(1000, 1000)
 )
@@ -76,6 +80,18 @@ def test_calc_data_fast_uint8():
 @pytest.mark.timeout(2)
 def test_calc_data_range_fast_big():
     val = calc_data_range(data_dask)
+    assert len(val) > 0
+
+
+@pytest.mark.timeout(2)
+def test_calc_data_range_fast_big_1d():
+    val = calc_data_range(data_dask_1d)
+    assert len(val) > 0
+
+
+@pytest.mark.timeout(2)
+def test_calc_data_range_fast_big_1d_rgb():
+    val = calc_data_range(data_dask_1d_rgb)
     assert len(val) > 0
 
 

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -84,7 +84,20 @@ def calc_data_range(data, rgb=False):
     """
     if data.dtype == np.uint8:
         return [0, 255]
-    if np.prod(data.shape) > 1e7:
+
+    if data.size > 1e7 and (data.ndim == 1 or (rgb and data.ndim == 2)):
+        # If data is very large take the average of start, middle and end.
+        center = int(data.shape[0] // 2)
+        slices = [
+            slice(0, 4096),
+            slice(center - 2048, center + 2048),
+            slice(-4096, None),
+        ]
+        reduced_data = [
+            [np.max(data[sl]) for sl in slices],
+            [np.min(data[sl]) for sl in slices],
+        ]
+    elif data.size > 1e7:
         # If data is very large take the average of the top, bottom, and
         # middle slices
         offset = 2 + int(rgb)
@@ -98,12 +111,12 @@ def calc_data_range(data, rgb=False):
             and data.shape[-offset] > 64
             and data.shape[-offset + 1] > 64
         ):
-            # Find a centeral patch of the image to take
+            # Find a central patch of the image to take
             center = [int(s // 2) for s in data.shape[-offset:]]
-            cental_slice = tuple(slice(c - 31, c + 31) for c in center[:2])
+            central_slice = tuple(slice(c - 31, c + 31) for c in center[:2])
             reduced_data = [
-                [np.max(data[idx + cental_slice]) for idx in idxs],
-                [np.min(data[idx + cental_slice]) for idx in idxs],
+                [np.max(data[idx + central_slice]) for idx in idxs],
+                [np.min(data[idx + central_slice]) for idx in idxs],
             ]
         else:
             reduced_data = [


### PR DESCRIPTION
# Description

In the layer utility `calc_data_range`, the code path for large data assumed the data was at least 2D. This assumption is removed in this PR and new 1D test cases are added. I tried to make the 1D logic similar to the 2D case where start, middle and end slices are used. I chose size 4096 as equivalent in size to the choice of a 64x64 region of the plane used in 2D.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
closes #3672

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: a new test case for large 1D data was added

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
