### PR TITLE
Fix surface wireframe

### DIFF
--- a/napari/_vispy/layers/surface.py
+++ b/napari/_vispy/layers/surface.py
@@ -25,7 +25,15 @@ class VispySurfaceLayer(VispyBaseLayer):
         )
         self.layer.events.gamma.connect(self._on_gamma_change)
         self.layer.events.shading.connect(self._on_shading_change)
-        self.layer.wireframe.events.connect(self._on_wireframe_change)
+        self.layer.wireframe.events.visible.connect(
+            self._on_wireframe_visible_change
+        )
+        self.layer.wireframe.events.width.connect(
+            self._on_wireframe_width_change
+        )
+        self.layer.wireframe.events.color.connect(
+            self._on_wireframe_color_change
+        )
         self.layer.normals.face.events.connect(self._on_face_normals_change)
         self.layer.normals.vertex.events.connect(
             self._on_vertex_normals_change
@@ -116,8 +124,16 @@ class VispySurfaceLayer(VispyBaseLayer):
             self.node.shading = shading
         self.node.update()
 
-    def _on_wireframe_change(self):
-        self.node.wireframe_filter.enabled = self.layer.wireframe
+    def _on_wireframe_visible_change(self):
+        self.node.wireframe_filter.enabled = self.layer.wireframe.visible
+        self.node.update()
+
+    def _on_wireframe_width_change(self):
+        self.node.wireframe_filter.width = self.layer.wireframe.width
+        self.node.update()
+
+    def _on_wireframe_color_change(self):
+        self.node.wireframe_filter.color = self.layer.wireframe.color
         self.node.update()
 
     def _on_face_normals_change(self):
@@ -147,6 +163,8 @@ class VispySurfaceLayer(VispyBaseLayer):
         self._on_colormap_change()
         self._on_contrast_limits_change()
         self._on_shading_change()
-        self._on_wireframe_change()
+        self._on_wireframe_visible_change()
+        self._on_wireframe_width_change()
+        self._on_wireframe_color_change()
         self._on_face_normals_change()
         self._on_vertex_normals_change()

--- a/napari/layers/surface/normals.py
+++ b/napari/layers/surface/normals.py
@@ -34,7 +34,7 @@ class Normals(EventedModel):
 
     mode: NormalMode = Field(NormalMode.FACE, allow_mutation=False)
     visible: bool = False
-    color: Union[str, Array[float, (3,), Array[float, (4,)]]] = 'white'
+    color: Union[str, Array[float, (3,)], Array[float, (4,)]] = 'black'
     width: float = 1
     length: float = 5
 

--- a/napari/layers/surface/wireframe.py
+++ b/napari/layers/surface/wireframe.py
@@ -21,5 +21,5 @@ class SurfaceWireframe(EventedModel):
     """
 
     visible: bool = False
-    color: Union[str, Array[float, (3,), Array[float, (4,)]]] = 'black'
+    color: Union[str, Array[float, (3,)], Array[float, (4,)]] = 'black'
     width: float = 1


### PR DESCRIPTION
# Description
Wireframe is currently broken (see #3878). This fixes some wrong (or missing!) hookups that were caused by the change to evented models.

There is still an issue: if a color is passes in the form of list/tuple/array, things break down because the evented model complains like this:

```python
~/git/napari/napari/utils/events/evented_model.py in __eq__(self, other)
    310             if f_name not in other.__eq_operators__:
    311                 return False
--> 312             if (
    313                 hasattr(self, f_name)
    314                 and hasattr(other, f_name)

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

I don't know how to fix this and don't have much time now, so I'll leave it here for now in the hopes that someone already knows the issue :)

cc @sofroniewn @tlambert03

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
