### PR TITLE
don't use `pytest.warns(None)` (avoids DeprecationWarning with pytest 7) 

### DIFF
--- a/napari/components/_tests/test_world_coordinates.py
+++ b/napari/components/_tests/test_world_coordinates.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pytest
 
@@ -82,7 +84,7 @@ def test_no_warning_non_affine_slicing():
     np.random.seed(0)
     data = np.random.random((10, 10, 10))
     viewer.add_image(data, scale=[2, 1, 1], translate=[10, 15, 20])
-    with pytest.warns(None) as recorded_warnings:
+    with warnings.catch_warnings(record=True) as recorded_warnings:
         viewer.layers[0].refresh()
     assert len(recorded_warnings) == 0
 


### PR DESCRIPTION
# Description

This PR fixes a test case for compatibility with upcoming pytest 7.0 (currently in release candidate).  `pytest.warns(None)` has been deprecated and the deprecation warnings suggests using `pytest.warns()` instead. However, `pytest.warns()` is like writing `pytest.warns(Warning)` so it will match any warning type, but will raise an error if there is no warning as in the case here.

In this case, I have used the `warnings.catch_warnings` context for equivalence to the old logic that just wants to assert that no warnings were raised. I made a PR to fix this in scikit-image earlier today, so thought I would check if the same issue occurs here. This was the only usage of `pytest.warns(None)` that `grep` found.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] existing test should continue to pass on current support Python and pytest
- [x] The test case passes without DeprecationWarning when testing locally with pytest 7.0.0rc1. 

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
