### PR TITLE
Fix error when setting ndisplay=3 with empty shapes layer in viewer

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -343,6 +343,7 @@ def test_emitting_data_doesnt_change_cursor_position(
 
 
 @skip_local_popups
+@skip_on_win_ci
 def test_empty_shapes_dims(make_napari_viewer):
     """make sure an empty shapes layer can render in 3D"""
     viewer = make_napari_viewer(show=True)

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -340,3 +340,11 @@ def test_emitting_data_doesnt_change_cursor_position(
     layer.events.data(value=layer.data)
 
     assert viewer.cursor.position == new_position
+
+
+@skip_local_popups
+def test_empty_shapes_dims(make_napari_viewer):
+    """make sure an empty shapes layer can render in 3D"""
+    viewer = make_napari_viewer(show=True)
+    viewer.add_shapes(None)
+    viewer.dims.ndisplay = 3

--- a/napari/_vispy/layers/shapes.py
+++ b/napari/_vispy/layers/shapes.py
@@ -41,7 +41,11 @@ class VispyShapesLayer(VispyBaseLayer):
             faces = np.array([[0, 1, 2]])
             colors = np.array([[0, 0, 0, 0]])
 
-        if self.layer._ndisplay == 3 and self.layer.ndim == 2:
+        if (
+            len(self.layer.data)
+            and self.layer._ndisplay == 3
+            and self.layer.ndim == 2
+        ):
             vertices = np.pad(vertices, ((0, 0), (0, 1)), mode='constant')
 
         self.node._subvisuals[0].set_data(


### PR DESCRIPTION
# Description
This fixes a bug when rendering an empty shapes layer in 3D

```py
viewer = napari.Viewer()
viewer.add_shapes(None)
viewer.dims.ndisplay = 3
```

<details>

<summary>traceback</summary>

```pytb
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
File ~/miniconda3/envs/napdev/lib/python3.9/site-packages/vispy/app/backends/_qt.py:897, in CanvasBackendDesktop.paintGL(self=<vispy.app.backends._qt.CanvasBackendDesktop object>)
    895 # (0, 0, self.width(), self.height()))
    896 self._vispy_canvas.set_current()
--> 897 self._vispy_canvas.events.draw(region=None)
        self._vispy_canvas = <VispyCanvas (PyQt5) at 0x182b88460>
        self._vispy_canvas.events.draw = <vispy.util.event.EventEmitter object at 0x182ba98e0>
        self = <vispy.app.backends._qt.CanvasBackendDesktop object at 0x182bac4c0>
        self._vispy_canvas.events = <vispy.util.event.EmitterGroup object at 0x182ba9880>
    899 # Clear the alpha channel with QOpenGLWidget (Qt >= 5.4), otherwise the
    900 # window is translucent behind non-opaque objects.
    901 # Reference:  MRtrix3/mrtrix3#266
    902 if QT5_NEW_API or PYSIDE6_API or PYQT6_API:

File ~/miniconda3/envs/napdev/lib/python3.9/site-packages/vispy/util/event.py:453, in EventEmitter.__call__(self=<vispy.util.event.EventEmitter object>, *args=(), **kwargs={'region': None})
    450 if self._emitting > 1:
    451     raise RuntimeError('EventEmitter loop detected!')
--> 453 self._invoke_callback(cb, event)
        event = <DrawEvent blocked=False handled=False native=None region=None source=None sources=[] type=draw>
        self = <vispy.util.event.EventEmitter object at 0x182ba98e0>
        cb = <bound method SceneCanvas.on_draw of <VispyCanvas (PyQt5) at 0x182b88460>>
    454 if event.blocked:
    455     break

File ~/miniconda3/envs/napdev/lib/python3.9/site-packages/vispy/util/event.py:471, in EventEmitter._invoke_callback(self=<vispy.util.event.EventEmitter object>, cb=<bound method SceneCanvas.on_draw of <VispyCanvas (PyQt5)>>, event=<DrawEvent blocked=False handled=False native=None region=None source=None sources=[] type=draw>)
    469     cb(event)
    470 except Exception:
--> 471     _handle_exception(self.ignore_callback_errors,
        self = <vispy.util.event.EventEmitter object at 0x182ba98e0>
        cb = <bound method SceneCanvas.on_draw of <VispyCanvas (PyQt5) at 0x182b88460>>
        event = <DrawEvent blocked=False handled=False native=None region=None source=None sources=[] type=draw>
        (cb, event) = (<bound method SceneCanvas.on_draw of <VispyCanvas (PyQt5) at 0x182b88460>>, <DrawEvent blocked=False handled=False native=None region=None source=None sources=[] type=draw>)
    472                       self.print_callback_errors,
    473                       self, cb_event=(cb, event))

File ~/miniconda3/envs/napdev/lib/python3.9/site-packages/vispy/util/event.py:469, in EventEmitter._invoke_callback(self=<vispy.util.event.EventEmitter object>, cb=<bound method SceneCanvas.on_draw of <VispyCanvas (PyQt5)>>, event=<DrawEvent blocked=False handled=False native=None region=None source=None sources=[] type=draw>)
    467 def _invoke_callback(self, cb, event):
    468     try:
--> 469         cb(event)
        cb = <bound method SceneCanvas.on_draw of <VispyCanvas (PyQt5) at 0x182b88460>>
        event = <DrawEvent blocked=False handled=False native=None region=None source=None sources=[] type=draw>
    470     except Exception:
    471         _handle_exception(self.ignore_callback_errors,
    472                           self.print_callback_errors,
    473                           self, cb_event=(cb, event))

File ~/miniconda3/envs/napdev/lib/python3.9/site-packages/vispy/scene/canvas.py:218, in SceneCanvas.on_draw(self=<VispyCanvas (PyQt5)>, event=<DrawEvent blocked=False handled=False native=None region=None source=None sources=[] type=draw>)
    215 # Now that a draw event is going to be handled, open up the
    216 # scheduling of further updates
    217 self._update_pending = False
--> 218 self._draw_scene()
        self = <VispyCanvas (PyQt5) at 0x182b88460>

File ~/miniconda3/envs/napdev/lib/python3.9/site-packages/vispy/scene/canvas.py:277, in SceneCanvas._draw_scene(self=<VispyCanvas (PyQt5)>, bgcolor=<class 'numpy.ndarray'> (4,) float32)
    275     bgcolor = self._bgcolor
    276 self.context.clear(color=bgcolor, depth=True)
--> 277 self.draw_visual(self.scene)
        self = <VispyCanvas (PyQt5) at 0x182b88460>

File ~/miniconda3/envs/napdev/lib/python3.9/site-packages/vispy/scene/canvas.py:315, in SceneCanvas.draw_visual(self=<VispyCanvas (PyQt5)>, visual=<SubScene>, event=None)
    313         else:
    314             if hasattr(node, 'draw'):
--> 315                 node.draw()
        node = <ShapesVisual at 0x16eddfa90>
    316                 prof.mark(str(node))
    317 else:

File ~/miniconda3/envs/napdev/lib/python3.9/site-packages/vispy/scene/visuals.py:99, in VisualNode.draw(self=<ShapesVisual>)
     97 if self.picking and not self.interactive:
     98     return
---> 99 self._visual_superclass.draw(self)
        self = <ShapesVisual at 0x16eddfa90>
        self._visual_superclass = <class 'vispy.visuals.visual.CompoundVisual'>

File ~/miniconda3/envs/napdev/lib/python3.9/site-packages/vispy/visuals/visual.py:605, in CompoundVisual.draw(self=<ShapesVisual>)
    603 for v in self._subvisuals:
    604     if v.visible:
--> 605         v.draw()
        v = <Mesh at 0x16eddfa60>

File ~/miniconda3/envs/napdev/lib/python3.9/site-packages/vispy/scene/visuals.py:99, in VisualNode.draw(self=<Mesh>)
     97 if self.picking and not self.interactive:
     98     return
---> 99 self._visual_superclass.draw(self)
        self = <Mesh at 0x16eddfa60>
        self._visual_superclass = <class 'vispy.visuals.mesh.MeshVisual'>

File ~/miniconda3/envs/napdev/lib/python3.9/site-packages/vispy/visuals/visual.py:442, in Visual.draw(self=<Mesh>)
    440 if not self.visible:
    441     return
--> 442 if self._prepare_draw(view=self) is False:
        self = <Mesh at 0x16eddfa60>
    443     return
    445 if self._vshare.draw_mode is None:

File ~/miniconda3/envs/napdev/lib/python3.9/site-packages/vispy/visuals/mesh.py:358, in MeshVisual._prepare_draw(self=<Mesh>, view=<Mesh>)
    356 def _prepare_draw(self, view):
    357     if self._data_changed:
--> 358         if self._update_data() is False:
        self = <Mesh at 0x16eddfa60>
    359             return False
    360         self._data_changed = False

File ~/miniconda3/envs/napdev/lib/python3.9/site-packages/vispy/visuals/mesh.py:320, in MeshVisual._update_data(self=<Mesh>)
    318 if v.shape[-1] == 2:
    319     v = np.concatenate((v, np.zeros((v.shape[:-1] + (1,)))), -1)
--> 320 self._vertices.set_data(v, convert=True)
        v = <class 'numpy.ndarray'> (1, 3, 4) float64
        self._vertices = <VertexBuffer size=3 last_dim=3>
        self = <Mesh at 0x16eddfa60>
    321 if md.has_vertex_color():
    322     colors = md.get_vertex_colors(indexed='faces')

File ~/miniconda3/envs/napdev/lib/python3.9/site-packages/vispy/gloo/buffer.py:189, in DataBuffer.set_data(self=<VertexBuffer size=3 last_dim=3>, data=<class 'numpy.ndarray'> (1, 3, 4) float64, copy=False, **kwargs={'convert': True})
    175 def set_data(self, data, copy=False, **kwargs):
    176     """Set data (deferred operation)
    177
    178     Parameters
   (...)
    187         Additional arguments.
    188     """
--> 189     data = self._prepare_data(data, **kwargs)
        data = <class 'numpy.ndarray'> (1, 3, 4) float64
        self = <VertexBuffer size=3 last_dim=3>
        kwargs = {'convert': True}
    190     self._dtype = data.dtype
    191     # This works around some strange NumPy bug where a float32 array
    192     # of shape (155407, 1) was said to have strides
    193     # (4, 9223372036854775807), which is crazy

File ~/miniconda3/envs/napdev/lib/python3.9/site-packages/vispy/gloo/buffer.py:442, in VertexBuffer._prepare_data(self=<VertexBuffer size=3 last_dim=3>, data=<class 'numpy.ndarray'> (1, 3, 4) float32, convert=True)
    440     c = 1
    441 if self._last_dim and c != self._last_dim:
--> 442     raise ValueError('Last dimension should be %s not %s'
        'Last dimension should be %s not %s'
                                 % (self._last_dim, c) = 'Last dimension should be 3 not 4'
        c = 4
        self._last_dim = 3
        self = <VertexBuffer size=3 last_dim=3>
        (self._last_dim, c) = (3, 4)
    443                      % (self._last_dim, c))
    444 dtype_def = ('f0', data.dtype.base)
    445 if c != 1:
    446     # numpy dtypes with size 1 are ambiguous, only add size if it is greater than 1

ValueError: Last dimension should be 3 not 4
```

</details>

@brisvag, @alisterburt  could you take a peek and let me know if there's a better way?


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
