### PR TITLE
Raise reader plugin errors sooner, (avoid cryptic error messages)

### DIFF
--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from contextlib import suppress
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -37,9 +36,12 @@ def read(
     path: Union[str, Sequence[str]], plugin: Optional[str] = None
 ) -> Optional[Tuple[List[LayerData], _FakeHookimpl]]:
     """Try to return data for `path`, from reader plugins using a manifest."""
-    with suppress(ValueError):
+    try:
         layer_data, reader = read_get_reader(path, plugin_name=plugin)
         return layer_data, _FakeHookimpl(reader.plugin_name)
+    except ValueError as e:
+        if 'No readers returned data' not in str(e):
+            raise e
     return None
 
 


### PR DESCRIPTION
# Description
@Czaki was debugging [this issue from zulip](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/Werid.20localization.20behaviour) with napari-molecule-reader (using the npe2 interface).  The first time he dragged a `pdb` file into napari, the error he saw was:

```
ValueError: There is no registered plugin named 'napari-molecule-reader'.
Names of plugins offering readers are: {'PartSeg Mask project reader', 'builtins', 'PartSeg Analysis project reader', 'PartSeg Masked Tiff reader', 'PartSeg Image reader'}
```

... which makes completely no sense.  What happened was:

1) napari had already selected `napari-molecule-reader` based on the extension (it's npe2).
2) it failed to read because of a strange locale-specific bug in the plugin's dependency
3) napari assumed no readers were found, and fell back to npe1 readers
4) there was no _npe1_ plugin named `napari-molecule-reader` ... hence the confusing error which only lists npe1 readers

**This PR does two things** to generally make plugin errors easier to debug:

- if any exceptions occur in an npe2 plugin, they are raised (the only one that isn't raised at that point is "no reader found"... but once we are [all in on npe2 interface](https://github.com/napari/napari/pull/4015), we can remove that try/except as well)
- this also makes it so that, for npe1 plugins, we only try the first plugin whose `napari_get_reader` returns a callable.  No falling back to look for additional plugins.  If a plugin says "i can do this", we let it try, maybe fail, but that's it. 


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
