### PR TITLE
fix error message when no reader available

### DIFF
--- a/napari/components/_tests/test_add_layers.py
+++ b/napari/components/_tests/test_add_layers.py
@@ -69,6 +69,15 @@ def test_viewer_open():
     assert all(lay.source == expected_source for lay in viewer.layers)
 
 
+def test_viewer_open_no_plugin(tmp_path):
+    viewer = ViewerModel()
+    fname = tmp_path / 'gibberish.gbrsh'
+    fname.touch()
+    with pytest.raises(ValueError) as e:
+        viewer.open(fname)
+    assert 'No plugin found capable of reading' in str(e.value)
+
+
 plugin_returns = [
     ([(img, {'name': 'foo'})], {'name': 'bar'}),
     ([(img, {'blending': 'additive'}), (img,)], {'blending': 'translucent'}),

--- a/napari/plugins/io.py
+++ b/napari/plugins/io.py
@@ -113,12 +113,12 @@ def read_data_with_plugins(
 
     layer_data = None
     result = hook_caller.call_with_result_obj(path=npe1_path)
-    reader = result.result  # will raise exceptions if any occurred
-    try:
-        layer_data = reader(npe1_path)  # try to read data
-        hookimpl = result.implementation
-    except Exception as exc:
-        raise PluginCallError(result.implementation, cause=exc)
+    if reader := result.result:  # will raise exceptions if any occurred
+        try:
+            layer_data = reader(npe1_path)  # try to read data
+            hookimpl = result.implementation
+        except Exception as exc:
+            raise PluginCallError(result.implementation, cause=exc) from exc
 
     if not layer_data:
         # if layer_data is empty, it means no plugin could read path


### PR DESCRIPTION
# Description
This fixes the error message that one gets when no reader is available (a regression introduced in #4026), and adds a test
fixes #4253