### PR TITLE
Use packaging.version, DeprecationWarnings since setuptools 59+ 

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -396,7 +396,8 @@ def main():
     # https://github.com/napari/napari/issues/380#issuecomment-659656775
     # and https://github.com/ContinuumIO/anaconda-issues/issues/199
     import platform
-    from distutils.version import StrictVersion
+
+    from packaging.version import Version as StrictVersion
 
     _MACOS_AT_LEAST_CATALINA = sys.platform == "darwin" and StrictVersion(
         platform.release()

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -397,14 +397,12 @@ def main():
     # and https://github.com/ContinuumIO/anaconda-issues/issues/199
     import platform
 
-    from packaging.version import Version as StrictVersion
-
-    _MACOS_AT_LEAST_CATALINA = sys.platform == "darwin" and StrictVersion(
-        platform.release()
-    ) > StrictVersion('19.0.0')
-    _MACOS_AT_LEAST_BIG_SUR = sys.platform == "darwin" and StrictVersion(
-        platform.release()
-    ) > StrictVersion('20.0.0')
+    _MACOS_AT_LEAST_CATALINA = (
+        sys.platform == "darwin" and int(platform.release().split('.')[0]) > 19
+    )
+    _MACOS_AT_LEAST_BIG_SUR = (
+        sys.platform == "darwin" and int(platform.release().split('.')[0]) > 20
+    )
 
     _RUNNING_CONDA = "CONDA_PREFIX" in os.environ
     _RUNNING_PYTHONW = "PYTHONEXECUTABLE" in os.environ

--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -1,8 +1,9 @@
 import os
 import sys
-from distutils.version import StrictVersion
 from pathlib import Path
 from warnings import warn
+
+from packaging.version import Version as StrictVersion
 
 from ..utils.translations import trans
 

--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -3,8 +3,6 @@ import sys
 from pathlib import Path
 from warnings import warn
 
-from packaging.version import Version as StrictVersion
-
 from ..utils.translations import trans
 
 try:
@@ -31,7 +29,7 @@ if API_NAME == 'PySide2':
 
 
 # When QT is not the specific version, we raise a warning:
-if StrictVersion(QtCore.__version__) < StrictVersion('5.12.3'):
+if tuple(int(x) for x in QtCore.__version__.split('.')[:3]) < (5, 12, 3):
     if sys.version_info >= (3, 8):
         from importlib import metadata as importlib_metadata
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ filterwarnings = [
   "ignore:Multiscale rendering is only supported in 2D. In 3D, only the lowest resolution scale is displayed",
   "ignore:Alternative shading modes are only available in 3D, defaulting to none",
   "ignore:.*Themes were changed to use evented model",  # specifying the full is not working here so glob pattern is used instead
+  "ignore:.*distutils Version classes are deprecated::napari._vendor.darkdetect",  # vendor darkdetect still use distutils
 ]
 markers = [
     "sync_only: Test should only be run synchronously",

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,7 @@ install_requires =
     tqdm>=4.56.0
     vispy>=0.9.4
     wrapt>=1.11.1
+    packaging>=21.0
 
 [options.package_data]
 * = *.pyi

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,6 @@ install_requires =
     tqdm>=4.56.0
     vispy>=0.9.4
     wrapt>=1.11.1
-    packaging>=21.0
 
 [options.package_data]
 * = *.pyi


### PR DESCRIPTION

This is creating CI failures as we turn warnings into error.
Follow deprecation warning message and use alternative.

See https://setuptools.pypa.io/en/latest/history.html#v59-6-0

Note that this introduces a new dependency.