### PR TITLE
Replace timeout in test by duration assertion.

### DIFF
--- a/napari/layers/image/_tests/test_big_image_timing.py
+++ b/napari/layers/image/_tests/test_big_image_timing.py
@@ -1,3 +1,5 @@
+import time
+
 import dask.array as da
 import pytest
 import zarr
@@ -10,7 +12,6 @@ data_dask = da.random.random(
 data_zarr = zarr.zeros((100_000, 1000, 1000))
 
 
-@pytest.mark.timeout(2)
 @pytest.mark.parametrize(
     'kwargs',
     [
@@ -23,7 +24,12 @@ data_zarr = zarr.zeros((100_000, 1000, 1000))
 )
 @pytest.mark.parametrize('data', [data_dask, data_zarr], ids=('dask', 'zarrs'))
 def test_timing_fast_big_dask(data, kwargs):
+    now = time.monotonic()
     assert Image(data, **kwargs).data.shape == data.shape
+    elapsed = time.monotonic() - now
+    assert (
+        elapsed < 2
+    ), "Test took to long some computation are likely not lazy"
 
 
 def test_non_visible_images():

--- a/napari/layers/image/_tests/test_image_utils.py
+++ b/napari/layers/image/_tests/test_image_utils.py
@@ -1,3 +1,5 @@
+import time
+
 import dask.array as da
 import numpy as np
 import pytest
@@ -91,6 +93,8 @@ def test_guess_multiscale_incorrect_order():
         _, _ = guess_multiscale(data)
 
 
-@pytest.mark.timeout(2)  # TODO: test that we're not computing more directly
 def test_timing_multiscale_big():
+    now = time.monotonic()
     assert not guess_multiscale(data_dask)[0]
+    elapsed = time.monotonic() - now
+    assert elapsed < 2, "test was too slow, computation was likely not lazy"

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1,4 +1,5 @@
 import itertools
+import time
 from dataclasses import dataclass
 from tempfile import TemporaryDirectory
 from typing import List
@@ -708,9 +709,9 @@ def test_paint_2d():
     assert np.sum(layer.data[5:26, 17:38] == 7) == 349
 
 
-@pytest.mark.timeout(1)  # TODO: see if we can test this more directly
 def test_paint_2d_xarray():
     """Test the memory usage of painting an xarray indirectly via timeout."""
+    now = time.monotonic()
     data = xr.DataArray(np.zeros((3, 3, 1024, 1024), dtype=np.uint32))
 
     layer = Labels(data)
@@ -719,6 +720,8 @@ def test_paint_2d_xarray():
     layer.paint((1, 1, 512, 512), 3)
     assert isinstance(layer.data, xr.DataArray)
     assert layer.data.sum() == 411
+    elapsed = time.monotonic() - now
+    assert elapsed < 1, "test was too slow, computation was likely not lazy"
 
 
 def test_paint_3d():

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -1,3 +1,5 @@
+import time
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -73,14 +75,16 @@ def test_calc_data_range():
     assert np.all(clim == [0, 2])
 
 
-@pytest.mark.timeout(2)  # TODO: test this more directly
 @pytest.mark.parametrize(
     'data',
     [data_dask_8b, data_dask, data_dask_1d, data_dask_1d_rgb, data_dask_plane],
 )
 def test_calc_data_range_fast(data):
+    now = time.monotonic()
     val = calc_data_range(data)
     assert len(val) > 0
+    elapsed = time.monotonic() - now
+    assert elapsed < 5, "test took too long, computation was likely not lazy"
 
 
 def test_segment_normal_2d():

--- a/setup.cfg
+++ b/setup.cfg
@@ -99,7 +99,6 @@ testing =
     pytest-faulthandler
     pytest-order
     pytest-qt
-    pytest-timeout
     hypothesis>=6.8.0
     xarray
     fsspec


### PR DESCRIPTION
There seem to be some problem when using pytest timeout. This might be
due to the fact that we use  a thread to interrupt the tests in the
middle.

Let try to keep the test going, just measure the duration and fail the
tests if they took too long.

We also remove the dependency on Pytest-timeout.

Here I'm using `time.monotonic()` (wall clock), but we can also switch to
`process_time()` (that exclude sleep-time and is thus closer to
cpu-time, it might be better in there is a lot of task switching and we
just want to make sure no computation is happening.

Mitigate #3869

