### PR TITLE
Fix QtModeRadioButton strong reference causing test failure

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -480,14 +480,14 @@ def test_memory_leaking(qtbot, make_napari_viewer):
 
 
 @skip_local_popups
-def test_leaks_image(qtbot, make_napari_viewer):
+def test_leaks_image(qapp, make_napari_viewer):
 
     viewer = make_napari_viewer(show=True)
     lr = weakref.ref(viewer.add_image(np.random.rand(10, 10)))
     dr = weakref.ref(lr().data)
 
     viewer.layers.clear()
-    qtbot.wait(100)
+    qapp.processEvents()
     gc.collect()
     assert not gc.collect()
     assert not lr()

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -495,14 +495,14 @@ def test_leaks_image(qapp, make_napari_viewer):
 
 
 @skip_local_popups
-def test_leaks_labels(qtbot, make_napari_viewer):
+def test_leaks_labels(qapp, make_napari_viewer):
     viewer = make_napari_viewer(show=True)
     lr = weakref.ref(
         viewer.add_labels((np.random.rand(10, 10) * 10).astype(np.uint8))
     )
     dr = weakref.ref(lr().data)
     viewer.layers.clear()
-    qtbot.wait(50)  # process events
+    qapp.processEvents()
     gc.collect()
     assert not gc.collect()
     assert not lr()

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -502,7 +502,6 @@ def test_leaks_labels(qtbot, make_napari_viewer):
     )
     dr = weakref.ref(lr().data)
     viewer.layers.clear()
-    qtbot.wait(200)  # TODO: figure out exactly what we're waiting for
     gc.collect()
     assert not gc.collect()
     assert not lr()

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -480,14 +480,14 @@ def test_memory_leaking(qtbot, make_napari_viewer):
 
 
 @skip_local_popups
-def test_leaks_image(qapp, make_napari_viewer):
+def test_leaks_image(qtbot, make_napari_viewer):
 
     viewer = make_napari_viewer(show=True)
     lr = weakref.ref(viewer.add_image(np.random.rand(10, 10)))
     dr = weakref.ref(lr().data)
 
     viewer.layers.clear()
-    qapp.processEvents()
+    qtbot.wait(100)
     gc.collect()
     assert not gc.collect()
     assert not lr()
@@ -495,14 +495,14 @@ def test_leaks_image(qapp, make_napari_viewer):
 
 
 @skip_local_popups
-def test_leaks_labels(qapp, make_napari_viewer):
+def test_leaks_labels(qtbot, make_napari_viewer):
     viewer = make_napari_viewer(show=True)
     lr = weakref.ref(
         viewer.add_labels((np.random.rand(10, 10) * 10).astype(np.uint8))
     )
     dr = weakref.ref(lr().data)
     viewer.layers.clear()
-    qapp.processEvents()
+    qtbot.wait(100)
     gc.collect()
     assert not gc.collect()
     assert not lr()

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -502,6 +502,7 @@ def test_leaks_labels(qtbot, make_napari_viewer):
     )
     dr = weakref.ref(lr().data)
     viewer.layers.clear()
+    qtbot.wait(50)  # process events
     gc.collect()
     assert not gc.collect()
     assert not lr()

--- a/napari/_qt/widgets/qt_mode_buttons.py
+++ b/napari/_qt/widgets/qt_mode_buttons.py
@@ -1,3 +1,5 @@
+import weakref
+
 from qtpy.QtWidgets import QPushButton, QRadioButton
 
 
@@ -31,7 +33,7 @@ class QtModeRadioButton(QRadioButton):
     ):
         super().__init__()
 
-        self.layer = layer
+        self.layer_ref = weakref.ref(layer)
         self.setToolTip(tooltip or button_name)
         self.setChecked(checked)
         self.setProperty('mode', button_name)
@@ -48,9 +50,13 @@ class QtModeRadioButton(QRadioButton):
         bool : bool
             Whether this mode is currently selected or not.
         """
-        with self.layer.events.mode.blocker(self._set_mode):
+        layer = self.layer_ref()
+        if layer is None:
+            return
+
+        with layer.events.mode.blocker(self._set_mode):
             if bool:
-                self.layer.mode = self.mode
+                layer.mode = self.mode
 
 
 class QtModePushButton(QPushButton):


### PR DESCRIPTION
# Description
Fixes [this](https://github.com/napari/napari/runs/4457614158?check_suite_focus=true#step:9:264) periodic test failure on mac.  (QtLayerControls mode buttons keeping a reference to a dead layer)
