### PR TITLE
Update on merge to stack action ordering

### DIFF
--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -121,7 +121,8 @@ def _convert(ll: LayerList, type_: str):
 
 
 def _merge_stack(ll: LayerList, rgb=False):
-    selection = list(ll.selection)
+    # force selection to follow LayerList ordering
+    selection = [layer for layer in ll if layer in ll.selection]
     for layer in selection:
         ll.remove(layer)
     if rgb:


### PR DESCRIPTION
# Description
This PR updates the `_merge_stack` function so the ordering of the slices of the stack is according to the LayerList ordering.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How has this been tested?
- [ ] passes existing tests

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
