### PR TITLE
remove leftover comments on `Points.n_dimensional`

### DIFF
--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -677,26 +677,10 @@ class Points(Layer):
         """
         This property will soon be deprecated in favor of `out_of_slice_display`. Use that instead.
         """
-        # warnings.warn(
-        # trans._(
-        # "'n_dimensional' is deprecated and will be removed in napari v0.5.0, "
-        # "use 'out_of_slice_display' instead."
-        # ),
-        # DeprecationWarning,
-        # stacklevel=2,
-        # )
         return self._out_of_slice_display
 
     @n_dimensional.setter
     def n_dimensional(self, value: bool) -> None:
-        # warnings.warn(
-        # trans._(
-        # "'n_dimensional' is deprecated and will be removed in napari v0.5.0, "
-        # "use 'out_of_slice_display' instead."
-        # ),
-        # DeprecationWarning,
-        # stacklevel=2,
-        # )
         self.out_of_slice_display = value
 
     @property

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -343,13 +343,6 @@ class Points(Layer):
             symbol=Event,
             out_of_slice_display=Event,
             n_dimensional=Event,
-            # n_dimensional=WarningEmitter(
-            # trans._(
-            # "'n_dimensional' is deprecated and will be removed in napari v0.5.0, "
-            # "use 'out_of_slice_display' instead."
-            # ),
-            # type='n_dimensional',
-            # ),
             highlight=Event,
             shading=Event,
             _antialias=Event,


### PR DESCRIPTION
# Description
This PR removes some comments leftover from the `Points.n_dimensional` -> `Points.out_of_slice_display` #4007

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
