### PR TITLE
Add support for property.setters to EventedModel

### DIFF
--- a/napari/utils/events/_tests/test_evented_model.py
+++ b/napari/utils/events/_tests/test_evented_model.py
@@ -1,6 +1,6 @@
 import inspect
 from enum import auto
-from typing import ClassVar
+from typing import ClassVar, List, Sequence
 from unittest.mock import Mock
 
 import dask.array as da
@@ -373,3 +373,53 @@ def test_evented_model_with_string_enum_parse_obj():
     model = ModelWithStringEnum(enum_field=SomeStringEnum.SOME_VALUE)
     deserialized_model = ModelWithStringEnum.parse_obj(model.dict())
     assert deserialized_model.enum_field == model.enum_field
+
+
+def test_evented_model_with_property_setters():
+    class T(EventedModel, dependencies={'c': ['a', 'b']}):
+        a: int = 1
+        b: int = 1
+
+        @property
+        def c(self) -> List[int]:
+            return [self.a, self.b]
+
+        @c.setter
+        def c(self, val: Sequence[int]):
+            self.a, self.b = val
+
+    t = T()
+
+    # all the fields and properties behave as expected
+    assert t.c == [1, 1]
+    t.a = 4
+    assert t.c == [4, 1]
+    t.c = [2, 3]
+    assert t.c == [2, 3]
+    assert t.a == 2
+    assert t.b == 3
+
+    assert 'c' in t.events  # the setter has an event
+    t.events.a = Mock(t.events.a)
+    t.events.b = Mock(t.events.b)
+    t.events.c = Mock(t.events.c)
+
+    # setting t.c emits events for all three a, b, and c
+    t.c = [10, 20]
+    t.events.a.assert_called_with(value=10)
+    t.events.b.assert_called_with(value=20)
+    t.events.c.assert_called_with(value=[10, 20])
+    assert t.a == 10
+    assert t.b == 20
+
+    t.events.a.reset_mock()
+    t.events.b.reset_mock()
+    t.events.c.reset_mock()
+
+    # setting t.a emits events for a and c, but not b
+    # this is because we declared c to be dependent on ['a', 'b']
+    t.a = 5
+    t.events.a.assert_called_with(value=5)
+    t.events.c.assert_called_with(value=[5, 20])
+    t.events.b.assert_not_called()
+    assert t.c == [5, 20]

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -125,7 +125,7 @@ def _get_field_dependents(cls: 'EventedModel') -> Dict[str, Set[str]]:
             class Config:
                 dependencies={'c': ['a', 'b']}
     """
-    if cls.__property_setters__:
+    if not cls.__property_setters__:
         return {}
 
     deps: Dict[str, Set[str]] = {}

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -144,9 +144,9 @@ def _get_field_dependents(cls: 'EventedModel') -> Dict[str, Set[str]]:
                 deps.setdefault(field, set()).add(prop)
     else:
         # if dependencies haven't been explicitly defined, we can glean
-        # them from the property.fset code object:
+        # them from the property.fget code object:
         for prop, setter in cls.__property_setters__.items():
-            for name in setter.fset.__code__.co_names:
+            for name in setter.fget.__code__.co_names:
                 if name in cls.__fields__:
                     deps.setdefault(name, set()).add(prop)
     return deps


### PR DESCRIPTION
# Description
I was starting to take another look at converting layers to EventedModels, and realized that it's become a lot harder since so many of the transformation fields are essentially computed properties.  This is the same problem that @alisterburt noted [on zulip](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/pydantic.20model.20with.20settable.20property) and in #3586 ... so this is a stab at solving that problem for EventedModel:

it works as follows:
- in `EventedModel.__setatttr__`, if the attribute being set is not a field (i.e. not `self.__fields__`), but it _does_ have an `@prop.setter` declared, then that setter is called.  (`prop` here is essentially a non-model field, so validation will only occur in the setter method itself, or, if it in turn sets model fields)
- props with setters _will_ have events, and they will be emitted when the setter is used.
- **edit**: those computed property events will _also_ be emitted when one of the fields it depends on to compute its property changes:
```py
    # the c property uses fields a and b...
    # events.c will be emitted whenever a or b changes
    class T(EventedModel):
        a: int = 1
        b: int = 1

        @property
        def c(self) -> List[int]:
            return [self.a, self.b]

        @c.setter
        def c(self, val: Sequence[int]):
            self.a, self.b = val
```

see [the test](https://github.com/napari/napari/pull/3711/files#diff-b58cc474cea833078bb33f084fd8b57579d86293c34416ae6aa6d0c587939423R378) for an example.
@sofroniewn, curious if you think this would work for the transforms on the base layer, and @alisterburt, curious if this would have worked for the camera model

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
see also https://github.com/samuelcolvin/pydantic/issues/935 ... which has been open for quite a while.

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
