### PR TITLE
integrate npe2 schema updates 

### DIFF
--- a/napari/builtins.yaml
+++ b/napari/builtins.yaml
@@ -156,7 +156,7 @@ contributions:
           ".tga",
         ]
       layer_types: ["image"]
-      name: lossless
+      display_name: lossless
 
     - command: napari.write_image
       filename_extensions:
@@ -174,7 +174,7 @@ contributions:
           ".mpo",
         ]
       layer_types: ["image"]
-      name: lossy
+      display_name: lossy
 
     - command: napari.write_labels
       filename_extensions:
@@ -192,21 +192,21 @@ contributions:
           ".stk",
         ]
       layer_types: ["labels"]
-      name: labels
+      display_name: labels
 
     - command: napari.write_points
       filename_extensions: [".csv"]
       layer_types: ["points"]
-      name: points
+      display_name: points
 
     - command: napari.write_shapes
       filename_extensions: [".csv"]
       layer_types: ["shapes"]
-      name: shapes
+      display_name: shapes
 
     - command: napari.write_directory
       layer_types: ["image*", "labels*", "points*", "shapes*"]
-      name: Save to Folder
+      display_name: Save to Folder
 
   sample_data:
     - display_name: Astronaut (RGB)

--- a/napari/components/_tests/test_layers_list.py
+++ b/napari/components/_tests/test_layers_list.py
@@ -6,6 +6,15 @@ import pytest
 from napari.components import LayerList
 from napari.layers import Image
 
+try:
+    import npe2  # noqa: F401
+
+    BUILTINS = 'napari'
+    SVG = 'napari-svg'
+except ImportError:
+    BUILTINS = 'builtins'
+    SVG = 'svg'
+
 
 def test_empty_layers_list():
     """
@@ -338,7 +347,7 @@ def test_layers_save(tmpdir, layer_data_and_types):
     assert not os.path.isdir(path)
 
     # Write data
-    layers.save(path, plugin='builtins')
+    layers.save(path, plugin=BUILTINS)
 
     # Check folder now exists
     assert os.path.isdir(path)
@@ -366,7 +375,7 @@ def test_layers_save_none_selected(tmpdir, layer_data_and_types):
 
     # Write data (will get a warning that nothing is selected)
     with pytest.warns(UserWarning):
-        layers.save(path, selected=True, plugin='builtins')
+        layers.save(path, selected=True, plugin=BUILTINS)
 
     # Check folder still does not exist
     assert not os.path.isdir(path)
@@ -393,7 +402,7 @@ def test_layers_save_selected(tmpdir, layer_data_and_types):
     assert not os.path.isdir(path)
 
     # Write data
-    layers.save(path, selected=True, plugin='builtins')
+    layers.save(path, selected=True, plugin=BUILTINS)
 
     # Check folder exists
     assert os.path.isdir(path)
@@ -418,7 +427,7 @@ def test_layers_save_svg(tmpdir, layers):
     assert not os.path.isfile(path)
 
     # Write data
-    layers.save(path, plugin='svg')
+    layers.save(path, plugin=SVG)
 
     # Check file now exists
     assert os.path.isfile(path)

--- a/napari/layers/_tests/test_layer_save.py
+++ b/napari/layers/_tests/test_layer_save.py
@@ -2,6 +2,15 @@ import os
 
 import numpy as np
 
+try:
+    import npe2  # noqa: F401
+
+    BUILTINS = 'napari'
+    SVG = 'napari-svg'
+except ImportError:
+    BUILTINS = 'builtins'
+    SVG = 'svg'
+
 
 # the layer_writer_and_data fixture is defined in napari/conftest.py
 def test_layer_save(tmpdir, layer_writer_and_data):
@@ -14,7 +23,7 @@ def test_layer_save(tmpdir, layer_writer_and_data):
     assert not os.path.isfile(path)
 
     # Write data
-    assert layer.save(path, plugin='builtins')
+    assert layer.save(path, plugin=BUILTINS)
 
     # Check file now exists
     assert os.path.isfile(path)
@@ -55,7 +64,7 @@ def test_layer_save_svg(tmpdir, layer):
     assert not os.path.isfile(path)
 
     # Write data
-    assert layer.save(path, plugin='svg')
+    assert layer.save(path, plugin=SVG)
 
     # Check file now exists
     assert os.path.isfile(path)

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -111,7 +111,10 @@ def get_widget_contribution(
     plugin_name: str, widget_name: str
 ) -> Optional[WidgetCallable]:
     for contrib in npe2.PluginManager.instance().iter_widgets():
-        if contrib.plugin_name == plugin_name and contrib.name == widget_name:
+        if (
+            contrib.plugin_name == plugin_name
+            and contrib.display_name == widget_name
+        ):
             return contrib.get_callable()
     return None
 
@@ -160,7 +163,11 @@ def file_extensions_string_for_layers(
         """Lookup the command name and its supported extensions."""
         for writer in writers:
             name = pm.get_manifest(writer.command).display_name
-            title = f"{name} {writer.name}" if writer.name else name
+            title = (
+                f"{name} {writer.display_name}"
+                if writer.display_name
+                else name
+            )
             yield title, writer.filename_extensions
 
     # extension strings are in the format:
@@ -185,7 +192,7 @@ def widget_iterator() -> Iterator[Tuple[str, Tuple[str, Sequence[str]]]]:
     # eg ('dock', ('my_plugin', {'My widget': MyWidget}))
     wdgs: DefaultDict[str, List[str]] = DefaultDict(list)
     for wdg_contrib in npe2.PluginManager.instance().iter_widgets():
-        wdgs[wdg_contrib.plugin_name].append(wdg_contrib.name)
+        wdgs[wdg_contrib.plugin_name].append(wdg_contrib.display_name)
     return (('dock', x) for x in wdgs.items())
 
 

--- a/napari/plugins/_tests/test_save_layers.py
+++ b/napari/plugins/_tests/test_save_layers.py
@@ -4,6 +4,15 @@ import pytest
 
 from napari.plugins.io import save_layers
 
+try:
+    import npe2  # noqa: F401
+
+    BUILTINS = 'napari'
+    SVG = 'napari-svg'
+except ImportError:
+    BUILTINS = 'builtins'
+    SVG = 'svg'
+
 
 # the layer_data_and_types fixture is defined in napari/conftest.py
 def test_save_layer_single_named_plugin(tmpdir, layer_data_and_types):
@@ -17,7 +26,7 @@ def test_save_layer_single_named_plugin(tmpdir, layer_data_and_types):
         assert not os.path.isfile(path)
 
         # Write data
-        save_layers(path, [layer], plugin='builtins')
+        save_layers(path, [layer], plugin=BUILTINS)
 
         # Check file now exists
         assert os.path.isfile(path)
@@ -28,7 +37,7 @@ def test_save_layer_no_results(tmpdir):
     """Test no layers is not an error, and warns on no results."""
 
     with pytest.warns(UserWarning):
-        result = save_layers('no_layers', [], plugin='builtins')
+        result = save_layers('no_layers', [], plugin=BUILTINS)
         assert result == []
 
 
@@ -67,7 +76,7 @@ def test_save_layer_multiple_named_plugin(tmpdir, layer_data_and_types):
     assert not os.path.isdir(path)
 
     # Write data
-    save_layers(path, layers, plugin='builtins')
+    save_layers(path, layers, plugin=BUILTINS)
 
     # Check folder now exists
     assert os.path.isdir(path)
@@ -97,7 +106,7 @@ def test_save_layer_multiple_no_named_plugin(tmpdir, layer_data_and_types):
     assert not os.path.isdir(path)
 
     # Write data
-    save_layers(path, layers, plugin='builtins')
+    save_layers(path, layers, plugin=BUILTINS)
 
     # Check folder now exists
     assert os.path.isdir(path)

--- a/setup.cfg
+++ b/setup.cfg
@@ -147,7 +147,7 @@ console_scripts =
 pytest11 =
     napari = napari.utils._testsupport
 napari.manifest =
-    napari-builtins = napari:builtins.yaml
+    napari = napari:builtins.yaml
     
 [flake8]
 # Ignores - https://lintlyci.github.io/Flake8Rules


### PR DESCRIPTION
# Description

This integrates changes from a final pass of npe2 schema changes. See napari/npe2#49.

Documentation updates will be made in #3769 

# How has this been tested?
The test suite was run with and without the presence of npe2.
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
