### PR TITLE
Convert remaining .gifs to .webm

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,5 @@ napari_gui/_version.py export-subst
 *.png filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
 *.gif filter=lfs diff=lfs merge=lfs -text
+*.webm filter=lfs diff=lfs merge=lfs -text
 napari/resources/* !filter=lfs !diff=lfs !merge=lfs -text

--- a/docs/guides/images/mitosis.gif
+++ b/docs/guides/images/mitosis.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f83175ef038ba41b68e3767578d7cf91d05a0c83d31d89fa8e7049b7bbf945e
-size 5426844

--- a/docs/guides/images/mitosis.webm
+++ b/docs/guides/images/mitosis.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe4c9f40d7cd7082a64b027552b8091a9113474b2e9ede2220eabed108c19cb2
+size 162215

--- a/docs/guides/images/scaling.gif
+++ b/docs/guides/images/scaling.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55aeb418ee158c2f50cea0c9982aa6dc4998327cf9362b58a6548faf55502567
-size 9931194

--- a/docs/guides/images/scaling.webm
+++ b/docs/guides/images/scaling.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1cf93e1628906f87092be63c36b01735c3497bf788703822fbc4672bdd30be69
+size 262838

--- a/docs/guides/layers.md
+++ b/docs/guides/layers.md
@@ -79,7 +79,7 @@ or 3 less than the total number of dimensions of the layer, allowing you to
 browse volumetric timeseries data and other high dimensional data. See for
 example these cells undergoing mitosis in this volumetric timeseries:
 
-![napari viewer with an image of a cell undergoing mitosis. The scroll bar below the canvas controls the timeseries, allowing different stages of mitosis to be visible.](./images/mitosis.gif)
+![napari viewer with an image of a cell undergoing mitosis. The scroll bar below the canvas controls the timeseries, allowing different stages of mitosis to be visible.](./images/mitosis.webm)
 
 ```{note}
 Switching to 3D mode for a very large data set could trigger computation that
@@ -134,7 +134,7 @@ napari.view_image(retina, name='retina', scale=[1,10,1,1])
 viewer.layers['retina'].scale = [1,10,1,1]
 ```
 
-![napari viewer with an image where all layers are scaled equally; when rotated, the image appears flat. By using console below the canvas and applying a scale factor to one of the dimensions, the image's volume becomes apparent.](images/scaling.gif)
+![napari viewer with an image where all layers are scaled equally; when rotated, the image appears flat. By using console below the canvas and applying a scale factor to one of the dimensions, the image's volume becomes apparent.](images/scaling.webm)
 
 
 ## Translating layers

--- a/docs/howtos/layers/image.md
+++ b/docs/howtos/layers/image.md
@@ -84,7 +84,7 @@ napari to seamlessly browse enormous datasets that are loaded in the right way.
 For example, here we are browsing over 100GB of lattice lightsheet data stored
 in a zarr file:
 
-![image: lattice light sheet microscopy](../../images/LLSM.gif)
+![image: lattice light sheet microscopy](../../images/LLSM.webm)
 
 ## Multiscale images
 
@@ -101,7 +101,7 @@ viewed in 2D or incredibly large 3D images when viewed in 3D. For example this
 easily browsed as at each moment in time we only load the level of the
 multiscale image and the part of the image that needs to be displayed:
 
-![image: pathology](../../images/pathology.gif)
+![image: pathology](../../images/pathology.webm)
 
 This example had precomputed multiscale images stored in a zarr file, which is
 best for performance. If, however you don't have a precomputed multiscale image

--- a/docs/howtos/layers/labels.md
+++ b/docs/howtos/layers/labels.md
@@ -258,7 +258,7 @@ checked).
 
 **Drawing a connected component**:
 
-![image: draw component](../../images/draw_component.gif)
+![image: draw component](../../images/draw_component.webm)
 
 Press `M` to select a new label color. Select the `paintbrush` tool and draw a
 closed contour around the object. Select the `fill bucket` tool and click inside
@@ -266,7 +266,7 @@ the contour to assign the label to all pixels of the object.
 
 **Selecting a connected component**:
 
-![image: delete label](../../images/delete_label.gif)
+![image: delete label](../../images/delete_label.webm)
 
 Select the background label with the `color picker` (alternative: press keyboard
 shortcut `E`), then use the `fill bucket` to set all pixels of the connected
@@ -274,14 +274,14 @@ component to background.
 
 **Merging connected components**:
 
-![image: merge labels](../../images/merge_labels.gif)
+![image: merge labels](../../images/merge_labels.webm)
 
 Select the label of one of the components with the `color picker` tool and then
 filling the components to be merged with the fill bucket.
 
 **Splitting a connected component**:
 
-![image: split label](../../images/split_label.gif)
+![image: split label](../../images/split_label.webm)
 
 Splitting a connected component will introduce an additional object, therefore
 press `M` to select a label number that is not already in use. Use the

--- a/docs/howtos/layers/points.md
+++ b/docs/howtos/layers/points.md
@@ -122,7 +122,7 @@ buttons can toggle between each mode. The number of dimensions sliders will be 2
 or 3 less than the total number of dimensions of the layer. See for example
 these points overlaid on an image in both 2D and 3D:
 
-![image: smFISH with points overlaid](../../images/smFISH.gif)
+![image: smFISH with points overlaid](../../images/smFISH.webm)
 
 Note though that when entering 3D rendering mode the point add, delete, and
 select tools are all disabled. Those options are only supported when viewing a
@@ -329,4 +329,4 @@ will be updated with the new slice values.
 Here you can see an example of adding, selecting, deleting points and change
 their properties:
 
-![image: editing points](../../images/editing_points.gif)
+![image: editing points](../../images/editing_points.webm)

--- a/docs/howtos/layers/shapes.md
+++ b/docs/howtos/layers/shapes.md
@@ -282,7 +282,7 @@ or 3 less than the total number of dimensions of the layer. See for example the
 [`examples/nD_shapes.py`](https://github.com/napari/napari/blob/main/examples/nD_shapes.py)
 to see shapes in both 2D and 3D:
 
-![image: nD shapes] (../../images/nD_shapes.gif)
+![image: nD shapes] (../../images/nD_shapes.webm)
 
 Note though that when entering 3D rendering mode the shape editing tools are all
 disabled. Those options are only supported when viewing a layer using 2D
@@ -340,7 +340,7 @@ key if you are in select mode.
 Once selected you can delete the selected shapes by clicking on the delete
 button in the layer controls panel or pressing the delete key.
 
-For example see below: ![image: shape resizing](../../images/shape_resizing.gif)
+For example see below: ![image: shape resizing](../../images/shape_resizing.webm)
 
 ## Adding, moving, and deleting individual vertices
 
@@ -358,7 +358,7 @@ can be selected either clicking on the vertex deletion tool in the layer
 controls panel or pressing the `X` key while the shapes layer is selected.
 
 For example see below: ![image: shape vertex
-editing](../../images/shape_vertex_editing.gif)
+editing](../../images/shape_vertex_editing.webm)
 
 ## Changing shape edge and face colors
 
@@ -421,4 +421,4 @@ added.
 Here you can see an example of adding, selecting, and editing shapes and change
 their properties:
 
-![image: editing shapes](../../images/editing_shapes.gif)
+![image: editing shapes](../../images/editing_shapes.webm)

--- a/docs/howtos/layers/surface.md
+++ b/docs/howtos/layers/surface.md
@@ -88,7 +88,7 @@ buttons can toggle between each mode. The number of dimensions sliders will be 2
 or 3 less than the total number of dimensions of the layer. See for example
 these brain surfaces rendered in 3D:
 
-![image: brain surface](../../images/brain_surface.gif)
+![image: brain surface](../../images/brain_surface.webm)
 
 ## Working with colormaps
 

--- a/docs/howtos/layers/tracks.md
+++ b/docs/howtos/layers/tracks.md
@@ -66,7 +66,7 @@ viewer.add_tracks(tracks_data, name='tracks')
 napari.run()
 ```
 
-![image: tracks simple demo](../../images/tracks_simple_demo.gif)
+![image: tracks simple demo](../../images/tracks_simple_demo.webm)
 
 ## Arguments of `view_tracks` and `add_tracks`
 
@@ -230,7 +230,7 @@ viewer.layers["my_tracks"].tail_width = 3
 
 Additionally, we can adjust the width of the track in the GUI using the "tail width" slider in the Tracks layer controls.
 
-![image: tracks tail width](../../images/tracks_tail_width.gif)
+![image: tracks tail width](../../images/tracks_tail_width.webm)
 
 ## Changing tail length
 
@@ -247,7 +247,7 @@ viewer.layers["my_tracks"].tail_length = 3
 
 Additionally, we can adjust the width of the track in the GUI using the "tail length" slider in the Tracks layer controls.
 
-![image: tracks tail length](../../images/tracks_tail_length.gif)
+![image: tracks tail length](../../images/tracks_tail_length.webm)
 
 ## Setting the track color with properties
 
@@ -287,10 +287,10 @@ viewer.add_tracks(tracks_data, properties=properties)
 napari.run()
 ```
 
-![image: tracks colored by properties](../../images/tracks_color_by.gif)
+![image: tracks colored by properties](../../images/tracks_color_by.webm)
 
 ## Putting it all together
 
 Here you can see an example of 3D+t tracks. You can view the source code for this example [here](https://github.com/napari/napari/blob/main/examples/tracks_3d.py)
 
-![image: tracks 3D plus time](../../images/tracks_3d_t.gif)
+![image: tracks 3D plus time](../../images/tracks_3d_t.webm)

--- a/docs/howtos/layers/vectors.md
+++ b/docs/howtos/layers/vectors.md
@@ -117,7 +117,7 @@ or 3 less than the total number of dimensions of the layer. See for example the
 [`examples/nD_vectors.py`](https://github.com/napari/napari/blob/main/examples/nD_vectors.py)
 to see shapes in both 2D and 3D:
 
-![image: nD vectors](../../images/nD_vectors.gif)
+![image: nD vectors](../../images/nD_vectors.webm)
 
 ## Changing vector length, width, and color
 

--- a/docs/images/LLSM.gif
+++ b/docs/images/LLSM.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8af49bb95c291432bdf1d559dd443fb6a8238394dd21589e4a113ca5a8e398ca
-size 5052861

--- a/docs/images/LLSM.webm
+++ b/docs/images/LLSM.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d0a0a90ca7e19bfd3c7a187aceac96a97799502a997b57bb68518d643916c67
+size 199165

--- a/docs/images/brain_surface.gif
+++ b/docs/images/brain_surface.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2cf78c3564661fd536d2357a9f8176429f4e4da12d5b36f8ba24c74f68b2285
-size 1197664

--- a/docs/images/brain_surface.webm
+++ b/docs/images/brain_surface.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a798e07019467435042aec772dd5f422d82eb89deef1c1390b8629aa2c0b3d4a
+size 127343

--- a/docs/images/delete_label.gif
+++ b/docs/images/delete_label.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:32808dae44338774c90c1857d9d74381a37aa72a21d566c1e80ce2eb79a2c620
-size 369393

--- a/docs/images/delete_label.webm
+++ b/docs/images/delete_label.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d16a9de2fd32ce8efe9a52e1a8ff40bd958d2cae592b0a0ce752f0b575508d0f
+size 178672

--- a/docs/images/draw_component.gif
+++ b/docs/images/draw_component.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b2229e51334c16b538f9ad061ebf502bffdfcb944614585f1983ebff3280e45a
-size 590033

--- a/docs/images/draw_component.webm
+++ b/docs/images/draw_component.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed947b1a2c0bc7030d37817a457d041a31ef2a2e4f455b50cbf0d94797b46fe5
+size 210527

--- a/docs/images/editing_points.gif
+++ b/docs/images/editing_points.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9b12c3071b805f39cb3e815fc979d4e297f296ce2a5831b1888f0228420ce61c
-size 8993761

--- a/docs/images/editing_points.webm
+++ b/docs/images/editing_points.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f196064d0950146e6cdcd98c1fc223033c6d5ddde50082853b14ee97ad4d7bd8
+size 352900

--- a/docs/images/editing_shapes.gif
+++ b/docs/images/editing_shapes.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eb4cc1e356d904b43e4dd0ad721373198a9c171d7dc55705432494a00b3cb8ec
-size 7163228

--- a/docs/images/editing_shapes.webm
+++ b/docs/images/editing_shapes.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76ee073ef7bc1416853622efae6ad1bebc084b8eb7976e6e0a202b96b7dee77f
+size 306653

--- a/docs/images/manual_label.gif
+++ b/docs/images/manual_label.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a74740c930a7618844a648e29c2c0376e44fd6847743e032d517a5bf0f225494
-size 318355

--- a/docs/images/manual_label.webm
+++ b/docs/images/manual_label.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80a661c17008520699cf0c59136768a125297d147e3a9a9552726cc78526c43c
+size 22768

--- a/docs/images/merge_labels.gif
+++ b/docs/images/merge_labels.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7e782d57d867e2c6489a15bcd96106c0be197a5e352027a0e2f5f55455704f2
-size 370619

--- a/docs/images/merge_labels.webm
+++ b/docs/images/merge_labels.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f69f477e460870ce97fd95626748f8e993ad1b034b1666847c6d5ea9faa3a4bb
+size 159277

--- a/docs/images/nD_shapes.gif
+++ b/docs/images/nD_shapes.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce449d8460af775b178cad5ed14195cab951d572504957ebbb109ce282f83f3b
-size 3073923

--- a/docs/images/nD_shapes.webm
+++ b/docs/images/nD_shapes.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0591d951ac50d73d7eb42a71e51f227f69bf06c4846f852b75224afd76b48e28
+size 796495

--- a/docs/images/nD_vectors.gif
+++ b/docs/images/nD_vectors.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a41867cc49680819e0b1761f0fdd05172a7abee8c2b56d105177a967d8e2f68e
-size 6668914

--- a/docs/images/nD_vectors.webm
+++ b/docs/images/nD_vectors.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45b4452145689e3c72ff1a1a31ea38c3d1faada5a64bc2a93001148c7effecf4
+size 1495542

--- a/docs/images/pathology.gif
+++ b/docs/images/pathology.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e464f53fa02b4145b449a80cef7ef0fe84087c7e71b8a67e00370cec54ce68b7
-size 21327935

--- a/docs/images/pathology.webm
+++ b/docs/images/pathology.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:198f12157ea3644f747a6199a62e834369e9fb91a242ec998044591be26cb8cf
+size 2911812

--- a/docs/images/shape_resizing.gif
+++ b/docs/images/shape_resizing.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:efec883686903ac2ee86b18ece51ce23ce9fa8c96ac026c1c29da8256aef87a7
-size 4832798

--- a/docs/images/shape_resizing.webm
+++ b/docs/images/shape_resizing.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcec7b51241da561b1fdb084009dd9aec1f48e20878c069488bd8eed7b94c699
+size 186365

--- a/docs/images/shape_vertex_editing.gif
+++ b/docs/images/shape_vertex_editing.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:baa87ae0c39d00a0b65ee42e3977188338006143794135d58e2d75383126ff39
-size 5093688

--- a/docs/images/shape_vertex_editing.webm
+++ b/docs/images/shape_vertex_editing.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb533400af3a75738c4305d86955e6a47abc30643fa554db77f9283b97ba70fa
+size 204378

--- a/docs/images/smFISH.gif
+++ b/docs/images/smFISH.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f7f84c6d38a85f09afd84b5f679ac1824a54eb8fcc26097f5abc3afd98456cd7
-size 6317510

--- a/docs/images/smFISH.webm
+++ b/docs/images/smFISH.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a2c1193edac4ad3dee57bd06ef46d497fc079dd2aa86d9d5a2f6b0c5ea2ee34
+size 546235

--- a/docs/images/split_label.gif
+++ b/docs/images/split_label.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1455d871082ee74307856772a3e932f2406476ba741612b8e76f0c6f4075bcca
-size 2561740

--- a/docs/images/split_label.webm
+++ b/docs/images/split_label.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be58b3d9924f2132de2617a5146b65885b3705a7085ac1e8bf8c86ee8da88d1f
+size 313446

--- a/docs/images/tracks_3d_t.gif
+++ b/docs/images/tracks_3d_t.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f319cf75867488616d6582fbfeafc2bfbaab4400bd9136d56ace88c8aa899ad
-size 3278943

--- a/docs/images/tracks_3d_t.webm
+++ b/docs/images/tracks_3d_t.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b09545d8b476c127bcfeaea21c16e2ea5f1e10f464a2a3377c83095dec5e0b5
+size 750384

--- a/docs/images/tracks_color_by.gif
+++ b/docs/images/tracks_color_by.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a82ac96e533c94be76996e0a189308f10cf64849c06e1bf85ab164f7da45a437
-size 120565

--- a/docs/images/tracks_color_by.webm
+++ b/docs/images/tracks_color_by.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83160b731b2fa9647c0af965ce843193feb217b6ec6a290375d6a10016ed3e58
+size 38036

--- a/docs/images/tracks_simple_demo.gif
+++ b/docs/images/tracks_simple_demo.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6d724a8c7a091e3195ff7e3a0657bc0fa45b2af85b33510612f870af3a963d85
-size 247904

--- a/docs/images/tracks_simple_demo.webm
+++ b/docs/images/tracks_simple_demo.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:355c197a4a3089abf6e91212f5537d2dcf4624b2a26eec21f6c0eca20aaab4e8
+size 56698

--- a/docs/images/tracks_tail_length.gif
+++ b/docs/images/tracks_tail_length.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a41d4b0d94f6c74874c3c2136cf169070467cf5c9726ed3a916d5c206f5d4490
-size 967924

--- a/docs/images/tracks_tail_length.webm
+++ b/docs/images/tracks_tail_length.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41becbaea66d40d01642c15669abfa0a7f48a460b115cd08820887410976636d
+size 68940

--- a/docs/images/tracks_tail_width.gif
+++ b/docs/images/tracks_tail_width.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1fcd1ae7dd8c4d21326db9c3fb5846c9f6beec62f4a68cfdc86ab0a5dc6d5b64
-size 157660

--- a/docs/images/tracks_tail_width.webm
+++ b/docs/images/tracks_tail_width.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8416d0c39a5d132c9b285eb913ea5da08d547e47bd64b8c4ff1c5da7e5b419c0
+size 41601

--- a/docs/tutorials/fundamentals/quick_start.md
+++ b/docs/tutorials/fundamentals/quick_start.md
@@ -160,7 +160,7 @@ The labels layer allows you to record the segmentation result by assigning backg
 1. Circle the cell
 1. Use "fill" bucket to fill it.
 
-![manual_label](../../images/manual_label.gif)
+![manual_label](../../images/manual_label.webm)
 
 Several plugins can perform automatic segmentation that takes image layers as input and generates labels layers as output.
 


### PR DESCRIPTION
This completes the transition started by @Carreau in napari/napari#4207.

This reduces the docs/images folder from 84MB to 13MB!

Note that we still need to deal with napari/docs#60, but I don't think that should block this PR.

_edited by Talley to prevent closing 4298 if this merges_