### PR TITLE
Add fixed_canvas_size argument to points

### DIFF
--- a/napari/_vispy/layers/points.py
+++ b/napari/_vispy/layers/points.py
@@ -19,10 +19,6 @@ class VispyPointsLayer(VispyBaseLayer):
         node = PointsVisual()
         super().__init__(layer, node)
 
-        # TODO: will be exposed in #3430
-        for i in (0, 1):
-            node._subvisuals[i].scaling = True
-
         self.layer.events.symbol.connect(self._on_symbol_change)
         self.layer.events.edge_width.connect(self._on_data_change)
         self.layer.events.edge_color.connect(self._on_data_change)
@@ -33,6 +29,7 @@ class VispyPointsLayer(VispyBaseLayer):
         self.layer._face.events.color_properties.connect(self._on_data_change)
         self.layer.events.highlight.connect(self._on_highlight_change)
         self.layer.text.events.connect(self._on_text_change)
+        self.layer.events.fixed_size.connect(self._on_fixed_canvas_size_change)
 
         self._on_data_change()
 
@@ -171,12 +168,16 @@ class VispyPointsLayer(VispyBaseLayer):
         text_node.set_gl_state(**text_blending_kwargs)
         self.node.update()
 
+    def _on_fixed_canvas_size_change(self):
+        self.node.scaling = not self.layer.fixed_canvas_size
+
     def reset(self, event=None):
         super().reset()
         self._update_text(update_node=False)
         self._on_blending_change()
         self._on_highlight_change()
         self._on_matrix_change()
+        self._on_fixed_canvas_size_change()
 
     def close(self):
         """Vispy visual is closing."""

--- a/napari/_vispy/visuals/points.py
+++ b/napari/_vispy/visuals/points.py
@@ -25,5 +25,14 @@ class PointsVisual(ClippingPlanesMixin, Compound):
 
     @symbol.setter
     def symbol(self, value):
-        for subv in self._subvisuals[:2]:
-            subv.symbol = value
+        for marker in self._subvisuals[:2]:
+            marker.symbol = value
+
+    @property
+    def scaling(self):
+        return self._subvisuals[0].scaling
+
+    @scaling.setter
+    def scaling(self, value):
+        for marker in self._subvisuals[:2]:
+            marker.scaling = value


### PR DESCRIPTION
# Description
This PR adds the `fixed_canvas_size` argument to the `Points` layer. When active, point sizes are no longer defined in data space, but canvas space, which means they will stay fixed when zooming.

This was split out of #3430.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
- #429

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
