### PR TITLE
Fix include_package_data inclusion in the "your first plugin" docs page

### DIFF
--- a/docs/plugins/first_plugin.md
+++ b/docs/plugins/first_plugin.md
@@ -206,8 +206,8 @@ Lastly, let's make a few small changes to `setup.cfg`.
    here.  Assume nothing about your user's environment!  Not even napari.)
 
 2. We need to instruct setuptools to *include* that `napari.yaml` file
-   when it bundles our package for distribution, by adding it to the
-   **`[options.package_data]`**
+   when it bundles our package for distribution, by adding
+   **`include_package_data = True`** to the `[options]` section.
 
 3. In order for napari to find our plugin when it's installed in
    the environment, we need to add a `napari.manifest` entry to our
@@ -232,11 +232,9 @@ classifiers =
 
 [options]
 packages = find:
+include_package_data = True
 install_requires =
     napari
-
-[options.package_data]
-napari-hello = napari.yaml
 
 [options.entry_points]
 napari.manifest =


### PR DESCRIPTION
# Description
This adds an important detail to the "your first plugin" page, which was echoing an issue we just discovered in the npe2 branch in the cookiecutter.  `include_package_data = True` must be in the `options` section of `setup.cfg` for all plugins bundling a `napari.yaml`  (this is actually more important than the `[options.package_data]` section)

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
