### PR TITLE
Use installer version instead of napari version for default paths

### DIFF
--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -206,7 +206,10 @@ jobs:
         run: |
           VER=$(python bundle_conda.py --version)
           echo "version=${VER}" >> $GITHUB_ENV
-          echo "Version: ${VER}"
+          echo "Napari version: ${VER}"
+          INST_VER=$(python bundle_conda.py --installer-version)
+          echo "installer_version=${INST_VER}" >> $GITHUB_ENV
+          echo "Installer version: ${INST_VER}"
           ARCH_SUFFIX=$(python bundle_conda.py --arch)
           echo "arch-suffix=${ARCH_SUFFIX}" >> $GITHUB_ENV
           echo "Machine: ${ARCH_SUFFIX}"
@@ -386,9 +389,9 @@ jobs:
       - name: Test installation (Linux)
         if: runner.os == 'Linux'
         run: |
-          bash napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }} -bfp "${{ runner.temp }}/napari-${{ env.version }}"
-          . "${{ runner.temp }}/napari-${{ env.version }}/etc/profile.d/conda.sh"
-          conda activate "${{ runner.temp }}/napari-${{ env.version }}/envs/napari-${{ env.version }}"
+          bash napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }} -bfp "${{ runner.temp }}/napari-app-${{ env.installer_version }}"
+          . "${{ runner.temp }}/napari-app-${{ env.installer_version }}/etc/profile.d/conda.sh"
+          conda activate "${{ runner.temp }}/napari-app-${{ env.installer_version }}/envs/napari-${{ env.version }}"
           xvfb-run --auto-servernum napari --info
 
       - name: Test installation (macOS)
@@ -396,16 +399,16 @@ jobs:
         run: |
           set -x
           installer -pkg napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }} -target CurrentUserHomeDirectory -dumplog
-          . "/Users/runner/Library/napari-${{ env.version }}/etc/profile.d/conda.sh"
-          conda activate "/Users/runner/Library/napari-${{ env.version }}/envs/napari-${{ env.version }}"
+          . "/Users/runner/Library/napari-app-${{ env.installer_version }}/etc/profile.d/conda.sh"
+          conda activate "/Users/runner/Library/napari-app-${{ env.installer_version }}/envs/napari-${{ env.version }}"
           napari --info
 
       - name: Test installation (Windows)
         if: runner.os == 'Windows'
         shell: cmd /C call {0}
         run: |
-          cmd.exe /c start /wait napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }} /S /D=${{ runner.temp }}\napari-${{ env.version }}
-          CALL ${{ runner.temp }}\napari-${{ env.version }}\Scripts\activate ${{ runner.temp }}\napari-${{ env.version }}\envs\napari-${{ env.version }}
+          cmd.exe /c start /wait napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }} /S /D=${{ runner.temp }}\napari-app-${{ env.installer_version }}
+          CALL ${{ runner.temp }}\napari-app-${{ env.installer_version }}\Scripts\activate ${{ runner.temp }}\napari-app-${{ env.installer_version }}\envs\napari-${{ env.version }}
           napari --info
 
       # Choose which one to keep; the one in `make_bundle` or this one.

--- a/bundle_conda.py
+++ b/bundle_conda.py
@@ -11,6 +11,9 @@ Some environment variables we use:
 CONSTRUCTOR_APP_NAME:
     in case you want to build a non-default distribution that is not
     named `napari`
+CONSTRUCTOR_INSTALLER_DEFAULT_PATH_STEM:
+    The last component of the default installation path. Defaults to
+    {CONSTRUCTOR_APP_NAME}-app-{CONSTRUCTOR_INSTALLER_VERSION}
 CONSTRUCTOR_INSTALLER_VERSION:
     Version for the installer, separate from the app being installed.
     This has an effect on the default install locations!
@@ -49,10 +52,13 @@ from tempfile import NamedTemporaryFile
 
 from ruamel import yaml
 
-APP = os.environ.get("CONSTRUCTOR_APP_NAME", "napari-app")
+APP = os.environ.get("CONSTRUCTOR_APP_NAME", "napari")
 # bump this when something in the installer infrastructure changes
 # note that this will affect the default installation path across platforms!
 INSTALLER_VERSION = os.environ.get("CONSTRUCTOR_INSTALLER_VERSION", "0.1")
+INSTALLER_DEFAULT_PATH_STEM = os.environ.get(
+    "CONSTRUCTOR_INSTALLER_DEFAULT_PATH_STEM", f"{APP}-app-{INSTALLER_VERSION}"
+)
 HERE = os.path.abspath(os.path.dirname(__file__))
 WINDOWS = os.name == 'nt'
 MACOS = sys.platform == 'darwin'
@@ -201,7 +207,7 @@ def _constructor(version=_version(), extra_specs=None):
         definitions["channels"].insert(0, "local")
     if LINUX:
         definitions["default_prefix"] = os.path.join(
-            "$HOME", ".local", f"{APP}-{INSTALLER_VERSION}"
+            "$HOME", ".local", INSTALLER_DEFAULT_PATH_STEM
         )
         definitions["license_file"] = os.path.join(
             HERE, "resources", "bundle_license.txt"
@@ -211,7 +217,7 @@ def _constructor(version=_version(), extra_specs=None):
     if MACOS:
         # These two options control the default install location:
         # ~/<default_location_pkg>/<pkg_name>
-        definitions["pkg_name"] = f"{APP}-{INSTALLER_VERSION}"
+        definitions["pkg_name"] = INSTALLER_DEFAULT_PATH_STEM
         definitions["default_location_pkg"] = "Library"
         definitions["installer_type"] = "pkg"
         definitions["welcome_image"] = os.path.join(
@@ -252,13 +258,13 @@ def _constructor(version=_version(), extra_specs=None):
                 ),
                 "register_python_default": False,
                 "default_prefix": os.path.join(
-                    '%LOCALAPPDATA%', f"{APP}-{INSTALLER_VERSION}"
+                    '%LOCALAPPDATA%', INSTALLER_DEFAULT_PATH_STEM
                 ),
                 "default_prefix_domain_user": os.path.join(
-                    '%LOCALAPPDATA%', f"{APP}-{INSTALLER_VERSION}"
+                    '%LOCALAPPDATA%', INSTALLER_DEFAULT_PATH_STEM
                 ),
                 "default_prefix_all_users": os.path.join(
-                    '%ALLUSERSPROFILE%', f"{APP}-{INSTALLER_VERSION}"
+                    '%ALLUSERSPROFILE%', INSTALLER_DEFAULT_PATH_STEM
                 ),
                 "check_path_length": False,
                 "installer_type": "exe",

--- a/bundle_conda.py
+++ b/bundle_conda.py
@@ -350,6 +350,11 @@ def cli(argv=None):
         help="Print local napari version and exit.",
     )
     p.add_argument(
+        "--installer-version",
+        action="store_true",
+        help="Print installer version and exit.",
+    )
+    p.add_argument(
         "--arch",
         action="store_true",
         help="Print machine architecture tag and exit.",
@@ -387,6 +392,9 @@ if __name__ == "__main__":
     args = cli()
     if args.version:
         print(_version())
+        sys.exit()
+    if args.installer_version:
+        print(INSTALLER_VERSION)
         sys.exit()
     if args.arch:
         print(ARCH)

--- a/bundle_conda.py
+++ b/bundle_conda.py
@@ -11,6 +11,9 @@ Some environment variables we use:
 CONSTRUCTOR_APP_NAME:
     in case you want to build a non-default distribution that is not
     named `napari`
+CONSTRUCTOR_INSTALLER_VERSION:
+    Version for the installer, separate from the app being installed.
+    This has an effect on the default install locations!
 CONSTRUCTOR_TARGET_PLATFORM:
     conda-style platform (as in `platform` in `conda info -a` output)
 CONSTRUCTOR_USE_LOCAL:
@@ -46,7 +49,10 @@ from tempfile import NamedTemporaryFile
 
 from ruamel import yaml
 
-APP = os.environ.get("CONSTRUCTOR_APP_NAME", "napari")
+APP = os.environ.get("CONSTRUCTOR_APP_NAME", "napari-app")
+# bump this when something in the installer infrastructure changes
+# note that this will affect the default installation path across platforms!
+INSTALLER_VERSION = os.environ.get("CONSTRUCTOR_INSTALLER_VERSION", "0.1")
 HERE = os.path.abspath(os.path.dirname(__file__))
 WINDOWS = os.name == 'nt'
 MACOS = sys.platform == 'darwin'
@@ -195,7 +201,7 @@ def _constructor(version=_version(), extra_specs=None):
         definitions["channels"].insert(0, "local")
     if LINUX:
         definitions["default_prefix"] = os.path.join(
-            "$HOME", ".local", f"{APP}-{version}"
+            "$HOME", ".local", f"{APP}-{INSTALLER_VERSION}"
         )
         definitions["license_file"] = os.path.join(
             HERE, "resources", "bundle_license.txt"
@@ -203,9 +209,9 @@ def _constructor(version=_version(), extra_specs=None):
         definitions["installer_type"] = "sh"
 
     if MACOS:
-        # we change this bc the installer takes the name
-        # as the default install location basename
-        definitions["name"] = f"{APP}-{version}"
+        # These two options control the default install location:
+        # ~/<default_location_pkg>/<pkg_name>
+        definitions["pkg_name"] = f"{APP}-{INSTALLER_VERSION}"
         definitions["default_location_pkg"] = "Library"
         definitions["installer_type"] = "pkg"
         definitions["welcome_image"] = os.path.join(
@@ -246,13 +252,13 @@ def _constructor(version=_version(), extra_specs=None):
                 ),
                 "register_python_default": False,
                 "default_prefix": os.path.join(
-                    '%LOCALAPPDATA%', f"{APP}-{version}"
+                    '%LOCALAPPDATA%', f"{APP}-{INSTALLER_VERSION}"
                 ),
                 "default_prefix_domain_user": os.path.join(
-                    '%LOCALAPPDATA%', f"{APP}-{version}"
+                    '%LOCALAPPDATA%', f"{APP}-{INSTALLER_VERSION}"
                 ),
                 "default_prefix_all_users": os.path.join(
-                    '%ALLUSERSPROFILE%', f"{APP}-{version}"
+                    '%ALLUSERSPROFILE%', f"{APP}-{INSTALLER_VERSION}"
                 ),
                 "check_path_length": False,
                 "installer_type": "exe",

--- a/bundle_conda.py
+++ b/bundle_conda.py
@@ -209,7 +209,7 @@ def _constructor(version=_version(), extra_specs=None):
         definitions["installer_type"] = "sh"
 
     if MACOS:
-        # These two options control the default install location:
+        # These two options control the default install location:
         # ~/<default_location_pkg>/<pkg_name>
         definitions["pkg_name"] = f"{APP}-{INSTALLER_VERSION}"
         definitions["default_location_pkg"] = "Library"


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] The installers are successfully created
- [x] The installation test uses a default location with stem = `napari-app-0.1`.

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).

With this PR, the installer will default to the following paths:

* Linux: `~/.local/napari-app-0.1/`
* macOS: `~/Library/napari-app-0.1/`
* Windows `%LOCALAPPDATA%/napari-app-0.1`

Note that `0.1` here is determined by `CONSTRUCTOR_INSTALLER_VERSION` (defaults to `0.1` right now in `bundle_conda.py`), and is separate from the actual napari version (e.g. `0.4.16`). This will allow us to tell users that try to update via downloading a new installer manually to use the in-app update mechanisms instead. See this part of our `constructor` fork:

https://github.com/jaimergp/constructor/commit/abb4960bc44d8b75ee3df27264effde2f8784b3b#diff-1060b38f812546ddcbc99c3c52d781bee492fe39450888d277071cfe921b58e0R20

Note: We might want to parametrize that text as part of the upstreaming work, but for now it's hardcoded in our fork.