### PR TITLE
Make sure dask scheduler has been torn-down between tests.

### DIFF
--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -187,7 +187,7 @@ def test_notification_error(mock_show, monkeypatch, clean_current):
 
 @pytest.mark.sync_only
 @pytest.mark.skipif(PY37_OR_LOWER, reason="Fails on py37")
-def test_notifications_error_with_threading(make_napari_viewer):
+def test_notifications_error_with_threading(make_napari_viewer, dask_shutdown):
     """Test notifications of `threading` threads, using a dask example."""
     random_image = da.random.random(size=(50, 50))
     with notification_manager:

--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -43,7 +43,7 @@ if os.getenv("CI") and os.name == 'nt' and 'to_screenshot.py' in examples:
 @pytest.mark.filterwarnings("ignore")
 @pytest.mark.skipif(not examples, reason="No examples were found.")
 @pytest.mark.parametrize("fname", examples)
-def test_examples(fname, monkeypatch):
+def test_examples(fname, monkeypatch, dask_shutdown):
     """Test that all of our examples are still working without warnings."""
 
     # hide viewer window

--- a/napari/_tests/test_numpy_like.py
+++ b/napari/_tests/test_numpy_like.py
@@ -4,7 +4,7 @@ import xarray as xr
 import zarr
 
 
-def test_dask_2D(make_napari_viewer):
+def test_dask_2D(make_napari_viewer, dask_shutdown):
     """Test adding 2D dask image."""
     viewer = make_napari_viewer()
 
@@ -14,7 +14,7 @@ def test_dask_2D(make_napari_viewer):
     assert np.all(viewer.layers[0].data == data)
 
 
-def test_dask_nD(make_napari_viewer):
+def test_dask_nD(make_napari_viewer, dask_shutdown):
     """Test adding nD dask image."""
     viewer = make_napari_viewer()
 
@@ -46,7 +46,7 @@ def test_zarr_nD(make_napari_viewer):
     assert np.all(viewer.layers[0].data == data)
 
 
-def test_zarr_dask_2D(make_napari_viewer):
+def test_zarr_dask_2D(make_napari_viewer, dask_shutdown):
     """Test adding 2D dask image."""
     viewer = make_napari_viewer()
 
@@ -57,7 +57,7 @@ def test_zarr_dask_2D(make_napari_viewer):
     assert np.all(viewer.layers[0].data == zdata)
 
 
-def test_zarr_dask_nD(make_napari_viewer):
+def test_zarr_dask_nD(make_napari_viewer, dask_shutdown):
     """Test adding nD zarr image."""
     viewer = make_napari_viewer()
 

--- a/napari/components/_tests/test_multichannel.py
+++ b/napari/components/_tests/test_multichannel.py
@@ -197,7 +197,7 @@ def test_multichannel_implicit_multiscale():
         assert viewer.layers[i].colormap.name == base_colormaps[i]
 
 
-def test_multichannel_dask_array():
+def test_multichannel_dask_array(dask_shutdown):
     """Test adding multichannel dask array."""
     viewer = ViewerModel()
     np.random.seed(0)

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -31,6 +31,8 @@ def dask_shutdown(request):
     if dask.threaded.default_pool is not None:
         dask.threaded.default_pool.shutdown()
         dask.threaded.default_pool = None
+    # we do not raise if there is no dask pool as this is used in some parametrized
+    # test that only _sometime_ use dask.
 
 
 if not hasattr(pooch.utils, 'file_hash'):

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -24,6 +24,15 @@ from napari.plugins._builtins import (
 from napari.utils import io
 from napari.utils.config import async_loading
 
+
+@pytest.fixture
+def dask_shutdown(request):
+    yield
+    if dask.threaded.default_pool is not None:
+        dask.threaded.default_pool.shutdown()
+        dask.threaded.default_pool = None
+
+
 if not hasattr(pooch.utils, 'file_hash'):
     setattr(pooch.utils, 'file_hash', pooch.hashes.file_hash)
 

--- a/napari/layers/_tests/test_dask_layers.py
+++ b/napari/layers/_tests/test_dask_layers.py
@@ -12,7 +12,7 @@ from napari.utils import _dask_utils, resize_dask_cache
 
 @pytest.mark.sync_only
 @pytest.mark.parametrize('dtype', ['float64', 'uint8'])
-def test_dask_not_greedy(dtype):
+def test_dask_not_greedy(dtype, dask_shutdown):
     """Make sure that we don't immediately calculate dask arrays."""
 
     FETCH_COUNT = 0
@@ -40,7 +40,7 @@ def test_dask_not_greedy(dtype):
         assert tuple(layer.contrast_limits) == (0, 255)
 
 
-def test_dask_array_creates_cache():
+def test_dask_array_creates_cache(dask_shutdown):
     """Test that dask arrays create cache but turns off fusion."""
     resize_dask_cache(1)
     assert _dask_utils._DASK_CACHE.cache.available_bytes == 1
@@ -73,7 +73,7 @@ def test_dask_array_creates_cache():
     layer2.set_view_slice()
 
 
-def test_list_of_dask_arrays_doesnt_create_cache():
+def test_list_of_dask_arrays_doesnt_create_cache(dask_shutdown):
     """Test that adding a list of dask array also creates a dask cache."""
     resize_dask_cache(1)  # in case other tests created it
     assert _dask_utils._DASK_CACHE.cache.available_bytes == 1
@@ -109,7 +109,9 @@ def delayed_dask_stack():
 
 
 @pytest.mark.sync_only
-def test_dask_global_optimized_slicing(delayed_dask_stack, monkeypatch):
+def test_dask_global_optimized_slicing(
+    delayed_dask_stack, monkeypatch, dask_shutdown
+):
     """Test that dask_configure reduces compute with dask stacks."""
 
     # add dask stack to the viewer, making sure to pass multiscale and clims
@@ -151,7 +153,9 @@ def test_dask_global_optimized_slicing(delayed_dask_stack, monkeypatch):
 
 
 @pytest.mark.sync_only
-def test_dask_unoptimized_slicing(delayed_dask_stack, monkeypatch):
+def test_dask_unoptimized_slicing(
+    delayed_dask_stack, monkeypatch, dask_shutdown
+):
     """Prove that the dask_configure function works with a counterexample."""
     # we start with a cache...but then intentionally turn it off per-layer.
     resize_dask_cache(10000)
@@ -192,7 +196,9 @@ def test_dask_unoptimized_slicing(delayed_dask_stack, monkeypatch):
 
 
 @pytest.mark.sync_only
-def test_dask_local_unoptimized_slicing(delayed_dask_stack, monkeypatch):
+def test_dask_local_unoptimized_slicing(
+    delayed_dask_stack, monkeypatch, dask_shutdown
+):
     """Prove that the dask_configure function works with a counterexample."""
     # make sure we are not caching for this test, which also tests that we
     # can turn off caching
@@ -233,7 +239,7 @@ def test_dask_local_unoptimized_slicing(delayed_dask_stack, monkeypatch):
 
 
 @pytest.mark.sync_only
-def test_dask_cache_resizing(delayed_dask_stack):
+def test_dask_cache_resizing(delayed_dask_stack, dask_shutdown):
     """Test that we can spin up, resize, and spin down the cache."""
 
     # make sure we have a cache
@@ -274,7 +280,7 @@ def test_dask_cache_resizing(delayed_dask_stack):
     assert len(_dask_utils._DASK_CACHE.cache.heap.heap) > 0
 
 
-def test_prevent_dask_cache(delayed_dask_stack):
+def test_prevent_dask_cache(delayed_dask_stack, dask_shutdown):
     """Test that pre-emptively setting cache to zero keeps it off"""
     resize_dask_cache(0)
 

--- a/napari/layers/image/_tests/test_big_image_timing.py
+++ b/napari/layers/image/_tests/test_big_image_timing.py
@@ -22,7 +22,7 @@ data_zarr = zarr.zeros((100_000, 1000, 1000))
     ids=('all', 'multiscale', 'clims', 'nothing'),
 )
 @pytest.mark.parametrize('data', [data_dask, data_zarr], ids=('dask', 'zarrs'))
-def test_timing_fast_big_dask(data, kwargs):
+def test_timing_fast_big_dask(data, kwargs, dask_shutdown):
     assert Image(data, **kwargs).data.shape == data.shape
 
 

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -73,7 +73,7 @@ def test_calc_data_range():
     assert np.all(clim == [0, 2])
 
 
-@pytest.mark.timeout(2)  # TODO: test this more directly
+@pytest.mark.timeout(6)  # TODO: test this more directly
 @pytest.mark.parametrize(
     'data',
     [data_dask_8b, data_dask, data_dask_1d, data_dask_1d_rgb, data_dask_plane],

--- a/napari/utils/events/_tests/test_evented_model.py
+++ b/napari/utils/events/_tests/test_evented_model.py
@@ -306,7 +306,7 @@ def test_nested_evented_model_serialization():
     assert deserialized == m
 
 
-def test_evented_model_dask_delayed():
+def test_evented_model_dask_delayed(dask_shutdown):
     """Test that evented models work with dask delayed objects"""
 
     class MyObject(EventedModel):


### PR DESCRIPTION
I'm not completely sure this is a public API though,
this also explicitly requests a dask fixture to shutdown dask threads,
first thing to be explicit, and second thing as the ordering of fixture
may matter, which is harder to ensure with autouse.

While in itself dask should not be a problem to keep on, it makes it a
bit harder to track threads leaks if a test may create new threads with
dask.

----

I also have a hope that this would fix issues /timeout in other areas. There is few reasons for idle thread to create scheduling contentions, but you never know. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
