### PR TITLE
Add warning to npe2 docs that they are in-progress

### DIFF
--- a/docs/plugins/for_napari_developers.md
+++ b/docs/plugins/for_napari_developers.md
@@ -7,9 +7,11 @@
 We introduced a new plugin engine in December 2021. The new library [`npe2`][npe2]
 is a re-imagining of how napari interacts with plugins. Plugins targeting
 `napari-plugin-engine` will continue to work, but we recommend migrating to
-`npe2` as soon as possible.  See the [](npe2-migration-guide).
+`npe2` eventually.  See the [](npe2-migration-guide).
 
 To learn more about the architecture see the [](npe2-manifest-spec).
+
+The content below describes the original [`napari-plugin-engine`](https://github.com/napari/napari-plugin-engine).
 ```
 
 The napari plugin architecture is contained in an independent package called [napari-plugin-engine](https://github.com/napari/napari-plugin-engine), which

--- a/docs/plugins/for_plugin_developers.md
+++ b/docs/plugins/for_plugin_developers.md
@@ -7,9 +7,11 @@
 We introduced a new plugin engine in December 2021. The new library [`npe2`][npe2]
 is a re-imagining of how napari interacts with plugins. Plugins targeting
 `napari-plugin-engine` will continue to work, but we recommend migrating to
-`npe2` as soon as possible. See the [](npe2-migration-guide).
+`npe2` eventually. See the [](npe2-migration-guide).
 
 To learn more about creating an `npe2` plugin see the [](npe2-getting-started).
+
+The content below describes the original [`napari-plugin-engine`](https://github.com/napari/napari-plugin-engine).
 ```
 
 This document explains how to extend napari's functionality by writing a plugin

--- a/docs/plugins/hook_specifications.md
+++ b/docs/plugins/hook_specifications.md
@@ -7,9 +7,11 @@
 We introduced a new plugin engine in December 2021. The new library [`npe2`][npe2]
 is a re-imagining of how napari interacts with plugins. Plugins targeting
 `napari-plugin-engine` will continue to work, but we recommend migrating to
-`npe2` as soon as possible. See the [](npe2-migration-guide).
+`npe2` eventually. See the [](npe2-migration-guide).
 
 To learn more about the specification see the [](npe2-manifest-spec).
+
+The content below describes the original [`napari-plugin-engine`](https://github.com/napari/napari-plugin-engine).
 ```
 
 ```{eval-rst}

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -11,7 +11,7 @@ file is used to declaratively describe a plugin's capabilities. Details can be
 found in the [](npe2-manifest-spec).
 
 Plugins targeting `napari-plugin-engine` will continue to work, but we
-recommend migrating to `npe2` as soon as possible. `npe2` includes tooling to
+recommend migrating to `npe2` eventually. `npe2` includes tooling to
 help automate the process of migrating plugins. See the [migration
 guide](npe2-migration-guide) for details.
 

--- a/docs/plugins/npe2_getting_started.md
+++ b/docs/plugins/npe2_getting_started.md
@@ -2,12 +2,19 @@
 
 # npe2 getting started guide
 
+```{warning}
+This guide is still a work in progress.
+
+There are inaccuracies and mistakes. If you notice any, feel free to submit
+issues to the [napari github repository](https://github.com/napari/napari).
+```
+
 ```{admonition} Introducing npe2
 :class: tip
 We introduced a new plugin engine in December 2021. The new library [`npe2`][npe2]
 is a re-imagining of how napari interacts with plugins. Plugins targeting
 `napari-plugin-engine` will continue to work, but we recommend migrating to
-`npe2` as soon as possible.
+`npe2` eventually.
 
 For more on migrating an existing plugins see the [](npe2-migration-guide).
 ```

--- a/docs/plugins/npe2_manifest_specification.md
+++ b/docs/plugins/npe2_manifest_specification.md
@@ -2,12 +2,19 @@
 
 # npe2 manifest specification
 
+```{warning}
+This guide is still a work in progress.
+
+There are inaccuracies and mistakes. If you notice any, feel free to submit
+issues to the [napari github repository](https://github.com/napari/napari).
+```
+
 ```{admonition} Backward compatibility
 :class: tip
 We introduced a new plugin engine in December 2021. The new library [`npe2`][npe2]
 is a re-imagining of how napari interacts with plugins. Plugins targeting
 `napari-plugin-engine` will continue to work, but we recommend migrating to
-`npe2` as soon as possible.  See the [](npe2-migration-guide).
+`npe2` eventually.  See the [](npe2-migration-guide).
 ```
 
 The **plugin manifest** is a specially formatted text file declaring the

--- a/docs/plugins/npe2_migration_guide.md
+++ b/docs/plugins/npe2_migration_guide.md
@@ -2,6 +2,13 @@
 
 # npe2 migration guide
 
+```{warning}
+This guide is still a work in progress.
+
+There are inaccuracies and mistakes. If you notice any, feel free to submit
+issues to the [napari github repository](https://github.com/napari/napari).
+```
+
 We've introduced a new plugin engine. The new library [npe2] is a
 re-imagining of how napari interacts with plugins. Rather than importing a
 package to discover plugin functionality, a static manifest file is used to


### PR DESCRIPTION
# Description

* Marks the npe2 documentation as work in progress
* walks back language around migration
* adds some clarifying text to npe1 pages 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
See this [zulip thread](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/npe2.20migration.20questions).
Other issues besides this one were noted in that thread.  This PR focuses on only a couple.

## Final checklist:
- [x] I have made corresponding changes to the documentation