### PR TITLE
Bugfix/broadcast projections by reducing number of axes (keepdims=False)

### DIFF
--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -67,15 +67,26 @@ def _project(ll: LayerList, axis: int = 0, mode='max'):
     # this is not the desired behavior for coordinate-based layers
     # but the action is currently only enabled for 'image_active and ndim > 2'
     # before opening up to other layer types, this line should be updated.
-    data = (getattr(np, mode)(layer.data, axis=axis, keepdims=True),)
+    data = (getattr(np, mode)(layer.data, axis=axis, keepdims=False),)
     layer = cast('Image', layer)
-    meta = {
-        **layer._get_base_state(),
+    # get the meta data of the layer, but without transforms
+    layer_meta = {
+        key: layer._get_base_state()[key]
+        for key in layer._get_base_state()
+        if key not in ('scale', 'translate', 'rotate', 'shear', 'affine')
+    }
+    # make metadata for the projection without transforms--will add them back later
+    proj_meta = {
+        **layer_meta,
         'name': f'{layer} {mode}-proj',
         'colormap': layer.colormap.name,
         'rendering': layer.rendering,
     }
-    new = Layer.create(data, meta, layer._type_string)
+    new = Layer.create(data, proj_meta, layer._type_string)
+    # add transforms from original layer, but drop the axis of the projection
+    new._transforms = layer._transforms.set_slice(
+        [ax for ax in range(0, layer.ndim) if ax != axis]
+    )
     ll.append(new)
 
 

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -70,18 +70,16 @@ def _project(ll: LayerList, axis: int = 0, mode='max'):
     data = (getattr(np, mode)(layer.data, axis=axis, keepdims=False),)
     layer = cast('Image', layer)
     # get the meta data of the layer, but without transforms
-    layer_meta = {
+    meta = {
         key: layer._get_base_state()[key]
         for key in layer._get_base_state()
         if key not in ('scale', 'translate', 'rotate', 'shear', 'affine')
     }
-    # make metadata for the projection without transforms--will add them back later
-    proj_meta = {
-        **layer_meta,
+    meta.update({
         'name': f'{layer} {mode}-proj',
         'colormap': layer.colormap.name,
         'rendering': layer.rendering,
-    }
+    })
     new = Layer.create(data, proj_meta, layer._type_string)
     # add transforms from original layer, but drop the axis of the projection
     new._transforms = layer._transforms.set_slice(

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -75,11 +75,13 @@ def _project(ll: LayerList, axis: int = 0, mode='max'):
         for key in layer._get_base_state()
         if key not in ('scale', 'translate', 'rotate', 'shear', 'affine')
     }
-    meta.update({
-        'name': f'{layer} {mode}-proj',
-        'colormap': layer.colormap.name,
-        'rendering': layer.rendering,
-    })
+    meta.update(
+        {
+            'name': f'{layer} {mode}-proj',
+            'colormap': layer.colormap.name,
+            'rendering': layer.rendering,
+        }
+    )
     new = Layer.create(data, proj_meta, layer._type_string)
     # add transforms from original layer, but drop the axis of the projection
     new._transforms = layer._transforms.set_slice(

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -75,12 +75,14 @@ def _project(ll: LayerList, axis: int = 0, mode='max'):
         for key in layer._get_base_state()
         if key not in ('scale', 'translate', 'rotate', 'shear', 'affine')
     }
-    meta.update({
-        'name': f'{layer} {mode}-proj',
-        'colormap': layer.colormap.name,
-        'rendering': layer.rendering,
-    })
-    new = Layer.create(data, proj_meta, layer._type_string)
+    meta.update(
+        {
+            'name': f'{layer} {mode}-proj',
+            'colormap': layer.colormap.name,
+            'rendering': layer.rendering,
+        }
+    )
+    new = Layer.create(data, meta, layer._type_string)
     # add transforms from original layer, but drop the axis of the projection
     new._transforms = layer._transforms.set_slice(
         [ax for ax in range(0, layer.ndim) if ax != axis]

--- a/napari/layers/_tests/test_layer_actions.py
+++ b/napari/layers/_tests/test_layer_actions.py
@@ -60,8 +60,8 @@ def test_projections(mode):
     assert ll[-1].data.ndim == 3
     _project(ll, mode=mode)
     assert len(ll) == 2
-    # because we use keepdims = True
-    assert ll[-1].data.shape == (1, 8, 8)
+    # because keepdims = False
+    assert ll[-1].data.shape == (8, 8)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description
Fixes https://github.com/napari/napari/issues/4350 (take 2!)
By changing the argument `keepdims` from `True` to `False` projections now have a reduced number of axes. So a 3D image with shape (a, b, c) is projected to a 2D image with shape (b, c). When added as a layer, this 2D image will then be properly broadcast. 
To account for possible transforms of the original layer, the layer with the projection is assigned transforms from the original layer, but with the projection axis sliced out using (`set_slice`)

You can see the behavior replicating the right-click menu in the GUI using this snippet in the console:
```
from skimage.data import binary_blobs
viewer.add_image(binary_blobs(64, volume_fraction=.2, n_dim=3), rotate=45)
from napari.layers._layer_actions import _project
_project(viewer.layers, mode='mean')
```
On live you will not see the projection—it's only visible on the first slice. Worse yet, if you delete the original stack you won't see the projection at all (and reset view doesn't help).
With this PR, you should see the projection over all slices and can change the opacity, etc. to see it overlayed. If you delete the original stack you will still see the projection.
Also, try `n_dim=4` I really don't get what is happening on live; this projection should result in a volume (3D), but on live it makes an anchored slice that then iterates? 🤷 

There is a catch.
With the live behavior if you project a 3D stack on a **non-0 axis**—programatically, you can't do this in the GUI—you can "find" the projection in the proper spot by changing the order of the dims (or using 3D viewer) because of the singleton dimension "anchoring" the projection in the right orientation. This is preserved with transformation of the axis you are projecting. 
With this PR, the dimension of the axis of the projection is gone and the projection is broadcast so it's always visible regardless of the order of dims. So it's a bit wierd until you change the order of the axis to "place" the projection correctly. Compare live vs PR for the outcome of:
```
from skimage.data import binary_blobs
viewer.add_image(binary_blobs(64, volume_fraction=.2, n_dim=3), scale=(1, 2, 1)
from napari.layers._layer_actions import _project
_project(viewer.layers, axis=1, mode='mean')
```
But again the IMO big upside is that for 4D stacks, the projections are properly broadcast as volumes. Try:
```
from skimage.data import binary_blobs
viewer.add_image(binary_blobs(64, volume_fraction=.2, n_dim=4), rotate=45)
from napari.layers._layer_actions import _project
_project(viewer.layers, axis=1, mode='mean')
```
With this PR you can see the volume in the 3D viewer or use the slider to see how the projection lines up vs. the slices.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
This fixes https://github.com/napari/napari/issues/4350
It follows the rationale of the experiments I did here: https://github.com/napari/napari/issues/4350#issuecomment-1094059698
and uses the hint from @jni to use `set_slice()`

# How has this been tested?
- [x] adjusted the test suite to account for the change to `keepdims`
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality — I think? I learned a ton about dicts and list comprehension, but I'm not sure it's really minimal.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
