### PR TITLE
bump skimage dep to 0.19.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -105,7 +105,7 @@ testing =
     fsspec
     zarr
     matplotlib
-    scikit-image>=0.18.1,!=0.19.0
+    scikit-image>=0.19.1
     pooch>=1.3.0
     semgrep
     tensorstore>=0.1.13 ; python_version < '3.10'


### PR DESCRIPTION
# Description
fix [test fail](https://github.com/napari/napari/runs/4855071683?check_suite_focus=true#step:9:620) caused by changing scikit-image API in #3974

probably supersedes #3979 

cc @tlambert03 

edit: 0.19.1 is very recent, 15th dec 2021, don't think there's any negative to depending on a recent version but good to know before merge?

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)


# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?

- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
