### PR TITLE
Fix point symbol on instantiation

### DIFF
--- a/napari/_vispy/layers/points.py
+++ b/napari/_vispy/layers/points.py
@@ -68,7 +68,6 @@ class VispyPointsLayer(VispyBaseLayer):
         self.reset()
 
     def _on_symbol_change(self):
-        print('asd')
         self.node.symbol = self.layer.symbol
 
     def _on_highlight_change(self):

--- a/napari/_vispy/layers/points.py
+++ b/napari/_vispy/layers/points.py
@@ -68,6 +68,7 @@ class VispyPointsLayer(VispyBaseLayer):
         self.reset()
 
     def _on_symbol_change(self):
+        print('asd')
         self.node.symbol = self.layer.symbol
 
     def _on_highlight_change(self):
@@ -188,9 +189,8 @@ class VispyPointsLayer(VispyBaseLayer):
     def reset(self):
         super().reset()
         self._update_text(update_node=False)
-        self._on_blending_change()
+        self._on_symbol_change()
         self._on_highlight_change()
-        self._on_matrix_change()
         self._on_antialias_change()
         self._on_shading_change()
         self._on_canvas_size_limits_change()


### PR DESCRIPTION
# Description
Fix #4042.

The issue was not the removed line (which was on purpose, after the uspream changes to `MarkersVisual`), but that we were missing `symbol` from the stuff that gets updated on `reset()`, which is called at the end of instantiation to initialize everything.

Also, I removed `on_matrix_change` [edit: and `on_blending_change`] because that's already in the super calls and it was being called twice!
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
