### PR TITLE
Initialize viewer point at data center

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -438,7 +438,7 @@ def test_process_mouse_event(make_napari_viewer):
     def on_click(layer, event):
         np.testing.assert_almost_equal(event.view_direction, [0, 1, 0, 0])
         np.testing.assert_array_equal(event.dims_displayed, [1, 2, 3])
-        assert event.dims_point[0] == 0
+        assert event.dims_point[0] == data.shape[0] // 2
 
         expected_position = view._map_canvas2world(new_pos)
         np.testing.assert_almost_equal(expected_position, list(event.position))

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -314,7 +314,7 @@ def test_swappable_dims():
     image_data = np.random.random((7, 12, 10, 15))
     image_name = viewer.add_image(image_data).name
     assert np.all(
-        viewer.layers[image_name]._data_view == image_data[0, 0, :, :]
+        viewer.layers[image_name]._data_view == image_data[3, 6, :, :]
     )
 
     points_data = np.random.randint(6, size=(10, 4))
@@ -325,18 +325,20 @@ def test_swappable_dims():
 
     labels_data = np.random.randint(20, size=(7, 12, 10, 15))
     labels_name = viewer.add_labels(labels_data).name
+    # midpoints indices into the data below depend on the data range.
+    # This depends on the values in vectors_data and thus the random seed.
     assert np.all(
-        viewer.layers[labels_name]._data_raw == labels_data[0, 0, :, :]
+        viewer.layers[labels_name]._data_raw == labels_data[4, 6, :, :]
     )
 
     # Swap dims
     viewer.dims.order = [0, 2, 1, 3]
     assert viewer.dims.order == (0, 2, 1, 3)
     assert np.all(
-        viewer.layers[image_name]._data_view == image_data[0, :, 0, :]
+        viewer.layers[image_name]._data_view == image_data[4, :, 5, :]
     )
     assert np.all(
-        viewer.layers[labels_name]._data_raw == labels_data[0, :, 0, :]
+        viewer.layers[labels_name]._data_raw == labels_data[4, :, 5, :]
     )
 
 

--- a/napari/components/_tests/test_world_coordinates.py
+++ b/napari/components/_tests/test_world_coordinates.py
@@ -97,7 +97,7 @@ def test_warning_affine_slicing():
             data,
             scale=[2, 1, 1],
             translate=[10, 15, 20],
-            shear=[[1, 0, 0], [0, 1, 0], [10, 0, 1]],
+            shear=[[1, 0, 0], [0, 1, 0], [4, 0, 1]],
         )
     assert 'Non-orthogonal slicing is being requested' in str(wrn[0].message)
     with pytest.warns(UserWarning) as recorded_warnings:

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -331,6 +331,10 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             self.cursor.size = active_layer.cursor_size
             self.camera.interactive = active_layer.interactive
 
+    @staticmethod
+    def rounded_division(min_val, max_val, precision):
+        return int(((min_val + max_val) / 2) / precision) * precision
+
     def _on_layers_change(self):
         if len(self.layers) == 0:
             self.dims.ndim = 2
@@ -340,6 +344,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             ndim = len(ranges)
             self.dims.ndim = ndim
             self.dims.set_range(range(ndim), ranges)
+            midpoint = [self.rounded_division(*_range) for _range in ranges]
+            self.dims.set_point(range(ndim), midpoint)
 
         new_dim = self.dims.ndim
         dim_diff = new_dim - len(self.cursor.position)

--- a/napari/layers/_tests/test_dask_layers.py
+++ b/napari/layers/_tests/test_dask_layers.py
@@ -119,7 +119,8 @@ def test_dask_global_optimized_slicing(delayed_dask_stack, monkeypatch):
     v = ViewerModel()
     dask_stack = delayed_dask_stack['stack']
     layer = v.add_image(dask_stack)
-    assert delayed_dask_stack['calls'] == 1  # the first stack will be loaded
+    # the first and the middle stack will be loaded
+    assert delayed_dask_stack['calls'] == 2
 
     with layer.dask_optimized_slicing() as (_, cache):
         assert cache.cache.available_bytes > 0
@@ -133,20 +134,20 @@ def test_dask_global_optimized_slicing(delayed_dask_stack, monkeypatch):
     # since the stack has already been loaded (& it is chunked as a 3D array)
     for i in range(3):
         v.dims.set_point(1, i)
-        assert delayed_dask_stack['calls'] == 1  # still just the first call
+        assert delayed_dask_stack['calls'] == 2  # still just the first call
 
     # changing the timepoint will, of course, incur some compute calls
     v.dims.set_point(0, 1)
-    assert delayed_dask_stack['calls'] == 2
-    v.dims.set_point(0, 2)
     assert delayed_dask_stack['calls'] == 3
+    v.dims.set_point(0, 2)
+    assert delayed_dask_stack['calls'] == 4
 
     # but going back to previous timepoints should not, since they are cached
     v.dims.set_point(0, 1)
     v.dims.set_point(0, 0)
-    assert delayed_dask_stack['calls'] == 3
-    v.dims.set_point(0, 3)
     assert delayed_dask_stack['calls'] == 4
+    v.dims.set_point(0, 3)
+    assert delayed_dask_stack['calls'] == 5
 
 
 @pytest.mark.sync_only
@@ -160,7 +161,8 @@ def test_dask_unoptimized_slicing(delayed_dask_stack, monkeypatch):
     v = ViewerModel()
     dask_stack = delayed_dask_stack['stack']
     layer = v.add_image(dask_stack, cache=False)
-    assert delayed_dask_stack['calls'] == 1
+    # the first and the middle stack will be loaded
+    assert delayed_dask_stack['calls'] == 2
 
     with layer.dask_optimized_slicing() as (_, cache):
         assert cache is None
@@ -170,12 +172,12 @@ def test_dask_unoptimized_slicing(delayed_dask_stack, monkeypatch):
     # even though we've already read this full timepoint.
     for i in range(3):
         v.dims.set_point(1, i)
-        assert delayed_dask_stack['calls'] == 1 + i  # 😞
+        assert delayed_dask_stack['calls'] == 2 + 1 + i  # 😞
 
     # of course we still incur calls when moving to a new timepoint...
     v.dims.set_point(0, 1)
     v.dims.set_point(0, 2)
-    assert delayed_dask_stack['calls'] == 5
+    assert delayed_dask_stack['calls'] == 7
 
     # without the cache we ALSO incur calls when returning to previously loaded
     # timepoints 😭
@@ -184,7 +186,7 @@ def test_dask_unoptimized_slicing(delayed_dask_stack, monkeypatch):
     v.dims.set_point(0, 3)
     # all told, we have ~2x as many calls as the optimized version above.
     # (should be exactly 8 calls, but for some reason, sometimes less on CI)
-    assert delayed_dask_stack['calls'] >= 7
+    assert delayed_dask_stack['calls'] >= 10
 
 
 @pytest.mark.sync_only
@@ -203,19 +205,20 @@ def test_dask_local_unoptimized_slicing(delayed_dask_stack, monkeypatch):
     v = ViewerModel()
     dask_stack = delayed_dask_stack['stack']
     v.add_image(dask_stack, cache=False)
-    assert delayed_dask_stack['calls'] == 1
+    # the first and the middle stack will be loaded
+    assert delayed_dask_stack['calls'] == 2
 
     # without optimized dask slicing, we get a new call to the get_array func
     # (which "re-reads" the full z stack) EVERY time we change the Z plane
     # even though we've already read this full timepoint.
     for i in range(3):
         v.dims.set_point(1, i)
-        assert delayed_dask_stack['calls'] == 1 + i  # 😞
+        assert delayed_dask_stack['calls'] == 2 + 1 + i  # 😞
 
     # of course we still incur calls when moving to a new timepoint...
     v.dims.set_point(0, 1)
     v.dims.set_point(0, 2)
-    assert delayed_dask_stack['calls'] == 5
+    assert delayed_dask_stack['calls'] == 7
 
     # without the cache we ALSO incur calls when returning to previously loaded
     # timepoints 😭
@@ -224,7 +227,7 @@ def test_dask_local_unoptimized_slicing(delayed_dask_stack, monkeypatch):
     v.dims.set_point(0, 3)
     # all told, we have ~2x as many calls as the optimized version above.
     # (should be exactly 8 calls, but for some reason, sometimes less on CI)
-    assert delayed_dask_stack['calls'] >= 7
+    assert delayed_dask_stack['calls'] >= 10
 
 
 @pytest.mark.sync_only


### PR DESCRIPTION
# Description

closes #3559

This PR replaces #3574 (it is updated based on recent changes to main and now focuses only on changing the viewer model's initial point to be at the midpoints of the LayerList's range). The change to include the point widths in the extent for Points layers will be added in a follow up PR.

Note that the increases to 'calls' in `test_dask_layers.py` are now less than in #3574.

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] existing tests pass after updating the initial point position


## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
