### PR TITLE
Fix docs warnings related to NAPs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,7 +130,6 @@ exclude_patterns = [
     '.DS_Store',
     '.jupyter_cache',
     'jupyter_execute',
-    'naps/template.md',
 ]
 
 

--- a/docs/naps/0-nap-process.md
+++ b/docs/naps/0-nap-process.md
@@ -1,15 +1,15 @@
----
-Author: "Juan Nunez-Iglesias <mailto:jni@fastmail.com>"
-Author: "Andy Sweet <mailto:andrewdsweet@gmail.com>"
-Author: "Kevin Yamauchi <mailto:kevin.yamauchi@gmail.com>"
-Created: '2022-03-23'
-Status: Active
-Type: Process
----
-
 (nap0)=
 
 # NAP 0 — Purpose and Process
+
+```{eval-rst}
+:Author: "Juan Nunez-Iglesias <mailto:jni@fastmail.com>"
+:Author: "Andy Sweet <mailto:andrewdsweet@gmail.com>"
+:Author: "Kevin Yamauchi <mailto:kevin.yamauchi@gmail.com>"
+:Created: '2022-03-23'
+:Status: Active
+:Type: Process
+```
 
 ## What is a NAP?
 
@@ -105,7 +105,7 @@ There are three kinds of NAPs:
    library itself. They may propose an implementation, but not to
    napari's codebase; they require community consensus. Examples include
    procedures, guidelines, changes to the
-   {doc}`decision-making process <napari-governance>`, and
+   {ref}`decision-making process <napari-governance>`, and
    changes to the tools or environment used in napari development.
    Any meta-NAP is also considered a Process NAP.
 
@@ -132,8 +132,10 @@ for the idea (e.g., `nap-35-lazy-slicing.md`). The draft must use the
 {ref}`nap-template` file.
 
 Once the PR is in place, the NAP should be announced on various channels
-for discussion, including the [#naps channel on Zulip]() and, if the NAP
-has significant user implications, on the [image.sc forum]().
+for discussion, including the
+[#naps channel on Zulip](https://napari.zulipchat.com/#narrow/stream/322105-naps) and, if the NAP
+has significant user implications, on the
+[image.sc forum](https://forum.image.sc/).
 
 At the earliest convenience, the PR should be merged (regardless of whether
 it is accepted during discussion). A NAP that outlines a coherent argument
@@ -259,7 +261,7 @@ proposed for acceptance again later once the objections are resolved.
 In unusual cases, when no consensus can be reached between core developers,
 the [napari Steering Council] may be asked to decide whether a
 controversial NAP is accepted, according to our
-{doc}`governance <napari-governance>`.
+{ref}`governance <napari-governance>`.
 
 ### Maintenance
 

--- a/docs/naps/template.md
+++ b/docs/naps/template.md
@@ -1,18 +1,18 @@
----
-Author: \<list of authors' real names and, optionally, email addresses>
-Created: \<date created on, in yyyy-mm-dd format>
-Resolution: \<url> (required for Accepted | Rejected | Withdrawn)
-Resolved: \<date resolved, in yyyy-mm-dd format>
-Status: |-
-  \<Draft | Provisional | Active | Accepted | Deferred | Rejected | Withdrawn |
-  Final | Superseded>
-Type: \<Standards Track | Process>
-Version effective: \<version-number> (for accepted NAPs)
----
+:orphan:
 
 (nap-template)=
 
 # NAP-X — Template and Instructions
+
+```{eval-rst}
+:Author: <list of authors' real names and, optionally, email addresses>
+:Created: <date created on, in yyyy-mm-dd format>
+:Resolution: <url> (required for Accepted | Rejected | Withdrawn)
+:Resolved: <date resolved, in yyyy-mm-dd format>
+:Status: <Draft | Provisional | Active | Accepted | Deferred | Rejected | Withdrawn | Final | Superseded>
+:Type: <Standards Track | Process>
+:Version effective: <version-number> (for accepted NAPs)
+```
 
 ## Abstract
 


### PR DESCRIPTION
# Description

Fixes some formatting issues with the NAPs.

The `eval-rst` block is used here to [enable myst-parser to parse a field list](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#field-lists). In the future, as myst-nb supports myst-parser>=0.16, it may be possible to use simpler syntax as noted in the link.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
