### PR TITLE
support conda-style (pyside2-)rcc locations

### DIFF
--- a/napari/_qt/qt_resources/_icons.py
+++ b/napari/_qt/qt_resources/_icons.py
@@ -202,7 +202,20 @@ def _compile_qrc_pyqt6(qrc) -> bytes:
     raise NotImplementedError('pyrcc discontinued on Pyqt6')
 
 
-def _find_pyside2_rcc():
+def _find_pyside2_rcc() -> Iterable[Tuple[str, str]]:
+    """
+    Return possible search paths for (pyside2-)rcc.
+
+    Note pyside2-rcc needs to be checked before the
+    "pure" rcc so we don't take an older qt's rcc
+    by mistake (with no -g support).
+
+    The binaries can be found in PySide2's directory
+    under site-packages (pip installs), or under a
+    directory immediately under sys.prefix (conda installs).
+    This subdirectory is platform dependent: `bin/` on Unix,
+    `Scripts/` (sometimes `Library/bin/` too) on Windows.
+    """
     import sys
     from itertools import product
 

--- a/napari/_qt/qt_resources/_icons.py
+++ b/napari/_qt/qt_resources/_icons.py
@@ -214,13 +214,17 @@ def _compile_qrc_pyside2(qrc) -> bytes:
     import PySide2
 
     pyside_root = Path(PySide2.__file__).parent
-    python_root = Path(sys.executable).parent
-    directories = pyside_root, python_root
 
     if os.name == 'nt':
         executables = ('pyside2-rcc.exe', 'rcc.exe')
+        directories = (
+            pyside_root,
+            Path(sys.prefix, 'Scripts'),
+            Path(sys.prefix, 'Library', 'bin')
+        )
     else:
         executables = ('pyside2-rcc', 'rcc')
+        directories = pyside_root, Path(sys.executable).parent
 
     for directory, executable in product(directories, executables):
         path = Path(directory, executable)

--- a/napari/_qt/qt_resources/_icons.py
+++ b/napari/_qt/qt_resources/_icons.py
@@ -219,10 +219,9 @@ def _find_pyside2_rcc():
         executables = ('pyside2-rcc', 'rcc')
         directories = (
             Path(PySide2.__file__).parent,
-            Path(sys.executable).parent
+            Path(sys.executable).parent,
         )
     return product(directories, executables)
-
 
 
 def _compile_qrc_pyside2(qrc) -> bytes:

--- a/napari/_qt/qt_resources/_icons.py
+++ b/napari/_qt/qt_resources/_icons.py
@@ -220,7 +220,7 @@ def _compile_qrc_pyside2(qrc) -> bytes:
         directories = (
             pyside_root,
             Path(sys.prefix, 'Scripts'),
-            Path(sys.prefix, 'Library', 'bin')
+            Path(sys.prefix, 'Library', 'bin'),
         )
     else:
         executables = ('pyside2-rcc', 'rcc')

--- a/napari/_qt/qt_resources/_icons.py
+++ b/napari/_qt/qt_resources/_icons.py
@@ -207,9 +207,9 @@ def _compile_qrc_pyside2(qrc) -> bytes:
     PySide compiles qrc files using the rcc binary in the root directory, (same
     path as PySide2.__init__)
     """
-    from subprocess import CalledProcessError, run
-    from itertools import product
     import sys
+    from itertools import product
+    from subprocess import CalledProcessError, run
 
     import PySide2
 

--- a/napari/_qt/qt_resources/_icons.py
+++ b/napari/_qt/qt_resources/_icons.py
@@ -29,7 +29,6 @@ inputs.
 """
 
 import os
-import sys
 from contextlib import contextmanager
 from itertools import product
 from pathlib import Path
@@ -255,8 +254,8 @@ def _compile_qrc_pyside2(qrc) -> bytes:
             break
     else:
         raise RuntimeError(
-            f"PySide2 rcc binary not found in any of the expected paths: "
-            ", ".join(Path(*parts) for parts in _find_pyside2_rcc())
+            "PySide2 rcc binary not found in any of the expected paths: "
+            ", ".join(f"'{Path(*parts)}'" for parts in _find_pyside2_rcc())
         )
 
     try:

--- a/napari/_qt/qt_resources/_tests/test_icons.py
+++ b/napari/_qt/qt_resources/_tests/test_icons.py
@@ -6,3 +6,14 @@ def test_icon_hash_equality():
     dir_hash_result = dir_hash(ICON_PATH)
     paths_hash_result = paths_hash(ICONS.values())
     assert dir_hash_result == paths_hash_result
+
+
+def test_pyside2_rcc_first():
+    """
+    Ensure pyside2-rcc is checked before rcc. Otherwise
+    we might use an older qt's rcc with no -g support.
+    """
+    from napari._qt.qt_resources._icons import _find_pyside2_rcc
+
+    exe_name = next(exe for _, exe in _find_pyside2_rcc())
+    assert "pyside2-" in exe_name

--- a/napari/_qt/qt_resources/_tests/test_icons.py
+++ b/napari/_qt/qt_resources/_tests/test_icons.py
@@ -17,6 +17,7 @@ def test_pyside2_rcc_first():
     """
     try:
         from napari._qt.qt_resources._icons import _find_pyside2_rcc
+
         exe_name = next(exe for _, exe in _find_pyside2_rcc())
         assert "pyside2-" in exe_name
     except ModuleNotFoundError as exc:

--- a/napari/_qt/qt_resources/_tests/test_icons.py
+++ b/napari/_qt/qt_resources/_tests/test_icons.py
@@ -1,3 +1,5 @@
+import pytest
+
 from napari.resources._icons import ICON_PATH, ICONS
 from napari.utils.misc import dir_hash, paths_hash
 
@@ -13,7 +15,11 @@ def test_pyside2_rcc_first():
     Ensure pyside2-rcc is checked before rcc. Otherwise
     we might use an older qt's rcc with no -g support.
     """
-    from napari._qt.qt_resources._icons import _find_pyside2_rcc
-
-    exe_name = next(exe for _, exe in _find_pyside2_rcc())
-    assert "pyside2-" in exe_name
+    try:
+        from napari._qt.qt_resources._icons import _find_pyside2_rcc
+        exe_name = next(exe for _, exe in _find_pyside2_rcc())
+        assert "pyside2-" in exe_name
+    except ModuleNotFoundError as exc:
+        if exc.name == "PySide2":
+            pytest.xfail("Test requires PySide2")
+        raise exc


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

I ran into same error as #3713 while testing new features in the bundle. conda's pyside will place their binaries in `$CONDA_PREFIX/bin`,  not `$SITE_PACKAGES/pyside2`. This adds the needed logic to search there as well.

However, `$CONDA_PREFIX/bin` will also list `qt`'s `rcc`, which is not compatible with pyside's in version 5.12 (`-g` flag missing). This means we need to try `pyside2-rcc` first, and _then_ `rcc`. I am unaware of the impact of this change beyond conda's so please review carefully!

We can also list the possible paths explicitly in the loop, like:

* `$SITE_PACKAGES/pyside2/rcc`
* `$SITE_PACKAGES/pyside2/pyside2-rcc`
* `$CONDA_PREFIX/bin/pyside2-rcc`
* `$CONDA_PREFIX/bin/rcc`

I also added more explicit output in the exception to understand what's going on with the error.

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [?] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [X] Bundled napari opens successfully with this change

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
