### PR TITLE
Change base point slice thickness to half a unit

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1729,12 +1729,12 @@ def test_slice_data():
     ]
     layer = Points(data)
     assert len(layer._slice_data((8, slice(None), slice(None)))[0]) == 1
-    assert len(layer._slice_data((10, slice(None), slice(None)))[0]) == 3
+    assert len(layer._slice_data((10, slice(None), slice(None)))[0]) == 4
     assert (
         len(layer._slice_data((10 + 2 * 1e-12, slice(None), slice(None)))[0])
-        == 3
+        == 4
     )
-    assert len(layer._slice_data((10.1, slice(None), slice(None)))[0]) == 1
+    assert len(layer._slice_data((10.1, slice(None), slice(None)))[0]) == 4
 
 
 def test_scale_init():

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1309,7 +1309,7 @@ class Points(Layer):
             else:
                 data = self.data[:, not_disp]
                 distances = np.abs(data - indices[not_disp])
-                matches = np.all(distances < 1e-5, axis=1)
+                matches = np.all(distances <= 0.5, axis=1)
                 slice_indices = np.where(matches)[0].astype(int)
                 return slice_indices, 1
         else:


### PR DESCRIPTION
# Description
Picking up here what emerged [in this comment](https://github.com/napari/napari/pull/2902#issuecomment-1017683574): when slicing `Points`, we currently consider a point to be "in the slice" if its distance from the slice is less than `1e-5`. An unfortunate consequence of this is that any points that are more than `1e-5` away from a round number in ~~world~~ data space are simply lost during slicing. Compare these two videos; the first is on main, the second is with this PR.


https://user-images.githubusercontent.com/23482191/150434291-e6ee318d-8e41-4729-9979-bbec839ee9a6.mp4


https://user-images.githubusercontent.com/23482191/150434301-38835d13-f790-410f-ae33-e5bbeaab066a.mp4


I found myself having this issue many times, not realizing that it was a very simple fix.

Are there any downsides to this?


PS: If this gets merged, the same should be done with `Vectors`; currently, those simply round down by using `np.astype(int)`, which is admittedly similar to what I'm proposing, if offset by 0.5.

cc @alisterburt @jni @sofroniewn

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
