### PR TITLE
dont pass app to QtToolTipEventFilter

### DIFF
--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -156,7 +156,7 @@ def get_app(
 
         # Intercept tooltip events in order to convert all text to rich text
         # to allow for text wrapping of tooltips
-        app.installEventFilter(QtToolTipEventFilter(app))
+        app.installEventFilter(QtToolTipEventFilter())
 
     if not _ipython_has_eventloop():
         notification_manager.notification_ready.connect(


### PR DESCRIPTION
# Description
I think this fixes #3813  (cc @melissawm)

incidentally, I think this will also fix the various mysterious `bus errors` that have been showing up in the last couple months on quitting the program.

@goanpeca ... I can't remember where a good place to check that the desired tooltip behavior is still happening.  Can you remember how you confirmed that QtToolTipEventFilter was working?


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
