### PR TITLE
Add napari.window to API docs

### DIFF
--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -12,6 +12,7 @@ For the average user's workflows.
    napari.view_layers
    napari.types
    napari.utils
+   napari.window
 
 .. rubric:: Advanced
 


### PR DESCRIPTION
# Description
I was looking for API docs on `napari.window.Window.add_plugin_dock_widget`, and couldn't find any. I think this adds the relevant docs.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
