### PR TITLE
Add function to show error in notification manager

### DIFF
--- a/napari/utils/_tests/test_notification_manager.py
+++ b/napari/utils/_tests/test_notification_manager.py
@@ -9,7 +9,9 @@ import pytest
 from napari.utils.notifications import (
     Notification,
     notification_manager,
+    show_error,
     show_info,
+    show_warning,
 )
 
 PY38_OR_HIGHER = bool(getattr(threading, 'excepthook', None))
@@ -82,6 +84,14 @@ def test_notification_manager_no_gui(monkeypatch):
         assert warnings.showwarning == notification_manager.receive_warning
         warnings.showwarning('this is a warning', UserWarning, '', 0)
         assert len(notification_manager.records) == 4
+        assert store[-1].type == 'warning'
+
+        show_error('This is an error')
+        assert len(notification_manager.records) == 5
+        assert store[-1].type == 'error'
+
+        show_warning('This is a warning')
+        assert len(notification_manager.records) == 6
         assert store[-1].type == 'warning'
 
     # make sure we've restored the except hook

--- a/napari/utils/notifications.py
+++ b/napari/utils/notifications.py
@@ -38,6 +38,7 @@ __all__ = [
     'WarningNotification',
     'NotificationManager',
     'show_info',
+    'show_error',
     'show_console_notification',
 ]
 
@@ -137,6 +138,10 @@ class Notification(Event):
 
 
 class ErrorNotification(Notification):
+    """
+    Notification at an Error severity level.
+    """
+
     exception: BaseException
 
     def __init__(self, exception: BaseException, *args, **kwargs):
@@ -169,6 +174,10 @@ class ErrorNotification(Notification):
 
 
 class WarningNotification(Notification):
+    """
+    Notification at a Warning severity level.
+    """
+
     warning: Warning
 
     def __init__(
@@ -317,10 +326,33 @@ notification_manager = NotificationManager()
 
 
 def show_info(message: str):
-    notification_manager.receive_info(message)
+    """
+    Show an info message in the notification manager.
+    """
+    notification_manager.dispatch(
+        Notification(message, severity=NotificationSeverity.INFO))
+
+
+def show_warning(message: str):
+    """
+    Show a warning in the notification manager.
+    """
+    notification_manager.dispatch(
+        Notification(message, severity=NotificationSeverity.WARNING))
+
+
+def show_error(message: str):
+    """
+    Show an error in the notification manager.
+    """
+    notification_manager.dispatch(
+        Notification(message, severity=NotificationSeverity.ERROR))
 
 
 def show_console_notification(notification: Notification):
+    """
+    Show a notification in the console.
+    """
     try:
         from ..settings import get_settings
 

--- a/napari/utils/notifications.py
+++ b/napari/utils/notifications.py
@@ -330,7 +330,8 @@ def show_info(message: str):
     Show an info message in the notification manager.
     """
     notification_manager.dispatch(
-        Notification(message, severity=NotificationSeverity.INFO))
+        Notification(message, severity=NotificationSeverity.INFO)
+    )
 
 
 def show_warning(message: str):
@@ -338,7 +339,8 @@ def show_warning(message: str):
     Show a warning in the notification manager.
     """
     notification_manager.dispatch(
-        Notification(message, severity=NotificationSeverity.WARNING))
+        Notification(message, severity=NotificationSeverity.WARNING)
+    )
 
 
 def show_error(message: str):
@@ -346,7 +348,8 @@ def show_error(message: str):
     Show an error in the notification manager.
     """
     notification_manager.dispatch(
-        Notification(message, severity=NotificationSeverity.ERROR))
+        Notification(message, severity=NotificationSeverity.ERROR)
+    )
 
 
 def show_console_notification(notification: Notification):


### PR DESCRIPTION
# Description
This adds a `show_error` that allows users to re-route errors to the notification manager. I also added some minimal docstrings to surrounding functions/classes.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] Extended the current notification manager tests
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
