### PR TITLE
Remove deprecation of sceenshot in qt_viewer

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -238,7 +238,7 @@ def test_screenshot(make_napari_viewer):
 
     # Take screenshot
     with pytest.warns(FutureWarning):
-        screenshot = viewer.window._qt_viewer.screenshot(flash=False)
+        screenshot = viewer.window.qt_viewer.screenshot(flash=False)
     screenshot = viewer.window.screenshot(flash=False, canvas_only=True)
     assert screenshot.ndim == 3
 
@@ -346,7 +346,7 @@ def test_qt_viewer_clipboard_with_flash(make_napari_viewer, qtbot):
 
     # capture screenshot
     with pytest.warns(FutureWarning):
-        viewer.window._qt_viewer.clipboard(flash=True)
+        viewer.window.qt_viewer.clipboard(flash=True)
 
     viewer.window.clipboard(flash=False, canvas_only=True)
 
@@ -393,7 +393,7 @@ def test_qt_viewer_clipboard_without_flash(make_napari_viewer):
 
     # capture screenshot
     with pytest.warns(FutureWarning):
-        viewer.window._qt_viewer.clipboard(flash=False)
+        viewer.window.qt_viewer.clipboard(flash=False)
 
     viewer.window.clipboard(flash=False, canvas_only=True)
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -647,15 +647,6 @@ class QtViewer(QSplitter):
             Numpy array of type ubyte and shape (h, w, 4). Index [0, 0] is the
             upper-left corner of the rendered region.
         """
-        import warnings
-
-        warnings.warn(
-            trans._(
-                "'window.qt_viewer.screenshot' is deprecated and will be removed in v0.4.14.  Please use 'window.screenshot(canvas_only=True)' instead"
-            ),
-            FutureWarning,
-            stacklevel=2,
-        )
 
         img = QImg2array(self._screenshot(flash))
         if path is not None:
@@ -672,15 +663,6 @@ class QtViewer(QSplitter):
             Flag to indicate whether flash animation should be shown after
             the screenshot was captured.
         """
-        import warnings
-
-        warnings.warn(
-            trans._(
-                "'window.qt_viewer.screenshot' is deprecated and will be removed in v0.4.14.  Please use 'window.screenshot(canvas_only=True)' instead"
-            ),
-            FutureWarning,
-            stacklevel=2,
-        )
         cb = QGuiApplication.clipboard()
         cb.setImage(self._screenshot(flash))
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Because QtViewer is still part of public API, then screenshot functions should not be deprecated. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
