### PR TITLE
Rename n_dimensional to out_of_slice_display in Points and Vectors

### DIFF
--- a/examples/add_points.py
+++ b/examples/add_points.py
@@ -41,8 +41,8 @@ layer.opacity = 0.9
 # change the layer point symbol using an alias
 layer.symbol = '+'
 
-# change the layer point n_dimensional status
-layer.n_dimensional = True
+# change the layer point out_of_slice_display status
+layer.out_of_slice_display = True
 
 # change the layer mode
 layer.mode = 'add'

--- a/examples/nD_points.py
+++ b/examples/nD_points.py
@@ -31,7 +31,7 @@ points = np.array(
     ], dtype=float
 )
 viewer.add_points(
-    points, size=[0, 6, 10, 10], face_color='blue', n_dimensional=True
+    points, size=[0, 6, 10, 10], face_color='blue', out_of_slice_display=True
 )
 
 napari.run()

--- a/examples/nD_points_with_properties.py
+++ b/examples/nD_points_with_properties.py
@@ -38,7 +38,7 @@ points_layer = viewer.add_points(
     edge_width=5,
     edge_color='edge_property',
     face_color='face_property',
-    n_dimensional=False,
+    out_of_slice_display=False,
 )
 
 # change the face color cycle

--- a/examples/swap_dims.py
+++ b/examples/swap_dims.py
@@ -29,7 +29,7 @@ points = np.array(
     ]
 )
 viewer.add_points(
-    points, size=[0, 6, 10, 10], face_color='blue', n_dimensional=True
+    points, size=[0, 6, 10, 10], face_color='blue', out_of_slice_display=True
 )
 
 viewer.dims.order = (0, 2, 1, 3)

--- a/napari/_qt/layer_controls/_tests/test_qt_points_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_points_layer.py
@@ -9,7 +9,7 @@ def test_out_of_slice_display_checkbox(qtbot):
     layer = Points(np.random.rand(10, 2))
     qtctrl = QtPointsControls(layer)
     qtbot.addWidget(qtctrl)
-    combo = qtctrl.ndimCheckBox
+    combo = qtctrl.outOfSliceCheckBox
 
     assert layer.out_of_slice_display is False
     combo.setChecked(True)

--- a/napari/_qt/layer_controls/_tests/test_qt_points_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_points_layer.py
@@ -4,13 +4,13 @@ from napari._qt.layer_controls.qt_points_controls import QtPointsControls
 from napari.layers import Points
 
 
-def test_n_dimensional_checkbox(qtbot):
+def test_out_of_slice_display_checkbox(qtbot):
     """Changing the model attribute should update the view"""
     layer = Points(np.random.rand(10, 2))
     qtctrl = QtPointsControls(layer)
     qtbot.addWidget(qtctrl)
     combo = qtctrl.ndimCheckBox
 
-    assert layer.n_dimensional is False
+    assert layer.out_of_slice_display is False
     combo.setChecked(True)
-    assert layer.n_dimensional is True
+    assert layer.out_of_slice_display is True

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -54,8 +54,8 @@ class QtLabelsControls(QtLayerControls):
         Layout of Qt widget controls for the layer.
     layer : napari.layers.Labels
         An instance of a napari Labels layer.
-    ndimCheckBox : qtpy.QtWidgets.QCheckBox
-        Checkbox to control if label layer is n-dimensional.
+    ndimSpinBox : qtpy.QtWidgets.QSpinBox
+        Spinbox to control the number of editable dimensions of label layer.
     paint_button : qtpy.QtWidgets.QtModeRadioButton
         Button to select PAINT mode on Labels layer.
     panzoom_button : qtpy.QtWidgets.QtModeRadioButton

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -47,8 +47,8 @@ class QtPointsControls(QtLayerControls):
         Layout of Qt widget controls for the layer.
     layer : napari.layers.Points
         An instance of a napari Points layer.
-    ndimCheckBox : qtpy.QtWidgets.QCheckBox
-        Checkbox to indicate whether layer is n-dimensional.
+    outOfSliceCheckBox : qtpy.QtWidgets.QCheckBox
+        Checkbox to indicate whether to render out of slice.
     panzoom_button : qtpy.QtWidgets.QtModeRadioButton
         Button for pan/zoom mode.
     select_button : qtpy.QtWidgets.QtModeRadioButton
@@ -123,11 +123,11 @@ class QtPointsControls(QtLayerControls):
         symbol_comboBox.activated[str].connect(self.changeSymbol)
         self.symbolComboBox = symbol_comboBox
 
-        ndim_cb = QCheckBox()
-        ndim_cb.setToolTip(trans._('N-dimensional points'))
-        ndim_cb.setChecked(self.layer.out_of_slice_display)
-        ndim_cb.stateChanged.connect(self.change_ndim)
-        self.ndimCheckBox = ndim_cb
+        out_of_slice_cb = QCheckBox()
+        out_of_slice_cb.setToolTip(trans._('Out of slice display'))
+        out_of_slice_cb.setChecked(self.layer.out_of_slice_display)
+        out_of_slice_cb.stateChanged.connect(self.change_out_of_slice)
+        self.outOfSliceCheckBox = out_of_slice_cb
 
         self.select_button = QtModeRadioButton(
             layer,
@@ -195,8 +195,8 @@ class QtPointsControls(QtLayerControls):
         self.grid_layout.addWidget(self.edgeColorEdit, 6, 1)
         self.grid_layout.addWidget(QLabel(trans._('display text:')), 7, 0)
         self.grid_layout.addWidget(self.textDispCheckBox, 7, 1)
-        self.grid_layout.addWidget(QLabel(trans._('n-dim:')), 8, 0)
-        self.grid_layout.addWidget(self.ndimCheckBox, 8, 1)
+        self.grid_layout.addWidget(QLabel(trans._('out of slice:')), 8, 0)
+        self.grid_layout.addWidget(self.outOfSliceCheckBox, 8, 1)
         self.grid_layout.setRowStretch(9, 1)
         self.grid_layout.setColumnStretch(1, 1)
         self.grid_layout.setSpacing(4)
@@ -251,13 +251,13 @@ class QtPointsControls(QtLayerControls):
         """
         self.layer.current_size = value
 
-    def change_ndim(self, state):
-        """Toggle n-dimensional state of points layer.
+    def change_out_of_slice(self, state):
+        """Toggleout of slice display of points layer.
 
         Parameters
         ----------
         state : QCheckBox
-            Checkbox indicating if points layer is n-dimensional.
+            Checkbox indicating whether to render out of slice.
         """
         self.layer.out_of_slice_display = state == Qt.Checked
 
@@ -277,9 +277,9 @@ class QtPointsControls(QtLayerControls):
             self.textDispCheckBox.setChecked(self.layer.text.visible)
 
     def _on_out_of_slice_display_change(self):
-        """Receive layer model n-dimensional change event and update checkbox."""
+        """Receive layer model out_of_slice_display change event and update checkbox."""
         with self.layer.events.out_of_slice_display.blocker():
-            self.ndimCheckBox.setChecked(self.layer.out_of_slice_display)
+            self.outOfSliceCheckBox.setChecked(self.layer.out_of_slice_display)
 
     def _on_symbol_change(self):
         """Receive marker symbol change event and update the dropdown menu."""

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -69,7 +69,9 @@ class QtPointsControls(QtLayerControls):
         super().__init__(layer)
 
         self.layer.events.mode.connect(self._on_mode_change)
-        self.layer.events.n_dimensional.connect(self._on_n_dimensional_change)
+        self.layer.events.out_of_slice_display.connect(
+            self._on_out_of_slice_display_change
+        )
         self.layer.events.symbol.connect(self._on_symbol_change)
         self.layer.events.size.connect(self._on_size_change)
         self.layer.events.current_edge_color.connect(
@@ -123,7 +125,7 @@ class QtPointsControls(QtLayerControls):
 
         ndim_cb = QCheckBox()
         ndim_cb.setToolTip(trans._('N-dimensional points'))
-        ndim_cb.setChecked(self.layer.n_dimensional)
+        ndim_cb.setChecked(self.layer.out_of_slice_display)
         ndim_cb.stateChanged.connect(self.change_ndim)
         self.ndimCheckBox = ndim_cb
 
@@ -257,7 +259,7 @@ class QtPointsControls(QtLayerControls):
         state : QCheckBox
             Checkbox indicating if points layer is n-dimensional.
         """
-        self.layer.n_dimensional = state == Qt.Checked
+        self.layer.out_of_slice_display = state == Qt.Checked
 
     def change_text_visibility(self, state):
         """Toggle the visibility of the text.
@@ -274,10 +276,10 @@ class QtPointsControls(QtLayerControls):
         with self.layer.text.events.visible.blocker():
             self.textDispCheckBox.setChecked(self.layer.text.visible)
 
-    def _on_n_dimensional_change(self):
+    def _on_out_of_slice_display_change(self):
         """Receive layer model n-dimensional change event and update checkbox."""
-        with self.layer.events.n_dimensional.blocker():
-            self.ndimCheckBox.setChecked(self.layer.n_dimensional)
+        with self.layer.events.out_of_slice_display.blocker():
+            self.ndimCheckBox.setChecked(self.layer.out_of_slice_display)
 
     def _on_symbol_change(self):
         """Receive marker symbol change event and update the dropdown menu."""

--- a/napari/_qt/layer_controls/qt_vectors_controls.py
+++ b/napari/_qt/layer_controls/qt_vectors_controls.py
@@ -49,7 +49,9 @@ class QtVectorsControls(QtLayerControls):
 
         self.layer.events.edge_width.connect(self._on_edge_width_change)
         self.layer.events.length.connect(self._on_length_change)
-        self.layer.events.n_dimensional.connect(self._on_n_dimensional_change)
+        self.layer.events.out_of_slice_display.connect(
+            self._on_out_of_slice_display_change
+        )
         self.layer.events.edge_color_mode.connect(
             self._on_edge_color_mode_change
         )
@@ -102,7 +104,7 @@ class QtVectorsControls(QtLayerControls):
 
         ndim_cb = QCheckBox()
         ndim_cb.setToolTip(trans._('N-dimensional points'))
-        ndim_cb.setChecked(self.layer.n_dimensional)
+        ndim_cb.setChecked(self.layer.out_of_slice_display)
         ndim_cb.stateChanged.connect(self.change_ndim)
         self.ndimCheckBox = ndim_cb
 
@@ -211,9 +213,9 @@ class QtVectorsControls(QtLayerControls):
             Checkbox indicating if vectors layer is n-dimensional.
         """
         if state == Qt.Checked:
-            self.layer.n_dimensional = True
+            self.layer.out_of_slice_display = True
         else:
-            self.layer.n_dimensional = False
+            self.layer.out_of_slice_display = False
 
     def _update_edge_color_gui(self, mode: str):
         """Update the GUI element associated with edge_color.
@@ -258,10 +260,10 @@ class QtVectorsControls(QtLayerControls):
         with self.layer.events.length.blocker():
             self.lengthSpinBox.setValue(self.layer.length)
 
-    def _on_n_dimensional_change(self, event):
+    def _on_out_of_slice_display_change(self, event):
         """Receive layer model n-dimensional change event and update checkbox."""
-        with self.layer.events.n_dimensional.blocker():
-            self.ndimCheckBox.setChecked(self.layer.n_dimensional)
+        with self.layer.events.out_of_slice_display.blocker():
+            self.ndimCheckBox.setChecked(self.layer.out_of_slice_display)
 
     def _on_edge_width_change(self):
         """Receive layer model width change event and update width spinbox."""

--- a/napari/_qt/layer_controls/qt_vectors_controls.py
+++ b/napari/_qt/layer_controls/qt_vectors_controls.py
@@ -35,8 +35,8 @@ class QtVectorsControls(QtLayerControls):
         Layout of Qt widget controls for the layer.
     layer : napari.layers.Vectors
         An instance of a napari Vectors layer.
-    ndimCheckBox : qtpy.QtWidgets.QCheckBox
-        Checkbox to indicate whether layer is n-dimensional.
+    outOfSliceCheckBox : qtpy.QtWidgets.QCheckBox
+        Checkbox to indicate whether to render out of slice.
     lengthSpinBox : qtpy.QtWidgets.QDoubleSpinBox
         Spin box widget controlling line length of vectors.
         Multiplicative factor on projections for length of all vectors.
@@ -102,11 +102,11 @@ class QtVectorsControls(QtLayerControls):
         self.lengthSpinBox.setMaximum(np.inf)
         self.lengthSpinBox.valueChanged.connect(self.change_length)
 
-        ndim_cb = QCheckBox()
-        ndim_cb.setToolTip(trans._('N-dimensional points'))
-        ndim_cb.setChecked(self.layer.out_of_slice_display)
-        ndim_cb.stateChanged.connect(self.change_ndim)
-        self.ndimCheckBox = ndim_cb
+        out_of_slice_cb = QCheckBox()
+        out_of_slice_cb.setToolTip(trans._('Out of slice display'))
+        out_of_slice_cb.setChecked(self.layer.out_of_slice_display)
+        out_of_slice_cb.stateChanged.connect(self.change_out_of_slice)
+        self.outOfSliceCheckBox = out_of_slice_cb
 
         # grid_layout created in QtLayerControls
         # addWidget(widget, row, column, [row_span, column_span])
@@ -124,8 +124,8 @@ class QtVectorsControls(QtLayerControls):
         self.grid_layout.addWidget(self.edgeColorEdit, 5, 1, 1, 2)
         self.grid_layout.addWidget(self.edge_prop_label, 6, 0)
         self.grid_layout.addWidget(self.color_prop_box, 6, 1, 1, 2)
-        self.grid_layout.addWidget(QLabel(trans._('n-dim:')), 7, 0)
-        self.grid_layout.addWidget(self.ndimCheckBox, 7, 1)
+        self.grid_layout.addWidget(QLabel(trans._('out of slice:')), 7, 0)
+        self.grid_layout.addWidget(self.outOfSliceCheckBox, 7, 1)
         self.grid_layout.setRowStretch(8, 1)
         self.grid_layout.setColumnStretch(1, 1)
         self.grid_layout.setSpacing(4)
@@ -204,13 +204,13 @@ class QtVectorsControls(QtLayerControls):
         self.lengthSpinBox.clearFocus()
         self.setFocus()
 
-    def change_ndim(self, state):
-        """Toggle n-dimensional state of vectors layer.
+    def change_out_of_slice(self, state):
+        """Toggle out of slice display of vectors layer.
 
         Parameters
         ----------
         state : QCheckBox
-            Checkbox indicating if vectors layer is n-dimensional.
+            Checkbox to indicate whether to render out of slice.
         """
         if state == Qt.Checked:
             self.layer.out_of_slice_display = True
@@ -261,9 +261,9 @@ class QtVectorsControls(QtLayerControls):
             self.lengthSpinBox.setValue(self.layer.length)
 
     def _on_out_of_slice_display_change(self, event):
-        """Receive layer model n-dimensional change event and update checkbox."""
+        """Receive layer model out_of_slice_display change event and update checkbox."""
         with self.layer.events.out_of_slice_display.blocker():
-            self.ndimCheckBox.setChecked(self.layer.out_of_slice_display)
+            self.outOfSliceCheckBox.setChecked(self.layer.out_of_slice_display)
 
     def _on_edge_width_change(self):
         """Receive layer model width change event and update width spinbox."""

--- a/napari/layers/_tests/test_serialize.py
+++ b/napari/layers/_tests/test_serialize.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 from napari._tests.utils import are_objects_equal, layer_test_data
-from napari.layers import Points
 
 
 @pytest.mark.parametrize('Layer, data, ndim', layer_test_data)

--- a/napari/layers/_tests/test_serialize.py
+++ b/napari/layers/_tests/test_serialize.py
@@ -28,16 +28,6 @@ def test_attrs_arrays(Layer, data, ndim):
     # excluding affine transform and `cache` which is not yet in `_get_state`
     assert len(properties) == len(signature.parameters) - 2
 
-    # remove deprecated properties. We do it here cause we want them to still exist and match
-    # the signature, but we don't want to access or set them, or they would trigger warnings
-    layer_deprecations = {
-        Points: ('n_dimensional',),
-    }
-
-    deprecated = layer_deprecations.get(Layer, ())
-    for dep in deprecated:
-        properties.pop(dep)
-
     # Check new layer can be created
     new_layer = Layer(**properties)
 

--- a/napari/layers/_tests/test_serialize.py
+++ b/napari/layers/_tests/test_serialize.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from napari._tests.utils import are_objects_equal, layer_test_data
+from napari.layers import Points
 
 
 @pytest.mark.parametrize('Layer, data, ndim', layer_test_data)
@@ -26,6 +27,16 @@ def test_attrs_arrays(Layer, data, ndim):
     # Check number of properties is same as number in signature
     # excluding affine transform and `cache` which is not yet in `_get_state`
     assert len(properties) == len(signature.parameters) - 2
+
+    # remove deprecated properties. We do it here cause we want them to still exist and match
+    # the signature, but we don't want to access or set them, or they would trigger warnings
+    layer_deprecations = {
+        Points: ('n_dimensional',),
+    }
+
+    deprecated = layer_deprecations.get(Layer, ())
+    for dep in deprecated:
+        properties.pop(dep)
 
     # Check new layer can be created
     new_layer = Layer(**properties)

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -888,30 +888,30 @@ def test_edge_width():
     assert layer.edge_width == 3
 
 
-def test_n_dimensional():
-    """Test setting n_dimensional flag for 2D and 4D data."""
+def test_out_of_slice_display():
+    """Test setting out_of_slice_display flag for 2D and 4D data."""
     shape = (10, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
     layer = Points(data)
-    assert layer.n_dimensional is False
+    assert layer.out_of_slice_display is False
 
-    layer.n_dimensional = True
-    assert layer.n_dimensional is True
+    layer.out_of_slice_display = True
+    assert layer.out_of_slice_display is True
 
-    layer = Points(data, n_dimensional=True)
-    assert layer.n_dimensional is True
+    layer = Points(data, out_of_slice_display=True)
+    assert layer.out_of_slice_display is True
 
     shape = (10, 4)
     data = 20 * np.random.random(shape)
     layer = Points(data)
-    assert layer.n_dimensional is False
+    assert layer.out_of_slice_display is False
 
-    layer.n_dimensional = True
-    assert layer.n_dimensional is True
+    layer.out_of_slice_display = True
+    assert layer.out_of_slice_display is True
 
-    layer = Points(data, n_dimensional=True)
-    assert layer.n_dimensional is True
+    layer = Points(data, out_of_slice_display=True)
+    assert layer.out_of_slice_display is True
 
 
 @pytest.mark.filterwarnings("ignore:elementwise comparison fail:FutureWarning")
@@ -1690,7 +1690,7 @@ def test_view_data():
 def test_view_size():
     coords = np.array([[0, 1, 1], [0, 2, 2], [1, 3, 3], [3, 3, 3]])
     sizes = np.array([[3, 5, 5], [3, 5, 5], [3, 3, 3], [2, 2, 3]])
-    layer = Points(coords, size=sizes, n_dimensional=False)
+    layer = Points(coords, size=sizes, out_of_slice_display=False)
 
     layer._slice_dims([0, slice(None), slice(None)])
     assert np.all(
@@ -1702,11 +1702,11 @@ def test_view_size():
         layer._view_size == sizes[np.ix_([2], layer._dims_displayed)]
     )
 
-    layer.n_dimensional = True
+    layer.out_of_slice_display = True
     assert len(layer._view_size) == 3
 
     # test a slice with no points
-    layer.n_dimensional = False
+    layer.out_of_slice_display = False
     layer._slice_dims([2, slice(None), slice(None)])
     assert np.all(layer._view_size == [])
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -98,8 +98,8 @@ class Points(Layer):
         The default value is None. If set the none, the clims will be set to
         (property.min(), property.max())
     out_of_slice_display : bool
-        If True, renders points not just in central plane but also in all
-        n-dimensions according to specified point marker size.
+        If True, renders points not just in central plane but also slightly out of slice
+        according to specified point marker size.
     name : str
         Name of the layer.
     metadata : dict
@@ -203,8 +203,8 @@ class Points(Layer):
         Size of the marker edge for the next point to be added or the currently
         selected point.
     out_of_slice_display : bool
-        If True, renders points not just in central plane but also in all
-        n-dimensions according to specified point marker size.
+        If True, renders points not just in central plane but also slightly out of slice
+        according to specified point marker size.
     selected_data : set
         Integer indices of any selected points.
     mode : str
@@ -646,7 +646,7 @@ class Points(Layer):
 
     @property
     def out_of_slice_display(self) -> bool:
-        """bool: renders points as n-dimensional."""
+        """bool: renders points slightly out of slice."""
         return self._out_of_slice_display
 
     @out_of_slice_display.setter

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -15,7 +15,6 @@ from ...utils.colormaps.standardize_color import (
 )
 from ...utils.events import Event
 from ...utils.events.custom_types import Array
-from ...utils.events.event import WarningEmitter
 from ...utils.geometry import project_points_onto_plane, rotate_points
 from ...utils.status_messages import generate_layer_status
 from ...utils.transforms import Affine
@@ -101,6 +100,9 @@ class Points(Layer):
     out_of_slice_display : bool
         If True, renders points not just in central plane but also slightly out of slice
         according to specified point marker size.
+    n_dimensional : bool
+        This property will soon be deprecated in favor of 'out_of_slice_display'.
+        Use that instead.
     name : str
         Name of the layer.
     metadata : dict
@@ -340,13 +342,14 @@ class Points(Layer):
             current_properties=Event,
             symbol=Event,
             out_of_slice_display=Event,
-            n_dimensional=WarningEmitter(
-                trans._(
-                    "'n_dimensional' is deprecated and will be removed in napari v0.5.0, "
-                    "use 'out_of_slice_display' instead."
-                ),
-                type='n_dimensional',
-            ),
+            n_dimensional=Event,
+            # n_dimensional=WarningEmitter(
+            # trans._(
+            # "'n_dimensional' is deprecated and will be removed in napari v0.5.0, "
+            # "use 'out_of_slice_display' instead."
+            # ),
+            # type='n_dimensional',
+            # ),
             highlight=Event,
             shading=Event,
             _antialias=Event,
@@ -429,14 +432,14 @@ class Points(Layer):
         )
 
         if n_dimensional is not None:
-            warnings.warn(
-                trans._(
-                    "'n_dimensional' is deprecated and will be removed in napari v0.5.0, "
-                    "use 'out_of_slice_display' instead."
-                ),
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            # warnings.warn(
+            # trans._(
+            # "'n_dimensional' is deprecated and will be removed in napari v0.5.0, "
+            # "use 'out_of_slice_display' instead."
+            # ),
+            # DeprecationWarning,
+            # stacklevel=2,
+            # )
             self._out_of_slice_display = n_dimensional
         else:
             self._out_of_slice_display = out_of_slice_display
@@ -679,26 +682,29 @@ class Points(Layer):
 
     @property
     def n_dimensional(self) -> bool:
-        warnings.warn(
-            trans._(
-                "'n_dimensional' is deprecated and will be removed in napari v0.5.0, "
-                "use 'out_of_slice_display' instead."
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        """
+        This property will soon be deprecated in favor of `out_of_slice_display`. Use that instead.
+        """
+        # warnings.warn(
+        # trans._(
+        # "'n_dimensional' is deprecated and will be removed in napari v0.5.0, "
+        # "use 'out_of_slice_display' instead."
+        # ),
+        # DeprecationWarning,
+        # stacklevel=2,
+        # )
         return self._out_of_slice_display
 
     @n_dimensional.setter
     def n_dimensional(self, value: bool) -> None:
-        warnings.warn(
-            trans._(
-                "'n_dimensional' is deprecated and will be removed in napari v0.5.0, "
-                "use 'out_of_slice_display' instead."
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        # warnings.warn(
+        # trans._(
+        # "'n_dimensional' is deprecated and will be removed in napari v0.5.0, "
+        # "use 'out_of_slice_display' instead."
+        # ),
+        # DeprecationWarning,
+        # stacklevel=2,
+        # )
         self.out_of_slice_display = value
 
     @property

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -674,6 +674,7 @@ class Points(Layer):
     def out_of_slice_display(self, out_of_slice_display: bool) -> None:
         self._out_of_slice_display = bool(out_of_slice_display)
         self.events.out_of_slice_display()
+        self.events.n_dimensional()
         self.refresh()
 
     @property
@@ -699,7 +700,6 @@ class Points(Layer):
             stacklevel=2,
         )
         self.out_of_slice_display = value
-        self.events.n_dimensional()
 
     @property
     def symbol(self) -> str:

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -97,7 +97,7 @@ class Points(Layer):
         of the specified property that are mapped to 0 and 1, respectively.
         The default value is None. If set the none, the clims will be set to
         (property.min(), property.max())
-    n_dimensional : bool
+    out_of_slice_rendering : bool
         If True, renders points not just in central plane but also in all
         n-dimensions according to specified point marker size.
     name : str
@@ -202,7 +202,7 @@ class Points(Layer):
     current_face_color : str
         Size of the marker edge for the next point to be added or the currently
         selected point.
-    n_dimensional : bool
+    out_of_slice_rendering : bool
         If True, renders points not just in central plane but also in all
         n-dimensions according to specified point marker size.
     selected_data : set
@@ -286,7 +286,7 @@ class Points(Layer):
         face_color_cycle=None,
         face_colormap='viridis',
         face_contrast_limits=None,
-        n_dimensional=False,
+        out_of_slice_rendering=False,
         name=None,
         metadata=None,
         scale=None,
@@ -337,7 +337,7 @@ class Points(Layer):
             properties=Event,
             current_properties=Event,
             symbol=Event,
-            n_dimensional=Event,
+            out_of_slice_rendering=Event,
             highlight=Event,
             shading=Event,
             _antialias=Event,
@@ -364,7 +364,7 @@ class Points(Layer):
 
         # Save the point style params
         self.symbol = symbol
-        self._n_dimensional = n_dimensional
+        self._out_of_slice_rendering = out_of_slice_rendering
         self.edge_width = edge_width
 
         # The following point properties are for the new points that will
@@ -645,14 +645,14 @@ class Points(Layer):
         return extrema
 
     @property
-    def n_dimensional(self) -> bool:
+    def out_of_slice_rendering(self) -> bool:
         """bool: renders points as n-dimensional."""
-        return self._n_dimensional
+        return self._out_of_slice_rendering
 
-    @n_dimensional.setter
-    def n_dimensional(self, n_dimensional: bool) -> None:
-        self._n_dimensional = n_dimensional
-        self.events.n_dimensional()
+    @out_of_slice_rendering.setter
+    def out_of_slice_rendering(self, out_of_slice_rendering: bool) -> None:
+        self._out_of_slice_rendering = out_of_slice_rendering
+        self.events.out_of_slice_rendering()
         self.refresh()
 
     @property
@@ -1057,7 +1057,7 @@ class Points(Layer):
                 'properties': self.properties,
                 'property_choices': self.property_choices,
                 'text': self.text.dict(),
-                'n_dimensional': self.n_dimensional,
+                'out_of_slice_rendering': self.out_of_slice_rendering,
                 'size': self.size,
                 'ndim': self.ndim,
                 'data': self.data,
@@ -1324,7 +1324,7 @@ class Points(Layer):
         slice_indices : list
             Indices of points in the currently viewed slice.
         scale : float, (N, ) array
-            If in `n_dimensional` mode then the scale factor of points, where
+            If in `out_of_slice_rendering` mode then the scale factor of points, where
             values of 1 corresponds to points located in the slice, and values
             less than 1 correspond to points located in neighboring slices.
         """
@@ -1332,7 +1332,7 @@ class Points(Layer):
         not_disp = list(self._dims_not_displayed)
         indices = np.array(dims_indices)
         if len(self.data) > 0:
-            if self.n_dimensional is True and self.ndim > 2:
+            if self.out_of_slice_rendering is True and self.ndim > 2:
                 distances = abs(self.data[:, not_disp] - indices[not_disp])
                 sizes = self.size[:, not_disp] / 2
                 matches = np.all(distances <= sizes, axis=1)

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1104,6 +1104,7 @@ class Points(Layer):
                 'property_choices': self.property_choices,
                 'text': self.text.dict(),
                 'out_of_slice_display': self.out_of_slice_display,
+                'n_dimensional': self.out_of_slice_display,
                 'size': self.size,
                 'ndim': self.ndim,
                 'data': self.data,

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -428,13 +428,6 @@ class Points(Layer):
             properties=color_properties,
         )
 
-        self._shown = np.empty(0).astype(bool)
-        self.size = size
-        self.shown = shown
-        self.experimental_canvas_size_limits = experimental_canvas_size_limits
-        self.shading = shading
-        self._antialias = True
-
         if n_dimensional is not None:
             warnings.warn(
                 trans._(
@@ -447,6 +440,13 @@ class Points(Layer):
             self._n_dimensional = n_dimensional
         else:
             self._out_of_slice_display = out_of_slice_display
+
+        self._shown = np.empty(0).astype(bool)
+        self.size = size
+        self.shown = shown
+        self.experimental_canvas_size_limits = experimental_canvas_size_limits
+        self.shading = shading
+        self._antialias = True
 
         # Trigger generation of view slice and thumbnail
         self._update_dims()

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -432,14 +432,6 @@ class Points(Layer):
         )
 
         if n_dimensional is not None:
-            # warnings.warn(
-            # trans._(
-            # "'n_dimensional' is deprecated and will be removed in napari v0.5.0, "
-            # "use 'out_of_slice_display' instead."
-            # ),
-            # DeprecationWarning,
-            # stacklevel=2,
-            # )
             self._out_of_slice_display = n_dimensional
         else:
             self._out_of_slice_display = out_of_slice_display

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -15,6 +15,7 @@ from ...utils.colormaps.standardize_color import (
 )
 from ...utils.events import Event
 from ...utils.events.custom_types import Array
+from ...utils.events.event import WarningEmitter
 from ...utils.geometry import project_points_onto_plane, rotate_points
 from ...utils.status_messages import generate_layer_status
 from ...utils.transforms import Affine
@@ -287,6 +288,7 @@ class Points(Layer):
         face_colormap='viridis',
         face_contrast_limits=None,
         out_of_slice_display=False,
+        n_dimensional=None,
         name=None,
         metadata=None,
         scale=None,
@@ -338,6 +340,13 @@ class Points(Layer):
             current_properties=Event,
             symbol=Event,
             out_of_slice_display=Event,
+            n_dimensional=WarningEmitter(
+                trans._(
+                    "'n_dimensional' is deprecated and will be removed in napari v0.5.0, "
+                    "use 'out_of_slice_display' instead."
+                ),
+                type='n_dimensional',
+            ),
             highlight=Event,
             shading=Event,
             _antialias=Event,
@@ -364,7 +373,6 @@ class Points(Layer):
 
         # Save the point style params
         self.symbol = symbol
-        self._out_of_slice_display = out_of_slice_display
         self.edge_width = edge_width
 
         # The following point properties are for the new points that will
@@ -426,6 +434,19 @@ class Points(Layer):
         self.experimental_canvas_size_limits = experimental_canvas_size_limits
         self.shading = shading
         self._antialias = True
+
+        if n_dimensional is not None:
+            warnings.warn(
+                trans._(
+                    "'n_dimensional' is deprecated and will be removed in napari v0.5.0, "
+                    "use 'out_of_slice_display' instead."
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self._n_dimensional = n_dimensional
+        else:
+            self._out_of_slice_display = out_of_slice_display
 
         # Trigger generation of view slice and thumbnail
         self._update_dims()
@@ -651,9 +672,34 @@ class Points(Layer):
 
     @out_of_slice_display.setter
     def out_of_slice_display(self, out_of_slice_display: bool) -> None:
-        self._out_of_slice_display = out_of_slice_display
+        self._out_of_slice_display = bool(out_of_slice_display)
         self.events.out_of_slice_display()
         self.refresh()
+
+    @property
+    def n_dimensional(self) -> bool:
+        warnings.warn(
+            trans._(
+                "'n_dimensional' is deprecated and will be removed in napari v0.5.0, "
+                "use 'out_of_slice_display' instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._out_of_slice_display
+
+    @n_dimensional.setter
+    def n_dimensional(self, value: bool) -> None:
+        warnings.warn(
+            trans._(
+                "'n_dimensional' is deprecated and will be removed in napari v0.5.0, "
+                "use 'out_of_slice_display' instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.out_of_slice_display = value
+        self.events.n_dimensional()
 
     @property
     def symbol(self) -> str:

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -97,7 +97,7 @@ class Points(Layer):
         of the specified property that are mapped to 0 and 1, respectively.
         The default value is None. If set the none, the clims will be set to
         (property.min(), property.max())
-    out_of_slice_rendering : bool
+    out_of_slice_display : bool
         If True, renders points not just in central plane but also in all
         n-dimensions according to specified point marker size.
     name : str
@@ -202,7 +202,7 @@ class Points(Layer):
     current_face_color : str
         Size of the marker edge for the next point to be added or the currently
         selected point.
-    out_of_slice_rendering : bool
+    out_of_slice_display : bool
         If True, renders points not just in central plane but also in all
         n-dimensions according to specified point marker size.
     selected_data : set
@@ -286,7 +286,7 @@ class Points(Layer):
         face_color_cycle=None,
         face_colormap='viridis',
         face_contrast_limits=None,
-        out_of_slice_rendering=False,
+        out_of_slice_display=False,
         name=None,
         metadata=None,
         scale=None,
@@ -337,7 +337,7 @@ class Points(Layer):
             properties=Event,
             current_properties=Event,
             symbol=Event,
-            out_of_slice_rendering=Event,
+            out_of_slice_display=Event,
             highlight=Event,
             shading=Event,
             _antialias=Event,
@@ -364,7 +364,7 @@ class Points(Layer):
 
         # Save the point style params
         self.symbol = symbol
-        self._out_of_slice_rendering = out_of_slice_rendering
+        self._out_of_slice_display = out_of_slice_display
         self.edge_width = edge_width
 
         # The following point properties are for the new points that will
@@ -645,14 +645,14 @@ class Points(Layer):
         return extrema
 
     @property
-    def out_of_slice_rendering(self) -> bool:
+    def out_of_slice_display(self) -> bool:
         """bool: renders points as n-dimensional."""
-        return self._out_of_slice_rendering
+        return self._out_of_slice_display
 
-    @out_of_slice_rendering.setter
-    def out_of_slice_rendering(self, out_of_slice_rendering: bool) -> None:
-        self._out_of_slice_rendering = out_of_slice_rendering
-        self.events.out_of_slice_rendering()
+    @out_of_slice_display.setter
+    def out_of_slice_display(self, out_of_slice_display: bool) -> None:
+        self._out_of_slice_display = out_of_slice_display
+        self.events.out_of_slice_display()
         self.refresh()
 
     @property
@@ -1057,7 +1057,7 @@ class Points(Layer):
                 'properties': self.properties,
                 'property_choices': self.property_choices,
                 'text': self.text.dict(),
-                'out_of_slice_rendering': self.out_of_slice_rendering,
+                'out_of_slice_display': self.out_of_slice_display,
                 'size': self.size,
                 'ndim': self.ndim,
                 'data': self.data,
@@ -1324,7 +1324,7 @@ class Points(Layer):
         slice_indices : list
             Indices of points in the currently viewed slice.
         scale : float, (N, ) array
-            If in `out_of_slice_rendering` mode then the scale factor of points, where
+            If in `out_of_slice_display` mode then the scale factor of points, where
             values of 1 corresponds to points located in the slice, and values
             less than 1 correspond to points located in neighboring slices.
         """
@@ -1332,7 +1332,7 @@ class Points(Layer):
         not_disp = list(self._dims_not_displayed)
         indices = np.array(dims_indices)
         if len(self.data) > 0:
-            if self.out_of_slice_rendering is True and self.ndim > 2:
+            if self.out_of_slice_display is True and self.ndim > 2:
                 distances = abs(self.data[:, not_disp] - indices[not_disp])
                 sizes = self.size[:, not_disp] / 2
                 matches = np.all(distances <= sizes, axis=1)

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -437,7 +437,7 @@ class Points(Layer):
                 DeprecationWarning,
                 stacklevel=2,
             )
-            self._n_dimensional = n_dimensional
+            self._out_of_slice_display = n_dimensional
         else:
             self._out_of_slice_display = out_of_slice_display
 

--- a/napari/layers/utils/_link_layers.py
+++ b/napari/layers/utils/_link_layers.py
@@ -9,6 +9,7 @@ from weakref import ReferenceType, ref
 if TYPE_CHECKING:
     from napari.layers import Layer
 
+from ...utils.events.event import WarningEmitter
 from ...utils.translations import trans
 
 #: Record of already linked layers... to avoid duplicating callbacks
@@ -223,7 +224,17 @@ def _get_common_evented_attributes(
             )
         )
 
-    common_events = set.intersection(*(set(lay.events) for lay in layers))
+    layer_events = []
+    for lay in layers:
+        # skip deprecated events
+        layer_events.append(
+            {
+                ev
+                for ev in lay.events
+                if not isinstance(lay.events[ev], WarningEmitter)
+            }
+        )
+    common_events = set.intersection(*layer_events)
     common_attrs = set.intersection(*(set(dir(lay)) for lay in layers))
     if not with_private:
         common_attrs = {x for x in common_attrs if not x.startswith("_")}

--- a/napari/layers/utils/_link_layers.py
+++ b/napari/layers/utils/_link_layers.py
@@ -224,16 +224,13 @@ def _get_common_evented_attributes(
             )
         )
 
-    layer_events = []
-    for lay in layers:
-        # skip deprecated events
-        layer_events.append(
-            {
-                ev
-                for ev in lay.events
-                if not isinstance(lay.events[ev], WarningEmitter)
-            }
-        )
+    layer_events = [
+        {
+            e for e in lay.events
+            if not isinstance(lay.events[e], WarningEmitter)
+        }
+        for lay in layers
+    ]
     common_events = set.intersection(*layer_events)
     common_attrs = set.intersection(*(set(dir(lay)) for lay in layers))
     if not with_private:

--- a/napari/layers/utils/_link_layers.py
+++ b/napari/layers/utils/_link_layers.py
@@ -226,7 +226,8 @@ def _get_common_evented_attributes(
 
     layer_events = [
         {
-            e for e in lay.events
+            e
+            for e in lay.events
             if not isinstance(lay.events[e], WarningEmitter)
         }
         for lay in layers

--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -639,27 +639,27 @@ def test_world_data_extent():
     check_layer_world_data_extent(layer, extent, (3, 1, 1), (10, 20, 5), False)
 
 
-def test_n_dimensional():
-    """Test setting n_dimensional flag for 2D and 4D data."""
+def test_out_of_slice_display():
+    """Test setting out_of_slice_display flag for 2D and 4D data."""
     shape = (10, 2, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
     layer = Vectors(data)
-    assert layer.n_dimensional is False
+    assert layer.out_of_slice_display is False
 
-    layer.n_dimensional = True
-    assert layer.n_dimensional is True
+    layer.out_of_slice_display = True
+    assert layer.out_of_slice_display is True
 
-    layer = Vectors(data, n_dimensional=True)
-    assert layer.n_dimensional is True
+    layer = Vectors(data, out_of_slice_display=True)
+    assert layer.out_of_slice_display is True
 
     shape = (10, 2, 4)
     data = 20 * np.random.random(shape)
     layer = Vectors(data)
-    assert layer.n_dimensional is False
+    assert layer.out_of_slice_display is False
 
-    layer.n_dimensional = True
-    assert layer.n_dimensional is True
+    layer.out_of_slice_display = True
+    assert layer.out_of_slice_display is True
 
-    layer = Vectors(data, n_dimensional=True)
-    assert layer.n_dimensional is True
+    layer = Vectors(data, out_of_slice_display=True)
+    assert layer.out_of_slice_display is True

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -56,7 +56,7 @@ class Vectors(Layer):
         of the specified property that are mapped to 0 and 1, respectively.
         The default value is None. If set the none, the clims will be set to
         (property.min(), property.max())
-    n_dimensional : bool
+    out_of_slice_rendering : bool
         If True, renders vectors not just in central plane but also in all
         n-dimensions according to vectors lengths.
     name : str
@@ -122,7 +122,7 @@ class Vectors(Layer):
         of the specified property that are mapped to 0 and 1, respectively.
         The default value is None. If set the none, the clims will be set to
         (property.min(), property.max())
-    n_dimensional : bool
+    out_of_slice_rendering : bool
         If True, renders vectors not just in central plane but also in all
         n-dimensions according to vectors lengths.
 
@@ -173,7 +173,7 @@ class Vectors(Layer):
         edge_color_cycle=None,
         edge_colormap='viridis',
         edge_contrast_limits=None,
-        n_dimensional=False,
+        out_of_slice_rendering=False,
         length=1,
         name=None,
         metadata=None,
@@ -217,12 +217,12 @@ class Vectors(Layer):
             edge_color=Event,
             edge_color_mode=Event,
             properties=Event,
-            n_dimensional=Event,
+            out_of_slice_rendering=Event,
         )
 
         # Save the vector style params
         self._edge_width = edge_width
-        self._n_dimensional = n_dimensional
+        self._out_of_slice_rendering = out_of_slice_rendering
 
         self._length = float(length)
 
@@ -398,7 +398,7 @@ class Vectors(Layer):
                 'property_choices': self.property_choices,
                 'ndim': self.ndim,
                 'features': self.features,
-                'n_dimensional': self.n_dimensional,
+                'out_of_slice_rendering': self.out_of_slice_rendering,
             }
         )
         return state
@@ -427,14 +427,14 @@ class Vectors(Layer):
         return extrema
 
     @property
-    def n_dimensional(self) -> bool:
+    def out_of_slice_rendering(self) -> bool:
         """bool: renders points as n-dimensionsal."""
-        return self._n_dimensional
+        return self._out_of_slice_rendering
 
-    @n_dimensional.setter
-    def n_dimensional(self, n_dimensional: bool) -> None:
-        self._n_dimensional = n_dimensional
-        self.events.n_dimensional()
+    @out_of_slice_rendering.setter
+    def out_of_slice_rendering(self, out_of_slice_rendering: bool) -> None:
+        self._out_of_slice_rendering = out_of_slice_rendering
+        self.events.out_of_slice_rendering()
         self.refresh()
 
     @property
@@ -642,7 +642,7 @@ class Vectors(Layer):
             Indices of vectors in the currently viewed slice.
         alpha : float, (N, ) array
             The computed, relative opacity of vectors in the current slice.
-            If `n_dimensional` is mode is off, this is always 1.
+            If `out_of_slice_rendering` is mode is off, this is always 1.
             Otherwise, vectors originating in the current slice are assigned a value of 1,
             while vectors passing through the current slice are assigned progressively lower
             values, based on how far from the current slice they originate.
@@ -652,7 +652,7 @@ class Vectors(Layer):
         if len(self.data) > 0:
             data = self.data[:, 0, not_disp]
             distances = abs(data - indices[not_disp])
-            if self.n_dimensional is True:
+            if self.out_of_slice_rendering is True:
                 projected_lengths = abs(
                     self.data[:, 1, not_disp] * self.length
                 )

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -57,8 +57,8 @@ class Vectors(Layer):
         The default value is None. If set the none, the clims will be set to
         (property.min(), property.max())
     out_of_slice_display : bool
-        If True, renders vectors not just in central plane but also in all
-        n-dimensions according to vectors lengths.
+        If True, renders vectors not just in central plane but also slightly out of slice
+        according to specified point marker size.
     name : str
         Name of the layer.
     metadata : dict
@@ -123,8 +123,8 @@ class Vectors(Layer):
         The default value is None. If set the none, the clims will be set to
         (property.min(), property.max())
     out_of_slice_display : bool
-        If True, renders vectors not just in central plane but also in all
-        n-dimensions according to vectors lengths.
+        If True, renders vectors not just in central plane but also slightly out of slice
+        according to specified point marker size.
 
     Notes
     -----
@@ -428,7 +428,7 @@ class Vectors(Layer):
 
     @property
     def out_of_slice_display(self) -> bool:
-        """bool: renders points as n-dimensionsal."""
+        """bool: renders vectors slightly out of slice."""
         return self._out_of_slice_display
 
     @out_of_slice_display.setter

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -56,7 +56,7 @@ class Vectors(Layer):
         of the specified property that are mapped to 0 and 1, respectively.
         The default value is None. If set the none, the clims will be set to
         (property.min(), property.max())
-    out_of_slice_rendering : bool
+    out_of_slice_display : bool
         If True, renders vectors not just in central plane but also in all
         n-dimensions according to vectors lengths.
     name : str
@@ -122,7 +122,7 @@ class Vectors(Layer):
         of the specified property that are mapped to 0 and 1, respectively.
         The default value is None. If set the none, the clims will be set to
         (property.min(), property.max())
-    out_of_slice_rendering : bool
+    out_of_slice_display : bool
         If True, renders vectors not just in central plane but also in all
         n-dimensions according to vectors lengths.
 
@@ -173,7 +173,7 @@ class Vectors(Layer):
         edge_color_cycle=None,
         edge_colormap='viridis',
         edge_contrast_limits=None,
-        out_of_slice_rendering=False,
+        out_of_slice_display=False,
         length=1,
         name=None,
         metadata=None,
@@ -217,12 +217,12 @@ class Vectors(Layer):
             edge_color=Event,
             edge_color_mode=Event,
             properties=Event,
-            out_of_slice_rendering=Event,
+            out_of_slice_display=Event,
         )
 
         # Save the vector style params
         self._edge_width = edge_width
-        self._out_of_slice_rendering = out_of_slice_rendering
+        self._out_of_slice_display = out_of_slice_display
 
         self._length = float(length)
 
@@ -398,7 +398,7 @@ class Vectors(Layer):
                 'property_choices': self.property_choices,
                 'ndim': self.ndim,
                 'features': self.features,
-                'out_of_slice_rendering': self.out_of_slice_rendering,
+                'out_of_slice_display': self.out_of_slice_display,
             }
         )
         return state
@@ -427,14 +427,14 @@ class Vectors(Layer):
         return extrema
 
     @property
-    def out_of_slice_rendering(self) -> bool:
+    def out_of_slice_display(self) -> bool:
         """bool: renders points as n-dimensionsal."""
-        return self._out_of_slice_rendering
+        return self._out_of_slice_display
 
-    @out_of_slice_rendering.setter
-    def out_of_slice_rendering(self, out_of_slice_rendering: bool) -> None:
-        self._out_of_slice_rendering = out_of_slice_rendering
-        self.events.out_of_slice_rendering()
+    @out_of_slice_display.setter
+    def out_of_slice_display(self, out_of_slice_display: bool) -> None:
+        self._out_of_slice_display = out_of_slice_display
+        self.events.out_of_slice_display()
         self.refresh()
 
     @property
@@ -642,7 +642,7 @@ class Vectors(Layer):
             Indices of vectors in the currently viewed slice.
         alpha : float, (N, ) array
             The computed, relative opacity of vectors in the current slice.
-            If `out_of_slice_rendering` is mode is off, this is always 1.
+            If `out_of_slice_display` is mode is off, this is always 1.
             Otherwise, vectors originating in the current slice are assigned a value of 1,
             while vectors passing through the current slice are assigned progressively lower
             values, based on how far from the current slice they originate.
@@ -652,7 +652,7 @@ class Vectors(Layer):
         if len(self.data) > 0:
             data = self.data[:, 0, not_disp]
             distances = abs(data - indices[not_disp])
-            if self.out_of_slice_rendering is True:
+            if self.out_of_slice_display is True:
                 projected_lengths = abs(
                     self.data[:, 1, not_disp] * self.length
                 )


### PR DESCRIPTION
# Description
Following up on [this comment](https://github.com/napari/napari/pull/2902#issuecomment-1020830067). I think we agree on `out_of_slice`; I prefer `rendering` to `display`, but I don't feel strongly about it. Alternatives:

- `out_of_slice_render`
- `out_of_slice_display`
- `render_out_of_slice`
- `display_out_of_slice`
- `out_of_slice`
- ...


Obviously we need to also update the gui, the docs and add deprecations.

cc @jni
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
