### PR TITLE
napari --info: list npe2 plugins

### DIFF
--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -77,6 +77,7 @@ def sys_info(as_html=False):
         if True, info will be returned as HTML, suitable for a QTextEdit widget
     """
     from napari.plugins import plugin_manager
+    from npe2 import PluginManager as Npe2PluginManager
 
     sys_version = sys.version.replace('\n', ' ')
     text = (
@@ -152,17 +153,29 @@ def sys_info(as_html=False):
         text += f"  - failed to load screen information {e}"
 
     plugin_manager.discover()
-    plugin_strings = []
+    plugin_strings = {}
     for meta in plugin_manager.list_plugin_metadata():
         plugin_name = meta.get('plugin_name')
         if plugin_name == 'builtins':
             continue
         version = meta.get('version')
         version_string = f": {version}" if version else ""
-        plugin_strings.append(f"  - {plugin_name}{version_string}")
+        plugin_strings[plugin_name] = f"  - {plugin_name}{version_string}"
+
+    npe2_plugin_manager = Npe2PluginManager.instance()
+    for manifest in npe2_plugin_manager.iter_manifests():
+        plugin_name = manifest.name
+        if plugin_name in ("napari", "builtins"):
+            continue
+        if version := manifest.package_version:
+            version_string = f": {version}"
+        else:
+            version_string = ""
+        plugin_strings[plugin_name] = f"  - {plugin_name}{version_string}"
+
     text += '<br><b>Plugins</b>:'
     text += (
-        ("<br>" + "<br>".join(sorted(plugin_strings)))
+        ("<br>" + "<br>".join(sorted(plugin_strings.values())))
         if plugin_strings
         else '  None'
     )

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -76,8 +76,9 @@ def sys_info(as_html=False):
     as_html : bool
         if True, info will be returned as HTML, suitable for a QTextEdit widget
     """
-    from napari.plugins import plugin_manager
     from npe2 import PluginManager as Npe2PluginManager
+
+    from napari.plugins import plugin_manager
 
     sys_version = sys.version.replace('\n', ' ')
     text = (

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -167,10 +167,8 @@ def sys_info(as_html=False):
         plugin_name = manifest.name
         if plugin_name in ("napari", "builtins"):
             continue
-        if version := manifest.package_version:
-            version_string = f": {version}"
-        else:
-            version_string = ""
+        version = manifest.package_version
+        version_string = f": {version}" if version else ""
         plugin_strings[plugin_name] = f"  - {plugin_name}{version_string}"
 
     text += '<br><b>Plugins</b>:'


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

Closes #4405 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] npe2 plugins are shown in the output of napari --info

Locally, I've seen:

Before this PR
```
napari --info             
/Users/jrodriguez/devel/napari/napari/__main__.py:437: UserWarning: pythonw executable not found.
To unfreeze the menubar on macOS, click away from napari to another app, then reactivate napari. To avoid this problem, please install python.app in conda using:
conda install -c conda-forge python.app
  warnings.warn(msg)
napari: 0.4.16.dev93+g731c2091
Platform: macOS-11.2.3-x86_64-i386-64bit
System: MacOS 11.2.3
Python: 3.10.4 | packaged by conda-forge | (main, Mar 24 2022, 17:43:32) [Clang 12.0.1 ]
Qt: 5.12.9
PyQt5: 5.12.3
NumPy: 1.22.3
SciPy: 1.8.0
Dask: 2022.04.1
VisPy: 0.9.6

OpenGL:
  - GL version:  2.1 Metal - 71.0.7
  - MAX_TEXTURE_SIZE: 16384

Screens:
  - screen 1: resolution 1440x900, scale 2.0
  - screen 2: resolution 2560x1440, scale 1.0

Plugins:
  - console: 0.0.4
  - scikit-image: 0.4.16.dev93+g731c2091
```

After this PR
```
napari --info             
/Users/jrodriguez/devel/napari/napari/__main__.py:437: UserWarning: pythonw executable not found.
To unfreeze the menubar on macOS, click away from napari to another app, then reactivate napari. To avoid this problem, please install python.app in conda using:
conda install -c conda-forge python.app
  warnings.warn(msg)
napari: 0.4.16.dev93+g731c2091
Platform: macOS-11.2.3-x86_64-i386-64bit
System: MacOS 11.2.3
Python: 3.10.4 | packaged by conda-forge | (main, Mar 24 2022, 17:43:32) [Clang 12.0.1 ]
Qt: 5.12.9
PyQt5: 5.12.3
NumPy: 1.22.3
SciPy: 1.8.0
Dask: 2022.04.1
VisPy: 0.9.6

OpenGL:
  - GL version:  2.1 Metal - 71.0.7
  - MAX_TEXTURE_SIZE: 16384

Screens:
  - screen 1: resolution 1440x900, scale 2.0
  - screen 2: resolution 2560x1440, scale 1.0

Plugins:
  - console: 0.0.4
  - napari-svg: 0.1.6
  - scikit-image: 0.4.16.dev93+g731c2091
```

(`napari-svg` was missing)


For now I started adding them to the same list, but maybe we want them to be separate lists? As in `Plugins (napari-plugin-engine)` and `Plugins (npe2)`?


## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
