### PR TITLE
Connect napari events first to EventEmitter

### DIFF
--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -369,6 +369,20 @@ class EventEmitter:
     def source(self, s):
         self._source = None if s is None else weakref.ref(s)
 
+    def _is_core_napari_callback(self, callback: Union[CallbackRef, Callback]):
+        try:
+            if isinstance(callback, partial):
+                callback = callback.func
+            if not isinstance(callback, tuple):
+                return callback.__module__.startswith('napari.')
+            obj = callback[0]()
+            if obj is None:
+                return False
+            return obj.__module__.startswith('napari.')
+
+        except AttributeError:
+            return False
+
     def connect(
         self,
         callback: Union[Callback, CallbackRef, CallbackStr, 'EventEmitter'],
@@ -473,12 +487,26 @@ class EventEmitter:
                     position=position,
                 )
             )
+        core_callbacks_indexes = [
+            i
+            for i, c in enumerate(self._callbacks)
+            if self._is_core_napari_callback(c)
+        ]
+        core_callbacks_count = (
+            max(core_callbacks_indexes) + 1 if core_callbacks_indexes else 0
+        )
+        if self._is_core_napari_callback(callback):
+            callback_bounds = (0, core_callbacks_count)
+        else:
+            callback_bounds = (core_callbacks_count, len(callback_refs))
 
         # bounds: upper & lower bnds (inclusive) of possible cb locs
-        bounds: List[int] = list()
+        bounds: List[int] = []
         for ri, criteria in enumerate((before, after)):
             if criteria is None or criteria == []:
-                bounds.append(len(callback_refs) if ri == 0 else 0)
+                bounds.append(
+                    callback_bounds[1] if ri == 0 else callback_bounds[0]
+                )
             else:
                 if not isinstance(criteria, list):
                     criteria = [criteria]

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -509,7 +509,7 @@ class EventEmitter:
         core_callbacks_count = (
             max(core_callbacks_indexes) + 1 if core_callbacks_indexes else 0
         )
-        if self._is_core_napari_callback(callback, 'napari'):
+        if self._is_core_callback(callback, 'napari'):
             callback_bounds = (0, core_callbacks_count)
         else:
             callback_bounds = (core_callbacks_count, len(callback_refs))

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -369,9 +369,11 @@ class EventEmitter:
     def source(self, s):
         self._source = None if s is None else weakref.ref(s)
 
-    def _is_core_napari_callback(self, callback: Union[CallbackRef, Callback]):
+    def _is_core_callback(
+        self, callback: Union[CallbackRef, Callback], core: str
+    ):
         """
-        Check if the callback is a core napari callback
+        Check if the callback is a core callback
 
         Parameters
         ----------
@@ -379,16 +381,18 @@ class EventEmitter:
             The callback to check. Callback could be function or
             weak reference to object method coded using weakreference
             to object and method name stored in tuple.
+        core : str
+            Name of core module, for example 'napari'.
         """
         try:
             if isinstance(callback, partial):
                 callback = callback.func
             if not isinstance(callback, tuple):
-                return callback.__module__.startswith('napari.')
+                return callback.__module__.startswith(core + '.')
             obj = callback[0]()  # get object behind weakref
             if obj is None:  # object is dead
                 return False
-            return obj.__module__.startswith('napari.')
+            return obj.__module__.startswith(core + '.')
 
         except AttributeError:
             return False
@@ -500,12 +504,12 @@ class EventEmitter:
         core_callbacks_indexes = [
             i
             for i, c in enumerate(self._callbacks)
-            if self._is_core_napari_callback(c)
+            if self._is_core_callback(c, 'napari')
         ]
         core_callbacks_count = (
             max(core_callbacks_indexes) + 1 if core_callbacks_indexes else 0
         )
-        if self._is_core_napari_callback(callback):
+        if self._is_core_napari_callback(callback, 'napari'):
             callback_bounds = (0, core_callbacks_count)
         else:
             callback_bounds = (core_callbacks_count, len(callback_refs))

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -370,13 +370,23 @@ class EventEmitter:
         self._source = None if s is None else weakref.ref(s)
 
     def _is_core_napari_callback(self, callback: Union[CallbackRef, Callback]):
+        """
+        Check if the callback is a core napari callback
+
+        Parameters
+        ----------
+        callback : Union[CallbackRef, Callback]
+            The callback to check. Callback could be function or
+            weak reference to object method coded using weakreference
+            to object and method name stored in tuple.
+        """
         try:
             if isinstance(callback, partial):
                 callback = callback.func
             if not isinstance(callback, tuple):
                 return callback.__module__.startswith('napari.')
-            obj = callback[0]()
-            if obj is None:
+            obj = callback[0]()  # get object behind weakref
+            if obj is None:  # object is dead
                 return False
             return obj.__module__.startswith('napari.')
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This PR ensures that napari callbacks events are triggered first before callbacks from external packages. Thanks to this reorder developers could faster get failing tests connected with real code bugs. Also using `--maxfail=n` have more sense in such a configuration. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

close #4425 
close #4421

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
