### PR TITLE
Refactor toward fixing local value capturing.

### DIFF
--- a/napari/utils/naming.py
+++ b/napari/utils/naming.py
@@ -149,7 +149,7 @@ def magic_name(value, *, path_prefix=ROOT_DIR):
     """
     # Iterate frames while filename starts with path_prefix (part of Napari)
     with CallerFrame(
-        lambda frame: frame.f_code.co_filename.startswith(path_prefix)
+        lambda n, frame: frame.f_code.co_filename.startswith(path_prefix)
     ) as w:
         varmap = w.namespace
         names = w.names

--- a/napari/utils/naming.py
+++ b/napari/utils/naming.py
@@ -59,7 +59,7 @@ class CallerFrame:
     For example to get the first caller frame which module is not napari::
 
         def not_napari(frame):
-            return frame.f_globals.get("__name__", '').startswith('napari')
+            return not frame.f_globals.get("__name__", '').startswith('napari')
 
         with CallerFrame(not_napari) as c:
             print(c.namespace)


### PR DESCRIPTION
See discussion in #4140, this refactor some of the logic to be reusable
in napari_console with a different predicate of which frames to inspect,
and capturing the full namespace instead of just the names.
