### PR TITLE
Fix style encoding tests on main

### DIFF
--- a/napari/layers/utils/_tests/test_style_encoding.py
+++ b/napari/layers/utils/_tests/test_style_encoding.py
@@ -13,6 +13,7 @@ from typing import Any, Union
 import numpy as np
 import pandas as pd
 import pytest
+from pydantic import Field
 
 from napari.layers.utils._style_encoding import (
     _ConstantStyleEncoding,
@@ -66,7 +67,7 @@ def test_scalar_constant_encoding_clear():
 
 class ScalarManualEncoding(_ManualStyleEncoding[Scalar, ScalarArray]):
     array: ScalarArray
-    default: Scalar = -1
+    default: Scalar = np.array(-1)
 
 
 def test_scalar_manual_encoding_update_with_shorter(features):
@@ -107,7 +108,7 @@ def test_scalar_manual_encoding_clear():
 
 class ScalarDirectEncoding(_DerivedStyleEncoding[Scalar, ScalarArray]):
     feature: str
-    fallback: Scalar = -1
+    fallback: Scalar = np.array(-1)
 
     def __call__(self, features: Any) -> ScalarArray:
         return ScalarArray.validate_type(features[self.feature])
@@ -192,7 +193,7 @@ def test_vector_constant_encoding_clear():
 
 class VectorManualEncoding(_ManualStyleEncoding[Vector, VectorArray]):
     array: VectorArray
-    default: Vector = [-1, -1]
+    default: Vector = Field(default_factory=lambda: np.array([-1, -1]))
 
 
 def test_vector_manual_encoding_update_with_shorter(features):
@@ -235,7 +236,7 @@ def test_vector_manual_encoding_clear():
 
 class VectorDirectEncoding(_DerivedStyleEncoding[Vector, VectorArray]):
     feature: str
-    fallback: Vector = [-1, -1]
+    fallback: Vector = Field(default_factory=lambda: np.array([-1, -1]))
 
     def __call__(self, features: Any) -> Union[Vector, VectorArray]:
         return VectorArray.validate_type(list(features[self.feature]))


### PR DESCRIPTION
# Description
Fixes tests after #4113, which merged after #4138 but didn't yet include it

cc @andy-sweet 
the `default_factory=lambda` is due to https://github.com/samuelcolvin/pydantic/issues/2923


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
