### PR TITLE
remove slow decorator

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -70,39 +70,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest]
-        python: [3.7, 3.8, 3.9]
-        include:
-          # Windows py37
-          - python: 3.7
-            platform: windows-latest
-            backend: pyqt
-          - python: 3.7
-            platform: windows-latest
-            backend: pyside
-          # Windows py38
-          - python: 3.8
-            platform: windows-latest
-            backend: pyqt
-          - python: 3.8
-            platform: windows-latest
-            backend: pyside
+        platform: [macos-11, macos-latest]
+        python: [3.9, 3.8]
+        backend: [pyqt, pyside]
+        # include:
+          # # Windows py37
+          # - python: 3.7
+          #   platform: windows-latest
+          #   backend: pyqt
+          # - python: 3.7
+          #   platform: windows-latest
+          #   backend: pyside
+          # # Windows py38
+          # - python: 3.8
+          #   platform: windows-latest
+          #   backend: pyqt
+          # - python: 3.8
+          #   platform: windows-latest
+          #   backend: pyside
           # macOS py38
-          - python: 3.9
-            platform: macos-11
-            backend: pyqt # (only testing pyqt on mac in the interest of speed)
-          # minimum specified requirements
-          - python: 3.7
-            platform: ubuntu-18.04
-            MIN_REQ: 1
-          # test with --async_only
-          - python: 3.8
-            platform: ubuntu-18.04
-            toxenv: async-pyqt-py38-linux
-          # test without any Qt backends
-          - python: 3.8
-            platform: ubuntu-18.04
-            toxenv: headless-py38-linux
+          # - python: 3.9
+          #   platform: macos-11
+          #   backend: pyqt
+          # # minimum specified requirements
+          # - python: 3.7
+          #   platform: ubuntu-18.04
+          #   MIN_REQ: 1
+          # # test with --async_only
+          # - python: 3.8
+          #   platform: ubuntu-18.04
+          #   toxenv: async-pyqt-py38-linux
+          # # test without any Qt backends
+          # - python: 3.8
+          #   platform: ubuntu-18.04
+          #   toxenv: headless-py38-linux
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -25,7 +25,7 @@ jobs:
           pip install --upgrade pip
           pip install tox
       - name: Run task
-        run: tox -e ${{ matrix.task }} -- --timeout=8
+        run: tox -e ${{ matrix.task }}
 
   manifest:
     # make sure all necessary files will be bundled in the release

--- a/napari/_qt/_tests/test_app.py
+++ b/napari/_qt/_tests/test_app.py
@@ -5,7 +5,6 @@ import pytest
 
 from napari import Viewer
 from napari._qt.qt_event_loop import _ipython_has_eventloop, run, set_app_id
-from napari._tests.utils import slow
 
 
 @pytest.mark.skipif(os.name != "Windows", reason="Windows specific")
@@ -30,7 +29,6 @@ def test_windows_grouping_overwrite(make_napari_viewer):
     assert get_app_id() == ""
 
 
-@slow(30)
 def test_run_outside_ipython(qapp, monkeypatch):
     """Test that we don't incorrectly give ipython the event loop."""
     assert not _ipython_has_eventloop()

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -16,7 +16,6 @@ from napari._tests.utils import (
     layer_test_data,
     skip_local_popups,
     skip_on_win_ci,
-    slow,
 )
 from napari.settings import get_settings
 from napari.utils.interactions import mouse_press_callbacks
@@ -199,7 +198,6 @@ def test_z_order_adding_removing_images(make_napari_viewer):
 
 
 @skip_on_win_ci
-@slow(15)
 def test_screenshot(make_napari_viewer):
     "Test taking a screenshot"
     viewer = make_napari_viewer()

--- a/napari/_qt/_tests/test_qt_window.py
+++ b/napari/_qt/_tests/test_qt_window.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 from napari._qt.qt_main_window import Window, _QtMainWindow
-from napari._tests.utils import slow
 from napari.utils.theme import (
     _themes,
     get_theme,
@@ -10,7 +9,6 @@ from napari.utils.theme import (
 )
 
 
-@slow(10)
 def test_current_viewer(make_napari_viewer, qapp):
     """Test that we can retrieve the "current" viewer window easily.
 

--- a/napari/_qt/perf/_tests/test_perf.py
+++ b/napari/_qt/perf/_tests/test_perf.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from napari._tests.utils import skip_local_popups, skip_on_win_ci, slow
+from napari._tests.utils import skip_local_popups, skip_on_win_ci
 
 # NOTE:
 # for some reason, running this test fails in a subprocess with a segfault
@@ -32,7 +32,6 @@ CONFIG = {
 
 
 @skip_on_win_ci
-@slow(20)
 @skip_local_popups
 def test_trace_on_start(tmp_path: Path):
     """Make sure napari can write a perfmon trace file."""

--- a/napari/_tests/test_adding_removing.py
+++ b/napari/_tests/test_adding_removing.py
@@ -5,14 +5,12 @@ from napari._tests.utils import (
     layer_test_data,
     skip_local_popups,
     skip_on_win_ci,
-    slow,
 )
 from napari.layers import Image
 from napari.utils.events.event import WarningEmitter
 
 
 @skip_on_win_ci
-@slow(15)
 @skip_local_popups
 @pytest.mark.parametrize('Layer, data, _', layer_test_data)
 def test_add_all_layers(make_napari_viewer, Layer, data, _):

--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -8,7 +8,6 @@ from qtpy import API_NAME
 import napari
 from napari.utils.notifications import notification_manager
 
-from napari._tests.utils import slow
 
 # not testing these examples
 skip = [
@@ -59,7 +58,6 @@ def qapp():
     yield app
 
 
-@slow(30)
 @pytest.mark.filterwarnings("ignore")
 @pytest.mark.skipif(not examples, reason="No examples were found.")
 @pytest.mark.parametrize("fname", examples)

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -11,7 +11,6 @@ from napari._tests.utils import (
     layer_test_data,
     skip_local_popups,
     skip_on_win_ci,
-    slow,
 )
 from napari.utils._tests.test_naming import eval_with_filename
 from napari.utils.action_manager import action_manager
@@ -143,7 +142,6 @@ def test_add_layer_magic_name(
 
 
 @skip_on_win_ci
-@slow(20)
 def test_screenshot(make_napari_viewer):
     """Test taking a screenshot."""
     viewer = make_napari_viewer()
@@ -300,7 +298,6 @@ def test_deleting_points(make_napari_viewer):
     assert len(pts_layer.data) == 3
 
 
-@slow(15)
 @skip_local_popups
 def test_custom_layer(make_napari_viewer):
     """Make sure that custom layers subclasses can be added to the viewer."""

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -329,7 +329,6 @@ def test_grid_mode(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 255, 255, 255])
 
 
-@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_changing_image_attenuation(make_napari_viewer):

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -7,7 +7,6 @@ from napari._tests.utils import (
     skip_local_popups,
     skip_on_mac_ci,
     skip_on_win_ci,
-    slow,
 )
 from napari.utils.interactions import (
     ReadOnlyWrapper,
@@ -62,7 +61,6 @@ def test_z_order_adding_removing_images(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 255, 0, 255])
 
 
-@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_images(make_napari_viewer):
@@ -84,7 +82,6 @@ def test_z_order_images(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
 
 
-@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_image_points(make_napari_viewer):
@@ -106,7 +103,6 @@ def test_z_order_image_points(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [255, 0, 0, 255])
 
 
-@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_images_after_ndisplay(make_napari_viewer):
@@ -136,7 +132,6 @@ def test_z_order_images_after_ndisplay(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
-@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_z_order_image_points_after_ndisplay(make_napari_viewer):
@@ -166,7 +161,6 @@ def test_z_order_image_points_after_ndisplay(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
-@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_changing_image_colormap(make_napari_viewer):
@@ -197,7 +191,6 @@ def test_changing_image_colormap(make_napari_viewer):
     np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
 
 
-@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_changing_image_gamma(make_napari_viewer):
@@ -228,7 +221,6 @@ def test_changing_image_gamma(make_napari_viewer):
     assert screenshot[center + (0,)] < 80
 
 
-@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_grid_mode(make_napari_viewer):
@@ -360,7 +352,6 @@ def test_changing_image_attenuation(make_napari_viewer):
     assert zero_att_value < more_att_value < mip_value
 
 
-@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_labels_painting(make_napari_viewer):
@@ -434,7 +425,6 @@ def test_labels_painting(make_napari_viewer):
     assert screenshot[:, :, :2].max() > 0
 
 
-@slow(30)
 @pytest.mark.skip("Welcome visual temporarily disabled")
 @skip_on_win_ci
 @skip_local_popups
@@ -460,7 +450,6 @@ def test_welcome(make_napari_viewer):
     assert screenshot[..., :-1].max() > 0
 
 
-@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_axes_visible(make_napari_viewer):
@@ -485,7 +474,6 @@ def test_axes_visible(make_napari_viewer):
     np.testing.assert_almost_equal(launch_screenshot, off_screenshot)
 
 
-@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_scale_bar_visible(make_napari_viewer):
@@ -510,7 +498,6 @@ def test_scale_bar_visible(make_napari_viewer):
     np.testing.assert_almost_equal(launch_screenshot, off_screenshot)
 
 
-@slow(30)
 @skip_on_win_ci
 @skip_local_popups
 def test_screenshot_has_no_border(make_napari_viewer):

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -209,19 +209,3 @@ def check_layer_world_data_extent(
     translated_world_extent = np.add(scaled_world_extent, translate)
     np.testing.assert_almost_equal(layer.extent.data, extent)
     np.testing.assert_almost_equal(layer.extent.world, translated_world_extent)
-
-
-def slow(timeout):
-    """
-    Both mark a function as slow, and with a timeout which is easily scalable
-    via an env variable.
-    """
-    factor = int(os.getenv('NAPARI_TESTING_TIMEOUT_SCALING', '1'))
-
-    def _slow(func):
-
-        func = pytest.mark.timeout(timeout * factor)(func)
-        func = pytest.mark.slow(func)
-        return func
-
-    return _slow

--- a/napari/_vispy/_tests/test_image_rendering.py
+++ b/napari/_vispy/_tests/test_image_rendering.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from napari._tests.utils import skip_on_win_ci, slow
+from napari._tests.utils import skip_on_win_ci
 
 
 def test_image_rendering(make_napari_viewer):
@@ -39,7 +39,6 @@ def test_image_rendering(make_napari_viewer):
     assert layer.rendering == 'additive'
 
 
-@slow(15)
 @skip_on_win_ci
 def test_visibility_consistency(qtbot, make_napari_viewer):
     """Make sure toggling visibility maintains image contrast.

--- a/napari/_vispy/_tests/test_vispy_big_images.py
+++ b/napari/_vispy/_tests/test_vispy_big_images.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from napari._tests.utils import slow
-
 
 def test_big_2D_image(make_napari_viewer):
     """Test big 2D image with axis exceeding max texture size."""
@@ -32,7 +30,6 @@ def test_big_3D_image(make_napari_viewer):
         assert np.all(layer._transforms['tile2data'].scale == s)
 
 
-@slow(10)
 @pytest.mark.parametrize(
     "shape",
     [(2, 4), (256, 4048), (4, 20_000), (20_000, 4)],

--- a/napari/layers/image/_tests/test_big_image_timing.py
+++ b/napari/layers/image/_tests/test_big_image_timing.py
@@ -8,35 +8,27 @@ data_dask = da.random.random(
     size=(100_000, 1000, 1000), chunks=(1, 1000, 1000)
 )
 data_zarr = zarr.zeros((100_000, 1000, 1000))
-data_dask_2D = da.random.random((100_000, 100_000))
 
 
-@pytest.mark.parametrize('data', [data_dask, data_zarr])
-def test_timing_fast_big_dask_all_specified_(data):
-    layer = Image(data, multiscale=False, contrast_limits=[0, 1])
-    assert layer.data.shape == data.shape
-
-
-@pytest.mark.parametrize('data', [data_dask, data_zarr])
-def test_timing_fast_big_dask_multiscale_specified(data):
-    layer = Image(data, multiscale=False)
-    assert layer.data.shape == data.shape
-
-
-@pytest.mark.parametrize('data', [data_dask, data_zarr])
-def test_timing_fast_big_dask_contrast_limits_specified(data):
-    layer = Image(data, contrast_limits=[0, 1])
-    assert layer.data.shape == data.shape
-
-
-@pytest.mark.parametrize('data', [data_dask, data_zarr])
-def test_timing_fast_big_dask_nothing_specified(data):
-    layer = Image(data)
-    assert layer.data.shape == data.shape
+@pytest.mark.timeout(2)
+@pytest.mark.parametrize(
+    'kwargs',
+    [
+        dict(multiscale=False, contrast_limits=[0, 1]),
+        dict(multiscale=False),
+        dict(contrast_limits=[0, 1]),
+        {},
+    ],
+    ids=('all', 'multiscale', 'clims', 'nothing'),
+)
+@pytest.mark.parametrize('data', [data_dask, data_zarr], ids=('dask', 'zarrs'))
+def test_timing_fast_big_dask(data, kwargs):
+    assert Image(data, **kwargs).data.shape == data.shape
 
 
 def test_non_visible_images():
     """Test loading non-visible images doesn't trigger compute."""
+    data_dask_2D = da.random.random((100_000, 100_000))
     layer = Image(
         data_dask_2D,
         visible=False,

--- a/napari/layers/image/_tests/test_big_image_timing.py
+++ b/napari/layers/image/_tests/test_big_image_timing.py
@@ -11,35 +11,30 @@ data_zarr = zarr.zeros((100_000, 1000, 1000))
 data_dask_2D = da.random.random((100_000, 100_000))
 
 
-@pytest.mark.timeout(2)
 @pytest.mark.parametrize('data', [data_dask, data_zarr])
 def test_timing_fast_big_dask_all_specified_(data):
     layer = Image(data, multiscale=False, contrast_limits=[0, 1])
     assert layer.data.shape == data.shape
 
 
-@pytest.mark.timeout(2)
 @pytest.mark.parametrize('data', [data_dask, data_zarr])
 def test_timing_fast_big_dask_multiscale_specified(data):
     layer = Image(data, multiscale=False)
     assert layer.data.shape == data.shape
 
 
-@pytest.mark.timeout(2)
 @pytest.mark.parametrize('data', [data_dask, data_zarr])
 def test_timing_fast_big_dask_contrast_limits_specified(data):
     layer = Image(data, contrast_limits=[0, 1])
     assert layer.data.shape == data.shape
 
 
-@pytest.mark.timeout(2)
 @pytest.mark.parametrize('data', [data_dask, data_zarr])
 def test_timing_fast_big_dask_nothing_specified(data):
     layer = Image(data)
     assert layer.data.shape == data.shape
 
 
-@pytest.mark.timeout(2)
 def test_non_visible_images():
     """Test loading non-visible images doesn't trigger compute."""
     layer = Image(

--- a/napari/layers/image/_tests/test_image_utils.py
+++ b/napari/layers/image/_tests/test_image_utils.py
@@ -91,6 +91,5 @@ def test_guess_multiscale_incorrect_order():
         _, _ = guess_multiscale(data)
 
 
-@pytest.mark.timeout(2)
 def test_timing_multiscale_big():
     assert not guess_multiscale(data_dask)[0]

--- a/napari/layers/image/_tests/test_image_utils.py
+++ b/napari/layers/image/_tests/test_image_utils.py
@@ -91,5 +91,6 @@ def test_guess_multiscale_incorrect_order():
         _, _ = guess_multiscale(data)
 
 
+@pytest.mark.timeout(2)  # TODO: test that we're not computing more directly
 def test_timing_multiscale_big():
     assert not guess_multiscale(data_dask)[0]

--- a/napari/layers/image/experimental/_tests/test_octree_import.py
+++ b/napari/layers/image/experimental/_tests/test_octree_import.py
@@ -2,8 +2,6 @@ import os
 import subprocess
 import sys
 
-from napari._tests.utils import slow
-
 CREATE_VIEWER_SCRIPT = """
 import numpy as np
 import napari
@@ -11,7 +9,6 @@ v = napari.view_image(np.random.rand(512, 512))
 """
 
 
-@slow(15)
 def test_octree_import():
     """Test we can create a viewer with NAPARI_OCTREE."""
 

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -688,6 +688,7 @@ def test_paint_2d():
     assert np.sum(layer.data[5:26, 17:38] == 7) == 349
 
 
+@pytest.mark.timeout(1)  # TODO: see if we can test this more directly
 def test_paint_2d_xarray():
     """Test the memory usage of painting an xarray indirectly via timeout."""
     data = xr.DataArray(np.zeros((3, 3, 1024, 1024), dtype=np.uint32))

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -688,7 +688,6 @@ def test_paint_2d():
     assert np.sum(layer.data[5:26, 17:38] == 7) == 349
 
 
-@pytest.mark.timeout(1)
 def test_paint_2d_xarray():
     """Test the memory usage of painting an xarray indirectly via timeout."""
     data = xr.DataArray(np.zeros((3, 3, 1024, 1024), dtype=np.uint32))

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -16,7 +16,9 @@ from napari.layers.utils.layer_utils import (
 data_dask = da.random.random(
     size=(100_000, 1000, 1000), chunks=(1, 1000, 1000)
 )
-
+data_dask_8b = da.random.randint(
+    0, 100, size=(1_000, 10, 10), chunks=(1, 10, 10), dtype=np.uint8
+)
 data_dask_1d = da.random.random(size=(20_000_000,), chunks=(5000,))
 
 data_dask_1d_rgb = da.random.random(size=(5_000_000, 3), chunks=(50_000, 3))
@@ -66,34 +68,13 @@ def test_calc_data_range():
     assert np.all(clim == [0, 2])
 
 
-def test_calc_data_fast_uint8():
-    data = da.random.randint(
-        0,
-        100,
-        size=(1_000, 10, 10),
-        chunks=(1, 10, 10),
-        dtype=np.uint8,
-    )
-    assert calc_data_range(data) == [0, 255]
-
-
-def test_calc_data_range_fast_big():
-    val = calc_data_range(data_dask)
-    assert len(val) > 0
-
-
-def test_calc_data_range_fast_big_1d():
-    val = calc_data_range(data_dask_1d)
-    assert len(val) > 0
-
-
-def test_calc_data_range_fast_big_1d_rgb():
-    val = calc_data_range(data_dask_1d_rgb)
-    assert len(val) > 0
-
-
-def test_calc_data_range_fast_big_plane():
-    val = calc_data_range(data_dask_plane)
+@pytest.mark.timeout(2)
+@pytest.mark.parametrize(
+    'data',
+    [data_dask_8b, data_dask, data_dask_1d, data_dask_1d_rgb, data_dask_plane],
+)
+def test_calc_data_range_fast(data):
+    val = calc_data_range(data)
     assert len(val) > 0
 
 

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -68,7 +68,7 @@ def test_calc_data_range():
     assert np.all(clim == [0, 2])
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.timeout(2)  # TODO: test this more directly
 @pytest.mark.parametrize(
     'data',
     [data_dask_8b, data_dask, data_dask_1d, data_dask_1d_rgb, data_dask_plane],

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -77,25 +77,21 @@ def test_calc_data_fast_uint8():
     assert calc_data_range(data) == [0, 255]
 
 
-@pytest.mark.timeout(2)
 def test_calc_data_range_fast_big():
     val = calc_data_range(data_dask)
     assert len(val) > 0
 
 
-@pytest.mark.timeout(2)
 def test_calc_data_range_fast_big_1d():
     val = calc_data_range(data_dask_1d)
     assert len(val) > 0
 
 
-@pytest.mark.timeout(2)
 def test_calc_data_range_fast_big_1d_rgb():
     val = calc_data_range(data_dask_1d_rgb)
     assert len(val) > 0
 
 
-@pytest.mark.timeout(2)
 def test_calc_data_range_fast_big_plane():
     val = calc_data_range(data_dask_plane)
     assert len(val) > 0

--- a/napari/plugins/_tests/test_plugins_manager.py
+++ b/napari/plugins/_tests/test_plugins_manager.py
@@ -8,10 +8,7 @@ from napari_plugin_engine import napari_hook_implementation
 if TYPE_CHECKING:
     from napari.plugins._plugin_manager import NapariPluginManager
 
-from napari._tests.utils import slow
 
-
-@slow(15)
 def test_plugin_discovery_is_delayed():
     """Test that plugins are not getting discovered at napari import time."""
     cmd = [

--- a/napari/utils/_tests/test_magicgui.py
+++ b/napari/utils/_tests/test_magicgui.py
@@ -8,7 +8,7 @@ import pytest
 from magicgui import magicgui
 
 from napari import Viewer, layers, types
-from napari._tests.utils import layer_test_data, slow
+from napari._tests.utils import layer_test_data
 from napari.layers import Image, Labels, Layer
 from napari.utils.misc import all_subclasses
 
@@ -67,7 +67,6 @@ def test_magicgui_add_data(make_napari_viewer, LayerType, data, ndim):
     assert viewer.layers[0].source.widget == add_data
 
 
-@slow(10)
 @pytest.mark.skipif(
     sys.version_info < (3, 9), reason='Futures not subscriptable before py3.9'
 )
@@ -157,7 +156,6 @@ def test_magicgui_get_data(make_napari_viewer, LayerType, data, ndim):
     viewer.add_layer(layer)
 
 
-@slow(10)
 @pytest.mark.parametrize('LayerType, data, ndim', test_data)
 def test_magicgui_add_layer(make_napari_viewer, LayerType, data, ndim):
     viewer = make_napari_viewer()

--- a/napari/utils/_tests/test_theme.py
+++ b/napari/utils/_tests/test_theme.py
@@ -4,7 +4,6 @@ import sys
 import pytest
 from pydantic import ValidationError
 
-from napari._tests.utils import slow
 from napari.settings import get_settings
 from napari.utils.theme import (
     Theme,
@@ -102,7 +101,6 @@ def test_rebuild_theme_settings():
     settings.appearance.theme = "another-theme"
 
 
-@slow(15)
 @pytest.mark.skipif(
     os.getenv('CI') and sys.version_info < (3, 9),
     reason="Testing theme on CI is extremely slow ~ 15s per test."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,5 +106,4 @@ filterwarnings = [
 markers = [
     "sync_only: Test should only be run synchronously",
     "async_only: Test should only be run asynchronously",
-    "slow: Slow test you can skip with `-m 'not slow'`, or adjust with the env variable NAPARI_TESTING_TIMEOUT_SCALING"
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,7 +98,6 @@ testing =
     pytest-faulthandler
     pytest-order
     pytest-qt
-    pytest-timeout
     hypothesis>=6.8.0
     pandas
     xarray

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,6 +98,7 @@ testing =
     pytest-faulthandler
     pytest-order
     pytest-qt
+    pytest-timeout
     hypothesis>=6.8.0
     pandas
     xarray


### PR DESCRIPTION
# Description
this PR removes pytest-timeout from our test dependencies.  I think it's caused more trouble than it's worth... even the readme states:

> **This is not the timeout you are looking for!**
>
> Warning
>
> Please read this README carefully and only use this plugin if you understand the consequences. Remember your test suite needs to be fast, timeouts are a last resort not an expected failure mode.

Given how many threading-sensitive things we have going on here, i think adding this one should be a last resort, most likely used locally for debugging, but not as a routine component of our CI.

