### PR TITLE
remove main push from pre test

### DIFF
--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -4,9 +4,6 @@
 name: --pre Test
 
 on:
-  push:
-    branches:
-      - main
   schedule:
     - cron: '0 */12 * * *'  # every 12 hours
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
# Description
this removes the "on push to main" trigger of the `--pre Test` workflow.  Currently it appears like the last PRs are always failing once we push to main, though they are not.  

Note that there is already an open issue for the broken `pre` test: https://github.com/napari/napari/issues/2481

and new ones will open again if there is not one currently open