### PR TITLE
Always pass list of strings to npe2.

### DIFF
--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -201,7 +201,7 @@ def get_readers(path: str) -> Dict[str, str]:
     pm = npe2.PluginManager.instance()
     return {
         pm.get_manifest(reader.command).display_name: reader.plugin_name
-        for reader in pm.iter_compatible_readers(path)
+        for reader in pm.iter_compatible_readers([path])
     }
 
 


### PR DESCRIPTION
iter_compatible_readers takes either a string or a list of strings
we are trying to standardise on only accepting list of strings.
The behavior in passing a string or a list with 1 item is the same as
iter_compatible_readers will just check that all the items have the
same extensions and then use only the first item to find compatible
readers.

With this change we can change the api of npe2 to stop accepting strings
by only touching the npe2 repo



# References

#4107

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
