### PR TITLE
Fix Labels.fill when Labels.data is an xarray.DataArray

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -986,6 +986,22 @@ def test_fill_tensorstore():
         np.testing.assert_array_equal(modified_labels, np.asarray(data))
 
 
+def test_fill_with_xarray():
+    """See https://github.com/napari/napari/issues/2374"""
+    data = xr.DataArray(np.zeros((5, 4, 4), dtype=int))
+    layer = Labels(data)
+
+    layer.fill((0, 2, 2), 1)
+
+    np.testing.assert_array_equal(layer.data[0, :, :], np.ones((4, 4)))
+    np.testing.assert_array_equal(layer.data[1:, :, :], np.zeros((4, 4, 4)))
+    # In the associated issue, using xarray.DataArray caused memory allocation
+    # problems due to different read indexing rules, so check that the data
+    # saved for undo has the expected vectorized shape and values.
+    undo_data = layer._undo_history[0][0][1]
+    np.testing.assert_array_equal(undo_data, np.zeros((16,)))
+
+
 @pytest.mark.parametrize(
     'scale', list(itertools.product([-2, 2], [-0.5, 0.5], [-0.5, 0.5]))
 )
@@ -1382,17 +1398,3 @@ def test_get_status_with_custom_index():
     assert layer.get_status((0, 0)) == 'Labels [0 0]: 0; [No Properties]'
     assert layer.get_status((3, 3)) == 'Labels [3 3]: 1; text1: 1, text2: 7'
     assert layer.get_status((6, 6)) == 'Labels [6 6]: 2; text1: 3, text2: -2'
-
-
-def test_ndarray_fill():
-    """See https://github.com/napari/napari/issues/2374"""
-    data = np.zeros((50, 512, 512), dtype=np.uint16)
-    layer = Labels(data)
-    layer.fill((0.0, 179.95039820946852, 71.67612463520015), 1)
-
-
-def test_xarray_fill():
-    """See https://github.com/napari/napari/issues/2374"""
-    data = xr.DataArray(np.zeros((50, 512, 512), dtype=np.uint16))
-    layer = Labels(data)
-    layer.fill((0.0, 179.95039820946852, 71.67612463520015), 1)

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1382,3 +1382,17 @@ def test_get_status_with_custom_index():
     assert layer.get_status((0, 0)) == 'Labels [0 0]: 0; [No Properties]'
     assert layer.get_status((3, 3)) == 'Labels [3 3]: 1; text1: 1, text2: 7'
     assert layer.get_status((6, 6)) == 'Labels [6 6]: 2; text1: 3, text2: -2'
+
+
+def test_ndarray_fill():
+    """See https://github.com/napari/napari/issues/2374"""
+    data = np.zeros((50, 512, 512), dtype=np.uint16)
+    layer = Labels(data)
+    layer.fill((0.0, 179.95039820946852, 71.67612463520015), 1)
+
+
+def test_xarray_fill():
+    """See https://github.com/napari/napari/issues/2374"""
+    data = xr.DataArray(np.zeros((50, 512, 512), dtype=np.uint16))
+    layer = Labels(data)
+    layer.fill((0.0, 179.95039820946852, 71.67612463520015), 1)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1199,7 +1199,9 @@ class Labels(_ImageBase):
         else:
             match_indices = match_indices_local
 
-        match_indices = _get_vectorized_indices(self.data, match_indices)
+        match_indices = _coerce_indices_for_vectorization(
+            self.data, match_indices
+        )
 
         self._save_history(
             (
@@ -1269,7 +1271,7 @@ class Labels(_ImageBase):
         else:
             slice_coord = slice_coord_temp
 
-        slice_coord = _get_vectorized_indices(self.data, slice_coord)
+        slice_coord = _coerce_indices_for_vectorization(self.data, slice_coord)
 
         # slice coord is a tuple of coordinate arrays per dimension
         # subset it if we want to only paint into background/only erase
@@ -1427,7 +1429,8 @@ if config.async_octree:
         pass
 
 
-def _get_vectorized_indices(data, indices):
+def _coerce_indices_for_vectorization(data, indices: list) -> tuple:
+    """Coerces indices so that they can be used for vectorized indexing in the given data array."""
     # Fix indexing for xarray if necessary
     # See http://xarray.pydata.org/en/stable/indexing.html#vectorized-indexing
     # for difference from indexing numpy

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -6,6 +6,8 @@ import numpy as np
 import pandas as pd
 from scipy import ndimage as ndi
 
+from napari.utils.misc import _is_array_type
+
 from ...utils import config
 from ...utils._dtype import normalize_dtype
 from ...utils.colormaps import (
@@ -1429,16 +1431,16 @@ if config.async_octree:
         pass
 
 
-def _coerce_indices_for_vectorization(data, indices: list) -> tuple:
+def _coerce_indices_for_vectorization(array, indices: list) -> tuple:
     """Coerces indices so that they can be used for vectorized indexing in the given data array."""
-    # Fix indexing for xarray if necessary
-    # See http://xarray.pydata.org/en/stable/indexing.html#vectorized-indexing
-    # for difference from indexing numpy
-    try:
-        import xarray as xr
+    if _is_array_type(array, 'xarray.DataArray'):
+        # Fix indexing for xarray if necessary
+        # See http://xarray.pydata.org/en/stable/indexing.html#vectorized-indexing
+        # for difference from indexing numpy
+        try:
+            import xarray as xr
 
-        if isinstance(data, xr.DataArray):
             return tuple(xr.DataArray(i) for i in indices)
-    except ImportError:
-        pass
+        except ImportError:
+            pass
     return tuple(indices)

--- a/napari/utils/_tests/test_misc.py
+++ b/napari/utils/_tests/test_misc.py
@@ -6,6 +6,7 @@ import pytest
 
 from napari.utils.misc import (
     StringEnum,
+    _is_array_type,
     _quiet_array_equal,
     abspath_or_url,
     ensure_iterable,
@@ -197,3 +198,16 @@ def test_equality_operator():
     eq = pick_equality_operator(np.asarray([]))
     # make sure this doesn't warn
     assert not eq(np.asarray([]), np.asarray([], '<U32'))
+
+
+def test_is_array_type_with_xarray():
+    import numpy as np
+    import xarray as xr
+
+    assert _is_array_type(xr.DataArray(), 'xarray.DataArray')
+    assert not _is_array_type(xr.DataArray(), 'xr.DataArray')
+    assert not _is_array_type(
+        xr.DataArray(), 'xarray.core.dataarray.DataArray'
+    )
+    assert not _is_array_type([], 'xarray.DataArray')
+    assert not _is_array_type(np.array([]), 'xarray.DataArray')

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -18,6 +18,7 @@ from typing import (
     Any,
     Callable,
     Iterable,
+    Iterator,
     Optional,
     Type,
     TypeVar,
@@ -465,6 +466,13 @@ def _quiet_array_equal(*a, **k):
         return np.array_equal(*a, **k)
 
 
+def _arraylike_short_names(obj) -> Iterator[str]:
+    """Yield all the short names of an array-like or its class."""
+    type_ = type(obj) if not inspect.isclass(obj) else obj
+    for base in type_.mro():
+        yield f'{base.__module__.split(".", maxsplit=1)[0]}.{base.__name__}'
+
+
 def pick_equality_operator(obj) -> Callable[[Any, Any], bool]:
     """Return a function that can check equality between ``obj`` and another.
 
@@ -488,8 +496,6 @@ def pick_equality_operator(obj) -> Callable[[Any, Any], bool]:
     """
     import operator
 
-    type_ = type(obj) if not inspect.isclass(obj) else obj
-
     # yes, it's a little riskier, but we are checking namespaces instead of
     # actual `issubclass` here to avoid slow import times
     _known_arrays = {
@@ -499,13 +505,33 @@ def pick_equality_operator(obj) -> Callable[[Any, Any], bool]:
         'zarr.Array': operator.is_,  # zarr.core.Array
         'xarray.DataArray': _quiet_array_equal,  # xarray.core.dataarray.DataArray
     }
-    for base in type_.mro():
-        key = f'{base.__module__.split(".", maxsplit=1)[0]}.{base.__name__}'
-        func = _known_arrays.get(key)
+
+    for name in _arraylike_short_names(obj):
+        func = _known_arrays.get(name)
         if func:
             return func
 
     return operator.eq
+
+
+def _is_array_type(array, type_name: str) -> bool:
+    """Checks if an array-like instance or class is of the type described by a short name.
+
+    This is useful when you want to check the type of array-like quickly without
+    importing its package, which might take a long time.
+
+    Parameters
+    ----------
+    array
+        The array-like object.
+    type_name : str
+        The short name of the type to test against (e.g. 'numpy.ndarray', 'xarray.DataArray').
+
+    Returns
+    -------
+    True if the array is associated with the type name.
+    """
+    return type_name in _arraylike_short_names(array)
 
 
 def dir_hash(


### PR DESCRIPTION
# Description

This fixes `Labels.fill` when `Labels.data` is an `xarray.DataArray`. The problem was caused by xarray's read indexing rules, which perform orthogonal indexing (like `np.ix_`) when given a tuple of array-likes that have no dimension labels. This issue was already handled by `Labels.paint`, so we use the same solution for `Labels.fill` by refactoring that small amount of logic into a helper function.

The original error was caused by a memory allocation issue, but writing a failing test with the same underlying cause, but small data was a little tricky. I considered testing the public API of `Labels.undo`, but that actually worked in my example (maybe because the write indexing rules of `DataArray` are not the same as the read indexing ones?), so I tested some internal state instead. I think that's fine in this case, especially as I wrote an explanatory comment.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #2374

# How has this been tested?
- [ ] new test to cover fill/undo with xarray passes
- [ ] all existing tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
