### PR TITLE
add project_urls to setup.cfg metadata to improve project metadata on PyPI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,10 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 author = napari team
 author_email = napari-steering-council@googlegroups.com
+project_urls =
+    Bug Tracker = https://github.com/napari/napari/issues
+    Documentation = https://napari.org
+    Source Code = https://github.com/napari/napari
 classifiers =
     Development Status :: 3 - Alpha
     Environment :: X11 Applications :: Qt


### PR DESCRIPTION
# Description

This PR adds additional project URLs for PyPI. Currently napari's [project links on PyPI](https://pypi.org/project/napari/) include only "Homepage" and "Download". I think with the fix here, you will also get links for "Source Code", "Documentation" and "Bug-Tracker" (see example including these for the [PyPI entry for scikit-image](https://pypi.org/project/scikit-image/)).

I noticed that the SourceRank score for `napari` seemed [a bit low on libraries.io](https://libraries.io/pypi/napari/). This is [apparently because the source repository and thus the README, # contributors, etc. aren't found](https://libraries.io/pypi/napari/sourcerank). Hopefully adding these links will boost the score there substantially.

## Type of change
update to project metadata for PyPI

# References
The various metadata fields for setuptools are [listed here](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#metadata)

# How has this been tested?

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
