### PR TITLE
Properly raise exception in test to set __traceback__

### DIFF
--- a/napari/plugins/_tests/test_exceptions.py
+++ b/napari/plugins/_tests/test_exceptions.py
@@ -17,12 +17,22 @@ def test_format_exceptions(cgitb, as_html, monkeypatch):
         'standard_metadata',
         lambda x: {'package': 'test-package', 'version': '0.1.0'},
     )
-    _ = PluginError(
-        'some error',
-        plugin_name='test_plugin',
-        plugin="mock",
-        cause=ValueError("cause"),
-    )
+
+    # we make sure to actually raise the exceptions,
+    # otherwise they will miss the __traceback__ attributes.
+    try:
+        try:
+            raise ValueError('cause')
+        except ValueError as e:
+            raise PluginError(
+                'some error',
+                plugin_name='test_plugin',
+                plugin="mock",
+                cause=e,
+            )
+    except PluginError:
+        pass
+
     formatted = exceptions.format_exceptions('test_plugin', as_html=as_html)
     assert "some error" in formatted
     assert "version: 0.1.0" in formatted


### PR DESCRIPTION
This ensure that there is no issues when trying to format the traceback
with IPython 8+ (still currently in alpha).

Closes #3872 (unless we also want to protect passing None values in
npe1)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
       - I haven't as IPython 8 is not released yet.
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
