### PR TITLE
Add size argument to Viewer.screenshot()

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1164,6 +1164,10 @@ class Window:
                     raise ValueError(
                         f'screenshot size must be 2 values, got {len(size)}'
                     )
+                # Scale the requested size to account for HiDPI
+                size = tuple(
+                    dim / self._qt_window.devicePixelRatio() for dim in size
+                )
                 canvas.size = size[::-1]  # invert x ad y for vispy
             if scale is not None:
                 # multiply canvas dimensions by the scale factor to get new size

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1165,7 +1165,7 @@ class Window:
                     )
                 prev_size = canvas.size
                 canvas.size = size[::-1]  # invert x ad y for vispy
-            elif scale is not None:
+            if scale is not None:
                 prev_size = canvas.size
                 # multiply canvas dimensions by the scale factor to get new size
                 canvas.size = tuple(dim * scale for dim in canvas.size)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1158,15 +1158,14 @@ class Window:
 
         if canvas_only:
             canvas = self._qt_viewer.canvas
+            prev_size = canvas.size
             if size is not None:
                 if len(size) != 2:
                     raise ValueError(
                         f'screenshot size must be 2 values, got {len(size)}'
                     )
-                prev_size = canvas.size
                 canvas.size = size[::-1]  # invert x ad y for vispy
             if scale is not None:
-                prev_size = canvas.size
                 # multiply canvas dimensions by the scale factor to get new size
                 canvas.size = tuple(dim * scale for dim in canvas.size)
             try:

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1129,7 +1129,9 @@ class Window:
         """Restart the napari application."""
         self._qt_window.restart()
 
-    def _screenshot(self, flash=True, canvas_only=False) -> 'QImage':
+    def _screenshot(
+        self, size=None, flash=True, canvas_only=False
+    ) -> 'QImage':
         """Capture screenshot of the currently displayed viewer.
 
         Parameters
@@ -1137,6 +1139,9 @@ class Window:
         flash : bool
             Flag to indicate whether flash animation should be shown after
             the screenshot was captured.
+        size : tuple (int, int)
+            Size (resolution) of the screenshot. By default, the currently displayed size.
+            Only used if `canvas_only` is True.
         canvas_only : bool
             If True, screenshot shows only the image display canvas, and
             if False include the napari viewer frame in the screenshot,
@@ -1149,22 +1154,31 @@ class Window:
         from .utils import add_flash_animation
 
         if canvas_only:
+            canvas = self._qt_viewer.canvas
+            if size is not None:
+                prev_size = canvas.size
+                canvas.size = size
             img = self._qt_viewer.canvas.native.grabFramebuffer()
             if flash:
                 add_flash_animation(self._qt_viewer._canvas_overlay)
+            if size is not None:
+                canvas.size = prev_size
         else:
             img = self._qt_window.grab().toImage()
             if flash:
                 add_flash_animation(self._qt_window)
         return img
 
-    def screenshot(self, path=None, flash=True, canvas_only=False):
+    def screenshot(self, path=None, size=None, flash=True, canvas_only=False):
         """Take currently displayed viewer and convert to an image array.
 
         Parameters
         ----------
         path : str
             Filename for saving screenshot image.
+        size : tuple (int, int)
+            Size (resolution) of the screenshot. By default, the currently displayed size.
+            Only used if `canvas_only` is True.
         flash : bool
             Flag to indicate whether flash animation should be shown after
             the screenshot was captured.
@@ -1179,7 +1193,7 @@ class Window:
             Numpy array of type ubyte and shape (h, w, 4). Index [0, 0] is the
             upper-left corner of the rendered region.
         """
-        img = QImg2array(self._screenshot(flash, canvas_only))
+        img = QImg2array(self._screenshot(size, flash, canvas_only))
         if path is not None:
             imsave(path, img)  # scikit-image imsave method
         return img

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1156,8 +1156,12 @@ class Window:
         if canvas_only:
             canvas = self._qt_viewer.canvas
             if size is not None:
+                if len(size) != 2:
+                    raise ValueError(
+                        f'screenshot size must be 2 values, got {len(size)}'
+                    )
                 prev_size = canvas.size
-                canvas.size = size
+                canvas.size = size[::-1]  # invert x ad y for vispy
             try:
                 img = self._qt_viewer.canvas.native.grabFramebuffer()
                 if flash:

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1158,11 +1158,14 @@ class Window:
             if size is not None:
                 prev_size = canvas.size
                 canvas.size = size
-            img = self._qt_viewer.canvas.native.grabFramebuffer()
-            if flash:
-                add_flash_animation(self._qt_viewer._canvas_overlay)
-            if size is not None:
-                canvas.size = prev_size
+            try:
+                img = self._qt_viewer.canvas.native.grabFramebuffer()
+                if flash:
+                    add_flash_animation(self._qt_viewer._canvas_overlay)
+            finally:
+                # make sure we always go back to the right canvas size
+                if size is not None:
+                    canvas.size = prev_size
         else:
             img = self._qt_window.grab().toImage()
             if flash:

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1130,7 +1130,7 @@ class Window:
         self._qt_window.restart()
 
     def _screenshot(
-        self, size=None, flash=True, canvas_only=False
+        self, size=None, scale=None, flash=True, canvas_only=False
     ) -> 'QImage':
         """Capture screenshot of the currently displayed viewer.
 
@@ -1141,6 +1141,9 @@ class Window:
             the screenshot was captured.
         size : tuple (int, int)
             Size (resolution) of the screenshot. By default, the currently displayed size.
+            Only used if `canvas_only` is True.
+        scale : float
+            Scale factor used to increase resolution of canvas for the screenshot. By default, the currently displayed resolution.
             Only used if `canvas_only` is True.
         canvas_only : bool
             If True, screenshot shows only the image display canvas, and
@@ -1162,6 +1165,10 @@ class Window:
                     )
                 prev_size = canvas.size
                 canvas.size = size[::-1]  # invert x ad y for vispy
+            elif scale is not None:
+                prev_size = canvas.size
+                # multiply canvas dimensions by the scale factor to get new size
+                canvas.size = tuple(dim * scale for dim in canvas.size)
             try:
                 img = self._qt_viewer.canvas.native.grabFramebuffer()
                 if flash:

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1183,7 +1183,9 @@ class Window:
                 add_flash_animation(self._qt_window)
         return img
 
-    def screenshot(self, path=None, size=None, flash=True, canvas_only=False):
+    def screenshot(
+        self, path=None, size=None, scale=None, flash=True, canvas_only=False
+    ):
         """Take currently displayed viewer and convert to an image array.
 
         Parameters
@@ -1192,6 +1194,9 @@ class Window:
             Filename for saving screenshot image.
         size : tuple (int, int)
             Size (resolution) of the screenshot. By default, the currently displayed size.
+            Only used if `canvas_only` is True.
+        scale : float
+            Scale factor used to increase resolution of canvas for the screenshot. By default, the currently displayed resolution.
             Only used if `canvas_only` is True.
         flash : bool
             Flag to indicate whether flash animation should be shown after
@@ -1207,7 +1212,7 @@ class Window:
             Numpy array of type ubyte and shape (h, w, 4). Index [0, 0] is the
             upper-left corner of the rendered region.
         """
-        img = QImg2array(self._screenshot(size, flash, canvas_only))
+        img = QImg2array(self._screenshot(size, scale, flash, canvas_only))
         if path is not None:
             imsave(path, img)  # scikit-image imsave method
         return img

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1175,7 +1175,7 @@ class Window:
                     add_flash_animation(self._qt_viewer._canvas_overlay)
             finally:
                 # make sure we always go back to the right canvas size
-                if size is not None:
+                if size is not None or scale is not None:
                     canvas.size = prev_size
         else:
             img = self._qt_window.grab().toImage()

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -80,13 +80,18 @@ class Viewer(ViewerModel):
         else:
             self.window._qt_viewer.console.push(variables)
 
-    def screenshot(self, path=None, *, canvas_only=True, flash: bool = True):
+    def screenshot(
+        self, path=None, size=None, *, canvas_only=True, flash: bool = True
+    ):
         """Take currently displayed screen and convert to an image array.
 
         Parameters
         ----------
         path : str
             Filename for saving screenshot image.
+        size : tuple (int, int)
+            Size (resolution) of the screenshot. By default, the currently displayed size.
+            Only used if `canvas_only` is True.
         canvas_only : bool
             If True, screenshot shows only the image display canvas, and
             if False include the napari viewer frame in the screenshot,
@@ -103,7 +108,10 @@ class Viewer(ViewerModel):
             upper-left corner of the rendered region.
         """
         return self.window.screenshot(
-            path=path, flash=flash, canvas_only=canvas_only
+            path=path,
+            size=size,
+            flash=flash,
+            canvas_only=canvas_only,
         )
 
     def show(self, *, block=False):

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -81,7 +81,7 @@ class Viewer(ViewerModel):
             self.window._qt_viewer.console.push(variables)
 
     def screenshot(
-        self, path=None, size=None, *, canvas_only=True, flash: bool = True
+        self, path=None, *, size=None, canvas_only=True, flash: bool = True
     ):
         """Take currently displayed screen and convert to an image array.
 

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -81,7 +81,13 @@ class Viewer(ViewerModel):
             self.window._qt_viewer.console.push(variables)
 
     def screenshot(
-        self, path=None, *, size=None, canvas_only=True, flash: bool = True
+        self,
+        path=None,
+        *,
+        size=None,
+        scale=None,
+        canvas_only=True,
+        flash: bool = True,
     ):
         """Take currently displayed screen and convert to an image array.
 
@@ -91,6 +97,9 @@ class Viewer(ViewerModel):
             Filename for saving screenshot image.
         size : tuple (int, int)
             Size (resolution) of the screenshot. By default, the currently displayed size.
+            Only used if `canvas_only` is True.
+        scale : float
+            Scale factor used to increase resolution of canvas for the screenshot. By default, the currently displayed resolution.
             Only used if `canvas_only` is True.
         canvas_only : bool
             If True, screenshot shows only the image display canvas, and
@@ -110,6 +119,7 @@ class Viewer(ViewerModel):
         return self.window.screenshot(
             path=path,
             size=size,
+            scale=scale,
             flash=flash,
             canvas_only=canvas_only,
         )


### PR DESCRIPTION
# Description
Following [this discussion on zulip](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/save.20labels.20.28in.20color.29.20as.20png), I implemented a simple addition to the `Viewer.screenshot()` method that takes a size. If passed, napari will resize the canvas just before taking the screenshot. Right after, it will restore it to the original size. This allows for taking screenshots at higher resolution than the current canvas or even the screen size.

cc @andy-sweet @psobolewskiPhD @alisterburt 

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
