### PR TITLE
Don't use git+https to install on CI

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -161,21 +161,24 @@ jobs:
         uses: codecov/codecov-action@v1
 
   test_pip_install:
-    name: ubuntu-latest 3.8 pip install
+    name: ubuntu-latest 3.9 pip install
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 3.8
+      - uses: actions/checkout@v2
+        with:
+          path: napari-from-github
+
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - uses: tlambert03/setup-qt-libs@v1
 
       - name: Install this commit
         run: |
-          # pip install this git sha directly from github
           pip install --upgrade pip
-          pip install git+https://github.com/${{ github.repository }}.git@${{ github.sha }}#egg=napari[all,testing]
+          pip install ./napari-from-github[all,testing]
 
       - name: Test
         uses: GabrielBB/xvfb-action@v1


### PR DESCRIPTION
# Description

This attempts to limit our git-lfs usage by removing a call to `pip install git+https://github.com/napari/napari`, which, it turns out, will download lfs files automatically if git-lfs is installed (which evidently it is, in the ubuntu-latest GitHub Actions image).


Context: #4115, #4114
