### PR TITLE
Restrict PublicOnlyProxy to napari namespace, allow napari-internal private usage

### DIFF
--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from napari_plugin_engine import napari_hook_implementation
 from qtpy.QtWidgets import QWidget
@@ -191,5 +193,8 @@ def test_inject_viewer_proxy(make_napari_viewer):
     viewer = make_napari_viewer()
     wdg = _instantiate_dock_widget(Widg3, viewer)
     assert isinstance(wdg.viewer, PublicOnlyProxy)
-    with pytest.warns(FutureWarning):
-        wdg.fail()
+
+    # simulate access from outside napari
+    with patch('napari.utils.misc.ROOT_DIR', new='/some/other/package'):
+        with pytest.warns(FutureWarning):
+            wdg.fail()

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -85,6 +85,9 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
         if not getattr(obj, '__module__', '').startswith('napari'):
             return obj
 
+        if isinstance(obj, PublicOnlyProxy):
+            # don't double wrap
+            return obj
         if callable(obj):
             return CallablePublicOnlyProxy(obj)
         return PublicOnlyProxy(obj)

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -43,10 +43,10 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
     __wrapped__: _T
 
     def __getattr__(self, name: str):
-        if _SUNDER.match(name):
+        if name.startswith("_"):
             # allow napari to access private attributes and get an non-proxy
             frame = sys._getframe(1) if hasattr(sys, "_getframe") else None
-            if frame and misc.ROOT_DIR in frame.f_code.co_filename:  # type: ignore
+            if frame.f_code.co_filename.startswith(misc.ROOT_DIR):
                 return super().__getattr__(name)
 
             typ = type(self.__wrapped__).__name__

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -42,7 +42,7 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
 
     # __root limits the scope of the Proxy to types from the __root module
     # set to empty string to recurse indefinitely
-    __root: str = __module__.split('.')[0]  # default to napari only
+    __root: str = __name__.split('.')[0]  # default to napari only
 
     def __getattr__(self, name: str):
         if name.startswith('_'):

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -80,7 +80,7 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
     @classmethod
     def create(cls, obj: Any) -> Union['PublicOnlyProxy', Any]:
         # restrict the scope of this proxy to napari objects
-        if not getattr(type(obj), '__module__', '').startswith(cls.__root):
+        if not getattr(obj, '__module__', '').startswith(cls.__root):
             return obj
 
         if callable(obj):

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -83,7 +83,7 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
         if not getattr(type(obj), '__module__', '').startswith(cls.__root):
             return obj
 
-        if callable:
+        if callable(obj):
             return CallablePublicOnlyProxy(obj)
         return PublicOnlyProxy(obj)
 

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -45,11 +45,14 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
     __root: str = __name__.split('.')[0]  # default to napari only
 
     def __getattr__(self, name: str):
-        if name.startswith('_'):
+        if _SUNDER.match(name):
+            typ = type(self.__wrapped__).__name__
             warnings.warn(
                 trans._(
-                    "Private attribute access in this context (e.g. inside a plugin widget or dock widget) is deprecated and will be unavailable in version 0.4.14",
+                    "Private attribute access ('{typ}.{name}') in this context (e.g. inside a plugin widget or dock widget) is deprecated and will be unavailable in version 0.4.14",
                     deferred=True,
+                    name=name,
+                    typ=typ,
                 ),
                 category=FutureWarning,
                 stacklevel=2,
@@ -57,9 +60,10 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
             # name = f'{type(self.__wrapped__).__name__}.{name}'
             # raise AttributeError(
             #     trans._(
-            #         "Private attribute access ('{name}') not allowed in this context.",
+            #         "Private attribute access ('{typ}.{name}') not allowed in this context.",
             #         deferred=True,
             #         name=name,
+            #         typ=typ,
             #     )
             # )
         return self.create(super().__getattr__(name))

--- a/napari/utils/_tests/test_proxies.py
+++ b/napari/utils/_tests/test_proxies.py
@@ -1,3 +1,6 @@
+from unittest.mock import patch
+
+import numpy as np
 import pytest
 
 from napari.components.viewer_model import ViewerModel
@@ -26,7 +29,14 @@ def test_ReadOnlyWrapper_setattr():
         tc_read_only.x = 5
 
 
-def test_PublicOnlyProxy():
+@pytest.fixture
+def patched_root_dir():
+    """Simulate a call from outside of napari"""
+    with patch('napari.utils.misc.ROOT_DIR', new='/some/other/package'):
+        yield
+
+
+def test_PublicOnlyProxy(patched_root_dir):
     class X:
         a = 1
         _b = 'nope'
@@ -50,35 +60,51 @@ def test_PublicOnlyProxy():
     assert isinstance(proxy, Tester)
     with pytest.warns(FutureWarning) as e:
         proxy._private
-        assert 'Private attribute access' in str(e[0].message)
+    assert 'Private attribute access' in str(e[0].message)
 
     with pytest.warns(FutureWarning) as e:
         # works on sub-objects too
         proxy.x._b
-        assert 'Private attribute access' in str(e[0].message)
+    assert 'Private attribute access' in str(e[0].message)
 
     with pytest.warns(FutureWarning) as e:
         # works on sub-items too
         proxy[0]._b
-        assert 'Private attribute access' in str(e[0].message)
+    assert 'Private attribute access' in str(e[0].message)
 
     assert '_private' not in dir(proxy)
     assert '_private' in dir(t)
 
 
-def test_public_proxy_limited_to_napari():
+def test_public_proxy_limited_to_napari(patched_root_dir):
     """Test that the recursive public proxy goes no farther than napari."""
-    v = ViewerModel()
-    v.add_points(None)
-    pv = PublicOnlyProxy(v)
+    viewer = ViewerModel()
+    viewer.add_points(None)
+    pv = PublicOnlyProxy(viewer)
     assert not isinstance(pv.layers[0].data, PublicOnlyProxy)
 
 
-def test_array_from_proxy_objects():
+def test_array_from_proxy_objects(patched_root_dir):
     """Test that the recursive public proxy goes no farther than napari."""
-    import numpy as np
-
-    v = ViewerModel()
-    v.add_points(None)
-    pv = PublicOnlyProxy(v)
+    viewer = ViewerModel()
+    viewer.add_points(None)
+    pv = PublicOnlyProxy(viewer)
     assert isinstance(np.array(pv.dims.displayed, dtype=int), np.ndarray)
+
+
+def test_receive_return_proxy_object():
+    """Test that an"""
+    viewer = ViewerModel()
+    viewer.add_image(np.random.random((20, 20)))
+    pv = PublicOnlyProxy(viewer)
+
+    # simulates behavior from outside of napari
+    with patch('napari.utils.misc.ROOT_DIR', new='/some/other/package'):
+        # the recursion means this layer will be a Proxy Object on __getitem__
+        layer = pv.layers[-1]
+        assert isinstance(layer, PublicOnlyProxy)
+        # remove and add it back, should be fine
+        add_layer = getattr(pv, 'add_layer')
+
+    add_layer(layer)
+    assert len(viewer.layers) == 2

--- a/napari/utils/_tests/test_proxies.py
+++ b/napari/utils/_tests/test_proxies.py
@@ -1,5 +1,6 @@
 import pytest
 
+from napari.components.viewer_model import ViewerModel
 from napari.utils._proxies import PublicOnlyProxy, ReadOnlyWrapper
 
 
@@ -67,9 +68,17 @@ def test_PublicOnlyProxy():
 
 def test_public_proxy_limited_to_napari():
     """Test that the recursive public proxy goes no farther than napari."""
-    from napari.components.viewer_model import ViewerModel
+    v = ViewerModel()
+    v.add_points(None)
+    pv = PublicOnlyProxy(v)
+    assert not isinstance(pv.layers[0].data, PublicOnlyProxy)
+
+
+def test_array_from_proxy_objects():
+    """Test that the recursive public proxy goes no farther than napari."""
+    import numpy as np
 
     v = ViewerModel()
     v.add_points(None)
-    pp = PublicOnlyProxy(v)
-    assert not isinstance(pp.layers[0].data, PublicOnlyProxy)
+    pv = PublicOnlyProxy(v)
+    assert isinstance(np.array(pv.dims.displayed, dtype=int), np.ndarray)

--- a/napari/utils/_tests/test_proxies.py
+++ b/napari/utils/_tests/test_proxies.py
@@ -63,3 +63,13 @@ def test_PublicOnlyProxy():
 
     assert '_private' not in dir(proxy)
     assert '_private' in dir(t)
+
+
+def test_public_proxy_limited_to_napari():
+    """Test that the recursive public proxy goes no farther than napari."""
+    from napari.components.viewer_model import ViewerModel
+
+    v = ViewerModel()
+    v.add_points(None)
+    pp = PublicOnlyProxy(v)
+    assert not isinstance(pp.layers[0].data, PublicOnlyProxy)


### PR DESCRIPTION
# Description
Fixes a few issues with the new viewer proxy.  Thanks all for the quick feedback!

This makes it so that only _napari_ objects get wrapped by `PublicOnlyProxy`... once we hit a type that comes from outside of napari (like `layer.data`; fixes #3774), we no longer wrap it.  Test added.

This also makes it so that _internal_ napari calls to private attributes on a proxied object still work, and napari gets the unwrapped object.  This happens, for example, when we process mouse_move_callbacks and [need to access `obj._mouse_drag_gen`](https://github.com/tlambert03/napari/blob/1bcb2fd383836cd316d07bf06caeaed808f7b2ab/napari/utils/interactions.py#L167) (fixes #3775) or a plugin extracts a layer from the proxy viewer, modifies it, and adds it back (fixes #3782)


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
