### PR TITLE
Adjust conditions that control package signing and artifact uploads (constructor installers)

### DIFF
--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -352,7 +352,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         # CI artifact uploads only for PRs and pushes to main
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' and github.ref_name == 'main')
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'main')
         with:
           name: napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }}
           path: napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }}

--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -129,6 +129,8 @@ jobs:
 
       - name: Upload to anaconda.org
         shell: bash -l {0}
+        # Only upload to anaconda.org/napari if it's a nightly (version with *dev* suffix)
+        # or a tag event (either RC or final). Nightlies and RCs go to the nightly channel.
         if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/v')
         run: |
           label_args=""
@@ -249,6 +251,7 @@ jobs:
       # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development#add-a-step-to-your-workflow
       - name: Load signing certificate (MacOS)
         shell: bash -l {0}
+        # We only sign pushes to main, nightlies, RCs and final releases
         if: runner.os == 'macOS' && (github.event_name == 'schedule' || github.event_name == 'push')
         env:
           APPLE_APPLICATION_CERTIFICATE_BASE64: ${{ secrets.APPLE_APPLICATION_CERTIFICATE_BASE64 }}
@@ -283,6 +286,7 @@ jobs:
           echo "CONSTRUCTOR_NOTARIZATION_IDENTITY=${notarization_identity}" >> $GITHUB_ENV
 
       - name: Load signing certificate (Windows)
+        # We only sign pushes to main, nightlies, RCs and final releases
         if: runner.os == 'Windows' && (github.event_name == 'schedule' || github.event_name == 'push')
         # We are signing with Apple's certificate to provide _something_
         # This is not trusted by Windows so the warnings are still there, but curious users
@@ -328,6 +332,7 @@ jobs:
           path: ${{ env.LICENSES_ARTIFACT_PATH }}
 
       - name: Notarize Bundle (macOS)
+        # We only sign pushes to main, nightlies, RCs and final releases
         if: runner.os == 'macOS' && (github.event_name == 'schedule' || github.event_name == 'push')
         uses: devbotsxyz/xcode-notarize@v1
         with:
@@ -338,6 +343,7 @@ jobs:
           verbose: true
 
       - name: Staple Bundle (macOS)
+        # We only sign pushes to main, nightlies, RCs and final releases
         if: runner.os == 'macOS' && (github.event_name == 'schedule' || github.event_name == 'push')
         uses: devbotsxyz/xcode-staple@v1
         with:
@@ -345,7 +351,8 @@ jobs:
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
-        if: github.event_name == 'pull_request'
+        # CI artifact uploads only for PRs and pushes to main
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' and github.ref_name == 'main')
         with:
           name: napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }}
           path: napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }}

--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -129,14 +129,18 @@ jobs:
 
       - name: Upload to anaconda.org
         shell: bash -l {0}
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/v')
         run: |
+          label_args=""
+          if [[ $NAPARI_VERSION == *rc* || $NAPARI_VERSION == *dev* ]]; then
+            label_args="-l nightly"
+          fi
           anaconda \
             -t ${{ secrets.ANACONDA_TOKEN }} \
             upload \
             --skip-existing \
             -u napari \
-            -l nightly \
+            $label_args \
             ${GITHUB_WORKSPACE}${conda_bld_suffix}noarch/*.tar.bz2
 
   constructor-bundle:
@@ -234,7 +238,7 @@ jobs:
         run: |
           pkgs=$(shopt -s nullglob dotglob; echo "${CONDA_BLD_PATH}/noarch/*.tar.bz2")
           if (( ${#pkgs} )); then
-            conda index "${CONDA_BLD_PATH}/noarch"
+            conda index "${CONDA_BLD_PATH}"
             conda search -c local --override-channels
             echo CONSTRUCTOR_USE_LOCAL=1 >> $GITHUB_ENV
           else
@@ -245,7 +249,7 @@ jobs:
       # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development#add-a-step-to-your-workflow
       - name: Load signing certificate (MacOS)
         shell: bash -l {0}
-        if: runner.os == 'macOS' && github.event_name == 'schedule'
+        if: runner.os == 'macOS' && (github.event_name == 'schedule' || github.event_name == 'push')
         env:
           APPLE_APPLICATION_CERTIFICATE_BASE64: ${{ secrets.APPLE_APPLICATION_CERTIFICATE_BASE64 }}
           APPLE_INSTALLER_CERTIFICATE_BASE64: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_BASE64 }}
@@ -279,7 +283,7 @@ jobs:
           echo "CONSTRUCTOR_NOTARIZATION_IDENTITY=${notarization_identity}" >> $GITHUB_ENV
 
       - name: Load signing certificate (Windows)
-        if: runner.os == 'Windows' && github.event_name == 'schedule'
+        if: runner.os == 'Windows' && (github.event_name == 'schedule' || github.event_name == 'push')
         # We are signing with Apple's certificate to provide _something_
         # This is not trusted by Windows so the warnings are still there, but curious users
         # will be able to check it's actually us if necessary
@@ -324,7 +328,7 @@ jobs:
           path: ${{ env.LICENSES_ARTIFACT_PATH }}
 
       - name: Notarize Bundle (macOS)
-        if: runner.os == 'macOS' && github.event_name == 'schedule'
+        if: runner.os == 'macOS' && (github.event_name == 'schedule' || github.event_name == 'push')
         uses: devbotsxyz/xcode-notarize@v1
         with:
           product-path: napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }}
@@ -334,13 +338,14 @@ jobs:
           verbose: true
 
       - name: Staple Bundle (macOS)
-        if: runner.os == 'macOS' && github.event_name == 'schedule'
+        if: runner.os == 'macOS' && (github.event_name == 'schedule' || github.event_name == 'push')
         uses: devbotsxyz/xcode-staple@v1
         with:
           product-path: napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }}
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
+        if: github.event_name == 'pull_request'
         with:
           name: napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }}
           path: napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }}


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

There are certain problems with #4210:

* Some steps (signing, stapling, Anaconda uploads) were only triggered for scheduled runs, but they need to run for every non-PR step (push to main, tags, _and_ scheduled runs).
* Some artifacts (final installers) are uploaded to several places under certain triggers (e.g. the GHA artifacts + the GH Release page), which is a waste of storage and adds confusion if one needs to find the "canonical" source for the installer.

This PR introduces:

* To avoid duplication of artifacts:
  * CI artifacts will only be used in PRs. 
  * Nightlies (scheduled) and tags (RC, releases) installers will go to their corresponding release pages.
* Anaconda.org uploads will only happen for nightlies (`*dev*` version string), RCs (`*rc*` version strings) and final releases. Note these go the `napari` channel for debugging purposes, but this is not an official distribution channel. End users should obtain final releases from `conda-forge`.

Hopefully this solves the confusing red mark we can see now in the repo frontpage too. See this [tweet](https://twitter.com/Mbussonn/status/1501135305017024515) for more details.

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] CI artifacts are uploaded in this PR
- [ ] Sadly, we can only test some the changes after merging :/

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
