### PR TITLE
remove `--checkout npe2` instructions for cookiecutter in documentation

### DIFF
--- a/docs/plugins/first_plugin.md
+++ b/docs/plugins/first_plugin.md
@@ -271,7 +271,7 @@ management, and deployment hooks.
 
 ```sh
 pip install cookiecutter
-cookiecutter https://github.com/napari/cookiecutter-napari-plugin --checkout npe2
+cookiecutter https://github.com/napari/cookiecutter-napari-plugin
 ```
 
 ## Next Steps


### PR DESCRIPTION
removes old cookiecutter instructions

cc @melissawm (for #4047)