### PR TITLE
remove @slow on a number of tests

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -143,7 +143,6 @@ def test_add_layer_magic_name(
 
 
 @skip_on_win_ci
-@slow(20)
 def test_screenshot(make_napari_viewer):
     """Test taking a screenshot."""
     viewer = make_napari_viewer()

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -106,7 +106,6 @@ def test_z_order_image_points(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
 
 
-@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_images_after_ndisplay(make_napari_viewer):
@@ -136,7 +135,6 @@ def test_z_order_images_after_ndisplay(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
-@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_image_points_after_ndisplay(make_napari_viewer):
@@ -166,7 +164,6 @@ def test_z_order_image_points_after_ndisplay(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
-@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_changing_image_colormap(make_napari_viewer):
@@ -329,7 +326,6 @@ def test_grid_mode(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 255, 255, 255])
 
 
-@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_changing_image_attenuation(make_napari_viewer):


### PR DESCRIPTION
# Description
In trying a few things with mac tests, I disabled the `@slow` decorator on a few tests, and suddenly _all_ mac tests passed, regardless of qt backend, python version or mac versions:
https://github.com/tlambert03/napari/runs/4336061486?check_suite_focus=true
moreover, all of the times reported on the corresponding tests were well below the timeout (which leads me to wonder whether simply decorating them with `@slow` is perhaps causing the timeout)

So this PR removes a few of the more critical ones, but if @Carreau agrees, I think we should remove `@slow` altogether.  I think it's possible that pytest-timeout just isn't as robust as we need it to be when it comes to dealing with other possibly threaded things like qt, etc...  They can also make things hard to debug, since it can sometimes make the following tests look like they're failing when they're no
