### PR TITLE
update plugin docs index

### DIFF
--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -1,36 +1,44 @@
 (plugins-index)=
 # Plugins
 
+
+```{note}
+These pages describe the process of **building** a plugin.
+
+If you are looking to **use** published plugins, see the [guide on installing
+plugins](find-and-install-plugins), or head to the [napari hub][napari_hub] to
+search for plugins.
+```
+
 Plugins allow developers to customize and extend napari.  This includes
 
-- Adding file format support with [readers](contributions-readers) and [writers](contributions-writers)
-- Adding custom [widgets](contributions-widgets) and user interface elements
-- Providing [sample data][contributions-sample_data]
-- Changing the look of napari with a color [theme](contributions-themes)
-
-```{admonition} Introducing npe2
-:class: important
-We introduced a new plugin engine ([`npe2`][npe2]) in December 2021.
-
-Plugins targeting the first generation `napari-plugin-engine` will
-continue to work for at least the first half of 2022, but we
-recommend migrating to `npe2`.
-See the [migration guide](npe2-migration-guide) for details.
-```
+- Adding file format support with [readers] and [writers]
+- Adding custom [widgets] and user interface elements
+- Providing [sample data][sample_data]
+- Changing the look of napari with a color [theme]
 
 Here you can find:
 
 - How to [build, test and publish a plugin](how-to-build-a-plugin).
 - Where to find [guides](./guides) to help get you started.
-- [Best practices](best-practices) when developing plugins.
+- [Best practices](./best_practices) when developing plugins.
 
-If you are looking to use published plugins, see the [guide on installing
-plugins](find-and-install-plugins), or head to the [napari hub][napari_hub] to
-search for plugins.
+```{admonition} Introducing npe2
+:class: important
 
+We introduced a new plugin engine [`npe2`][npe2] in December 2021.
+
+Unless otherwise stated, most of the documentation herein pertains
+to the new npe2 format (which uses a static `napari.yaml` manifest)
+
+Plugins targeting the first generation `napari-plugin-engine` 
+(using `@napari_hook_implementation` decorators) will
+continue to work for at least the first half of 2022, but we
+recommend migrating to `npe2`. See the
+[migration guide](npe2-migration-guide) for details.
+```
 
 (how-to-build-a-plugin)=
-
 ## How to build plugins
 
 If you're just getting started with napari plugins, try our
@@ -54,3 +62,8 @@ Submit issues to the [napari github repository][napari_issues].
 [napari_issues]: https://github.com/napari/napari/issues/new/choose
 [napari_zulip]: https://napari.zulipchat.com/
 [napari_hub]: https://napari-hub.org
+[readers]: ./contributions.html#contributions-readers
+[writers]: ./contributions.html#contributions-writers
+[widgets]: ./contributions.html#contributions-widgets
+[sample_data]: ./contributions.html#contributions-sample-data
+[theme]: ./contributions.html#contributions-themes


### PR DESCRIPTION
# Description
With #3951 the content of the docs is now at least showing correctly.  The TOC is still messed up and copy-docs needs work (short term patch here: https://github.com/napari/napari.github.io/pull/326)

This PR just touches up the plugins index a bit