### PR TITLE
Update shapes color mapping when changing property

### DIFF
--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -122,6 +122,25 @@ def test_adding_properties(attribute):
         layer.properties = properties_2
 
 
+def test_colormap_scale_change():
+    data = 20 * np.random.random((10, 4, 2))
+    properties = {'a': np.linspace(0, 1, 10), 'b': np.linspace(0, 100000, 10)}
+    layer = Shapes(data, properties=properties, edge_color='b')
+
+    assert not np.allclose(
+        layer.edge_color[0], layer.edge_color[1], atol=0.001
+    )
+
+    layer.edge_color = 'a'
+
+    # note that VisPy colormaps linearly interpolate by default, so
+    # non-rescaled colors are not identical, but they are closer than 24-bit
+    # color precision can distinguish!
+    assert not np.allclose(
+        layer.edge_color[0], layer.edge_color[1], atol=0.001
+    )
+
+
 def test_data_setter_with_properties():
     """Test layer data on a layer with properties via the data setter"""
     shape = (10, 4, 2)

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1238,7 +1238,7 @@ class Shapes(Layer):
             else:
                 setattr(self, f'_{attribute}_color_mode', ColorMode.CYCLE)
             setattr(self, f'_{attribute}_color_property', color)
-            self.refresh_colors()
+            self.refresh_colors(update_color_mapping=True)
 
         else:
             if len(self.data) > 0:


### PR DESCRIPTION
I was playing around with shapes and property-based colors, and noticed that
the colors depended on the order in which I displayed the properties. It turns
out that it was because the initial scaling from features to colors is created
and fixed on the first property displayed. Instead, I think it should be
updated automatically, since different columns of the property table are in
general on completely different scales.
