### PR TITLE
reduce NumPy overhead in ScaleTranslate and Affine transform calls

### DIFF
--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -197,14 +197,27 @@ class ScaleTranslate(Transform):
         self.translate = np.array(translate)
 
     def __call__(self, coords):
-        coords = np.atleast_2d(coords)
-        scale = np.concatenate(
-            ([1.0] * (coords.shape[1] - len(self.scale)), self.scale)
-        )
-        translate = np.concatenate(
-            ([0.0] * (coords.shape[1] - len(self.translate)), self.translate)
-        )
-        return np.atleast_1d(np.squeeze(scale * coords + translate))
+        coords = np.asarray(coords)
+        append_first_axis = coords.ndim == 1
+        if append_first_axis:
+            coords = coords[np.newaxis, :]
+
+        coords_ndim = coords.shape[1]
+        if coords_ndim == len(self.scale):
+            scale = self.scale
+            translate = self.translate
+        else:
+            scale = np.concatenate(
+                ([1.0] * (coords_ndim - len(self.scale)), self.scale)
+            )
+            translate = np.concatenate(
+                ([0.0] * (coords_ndim - len(self.translate)), self.translate)
+            )
+        out = scale * coords
+        out += translate
+        if append_first_axis:
+            out = out[0]
+        return out
 
     @property
     def inverse(self) -> 'ScaleTranslate':
@@ -369,15 +382,20 @@ class Affine(Transform):
         self._translate = translate_to_vector(translate, ndim=ndim)
 
     def __call__(self, coords):
-        coords = np.atleast_2d(coords)
+        coords = np.asarray(coords)
+        append_first_axis = coords.ndim == 1
+        if append_first_axis:
+            coords = coords[np.newaxis, :]
         coords_ndim = coords.shape[1]
         padded_linear_matrix = embed_in_identity_matrix(
             self._linear_matrix, coords_ndim
         )
         translate = translate_to_vector(self._translate, ndim=coords_ndim)
-        return np.atleast_1d(
-            np.squeeze(coords @ padded_linear_matrix.T + translate)
-        )
+        out = coords @ padded_linear_matrix.T
+        out += translate
+        if append_first_axis:
+            out = out[0]
+        return out
 
     @property
     def ndim(self) -> int:


### PR DESCRIPTION
# Description

This is a performance-related refactor of the `__call__` method for `Affine` and `ScaleTransform`. It removes calls to `np.atleast_2d`, `np.squeeze` and `np.atleast_1d` to reduce overhead when `coords` is small. The switch to `out += translate` also helps improve efficiency when coords is large.

I benchmarked with `%timeit A(coords)` for coords a single 3-tuple or an ndarray of shape (1000, 3) or (1000000, 3). Results are:

number of 3D coords | transform | duration (main) | duration (PR)
------------|-----------|-----------------|--------------
1 | ScaleTransform | 7.24 µs | 2.62 µs
1 | AffineTransform | 6.4 µs | 4.48 µs
1,000 | ScaleTransform | 16.1 µs | 11.7 µs
1,000 | AffineTransform | 15.7 µs | 14.0 µs
1,000,000 | ScaleTransform | 20.2 ms | 13.1 ms
1,000,000 | AffineTransform | 28.7 ms | 15.9 ms

Another potential change that could be made would be to store private attributes indicating whether all `np.all(scale == 1)` and whether `np.all(translate == 0)`. This would allow skipping the multiplication by `scales` or addition of `translate`, respectively. If the transform is just the identity we could just `return coords.copy()`. Do you think it is worth adding something like that as well?

attn: @andy-sweet, @jni (mentioned earlier today in the architecture group meeting)

## Type of change
minor refactor for performance (no change in behavior)

# References

# How has this been tested?
- [ ] passes existing tests

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
