### PR TITLE
Tracks graph shader buffer order update

### DIFF
--- a/napari/_vispy/layers/tracks.py
+++ b/napari/_vispy/layers/tracks.py
@@ -95,10 +95,6 @@ class VispyTracksLayer(VispyBaseLayer):
     def _on_graph_change(self):
         """Update the shader when the graph data changes."""
 
-        self.node.graph_filter.use_fade = self.layer.use_fade
-        self.node.graph_filter.tail_length = self.layer.tail_length
-        self.node.graph_filter.vertex_time = self.layer.graph_times
-
         # if the user clears a graph after it has been created, vispy offers
         # no method to clear the data, therefore, we need to set private
         # attributes to None to prevent errors
@@ -107,6 +103,11 @@ class VispyTracksLayer(VispyBaseLayer):
             self.node._subvisuals[2]._connect = None
             self.node.update()
             return
+
+        # vertex time buffer must change only if data is updated, otherwise vispy buffers might be of different lengths
+        self.node.graph_filter.use_fade = self.layer.use_fade
+        self.node.graph_filter.tail_length = self.layer.tail_length
+        self.node.graph_filter.vertex_time = self.layer.graph_times
 
         self.node._subvisuals[2].set_data(
             pos=self.layer._view_graph,


### PR DESCRIPTION
# Description

This PR changes how buffers are updated on the tracks vispy object.

@pmcesky, can you check if it solves your issue? I got the bug on the jupyter notebook you provided but it depended on the order in that I executed the chunks. I think I solved it. Right now, it works in any ordering on my end.

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# References
Closes issue #4155 

# How has this been tested?
- [X] It fixes the issue error
- [ ] It runs on GitHub's CI

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
