### PR TITLE
Add a button linking to the plugin homepage in the plugin installer dialog

### DIFF
--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -268,6 +268,9 @@ class Installer(QObject):
             except KeyError:
                 pass
 
+    def help(self):
+        pass # not sure why this is necessary, but it crashes without
+
     @staticmethod
     def _is_installed_with_conda():
         """
@@ -318,6 +321,9 @@ class PluginListItem(QFrame):
         self.summary.setText(summary)
         self.package_author.setText(author)
         self.cancel_btn.setVisible(False)
+
+        self.help_button.setText(trans._("Website"))
+        self.help_button.setObjectName("help_button")
 
         if installed:
             self.enabled_checkbox.show()
@@ -397,6 +403,7 @@ class PluginListItem(QFrame):
         self.update_btn.setObjectName("install_button")
         self.row1.addWidget(self.update_btn)
         self.update_btn.setVisible(False)
+        self.help_button = QPushButton(self)
         self.action_button = QPushButton(self)
         sizePolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         sizePolicy.setHorizontalStretch(0)
@@ -404,7 +411,9 @@ class PluginListItem(QFrame):
         sizePolicy.setHeightForWidth(
             self.action_button.sizePolicy().hasHeightForWidth()
         )
+        self.help_button.setSizePolicy(sizePolicy)
         self.action_button.setSizePolicy(sizePolicy)
+        self.row1.addWidget(self.help_button)
         self.row1.addWidget(self.action_button)
         self.v_lay.addLayout(self.row1)
         self.row2 = QHBoxLayout()
@@ -487,6 +496,9 @@ class QPluginList(QListWidget):
         item.setSizeHint(widg.sizeHint())
         self.setItemWidget(item, widg)
 
+        widg.help_button.clicked.connect(
+            lambda: self.handle_action(item, project_info.name, "help")
+        )
         widg.action_button.clicked.connect(
             lambda: self.handle_action(item, project_info.name, action_name)
         )
@@ -524,6 +536,9 @@ class QPluginList(QListWidget):
         elif action_name == "cancel":
             widget.set_busy(trans._("cancelling..."), update)
             method((pkg_name,))
+        elif action_name == "help":
+            import webbrowser
+            webbrowser.open("https://napari-hub.org/plugins/" + pkg_name)
 
     @Slot(ProjectInfo)
     def tag_outdated(self, project_info: ProjectInfo):

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -495,7 +495,10 @@ class QPluginList(QListWidget):
 
         if project_info.url:
             import webbrowser
-            widg.help_button.clicked.connect(lambda: webbrowser.open(project_info.url))
+
+            widg.help_button.clicked.connect(
+                lambda: webbrowser.open(project_info.url)
+            )
         else:
             widg.help_button.setVisible(False)
 

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -268,9 +268,6 @@ class Installer(QObject):
             except KeyError:
                 pass
 
-    def help(self):
-        pass # not sure why this is necessary, but it crashes without
-
     @staticmethod
     def _is_installed_with_conda():
         """
@@ -496,9 +493,12 @@ class QPluginList(QListWidget):
         item.setSizeHint(widg.sizeHint())
         self.setItemWidget(item, widg)
 
-        widg.help_button.clicked.connect(
-            lambda: self.handle_action(item, project_info.name, "help")
-        )
+        if project_info.url:
+            import webbrowser
+            widg.help_button.clicked.connect(lambda: webbrowser.open(project_info.url))
+        else:
+            widg.help_button.setVisible(False)
+
         widg.action_button.clicked.connect(
             lambda: self.handle_action(item, project_info.name, action_name)
         )

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -536,9 +536,6 @@ class QPluginList(QListWidget):
         elif action_name == "cancel":
             widget.set_busy(trans._("cancelling..."), update)
             method((pkg_name,))
-        elif action_name == "help":
-            import webbrowser
-            webbrowser.open("https://napari-hub.org/plugins/" + pkg_name)
 
     @Slot(ProjectInfo)
     def tag_outdated(self, project_info: ProjectInfo):


### PR DESCRIPTION
# Description

Hi all,

this PR is a suggestion for the plugin installer dialog. It adds a `Website` button which links to the `napari hub` page of a given plugin:
 
![image](https://user-images.githubusercontent.com/12660498/143884346-d04e04f0-4c2a-415f-9de0-41fbb0894c08.png)

This could be helpful in case an installation fails for example.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] I tested this manually

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).

It would be cool if somebody could comment on my code. I assume for example that the "http://napari..." string should live somewhere else, but I'm not sure where.

Let me know what you think!

Best,
Robert