### PR TITLE
Fix progress update signature

### DIFF
--- a/napari/utils/_tests/test_progress.py
+++ b/napari/utils/_tests/test_progress.py
@@ -69,6 +69,10 @@ def test_progress_update():
     pbr.refresh()
     assert pbr.n == 3
 
+    pbr.update()
+    pbr.refresh()
+    assert pbr.n == 4
+
     with assert_progress_added_to_all(pbr):
         pbr.close()
 

--- a/napari/utils/_tests/test_progress.py
+++ b/napari/utils/_tests/test_progress.py
@@ -1,6 +1,8 @@
 from contextlib import contextmanager
 
+import dask.array as da
 import numpy as np
+from tqdm.dask import TqdmCallback
 
 from napari.utils import progrange, progress
 
@@ -94,3 +96,13 @@ def test_progrange():
         with progress(range(10)) as pbr2:
             assert pbr.iterable == pbr2.iterable
     assert pbr not in progress._all_instances
+
+
+def test_progress_with_dask():
+    """Test that update works as expected"""
+    with TqdmCallback(tqdm_class=progress, desc="description") as cb:
+        array0 = da.from_array(np.random.random((10, 10)))
+        array1 = array0 * 1.0
+        array1.compute()
+        assert cb.pbar.total > 0
+        assert cb.pbar.n == cb.pbar.total

--- a/napari/utils/_tests/test_progress.py
+++ b/napari/utils/_tests/test_progress.py
@@ -1,8 +1,6 @@
 from contextlib import contextmanager
 
-import dask.array as da
 import numpy as np
-from tqdm.dask import TqdmCallback
 
 from napari.utils import progrange, progress
 
@@ -96,13 +94,3 @@ def test_progrange():
         with progress(range(10)) as pbr2:
             assert pbr.iterable == pbr2.iterable
     assert pbr not in progress._all_instances
-
-
-def test_progress_with_dask():
-    """Test that update works as expected"""
-    with TqdmCallback(tqdm_class=progress, desc="description") as cb:
-        array0 = da.from_array(np.random.random((10, 10)))
-        array1 = array0 * 1.0
-        array1.compute()
-        assert cb.pbar.total > 0
-        assert cb.pbar.n == cb.pbar.total

--- a/napari/utils/progress.py
+++ b/napari/utils/progress.py
@@ -112,7 +112,7 @@ class progress(tqdm):
         etas = str(self).split('|')[-1] if self.total != 0 else ""
         self.events.eta(value=etas)
 
-    def update(self, n):
+    def update(self, n=1):
         """Update progress value by n and emit value event"""
         super().update(n)
         self.events.value(value=self.n)


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
`napari.utils.progress` subclasses tqdm, but the signature of [`update(n)`](https://github.com/napari/napari/blob/978dd9e8108a3cd243c2266013eed4b3d2a604fc/napari/utils/progress.py#L115) did not match the tqdm's [`update(n=1)`](https://github.com/tqdm/tqdm/blob/165a23a31c746447707bb1ec6417776e9fd06140/tqdm/std.py#L1212). 

This prevented for example using Napari's progress together with [TqdmCallback](https://tqdm.github.io/docs/dask/) for getting progress indication for dask computations.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
closes https://github.com/napari/napari/issues/4332

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] additional test case for calling `update` without arguments
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
