### PR TITLE
Remove `needs: code` from test_comprehensive workflow

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -15,7 +15,6 @@ jobs:
 
   manifest:
     name: Check Manifest
-    needs: code
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -31,7 +30,6 @@ jobs:
         run: check-manifest
 
   test:
-    needs: code
     name: ${{ matrix.platform }} py${{ matrix.python }} ${{ matrix.toxenv }} ${{ matrix.MIN_REQ && 'min_req' }}
     runs-on: ${{ matrix.platform }}
     strategy:


### PR DESCRIPTION
# Description
comprehensive tests are [failing](https://github.com/napari/napari/actions/runs/1593064606) because the workflow is invalid: it's looking for the `code` step that no longer exists  