### PR TITLE
Only add progress widget on worker start

### DIFF
--- a/napari/_qt/_tests/test_threading_progress.py
+++ b/napari/_qt/_tests/test_threading_progress.py
@@ -1,6 +1,7 @@
 import pytest
 
 from napari._qt import qthreading
+from napari._qt.widgets.qt_progress_bar import QtLabeledProgressBar
 
 pytest.importorskip(
     'qtpy', reason='Cannot test threading progress without qtpy.'
@@ -133,3 +134,24 @@ def test_function_worker_0_total():
     )
     worker = thread_func()
     assert worker.pbar.total == 0
+
+
+def test_unstarted_worker_no_widget(make_napari_viewer):
+    viewer = make_napari_viewer()
+
+    def func():
+        for _ in range(5):
+            yield
+
+    thread_func = qthreading.thread_worker(
+        func,
+        progress={'total': 5},
+        start_thread=False,
+    )
+
+    thread_func()
+    assert not bool(
+        viewer.window._qt_viewer.window()._activity_dialog.findChildren(
+            QtLabeledProgressBar
+        )
+    )


### PR DESCRIPTION
# Description
Addresses #4038 by only adding progress bar widget to viewer on `worker.start`.

To verify this change addresses the issue you can run the following script - the progress bar widget should only show up when you press `"Run"` on the widget:

```python
from time import sleep
from magicgui import magicgui
import napari
from napari.qt import thread_worker

@thread_worker(
    start_thread=False,
    progress={'total': 5}
)
def get_worker():
    for i in range(5):
        print(i)
        sleep(0.5)
        yield


viewer = napari.Viewer()
my_worker = get_worker()

@magicgui
def start_worker():
    my_worker.start()

viewer.window.add_dock_widget(start_worker)

napari.run()
```

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #4038

# How has this been tested?
- Added test for widget not being added
- Visually confirmed issue is addressed

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
