### PR TITLE
Fix broken link and adds packaging page to toc

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -104,6 +104,7 @@ subtrees:
           - file: developers/testing
           - file: developers/profiling
           - file: developers/benchmarks
+          - file: developers/packaging
       - file: release/index
         subtrees:
         - entries:

--- a/docs/developers/packaging.md
+++ b/docs/developers/packaging.md
@@ -122,9 +122,9 @@ signing_identity_name: "Apple Developer ID: ..."  # Name of our installer signin
 welcome_image: resources/napari_164x314.png  # logo image for the first screen
 header_image:  resources/napari_150x57.png  # logo image (top left) for the rest of the installer
 icon_image: napari/resources/icon.ico  # favicon for the taskbar and title bar
-default_prefix: %USERPROFILE%/napari-0.4.12  # default location for user installs
-default_prefix_domain_user: %LOCALAPPDATA%/napari-0.4.12  # default location for network installs
-default_prefix_all_users: %ALLUSERSPROFILE%/napari-0.4.12  # default location for admin installs
+default_prefix: '%USERPROFILE%/napari-0.4.12'  # default location for user installs
+default_prefix_domain_user: '%LOCALAPPDATA%/napari-0.4.12'  # default location for network installs
+default_prefix_all_users: '%ALLUSERSPROFILE%/napari-0.4.12'  # default location for admin installs
 signing_certificate: certificate.pfx  # path to signing certificate
 ```
 

--- a/docs/tutorials/segmentation/index.md
+++ b/docs/tutorials/segmentation/index.md
@@ -1,5 +1,5 @@
 # Segmentation
 
-This section contains tutorials for segmentation [labeling](../howtos/layers/labels). 
+This section contains tutorials for segmentation [labeling](../../howtos/layers/labels).
 
 * [Annotating segmentation with text and bounding boxes](annotate_segmentation)


### PR DESCRIPTION
# Description
Fixes a broken link in the segmentation tutorials index page, and adds the packaging page to the ToC.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
