### PR TITLE
fix edge width factor of 2

### DIFF
--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -385,7 +385,7 @@ class QtShapesControls(QtLayerControls):
         value : float
             Line width of shapes.
         """
-        self.layer.current_edge_width = float(value) / 2
+        self.layer.current_edge_width = float(value)
 
     def change_text_visibility(self, state):
         """Toggle the visibility of the text.
@@ -409,7 +409,7 @@ class QtShapesControls(QtLayerControls):
         """Receive layer model edge line width change event and update slider."""
         with self.layer.events.edge_width.blocker():
             value = self.layer.current_edge_width
-            value = np.clip(int(2 * value), 0, 40)
+            value = np.clip(int(value), 0, 40)
             self.widthSlider.setValue(value)
 
     def _on_current_edge_color_change(self):


### PR DESCRIPTION
# Description
This is an attempt at fixing the issue https://github.com/napari/napari/issues/3856 showing a discrepancy between the shape edge width set programmatically or via the edge slider of the interface. With this PR, when now adding a shape with ```edge_width=3```, the slider keeps the same value 3 when the shape is selected.
![edge_width_fixed](https://user-images.githubusercontent.com/4622767/146750970-f930cb41-8442-4bfa-9a1d-1541d0253722.gif)

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)

# References
This PR closes #3856 

# How has this been tested?
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
