### PR TITLE
Fix setting attribute to None for single slices of image stacks on stack creation

### DIFF
--- a/napari/layers/utils/stack_utils.py
+++ b/napari/layers/utils/stack_utils.py
@@ -113,7 +113,10 @@ def split_channels(
         ):
             kwargs[key] = iter(
                 ensure_sequence_of_iterables(
-                    val, n_channels, repeat_empty=True
+                    val,
+                    n_channels,
+                    repeat_empty=True,
+                    allow_none=True,
                 )
             )
         else:

--- a/napari/utils/_tests/test_misc.py
+++ b/napari/utils/_tests/test_misc.py
@@ -45,6 +45,11 @@ def test_sequence_of_iterables(input, expected):
         assert result == expectation
 
 
+def test_sequence_of_iterables_allow_none():
+    input = [(1, 2), None]
+    assert ensure_sequence_of_iterables(input, allow_none=True) == input
+
+
 def test_sequence_of_iterables_no_repeat_empty():
     assert ensure_sequence_of_iterables([], repeat_empty=False) == []
     with pytest.raises(ValueError):

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -188,7 +188,7 @@ def ensure_sequence_of_iterables(
     In [2]: ensure_sequence_of_iterables([(1, 2), (3, 4)])
     Out[2]: [(1, 2), (3, 4)]
 
-    In [3]: ensure_sequence_of_iterables([(1, 2), None])
+    In [3]: ensure_sequence_of_iterables([(1, 2), None], allow_none=True)
     Out[3]: [(1, 2), None]
 
     In [4]: ensure_sequence_of_iterables({'a':1})

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -116,12 +116,12 @@ def ensure_iterable(arg, color=False):
         return itertools.repeat(arg)
 
 
-def is_iterable(arg, color=False):
+def is_iterable(arg, color=False, allow_none=False):
     """Determine if a single argument is an iterable. If a color is being
     provided and the argument is a 1-D array of length 3 or 4 then the input
-    is taken to not be iterable.
+    is taken to not be iterable. If allow_none is True, `None` is considered iterable.
     """
-    if arg is None:
+    if arg is None and not allow_none:
         return False
     elif type(arg) is str:
         return False
@@ -154,7 +154,10 @@ def is_sequence(arg):
 
 
 def ensure_sequence_of_iterables(
-    obj, length: Optional[int] = None, repeat_empty: bool = False
+    obj,
+    length: Optional[int] = None,
+    repeat_empty: bool = False,
+    allow_none: bool = False,
 ):
     """Ensure that ``obj`` behaves like a (nested) sequence of iterables.
 
@@ -169,6 +172,8 @@ def ensure_sequence_of_iterables(
         If provided, assert that obj has len ``length``, by default None
     repeat_empty : bool
         whether to repeat an empty sequence (otherwise return the empty sequence itself)
+    allow_none : bool
+        treat None as iterable
 
     Returns
     -------
@@ -183,23 +188,26 @@ def ensure_sequence_of_iterables(
     In [2]: ensure_sequence_of_iterables([(1, 2), (3, 4)])
     Out[2]: [(1, 2), (3, 4)]
 
-    In [3]: ensure_sequence_of_iterables({'a':1})
-    Out[3]: repeat({'a': 1})
+    In [3]: ensure_sequence_of_iterables([(1, 2), None])
+    Out[3]: [(1, 2), None]
 
-    In [4]: ensure_sequence_of_iterables(None)
-    Out[4]: repeat(None)
+    In [4]: ensure_sequence_of_iterables({'a':1})
+    Out[4]: repeat({'a': 1})
 
-    In [5]: ensure_sequence_of_iterables([])
-    Out[5]: repeat([])
+    In [5]: ensure_sequence_of_iterables(None)
+    Out[5]: repeat(None)
 
-    In [6]: ensure_sequence_of_iterables([], repeat_empty=False)
-    Out[6]: []
+    In [6]: ensure_sequence_of_iterables([])
+    Out[6]: repeat([])
+
+    In [7]: ensure_sequence_of_iterables([], repeat_empty=False)
+    Out[7]: []
     """
 
     if (
         obj is not None
         and is_sequence(obj)
-        and all(is_iterable(el) for el in obj)
+        and all(is_iterable(el, allow_none=allow_none) for el in obj)
     ):
         if length is not None and len(obj) != length:
             if (len(obj) == 0 and not repeat_empty) or len(obj) > 0:


### PR DESCRIPTION
# Description
Possible fix for #3934. This adds an `allow_none` attribute to `is_iterable` and `ensure_sequence_of_iterables`; when set to `True`, it will treat `None` as iterable. Let's see how many things break...
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
