### PR TITLE
Fix minreq test take 3.

### DIFF
--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -23,9 +23,12 @@ skip = [
     'dynamic-projections-dask.py',  # extremely slow / does not finish
 ]
 
-
-if os.environ.get('MIN_REQ', '') == '1':
+try:
+    import meshzoo
+except ModuleNotFoundError:
+    # this should be restored once numpy min req is
     skip.extend(['spheres.py', 'clipping_planes_interactive.py'])
+
 
 EXAMPLE_DIR = Path(napari.__file__).parent.parent / 'examples'
 # using f.name here and re-joining at `run_path()` for test key presentation

--- a/tools/minreq.py
+++ b/tools/minreq.py
@@ -10,6 +10,7 @@ other than '1'.
 """
 
 import os
+import sys
 from configparser import ConfigParser
 
 
@@ -17,6 +18,13 @@ def pin_config_minimum_requirements(config_filename):
     # read it with configparser
     config = ConfigParser()
     config.read(config_filename)
+
+    if 'numpy>=1.20' in config['options.extras_require']:
+        sys.exit('please restore meshzoo install in minreq.py, ')
+    else:
+        config['options.extras_require']['testing'] = config[
+            'options.extras_require'
+        ]['testing'].replace('meshzoo', '')
 
     # swap out >= requirements for ==
     config['options']['install_requires'] = config['options'][


### PR DESCRIPTION
Here we try to not install meshzoo on minreq install, and add a failing
condition once we bump min numpy to meshzoo supported version
