### PR TITLE
Prevent errors in qt/test_plugin_widgets from installed plugins

### DIFF
--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -97,18 +97,14 @@ def test_plugin_widgets_menus(test_plugin_widgets, make_napari_viewer):
             # this is the separator
             break
     actions = actions[cnt + 1 :]
-    assert len(actions) == 3
-    expected_text = ['TestP1', 'TestP2: Widg3', 'TestP3: magic']
-    assert [a.text() for a in actions] == expected_text
+    texts = [a.text() for a in actions]
+    for t in ['TestP1', 'TestP2: Widg3', 'TestP3: magic']:
+        assert t in texts
 
     # the first item of the plugins is a submenu (for "Test plugin1")
-    assert actions[0].menu()
-    subnames = ['Widg1', 'Widg2']
-    assert [a.text() for a in actions[0].menu().actions()] == subnames
-
-    # the other items for the plugins are not submenus
-    assert not actions[1].menu()
-    assert not actions[2].menu()
+    tp1 = next(m for m in actions if m.text() == 'TestP1')
+    assert tp1.menu()
+    assert [a.text() for a in tp1.menu().actions()] == ['Widg1', 'Widg2']
 
 
 def test_making_plugin_dock_widgets(test_plugin_widgets, make_napari_viewer):
@@ -123,7 +119,8 @@ def test_making_plugin_dock_widgets(test_plugin_widgets, make_napari_viewer):
     actions = actions[cnt + 1 :]
 
     # trigger the 'TestP2: Widg3' action
-    actions[1].trigger()
+    tp2 = next(m for m in actions if m.text().startswith('TestP2'))
+    tp2.trigger()
     # make sure that a dock widget was created
     assert 'TestP2: Widg3' in viewer.window._dock_widgets
     dw = viewer.window._dock_widgets['TestP2: Widg3']
@@ -131,10 +128,11 @@ def test_making_plugin_dock_widgets(test_plugin_widgets, make_napari_viewer):
     # This widget uses the parameter annotation method to receive a viewer
     assert isinstance(dw.widget().viewer, napari.Viewer)
     # Add twice is ok, only does a show
-    actions[1].trigger()
+    tp2.trigger()
 
     # trigger the 'TestP1 > Widg2' action (it's in a submenu)
-    action = actions[0].menu().actions()[1]
+    tp2 = next(m for m in actions if m.text().startswith('TestP1'))
+    action = tp2.menu().actions()[1]
     assert action.text() == 'Widg2'
     action.trigger()
     # make sure that a dock widget was created
@@ -169,7 +167,8 @@ def test_making_function_dock_widgets(test_plugin_widgets, make_napari_viewer):
     actions = actions[cnt + 1 :]
 
     # trigger the 'TestP3: magic' action
-    actions[2].trigger()
+    tp3 = next(m for m in actions if m.text().startswith('TestP3'))
+    tp3.trigger()
     # make sure that a dock widget was created
     assert 'TestP3: magic' in viewer.window._dock_widgets
     dw = viewer.window._dock_widgets['TestP3: magic']
@@ -185,7 +184,7 @@ def test_making_function_dock_widgets(test_plugin_widgets, make_napari_viewer):
     # The function just returns the viewer... make sure we can call it
     assert isinstance(magic_widget(), napari.Viewer)
     # Add twice is ok, only does a show
-    actions[2].trigger()
+    tp3.trigger()
 
 
 def test_inject_viewer_proxy(make_napari_viewer):

--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -101,7 +101,7 @@ def test_plugin_widgets_menus(test_plugin_widgets, make_napari_viewer):
     for t in ['TestP1', 'TestP2: Widg3', 'TestP3: magic']:
         assert t in texts
 
-    # the first item of the plugins is a submenu (for "Test plugin1")
+    # Expect a submenu ("Test plugin1") with particular entries.
     tp1 = next(m for m in actions if m.text() == 'TestP1')
     assert tp1.menu()
     assert [a.text() for a in tp1.menu().actions()] == ['Widg1', 'Widg2']


### PR DESCRIPTION
# Description
small path that makes the test_plugin_widgets test less less prone to fail due to plugins installed in the env.  

can wait till after the release