### PR TITLE
Do not leak QtViewer between tests.

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -17,6 +17,7 @@ from typing import (
     Sequence,
     Tuple,
 )
+from weakref import WeakValueDictionary
 
 from qtpy.QtCore import QEvent, QEventLoop, QPoint, QProcess, QSize, Qt, Slot
 from qtpy.QtGui import QIcon
@@ -408,7 +409,9 @@ class Window:
         get_app()
 
         # Dictionary holding dock widgets
-        self._dock_widgets: Dict[str, QtViewerDockWidget] = {}
+        self._dock_widgets: Dict[
+            str, QtViewerDockWidget
+        ] = WeakValueDictionary()
         self._unnamed_dockwidget_count = 1
 
         # Connect the Viewer and create the Main Window

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import warnings
 from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple
+from weakref import WeakSet
 
 import numpy as np
 from qtpy.QtCore import QCoreApplication, QObject, Qt
@@ -177,11 +178,14 @@ class QtViewer(QSplitter):
         Button controls for the napari viewer.
     """
 
+    _instances = WeakSet()
+
     def __init__(self, viewer: ViewerModel, show_welcome_screen: bool = False):
         # Avoid circular import.
         from .layer_controls import QtLayerControlsContainer
 
         super().__init__()
+        self._instances.add(self)
         self.setAttribute(Qt.WA_DeleteOnClose)
 
         self._show_welcome_screen = show_welcome_screen

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -3,6 +3,7 @@ from functools import reduce
 from itertools import count
 from operator import ior
 from typing import List, Optional
+from weakref import ref
 
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
@@ -71,7 +72,7 @@ class QtViewerDockWidget(QDockWidget):
         object_name: str = '',
         add_vertical_stretch=True,
     ):
-        self._qt_viewer = qt_viewer
+        self._ref_qt_viewer = ref(qt_viewer)
         super().__init__(name)
         self._parent = qt_viewer
         self.name = name
@@ -142,9 +143,23 @@ class QtViewerDockWidget(QDockWidget):
         self.setTitleBarWidget(self.title)
         self.visibilityChanged.connect(self._on_visibility_changed)
 
+    @property
+    def _parent(self):
+        """
+        Let's make sure parent always a weakref:
+
+            1) parent is likely to always exists after child
+            2) even if not strictly necessary it make it easier to view reference cycles.
+        """
+        return self._ref_parent()
+
+    @_parent.setter
+    def _parent(self, obj):
+        self._ref_parent = ref(obj)
+
     def destroyOnClose(self):
         """Destroys dock plugin dock widget when 'x' is clicked."""
-        self._qt_viewer.viewer.window.remove_dock_widget(self)
+        self._ref_qt_viewer().viewer.window.remove_dock_widget(self)
 
     def _maybe_add_vertical_stretch(self, widget):
         """Add vertical stretch to the bottom of a vertical layout only
@@ -198,7 +213,7 @@ class QtViewerDockWidget(QDockWidget):
         # if you subclass QtViewerDockWidget and override the keyPressEvent
         # method, be sure to call super().keyPressEvent(event) at the end of
         # your method to pass uncaught key-combinations to the viewer.
-        return self._qt_viewer.keyPressEvent(event)
+        return self._ref_qt_viewer().keyPressEvent(event)
 
     def _set_title_orientation(self, area):
         if area in (Qt.LeftDockWidgetArea, Qt.RightDockWidgetArea):
@@ -224,12 +239,12 @@ class QtViewerDockWidget(QDockWidget):
         try:
             actions = [
                 action.text()
-                for action in self._qt_viewer.viewer.window.plugins_menu.actions()
+                for action in self._ref_qt_viewer().viewer.window.plugins_menu.actions()
             ]
             idx = actions.index(self.name)
 
             current_action = (
-                self._qt_viewer.viewer.window.plugins_menu.actions()[idx]
+                self._ref_qt_viewer().viewer.window.plugins_menu.actions()[idx]
             )
             current_action.setChecked(visible)
             self.setVisible(visible)

--- a/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
+++ b/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
@@ -74,3 +74,4 @@ def test_vispy_text_visual(make_napari_viewer):
     viewer.scale_bar.visible = False
     viewer.scale_bar.unit = "pixel"
     assert qt_widget.scale_bar._quantity.units == "pixel"
+    del qt_widget

--- a/napari/_vispy/canvas.py
+++ b/napari/_vispy/canvas.py
@@ -1,5 +1,7 @@
 """VispyCanvas class.
 """
+from weakref import WeakSet
+
 from qtpy.QtCore import QSize
 from vispy.scene import SceneCanvas, Widget
 
@@ -20,6 +22,8 @@ class VispyCanvas(SceneCanvas):
 
     """
 
+    _instances = WeakSet()
+
     def __init__(self, *args, **kwargs):
 
         # Since the base class is frozen we must create this attribute
@@ -28,6 +32,7 @@ class VispyCanvas(SceneCanvas):
         self._last_theme_color = None
         self._background_color_override = None
         super().__init__(*args, **kwargs)
+        self._instances.add(self)
 
         # Call get_max_texture_sizes() here so that we query OpenGL right
         # now while we know a Canvas exists. Later calls to

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -1,15 +1,19 @@
 import collections
+import gc
 import os
 import sys
 import warnings
 from contextlib import suppress
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 from unittest.mock import patch
+from weakref import WeakSet
 
 import pytest
 
 if TYPE_CHECKING:
     from pytest import FixtureRequest
+
+_SAVE_GRAPH_OPNAME = "--save-leaked-object-graph"
 
 
 def pytest_addoption(parser):
@@ -19,6 +23,45 @@ def pytest_addoption(parser):
         default=False,
         help="don't show viewer during tests",
     )
+
+    parser.addoption(
+        _SAVE_GRAPH_OPNAME,
+        action="store_true",
+        default=False,
+        help="Try to save a graph of leaked object's reference (need objgraph"
+        "and graphviz installed",
+    )
+
+
+COUNTER = 0
+
+
+def fail_obj_graph(Klass):
+    """
+    Fail is a given class _instances weakset is non empty and print the object graph.
+    """
+
+    try:
+        import objgraph
+    except ImportError:
+        return
+
+    if not len(Klass._instances) == 0:
+        global COUNTER
+        COUNTER += 1
+        import gc
+
+        gc.collect()
+
+        objgraph.show_backrefs(
+            list(Klass._instances),
+            max_depth=20,
+            filename=f'{Klass.__name__}-leak-backref-graph-{COUNTER}.pdf',
+        )
+
+        # DO not remove len, this can break as C++ obj are gone, but python objects
+        # still hang around and _repr_ would crash.
+        assert False, len(Klass._instances)
 
 
 @pytest.fixture
@@ -103,12 +146,13 @@ def make_napari_viewer(
     from qtpy.QtWidgets import QApplication
 
     from napari import Viewer
+    from napari._qt.qt_viewer import QtViewer
     from napari.settings import get_settings
 
     settings = get_settings()
     settings.reset()
 
-    viewers: List[Viewer] = []
+    viewers: WeakSet[Viewer] = WeakSet()
 
     # may be overridden by using `make_napari_viewer(strict=True)`
     _strict = False
@@ -133,7 +177,7 @@ def make_napari_viewer(
         should_show = request.config.getoption("--show-napari-viewer")
         model_kwargs['show'] = model_kwargs.pop('show', should_show)
         viewer = ViewerClass(*model_args, **model_kwargs)
-        viewers.append(viewer)
+        viewers.add(viewer)
 
         return viewer
 
@@ -153,6 +197,16 @@ def make_napari_viewer(
                 viewer.close()
         else:
             viewer.close()
+
+    gc.collect()
+
+    if request.config.getoption(_SAVE_GRAPH_OPNAME):
+        fail_obj_graph(QtViewer)
+
+    _do_not_inline_below = len(QtViewer._instances)
+    # do not inline to avoid pytest trying to compute repr of expression.
+    # it fails if C++ object gone but not Python object.
+    assert _do_not_inline_below == 0
 
     # only check for leaked widgets if an exception was raised during the test,
     # or "strict" mode was used.


### PR DESCRIPTION
This is a first step toward removing leaked references during the test.
So far it make sure that nothing keeps references to the QtViewer
between tests.

We do so by turning a couple of hard references into weak ones.

They might not be the obvious ones to turn into weak ones, nor the best
ones, but _at least_ they allow collections.

We also add a flag  "--save-leaked-object-graph", that when passed to
pytest tries to save a graph (pdf) of the leaked objects, which can be
useful for debugging.

--- 

I'm of course hopping that this will fix some of the intermittent failures, and maybe speedup test suite. 
