### PR TITLE
Only build docs when PR is tagged

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -2,8 +2,9 @@ name: Build Docs
 
 on:
   pull_request:
-    branches:
-      - main
+#    branches:
+#      - main
+    types: [labeled]
   push:
     branches:
       - docs
@@ -11,6 +12,7 @@ on:
 
 jobs:
   build-and-upload-artifact:
+    if: ${{ github.event.label.name == 'build-docs' && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     name: Build & Upload Artifact
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description

We've been eating up git lfs bandwidth like candy and it's [disrupting even non-docs workflows](https://github.com/napari/napari/pull/4030#issuecomment-1043817206). This PR stops building the docs on every push to a PR, instead only building them on-demand when the "build-docs" label is added to the PR. That should temporarily stop the bleeding. Two things to note:

- the action was *supposed* to cache git-lfs content to avoid this situation. Clearly it's not working, or I don't understand how github actions caching works, or both. (Likely both! 😂) There's [breadcrumbs in the action itself](https://github.com/napari/napari/blob/eb9ef90f5de9858523da5a02ab7044427911410c/.github/workflows/build_docs.yml#L17-L21) to investigate this further.
- [non-docs builds](https://github.com/napari/napari/runs/5242457597?check_suite_focus=true#step:4:13) are failing due to LFS bandwidth being exceeded. This should absolutely never happen. We should make sure that git-lfs objects are not downloaded during the normal build process, or this PR does nothing.

I'll make a separate issue to discuss our best path forward.
