### PR TITLE
Fix: Always save settings after migration

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1399,11 +1399,14 @@ def test_get_status_with_custom_index():
     assert layer.get_status((3, 3)) == 'Labels [3 3]: 1; text1: 1, text2: 7'
     assert layer.get_status((6, 6)) == 'Labels [6 6]: 2; text1: 3, text2: -2'
 
+
 def test_labels_features_event():
     event_emitted = False
+
     def on_event():
         nonlocal event_emitted
         event_emitted = True
+
     layer = Labels(np.zeros((4, 5), dtype=np.uint8))
     layer.events.features.connect(on_event)
 

--- a/napari/settings/_base.py
+++ b/napari/settings/_base.py
@@ -102,10 +102,13 @@ class EventedConfigFileSettings(EventedSettings, PydanticYamlMixin):
         super().__init__(**values)
         self._config_path = _cfg
 
-    def _on_sub_event(self, event, field=None):
-        super()._on_sub_event(event, field)
+    def _maybe_save(self):
         if self._save_on_change and self.config_path:
             self.save()
+
+    def _on_sub_event(self, event, field=None):
+        super()._on_sub_event(event, field)
+        self._maybe_save()
 
     @property
     def config_path(self):

--- a/napari/settings/_migrations.py
+++ b/napari/settings/_migrations.py
@@ -43,6 +43,7 @@ def do_migrations(model: NapariSettings):
                         msg += 'Settings rollback also failed. Please run `napari --reset`.'
                     warnings.warn(msg)
                     return
+    model._maybe_save()
 
 
 @contextmanager

--- a/napari/settings/_tests/test_migrations.py
+++ b/napari/settings/_tests/test_migrations.py
@@ -1,5 +1,6 @@
 import os
 from importlib.metadata import distribution
+from unittest.mock import patch
 
 import pytest
 
@@ -44,6 +45,18 @@ def test_migration_works(_test_migrator):
     settings = NapariSettings(schema_version='0.1.0')
     assert settings.schema_version == '0.2.0'
     assert settings.appearance.theme == 'light'
+
+
+def test_migration_saves(_test_migrator):
+    @_test_migrator('0.1.0', '0.2.0')
+    def _(model: NapariSettings):
+        ...
+
+    with patch.object(NapariSettings, 'save') as mock:
+        mock.assert_not_called()
+        settings = NapariSettings(config_path='junk', schema_version='0.1.0')
+        assert settings.schema_version == '0.2.0'
+        mock.assert_called()
 
 
 def test_failed_migration_leaves_version(_test_migrator):

--- a/napari/settings/_tests/test_settings.py
+++ b/napari/settings/_tests/test_settings.py
@@ -20,7 +20,9 @@ def test_settings(tmp_path):
         class Config:
             env_prefix = 'testnapari_'
 
-    return TestSettings(tmp_path / 'test_settings.yml')
+    return TestSettings(
+        tmp_path / 'test_settings.yml', schema_version=CURRENT_SCHEMA_VERSION
+    )
 
 
 def test_settings_file(test_settings):
@@ -293,14 +295,16 @@ def test_settings_only_saves_non_default_values(monkeypatch, tmp_path):
 
 
 def test_get_settings(tmp_path):
-    s = settings.get_settings(tmp_path)
-    assert s.config_path == tmp_path
+    p = f'{tmp_path}.yaml'
+    s = settings.get_settings(p)
+    assert str(s.config_path) == str(p)
 
 
 def test_get_settings_fails(monkeypatch, tmp_path):
-    settings.get_settings(tmp_path)
+    p = f'{tmp_path}.yaml'
+    settings.get_settings(p)
     with pytest.raises(Exception) as e:
-        settings.get_settings(tmp_path)
+        settings.get_settings(p)
 
     assert 'The path can only be set once per session' in str(e)
 


### PR DESCRIPTION
Small change to make sure that settings schema versions are written to disk after a migration (even if they don't trigger a change event in the model itself).
