### PR TITLE
block some duplications in Plugins menu

### DIFF
--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -1,14 +1,20 @@
+from npe2 import PluginManager as _PluginManager
+
 from ..settings import get_settings
 from ._plugin_manager import NapariPluginManager
 
 __all__ = ["plugin_manager", "menu_item_template"]
 
+_npe2pm = _PluginManager.instance()
 
 # the main plugin manager instance for the `napari` plugin namespace.
 plugin_manager = NapariPluginManager()
 plugin_manager._initialize()
-# Disable plugins listed as disabled in settings.
-plugin_manager._blocked.update(get_settings().plugins.disabled_plugins)
+
+# Disable plugins listed as disabled in settings, or detected in npe2
+_from_npe2 = {m.package_metadata.name for m in _npe2pm._manifests.values()}
+_toblock = get_settings().plugins.disabled_plugins.union(_from_npe2)
+plugin_manager._blocked.update(_toblock)
 
 #: Template to use for namespacing a plugin item in the menu bar
 menu_item_template = '{}: {}'


### PR DESCRIPTION
# Description
This is a small, but not 100% robust way to prevent plugins that support both npe1 and npe2 entry points from appearing twice.  npe2 detection happens first, any package names that are detected will be blocked from the npe1 mechanism.  For now, this will only work if the plugin name is the same as the package name.  but, it will be better than nothing (and requires no modifications to either npe2 or napari_plugin_engine)