### PR TITLE
Don't validate defaults on `EventedModel`

### DIFF
--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -776,3 +776,9 @@ def test_status_tooltip(Layer, data, ndim):
     viewer.layers.append(layer)
     viewer.cursor.position = (1,) * ndim
     viewer._on_cursor_position_change()
+
+
+def test_viewer_object_event_sources():
+    viewer = ViewerModel()
+    assert viewer.cursor.events.source is viewer.cursor
+    assert viewer.camera.events.source is viewer.camera

--- a/napari/layers/utils/_string_encoding.py
+++ b/napari/layers/utils/_string_encoding.py
@@ -23,7 +23,7 @@ StringArray = Array[str, (-1,)]
 
 
 """The default string value, which may also be used a safe fallback string."""
-DEFAULT_STRING = ''
+DEFAULT_STRING = np.array('', dtype='<U1')
 
 
 @runtime_checkable

--- a/napari/layers/utils/color_manager.py
+++ b/napari/layers/utils/color_manager.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple, Union
 
 import numpy as np
-from pydantic import root_validator, validator
+from pydantic import Field, root_validator, validator
 
 from ...utils.colormaps import Colormap
 from ...utils.colormaps.categorical_colormap import CategoricalColormap
@@ -151,7 +151,9 @@ class ColorManager(EventedModel):
     categorical_colormap: CategoricalColormap = CategoricalColormap.from_array(
         [0, 0, 0, 1]
     )
-    colors: Array[float, (-1, 4)] = np.empty((0, 4))
+    colors: Array[float, (-1, 4)] = Field(
+        default_factory=lambda: np.empty((0, 4))
+    )
 
     # validators
     @validator('continuous_colormap', pre=True)
@@ -159,7 +161,7 @@ class ColorManager(EventedModel):
         return ensure_colormap(v)
 
     @validator('colors', pre=True)
-    def _ensure_color_array(cls, v, values):
+    def _ensure_color_array(cls, v):
         if len(v) > 0:
             return transform_color(v)
         else:

--- a/napari/layers/utils/color_manager.py
+++ b/napari/layers/utils/color_manager.py
@@ -146,16 +146,17 @@ class ColorManager(EventedModel):
     current_color: Optional[Array[float, (4,)]] = None
     color_mode: ColorMode = ColorMode.DIRECT
     color_properties: Optional[ColorProperties] = None
-    continuous_colormap: Colormap = 'viridis'
+    continuous_colormap: Colormap = ensure_colormap('viridis')
     contrast_limits: Optional[Tuple[float, float]] = None
-    categorical_colormap: CategoricalColormap = [0, 0, 0, 1]
-    colors: Array[float, (-1, 4)] = []
+    categorical_colormap: CategoricalColormap = CategoricalColormap.from_array(
+        [0, 0, 0, 1]
+    )
+    colors: Array[float, (-1, 4)] = np.empty((0, 4))
 
     # validators
     @validator('continuous_colormap', pre=True)
     def _ensure_continuous_colormap(cls, v):
-        coerced_colormap = ensure_colormap(v)
-        return coerced_colormap
+        return ensure_colormap(v)
 
     @validator('colors', pre=True)
     def _ensure_color_array(cls, v, values):

--- a/napari/utils/colormaps/categorical_colormap.py
+++ b/napari/utils/colormaps/categorical_colormap.py
@@ -26,12 +26,11 @@ class CategoricalColormap(EventedModel):
     """
 
     colormap: Dict[Any, Array[np.float32, (4,)]] = {}
-    fallback_color: ColorCycle = 'white'
+    fallback_color: ColorCycle = ColorCycle.validate_type('white')
 
     @validator('colormap', pre=True)
     def _standardize_colormap(cls, v):
-        transformed_colormap = {k: transform_color(v)[0] for k, v in v.items()}
-        return transformed_colormap
+        return {k: transform_color(v)[0] for k, v in v.items()}
 
     def map(self, color_properties: Union[list, np.ndarray]) -> np.ndarray:
         """Map an array of values to an array of colors

--- a/napari/utils/events/_tests/test_evented_model.py
+++ b/napari/utils/events/_tests/test_evented_model.py
@@ -74,7 +74,7 @@ def test_evented_model_with_array():
     """Test creating an evented pydantic model with an array."""
 
     def make_array():
-        return np.array([4, 3])
+        return np.array([[4, 3]])
 
     class Model(EventedModel):
         """Demo evented model."""

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -181,7 +181,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
         # https://pydantic-docs.helpmanual.io/usage/models/#private-model-attributes
         underscore_attrs_are_private = True
         # whether to validate field defaults (default: False)
-        validate_all = True
+        validate_all = False
         # https://pydantic-docs.helpmanual.io/usage/exporting_models/#modeljson
         # NOTE: json_encoders are also added EventedMetaclass.__new__ if the
         # field declares a _json_encode method.

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -156,6 +156,11 @@ def _get_field_dependents(cls: 'EventedModel') -> Dict[str, Set[str]]:
 
 
 class EventedModel(BaseModel, metaclass=EventedMetaclass):
+    """A Model subclass that emits an event whenever a field value is changed.
+
+    Note: As per the standard pydantic behavior, default Field values are
+    not validated (#4138) and should be correctly typed.
+    """
 
     # add private attributes for event emission
     _events: EmitterGroup = PrivateAttr(default_factory=EmitterGroup)

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -181,6 +181,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
         # https://pydantic-docs.helpmanual.io/usage/models/#private-model-attributes
         underscore_attrs_are_private = True
         # whether to validate field defaults (default: False)
+        # see https://github.com/napari/napari/pull/4138 before changing.
         validate_all = False
         # https://pydantic-docs.helpmanual.io/usage/exporting_models/#modeljson
         # NOTE: json_encoders are also added EventedMetaclass.__new__ if the


### PR DESCRIPTION
# Description
This one is rather crazy and took me a long time to debug, and it's equally hard to explain.   @brisvag cued me into this when using the event debugger, and noticing that cursor event objects didn't know their "source"

### problem

all `EventedModel` types used as subfields on pydantic Models are losing their `event.source`.  For example, see here, where `viewer.cursor.events` doesn't have a source, but a plain `Cursor` object _does_.

```python
In [1]: v = napari.Viewer()

In [2]: v.cursor.events.source

In [3]: from napari.components.cursor import Cursor

In [4]: c = Cursor()

In [5]: c.events.source
Out[5]: Cursor(position=(1.0, 1.0), scaled=True, size=1, style=<CursorStyle.STANDARD: 'standard'>)
```

### rough explanation

Ultimately, this is the combined result of `validate_all=True` used on `EventedModel`  (which "validates defaults" upon object creation, and which can result in the creation of a new object for that field)... **_combined_** with the fact that `events.Emitter` stores the source as a `weakref.ref` (right [here](https://github.com/tlambert03/napari/blob/d710c9425275a68d179df9e2ed101c2e7f58f2c6/napari/utils/events/event.py#L370)).  It appears that the object is getting garbage collected during the default validation before it even has time to exist.  

The problem is fixed _either_ by using `validate_all=False` in the `EventedModel` config, or by storing a strong reference as `Emitter.source`.  

That strong reference seems like a very bad idea, so this PR avoids validating defaults on EventedModels.  This just means that we can't be lazy when we declare a model... and the default or default_factory we provide should actually be correct.


### mre

The following script is the most minimal reproducible example I could make.  It uses no napari objects, just mocks the bare minimum.  I'm putting it here so that if we ever want to undo this change, this script can be used as a test case.

<details>

```python
from pydantic import BaseModel, Field, PrivateAttr
from typing import Any, ClassVar, Set
import weakref


class EmitterGroup:
    def __init__(self):
        self.source = None

    @property
    def source(self) -> Any:
        return None if self._source is None else self._source()

    @source.setter
    def source(self, s):
        self._source = None if s is None else weakref.ref(s)



class EventedModel(BaseModel):

    # add private attributes for event emission
    _events: EmitterGroup = PrivateAttr(default_factory=EmitterGroup)
    __slots__: ClassVar[Set[str]] = {"__weakref__"}

    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self._events.source = self

    @property
    def events(self):
        return self._events


class Cursor(EventedModel):
    x: int = 1


class Mod(BaseModel):
    curs: Cursor = Field(default_factory=Cursor)

    class Config:
        validate_all = True


obj = Mod()

print(id(obj.curs.events.source), id(obj.curs))
print("Are same?: ", obj.curs.events.source is obj.curs)
```

</details>