### PR TITLE
Add plugin dialog initial tests

### DIFF
--- a/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
@@ -1,0 +1,107 @@
+import pytest
+from npe2.manifest.package_metadata import PackageMetadata
+
+from napari._qt.dialogs import qt_plugin_dialog
+
+
+def _hub_or_pypi(conda_forge):
+    base_data = {
+        "metadata_version": "1.0",
+        "version": "0.1.0",
+        "summary": "some test package",
+        "home_page": "http://napari.org",
+        "author": "test author",
+        "license": "UNKNOWN",
+}
+    for i in range(2):
+        yield PackageMetadata(name=f"test-name-{i}", **base_data), bool(i)
+
+
+@pytest.fixture
+def plugin_dialog(qtbot, monkeypatch):
+    """test that QtPluginErrReporter shows any instantiated PluginErrors."""
+
+    for method_name in ["iter_hub_plugin_info", "iter_napari_plugin_info"]:
+        monkeypatch.setattr(
+            qt_plugin_dialog,
+            method_name,
+            _hub_or_pypi,
+        )
+
+    monkeypatch.setattr(
+        qt_plugin_dialog,
+        "running_as_constructor_app",
+        lambda: False,
+    )
+
+    widget = qt_plugin_dialog.QtPluginDialog()
+    widget.show()
+    qtbot.add_widget(widget)
+    return widget
+
+
+@pytest.fixture
+def plugin_dialog_constructor(qtbot, monkeypatch):
+    """test that QtPluginErrReporter shows any instantiated PluginErrors."""
+
+    for method_name in ["iter_hub_plugin_info", "iter_napari_plugin_info"]:
+        monkeypatch.setattr(
+            qt_plugin_dialog,
+            method_name,
+            _hub_or_pypi,
+        )
+
+    monkeypatch.setattr(
+        qt_plugin_dialog,
+        "running_as_constructor_app",
+        lambda: True,
+    )
+    widget = qt_plugin_dialog.QtPluginDialog()
+    widget.show()
+    qtbot.add_widget(widget)
+    return widget
+
+
+def test_filter_not_available_plugins(plugin_dialog_constructor):
+    """test that filtering works."""
+    item = plugin_dialog_constructor.available_list.item(0)
+    widget = plugin_dialog_constructor.available_list.itemWidget(item)
+    assert not widget.action_button.isEnabled()
+    assert widget.warning_tooltip.isVisible()
+
+    item = plugin_dialog_constructor.available_list.item(1)
+    widget = plugin_dialog_constructor.available_list.itemWidget(item)
+    assert widget.action_button.isEnabled()
+    assert not widget.warning_tooltip.isVisible()
+
+
+def test_filter_available_plugins(plugin_dialog):
+    """test that filtering works."""
+    plugin_dialog.filter("")
+    assert plugin_dialog.available_list._count_visible() == 2
+
+    plugin_dialog.filter("no-match@123")
+    assert plugin_dialog.available_list._count_visible() == 0
+
+    plugin_dialog.filter("")
+    plugin_dialog.filter("test-name-0")
+    assert plugin_dialog.available_list._count_visible() == 1
+
+
+def test_filter_installed_plugins(plugin_dialog):
+    """test that filtering works."""
+    plugin_dialog.filter("")
+    assert plugin_dialog.installed_list._count_visible() >= 0
+
+    plugin_dialog.filter("no-match@123")
+    assert plugin_dialog.installed_list._count_visible() == 0
+
+
+def test_visible_widgets(plugin_dialog):
+    assert plugin_dialog.direct_entry_edit.isVisible()
+    assert plugin_dialog.direct_entry_btn.isVisible()
+
+
+def test_constructor_visible_widgets(plugin_dialog_constructor):
+    assert not plugin_dialog_constructor.direct_entry_edit.isVisible()
+    assert not plugin_dialog_constructor.direct_entry_btn.isVisible()

--- a/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
@@ -53,6 +53,7 @@ def plugin_dialog(qtbot, monkeypatch):
 
     widget = qt_plugin_dialog.QtPluginDialog()
     widget.show()
+    qtbot.wait(300)
     qtbot.add_widget(widget)
     return widget
 
@@ -78,6 +79,7 @@ def plugin_dialog_constructor(qtbot, monkeypatch):
     )
     widget = qt_plugin_dialog.QtPluginDialog()
     widget.show()
+    qtbot.wait(300)
     qtbot.add_widget(widget)
     return widget
 
@@ -95,8 +97,9 @@ def test_filter_not_available_plugins(plugin_dialog_constructor):
     """
     item = plugin_dialog_constructor.available_list.item(0)
     widget = plugin_dialog_constructor.available_list.itemWidget(item)
-    assert not widget.action_button.isEnabled()
-    assert widget.warning_tooltip.isVisible()
+    if widget:
+        assert not widget.action_button.isEnabled()
+        assert widget.warning_tooltip.isVisible()
 
     item = plugin_dialog_constructor.available_list.item(1)
     widget = plugin_dialog_constructor.available_list.itemWidget(item)
@@ -110,6 +113,7 @@ def test_filter_available_plugins(plugin_dialog):
     list (the bottom one).
     """
     plugin_dialog.filter("")
+    assert plugin_dialog.available_list.count() == 2
     assert plugin_dialog.available_list._count_visible() == 2
 
     plugin_dialog.filter("no-match@123")

--- a/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
@@ -19,8 +19,6 @@ def _hub_or_pypi(conda_forge):
 
 @pytest.fixture
 def plugin_dialog(qtbot, monkeypatch):
-    """test that QtPluginErrReporter shows any instantiated PluginErrors."""
-
     for method_name in ["iter_hub_plugin_info", "iter_napari_plugin_info"]:
         monkeypatch.setattr(
             qt_plugin_dialog,
@@ -42,8 +40,6 @@ def plugin_dialog(qtbot, monkeypatch):
 
 @pytest.fixture
 def plugin_dialog_constructor(qtbot, monkeypatch):
-    """test that QtPluginErrReporter shows any instantiated PluginErrors."""
-
     for method_name in ["iter_hub_plugin_info", "iter_napari_plugin_info"]:
         monkeypatch.setattr(
             qt_plugin_dialog,
@@ -63,7 +59,6 @@ def plugin_dialog_constructor(qtbot, monkeypatch):
 
 
 def test_filter_not_available_plugins(plugin_dialog_constructor):
-    """test that filtering works."""
     item = plugin_dialog_constructor.available_list.item(0)
     widget = plugin_dialog_constructor.available_list.itemWidget(item)
     assert not widget.action_button.isEnabled()
@@ -76,7 +71,6 @@ def test_filter_not_available_plugins(plugin_dialog_constructor):
 
 
 def test_filter_available_plugins(plugin_dialog):
-    """test that filtering works."""
     plugin_dialog.filter("")
     assert plugin_dialog.available_list._count_visible() == 2
 
@@ -89,7 +83,6 @@ def test_filter_available_plugins(plugin_dialog):
 
 
 def test_filter_installed_plugins(plugin_dialog):
-    """test that filtering works."""
     plugin_dialog.filter("")
     assert plugin_dialog.installed_list._count_visible() >= 0
 

--- a/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
@@ -1,10 +1,27 @@
+from typing import Generator, Optional, Tuple
+
 import pytest
 from npe2.manifest.package_metadata import PackageMetadata
 
 from napari._qt.dialogs import qt_plugin_dialog
 
 
-def _hub_or_pypi(conda_forge):
+def _iter_napari_hub_or_pypi_plugin_info(
+    conda_forge: bool,
+) -> Generator[Tuple[Optional[PackageMetadata], bool], None, None]:
+    """This helper generator function is mocking the hub and pypi
+    methods used to collect the available plugins.
+
+    This will mocjk `napari.plugins.hub.iter_hub_plugin_info` for napari-hub,
+    and `napari.plugins.pypi.iter_napari_plugin_info` for pypi.
+
+    This generator will return two fake plugins that will populate the
+    available plugins list (the bottom one). The first plugin will not be
+    available on conda-forge so will be greyed out ("test-name-0"). The
+    second plugin will be available on conda-forge so will be enabled
+    ("test-name-1").
+    """
+    # This mock `base_data`` will be the same for both fake plugins.
     base_data = {
         "metadata_version": "1.0",
         "version": "0.1.0",
@@ -19,13 +36,16 @@ def _hub_or_pypi(conda_forge):
 
 @pytest.fixture
 def plugin_dialog(qtbot, monkeypatch):
+    """Fixture that provides a plugin dialog for a normal napari install."""
     for method_name in ["iter_hub_plugin_info", "iter_napari_plugin_info"]:
         monkeypatch.setattr(
             qt_plugin_dialog,
             method_name,
-            _hub_or_pypi,
+            _iter_napari_hub_or_pypi_plugin_info,
         )
 
+    # This is patching `napari.utils.misc.running_as_constructor_app` function
+    # to mock a normal napari install.
     monkeypatch.setattr(
         qt_plugin_dialog,
         "running_as_constructor_app",
@@ -40,13 +60,18 @@ def plugin_dialog(qtbot, monkeypatch):
 
 @pytest.fixture
 def plugin_dialog_constructor(qtbot, monkeypatch):
+    """
+    Fixture that provides a plugin dialog for a constructor based install.
+    """
     for method_name in ["iter_hub_plugin_info", "iter_napari_plugin_info"]:
         monkeypatch.setattr(
             qt_plugin_dialog,
             method_name,
-            _hub_or_pypi,
+            _iter_napari_hub_or_pypi_plugin_info,
         )
 
+    # This is patching `napari.utils.misc.running_as_constructor_app` function
+    # to mock a constructor based install.
     monkeypatch.setattr(
         qt_plugin_dialog,
         "running_as_constructor_app",
@@ -59,6 +84,16 @@ def plugin_dialog_constructor(qtbot, monkeypatch):
 
 
 def test_filter_not_available_plugins(plugin_dialog_constructor):
+    """
+    Check that the plugins listed under available plugins are
+    enabled and disabled accordingly.
+
+    The first plugin ("test-name-0") is not available on conda-forge and
+    should be disabled, and show a tooltip warning.
+
+    The second plugin ("test-name-1") is available on conda-forge and
+    should be enabled without the tooltip warning.
+    """
     item = plugin_dialog_constructor.available_list.item(0)
     widget = plugin_dialog_constructor.available_list.itemWidget(item)
     assert not widget.action_button.isEnabled()
@@ -71,6 +106,10 @@ def test_filter_not_available_plugins(plugin_dialog_constructor):
 
 
 def test_filter_available_plugins(plugin_dialog):
+    """
+    Test the dialog is correctly filtering plugins in the available plugins
+    list (the bottom one).
+    """
     plugin_dialog.filter("")
     assert plugin_dialog.available_list._count_visible() == 2
 
@@ -83,6 +122,10 @@ def test_filter_available_plugins(plugin_dialog):
 
 
 def test_filter_installed_plugins(plugin_dialog):
+    """
+    Test the dialog is correctly filtering plugins in the installed plugins
+    list (the top one).
+    """
     plugin_dialog.filter("")
     assert plugin_dialog.installed_list._count_visible() >= 0
 
@@ -91,10 +134,19 @@ def test_filter_installed_plugins(plugin_dialog):
 
 
 def test_visible_widgets(plugin_dialog):
+    """
+    Test that the direct entry button and textbox are visible for
+    normal napari installs.
+    """
+
     assert plugin_dialog.direct_entry_edit.isVisible()
     assert plugin_dialog.direct_entry_btn.isVisible()
 
 
 def test_constructor_visible_widgets(plugin_dialog_constructor):
+    """
+    Test that the direct entry button and textbox are hidden for
+    constructor based napari installs.
+    """
     assert not plugin_dialog_constructor.direct_entry_edit.isVisible()
     assert not plugin_dialog_constructor.direct_entry_btn.isVisible()

--- a/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
@@ -12,7 +12,7 @@ def _hub_or_pypi(conda_forge):
         "home_page": "http://napari.org",
         "author": "test author",
         "license": "UNKNOWN",
-}
+    }
     for i in range(2):
         yield PackageMetadata(name=f"test-name-{i}", **base_data), bool(i)
 

--- a/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
@@ -9,8 +9,7 @@ from napari._qt.dialogs import qt_plugin_dialog
 def _iter_napari_hub_or_pypi_plugin_info(
     conda_forge: bool,
 ) -> Generator[Tuple[Optional[PackageMetadata], bool], None, None]:
-    """This helper generator function is mocking the hub and pypi
-    methods used to collect the available plugins.
+    """Mock the hub and pypi methods to collect available plugins.
 
     This will mock `napari.plugins.hub.iter_hub_plugin_info` for napari-hub,
     and `napari.plugins.pypi.iter_napari_plugin_info` for pypi.

--- a/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
@@ -12,14 +12,13 @@ def _iter_napari_hub_or_pypi_plugin_info(
     """This helper generator function is mocking the hub and pypi
     methods used to collect the available plugins.
 
-    This will mocjk `napari.plugins.hub.iter_hub_plugin_info` for napari-hub,
+    This will mock `napari.plugins.hub.iter_hub_plugin_info` for napari-hub,
     and `napari.plugins.pypi.iter_napari_plugin_info` for pypi.
 
-    This generator will return two fake plugins that will populate the
-    available plugins list (the bottom one). The first plugin will not be
-    available on conda-forge so will be greyed out ("test-name-0"). The
-    second plugin will be available on conda-forge so will be enabled
-    ("test-name-1").
+    It will return two fake plugins that will populate the available plugins
+    list (the bottom one). The first plugin will not be available on
+    conda-forge so will be greyed out ("test-name-0"). The second plugin will
+    be available on conda-forge so will be enabled ("test-name-1").
     """
     # This mock `base_data`` will be the same for both fake plugins.
     base_data = {

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -510,6 +510,20 @@ class QPluginList(QListWidget):
         self.setSortingEnabled(True)
         self._remove_list = []
 
+    def _count_visible(self) -> int:
+        """Return the number of visible items.
+
+        Visible items are the result of the normal `count` method minus
+        any hidden items.
+        """
+        hidden = 0
+        count = self.count()
+        for i in range(count):
+            item = self.item(i)
+            hidden += item.isHidden()
+
+        return count - hidden
+
     @Slot(PackageMetadata)
     def addItem(
         self,


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This adds initial tests for the plugin dialog. It should help catch the pyside2 issue but with conda installs. For pypi the issue seems to not be there? (or maybe the versions have been updated)

**Some updates**

it did catch the error 

```bash
napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py FFF
  
  ==================================== ERRORS ====================================
  ____________ ERROR at teardown of test_filter_not_available_plugins ____________
  TEARDOWN ERROR: Exceptions caught in Qt event loop:
  ________________________________________________________________________________
  Traceback (most recent call last):
    File "/home/runner/work/napari/napari/napari/_qt/dialogs/qt_plugin_dialog.py", line 947, in _handle_yield
      self.filter()
    File "/home/runner/work/napari/napari/napari/_qt/dialogs/qt_plugin_dialog.py", line 956, in filter
      self.installed_list.filter(text)
    File "/home/runner/work/napari/napari/napari/_qt/dialogs/qt_plugin_dialog.py", line 673, in filter
      item.setHidden(item not in shown)
  NotImplementedError: operator not implemented.
  ________________________________________________________________________________
  Traceback (most recent call last):
    File "/home/runner/work/napari/napari/napari/_qt/dialogs/qt_plugin_dialog.py", line 947, in _handle_yield
      self.filter()
    File "/home/runner/work/napari/napari/napari/_qt/dialogs/qt_plugin_dialog.py", line 956, in filter
      self.installed_list.filter(text)
    File "/home/runner/work/napari/napari/napari/_qt/dialogs/qt_plugin_dialog.py", line 673, in filter
      item.setHidden(item not in shown)
  NotImplementedError: operator not implemented.
```
## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
