### PR TITLE
fix outdated API in eventloop docs

### DIFF
--- a/docs/guides/event_loop.md
+++ b/docs/guides/event_loop.md
@@ -29,7 +29,7 @@ If you would prefer that napari did *not* start the interactive
 event loop for you in IPython, then you can disable it with:
 
 ```python
-from napari.utils import get_settings
+from napari.settings import get_settings
 
 get_settings().application.ipy_interactive = False
 ```


### PR DESCRIPTION
# Description
fixes an old import in our event_loop guide