### PR TITLE
Minor copy update: Usage page

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,8 +4,8 @@ napari leverages the power of Python to enable fast and interactive browsing,
 annotation and analysis of large multi-dimensional images.
 
 The tutorials and guides to your left are meant to help you understand how to use
-napari, as well as learn about its features and use-cases. The
-*In-depth explanations* are aimed at advanced users looking for best practices and more
+napari, as well as learn about its features and use cases. The
+*In-depth explanations* are aimed at those looking for best practices and more
 information on how napari works. 
 
 If you are new to napari, check out the [napari quickstart tutorial](tutorials/fundamentals/quick_start).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,9 +3,9 @@
 napari leverages the power of Python to enable fast and interactive browsing,
 annotation and analysis of large multi-dimensional images.
 
-The tutorials and guides below are meant to help you understand how to use
+The tutorials and guides to your left are meant to help you understand how to use
 napari, as well as learn about its features and use-cases. The
-*In-depth explanations* are aimed at those looking for best practices and more
+*In-depth explanations* are aimed at advanced users looking for best practices and more
 information on how napari works. 
 
 If you are new to napari, check out the [napari quickstart tutorial](tutorials/fundamentals/quick_start).


### PR DESCRIPTION
# Description
https://napari.org/usage.html

Simply clarifying that _in-depth explanations_ will be geared more toward advanced users. Also omitted the mention that tutorials and guides can be found below, as they're now only accessible from the side nav. 

## Type of change
- [ ] This change requires a documentation update

