### PR TITLE
Support python 3.10

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -75,6 +75,9 @@ jobs:
           - python: 3.8
             platform: ubuntu-18.04
             toxenv: headless-py38-linux
+          - python: '3.10'
+            platform: ubuntu-latest
+            toxenv: py310-linux-pyside
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -103,6 +103,9 @@ jobs:
           - python: 3.8
             platform: ubuntu-18.04
             toxenv: headless-py38-linux
+          - python: '3.10'
+            platform: ubuntu-latest
+            backend: pyside
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -105,7 +105,7 @@ jobs:
             toxenv: headless-py38-linux
           - python: '3.10'
             platform: ubuntu-latest
-            backend: pyside
+            backend: pyqt
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We recommend that you use conda to help manage the virtual environment. Otherwis
 ### from pip, with "batteries included"
 
 napari can be installed on most macOS, Linux, and Windows systems with
-Python 3.7, 3.8, and 3.9 using pip. However, for Windows users, you need to preinstall [Microsoft Visual C++ Build Tools](https://visualstudio.microsoft.com/downloads/)
+Python 3.7 - 3.10 using pip. However, for Windows users, you need to preinstall [Microsoft Visual C++ Build Tools](https://visualstudio.microsoft.com/downloads/)
 in order to install VisPy (one of the packages we depend on) on Windows machines.
 
 The simplest command to install with pip is:

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -73,19 +73,9 @@ layer_test_data = [
 try:
     import tensorstore as ts
 
-    layer_test_data.extend(
-        [
-            (Image, ts.array(np.random.random((10, 15))), 2),
-            (
-                Image,
-                [
-                    ts.array(np.random.random(s))
-                    for s in [(40, 20), (20, 10), (10, 5)]
-                ],
-                2,
-            ),
-        ]
-    )
+    m = ts.array(np.random.random((10, 15)))
+    p = [ts.array(np.random.random(s)) for s in [(40, 20), (20, 10), (10, 5)]]
+    layer_test_data.extend([(Image, m, 2), (Image, p, 2)])
 except ImportError:
     pass
 

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -3,7 +3,6 @@ import sys
 
 import numpy as np
 import pytest
-import tensorstore as ts
 
 from napari import Viewer
 from napari.layers import (
@@ -37,15 +36,9 @@ Used as pytest params for testing layer add and view functionality (Layer class,
 """
 layer_test_data = [
     (Image, np.random.random((10, 15)), 2),
-    (Image, ts.array(np.random.random((10, 15))), 2),
     (Image, np.random.random((10, 15, 20)), 3),
     (Image, np.random.random((5, 10, 15, 20)), 4),
     (Image, [np.random.random(s) for s in [(40, 20), (20, 10), (10, 5)]], 2),
-    (
-        Image,
-        [ts.array(np.random.random(s)) for s in [(40, 20), (20, 10), (10, 5)]],
-        2,
-    ),
     (Labels, np.random.randint(20, size=(10, 15)), 2),
     (Labels, np.random.randint(20, size=(6, 10, 15)), 3),
     (Points, 20 * np.random.random((10, 2)), 2),
@@ -77,6 +70,24 @@ layer_test_data = [
     ),
 ]
 
+try:
+    import tensorstore as ts
+
+    layer_test_data.extend(
+        [
+            (Image, ts.array(np.random.random((10, 15))), 2),
+            (
+                Image,
+                [
+                    ts.array(np.random.random(s))
+                    for s in [(40, 20), (20, 10), (10, 5)]
+                ],
+                2,
+            ),
+        ]
+    )
+except ImportError:
+    pass
 
 classes = [Labels, Points, Vectors, Shapes, Surface, Tracks, Image]
 names = [cls.__name__.lower() for cls in classes]

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -1,7 +1,6 @@
 import dask.array as da
 import numpy as np
 import pytest
-import tensorstore as ts
 import xarray as xr
 
 from napari._tests.utils import check_layer_world_data_extent
@@ -788,6 +787,8 @@ def test_instantiate_with_experimental_clipping_planes_dict():
 
 def test_tensorstore_image():
     """Test an image coming from a tensorstore array."""
+    ts = pytest.importorskip('tensorstore')
+
     data = ts.array(
         np.full(shape=(1024, 1024), fill_value=255, dtype=np.uint8)
     )

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -6,7 +6,6 @@ from typing import List
 import numpy as np
 import pandas as pd
 import pytest
-import tensorstore as ts
 import xarray as xr
 import zarr
 from numpy.core.numerictypes import issubdtype
@@ -931,6 +930,8 @@ def test_add_large_colors():
 
 
 def test_fill_tensorstore():
+    ts = pytest.importorskip('tensorstore')
+
     labels = np.zeros((5, 7, 8, 9), dtype=int)
     labels[1, 2:4, 4:6, 4:6] = 1
     labels[1, 3:5, 5:7, 6:8] = 2

--- a/napari/layers/labels/_tests/test_labels_key_bindings.py
+++ b/napari/layers/labels/_tests/test_labels_key_bindings.py
@@ -2,7 +2,6 @@ from tempfile import TemporaryDirectory
 
 import numpy as np
 import pytest
-import tensorstore as ts
 import zarr
 
 from napari.layers import Labels
@@ -25,6 +24,8 @@ def test_max_label(labels_data_4d):
 
 
 def test_max_label_tensorstore(labels_data_4d):
+    ts = pytest.importorskip('tensorstore')
+
     with TemporaryDirectory(suffix='.zarr') as fout:
         labels_temp = zarr.open(
             fout,

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Visualization
     Topic :: Scientific/Engineering :: Information Analysis

--- a/setup.cfg
+++ b/setup.cfg
@@ -107,7 +107,7 @@ testing =
     scikit-image>=0.18.1
     pooch>=1.3.0
     semgrep
-    tensorstore>=0.1.13
+    tensorstore>=0.1.13 ; python_version < '3.10'
     torch>=1.7 ; python_version < '3.10'
     meshzoo
 release = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -107,7 +107,7 @@ testing =
     pooch>=1.3.0
     semgrep
     tensorstore>=0.1.13
-    torch>=1.7
+    torch>=1.7 ; python_version < '3.10'
     meshzoo
 release = 
     PyGithub>=1.44.1

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@
 # "tox -e py38-macos-pyqt" will test python3.8 with pyqt on macos
 # (even if a combination of factors is not in the default envlist
 # you can run it manually... like py39-linux-pyside2-async)
-envlist = py{37,38,39}-{linux,macos,windows}-{pyqt,pyside}
+envlist = py{37,38,39,310}-{linux,macos,windows}-{pyqt,pyside}
 toxworkdir=/tmp/.tox
 
 [gh-actions]
@@ -24,6 +24,7 @@ python =
     3.8: py38
     3.9: py39
     3.9.0: py390
+    3.10: py310
 
 # This section turns environment variables from github actions
 # into tox environment factors. This, combined with the [gh-actions]


### PR DESCRIPTION
# Description
run our tests on py3.10 ... only pyqt5's wheels work at the moment (pyside2 puts you back to 5.13, which has some casting issues), so only testing that.  