### PR TITLE
throttle status update

### DIFF
--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -584,8 +584,8 @@ def test_active_layer_status_update():
     assert len(viewer.layers) == 2
     assert viewer.layers.selection.active == viewer.layers[1]
 
-    # wait 100 ms to avoid the cursor event throttling
-    time.sleep(0.1)
+    # wait 1 s to avoid the cursor event throttling
+    time.sleep(1)
     viewer.cursor.position = [1, 1, 1, 1, 1]
     assert viewer.status == viewer.layers.selection.active.get_status(
         viewer.cursor.position, world=True

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -1,3 +1,5 @@
+import time
+
 import numpy as np
 import pytest
 
@@ -582,6 +584,8 @@ def test_active_layer_status_update():
     assert len(viewer.layers) == 2
     assert viewer.layers.selection.active == viewer.layers[1]
 
+    # wait 100 ms to avoid the cursor event throttling
+    time.sleep(0.1)
     viewer.cursor.position = [1, 1, 1, 1, 1]
     assert viewer.status == viewer.layers.selection.active.get_status(
         viewer.cursor.position, world=True

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -19,8 +19,8 @@ from typing import (
 )
 
 import numpy as np
+from psygnal import throttled
 from pydantic import Extra, Field, validator
-from superqt.utils import qthrottled
 
 from .. import layers
 from ..errors import (
@@ -181,7 +181,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         self.dims.events.current_step.connect(self._update_layers)
         self.cursor.events.position.connect(self._on_cursor_position_change)
         self.cursor.events.position.connect(
-            qthrottled(self._update_status_bar_from_cursor, timeout=50)
+            throttled(self._update_status_bar_from_cursor, timeout=50)
         )
         self.layers.events.inserted.connect(self._on_add_layer)
         self.layers.events.removed.connect(self._on_remove_layer)
@@ -392,7 +392,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             for layer in self.layers:
                 layer.position = self.cursor.position
 
-    def _update_status_bar_from_cursor(self):
+    def _update_status_bar_from_cursor(self, event=None):
         """Update the status bar based on the current cursor position.
 
         This is generally used as a callback when cursor.position is updated.

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -20,6 +20,7 @@ from typing import (
 
 import numpy as np
 from pydantic import Extra, Field, validator
+from superqt.utils import qthrottled
 
 from .. import layers
 from ..errors import (
@@ -179,6 +180,9 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         self.dims.events.order.connect(self.reset_view)
         self.dims.events.current_step.connect(self._update_layers)
         self.cursor.events.position.connect(self._on_cursor_position_change)
+        self.cursor.events.position.connect(
+            qthrottled(self._update_status_bar_from_cursor, timeout=50)
+        )
         self.layers.events.inserted.connect(self._on_add_layer)
         self.layers.events.removed.connect(self._on_remove_layer)
         self.layers.events.reordered.connect(self._on_grid_change)
@@ -388,6 +392,11 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             for layer in self.layers:
                 layer.position = self.cursor.position
 
+    def _update_status_bar_from_cursor(self):
+        """Update the status bar based on the current cursor position.
+
+        This is generally used as a callback when cursor.position is updated.
+        """
         # Update status and help bar based on active layer
         active = self.layers.selection.active
         if active is not None:

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1399,11 +1399,14 @@ def test_get_status_with_custom_index():
     assert layer.get_status((3, 3)) == 'Labels [3 3]: 1; text1: 1, text2: 7'
     assert layer.get_status((6, 6)) == 'Labels [6 6]: 2; text1: 3, text2: -2'
 
+
 def test_labels_features_event():
     event_emitted = False
+
     def on_event():
         nonlocal event_emitted
         event_emitted = True
+
     layer = Labels(np.zeros((4, 5), dtype=np.uint8))
     layer.events.features.connect(on_event)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,7 @@ install_requires =
     scipy>=1.4.1 ; python_version < '3.9'
     scipy>=1.5.4 ; python_version >= '3.9'
     scikit-image>=0.19.1
-    superqt>=0.2.5
+    superqt>=0.3.0
     tifffile>=2020.2.16
     typing_extensions
     toolz>=0.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ install_requires =
     Pillow!=7.1.0,!=7.1.1  # not a direct dependency, but 7.1.0 and 7.1.1 broke imageio
     pint>=0.17
     psutil>=5.0
+    psygnal>=0.3.4
     PyOpenGL>=3.1.0
     PyYAML>=5.1
     pydantic>=1.9.0
@@ -68,7 +69,7 @@ install_requires =
     scipy>=1.4.1 ; python_version < '3.9'
     scipy>=1.5.4 ; python_version >= '3.9'
     scikit-image>=0.19.1
-    superqt>=0.3.0
+    superqt>=0.2.5
     tifffile>=2020.2.16
     typing_extensions
     toolz>=0.10.0


### PR DESCRIPTION
# Description
This PR throttles the max rate of updating the status bar from the mouse event to 20 frames per second. This is similar to #4319, but this PR throttles only throttles the status bar update and doesn't impact the other behavior (e.g., painting)

## Type of change
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References


# How has this been tested?

- [x] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
