### PR TITLE
Image layer control dtype normalization for tensorstore compatibility

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
+import tensorstore as ts
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QPushButton
 
@@ -125,3 +126,9 @@ def test_qt_image_controls_change_contrast(qtbot):
     qtbot.addWidget(qtctrl)
     qtctrl.contrastLimitsSlider.setValue((0.1, 0.8))
     assert tuple(layer.contrast_limits) == (0.1, 0.8)
+
+
+def test_tensorstore_clim_popup():
+    """Regression to test, makes sure it works with tensorstore dtype"""
+    layer = Image(ts.array(np.random.rand(20, 20)))
+    QContrastLimitsPopup(layer)

--- a/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
-import tensorstore as ts
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QPushButton
 
@@ -130,5 +129,6 @@ def test_qt_image_controls_change_contrast(qtbot):
 
 def test_tensorstore_clim_popup():
     """Regression to test, makes sure it works with tensorstore dtype"""
+    ts = pytest.importorskip('tensorstore')
     layer = Image(ts.array(np.random.rand(20, 20)))
     QContrastLimitsPopup(layer)

--- a/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -8,6 +8,7 @@ from qtpy.QtGui import QImage, QPixmap
 from qtpy.QtWidgets import QHBoxLayout, QLabel, QPushButton, QWidget
 from superqt import QDoubleRangeSlider
 
+from ...utils._dtype import normalize_dtype
 from ...utils.colormaps import AVAILABLE_COLORMAPS
 from ...utils.events.event_utils import connect_no_arg, connect_setattr
 from ...utils.translations import trans
@@ -246,7 +247,7 @@ class QContrastLimitsPopup(QRangeSliderPopup):
         # the "full range" button doesn't do anything if it's not an
         # unsigned integer type (it's unclear what range should be set)
         # so we don't show create it at all.
-        if np.issubdtype(layer.dtype, np.integer):
+        if np.issubdtype(normalize_dtype(layer.dtype), np.integer):
             range_btn = QPushButton("full range")
             range_btn.setObjectName("full_clim_range_button")
             range_btn.setToolTip(


### PR DESCRIPTION
# Description
It fixes a bug where you can't adjust the contrast of tensorstore data using the mouse right click.
Before it resulted in an error `TypeError: Cannot interpret 'dtype("uint16")' as a data type` because tensorstore dtype is not numpy compatible out-of-the-box.

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
- [X] bug does not reproduce after the changes;
- [X] added regression test.

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).

## Note:

Shouldn't [this function](https://github.com/napari/napari/blob/5cd46682a25022cb01150f1281286bc481cd7c31/napari/_qt/layer_controls/qt_image_controls_base.py#L277) also be using the `normalize_dtype` rather than having a `tensorstore` only solution?
