### PR TITLE
Rename feature manager attribute to table

### DIFF
--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -291,7 +291,7 @@ class Labels(_ImageBase):
             contour=Event,
         )
 
-        self._feature_manager = _FeatureTable.from_layer(
+        self._feature_table = _FeatureTable.from_layer(
             features=features, properties=properties
         )
         self._label_index = self._make_label_index()
@@ -447,28 +447,28 @@ class Labels(_ImageBase):
         ----------
         .. [1]: https://data-apis.org/dataframe-protocol/latest/API.html
         """
-        return self._feature_manager.values
+        return self._feature_table.values
 
     @features.setter
     def features(
         self,
         features: Union[Dict[str, np.ndarray], pd.DataFrame],
     ) -> None:
-        self._feature_manager.set_values(features)
+        self._feature_table.set_values(features)
         self._label_index = self._make_label_index()
         self.events.properties()
 
     @property
     def properties(self) -> Dict[str, np.ndarray]:
         """dict {str: array (N,)}, DataFrame: Properties for each label."""
-        return self._feature_manager.properties()
+        return self._feature_table.properties()
 
     @properties.setter
     def properties(self, properties: Dict[str, Array]):
         self.features = properties
 
     def _make_label_index(self) -> Dict[int, int]:
-        features = self._feature_manager.values
+        features = self._feature_table.values
         label_index = {}
         if 'index' in features:
             label_index = {i: k for k, i in enumerate(features['index'])}

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -491,7 +491,7 @@ class Shapes(Layer):
         self._display_order_stored = []
         self._ndisplay_stored = self._ndisplay
 
-        self._feature_manager = _FeatureTable.from_layer(
+        self._feature_table = _FeatureTable.from_layer(
             features=features,
             properties=properties,
             property_choices=property_choices,
@@ -718,14 +718,14 @@ class Shapes(Layer):
         ----------
         .. [1]: https://data-apis.org/dataframe-protocol/latest/API.html
         """
-        return self._feature_manager.values
+        return self._feature_table.values
 
     @features.setter
     def features(
         self,
         features: Union[Dict[str, np.ndarray], pd.DataFrame],
     ) -> None:
-        self._feature_manager.set_values(features, num_data=self.nshapes)
+        self._feature_table.set_values(features, num_data=self.nshapes)
         if self._face_color_property and (
             self._face_color_property not in self.features
         ):
@@ -760,12 +760,12 @@ class Shapes(Layer):
 
         See `features` for more details on the type of this property.
         """
-        return self._feature_manager.defaults
+        return self._feature_table.defaults
 
     @property
     def properties(self) -> Dict[str, np.ndarray]:
         """dict {str: np.ndarray (N,)}, DataFrame: Annotations for each shape"""
-        return self._feature_manager.properties()
+        return self._feature_table.properties()
 
     @properties.setter
     def properties(self, properties: Dict[str, Array]):
@@ -773,7 +773,7 @@ class Shapes(Layer):
 
     @property
     def property_choices(self) -> Dict[str, np.ndarray]:
-        return self._feature_manager.choices()
+        return self._feature_table.choices()
 
     def _get_ndim(self):
         """Determine number of dimensions of the layer."""
@@ -852,7 +852,7 @@ class Shapes(Layer):
     @property
     def current_properties(self) -> Dict[str, np.ndarray]:
         """dict{str: np.ndarray(1,)}: properties for the next added shape."""
-        return self._feature_manager.currents()
+        return self._feature_table.currents()
 
     @current_properties.setter
     def current_properties(self, current_properties):
@@ -863,7 +863,7 @@ class Shapes(Layer):
             and self._mode in [Mode.SELECT, Mode.PAN_ZOOM]
         ):
             update_indices = list(self.selected_data)
-        self._feature_manager.set_currents(
+        self._feature_table.set_currents(
             current_properties, update_indices=update_indices
         )
         if update_indices is not None:
@@ -2010,7 +2010,7 @@ class Shapes(Layer):
             else:
                 n_prop_values = 0
             total_shapes = n_new_shapes + self.nshapes
-            self._feature_manager.resize(total_shapes)
+            self._feature_table.resize(total_shapes)
             if total_shapes > n_prop_values:
                 n_props_to_add = total_shapes - n_prop_values
                 self.text.add(self.current_properties, n_props_to_add)
@@ -2566,7 +2566,7 @@ class Shapes(Layer):
             self._data_view.remove(ind)
 
         if len(index) > 0:
-            self._feature_manager.remove(index)
+            self._feature_table.remove(index)
             self.text.remove(index)
             self._data_view._edge_color = np.delete(
                 self._data_view._edge_color, index, axis=0
@@ -2893,7 +2893,7 @@ class Shapes(Layer):
                 for i in self._dims_not_displayed
             ]
 
-            self._feature_manager.append(self._clipboard['features'])
+            self._feature_table.append(self._clipboard['features'])
 
             # Add new shape data
             for i, s in enumerate(self._clipboard['data']):

--- a/napari/layers/tracks/_track_utils.py
+++ b/napari/layers/tracks/_track_utils.py
@@ -70,7 +70,7 @@ class TrackManager:
 
         # store the raw data here
         self._data = None
-        self._feature_manager = _FeatureTable()
+        self._feature_table = _FeatureTable()
         self._order = None
 
         # use a kdtree to help with fast lookup of the nearest track
@@ -157,22 +157,22 @@ class TrackManager:
         ----------
         .. [1]: https://data-apis.org/dataframe-protocol/latest/API.html
         """
-        return self._feature_manager.values
+        return self._feature_table.values
 
     @features.setter
     def features(
         self,
         features: Union[Dict[str, np.ndarray], pd.DataFrame],
     ) -> None:
-        self._feature_manager.set_values(features, num_data=len(self.data))
-        if 'track_id' not in self._feature_manager.values:
-            self._feature_manager.values['track_id'] = self.track_ids
-        self._feature_manager.reorder(self._order)
+        self._feature_table.set_values(features, num_data=len(self.data))
+        if 'track_id' not in self._feature_table.values:
+            self._feature_table.values['track_id'] = self.track_ids
+        self._feature_table.reorder(self._order)
 
     @property
     def properties(self) -> Dict[str, np.ndarray]:
         """dict {str: np.ndarray (N,)}: Properties for each track."""
-        return self._feature_manager.properties()
+        return self._feature_table.properties()
 
     @properties.setter
     def properties(self, properties: Dict[str, Array]):

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -262,40 +262,38 @@ def test_dims_displayed_world_to_layer(
     np.testing.assert_array_equal(dims_displayed_layer, expected)
 
 
-def test_feature_manager_from_layer_with_none_then_empty():
-    feature_manager = _FeatureTable.from_layer(features=None)
-    assert feature_manager.values.shape == (0, 0)
+def test_feature_table_from_layer_with_none_then_empty():
+    feature_table = _FeatureTable.from_layer(features=None)
+    assert feature_table.values.shape == (0, 0)
 
 
-def test_feature_manager_from_layer_with_num_data_only():
-    feature_manager = _FeatureTable.from_layer(num_data=5)
-    assert feature_manager.values.shape == (5, 0)
-    assert feature_manager.defaults.shape == (1, 0)
+def test_feature_table_from_layer_with_num_data_only():
+    feature_table = _FeatureTable.from_layer(num_data=5)
+    assert feature_table.values.shape == (5, 0)
+    assert feature_table.defaults.shape == (1, 0)
 
 
-def test_feature_manager_from_layer_with_properties_and_num_data():
+def test_feature_table_from_layer_with_properties_and_num_data():
     properties = {
         'class': np.array(['sky', 'person', 'building', 'person']),
         'confidence': np.array([0.2, 0.5, 1, 0.8]),
     }
 
-    feature_manager = _FeatureTable.from_layer(
-        properties=properties, num_data=4
-    )
+    feature_table = _FeatureTable.from_layer(properties=properties, num_data=4)
 
-    features = feature_manager.values
+    features = feature_table.values
     assert features.shape == (4, 2)
     np.testing.assert_array_equal(features['class'], properties['class'])
     np.testing.assert_array_equal(
         features['confidence'], properties['confidence']
     )
-    defaults = feature_manager.defaults
+    defaults = feature_table.defaults
     assert defaults.shape == (1, 2)
     assert defaults['class'][0] == properties['class'][-1]
     assert defaults['confidence'][0] == properties['confidence'][-1]
 
 
-def test_feature_manager_from_layer_with_properties_and_choices():
+def test_feature_table_from_layer_with_properties_and_choices():
     properties = {
         'class': np.array(['sky', 'person', 'building', 'person']),
     }
@@ -303,11 +301,11 @@ def test_feature_manager_from_layer_with_properties_and_choices():
         'class': np.array(['building', 'person', 'sky']),
     }
 
-    feature_manager = _FeatureTable.from_layer(
+    feature_table = _FeatureTable.from_layer(
         properties=properties, property_choices=property_choices, num_data=4
     )
 
-    features = feature_manager.values
+    features = feature_table.values
     assert features.shape == (4, 1)
     class_column = features['class']
     np.testing.assert_array_equal(class_column, properties['class'])
@@ -315,33 +313,33 @@ def test_feature_manager_from_layer_with_properties_and_choices():
     np.testing.assert_array_equal(
         class_column.dtype.categories, property_choices['class']
     )
-    defaults = feature_manager.defaults
+    defaults = feature_table.defaults
     assert defaults.shape == (1, 1)
     assert defaults['class'][0] == properties['class'][-1]
 
 
-def test_feature_manager_from_layer_with_choices_only():
+def test_feature_table_from_layer_with_choices_only():
     property_choices = {
         'class': np.array(['building', 'person', 'sky']),
     }
 
-    feature_manager = _FeatureTable.from_layer(
+    feature_table = _FeatureTable.from_layer(
         property_choices=property_choices, num_data=0
     )
 
-    features = feature_manager.values
+    features = feature_table.values
     assert features.shape == (0, 1)
     class_column = features['class']
     assert isinstance(class_column.dtype, pd.CategoricalDtype)
     np.testing.assert_array_equal(
         class_column.dtype.categories, property_choices['class']
     )
-    defaults = feature_manager.defaults
+    defaults = feature_table.defaults
     assert defaults.shape == (1, 1)
     assert defaults['class'][0] == property_choices['class'][0]
 
 
-def test_feature_manager_from_layer_with_empty_properties_and_choices():
+def test_feature_table_from_layer_with_empty_properties_and_choices():
     properties = {
         'class': np.array([]),
     }
@@ -349,18 +347,18 @@ def test_feature_manager_from_layer_with_empty_properties_and_choices():
         'class': np.array(['building', 'person', 'sky']),
     }
 
-    feature_manager = _FeatureTable.from_layer(
+    feature_table = _FeatureTable.from_layer(
         properties=properties, property_choices=property_choices, num_data=0
     )
 
-    features = feature_manager.values
+    features = feature_table.values
     assert features.shape == (0, 1)
     class_column = features['class']
     assert isinstance(class_column.dtype, pd.CategoricalDtype)
     np.testing.assert_array_equal(
         class_column.dtype.categories, property_choices['class']
     )
-    defaults = feature_manager.defaults
+    defaults = feature_table.defaults
     assert defaults.shape == (1, 1)
     assert defaults['class'][0] == property_choices['class'][0]
 
@@ -378,32 +376,32 @@ TEST_FEATURES = pd.DataFrame(
 )
 
 
-def test_feature_manager_from_layer_with_properties_as_dataframe():
-    feature_manager = _FeatureTable.from_layer(properties=TEST_FEATURES)
-    pd.testing.assert_frame_equal(feature_manager.values, TEST_FEATURES)
+def test_feature_table_from_layer_with_properties_as_dataframe():
+    feature_table = _FeatureTable.from_layer(properties=TEST_FEATURES)
+    pd.testing.assert_frame_equal(feature_table.values, TEST_FEATURES)
 
 
-def _make_feature_manager():
+def _make_feature_table():
     return _FeatureTable(TEST_FEATURES.copy(deep=True), num_data=4)
 
 
-def test_feature_manager_resize_smaller():
-    feature_manager = _make_feature_manager()
+def test_feature_table_resize_smaller():
+    feature_table = _make_feature_table()
 
-    feature_manager.resize(2)
+    feature_table.resize(2)
 
-    features = feature_manager.values
+    features = feature_table.values
     assert features.shape == (2, 2)
     np.testing.assert_array_equal(features['class'], ['sky', 'person'])
     np.testing.assert_array_equal(features['confidence'], [0.2, 0.5])
 
 
-def test_feature_manager_resize_larger():
-    feature_manager = _make_feature_manager()
+def test_feature_table_resize_larger():
+    feature_table = _make_feature_table()
 
-    feature_manager.resize(6)
+    feature_table.resize(6)
 
-    features = feature_manager.values
+    features = feature_table.values
     assert features.shape == (6, 2)
     np.testing.assert_array_equal(
         features['class'],
@@ -415,8 +413,8 @@ def test_feature_manager_resize_larger():
     )
 
 
-def test_feature_manager_append():
-    feature_manager = _make_feature_manager()
+def test_feature_table_append():
+    feature_table = _make_feature_table()
     to_append = pd.DataFrame(
         {
             'class': ['sky', 'building'],
@@ -424,9 +422,9 @@ def test_feature_manager_append():
         }
     )
 
-    feature_manager.append(to_append)
+    feature_table.append(to_append)
 
-    features = feature_manager.values
+    features = feature_table.values
     assert features.shape == (6, 2)
     np.testing.assert_array_equal(
         features['class'],
@@ -438,26 +436,26 @@ def test_feature_manager_append():
     )
 
 
-def test_feature_manager_remove():
-    feature_manager = _make_feature_manager()
+def test_feature_table_remove():
+    feature_table = _make_feature_table()
 
-    feature_manager.remove([1, 3])
+    feature_table.remove([1, 3])
 
-    features = feature_manager.values
+    features = feature_table.values
     assert features.shape == (2, 2)
     np.testing.assert_array_equal(features['class'], ['sky', 'building'])
     np.testing.assert_array_equal(features['confidence'], [0.2, 1])
 
 
-def test_feature_manager_from_layer_with_custom_index():
+def test_feature_table_from_layer_with_custom_index():
     features = pd.DataFrame({'a': [1, 3], 'b': [7.5, -2.1]}, index=[1, 2])
-    feature_manager = _FeatureTable.from_layer(features=features)
+    feature_table = _FeatureTable.from_layer(features=features)
     expected = features.reset_index(drop=True)
-    pd.testing.assert_frame_equal(feature_manager.values, expected)
+    pd.testing.assert_frame_equal(feature_table.values, expected)
 
 
-def test_feature_manager_from_layer_with_custom_index_and_num_data():
+def test_feature_table_from_layer_with_custom_index_and_num_data():
     features = pd.DataFrame({'a': [1, 3], 'b': [7.5, -2.1]}, index=[1, 2])
-    feature_manager = _FeatureTable.from_layer(features=features, num_data=2)
+    feature_table = _FeatureTable.from_layer(features=features, num_data=2)
     expected = features.reset_index(drop=True)
-    pd.testing.assert_frame_equal(feature_manager.values, expected)
+    pd.testing.assert_frame_equal(feature_table.values, expected)

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -226,7 +226,7 @@ class Vectors(Layer):
         self._mesh_triangles = triangles
         self._displayed_stored = copy(self._dims_displayed)
 
-        self._feature_manager = _FeatureTable.from_layer(
+        self._feature_table = _FeatureTable.from_layer(
             features=features,
             properties=properties,
             property_choices=property_choices,
@@ -279,7 +279,7 @@ class Vectors(Layer):
         # Adjust the props/color arrays when the number of vectors has changed
         with self.events.blocker_all():
             with self._edge.events.blocker_all():
-                self._feature_manager.resize(n_vectors)
+                self._feature_table.resize(n_vectors)
                 if n_vectors < previous_n_vectors:
                     # If there are now fewer points, remove the size and colors of the
                     # extra ones
@@ -314,14 +314,14 @@ class Vectors(Layer):
         ----------
         .. [1]: https://data-apis.org/dataframe-protocol/latest/API.html
         """
-        return self._feature_manager.values
+        return self._feature_table.values
 
     @features.setter
     def features(
         self,
         features: Union[Dict[str, np.ndarray], pd.DataFrame],
     ) -> None:
-        self._feature_manager.set_values(features, num_data=len(self.data))
+        self._feature_table.set_values(features, num_data=len(self.data))
         if self._edge.color_properties is not None:
             if self._edge.color_properties.name not in self.features:
                 self._edge.color_mode = ColorMode.DIRECT
@@ -346,7 +346,7 @@ class Vectors(Layer):
     @property
     def properties(self) -> Dict[str, np.ndarray]:
         """dict {str: array (N,)}, DataFrame: Annotations for each point"""
-        return self._feature_manager.properties()
+        return self._feature_table.properties()
 
     @properties.setter
     def properties(self, properties: Dict[str, Array]):
@@ -358,11 +358,11 @@ class Vectors(Layer):
 
         See `features` for more details on the type of this property.
         """
-        return self._feature_manager.defaults
+        return self._feature_table.defaults
 
     @property
     def property_choices(self) -> Dict[str, np.ndarray]:
-        return self._feature_manager.choices()
+        return self._feature_table.choices()
 
     def _get_state(self):
         """Get dictionary of layer state.
@@ -466,7 +466,7 @@ class Vectors(Layer):
             color=edge_color,
             n_colors=len(self.data),
             properties=self.properties,
-            current_properties=self._feature_manager.currents(),
+            current_properties=self._feature_table.currents(),
         )
         self.events.edge_color()
 


### PR DESCRIPTION
# Description
Renames `Layer._feature_manager` to `Layer._feature_table`.

I renamed the class name to `_FeatureTable` in #3904, but forgot to update the attribute name.

## Type of change

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
- [ ] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
