### PR TITLE
Fix test_kwargs_passed to include viewer kwargs after #4021

### DIFF
--- a/napari/_tests/test_view_layers.py
+++ b/napari/_tests/test_view_layers.py
@@ -159,6 +159,6 @@ def test_kwargs_passed(monkeypatch):
         scale=(1, 2, 3),
     )
     assert viewer_mock.mock_calls == [
-        call(title='my viewer'),
+        call(title='my viewer', ndisplay=3),
         call().open(path='some/path', name='img name', scale=(1, 2, 3)),
     ]


### PR DESCRIPTION
# Description
I'm seeing a consistent local test failure in `_tests/test_view_layers.py::test_kwargs_passed` after #4021. 
Oddly enough, we don't seem to be seeing this on CI, but the local failure seems more "correct" (in that the tested kwargs passed to the viewer constructor are no longer accurate after #4021).  

small fix, let's see if it works equally well on CI