### PR TITLE
npe2 docs (ref #3769)

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -27,10 +27,13 @@
 - file: plugins/index
   sections:
     - file: plugins/find-and-install-plugin
+    - file: plugins/npe2_getting_started
+    - file: plugins/npe2_manifest_specification
+    - file: plugins/npe2_migration_guide
+    - file: plugins/best_practices
     - file: plugins/for_plugin_developers
     - file: plugins/hook_specifications
     - file: plugins/for_napari_developers
-    - file: plugins/best_practices
 
 - file: developers/index
   sections:

--- a/docs/plugins/for_napari_developers.md
+++ b/docs/plugins/for_napari_developers.md
@@ -2,8 +2,18 @@
 
 # napari plugin architecture
 
+```{admonition} Introducing npe2
+:class: tip
+We introduced a new plugin engine in December 2021. The new library [`npe2`][npe2]
+is a re-imagining of how napari interacts with plugins. Plugins targeting
+`napari-plugin-engine` will continue to work, but we recommend migrating to
+`npe2` as soon as possible.  See the [](npe2-migration-guide).
+
+To learn more about the architecture see the [](npe2-manifest-spec).
+```
+
 The napari plugin architecture is contained in an independent package called [napari-plugin-engine](https://github.com/napari/napari-plugin-engine), which
-is a fork of [pluggy](https://github.com/pytest-dev/pluggy).  The concept is
+is a fork of [pluggy](https://github.com/pytest-dev/pluggy). The concept is
 based around:
 
 - **hook specifications**: function signatures that identify an API (argument
@@ -13,10 +23,12 @@ based around:
   a specific hook specification.
 
 The best place to get started with learning how plugins are incorporated into
-napari is to look at the `napari-plugin-engine` [documentation](https://napari-plugin-engine.readthedocs.io/en/latest/).  In particular,
+napari is to look at the `napari-plugin-engine` [documentation](https://napari-plugin-engine.readthedocs.io/en/latest/). In particular,
 look through the [Usage Overview](https://napari-plugin-engine.readthedocs.io/en/latest/usage.html) and the
 [API Reference](https://napari-plugin-engine.readthedocs.io/en/latest/api.html).
 
 The [documentation for pluggy](https://pluggy.readthedocs.io/en/latest/) is
 also useful for understanding the concepts, but do note that a lot of the
 attribute names and API is different in `napari-plugin-engine`.
+
+[npe2]: https://github.com/napari/npe2

--- a/docs/plugins/for_plugin_developers.md
+++ b/docs/plugins/for_plugin_developers.md
@@ -2,8 +2,18 @@
 
 # Creating a napari plugin
 
+```{admonition} Introducing npe2
+:class: tip
+We introduced a new plugin engine in December 2021. The new library [`npe2`][npe2]
+is a re-imagining of how napari interacts with plugins. Plugins targeting
+`napari-plugin-engine` will continue to work, but we recommend migrating to
+`npe2` as soon as possible. See the [](npe2-migration-guide).
+
+To learn more about creating an `npe2` plugin see the [](npe2-getting-started).
+```
+
 This document explains how to extend napari's functionality by writing a plugin
-that can be installed with `pip` and autodetected by napari.  For more
+that can be installed with `pip` and autodetected by napari. For more
 information on how plugins are implemented internally in napari, see
 {ref}`plugins-for-napari-developers`.
 
@@ -13,31 +23,31 @@ information on how plugins are implemented internally in napari, see
 specific places in the napari
 codebase where functionality can be extended.
 For example, when a user tries to open a filepath in napari, we
-might want to enable plugins to extend the file formats that can be handled.  A
-*hook*, then, is the place within napari where we
+might want to enable plugins to extend the file formats that can be handled. A
+_hook_, then, is the place within napari where we
 "promise" to call functions created by external developers & installed by the user.
 
-1. **Hook specifications**:  For each supported hook, we have created
-"*hook specifications*", which are
-well-documented function signatures that define the API (or
-"contract") that a plugin developer must adhere to when writing their function
-that we promise to call somewhere in the napari codebase.
-See {ref}`plugins-hook-spec`.
+1. **Hook specifications**: For each supported hook, we have created
+   "_hook specifications_", which are
+   well-documented function signatures that define the API (or
+   "contract") that a plugin developer must adhere to when writing their function
+   that we promise to call somewhere in the napari codebase.
+   See {ref}`plugins-hook-spec`.
 
-2. **Hook implementations**: To make a plugin, plugin developers then write functions ("*hook
-implementations*") and mark that function as meeting the requirements of a
-specific *hook specification* offered by napari.
-See {ref}`plugins-hook-implement`.
+2. **Hook implementations**: To make a plugin, plugin developers then write functions ("_hook
+   implementations_") and mark that function as meeting the requirements of a
+   specific _hook specification_ offered by napari.
+   See {ref}`plugins-hook-implement`.
 
 3. **Plugin discovery**: Plugins that are installed in the same python
-environment as napari can make themselves known to napari. `napari` will then
-scan plugin modules for *hook implementations* that will be called at the
-appropriate time and place during the execution of `napari`.
-See {ref}`plugin-discovery`.
+   environment as napari can make themselves known to napari. `napari` will then
+   scan plugin modules for _hook implementations_ that will be called at the
+   appropriate time and place during the execution of `napari`.
+   See {ref}`plugin-discovery`.
 
 4. **Plugin sharing**: When you are ready to share your plugin, tag your repo
-with `napari-plugin`, push a release to pypi, and announce it on Image.sc.
-Your plugin will then be available for users on the [napari hub](https://napari-hub.org/). See {ref}`plugin-sharing`.
+   with `napari-plugin`, push a release to pypi, and announce it on Image.sc.
+   Your plugin will then be available for users on the [napari hub](https://napari-hub.org/). See {ref}`plugin-sharing`.
 
 (plugin-cookiecutter-template)=
 
@@ -48,7 +58,7 @@ module of a Python package. This allows them to be "pip installable" and
 shared via [PyPI](https://pypi.org/) and the [napari hub](https://napari-hub.org/).
 
 To quickly generate a new napari plugin project, you may wish to use the
-[cookiecutter-napari-plugin](https://github.com/napari/cookiecutter-napari-plugin) template.  This uses
+[cookiecutter-napari-plugin](https://github.com/napari/cookiecutter-napari-plugin) template. This uses
 the [cookiecutter](https://github.com/cookiecutter/cookiecutter) command line
 utility, which will ask you a few questions about your project and get you
 started with a ready-to-go package layout where you can begin implementing your
@@ -70,16 +80,16 @@ package and all its associated configuration.
 ## Step 1: Choose a hook specification to implement
 
 The functionality of plugins, as currently designed and implemented in
-`napari`, is rather specific in scope: They are *not* just independent code
+`napari`, is rather specific in scope: They are _not_ just independent code
 blocks with their own GUIs that show up next to the main napari window. Rather,
-plugin developers must decide which of the current *hook specifications*
+plugin developers must decide which of the current _hook specifications_
 defined by napari they would like to implement.
 
-For a complete list of *hook specifications* that developers can implement, see
+For a complete list of _hook specifications_ that developers can implement, see
 the {ref}`hook-specifications-reference`.
 
-A single plugin package may implement more than one *hook specification*, and
-each *hook specification* could have multiple *hook implementations* within
+A single plugin package may implement more than one _hook specification_, and
+each _hook specification_ could have multiple _hook implementations_ within
 a single package.
 
 ```{note}
@@ -95,7 +105,7 @@ a single package.
 ```
 
 Let's take the {func}`~napari.plugins.hook_specifications.napari_get_reader`
-hook (our primary "reader plugin" hook) as an example.  It is defined as:
+hook (our primary "reader plugin" hook) as an example. It is defined as:
 
 ```python
    LayerData = Union[Tuple[Any], Tuple[Any, Dict], Tuple[Any, Dict, str]]
@@ -109,14 +119,14 @@ hook (our primary "reader plugin" hook) as an example.  It is defined as:
 ```
 
 Note that it takes a `str` or a `list` of `str` and either returns
-`None` or a function.  From the {func}`docstring <napari.plugins.hook_specifications.napari_get_reader>` of the hook
+`None` or a function. From the {func}`docstring <napari.plugins.hook_specifications.napari_get_reader>` of the hook
 specification, we see that the implementation should return `None` if the
 path is of an unrecognized format, otherwise it should return a
 `ReaderFunction`, which is a function that takes a `str` (the filepath to
 read) and returns a `list` of `LayerData`, where `LayerData` is any one
 of `(data,)`, `(data, meta)`, or `(data, meta, layer_type)`.
 
-That seems like a bit of a mouthful!  But it's a precise (though flexible)
+That seems like a bit of a mouthful! But it's a precise (though flexible)
 contract that you can follow, and know that napari will handle the rest.
 
 (plugins-hook-implement)=
@@ -124,7 +134,7 @@ contract that you can follow, and know that napari will handle the rest.
 ## Step 2: Write your hook implementation
 
 Once you have identified the {ref}`hook specification <hook-specifications-reference>` that you want to implement, you have to create
-a *hook implementation*: a function that accepts the arguments specified by the
+a _hook implementation_: a function that accepts the arguments specified by the
 hook specification signature and returns a value with the expected return type.
 
 Here's an example hook implementation for
@@ -159,13 +169,13 @@ with {func}`numpy.save`)
 ### Decorating your function with `HookImplementationMarker`
 
 In order to let `napari` know that one of your functions satisfies the API of
-one of the napari *hook specifications*, you must decorate your function with
+one of the napari _hook specifications_, you must decorate your function with
 an instance of {class}`~napari_plugin_engine.HookImplementationMarker`,
-initialized with the name `"napari"`.  As a convenience, napari provides this
+initialized with the name `"napari"`. As a convenience, napari provides this
 decorator at `napari_plugin_engine.napari_hook_implementation` as shown in
 the example above.
 
-However, it's not required to import from or depend on napari *at all* when
+However, it's not required to import from or depend on napari _at all_ when
 writing a plugin. You can import a `napari_hook_implementation` decorator
 directly from `napari_plugin_engine` (a very lightweight dependency that uses
 only standard lib python).
@@ -177,7 +187,7 @@ only standard lib python).
 #### Matching hook implementations to specifications
 
 By default, `napari` matches your implementation to one of our hook
-specifications by looking at the *name* of your decorated function.  So in the
+specifications by looking at the _name_ of your decorated function. So in the
 example above, because the hook implementation was literally
 named `napari_get_reader`, it gets interpreted as an implementation for the
 hook specification of the same name.
@@ -188,7 +198,7 @@ hook specification of the same name.
       ...
 ```
 
-However, you may also mark *any* function as satisfying a particular napari
+However, you may also mark _any_ function as satisfying a particular napari
 hook specification (regardless of the function's name) by providing the name of
 the target hook specification to the `specname` argument in your
 implementation decorator:
@@ -199,7 +209,7 @@ implementation decorator:
       ...
 ```
 
-This allows you to specify multiple hook implementations of the same hook 
+This allows you to specify multiple hook implementations of the same hook
 specification in the same module or class, without needing a separate entry point.
 
 (plugin-discovery)=
@@ -240,18 +250,18 @@ functionality by simply installing your package along with napari:
 
 ## Step 4: Preparing for release
 
-To make your plugin easily discoverable by napari users, you can use the 
-`'Framework :: napari'` [classifier](https://pypi.org/classifiers/) in your 
-`setup.py` file, which will allow your package to be 
+To make your plugin easily discoverable by napari users, you can use the
+`'Framework :: napari'` [classifier](https://pypi.org/classifiers/) in your
+`setup.py` file, which will allow your package to be
 [displayed on the napari-hub](https://napari-hub.org/) and easily searched
 for on PyPI.
 
-Once your package, with its `'Framework :: napari'` classifier,  is listed on [PyPI](https://pypi.org/), it will also be visible
+Once your package, with its `'Framework :: napari'` classifier, is listed on [PyPI](https://pypi.org/), it will also be visible
 on the [napari hub](https://napari-hub.org/), alongside all other napari plugins.
 
 The napari hub reads the metadata of your package and displays it in a number of places
-so that users can easily find your plugin and decide if it provides functionality they 
-need. Most of this metadata lives inside your package configuration files. You can customize 
+so that users can easily find your plugin and decide if it provides functionality they
+need. Most of this metadata lives inside your package configuration files. You can customize
 your plugin's listing for the hub by following [this guide](https://github.com/chanzuckerberg/napari-hub/blob/main/docs/customizing-plugin-listing.md).
 
 You can also include a napari hub specific description file at `/.napari/DESCRIPTION.md`.
@@ -262,13 +272,13 @@ with your plugin. For more information on this file, see [the guide](https://git
 
 Finally, once you have curated your package metadata and description, you can preview your
 metadata, and check any missing fields using the `napari-hub-cli` tool. Install this tool
-using 
+using
 
 ```sh
    pip install napari-hub-cli
 ```
 
-and preview your metadata with 
+and preview your metadata with
 
 ```sh
    napari-hub-cli preview-metadata /tmp/example-plugin
@@ -276,9 +286,9 @@ and preview your metadata with
 
 For more information on the tool see the repository README](https://github.com/chanzuckerberg/napari-hub-cli).
 
-If you want your plugin to be available on PyPI, but not visible on the napari hub, 
+If you want your plugin to be available on PyPI, but not visible on the napari hub,
 submit an issue on the [napari hub repository]
-(https://github.com/chanzuckerberg/napari-hub/issues/new) or send an email to 
+(https://github.com/chanzuckerberg/napari-hub/issues/new) or send an email to
 `team@napari-hub.org` and it will be removed.
 
 (plugin-sharing)=
@@ -314,7 +324,7 @@ For a minimal working plugin example, see the [napari-dv](https://github.com/tla
 read the [Priism/MRC/Deltavision image file format](https://github.com/tlambert03/mrc).
 
 For a more thorough plugin see [napari-aicsimageio](https://github.com/AllenCellModeling/napari-aicsimageio), one of the first
-community plugins developed for napari.  This plugin takes advantage of
+community plugins developed for napari. This plugin takes advantage of
 {ref}`entry_point discovery <plugin-discovery>` to offer multiple
 readers for both in-memory and lazy-loading of image files.
 
@@ -326,3 +336,5 @@ If you run into trouble creating your plugin, please don't hesitate to reach
 out for help in the [Image.sc Forum](https://forum.image.sc/tag/napari).
 Alternatively, if you find a bug or have a specific feature request for plugin
 support, please open an issue at our [GitHub issue tracker](https://github.com/napari/napari/issues/new/choose).
+
+[npe2]: https://github.com/napari/npe2

--- a/docs/plugins/hook_specifications.md
+++ b/docs/plugins/hook_specifications.md
@@ -2,12 +2,22 @@
 
 # napari hook specification reference
 
+```{admonition} Introducing npe2
+:class: tip
+We introduced a new plugin engine in December 2021. The new library [`npe2`][npe2]
+is a re-imagining of how napari interacts with plugins. Plugins targeting
+`napari-plugin-engine` will continue to work, but we recommend migrating to
+`npe2` as soon as possible. See the [](npe2-migration-guide).
+
+To learn more about the specification see the [](npe2-manifest-spec).
+```
+
 ```{eval-rst}
 .. automodule:: napari.plugins.hook_specifications
   :noindex:
 
 .. currentmodule:: napari.plugins.hook_specifications
-````
+```
 
 ## IO hooks
 
@@ -18,6 +28,7 @@
 ```
 
 (write-single-layer-hookspecs)=
+
 ### Single Layers IO
 
 The following hook specifications will be called when a user saves a single
@@ -25,7 +36,7 @@ layer in napari, and should save the layer to the requested format and return
 the save path if the data are successfully written. Otherwise, if nothing was saved, return `None`.
 They each accept a `path`.
 It is up to plugins to inspect and obey the extension of the path (and return
-`False` if it is an unsupported extension).  The `data` argument will come
+`False` if it is an unsupported extension). The `data` argument will come
 from `Layer.data`, and a `meta` dict that will correspond to the layer's
 {meth}`~napari.layers.base.base.Layer._get_state` method.
 
@@ -36,7 +47,7 @@ from `Layer.data`, and a `meta` dict that will correspond to the layer's
 .. autofunction:: napari_write_shapes
 .. autofunction:: napari_write_surface
 .. autofunction:: napari_write_vectors
-````
+```
 
 ## Analysis hooks
 
@@ -50,3 +61,5 @@ from `Layer.data`, and a `meta` dict that will correspond to the layer's
 .. autofunction:: napari_experimental_provide_theme
 .. autofunction:: napari_experimental_provide_dock_widget
 ```
+
+[npe2]: https://github.com/napari/npe2

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -2,14 +2,61 @@
 
 # Plugins
 
-`napari` enables developers to extend functionality of the program by writing
-plugins. For a guide on how to create a plugin, see
-{ref}`plugins-for-plugin-developers`. For napari contributors looking to
-understand how the napari plugin architecture is implemented, see
-{ref}`plugins-for-napari-developers`. For a complete list of _hook
+```{admonition} Introducing npe2
+:class: tip
+We introduced a new plugin engine in December 2021. The new library
+[`npe2`][npe2] is a re-imagining of how napari interacts with plugins. Rather
+than importing a package to discover plugin functionality, a static manifest
+file is used to declaratively describe a plugin's capabilities. Details can be
+found in the [](npe2-manifest-spec).
+
+Plugins targeting `napari-plugin-engine` will continue to work, but we
+recommend migrating to `npe2` as soon as possible. `npe2` includes tooling to
+help automate the process of migrating plugins. See the [migration
+guide](npe2-migration-guide) for details.
+
+For getting started writing new npe2 plugins see the [](npe2-getting-started).
+```
+
+napari loves plugins. Plugins allow people to customize and extend to napari.
+
+This document describes:
+
+- How to [build, run and publish a plugin](how-to-build-a-plugin).
+- Where to find guides and code samples to help get you started.
+- [Guidelines](best-practices) for writing plugins.
+
+If you are looking for plugins, head to the [napari
+hub](https://napari-hub.org). Plugins can be installed directly from within
+napari or with package installers (pip/conda) via the command line -- to learn
+more see {ref}`find-and-install-plugins`.
+
+## What can plugins do?
+
+- Change the look of napari with a color theme
+- Add custom widgets and user interface elements
+- Add file format support - readers and writers
+- Provide sample data
+
+(how-to-build-a-plugin)=
+
+## How to build plugins?
+
+New plugins should target `npe2`. See the {ref}`npe2-getting-started`.
+
+For a guide on how to create a plugin using `napari-plugin-engine`, see
+{ref}`plugins-for-plugin-developers`. For a complete list of _hook
 specifications_ that developers can implement, see the
 {ref}`hook-specifications-reference`.
 
-napari users can install plugins directly from their instance of napari to enhance their workflows; to learn more see {ref}`find-and-install-plugins`.
+For special considerations when building a napari plugin, see
+{ref}`best-practices`.
 
-To read about recommendations on how to develop your own plugin, see {ref}`best-practices`.
+## Looking for help
+
+If you have questions, try asking on the [zulip
+chat](https://napari.zulipchat.com/). Submit issues to the [napari github
+repository](https://github.com/napari/napari).
+
+[npe1]: https://github.com/napari/napari-plugin-engine
+[npe2]: https://github.com/tlambert03/npe2

--- a/docs/plugins/npe2_getting_started.md
+++ b/docs/plugins/npe2_getting_started.md
@@ -1,0 +1,306 @@
+(npe2-getting-started)=
+
+# npe2 getting started guide
+
+```{admonition} Introducing npe2
+:class: tip
+We introduced a new plugin engine in December 2021. The new library [`npe2`][npe2]
+is a re-imagining of how napari interacts with plugins. Plugins targeting
+`napari-plugin-engine` will continue to work, but we recommend migrating to
+`npe2` as soon as possible.
+```
+
+This guide will walk you through the steps required to write a napari plugin
+from scratch.
+
+At the end of this guide, you will have a working plugin that can be installed
+with `pip` and autodetected by napari.
+
+## Overview
+
+Plugins are special python packages. They include a _plugin manifest_ file
+that lists _contributions_ that napari may use when performing tasks.
+
+Creating a new plugin involves the following steps:
+
+1. Configure a python package to use an npe2 manifest (e.g. by [editing
+   `setup.cfg`](edit-package-meta)):
+   - Create the _entry point group_.
+   - Make sure the manifest file is added to `package_data`.
+2. Create the [plugin manifest](manifest) file.
+
+This guide will walk you through the steps using a [cookiecutter] template.
+cookiecutter is a command line utility that generates a python package for you
+after asking a few questions. In this case, the package contains all the
+boilerplate needed for building, documenting, testing and deploying your plugin.
+
+```{note}
+Minimally, a plugin could be just three files: `setup.cfg`, a python file, and
+the plugin manifest file.
+```
+
+## 1. Create the project using cookiecutter
+
+Install cookiecutter and use the template as follows:
+
+```bash
+pip install cookiecutter
+cookiecutter https://github.com/napari/cookiecutter-napari-plugin --checkout npe2
+```
+
+`cookiecutter` will ask you a series of questions
+about the functionality you want your plugin to provide. In this guide we'll
+focus on creating a reader that can read numpy (`*.npy`) files.
+
+```sh
+# example questions asked when running cookiecutter:
+...
+plugin_name [napari-foobar]: my-npy-reader
+module_name [my_npy_reader]:
+display_name [napari FooBar]: My npy reader
+short_description [A simple plugin to use with napari]: A simple npy reader
+include_reader_plugin [y]:
+include_writer_plugin [y]: n
+include_sample_data_plugin [y]: n
+include_widget_plugin [y]: n
+...
+```
+
+We named our plugin `my-py-reader`. This is the name that will be used for
+the python package. It should conform to the [PEP8] naming convention
+(short, all-lowercase names, using dashes instead of underscores).
+
+When the cookiecutter asked to include a reader plugin, we selected `y`, and
+in the next question we told cookiecutter that our reader should be invoked
+for files matching the `*.npy` [glob] pattern.
+
+After answering all the prompts, `cookiecutter` will create a directory called
+`my_npy_reader` in the current directory that holds the generated files. It
+will look something like this:
+
+```
+my-npy-reader
+├── .napari                    <-- napari-hub customizations
+│   └── DESCRIPTION.md
+│   └── config.yml
+├── LICENSE
+├── MANIFEST.in
+├── README.md
+├── docs
+│   └── index.md
+├── mkdocs.yml
+├── requirements.txt
+├── setup.cfg                  <-- Defines an entry point group
+├── setup.py                       pointing to the plugin manifest
+├── src
+│   └── my_npy_reader
+│       ├── __init__.py
+│       ├── _reader.py         <-- example reader code
+│       ├── _tests
+│       │   ├── __init__.py
+│       │   └── test_reader.py
+│       └── napari.yml         <-- The plugin manifest
+└── tox.ini
+```
+
+(manifest)=
+
+### Plugin manifest file
+
+The plugin manifest file is specified relative to the top level module path as specified in `setup.cfg` `options.packages.find`. For
+the example it will be loaded from:
+`<path/to/my-npy-reader>/my_npy_reader/src/my_npy_reader/napari.yaml`.
+
+The generated `napari.yml` file looks like this:
+
+```yaml
+name: my-npy-reader
+display_name: My Plugin
+contributions:
+  commands:
+    - id: my-npy-reader.get_reader
+      python_name: my_plugin._reader:napari_get_reader
+      title: Open data with napari FooBar
+  readers:
+    - command: my-npy-reader.get_reader
+      accepts_directories: false
+      filename_patterns: ["*.npy"]
+```
+
+With `npe2` installed, we can check that this is a valid plugin manifest:
+
+```bash
+> npe2 validate src/my_npy_reader
+✔ Manifest for 'My Plugin' valid!
+```
+
+See the {ref}`npe2-manifest-spec` for more details.
+
+## 2. Write code to implement your plugin
+
+For our example `*.npy` reader, edit `src/my_npy_reader/_reader.py`:
+
+```python
+import numpy as np
+
+def npy_file_reader(path):
+    array = np.load(path)
+    # return it as a list of LayerData tuples,
+    # here with no optional metadata
+    return [(array,)]
+
+# This is the function referenced by the reader command in `napari.yml`.
+def napari_get_reader(path):
+    # remember, path can be a list, so we check its type first...
+    # (this example plugin doesn't handle lists)
+    if isinstance(path, str) and path.endswith(".npy"):
+        # If we recognize the format, we return the actual reader function
+        return npy_file_reader
+    # otherwise we return None.
+    return None
+```
+
+You can start interacting with your plugin using a local editable install,
+and opening napari:
+
+```bash
+# from the my-npy-reader folder
+pip install -e .
+napari
+```
+
+(edit-package-meta)=
+
+## 3. Make your plugin discoverable
+
+Packages and modules installed in the same environment as napari may make
+themselves discoverable to napari using package metadata.
+
+The manifest file should be specified in the plugin's `setup.cfg` or
+`setup.py` file using the _[entry point group][epg]_: `napari.manifest`. For
+example, this would be the section for a plugin `npe2-tester` with
+`napari.yaml` as the manifest file:
+
+```cfg
+[options.entry_points]
+napari.manifest =
+    npe2-tester = npe2_tester:napari.yaml
+```
+
+The manifest file is specified relative to the submodule root path.
+So for the example it will be loaded from:
+`<path/to/npe2-tester>/napari.yaml`.
+
+The manifest file also needs to be included as _[package data][pd]_ in
+distributable forms for the package. For example:
+
+```toml
+[metadata]
+...
+include_package_data=True
+
+[options.package_data]
+npe2_tester =
+    napari.yaml
+```
+
+A user can install napari and your plugin with:
+
+```bash
+pip install napari myplugin
+```
+
+## 4. Preparing for release
+
+Use the `Framework :: napari` [classifier] in your package's core metadata to
+make your plugin more discoverable. If you used the cookiecutter, this has
+already been done for you.
+
+Once your package, with its `Framework :: napari` classifier, is listed on
+[PyPI], it will also be visible on the [napari hub][hub], alongside all other
+napari plugins. More about python packing can be found in the [packaging guide].
+
+You can customize your plugin’s listing for the hub by following this
+[guide][hubguide]. If you'd like to know what your _napari hub_ plugin page
+will look like, you can use the _napari hub plugin preview_ service - see this
+[guide][hub-guide-preview] to get started.
+
+The napari hub reads the metadata of your package and displays it in a number
+of places so that users can easily find your plugin and decide if it provides
+functionality they need. Most of this metadata lives inside your package
+configuration files.
+
+You can also include a napari hub specific description file at
+`/.napari/DESCRIPTION.md`. The hub preferentially displays this file over your
+repository’s `README.md` when it’s available. This file allows you to maintain a
+more developer/repository oriented `README.md` while still making sure potential
+users get all the information they need to get started with your plugin.
+
+Finally, once you have curated your package metadata and description, you can
+preview your metadata, and check any missing fields using the `napari-hub-cli`
+tool. Install this tool using
+
+```bash
+pip install napari-hub-cli
+```
+
+and preview your metadata with
+
+```bash
+napari-hub-cli preview-metadata ./my-npy-reader
+```
+
+For more information on the tool see the `napari-hub-cli`
+[README](https://github.com/chanzuckerberg/napari-hub-cli).
+
+If you want your plugin to be available on PyPI, but not visible on the napari
+hub, you can add a `.napari/config.yml` file to the root of your repository
+with a visibility key. For details, see the [customization
+guide][hub-guide-custom-viz].
+
+## 5. Share your plugin with the world
+
+Once you are ready to share your plugin, [upload the Python package to
+PyPI][pypi-upload] and it can then be installed with a simple
+`pip install mypackage`. If you used the {ref}`plugin-cookiecutter-template`,
+you can also [setup automated deployments][autodeploy].
+
+If you are using Github, add the ["napari-plugin"
+topic](https://github.com/topics/napari-plugin) to your repo so other
+developers can see your work.
+
+The [napari hub](https://www.napari-hub.org/) automatically displays
+information about PyPI packages annotated with the `Framework :: napari`
+[Trove classifier](https://pypi.org/classifiers/), to help end users discover
+plugins that fit their needs. To ensure you are providing the relevant
+metadata and description for your plugin, see the following documentation in
+the [napari hub
+GitHub](https://github.com/chanzuckerberg/napari-hub/tree/main/docs)’s docs
+folder:
+
+- [Customizing your plugin’s listing](https://github.com/chanzuckerberg/napari-hub/blob/main/docs/customizing-plugin-listing.md)
+- [Writing the perfect description for your plugin](https://github.com/chanzuckerberg/napari-hub/blob/main/docs/writing-the-perfect-description.md)
+
+For more about the napari hub, see the [napari hub About page](https://www.napari-hub.org/about).
+To learn more about the hub’s development process, see the [napari hub GitHub’s Wiki](https://github.com/chanzuckerberg/napari-hub/wiki).
+
+When you are ready for users, announce your plugin on the [Image.sc Forum](https://forum.image.sc/tag/napari).
+
+[npe2]: https://github.com/napari/npe2
+[json]: https://www.json.org/
+[yaml]: https://yaml.org/
+[toml]: https://toml.io/
+[cookiecutter]: https://github.com/cookiecutter/cookiecutter
+[pep8]: https://www.python.org/dev/peps/pep-0008/#package-and-module-names
+[epg]: https://packaging.python.org/specifications/entry-points/
+[pd]: https://setuptools.pypa.io/en/latest/userguide/datafiles.html
+[hub]: https://www.napari-hub.org/
+[hubguide]: https://github.com/chanzuckerberg/napari-hub/blob/main/docs/customizing-plugin-listing.md
+[pypi-upload]: https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives
+[autodeploy]: https://github.com/napari/cookiecutter-napari-plugin#set-up-automatic-deployments
+[glob]: https://en.wikipedia.org/wiki/Glob_(programming)
+[classifier]: https://pypi.org/classifiers/
+[hub-guide-custom-viz]: https://github.com/chanzuckerberg/napari-hub/blob/main/docs/customizing-plugin-listing.md#visibility
+[hub-guide-preview]: https://github.com/chanzuckerberg/napari-hub/blob/main/docs/setting-up-preview.md
+[packaging guide]: https://packaging.python.org/en/latest/tutorials/packaging-projects/
+[pypi]: https://pypi.org/

--- a/docs/plugins/npe2_getting_started.md
+++ b/docs/plugins/npe2_getting_started.md
@@ -8,6 +8,8 @@ We introduced a new plugin engine in December 2021. The new library [`npe2`][npe
 is a re-imagining of how napari interacts with plugins. Plugins targeting
 `napari-plugin-engine` will continue to work, but we recommend migrating to
 `npe2` as soon as possible.
+
+For more on migrating an existing plugins see the [](npe2-migration-guide).
 ```
 
 This guide will walk you through the steps required to write a napari plugin

--- a/docs/plugins/npe2_manifest_specification.md
+++ b/docs/plugins/npe2_manifest_specification.md
@@ -406,7 +406,7 @@ meta[‘multiscale’] is True, then the data should be interpreted as a
 multiscale image.
 
 meta(dict)
-: Layer metadata.
+: layer attributes.
 
 **Return**
 

--- a/docs/plugins/npe2_manifest_specification.md
+++ b/docs/plugins/npe2_manifest_specification.md
@@ -470,7 +470,7 @@ Sample data uri
 name: my-sample
 contributions:
   sample_data:
-    - display_name: Tabueran Kribati
+    - display_name: Tabueran Kiribati
       key: napari
       uri: https://en.wikipedia.org/wiki/Napari#/media/File:Tabuaeran_Kiribati.jpg
 ```

--- a/docs/plugins/npe2_manifest_specification.md
+++ b/docs/plugins/npe2_manifest_specification.md
@@ -1,0 +1,604 @@
+(npe2-manifest-spec)=
+
+# npe2 manifest specification
+
+```{admonition} Backward compatibility
+:class: tip
+We introduced a new plugin engine in December 2021. The new library [`npe2`][npe2]
+is a re-imagining of how napari interacts with plugins. Plugins targeting
+`napari-plugin-engine` will continue to work, but we recommend migrating to
+`npe2` as soon as possible.  See the [](npe2-migration-guide).
+```
+
+The **plugin manifest** is a specially formatted text file declaring the
+functionality of a [npe2][] plugin. A **plugin** is a python package that
+contains the manifest together with a suitable _[entry point group][epg]_ in
+the package metadata.
+
+Manifest files may be [json][], [yaml][], or [toml][] files conforming to the
+manifest schema. The **schema** defines what to expect in a manifest by
+defining the fields and their data types. These fields and their meanings are
+described below.
+
+A **plugin engine** is used to discover plugins, provide utilities for
+querying and manipulating plugins, and for exposing plugin-backed
+functionality to _napari_. **Discovery** is the process that finds plugins,
+parses the manifests and indexes them for later use. The [npe2][] library
+manages these responsibilities.
+
+## Configuring a python package to use a plugin manifest
+
+### 1. Add package metadata for locating the manifest
+
+The manifest file should be specified in the plugin's `setup.cfg` or
+`setup.py` file using the _[entry point group][epg]_: `napari.manifest`. For
+example, this would be the section for a plugin `npe2-tester` with
+`napari.yaml` as the manifest file:
+
+```cfg
+[options.entry_points]
+napari.manifest =
+    npe2-tester = npe2_tester:napari.yaml
+```
+
+The manifest file is specified relative to the submodule root path.
+So for the example it will be loaded from: `<path/to/npe2-tester>/napari.yaml`.
+
+### 2. Include the manifest in the package distribution
+
+The manifest file needs to be included as _[package data][pd]_ in
+distributable forms for the package. For example:
+
+```toml
+[metadata]
+...
+include_package_data=True
+
+[options.package_data]
+npe2_tester =
+    napari.yaml
+```
+
+## Manifest schema
+
+The plugin manifest file is a [json][], [yaml][], or [toml][] conforming to
+a schema. The `npe2` package includes a command-line tool that can be used
+to validate a schema:
+
+```
+pip install npe2
+npe2 validate my_plugin_manifest.yml
+```
+
+The manifest file's fields are described in detail below. The manifest file's
+overall structure can be viewed as a hierarchy:
+
+```
+<top-level properties>
+contributions:
+  commands:     <list of commands>
+  readers:      <list of readers>
+  writers:      <list of writers>
+  sample_data:  <list of sample data providers>
+  widgets:      <list of widget providers>
+  themes:       <list of themes>
+```
+
+Readers, writers, sample data providers and widget providers refer to callable
+python functions that a plugin defines. Each callable is identified with an
+entry in the list of `commands` via a unique id. For more see {ref}`Commands`
+below.
+
+```{note}
+Python package metadata (`setup.py` or `setup.cfg`) may be used to populate
+some internal properties of the plugin manifest. These include the authors,
+description, and version.
+```
+
+(top-level-props)=
+
+## Top-level properties
+
+### Required
+
+- **name** The name of the plugin. Example: `napari-svg`. Should be a
+  [PEP-8]-compatible package name. If missing, this is populated from the
+  python package [name][setup-name].
+
+### Optional
+
+- **engine**: A SemVer compatible version string matching the versions of the
+  plugin engine that the extension is compatible with. Example: "0.1.0".
+  See [][compatibility] for details.
+- **display_name**: User-facing text to display as the name of this plugin.
+  Example: `napari SVG`. Must be 3-40 characters long, containing
+  printable word characters, and must not begin or end with an underscore,
+  white space, or non-word character.
+- **entry_point**: The module containing the `activate()` function. Example:
+  `foo.bar.baz`. This should be a fully qualified module string.
+
+```{admonition} activation and deactivation
+An `activate()` function can be used to perform one-time initialization for a
+plugin.  Similarly, a `deactivate()` function can be used to perform tear-down
+on deactivation.  These must be defined relative to the `entry_point`.
+```
+
+(compatibility)=
+
+### Compatibility
+
+A goal of `npe2` was to make it possible to add or change the plugin interface
+without breaking existing plugins. This is achieved by defining an
+**engine version**. When we want to change the plugin interface, we increment
+this number to indicate there is something new. New plugins can opt-in to the
+new behavior by declaring compatibility with that version.
+
+When authoring a plugin, you will need to describe what is the plugin's
+compatibility with `npe2`. This can be done via the `engine` field in the
+plugin manifest (see {ref}`top-level-props`).
+
+You can use the `engine` field to makes sure the plugin only gets installed
+for clients that use the plugin specification you depend on.
+
+For example, imagine you develop your plugin using the `0.1.0` engine
+specification. A few months of development go by and a new API is introduced
+to the plugin engine defining a new _engine version_, `0.2.0`. You add that
+new API and update your plugin's manifest file accordingly.
+
+Users running older versions of napari will not have the new API. Their plugin
+engine will inspect the _engine version_ declared by your plugin and correctly
+prevent your plugin from being used. When those users upgrade their napari
+installation, they'll be able to take advantage of the new functionality you
+added.
+
+(commands)=
+
+## Commands
+
+**command** is a python function associated with an id. The **id** is
+a unique identifier to which other contributions, like readers, can refer.
+
+When a contribution like a reader refers to a command, it gives the command
+meaning. The command will be expected to conform to a specific _calling
+convention_. The **calling convention** is described by the argument and return
+types of the associated callable, as well as conventions regarding it's
+behavior.
+
+### Required fields
+
+- **id** An identifier used to reference this command within this plugin.
+- **title** A description of the command. This might be used, for example,
+  when searching in a command palette. Examples: "Generate lily sample",
+  "Read tiff image", "Open gaussian blur widget".
+
+### Optional fields
+
+- **python_name** Fully qualified name to callable python object implementing
+  this command. This usually takes the form of
+  `{obj.__module__}:{obj.__qualname__}` (e.g.
+  `my_package.a_module:some_function`). For a command to be useful, this
+  field must be specified. If it isn't specified here it should be done
+  dynamically inside the plugin's 'activate()' function. _Must_ be populated
+  before being invoked at runtime.
+
+### Example
+
+```yaml
+name: my-plugin
+contribution:
+  commands:
+    - id: my-plugin.publish_paper
+      title: Do experiments, analysis, write paper, and submit
+      python_name: my_plugin:publish_func
+```
+
+````{admonition} Dynamic command registration
+
+Commands can be registered dynamically by the plugin's `activate()` function.
+This is purely an alternative to listing `python_name` in the manifest.
+
+For example,
+
+```python
+# inside my_plugin/__init__.py
+from npe2 import PluginContext
+def activate(context: PluginContext):
+    @context.register_command("my_plugin.hello_world")
+    def _hello():
+        ...
+
+    context.register_command("my_plugin.another_command", lambda: print("yo!"))
+```
+
+The `activate()` function is called when the plugin is loaded. It is found in
+the `entry_point` specified in the plugin manifest.
+````
+
+## Readers
+
+### Required fields
+
+- **command** Identifier of the _command_ to execute.
+- **filename_patterns** List of filename patterns (for fnmatch) that this
+  reader can accept. Reader will be tried only if `fnmatch(filename, pattern) == True`.
+
+### Optional fields
+
+- **accepts_directories** If true, the reader will accept paths to directories
+  for reading data.
+
+### Example
+
+```yaml
+name: my-reader
+contribution:
+  commands:
+    - id: my-reader.read_npy_image
+      title: Open an npy file as an image
+      python_name: my_reader.load_as_image
+  readers:
+    - command: my-reader.read_npy_image
+      accepts_directories: false
+      filename_patterns: ["*.npy"]
+```
+
+### Calling convention
+
+```python
+def get_reader(path:str)->Optional[Callable[[str],List[LayerData]]]:
+  ...
+  return reader
+
+def reader(path: str) -> List[LayerData]:
+    ...
+```
+
+```{note}
+The reader command is compatible with functions used for the `napari_get_reader`
+[hook specification][get-reader-hook] used by plugins based on the
+`napari-plugin-engine`. See the [](npe2-migration-guide) for more details.
+```
+
+**Parameters**
+
+path(str)
+: Path to file, directory, or resource (like a url).
+
+**Return**
+
+layer_data(list of LayerData)
+: Each `LayerData` element is a tuple of `(data,meta,layer_type)`.
+
+## Writers
+
+### Required fields
+
+- **command** Identifier of the _command_ providing the writer.
+- **layer_types** List of layer type constraints. These determine what
+  combinations of layers this writer handles.
+
+### Optional fields
+
+- **display_name** Brief text used to describe this writer when presented.
+  Empty by default. When present this is presented along side the plugin name
+  and may be used to distinguish the kind of writer for the user. E.g. "lossy"
+  or "lossless".
+- **filename_extensions** List of filename extensions compatible with this
+  writer. The first entry is used as the default if necessary. Empty by default.
+  When empty, any filename extension is accepted.
+
+### Examples
+
+**Example**
+
+Single-layer writer
+
+```yaml
+name: napari
+contributions:
+  commands:
+    - id: napari.write_points
+      python_name: napari.plugins._builtins:napari_write_points
+      title: Save points layer to csv
+  writers:
+    - command: napari.write_points
+      filename_extensions: [".csv"]
+      layer_types: ["points"]
+```
+
+**Example**
+
+Multi-layer writer
+
+```yaml
+name: napari-svg
+contributions:
+  commands:
+    - id: napari-svg.svg_writer
+      python_name: napari-svg.hook_implementations:writer
+      title: Save layers as SVG
+  writers:
+    - command: napari_svg.svg_writer
+      layer_types: ["image*", "labels*", "points*", "shapes*", "vectors*"]
+      filename_extensions: [".svg"]
+```
+
+### Layer type constraints
+
+Given a set of layers, compatible writer plugins are selected based their
+_layer type constraints_.
+
+A writer plugin can declare that it will write between _m_ and _n_ layers of a
+specific type where _0≤m≤n_.
+
+For example:
+
+```
+    image      Write exactly 1 image layer.
+    image?     Write 0 or 1 image layers.
+    image+     Write 1 or more image layers.
+    image*     Write 0 or more image layers.
+    image{k}   Write exactly k image layers.
+    image{m,n} Write between m and n layers (inclusive range). Must have m<=n.
+```
+
+When a type is not present in the list of constraints, that corresponds to a
+writer that is not compatible with that type. For example, a writer declaring:
+
+```
+    layer_types=["image+", "points*"]
+```
+
+would not be selected when trying to write an `image` and a `vector` layer
+because the above only works for cases with 0 `vector` layers.
+
+Note that just because a writer declares compatibility with a layer type does
+not mean it actually writes that type. In the example above, the writer might
+accept a set of layers containing `image`s and `point`s, but the write command
+might just ignore the `point` layers. The writer must return `None` for
+unwritten layers.
+
+### Calling convention
+
+Currently, two calling conventions are supported for writers: single-layer and
+multi-layer writers. When at most one layer can be matched by a writer, it
+must use the single-layer convention. Otherwise, the multi-layer convention
+must be used.
+
+#### multi-layer writer
+
+```python
+def writer_function(
+    path: str, layer_data: List[LayerData]
+) -> List[str]:
+    ...
+```
+
+**Parameters**
+
+path(str)
+: Path to file, directory, or resource (like a url).
+
+layer_data(list of LayerData)
+: Each `LayerData` element is a tuple of `(data,meta,layer_type)`.
+
+**Return**
+
+Returns a list of paths that were successfully written.
+
+#### single-layer writer
+
+```python
+def writer_function(
+    path: str, data, meta
+) -> Optional[str]:
+    ...
+```
+
+**Parameters**
+
+path(str)
+: Path to file, directory, or resource (like a url).
+
+data(array or list of array) : Layer data. Can be N dimensional. If an image
+and meta[‘rgb’] is True then the data should be interpreted as RGB or RGBA. If
+meta[‘multiscale’] is True, then the data should be interpreted as a
+multiscale image.
+
+meta(dict)
+: Layer metadata.
+
+**Return**
+
+If data is successfully written, return the path that was written. Otherwise,
+if nothing was done, return None.
+
+## Sample Data
+
+There are two ways of specifying sample data.
+
+1. As a **sample data generator**, a function that returns layer data.
+2. As a **sample data uri**, a `uri` that should be read using a `reader`
+   plugin.
+
+### Required fields
+
+_sample data generator_
+
+- **command** Identifier of a command that returns a layer data tuple.
+- **display_name** String to show in the GUI when referring to this sample.
+- **key** A key to identify this sample. Must be unique across the samples
+  provided by a single plugin.
+
+_sample data uri_
+
+- **uri** Path or URL to a data resource.
+- **display_name** String to show in the GUI when referring to this sample.
+- **key** A key to identify this sample. Must be unique across the samples
+  provided by a single plugin.
+
+### Optional fields
+
+_sample data uri_
+
+- **reader_plugin** Name of plugin to use to open the `uri`.
+
+### Examples
+
+**Example**
+
+Sample data generator
+
+```yaml
+name: napari
+contributions:
+  commands:
+    - id: napari.data.astronaut
+      title: Generate astronaut sample
+      python_name: napari.plugins._skimage_data:astronaut
+  sample_data:
+    - display_name: Astronaut (RGB)
+      key: astronaut
+      command: napari.data.astronaut
+```
+
+**Example**
+
+Sample data uri
+
+```yaml
+name: my-sample
+contributions:
+  sample_data:
+    - display_name: Tabueran Kribati
+      key: napari
+      uri: https://en.wikipedia.org/wiki/Napari#/media/File:Tabuaeran_Kiribati.jpg
+```
+
+### Calling convention
+
+_sample data generator_
+
+```python
+def sample_data_generator()->List[LayerData]:
+  ...
+```
+
+## Widgets
+
+```{note}
+The `napari_experimental_provide_dock_widget` and
+`napari_experimental_provide_function` hook implementations may be bound as the
+callable for Widget contributions.  `napari_experimental_provide_function`
+should use `autogenerate: true`.  See more details below.
+```
+
+### Required fields
+
+- **command** Identifier of a command that returns a Widget instance. The
+  `python_name` of the command must be populated before being invoked.
+- **display_name** User-facing name to use for the widget in, for example,
+  menu items.
+
+### Optional fields
+
+- **autogenerate** If True, the widget will be automatically generated with
+  [magicgui] using the type-signature of the associated command.
+
+### Examples
+
+```yaml
+name: napari-animation
+contributions:
+  commands:
+    - id: napari-animation.AnimationWidget
+      python_name: napari_animation._hookimpls:AnimationWidget
+      title: Open animation wizard
+  widgets:
+    - command: napari-animation.AnimationWidget
+      display_name: Wizard
+```
+
+### Calling Convention
+
+```python
+
+# Bind the constructor as the callable:
+# e.g. python_name: my-plugin.MyWidget
+class MyWidget(QWidget):
+  ...
+
+# Bind the function as the callable:
+# e.g. python_name: my_typed_function
+@magic_factory
+def my_typed_function(...):
+  ...
+
+# Use `autogenerate: true` for the Widget and bind the function as the callable:
+# e.g. python_name: my_other_function
+def my_other_function(image : ImageData) -> LayerDataTuple:
+    # process the image
+    result = -image
+    # return it + some layer properties
+    return result, {'colormap':'turbo'}
+```
+
+## Themes
+
+### Required fields
+
+- **label** Label of the color theme as shown in the UI.
+- **id** Id of the color theme as used in the user settings.
+- **type** "dark" or "light"
+- **colors**
+  - **canvas**
+  - **console**
+  - **background**
+  - **foreground**
+  - **primary**
+  - **secondary**
+  - **highlight**
+  - **text**
+  - **icon**
+  - **warning**
+  - **current**
+
+### Example
+
+```yaml
+themes:
+  - label: "Monokai"
+    id: "monokai"
+    type: "dark"
+    colors:
+      canvas: "#000000"
+      console: "#000000"
+      background: "#272822"
+      foreground: "#75715e"
+      primary: "#cfcfc2"
+      secondary: "#f8f8f2"
+      highlight: "#e6db74"
+      text: "#a1ef34"
+      warning: "#f92672"
+      current: "#66d9ef"
+```
+
+[epg]: https://packaging.python.org/specifications/entry-points/
+[pd]: https://setuptools.pypa.io/en/latest/userguide/datafiles.html
+[npe2]: https://github.com/tlambert03/npe2
+[json]: https://www.json.org/
+[yaml]: https://yaml.org/
+[toml]: https://toml.io/
+[pydantic]: https://pydantic-docs.helpmanual.io/
+[pluginmanifest]: https://github.com/tlambert03/npe2/blob/main/npe2/manifest/schema.py
+[pep-8]: https://www.python.org/dev/peps/pep-0008/
+[setup-name]: https://packaging.python.org/guides/distributing-packages-using-setuptools/#name
+[setup-version]: https://packaging.python.org/guides/distributing-packages-using-setuptools/#version
+[setup-desc]: https://packaging.python.org/guides/distributing-packages-using-setuptools/#description
+[setup-lic]: https://packaging.python.org/guides/distributing-packages-using-setuptools/#license
+[setup-classifier]: https://packaging.python.org/guides/distributing-packages-using-setuptools/#classifiers
+[spdx]: https://spdx.org/licenses/
+[get-reader-hook]: https://napari.org/plugins/stable/hook_specifications.html#napari.plugins.hook_specifications.napari_get_reader
+[get-writer-hook]: https://napari.org/plugins/stable/hook_specifications.html#napari.plugins.hook_specifications.napari_get_writer
+[write-image-hook]: https://napari.org/plugins/stable/hook_specifications.html#napari.plugins.hook_specifications.napari_write_image
+[magicgui]: https://napari.org/magicgui/

--- a/docs/plugins/npe2_migration_guide.md
+++ b/docs/plugins/npe2_migration_guide.md
@@ -1,0 +1,463 @@
+(npe2-migration-guide)=
+
+# npe2 migration guide
+
+We've introduced a new plugin engine. The new library [npe2] is a
+re-imagining of how napari interacts with plugins. Rather than importing a
+package to discover plugin functionality, a static manifest file is used to
+declaratively describe a plugin's capabilities. Details can be found in the
+[](npe2-manifest-spec).
+
+Plugins targeting `napari-plugin-engine` will continue to work, but we
+recommend migrating to `npe2`. This guide will help you learn how!
+
+## Migrating using the `npe2` command line tool
+
+`npe2` provides a command line interface to help convert a
+`napari-plugin-engine`-style plugin.
+
+### 1. Install the `npe2` command
+
+```bash
+pip install npe2
+npe2 convert --help
+```
+
+The `npe2` tool provides a few commands to help you develop your plugin. In
+this case we're asking for help with the `convert` command:
+
+```
+Usage: npe2 convert [OPTIONS] PLUGIN_NAME
+
+  Convert existing plugin to new manifest.
+
+Arguments:
+  PLUGIN_NAME  The name of the plugin to convert  [required]
+
+Options:
+  --format [yaml|json|toml]  [default: yaml]
+  --out PATH
+  --help                     Show this message and exit.
+```
+
+### 2. Install your `napari-plugin-engine` based plugin.
+
+As an example, we'll walk through the process using the `napari-animation`
+plugin.
+
+We checkout the plugin and install it as a local editable package.
+
+```bash
+git clone https://github.com/napari/napari-animation.git
+cd napari-animation
+pip install -e .
+```
+
+### 3. Inspect package metadata
+
+The `napari-animation` package defines it's core metadata in `setup.cfg`.
+Inside, it defines an _entry point group_. That section should initially
+contain:
+
+```ini
+[options.entry_points]
+napari.plugin =
+    animation = napari_animation
+```
+
+That metadata gives the name of the plugin: "animation". The name is used in
+the next step. Later we're going to come back and update this section.
+
+### 4. Generate the plugin manifest
+
+To create the manifest, use the npe2 command in the terminal:
+
+```bash
+# we're in the napari-animation directory
+npe2 convert animation --out napari_animation/napari.yaml
+```
+
+```{note}
+This step uses `napari-plugin-engine` to discover the plugins installed on the
+system. If you have other plugins installed there's a chance they may interfere.
+```
+
+This generates `napari_animation/napari.yaml` with contents:
+
+```yaml
+name: napari_animation
+contributions:
+  commands:
+    - id: napari_animation.AnimationWidget
+      python_name: napari_animation._hookimpls:AnimationWidget
+      title: Create Wizard
+  widgets:
+    - command: napari_animation.AnimationWidget
+      name: Wizard
+```
+
+In this case, the manifest could be created without any intervention, but
+sometimes the generated manifest needs to be edited. The conversion tool will
+let you know when this happens.
+
+### 5. Update the package metadata
+
+Finally, we need to make sure `napari-animation` defines the npe2 entry point
+group. This lets the plugin engine know where to find the plugin manifest file.
+
+```ini
+[options.entry_points]
+# napari.plugin =
+  # animation = napari_animation
+napari.manifest =
+    napari-animation = napari_animation:napari.yaml
+```
+
+Since we're interested in creating distributions of our package, make sure the
+manifest gets included as package data:
+
+```ini
+[options]
+include_package_data = True
+   ...
+
+[options.package_data]
+napari_animation =
+    napari.yaml
+```
+
+All done! Update the local package metadata by repeating:
+
+```
+> pip install -e .
+```
+
+and the next time napari is run `napari-animation` will be discovered as an
+`npe2` plugin!
+
+## Migration details
+
+Existing `napari-plugin-engine` plugins expose functionality via _hook
+implementations_. These are functions decorated to indicate they fullfil a
+_hook specification_ described by napari. Though there are some exceptions,
+most _hook implementations_ can be straightforwardly mapped as a
+_contribution_ in the `npe2` manifest. More information can be found in the
+{ref}`npe2-manifest-spec` - Look for "calling conventions" for each field.
+
+`npe2` provides a command-line tool that will generate plugin manifests by
+inspecting exposed _hook implementations_. Below, we will walk through the
+kinds of migrations `npe2 convert` helps with.
+
+For each type of _hook specification_ there is a corresponding section below
+with migration tips. Each lists the _hook specifications_ that are relevant to
+that section and an example manifest. For details, refer to the
+{ref}`npe2-manifest-spec`.
+
+### Readers
+
+Functions that acted as `napari_get_reader` hooks can be bound directly as the
+command for an `npe2` reader.
+
+#### napari_hook_spec
+
+```python
+def napari_get_reader(path: Union[str, List[str]]) -> Optional[ReaderFunction]
+```
+
+#### npe2 contributions
+
+```yaml
+name: napari
+contributions:
+  commands:
+    - id: napari.get_reader
+      python_name: napari.plugins._builtins:napari_get_reader
+      title: Read data using napari's builtin reader
+  readers:
+    - command: napari.get_reader
+      accepts_directories: true
+      filename_patterns: ["*.csv", "*.npy"]
+```
+
+### Writers: Single-layer writers
+
+Functions that act as single-layer writers like `napari_write_image` hooks can
+be bound directly as the command for an `npe2` writer. The layer
+constraint(`layer_types`) and `filename_extensions` fields need to be
+populated.
+
+Since these writers handle only one layer at a time, the `layer_type` is
+straightforward: `['image']` for an image writer, `['points']` for a point-set
+writer, etc.
+
+The list of `filename_extensions` is used to determine how the writer is
+presented in napari's "Save As" dialog.
+
+#### napari_hook_spec
+
+```python
+def napari_write_image(path: str, data: Any, meta: dict) -> Optional[str]
+def napari_write_labels(path: str, data: Any, meta: dict) -> Optional[str]
+def napari_write_points(path: str, data: Any, meta: dict) -> Optional[str]
+def napari_write_shapes(path: str, data: Any, meta: dict) -> Optional[str]
+def napari_write_surfaces(path: str, data: Any, meta: dict) -> Optional[str]
+def napari_write_vectors(path: str, data: Any, meta: dict) -> Optional[str]
+```
+
+#### Example npe2 contribution
+
+```yaml
+name: napari_svg
+display_name: napari svg
+contributions:
+  commands:
+    - id: napari_svg.write_image
+      python_name: napari_svg.hook_implementations:napari_write_image
+      title: Write Image as SVG
+  writers:
+    - command: napari_svg.write_image
+      layer_types: ["image"]
+      filename_extensions: [".svg"]
+```
+
+### Writers: Multi-layer writers
+
+In npe2, the writer specification declares what file extensions and layer
+types are compatible with a writer. This is a departure from the behavior of
+the `napari_get_writer` which was responsible for rejecting data that was
+incompatible.
+
+Usually, the npe2 writer command should be bound to one of the functions
+returned by `napari_get_writer`. From the example below, this is the `writer`
+function.
+
+When migrating, you'll need to fill out the `layer_types` and
+`filename_extensions` used by your writer. `layer_types` is a set of
+constraints describing the combinations of layer types acceptable by this
+writer. More about layer types can be found in the {ref}`npe2-manifest-spec`.
+
+In the example below, the svg writer accepts a set of layers with 0 or more
+images, and 0 or more label layers, and so on. It will not accept surface
+layers, so if any surface layer is present this writer won't be invoked.
+
+Because layer type constraints are specified in the manifest, no plugin code
+has to be imported or run until a compatible writer is found.
+
+#### napari_hook_spec
+
+```python
+def napari_get_writer(
+    path: str, layer_types: List[str]
+) -> Optional[WriterFunction]
+```
+
+Where the `WriterFunction` is something like:
+
+```python
+def writer(
+    path: str, layer_data: List[Tuple[Any, Dict, str]]
+    ) -> List[str]
+```
+
+#### Example npe2 contribution
+
+```yaml
+name: napari_svg
+display_name: napari SVG
+entry_point: napari_svg
+contributions:
+  commands:
+    - id: napari_svg.svg_writer
+      title: Write SVG
+      python_name: napari_svg.hook_implementations:writer
+  writers:
+    - command: napari_svg.svg_writer
+      layer_types: ["image*", "labels*", "points*", "shapes*", "vectors*"]
+      filename_extensions: [".svg"]
+```
+
+### Widgets
+
+`napari_experimental_provide_dock_widget` hooks return another function that
+can be used to instantiate a widget and, optionally, arguments to be passed to
+that function.
+
+In contrast the callable for an `npe2` widget contribution is bound to the
+function actually instantiating the widget. It accepts only one argument: a
+napari `Viewer` proxy instance. The proxy restricts access to some `Viewer`
+functionality like private methods.
+
+Similarly `napari_experimental_provide_function` hooks return ane or more
+functions to be wrapped with [magicgui]. In `npe2`, each of these functions
+should be added as a `Command` contribution with an associated `Widget`
+contribution. For each of these `Widget` contributions, the manifest
+`autogenerate: true` flag should be set so that `npe2` knows to use `magicgui`.
+
+#### napari_hook_spec
+
+```python
+def napari_experimental_provide_dock_widget() -> Union[
+    AugmentedWidget, List[AugmentedWidget]
+]
+```
+
+or
+
+```python
+def napari_experimental_provide_function() -> Union[
+    FunctionType, List[FunctionType]
+]
+```
+
+#### Example npe2 contribution
+
+_Dock Widget_
+
+```yaml
+name: napari-animation
+display_name: animation
+contributions:
+  commands:
+    - id: napari-animation.widget
+      python_name: napari_animation._qt:AnimationWidget
+      title: Make animation widget
+  widgets:
+    - command: napari_animation.widget
+      display_name: Wizard
+```
+
+_Function widget_
+
+```yaml
+name: my-function-plugin
+display_name: My function plugin!
+contributions:
+  commands:
+    - id: my-function-plugin.func
+      python_name: my_function_plugin:my_typed_function
+      title: Open widget for my function
+  widgets:
+    - command: my-function-plugin.func
+      display_name: My function
+      autogenerate: true # <-- will wrap my_typed_function with magicgui
+```
+
+### Sample data providers
+
+Each sample returned from `napari_provide_sample_data()` should be bound as an
+individual sample data contribution.
+
+#### napari_hook_spec
+
+```python
+def napari_provide_sample_data() -> Dict[str, Union[SampleData, SampleDict]]
+```
+
+#### Example npe2 contribution
+
+This example sample data provider:
+
+```python
+def _generate_random_data(shape=(512, 512)):
+    data = np.random.rand(*shape)
+    return [(data, {'name': 'random data'})]
+
+@napari_hook_implementation
+def napari_provide_sample_data():
+    return {
+        'random data': _generate_random_data,
+        'random image': 'https://picsum.photos/1024',
+        'sample_key': {
+            'display_name': 'Some Random Data (512 x 512)'
+            'data': _generate_random_data,
+        }
+    }
+```
+
+Should be migrated to:
+
+```yaml
+name: my-plugin
+contributions:
+  commands:
+    - id: my-plugin.random
+      title: Generate random data
+      python_name: my_plugin:_generate_random_data
+  sample_data:
+    - display_name: Some Random Data (512 x 512)
+      key: random data
+      command: my-plugin.random
+    - uri: https://picsum.photos/1024
+      key: random image
+```
+
+### Themes
+
+`napari_experimental_provide_theme()` hooks return a dictionary of theme
+properties. These properties can be directly embedded in `npe2` theme
+contributions. This allows napari to read the theming data without running any
+code in the plugin package!
+
+#### Example
+
+The theme provided by this hook:
+
+```python
+def get_new_theme() -> Dict[str, Dict[str, Union[str, Tuple, List]]:
+    # specify theme(s) that should be added to napari
+    themes = {
+        "super_dark": {
+            "name": "super_dark",
+            "background": "rgb(12, 12, 12)",
+            "foreground": "rgb(65, 72, 81)",
+            "primary": "rgb(90, 98, 108)",
+            "secondary": "rgb(134, 142, 147)",
+            "highlight": "rgb(106, 115, 128)",
+            "text": "rgb(240, 241, 242)",
+            "icon": "rgb(209, 210, 212)",
+            "warning": "rgb(153, 18, 31)",
+            "current": "rgb(0, 122, 204)",
+            "syntax_style": "native",
+            "console": "rgb(0, 0, 0)",
+            "canvas": "black",
+        }
+    }
+    return themes
+```
+
+becomes this theme contribution in the plugin manifest:
+
+```yaml
+name: my-plugin
+contributions:
+  themes:
+    - label: Super dark
+      id: super_dark
+      type: dark
+      colors:
+        background: "rgb(12, 12, 12)"
+        foreground: "rgb(65, 72, 81)"
+        primary: "rgb(90, 98, 108)"
+        secondary: "rgb(134, 142, 147)"
+        highlight: "rgb(106, 115, 128)"
+        text: "rgb(240, 241, 242)"
+        icon: "rgb(209, 210, 212)"
+        warning: "rgb(153, 18, 31)"
+        current: "rgb(0, 122, 204)"
+        syntax_style: "native"
+        console: "rgb(0, 0, 0)"
+        canvas: "black"
+```
+
+[epg]: https://packaging.python.org/specifications/entry-points/
+[pd]: https://setuptools.pypa.io/en/latest/userguide/datafiles.html
+[npe1]: https://github.com/napari/napari-plugin-engine
+[npe2]: https://github.com/tlambert03/npe2
+[json]: https://www.json.org/
+[yaml]: https://yaml.org/
+[toml]: https://toml.io/
+[get-reader-hook]: https://napari.org/plugins/stable/hook_specifications.html#napari.plugins.hook_specifications.napari_get_reader
+[get-writer-hook]: https://napari.org/plugins/stable/hook_specifications.html#napari.plugins.hook_specifications.napari_get_writer
+[write-image-hook]: https://napari.org/plugins/stable/hook_specifications.html#napari.plugins.hook_specifications.napari_write_image
+[dock-widget-hook]: https://napari.org/plugins/stable/hook_specifications.html#napari.plugins.hook_specifications.napari_experimental_provide_dock_widget
+[magicgui]: https://napari.org/magicgui


### PR DESCRIPTION
# Context

This PR is a rollup after feedback on #3769.  Most (but not all) conversations in that PR have been resolved. Please add further review to this one.  I imagine this represents a first public offering of the docs. There are changes I'd like to make in the future though, including:

- [ ] making the manifest spec more maintainable
- [ ] separating the narrative content in the manifest spec
- [ ] creating focused guides for each kind of plugin

I'll add to the above list as I get comments, and will consolidate/break those out into follow-up issues later.

# Description

This adds documentation for npe2 to the napari docs.  Some of the details are awaiting the last few changes to the npe2 manifest before release.

~I'll keep this as draft until npe2 release. Please feel free to review while this is in draft.~

There is a 

- [x] npe2 manifest specification
- [x] npe2 getting started guide
- [x] npe2 migration guide
- [x] introduction of npe2 on the plugin index page
- [x] added new pages to the top level _toc.yml

## Type of change
- [x] This change requires a documentation update

## Todo
- [x] update for napari/npe2#51
- [x] update for napari/npe2#49
- [x] add announcement date it "introducing npe2" news item. Gives it some time context.
- [x] add "introducing npe2" to various pages (not just the plugin index page)
- [x] hint that napari-plugin-engine will be deprecated soon (at the support/doc level).