### PR TITLE
Only set dims kwargs on viewer after adding layer

### DIFF
--- a/napari/_tests/test_view_layers.py
+++ b/napari/_tests/test_view_layers.py
@@ -159,6 +159,6 @@ def test_kwargs_passed(monkeypatch):
         scale=(1, 2, 3),
     )
     assert viewer_mock.mock_calls == [
-        call(title='my viewer', ndisplay=3),
+        call(title='my viewer'),
         call().open(path='some/path', name='img name', scale=(1, 2, 3)),
     ]

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -16,6 +16,8 @@ import inspect
 
 from numpydoc.docscrape import NumpyDocString as _NumpyDocString
 
+from napari.components.dims import Dims
+
 from .viewer import Viewer
 
 __all__ = [
@@ -107,16 +109,23 @@ def _merge_layer_viewer_sigs_docs(func):
 
 
 _viewer_params = inspect.signature(Viewer).parameters
+_dims_params = inspect.signature(Dims).parameters
 
 
 def _make_viewer_then(add_method: str, args, kwargs) -> Viewer:
     """Utility function that creates a viewer, adds a layer, returns viewer."""
     vkwargs = {k: kwargs.pop(k) for k in list(kwargs) if k in _viewer_params}
+    # separate dims kwargs because we want to set those after adding data
+    dims_kwargs = {
+        k: vkwargs.pop(k) for k in list(vkwargs) if k in _dims_params
+    }
     viewer = Viewer(**vkwargs)
     if 'kwargs' in kwargs:
         kwargs.update(kwargs.pop("kwargs"))
     method = getattr(viewer, add_method)
     method(*args, **kwargs)
+    for arg_name, arg_val in dims_kwargs.items():
+        setattr(viewer.dims, arg_name, arg_val)
     return viewer
 
 


### PR DESCRIPTION
# Description
I lost track of #3344 amid the rush to Christmas, but coming back to it now it seems people liked the suggestion of setting `Dims` attributes on the `Viewer` only *after* data had been loaded by `Viewer.view_*` methods. 

I kept the change pretty minimal, so this should only affect the creation of a `Viewer` via the `view_*` methods. Any non-dims parameters are still passed normally. I've verified that this addresses the issue in #3344, however I'm not sure if there are bigger architecture changes in flux that would address this in a "better" way.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #3344

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
