### PR TITLE
Fix import in plugin_manager that is causing typing fails

### DIFF
--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.util
 import sys
 import warnings
 from functools import partial


### PR DESCRIPTION
# Description

This fixes a fail we're seeing on the `Test typing` CI test:
https://github.com/napari/napari/runs/5232532863?check_suite_focus=true
