### PR TITLE
more efficient computation of displayed dimension order

### DIFF
--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -183,9 +183,9 @@ class Dims(EventedModel):
 
     @property
     def displayed_order(self) -> Tuple[int, ...]:
-        """Tuple: Order of only displayed dimensions."""
-        order = np.array(self.displayed)
-        order[np.argsort(order)] = list(range(len(order)))
+        displayed = self.displayed
+        # equivalent to: order = np.argsort(self.displayed)
+        order = sorted(range(self.ndisplay), key=lambda x: displayed[x])
         return tuple(order)
 
     def set_range(
@@ -359,9 +359,8 @@ def reorder_after_dim_reduction(order):
         The original array with the unneeded dimension
         thrown away.
     """
-    arr = np.array(order)
-    arr[np.argsort(arr)] = range(len(arr))
-    return tuple(arr.tolist())
+    arr = sorted(range(len(order)), key=lambda x: order[x])
+    return tuple(arr)
 
 
 def assert_axis_in_bounds(axis: int, ndim: int) -> int:

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -185,7 +185,7 @@ class Dims(EventedModel):
     def displayed_order(self) -> Tuple[int, ...]:
         displayed = self.displayed
         # equivalent to: order = np.argsort(self.displayed)
-        order = sorted(range(self.ndisplay), key=lambda x: displayed[x])
+        order = sorted(range(len(displayed)), key=lambda x: displayed[x])
         return tuple(order)
 
     def set_range(

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -11,7 +11,6 @@ import magicgui as mgui
 import numpy as np
 
 from ..._vendor.cpython.functools import cached_property
-from ...components.dims import reorder_after_dim_reduction
 from ...utils._dask_utils import configure_dask
 from ...utils._magicgui import add_layer_to_viewer, get_layers
 from ...utils.events import EmitterGroup, Event
@@ -626,6 +625,8 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         This function needs to be called whenever data or transform information
         changes, and should be called before events get emitted.
         """
+        from ...components.dims import reorder_after_dim_reduction
+
         ndim = self._get_ndim()
 
         old_ndim = self._ndim

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -617,7 +617,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         # for additional discussion.
         displayed = self._dims_displayed
         # equivalent to: order = np.argsort(displayed)
-        order = sorted(range(self._ndisplay), key=lambda x: displayed[x])
+        order = sorted(range(len(displayed)), key=lambda x: displayed[x])
         return tuple(order)
 
     def _update_dims(self, event=None):

--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -427,8 +427,9 @@ class Shape(ABC):
                     )
                 j += 1
             # equivalent to: displayed_order = np.argsort(self.dims_displayed)
+            dims_displayed = self.dims_displayed
             displayed_order = sorted(
-                range(self.ndisplay), key=lambda x: self.dims_displayed[x]
+                range(len(dims_displayed)), key=lambda x: dims_displayed[x]
             )
             mask[tuple(slice_key)] = mask_p.transpose(displayed_order)
         else:

--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from copy import copy
 
 import numpy as np
 
@@ -427,9 +426,9 @@ class Shape(ABC):
                         self.slice_key[0, j], self.slice_key[1, j] + 1
                     )
                 j += 1
-            displayed_order = np.array(copy(self.dims_displayed))
-            displayed_order[np.argsort(displayed_order)] = list(
-                range(len(displayed_order))
+            # equivalent to: displayed_order = np.argsort(self.dims_displayed)
+            displayed_order = sorted(
+                range(self.ndisplay), key=lambda x: self.dims_displayed[x]
             )
             mask[tuple(slice_key)] = mask_p.transpose(displayed_order)
         else:


### PR DESCRIPTION
# Description

This PR is just a minor efficiency refactor. I noticed that `Dims.displayed_order` calculates the order in an inefficient way. I saw that the same logic was also used by `Layer._dims_displayed_order`.

Some searching of the code turned up the same pattern in a couple of other places as well.

## Type of change

minor refactor without change in functionality

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change

I created standalone functions corresponding to the old and new implementations
and tested equivalence with

```Python
import itertools

import numpy as np

def displayed_order_old(displayed):
    order = np.array(displayed)
    order[np.argsort(order)] = list(range(len(order)))
    return tuple(order)


def displayed_order_new(displayed):
    order = sorted(range(len(displayed)), key=lambda x: displayed[x])
    return tuple(order)


for displayed in itertools.permutations(range(5), 2):
    assert displayed_order_old(displayed) == displayed_order_new(displayed)

```

and to verify performance
```
displayed = (3, 2)

In [6]: %timeit displayed_order_old(displayed)
2.82 µs ± 16.4 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [7]: %timeit displayed_order_new(displayed)
493 ns ± 3.63 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```


## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
