### PR TITLE
move pixel center offset code into _ImageBase

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1403,13 +1403,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
         # create the bounding box in data coordinates
         bounding_box = self._display_bounding_box(dims_displayed)
-        if not world:
-            # VisPy considers the coordinate system origin to be the canvas
-            # corner, while napari considers the origin to be the **center** of
-            # the corner pixel. To get the correct value under the mouse
-            # cursor, we need to shift the position by 0.5 pixels on each
-            # axis.
-            position = tuple(p + 0.5 for p in position)
+
         start_point, end_point = self._get_ray_intersections(
             position=position,
             view_direction=view_direction,
@@ -1418,6 +1412,10 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             bounding_box=bounding_box,
         )
         return start_point, end_point
+
+    def _get_offset_data_position(self, position: List[float]) -> List[float]:
+        """Adjust position for offset between viewer and data coordinates."""
+        return position
 
     def _get_ray_intersections(
         self,
@@ -1470,6 +1468,10 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
                 position, dims_displayed
             )
         else:
+
+            # adjust for any offset between viewer and data coordinates
+            position = self._get_offset_data_position(position)
+
             view_dir = np.asarray(view_direction)[dims_displayed]
             click_pos_data = np.asarray(position)[dims_displayed]
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import types
 import warnings
-from typing import TYPE_CHECKING, Sequence, Union
+from typing import TYPE_CHECKING, List, Sequence, Union
 
 import numpy as np
 from scipy import ndimage as ndi
@@ -924,6 +924,16 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
             value = (self.data_level, value)
 
         return value
+
+    def _get_offset_data_position(self, position: List[float]) -> List[float]:
+        """Adjust position for offset between viewer and data coordinates.
+
+        VisPy considers the coordinate system origin to be the canvas corner,
+        while napari considers the origin to be the **center** of the corner
+        pixel. To get the correct value under the mouse cursor, we need to
+        shift the position by 0.5 pixels on each axis.
+        """
+        return [p + 0.5 for p in position]
 
     # For async we add an on_chunk_loaded() method.
     if config.async_loading:


### PR DESCRIPTION
# Description

This is a small followup to #4315 to address comment https://github.com/napari/napari/pull/4315#discussion_r836633168. It is does not modify existing behavior, but just moves this pixel offset code from `Layer` to `ImageBase`.

## Type of change
minor refactor

# References
https://github.com/napari/napari/pull/4315#discussion_r836633168

# How has this been tested?
- [ x ] example: all tests pass with my change

## Final checklist:
- [ x ] My PR is the minimum possible work for the desired functionality
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
