### PR TITLE
Add doc specific Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,18 @@
+.PHONY: typestubs pre watch dist settings-schema
+
+clean:
+	rm -rf docs/_build/
+	rm -rf docs/api/napari*.rst
+	rm -rf docs/gallery/*
+
+docs:
+	python _scripts/prep_docs.py
+	NAPARI_APPLICATION_IPY_INTERACTIVE=0 sphinx-build -b html . ./_build
+
+html:
+	python _scripts/prep_docs.py
+	NAPARI_APPLICATION_IPY_INTERACTIVE=0 sphinx-build -b html . ./_build
+
+html-noplot:
+	python _scripts/prep_docs.py
+	NAPARI_APPLICATION_IPY_INTERACTIVE=0 sphinx-build -D plot_gallery=0 -b html . ./_build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+from pathlib import Path
 
 import qtgallery
 
@@ -148,7 +149,10 @@ sphinx_gallery_conf = {
     'gallery_dirs': 'gallery',  # path to where to save gallery generated output
     'filename_pattern': '/*.py',
     'ignore_pattern': 'README.rst|/*_.py',
-    'default_thumb_file': 'napari/resources/logo.png',
+    'default_thumb_file': Path(__file__).parent.parent
+    / 'napari'
+    / 'resources'
+    / 'logo.png',
     'plot_gallery': True,
     'download_all_examples': False,
     'min_reported_time': 10,


### PR DESCRIPTION
# Description
For almost all other scientific Python projects, there is a sphinx makefile in the `docs` folder. I've mirrored that here to reduce (experienced Python + new napari) developer friction, with options that are common to other projects that use sphinx. Fixes https://github.com/napari/napari/issues/4451 (in my opinion).

I also had to fix the sphinx-gallery logo path to be relative to fix the `html-noplot` option, which skips building the sphinx gallery.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
