### PR TITLE
Remove float64 from GPU-accepted dtypes

### DIFF
--- a/napari/_vispy/utils/gl.py
+++ b/napari/_vispy/utils/gl.py
@@ -15,7 +15,6 @@ texture_dtypes = [
     np.dtype(np.uint8),
     np.dtype(np.uint16),
     np.dtype(np.float32),
-    np.dtype(np.float64),
 ]
 
 


### PR DESCRIPTION
# Description
With #3701 we switched over to GPU float textures. There, I mistakenly added `float64` to the accepted formats, which resulted in vispy doing the conversion to float32 and complaining about it, which raises a ton of warnings. To prevent that, we can simply do the conversion ourselves.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
