### PR TITLE
Fix single colormap create

### DIFF
--- a/napari/utils/colormaps/_tests/test_colormap.py
+++ b/napari/utils/colormaps/_tests/test_colormap.py
@@ -96,3 +96,8 @@ def test_colormap_equality():
     cmap_3 = Colormap(colors, name='testing', controls=[0, 0.25, 1])
     assert cmap_1 == cmap_2
     assert cmap_1 != cmap_3
+
+
+def test_colormap_recreate():
+    c_map = Colormap("black")
+    Colormap(**c_map.dict())

--- a/napari/utils/colormaps/colormap.py
+++ b/napari/utils/colormaps/colormap.py
@@ -75,7 +75,7 @@ class Colormap(EventedModel):
             return np.linspace(0, 1, n_controls)
 
         # Check control end points are correct
-        if v[0] != 0 or v[-1] != 1:
+        if v[0] != 0 or (len(v) > 1 and v[-1] != 1):
             raise ValueError(
                 trans._(
                     'Control points must start with 0.0 and end with 1.0. Got {start_control_point} and {end_control_point}',

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -251,18 +251,6 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             ):
                 setattr(self, name, value)
 
-    def asdict(self) -> Dict[str, Any]:
-        """Convert a model to a dictionary."""
-        warnings.warn(
-            trans._(
-                "The `asdict` method has been renamed `dict` and is now deprecated. It will be removed in 0.4.7",
-                deferred=True,
-            ),
-            category=FutureWarning,
-            stacklevel=2,
-        )
-        return self.dict()
-
     def update(self, values: Union['EventedModel', dict]):
         """Update a model in place.
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

I meet this problem with play serialization of colormap on disc. `BaseModel` has `dict` method that allows getting all kwargs needed for construct object, but this does not work for a single color colormap created from the string:

```python
    c_map = Colormap("black")
    Colormap(**c_map.dict())
```


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
