### PR TITLE
Fixes several sphinx warnings.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -154,3 +154,12 @@ sphinx_gallery_conf = {
     'image_scrapers': (qtgallery.qtscraper,),
     'reset_modules': (reset_napari_theme,),
 }
+
+def setup(app):
+    """Ignore .ipynb files.
+
+    Prevents sphinx from complaining about multiple files found for document
+    when generating the gallery.
+
+    """
+    app.registry.source_suffix.pop(".ipynb", None)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -155,6 +155,7 @@ sphinx_gallery_conf = {
     'reset_modules': (reset_napari_theme,),
 }
 
+
 def setup(app):
     """Ignore .ipynb files.
 

--- a/docs/tutorials/fundamentals/index.md
+++ b/docs/tutorials/fundamentals/index.md
@@ -1,3 +1,0 @@
-# Fundamentals
-
-This section contains tutorials on fundamentals.

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -601,8 +601,9 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             expanded as channels.
         depiction : str
             Selects a preset volume depiction mode in vispy
-              * volume: images are rendered as 3D volumes.
-              * plane: images are rendered as 2D planes embedded in 3D.
+
+            * volume: images are rendered as 3D volumes.
+            * plane: images are rendered as 2D planes embedded in 3D.
         iso_threshold : float or list
             Threshold for isosurface. If a list then must be same length as the
             axis that is being expanded as channels.

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -114,23 +114,24 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         Whether the layer visual is currently being displayed.
     blending : Blending
         Determines how RGB and alpha values get mixed.
-            Blending.OPAQUE
-                Allows for only the top layer to be visible and corresponds to
-                depth_test=True, cull_face=False, blend=False.
-            Blending.TRANSLUCENT
-                Allows for multiple layers to be blended with different opacity
-                and corresponds to depth_test=True, cull_face=False,
-                blend=True, blend_func=('src_alpha', 'one_minus_src_alpha').
-            Blending.TRANSLUCENT_NO_DEPTH
-                Allows for multiple layers to be blended with different opacity,
-                but no depth testing is performed.
-                and corresponds to depth_test=False, cull_face=False,
-                blend=True, blend_func=('src_alpha', 'one_minus_src_alpha').
-            Blending.ADDITIVE
-                Allows for multiple layers to be blended together with
-                different colors and opacity. Useful for creating overlays. It
-                corresponds to depth_test=False, cull_face=False, blend=True,
-                blend_func=('src_alpha', 'one').
+
+        * ``Blending.OPAQUE``
+          Allows for only the top layer to be visible and corresponds to
+          ``depth_test=True``, ``cull_face=False``, ``blend=False``.
+        * ``Blending.TRANSLUCENT``
+          Allows for multiple layers to be blended with different opacity and
+          corresponds to ``depth_test=True``, ``cull_face=False``,
+          ``blend=True``, ``blend_func=('src_alpha', 'one_minus_src_alpha')``.
+        * ``Blending.TRANSLUCENT_NO_DEPTH``
+          Allows for multiple layers to be blended with different opacity, but
+          no depth testing is performed. Corresponds to ``depth_test=False``,
+          ``cull_face=False``, ``blend=True``,
+          ``blend_func=('src_alpha', 'one_minus_src_alpha')``.
+        * ``Blending.ADDITIVE``
+          Allows for multiple layers to be blended together with different
+          colors and opacity. Useful for creating overlays. It corresponds to
+          ``depth_test=False``, ``cull_face=False``, ``blend=True``,
+          ``blend_func=('src_alpha', 'one')``.
     scale : tuple of float
         Scale factors for the layer.
     translate : tuple of float
@@ -191,12 +192,14 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     Notes
     -----
     Must define the following:
-        * `_extent_data`: property
-        * `data` property (setter & getter)
+
+    * `_extent_data`: property
+    * `data` property (setter & getter)
 
     May define the following:
-        * `_set_view_slice()`: called to set currently viewed slice
-        * `_basename()`: base/default name of the layer
+
+    * `_set_view_slice()`: called to set currently viewed slice
+    * `_basename()`: base/default name of the layer
     """
 
     def __init__(

--- a/napari/layers/image/_image_constants.py
+++ b/napari/layers/image/_image_constants.py
@@ -64,23 +64,24 @@ class ImageRendering(StringEnum):
     """Rendering: Rendering mode for the layer.
 
     Selects a preset rendering mode in vispy
-        * translucent: voxel colors are blended along the view ray until
-          the result is opaque.
-        * mip: maximum intensity projection. Cast a ray and display the
-          maximum value that was encountered.
-        * minip: minimum intensity projection. Cast a ray and display the
-          minimum value that was encountered.
-        * attenuated_mip: attenuated maximum intensity projection. Cast a
-          ray and attenuate values based on integral of encountered values,
-          display the maximum value that was encountered after attenuation.
-          This will make nearer objects appear more prominent.
-        * additive: voxel colors are added along the view ray until
-          the result is saturated.
-        * iso: isosurface. Cast a ray until a certain threshold is
-          encountered. At that location, lighning calculations are
-          performed to give the visual appearance of a surface.
-        * average: average intensity projection. Cast a ray and display the
-          average of values that were encountered.
+
+    * translucent: voxel colors are blended along the view ray until
+      the result is opaque.
+    * mip: maximum intensity projection. Cast a ray and display the
+      maximum value that was encountered.
+    * minip: minimum intensity projection. Cast a ray and display the
+      minimum value that was encountered.
+    * attenuated_mip: attenuated maximum intensity projection. Cast a
+      ray and attenuate values based on integral of encountered values,
+      display the maximum value that was encountered after attenuation.
+      This will make nearer objects appear more prominent.
+    * additive: voxel colors are added along the view ray until
+      the result is saturated.
+    * iso: isosurface. Cast a ray until a certain threshold is
+      encountered. At that location, lighning calculations are
+      performed to give the visual appearance of a surface.
+    * average: average intensity projection. Cast a ray and display the
+      average of values that were encountered.
     """
 
     TRANSLUCENT = auto()

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -141,10 +141,11 @@ class Points(Layer):
         Currently, this only applies to dask arrays.
     shading : str, Shading
         Render lighting and shading on points. Options are:
-            * 'none'
-                No shading is added to the points.
-            * 'spherical'
-                Shading and depth buffer are changed to give a 3D spherical look to the points
+
+        * 'none'
+          No shading is added to the points.
+        * 'spherical'
+          Shading and depth buffer are changed to give a 3D spherical look to the points
     experimental_canvas_size_limits : tuple of float
         Lower and upper limits for the size of points in canvas pixels.
     shown : 1-D array of bool

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -73,12 +73,12 @@ class Surface(IntensityVisualizationMixin, Layer):
         One of a list of preset shading modes that determine the lighting model
         using when rendering the surface in 3D.
 
-        * Shading.NONE
-            Corresponds to shading='none'.
-        * Shading.FLAT
-            Corresponds to shading='flat'.
-        * Shading.SMOOTH
-            Corresponds to shading='smooth'.
+        * ``Shading.NONE``
+          Corresponds to ``shading='none'``.
+        * ``Shading.FLAT``
+          Corresponds to ``shading='flat'``.
+        * ``Shading.SMOOTH``
+          Corresponds to ``shading='smooth'``.
     visible : bool
         Whether the layer visual is currently being displayed.
     cache : bool
@@ -118,9 +118,9 @@ class Surface(IntensityVisualizationMixin, Layer):
         One of a list of preset shading modes that determine the lighting model
         using when rendering the surface.
 
-        * 'none'
-        * 'flat'
-        * 'smooth'
+        * ``'none'``
+        * ``'flat'``
+        * ``'smooth'``
     gamma : float
         Gamma correction for determining colormap linearity.
     wireframe : SurfaceWireframe


### PR DESCRIPTION
# Description
- Fixes a few unexpected indentation warnings
- Excludes ipynb files from build (useful when re-building the gallery)
- Improves formatting for a few docstrings

With this, we go from 390 warnings to ~310.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
