### PR TITLE
Prevent deepcopy of layer._source

### DIFF
--- a/napari/layers/_source.py
+++ b/napari/layers/_source.py
@@ -33,6 +33,15 @@ class Source(BaseModel):
         arbitrary_types_allowed = True
         frozen = True
 
+    def __deepcopy__(self, memo):
+        """Custom deepcopy implementation.
+
+        this prevents deep copy. `Source` doesn't really need to be copied
+        (i.e. if we deepcopy a layer, it essentially has the same `Source`).
+        Moreover, deepcopying a widget is challenging, and maybe odd anyway.
+        """
+        return self
+
 
 # layer source context management
 


### PR DESCRIPTION
# Description
Fixes #4127 (transferred from magicgui issues)

`deepcopy(layer)` was failing if `layer.source` came from a magicgui widget.  One way to solve this is to make widgets pickleable.  While that would be possible, in this case, I'm actually not sure we _want_ to create an entirely new widget when a layer is duplicated, so i think the more appropriate fix here is to just prevent deepcopy on a `Source` object.  this would mean that `deepcopy(layer).source is layer.source`, which actually makes sense.

Side note: we definitely do need deepcopy though, otherwise if you edit the data of the duplicated layer, you'll edit the original layer, which presumably defeats the purpose of the dupe.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
