### PR TITLE
catch elementwise comparison warning that now shows frequently on layer creation

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -930,7 +930,6 @@ def test_out_of_slice_display():
     assert layer.out_of_slice_display is True
 
 
-@pytest.mark.filterwarnings("ignore:elementwise comparison fail:FutureWarning")
 @pytest.mark.parametrize("attribute", ['edge', 'face'])
 def test_switch_color_mode(attribute):
     """Test switching between color modes"""

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -1342,7 +1342,6 @@ def test_blending():
     assert layer.blending == 'opaque'
 
 
-@pytest.mark.filterwarnings("ignore:elementwise comparison fail:FutureWarning")
 @pytest.mark.parametrize("attribute", ['edge', 'face'])
 def test_switch_color_mode(attribute):
     """Test switching between color modes"""

--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -475,7 +475,6 @@ def test_edge_color_map_non_numeric_property():
         layer.edge_color_mode = 'colormap'
 
 
-@pytest.mark.filterwarnings("ignore:elementwise comparis:FutureWarning:numpy")
 def test_switching_edge_color_mode():
     """Test transitioning between all color modes"""
     np.random.seed(0)

--- a/napari/utils/_tests/test_misc.py
+++ b/napari/utils/_tests/test_misc.py
@@ -192,3 +192,6 @@ def test_equality_operator():
     assert (
         pick_equality_operator(xr.DataArray(np.ones((1, 1)))) == np.array_equal
     )
+    eq = pick_equality_operator(np.asarray([]))
+    # make sure this doesn't warn
+    assert not eq(np.asarray([]), np.asarray([], '<U32'))

--- a/napari/utils/_tests/test_misc.py
+++ b/napari/utils/_tests/test_misc.py
@@ -6,6 +6,7 @@ import pytest
 
 from napari.utils.misc import (
     StringEnum,
+    _quiet_array_equal,
     abspath_or_url,
     ensure_iterable,
     ensure_sequence_of_iterables,
@@ -185,12 +186,13 @@ def test_equality_operator():
     class MyNPArray(np.ndarray):
         pass
 
-    assert pick_equality_operator(np.ones((1, 1))) == np.array_equal
-    assert pick_equality_operator(MyNPArray([1, 1])) == np.array_equal
+    assert pick_equality_operator(np.ones((1, 1))) == _quiet_array_equal
+    assert pick_equality_operator(MyNPArray([1, 1])) == _quiet_array_equal
     assert pick_equality_operator(da.ones((1, 1))) == operator.is_
     assert pick_equality_operator(zarr.ones((1, 1))) == operator.is_
     assert (
-        pick_equality_operator(xr.DataArray(np.ones((1, 1)))) == np.array_equal
+        pick_equality_operator(xr.DataArray(np.ones((1, 1))))
+        == _quiet_array_equal
     )
     eq = pick_equality_operator(np.asarray([]))
     # make sure this doesn't warn

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -484,13 +484,13 @@ def pick_equality_operator(obj) -> Callable[[Any, Any], bool]:
 
     type_ = type(obj) if not inspect.isclass(obj) else obj
 
-    # yes, it's a little riskier, but we are checking namespaces instead of
-    # actual `issubclass` here to avoid slow import times
     def _quiet_array_equal(*a, **k):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", "elementwise comparison")
             return np.array_equal(*a, **k)
 
+    # yes, it's a little riskier, but we are checking namespaces instead of
+    # actual `issubclass` here to avoid slow import times
     _known_arrays = {
         'numpy.ndarray': _quiet_array_equal,  # numpy.ndarray
         'dask.Array': operator.is_,  # dask.array.core.Array

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -459,6 +459,12 @@ def ensure_list_of_layer_data_tuple(val):
     )
 
 
+def _quiet_array_equal(*a, **k):
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "elementwise comparison")
+        return np.array_equal(*a, **k)
+
+
 def pick_equality_operator(obj) -> Callable[[Any, Any], bool]:
     """Return a function that can check equality between ``obj`` and another.
 
@@ -483,11 +489,6 @@ def pick_equality_operator(obj) -> Callable[[Any, Any], bool]:
     import operator
 
     type_ = type(obj) if not inspect.isclass(obj) else obj
-
-    def _quiet_array_equal(*a, **k):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", "elementwise comparison")
-            return np.array_equal(*a, **k)
 
     # yes, it's a little riskier, but we are checking namespaces instead of
     # actual `issubclass` here to avoid slow import times


### PR DESCRIPTION
# Description
fixes #4231
our `pick_equality_operator` (which runs anytime an evented model field is changed) is now throwing warnings for numpy array fields.  This catches the element wise comparison FutureWarning (which doesn't seem like it should affect our equality check).  


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
