### PR TITLE
Better Notification __str__ method

### DIFF
--- a/docs/release/release_0_4_13.md
+++ b/docs/release/release_0_4_13.md
@@ -132,7 +132,7 @@ Complete list of changes below:
 - Update typing test on CI (#3903)
 - Features implementation refactor (#3904)
 - Rename feature manager attribute to table (#3931)
-
+- Better Notification __str__ method (#3933)
 
 ## Bug Fixes
 - Fix removing selected points with derived text (#3505)

--- a/napari/utils/notifications.py
+++ b/napari/utils/notifications.py
@@ -111,6 +111,9 @@ class Notification(Event):
     def from_warning(cls, warning: Warning, **kwargs) -> Notification:
         return WarningNotification(warning, **kwargs)
 
+    def __str__(self):
+        return f'{str(self.severity).upper()}: {self.message}'
+
 
 class ErrorNotification(Notification):
     exception: BaseException


### PR DESCRIPTION
# Description
Tiny change to fix the notification string that gets printed to the console (we don't tend to pay attention to it since it's also in the GUI, but it currently prints "Notification" to the terminal which is useless :)
