### PR TITLE
Bugfix: Conversion between Label and Image with original scaling

### DIFF
--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -116,7 +116,7 @@ def _convert(ll: LayerList, type_: str):
             data = lay.to_labels()
         else:
             data = lay.data.astype(int) if type_ == 'labels' else lay.data
-        new_layer = Layer.create(data, {'name': lay.name}, type_)
+        new_layer = Layer.create(data, lay._get_base_state(), type_)
         ll.insert(idx, new_layer)
 
 

--- a/napari/layers/_tests/test_layer_actions.py
+++ b/napari/layers/_tests/test_layer_actions.py
@@ -105,4 +105,4 @@ def test_convert_layer(input, type_):
     assert ll[0]._type_string != type_
     _convert(ll, type_)
     assert ll[0]._type_string == type_
-    assert (ll[0].scale == original_scale).all()
+    assert np.array_equal(ll[0].scale, original_scale)

--- a/napari/layers/_tests/test_layer_actions.py
+++ b/napari/layers/_tests/test_layer_actions.py
@@ -99,7 +99,10 @@ def test_convert_dtype(mode):
 )
 def test_convert_layer(input, type_):
     ll = LayerList()
+    input.scale *= 1.5
+    original_scale = input.scale.copy()
     ll.append(input)
     assert ll[0]._type_string != type_
     _convert(ll, type_)
     assert ll[0]._type_string == type_
+    assert (ll[0].scale == original_scale).all()


### PR DESCRIPTION
# Description
Adding a change to fix https://github.com/napari/napari/issues/3389

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] loading image with `napari.view_image(skimage.data.moon(), scale=[2, 1])` and convert it to Label and back to Image.  

Could anyone tell me what test is required and how to run tests?

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
