### PR TITLE
Locking mechanism

### DIFF
--- a/napari/_tests/test_lock.py
+++ b/napari/_tests/test_lock.py
@@ -1,0 +1,108 @@
+"""Tests locker functionality"""
+import pytest
+from napari.utils.lock import LockMode, Locker, Lock, AttributeNotFound, ValueNotCompatibleWithLockMode
+
+def test_locker_initialization():
+    """Tests locker initialization"""
+    locker_dictionary = {"attribute1": Lock(), "attribute2": Lock()}
+    locker = Locker(locker_dictionary)
+    assert locker.has_attribute("attribute1")
+    assert len(locker.list_locks()) == 2
+
+    locker = Locker()
+    assert not locker.has_attribute("attribute1")
+    assert len(locker.list_locks()) == 0
+
+def test_adding_locks():
+    """Tests adding locks"""
+    locker = Locker()
+    locker.add_lock("attribute1")
+    locker.add_lock("attribute2", [3,4], False)
+    assert locker.has_attribute("attribute1")
+    assert len(locker.list_locks()) == 2
+
+def test_locking():
+    """Tests locking mechanism"""
+    locker = Locker()
+    locker.add_lock("attribute1")
+    assert locker.is_locked("attribute1")==True
+    assert locker.is_locked("attribute1", hard_lock=False)==True
+    locker.unlock("attribute1")
+    assert locker.is_locked("attribute1")==False
+    assert locker.is_locked("attribute1", hard_lock=False)==False
+    locker.lock("attribute1")
+    assert locker.is_locked("attribute1")==True
+    assert locker.is_locked("attribute1", hard_lock=False)==True
+
+    assert locker.is_locked("attribute2")==False
+    with pytest.raises(AttributeNotFound):
+        locker.unlock("attribute2")
+
+    with pytest.raises(AttributeNotFound):
+        locker.lock("attribute2")
+    
+    locker.add_lock("attribute2", hard_lock=False)
+    assert locker.is_locked("attribute2", hard_lock=True)==False
+    assert locker.is_locked("attribute2", hard_lock=False)==True
+    locker.unlock("attribute2")
+    assert locker.is_locked("attribute2", hard_lock=True)==False
+    assert locker.is_locked("attribute2", hard_lock=True)==False
+    locker.lock("attribute2")
+    assert locker.is_locked("attribute2", hard_lock=True)==False
+    assert locker.is_locked("attribute2", hard_lock=False)==True
+
+def test_in_list_lock_mode():
+    """Testing in list lock mode"""
+    locker = Locker()
+    locker.add_lock("attribute1", value=[1,2,3], hard_lock=True, value_lock_mode=LockMode.IN_LIST)
+    is_locked = locker.is_locked("attribute1", value=3)
+    assert is_locked==False
+    is_locked = locker.is_locked("attribute1", value=4)
+    assert is_locked==True
+
+def test_in_range_lock_mode():
+    """Testing in range lock mode"""
+    locker = Locker()
+    locker.add_lock("attribute1", value=[0,10], hard_lock=True, value_lock_mode=LockMode.IN_RANGE)
+    assert locker.is_locked("attribute1", value=3)==False
+    assert locker.is_locked("attribute1", value=11)==True
+
+def test_inequality_lock_modes():
+    """Testing in range lock mode"""
+    locker = Locker()
+    locker.add_lock("attribute1", value=10, hard_lock=True, value_lock_mode=LockMode.SMALLER_THAN)
+    locker.add_lock("attribute2", value=10, hard_lock=True, value_lock_mode=LockMode.LARGER_THAN)
+    assert locker.is_locked("attribute1", value=3)==False
+    assert locker.is_locked("attribute1", value=11)==True
+    assert locker.is_locked("attribute2", value=11)==False
+    assert locker.is_locked("attribute2", value=3)==True
+
+def test_value_mode_errors():
+    """Testing in range lock mode"""
+    locker = Locker()
+    with pytest.raises(ValueNotCompatibleWithLockMode):
+        locker.add_lock("attribute1", value='10', value_lock_mode=LockMode.SMALLER_THAN)
+    with pytest.raises(ValueNotCompatibleWithLockMode):
+        locker.add_lock("attribute1", value='10', value_lock_mode=LockMode.LARGER_THAN)
+    with pytest.raises(ValueNotCompatibleWithLockMode):
+        locker.add_lock("attribute1", value='10', value_lock_mode=LockMode.IN_LIST)
+    with pytest.raises(ValueNotCompatibleWithLockMode):
+        locker.add_lock("attribute1", value='10', value_lock_mode=LockMode.IN_RANGE)
+
+def test_locks_dictionary_update():
+    """Testing the update mechanism using dictionaries"""
+    locker = Locker()
+    locker_data = dict()
+    locker_data['attribute1']= {"value":3, "locked":False}
+
+    locker.update_locks(locker_data)
+    assert locker._get_lock('attribute1').value==3
+    assert locker._get_lock('attribute1').locked==False
+
+    locker_data['attribute1']= {"value":4}
+    locker_data['attribute2']= {"value":6}
+    locker.update_locks(locker_data)
+    assert locker._get_lock('attribute1').value==4
+    assert locker._get_lock('attribute1').locked==False
+    assert locker._get_lock('attribute2').value==6
+    assert locker._get_lock('attribute2').locked==True

--- a/napari/_tests/test_lock.py
+++ b/napari/_tests/test_lock.py
@@ -96,13 +96,13 @@ def test_locks_dictionary_update():
     locker_data['attribute1']= {"value":3, "locked":False}
 
     locker.update_locks(locker_data)
-    assert locker._get_lock('attribute1').value==3
-    assert locker._get_lock('attribute1').locked==False
+    assert locker.get_lock('attribute1').value==3
+    assert locker.get_lock('attribute1').locked==False
 
     locker_data['attribute1']= {"value":4}
     locker_data['attribute2']= {"value":6}
     locker.update_locks(locker_data)
-    assert locker._get_lock('attribute1').value==4
-    assert locker._get_lock('attribute1').locked==False
-    assert locker._get_lock('attribute2').value==6
-    assert locker._get_lock('attribute2').locked==True
+    assert locker.get_lock('attribute1').value==4
+    assert locker.get_lock('attribute1').locked==False
+    assert locker.get_lock('attribute2').value==6
+    assert locker.get_lock('attribute2').locked==True

--- a/napari/_tests/test_lock.py
+++ b/napari/_tests/test_lock.py
@@ -2,6 +2,7 @@
 import pytest
 
 from napari.utils.lock import (
+    AttributeAlreadyAdded,
     AttributeNotFound,
     Lock,
     Locker,
@@ -29,6 +30,8 @@ def test_adding_locks():
     locker.add_lock("attribute2", [3, 4], False)
     assert locker.has_attribute("attribute1")
     assert len(locker.list_locks()) == 2
+    with pytest.raises(AttributeAlreadyAdded):
+        locker.add_lock("attribute1")
 
 
 def test_locking():

--- a/napari/_tests/test_lock.py
+++ b/napari/_tests/test_lock.py
@@ -1,6 +1,14 @@
 """Tests locker functionality"""
 import pytest
-from napari.utils.lock import LockMode, Locker, Lock, AttributeNotFound, ValueNotCompatibleWithLockMode
+
+from napari.utils.lock import (
+    AttributeNotFound,
+    Lock,
+    Locker,
+    LockMode,
+    ValueNotCompatibleWithLockMode,
+)
+
 
 def test_locker_initialization():
     """Tests locker initialization"""
@@ -13,96 +21,131 @@ def test_locker_initialization():
     assert not locker.has_attribute("attribute1")
     assert len(locker.list_locks()) == 0
 
+
 def test_adding_locks():
     """Tests adding locks"""
     locker = Locker()
     locker.add_lock("attribute1")
-    locker.add_lock("attribute2", [3,4], False)
+    locker.add_lock("attribute2", [3, 4], False)
     assert locker.has_attribute("attribute1")
     assert len(locker.list_locks()) == 2
+
 
 def test_locking():
     """Tests locking mechanism"""
     locker = Locker()
     locker.add_lock("attribute1")
-    assert locker.is_locked("attribute1")==True
-    assert locker.is_locked("attribute1", hard_lock=False)==True
+    assert locker.is_locked("attribute1") == True
+    assert locker.is_locked("attribute1", hard_lock=False) == True
     locker.unlock("attribute1")
-    assert locker.is_locked("attribute1")==False
-    assert locker.is_locked("attribute1", hard_lock=False)==False
+    assert locker.is_locked("attribute1") == False
+    assert locker.is_locked("attribute1", hard_lock=False) == False
     locker.lock("attribute1")
-    assert locker.is_locked("attribute1")==True
-    assert locker.is_locked("attribute1", hard_lock=False)==True
+    assert locker.is_locked("attribute1") == True
+    assert locker.is_locked("attribute1", hard_lock=False) == True
 
-    assert locker.is_locked("attribute2")==False
+    assert locker.is_locked("attribute2") == False
     with pytest.raises(AttributeNotFound):
         locker.unlock("attribute2")
 
     with pytest.raises(AttributeNotFound):
         locker.lock("attribute2")
-    
+
     locker.add_lock("attribute2", hard_lock=False)
-    assert locker.is_locked("attribute2", hard_lock=True)==False
-    assert locker.is_locked("attribute2", hard_lock=False)==True
+    assert locker.is_locked("attribute2", hard_lock=True) == False
+    assert locker.is_locked("attribute2", hard_lock=False) == True
     locker.unlock("attribute2")
-    assert locker.is_locked("attribute2", hard_lock=True)==False
-    assert locker.is_locked("attribute2", hard_lock=True)==False
+    assert locker.is_locked("attribute2", hard_lock=True) == False
+    assert locker.is_locked("attribute2", hard_lock=True) == False
     locker.lock("attribute2")
-    assert locker.is_locked("attribute2", hard_lock=True)==False
-    assert locker.is_locked("attribute2", hard_lock=False)==True
+    assert locker.is_locked("attribute2", hard_lock=True) == False
+    assert locker.is_locked("attribute2", hard_lock=False) == True
+
 
 def test_in_list_lock_mode():
     """Testing in list lock mode"""
     locker = Locker()
-    locker.add_lock("attribute1", value=[1,2,3], hard_lock=True, value_lock_mode=LockMode.IN_LIST)
+    locker.add_lock(
+        "attribute1",
+        value=[1, 2, 3],
+        hard_lock=True,
+        value_lock_mode=LockMode.IN_LIST,
+    )
     is_locked = locker.is_locked("attribute1", value=3)
-    assert is_locked==False
+    assert is_locked == False
     is_locked = locker.is_locked("attribute1", value=4)
-    assert is_locked==True
+    assert is_locked == True
+
 
 def test_in_range_lock_mode():
     """Testing in range lock mode"""
     locker = Locker()
-    locker.add_lock("attribute1", value=[0,10], hard_lock=True, value_lock_mode=LockMode.IN_RANGE)
-    assert locker.is_locked("attribute1", value=3)==False
-    assert locker.is_locked("attribute1", value=11)==True
+    locker.add_lock(
+        "attribute1",
+        value=[0, 10],
+        hard_lock=True,
+        value_lock_mode=LockMode.IN_RANGE,
+    )
+    assert locker.is_locked("attribute1", value=3) == False
+    assert locker.is_locked("attribute1", value=11) == True
+
 
 def test_inequality_lock_modes():
     """Testing in range lock mode"""
     locker = Locker()
-    locker.add_lock("attribute1", value=10, hard_lock=True, value_lock_mode=LockMode.SMALLER_THAN)
-    locker.add_lock("attribute2", value=10, hard_lock=True, value_lock_mode=LockMode.LARGER_THAN)
-    assert locker.is_locked("attribute1", value=3)==False
-    assert locker.is_locked("attribute1", value=11)==True
-    assert locker.is_locked("attribute2", value=11)==False
-    assert locker.is_locked("attribute2", value=3)==True
+    locker.add_lock(
+        "attribute1",
+        value=10,
+        hard_lock=True,
+        value_lock_mode=LockMode.SMALLER_THAN,
+    )
+    locker.add_lock(
+        "attribute2",
+        value=10,
+        hard_lock=True,
+        value_lock_mode=LockMode.LARGER_THAN,
+    )
+    assert locker.is_locked("attribute1", value=3) == False
+    assert locker.is_locked("attribute1", value=11) == True
+    assert locker.is_locked("attribute2", value=11) == False
+    assert locker.is_locked("attribute2", value=3) == True
+
 
 def test_value_mode_errors():
     """Testing in range lock mode"""
     locker = Locker()
     with pytest.raises(ValueNotCompatibleWithLockMode):
-        locker.add_lock("attribute1", value='10', value_lock_mode=LockMode.SMALLER_THAN)
+        locker.add_lock(
+            "attribute1", value='10', value_lock_mode=LockMode.SMALLER_THAN
+        )
     with pytest.raises(ValueNotCompatibleWithLockMode):
-        locker.add_lock("attribute1", value='10', value_lock_mode=LockMode.LARGER_THAN)
+        locker.add_lock(
+            "attribute1", value='10', value_lock_mode=LockMode.LARGER_THAN
+        )
     with pytest.raises(ValueNotCompatibleWithLockMode):
-        locker.add_lock("attribute1", value='10', value_lock_mode=LockMode.IN_LIST)
+        locker.add_lock(
+            "attribute1", value='10', value_lock_mode=LockMode.IN_LIST
+        )
     with pytest.raises(ValueNotCompatibleWithLockMode):
-        locker.add_lock("attribute1", value='10', value_lock_mode=LockMode.IN_RANGE)
+        locker.add_lock(
+            "attribute1", value='10', value_lock_mode=LockMode.IN_RANGE
+        )
+
 
 def test_locks_dictionary_update():
     """Testing the update mechanism using dictionaries"""
     locker = Locker()
     locker_data = dict()
-    locker_data['attribute1']= {"value":3, "locked":False}
+    locker_data['attribute1'] = {"value": 3, "locked": False}
 
     locker.update_locks(locker_data)
-    assert locker.get_lock('attribute1').value==3
-    assert locker.get_lock('attribute1').locked==False
+    assert locker.get_lock('attribute1').value == 3
+    assert locker.get_lock('attribute1').locked == False
 
-    locker_data['attribute1']= {"value":4}
-    locker_data['attribute2']= {"value":6}
+    locker_data['attribute1'] = {"value": 4}
+    locker_data['attribute2'] = {"value": 6}
     locker.update_locks(locker_data)
-    assert locker.get_lock('attribute1').value==4
-    assert locker.get_lock('attribute1').locked==False
-    assert locker.get_lock('attribute2').value==6
-    assert locker.get_lock('attribute2').locked==True
+    assert locker.get_lock('attribute1').value == 4
+    assert locker.get_lock('attribute1').locked == False
+    assert locker.get_lock('attribute2').value == 6
+    assert locker.get_lock('attribute2').locked == True

--- a/napari/_tests/test_lock.py
+++ b/napari/_tests/test_lock.py
@@ -1,6 +1,14 @@
 """Tests locker functionality"""
 import pytest
-from napari.utils.lock import LockMode, Locker, Lock, AttributeNotFound, ValueNotCompatibleWithLockMode
+
+from napari.utils.lock import (
+    AttributeNotFound,
+    Lock,
+    Locker,
+    LockMode,
+    ValueNotCompatibleWithLockMode,
+)
+
 
 def test_locker_initialization():
     """Tests locker initialization"""
@@ -13,96 +21,131 @@ def test_locker_initialization():
     assert not locker.has_attribute("attribute1")
     assert len(locker.list_locks()) == 0
 
+
 def test_adding_locks():
     """Tests adding locks"""
     locker = Locker()
     locker.add_lock("attribute1")
-    locker.add_lock("attribute2", [3,4], False)
+    locker.add_lock("attribute2", [3, 4], False)
     assert locker.has_attribute("attribute1")
     assert len(locker.list_locks()) == 2
+
 
 def test_locking():
     """Tests locking mechanism"""
     locker = Locker()
     locker.add_lock("attribute1")
-    assert locker.is_locked("attribute1")==True
-    assert locker.is_locked("attribute1", hard_lock=False)==True
+    assert locker.is_locked("attribute1") is True
+    assert locker.is_locked("attribute1", hard_lock=False) is True
     locker.unlock("attribute1")
-    assert locker.is_locked("attribute1")==False
-    assert locker.is_locked("attribute1", hard_lock=False)==False
+    assert locker.is_locked("attribute1") is False
+    assert locker.is_locked("attribute1", hard_lock=False) is False
     locker.lock("attribute1")
-    assert locker.is_locked("attribute1")==True
-    assert locker.is_locked("attribute1", hard_lock=False)==True
+    assert locker.is_locked("attribute1") is True
+    assert locker.is_locked("attribute1", hard_lock=False) is True
 
-    assert locker.is_locked("attribute2")==False
+    assert locker.is_locked("attribute2") is False
     with pytest.raises(AttributeNotFound):
         locker.unlock("attribute2")
 
     with pytest.raises(AttributeNotFound):
         locker.lock("attribute2")
-    
+
     locker.add_lock("attribute2", hard_lock=False)
-    assert locker.is_locked("attribute2", hard_lock=True)==False
-    assert locker.is_locked("attribute2", hard_lock=False)==True
+    assert locker.is_locked("attribute2", hard_lock=True) is False
+    assert locker.is_locked("attribute2", hard_lock=False) is True
     locker.unlock("attribute2")
-    assert locker.is_locked("attribute2", hard_lock=True)==False
-    assert locker.is_locked("attribute2", hard_lock=True)==False
+    assert locker.is_locked("attribute2", hard_lock=True) is False
+    assert locker.is_locked("attribute2", hard_lock=True) is False
     locker.lock("attribute2")
-    assert locker.is_locked("attribute2", hard_lock=True)==False
-    assert locker.is_locked("attribute2", hard_lock=False)==True
+    assert locker.is_locked("attribute2", hard_lock=True) is False
+    assert locker.is_locked("attribute2", hard_lock=False) is True
+
 
 def test_in_list_lock_mode():
     """Testing in list lock mode"""
     locker = Locker()
-    locker.add_lock("attribute1", value=[1,2,3], hard_lock=True, value_lock_mode=LockMode.IN_LIST)
+    locker.add_lock(
+        "attribute1",
+        value=[1, 2, 3],
+        hard_lock=True,
+        value_lock_mode=LockMode.IN_LIST,
+    )
     is_locked = locker.is_locked("attribute1", value=3)
-    assert is_locked==False
+    assert is_locked is False
     is_locked = locker.is_locked("attribute1", value=4)
-    assert is_locked==True
+    assert is_locked is True
+
 
 def test_in_range_lock_mode():
     """Testing in range lock mode"""
     locker = Locker()
-    locker.add_lock("attribute1", value=[0,10], hard_lock=True, value_lock_mode=LockMode.IN_RANGE)
-    assert locker.is_locked("attribute1", value=3)==False
-    assert locker.is_locked("attribute1", value=11)==True
+    locker.add_lock(
+        "attribute1",
+        value=[0, 10],
+        hard_lock=True,
+        value_lock_mode=LockMode.IN_RANGE,
+    )
+    assert locker.is_locked("attribute1", value=3) is False
+    assert locker.is_locked("attribute1", value=11) is True
+
 
 def test_inequality_lock_modes():
     """Testing in range lock mode"""
     locker = Locker()
-    locker.add_lock("attribute1", value=10, hard_lock=True, value_lock_mode=LockMode.SMALLER_THAN)
-    locker.add_lock("attribute2", value=10, hard_lock=True, value_lock_mode=LockMode.LARGER_THAN)
-    assert locker.is_locked("attribute1", value=3)==False
-    assert locker.is_locked("attribute1", value=11)==True
-    assert locker.is_locked("attribute2", value=11)==False
-    assert locker.is_locked("attribute2", value=3)==True
+    locker.add_lock(
+        "attribute1",
+        value=10,
+        hard_lock=True,
+        value_lock_mode=LockMode.SMALLER_THAN,
+    )
+    locker.add_lock(
+        "attribute2",
+        value=10,
+        hard_lock=True,
+        value_lock_mode=LockMode.LARGER_THAN,
+    )
+    assert locker.is_locked("attribute1", value=3) is False
+    assert locker.is_locked("attribute1", value=11) is True
+    assert locker.is_locked("attribute2", value=11) is False
+    assert locker.is_locked("attribute2", value=3) is True
+
 
 def test_value_mode_errors():
     """Testing in range lock mode"""
     locker = Locker()
     with pytest.raises(ValueNotCompatibleWithLockMode):
-        locker.add_lock("attribute1", value='10', value_lock_mode=LockMode.SMALLER_THAN)
+        locker.add_lock(
+            "attribute1", value='10', value_lock_mode=LockMode.SMALLER_THAN
+        )
     with pytest.raises(ValueNotCompatibleWithLockMode):
-        locker.add_lock("attribute1", value='10', value_lock_mode=LockMode.LARGER_THAN)
+        locker.add_lock(
+            "attribute1", value='10', value_lock_mode=LockMode.LARGER_THAN
+        )
     with pytest.raises(ValueNotCompatibleWithLockMode):
-        locker.add_lock("attribute1", value='10', value_lock_mode=LockMode.IN_LIST)
+        locker.add_lock(
+            "attribute1", value='10', value_lock_mode=LockMode.IN_LIST
+        )
     with pytest.raises(ValueNotCompatibleWithLockMode):
-        locker.add_lock("attribute1", value='10', value_lock_mode=LockMode.IN_RANGE)
+        locker.add_lock(
+            "attribute1", value='10', value_lock_mode=LockMode.IN_RANGE
+        )
+
 
 def test_locks_dictionary_update():
     """Testing the update mechanism using dictionaries"""
     locker = Locker()
     locker_data = dict()
-    locker_data['attribute1']= {"value":3, "locked":False}
+    locker_data['attribute1'] = {"value": 3, "locked": False}
 
     locker.update_locks(locker_data)
-    assert locker.get_lock('attribute1').value==3
-    assert locker.get_lock('attribute1').locked==False
+    assert locker.get_lock('attribute1').value == 3
+    assert locker.get_lock('attribute1').locked is False
 
-    locker_data['attribute1']= {"value":4}
-    locker_data['attribute2']= {"value":6}
+    locker_data['attribute1'] = {"value": 4}
+    locker_data['attribute2'] = {"value": 6}
     locker.update_locks(locker_data)
-    assert locker.get_lock('attribute1').value==4
-    assert locker.get_lock('attribute1').locked==False
-    assert locker.get_lock('attribute2').value==6
-    assert locker.get_lock('attribute2').locked==True
+    assert locker.get_lock('attribute1').value == 4
+    assert locker.get_lock('attribute1').locked is False
+    assert locker.get_lock('attribute2').value == 6
+    assert locker.get_lock('attribute2').locked is True

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -353,6 +353,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
                     deferred=True,
                 ),
                 category=UserWarning,
+                stacklevel=2,
             )
             return None
         else:

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -15,12 +15,12 @@ from ...utils._dask_utils import configure_dask
 from ...utils._magicgui import add_layer_to_viewer, get_layers
 from ...utils.events import EmitterGroup, Event
 from ...utils.events.event import WarningEmitter
-from ...utils.lock import Locker
 from ...utils.geometry import (
     find_front_back_face,
     intersect_line_with_axis_aligned_bounding_box_3d,
 )
 from ...utils.key_bindings import KeymapProvider
+from ...utils.lock import Locker
 from ...utils.mouse_bindings import MousemapProvider
 from ...utils.naming import magic_name
 from ...utils.status_messages import generate_layer_status
@@ -199,7 +199,9 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         * `_set_view_slice()`: called to set currently viewed slice
         * `_basename()`: base/default name of the layer
     """
-    locker:Locker=Locker()
+
+    locker: Locker = Locker()
+
     def __init__(
         self,
         data,
@@ -216,7 +218,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         blending='translucent',
         visible=True,
         multiscale=False,
-        locker:Locker=Locker(),
+        locker: Locker = Locker(),
         cache=True,  # this should move to future "data source" object.
         experimental_clipping_planes=None,
     ):
@@ -346,11 +348,11 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         """Checks locks before changing value"""
         if self.locker.is_locked(__name, hard_lock=True):
             warnings.warn(
-                    trans._(
-                        f'Attribute ({__name}) is locked is locked',
-                        deferred=True,
-                    ),
-                    category=UserWarning,
+                trans._(
+                    f'Attribute ({__name}) is locked is locked',
+                    deferred=True,
+                ),
+                category=UserWarning,
             )
             return None
         else:

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -8,7 +8,6 @@ import numpy as np
 from pydantic import BaseModel, PrivateAttr, main, utils
 
 from ...utils.misc import pick_equality_operator
-from ...utils.lock import Locker
 from ..translations import trans
 from .event import EmitterGroup, Event
 
@@ -168,7 +167,6 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
     __field_dependents__: ClassVar[Dict[str, Set[str]]]
     __eq_operators__: ClassVar[Dict[str, Callable[[Any, Any], bool]]]
     __slots__: ClassVar[Set[str]] = {"__weakref__"}  # type: ignore
-
 
     # pydantic BaseModel configuration.  see:
     # https://pydantic-docs.helpmanual.io/usage/model_config/

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -168,7 +168,6 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
     __field_dependents__: ClassVar[Dict[str, Set[str]]]
     __eq_operators__: ClassVar[Dict[str, Callable[[Any, Any], bool]]]
     __slots__: ClassVar[Set[str]] = {"__weakref__"}  # type: ignore
-    locker:Locker=Locker()
 
 
     # pydantic BaseModel configuration.  see:
@@ -213,15 +212,6 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             super().__setattr__(name, value)
 
     def __setattr__(self, name: str, value: Any) -> None:
-        if self.locker.is_locked(name, hard_lock=True):
-            warnings.warn(
-                    trans._(
-                        f'Event ({name}) is locked is locked',
-                        deferred=True,
-                    ),
-                    category=UserWarning,
-            )
-            return None
         if name not in getattr(self, 'events', {}):
             # fallback to default behavior
             self._super_setattr_(name, value)

--- a/napari/utils/lock.py
+++ b/napari/utils/lock.py
@@ -4,6 +4,7 @@ A generic lock class to be used as a locking mechanism.
 from enum import Enum
 from typing import Dict, Optional, Any, List
 from pydantic import BaseModel, validator
+from napari.utils.translations import trans
 
 
 class LockMode(Enum):
@@ -63,7 +64,7 @@ class Lock(BaseModel):
         ) and not is_numeric(value):
             raise ValueNotCompatibleWithLockMode(
                 value=value,
-                message="Value should be numeric for lock modes: LARGER_THAN and SMALLER_THAN",
+                message=trans._("Value should be numeric for lock modes: LARGER_THAN and SMALLER_THAN",  deferred=True),
             )
 
         if value_lock_mode == LockMode.IN_LIST and type(value) not in (
@@ -72,7 +73,7 @@ class Lock(BaseModel):
         ):
             raise ValueNotCompatibleWithLockMode(
                 value=value,
-                message="Value should be list or tuple for lock mode: IN_LIST",
+                message=trans._("Value should be list or tuple for lock mode: IN_LIST",  deferred=True),
             )
 
         if value_lock_mode == LockMode.IN_RANGE and (
@@ -80,7 +81,7 @@ class Lock(BaseModel):
         ):
             raise ValueNotCompatibleWithLockMode(
                 value=value,
-                message="Value should be list or tuple of 2 elements for lock mode: IN_RANGE",
+                message=trans._("Value should be list or tuple of 2 elements for lock mode: IN_RANGE",  deferred=True),
             )
 
         return value

--- a/napari/utils/lock.py
+++ b/napari/utils/lock.py
@@ -61,13 +61,9 @@ class Lock(BaseModel):
         """Validate value"""
         value_lock_mode = values["value_lock_mode"]
 
-        def is_numeric(x):
-            """Quick checking if it is numeric type"""
-            return type(x) in (int, float)
-
         if (
             value_lock_mode in (LockMode.LARGER_THAN, LockMode.SMALLER_THAN)
-        ) and not is_numeric(value):
+        ) and not type(value) in (int, float):
             raise ValueNotCompatibleWithLockMode(
                 value=value,
                 message=trans._(

--- a/napari/utils/lock.py
+++ b/napari/utils/lock.py
@@ -2,8 +2,10 @@
 A generic lock class to be used as a locking mechanism.
 """
 from enum import Enum
-from typing import Dict, Optional, Any, List
+from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel, validator
+
 from napari.utils.translations import trans
 
 
@@ -51,20 +53,27 @@ class Lock(BaseModel):
 
     @validator("value_lock_mode")
     def value_lock_mode_lock_mode_valid(cls, value):
+        """Validate value lock mode"""
         return value
 
     @validator("value")
     def value_lock_mode_valid(cls, value, values, **kwargs):
+        """Validate value"""
         value_lock_mode = values["value_lock_mode"]
 
-        is_numeric = lambda x: type(x) in (int, float)
+        def is_numeric(x):
+            """Quick checking if it is numeric type"""
+            return type(x) in (int, float)
 
         if (
             value_lock_mode in (LockMode.LARGER_THAN, LockMode.SMALLER_THAN)
         ) and not is_numeric(value):
             raise ValueNotCompatibleWithLockMode(
                 value=value,
-                message=trans._("Value should be numeric for lock modes: LARGER_THAN and SMALLER_THAN",  deferred=True),
+                message=trans._(
+                    "Value should be numeric for lock modes: LARGER_THAN and SMALLER_THAN",
+                    deferred=True,
+                ),
             )
 
         if value_lock_mode == LockMode.IN_LIST and type(value) not in (
@@ -73,7 +82,10 @@ class Lock(BaseModel):
         ):
             raise ValueNotCompatibleWithLockMode(
                 value=value,
-                message=trans._("Value should be list or tuple for lock mode: IN_LIST",  deferred=True),
+                message=trans._(
+                    "Value should be list or tuple for lock mode: IN_LIST",
+                    deferred=True,
+                ),
             )
 
         if value_lock_mode == LockMode.IN_RANGE and (
@@ -81,7 +93,10 @@ class Lock(BaseModel):
         ):
             raise ValueNotCompatibleWithLockMode(
                 value=value,
-                message=trans._("Value should be list or tuple of 2 elements for lock mode: IN_RANGE",  deferred=True),
+                message=trans._(
+                    "Value should be list or tuple of 2 elements for lock mode: IN_RANGE",
+                    deferred=True,
+                ),
             )
 
         return value

--- a/napari/utils/lock.py
+++ b/napari/utils/lock.py
@@ -2,8 +2,10 @@
 A generic lock class to be used as a locking mechanism.
 """
 from enum import Enum
-from typing import Dict, Optional, Any, List
+from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel, validator
+
 from napari.utils.translations import trans
 
 
@@ -64,7 +66,10 @@ class Lock(BaseModel):
         ) and not is_numeric(value):
             raise ValueNotCompatibleWithLockMode(
                 value=value,
-                message=trans._("Value should be numeric for lock modes: LARGER_THAN and SMALLER_THAN",  deferred=True),
+                message=trans._(
+                    "Value should be numeric for lock modes: LARGER_THAN and SMALLER_THAN",
+                    deferred=True,
+                ),
             )
 
         if value_lock_mode == LockMode.IN_LIST and type(value) not in (
@@ -73,7 +78,10 @@ class Lock(BaseModel):
         ):
             raise ValueNotCompatibleWithLockMode(
                 value=value,
-                message=trans._("Value should be list or tuple for lock mode: IN_LIST",  deferred=True),
+                message=trans._(
+                    "Value should be list or tuple for lock mode: IN_LIST",
+                    deferred=True,
+                ),
             )
 
         if value_lock_mode == LockMode.IN_RANGE and (
@@ -81,7 +89,10 @@ class Lock(BaseModel):
         ):
             raise ValueNotCompatibleWithLockMode(
                 value=value,
-                message=trans._("Value should be list or tuple of 2 elements for lock mode: IN_RANGE",  deferred=True),
+                message=trans._(
+                    "Value should be list or tuple of 2 elements for lock mode: IN_RANGE",
+                    deferred=True,
+                ),
             )
 
         return value

--- a/napari/utils/lock.py
+++ b/napari/utils/lock.py
@@ -1,0 +1,199 @@
+"""
+A generic lock class to be used as a locking mechanism.
+"""
+from enum import Enum
+from typing import Dict, Optional, Any, List
+from pydantic import BaseModel, validator
+
+
+class LockMode(Enum):
+    """Lock modes"""
+
+    EXACT = 0
+    IN_LIST = 1
+    IN_RANGE = 2
+    LARGER_THAN = 3
+    SMALLER_THAN = 4
+
+
+class ValueNotCompatibleWithLockMode(Exception):
+    """Custom error that is raised when the value is not compatible with lock mode"""
+
+    def __init__(self, value, message: str) -> None:
+        self.value = value
+        self.message = f"value: {value}. " + message
+        super().__init__(message)
+
+
+class AttributeNotFound(Exception):
+    """Custom error that is raised when the attribute is not found in the locker"""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+class Lock(BaseModel):
+    """
+    A lock consists of components:
+    1. A boolean to house the status of the lock (open, locked).
+    2. A value of the lock, for example, an attribute maximum can be locked to certain number.
+    3. A lock mode to desginate the type of lock (soft (user), or hard (code and user))
+    4. comments
+    """
+
+    value_lock_mode: LockMode = LockMode.EXACT
+    value: Any = None
+    locked: bool = True
+    hard_lock: bool = True
+    comments: Optional[str] = None
+
+    @validator("value_lock_mode")
+    def value_lock_mode_lock_mode_valid(cls, value):
+        return value
+
+    @validator("value")
+    def value_lock_mode_valid(cls, value, values, **kwargs):
+        value_lock_mode = values["value_lock_mode"]
+
+        is_numeric = lambda x: type(x) in (int, float)
+
+        if (
+            value_lock_mode in (LockMode.LARGER_THAN, LockMode.SMALLER_THAN)
+        ) and not is_numeric(value):
+            raise ValueNotCompatibleWithLockMode(
+                value=value,
+                message="Value should be numeric for lock modes: LARGER_THAN and SMALLER_THAN",
+            )
+
+        if value_lock_mode == LockMode.IN_LIST and type(value) not in (
+            list,
+            tuple,
+        ):
+            raise ValueNotCompatibleWithLockMode(
+                value=value,
+                message="Value should be list or tuple for lock mode: IN_LIST",
+            )
+
+        if value_lock_mode == LockMode.IN_RANGE and (
+            type(value) not in (list, tuple) or len(value) != 2
+        ):
+            raise ValueNotCompatibleWithLockMode(
+                value=value,
+                message="Value should be list or tuple of 2 elements for lock mode: IN_RANGE",
+            )
+
+        return value
+
+    def lock(self) -> None:
+        """locks the lock"""
+        self.locked = True
+
+    def unlock(self) -> None:
+        """locks the lock"""
+        self.locked = False
+
+    def is_valid_value(self, value: Any) -> bool:
+        """Checks if value is permitted in the lock"""
+        if self.value_lock_mode == LockMode.EXACT:
+            return False
+        elif self.value_lock_mode == LockMode.IN_LIST:
+            return value in self.value
+        elif self.value_lock_mode == LockMode.IN_RANGE:
+            return value >= self.value[0] and value <= self.value[1]
+        elif self.value_lock_mode == LockMode.SMALLER_THAN:
+            return value <= self.value
+        # elif self.value_lock_mode == LockMode.LARGER_THAN:
+        return value >= self.value
+
+    def is_locked(self, hard_lock: bool = True, value: Any = None):
+        """Check if there is a lock on a specific attribute"""
+        if not self.locked:
+            return False
+
+        if self.hard_lock is True or hard_lock is False:
+            if self.is_valid_value(value):
+                return False
+            else:
+                return True
+
+        return False
+
+
+class Locker:
+    """
+    A generic class to be used as a locking mechanism. It contains a collection of locks
+    for different attributes.
+    """
+
+    _lock_dictionary: Dict[str, Lock]
+
+    def __init__(self, lock_dictionary: Optional[Dict[str, Lock]] = None):
+        """Initializes the locker"""
+        if lock_dictionary is not None:
+            self._lock_dictionary = lock_dictionary
+        else:
+            self._lock_dictionary = {}
+
+    def add_lock(
+        self,
+        attribute: str,
+        value: Any = None,
+        hard_lock: bool = True,
+        locked: bool = True,
+        value_lock_mode: LockMode = LockMode.EXACT,
+        comments: Optional[str] = None,
+    ) -> None:
+        """Adds a lock to the locker"""
+        self._lock_dictionary[attribute] = Lock(
+            value=value,
+            hard_lock=hard_lock,
+            value_lock_mode=value_lock_mode,
+            comments=comments,
+            locked=locked,
+        )
+
+    def is_locked(
+        self, attribute: str, hard_lock: bool = True, value: Any = None
+    ) -> bool:
+        """Check if there is a lock on a specific attribute"""
+        if not self.has_attribute(attribute):
+            return False
+
+        lock = self._lock_dictionary[attribute]
+        return lock.is_locked(hard_lock=hard_lock, value=value)
+
+    def has_attribute(self, attribute: str) -> bool:
+        """Checks if the lock has a specific attribute"""
+        return attribute in self._lock_dictionary
+
+    def lock(self, attribute: str) -> None:
+        """Locks a specifc attribute"""
+        if not self.has_attribute(attribute):
+            raise AttributeNotFound("Attribute not found in the locker")
+        self.get_lock(attribute).lock()
+
+    def unlock(self, attribute: str) -> None:
+        """Unlocks a specific attribute"""
+        if not self.has_attribute(attribute):
+            raise AttributeNotFound("Attribute not found in the locker")
+        self.get_lock(attribute).unlock()
+
+    def list_locks(self) -> List[str]:
+        """Returns the list of locks available"""
+        return list(self._lock_dictionary.keys())
+
+    def get_lock(self, attribute: str) -> Lock:
+        """Returns the lock value"""
+        return self._lock_dictionary[attribute]
+
+    def update_locks(self, locker_dictionary_update: Dict):
+        """Update the locks using a dictionary"""
+        for attribute, lock_data in locker_dictionary_update.items():
+            if attribute in self._lock_dictionary.keys():
+                current_lock = self.get_lock(attribute)
+                updated_lock = current_lock.copy(update=lock_data)
+            else:
+                updated_lock = Lock(**lock_data)
+
+            self._lock_dictionary[attribute] = updated_lock

--- a/napari/utils/lock.py
+++ b/napari/utils/lock.py
@@ -24,12 +24,20 @@ class ValueNotCompatibleWithLockMode(Exception):
 
     def __init__(self, value, message: str) -> None:
         self.value = value
-        self.message = f"value: {value}. " + message
+        self.message = message
         super().__init__(message)
 
 
 class AttributeNotFound(Exception):
     """Custom error that is raised when the attribute is not found in the locker"""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+class AttributeAlreadyAdded(Exception):
+    """Custom error that is raised when the atribute is already found in the locker"""
 
     def __init__(self, message: str) -> None:
         self.message = message
@@ -157,6 +165,13 @@ class Locker:
         comments: Optional[str] = None,
     ) -> None:
         """Adds a lock to the locker"""
+        if self.has_attribute(attribute):
+            raise AttributeAlreadyAdded(
+                trans._(
+                    "Attribute is already added to the locker", deferred=True
+                )
+            )
+
         self._lock_dictionary[attribute] = Lock(
             value=value,
             hard_lock=hard_lock,
@@ -182,13 +197,17 @@ class Locker:
     def lock(self, attribute: str) -> None:
         """Locks a specifc attribute"""
         if not self.has_attribute(attribute):
-            raise AttributeNotFound("Attribute not found in the locker")
+            raise AttributeNotFound(
+                trans._("Attribute not found in the locker", deferred=True)
+            )
         self.get_lock(attribute).lock()
 
     def unlock(self, attribute: str) -> None:
         """Unlocks a specific attribute"""
         if not self.has_attribute(attribute):
-            raise AttributeNotFound("Attribute not found in the locker")
+            raise AttributeNotFound(
+                trans._("Attribute not found in the locker", deferred=True)
+            )
         self.get_lock(attribute).unlock()
 
     def list_locks(self) -> List[str]:


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->
This is the pull request for the implementation discussed in #3466. It is a locking mechanism that can be used anywhere in napari.

## Architecture
Two classes: Lock and Locker. Locker is composed of a number of locks (dictionary). The locks are pydantic model with validation on the parameters. The lock itself can accomdate multiple locking mode (exact, in list, in range, larger than, and smaller than).  There is also a hard lock (which is currently implemented in the setattribute in the layer automatically. And soft lock (if needed) as discussed in #3466.

## What's missing (enahancement)
- I tried adding the same setattribute to Evented model but it failed the tests. I don't know why as I am not familiar with EventedModel and its use.
- As disccussed in #3466, I am still not sure how to implement ownership and automatic release of locks once the owner is closed. I am thinking we can tab in to the plugin life cycle for this but I am not familiar with that.
- Currently, all functions are public but some can be safely made private i think depending on the above enhancement.

Any help is appreciated with the two enhancements.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
Closes issue #3466

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] New tests were written with 100% coverage for added class.
- [x] All tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).