### PR TITLE
Fix README links Contributing Guide, Mission&Values, Code of Conduct, & GovModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You can see details of [the project roadmap here](https://napari.org/roadmaps/in
 
 ## contributing
 
-Contributions are encouraged! Please read our [contributing guide](https://napari.org/docs/dev/developers/contributing.html) to get started. Given that we're in an early stage, you may want to reach out on our [Github Issues](https://github.com/napari/napari/issues) before jumping in.
+Contributions are encouraged! Please read our [contributing guide](https://napari.org/developers/contributing.html) to get started. Given that we're in an early stage, you may want to reach out on our [Github Issues](https://github.com/napari/napari/issues) before jumping in.
 
 ## code of conduct
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For more details on how to use `napari` checkout our [tutorials](https://napari.
 
 ## mission, values, and roadmap
 
-For more information about our plans for `napari` you can read our [mission and values statement](https://napari.org/docs/dev/developers/mission_and_values.html), which includes more details on our vision for supporting a plugin ecosystem around napari.
+For more information about our plans for `napari` you can read our [mission and values statement](https://napari.org/community/mission_and_values.html), which includes more details on our vision for supporting a plugin ecosystem around napari.
 You can see details of [the project roadmap here](https://napari.org/roadmaps/index.html).
 
 ## contributing

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Contributions are encouraged! Please read our [contributing guide](https://napar
 
 ## code of conduct
 
-`napari` has a [Code of Conduct](https://napari.org/docs/dev/developers/code_of_conduct.html) that should be honored by everyone who participates in the `napari` community.
+`napari` has a [Code of Conduct](https://napari.org/community/code_of_conduct.html) that should be honored by everyone who participates in the `napari` community.
 
 ## governance
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Contributions are encouraged! Please read our [contributing guide](https://napar
 
 ## governance
 
-You can learn more about how the `napari` project is organized and managed from our [governance model](https://napari.org/docs/dev/developers/governance.html), which includes information about, and ways to contact, the [@napari/steering-council](https://github.com/orgs/napari/teams/steering-council) and [@napari/core-devs](https://github.com/orgs/napari/teams/core-devs).
+You can learn more about how the `napari` project is organized and managed from our [governance model](https://napari.org/community/governance.html), which includes information about, and ways to contact, the [@napari/steering-council](https://github.com/orgs/napari/teams/steering-council) and [@napari/core-devs](https://github.com/orgs/napari/teams/core-devs).
 
 ## citing napari
 


### PR DESCRIPTION


# Description
Not sure I'm doing this correctly, but the link in the GitHub README was to an old doc and now is a 404.
This should point to the proper napari.org page.

## Type of change
- [. ] Bug-fix (non-breaking change which fixes an issue)

# References
napari.org Contributing Resources

This should fix: https://github.com/napari/napari/issues/4266

# How has this been tested?
N/A ? I think?

## Final checklist:
- [. ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
