### PR TITLE
Make small tweaks and proofread npe2 docs

### DIFF
--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -18,7 +18,7 @@ guide](npe2-migration-guide) for details.
 For getting started writing new npe2 plugins see the [](npe2-getting-started).
 ```
 
-napari loves plugins. Plugins allow people to customize and extend to napari.
+napari loves plugins. Plugins allow people to customize and extend napari.
 
 This document describes:
 
@@ -44,7 +44,7 @@ more see {ref}`find-and-install-plugins`.
 
 New plugins should target `npe2`. See the {ref}`npe2-getting-started`.
 
-For a guide on how to create a plugin using `napari-plugin-engine`, see
+For a guide on how to create a plugin using the original `napari-plugin-engine`, see
 {ref}`plugins-for-plugin-developers`. For a complete list of _hook
 specifications_ that developers can implement, see the
 {ref}`hook-specifications-reference`.
@@ -52,7 +52,7 @@ specifications_ that developers can implement, see the
 For special considerations when building a napari plugin, see
 {ref}`best-practices`.
 
-## Looking for help
+## Looking for help?
 
 If you have questions, try asking on the [zulip
 chat](https://napari.zulipchat.com/). Submit issues to the [napari github

--- a/docs/plugins/npe2_getting_started.md
+++ b/docs/plugins/npe2_getting_started.md
@@ -5,7 +5,7 @@
 ```{warning}
 This guide is still a work in progress.
 
-There are inaccuracies and mistakes. If you notice any, feel free to submit
+There are inaccuracies and mistakes. If you notice any, please submit
 issues to the [napari github repository](https://github.com/napari/napari).
 ```
 
@@ -16,7 +16,7 @@ is a re-imagining of how napari interacts with plugins. Plugins targeting
 `napari-plugin-engine` will continue to work, but we recommend migrating to
 `npe2` eventually.
 
-For more on migrating an existing plugins see the [](npe2-migration-guide).
+For more on migrating an existing plugin see the [](npe2-migration-guide).
 ```
 
 This guide will walk you through the steps required to write a napari plugin
@@ -27,24 +27,24 @@ with `pip` and autodetected by napari.
 
 ## Overview
 
-Plugins are special python packages. They include a _plugin manifest_ file
+Plugins are special Python packages. They include a _plugin manifest_ file
 that lists _contributions_ that napari may use when performing tasks.
 
 Creating a new plugin involves the following steps:
 
-1. Configure a python package to use an npe2 manifest (e.g. by [editing
+1. Configure a Python package to use an npe2 manifest (e.g. by [editing
    `setup.cfg`](edit-package-meta)):
    - Create the _entry point group_.
    - Make sure the manifest file is added to `package_data`.
 2. Create the [plugin manifest](manifest) file.
 
 This guide will walk you through the steps using a [cookiecutter] template.
-cookiecutter is a command line utility that generates a python package for you
+cookiecutter is a command line utility that generates a Python package for you
 after asking a few questions. In this case, the package contains all the
 boilerplate needed for building, documenting, testing and deploying your plugin.
 
 ```{note}
-Minimally, a plugin could be just three files: `setup.cfg`, a python file, and
+Minimally, a plugin could be just three files: `setup.cfg`, a Python file, and
 the plugin manifest file.
 ```
 
@@ -75,17 +75,17 @@ include_widget_plugin [y]: n
 ...
 ```
 
-We named our plugin `my-py-reader`. This is the name that will be used for
-the python package. It should conform to the [PEP8] naming convention
+We named our plugin `my-npy-reader`. This is the name that will be used for
+the Python package. It should conform to the [PEP8] naming convention
 (short, all-lowercase names, using dashes instead of underscores).
 
 After answering all the prompts, `cookiecutter` will create a directory called
-`my_npy_reader` in the current directory that holds the generated files. It
+`my-npy-reader` in the current directory that holds the generated files. It
 will look something like this:
 
 ```
 my-npy-reader
-├── .napari                    <-- napari-hub customizations
+├── .napari                    <-- napari hub customizations
 │   └── DESCRIPTION.md
 │   └── config.yml
 ├── LICENSE
@@ -114,7 +114,7 @@ my-npy-reader
 
 The plugin manifest file is specified relative to the top level module path as specified in `setup.cfg` `options.packages.find`. For
 the example it will be loaded from:
-`<path/to/my-npy-reader>/my_npy_reader/src/my_npy_reader/napari.yaml`.
+`<path/to/my-npy-reader>/my-npy-reader/src/my_npy_reader/napari.yml`.
 
 The generated `napari.yml` file looks like this:
 
@@ -194,13 +194,14 @@ napari.manifest =
 
 The manifest file is specified relative to the submodule root path.
 So for the example it will be loaded from:
-`<path/to/npe2-tester>/napari.yaml`.
+`<path/to/npe2-tester>/npe2_tester/napari.yaml`.
 
 The manifest file also needs to be included as _[package data][pd]_ in
-distributable forms for the package. For example:
+distributable forms of the package. For example:
 
 ```toml
 [metadata]
+name=npe2-tester
 ...
 include_package_data=True
 
@@ -212,7 +213,7 @@ npe2_tester =
 A user can install napari and your plugin with:
 
 ```bash
-pip install napari myplugin
+pip install "napari[all]" npe2-tester
 ```
 
 ## 4. Preparing for release
@@ -223,7 +224,7 @@ already been done for you.
 
 Once your package, with its `Framework :: napari` classifier, is listed on
 [PyPI], it will also be visible on the [napari hub][hub], alongside all other
-napari plugins. More about python packing can be found in the [packaging guide].
+napari plugins. More about Python packing can be found in the [packaging guide].
 
 You can customize your plugin’s listing for the hub by following this
 [guide][hubguide]. If you'd like to know what your _napari hub_ plugin page
@@ -240,23 +241,6 @@ You can also include a napari hub specific description file at
 repository’s `README.md` when it’s available. This file allows you to maintain a
 more developer/repository oriented `README.md` while still making sure potential
 users get all the information they need to get started with your plugin.
-
-Finally, once you have curated your package metadata and description, you can
-preview your metadata, and check any missing fields using the `napari-hub-cli`
-tool. Install this tool using
-
-```bash
-pip install napari-hub-cli
-```
-
-and preview your metadata with
-
-```bash
-napari-hub-cli preview-metadata ./my-npy-reader
-```
-
-For more information on the tool see the `napari-hub-cli`
-[README](https://github.com/chanzuckerberg/napari-hub-cli).
 
 If you want your plugin to be available on PyPI, but not visible on the napari
 hub, you can add a `.napari/config.yml` file to the root of your repository

--- a/docs/plugins/npe2_manifest_specification.md
+++ b/docs/plugins/npe2_manifest_specification.md
@@ -5,7 +5,7 @@
 ```{warning}
 This guide is still a work in progress.
 
-There are inaccuracies and mistakes. If you notice any, feel free to submit
+There are inaccuracies and mistakes. If you notice any, please submit
 issues to the [napari github repository](https://github.com/napari/napari).
 ```
 
@@ -18,7 +18,7 @@ is a re-imagining of how napari interacts with plugins. Plugins targeting
 ```
 
 The **plugin manifest** is a specially formatted text file declaring the
-functionality of a [npe2][] plugin. A **plugin** is a python package that
+functionality of an [npe2][] plugin. A **plugin** is a Python package that
 contains the manifest together with a suitable _[entry point group][epg]_ in
 the package metadata.
 
@@ -49,12 +49,12 @@ napari.manifest =
 ```
 
 The manifest file is specified relative to the submodule root path.
-So for the example it will be loaded from: `<path/to/npe2-tester>/napari.yaml`.
+So for the example it will be loaded from: `<path/to/npe2-tester>/npe2_tester/napari.yaml`.
 
 ### 2. Include the manifest in the package distribution
 
 The manifest file needs to be included as _[package data][pd]_ in
-distributable forms for the package. For example:
+distributable forms of the package. For example:
 
 ```toml
 [metadata]
@@ -92,8 +92,8 @@ contributions:
 ```
 
 Readers, writers, sample data providers and widget providers refer to callable
-python functions that a plugin defines. Each callable is identified with an
-entry in the list of `commands` via a unique id. For more see {ref}`Commands`
+Python functions that a plugin defines. Each callable is identified with an
+entry in the list of `commands` via a unique id. For more detail, see {ref}`Commands`
 below.
 
 ```{note}
@@ -108,14 +108,14 @@ description, and version.
 
 ### Required
 
-- **name** The name of the plugin. Example: `napari-svg`. Should be a
+- **name** The name of the plugin. Example: `napari-svg`. Must be a
   [PEP-8]-compatible package name. If missing, this is populated from the
-  python package [name][setup-name].
+  Python package [name][setup-name].
 
 ### Optional
 
 - **engine**: A SemVer compatible version string matching the versions of the
-  plugin engine that the extension is compatible with. Example: "0.1.0".
+  plugin engine that the plugin is compatible with. Example: "0.1.0".
   See [][compatibility] for details.
 - **display_name**: User-facing text to display as the name of this plugin.
   Example: `napari SVG`. Must be 3-40 characters long, containing
@@ -134,13 +134,13 @@ on deactivation.  These must be defined relative to the `entry_point`.
 
 ### Compatibility
 
-A goal of `npe2` was to make it possible to add or change the plugin interface
+One goal of `npe2` is to make it possible to add or change the plugin interface
 without breaking existing plugins. This is achieved by defining an
 **engine version**. When we want to change the plugin interface, we increment
 this number to indicate there is something new. New plugins can opt-in to the
 new behavior by declaring compatibility with that version.
 
-When authoring a plugin, you will need to describe what is the plugin's
+When authoring a plugin, you will need to describe the plugin's
 compatibility with `npe2`. This can be done via the `engine` field in the
 plugin manifest (see {ref}`top-level-props`).
 
@@ -162,13 +162,13 @@ added.
 
 ## Commands
 
-**command** is a python function associated with an id. The **id** is
+A **command** is a Python function associated with an id. The **id** is
 a unique identifier to which other contributions, like readers, can refer.
 
 When a contribution like a reader refers to a command, it gives the command
 meaning. The command will be expected to conform to a specific _calling
 convention_. The **calling convention** is described by the argument and return
-types of the associated callable, as well as conventions regarding it's
+types of the associated callable, as well as conventions regarding its
 behavior.
 
 ### Required fields
@@ -180,7 +180,7 @@ behavior.
 
 ### Optional fields
 
-- **python_name** Fully qualified name to callable python object implementing
+- **python_name** Fully qualified name to callable Python object implementing
   this command. This usually takes the form of
   `{obj.__module__}:{obj.__qualname__}` (e.g.
   `my_package.a_module:some_function`). For a command to be useful, this
@@ -262,7 +262,7 @@ def reader(path: str) -> List[LayerData]:
 
 ```{note}
 The reader command is compatible with functions used for the `napari_get_reader`
-[hook specification][get-reader-hook] used by plugins based on the
+[hook specification][get-reader-hook] by plugins based on the
 `napari-plugin-engine`. See the [](npe2-migration-guide) for more details.
 ```
 
@@ -287,7 +287,7 @@ layer_data(list of LayerData)
 ### Optional fields
 
 - **display_name** Brief text used to describe this writer when presented.
-  Empty by default. When present this is presented along side the plugin name
+  Empty by default. When present this is shown along side the plugin name
   and may be used to distinguish the kind of writer for the user. E.g. "lossy"
   or "lossless".
 - **filename_extensions** List of filename extensions compatible with this
@@ -332,7 +332,7 @@ contributions:
 
 ### Layer type constraints
 
-Given a set of layers, compatible writer plugins are selected based their
+Given a set of layers, compatible writer plugins are selected based on their
 _layer type constraints_.
 
 A writer plugin can declare that it will write between _m_ and _n_ layers of a
@@ -469,6 +469,7 @@ Sample data uri
 
 ```yaml
 name: my-sample
+# note that uri based sample data contributions do not require an associated command
 contributions:
   sample_data:
     - display_name: Tabueran Kiribati
@@ -504,7 +505,7 @@ should use `autogenerate: true`.  See more details below.
 ### Optional fields
 
 - **autogenerate** If True, the widget will be automatically generated with
-  [magicgui] using the type-signature of the associated command.
+  [magicgui] using the type-signature of the associated command's `python_name`.
 
 ### Examples
 

--- a/docs/plugins/npe2_migration_guide.md
+++ b/docs/plugins/npe2_migration_guide.md
@@ -5,7 +5,7 @@
 ```{warning}
 This guide is still a work in progress.
 
-There are inaccuracies and mistakes. If you notice any, feel free to submit
+There are inaccuracies and mistakes. If you notice any, please submit
 issues to the [napari github repository](https://github.com/napari/napari).
 ```
 
@@ -20,10 +20,10 @@ recommend migrating to `npe2`. This guide will help you learn how!
 
 ## Migrating using the `npe2` command line tool
 
-`npe2` provides a command line interface to help convert a
+`npe2` provides a command line interface to help convert an original
 `napari-plugin-engine`-style plugin.
 
-### 1. Install the `npe2` command
+### 1. Install the `npe2` tool
 
 ```bash
 pip install npe2
@@ -52,7 +52,7 @@ Options:
   --help          Show this message and exit.
 ```
 
-### 2. Install your `napari-plugin-engine` based plugin.
+### 2. Install your `napari-plugin-engine` based plugin
 
 As an example, we'll walk through the process using the `napari-animation`
 plugin.
@@ -67,7 +67,7 @@ pip install -e .
 
 ### 3. Inspect package metadata
 
-The `napari-animation` package defines it's core metadata in `setup.cfg`.
+The `napari-animation` package defines its core metadata in `setup.cfg`.
 Inside, it defines an _entry point group_. That section should initially
 contain:
 
@@ -78,7 +78,7 @@ napari.plugin =
 ```
 
 That metadata gives the name of the plugin: "animation". The name is used in
-the next step. Later we're going to come back and update this section.
+the next step. Later, we're going to come back and update this section.
 
 ### 4. Convert your plugin.
 
@@ -96,8 +96,8 @@ This step uses `napari-plugin-engine` to discover the plugins installed on the
 system. If you have other plugins installed there's a chance they may interfere.
 ```
 
-This generates `napari_animation/napari.yaml` and modifies the package metadta
-(in `setup.cfg` or `setup.py`).
+This generates `napari_animation/napari.yaml` and modifies the package metadata
+(in `setup.cfg` or `setup.py` depending on what setup file the original plugin used).
 
 The plugin manifest contains:
 
@@ -131,7 +131,7 @@ The package metadata will have a new entry point. The old one is removed:
 +    napari-animation = napari_animation:napari.yaml
 ```
 
-the manifest was also added to `options.package_data` so that it will be
+The manifest was also added to `options.package_data` so that it will be
 included with any distribution.
 
 ```diff
@@ -145,13 +145,13 @@ All done! Update the local package metadata by repeating:
 > pip install -e .
 ```
 
-and the next time napari is run `napari-animation` will be discovered as an
+and the next time napari is run, `napari-animation` will be discovered as an
 `npe2` plugin!
 
 ## Migration details
 
 Existing `napari-plugin-engine` plugins expose functionality via _hook
-implementations_. These are functions decorated to indicate they fullfil a
+implementations_. These are functions decorated to indicate they fulfill a
 _hook specification_ described by napari. Though there are some exceptions,
 most _hook implementations_ can be straightforwardly mapped as a
 _contribution_ in the `npe2` manifest. More information can be found in the
@@ -162,7 +162,7 @@ inspecting exposed _hook implementations_. Below, we will walk through the
 kinds of migrations `npe2 convert` helps with.
 
 For each type of _hook specification_ there is a corresponding section below
-with migration tips. Each lists the _hook specifications_ that are relevant to
+with migration tips. Each section lists the _hook specifications_ that are relevant to
 that section and an example manifest. For details, refer to the
 {ref}`npe2-manifest-spec`.
 
@@ -247,7 +247,7 @@ function.
 When migrating, you'll need to fill out the `layer_types` and
 `filename_extensions` used by your writer. `layer_types` is a set of
 constraints describing the combinations of layer types acceptable by this
-writer. More about layer types can be found in the {ref}`npe2-manifest-spec`.
+writer. More detail about layer types can be found in the {ref}`npe2-manifest-spec`.
 
 In the example below, the svg writer accepts a set of layers with 0 or more
 images, and 0 or more label layers, and so on. It will not accept surface
@@ -295,12 +295,12 @@ contributions:
 can be used to instantiate a widget and, optionally, arguments to be passed to
 that function.
 
-In contrast the callable for an `npe2` widget contribution is bound to the
+In contrast, the callable for an `npe2` widget contribution is bound to the
 function actually instantiating the widget. It accepts only one argument: a
 napari `Viewer` proxy instance. The proxy restricts access to some `Viewer`
 functionality like private methods.
 
-Similarly `napari_experimental_provide_function` hooks return ane or more
+Similarly, `napari_experimental_provide_function` hooks return ane or more
 functions to be wrapped with [magicgui]. In `npe2`, each of these functions
 should be added as a `Command` contribution with an associated `Widget`
 contribution. For each of these `Widget` contributions, the manifest

--- a/docs/plugins/npe2_migration_guide.md
+++ b/docs/plugins/npe2_migration_guide.md
@@ -23,7 +23,7 @@ recommend migrating to `npe2`. This guide will help you learn how!
 `npe2` provides a command line interface to help convert an original
 `napari-plugin-engine`-style plugin.
 
-### 1. Install the `npe2` tool
+### 1. Install the `npe2` command-line interface
 
 ```bash
 pip install npe2


### PR DESCRIPTION
# Description
This PR makes small tweaks to the `npe2` docs and proofreads for grammar and spelling. Most of the changes are trivial but there are a few cases where I've swapped plugin names being used for commands and module names, to better fit the example at hand. @nclack can you please do a thorough review of these changes just to make sure I haven't messed anything up or misunderstood something.

## Type of change
- [x] This change is a documentation update
