### PR TITLE
Delay import of _npe2 module in napari.__main__ to prevent duplicate discovery of plugins

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -12,8 +12,6 @@ from pathlib import Path
 from textwrap import wrap
 from typing import Any, Dict, List
 
-import napari.plugins._npe2 as _npe2
-
 
 class InfoAction(argparse.Action):
     def __call__(self, *args, **kwargs):
@@ -282,7 +280,7 @@ def _run():
 
     else:
         if args.with_:
-            from .plugins import plugin_manager
+            from .plugins import _npe2, plugin_manager
 
             # if a plugin widget has been requested, this will fail immediately
             # if the requested plugin/widget is not available.


### PR DESCRIPTION
# Description
Moves the import of `napari.plugins._npe2` in `napari.__main__` to prevent running plugin discovery twice. (this just speeds up start time)

tried for a while to add a test for this (essentially, to test that importing `__main__` doesn't import anything but the top level `napari` module) ... but wasn't able to figure out the monkeypatch correctly.  The issue is that all that stuff has already been imported by the time the test runs... and naively clearing sys.modules and importing again doesn't work 