### PR TITLE
refactor npe2 widget name to display_name

### DIFF
--- a/napari/builtins.yaml
+++ b/napari/builtins.yaml
@@ -156,7 +156,7 @@ contributions:
           ".tga",
         ]
       layer_types: ["image"]
-      name: lossless
+      display_name: lossless
 
     - command: napari.write_image
       filename_extensions:
@@ -174,7 +174,7 @@ contributions:
           ".mpo",
         ]
       layer_types: ["image"]
-      name: lossy
+      display_name: lossy
 
     - command: napari.write_labels
       filename_extensions:
@@ -192,21 +192,21 @@ contributions:
           ".stk",
         ]
       layer_types: ["labels"]
-      name: labels
+      display_name: labels
 
     - command: napari.write_points
       filename_extensions: [".csv"]
       layer_types: ["points"]
-      name: points
+      display_name: points
 
     - command: napari.write_shapes
       filename_extensions: [".csv"]
       layer_types: ["shapes"]
-      name: shapes
+      display_name: shapes
 
     - command: napari.write_directory
       layer_types: ["image*", "labels*", "points*", "shapes*"]
-      name: Save to Folder
+      display_name: Save to Folder
 
   sample_data:
     - display_name: Astronaut (RGB)

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -111,7 +111,10 @@ def get_widget_contribution(
     plugin_name: str, widget_name: str
 ) -> Optional[WidgetCallable]:
     for contrib in npe2.PluginManager.instance().iter_widgets():
-        if contrib.plugin_name == plugin_name and contrib.name == widget_name:
+        if (
+            contrib.plugin_name == plugin_name
+            and contrib.display_name == widget_name
+        ):
             return contrib.get_callable()
     return None
 
@@ -185,7 +188,7 @@ def widget_iterator() -> Iterator[Tuple[str, Tuple[str, Sequence[str]]]]:
     # eg ('dock', ('my_plugin', {'My widget': MyWidget}))
     wdgs: DefaultDict[str, List[str]] = DefaultDict(list)
     for wdg_contrib in npe2.PluginManager.instance().iter_widgets():
-        wdgs[wdg_contrib.plugin_name].append(wdg_contrib.name)
+        wdgs[wdg_contrib.plugin_name].append(wdg_contrib.display_name)
     return (('dock', x) for x in wdgs.items())
 
 


### PR DESCRIPTION
# Description
This updates napari for napari/npe2#51 which changes the widget "name" field to "display_name"

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
