### PR TITLE
Use conda instead of mamba in windows conda-forge bundled app

### DIFF
--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -703,7 +703,7 @@ class QtPluginDialog(QDialog):
 
         installer_type = "pip"
         if running_as_constructor_app():
-            installer_type = "mamba"
+            installer_type = "mamba" if os.name != "nt" else "conda"
 
         self.installer = Installer(installer=installer_type)
         self.setup_ui()


### PR DESCRIPTION
# Description

The fixes by @jaimergp worked like a charm, but a new problem appeared with `mamba`. Not sure what the issue is but seems related to `win32com`.

This PR uses conda on windows and mamba for the rest. If we cannot find a quick fix for the mamba problem this is a quick workaround to go ahead with the release in the meantime.

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
