### PR TITLE
protect against setting corner_pixels with extent 0 for multiscale images

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -597,6 +597,7 @@ def test_remove_add_image_3D(make_napari_viewer):
     viewer.layers.append(layer)
 
 
+@skip_on_win_ci
 @skip_local_popups
 def test_qt_viewer_multscale_image_out_of_view(make_napari_viewer):
     """Test out-of-view multiscale image viewing fix.
@@ -610,12 +611,8 @@ def test_qt_viewer_multscale_image_out_of_view(make_napari_viewer):
     viewer.add_shapes(
         data=[
             np.array(
-                [
-                    [1500.0, 4500.0],
-                    [4500.0, 4500.0],
-                    [4500.0, 1500.0],
-                    [1500.0, 1500.0],
-                ]
+                [[1500, 4500], [4500, 4500], [4500, 1500], [1500, 1500]],
+                dtype=float,
             )
         ],
         shape_type=['polygon'],

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -595,3 +595,29 @@ def test_remove_add_image_3D(make_napari_viewer):
     layer = viewer.add_image(img)
     viewer.layers.remove(layer)
     viewer.layers.append(layer)
+
+
+@skip_local_popups
+def test_qt_viewer_multscale_image_out_of_view(make_napari_viewer):
+    """Test out-of-view multiscale image viewing fix.
+
+    Just verifies that no RuntimeError is raised in this scenario.
+
+    see: https://github.com/napari/napari/issues/3863.
+    """
+    # show=True required to test fix for OpenGL error
+    viewer = make_napari_viewer(ndisplay=2, show=True)
+    viewer.add_shapes(
+        data=[
+            np.array(
+                [
+                    [1500.0, 4500.0],
+                    [4500.0, 4500.0],
+                    [4500.0, 1500.0],
+                    [1500.0, 1500.0],
+                ]
+            )
+        ],
+        shape_type=['polygon'],
+    )
+    viewer.add_image([np.eye(1024), np.eye(512), np.eye(256)])

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1537,6 +1537,11 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             corners = np.zeros((2, self.ndim))
             corners[:, displayed_axes] = scaled_corners
             corners = corners.astype(int)
+            display_shape = tuple(
+                corners[1, displayed_axes] - corners[0, displayed_axes]
+            )
+            if any(s == 0 for s in display_shape):
+                return
             if self.data_level != level or not np.all(
                 self.corner_pixels == corners
             ):


### PR DESCRIPTION
# Description

This PR avoids a couple of scenarios leading to: `RuntimeError: OpenGL got errors (Check before draw): GL_INVALID_VALUE` when viewing with multiresolution images. The error seems to occur when `Layer.refresh()` calls `self.events.set_data()` with `Layer.corner_pixels` having overlapping start and end values (i.e. size 0 along some axis).

The solution taken here is to exit `Layer._update_draw` early before setting a `corner_pixels` value with empty extent when the image is out of view.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
closes #3567, #3863

# How has this been tested?
- [x] example given in first comment of #3863 no longer raises the RuntimeErrors described there
- [x] dragging a multiresolution image outside of the viewer window as in #3567 no longer raises errors

a test case corresponding to the example from #3863 was added

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
