### PR TITLE
don't use texture_format auto if float textures not available on machine

### DIFF
--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -4,9 +4,8 @@ import numpy as np
 from vispy.color import Colormap as VispyColormap
 from vispy.scene.node import Node
 
-from ...utils.info import supports_float
 from ...utils.translations import trans
-from ..utils.gl import fix_data_dtype
+from ..utils.gl import fix_data_dtype, get_gl_extensions
 from ..visuals.image import Image as ImageNode
 from ..visuals.volume import Volume as VolumeNode
 from .base import VispyBaseLayer
@@ -14,7 +13,10 @@ from .base import VispyBaseLayer
 
 class ImageLayerNode:
     def __init__(self, custom_node: Node = None, texture_format=None):
-        if texture_format == 'auto' and not supports_float():
+        if (
+            texture_format == 'auto'
+            and 'texture_float' not in get_gl_extensions()
+        ):
             # if the GPU doesn't support float textures, texture_format auto
             # WILL fail on float dtypes
             # https://github.com/napari/napari/issues/3988

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -4,6 +4,7 @@ import numpy as np
 from vispy.color import Colormap as VispyColormap
 from vispy.scene.node import Node
 
+from ...utils.info import supports_float
 from ...utils.translations import trans
 from ..utils.gl import fix_data_dtype
 from ..visuals.image import Image as ImageNode
@@ -13,6 +14,12 @@ from .base import VispyBaseLayer
 
 class ImageLayerNode:
     def __init__(self, custom_node: Node = None, texture_format=None):
+        if texture_format == 'auto' and not supports_float():
+            # if the GPU doesn't support float textures, texture_format auto
+            # WILL fail on float dtypes
+            # https://github.com/napari/napari/issues/3988
+            texture_format = None
+
         self._custom_node = custom_node
         self._image_node = ImageNode(
             None,

--- a/napari/_vispy/utils/gl.py
+++ b/napari/_vispy/utils/gl.py
@@ -35,6 +35,13 @@ def _opengl_context():
             canvas.close()
 
 
+@lru_cache(maxsize=1)
+def get_gl_extensions() -> str:
+    """Get basic info about the Gl capabilities of this machine"""
+    with _opengl_context():
+        return gl.glGetParameter(gl.GL_EXTENSIONS)
+
+
 @lru_cache()
 def get_max_texture_sizes() -> Tuple[int, int]:
     """Return the maximum texture sizes for 2D and 3D rendering.

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -2,8 +2,6 @@ import os
 import platform
 import subprocess
 import sys
-from functools import lru_cache
-from typing import NamedTuple
 
 import napari
 
@@ -69,31 +67,6 @@ def _sys_name():
     except Exception:
         pass
     return ""
-
-
-class GlInfo(NamedTuple):
-    version: str
-    max_texture: int
-    extensions: str
-
-
-@lru_cache(maxsize=1)
-def gl_info() -> GlInfo:
-    """Get basic info about the Gl capabilities of this machine"""
-    from vispy.app import Canvas, use_app
-    from vispy.gloo import gl
-
-    canvas = Canvas('Test', (10, 10), show=False, app=use_app())
-    version = gl.glGetParameter(gl.GL_VERSION)
-    max_tex = gl.glGetParameter(gl.GL_MAX_TEXTURE_SIZE)
-    extensions = gl.glGetParameter(gl.GL_EXTENSIONS)
-    canvas.close()
-
-    return GlInfo(version, max_tex, extensions)
-
-
-def supports_float() -> bool:
-    return 'texture_float' in gl_info()[2]
 
 
 def sys_info(as_html=False):

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -2,6 +2,8 @@ import os
 import platform
 import subprocess
 import sys
+from functools import lru_cache
+from typing import NamedTuple
 
 import napari
 
@@ -67,6 +69,31 @@ def _sys_name():
     except Exception:
         pass
     return ""
+
+
+class GlInfo(NamedTuple):
+    version: str
+    max_texture: int
+    extensions: str
+
+
+@lru_cache(maxsize=1)
+def gl_info() -> GlInfo:
+    """Get basic info about the Gl capabilities of this machine"""
+    from vispy.app import Canvas, use_app
+    from vispy.gloo import gl
+
+    canvas = Canvas('Test', (10, 10), show=False, app=use_app())
+    version = gl.glGetParameter(gl.GL_VERSION)
+    max_tex = gl.glGetParameter(gl.GL_MAX_TEXTURE_SIZE)
+    extensions = gl.glGetParameter(gl.GL_EXTENSIONS)
+    canvas.close()
+
+    return GlInfo(version, max_tex, extensions)
+
+
+def supports_float() -> bool:
+    return 'texture_float' in gl_info()[2]
 
 
 def sys_info(as_html=False):


### PR DESCRIPTION
# Description
hopefully fixes #3988 

@alonyan, would be great if you could test this out.  this should work to install:

`pip install -U git+https://github.com/tlambert03/napari.git@fallback-float-texture`

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
