### PR TITLE
Add value method to extension2reader widget

### DIFF
--- a/napari/_qt/widgets/qt_extension2reader.py
+++ b/napari/_qt/widgets/qt_extension2reader.py
@@ -108,3 +108,13 @@ class Extension2ReaderTable(QWidget):
             if row_widg_name == extension_to_remove:
                 self._table.removeRow(i)
                 return
+
+    def value(self):
+        """Return extension:reader mapping from settings
+
+        Returns
+        -------
+        Dict[str, str]
+            mapping of extension to reader plugin display name
+        """
+        return get_settings().plugins.extension2reader


### PR DESCRIPTION
# Description
This is a partial fix for #4175, adding a `value` method to the `extension2reader` widget so that it can respond to `stateChanged` signals.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Partially addresses #4175

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
