### PR TITLE
avoid scikit-image deprecation warnings in test suite

### DIFF
--- a/napari/layers/image/_tests/test_image_utils.py
+++ b/napari/layers/image/_tests/test_image_utils.py
@@ -3,6 +3,7 @@ import time
 import dask.array as da
 import numpy as np
 import pytest
+import skimage
 from hypothesis import given
 from hypothesis.extra.numpy import array_shapes
 from skimage.transform import pyramid_gaussian
@@ -52,15 +53,18 @@ def test_guess_multiscale():
     data = tuple(data)
     assert guess_multiscale(data)[0]
 
+    if skimage.__version__ > '0.19':
+        pyramid_kwargs = {'channel_axis': None}
+    else:
+        pyramid_kwargs = {'multichannel': False}
+
     data = tuple(
-        pyramid_gaussian(np.random.random((10, 15)), multichannel=False)
+        pyramid_gaussian(np.random.random((10, 15)), **pyramid_kwargs)
     )
     assert guess_multiscale(data)[0]
 
     data = np.asarray(
-        tuple(
-            pyramid_gaussian(np.random.random((10, 15)), multichannel=False)
-        ),
+        tuple(pyramid_gaussian(np.random.random((10, 15)), **pyramid_kwargs)),
         dtype=object,
     )
     assert guess_multiscale(data)[0]

--- a/napari/layers/image/_tests/test_multiscale.py
+++ b/napari/layers/image/_tests/test_multiscale.py
@@ -1,4 +1,5 @@
 import numpy as np
+import skimage
 from skimage.transform import pyramid_gaussian
 
 from napari._tests.utils import check_layer_world_data_extent
@@ -67,7 +68,13 @@ def test_multiscale_tuple():
     shape = (40, 20)
     np.random.seed(0)
     img = np.random.random(shape)
-    data = list(pyramid_gaussian(img, multichannel=False))
+
+    if skimage.__version__ > '0.19':
+        pyramid_kwargs = {'channel_axis': None}
+    else:
+        pyramid_kwargs = {'multichannel': False}
+
+    data = list(pyramid_gaussian(img, **pyramid_kwargs))
     layer = Image(data)
     assert layer.data == data
     assert layer.multiscale is True


### PR DESCRIPTION
# Description

This PR just modifies a couple of the test suite files to avoid a warning about use of the deprecated `multichannel` argument in scikit-image >= 0.19. 

## Type of change
no user-facing change (minimal test suite change to avoid warnings)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] warnings were no longer present when I tested locally with scikit-image 0.19.1dev

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
