### PR TITLE
Change from tifffile.imsave to tifffile.imwrite because of deprectaion of first method

### DIFF
--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -54,9 +54,9 @@ def imsave(filename: str, data: np.ndarray):
         if compression_instead_of_compress:
             # 'compression' scheme is more complex. See:
             # https://forum.image.sc/t/problem-saving-generated-labels-in-cellpose-napari/54892/8
-            tifffile.imsave(filename, data, compression=('zlib', 1))
+            tifffile.imwrite(filename, data, compression=('zlib', 1))
         else:  # older version of tifffile since 2021.6.6  this is deprecated
-            tifffile.imsave(filename, data, compress=1)
+            tifffile.imwrite(filename, data, compress=1)
     else:
         import imageio
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

In the last `tifffile` release the `imsave` method was deprecated which causes `fails` of napari tests

```
args = ('/tmp/.tox/py38-linux-pyqt/tmp/test_layers_save0/layers_folder/tmpnrouq_q5/ex_img.tif', array([[0.00619771, 0.9198067... 0.42631844, 0.75095622, 0.34007033, 0.66236025,
          0.88943839, 0.79316199, 0.10159586, 0.44607533, 0.03799265]]))
  kwargs = {'compression': ('zlib', 1)}
  
      def imsave(*args, **kwargs):
          """Deprecated. Use imwrite."""
  >       warnings.warn(
              '<tifffile.imsave> is deprecated. Use tifffile.imwrite',
              DeprecationWarning,
              stacklevel=2,
          )
  E       DeprecationWarning: <tifffile.imsave> is deprecated. Use tifffile.imwrite
  
  /tmp/.tox/py38-linux-pyqt/lib/python3.8/site-packages/tifffile/tifffile.py:985: DeprecationWarning\
```


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
