### PR TITLE
bump magicgui dep (fix `_normalize_slot` AttributeError and minreqs test)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     imageio>=2.5.0,!=2.11.0
     importlib-metadata>=1.5.0 ; python_version < '3.8'
     jsonschema>=3.2.0
-    magicgui>=0.3.3
+    magicgui>=0.3.6
     napari-console>=0.0.4
     napari-plugin-engine>=0.1.9
     napari-svg>=0.1.4


### PR DESCRIPTION
# Description
magicgui 0.3.6 fixes the issues with `_normalize_slot` AttributeError.  (side note: 0.3.6 will be the last release before 0.4.0, which will remove [the events deprecation strategy](https://github.com/napari/magicgui/pull/253) that caused this 2-repo dance in the first place).

However, our min-reqs tests are still failing because we don't _also_ pin a min psygnal version (so we get old magicgui, but new psygnal).  Rather than bringing psygnal into our min-reqs, I'm just bumping the min required magicgui version