### PR TITLE
Bugfix/Add affine to base_dict via _get_base_state()

### DIFF
--- a/napari/layers/_tests/test_serialize.py
+++ b/napari/layers/_tests/test_serialize.py
@@ -24,8 +24,8 @@ def test_attrs_arrays(Layer, data, ndim):
         assert prop in signature.parameters
 
     # Check number of properties is same as number in signature
-    # excluding affine transform and `cache` which is not yet in `_get_state`
-    assert len(properties) == len(signature.parameters) - 2
+    # excluding `cache` which is not yet in `_get_state`
+    assert len(properties) == len(signature.parameters) - 1
 
     # Check new layer can be created
     new_layer = Layer(**properties)

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -793,6 +793,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             'translate': list(self.translate),
             'rotate': [list(r) for r in self.rotate],
             'shear': list(self.shear),
+            'affine': self.affine.affine_matrix,
             'opacity': self.opacity,
             'blending': self.blending,
             'visible': self.visible,


### PR DESCRIPTION
# Description
This PR adds `affine.affine_matrix` to the `base_dict` generated by `_get_base_state()`.
This function is called by the `_convert` layer actions, so this ensures that converted layers retain the affines of the original, fixing https://github.com/napari/napari/issues/4450

Try the following in the napari console:
```python
import numpy as np

from skimage.data import binary_blobs
viewer.add_image(binary_blobs(64, volume_fraction=.2, n_dim=3), affine=np.array([[1, -1, 4], [2, 3, 2], [0, 0, 1]]))

from napari.layers._layer_actions import _convert
_convert(viewer.layers, type_="labels")
```
On `main` the labels layer will be square, with the affine not applied. With this PR, the labels layer will be transformed.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes https://github.com/napari/napari/issues/4450

# How has this been tested?
- [x] locally running `pytest` on `test_layer_actions.py ` results in all pass.
- [x] fixed `test_serialize` to account for the extra property in `test_attrs_arrays`. Now all pass.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).