### PR TITLE
Fix mypy error in CI

### DIFF
--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -440,7 +440,7 @@ class NapariPluginManager(PluginManager):
 
         dock_widgets = zip(repeat("dock"), self._dock_widgets.items())
         func_widgets = zip(repeat("func"), self._function_widgets.items())
-        yield from chain(dock_widgets, func_widgets)  # type: ignore [misc]
+        yield from chain(dock_widgets, func_widgets)
 
     def register_dock_widget(
         self,


### PR DESCRIPTION
# Description
Fix error in CI (from #4438):
```
Run make typecheck
mypy napari/settings napari/types.py napari/plugins napari/utils/context
napari/plugins/_plugin_manager.py:443: error: Unused "type: ignore" comment
Found 1 error in 1 file (checked 29 source files)
make: *** [Makefile:18: typecheck] Error 1
Error: Process completed with exit code 2.
```
Says it was unused so removed.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
