### PR TITLE
bug fix: too many entries in available plugins list

### DIFF
--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -643,16 +643,15 @@ class QtPluginDialog(QDialog):
 
         plugin_manager.discover()  # since they might not be loaded yet
 
-        already_installed = set()
+        self.already_installed = set()
 
         def _add_to_installed(distname, enabled, npe_version=1):
-
             if distname:
                 meta = standard_metadata(distname)
                 if len(meta) == 0:
                     # will not add builtins.
                     return
-                already_installed.add(distname)
+                self.already_installed.add(distname)
             else:
                 meta = {}
 
@@ -672,7 +671,7 @@ class QtPluginDialog(QDialog):
 
         for manifest in _npe2.iter_manifests():
             distname = normalized_name(manifest.name or '')
-            if distname in already_installed or distname == 'napari':
+            if distname in self.already_installed or distname == 'napari':
                 continue
             _add_to_installed(distname, True, npe_version=2)
 
@@ -680,7 +679,7 @@ class QtPluginDialog(QDialog):
             # not showing these in the plugin dialog
             if plugin_name in ('napari_plugin_engine',):
                 continue
-            if distname in already_installed:
+            if distname in self.already_installed:
                 continue
             _add_to_installed(
                 distname, not plugin_manager.is_blocked(plugin_name)


### PR DESCRIPTION
# Description
There was a member variable was shadowed by a local variable in the plugin installer dialog. That's why the list of available pluigns also contained the installed plugins.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
closes #3942 

# How has this been tested?
Manually

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
