### PR TITLE
Fix bug preventing close button on dock widgets

### DIFF
--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -301,12 +301,11 @@ class QtCustomTitleBar(QLabel):
         try:
             # if the plugins menu is already created, check to see if this is a plugin
             # dock widget.  If it is, then add the close button option to the title bar.
-            actions = [
-                action.text()
-                for action in self.parent()
-                .parent()
-                ._qt_viewer.viewer.window.plugins_menu.actions()
-            ]
+            plugins_menu = (
+                self.parent().parent()._qt_viewer.viewer.window.plugins_menu
+            )
+            actions = [action.text() for action in plugins_menu.actions()]
+
             if self.parent().name in actions:
                 add_close = True
                 self.close_button = QPushButton(self)

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -301,10 +301,8 @@ class QtCustomTitleBar(QLabel):
         try:
             # if the plugins menu is already created, check to see if this is a plugin
             # dock widget.  If it is, then add the close button option to the title bar.
-            plugins_menu = (
-                self.parent().parent()._qt_viewer.viewer.window.plugins_menu
-            )
-            actions = [action.text() for action in plugins_menu.actions()]
+            win = self.parent().parent()._qt_viewer.viewer.window
+            actions = [action.text() for action in win.plugins_menu.actions()]
 
             if self.parent().name in actions:
                 add_close = True

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -303,7 +303,9 @@ class QtCustomTitleBar(QLabel):
             # dock widget.  If it is, then add the close button option to the title bar.
             actions = [
                 action.text()
-                for action in self.parent()._qt_viewer.viewer.window.plugins_menu.actions()
+                for action in self.parent()
+                .parent()
+                ._qt_viewer.viewer.window.plugins_menu.actions()
             ]
             if self.parent().name in actions:
                 add_close = True


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
There was bug introduced at some point that prevented the close button on dock widgets from appearing in the title bar.  This PR fixes that bug.  

Closes #3983 
