### PR TITLE
Add matplotlib to test dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -104,6 +104,7 @@ testing =
     xarray
     fsspec
     zarr
+    matplotlib
     scikit-image>=0.18.1,!=0.19.0
     pooch>=1.3.0
     semgrep


### PR DESCRIPTION
# Description
looks like scikit image removing matplotlib has broken our tests 😂   which is great!
I'm adding it back, since it's used in at least one example, and it looks like perhaps one additional test was assuming its presence for a colormap thing, but we can remove/modify that test too