### PR TITLE
Address concurrent refresh in plugin list during multiple (un)installs

### DIFF
--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -946,7 +946,7 @@ class QtPluginDialog(QDialog):
     def _end_refresh(self):
         refresh_state = self.refresh_state
         self.refresh_state = RefreshState.DONE
-        if refresh_state == RefreshState.Outdated:
+        if refresh_state == RefreshState.OUTDATED:
             self.refresh()
 
     def eventFilter(self, watched, event):

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from enum import Enum, auto
-from importlib.metadata import metadata, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, metadata
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
@@ -765,7 +765,7 @@ class QtPluginDialog(QDialog):
                     meta = metadata(distname)
                 except PackageNotFoundError:
                     self.refresh_state = RefreshState.OUTDATED
-                    return # a race condition has occurred and the package is uninstalled by another thread
+                    return  # a race condition has occurred and the package is uninstalled by another thread
                 if len(meta) == 0:
                     # will not add builtins.
                     return

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -1,9 +1,9 @@
 import os
 import sys
+from enum import Enum, auto
 from importlib.metadata import metadata
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
-from enum import Enum, auto
 
 from npe2 import PluginManager
 from npe2.manifest.package_metadata import PackageMetadata

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from enum import Enum, auto
-from importlib.metadata import metadata
+from importlib.metadata import metadata, PackageNotFoundError
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
@@ -761,7 +761,11 @@ class QtPluginDialog(QDialog):
         def _add_to_installed(distname, enabled, npe_version=1):
             norm_name = normalized_name(distname or '')
             if distname:
-                meta = metadata(distname)
+                try:
+                    meta = metadata(distname)
+                except PackageNotFoundError:
+                    self.refresh_state = RefreshState.OUTDATED
+                    return # a race condition has occurred and the package is uninstalled by another thread
                 if len(meta) == 0:
                     # will not add builtins.
                     return

--- a/napari/plugins/hub.py
+++ b/napari/plugins/hub.py
@@ -16,7 +16,7 @@ NAPARI_HUB_PLUGINS = 'https://api.napari-hub.org/plugins'
 ANACONDA_ORG = 'https://api.anaconda.org/package/{channel}/{package_name}'
 
 
-@lru_cache(maxsize=128)
+@lru_cache(maxsize=1024)
 def hub_plugin_info(
     name: str,
     min_dev_status=3,

--- a/napari/plugins/pypi.py
+++ b/napari/plugins/pypi.py
@@ -23,7 +23,7 @@ setup_py_pypi_name = re.compile(
 )
 
 
-@lru_cache(maxsize=128)
+@lru_cache(maxsize=1024)
 def get_packages_by_prefix(prefix: str) -> Dict[str, str]:
     """Search for packages starting with ``prefix`` on pypi.
 
@@ -48,7 +48,7 @@ def get_packages_by_prefix(prefix: str) -> Dict[str, str]:
     }
 
 
-@lru_cache(maxsize=128)
+@lru_cache(maxsize=1024)
 def get_packages_by_classifier(classifier: str) -> List[str]:
     """Search for packages declaring ``classifier`` on PyPI
 
@@ -72,7 +72,7 @@ def get_packages_by_classifier(classifier: str) -> List[str]:
     return packages
 
 
-@lru_cache(maxsize=128)
+@lru_cache(maxsize=1024)
 def get_package_versions(name: str) -> List[str]:
     """Get available versions of a package on pypi
 
@@ -92,7 +92,7 @@ def get_package_versions(name: str) -> List[str]:
     return re.findall(f'>{name}-(.+).tar', html.decode())
 
 
-@lru_cache(maxsize=128)
+@lru_cache(maxsize=1024)
 def ensure_published_at_pypi(
     name: str, min_dev_status=3
 ) -> Optional[PackageMetadata]:


### PR DESCRIPTION
# Description
* increase plugin entry caching to 1024 to reduce eviction given the size of plugins increase. (One day someone will add paging here, I hope)

* add lock on refresh to avoid concurrent refreshes during multiple plugin (un)installs

* in the rare case where the refresh thread cannot find a package that is likely uninstalled by another thread: ignore the error and rely on the hard refresh to resolve the inconsistency


## Type of change
- Bug-fix (non-breaking change which fixes an issue)

# References
closes #4233 
closes #4229 
closes #4232

# How has this been tested?
I need someone to help me test this, I can only run bundled app on my m1 mac as of now

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
