### PR TITLE
Add a `recurse` option to `EventedModel.update`

### DIFF
--- a/napari/utils/events/_tests/test_evented_model.py
+++ b/napari/utils/events/_tests/test_evented_model.py
@@ -9,6 +9,7 @@ import pytest
 from dask import delayed
 from dask.delayed import Delayed
 from pydantic import Field
+from typing_extensions import Protocol, runtime_checkable
 
 from napari.utils.events import EmitterGroup, EventedModel
 from napari.utils.events.custom_types import Array
@@ -239,18 +240,57 @@ def test_values_updated():
 
 
 def test_update_with_inner_model_union():
-    class AltInner(EventedModel):
+    class Inner(EventedModel):
         w: str
 
-    class Inner(EventedModel):
+    class AltInner(EventedModel):
         x: str
 
     class Outer(EventedModel):
         y: int
         z: Union[Inner, AltInner]
 
-    original = Outer(y=1, z=Inner(x='a'))
-    updated = Outer(y=2, z=AltInner(w='b'))
+    original = Outer(y=1, z=Inner(w='a'))
+    updated = Outer(y=2, z=AltInner(x='b'))
+
+    original.update(updated, recurse=False)
+
+    assert original == updated
+
+
+def test_update_with_inner_model_protocol():
+    @runtime_checkable
+    class InnerProtocol(Protocol):
+        def string(self) -> str:
+            ...
+
+        # Protocol fields are not successfully set without explicit validation.
+        @classmethod
+        def __get_validators__(cls):
+            yield cls.validate
+
+        @classmethod
+        def validate(cls, v):
+            return v
+
+    class Inner(EventedModel):
+        w: str
+
+        def string(self) -> str:
+            return self.w
+
+    class AltInner(EventedModel):
+        x: str
+
+        def string(self) -> str:
+            return self.x
+
+    class Outer(EventedModel):
+        y: int
+        z: InnerProtocol
+
+    original = Outer(y=1, z=Inner(w='a'))
+    updated = Outer(y=2, z=AltInner(x='b'))
 
     original.update(updated, recurse=False)
 

--- a/napari/utils/events/_tests/test_evented_model.py
+++ b/napari/utils/events/_tests/test_evented_model.py
@@ -1,6 +1,6 @@
 import inspect
 from enum import auto
-from typing import ClassVar, List, Sequence
+from typing import ClassVar, List, Sequence, Union
 from unittest.mock import Mock
 
 import dask.array as da
@@ -236,6 +236,25 @@ def test_values_updated():
     user1.events.id.assert_not_called()
     user2.events.id.assert_not_called()
     assert user1_events.call_count == 0
+
+
+def test_update_with_inner_model_union():
+    class AltInner(EventedModel):
+        w: str
+
+    class Inner(EventedModel):
+        x: str
+
+    class Outer(EventedModel):
+        y: int
+        z: Union[Inner, AltInner]
+
+    original = Outer(y=1, z=Inner(x='a'))
+    updated = Outer(y=2, z=AltInner(w='b'))
+
+    original.update(updated, recurse=False)
+
+    assert original == updated
 
 
 def test_evented_model_signature():

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -263,7 +263,9 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
         )
         return self.dict()
 
-    def update(self, values: Union['EventedModel', dict]):
+    def update(
+        self, values: Union['EventedModel', dict], recurse: bool = True
+    ) -> None:
         """Update a model in place.
 
         Parameters
@@ -272,6 +274,9 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             Values to update the model with. If an EventedModel is passed it is
             first converted to a dictionary. The keys of this dictionary must
             be found as attributes on the current model.
+        recurse : bool
+            If True, recursively update fields that are EventedModels.
+            Otherwise, just update the immediate fields of this EventedModel.
         """
         if isinstance(values, self.__class__):
             values = values.dict()
@@ -287,7 +292,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
         with self.events.blocker() as block:
             for key, value in values.items():
                 field = getattr(self, key)
-                if isinstance(field, EventedModel):
+                if isinstance(field, EventedModel) and recurse:
                     field.update(value)
                 else:
                     setattr(self, key, value)

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -276,7 +276,9 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             be found as attributes on the current model.
         recurse : bool
             If True, recursively update fields that are EventedModels.
-            Otherwise, just update the immediate fields of this EventedModel.
+            Otherwise, just update the immediate fields of this EventedModel,
+            which is useful when the declared field type (e.g. ``Union``) can have
+            different realized types with different fields.
         """
         if isinstance(values, self.__class__):
             values = values.dict()
@@ -293,7 +295,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             for key, value in values.items():
                 field = getattr(self, key)
                 if isinstance(field, EventedModel) and recurse:
-                    field.update(value)
+                    field.update(value, recurse=recurse)
                 else:
                     setattr(self, key, value)
 


### PR DESCRIPTION
# Description
Adds an option to `EventedModel.update` to not recursively update inner models. This is useful when the inner `EventedModel` field can have different fields itself depending on its exact type.

I encountered this issue while working on style encodings. You can see https://github.com/andy-sweet/napari/pull/2 for more context. I thought it made sense to pull out this small PR to define exactly how we should handle this and not let the change slip through too easily.

I added two tests to cover the specific cases I've encountered: fields with a `Union` or `Protocol` type.

The solution is crude, so I'm definitely open to other ideas.

## Type of change
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Related to #3992 

# How has this been tested?
- [ ] newly added tests pass with my change
- [ ] existing tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
