### PR TITLE
Minor error message improvement.

### DIFF
--- a/napari/utils/colormaps/standardize_color.py
+++ b/napari/utils/colormaps/standardize_color.py
@@ -442,10 +442,15 @@ def _check_color_dim(val):
     """
     val = np.atleast_2d(val)
     if val.shape[1] not in (3, 4):
+        strval = str(val)
+        if len(strval) > 100:
+            strval = strval[:97] + '...'
         raise RuntimeError(
             trans._(
-                'Value must have second dimension of size 3 or 4',
+                'Value must have second dimension of size 3 or 4. Got `{val}`, shape={shape}',
                 deferred=True,
+                shape=val.shape,
+                val=strval,
             )
         )
 


### PR DESCRIPTION
Include the value and the shape in the error message for easier
debugging.

I could easily be convinced to put only the shape as I guess the value
itself could be quite long.