### PR TITLE
Fix ampersand in sample menu

### DIFF
--- a/napari/_qt/menus/file_menu.py
+++ b/napari/_qt/menus/file_menu.py
@@ -177,7 +177,7 @@ class FileMenu(NapariMenu):
                 menu = self.open_sample_menu
 
             for samp_name, samp_dict in samples.items():
-                display_name = samp_dict['display_name']
+                display_name = samp_dict['display_name'].replace("&", "&&")
                 if multiprovider:
                     action = QAction(display_name, parent=self)
                 else:

--- a/napari/_qt/menus/plugins_menu.py
+++ b/napari/_qt/menus/plugins_menu.py
@@ -78,10 +78,10 @@ class PluginsMenu(NapariMenu):
         for wdg_name in widgets:
             key = (plugin_name, wdg_name)
             if multiprovider:
-                action = QAction(wdg_name, parent=self)
+                action = QAction(wdg_name.replace("&", "&&"), parent=self)
             else:
                 full_name = menu_item_template.format(*key)
-                action = QAction(full_name, parent=self)
+                action = QAction(full_name.replace("&", "&&"), parent=self)
 
             def _add_toggle_widget(*, key=key, hook_type=hook_type):
                 full_name = menu_item_template.format(*key)


### PR DESCRIPTION
# Description
To show a literal ampersand in a QMenu item, you need a double `&&`.  I don't think we want plugin devs to have to do that, so this just replaces `"&"` with `"&&"` before adding to the menu