### PR TITLE
Ignore custom index when coercing features table

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1344,3 +1344,18 @@ def test_negative_label_doesnt_flicker():
     # the label colors. Now -1 is seen so it is taken into account in the
     # indexing calculation, and changes color
     assert tuple(layer.get_color(-1)) == minus_one_color_original
+
+
+def test_get_status_with_custom_index():
+    """See https://github.com/napari/napari/issues/3811"""
+    data = np.zeros((10, 10), dtype=np.uint8)
+    data[2:5, 2:-2] = 1
+    data[5:-2, 2:-2] = 2
+    layer = Labels(data)
+    df = pd.DataFrame(
+        {'text1': [1, 3], 'text2': [7, -2], 'index': [1, 2]}, index=[1, 2]
+    )
+    layer.properties = df
+    assert layer.get_status((0, 0)) == 'Labels [0 0]: 0; [No Properties]'
+    assert layer.get_status((3, 3)) == 'Labels [3 3]: 1; text1: 1, text2: 7'
+    assert layer.get_status((6, 6)) == 'Labels [6 6]: 2; text1: 3, text2: -2'

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -432,3 +432,17 @@ def test_remove_features():
         new_features['confidence'],
         [0.2, 1],
     )
+
+
+def test_validate_features_with_custom_index_without_num_data():
+    input = pd.DataFrame({'a': [1, 3], 'b': [7.5, -2.1]}, index=[1, 2])
+    actual = _validate_features(input)
+    expected = input.reset_index(drop=True)
+    pd.testing.assert_frame_equal(actual, expected)
+
+
+def test_validate_features_with_custom_index_and_num_data():
+    input = pd.DataFrame({'a': [1, 3], 'b': [7.5, -2.1]}, index=[1, 2])
+    actual = _validate_features(input, num_data=2)
+    expected = input.reset_index(drop=True)
+    pd.testing.assert_frame_equal(actual, expected)

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -695,8 +695,9 @@ def _validate_features(
     ----------
     features : Union[Dict[str, np.ndarray], pd.DataFrame]
         The features table input, which will be passed to the pandas
-        DataFrame initializer. If this has a non-default index, it
-        will be ignored.
+        DataFrame initializer. If this is a pandas DataFrame with a
+        non-default index, that index (except its length) will be
+        ignored.
     num_data : Optional[int]
         The number of the elements in the layer calling this, such as
         the number of points, which is used to check that the features
@@ -706,9 +707,8 @@ def _validate_features(
     Returns
     -------
     pd.DataFrame
-        The pandas DataFrame created from the input features table.
-        In general, this is will copy the features data, though that
-        behavior should not be relied on.
+        The pandas DataFrame created from the input features table. This
+        may or may not store a copy of the input data.
 
     Raises
     ------

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -695,7 +695,8 @@ def _validate_features(
     ----------
     features : Union[Dict[str, np.ndarray], pd.DataFrame]
         The features table input, which will be passed to the pandas
-        DataFrame initializer.
+        DataFrame initializer. If this has a non-default index, it
+        will be ignored.
     num_data : Optional[int]
         The number of the elements in the layer calling this, such as
         the number of points, which is used to check that the features
@@ -706,8 +707,8 @@ def _validate_features(
     -------
     pd.DataFrame
         The pandas DataFrame created from the input features table.
-        If the input features are already a DataFrame, the data will not
-        be copied, otherwise they will.
+        In general, this is will copy the features data, though that
+        behavior should not be relied on.
 
     Raises
     ------
@@ -715,6 +716,8 @@ def _validate_features(
         If the input feature columns are not all the same length, or if
         that length is not equal to the given num_data.
     """
+    if isinstance(features, pd.DataFrame):
+        features = features.reset_index(drop=True)
     index = None if num_data is None else range(num_data)
     return pd.DataFrame(data=features, index=index)
 


### PR DESCRIPTION
# Description

The input to the `features` and `properties` setters may be a pandas `DataFrame`, which may have a custom index (i.e. not the default integer range index). Currently, a custom index will generally cause odd behavior at best (likely creating rows with missing values) and will sometimes cause undesirable exceptions to be raised (e.g. see #3811).

This PR adds a few tests to describe some of those cases. It fixes those cases by always resetting the index of a given pandas `DataFrame` to the default integer range index. This also allows us to use `Series.[]` instead of `Series.iloc[]` when looking up values, which was the cause of the bug.

Alternatively, we could try to maintain the index of the given `DataFrame`. But in that case we'd have to explicitly check its length against the expected length (if relevant), and also replace all use of `Series.[]` with `Series.iloc[]` throughout napari.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #3811 

# How has this been tested?
- [x] new tests pass with my change
- [x] all existing tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
