### PR TITLE
Remove excess installation details from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,79 +22,11 @@ We're working on [tutorials](https://napari.org/tutorials/), but you can also qu
 
 ## installation
 
-### which distribution to install
-If you want to contribute back to napari codebase, you need to install from source code: see the [from source](#from-source) section.
+You can install napari with pip or conda (or alternatively install [napari as a bundled app](https://napari.org/tutorials/fundamentals/installation.html#install-as-a-bundled-app)):
+- `pip install "napari[all]"`
+- `conda install -c conda-forge napari
 
-If you do not want to use napari as python code and only use it as GUI app, the bundled app is the easiest way to install.
-This is also the only method that does not require python knowledge to work with napari, see the [from bundled app](https://napari.org/tutorials/fundamentals/installation#installing-as-a-bundled-app) section.
-
-If you are using napari from Python to programmatically interact with the app, you can install via pip, conda-forge, or from source.
-We recommend that you use conda to help manage the virtual environment. Otherwise you may see compilation issues that are specific to your particular machine, which is difficult for us to debug.
-
-
-### from pip, with "batteries included"
-
-napari can be installed on most macOS, Linux, and Windows systems with
-Python 3.7 - 3.10 using pip. However, for Windows users, you need to preinstall [Microsoft Visual C++ Build Tools](https://visualstudio.microsoft.com/downloads/)
-in order to install VisPy (one of the packages we depend on) on Windows machines.
-
-The simplest command to install with pip is:
-
-```sh
-pip install "napari[all]"
-```
-
-(See `Specifying a GUI Backend` below for an explanation of the `[all]` notation.)
-Note: while not strictly required, it is *highly* recommended to install
-napari into a clean virtual environment using an environment manager like
-[conda](https://docs.conda.io/en/latest/miniconda.html) or
-[venv](https://docs.python.org/3/library/venv.html).  For example, with `conda`:
-
-```sh
-conda create -y -n napari-env -c conda-forge python=3.9
-conda activate napari-env
-pip install "napari[all]"
-```
-
-### from source
-
-To clone the repository locally and install in editable mode use
-
-```sh
-git clone https://github.com/napari/napari.git
-cd napari
-pip install -e ".[all]"
-
-# or, to install in editable mode AND grab all of the developer tools
-# (this is required if you want to contribute code back to napari)
-pip install -r requirements.txt
-```
-
-For more information or troubleshooting see our [installation tutorial](https://napari.org/tutorials/fundamentals/installation)
-
-> ℹ️ **Specifying a GUI Backend**
->
-> napari needs a library called [Qt](https://www.qt.io/) to run its user interface
-> (UI). In Python, there are two alternative libraries to run this, called
-> [PyQt5](https://www.riverbankcomputing.com/software/pyqt/download5) and
-> [PySide2](https://doc.qt.io/qtforpython/). By default, we don't choose for you,
-> and simply running `pip install napari` will not install either. You *might*
-> already have one of them installed in your environment, thanks to other
-> scientific packages such as Spyder or matplotlib. If neither is available,
-> running napari will result in an error message asking you to install one of
-> them.
->
-> Running `pip install "napari[all]"` will install the default framework – currently
-> PyQt5, but this could change in the future.
->
-> To install napari with a specific framework, you can use:
->
-> ```sh
-> pip install "napari[pyqt5]"    # for PyQt5
->
-> # OR
-> pip install "napari[pyside2]"  # for PySide2
-> ```
+See here for the full [installation guide](https://napari.org/tutorials/fundamentals/installation.html).
 
 ## simple example
 


### PR DESCRIPTION
# Description

This PR replaces the long installation section in the README with a much shorter text,summary, plus a link to the full installation guide:

Why do I want to make this change? I want us to avoid these problems:
- You have to scroll a really long way down before you ever see the first screenshot of napari. That's pretty important, I think it should be much closer to the top
- This information is largely duplicated in the actual installation guide. I would like us to have a single source of truth wherever possible, to avoid the two drifting out of sync.
- It prioritizes detail that users are unlikely to care about at this stage (like how to change pyside vs pyqt backends)


## Type of change
- [x] This change is a documentation update

# References
Closes https://github.com/napari/napari/issues/3831

# How has this been tested?
Documentation update only, no new rests required.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
