### PR TITLE
Fix get_value() when called before canvas has been interacted with

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -618,3 +618,23 @@ def test_qt_viewer_multscale_image_out_of_view(make_napari_viewer):
         shape_type=['polygon'],
     )
     viewer.add_image([np.eye(1024), np.eye(512), np.eye(256)])
+
+
+def test_surface_mixed_dim(make_napari_viewer):
+    """Test that adding a layer that changes the world ndim
+    when ndisplay=3 before the mouse cursor has been updated
+    doesn't raise an error.
+
+    See PR: https://github.com/napari/napari/pull/3881
+    """
+    viewer = make_napari_viewer(ndisplay=3)
+
+    verts = np.array([[0, 0, 0], [0, 20, 10], [10, 0, -10], [10, 10, -10]])
+    faces = np.array([[0, 1, 2], [1, 2, 3]])
+    values = np.linspace(0, 1, len(verts))
+    data = (verts, faces, values)
+    viewer.add_surface(data)
+
+    timeseries_values = np.vstack([values, values])
+    timeseries_data = (verts, faces, timeseries_values)
+    viewer.add_surface(timeseries_data)

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1049,7 +1049,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
                     )
                 position = self.world_to_data(position)
 
-            if dims_displayed is not None:
+            if (dims_displayed is not None) and (view_direction is not None):
                 if len(dims_displayed) == 2 or self.ndim == 2:
                     value = self._get_value(position=tuple(position))
 


### PR DESCRIPTION
# Description
This fixes a bug where calling `layer.get_value()` before the the canvas has been interacted with. The bug was caused because the `Cursor._view_direction` defaults to `None`. Thus when `get_cursor()` is called before a mouse event has given a value to `Cursor._view_direction` and ndisplay=3, an error is raised.

As reported in #3876, one example of this is the `surface_timeseries.py` example where the viewer is in 3D mode and a 4D surface layer is added after a 3D surface layer. The change in world ndim causes  a call to the `get_status` function, which calls the `get_value` function.



## Type of change

- [x] Bug-fix (non-breaking change which fixes an issue)


# References
Closes #3876 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added a regression test
- [x] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
