### PR TITLE
add is_diagonal utility and Transform property

### DIFF
--- a/napari/utils/transforms/_tests/test_transform_utils.py
+++ b/napari/utils/transforms/_tests/test_transform_utils.py
@@ -87,3 +87,13 @@ def test_is_matrix_triangular():
 def test_is_diagonal():
     assert is_diagonal(np.eye(3))
     assert not is_diagonal(np.asarray([[0, 1, 0], [1, 0, 0], [0, 0, 1]]))
+
+    # affine with tiny off-diagonal elements will be considered diagonal
+    m = np.full((3, 3), 1e-10)
+    m[0, 0] = 1
+    m[1, 1] = 1
+    m[2, 2] = 1
+    assert is_diagonal(m)
+
+    # will be considered non-diagonal with stricter tolerance
+    assert not is_diagonal(m, tol=1e-12)

--- a/napari/utils/transforms/_tests/test_transform_utils.py
+++ b/napari/utils/transforms/_tests/test_transform_utils.py
@@ -4,6 +4,7 @@ import pytest
 from napari.utils.transforms.transform_utils import (
     compose_linear_matrix,
     decompose_linear_matrix,
+    is_diagonal,
     is_matrix_lower_triangular,
     is_matrix_triangular,
     is_matrix_upper_triangular,
@@ -81,3 +82,8 @@ def test_is_matrix_triangular():
     assert is_matrix_triangular(upper)
     assert is_matrix_triangular(lower)
     assert not is_matrix_triangular(full)
+
+
+def test_is_diagonal():
+    assert is_diagonal(np.eye(3))
+    assert not is_diagonal(np.asarray([[0, 1, 0], [1, 0, 0], [0, 0, 1]]))

--- a/napari/utils/transforms/_tests/test_transforms.py
+++ b/napari/utils/transforms/_tests/test_transforms.py
@@ -18,6 +18,26 @@ def test_scale_translate(Transform):
     npt.assert_allclose(new_coord, target_coord)
 
 
+@pytest.mark.parametrize('Transform', [Affine, CompositeAffine])
+def test_affine_is_diagonal(Transform):
+    transform = Transform(scale=[2, 3], translate=[8, -5], name='st')
+    assert transform.is_diagonal
+    transform.rotate = 5.0
+    assert not transform.is_diagonal
+    # Rotation back to 0.0 will result in tiny non-zero off-diagonal values.
+    # is_diagonal assumes values below 1e-8 are equivalent to 0.
+    transform.rotate = 0.0
+    assert transform.is_diagonal
+
+
+def test_diagonal_scale_setter():
+    # diagonal matrices are also considered a permutation
+    diag_transform = Affine(scale=[2, 3], name='st')
+    assert diag_transform.is_diagonal
+    diag_transform.scale = [1]
+    npt.assert_allclose(diag_transform.scale, [1.0, 1.0])
+
+
 @pytest.mark.parametrize('Transform', transform_types)
 def test_scale_translate_broadcast_scale(Transform):
     coord = [1, 10, 13]

--- a/napari/utils/transforms/_tests/test_transforms.py
+++ b/napari/utils/transforms/_tests/test_transforms.py
@@ -21,19 +21,18 @@ def test_scale_translate(Transform):
 @pytest.mark.parametrize('Transform', [Affine, CompositeAffine])
 def test_affine_is_diagonal(Transform):
     transform = Transform(scale=[2, 3], translate=[8, -5], name='st')
-    assert transform.is_diagonal
+    assert transform._is_diagonal
     transform.rotate = 5.0
-    assert not transform.is_diagonal
+    assert not transform._is_diagonal
     # Rotation back to 0.0 will result in tiny non-zero off-diagonal values.
-    # is_diagonal assumes values below 1e-8 are equivalent to 0.
+    # _is_diagonal assumes values below 1e-8 are equivalent to 0.
     transform.rotate = 0.0
-    assert transform.is_diagonal
+    assert transform._is_diagonal
 
 
 def test_diagonal_scale_setter():
-    # diagonal matrices are also considered a permutation
     diag_transform = Affine(scale=[2, 3], name='st')
-    assert diag_transform.is_diagonal
+    assert diag_transform._is_diagonal
     diag_transform.scale = [1]
     npt.assert_allclose(diag_transform.scale, [1.0, 1.0])
 

--- a/napari/utils/transforms/_tests/test_transforms.py
+++ b/napari/utils/transforms/_tests/test_transforms.py
@@ -12,6 +12,7 @@ transform_types = [Affine, CompositeAffine, ScaleTranslate]
 def test_scale_translate(Transform):
     coord = [10, 13]
     transform = Transform(scale=[2, 3], translate=[8, -5], name='st')
+    assert transform._is_diagonal
     new_coord = transform(coord)
     target_coord = [2 * 10 + 8, 3 * 13 - 5]
     assert transform.name == 'st'

--- a/napari/utils/transforms/transform_utils.py
+++ b/napari/utils/transforms/transform_utils.py
@@ -466,3 +466,27 @@ def is_matrix_triangular(matrix):
     return is_matrix_upper_triangular(matrix) or is_matrix_lower_triangular(
         matrix
     )
+
+
+def is_diagonal(matrix, tol=1e-8):
+    """Determine whether affine is a diagonal matrix.
+
+    Parameters
+    ----------
+    matrix : 2-D array
+        The matrix to test.
+    tol : float, optional
+        Consider any entries with magnitude < `tol` as 0.
+
+    Returns
+    -------
+    is_diag : bool
+        Boolean indicating whether affine is diagonal.
+    """
+    if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
+        raise ValueError("matrix must be square")
+    non_diag = matrix[~np.eye(matrix.shape[0], dtype=bool)]
+    if tol == 0:
+        return np.count_nonzero(non_diag) == 0
+    else:
+        return np.max(np.abs(non_diag)) <= tol

--- a/napari/utils/transforms/transform_utils.py
+++ b/napari/utils/transforms/transform_utils.py
@@ -469,7 +469,7 @@ def is_matrix_triangular(matrix):
 
 
 def is_diagonal(matrix, tol=1e-8):
-    """Determine whether affine is a diagonal matrix.
+    """Determine whether a matrix is diagonal up to some tolerance.
 
     Parameters
     ----------
@@ -481,7 +481,7 @@ def is_diagonal(matrix, tol=1e-8):
     Returns
     -------
     is_diag : bool
-        Boolean indicating whether affine is diagonal.
+        True if matrix is diagonal, False otherwise.
     """
     if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
         raise ValueError("matrix must be square")

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -216,7 +216,6 @@ class ScaleTranslate(Transform):
 
         self.scale = np.array(scale)
         self.translate = np.array(translate)
-        self._is_diagonal = True
 
     def __call__(self, coords):
         coords = np.asarray(coords)

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -122,10 +122,10 @@ class TransformChain(EventedList, Transform):
         return TransformChain([tf.inverse for tf in self[::-1]])
 
     @property
-    def is_diagonal(self):
-        if all(getattr(tf, 'is_diagonal', False) for tf in self):
+    def _is_diagonal(self):
+        if all(getattr(tf, '_is_diagonal', False) for tf in self):
             return True
-        return getattr(self.simplified, 'is_diagonal', False)
+        return getattr(self.simplified, '_is_diagonal', False)
 
     @property
     def simplified(self) -> 'Transform':
@@ -203,7 +203,7 @@ class ScaleTranslate(Transform):
 
         self.scale = np.array(scale)
         self.translate = np.array(translate)
-        self.is_diagonal = True
+        self._is_diagonal = True
 
     def __call__(self, coords):
         coords = np.asarray(coords)
@@ -414,7 +414,7 @@ class Affine(Transform):
     @property
     def scale(self) -> np.array:
         """Return the scale of the transform."""
-        if self.is_diagonal:
+        if self._is_diagonal:
             return np.diag(self._linear_matrix)
         else:
             return decompose_linear_matrix(
@@ -424,7 +424,7 @@ class Affine(Transform):
     @scale.setter
     def scale(self, scale):
         """Set the scale of the transform."""
-        if self.is_diagonal:
+        if self._is_diagonal:
             scale = scale_to_vector(scale, ndim=self.ndim)
             for i in range(len(scale)):
                 self._linear_matrix[i, i] = scale[i]
@@ -464,7 +464,7 @@ class Affine(Transform):
     @property
     def shear(self) -> np.array:
         """Return the shear of the transform."""
-        if self.is_diagonal:
+        if self._is_diagonal:
             return np.zeros((self.ndim,))
         return decompose_linear_matrix(
             self.linear_matrix, upper_triangular=self._upper_triangular
@@ -552,7 +552,7 @@ class Affine(Transform):
             Resulting transform.
         """
         axes = list(axes)
-        if self.is_diagonal:
+        if self._is_diagonal:
             linear_matrix = np.diag(self.scale[axes])
         else:
             linear_matrix = self.linear_matrix[np.ix_(axes, axes)]
@@ -629,11 +629,16 @@ class Affine(Transform):
         )
 
     @cached_property
-    def is_diagonal(self):
+    def _is_diagonal(self):
+        """Determine whether linear_matrix is diagonal up to some tolerance.
+
+        Since only `self.linear_matrix` is checked, affines with a translation
+        component can still be considered diagonal.
+        """
         return is_diagonal(self.linear_matrix, tol=1e-8)
 
     def _clean_cache(self):
-        cached_properties = ('is_diagonal',)
+        cached_properties = ('_is_diagonal',)
         [self.__dict__.pop(p, None) for p in cached_properties]
 
 

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -95,7 +95,7 @@ class Transform:
             trans._('Cannot subset arbitrary transforms.', deferred=True)
         )
 
-    @cached_property
+    @property
     def _is_diagonal(self):
         """Indicate when a transform does not mix or permute dimensions.
 
@@ -293,7 +293,7 @@ class ScaleTranslate(Transform):
         translate[not_axes] = self.translate
         return ScaleTranslate(scale, translate, name=self.name)
 
-    @cached_property
+    @property
     def _is_diagonal(self):
         """Indicate that this transform does not mix or permute dimensions."""
         return True

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from typing import Sequence
 
 import numpy as np
@@ -10,6 +11,7 @@ from .transform_utils import (
     decompose_linear_matrix,
     embed_in_identity_matrix,
     infer_ndim,
+    is_diagonal,
     is_matrix_triangular,
     is_matrix_upper_triangular,
     rotate_to_matrix,
@@ -120,6 +122,12 @@ class TransformChain(EventedList, Transform):
         return TransformChain([tf.inverse for tf in self[::-1]])
 
     @property
+    def is_diagonal(self):
+        if all(getattr(tf, 'is_diagonal', False) for tf in self):
+            return True
+        return getattr(self.simplified, 'is_diagonal', False)
+
+    @property
     def simplified(self) -> 'Transform':
         """Return the composite of the transforms inside the transform chain."""
         if len(self) == 0:
@@ -195,6 +203,7 @@ class ScaleTranslate(Transform):
 
         self.scale = np.array(scale)
         self.translate = np.array(translate)
+        self.is_diagonal = True
 
     def __call__(self, coords):
         coords = np.asarray(coords)
@@ -405,17 +414,25 @@ class Affine(Transform):
     @property
     def scale(self) -> np.array:
         """Return the scale of the transform."""
-        return decompose_linear_matrix(
-            self._linear_matrix, upper_triangular=self._upper_triangular
-        )[1]
+        if self.is_diagonal:
+            return np.diag(self._linear_matrix)
+        else:
+            return decompose_linear_matrix(
+                self._linear_matrix, upper_triangular=self._upper_triangular
+            )[1]
 
     @scale.setter
     def scale(self, scale):
         """Set the scale of the transform."""
-        rotate, _, shear = decompose_linear_matrix(
-            self.linear_matrix, upper_triangular=self._upper_triangular
-        )
-        self._linear_matrix = compose_linear_matrix(rotate, scale, shear)
+        if self.is_diagonal:
+            scale = scale_to_vector(scale, ndim=self.ndim)
+            for i in range(len(scale)):
+                self._linear_matrix[i, i] = scale[i]
+        else:
+            rotate, _, shear = decompose_linear_matrix(
+                self.linear_matrix, upper_triangular=self._upper_triangular
+            )
+            self._linear_matrix = compose_linear_matrix(rotate, scale, shear)
 
     @property
     def translate(self) -> np.array:
@@ -441,10 +458,14 @@ class Affine(Transform):
             self.linear_matrix, upper_triangular=self._upper_triangular
         )
         self._linear_matrix = compose_linear_matrix(rotate, scale, shear)
+        # previously cached properties may have changed
+        self._clean_cache()
 
     @property
     def shear(self) -> np.array:
         """Return the shear of the transform."""
+        if self.is_diagonal:
+            return np.zeros((self.ndim,))
         return decompose_linear_matrix(
             self.linear_matrix, upper_triangular=self._upper_triangular
         )[2]
@@ -452,7 +473,8 @@ class Affine(Transform):
     @shear.setter
     def shear(self, shear):
         """Set the shear of the transform."""
-        if np.array(shear).ndim == 2:
+        shear = np.asarray(shear)
+        if shear.ndim == 2:
             if is_matrix_triangular(shear):
                 self._upper_triangular = is_matrix_upper_triangular(shear)
             else:
@@ -469,6 +491,8 @@ class Affine(Transform):
             self.linear_matrix, upper_triangular=self._upper_triangular
         )
         self._linear_matrix = compose_linear_matrix(rotate, scale, shear)
+        # previously cached properties may have changed
+        self._clean_cache()
 
     @property
     def linear_matrix(self) -> np.array:
@@ -481,6 +505,7 @@ class Affine(Transform):
         self._linear_matrix = embed_in_identity_matrix(
             linear_matrix, ndim=self.ndim
         )
+        self._clean_cache()
 
     @property
     def affine_matrix(self) -> np.array:
@@ -495,6 +520,7 @@ class Affine(Transform):
         """Set the affine matrix for the transform."""
         self._linear_matrix = affine_matrix[:-1, :-1]
         self._translate = affine_matrix[:-1, -1]
+        self._clean_cache()
 
     def __array__(self, *args, **kwargs):
         """NumPy __array__ protocol to get the affine transform matrix."""
@@ -522,11 +548,16 @@ class Affine(Transform):
 
         Returns
         -------
-        Transform
+        Affine
             Resulting transform.
         """
+        axes = list(axes)
+        if self.is_diagonal:
+            linear_matrix = np.diag(self.scale[axes])
+        else:
+            linear_matrix = self.linear_matrix[np.ix_(axes, axes)]
         return Affine(
-            linear_matrix=self.linear_matrix[np.ix_(axes, axes)],
+            linear_matrix=linear_matrix,
             translate=self.translate[axes],
             ndim=len(axes),
             name=self.name,
@@ -596,6 +627,14 @@ class Affine(Transform):
             ndim=n,
             name=self.name,
         )
+
+    @cached_property
+    def is_diagonal(self):
+        return is_diagonal(self.linear_matrix, tol=1e-8)
+
+    def _clean_cache(self):
+        cached_properties = ('is_diagonal',)
+        [self.__dict__.pop(p, None) for p in cached_properties]
 
 
 class CompositeAffine(Affine):
@@ -678,6 +717,7 @@ class CompositeAffine(Affine):
         """Set the rotation of the transform."""
         self._rotate = rotate_to_matrix(rotate, ndim=self.ndim)
         self._linear_matrix = self._make_linear_matrix()
+        self._clean_cache()
 
     @property
     def shear(self) -> np.array:
@@ -693,6 +733,7 @@ class CompositeAffine(Affine):
         """Set the shear of the transform."""
         self._shear = shear_to_matrix(shear, ndim=self.ndim)
         self._linear_matrix = self._make_linear_matrix()
+        self._clean_cache()
 
     @Affine.linear_matrix.setter
     def linear_matrix(self, linear_matrix):

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -458,7 +458,6 @@ class Affine(Transform):
             self.linear_matrix, upper_triangular=self._upper_triangular
         )
         self._linear_matrix = compose_linear_matrix(rotate, scale, shear)
-        # previously cached properties may have changed
         self._clean_cache()
 
     @property
@@ -491,7 +490,6 @@ class Affine(Transform):
             self.linear_matrix, upper_triangular=self._upper_triangular
         )
         self._linear_matrix = compose_linear_matrix(rotate, scale, shear)
-        # previously cached properties may have changed
         self._clean_cache()
 
     @property


### PR DESCRIPTION
# Description

This small PR was split off from #4303 as requested by @andy-sweet for ease of review. It adds an `is_diagonal` property to Transforms that makes `Affine` transforms more efficient in the case when they are known to be diagonal.

I chose to ignore any entries below a certain tolerance when determining if a matrix is diagonal. I think in practice it is desirable as things like applying a rotation followed by an opposite rotation on a diagonal Affine, should ideally return the original Affine again, but in practice will have tiny off diagonal elements (e.g. ~1e-15) due to finite floating point precision. This scenario is covered in one of the test cases here.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
maybe more of a "performance optimization" than new feature as end users would typically not need to interact with this at all.

# References
split off from #4303 as it is not strictly related to permutations. The caching used only for the `is_diagonal` property here also is used for a couple of other properties in that PR.

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] existing tests pass
- [x] new tests were added

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
