### PR TITLE
Try to standardise API as list of strings.

### DIFF
--- a/napari/components/_tests/test_add_layers.py
+++ b/napari/components/_tests/test_add_layers.py
@@ -28,7 +28,7 @@ def test_add_layers_with_plugins(layer_datum):
         MagicMock(return_value=([layer_datum], _testimpl)),
     ):
         v = ViewerModel()
-        v._add_layers_with_plugins('mock_path')
+        v._add_layers_with_plugins(['mock_path'], stack=False)
         layertypes = [layer._type_string for layer in v.layers]
         assert layertypes == [layer_datum[2]]
 
@@ -43,7 +43,7 @@ def test_add_layers_with_plugins(layer_datum):
 def test_plugin_returns_nothing():
     """Test that a plugin returning nothing adds nothing to the Viewer."""
     v = ViewerModel()
-    v._add_layers_with_plugins('mock_path')
+    v._add_layers_with_plugins(['mock_path'], stack=False)
     assert not v.layers
 
 
@@ -87,7 +87,7 @@ def test_add_layers_with_plugins_and_kwargs(layer_data, kwargs):
     ):
 
         v = ViewerModel()
-        v._add_layers_with_plugins('mock_path', kwargs=kwargs)
+        v._add_layers_with_plugins(['mock_path'], kwargs=kwargs, stack=False)
         expected_source = Source(path='mock_path', reader_plugin='testimpl')
         for layer in v.layers:
             for key, val in kwargs.items():

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -893,7 +893,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         if stack:
             return self._add_layers_with_plugins(
                 paths,
-                kwargs,
+                kwargs=kwargs,
                 plugin=plugin,
                 layer_type=layer_type,
                 stack=stack,
@@ -911,7 +911,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
                 added.extend(
                     self._add_layers_with_plugins(
                         [_path],
-                        kwargs,
+                        kwargs=kwargs,
                         plugin=plugin,
                         layer_type=layer_type,
                         stack=stack,
@@ -922,10 +922,11 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
     def _add_layers_with_plugins(
         self,
         paths: List[str],
+        *,
+        stack: bool,
         kwargs: Optional[dict] = None,
         plugin: Optional[str] = None,
         layer_type: Optional[str] = None,
-        stack: bool = None,
     ) -> List[Layer]:
         """Load a path or a list of paths into the viewer using plugins.
 

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -968,11 +968,13 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         assert not isinstance(paths, str)
 
         if stack:
-            layer_data, hookimpl = read_data_with_plugins(paths, plugin=plugin)
+            layer_data, hookimpl = read_data_with_plugins(
+                paths, plugin=plugin, stack=stack
+            )
         else:
             assert len(paths) == 1
             layer_data, hookimpl = read_data_with_plugins(
-                paths[0], plugin=plugin
+                paths, plugin=plugin, stack=stack
             )
 
         # glean layer names from filename. These will be used as *fallback*

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -34,9 +34,7 @@ class _FakeHookimpl:
 
 
 def read(
-    paths: Sequence[str],
-    plugin: Optional[str] = None,
-    stack: bool = None,
+    paths: Sequence[str], plugin: Optional[str] = None, *, stack: bool
 ) -> Optional[Tuple[List[LayerData], _FakeHookimpl]]:
     """Try to return data for `path`, from reader plugins using a manifest."""
     assert stack is not None

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -11,7 +11,6 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
-    Union,
 )
 
 import npe2
@@ -35,11 +34,22 @@ class _FakeHookimpl:
 
 
 def read(
-    path: Union[str, Sequence[str]], plugin: Optional[str] = None
+    paths: Sequence[str],
+    plugin: Optional[str] = None,
+    stack: bool = None,
 ) -> Optional[Tuple[List[LayerData], _FakeHookimpl]]:
     """Try to return data for `path`, from reader plugins using a manifest."""
+    assert stack is not None
+    # the goal here would be to make read_get_reader of npe2 aware of "stack",
+    # and not have this conditional here.
+    # this would also allow the npe2-npe1 shim to do this transform as well
+    if stack:
+        npe1_path = paths
+    else:
+        assert len(paths) == 1
+        npe1_path = paths[0]
     try:
-        layer_data, reader = read_get_reader(path, plugin_name=plugin)
+        layer_data, reader = read_get_reader(npe1_path, plugin_name=plugin)
         return layer_data, _FakeHookimpl(reader.plugin_name)
     except ValueError as e:
         if 'No readers returned data' not in str(e):

--- a/napari/plugins/_tests/test_reader_plugins.py
+++ b/napari/plugins/_tests/test_reader_plugins.py
@@ -16,7 +16,9 @@ def test_builtin_reader_plugin():
         data = np.random.rand(20, 20)
         utils.io.imsave(tmp.name, data)
         tmp.seek(0)
-        layer_data, _ = io.read_data_with_plugins(tmp.name, 'builtins')
+        layer_data, _ = io.read_data_with_plugins(
+            [tmp.name], 'builtins', stack=False
+        )
 
         assert layer_data is not None
         assert isinstance(layer_data, list)
@@ -37,7 +39,9 @@ def test_builtin_reader_plugin_npy():
         data = np.random.rand(20, 20)
         np.save(tmp.name, data)
         tmp.seek(0)
-        layer_data, _ = io.read_data_with_plugins(tmp.name, 'builtins')
+        layer_data, _ = io.read_data_with_plugins(
+            [tmp.name], 'builtins', stack=False
+        )
 
         assert layer_data is not None
         assert isinstance(layer_data, list)
@@ -59,7 +63,7 @@ def test_builtin_reader_plugin_csv(tmpdir):
     data = table[:, 1:]
     # Write csv file
     utils.io.write_csv(tmp, table, column_names=column_names)
-    layer_data, _ = io.read_data_with_plugins(tmp, 'builtins')
+    layer_data, _ = io.read_data_with_plugins([tmp], 'builtins', stack=False)
 
     assert layer_data is not None
     assert isinstance(layer_data, list)
@@ -113,6 +117,6 @@ def test_reader_plugin_can_return_null_layer_sentinel(
 
     monkeypatch.setattr(io, 'plugin_manager', napari_plugin_manager)
 
-    layer_data, _ = io.read_data_with_plugins('')
+    layer_data, _ = io.read_data_with_plugins([''], stack=False)
     assert layer_data is not None
     assert len(layer_data) == 0

--- a/napari/plugins/io.py
+++ b/napari/plugins/io.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 def read_data_with_plugins(
     paths: Sequence[str],
     plugin: Optional[str] = None,
-    stack: bool = None,
+    stack: bool = False,
 ) -> Tuple[Optional[List[LayerData]], Optional[HookImplementation]]:
     """Iterate reader hooks and return first non-None LayerData or None.
 

--- a/napari/plugins/io.py
+++ b/napari/plugins/io.py
@@ -35,8 +35,8 @@ def read_data_with_plugins(
 
     Parameters
     ----------
-    path : str
-        The path (file, directory, url) to open
+    path : str, or list of string
+        The path, or list of path (file, directory, url) to open
     plugin : str, optional
         Name of a plugin to use.  If provided, will force ``path`` to be read
         with the specified ``plugin``.  If the requested plugin cannot read

--- a/napari/plugins/io.py
+++ b/napari/plugins/io.py
@@ -4,7 +4,7 @@ import os
 import pathlib
 import warnings
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple
 
 from napari_plugin_engine import HookImplementation, PluginCallError
 
@@ -20,8 +20,9 @@ if TYPE_CHECKING:
 
 
 def read_data_with_plugins(
-    path: Union[str, Sequence[str]],
+    paths: Sequence[str],
     plugin: Optional[str] = None,
+    stack: bool = None,
 ) -> Tuple[Optional[List[LayerData]], Optional[HookImplementation]]:
     """Iterate reader hooks and return first non-None LayerData or None.
 
@@ -35,12 +36,14 @@ def read_data_with_plugins(
 
     Parameters
     ----------
-    path : str, or list of string
-        The path, or list of path (file, directory, url) to open
+    paths : str, or list of string
+        The of path (file, directory, url) to open
     plugin : str, optional
         Name of a plugin to use.  If provided, will force ``path`` to be read
         with the specified ``plugin``.  If the requested plugin cannot read
         ``path``, a PluginCallError will be raised.
+    stack : bool
+        See `Viewer.open`
 
     Returns
     -------
@@ -57,18 +60,25 @@ def read_data_with_plugins(
     PluginCallError
         If ``plugin`` is specified but raises an Exception while reading.
     """
+    assert isinstance(paths, list)
+    if not stack:
+        assert len(paths) == 1
     hookimpl: Optional[HookImplementation]
-    res = _npe2.read(path, plugin)
+
+    res = _npe2.read(paths, plugin, stack=stack)
     if res is not None:
         _ld, hookimpl = res
         return [] if _is_null_layer_sentinel(_ld) else _ld, hookimpl
 
     hook_caller = plugin_manager.hook.napari_get_reader
-    path = abspath_or_url(path, must_exist=True)
-    if not plugin and isinstance(path, (str, pathlib.Path)):
-        extension = os.path.splitext(path)[-1]
+    paths = [abspath_or_url(p, must_exist=True) for p in paths]
+    if not plugin and (stack is False):
+        extension = os.path.splitext(paths[0])[-1]
         plugin = plugin_manager.get_reader_for_extension(extension)
 
+    # npe1 compact whether we are reading as stack or not is carried in the type
+    # of paths
+    npe1_path = paths if stack else paths[0]
     hookimpl = None
     if plugin:
         if plugin not in plugin_manager.plugins:
@@ -81,19 +91,19 @@ def read_data_with_plugins(
                     names=names,
                 )
             )
-        reader = hook_caller._call_plugin(plugin, path=path)
+        reader = hook_caller._call_plugin(plugin, path=npe1_path)
         if not callable(reader):
             raise ValueError(
                 trans._(
-                    'Plugin {plugin!r} does not support file {path}',
+                    'Plugin {plugin!r} does not support file(s) {paths}',
                     deferred=True,
                     plugin=plugin,
-                    path=path,
+                    paths=paths,
                 )
             )
 
         hookimpl = hook_caller.get_plugin_implementation(plugin)
-        layer_data = reader(path)
+        layer_data = reader(npe1_path)
         # if the reader returns a "null layer" sentinel indicating an empty
         # file, return an empty list, otherwise return the result or None
         if _is_null_layer_sentinel(layer_data):
@@ -102,10 +112,10 @@ def read_data_with_plugins(
         return layer_data or None, hookimpl
 
     layer_data = None
-    result = hook_caller.call_with_result_obj(path=path)
+    result = hook_caller.call_with_result_obj(path=npe1_path)
     reader = result.result  # will raise exceptions if any occurred
     try:
-        layer_data = reader(path)  # try to read data
+        layer_data = reader(npe1_path)  # try to read data
         hookimpl = result.implementation
     except Exception as exc:
         raise PluginCallError(result.implementation, cause=exc)
@@ -114,17 +124,17 @@ def read_data_with_plugins(
         # if layer_data is empty, it means no plugin could read path
         # we just want to provide some useful feedback, which includes
         # whether or not paths were passed to plugins as a list.
-        if isinstance(path, (tuple, list)):
+        if stack:
             message = trans._(
-                'No plugin found capable of reading [{repr_path}, ...] as stack.',
+                'No plugin found capable of reading [{repr_path!r}, ...] as stack.',
                 deferred=True,
-                repr_path=path[0],
+                repr_path=paths[0],
             )
         else:
             message = trans._(
-                'No plugin found capable of reading {repr_path}.',
+                'No plugin found capable of reading {repr_path!r}.',
                 deferred=True,
-                repr_path=repr(path),
+                repr_path=paths,
             )
 
         # TODO: change to a warning notification in a later PR

--- a/napari/utils/_tests/test_misc.py
+++ b/napari/utils/_tests/test_misc.py
@@ -164,10 +164,6 @@ def test_abspath_or_url():
     assert abspath_or_url('ftp://something') == 'ftp://something'
     assert abspath_or_url('s3://something') == 's3://something'
     assert abspath_or_url('file://something') == 'file://something'
-    assert abspath_or_url(('a', '~')) == (abspath('a'), expanduser('~'))
-    assert abspath_or_url(['a', '~']) == [abspath('a'), expanduser('~')]
-
-    assert abspath_or_url(('a', Path('~'))) == (abspath('a'), expanduser('~'))
 
     with pytest.raises(TypeError):
         abspath_or_url({'a', '~'})

--- a/napari/utils/_tests/test_misc.py
+++ b/napari/utils/_tests/test_misc.py
@@ -173,6 +173,11 @@ def test_abspath_or_url():
         abspath_or_url({'a', '~'})
 
 
+def test_type_stable():
+    assert isinstance(abspath_or_url('~'), str)
+    assert isinstance(abspath_or_url(Path('~')), Path)
+
+
 def test_equality_operator():
     import operator
 

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -19,6 +19,7 @@ from typing import (
     Iterable,
     Optional,
     Type,
+    TypeVar,
     Union,
 )
 
@@ -319,7 +320,10 @@ def camel_to_spaces(val):
     return camel_to_spaces_pattern.sub(r" \1", val)
 
 
-def abspath_or_url(relpath: str, *, must_exist: bool = False) -> str:
+T = TypeVar('T', str, Path)
+
+
+def abspath_or_url(relpath: T, *, must_exist: bool = False) -> T:
     """Utility function that normalizes paths or a sequence thereof.
 
     Expands user directory and converts relpaths to abspaths... but ignores
@@ -327,20 +331,24 @@ def abspath_or_url(relpath: str, *, must_exist: bool = False) -> str:
 
     Parameters
     ----------
-    relpath : str
+    relpath : str|Path
         A path, either as string or Path object.
     must_exist : bool, default True
         Raise ValueError if `relpath` is not a URL and does not exist.
 
     Returns
     -------
-    abspath : str
-        An absolute path.
+    abspath : str|Path
+        An absolute path, or list or tuple of absolute paths (same type as
+        input)
     """
     from urllib.parse import urlparse
 
-    if not isinstance(relpath, str):
-        raise TypeError(trans._("Argument must be a string", deferred=True))
+    if not isinstance(relpath, (str, Path)):
+        raise TypeError(
+            trans._("Argument must be a string or Path", deferred=True)
+        )
+    OriginType = type(relpath)
 
     relpath = fspath(relpath)
     urlp = urlparse(relpath)
@@ -356,7 +364,7 @@ def abspath_or_url(relpath: str, *, must_exist: bool = False) -> str:
                 path=path,
             )
         )
-    return path
+    return OriginType(path)
 
 
 class CallDefault(inspect.Parameter):

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -9,7 +9,7 @@ import os
 import re
 import sys
 from enum import Enum, EnumMeta
-from os import PathLike, fspath
+from os import fspath
 from os import path as os_path
 from pathlib import Path
 from typing import (
@@ -18,9 +18,7 @@ from typing import (
     Callable,
     Iterable,
     Optional,
-    Sequence,
     Type,
-    TypeVar,
     Union,
 )
 
@@ -321,10 +319,7 @@ def camel_to_spaces(val):
     return camel_to_spaces_pattern.sub(r" \1", val)
 
 
-T = TypeVar('T', str, Sequence[str])
-
-
-def abspath_or_url(relpath: T, *, must_exist: bool = False) -> T:
+def abspath_or_url(relpath: str, *, must_exist: bool = False) -> str:
     """Utility function that normalizes paths or a sequence thereof.
 
     Expands user directory and converts relpaths to abspaths... but ignores
@@ -332,49 +327,36 @@ def abspath_or_url(relpath: T, *, must_exist: bool = False) -> T:
 
     Parameters
     ----------
-    relpath : str or list or tuple
-        A path, or list or tuple of paths.
+    relpath : str
+        A path, either as string or Path object.
     must_exist : bool, default True
         Raise ValueError if `relpath` is not a URL and does not exist.
 
     Returns
     -------
-    abspath : str or list or tuple
-        An absolute path, or list or tuple of absolute paths (same type as
-        input).
+    abspath : str
+        An absolute path.
     """
     from urllib.parse import urlparse
 
-    if isinstance(relpath, (tuple, list)):
-        return type(relpath)(
-            abspath_or_url(p, must_exist=must_exist) for p in relpath
-        )
+    if not isinstance(relpath, str):
+        raise TypeError(trans._("Argument must be a string", deferred=True))
 
-    if isinstance(relpath, (str, PathLike)):
-        relpath = fspath(relpath)
-        urlp = urlparse(relpath)
-        if urlp.scheme and urlp.netloc:
-            return relpath
+    relpath = fspath(relpath)
+    urlp = urlparse(relpath)
+    if urlp.scheme and urlp.netloc:
+        return relpath
 
-        path = os_path.abspath(os_path.expanduser(relpath))
-        if must_exist and not (
-            urlp.scheme or urlp.netloc or os.path.exists(path)
-        ):
-            raise ValueError(
-                trans._(
-                    "Requested path {path!r} does not exist.",
-                    deferred=True,
-                    path=path,
-                )
+    path = os_path.abspath(os_path.expanduser(relpath))
+    if must_exist and not (urlp.scheme or urlp.netloc or os.path.exists(path)):
+        raise ValueError(
+            trans._(
+                "Requested path {path!r} does not exist.",
+                deferred=True,
+                path=path,
             )
-        return path
-
-    raise TypeError(
-        trans._(
-            "Argument must be a string, PathLike, or sequence thereof",
-            deferred=True,
         )
-    )
+    return path
 
 
 class CallDefault(inspect.Parameter):


### PR DESCRIPTION
# Description

This currently as a few commits in case we want only part of it.

First:

Try to push the stack parameter down in the API 1 level.

This is an attempt to try to simplify the `path_or_paths` in many places
that is tricky to get right. The goal would be to alway pass a list of
strings and a boolean flag as far as possible. We can't go all the way
in particular because of npe1 as this is the API plugin are expecting,
but with npe2 we should be able with a manifest revision to get a new
API for reader/writers which is simpler both for us and plugin writers

Second

Push the stack keyword further down the API.

Here we push the `stack=` Argument further down the API making sure the
object we manipulate are always list of strings.

This allow to simplify even a number of utility functions that actually
were incorrectly typed as they were checking for string/Path, while only
ever strings would be given. The docs was also saying that the output
type would match the input which was technically incorrect as they could
receive a Path, and would have returned a str (or collection thereof),

The last layer (of the API) we may want to push that through is npe2 and npe2 shim
for npe1, at that point all internal call would always be (list_of_str,
bool)


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Part of discussion in https://github.com/napari/npe2/issues/106

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
