### PR TITLE
Use python -m pytest with xvfb-action

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -66,14 +66,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      # these libraries, along with pytest-xvfb (added in the `deps` in tox.ini),
-      # enable testing on Qt on linux
-      - name: Install Linux libraries
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 \
-            libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
-            libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0
+      - uses: tlambert03/setup-qt-libs@v1
 
       # strategy borrowed from vispy for installing opengl libs on windows
       - name: Install Windows OpenGL
@@ -135,11 +128,7 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Install Linux libraries
-        run: |
-          sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 \
-            libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
-            libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0
+      - uses: tlambert03/setup-qt-libs@v1
 
       - name: Install this commit
         run: |
@@ -150,4 +139,4 @@ jobs:
       - name: Test
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: pytest --pyargs napari --color=yes
+          run: python -m pytest --pyargs napari --color=yes

--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Test with tox
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: tox
+          run: python -m tox
         env:
           PLATFORM: ${{ matrix.platform }}
           TOXENV: ${{ matrix.toxenv }}

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -29,12 +29,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Install Linux libraries
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 \
-            libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
-            libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0
+      - uses: tlambert03/setup-qt-libs@v1
 
       - name: Install Windows OpenGL
         if: runner.os == 'Windows'

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -47,7 +47,7 @@ jobs:
         # run tests using pip install --pre
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: tox -v --pre
+          run: python -m tox -v --pre
         env:
           PLATFORM: ${{ matrix.platform }}
           BACKEND: ${{ matrix.backend }}

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -95,14 +95,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      # these libraries, along with pytest-xvfb (added in the `deps` in tox.ini),
-      # enable testing on Qt on linux
-      - name: Install Linux libraries
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 \
-            libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
-            libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0
+      - uses: tlambert03/setup-qt-libs@v1
 
       # strategy borrowed from vispy for installing opengl libs on windows
       - name: Install Windows OpenGL
@@ -187,11 +180,7 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Install Linux libraries
-        run: |
-          sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 \
-            libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
-            libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0
+      - uses: tlambert03/setup-qt-libs@v1
 
       - name: Install this commit
         run: |
@@ -202,4 +191,4 @@ jobs:
       - name: Test
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: pytest --pyargs napari --color=yes
+          run: python -m pytest --pyargs napari --color=yes

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Test with tox
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: tox
+          run: python -m tox
         env:
           PLATFORM: ${{ matrix.platform }}
           BACKEND: ${{ matrix.backend }}

--- a/.github/workflows/test_translations.yml
+++ b/.github/workflows/test_translations.yml
@@ -21,7 +21,7 @@ jobs:
           pip install -e .[testing]
       - name: Run check
         run: |
-          pytest -Wignore tools/ --tb=short
+          python -m pytest -Wignore tools/ --tb=short
       - uses: JasonEtco/create-an-issue@v2
         if: ${{ failure() }}
         env:

--- a/tox.ini
+++ b/tox.ini
@@ -80,8 +80,8 @@ commands_pre =
     # the rest is for good measure
     headless: pip uninstall -y pytest-qt qtpy pyqt5 pyside2
 commands =
-    !headless: pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir} --cov-report=xml --cov={env:PYTEST_PATH:napari} --ignore tools {posargs}
-    headless: pytest --color=yes --basetemp={envtmpdir} --ignore napari/_vispy --ignore napari/_qt --ignore napari/_tests --ignore tools {posargs}
+    !headless: python -m pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir} --cov-report=xml --cov={env:PYTEST_PATH:napari} --ignore tools {posargs}
+    headless: python -m pytest --color=yes --basetemp={envtmpdir} --ignore napari/_vispy --ignore napari/_qt --ignore napari/_tests --ignore tools {posargs}
 
 
 [testenv:isort]


### PR DESCRIPTION
# Description
After running a bunch of tests on a fork of the xvfb-action, it looks like it wasn't the version of actions/core or actions/exec that mattered, but something seems to have changed with regards to how the `pytest` command on the command line finds the proper python environment.  Changing to `python -m pytest` fixed it in my tests... lets see if it fixes here as well.

also, taking the opportunity to use `setup-qt-libs` here as well

closes #4031


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
