### PR TITLE
Deploy to napari.github.io

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -47,7 +47,8 @@ jobs:
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          external_repository: napari/napari.github.io
           publish_dir: docs/_build
           publish_branch: gh-pages
           cname: napari.org


### PR DESCRIPTION
Deploying to gh-pages on this repo causes the repo to be bloated on clone, which is the whole thing we were trying to avoid with git-lfs. This reverts to deploying to the other repo, although now the deployment is completely static, which is a lot simpler than before.
