### PR TITLE
Fix image and label layer values reported in GUI status bar when display is 3D

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -823,6 +823,11 @@ class QtViewer(QSplitter):
         mapped_position = transform.imap(list(position))[:nd]
         position_world_slice = mapped_position[::-1]
 
+        # handle position for 3D views of 2D data
+        nd_point = len(self.viewer.dims.point)
+        if nd_point < nd:
+            position_world_slice = position_world_slice[-nd_point:]
+
         position_world = list(self.viewer.dims.point)
         for i, d in enumerate(self.viewer.dims.displayed):
             position_world[d] = position_world_slice[i]

--- a/napari/layers/_tests/test_layer_attributes.py
+++ b/napari/layers/_tests/test_layer_attributes.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from napari._tests.utils import layer_test_data
-from napari.layers import Image
+from napari.layers import Image, Labels
 
 
 @pytest.mark.parametrize(
@@ -54,3 +54,72 @@ def test_update_data_updates_layer_extent_cache(Layer, data, ndim):
     new_extent = layer.extent
     assert old_extent is not layer.extent
     assert new_extent is layer.extent
+
+
+def _check_subpixel_values(layer, val_dict):
+    ndisplay = layer._ndisplay
+    for center, expected_value in val_dict.items():
+        # ensure all positions within the pixel extent report the same value
+        # note: world=False so do not multiply offsets by the layer scale
+        for offset_0 in [-0.4999, 0, 0.4999]:
+            for offset_1 in [-0.4999, 0, 0.4999]:
+                position = [center[0] + offset_0, center[1] + offset_1]
+                view_direction = None
+                dims_displayed = None
+                if ndisplay == 3:
+                    position = [0] + position
+                    if isinstance(layer, Labels):
+                        # Labels implements _get_value_3d, Image does not
+                        view_direction = np.asarray([1.0, 0, 0])
+                        dims_displayed = [0, 1, 2]
+
+                val = layer.get_value(
+                    position=position,
+                    view_direction=view_direction,
+                    dims_displayed=dims_displayed,
+                    world=False,
+                )
+                assert val == expected_value
+
+
+@pytest.mark.parametrize('ImageClass', [Image, Labels])
+@pytest.mark.parametrize('ndim', [2, 3])
+def test_get_value_at_subpixel_offsets(ImageClass, ndim):
+    """check value at various shifts within a pixel/voxel's extent"""
+    if ndim == 3:
+        data = np.arange(1, 9).reshape(2, 2, 2)
+    elif ndim == 2:
+        data = np.arange(1, 5).reshape(2, 2)
+
+    # test using non-uniform scale per-axis
+    layer = ImageClass(data, scale=(0.5, 1, 2)[:ndim])
+    layer._slice_dims([0] * ndim, ndisplay=ndim)
+
+    # dictionary of expected values at each voxel center coordinate
+    val_dict = {
+        (0, 0): data[(0,) * (ndim - 2) + (0, 0)],
+        (0, 1): data[(0,) * (ndim - 2) + (0, 1)],
+        (1, 0): data[(0,) * (ndim - 2) + (1, 0)],
+        (1, 1): data[(0,) * (ndim - 2) + (1, 1)],
+    }
+    _check_subpixel_values(layer, val_dict)
+
+
+@pytest.mark.parametrize('ImageClass', [Image, Labels])
+def test_get_value_3d_view_of_2d_image(ImageClass):
+    """check value at various shifts within a pixel/voxel's extent"""
+    data = np.arange(1, 5).reshape(2, 2)
+
+    ndisplay = 3
+    # test using non-uniform scale per-axis
+    layer = ImageClass(data, scale=(0.5, 1))
+    layer._slice_dims([0] * ndisplay, ndisplay=ndisplay)
+
+    # dictionary of expected values at each voxel center coordinate
+    val_dict = {
+        (0, 0): data[(0, 0)],
+        (0, 1): data[(0, 1)],
+        (1, 0): data[(1, 0)],
+        (1, 1): data[(1, 1)],
+    }
+    _check_subpixel_values(layer, val_dict)

--- a/napari/layers/_tests/test_layer_attributes.py
+++ b/napari/layers/_tests/test_layer_attributes.py
@@ -60,7 +60,7 @@ def _check_subpixel_values(layer, val_dict):
     ndisplay = layer._ndisplay
     for center, expected_value in val_dict.items():
         # ensure all positions within the pixel extent report the same value
-        # note: world=False so do not multiply offsets by the layer scale
+        # note: values are checked in data coordinates in this function
         for offset_0 in [-0.4999, 0, 0.4999]:
             for offset_1 in [-0.4999, 0, 0.4999]:
                 position = [center[0] + offset_0, center[1] + offset_1]

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1403,6 +1403,11 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
         # create the bounding box in data coordinates
         bounding_box = self._display_bounding_box(dims_displayed)
+        # Since coordinate 0 corresponds to a pixel center, in order to
+        # correctly get the data value under the mouse at the pixel
+        # edges, we need to shift by 0.5 pixels on each axis here.
+        if not world:
+            position = tuple(p + 0.5 for p in position)
         start_point, end_point = self._get_ray_intersections(
             position=position,
             view_direction=view_direction,
@@ -1470,7 +1475,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         front_face_normal, back_face_normal = find_front_back_face(
             click_pos_data, bounding_box, view_dir
         )
-
         if front_face_normal is None and back_face_normal is None:
             # click does not intersect the data bounding box
             return None, None

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1403,10 +1403,12 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
         # create the bounding box in data coordinates
         bounding_box = self._display_bounding_box(dims_displayed)
-        # Since coordinate 0 corresponds to a pixel center, in order to
-        # correctly get the data value under the mouse at the pixel
-        # edges, we need to shift by 0.5 pixels on each axis here.
         if not world:
+            # VisPy considers the coordinate system origin to be the canvas
+            # corner, while napari considers the origin to be the **center** of
+            # the corner pixel. To get the correct value under the mouse
+            # cursor, we need to shift the position by 0.5 pixels on each
+            # axis.
             position = tuple(p + 0.5 for p in position)
         start_point, end_point = self._get_ray_intersections(
             position=position,

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -4,7 +4,7 @@ import pytest
 import xarray as xr
 
 from napari._tests.utils import check_layer_world_data_extent
-from napari.layers import Image, Labels
+from napari.layers import Image
 from napari.layers.image._image_constants import ImageRendering
 from napari.layers.utils.plane import ClippingPlaneList, SlicingPlane
 from napari.utils import Colormap
@@ -538,78 +538,6 @@ def test_value_3d(position, view_direction, dims_displayed, world):
         world=world,
     )
     assert value is None
-
-
-def _check_subpixel_values(layer, val_dict):
-    ndisplay = layer._ndisplay
-    for center, expected_value in val_dict.items():
-        # ensure all positions within the pixel extent report the same value
-        # note: world=False so do not multiply offsets by the layer scale
-        for offset_0 in [-0.4999, 0, 0.4999]:
-            for offset_1 in [-0.4999, 0, 0.4999]:
-                if ndisplay == 3:
-                    position = [0, center[0] + offset_0, center[1] + offset_1]
-                else:
-                    position = [center[0] + offset_0, center[1] + offset_1]
-
-                if ndisplay == 3 and isinstance(layer, Labels):
-                    # Labels implements _get_value_3d, Image does not
-                    view_direction = np.asarray([1.0, 0, 0])
-                    dims_displayed = [0, 1, 2]
-                else:
-                    view_direction = None
-                    dims_displayed = None
-
-                val = layer.get_value(
-                    position=position,
-                    view_direction=view_direction,
-                    dims_displayed=dims_displayed,
-                    world=False,
-                )
-                assert val == expected_value
-
-
-@pytest.mark.parametrize('ImageClass', [Image, Labels])
-@pytest.mark.parametrize('ndim', [2, 3])
-def test_get_value_at_subpixel_offsets(ImageClass, ndim):
-    """check value at various shifts within a pixel/voxel's extent"""
-    if ndim == 3:
-        data = np.arange(1, 9).reshape(2, 2, 2)
-    elif ndim == 2:
-        data = np.arange(1, 5).reshape(2, 2)
-
-    # test using non-uniform scale per-axis
-    layer = ImageClass(data, scale=(0.5, 1, 2)[:ndim])
-    layer._slice_dims([0] * ndim, ndisplay=ndim)
-
-    # dictionary of expected values at each voxel center coordinate
-    val_dict = {
-        (0, 0): data[(0,) * (ndim - 2) + (0, 0)],
-        (0, 1): data[(0,) * (ndim - 2) + (0, 1)],
-        (1, 0): data[(0,) * (ndim - 2) + (1, 0)],
-        (1, 1): data[(0,) * (ndim - 2) + (1, 1)],
-    }
-    _check_subpixel_values(layer, val_dict)
-
-
-@pytest.mark.parametrize('ImageClass', [Image, Labels])
-def test_get_value_3d_view_of_2d_data(ImageClass):
-    """check value at various shifts within a pixel/voxel's extent"""
-    data = np.arange(1, 5).reshape(2, 2)
-
-    ndisplay = 3
-    # test using non-uniform scale per-axis
-    layer = ImageClass(data, scale=(0.5, 1))
-    layer._slice_dims([0] * ndisplay, ndisplay=ndisplay)
-
-    # dictionary of expected values at each voxel center coordinate
-    val_dict = {
-        (0, 0): data[(0, 0)],
-        (0, 1): data[(0, 1)],
-        (1, 0): data[(1, 0)],
-        (1, 1): data[(1, 1)],
-    }
-    _check_subpixel_values(layer, val_dict)
 
 
 def test_message():

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -908,8 +908,15 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         else:
             shape = raw.shape
 
-        if all(0 <= c < s for c, s in zip(coord[self._dims_displayed], shape)):
-            value = raw[tuple(coord[self._dims_displayed])]
+        if self.ndim < len(coord):
+            # handle 3D views of 2D data by omitting extra coordinate
+            offset = len(coord) - len(shape)
+            coord = coord[[d + offset for d in self._dims_displayed]]
+        else:
+            coord = coord[self._dims_displayed]
+
+        if all(0 <= c < s for c, s in zip(coord, shape)):
+            value = raw[tuple(coord)]
         else:
             value = None
 


### PR DESCRIPTION
# Description

closes #4304 as well as the second issue mentioned in https://github.com/napari/napari/issues/4304#issuecomment-1077913821

I recommend reviewing the first three commits here in sequential order: 
- f580f63 fixes the original issue raised in #4304. It was split off here from #4303 and now has test cases added
- 57d1eb1 fixes the pixel values reported by `get_value` for 3D views of 2D data
- c083536 is a separate fix to the mouse coordinates used as input to `get_status/get_value` for 3D views of 2D data. This was also required in addition to the fix in 57d1eb1 to get the expected values reported correctly from the GUI.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] new test cases for `get_value` for various subpixel positions for Image and Label layers
- [x] new test cases for `get_value` when displaying 2D data in 3D mode

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
