### PR TITLE
Raise error when binding a button to a generator function

### DIFF
--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -197,6 +197,9 @@ class ActionManager:
         calling `bind_button` can be done before an action with the
         corresponding name is registered, in which case the effect will be
         delayed until the corresponding action is registered.
+        
+        Note: this method cannot be used with generator functions,
+        see https://github.com/napari/napari/issues/4164 for details.
         """
         self._validate_action_name(name)
 

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -197,7 +197,7 @@ class ActionManager:
         calling `bind_button` can be done before an action with the
         corresponding name is registered, in which case the effect will be
         delayed until the corresponding action is registered.
-        
+
         Note: this method cannot be used with generator functions,
         see https://github.com/napari/napari/issues/4164 for details.
         """


### PR DESCRIPTION
# Description
fixes #4164 

It's tempting to use the same generator function as a keybinding and a button binding, but there be lots o' dragons there.  See #4164  for long discussion.  This PR checks to see if the action to which someone is binding a button is registered to a generator function, and raises an exception if so.
It still cannot prevent the unexpected behavior if someone registers the action _after_ binding the button

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
