### PR TITLE
Better track state for starting/shutting down app.

### DIFF
--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -46,7 +46,7 @@ if os.getenv("CI") and os.name == 'nt':
 def qapp():
     from qtpy.QtCore import QTimer
 
-    from napari._qt.qt_event_loop import get_app
+    from napari._qt.qt_event_loop import get_app, quit_app
 
     # it's important that we use get_app so that it connects to the
     # app.aboutToQuit.connect(wait_for_workers_to_quit)
@@ -54,7 +54,7 @@ def qapp():
 
     # quit examples that explicitly start the event loop with `napari.run()`
     # so that tests aren't waiting on a manual exit
-    QTimer.singleShot(100, app.quit)
+    QTimer.singleShot(100, quit_app)
 
     yield app
 

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -6,6 +6,7 @@ import dask.threaded
 import numpy as np
 import pooch
 import pytest
+from IPython.core.history import HistoryManager
 
 from napari.components import LayerList
 from napari.layers import Image, Labels, Points, Shapes, Vectors
@@ -376,3 +377,6 @@ if sys.version_info > (
             if dask.threaded.default_pool is not None:
                 dask.threaded.default_pool.shutdown()
                 dask.threaded.default_pool = None
+
+
+HistoryManager.enabled = False


### PR DESCRIPTION
We know make get_app and quit_app bound method on the same class which
makes it easier to track wether or not we are the one that have started
the app.

In particular this will properly close app that are not named napari.

We use quit_app in the examples to make use of that logic.

Hope this will be a step toward #3690, it also include making IPython history in-memory as that was triggering a bug and I want to see if that fixes it.

-- 
Better seen without whitespace changes as it's mostly indenting and putting functions in a class.