### PR TITLE
Test if events for all properties are defined

### DIFF
--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -499,6 +499,7 @@ def pytest_generate_tests(metafunc):
 
         metafunc.parametrize('event_define_check,obj', res, ids=ids)
 
+
 def pytest_collection_modifyitems(session, config, items):
     test_order_prefix = [
         "napari/utils",

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -496,4 +496,4 @@ def pytest_generate_tests(metafunc):
                 res.append((check, instance))
                 ids.append(f"{name}-{instance}")
 
-        metafunc.parametrize('event_checker,obj', res, ids=ids)
+        metafunc.parametrize('event_define_check,obj', res, ids=ids)

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1398,3 +1398,15 @@ def test_get_status_with_custom_index():
     assert layer.get_status((0, 0)) == 'Labels [0 0]: 0; [No Properties]'
     assert layer.get_status((3, 3)) == 'Labels [3 3]: 1; text1: 1, text2: 7'
     assert layer.get_status((6, 6)) == 'Labels [6 6]: 2; text1: 3, text2: -2'
+
+
+class TestLabels:
+    @staticmethod
+    def get_objects():
+        return [(Labels(np.zeros((10, 10), dtype=np.uint8)))]
+
+    def test_events_defined(self, event_define_check, obj):
+        event_define_check(
+            obj,
+            {"seed", "num_colors", "features", "show_selected_label", "color"},
+        )

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1423,5 +1423,5 @@ class TestLabels:
     def test_events_defined(self, event_define_check, obj):
         event_define_check(
             obj,
-            {"seed", "num_colors", "features", "show_selected_label", "color"},
+            {"seed", "num_colors", "show_selected_label", "color"},
         )


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This PR adds `pytest_generate_tests` pytest fixture that automatically parameterized the test to check if events for all properties are defined. This allows also to define if some event is obsolete. Then check if this event is not defined. 

Because of limitations of napari events system (event are defined in runtime, so one needs to have the instance of the object instead of class this PR requires to use class-based test. 

Alternative for this PR could be to define a function that will consume an object and return a list of parameters to use with `pytest.mark.parameterize` decorator. but I have no idea where such function should live.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

suggested in #4481

https://docs.pytest.org/en/6.2.x/reference.html?highlight=metafunc#pytest.python.Metafunc
https://docs.pytest.org/en/6.2.x/parametrize.html#pytest-generate-tests

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).

## Additiona notes

A similar approach could be used to test docstrings if contains documentation for all events/properties. 

This PR contains only one example of usage. It needs to be followed by defining multiple tests and deciding about exclusion or adding events.
