### PR TITLE
bump scipy minimum requirement from 1.4.0 to 1.4.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ install_requires =
     PyYAML>=5.1
     pydantic>=1.9.0
     qtpy>=1.7.0
-    scipy>=1.4.0 ; python_version < '3.9'
+    scipy>=1.4.1 ; python_version < '3.9'
     scipy>=1.5.4 ; python_version >= '3.9'
     superqt>=0.2.5
     tifffile>=2020.2.16


### PR DESCRIPTION
# Description
scikit-image bumped their minimum dependency of scipy to 1.4.1 leading to [minreq test failures on CI](https://github.com/napari/napari/runs/5693628606?check_suite_focus=true#step:9:823). This PR bumps our minimum scipy requirement to 1.4.1 to match theirs

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
