### PR TITLE
fix bugs in setting plane orientation with nD data 

### DIFF
--- a/napari/layers/image/_image_key_bindings.py
+++ b/napari/layers/image/_image_key_bindings.py
@@ -38,7 +38,9 @@ def orient_plane_normal_along_view_direction(layer: Image):
     viewer = napari.viewer.current_viewer()
     if viewer.dims.ndisplay != 3:
         return
-    layer.plane.normal = layer._world_to_data_ray(viewer.camera.view_direction)
+    layer.plane.normal = layer._world_to_displayed_data_ray(
+        viewer.camera.view_direction, [-3, -2, -1]
+    )
 
 
 @Image.bind_key('o')
@@ -49,8 +51,8 @@ def synchronise_plane_normal_with_view_direction(layer: Image):
 
     def sync_plane_normal_with_view_direction(event=None):
         """Plane normal syncronisation mouse callback."""
-        layer.plane.normal = layer._world_to_data_ray(
-            viewer.camera.view_direction
+        layer.plane.normal = layer._world_to_displayed_data_ray(
+            viewer.camera.view_direction, [-3, -2, -1]
         )
 
     # update plane normal and add callback to mouse drag

--- a/napari/layers/image/_image_key_bindings.py
+++ b/napari/layers/image/_image_key_bindings.py
@@ -39,7 +39,7 @@ def orient_plane_normal_along_view_direction(layer: Image):
     if viewer.dims.ndisplay != 3:
         return
     layer.plane.normal = layer._world_to_displayed_data_ray(
-        viewer.camera.view_direction, [-3, -2, -1]
+        viewer.camera.view_direction, dims_displayed=[-3, -2, -1]
     )
 
 

--- a/napari/layers/utils/interactivity_utils.py
+++ b/napari/layers/utils/interactivity_utils.py
@@ -123,7 +123,9 @@ def orient_plane_normal_around_cursor(layer: Image, plane_normal: tuple):
     cursor_position = layer._world_to_displayed_data(
         position=viewer.cursor.position, dims_displayed=layer._dims_displayed
     )
-    view_direction = layer._world_to_data_ray(viewer.camera.view_direction)
+    view_direction = np.asarray(
+        layer._world_to_data_ray(viewer.camera.view_direction)
+    )[-3:]
     intersection = layer.plane.intersect_with_line(
         line_position=cursor_position, line_direction=view_direction
     )
@@ -136,4 +138,6 @@ def orient_plane_normal_around_cursor(layer: Image, plane_normal: tuple):
         layer.plane.position = intersection
 
     # update plane normal
-    layer.plane.normal = layer._world_to_data_ray(plane_normal)
+    layer.plane.normal = layer._world_to_displayed_data_ray(
+        plane_normal, layer._dims_displayed
+    )

--- a/napari/layers/utils/interactivity_utils.py
+++ b/napari/layers/utils/interactivity_utils.py
@@ -113,7 +113,7 @@ def orient_plane_normal_around_cursor(layer: Image, plane_normal: tuple):
 
     from ..image._image_constants import VolumeDepiction
 
-    viewer = napari.current_viewer()
+    viewer = napari.viewer.current_viewer()
 
     # early exit
     if viewer.dims.ndisplay != 3 or layer.depiction != VolumeDepiction.PLANE:
@@ -123,9 +123,9 @@ def orient_plane_normal_around_cursor(layer: Image, plane_normal: tuple):
     cursor_position = layer._world_to_displayed_data(
         position=viewer.cursor.position, dims_displayed=layer._dims_displayed
     )
-    view_direction = np.asarray(
-        layer._world_to_data_ray(viewer.camera.view_direction)
-    )[-3:]
+    view_direction = layer._world_to_displayed_data_ray(
+        viewer.camera.view_direction, [-3, -2, -1]
+    )
     intersection = layer.plane.intersect_with_line(
         line_position=cursor_position, line_direction=view_direction
     )

--- a/napari/layers/utils/interactivity_utils.py
+++ b/napari/layers/utils/interactivity_utils.py
@@ -124,7 +124,7 @@ def orient_plane_normal_around_cursor(layer: Image, plane_normal: tuple):
         position=viewer.cursor.position, dims_displayed=layer._dims_displayed
     )
     view_direction = layer._world_to_displayed_data_ray(
-        viewer.camera.view_direction, [-3, -2, -1]
+        viewer.camera.view_direction, dims_displayed=[-3, -2, -1]
     )
     intersection = layer.plane.intersect_with_line(
         line_position=cursor_position, line_direction=view_direction
@@ -139,5 +139,5 @@ def orient_plane_normal_around_cursor(layer: Image, plane_normal: tuple):
 
     # update plane normal
     layer.plane.normal = layer._world_to_displayed_data_ray(
-        plane_normal, layer._dims_displayed
+        plane_normal, dims_displayed=layer._dims_displayed
     )


### PR DESCRIPTION
# Description
fix for #4196 - added some extra guards which ensure that new plane normal directions are always 3D with nD data

cc @brisvag @jni 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
