### PR TITLE
Add points size slider tooltip.

### DIFF
--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -92,7 +92,7 @@ class QtPointsControls(QtLayerControls):
         sld = QSlider(Qt.Horizontal)
         sld.setToolTip(
             trans._(
-                "Change the size of currently selected points and the future ones."
+                "Change the size of the currently selected points and the future ones."
             )
         )
         sld.setFocusPolicy(Qt.NoFocus)

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -90,6 +90,11 @@ class QtPointsControls(QtLayerControls):
         self.layer.text.events.visible.connect(self._on_text_visibility_change)
 
         sld = QSlider(Qt.Horizontal)
+        sld.setToolTip(
+            trans._(
+                "Change the size of currently selected points and the future ones."
+            )
+        )
         sld.setFocusPolicy(Qt.NoFocus)
         sld.setMinimum(1)
         sld.setMaximum(100)

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -92,7 +92,7 @@ class QtPointsControls(QtLayerControls):
         sld = QSlider(Qt.Horizontal)
         sld.setToolTip(
             trans._(
-                "Change the size of the currently selected points and the future ones."
+                "Change the size of currently selected points and any added afterwards."
             )
         )
         sld.setFocusPolicy(Qt.NoFocus)


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This PR is a response to the problem raised on the image.sc: 
https://forum.image.sc/t/point-size-and-edge-width-sliders-not-working/65784

It adds a tooltip with a simple explanation of what the points size slider does 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).

@jni I'm totally open to rephrasing this sentence. 
