### PR TITLE
Split_channel makes base channel translucent, rest additive

### DIFF
--- a/napari/components/_tests/test_multichannel.py
+++ b/napari/components/_tests/test_multichannel.py
@@ -119,7 +119,11 @@ def test_multichannel(shape, kwargs):
             else:
                 assert viewer.layers[i].colormap.name == base_colormaps[i]
         if 'blending' not in kwargs:
-            assert viewer.layers[i].blending == 'additive'
+            assert (
+                viewer.layers[i].blending == 'translucent'
+                if i == 0
+                else 'additive'
+            )
         for key, expectation in kwargs.items():
             # broadcast exceptions
             if key in {

--- a/napari/layers/utils/_tests/test_stack_utils.py
+++ b/napari/layers/utils/_tests/test_stack_utils.py
@@ -224,9 +224,11 @@ def test_split_channels_missing_keywords():
     result_list = split_channels(data, 0)
 
     assert len(result_list) == 3
-    for d, meta, _ in result_list:
-        assert d.shape == (128, 128)
-        assert meta['blending'] == 'additive'
+    for chan, layer in enumerate(result_list):
+        assert layer[0].shape == (128, 128)
+        assert (
+            layer[1]['blending'] == 'translucent' if chan == 0 else 'additive'
+        )
 
 
 def test_split_channels_affine_nparray(kwargs):

--- a/napari/layers/utils/stack_utils.py
+++ b/napari/layers/utils/stack_utils.py
@@ -51,7 +51,7 @@ def split_channels(
     function. Colormap, blending, or multiscale are set as follows if not
     overridden by a keyword:
     - colormap : (magenta, green) for 2 channels, (CYMRGB) for more than 2
-    - blending : additive
+    - blending : translucent for first channel, additive for others
     - multiscale : determined by layers.image._image_utils.guess_multiscale.
 
     Colormap, blending and multiscale will be set and returned in meta if not in kwargs.
@@ -81,7 +81,9 @@ def split_channels(
 
     n_channels = (data[0] if multiscale else data).shape[channel_axis]
 
-    kwargs['blending'] = kwargs.get('blending') or 'additive'
+    kwargs['blending'] = kwargs.get('blending') or ['translucent'] + [
+        'additive'
+    ] * (n_channels - 1)
     kwargs.setdefault('colormap', None)
     # these arguments are *already* iterables in the single-channel case.
     iterable_kwargs = {

--- a/napari/layers/utils/stack_utils.py
+++ b/napari/layers/utils/stack_utils.py
@@ -80,7 +80,7 @@ def split_channels(
         kwargs['multiscale'] = multiscale
 
     n_channels = (data[0] if multiscale else data).shape[channel_axis]
-
+    # Use original blending mode or for multichannel use translucent for first channel then additive
     kwargs['blending'] = kwargs.get('blending') or ['translucent'] + [
         'additive'
     ] * (n_channels - 1)


### PR DESCRIPTION
# Description
This is related to https://github.com/napari/napari/issues/3374 and https://github.com/napari/napari/issues/3353
I was looking at blending again, because the Light mode issue is really irritating.
So, in reference to https://github.com/napari/napari/issues/3353 the default for images is indeed `translucent`. See:
https://github.com/napari/napari/blob/57c3c348022ffc362f8712ec844dadb0579b7276/napari/layers/image/image.py#L232
https://github.com/napari/napari/blob/57c3c348022ffc362f8712ec844dadb0579b7276/napari/components/viewer_model.py#L726
...but this is only if `channel_axis` is `None`, so single channels.
For a single channel image, it's not clear to me what the advantage would be of using additive —is blending with the canvas ever desired? Meanwhile, the drawback of additive is that in Light mode (white canvas) additive mode means no image, which is a pretty broken behavior IMO.

Now, when a multichannel image is opened and is split into channels, then additive is forced:
https://github.com/napari/napari/blob/57c3c348022ffc362f8712ec844dadb0579b7276/napari/layers/utils/stack_utils.py#L84
...and this of course is the source of the issue with Light mode https://github.com/napari/napari/issues/3374
none of the multichannel examples "work" (Cells, Kidney, Lilly, etc). They all return white squares.
But additive blending is really nice for multichannel overlays.

My solution here is, when splitting, to make the first channel translucent and the rest additive. This eliminates blending with the canvas, restoring expected behavior with sample images and other multichannel images in Light mode.
Check it out:
```
import napari
from skimage import data

viewer = napari.Viewer()
viewer.theme = "light"
viewer.open_sample('napari', 'kidney')
```

You can switch to Dark mode and should see no difference.
Now, if you have images open the behavior will change, again for the better I think. Try:
```
viewer.open_sample('napari', 'binary_blobs')
viewer.open_sample('napari', 'kidney')
```
With this change the new stack doesn't blend with the previously opened image.


## Type of change
- [x] Bug-fix for https://github.com/napari/napari/issues/3374
- [?] Breaking change (stack splitting will be different)
- [ ] This change requires a documentation update

# References
Closes https://github.com/napari/napari/issues/3374
See also https://github.com/napari/napari/issues/3353 and https://github.com/napari/napari/discussions/3914

# How has this been tested?
- [x] tested locally: fixes opening sample images in Light mode
- [x] fixed test to take into account the change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).

