### PR TITLE
Check skimage version to get appropriate fetcher

### DIFF
--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -6,6 +6,7 @@ import dask.threaded
 import numpy as np
 import pooch
 import pytest
+import skimage
 
 from napari.components import LayerList
 from napari.layers import Image, Labels, Points, Shapes, Vectors
@@ -21,9 +22,14 @@ from napari.utils.config import async_loading
 if not hasattr(pooch.utils, 'file_hash'):
     setattr(pooch.utils, 'file_hash', pooch.hashes.file_hash)
 
-try:
+
+SKIMAGE_VERSION = tuple(int(v) for v in skimage.__version__.split('.'))
+
+if SKIMAGE_VERSION[:2] >= (0, 19):
+    from skimage.data._fetchers import image_fetcher
+elif SKIMAGE_VERSION[:2] >= (0, 16):
     from skimage.data import image_fetcher
-except ImportError:
+else:
     from skimage.data import data_dir
 
     class image_fetcher:


### PR DESCRIPTION
# Description
After skimage/skimage#5996 (available from release 0.19), our CI tests or PRs are failing due to an import error. There was already a check for this; I updated it to include the new change, but to use skimage version to choose the right import instead of exception catching. I' not sure if this is the right way to go about this, but I wanted to see if this worked.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
