### PR TITLE
Use GPU scaled textures (fix NaN)

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -275,32 +275,42 @@ def test_screenshot_dialog(make_napari_viewer, tmpdir):
 
 
 @pytest.mark.parametrize(
-    "dtype", ['int8', 'uint8', 'int16', 'uint16', 'float32']
+    "dtype",
+    [
+        'int8',
+        'uint8',
+        'int16',
+        'uint16',
+        'int32',
+        'float16',
+        'float32',
+        'float64',
+    ],
 )
 def test_qt_viewer_data_integrity(make_napari_viewer, dtype):
     """Test that the viewer doesn't change the underlying array."""
-
     image = np.random.rand(10, 32, 32)
     image *= 200 if dtype.endswith('8') else 2 ** 14
     image = image.astype(dtype)
     imean = image.mean()
 
     viewer = make_napari_viewer()
+    layer = viewer.add_image(image.copy())
+    data = layer.data
 
-    viewer.add_image(image.copy())
-    datamean = viewer.layers[0].data.mean()
+    datamean = np.mean(data)
     assert datamean == imean
     # toggle dimensions
     viewer.dims.ndisplay = 3
-    datamean = viewer.layers[0].data.mean()
+    datamean = np.mean(data)
     assert datamean == imean
     # back to 2D
     viewer.dims.ndisplay = 2
-    datamean = viewer.layers[0].data.mean()
+    datamean = np.mean(data)
     assert datamean == imean
     # also check that vispy gets (almost) the same data
-    datamean = fix_data_dtype(image).mean()
-    assert np.allclose(datamean, imean)
+    datamean = np.mean(fix_data_dtype(data))
+    assert np.allclose(datamean, imean, rtol=3e-04)
 
 
 def test_points_layer_display_correct_slice_on_scale(make_napari_viewer):

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -310,7 +310,7 @@ def test_qt_viewer_data_integrity(make_napari_viewer, dtype):
     assert datamean == imean
     # also check that vispy gets (almost) the same data
     datamean = np.mean(fix_data_dtype(data))
-    assert np.allclose(datamean, imean, rtol=3e-04)
+    assert np.allclose(datamean, imean, rtol=5e-04)
 
 
 def test_points_layer_display_correct_slice_on_scale(make_napari_viewer):

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -18,6 +18,7 @@ from napari._tests.utils import (
     skip_on_win_ci,
     slow,
 )
+from napari._vispy.utils.gl import fix_data_dtype
 from napari.settings import get_settings
 from napari.utils.interactions import mouse_press_callbacks
 from napari.utils.io import imread
@@ -297,6 +298,9 @@ def test_qt_viewer_data_integrity(make_napari_viewer, dtype):
     viewer.dims.ndisplay = 2
     datamean = viewer.layers[0].data.mean()
     assert datamean == imean
+    # also check that vispy gets (almost) the same data
+    datamean = fix_data_dtype(image).mean()
+    assert np.allclose(datamean, imean)
 
 
 def test_points_layer_display_correct_slice_on_scale(make_napari_viewer):

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -209,7 +209,7 @@ def test_changing_image_gamma(make_napari_viewer):
 
     screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
-    assert 127 <= screenshot[center + (0,)] == 129
+    assert 127 <= screenshot[center + (0,)] <= 129
 
     layer.gamma = 0.1
     screenshot = viewer.screenshot(canvas_only=True, flash=False)

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -209,7 +209,7 @@ def test_changing_image_gamma(make_napari_viewer):
 
     screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
-    assert screenshot[center + (0,)] == 128
+    assert 127 <= screenshot[center + (0,)] == 129
 
     layer.gamma = 0.1
     screenshot = viewer.screenshot(canvas_only=True, flash=False)

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -135,7 +135,7 @@ def are_objects_equal(object1, object2):
     # equal_nan does not exist in array_equal in old numpy
     if tuple(int(v) for v in np.__version__.split('.')) < (1, 19):
         fixed = [(np.nan_to_num(a1), np.nan_to_num(a2)) for a1, a2 in items]
-        return np.all([a1 == a2 for a1, a2 in fixed])
+        return np.all([np.all(a1 == a2) for a1, a2 in fixed])
 
     try:
         return np.all(

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -134,16 +134,8 @@ def are_objects_equal(object1, object2):
 
     # equal_nan does not exist in array_equal in old numpy
     if tuple(int(v) for v in np.__version__.split('.')) < (1, 19):
-        fixed = []
-        for a1, a2 in items:
-            a1 = np.asarray(a1)
-            a2 = np.asarray(a2)
-            if a1.dtype.kind == 'f':
-                a1 = a1[np.isfinite(a1)]
-            if a2.dtype.kind == 'f':
-                a2 = a2[np.isfinite(a2)]
-            fixed.append((a1, a2))
-        return np.all([a1 == a2 for a1, a2 in items])
+        fixed = [(np.nan_to_num(a1), np.nan_to_num(a2)) for a1, a2 in items]
+        return np.all([a1 == a2 for a1, a2 in fixed])
 
     try:
         return np.all(

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -133,7 +133,7 @@ def are_objects_equal(object1, object2):
         items = [(object1, object2)]
 
     # equal_nan does not exist in array_equal in old numpy
-    if sys.version_info <= (3, 7):
+    if tuple(int(v) for v in np.__version__.split('.')) < (1, 19):
         fixed = []
         for a1, a2 in items:
             a1 = np.asarray(a1)

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -132,6 +132,19 @@ def are_objects_equal(object1, object2):
     else:
         items = [(object1, object2)]
 
+    # equal_nan does not exist in array_equal in old numpy
+    if sys.version_info <= (3, 7):
+        fixed = []
+        for a1, a2 in items:
+            a1 = np.asarray(a1)
+            a2 = np.asarray(a2)
+            if a1.dtype.kind == 'f':
+                a1 = a1[np.isfinite(a1)]
+            if a2.dtype.kind == 'f':
+                a2 = a2[np.isfinite(a2)]
+            fixed.append((a1, a2))
+        return np.all([a1 == a2 for a1, a2 in items])
+
     try:
         return np.all(
             [np.array_equal(a1, a2, equal_nan=True) for a1, a2 in items]

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -14,9 +14,15 @@ from .base import VispyBaseLayer
 class ImageLayerNode:
     def __init__(self, custom_node: Node = None):
         self._custom_node = custom_node
-        self._image_node = ImageNode(None, method='auto')
+        self._image_node = ImageNode(
+            None,
+            method='auto',
+            texture_format='auto',
+        )
         self._volume_node = VolumeNode(
-            np.zeros((1, 1, 1), dtype=np.float32), clim=[0, 1]
+            np.zeros((1, 1, 1), dtype=np.float32),
+            clim=[0, 1],
+            texture_format='auto',
         )
 
     def get_node(self, ndisplay: int) -> Node:

--- a/napari/_vispy/utils/gl.py
+++ b/napari/_vispy/utils/gl.py
@@ -12,11 +12,10 @@ from vispy.gloo.context import get_current_canvas
 from ...utils.translations import trans
 
 texture_dtypes = [
-    np.dtype(np.int8),
     np.dtype(np.uint8),
-    np.dtype(np.int16),
     np.dtype(np.uint16),
     np.dtype(np.float32),
+    np.dtype(np.float64),
 ]
 
 
@@ -91,7 +90,7 @@ def fix_data_dtype(data):
         return data
     else:
         try:
-            dtype = dict(i=np.int16, f=np.float32, u=np.uint16, b=np.uint8)[
+            dtype = dict(i=np.float64, f=np.float64, u=np.uint16, b=np.uint8)[
                 dtype.kind
             ]
         except KeyError:  # not an int or float

--- a/napari/_vispy/utils/gl.py
+++ b/napari/_vispy/utils/gl.py
@@ -90,7 +90,7 @@ def fix_data_dtype(data):
         return data
     else:
         try:
-            dtype = dict(i=np.float64, f=np.float64, u=np.uint16, b=np.uint8)[
+            dtype = dict(i=np.float32, f=np.float32, u=np.uint16, b=np.uint8)[
                 dtype.kind
             ]
         except KeyError:  # not an int or float

--- a/napari/layers/_tests/test_serialize.py
+++ b/napari/layers/_tests/test_serialize.py
@@ -3,7 +3,7 @@ import inspect
 import numpy as np
 import pytest
 
-from napari._tests.utils import layer_test_data
+from napari._tests.utils import are_objects_equal, layer_test_data
 
 
 @pytest.mark.parametrize('Layer, data, ndim', layer_test_data)
@@ -31,25 +31,9 @@ def test_attrs_arrays(Layer, data, ndim):
 
     # Check that new layer matches old on all properties:
     for prop in properties.keys():
-        # If lists check equality of all elements with np.all
-        if isinstance(getattr(layer, prop), list):
-            assert np.all(
-                [
-                    np.all(ol == nl)
-                    for ol, nl in zip(
-                        getattr(layer, prop), getattr(new_layer, prop)
-                    )
-                ]
-            )
-        elif isinstance(getattr(layer, prop), dict):
-            assert np.all(
-                [
-                    np.all(value == getattr(new_layer, prop)[key])
-                    for key, value in getattr(layer, prop).items()
-                ]
-            )
-        else:
-            assert np.all(getattr(layer, prop) == getattr(new_layer, prop))
+        assert are_objects_equal(
+            getattr(layer, prop), getattr(new_layer, prop)
+        )
 
 
 @pytest.mark.parametrize('Layer, data, ndim', layer_test_data)

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -94,8 +94,8 @@ def calc_data_range(data, rgb=False):
             slice(-4096, None),
         ]
         reduced_data = [
-            [np.max(data[sl]) for sl in slices],
-            [np.min(data[sl]) for sl in slices],
+            [np.nanmax(data[sl]) for sl in slices],
+            [np.nanmin(data[sl]) for sl in slices],
         ]
     elif data.size > 1e7:
         # If data is very large take the average of the top, bottom, and
@@ -115,21 +115,21 @@ def calc_data_range(data, rgb=False):
             center = [int(s // 2) for s in data.shape[-offset:]]
             central_slice = tuple(slice(c - 31, c + 31) for c in center[:2])
             reduced_data = [
-                [np.max(data[idx + central_slice]) for idx in idxs],
-                [np.min(data[idx + central_slice]) for idx in idxs],
+                [np.nanmax(data[idx + central_slice]) for idx in idxs],
+                [np.nanmin(data[idx + central_slice]) for idx in idxs],
             ]
         else:
             reduced_data = [
-                [np.max(data[idx]) for idx in idxs],
-                [np.min(data[idx]) for idx in idxs],
+                [np.nanmax(data[idx]) for idx in idxs],
+                [np.nanmin(data[idx]) for idx in idxs],
             ]
         # compute everything in one go
         reduced_data = dask.compute(*reduced_data)
     else:
         reduced_data = data
 
-    min_val = np.min(reduced_data)
-    max_val = np.max(reduced_data)
+    min_val = np.nanmin(reduced_data)
+    max_val = np.nanmax(reduced_data)
 
     if min_val == max_val:
         min_val = 0

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -66,9 +66,9 @@ def _nanmin(array):
     """
     call np.min but fall back to avoid nan and inf if necessary
     """
-    min = array.min()
+    min = np.min(array)
     if not np.isfinite(min):
-        min = np.ma.masked_invalid(array).min()
+        min = np.min(array[np.isfinite(array)])
     return min
 
 
@@ -76,9 +76,9 @@ def _nanmax(array):
     """
     call np.max but fall back to avoid nan and inf if necessary
     """
-    max = array.max()
+    max = np.max(array)
     if not np.isfinite(max):
-        max = np.ma.masked_invalid(array).max()
+        max = np.max(array[np.isfinite(array)])
     return max
 
 

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -62,6 +62,26 @@ def register_layer_action(keymapprovider, description: str, shortcuts=None):
     return _inner
 
 
+def _nanmin(*args, **kwargs):
+    """
+    call np.min but fall back to the slower np.nanmin if necessary
+    """
+    min = np.min(*args, **kwargs)
+    if min in [np.nan, -np.inf]:
+        min = np.nanmin(*args, **kwargs)
+    return min
+
+
+def _nanmax(*args, **kwargs):
+    """
+    call np.max but fall back to the slower np.nanmax if necessary
+    """
+    max = np.max(*args, **kwargs)
+    if max in [np.nan, np.inf]:
+        max = np.nanmax(*args, **kwargs)
+    return max
+
+
 def calc_data_range(data, rgb=False):
     """Calculate range of data values. If all values are equal return [0, 1].
 
@@ -94,8 +114,8 @@ def calc_data_range(data, rgb=False):
             slice(-4096, None),
         ]
         reduced_data = [
-            [np.nanmax(data[sl]) for sl in slices],
-            [np.nanmin(data[sl]) for sl in slices],
+            [_nanmax(data[sl]) for sl in slices],
+            [_nanmin(data[sl]) for sl in slices],
         ]
     elif data.size > 1e7:
         # If data is very large take the average of the top, bottom, and
@@ -115,21 +135,21 @@ def calc_data_range(data, rgb=False):
             center = [int(s // 2) for s in data.shape[-offset:]]
             central_slice = tuple(slice(c - 31, c + 31) for c in center[:2])
             reduced_data = [
-                [np.nanmax(data[idx + central_slice]) for idx in idxs],
-                [np.nanmin(data[idx + central_slice]) for idx in idxs],
+                [_nanmax(data[idx + central_slice]) for idx in idxs],
+                [_nanmin(data[idx + central_slice]) for idx in idxs],
             ]
         else:
             reduced_data = [
-                [np.nanmax(data[idx]) for idx in idxs],
-                [np.nanmin(data[idx]) for idx in idxs],
+                [_nanmax(data[idx]) for idx in idxs],
+                [_nanmin(data[idx]) for idx in idxs],
             ]
         # compute everything in one go
         reduced_data = dask.compute(*reduced_data)
     else:
         reduced_data = data
 
-    min_val = np.nanmin(reduced_data)
-    max_val = np.nanmax(reduced_data)
+    min_val = _nanmin(reduced_data)
+    max_val = _nanmax(reduced_data)
 
     if min_val == max_val:
         min_val = 0

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -62,23 +62,23 @@ def register_layer_action(keymapprovider, description: str, shortcuts=None):
     return _inner
 
 
-def _nanmin(*args, **kwargs):
+def _nanmin(array):
     """
-    call np.min but fall back to the slower np.nanmin if necessary
+    call np.min but fall back to avoid nan and inf if necessary
     """
-    min = np.min(*args, **kwargs)
-    if min in [np.nan, -np.inf]:
-        min = np.nanmin(*args, **kwargs)
+    min = array.min()
+    if not np.isfinite(min):
+        min = np.ma.masked_invalid(array).min()
     return min
 
 
-def _nanmax(*args, **kwargs):
+def _nanmax(array):
     """
-    call np.max but fall back to the slower np.nanmax if necessary
+    call np.max but fall back to avoid nan and inf if necessary
     """
-    max = np.max(*args, **kwargs)
-    if max in [np.nan, np.inf]:
-        max = np.nanmax(*args, **kwargs)
+    max = array.max()
+    if not np.isfinite(max):
+        max = np.ma.masked_invalid(array).max()
     return max
 
 

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -68,7 +68,10 @@ def _nanmin(array):
     """
     min = np.min(array)
     if not np.isfinite(min):
-        min = np.min(array[np.isfinite(array)])
+        masked = array[np.isfinite(array)]
+        if masked.size == 0:
+            return 0
+        min = np.min(masked)
     return min
 
 
@@ -78,7 +81,10 @@ def _nanmax(array):
     """
     max = np.max(array)
     if not np.isfinite(max):
-        max = np.max(array[np.isfinite(array)])
+        masked = array[np.isfinite(array)]
+        if masked.size == 0:
+            return 1
+        max = np.max(masked)
     return max
 
 


### PR DESCRIPTION
# Description
After #3494, napari should be able to handle `nan` values. Indeed, we do not get crashes anymore like shown in #1310, but we still don't see things properly. An `Image` containing even a single `nan` becomes completely black and opaque.

Changes needed:
- [x] diplay image correctly. Done by ensuring `clim` calculation ignores `nan` values (using `np.nanmin` and `np.nanmax`)
- [x] make `nan` pixels transparent. ~This should already happen, in theory, because vispy discards `nan` fragments. Also, this might be not trivial/impossible with interpolation different from `nearest`?~ EDIT: This needed GPU scaled textures, and now works!

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
#3446

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
