### PR TITLE
Remove headless test ignore, move orient_plane_normal test

### DIFF
--- a/napari/__init__.pyi
+++ b/napari/__init__.pyi
@@ -1,5 +1,3 @@
-from typing import Callable
-
 import napari._qt.qt_event_loop
 import napari.plugins.io
 import napari.utils.notifications
@@ -10,7 +8,7 @@ __version__: str
 
 notification_manager: napari.utils.notifications.NotificationManager
 Viewer = napari.viewer.Viewer
-current_viewer: Callable[[], Viewer]
+current_viewer = napari.viewer.current_viewer
 
 gui_qt = napari._qt.qt_event_loop.gui_qt
 run = napari._qt.qt_event_loop.run

--- a/napari/_tests/test_layer_utils_with_qt.py
+++ b/napari/_tests/test_layer_utils_with_qt.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+
+from napari.layers import Image
+from napari.layers.utils.interactivity_utils import (
+    orient_plane_normal_around_cursor,
+)
+
+
+@pytest.mark.parametrize(
+    'layer',
+    [
+        Image(np.zeros(shape=(28, 28, 28))),
+        Image(np.zeros(shape=(2, 28, 28, 28))),
+    ],
+)
+def test_orient_plane_normal_around_cursor(make_napari_viewer, layer):
+    viewer = make_napari_viewer()
+    viewer.dims.ndisplay = 3
+    viewer.camera.angles = (0, 0, 90)
+    viewer.cursor.position = [14] * layer._ndim
+
+    viewer.add_layer(layer)
+    layer.depiction = 'plane'
+    layer.plane.normal = (1, 0, 0)
+    layer.plane.position = (14, 14, 14)
+
+    # apply simple transformation on the volume
+    layer.translate = [1] * layer._ndim
+
+    # orient plane normal
+    orient_plane_normal_around_cursor(layer=layer, plane_normal=(1, 0, 1))
+
+    # check that plane normal has been updated
+    assert np.allclose(
+        layer.plane.normal, [1, 0, 1] / np.linalg.norm([1, 0, 1])
+    )
+    assert np.allclose(layer.plane.position, (14, 13, 13))

--- a/napari/layers/utils/_tests/test_interactivity_utils.py
+++ b/napari/layers/utils/_tests/test_interactivity_utils.py
@@ -1,10 +1,8 @@
 import numpy as np
 import pytest
 
-from napari.layers import Image
 from napari.layers.utils.interactivity_utils import (
     drag_data_to_projected_distance,
-    orient_plane_normal_around_cursor,
 )
 
 
@@ -32,34 +30,3 @@ def test_drag_data_to_projected_distance(
         start_position, end_position, view_direction, vector
     )
     assert np.allclose(result, expected_value)
-
-
-@pytest.mark.parametrize(
-    'layer',
-    [
-        Image(np.zeros(shape=(28, 28, 28))),
-        Image(np.zeros(shape=(2, 28, 28, 28))),
-    ],
-)
-def test_orient_plane_normal_around_cursor(make_napari_viewer, layer):
-    viewer = make_napari_viewer()
-    viewer.dims.ndisplay = 3
-    viewer.camera.angles = (0, 0, 90)
-    viewer.cursor.position = [14] * layer._ndim
-
-    viewer.add_layer(layer)
-    layer.depiction = 'plane'
-    layer.plane.normal = (1, 0, 0)
-    layer.plane.position = (14, 14, 14)
-
-    # apply simple transformation on the volume
-    layer.translate = [1] * layer._ndim
-
-    # orient plane normal
-    orient_plane_normal_around_cursor(layer=layer, plane_normal=(1, 0, 1))
-
-    # check that plane normal has been updated
-    assert np.allclose(
-        layer.plane.normal, [1, 0, 1] / np.linalg.norm([1, 0, 1])
-    )
-    assert np.allclose(layer.plane.position, (14, 13, 13))

--- a/tox.ini
+++ b/tox.ini
@@ -81,7 +81,9 @@ commands_pre =
     headless: pip uninstall -y pytest-qt qtpy pyqt5 pyside2
 commands =
     !headless: python -m pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir} --cov-report=xml --cov={env:PYTEST_PATH:napari} --ignore tools {posargs}
-    headless: python -m pytest --color=yes --basetemp={envtmpdir} --ignore napari/_vispy --ignore napari/_qt --ignore napari/_tests --ignore tools --ignore napari/layers/utils/_tests/test_interactivity_utils.py {posargs}
+    # do not add ignores to this line just to make headless tests pass.
+    # nothing outside of _qt or _vispy should require Qt or make_napari_viewer
+    headless: python -m pytest --color=yes --basetemp={envtmpdir} --ignore napari/_vispy --ignore napari/_qt --ignore napari/_tests --ignore tools {posargs}
 
 
 [testenv:isort]


### PR DESCRIPTION
# Description
This moves the test added to `napari/layers/utils` #3759 that required a manual skip added to the headless tests in tox.

I added a comment to `tox.ini` to this effect, but the point of headless tests is that we should always be able to run `pytest napari/layers` or `pytest napari/components` ... or _any_ tests outside of the `_tests`, `_qt` or `_vispy` folders, and have it work without qt.  Rather than adding more ignores to that line in tox.ini, let's just move the tests when they require a full qt-backed viewer.