### PR TITLE
Remove access to private npe2 plugin manager attributes

### DIFF
--- a/docs/release/release_0_4_15.md
+++ b/docs/release/release_0_4_15.md
@@ -126,6 +126,7 @@ Keep reading below for the full list of changes!
 - Adjust conditions that control package signing and artifact uploads (constructor installers) (#4221)
 - Fix name normalization of already installed plugins (#4223)
 - Use conda instead of mamba in windows conda-forge bundled app (#4225)
+- Remove access to private npe2 plugin manager attributes (#4236)
 
 ## API Changes
 


### PR DESCRIPTION
# Description

This removes a 2-repo dance issue: there is a private npe2 attribute access [in `_npe2.get_sample_data`](https://github.com/napari/napari/pull/4236/files#diff-42c5982cc856a4d25d9897338acdc2ae15840f994d9d9e7417ed8e2053e47871L255) that has the potential to give bugs if changes are made upstream in npe2.  In fact, changes _were_ made, but have already been caught and fixed in https://github.com/napari/npe2/pull/116

However, it would be great to remove this anyway (preferably for 0.4.15) to avoid incompatibilities with napari and future npe2 versions.  (Note also, I've added tests on the npe2 side https://github.com/napari/npe2/pull/117 to pull and test `napari/plugins` ... but those will require #4103 to be of much use)