### PR TITLE
Rewrite ellipse discretization from scratch

### DIFF
--- a/examples/add_points_on_nD_shapes.py
+++ b/examples/add_points_on_nD_shapes.py
@@ -3,8 +3,7 @@ import napari
 import numpy as np
 
 # Create rectangles in 4D
-shapes_data = np.array(
-    [
+data = [
         [
             [0, 50, 75, 75],
             [0, 50, 125, 75],
@@ -24,7 +23,8 @@ shapes_data = np.array(
             [1, 50, 75, 125]
         ]
     ]
-)
+
+shapes_data = np.array(data)
 
 # add an empty 4d points layer
 viewer = napari.view_points(ndim=4, size=3)
@@ -32,29 +32,30 @@ points_layer = viewer.layers[0]
 
 # add the shapes layer to the viewer
 features = {'index': [0, 1, 2]}
-shapes_layer = viewer.add_shapes(
-    shapes_data,
-    face_color=['magenta', 'green', 'blue'],
-    edge_color='white',
-    blending='additive',
-    features=features,
-    text='index'
-)
-
-
-@shapes_layer.mouse_drag_callbacks.append
-def on_click(layer, event):
-
-    shape_index, intersection_point = layer.get_index_and_intersection(
-        event.position,
-        event.view_direction,
-        event.dims_displayed
+for shape_type, mult in {('ellipse', 1), ('rectangle', -1)}:
+    shapes_layer = viewer.add_shapes(
+        shapes_data * mult,
+        face_color=['magenta', 'green', 'blue'],
+        edge_color='white',
+        blending='additive',
+        features=features,
+        text='index',
+        shape_type=shape_type,
     )
 
-    if (shape_index is not None) and (intersection_point is not None):
-        points_layer.add(intersection_point)
+    @shapes_layer.mouse_drag_callbacks.append
+    def on_click(layer, event):
+
+        shape_index, intersection_point = layer.get_index_and_intersection(
+            event.position, event.view_direction, event.dims_displayed
+        )
+
+        if (shape_index is not None) and (intersection_point is not None):
+            points_layer.add(intersection_point)
 
 
+for d in data:
+    viewer.add_points(np.array(d))
 # set the viewer to 3D rendering mode with the first two rectangles in view
 viewer.dims.ndisplay = 3
 viewer.dims.set_point(axis=0, value=0)

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -451,7 +451,7 @@ def triangulate_ellipse(corners, num_segments=100):
     corners : np.ndarray
         4xD array of four bounding corners of the ellipse. The ellipse will
         still be computed properly even if the rectangle determined by the
-        corners is not axis aligned
+        corners is not axis aligned. D in {2,3}
     num_segments : int
         Integer determining the number of segments to use when triangulating
         the ellipse
@@ -459,12 +459,23 @@ def triangulate_ellipse(corners, num_segments=100):
     Returns
     -------
     vertices : np.ndarray
-        Mx2 array coordinates of vertices for triangulating an ellipse.
+        Mx2/Mx3 array coordinates of vertices for triangulating an ellipse.
         Includes the center vertex of the ellipse, followed by `num_segments`
-        vertices around the boundary of the ellipse
+        vertices around the boundary of the ellipse (M = `num_segments`+1)
     triangles : np.ndarray
-        Px2 array of the indices of the vertices for the triangles of the
-        triangulation. Has length given by `num_segments`
+        Px3 array of the indices of the vertices for the triangles of the
+        triangulation. Has length (P) given by `num_segments`,
+        (P = M-1 = num_segments)
+
+    Notes
+    -----
+    Despite it's name the ellipse will have num_segments-1 segments on their outline.
+    That is to say num_segments=7 will lead to ellipses looking like hexagons.
+
+    The behavior of this function is not well defined if the ellipse is degenerate
+    in the current plane/volume you are currently observing.
+
+
     """
     if not corners.shape[0] == 4:
         raise ValueError(
@@ -473,45 +484,40 @@ def triangulate_ellipse(corners, num_segments=100):
                 deferred=True,
             )
         )
-
+    assert corners.shape in {(4, 2), (4, 3)}
     center = corners.mean(axis=0)
     adjusted = corners - center
 
-    vec = adjusted[1] - adjusted[0]
-    len_vec = np.linalg.norm(vec)
-    if len_vec > 0:
-        # rotate to be axis aligned
-        norm_vec = vec / len_vec
-        if corners.shape[1] == 2:
-            transform = np.array(
-                [[norm_vec[0], -norm_vec[1]], [norm_vec[1], norm_vec[0]]]
-            )
-        else:
-            transform = np.array(
-                [
-                    [0, 0],
-                    [norm_vec[0], -norm_vec[1]],
-                    [norm_vec[1], norm_vec[0]],
-                ]
-            )
-        adjusted = np.matmul(adjusted, transform)
+    # Take to consecutive corners difference
+    # that give us the 1/2 minor and major axes.
+    ax1 = (adjusted[1] - adjusted[0]) / 2
+    ax2 = (adjusted[2] - adjusted[1]) / 2
+    # Compute the transformation matrix from the unit circle
+    # to our current ellipse.
+    # ... it's easy just the 1/2 minor/major axes for the two column
+    # note that our transform shape will depends on wether we are 2D-> 2D (matrix, 2 by 2),
+    # or 2D -> 3D (matrix 2 by 3).
+    transform = np.stack((ax1, ax2))
+    if corners.shape == (4, 2):
+        assert transform.shape == (2, 2)
     else:
-        transform = np.eye(corners.shape[1])
+        assert transform.shape == (2, 3)
 
-    radii = abs(adjusted[0])
-    vertices = np.zeros((num_segments + 1, 2), dtype=np.float32)
+    # we discretize the unit circle always in 2D.
+    v2d = np.zeros((num_segments + 1, 2), dtype=np.float32)
     theta = np.linspace(0, np.deg2rad(360), num_segments)
-    vertices[1:, 0] = radii[0] * np.cos(theta)
-    vertices[1:, 1] = radii[1] * np.sin(theta)
+    v2d[1:, 0] = np.cos(theta)
+    v2d[1:, 1] = np.sin(theta)
 
-    if len_vec > 0:
-        # rotate back
-        vertices = np.matmul(vertices, transform.T)
+    # ! vertices shape can be 2,M or 3,M depending on the transform.
+    vertices = np.matmul(v2d, transform)
 
     # Shift back to center
     vertices = vertices + center
 
-    triangles = np.array([[0, i + 1, i + 2] for i in range(num_segments)])
+    triangles = (
+        np.arange(num_segments) + np.array([[0], [1], [2]])
+    ).T * np.array([0, 1, 1])
     triangles[-1, 2] = 1
 
     return vertices, triangles


### PR DESCRIPTION
There was many problem with ellipse discretization, which was losing a
lot of informations about the ellipse orientation in 3D. (Aka, fas often completely wrong if not axis aligned).

This almost completely rewrite it to be more general, as well as a bit
more efficient in the generation of the triangulation indices.

I'm not sure it is more readable (but it looks way more generic).

Main difficulty in reading this code is that the shapes of objects
(transforms), depends on Wether you are in 2 or 3D, but the math is the
same.

I've tried to heavily comment it for the next modification, as I'm
pretty sure we will hit some degenerate cases.

I've also modified one of the existing example that display ellipses
in addition to points where the 4 corners would be in order to properly
visually check the rendering it correct.

See #4326 for some visualisation of incorrect rendering.

The triangle index generation at the end is a bit hard to read:

```
-    triangles = np.array([[0, i + 1, i + 2] for i in range(num_segments)])
+    triangles = (
+        np.arange(num_segments) + np.array([[0], [1], [2]])
+    ).T * np.array([0, 1, 1])
```

So I'm' happy to revert it, but it is about an order of magnitude faster
than the Python list comprehension.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)



# How has this been tested?

Currently only visually, let's see how the test suite reacts.
I likely need to add a few test to make sure some discretizations are ok.
