### PR TITLE
[WIP] PropertyView (evented properties #2)

### DIFF
--- a/examples/dev/property_view.py
+++ b/examples/dev/property_view.py
@@ -1,0 +1,39 @@
+from rich import print
+from napari.utils.events import EventedModel, EventedList
+from napari.utils.property_view import property_view
+
+
+class A(EventedModel):
+    x: EventedList[int] = [1, 2]
+    y: EventedList[int] = [3, 5]
+
+    class Config:
+        dependencies = {'z': ['x', 'y']}
+
+    @property_view
+    def z(self) -> list[int]:
+        return [x + y for x, y in zip(self.x, self.y)]
+
+    @z.setter
+    def z(self, value):
+        self.x = [(z - y) for y, z in zip(self.y, value)]
+
+    @property_view
+    def xy(self) -> list[list[int]]:
+        return [[x, y] for x, y in zip(self.x, self.y)]
+
+    @xy.setter
+    def xy(self, value):
+        self.x, self.y = zip(*value)
+
+
+a = A()
+a.events.connect(lambda x: print(f'event {x.type} from source {x.source}'))
+
+print(a)
+print('a.z[0] = 8')
+a.z[0] = 8
+print(a)
+print('a.xy[0][0] = 100')
+a.xy[0][0] = 100
+print(a)

--- a/examples/dev/property_view.py
+++ b/examples/dev/property_view.py
@@ -47,8 +47,14 @@ m = M()
 for field in 'xyzw':
     getattr(m.events, field).connect(lambda _, field=field: print(f'Event {field} triggered'))
 
-print(m)
+print(f'>>> {m=}')
+print('>>> m.z.b.a[1] = 12')
+# deep nested properties are fine
 m.z.b.a[1] = 12
-print(m)
+print('>>> m.w = [[1, 2], [3, 4]]')
+# complex properties trigger all the appropriate events
 m.w = [[1, 2], [3, 4]]
-print(m)
+print('>>> m.w[1][0] = 2')
+# but if only some parts of nested properties are updated, only the relative events are triggered
+m.w[1][0] = 2
+print(f'>>> {m=}')

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -768,7 +768,12 @@ def test_not_mutable_fields(field):
     # Check attribute lives on the viewer
     assert hasattr(viewer, field)
     # Check attribute does not have an event emitter
-    assert not hasattr(viewer.events, field)
+    attr = getattr(viewer, field)
+    evented = hasattr(viewer.events, field)
+    if hasattr(attr, 'events'):
+        assert evented
+    else:
+        assert not evented
 
     # Check attribute is not settable
     with pytest.raises(TypeError) as err:

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -198,20 +198,21 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
 
         self._events.source = self
         # add event emitters for each field which is mutable
-        mutable_fields = [
-            name
-            for name, field in self.__fields__.items()
-            if field.field_info.allow_mutation
-        ]
+        field_events = []
+        for name, field in self.__fields__.items():
+            value = getattr(self, name)
+            if field.field_info.allow_mutation or hasattr(value, 'events'):
+                field_events.append(name)
+
         self._events.add(
-            **dict.fromkeys(mutable_fields + list(self.__property_setters__))
+            **dict.fromkeys(field_events + list(self.__property_setters__))
         )
 
         # hook up events from children
-        for name, field in self.__fields__.items():
+        for name in field_events:
             value = getattr(self, name)
             if hasattr(value, 'events'):
-                # TODO: won't track source all the way in...
+                # TODO: won't track source all the way in?
                 value.events.connect(getattr(self.events, name))
 
     def _super_setattr_(self, name: str, value: Any) -> None:

--- a/napari/utils/property_view.py
+++ b/napari/utils/property_view.py
@@ -1,0 +1,51 @@
+class PropertyView:
+    """
+    Proxy object that wraps the return value of a property so that any changes
+    to it are redirected to the property setter (therefore changing the parent object)
+    """
+
+    def __init__(self, viewed, key, parent, prop=None):
+        self._viewed = viewed
+        self._key = key
+        self._parent = parent
+        self._prop = prop
+
+    def _call_setter(self):
+        # this won't fire for nested views, so only the top level does something
+        if self._prop is not None:
+            self._prop.fset(self._parent, self._viewed)
+
+    def __getattribute__(self, name):
+        # proxy as much as possible
+        if name in ('_viewed', '_key', '_prop', '_parent', '_call_setter'):
+            return super().__getattribute__(name)
+        return getattr(self._viewed, name)
+
+    def __getitem__(self, k):
+        # recursively return views so you can index as deep as you want
+        return PropertyView(self._viewed[k], k, self)
+
+    def __setitem__(self, k, v):
+        self._viewed[k] = v
+        if self._prop is None:
+            # if nested, update the *parent*. (directly the viewed object to avoid recursion)
+            self._parent._viewed[self._key][k] = v
+            self._parent._call_setter()
+        else:
+            # call directly setter
+            self._call_setter()
+
+    def __iter__(self, k, v):
+        yield from self._viewed
+
+    def __repr__(self):
+        return f'View({repr(self._viewed)})'
+
+    # more proxy methods
+
+
+class property_view(property):
+    def __get__(self, obj, objtype=None):
+        return PropertyView(
+            super().__get__(obj, objtype), key=None, parent=obj, prop=self
+        )


### PR DESCRIPTION
# Description
This is an alternative implementation of #4417, fruit of a fruitful chat with @tlambert03 and some more playing around. Properties are cool, y'all!

I call it an alternative implementation, but while it's trying to solve the same problem, the approach is completely different. Instead of hijacking the `EventedModel.__getattribute__` and using self-referring events to update it, in this PR I subclassed `property` to create a `property_view` (no events involved).

This property returns a `PropertyView` object, which should behave exactly like the original object, except that it even when it's recursively indexed, it will upstream any of the changes to the `property_view.setter` and thus update the original object. In practice, it feels the same as #4417, but without events and duplications.

cc @jni and @sofroniewn , I know you were interested!
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
