### PR TITLE
Make npe2 writer test more lenient

### DIFF
--- a/napari/plugins/_tests/test_npe2.py
+++ b/napari/plugins/_tests/test_npe2.py
@@ -113,8 +113,8 @@ def test_write(mock_pm: PluginManager):
     writer.exec.return_value = ['']
     assert _npe2.write_layers('some_file.tif', [points], writer=writer) == ['']
     mock_pm.commands.get.assert_not_called()
-    expected_args = ('some_file.tif', *points.as_layer_data_tuple()[:2])
-    writer.exec.assert_called_once_with(args=expected_args)
+    writer.exec.assert_called_once()
+    assert writer.exec.call_args_list[0].kwargs['args'][0] == 'some_file.tif'
 
 
 def test_get_widget_contribution(mock_pm):


### PR DESCRIPTION
# Description

The current testing based on Mock doesn't play well with arguments that are NumPy arrays, which is interfering with improvements to our layer serialisation code. See:

https://github.com/napari/napari/pull/4453#issuecomment-1114369409

