### PR TITLE
Remove excess fields from plugin manifest

### DIFF
--- a/napari/builtins.yaml
+++ b/napari/builtins.yaml
@@ -1,5 +1,4 @@
 display_name: napari
-entry_point: napari.plugins._builtins
 name: napari
 
 contributions:


### PR DESCRIPTION
# Description
This removes an optional field from the builtins plugin manifest. This change won't affect functionality. The builtins don't use `entry_point`.

This makes it less susceptible to breaks if the schema changes.