### PR TITLE
Changes so viewer is centered only when first layer is added. 

### DIFF
--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -328,17 +328,17 @@ def test_swappable_dims():
     # midpoints indices into the data below depend on the data range.
     # This depends on the values in vectors_data and thus the random seed.
     assert np.all(
-        viewer.layers[labels_name]._slice.image.raw == labels_data[4, 6, :, :]
+        viewer.layers[labels_name]._slice.image.raw == labels_data[3, 6, :, :]
     )
 
     # Swap dims
     viewer.dims.order = [0, 2, 1, 3]
     assert viewer.dims.order == (0, 2, 1, 3)
     assert np.all(
-        viewer.layers[image_name]._data_view == image_data[4, :, 5, :]
+        viewer.layers[image_name]._data_view == image_data[3, :, 5, :]
     )
     assert np.all(
-        viewer.layers[labels_name]._slice.image.raw == labels_data[4, :, 5, :]
+        viewer.layers[labels_name]._slice.image.raw == labels_data[3, :, 5, :]
     )
 
 

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -287,6 +287,28 @@ def test_new_points():
     assert viewer.dims.ndim == 2
 
 
+def test_view_centering_with_points_add():
+    """Test if the viewer is only centered when the first
+    points were added
+    Regression test for issue  #3803
+    """
+    image = np.zeros((5, 10, 10))
+
+    viewer = ViewerModel()
+    viewer.add_image(image)
+    assert tuple(viewer.dims.point) == (2, 5, 5)
+
+    viewer.dims.set_point(0, 0)
+    # viewer point shouldn't change after this
+    assert tuple(viewer.dims.point) == (0, 5, 5)
+
+    pts_layer = viewer.add_points(ndim=3)
+    assert tuple(viewer.dims.point) == (0, 5, 5)
+
+    pts_layer.add([(0, 8, 8)])
+    assert tuple(viewer.dims.point) == (0, 5, 5)
+
+
 def test_new_shapes():
     """Test adding new shapes layer."""
     # Add labels to empty viewer

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -344,8 +344,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             ndim = len(ranges)
             self.dims.ndim = ndim
             self.dims.set_range(range(ndim), ranges)
-            midpoint = [self.rounded_division(*_range) for _range in ranges]
-            self.dims.set_point(range(ndim), midpoint)
 
         new_dim = self.dims.ndim
         dim_diff = new_dim - len(self.cursor.position)
@@ -468,6 +466,9 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
         if len(self.layers) == 1:
             self.reset_view()
+            ranges = self.layers._ranges
+            midpoint = [self.rounded_division(*_range) for _range in ranges]
+            self.dims.set_point(range(len(ranges)), midpoint)
 
     def _on_remove_layer(self, event):
         """Disconnect old layer events.


### PR DESCRIPTION
# Description
This PR changes the behavior introduced in #3718 so that the viewer only centers the data when the first data layer is added.

I also had to update one of the tests, I'm not sure how it was passing before because the truncation of 7 divided by 2 is 3 and it was 4 to select the midpoint.

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #3803 

# How has this been tested?
- [X] tested with existing tests.
- [X] tested locally by observing the behavior when adding points to 4d data.

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality