### PR TITLE
MAINT: separate ImportError from ModuleNotFoundError

### DIFF
--- a/docs/howtos/napari_imageJ.md
+++ b/docs/howtos/napari_imageJ.md
@@ -18,8 +18,8 @@ if len(sys.argv) <= 1:
 
 try:
     import imagej
-except ImportError:
-    raise ImportError("""This example uses ImageJ but pyimagej is not
+except ModuleNotFoundError:
+    raise ModuleNotFoundError("""This example uses ImageJ but pyimagej is not
     installed. To install try 'conda install pyimagej'.""")
 
 print('--> Initializing imagej')

--- a/docs/release/generate_release_notes.py
+++ b/docs/release/generate_release_notes.py
@@ -34,7 +34,7 @@ from github import Github
 
 try:
     from tqdm import tqdm
-except ImportError:
+except ModuleNotFoundError:
     warn(
         'tqdm not installed. This script takes approximately 5 minutes '
         'to run. To view live progressbars, please install tqdm. '

--- a/examples/clipping_planes_interactive_.py
+++ b/examples/clipping_planes_interactive_.py
@@ -12,8 +12,8 @@ from scipy import ndimage
 
 try:
     from meshzoo import icosa_sphere
-except ImportError as e:
-    raise ImportError(
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
         "This example uses a meshzoo but meshzoo is not installed. "
         "To install try 'pip install meshzoo'."
     ) from e

--- a/examples/dask_nD_image.py
+++ b/examples/dask_nD_image.py
@@ -7,9 +7,11 @@ Display a dask array
 
 try:
     from dask import array as da
-except ImportError:
-    raise ImportError("""This example uses a dask array but dask is not
-    installed. To install try 'pip install dask'.""")
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(
+        """This example uses a dask array but dask is not
+    installed. To install try 'pip install dask'."""
+    )
 
 import numpy as np
 from skimage import data

--- a/examples/spheres_.py
+++ b/examples/spheres_.py
@@ -7,8 +7,8 @@ Display two spheres with Surface layers
 
 try:
     from meshzoo import icosa_sphere
-except ImportError as e:
-    raise ImportError(
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
         "This example uses a meshzoo but meshzoo is not installed. "
         "To install try 'pip install meshzoo'."
     ) from e

--- a/examples/surface_timeseries_.py
+++ b/examples/surface_timeseries_.py
@@ -8,8 +8,8 @@ Display a surface timeseries using data from nilearn
 try:
     from nilearn import datasets
     from nilearn import surface
-except ImportError:
-    raise ImportError(
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(
         "You must have nilearn installed to run this example."
     )
 

--- a/examples/xarray_nD_image_.py
+++ b/examples/xarray_nD_image_.py
@@ -7,9 +7,11 @@ Displays an xarray
 
 try:
     import xarray as xr
-except ImportError:
-    raise ImportError("""This example uses a xarray but xarray is not
-    installed. To install try 'pip install xarray'.""")
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(
+        """This example uses a xarray but xarray is not
+    installed. To install try 'pip install xarray'."""
+    )
 
 import numpy as np
 import napari

--- a/examples/zarr_nD_image_.py
+++ b/examples/zarr_nD_image_.py
@@ -7,9 +7,11 @@ Display a zarr array
 
 try:
     import zarr
-except ImportError:
-    raise ImportError("""This example uses a zarr array but zarr is not
-    installed. To install try 'pip install zarr'.""")
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(
+        """This example uses a zarr array but zarr is not
+    installed. To install try 'pip install zarr'."""
+    )
 
 import napari
 

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -27,13 +27,8 @@ from napari.utils.interactions import mouse_press_callbacks
 from napari.utils.io import imread
 from napari.utils.theme import available_themes
 
-try:
-    import npe2  # noqa: F401
-
-    BUILTINS_DISP = 'napari'
-    BUILTINS_NAME = 'builtins'
-except ModuleNotFoundError:
-    BUILTINS_DISP = BUILTINS_NAME = 'builtins'
+BUILTINS_DISP = 'napari'
+BUILTINS_NAME = 'builtins'
 
 
 def test_qt_viewer(make_napari_viewer):

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -32,7 +32,7 @@ try:
 
     BUILTINS_DISP = 'napari'
     BUILTINS_NAME = 'builtins'
-except ImportError:
+except ModuleNotFoundError:
     BUILTINS_DISP = BUILTINS_NAME = 'builtins'
 
 

--- a/napari/_qt/menus/help_menu.py
+++ b/napari/_qt/menus/help_menu.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 try:
     from napari_error_reporter import ask_opt_in
-except ImportError:
+except ModuleNotFoundError:
     ask_opt_in = None
 
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import traceback
 import warnings
 from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple
 from weakref import WeakSet
@@ -438,11 +439,19 @@ class QtViewer(QSplitter):
                     self.console.push(
                         {'napari': napari, 'action_manager': action_manager}
                     )
-            except ImportError:
+            except ModuleNotFoundError:
                 warnings.warn(
                     trans._(
                         'napari-console not found. It can be installed with'
                         ' "pip install napari_console"'
+                    )
+                )
+                self._console = None
+            except ImportError:
+                traceback.print_exc()
+                warnings.warn(
+                    trans._(
+                        'error importing napari-console. See console for full error.'
                     )
                 )
                 self._console = None

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -1,6 +1,6 @@
 try:
     __import__('dotenv').load_dotenv()
-except ImportError:
+except ModuleNotFoundError:
     pass
 
 import os

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1441,6 +1441,6 @@ def _coerce_indices_for_vectorization(array, indices: list) -> tuple:
             import xarray as xr
 
             return tuple(xr.DataArray(i) for i in indices)
-        except ImportError:
+        except ModuleNotFoundError:
             pass
     return tuple(indices)

--- a/napari/utils/_tests/test_magicgui.py
+++ b/napari/utils/_tests/test_magicgui.py
@@ -14,7 +14,7 @@ from napari.utils.misc import all_subclasses
 
 try:
     import qtpy  # noqa
-except ImportError:
+except ModuleNotFoundError:
     pytest.skip('Cannot test magicgui without qtpy.', allow_module_level=True)
 except RuntimeError:
     pytest.skip(

--- a/napari/utils/_tests/test_notification_manager.py
+++ b/napari/utils/_tests/test_notification_manager.py
@@ -45,7 +45,7 @@ def test_notification_manager_no_gui(monkeypatch):
         from napari._qt.dialogs.qt_notification import NapariQtNotification
 
         monkeypatch.setattr(NapariQtNotification, "DISMISS_AFTER", 0)
-    except ImportError:
+    except ModuleNotFoundError:
         pass
     previous_exhook = sys.excepthook
     with notification_manager:

--- a/napari/utils/_tracebacks.py
+++ b/napari/utils/_tracebacks.py
@@ -52,7 +52,7 @@ def get_tb_formatter() -> Callable[[ExcInfo, bool], str]:
             np.set_string_function(None)
             return tb_text
 
-    except ImportError:
+    except ModuleNotFoundError:
         import cgitb
         import traceback
 

--- a/napari/utils/events/debugging.py
+++ b/napari/utils/events/debugging.py
@@ -11,7 +11,7 @@ from ...utils.translations import trans
 
 try:
     from rich import print
-except ImportError:
+except ModuleNotFoundError:
     print(
         trans._(
             "TIP: run `pip install rich` for much nicer event debug printout."
@@ -19,7 +19,7 @@ except ImportError:
     )
 try:
     import dotenv
-except ImportError:
+except ModuleNotFoundError:
     dotenv = None  # type: ignore
 
 if TYPE_CHECKING:

--- a/napari/utils/notebook_display.py
+++ b/napari/utils/notebook_display.py
@@ -8,7 +8,7 @@ try:
     from lxml.html.clean import Cleaner
 
     lxml_unavailable = False
-except ImportError:
+except ModuleNotFoundError:
     lxml_unavailable = True
 
 __all__ = ['nbscreenshot']


### PR DESCRIPTION
ModuleNotFoundError mean that the module is not installed,
while ImportError is anything went wrong.

I think in most of the case we shouldn't catch and silence ImportErrors,
only ModuleNotFoundError otherwise it may hide later issues.

For example I've been scratching my head with napari telling me to
install napari_qtconsole, and it _is_ installed, but have another
unrelated issues when importing


---- 

That might be controversial, I understand that we might want to be more conservative for end user and really not fail even if something else is not ok with a package. So I appreciate careful reviews of the place I have changed.