### PR TITLE
npe2 tooltip and icon

### DIFF
--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -339,7 +339,6 @@ class PluginListItem(QFrame):
             self.action_button.setObjectName("install_button")
 
     def _handle_npe2_plugin(self):
-
         npe2_icon = QLabel(self)
         icon = QColoredSVGIcon.from_resources('logo_silhouette')
         npe2_icon.setPixmap(icon.colored(color='#33F0FF').pixmap(20, 20))
@@ -470,7 +469,6 @@ class PluginListItem(QFrame):
         for plugin_name, _, distname in plugin_manager.iter_available():
             if distname and distname == current_distname:
                 plugin_manager.set_blocked(plugin_name, not enabled)
-
 
 
 class QPluginList(QListWidget):

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -327,16 +327,7 @@ class PluginListItem(QFrame):
         self.help_button.setText(trans._("Website"))
         self.help_button.setObjectName("help_button")
         if npe_version != 1:
-            self.enabled_checkbox.setEnabled(False)
-            self.enabled_checkbox.setToolTip(
-                'This is a npe2 plugin and cannot be enabled/disabled at this time.'
-            )
-
-            icon = QColoredSVGIcon.from_resources('logo_silhouette')
-            self.npe2_icon.setPixmap(
-                icon.colored(color='#33F0FF').pixmap(20, 20)
-            )
-            self.npe2_text.show()
+            self._handle_npe2_plugin()
 
         if installed:
             self.enabled_checkbox.show()
@@ -346,6 +337,18 @@ class PluginListItem(QFrame):
             self.enabled_checkbox.hide()
             self.action_button.setText(trans._("install"))
             self.action_button.setObjectName("install_button")
+
+    def _handle_npe2_plugin(self):
+        self.enabled_checkbox.setEnabled(False)
+        self.enabled_checkbox.setToolTip(
+            'This is a npe2 plugin and cannot be enabled/disabled at this time.'
+        )
+
+        icon = QColoredSVGIcon.from_resources('logo_silhouette')
+        self.npe2_icon.setPixmap(
+            icon.colored(color='#33F0FF').pixmap(20, 20)
+        )
+        self.npe2_text.show()
 
     def _get_dialog(self) -> QDialog:
         p = self.parent()
@@ -382,10 +385,6 @@ class PluginListItem(QFrame):
         self.enabled_checkbox.setText("")
         self.row1.addWidget(self.enabled_checkbox)
         self.plugin_name = QLabel(self)
-        self.npe2_icon = QLabel(self)
-        self.npe2_text = QLabel(self)
-        self.npe2_text.setText('npe2')
-        self.npe2_text.hide()
         sizePolicy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Minimum)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -397,9 +396,14 @@ class PluginListItem(QFrame):
         font15.setPointSize(15)
         self.plugin_name.setFont(font15)
         self.row1.addWidget(self.plugin_name)
+
+        self.npe2_icon = QLabel(self)
+        self.npe2_text = QLabel(self)
+        self.npe2_text.setText('npe2')
+        self.npe2_text.hide()
         self.row1.addWidget(self.npe2_icon)
         self.row1.addWidget(self.npe2_text)
-        self.row1.setSpacing(-1)
+
 
         self.item_status = QLabel(self)
         self.item_status.setObjectName("small_italic_text")
@@ -474,6 +478,7 @@ class PluginListItem(QFrame):
         for plugin_name, _, distname in plugin_manager.iter_available():
             if distname and distname == current_distname:
                 plugin_manager.set_blocked(plugin_name, not enabled)
+
 
 
 class QPluginList(QListWidget):

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -345,9 +345,7 @@ class PluginListItem(QFrame):
         )
 
         icon = QColoredSVGIcon.from_resources('logo_silhouette')
-        self.npe2_icon.setPixmap(
-            icon.colored(color='#33F0FF').pixmap(20, 20)
-        )
+        self.npe2_icon.setPixmap(icon.colored(color='#33F0FF').pixmap(20, 20))
         self.npe2_text.show()
 
     def _get_dialog(self) -> QDialog:
@@ -403,7 +401,6 @@ class PluginListItem(QFrame):
         self.npe2_text.hide()
         self.row1.addWidget(self.npe2_icon)
         self.row1.addWidget(self.npe2_text)
-
 
         self.item_status = QLabel(self)
         self.item_status.setObjectName("small_italic_text")
@@ -478,7 +475,6 @@ class PluginListItem(QFrame):
         for plugin_name, _, distname in plugin_manager.iter_available():
             if distname and distname == current_distname:
                 plugin_manager.set_blocked(plugin_name, not enabled)
-
 
 
 class QPluginList(QListWidget):

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -339,16 +339,16 @@ class PluginListItem(QFrame):
             self.action_button.setObjectName("install_button")
 
     def _handle_npe2_plugin(self):
+
+        npe2_icon = QLabel(self)
+        icon = QColoredSVGIcon.from_resources('logo_silhouette')
+        npe2_icon.setPixmap(icon.colored(color='#33F0FF').pixmap(20, 20))
+        self.row1.insertWidget(2, QLabel('npe2'))
+        self.row1.insertWidget(2, npe2_icon)
         self.enabled_checkbox.setEnabled(False)
         self.enabled_checkbox.setToolTip(
             'This is a npe2 plugin and cannot be enabled/disabled at this time.'
         )
-
-        icon = QColoredSVGIcon.from_resources('logo_silhouette')
-        self.npe2_icon.setPixmap(
-            icon.colored(color='#33F0FF').pixmap(20, 20)
-        )
-        self.npe2_text.show()
 
     def _get_dialog(self) -> QDialog:
         p = self.parent()
@@ -396,14 +396,6 @@ class PluginListItem(QFrame):
         font15.setPointSize(15)
         self.plugin_name.setFont(font15)
         self.row1.addWidget(self.plugin_name)
-
-        self.npe2_icon = QLabel(self)
-        self.npe2_text = QLabel(self)
-        self.npe2_text.setText('npe2')
-        self.npe2_text.hide()
-        self.row1.addWidget(self.npe2_icon)
-        self.row1.addWidget(self.npe2_text)
-
 
         self.item_status = QLabel(self)
         self.item_status.setObjectName("small_italic_text")

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -51,6 +51,8 @@ from ..widgets.qt_message_popup import WarnPopup
 
 InstallerTypes = Literal['pip', 'conda', 'mamba']
 
+from ..qt_resources import QColoredSVGIcon
+
 
 # TODO: add error icon and handle pip install errors
 class Installer(QObject):
@@ -326,6 +328,15 @@ class PluginListItem(QFrame):
         self.help_button.setObjectName("help_button")
         if npe_version != 1:
             self.enabled_checkbox.setEnabled(False)
+            self.enabled_checkbox.setToolTip(
+                'This is a npe2 plugin and cannot be enabled/disabled at this time.'
+            )
+
+            icon = QColoredSVGIcon.from_resources('logo_silhouette')
+            self.npe2_icon.setPixmap(
+                icon.colored(color='#33F0FF').pixmap(20, 20)
+            )
+            self.npe2_text.show()
 
         if installed:
             self.enabled_checkbox.show()
@@ -371,6 +382,10 @@ class PluginListItem(QFrame):
         self.enabled_checkbox.setText("")
         self.row1.addWidget(self.enabled_checkbox)
         self.plugin_name = QLabel(self)
+        self.npe2_icon = QLabel(self)
+        self.npe2_text = QLabel(self)
+        self.npe2_text.setText('npe2')
+        self.npe2_text.hide()
         sizePolicy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Minimum)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -382,6 +397,9 @@ class PluginListItem(QFrame):
         font15.setPointSize(15)
         self.plugin_name.setFont(font15)
         self.row1.addWidget(self.plugin_name)
+        self.row1.addWidget(self.npe2_icon)
+        self.row1.addWidget(self.npe2_text)
+        self.row1.setSpacing(-1)
 
         self.item_status = QLabel(self)
         self.item_status.setObjectName("small_italic_text")


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
This PR adds a tooltip and an icon to indicate that a plugin is an npe2 plugin on the installed plugins menu.  

For now, I just have a colored napari icon there is a placeholder.  We can create a cooler npe2 icon soon.
<img width="1048" alt="Screen Shot 2021-12-16 at 1 15 08 AM" src="https://user-images.githubusercontent.com/54282105/146329742-00621a47-cf9e-4dee-a339-80f21d269221.png">



I thought about adding an icon to the top that explains that the napari icon indications the plugin is an npe2 plugin, but the placement didn't look great.  I also tried to add a little bit of text next to the icon (still need to work on spacing) as shown here:

<img width="560" alt="Screen Shot 2021-12-16 at 1 47 45 AM" src="https://user-images.githubusercontent.com/54282105/146329770-a09db443-1b6b-4a98-846b-f13b306359fc.png">

Fixes #3780 
