### PR TITLE
Fix magicgui layer combobox not populated when adding to viewer

### DIFF
--- a/docs/release/release_0_4_13.md
+++ b/docs/release/release_0_4_13.md
@@ -168,6 +168,7 @@ Complete list of changes below:
 - Fix contrast limit slider for small range (#3895)
 - Fix tracks instantiation with floating point time values (#3909)
 - Fix cleaning of resources in function contextmanagers (#3918)
+- Fix magicgui layer combobox not populated when adding to viewer (#3938)
 
 ## API Changes
 

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -2,8 +2,8 @@ import warnings
 from functools import reduce
 from itertools import count
 from operator import ior
-from typing import List, Optional
-from weakref import ref
+from typing import TYPE_CHECKING, List, Optional
+from weakref import ReferenceType, ref
 
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
@@ -19,6 +19,9 @@ from qtpy.QtWidgets import (
 
 from ...utils.translations import trans
 from ..utils import combine_widgets, qt_signals_blocked
+
+if TYPE_CHECKING:
+    from ..qt_viewer import QtViewer
 
 counter = count()
 _sentinel = object()
@@ -72,7 +75,7 @@ class QtViewerDockWidget(QDockWidget):
         object_name: str = '',
         add_vertical_stretch=True,
     ):
-        self._ref_qt_viewer = ref(qt_viewer)
+        self._ref_qt_viewer: 'ReferenceType[QtViewer]' = ref(qt_viewer)
         super().__init__(name)
         self._parent = qt_viewer
         self.name = name

--- a/napari/utils/_magicgui.py
+++ b/napari/utils/_magicgui.py
@@ -270,6 +270,8 @@ def find_viewer_ancestor(widget) -> Optional[Viewer]:
     viewer : napari.Viewer or None
         Viewer instance if one exists, else None.
     """
+    from .._qt.widgets.qt_viewer_dock_widget import QtViewerDockWidget
+
     # magicgui v0.2.0 widgets are no longer QWidget subclasses, but the native
     # widget is available at widget.native
     if hasattr(widget, 'native') and hasattr(widget.native, 'parent'):
@@ -277,8 +279,11 @@ def find_viewer_ancestor(widget) -> Optional[Viewer]:
     else:
         parent = widget.parent()
     while parent:
-        if hasattr(parent, '_qt_viewer'):
-            return parent._qt_viewer.viewer
+        if isinstance(parent, QtViewerDockWidget):
+            qt_viewer = parent._ref_qt_viewer()
+            if qt_viewer is not None:
+                return qt_viewer.viewer
+            return None
         parent = parent.parent()
     return None
 

--- a/napari/utils/_magicgui.py
+++ b/napari/utils/_magicgui.py
@@ -279,7 +279,9 @@ def find_viewer_ancestor(widget) -> Optional[Viewer]:
     else:
         parent = widget.parent()
     while parent:
-        if isinstance(parent, QtViewerDockWidget):
+        if hasattr(parent, '_qt_viewer'):  # QMainWindow
+            return parent._qt_viewer.viewer
+        if isinstance(parent, QtViewerDockWidget):  # DockWidget
             qt_viewer = parent._ref_qt_viewer()
             if qt_viewer is not None:
                 return qt_viewer.viewer

--- a/napari/utils/_tests/test_magicgui.py
+++ b/napari/utils/_tests/test_magicgui.py
@@ -284,3 +284,15 @@ def test_mgui_forward_refs(tmp_path, name):
     script_path = tmp_path / 'script.py'
     script_path.write_text(textwrap.dedent(script.format(name)))
     subprocess.run([sys.executable, str(script_path)], check=True)
+
+
+def test_layers_populate_immediately(make_napari_viewer):
+    """make sure that the layers dropdown is populated upon adding to viewer"""
+    from magicgui.widgets import create_widget
+
+    labels_layer = create_widget(annotation=Labels, label="ROI")
+    viewer = make_napari_viewer()
+    viewer.add_labels(np.zeros((10, 10), dtype=int))
+    assert not len(labels_layer.choices)
+    viewer.window.add_dock_widget(labels_layer)
+    assert len(labels_layer.choices) == 1


### PR DESCRIPTION
# Description
@Czaki  just alerted me to a regression that happened in #3890, resulting in magicgui comboboxes being empty when first added to a viewer with a pre-existing layer.

This fixes it and adds a test.