### PR TITLE
Add a dependency prerelease entry to the test matrix

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -45,7 +45,7 @@ jobs:
           semgrep --error --lang python --pattern 'trans._($X.format(...))' napari
 
   test:
-    name: ${{ matrix.platform }} ${{ matrix.python }} ${{ matrix.toxenv || matrix.backend }} ${{ matrix.MIN_REQ && 'min_req' }}
+    name: ${{ matrix.platform }} ${{ matrix.python }} ${{ matrix.toxenv || matrix.backend }} ${{ matrix.MIN_REQ && 'min_req' }} ${{ matrix.PRE && 'pre' }}
     runs-on: ${{ matrix.platform }}
     strategy:
       fail-fast: false
@@ -86,6 +86,10 @@ jobs:
           - python: '3.10'
             platform: ubuntu-latest
             backend: pyqt
+          - python: '3.10'
+            platform: ubuntu-latest
+            backend: pyqt
+            PRE: 1
 
     steps:
       - uses: actions/checkout@v2
@@ -197,7 +201,7 @@ jobs:
         run: |
           # pip install this git sha directly from github
           pip install --upgrade pip
-          pip install git+git://github.com/${{ github.repository }}.git@${{ github.sha }}#egg=napari[all,testing]
+          pip install ${{ matrix.PRE && '--pre' }} git+git://github.com/${{ github.repository }}.git@${{ github.sha }}#egg=napari[all,testing]
 
       - name: Test
         uses: GabrielBB/xvfb-action@v1


### PR DESCRIPTION
# Description

I was wondering why the ~1w that scikit-image 0.19.0rc0 was out didn't pick up any test failures in our test suite, and I realised we don't test pre-releases, which isn't great!

Not sure whether I've done this correctly/in the neatest way possible, please let me know if there are any better suggestions.

