### PR TITLE
Better error message on failed window import

### DIFF
--- a/napari/window.py
+++ b/napari/window.py
@@ -13,7 +13,9 @@ from .utils.translations import trans
 try:
     from ._qt import Window
 
-except ImportError:
+except ImportError as e:
+
+    err = e
 
     class Window:  # type: ignore
         def __init__(self, *args, **kwargs):
@@ -23,6 +25,9 @@ except ImportError:
             pass
 
         def __getattr__(self, name):
-            raise ImportError(
-                trans._("could not import `qtpy`. Cannot show napari window.")
-            )
+            raise type(err)(
+                trans._(
+                    "An error occured when importing Qt dependencies.  Cannot show napari window.  See cause above",
+                    err=err,
+                )
+            ) from err

--- a/napari/window.py
+++ b/napari/window.py
@@ -28,6 +28,5 @@ except ImportError as e:
             raise type(err)(
                 trans._(
                     "An error occured when importing Qt dependencies.  Cannot show napari window.  See cause above",
-                    err=err,
                 )
             ) from err


### PR DESCRIPTION
# Description
This PR shows a better error message when an exception occurs while importing `napari/_qt/qt_main_window.py`.

This would have been useful for https://forum.image.sc/t/add-napari-to-another-window/61462/5 ... and also @AhmetCanSolak had a case recently where this would have been helpful