### PR TITLE
npe2 icon on plugin install dialog

### DIFF
--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -367,7 +367,6 @@ class PluginListItem(QFrame):
         self.v_lay.setContentsMargins(-1, 6, -1, 6)
         self.v_lay.setSpacing(0)
         self.row1 = QHBoxLayout()
-        self.row1.setSpacing(6)
         self.enabled_checkbox = QCheckBox(self)
         self.enabled_checkbox.setChecked(enabled)
         self.enabled_checkbox.stateChanged.connect(self._on_enabled_checkbox)


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
I didn't like the look of the spacing between the napari icon and the "npe2" text.  See here:

<img width="1064" alt="Screen Shot 2021-12-20 at 2 31 01 PM" src="https://user-images.githubusercontent.com/54282105/146828978-87380bfc-d8e1-4d27-ac62-6fcd7f6f8736.png">


I removed a setSpacing call and it changed to this:
<img width="1056" alt="Screen Shot 2021-12-20 at 2 30 26 PM" src="https://user-images.githubusercontent.com/54282105/146829002-ee2a6536-e6e4-4ee4-84d7-9d3b38fa73f9.png">

What do you think?  Or, should we change the design of this to something else?  


