### PR TITLE
Indicate how to enable test in warning message

### DIFF
--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -30,7 +30,8 @@ skip_on_mac_ci = pytest.mark.skipif(
 
 skip_local_popups = pytest.mark.skipif(
     not os.getenv('CI') and os.getenv('NAPARI_POPUP_TESTS', '0') == '0',
-    reason='Tests requiring GUI windows are skipped locally by default.',
+    reason='Tests requiring GUI windows are skipped locally by default.'
+    ' Set NAPARI_POPUP_TESTS=1 environment variable to enable.',
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ skip_glob = ["*examples/*", "*vendored*", "*_vendor*"]
 [tool.pytest.ini_options]
 # These follow standard library warnings filters syntax.  See more here:
 # https://docs.python.org/3/library/warnings.html#describing-warning-filters
-addopts = "--maxfail=5 --durations=10"
+addopts = "--maxfail=5 --durations=10 -rXxs"
 
 # NOTE: only put things that will never change in here.
 # napari deprecation and future warnings should NOT go in here.


### PR DESCRIPTION
Also add flags to pytest to show a summary of xfailed/xpass and skipped
tests, which make it easier to know why they skipped/failed.
