### PR TITLE
Set `TMP` on Windows+Mamba subprocesses if not set

### DIFF
--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -57,7 +57,7 @@ from ..qthreading import create_worker
 from ..widgets.qt_message_popup import WarnPopup
 from ..widgets.qt_tooltip import QtToolTipLabel
 
-InstallerTypes = Literal['pip', 'conda', 'mamba']
+InstallerTypes = Literal['pip', 'mamba']
 
 
 # TODO: add error icon and handle pip install errors

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -3,8 +3,8 @@ import sys
 from enum import Enum, auto
 from importlib.metadata import PackageNotFoundError, metadata
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Sequence, Tuple
 from tempfile import gettempdir
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 from npe2 import PackageMetadata, PluginManager
 from qtpy.QtCore import (

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -4,6 +4,7 @@ from enum import Enum, auto
 from importlib.metadata import PackageNotFoundError, metadata
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
+from tempfile import gettempdir
 
 from npe2 import PackageMetadata, PluginManager
 from qtpy.QtCore import (
@@ -115,9 +116,9 @@ class Installer(QObject):
             and os.name == "nt"
             and not QProcessEnvironment.systemEnvironment().contains("TEMP")
         ):
-            temp = tempfile.gettempdir()
-            env.insert("TEMP", temp)
+            temp = gettempdir()
             env.insert("TMP", temp)
+            env.insert("TEMP", temp)
 
         process.setProcessEnvironment(env)
         self.set_output_widget(self._output_widget)
@@ -719,9 +720,7 @@ class QtPluginDialog(QDialog):
         self.refresh_state = RefreshState.DONE
         self.already_installed = set()
 
-        installer_type = "pip"
-        if running_as_constructor_app():
-            installer_type = "mamba"  # if os.name != "nt" else "conda"
+        installer_type = "mamba" if running_as_constructor_app() else "pip"
 
         self.installer = Installer(installer=installer_type)
         self.setup_ui()

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -108,6 +108,17 @@ class Installer(QObject):
         env.insert(
             "PATH", QProcessEnvironment.systemEnvironment().value("PATH")
         )
+
+        # workaround https://github.com/napari/napari/issues/4247
+        if (
+            installer == "mamba"
+            and os.name == "nt"
+            and not QProcessEnvironment.systemEnvironment().contains("TEMP")
+        ):
+            temp = tempfile.gettempdir()
+            env.insert("TEMP", temp)
+            env.insert("TMP", temp)
+
         process.setProcessEnvironment(env)
         self.set_output_widget(self._output_widget)
         process.finished.connect(
@@ -710,7 +721,7 @@ class QtPluginDialog(QDialog):
 
         installer_type = "pip"
         if running_as_constructor_app():
-            installer_type = "mamba" if os.name != "nt" else "conda"
+            installer_type = "mamba"  # if os.name != "nt" else "conda"
 
         self.installer = Installer(installer=installer_type)
         self.setup_ui()


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Windows installations without TEMP set will run into installation errors due to a fun chain of events:

* Napari creates a `mamba install ...` process
* Mamba solves the request and passes the list of packages to Conda, which creates the `Transaction` object
* The Transaction contains a list of actions, like downloads, extractions, linking, etc
* One of the actions is creating the menu shortcuts through `menuinst` if a file on `$PREFIX/Menu` was added to the install.
* `menuinst` has a legacy dependency on pywin32, which loads or creates a cached file on imports. Usually, from a temporary location. However, if TEMP was not defined in the environment, it relies on the [Windows API](https://github.com/mhammond/pywin32/blob/70ddf693927fa1635f15e9ef41eb1aea37fdf32a/com/win32com/__init__.py#L111): using [`C:\Windows` as a fallback default](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha#remarks).
* Of course, this can fail with permission errors.

I think we only saw this because we are using AWS Workspaces for Windows debugging, which use network locations for the user directory. Lucky us. This should fix it @goanpeca!

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

Closes #4247 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] Installing plugins with mamba on Windows works without errors.

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
