### PR TITLE
Use public-only object proxy for magicgui and plugin dock_widgets

### DIFF
--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -23,7 +23,7 @@ class Widg3(QWidget):
         self.viewer = v
         super().__init__()
 
-    def _fail(self):
+    def fail(self):
         """private attr not allowed"""
         self.viewer.window._qt_window
 
@@ -191,5 +191,5 @@ def test_inject_viewer_proxy(make_napari_viewer):
     viewer = make_napari_viewer()
     wdg = _instantiate_dock_widget(Widg3, viewer)
     assert isinstance(wdg.viewer, PublicOnlyProxy)
-    with pytest.raises(AttributeError):
-        wdg.viewer._fail()
+    with pytest.warns(FutureWarning):
+        wdg.fail()

--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -4,6 +4,8 @@ from qtpy.QtWidgets import QWidget
 
 import napari
 from napari import Viewer
+from napari._qt.qt_main_window import _instantiate_dock_widget
+from napari.utils._proxies import PublicOnlyProxy
 
 
 class Widg1(QWidget):
@@ -20,6 +22,10 @@ class Widg3(QWidget):
     def __init__(self, v: Viewer):
         self.viewer = v
         super().__init__()
+
+    def _fail(self):
+        """private attr not allowed"""
+        self.viewer.window._qt_window
 
 
 def magicfunc(viewer: 'napari.Viewer'):
@@ -178,3 +184,12 @@ def test_making_function_dock_widgets(test_plugin_widgets, make_napari_viewer):
     assert isinstance(magic_widget(), napari.Viewer)
     # Add twice is ok, only does a show
     actions[2].trigger()
+
+
+def test_inject_viewer_proxy(make_napari_viewer):
+    """Test that the injected viewer is a public-only proxy"""
+    viewer = make_napari_viewer()
+    wdg = _instantiate_dock_widget(Widg3, viewer)
+    assert isinstance(wdg.viewer, PublicOnlyProxy)
+    with pytest.raises(AttributeError):
+        wdg.viewer._fail()

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -643,6 +643,7 @@ class Window:
         from ..plugins import _npe2
 
         Widget = _npe2.get_widget_contribution(plugin_name, widget_name)
+        dock_kwargs = {}
 
         if Widget is None:
             Widget, dock_kwargs = plugin_manager.get_widget(

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -34,6 +34,7 @@ from ..plugins import menu_item_template as plugin_menu_item_template
 from ..plugins import plugin_manager
 from ..settings import get_settings
 from ..utils import perf
+from ..utils._proxies import PublicOnlyProxy
 from ..utils.io import imsave
 from ..utils.misc import in_jupyter, running_as_bundled_app
 from ..utils.notifications import Notification
@@ -670,10 +671,12 @@ class Window:
         else:
             for param in sig.parameters.values():
                 if param.name == 'napari_viewer':
-                    kwargs['napari_viewer'] = self.qt_viewer.viewer
+                    kwargs['napari_viewer'] = PublicOnlyProxy(
+                        self.qt_viewer.viewer
+                    )
                     break
                 if param.annotation in ('napari.viewer.Viewer', Viewer):
-                    kwargs[param.name] = self.qt_viewer.viewer
+                    kwargs[param.name] = PublicOnlyProxy(self.qt_viewer.viewer)
                     break
                 # cannot look for param.kind == param.VAR_KEYWORD because
                 # QWidget allows **kwargs but errs on unknown keyword arguments

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -641,7 +641,6 @@ class Window:
             instance).
         """
         from ..plugins import _npe2
-        from ..viewer import Viewer
 
         Widget = _npe2.get_widget_contribution(plugin_name, widget_name)
 
@@ -662,27 +661,7 @@ class Window:
                 wdg = wdg._magic_widget
             return dock_widget, wdg
 
-        # if the signature is looking a for a napari viewer, pass it.
-        kwargs = {}
-        try:
-            sig = inspect.signature(Widget.__init__)
-        except ValueError:
-            pass
-        else:
-            for param in sig.parameters.values():
-                if param.name == 'napari_viewer':
-                    kwargs['napari_viewer'] = PublicOnlyProxy(
-                        self.qt_viewer.viewer
-                    )
-                    break
-                if param.annotation in ('napari.viewer.Viewer', Viewer):
-                    kwargs[param.name] = PublicOnlyProxy(self.qt_viewer.viewer)
-                    break
-                # cannot look for param.kind == param.VAR_KEYWORD because
-                # QWidget allows **kwargs but errs on unknown keyword arguments
-
-        # instantiate the widget
-        wdg = Widget(**kwargs)
+        wdg = _instantiate_dock_widget(Widget, self.qt_viewer.viewer)
 
         # Add dock widget
         dock_kwargs.pop('name', None)
@@ -1200,3 +1179,27 @@ class Window:
             self.qt_viewer.close()
             self._qt_window.close()
             del self._qt_window
+
+
+def _instantiate_dock_widget(wdg_cls, viewer: 'Viewer'):
+    # if the signature is looking a for a napari viewer, pass it.
+    from ..viewer import Viewer
+
+    kwargs = {}
+    try:
+        sig = inspect.signature(wdg_cls.__init__)
+    except ValueError:
+        pass
+    else:
+        for param in sig.parameters.values():
+            if param.name == 'napari_viewer':
+                kwargs['napari_viewer'] = PublicOnlyProxy(viewer)
+                break
+            if param.annotation in ('napari.viewer.Viewer', Viewer):
+                kwargs[param.name] = PublicOnlyProxy(viewer)
+                break
+            # cannot look for param.kind == param.VAR_KEYWORD because
+            # QWidget allows **kwargs but errs on unknown keyword arguments
+
+    # instantiate the widget
+    return wdg_cls(**kwargs)

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -17,6 +17,7 @@ from ..components.layerlist import LayerList
 from ..layers.base.base import Layer
 from ..plugins import _npe2
 from ..utils import config, perf
+from ..utils._proxies import ReadOnlyWrapper
 from ..utils.action_manager import action_manager
 from ..utils.colormaps.standardize_color import transform_color
 from ..utils.history import (
@@ -26,7 +27,6 @@ from ..utils.history import (
     update_save_history,
 )
 from ..utils.interactions import (
-    ReadOnlyWrapper,
     mouse_double_click_callbacks,
     mouse_move_callbacks,
     mouse_press_callbacks,

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -8,8 +8,8 @@ from napari._tests.utils import (
     skip_on_mac_ci,
     skip_on_win_ci,
 )
+from napari.utils._proxies import ReadOnlyWrapper
 from napari.utils.interactions import (
-    ReadOnlyWrapper,
     mouse_move_callbacks,
     mouse_press_callbacks,
     mouse_release_callbacks,

--- a/napari/benchmarks/benchmark_shapes_layer.py
+++ b/napari/benchmarks/benchmark_shapes_layer.py
@@ -7,8 +7,8 @@ import collections
 import numpy as np
 
 from napari.layers import Shapes
+from napari.utils._proxies import ReadOnlyWrapper
 from napari.utils.interactions import (
-    ReadOnlyWrapper,
     mouse_move_callbacks,
     mouse_press_callbacks,
     mouse_release_callbacks,

--- a/napari/components/_tests/test_viewer_mouse_bindings.py
+++ b/napari/components/_tests/test_viewer_mouse_bindings.py
@@ -4,7 +4,8 @@ import numpy as np
 import pytest
 
 from napari.components import ViewerModel
-from napari.utils.interactions import ReadOnlyWrapper, mouse_wheel_callbacks
+from napari.utils._proxies import ReadOnlyWrapper
+from napari.utils.interactions import mouse_wheel_callbacks
 
 
 @pytest.fixture

--- a/napari/layers/labels/_tests/test_labels_mouse_bindings.py
+++ b/napari/layers/labels/_tests/test_labels_mouse_bindings.py
@@ -2,8 +2,8 @@ import numpy as np
 from scipy import ndimage as ndi
 
 from napari.layers import Labels
+from napari.utils._proxies import ReadOnlyWrapper
 from napari.utils.interactions import (
-    ReadOnlyWrapper,
     mouse_move_callbacks,
     mouse_press_callbacks,
     mouse_release_callbacks,

--- a/napari/layers/labels/_tests/test_labels_utils.py
+++ b/napari/layers/labels/_tests/test_labels_utils.py
@@ -7,7 +7,7 @@ from napari.layers.labels._labels_utils import (
     interpolate_coordinates,
     mouse_event_to_labels_coordinate,
 )
-from napari.utils.interactions import ReadOnlyWrapper
+from napari.utils._proxies import ReadOnlyWrapper
 
 
 def test_interpolate_coordinates():

--- a/napari/layers/points/_tests/test_points_mouse_bindings.py
+++ b/napari/layers/points/_tests/test_points_mouse_bindings.py
@@ -5,8 +5,8 @@ import numpy as np
 import pytest
 
 from napari.layers import Points
+from napari.utils._proxies import ReadOnlyWrapper
 from napari.utils.interactions import (
-    ReadOnlyWrapper,
     mouse_move_callbacks,
     mouse_press_callbacks,
     mouse_release_callbacks,

--- a/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
@@ -5,8 +5,8 @@ import pytest
 
 from napari.layers import Shapes
 from napari.layers.shapes.shapes import Mode
+from napari.utils._proxies import ReadOnlyWrapper
 from napari.utils.interactions import (
-    ReadOnlyWrapper,
     mouse_double_click_callbacks,
     mouse_move_callbacks,
     mouse_press_callbacks,

--- a/napari/utils/_magicgui.py
+++ b/napari/utils/_magicgui.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple, Type
 
 from typing_extensions import get_args
 
+from ..utils._proxies import PublicOnlyProxy
+
 if TYPE_CHECKING:
     from concurrent.futures import Future
 
@@ -24,7 +26,6 @@ if TYPE_CHECKING:
 
     from .._qt.qthreading import FunctionWorker
     from ..layers import Layer
-    from ..utils._proxies import PublicOnlyProxy
     from ..viewer import Viewer
 
 

--- a/napari/utils/_magicgui.py
+++ b/napari/utils/_magicgui.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
     from .._qt.qthreading import FunctionWorker
     from ..layers import Layer
+    from ..utils._proxies import PublicOnlyProxy
     from ..viewer import Viewer
 
 
@@ -278,6 +279,13 @@ def find_viewer_ancestor(widget) -> Optional[Viewer]:
         if hasattr(parent, 'qt_viewer'):
             return parent.qt_viewer.viewer
         parent = parent.parent()
+    return None
+
+
+def proxy_viewer_ancestor(widget) -> Optional[PublicOnlyProxy[Viewer]]:
+    viewer = find_viewer_ancestor(widget)
+    if viewer:
+        return PublicOnlyProxy(viewer)
     return None
 
 

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -1,5 +1,5 @@
 import re
-from typing import Generic, TypeVar
+from typing import Callable, Generic, TypeVar
 
 import wrapt
 
@@ -63,6 +63,6 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
         return [x for x in dir(self.__wrapped__) if not _SUNDER.match(x)]
 
 
-class CallablePublicOnlyProxy(PublicOnlyProxy[_T]):
+class CallablePublicOnlyProxy(PublicOnlyProxy[Callable]):
     def __call__(self, *args, **kwargs):
         return self.__wrapped__(*args, **kwargs)

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -49,10 +49,20 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
                     name=name,
                 )
             )
-        return PublicOnlyProxy(super().__getattr__(name))
+        attr = super().__getattr__(name)
+        return (
+            CallablePublicOnlyProxy(attr)
+            if callable(attr)
+            else PublicOnlyProxy(attr)
+        )
 
     def __repr__(self):
         return repr(self.__wrapped__)
 
     def __dir__(self):
         return [x for x in dir(self.__wrapped__) if not _SUNDER.match(x)]
+
+
+class CallablePublicOnlyProxy(PublicOnlyProxy[_T]):
+    def __call__(self, *args, **kwargs):
+        return self.__wrapped__(*args, **kwargs)

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -1,0 +1,51 @@
+from typing import Generic, TypeVar
+
+import wrapt
+
+from ..utils.translations import trans
+
+_T = TypeVar("_T")
+
+
+class ReadOnlyWrapper(wrapt.ObjectProxy):
+    """
+    Disable item and attribute setting with the exception of  ``__wrapped__``.
+    """
+
+    def __setattr__(self, name, val):
+        if name != '__wrapped__':
+            raise TypeError(
+                trans._(
+                    'cannot set attribute {name}',
+                    deferred=True,
+                    name=name,
+                )
+            )
+
+        super().__setattr__(name, val)
+
+    def __setitem__(self, name, val):
+        raise TypeError(
+            trans._('cannot set item {name}', deferred=True, name=name)
+        )
+
+
+class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
+    """Prevent's private access."""
+
+    __wrapped__: _T
+
+    def __getattr__(self, name: str):
+        if name.startswith('_'):
+            name = f'{type(self.__wrapped__).__name__}.{name}'
+            raise AttributeError(
+                trans._(
+                    "Private attribute access ('{name}') not allowed in this context.",
+                    deferred=True,
+                    name=name,
+                )
+            )
+        return PublicOnlyProxy(super().__getattr__(name))
+
+    def __repr__(self):
+        return repr(self.__wrapped__)

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from typing import Any, Callable, Generic, TypeVar
 
 import wrapt
@@ -41,14 +42,22 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
 
     def __getattr__(self, name: str):
         if name.startswith('_'):
-            name = f'{type(self.__wrapped__).__name__}.{name}'
-            raise AttributeError(
+            warnings.warn(
                 trans._(
-                    "Private attribute access ('{name}') not allowed in this context.",
+                    "Private attribute access in this context is deprecated and will be unavailable in version 0.4.14",
                     deferred=True,
-                    name=name,
-                )
+                ),
+                category=FutureWarning,
+                stacklevel=2,
             )
+            # name = f'{type(self.__wrapped__).__name__}.{name}'
+            # raise AttributeError(
+            #     trans._(
+            #         "Private attribute access ('{name}') not allowed in this context.",
+            #         deferred=True,
+            #         name=name,
+            #     )
+            # )
         return self.create(super().__getattr__(name))
 
     def __getitem__(self, key):

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -44,7 +44,7 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
         if name.startswith('_'):
             warnings.warn(
                 trans._(
-                    "Private attribute access in this context is deprecated and will be unavailable in version 0.4.14",
+                    "Private attribute access in this context (e.g. inside a plugin widget or dock widget) is deprecated and will be unavailable in version 0.4.14",
                     deferred=True,
                 ),
                 category=FutureWarning,

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -1,3 +1,4 @@
+import re
 from typing import Generic, TypeVar
 
 import wrapt
@@ -30,6 +31,9 @@ class ReadOnlyWrapper(wrapt.ObjectProxy):
         )
 
 
+_SUNDER = re.compile('^_[^_]')
+
+
 class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
     """Prevent's private access."""
 
@@ -49,3 +53,6 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
 
     def __repr__(self):
         return repr(self.__wrapped__)
+
+    def __dir__(self):
+        return [x for x in dir(self.__wrapped__) if not _SUNDER.match(x)]

--- a/napari/utils/_tests/test_interactions.py
+++ b/napari/utils/_tests/test_interactions.py
@@ -1,28 +1,6 @@
 import pytest
 
-from ..interactions import ReadOnlyWrapper, Shortcut
-
-
-def test_ReadOnlyWrapper_setitem():
-    """test that ReadOnlyWrapper prevents setting items"""
-    d = {'hi': 3}
-    d_read_only = ReadOnlyWrapper(d)
-
-    with pytest.raises(TypeError):
-        d_read_only['hi'] = 5
-
-
-def test_ReadOnlyWrapper_setattr():
-    """test that ReadOnlyWrapper prevents setting attributes"""
-
-    class TestClass:
-        x = 3
-
-    tc = TestClass()
-    tc_read_only = ReadOnlyWrapper(tc)
-
-    with pytest.raises(TypeError):
-        tc_read_only.x = 5
+from ..interactions import Shortcut
 
 
 @pytest.mark.parametrize(

--- a/napari/utils/_tests/test_magicgui.py
+++ b/napari/utils/_tests/test_magicgui.py
@@ -10,6 +10,7 @@ from magicgui import magicgui
 from napari import Viewer, layers, types
 from napari._tests.utils import layer_test_data
 from napari.layers import Image, Labels, Layer
+from napari.utils._proxies import PublicOnlyProxy
 from napari.utils.misc import all_subclasses
 
 try:
@@ -247,7 +248,9 @@ def test_magicgui_get_viewer(make_napari_viewer):
 
     assert func() is None
     viewer.window.add_dock_widget(func)
-    assert func() is viewer
+    v = func()
+    assert isinstance(v, PublicOnlyProxy)
+    assert v.__wrapped__ is viewer
     # no widget should be shown
     assert not func.v.visible
 

--- a/napari/utils/_tests/test_proxies.py
+++ b/napari/utils/_tests/test_proxies.py
@@ -30,6 +30,9 @@ def test_PublicOnlyProxy():
         a = 1
         _b = 'nope'
 
+        def method(self):
+            return 2
+
     class Tester:
         x = X()
         _private = 2
@@ -37,6 +40,8 @@ def test_PublicOnlyProxy():
     t = Tester()
     proxy = PublicOnlyProxy(t)
     assert proxy.x.a == 1
+    assert proxy.x.method() == 2
+
     assert isinstance(proxy, Tester)
     with pytest.raises(AttributeError):
         proxy._private

--- a/napari/utils/_tests/test_proxies.py
+++ b/napari/utils/_tests/test_proxies.py
@@ -1,6 +1,6 @@
 import pytest
 
-from napari.utils._proxies import ReadOnlyWrapper
+from napari.utils._proxies import PublicOnlyProxy, ReadOnlyWrapper
 
 
 def test_ReadOnlyWrapper_setitem():
@@ -23,3 +23,27 @@ def test_ReadOnlyWrapper_setattr():
 
     with pytest.raises(TypeError):
         tc_read_only.x = 5
+
+
+def test_PublicOnlyProxy():
+    class X:
+        a = 1
+        _b = 'nope'
+
+    class Tester:
+        x = X()
+        _private = 2
+
+    t = Tester()
+    proxy = PublicOnlyProxy(t)
+    assert proxy.x.a == 1
+    assert isinstance(proxy, Tester)
+    with pytest.raises(AttributeError):
+        proxy._private
+
+    with pytest.raises(AttributeError):
+        # works on sub-objects too
+        proxy.x._b
+
+    assert '_private' not in dir(proxy)
+    assert '_private' in dir(t)

--- a/napari/utils/_tests/test_proxies.py
+++ b/napari/utils/_tests/test_proxies.py
@@ -1,0 +1,25 @@
+import pytest
+
+from napari.utils._proxies import ReadOnlyWrapper
+
+
+def test_ReadOnlyWrapper_setitem():
+    """test that ReadOnlyWrapper prevents setting items"""
+    d = {'hi': 3}
+    d_read_only = ReadOnlyWrapper(d)
+
+    with pytest.raises(TypeError):
+        d_read_only['hi'] = 5
+
+
+def test_ReadOnlyWrapper_setattr():
+    """test that ReadOnlyWrapper prevents setting attributes"""
+
+    class TestClass:
+        x = 3
+
+    tc = TestClass()
+    tc_read_only = ReadOnlyWrapper(tc)
+
+    with pytest.raises(TypeError):
+        tc_read_only.x = 5

--- a/napari/utils/_tests/test_proxies.py
+++ b/napari/utils/_tests/test_proxies.py
@@ -37,18 +37,29 @@ def test_PublicOnlyProxy():
         x = X()
         _private = 2
 
+        def __getitem__(self, key):
+            return X()
+
     t = Tester()
     proxy = PublicOnlyProxy(t)
     assert proxy.x.a == 1
+    assert proxy[0].a == 1
     assert proxy.x.method() == 2
 
     assert isinstance(proxy, Tester)
-    with pytest.raises(AttributeError):
+    with pytest.raises(AttributeError) as e:
         proxy._private
+        assert 'Private attribute access' in str(e)
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(AttributeError) as e:
         # works on sub-objects too
         proxy.x._b
+        assert 'Private attribute access' in str(e)
+
+    with pytest.raises(AttributeError) as e:
+        # works on sub-items too
+        proxy[0]._b
+        assert 'Private attribute access' in str(e)
 
     assert '_private' not in dir(proxy)
     assert '_private' in dir(t)

--- a/napari/utils/_tests/test_proxies.py
+++ b/napari/utils/_tests/test_proxies.py
@@ -47,19 +47,19 @@ def test_PublicOnlyProxy():
     assert proxy.x.method() == 2
 
     assert isinstance(proxy, Tester)
-    with pytest.raises(AttributeError) as e:
+    with pytest.warns(FutureWarning) as e:
         proxy._private
-        assert 'Private attribute access' in str(e)
+        assert 'Private attribute access' in str(e[0].message)
 
-    with pytest.raises(AttributeError) as e:
+    with pytest.warns(FutureWarning) as e:
         # works on sub-objects too
         proxy.x._b
-        assert 'Private attribute access' in str(e)
+        assert 'Private attribute access' in str(e[0].message)
 
-    with pytest.raises(AttributeError) as e:
+    with pytest.warns(FutureWarning) as e:
         # works on sub-items too
         proxy[0]._b
-        assert 'Private attribute access' in str(e)
+        assert 'Private attribute access' in str(e[0].message)
 
     assert '_private' not in dir(proxy)
     assert '_private' in dir(t)

--- a/napari/utils/interactions.py
+++ b/napari/utils/interactions.py
@@ -3,33 +3,9 @@ import re
 import sys
 import warnings
 
-import wrapt
 from numpydoc.docscrape import FunctionDoc
 
 from ..utils.translations import trans
-
-
-class ReadOnlyWrapper(wrapt.ObjectProxy):
-    """
-    Disable item and attribute setting with the exception of  ``__wrapped__``.
-    """
-
-    def __setattr__(self, name, val):
-        if name != '__wrapped__':
-            raise TypeError(
-                trans._(
-                    'cannot set attribute {name}',
-                    deferred=True,
-                    name=name,
-                )
-            )
-
-        super().__setattr__(name, val)
-
-    def __setitem__(self, name, val):
-        raise TypeError(
-            trans._('cannot set item {name}', deferred=True, name=name)
-        )
 
 
 def mouse_wheel_callbacks(obj, event):

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from ._qt.qt_main_window import Window
 
 
-@mgui.register_type(bind=_magicgui.find_viewer_ancestor)
+@mgui.register_type(bind=_magicgui.proxy_viewer_ancestor)
 class Viewer(ViewerModel):
     """Napari ndarray viewer.
 


### PR DESCRIPTION
# Description
To prevent undesired/accidental breakage of plugins using the viewer via magicgui or dock widget hooks, this PR wraps the viewer object injected into those widgets in a proxy that prevents access of private attributes.

note: a decent amount of the PR is just moving the ReadOnlyProxy (and associated imports) into the same file: `utils._proxies`


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
