### PR TITLE
Fire features event on Labels feature change

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1398,3 +1398,15 @@ def test_get_status_with_custom_index():
     assert layer.get_status((0, 0)) == 'Labels [0 0]: 0; [No Properties]'
     assert layer.get_status((3, 3)) == 'Labels [3 3]: 1; text1: 1, text2: 7'
     assert layer.get_status((6, 6)) == 'Labels [6 6]: 2; text1: 3, text2: -2'
+
+def test_labels_features_event():
+    event_emitted = False
+    def on_event():
+        nonlocal event_emitted
+        event_emitted = True
+    layer = Labels(np.zeros((4, 5), dtype=np.uint8))
+    layer.events.features.connect(on_event)
+
+    layer.features = {'some_feature': []}
+
+    assert event_emitted

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -469,6 +469,7 @@ class Labels(_ImageBase):
         self._feature_table.set_values(features)
         self._label_index = self._make_label_index()
         self.events.properties()
+        self.events.features()
 
     @property
     def properties(self) -> Dict[str, np.ndarray]:

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -296,6 +296,7 @@ class Labels(_ImageBase):
             color_mode=Event,
             brush_shape=Event,
             contour=Event,
+            features=Event,
         )
 
         self._feature_table = _FeatureTable.from_layer(


### PR DESCRIPTION
# Description
This PR adds a feature event to the labels layer, analogous to other layer types like the points layer. We were discussing the issue in the [napari cluster plotter](https://github.com/BiAPoL/napari-clusters-plotter/issues/90) with @jni where we realised this event is missing for the labels layer which we use to store information about the labels.


## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# References
I implemented the feature event analogously to how it is implemented in the points layer (napari/layers/points/points.py line 563):
```
 @features.setter
    def features(
        self,
        features: Union[Dict[str, np.ndarray], pd.DataFrame],
    ) -> None:
        self._feature_table.set_values(features, num_data=len(self.data))
        self._update_color_manager(
            self._face, self._feature_table, "face_color"
        )
        self._update_color_manager(
            self._edge, self._feature_table, "edge_color"
        )
        self.text.refresh(self.features)
        self.events.properties()
        self.events.features()
```

# How has this been tested?
- [x] Personal Notebooks
- [ ] Tests passing

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
