### PR TITLE
Use conda-forge/napari-feedstock source on main

### DIFF
--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -36,9 +36,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          # TODO: Match upstream, not fork!
-          repository: jaimergp/napari-feedstock
-          ref: menuinst-cep
+          repository: conda-forge/napari-feedstock
           path: napari-feedstock
 
       - name: Create environment.yml


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References

Now that https://github.com/conda-forge/napari-feedstock/pull/32 is merged, the workflow can use `conda-forge/napari-feedstock` as the recipe source, instead of my fork.

This allows us to finalize goal number 5 in https://github.com/orgs/napari/projects/10

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] PR passes and artifacts are uploaded as usual


## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
