### PR TITLE
Decrease LFS size, gif -> webm.

### DIFF
--- a/docs/tutorials/annotation/annotate_points.md
+++ b/docs/tutorials/annotation/annotate_points.md
@@ -15,7 +15,7 @@ point_annotator(im_path, labels=['ear_l', 'ear_r', 'tail'])
 
 The resulting viewer looks like this (images from [Mathis et al., 2018](https://www.nature.com/articles/s41593-018-0209-y), downloaded from [here](https://github.com/DeepLabCut/DeepLabCut/tree/f21321ef8060c537f9df0ce9346189bda07701b5/examples/openfield-Pranav-2018-10-30/labeled-data/m4s1)):
 
-![image: point annotator demo](../assets/tutorials/point_annotator_demo.gif)
+![image: point annotator demo](../assets/tutorials/point_annotator_demo.webm)
 
 You can explore the project in [this repository](https://github.com/kevinyamauchi/PointAnnotator) or check out the main function below.
 We will walk through the code in the following sections.

--- a/docs/tutorials/assets/tutorials/.gitattributes
+++ b/docs/tutorials/assets/tutorials/.gitattributes
@@ -1,0 +1,1 @@
+*.webm filter=lfs diff=lfs merge=lfs -text

--- a/docs/tutorials/assets/tutorials/dask1.gif
+++ b/docs/tutorials/assets/tutorials/dask1.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:11eb81f37ce794b3cb471f47dc091c3822f9c5302318d5c034ecb7430ebd093c
-size 4260620

--- a/docs/tutorials/assets/tutorials/dask1.webm
+++ b/docs/tutorials/assets/tutorials/dask1.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84cb5040d82fb1dda29b9fc9337dc63882f6cf650a0e92505c3ffddb33b3ccde
+size 111246

--- a/docs/tutorials/assets/tutorials/dask2.gif
+++ b/docs/tutorials/assets/tutorials/dask2.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d94972e60443d0174a6f526b47bd502f7c40b9fa64c388921fdae11f2ca05f50
-size 12819136

--- a/docs/tutorials/assets/tutorials/dask2.webm
+++ b/docs/tutorials/assets/tutorials/dask2.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1edcd667b050e27760cb8b124285b020dc6b6a0df65f595027d922c4fa9b63a
+size 363827

--- a/docs/tutorials/assets/tutorials/painting.gif
+++ b/docs/tutorials/assets/tutorials/painting.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7556b5d4c76647ae1435cbba8043deb24404baaefe8f3abb5af49649ddd32d00
-size 3580416

--- a/docs/tutorials/assets/tutorials/painting.webm
+++ b/docs/tutorials/assets/tutorials/painting.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffcb1c78d26f75cd01e622a7b59615380de6d017e644dd5a475afd55a9f6c94a
+size 235439

--- a/docs/tutorials/assets/tutorials/point_annotator_demo.gif
+++ b/docs/tutorials/assets/tutorials/point_annotator_demo.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:066bb82ce05513afbbbefb5bf7d386d8ead665186949585794fa3c693dae6413
-size 18451396

--- a/docs/tutorials/assets/tutorials/point_annotator_demo.webm
+++ b/docs/tutorials/assets/tutorials/point_annotator_demo.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04aec2e774cfeaaa11829635f81e4a7af2d6e8fb492ad71bb7916fd66d66bcd2
+size 104642

--- a/docs/tutorials/assets/tutorials/tracks_isbi.gif
+++ b/docs/tutorials/assets/tutorials/tracks_isbi.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:32519c4240c38bed0bce32d0dadd529e651073b1561201c18cc4fe4d4141f0ad
-size 11445017

--- a/docs/tutorials/assets/tutorials/tracks_isbi.webm
+++ b/docs/tutorials/assets/tutorials/tracks_isbi.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:828eb44189f1ff784f511c684ae905375376366172fdc37643dc12fe683e4a9a
+size 1456717

--- a/docs/tutorials/assets/tutorials/viewer_pan_zoom.gif
+++ b/docs/tutorials/assets/tutorials/viewer_pan_zoom.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a8fda275770b46746274cb04548320d6c53e3f0b55a949a471fa23732bee9c6
-size 3739026

--- a/docs/tutorials/assets/tutorials/viewer_pan_zoom.webm
+++ b/docs/tutorials/assets/tutorials/viewer_pan_zoom.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50f0ee2a6530ee2414331cbc8c8df52a38cc80a5d7506c6a3e8fa3c0ffe435fd
+size 220712

--- a/docs/tutorials/fundamentals/viewer.md
+++ b/docs/tutorials/fundamentals/viewer.md
@@ -118,7 +118,7 @@ performant. You can also return to the original zoom level by clicking the
 
 +++
 
-![image: pan and zoom with napari](../assets/tutorials/viewer_pan_zoom.gif)
+![image: pan and zoom with napari](../assets/tutorials/viewer_pan_zoom.webm)
 
 +++
 

--- a/docs/tutorials/processing/dask.md
+++ b/docs/tutorials/processing/dask.md
@@ -128,7 +128,7 @@ stack = imread("/path/to/experiment/*.tif")
 napari.view_image(stack, contrast_limits=[0,2000], multiscale=False)
 ```
 
-![image: mCherry-H2B showing chromosome separation during mitosis. Collected on a lattice light sheet microscope](../assets/tutorials/dask1.gif)
+![image: mCherry-H2B showing chromosome separation during mitosis. Collected on a lattice light sheet microscope](../assets/tutorials/dask1.webm)
 
 ### **Side note regarding higher-dimensional datasets**
 
@@ -248,7 +248,7 @@ but it's surprisingly usable,
 and allows you to preview the result of a relatively complex processing pipeline *on-the-fly*,
 for arbitrary timepoints/channels, while storing *only* the raw data on disk.
 
-![image: same dataset, demonstrating on-the-fly read → deskew → deconvolve → crop](../assets/tutorials/dask2.gif)
+![image: same dataset, demonstrating on-the-fly read → deskew → deconvolve → crop](../assets/tutorials/dask2.webm)
 
 This workflow is very much patterned after [another great post by John Kirkham, Matthew Rocklin, and Matthew McCormick](https://blog.dask.org/2019/08/09/image-itk)
 that describes a similar image processing pipeline using [ITK](https://itk.org/).

--- a/docs/tutorials/tracking/cell_tracking.md
+++ b/docs/tutorials/tracking/cell_tracking.md
@@ -176,7 +176,7 @@ viewer.add_tracks(data, properties=properties, graph=graph, scale=SCALE, name='t
 napari.run()
 ```
 
-![image: tracks isbi](../assets/tutorials/tracks_isbi.gif)
+![image: tracks isbi](../assets/tutorials/tracks_isbi.webm)
 
 ---
 


### PR DESCRIPTION
This should reduce quite a bit the size of git LFS and loading the
napari website.

It converts a few of the gifs (or gifs depending on how you pronounce) to
webm.

Webm can be put in img tag in most recent browser and will behave like a
video. https://caniuse.com/webm current says 95.36% of global users,
97.64% if we restrict to desktop ones.

Conversion was done using:

    ffmpeg -i {base}.gif -c vp9 -b:v 0 -crf 40 {base}.webm

With a quality of 40. You can see _some_ color quantisation by looking
well, though personally on an old and slow machine this video is nicer
than gif as it is more fluid because of the smaller size I guess ?

Other advantage, I get a play/pause/scrubber with webm, I don't get with
Gif, so it's easier to replay and find when it loops.

I also add webm to `.gitattributes` so that all webm should be tracked by
LFS automatically.

Technically I'm not sure this actually reduce the LFS payload as the old
files are likely still there, but I'm going to assume git lfs is smart
enough sometime to just pull the ones from current commit (?) and/or
that we can purge later.

I'm also not super good at git lfs, so I'd love for someone else to try
this commit manually to see if I haven't screwed up anything.
```
$ git lfs ls-files -s  | grep tutori |grep -v png | cut -f2 -d'-' | sort
 docs/tutorials/assets/tutorials/dask1.gif (4.3 MB)
 docs/tutorials/assets/tutorials/dask1.webm (111 KB)
 docs/tutorials/assets/tutorials/dask2.gif (13 MB)
 docs/tutorials/assets/tutorials/dask2.webm (364 KB)
 docs/tutorials/assets/tutorials/painting.gif (3.6 MB)
 docs/tutorials/assets/tutorials/painting.webm (235 KB)
 docs/tutorials/assets/tutorials/point_annotator_demo.gif (18 MB)
 docs/tutorials/assets/tutorials/point_annotator_demo.webm (105 KB)
 docs/tutorials/assets/tutorials/tracks_isbi.gif (11 MB)
 docs/tutorials/assets/tutorials/tracks_isbi.webm (1.5 MB)
 docs/tutorials/assets/tutorials/viewer_layout.jpg (141 KB)
 docs/tutorials/assets/tutorials/viewer_pan_zoom.gif (3.7 MB)
 docs/tutorials/assets/tutorials/viewer_pan_zoom.webm (221 KB)
```


--- 

More things I don't know what I'm doing:


```
$ git lfs ls-files  | cut -f2 -d '*' | xargs  du -k | awk '{ sum += $1 } END { print sum }'
132936 (HEAD) vs 183528 (HEAD~1)
```
which I assume if KB, but du on mac is weird, so it looks like a non-negligible reduction, and the difference seem to match with the sum of the size of the above gifs...

It's also relatively easy to redo with a different compress ratio... and to extend to other gifs and 9 of the top 10 files in lfs are gifs:

```
$ git lfs ls-files  | cut -f2 -d '*'| xargs ls -lhS | head -n 10
-rw-r--r--  1 bussonniermatthias  staff    20M Mar  6 15:02 docs/images/pathology.gif
-rw-r--r--  1 bussonniermatthias  staff   8.6M Mar  6 15:01 docs/images/editing_points.gif
-rw-r--r--  1 bussonniermatthias  staff   6.8M Mar  6 15:01 docs/images/editing_shapes.gif
-rw-r--r--  1 bussonniermatthias  staff   6.4M Mar  6 15:01 docs/images/nD_vectors.gif
-rw-r--r--  1 bussonniermatthias  staff   6.0M Mar  6 15:01 docs/images/smFISH.gif
-rw-r--r--  1 bussonniermatthias  staff   5.2M Mar  6 15:01 docs/guides/images/mitosis.gif
-rw-r--r--  1 bussonniermatthias  staff   4.9M Mar  6 15:01 docs/images/shape_vertex_editing.gif
-rw-r--r--  1 bussonniermatthias  staff   4.8M Mar  6 15:01 docs/images/LLSM.gif
-rw-r--r--  1 bussonniermatthias  staff   4.6M Mar  6 15:01 docs/images/shape_resizing.gif
-rw-r--r--  1 bussonniermatthias  staff   3.5M Mar  6 15:01 docs/tutorials/assets/tutorials/launch_ipython.png
```

It's also a redo of https://github.com/napari/napari.github.io/pull/314
