### PR TITLE
Update installation docs to use git clone instead of `pip install git+` (for LFS)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -126,7 +126,10 @@ To install the current `main` branch on github (which will usually be ahead
 of the latest release on pypi)
 
 ```sh
-pip install "git+https://github.com/napari/napari.git#egg=napari[all]"
+git clone https://github.com/napari/napari.git
+pip install "./napari[all]"
+# optionally
+rm -rf ./napari
 ```
 
 For more information or troubleshooting see our [installation

--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -120,7 +120,10 @@ conda update napari
 To install the latest version with yet to be released features from github via pip, call
 
 ```sh
-python -m pip install "git+https://github.com/napari/napari.git#egg=napari[all]"
+git clone https://github.com/napari/napari.git
+pip install "./napari[all]"
+# optionally
+rm -rf ./napari
 ```
 ````
 


### PR DESCRIPTION
# Description
more LFS bandwidth stuff... This changes how we suggest people install the latest version from `main`