### PR TITLE
avoid repeated computation of layers.extent when adding a new Labels layer

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -293,10 +293,11 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
     def _new_labels(self):
         """Create new labels layer filling full world coordinates space."""
-        extent = self.layers.extent.world
-        scale = self.layers.extent.step
+        layers_extent = self.layers.extent
+        extent = layers_extent.world
+        scale = layers_extent.step
         scene_size = extent[1] - extent[0]
-        corner = extent[0] + 0.5 * self.layers.extent.step
+        corner = extent[0] + 0.5 * layers_extent.step
         shape = [
             np.round(s / sc).astype('int') if s > 0 else 1
             for s, sc in zip(scene_size, scale)


### PR DESCRIPTION
# Description

This is a small change to avoid a couple of repeated computation of the world image extents from the `LayerList` when adding a new Labels layer via the GUI button. This is a somewhat expensive property to compute as it involves looping over all existing layers to determine the global world extent and step size.

The `_new_labels` helper modified here gets called when `QtViewer.layerButtons.newLabelsButton` is pressed.

## Type of change
minor performance refactor

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] existing tests still pass

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
