### PR TITLE
Correctly order vispy layers on insertion

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -18,6 +18,7 @@ from napari._tests.utils import (
     skip_on_win_ci,
 )
 from napari._vispy.utils.gl import fix_data_dtype
+from napari.layers import Points
 from napari.settings import get_settings
 from napari.utils.interactions import mouse_press_callbacks
 from napari.utils.io import imread
@@ -641,3 +642,18 @@ def test_surface_mixed_dim(make_napari_viewer):
     timeseries_values = np.vstack([values, values])
     timeseries_data = (verts, faces, timeseries_values)
     viewer.add_surface(timeseries_data)
+
+
+def test_insert_layer_ordering(make_napari_viewer):
+    """make sure layer ordering is correct in vispy when inserting layers"""
+    viewer = make_napari_viewer()
+    pl1 = Points()
+    pl2 = Points()
+
+    viewer.layers.append(pl1)
+    viewer.layers.insert(0, pl2)
+
+    pl1_vispy = viewer.window._qt_viewer.layer_to_visual[pl1].node
+    pl2_vispy = viewer.window._qt_viewer.layer_to_visual[pl2].node
+    assert pl1_vispy.order == 1
+    assert pl2_vispy.order == 0

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -499,8 +499,8 @@ class QtViewer(QSplitter):
                 vispy_layer.events.loaded.connect(self._qt_poll.wake_up)
 
         vispy_layer.node.parent = self.view.scene
-        vispy_layer.order = len(self.viewer.layers) - 1
         self.layer_to_visual[layer] = vispy_layer
+        self._reorder_layers()
 
     def _remove_layer(self, event):
         """When a layer is removed, remove its parent.


### PR DESCRIPTION
# Description
Fixes #4420. It appears that we simply assumed that `insert == append`, which broke the use of `viewer.layers.insert()`.

Surprising that this bug did not come up earlier!

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
