### PR TITLE
Add napari.yaml to first plugin file layout

### DIFF
--- a/docs/plugins/first_plugin.md
+++ b/docs/plugins/first_plugin.md
@@ -1,7 +1,7 @@
 # Your First Plugin
 
 In this tutorial, we'll step through the fundamental concepts for building a
-**bare minimum** "hello napari" plugin from scratch. 
+**bare minimum** "hello napari" plugin from scratch.
 
 At the end, we'll point you to a "cookiecutter" template
 repository that helps automate the creation of new plugins, and adds a number
@@ -57,7 +57,7 @@ then create a `napari_hello` directory with a single `__init__.py` file inside o
 ````{tabbed} macOS / Linux
 ```sh
 mkdir napari_hello
-touch napari_hello/__init__.py pyproject.toml setup.cfg
+touch napari_hello/__init__.py napari_hello/napari.yaml pyproject.toml setup.cfg
 ```
 ````
 
@@ -65,6 +65,7 @@ touch napari_hello/__init__.py pyproject.toml setup.cfg
 ```bat
 mkdir napari_hello
 copy /b napari_hello\__init__.py +,,
+copy /b napari_hello\napari.yaml +,,
 copy /b pyproject.toml +,,
 copy /b setup.cfg +,,
 ```
@@ -76,6 +77,7 @@ Your project should now look like this:
 ~/napari-hello/
 ├── napari_hello/
 │   └── __init__.py
+│   └── napari.yaml
 ├── pyproject.toml
 ├── setup.cfg
 ```
@@ -141,7 +143,7 @@ classifiers =
 packages = find:
 ```
 
-There is a *lot* more than can go in the package metadata. 
+There is a *lot* more than can go in the package metadata.
 See the [setuptools quickstart](https://setuptools.pypa.io/en/latest/userguide/quickstart.html)
 for more.
 
@@ -170,7 +172,8 @@ autogeneration capabilities to turn this function into a widget)*
 
 ### Add a `napari.yaml` manifest
 
-Create an empty [plugin manifest](./manifest) file at `napari_hello/napari.yaml`
+
+If you haven't already, create an empty [plugin manifest](./manifest) file at `napari_hello/napari.yaml`
 We will use this file to tell napari:
 
 1. That our plugin contributes a [**command**](contributions-commands)

--- a/docs/plugins/first_plugin.md
+++ b/docs/plugins/first_plugin.md
@@ -76,7 +76,7 @@ Your project should now look like this:
 ```
 ~/napari-hello/
 ├── napari_hello/
-│   └── __init__.py
+│   ├── __init__.py
 │   └── napari.yaml
 ├── pyproject.toml
 ├── setup.cfg


### PR DESCRIPTION
# Description
Reading through the first plugin tutorial it seemed like `napari.yaml` was missing from the initial file setup stage.

## Type of change
<!-- Please delete options that are not relevant. -->
Improved docs

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
