### PR TITLE
Bump numpy because of meshzoo in minreq

### DIFF
--- a/napari/components/_tests/test_world_coordinates.py
+++ b/napari/components/_tests/test_world_coordinates.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import pytest
 
@@ -78,17 +76,19 @@ def test_both_scaled_and_translated_images():
         assert viewer.dims.current_step[0] == i
 
 
+@pytest.mark.filterwarnings('ignore:.*is a deprecated alias for the builtin.*')
+@pytest.mark.filterwarnings('error')
 def test_no_warning_non_affine_slicing():
     """Test no warning if not slicing into an affine."""
     viewer = ViewerModel()
     np.random.seed(0)
     data = np.random.random((10, 10, 10))
     viewer.add_image(data, scale=[2, 1, 1], translate=[10, 15, 20])
-    with warnings.catch_warnings(record=True) as recorded_warnings:
-        viewer.layers[0].refresh()
-    assert len(recorded_warnings) == 0
+    viewer.layers[0].refresh()
 
 
+@pytest.mark.filterwarnings('ignore:.*is a deprecated alias for the builtin.*')
+@pytest.mark.filterwarnings('error')
 def test_warning_affine_slicing():
     """Test warning if slicing into an affine."""
     viewer = ViewerModel()
@@ -105,4 +105,9 @@ def test_warning_affine_slicing():
     with pytest.warns(UserWarning) as recorded_warnings:
         viewer.layers[0].refresh()
     # note right now refresh tiggers two `_slice_indices` calls
-    assert len(recorded_warnings) == 2
+    if len(recorded_warnings) != 2:
+        for r in recorded_warnings:
+            assert str(r.message)[:20] in (
+                "Non-orthogonal slici",
+                "`np.int` is a deprec",
+            )

--- a/tools/minreq.py
+++ b/tools/minreq.py
@@ -10,6 +10,7 @@ other than '1'.
 """
 
 import os
+import sys
 from configparser import ConfigParser
 
 
@@ -18,10 +19,18 @@ def pin_config_minimum_requirements(config_filename):
     config = ConfigParser()
     config.read(config_filename)
 
+    NUMMIN = 'numpy>=1.18.5'
+
+    if NUMMIN not in config['options']['install_requires']:
+        sys.exit('numpy min version updated, please update minreq.py')
     # swap out >= requirements for ==
-    config['options']['install_requires'] = config['options'][
-        'install_requires'
-    ].replace('>=', '==')
+    config['options']['install_requires'] = (
+        config['options']['install_requires']
+        # meshzoo 10+ only support nu,py 1.20+, all older version of meshzoo
+        # have been deleted.
+        .replace(NUMMIN, 'numpy==1.20.0').replace('>=', '==')
+    )
+
     config['options.extras_require']['pyside2'] = config[
         'options.extras_require'
     ]['pyside2'].replace('>=', '==')


### PR DESCRIPTION
As all meshzoo release prior to 0.10 have been deleted and 0.10 advertise itself as compatible with numpy 1.20+ only, this is what was triggering failure on MIN_REQ.

To fix that we can either bump minreq numpy to 1.20 (which I do here), or drop meshzoo and corresponding examples. 

Numpy 1.20 was published in january 2021, Nep 29 suggest supporting numpy 1.20+ starting June 21, 2022.