### PR TITLE
Attempt at viewer capturing caller.

### DIFF
--- a/examples/update_console.py
+++ b/examples/update_console.py
@@ -1,5 +1,5 @@
 """
-Display one shapes layer ontop of one image layer using the add_shapes and
+Display one shapes layer on top of one image layer using the add_shapes and
 add_image APIs. When the window is closed it will print the coordinates of
 your shapes.
 """
@@ -10,6 +10,13 @@ import napari
 
 
 # create the viewer and window
+#
+# Creating the viewer will try to keep a reference to the first higher scope
+# that is not inside napari related code, and inject the locals into the jupyter
+# console namespace. This means that runing this example and opening the console
+# you will see `polygons`, `shapes_layer`, `data`, `photographer` ... as
+# variables.
+#
 viewer = napari.Viewer()
 
 # add the image
@@ -69,7 +76,5 @@ shapes_layer = viewer.add_shapes(
     name='shapes',
 )
 
-# Send local variables to the console
-viewer.update_console(locals())
 
 napari.run()

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -438,6 +438,7 @@ class QtViewer(QSplitter):
                     self.console.push(
                         {'napari': napari, 'action_manager': action_manager}
                     )
+                self.console.push(self.viewer._caller_frame_locals)
             except ImportError:
                 warnings.warn(
                     trans._(

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -65,7 +65,7 @@ class Viewer(ViewerModel):
         self._window = Window(self, show=show)
         self._instances.add(self)
         if console_local_update:
-            self._caller_frame_locals = self._find_calling_frame.f_locals
+            self._caller_frame_locals = self._find_calling_frame().f_locals
         else:
             self._caller_frame_locals = {}
 


### PR DESCRIPTION
See #4098,

I'm not a huge fan as I'm scared of leaks, but ti seem to be what people
expect.

I'm tempted to think that `update_console()` should keep a hard
reference on the objects that were given to it until the console is
opened.

I'm not sure if the behavior should be enabled by default, or now.
I've enabled it by default so that all the convenience method that
return a viewer also capture local variables.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
Manually running `napari examples/update_console.py`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).

I'm not sure how to test this, and/or if/where we want to document this.
