### PR TITLE
Fix lack of enters in properties tooltip

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -27,6 +27,7 @@ from qtpy.QtWidgets import (
     QHBoxLayout,
     QMainWindow,
     QShortcut,
+    QToolTip,
     QWidget,
 )
 
@@ -115,7 +116,6 @@ class _QtMainWindow(QMainWindow):
             plugin_manager.set_call_order(settings.plugins.call_order)
 
         _QtMainWindow._instances.append(self)
-        self._qt_viewer.viewer.tooltip.events.text.connect(self.update_tooltip)
 
         # since we initialize canvas before window,
         # we need to manually connect them again.
@@ -128,12 +128,6 @@ class _QtMainWindow(QMainWindow):
     def statusBar(self) -> 'ViewerStatusBar':
         return super().statusBar()
 
-    def update_tooltip(self, event):
-        if self._qt_viewer.viewer.tooltip.visible:
-            self._qt_viewer.setToolTip(event.value)
-        else:
-            self._qt_viewer.setToolTip("")
-
     @classmethod
     def current(cls):
         return cls._instances[-1] if cls._instances else None
@@ -144,6 +138,13 @@ class _QtMainWindow(QMainWindow):
         return window._qt_viewer.viewer if window else None
 
     def event(self, e):
+        if (
+            e.type() == QEvent.ToolTip
+            and self._qt_viewer.viewer.tooltip.visible
+        ):
+            QToolTip.showText(
+                e.globalPos(), self._qt_viewer.viewer.tooltip.text, self
+            )
         if e.type() == QEvent.Close:
             # when we close the MainWindow, remove it from the instances list
             try:


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->
In this PR I would like to fix the problem with missing enters in the tooltip for properties of object in labels or point layer. 

Before Fix: 
![Zrzut ekranu z 2021-12-13 01-43-28](https://user-images.githubusercontent.com/3826210/145736682-de915746-0f7a-46a8-90ed-969c93cc4750.png)

After Fix:
![Zrzut ekranu z 2021-12-13 01-42-56](https://user-images.githubusercontent.com/3826210/145736686-070dad1d-7739-4db9-a96b-cdab9748aaf4.png)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

I do not know why this contains enters, and setting tooltip by `setToolTip` does not have this. 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
