### PR TITLE
Add hook implementation name to order sorting

### DIFF
--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -220,8 +220,10 @@ class NapariPluginManager(PluginManager):
                         # get the HookImplementation objects matching this entry
                         hook_impl = list(
                             filter(
+                                # plugin name has to match
                                 lambda impl: impl.plugin_name == plugin
                                 and (
+                                    # if we have a hook_impl_name it must match
                                     not hook_impl_name
                                     or impl.function.__name__ == hook_impl_name
                                 ),

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -37,7 +37,6 @@ class PluginHookOption(TypedDict):
     """Custom type specifying plugin and enabled state."""
 
     plugin: str
-    hook_impl: str
     enabled: bool
 
 
@@ -183,8 +182,7 @@ class NapariPluginManager(PluginManager):
             if len(impls) > 1:
                 order[spec_name] = [
                     {
-                        'plugin': impl.plugin_name,
-                        'hook_impl': impl.function.__name__,
+                        'plugin': f'{impl.plugin_name}--{impl.function.__name__}',
                         'enabled': impl.enabled,
                     }
                     for impl in reversed(impls)
@@ -213,11 +211,15 @@ class NapariPluginManager(PluginManager):
                         hook_caller._set_plugin_enabled(
                             p['plugin'], p['enabled']
                         )
+                        plugin_name, hook_impl_name = tuple(
+                            p['plugin'].split('--')
+                        )
                         hook_impls = hook_caller.get_hookimpls()
+                        # get the HookImplementation object matching this entry
                         hook_impl = list(
                             filter(
-                                lambda impl: impl.plugin_name == p['plugin']
-                                and impl.function.__name__ == p['hook_impl'],
+                                lambda impl: impl.plugin_name == plugin_name
+                                and impl.function.__name__ == hook_impl_name,
                                 hook_impls,
                             )
                         )[0]

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -37,6 +37,7 @@ class PluginHookOption(TypedDict):
     """Custom type specifying plugin and enabled state."""
 
     plugin: str
+    hook_impl: str
     enabled: bool
 
 

--- a/napari/settings/_plugins.py
+++ b/napari/settings/_plugins.py
@@ -8,9 +8,10 @@ from ..utils.translations import trans
 
 
 class PluginHookOption(TypedDict):
-    """Custom type specifying plugin and enabled state."""
+    """Custom type specifying plugin, hook implementation function name, and enabled state."""
 
     plugin: str
+    hook_impl: str
     enabled: bool
 
 

--- a/napari/settings/_plugins.py
+++ b/napari/settings/_plugins.py
@@ -11,7 +11,6 @@ class PluginHookOption(TypedDict):
     """Custom type specifying plugin, hook implementation function name, and enabled state."""
 
     plugin: str
-    hook_impl: str
     enabled: bool
 
 


### PR DESCRIPTION
# Description
Addresses the last part of #4175 by adding `hook_impl` to plugin call order for `napari-plugin-engine` plugins to disambiguate order for plugins providing multiple readers.

This needs a settings reset to work - I don't know how to add that. On my machine I was able to just run napari, it crashed and reset settings to default, and then it was fine from there. I don't know if we should be adding a warning or something?

Also, this functionality will soon be entirely deprecated with the move to `npe2` so I'm not sure if we want it at all, or if there's a better way to do it.. See comments in #4175 for more discussion

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Partially addresses #4175, together with #4179

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
