### PR TITLE
Fix reference to missing q in npe2 getting started guide

### DIFF
--- a/docs/plugins/npe2_getting_started.md
+++ b/docs/plugins/npe2_getting_started.md
@@ -79,10 +79,6 @@ We named our plugin `my-py-reader`. This is the name that will be used for
 the python package. It should conform to the [PEP8] naming convention
 (short, all-lowercase names, using dashes instead of underscores).
 
-When the cookiecutter asked to include a reader plugin, we selected `y`, and
-in the next question we told cookiecutter that our reader should be invoked
-for files matching the `*.npy` [glob] pattern.
-
 After answering all the prompts, `cookiecutter` will create a directory called
 `my_npy_reader` in the current directory that holds the generated files. It
 will look something like this:


### PR DESCRIPTION
# Description

Fixes reference to missing cookie cutter prompt in the npe2 getting started guide.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
napari/cookiecutter-napari-plugin#73

