### PR TITLE
Allow the calendar to build correctly in PR build docs

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -33,6 +33,9 @@ jobs:
 
       - name: Build Docs
         uses: GabrielBB/xvfb-action@v1
+        env:
+          GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
+          GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
         with:
           run: make docs
 


### PR DESCRIPTION
This will allow the calendar to be visible in downloaded built docs artifacts from pull requests.

See discussion in https://github.com/napari/napari/pull/4176#issuecomment-1055986791
