### PR TITLE
Allow remote .tiff files to be loaded

### DIFF
--- a/napari/plugins/_tests/test_reader_plugins.py
+++ b/napari/plugins/_tests/test_reader_plugins.py
@@ -100,6 +100,17 @@ def test_builtin_reader_plugin_stacks():
         os.unlink(tmp.name)
 
 
+def test_builtin_reader_plugin_url():
+    layer_data, _ = io.read_data_with_plugins(
+        ['https://samples.fiji.sc/FakeTracks.tif']
+    )
+
+    assert layer_data is not None
+    assert isinstance(layer_data, list)
+    assert len(layer_data) == 1
+    assert isinstance(layer_data[0], tuple)
+
+
 def test_reader_plugin_can_return_null_layer_sentinel(
     napari_plugin_manager, monkeypatch
 ):

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -1,10 +1,15 @@
 import csv
 import os
 import re
+import tempfile
+import urllib.parse
+import urllib.request
 import warnings
+from contextlib import contextmanager
 from glob import glob
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
+from urllib.error import HTTPError, URLError
 
 import imageio
 import numpy as np
@@ -134,7 +139,9 @@ def imread(filename: str) -> np.ndarray:
     if ext.lower() in [".tif", ".tiff", ".lsm"]:
         import tifffile
 
-        return tifffile.imread(filename)
+        # Pre-download urls before loading them with tifffile
+        with file_or_url_context(filename) as filename:
+            return tifffile.imread(filename)
     else:
         import imageio
 
@@ -204,7 +211,11 @@ def magic_imread(filenames, *, use_dask=None, stack=True):
     filenames_expanded = []
     for filename in filenames:
         # zarr files are folders, but should be read as 1 file
-        if os.path.isdir(filename) and not guess_zarr_path(filename):
+        if (
+            os.path.isdir(filename)
+            and not guess_zarr_path(filename)
+            and not is_url(filename)
+        ):
             dir_contents = sorted(
                 glob(os.path.join(filename, '*.*')), key=_alphanumeric_key
             )
@@ -583,3 +594,47 @@ csv_reader_functions = {
     'points': _points_csv_to_layerdata,
     'shapes': _shapes_csv_to_layerdata,
 }
+
+
+URL_REGEX = re.compile(r'http://|https://|ftp://|file://|file:\\')
+
+
+def is_url(filename):
+    """Return True if string is an http or ftp path.
+
+    Originally vendored from scikit-image/skimage/io/util.py
+    """
+    return isinstance(filename, str) and URL_REGEX.match(filename) is not None
+
+
+@contextmanager
+def file_or_url_context(resource_name):
+    """Yield name of file from the given resource (i.e. file or url).
+
+    Originally vendored from scikit-image/skimage/io/util.py
+    """
+    if is_url(resource_name):
+        url_components = urllib.parse.urlparse(resource_name)
+        _, ext = os.path.splitext(url_components.path)
+        try:
+            with tempfile.NamedTemporaryFile(delete=False, suffix=ext) as f:
+                u = urllib.request.urlopen(resource_name)
+                f.write(u.read())
+            # f must be closed before yielding
+            yield f.name
+        except (URLError, HTTPError):
+            # could not open URL
+            os.remove(f.name)
+            raise
+        except (
+            FileNotFoundError,
+            FileExistsError,
+            PermissionError,
+            BaseException,
+        ):
+            # could not create temporary file
+            raise
+        else:
+            os.remove(f.name)
+    else:
+        yield resource_name

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -596,7 +596,7 @@ csv_reader_functions = {
 }
 
 
-URL_REGEX = re.compile(r'http://|https://|ftp://|file://|file:\\')
+URL_REGEX = re.compile(r'https?://|ftps?://|file://|file:\\')
 
 
 def is_url(filename):


### PR DESCRIPTION
# Description
Fixes https://github.com/napari/napari/issues/4277, by enabling remotely accesible .tiff files to be read in.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
Added test to check that a `ValueError` with a sensible error message is raised.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
