### PR TITLE
Add sequence support to more Dims setters

### DIFF
--- a/napari/components/_tests/test_dims.py
+++ b/napari/components/_tests/test_dims.py
@@ -105,6 +105,13 @@ def test_point_variable_step_size():
     assert dims.current_step == (0, 0, 2)
     assert dims.point == (0, 0, 4)
 
+    # mismatched len(axis) vs. len(value)
+    with pytest.raises(ValueError):
+        dims.set_point((0, 1), (0, 0, 0))
+
+    with pytest.raises(ValueError):
+        dims.set_current_step((0, 1), (0, 0, 0))
+
 
 def test_range():
     """
@@ -153,6 +160,10 @@ def test_axis_labels():
 
     dims.set_axis_label((0, 1, 3), ('t', 'c', 'last'))
     assert dims.axis_labels == ('t', 'c', '2', 'last')
+
+    # mismatched len(axis) vs. len(value)
+    with pytest.raises(ValueError):
+        dims.set_point((0, 1), ('x', 'y', 'z'))
 
 
 def test_order_when_changing_ndim():

--- a/napari/components/_tests/test_dims.py
+++ b/napari/components/_tests/test_dims.py
@@ -70,13 +70,40 @@ def test_point():
     dims = Dims(ndim=4)
     assert dims.point == (0,) * 4
 
-    dims.set_range(3, (0, 5, 1))
+    dims.set_range(range(dims.ndim), ((0, 5, 1),) * dims.ndim)
     dims.set_point(3, 4)
     assert dims.point == (0, 0, 0, 4)
 
-    dims.set_range(2, (0, 5, 1))
     dims.set_point(2, 1)
     assert dims.point == (0, 0, 1, 4)
+
+    dims.set_point((0, 1, 2), (2.1, 2.6, 0.0))
+    assert dims.point == (2, 3, 0, 4)
+
+
+def test_point_variable_step_size():
+    dims = Dims(ndim=3)
+    assert dims.point == (0,) * 3
+
+    desired_range = ((0, 6, 0.5), (0, 6, 1), (0, 6, 2))
+    dims.set_range(range(3), desired_range)
+    assert dims.range == desired_range
+
+    # set point updates current_step indirectly
+    dims.set_point([0, 1, 2], (2.9, 2.9, 2.9))
+    assert dims.current_step == (6, 3, 1)
+    # point is a property computed on demand from current_step
+    assert dims.point == (3, 3, 2)
+
+    # can set step directly as well
+    # note that out of range values get clipped
+    dims.set_current_step((0, 1, 2), (1, -3, 5))
+    assert dims.current_step == (1, 0, 2)
+    assert dims.point == (0.5, 0, 4)
+
+    dims.set_current_step(0, -1)
+    assert dims.current_step == (0, 0, 2)
+    assert dims.point == (0, 0, 4)
 
 
 def test_range():
@@ -120,6 +147,12 @@ def test_range_set_multiple():
 def test_axis_labels():
     dims = Dims(ndim=4)
     assert dims.axis_labels == ('0', '1', '2', '3')
+
+    dims.set_axis_label(0, 't')
+    assert dims.axis_labels == ('t', '1', '2', '3')
+
+    dims.set_axis_label((0, 1, 3), ('t', 'c', 'last'))
+    assert dims.axis_labels == ('t', 'c', '2', 'last')
 
 
 def test_order_when_changing_ndim():

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -195,13 +195,13 @@ class Dims(EventedModel):
             Sequence[Union[int, float]], Sequence[Sequence[Union[int, float]]]
         ],
     ):
-        """Sets the range (min, max, step) for a given dimension.
+        """Sets ranges (min, max, step) for the given dimensions.
 
         Parameters
         ----------
         axis : int or sequence of int
             Dimension index or a sequence of axes whos range will be set.
-        _range : tuple
+        _range : tuple or sequence of tuple
             Range specified as (min, max, step) or a sequence of these range
             tuples.
         """
@@ -213,7 +213,7 @@ class Dims(EventedModel):
                 self.range = full_range
         else:
             full_range = list(self.range)
-            _range = list(_range)  # type: ignore
+            _range = tuple(_range)  # type: ignore
             axis = tuple(axis)  # type: ignore
             if len(axis) != len(_range):
                 raise ValueError(
@@ -225,7 +225,11 @@ class Dims(EventedModel):
                     full_range[ax] = r
                 self.range = full_range
 
-    def set_point(self, axis: int, value: Union[int, float]):
+    def set_point(
+        self,
+        axis: Union[int, Sequence[int]],
+        value: Union[Union[int, float], Sequence[Union[int, float]]],
+    ):
         """Sets point to slice dimension in world coordinates.
 
         The desired point gets transformed into an integer step
@@ -233,54 +237,105 @@ class Dims(EventedModel):
 
         Parameters
         ----------
-        axis : int
-            Dimension index.
-        value : int or float
-            Value of the point.
+        axis : int or sequence of int
+            Dimension index or a sequence of axes whos point will be set.
+        value : scalar or sequence of scalars
+            Value of the point for each axis.
         """
-        axis = assert_axis_in_bounds(axis, self.ndim)
-        (min_val, max_val, step_size) = self.range[axis]
-        raw_step = (value - min_val) / step_size
-        self.set_current_step(axis, raw_step)
+        if isinstance(axis, Integral):
+            axis = assert_axis_in_bounds(axis, self.ndim)  # type: ignore
+            (min_val, max_val, step_size) = self.range[axis]
+            raw_step = (value - min_val) / step_size
+            self.set_current_step(axis, raw_step)
+        else:
+            value = tuple(value)  # type: ignore
+            axis = tuple(axis)  # type: ignore
+            if len(axis) != len(value):
+                raise ValueError(
+                    "axis and value sequences must have equal length"
+                )
+            raw_steps = []
+            for ax, val in zip(axis, value):
+                ax = assert_axis_in_bounds(int(ax), self.ndim)
+                min_val, _, step_size = self.range[ax]
+                raw_steps.append((val - min_val) / step_size)
+            self.set_current_step(axis, raw_steps)
 
-    def set_current_step(self, axis: int, value: int):
-        """Sets the slider step at which to slice this dimension.
+    def set_current_step(
+        self,
+        axis: Union[int, Sequence[int]],
+        value: Union[Union[int, float], Sequence[Union[int, float]]],
+    ):
+        """Set the slider steps at which to slice this dimension.
 
         The position of the slider in world coordinates gets
         calculated from the current_step of the slider.
 
         Parameters
         ----------
-        axis : int
-            Dimension index.
-        value : int or float
-            Value of the point.
+        axis : int or sequence of int
+            Dimension index or a sequence of axes whos step will be set.
+        value : scalar or sequence of scalars
+            Value of the step for each axis.
         """
-        axis = assert_axis_in_bounds(axis, self.ndim)
-        step = np.round(np.clip(value, 0, self.nsteps[axis] - 1)).astype(int)
-
-        if self.current_step[axis] != step:
+        if isinstance(axis, Integral):
+            axis = assert_axis_in_bounds(axis, self.ndim)
+            step = round(min(max(value, 0), self.nsteps[axis] - 1))
+            if self.current_step[axis] != step:
+                full_current_step = list(self.current_step)
+                full_current_step[axis] = step
+                self.current_step = full_current_step
+        else:
             full_current_step = list(self.current_step)
-            full_current_step[axis] = step
-            self.current_step = full_current_step
-        self.last_used = axis
+            value = tuple(value)  # type: ignore
+            axis = tuple(axis)  # type: ignore
+            if len(axis) != len(value):
+                raise ValueError(
+                    "axis and value sequences must have equal length"
+                )
+            if value != full_current_step:
+                # (computed) nsteps property outside of the loop for efficiency
+                nsteps = self.nsteps
+                for ax, val in zip(axis, value):
+                    ax = assert_axis_in_bounds(int(ax), self.ndim)
+                    step = round(min(max(val, 0), nsteps[ax] - 1))
+                    full_current_step[ax] = step
+                self.current_step = full_current_step
 
-    def set_axis_label(self, axis: int, label: str):
-        """Sets a new axis label for the given axis.
+    def set_axis_label(
+        self,
+        axis: Union[int, Sequence[int]],
+        label: Union[str, Sequence[str]],
+    ):
+        """Sets new axis labels for the given axes.
 
         Parameters
         ----------
-        axis : int
-            Dimension index
-        label : str
-            Given label
+        axis : int or sequence of int
+            Dimension index or a sequence of axes whos labels will be set.
+        label : str or sequence of str
+            Given labels for the specified axes.
         """
-        axis = assert_axis_in_bounds(axis, self.ndim)
-        if self.axis_labels[axis] != str(label):
+        if isinstance(axis, Integral):
+            axis = assert_axis_in_bounds(axis, self.ndim)
+            if self.axis_labels[axis] != str(label):
+                full_axis_labels = list(self.axis_labels)
+                full_axis_labels[axis] = str(label)
+                self.axis_labels = full_axis_labels
+            self.last_used = axis
+        else:
             full_axis_labels = list(self.axis_labels)
-            full_axis_labels[axis] = str(label)
-            self.axis_labels = full_axis_labels
-        self.last_used = axis
+            label = tuple(label)  # type: ignore
+            axis = tuple(axis)  # type: ignore
+            if len(axis) != len(label):
+                raise ValueError(
+                    "axis and label sequences must have equal length"
+                )
+            if label != full_axis_labels:
+                for ax, val in zip(axis, label):
+                    ax = assert_axis_in_bounds(int(ax), self.ndim)
+                    full_axis_labels[ax] = val
+                self.axis_labels = full_axis_labels
 
     def reset(self):
         """Reset dims values to initial states."""

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -213,7 +213,8 @@ class Dims(EventedModel):
                 self.range = full_range
         else:
             full_range = list(self.range)
-            _range = tuple(_range)  # type: ignore
+            # cast range to list for list comparison below
+            _range = list(_range)  # type: ignore
             axis = tuple(axis)  # type: ignore
             if len(axis) != len(_range):
                 raise ValueError(
@@ -287,7 +288,8 @@ class Dims(EventedModel):
                 self.current_step = full_current_step
         else:
             full_current_step = list(self.current_step)
-            value = tuple(value)  # type: ignore
+            # cast value to list for list comparison below
+            value = list(value)  # type: ignore
             axis = tuple(axis)  # type: ignore
             if len(axis) != len(value):
                 raise ValueError(
@@ -325,7 +327,8 @@ class Dims(EventedModel):
             self.last_used = axis
         else:
             full_axis_labels = list(self.axis_labels)
-            label = tuple(label)  # type: ignore
+            # cast label to list for list comparison below
+            label = list(label)  # type: ignore
             axis = tuple(axis)  # type: ignore
             if len(axis) != len(label):
                 raise ValueError(


### PR DESCRIPTION
Following the update to `Dims.set_range` that allows setting a sequence of range values in one call, it was suggested in https://github.com/napari/napari/pull/3677#issuecomment-978728615 to also update `set_point`, `set_current_step` and `set_axis_label` in the same way.

There are a few places in the world coordinates tests that call `set_current_step` in a loop, but I did not find any user-facing napari code where we could replace a loop as we did for `set_range`. 

I removed setting `self.last_used` within `set_current_step` since that was previously done for the `set_range` case. 

I did also make one minor performance refactor in `set_current_step` to go from
```Python
np.round(np.clip(value, 0, self.nsteps[axis] -1).astype(int)
```
to
```Python
round(min(max(value, 0), self.nsteps[axis] - 1))
```
which is much more efficient for use with scalar `value` (~250 ns vs 10 microseconds)

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] new test cases were added that call these setters with sequence arguments

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
