### PR TITLE
Add parser for Events section in docstrings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,6 +133,7 @@ exclude_patterns = [
     'naps/template.md',
 ]
 
+napoleon_custom_sections = [('Events', 'params_style')]
 
 def reset_napari_theme(gallery_conf, fname):
     from napari.settings import get_settings

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,6 +135,7 @@ exclude_patterns = [
 
 napoleon_custom_sections = [('Events', 'params_style')]
 
+
 def reset_napari_theme(gallery_conf, fname):
     from napari.settings import get_settings
 

--- a/napari/utils/events/containers/_selection.py
+++ b/napari/utils/events/containers/_selection.py
@@ -12,9 +12,9 @@ _S = TypeVar("_S")
 
 
 class Selection(EventedSet[_T]):
-    """An model of selected items, with a `active` and `current` item.
+    """A model of selected items, with ``active`` and ``current`` item.
 
-    There can only be one `active` and one `current` item, but there can be
+    There can only be one ``active`` and one ``current` item, but there can be
     multiple selected items.  An "active" item is defined as a single selected
     item (if multiple items are selected, there is no active item).  The
     "current" item is mostly useful for (e.g.) keyboard actions: even with


### PR DESCRIPTION
# Description

This PR adds a new custom section called `Events` to the docstrings that use numpydoc format.

Before:

<img width="1069" alt="image" src="https://user-images.githubusercontent.com/3949932/165408426-93dc87c6-37a8-411c-9010-b431533bc323.png">

After:

<img width="1069" alt="image" src="https://user-images.githubusercontent.com/3949932/165408475-8783f933-d5eb-453b-b63d-788cd6546858.png">
 
Closes #4423

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
