### PR TITLE
hack sys.argv to fix #2389 on macos

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -443,10 +443,15 @@ def main():
 
     # Prevent __main__.py from being the app name if run with python -m napari
     if sys.platform == "darwin" and not sys.argv[0].endswith("/napari"):
-        # we need a path with basename `napari`; adding ../ makes it an existing
+        # we need a path with basename `napari`; adding ../../ makes it an existing
         # path too, just in case -- we undo this later once QApplication() is created
+        # example:
+        # sys.argv[0] was /path/to/installation/napari/__main__.py
+        # sys.argv[0] + "/../../napari" turns that into 
+        # /path/to/installation/napari/__main__.py/../../napari
+        # which is the same as /path/to/installation/napari
         sys._old_argv_0 = sys.argv[0]
-        sys.argv[0] += "/../napari"
+        sys.argv[0] += "/../../napari"
 
     _run()
 

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -441,18 +441,6 @@ def main():
 
         multiprocessing.set_start_method('fork')
 
-    # Prevent __main__.py from being the app name if run with python -m napari
-    if sys.platform == "darwin" and not sys.argv[0].endswith("/napari"):
-        # we need a path with basename `napari`; adding ../../ makes it an existing
-        # path too, just in case -- we undo this later once QApplication() is created
-        # example:
-        # sys.argv[0] was /path/to/installation/napari/__main__.py
-        # sys.argv[0] + "/../../napari" turns that into 
-        # /path/to/installation/napari/__main__.py/../../napari
-        # which is the same as /path/to/installation/napari
-        sys._old_argv_0 = sys.argv[0]
-        sys.argv[0] += "/../../napari"
-
     _run()
 
 

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -441,6 +441,13 @@ def main():
 
         multiprocessing.set_start_method('fork')
 
+    # Prevent __main__.py from being the app name if run with python -m napari
+    if sys.platform == "darwin" and not sys.argv[0].endswith("/napari"):
+        # we need a path with basename `napari`; adding ../ makes it an existing
+        # path too, just in case -- we undo this later once QApplication() is created
+        sys._old_argv_0 = sys.argv[0]
+        sys.argv[0] += "/../napari"
+
     _run()
 
 

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -139,12 +139,19 @@ def get_app(
             QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
             QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps)
 
+        argv = sys.argv.copy()
+        if sys.platform == "darwin" and not argv[0].endswith("napari"):
+            # Make sure the app name in the Application menu is `napari`
+            # which is taken from the basename of sys.argv[0]; we use
+            # a copy so the original value is still available at sys.argv
+            argv[0] = "napari"
+
         if perf_config and perf_config.trace_qt_events:
             from .perf.qt_event_tracing import QApplicationWithTracing
 
-            app = QApplicationWithTracing(sys.argv)
+            app = QApplicationWithTracing(argv)
         else:
-            app = QApplication(sys.argv)
+            app = QApplication(argv)
 
         # if this is the first time the Qt app is being instantiated, we set
         # the name and metadata
@@ -356,12 +363,6 @@ def run(
         return
 
     app = QApplication.instance()
-
-    # Undo __main__.py sys.argv[0] workaround now that the app has been created
-    # in case something else relies on argv[0] being the real thing
-    if sys.platform == "darwin" and hasattr(sys, "_old_argv_0"):
-        sys.argv[0] = sys._old_argv_0
-        del sys._old_argv_0
 
     if _pycharm_has_eventloop(app):
         # explicit check for PyCharm pydev console

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -356,6 +356,13 @@ def run(
         return
 
     app = QApplication.instance()
+
+    # Undo __main__.py sys.argv[0] workaround now that the app has been created
+    # in case something else relies on argv[0] being the real thing
+    if sys.platform == "darwin" and hasattr(sys, "_old_argv_0"):
+        sys.argv[0] = sys._old_argv_0
+        del sys._old_argv_0
+
     if _pycharm_has_eventloop(app):
         # explicit check for PyCharm pydev console
         return


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

Closes #2389 


QMenuBar will populate the App menu on MacOS by using the basename of `sys.argv[0]`. We check whether this is not `napari` and, in that case, we add a new a path component to make Qt believe it was (before any qt imports). We undo that change as quickly as possible, after QApplication has been instantiated. 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [X] Opened a napari installation with `python -m napari` and check name is napari
- [X] sys.argv is restored in IPython console

__BEFORE__

![image](https://user-images.githubusercontent.com/2559438/146697900-ff6b7f7a-a18d-4946-8212-fddc2cc5f5ae.png)

__AFTER__

![image](https://user-images.githubusercontent.com/2559438/146697434-4ada32ca-4d76-4e25-a8ee-ec623224c5f2.png)



## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
