### PR TITLE
Fix make-typestubs: use union for type hint instead of '|'

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -933,7 +933,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
     def _open_or_raise_error(
         self,
-        paths: List[Path | str],
+        paths: List[Union[Path, str]],
         kwargs: Dict[str, Any] = {},
         layer_type: Optional[str] = None,
         stack: bool = False,


### PR DESCRIPTION
Should fix `make typestubs` during release creation, but changing the Union syntax in `_open_or_raise_error` from `|` to `Union`