### PR TITLE
Update `QtProgressBar` total when `progress` total is changed

### DIFF
--- a/napari/_qt/dialogs/qt_activity_dialog.py
+++ b/napari/_qt/dialogs/qt_activity_dialog.py
@@ -153,6 +153,7 @@ class QtActivityDialog(QDialog):
         prog.events.description.connect(pbar._set_description)
         prog.events.overflow.connect(pbar._make_indeterminate)
         prog.events.eta.connect(pbar._set_eta)
+        prog.events.total.connect(pbar._set_total)
 
         # connect pbar close method if we're closed
         self.destroyed.connect(prog.close)

--- a/napari/_qt/widgets/qt_progress_bar.py
+++ b/napari/_qt/widgets/qt_progress_bar.py
@@ -71,6 +71,9 @@ class QtLabeledProgressBar(QWidget):
     def _set_eta(self, event):
         self.eta_label.setText(event.value)
 
+    def _set_total(self, event):
+        self.setRange(0, event.value)
+
     def _close(self, event):
         super().close()
 

--- a/napari/utils/progress.py
+++ b/napari/utils/progress.py
@@ -75,7 +75,11 @@ class progress(tqdm):
         **kwargs,
     ) -> None:
         self.events = EmitterGroup(
-            value=Event, description=Event, overflow=Event, eta=Event
+            value=Event,
+            description=Event,
+            overflow=Event,
+            eta=Event,
+            total=Event,
         )
         self.nest_under = nest_under
         self.is_init = True
@@ -88,6 +92,15 @@ class progress(tqdm):
 
     def __repr__(self) -> str:
         return self.desc
+
+    @property
+    def total(self):
+        return self._total
+
+    @total.setter
+    def total(self, total):
+        self._total = total
+        self.events.total(value=self.total)
 
     def display(self, msg: str = None, pos: int = None) -> None:
         """Update the display and emit eta event."""


### PR DESCRIPTION
# Description
Addressing the issue discovered in this image.sc thread by emitting an event when `progress.total` is set, and connecting `QtProgressBar` to it.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
