### PR TITLE
Recenter 0-axis when adding a new image layer

### DIFF
--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -310,17 +310,17 @@ def test_view_centering_with_points_add():
 
 
 def test_view_centering_with_new_image():
-    """Test if the viewer is  recentered when new ImageLayer is added"""
+    """Test if the viewer is  recentered when new ImageLayer is added with smaller 0-axis"""
     image_3d = np.zeros((10, 10, 10))
 
     viewer = ViewerModel()
     viewer.add_image(image_3d)
     assert tuple(viewer.dims.point) == (5, 5, 5)
 
-    image_2d = np.ones((10, 10))
-    viewer.add_image(image_2d)
-    # 2D image should set to 0-slice
-    assert tuple(viewer.dims.point) == (0, 5, 5)
+    image_3d = np.ones((10, 10, 10))
+    viewer.add_image(image_3d)
+    # should not re-center
+    assert tuple(viewer.dims.point) == (5, 5, 5)
 
     # Check with new, but reduced 3D layer
     image_3d = np.zeros((5, 10, 10))

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -309,6 +309,32 @@ def test_view_centering_with_points_add():
     assert tuple(viewer.dims.point) == (0, 5, 5)
 
 
+def test_view_centering_with_new_image():
+    """Test if the viewer is  recentered when new ImageLayer is added"""
+    image_3d = np.zeros((10, 10, 10))
+
+    viewer = ViewerModel()
+    viewer.add_image(image_3d)
+    assert tuple(viewer.dims.point) == (5, 5, 5)
+
+    image_2d = np.ones((10, 10))
+    viewer.add_image(image_2d)
+    # 2D image should set to 0-slice
+    assert tuple(viewer.dims.point) == (0, 5, 5)
+
+    # Check with new, but reduced 3D layer
+    image_3d = np.zeros((5, 10, 10))
+    viewer.add_image(image_3d)
+    assert tuple(viewer.dims.point) == (2, 5, 5)
+
+    # make sure no regression with points, viewer point shouldn't change
+    pts_layer = viewer.add_points(ndim=3)
+    assert tuple(viewer.dims.point) == (2, 5, 5)
+
+    pts_layer.add([(0, 8, 8)])
+    assert tuple(viewer.dims.point) == (2, 5, 5)
+
+
 def test_new_shapes():
     """Test adding new shapes layer."""
     # Add labels to empty viewer

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -471,7 +471,11 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             midpoint = [self.rounded_division(*_range) for _range in ranges]
             self.dims.set_point(range(len(ranges)), midpoint)
         elif isinstance(layer, layers.Image):
-            self.dims.set_point(0, layer.data.shape[0] // 2)
+            # Check if rgb or 2D
+            if layer.rgb is True or len(layer.data.shape) == 2:
+                self.dims.set_point(0, 0)
+            else:
+                self.dims.set_point(0, layer.data.shape[0] // 2)
 
     def _on_remove_layer(self, event):
         """Disconnect old layer events.

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -470,6 +470,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             ranges = self.layers._ranges
             midpoint = [self.rounded_division(*_range) for _range in ranges]
             self.dims.set_point(range(len(ranges)), midpoint)
+        elif isinstance(layer, layers.Image):
+            self.dims.set_point(0, layer.data.shape[0] // 2)
 
     def _on_remove_layer(self, event):
         """Disconnect old layer events.

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -471,10 +471,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             midpoint = [self.rounded_division(*_range) for _range in ranges]
             self.dims.set_point(range(len(ranges)), midpoint)
         elif isinstance(layer, layers.Image):
-            # Check if rgb or 2D
-            if layer.rgb is True or len(layer.data.shape) == 2:
-                self.dims.set_point(0, 0)
-            else:
+            # Check if the layer is same smaller as viewer 0-axis, if so recenter 0-axis
+            if layer.data.shape[0] < self.dims.range[0][1]:
                 self.dims.set_point(0, layer.data.shape[0] // 2)
 
     def _on_remove_layer(self, event):


### PR DESCRIPTION
# Description
I've added a check if a new layer is an ImageLayer and if so, set the 0-axis to the mid-point of the 0-axis of the new layer. For RGB or 2D image layers the 0-axis is set to 0.
This is a fix for https://github.com/napari/napari/issues/4350
Importantly, this makes the right-click Projections JustWork and if the underlying 3D layer is deleted the 2D image is visible.

(I think an argument can be made for doing a `reset_view()` as well, but this isn't *always* desired, so I didn't implement that.)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
- Related to: https://github.com/napari/napari/pull/3859
Here the recentering was disabled after the first layer, but for images I think it makes sense to add it.
- Closes #4350 

# How has this been tested?
- [x] added a test based on https://github.com/napari/napari/pull/3859
- [x] all `test_viewer_model` tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
