### PR TITLE
Fix black line ellipse

### DIFF
--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -942,6 +942,9 @@ def points_in_poly(points, vertices):
         )
         cond_3 = np.logical_or(cond_1, cond_2)
         d = vertices[j] - vertices[i]
+        # Prevents floating point imprecision from generating false positives
+        tolerance = 1e-14
+        d = np.where(abs(d) < tolerance, 0, d)
         if d[1] == 0:
             # If y vertices are aligned avoid division by zero
             cond_4 = 0 < d[0] * (points[:, 1] - vertices[i, 1])

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -943,7 +943,7 @@ def points_in_poly(points, vertices):
         cond_3 = np.logical_or(cond_1, cond_2)
         d = vertices[j] - vertices[i]
         # Prevents floating point imprecision from generating false positives
-        tolerance = 1e-14
+        tolerance = 1e-12
         d = np.where(abs(d) < tolerance, 0, d)
         if d[1] == 0:
             # If y vertices are aligned avoid division by zero


### PR DESCRIPTION
# Description
Hi napari developers,

First of all thank you for developing and maintaining such an amazing tool as napari, I use and enjoy it a lot!!
I hope I can contribute to improve it to the best of my skills.

About this draft PR, I spent some time trying to fix #4075 in order to make the [napari-crop](https://github.com/BiAPoL/napari-crop) plugin work as expected. When manually drawing in the viewer, this rarely happens, but it happens very often if the shape is defined by a numpy array (there is a MWE in #4075, but also in [this notebook](https://haesleinhuepf.github.io/BioImageAnalysisNotebooks/31_graphical_user_interfaces/napari_crop.html)).

I found out the black lines appear due to a floating result imprecision after a subtraction [in this line](https://github.com/napari/napari/blob/0ff842d11c6e67c77373ffda011125ee9d7bc98b/napari/layers/shapes/_shapes_utils.py#L944).  I have a few solutions to propose that I would like to discuss here.

The one proposed is to simply insert a tolerance at that point so that those super small values would round to 0. Another way of doing this would be with `np.around(vertices[j] - vertices[i], x)`.

Besides that, I noticed that this happens because the center of the ellipse is passed as the first element of the `vertices` array. And because the first and last vertices are the same, this makes `vertices[0]`, `vertices[1]` and `vertices[-1]` have the same 'x' coordinate, increasing the chances of the floating imprecision situation. Thus, another workaround could be to pass `vertices[:2]` in [this line](https://github.com/napari/napari/blob/0ff842d11c6e67c77373ffda011125ee9d7bc98b/napari/layers/shapes/_shapes_utils.py#L911). I am just not sure if this could impact other shapes.

Please let me know what you think of the proposed solutions.
I could also try to add a test somewhere if you think it is worth it :)

Best,
Marcelo

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
This would close #4075. It would also close an [issue in napari-crop](https://github.com/BiAPoL/napari-crop/issues/8). This was referenced in [image.sc forum](https://forum.image.sc/t/napari-how-can-i-see-the-code-of-what-i-do-in-gui/62885/8) before.
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
I tested with the MWE provided in #4075 and also executing the [jupyter notebook mentioned before](https://haesleinhuepf.github.io/BioImageAnalysisNotebooks/31_graphical_user_interfaces/napari_crop.html).
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
