### PR TITLE
Add test for new large labels when in contour mode

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -563,6 +563,24 @@ def test_contour(input_data, expected_data_view):
     )
 
 
+def test_contour_large_new_labels(make_napari_viewer):
+    """Check that new labels larger than the lookup table work in contour mode.
+
+    References
+    ----------
+    [1]: https://forum.image.sc/t/data-specific-reason-for-indexerror-in-raw-to-displayed/60808
+    [2]: https://github.com/napari/napari/pull/3697
+    """
+    viewer = make_napari_viewer()
+
+    labels = np.zeros((5, 10, 10), dtype=int)
+    labels[0, 4:6, 4:6] = 1
+    labels[4, 4:6, 4:6] = 1000
+    labels_layer = viewer.add_labels(labels)
+    labels_layer.contour = 1
+    viewer.dims.set_point(axis=0, value=4)
+
+
 def test_selecting_label():
     """Test selecting label."""
     np.random.seed(0)

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -579,6 +579,7 @@ def test_contour_large_new_labels():
     labels[4, 4:6, 4:6] = 1000
     labels_layer = viewer.add_labels(labels)
     labels_layer.contour = 1
+    # This used to fail with IndexError
     viewer.dims.set_point(axis=0, value=4)
 
 

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -13,6 +13,7 @@ from numpy.testing import assert_array_almost_equal, assert_raises
 from skimage import data
 
 from napari._tests.utils import check_layer_world_data_extent
+from napari.components import ViewerModel
 from napari.layers import Labels
 from napari.layers.labels._labels_constants import LabelsRendering
 from napari.utils import Colormap
@@ -563,7 +564,7 @@ def test_contour(input_data, expected_data_view):
     )
 
 
-def test_contour_large_new_labels(make_napari_viewer):
+def test_contour_large_new_labels():
     """Check that new labels larger than the lookup table work in contour mode.
 
     References
@@ -571,7 +572,7 @@ def test_contour_large_new_labels(make_napari_viewer):
     [1]: https://forum.image.sc/t/data-specific-reason-for-indexerror-in-raw-to-displayed/60808
     [2]: https://github.com/napari/napari/pull/3697
     """
-    viewer = make_napari_viewer()
+    viewer = ViewerModel()
 
     labels = np.zeros((5, 10, 10), dtype=int)
     labels[0, 4:6, 4:6] = 1


### PR DESCRIPTION
# Description

I went through the trouble of creating a reproducible test case for [this imagesc post](https://forum.image.sc/t/data-specific-reason-for-indexerror-in-raw-to-displayed/60808) before realising that @Czaki had already fixed the issue in #3697 :joy: so I figured why waste a nice test case. :blush:

