### PR TITLE
QtViewer viewer argument type annotation fix

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -59,7 +59,7 @@ from .._vispy import (  # isort:skip
 
 
 if TYPE_CHECKING:
-    from ..viewer import Viewer
+    from ..components import ViewerModel
     from npe2.manifest.contributions import WriterContribution
 
 from ..settings import get_settings
@@ -177,7 +177,7 @@ class QtViewer(QSplitter):
         Button controls for the napari viewer.
     """
 
-    def __init__(self, viewer: Viewer, show_welcome_screen: bool = False):
+    def __init__(self, viewer: ViewerModel, show_welcome_screen: bool = False):
         # Avoid circular import.
         from .layer_controls import QtLayerControlsContainer
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->
This PR fixes viewer argument type annotation on qt_viewer __init__ method. Practically, expected argument type is already `ViewerModel` but annotation was `Viewer`. This PR only introduces a change on annotation.

Required documentation updates related to this change mostly will be on auto-generated part I believe. If this is not the case please direct me to correct place for me to update the documentation accordingly.

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update (Maybe?)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
Tested manually, will see how CI tests are running.

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
