### PR TITLE
Use napari-sphinx-theme in docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ external_toc_exclude_missing = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'pydata_sphinx_theme'
+html_theme = 'napari_sphinx_theme'
 html_theme_options = {
     "external_links": [
         {"name": "napari hub", "url": "https://napari-hub.org"}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ external_toc_exclude_missing = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'napari_sphinx_theme'
+html_theme = 'napari'
 html_theme_options = {
     "external_links": [
         {"name": "napari hub", "url": "https://napari-hub.org"}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,5 @@ Jinja2
 sphinx-tabs
 sphinx-panels
 myst-nb
-pydata-sphinx-theme==0.8.0
+napari-sphinx-theme
 sphinx-external-toc

--- a/setup.cfg
+++ b/setup.cfg
@@ -132,7 +132,7 @@ docs =
     sphinx-tabs
     sphinx-panels
     myst-nb
-    pydata-sphinx-theme==0.8.0
+    napari-sphinx-theme
     sphinx-external-toc
 build =
     black


### PR DESCRIPTION
# Description
We need to deploy our new docs build before the next release candidate, Mar 1. Ideally, we should be using the new theme. Currently, this PR doesn't build for me locally, with the error:

```
no theme named 'napari_sphinx_theme' found (missing theme.conf?)
```

But opening as a way to start the process/discussion.

CC @codemonkey800 @tlambert03 
