### PR TITLE
Fix name normalization of already installed plugins

### DIFF
--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -719,19 +719,20 @@ class QtPluginDialog(QDialog):
         self.already_installed = set()
 
         def _add_to_installed(distname, enabled, npe_version=1):
+            norm_name = normalized_name(distname or '')
             if distname:
                 meta = metadata(distname)
                 if len(meta) == 0:
                     # will not add builtins.
                     return
-                self.already_installed.add(distname)
+                self.already_installed.add(norm_name)
             else:
                 meta = {}
 
             self.installed_list.addItem(
                 PackageMetadata(
                     metadata_version="1.0",
-                    name=normalized_name(distname or ''),
+                    name=norm_name,
                     version=meta.get('version', ''),
                     summary=meta.get('summary', ''),
                     home_page=meta.get('url', ''),


### PR DESCRIPTION
# Description

Fixes an issue with constructor plugin installs, where some plugins with uppercase-lowercase mix.

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
