### PR TITLE
Add descriptive information to assertion checking if QtViewer is cleaned properly

### DIFF
--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -149,6 +149,8 @@ def make_napari_viewer(
     from napari._qt.qt_viewer import QtViewer
     from napari.settings import get_settings
 
+    gc.collect()
+
     _do_not_inline_below = len(QtViewer._instances)
     # # do not inline to avoid pytest trying to compute repr of expression.
     # # it fails if C++ object gone but not Python object.

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -149,6 +149,19 @@ def make_napari_viewer(
     from napari._qt.qt_viewer import QtViewer
     from napari.settings import get_settings
 
+    _do_not_inline_below = len(QtViewer._instances)
+    # # do not inline to avoid pytest trying to compute repr of expression.
+    # # it fails if C++ object gone but not Python object.
+    if request.config.getoption(_SAVE_GRAPH_OPNAME):
+        fail_obj_graph(QtViewer)
+    QtViewer._instances.clear()
+    assert _do_not_inline_below == 0, (
+        "Some instance of QtViewer is not properly cleaned in one of previous test. For easier debug one may "
+        f"use {_SAVE_GRAPH_OPNAME} flag for pytest to get graph of leaked objects. If you use qtbot (from pytest-qt)"
+        " to clean Qt objects after test you may need to switch to manual clean using "
+        "`deleteLater()` and `qtbot.wait(50)` later."
+    )
+
     settings = get_settings()
     settings.reset()
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This is my proposition for solution #3948. 
The core problem for me to understand what happens is that number of `QtViewer` instances count was checked only at the end of the test, not at the beginning, so there is no clear information that `AssertionError` is caused by an object from the previous test. I also need to read the code to understand what happened, because there is no comment with an explanation. 

The source of my problem is that in my test order test of napari plugins is after some tests that check QtViewer integration in PartSeg. So I think that probability that some plugin create meet this problem is much smaller than I expect ealier. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] More descriptive test fail

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
