### PR TITLE
Fix link to myst-parser documentation

### DIFF
--- a/docs/ORGANIZATION.md
+++ b/docs/ORGANIZATION.md
@@ -5,7 +5,7 @@ the [`napari/napari`] repo which houses the source code for napari, the [`napari
 
 ## Location of documentation sources
 
-API docs, guides, plugins, roadmaps, releases, developer guides, developer resources, and community resources live in the [`napari/napari`] repo under the `docs` directory. For backwards compatibility with the previous structure as used in [`napari/docs`], some files are "duplicated" by using the [MyST `include` directive](https://myst-parser.readthedocs.io/en/latest/using/howto.html#include-a-file-from-outside-the-docs-folder-like-readme-md).
+API docs, guides, plugins, roadmaps, releases, developer guides, developer resources, and community resources live in the [`napari/napari`] repo under the `docs` directory. For backwards compatibility with the previous structure as used in [`napari/docs`], some files are "duplicated" by using the [MyST `include` directive](https://myst-parser.readthedocs.io/en/latest/sphinx/use.html#include-a-file-from-outside-the-docs-folder-like-readme-md).
 
 Tutorials, the main index page, and the WIP sphinx theme are in the [`napari/napari.github.io`] repo.
 


### PR DESCRIPTION
# Description

This link to the myst-parser documentation website is broken. This PR fixes it to point to the new correct location.

## Type of change
- [x] This change is a documentation update

# References
Related: https://github.com/napari/napari.github.io/pull/293

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] I manually checked the new link does not produce a 404 error. The automated lychee link checker over at the napari.github.io repo is what flagged this issue in the first place, so it should also catch any future breakages.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~If I included new strings, I have used `trans.` to make them localizable.~~
      ~~For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).~~
