### PR TITLE
Bugfix: Divide by zero error making empty shapes layer

### DIFF
--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -35,6 +35,13 @@ def test_empty_shapes():
     assert shp.ndim == 2
 
 
+def test_update_thumbnail_empty_shapes():
+    """Test updating the thumbnail with an empty shapes layer."""
+    layer = Shapes()
+    layer._allow_thumbnail_update = True
+    layer._update_thumbnail()
+
+
 properties_array = {'shape_type': _make_cycled_properties(['A', 'B'], 10)}
 properties_list = {'shape_type': list(_make_cycled_properties(['A', 'B'], 10))}
 

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2560,8 +2560,7 @@ class Shapes(Layer):
                 offset=offset[-2:],
                 max_shapes=self._max_shapes_thumbnail,
             )
-            # Set opacity to respect the layer setting
-            colormapped[..., 3] *= self.opacity
+
             self.thumbnail = colormapped
 
     def remove_selected(self):

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2560,7 +2560,8 @@ class Shapes(Layer):
                 offset=offset[-2:],
                 max_shapes=self._max_shapes_thumbnail,
             )
-
+            # Set opacity to respect the layer setting
+            colormapped[..., 3] *= self.opacity
             self.thumbnail = colormapped
 
     def remove_selected(self):

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2532,8 +2532,12 @@ class Shapes(Layer):
     def _update_thumbnail(self, event=None):
         """Update thumbnail with current shapes and colors."""
 
-        # don't update the thumbnail if dragging a shape
-        if self._is_moving is False and self._allow_thumbnail_update is True:
+        # don't update the thumbnail if dragging a shape or shapes layer is empty
+        if (
+            self._is_moving is False
+            and self._allow_thumbnail_update is True
+            and len(self.data) > 0
+        ):
             # calculate min vals for the vertices and pad with 0.5
             # the offset is needed to ensure that the top left corner of the shapes
             # corresponds to the top left corner of the thumbnail

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2531,13 +2531,14 @@ class Shapes(Layer):
 
     def _update_thumbnail(self, event=None):
         """Update thumbnail with current shapes and colors."""
-
-        # don't update the thumbnail if dragging a shape or shapes layer is empty
-        if (
-            self._is_moving is False
-            and self._allow_thumbnail_update is True
-            and len(self.data) > 0
-        ):
+        # Set the thumbnail to black, opacity 1
+        colormapped = np.zeros(self._thumbnail_shape)
+        colormapped[..., 3] = 1
+        # if the shapes layer is empty, don't update, just leave it black
+        if len(self.data) == 0:
+            self.thumbnail = colormapped
+        # don't update the thumbnail if dragging a shape
+        elif self._is_moving is False and self._allow_thumbnail_update is True:
             # calculate min vals for the vertices and pad with 0.5
             # the offset is needed to ensure that the top left corner of the shapes
             # corresponds to the top left corner of the thumbnail


### PR DESCRIPTION
# Description
I'm adding the check for empty layer data to the Shapes layer thumbnail creating function.
This function at present triggers a `divide by zero` error on arm64/macOS (and perhaps just that?). 
This patch avoids that error.
See: https://github.com/napari/napari/issues/3568

I noticed that thumbnail generation for the Shapes layer does not check if the data is empty. 
Points and Tracks do check for this.
Here I've copy-pasta'd the Points thumbnail check. This eliminates the error on macos 12.2.1 arm64.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Copy paste from: https://github.com/napari/napari/blob/785e49a1e4a54f10a09ce87fccb95dc19e3886d5/napari/layers/points/points.py#L1354-L1355

Closes: https://github.com/napari/napari/issues/3568

# How has this been tested?
I've tested this locally on my M1 (arm64) MacbookPro—I've had this patch applied to every napari release since Nov. 2021.
I'm not sure if this needs a test nor how to write one.
Edit: @alisterburt wrote a test. Here are the results of the test run on live (0.4.15) where the error is emitted and with the patch where that doesn't occur:
https://github.com/psobolewskiPhD/napari/pull/1#issuecomment-1068883886

- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
