### PR TITLE
MAINT: remove unnecessary lazy imports.

### DIFF
--- a/napari/_qt/dialogs/qt_plugin_report.py
+++ b/napari/_qt/dialogs/qt_plugin_report.py
@@ -16,6 +16,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from ...plugins import plugin_manager
 from ...plugins.exceptions import format_exceptions
 from ...utils.translations import trans
 
@@ -58,7 +59,6 @@ class QtPluginErrReporter(QDialog):
         initial_plugin: Optional[str] = None,
     ) -> None:
         super().__init__(parent)
-        from ...plugins import plugin_manager
 
         self.plugin_manager = plugin_manager
 

--- a/napari/_qt/menus/plugins_menu.py
+++ b/napari/_qt/menus/plugins_menu.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Sequence
 
 from qtpy.QtWidgets import QAction
 
-from ...plugins import _npe2
+from ...plugins import _npe2, plugin_manager
 from ...utils.translations import trans
 from ..dialogs.qt_plugin_dialog import QtPluginDialog
 from ..dialogs.qt_plugin_report import QtPluginErrReporter
@@ -17,8 +17,6 @@ class PluginsMenu(NapariMenu):
     def __init__(self, window: 'Window'):
         self._win = window
         super().__init__(trans._('&Plugins'), window._qt_window)
-
-        from ...plugins import plugin_manager
 
         plugin_manager.discover_widgets()
         plugin_manager.events.disabled.connect(
@@ -54,7 +52,6 @@ class PluginsMenu(NapariMenu):
                 self._win._remove_dock_widget(event=event)
 
     def _add_registered_widget(self, event=None, call_all=False):
-        from ...plugins import plugin_manager
 
         # eg ('dock', ('my_plugin', {'My widget': MyWidget}))
         for hook_type, (plugin_name, widgets) in chain(


### PR DESCRIPTION
Those are unnecessary as the top level import already instantiate
the plugin manager.
