### PR TITLE
Fix missing builtins in bundle

### DIFF
--- a/napari/plugins/__init__.py
+++ b/napari/plugins/__init__.py
@@ -1,4 +1,8 @@
+from pathlib import Path
+
 from npe2 import PluginManager as _PluginManager
+from npe2 import PluginManifest
+from npe2.manifest.package_metadata import PackageMetadata
 
 from ..settings import get_settings
 from ._plugin_manager import NapariPluginManager
@@ -6,6 +10,16 @@ from ._plugin_manager import NapariPluginManager
 __all__ = ["plugin_manager", "menu_item_template"]
 
 _npe2pm = _PluginManager.instance()
+
+# this is a workaround for the fact that briefcase does not seem to
+# include napari's entry_points.txt in the bundled app, so the builtin plugins
+# don't get detected.  So we just register it manually.  This could potentially
+# be removed when we move to a different bundle strategy
+if 'napari' not in _npe2pm._manifests:
+    mf_file = Path(__file__).parent.parent / 'builtins.yaml'
+    mf = PluginManifest.from_file(mf_file)
+    mf.package_metadata = PackageMetadata.for_package('napari')
+    _npe2pm.register(mf)
 
 # the main plugin manager instance for the `napari` plugin namespace.
 plugin_manager = NapariPluginManager()


### PR DESCRIPTION
# Description
this should fix the fact that napari's built-in plugins (including samples and writers) are not being detected in the v0.4.13 bundle.  Long story short, it appears that briefcase isn't including napari's `entry_points.txt` along with the package metadata in the bundle (though it does for dependencies like napari-svg).  This manually registers it if it hasn't been detected.