### PR TITLE
switch pd.append to pd.concat

### DIFF
--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -818,7 +818,7 @@ class _FeatureTable:
         to_append : pd.DataFrame
             The features to append.
         """
-        self._values = self._values.append(to_append, ignore_index=True)
+        self._values = pd.concat([self._values, to_append], ignore_index=True)
 
     def remove(self, indices: Any) -> None:
         """Remove rows from this by index.


### PR DESCRIPTION
# Description
This is a proposed fix for #3962. Pandas is deprecating `DataFrame.append` in favor of `pd.concat`. Currently, causes a `FutureWarning` to be emitted when items are appended to the `_FeatureTable`.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #3962

# How has this been tested?
- [x] the test suite for my feature covers cases x, y, and z

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
