### PR TITLE
Contrast limits popup fix

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
@@ -59,7 +59,9 @@ def test_changing_model_updates_view(qtbot, layer):
 
 
 @patch.object(QRangeSliderPopup, 'show')
-@pytest.mark.parametrize('layer', [Image(_IMAGE), Surface(_SURF)])
+@pytest.mark.parametrize(
+    'layer', [Image(_IMAGE), Image(_IMAGE.astype(np.int32)), Surface(_SURF)]
+)
 def test_range_popup_clim_buttons(mock_show, qtbot, layer):
     """The buttons in the clim_popup should adjust the contrast limits value"""
     qtctrl = QtBaseImageControls(layer)
@@ -79,15 +81,16 @@ def test_range_popup_clim_buttons(mock_show, qtbot, layer):
     rangebtn = qtctrl.clim_popup.findChild(
         QPushButton, "full_clim_range_button"
     )
-    # the data we created above was uint16 for Image, and float for Surface
+    # data in this test is uint16 or int32 for Image, and float for Surface.
     # Surface will not have a "full range button"
     if np.issubdtype(layer.dtype, np.integer):
+        info = np.iinfo(layer.dtype)
         rangebtn.click()
         qtbot.wait(20)
-        assert tuple(layer.contrast_limits_range) == (0, 2**16 - 1)
+        assert tuple(layer.contrast_limits_range) == (info.min, info.max)
         min_ = qtctrl.contrastLimitsSlider.minimum()
         max_ = qtctrl.contrastLimitsSlider.maximum()
-        assert (min_, max_) == (0, 2**16 - 1)
+        assert (min_, max_) == (info.min, info.max)
     else:
         assert rangebtn is None
 

--- a/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -242,7 +242,7 @@ class QContrastLimitsPopup(QRangeSliderPopup):
         # the "full range" button doesn't do anything if it's not an
         # unsigned integer type (it's unclear what range should be set)
         # so we don't show create it at all.
-        if np.issubdtype(layer.dtype, np.unsignedinteger):
+        if np.issubdtype(layer.dtype, np.integer):
             range_btn = QPushButton("full range")
             range_btn.setObjectName("full_clim_range_button")
             range_btn.setToolTip(

--- a/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -242,7 +242,7 @@ class QContrastLimitsPopup(QRangeSliderPopup):
         # the "full range" button doesn't do anything if it's not an
         # unsigned integer type (it's unclear what range should be set)
         # so we don't show create it at all.
-        if np.issubdtype(layer.dtype, np.integer):
+        if np.issubdtype(layer.dtype, np.unsignedinteger):
             range_btn = QPushButton("full range")
             range_btn.setObjectName("full_clim_range_button")
             range_btn.setToolTip(

--- a/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -235,7 +235,7 @@ class QContrastLimitsPopup(QRangeSliderPopup):
         reset_btn = QPushButton("reset")
         reset_btn.setObjectName("reset_clims_button")
         reset_btn.setToolTip(trans._("autoscale contrast to data range"))
-        reset_btn.setFixedWidth(40)
+        reset_btn.setFixedWidth(45)
         reset_btn.clicked.connect(reset)
         self._layout.addWidget(reset_btn, alignment=Qt.AlignBottom)
 
@@ -248,7 +248,7 @@ class QContrastLimitsPopup(QRangeSliderPopup):
             range_btn.setToolTip(
                 trans._("set contrast range to full bit-depth")
             )
-            range_btn.setFixedWidth(65)
+            range_btn.setFixedWidth(75)
             range_btn.clicked.connect(layer.reset_contrast_limits_range)
             self._layout.addWidget(range_btn, alignment=Qt.AlignBottom)
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -63,8 +63,11 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         Colormap.
     contrast_limits : list (2,)
         Color limits to be used for determining the colormap bounds for
-        luminance images. If not passed is calculated as the min and max of
-        the image.
+        luminance images. For integer data types it is set to the data type's
+        range. Otherwise, it is calculated as the min and max of the image,
+        although if the image size is sufficiently large, this value
+        is computed from only a subset of the image. If ``rgb`` is `True`,
+        ``contrast_limits`` is ignored.
     gamma : float
         Gamma correction for determining colormap linearity. Defaults to 1.
     interpolation : str
@@ -315,6 +318,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         self._mode = Mode.PAN_ZOOM
         # Whether to calculate clims on the next set_view_slice
         self._should_calc_clims = False
+        self._initial_contrast_limits = None
         if contrast_limits is None:
             if not isinstance(data, np.ndarray):
                 dtype = normalize_dtype(getattr(data, 'dtype', None))
@@ -326,6 +330,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
             else:
                 self.contrast_limits_range = self._calc_data_range()
         else:
+            self._initial_contrast_limits = contrast_limits
             self.contrast_limits_range = contrast_limits
         self._contrast_limits = tuple(self.contrast_limits_range)
         self.colormap = colormap

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -63,11 +63,8 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         Colormap.
     contrast_limits : list (2,)
         Color limits to be used for determining the colormap bounds for
-        luminance images. For integer data types it is set to the data type's
-        range. Otherwise, it is calculated as the min and max of the image,
-        although if the image size is sufficiently large, this value
-        is computed from only a subset of the image. If ``rgb`` is `True`,
-        ``contrast_limits`` is ignored.
+        luminance images. If not passed is calculated as the min and max of
+        the image.
     gamma : float
         Gamma correction for determining colormap linearity. Defaults to 1.
     interpolation : str
@@ -318,7 +315,6 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         self._mode = Mode.PAN_ZOOM
         # Whether to calculate clims on the next set_view_slice
         self._should_calc_clims = False
-        self._initial_contrast_limits = None
         if contrast_limits is None:
             if not isinstance(data, np.ndarray):
                 dtype = normalize_dtype(getattr(data, 'dtype', None))
@@ -330,7 +326,6 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
             else:
                 self.contrast_limits_range = self._calc_data_range()
         else:
-            self._initial_contrast_limits = contrast_limits
             self.contrast_limits_range = contrast_limits
         self._contrast_limits = tuple(self.contrast_limits_range)
         self.colormap = colormap

--- a/napari/layers/intensity_mixin.py
+++ b/napari/layers/intensity_mixin.py
@@ -36,9 +36,12 @@ class IntensityVisualizationMixin:
         self._keep_auto_contrast = False
 
     def reset_contrast_limits(self: 'Image', mode=None):
-        """Scale contrast limits to data range"""
+        """Scale contrast limits to data range or initial contrast_limits"""
         mode = mode or self._auto_contrast_source
-        self.contrast_limits = self._calc_data_range(mode)
+        if getattr(self, '_initial_contrast_limits', None):
+            self.contrast_limits = self._initial_contrast_limits
+        else:
+            self.contrast_limits = self._calc_data_range(mode)
 
     def reset_contrast_limits_range(self):
         """Scale contrast limits range to data type.

--- a/napari/layers/intensity_mixin.py
+++ b/napari/layers/intensity_mixin.py
@@ -36,12 +36,9 @@ class IntensityVisualizationMixin:
         self._keep_auto_contrast = False
 
     def reset_contrast_limits(self: 'Image', mode=None):
-        """Scale contrast limits to data range or initial contrast_limits"""
+        """Scale contrast limits to data range"""
         mode = mode or self._auto_contrast_source
-        if getattr(self, '_initial_contrast_limits', None):
-            self.contrast_limits = self._initial_contrast_limits
-        else:
-            self.contrast_limits = self._calc_data_range(mode)
+        self.contrast_limits = self._calc_data_range(mode)
 
     def reset_contrast_limits_range(self):
         """Scale contrast limits range to data type.

--- a/napari/layers/intensity_mixin.py
+++ b/napari/layers/intensity_mixin.py
@@ -43,10 +43,10 @@ class IntensityVisualizationMixin:
     def reset_contrast_limits_range(self):
         """Scale contrast limits range to data type.
 
-        Currently, this only does something if the data type is an unsigned
-        integer... otherwise it's unclear what the full range should be.
+        Currently, this only does something if the data type is an integer...
+        otherwise it's unclear what the full range should be.
         """
-        if np.issubdtype(self.dtype, np.unsignedinteger):
+        if np.issubdtype(self.dtype, np.integer):
             info = np.iinfo(self.dtype)
             self.contrast_limits_range = (info.min, info.max)
 


### PR DESCRIPTION
# Description
Updates a few things related to the contrast slider pop
1.) Hides "full range" button for signed integers (it does nothing in this case)
2.) Increase button size slightly to avoid truncated text as in the screenshot [here](https://github.com/napari/napari/issues/4112#issue-1142147690)

needs discussion as possibly more controversial:
3.) Change "reset" button behavior to reset to the user-provided contrast limits
e.g. with a layer added via `layer.add_image(image_uint8, contrast_limits=(64, 128))`, reset would restore the range to [64, 128] rather than [0, 255].

## Type of change
mostly bug fix, but item 3 above is a behavior change

# References
closes #4112

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- New test case for "full range" button behavior with a signed integer dtype

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
