### PR TITLE
Add _get_value_3d to surface

### DIFF
--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -26,7 +26,7 @@ from ..utils.color_transformations import (
     transform_color_cycle,
     transform_color_with_defaults,
 )
-from ..utils.interactivity_utils import mouse_click_line_segment_to_ray
+from ..utils.interactivity_utils import nd_line_segment_to_displayed_data_ray
 from ..utils.layer_utils import _FeatureTable
 from ..utils.text_manager import TextManager
 from ._shape_list import ShapeList
@@ -2797,13 +2797,13 @@ class Shapes(Layer):
             return None, None
 
         # Get the normal vector of the click plane
-        start_position, ray_direction_normed = mouse_click_line_segment_to_ray(
+        start_position, ray_direction = nd_line_segment_to_displayed_data_ray(
             start_point=start_point,
             end_point=end_point,
             dims_displayed=dims_displayed,
         )
         value, intersection = self._data_view._inside_3d(
-            start_position, ray_direction_normed
+            start_position, ray_direction
         )
 
         # add the full nD coords to intersection

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -26,6 +26,7 @@ from ..utils.color_transformations import (
     transform_color_cycle,
     transform_color_with_defaults,
 )
+from ..utils.interactivity_utils import mouse_click_line_segment_to_ray
 from ..utils.layer_utils import _FeatureTable
 from ..utils.text_manager import TextManager
 from ._shape_list import ShapeList
@@ -2761,7 +2762,7 @@ class Shapes(Layer):
         start_point: np.ndarray,
         end_point: np.ndarray,
         dims_displayed: List[int],
-    ) -> Tuple[Union[float, int], None]:
+    ) -> Tuple[Union[None, float, int], Union[None, np.ndarray]]:
         """Get the shape index and intersection point of the first shape
         (i.e., closest to start_point) along the specified 3D line segment.
 
@@ -2781,41 +2782,34 @@ class Shapes(Layer):
 
         Returns
         -------
-        value
+        value Union[None, int]
             The data value along the supplied ray.
-        intersection_point : np.ndarray
+        intersection_point : Union[None, np.ndarray]
             (n,) array containing the point where the ray intersects the first shape
             (i.e., the shape most in the foreground). The coordinate is in layer
             coordinates.
         """
-        if len(dims_displayed) == 3:
-            if (start_point is not None) and (end_point is not None):
-                # Get the normal vector of the click plane
-                start_position_view = start_point[dims_displayed]
-                end_position_view = end_point[dims_displayed]
-                ray_direction = end_position_view - start_position_view
-                ray_direction_normed = ray_direction / np.linalg.norm(
-                    ray_direction
-                )
-                # step the start position back a little bit to be able to detect shapes
-                # that contain the start_position
-                start_position_view = (
-                    start_position_view - 0.1 * ray_direction_normed
-                )
-                value, intersection = self._data_view._inside_3d(
-                    start_position_view, ray_direction_normed
-                )
+        if len(dims_displayed) != 3:
+            # return None if in 2D mode
+            return None, None
+        if (start_point is None) or (end_point is None):
+            # return None if the ray doesn't intersect the data bounding box
+            return None, None
 
-                # add the full nD coords to intersection
-                intersection_point = start_point.copy()
-                intersection_point[dims_displayed] = intersection
+        # Get the normal vector of the click plane
+        start_position, ray_direction_normed = mouse_click_line_segment_to_ray(
+            start_point=start_point,
+            end_point=end_point,
+            dims_displayed=dims_displayed,
+        )
+        value, intersection = self._data_view._inside_3d(
+            start_position, ray_direction_normed
+        )
 
-            else:
-                value = None
-                intersection_point = None
-        else:
-            value = None
-            intersection_point = None
+        # add the full nD coords to intersection
+        intersection_point = start_point.copy()
+        intersection_point[dims_displayed] = intersection
+
         return value, intersection_point
 
     def get_index_and_intersection(

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2782,7 +2782,7 @@ class Shapes(Layer):
 
         Returns
         -------
-        value Union[None, int]
+        value Union[None, float, int]
             The data value along the supplied ray.
         intersection_point : Union[None, np.ndarray]
             (n,) array containing the point where the ray intersects the first shape

--- a/napari/layers/surface/_surface_utils.py
+++ b/napari/layers/surface/_surface_utils.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import numpy as np
 
 

--- a/napari/layers/surface/_surface_utils.py
+++ b/napari/layers/surface/_surface_utils.py
@@ -19,12 +19,10 @@ def calculate_barycentric_coordinates(
 
     Returns
     -------
-    u : float
-        The barycentric coordinate for the first triangle vertex.
-    v : float
-        The barycentric coordinate for the second triangle vertex.
-    w : float
-        The barycentric coordinate for the third triangle vertex
+    barycentric_coorinates : np.ndarray
+        The barycentric coordinate [u, v, w], where u, v, and w are the
+        barycentric coordinates for the first, second, third triangle
+        vertex, respectively.
     """
     vertex_a = triangle_vertices[0, :]
     vertex_b = triangle_vertices[1, :]
@@ -42,4 +40,4 @@ def calculate_barycentric_coordinates(
     v = (d11 * d20 - d01 * d21) / denominator
     w = (d00 * d21 - d01 * d20) / denominator
     u = 1 - v - w
-    return u, v, w
+    return np.array([u, v, w])

--- a/napari/layers/surface/_surface_utils.py
+++ b/napari/layers/surface/_surface_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 
 def calculate_barycentric_coordinates(
     point: np.ndarray, triangle_vertices: np.ndarray
-) -> Tuple[float, float, float]:
+) -> np.ndarray:
     """Calculate the barycentric coordinates for a point in a triangle.
 
     http://gamedev.stackexchange.com/questions/23743/whats-the-most-efficient-way-to-find-barycentric-coordinates

--- a/napari/layers/surface/_surface_utils.py
+++ b/napari/layers/surface/_surface_utils.py
@@ -15,7 +15,7 @@ def calculate_barycentric_coordinates(
     point : np.ndarray
         The coordinates of the point for which to calculate the barycentric coordinate.
     triangle_vertices : np.ndarray
-        (3, D) array containing the triangle vertices
+        (3, D) array containing the triangle vertices.
 
     Returns
     -------

--- a/napari/layers/surface/_surface_utils.py
+++ b/napari/layers/surface/_surface_utils.py
@@ -1,0 +1,45 @@
+from typing import Tuple
+
+import numpy as np
+
+
+def calculate_barycentric_coordinates(
+    point: np.ndarray, triangle_vertices: np.ndarray
+) -> Tuple[float, float, float]:
+    """Calculate the barycentric coordinates for a point in a triangle.
+
+    http://gamedev.stackexchange.com/questions/23743/whats-the-most-efficient-way-to-find-barycentric-coordinates
+
+    Parameters
+    ----------
+    point : np.ndarray
+        The coordinates of the point for which to calculate the barycentric coordinate.
+    triangle_vertices : np.ndarray
+        (3, D) array containing the triangle vertices
+
+    Returns
+    -------
+    u : float
+        The barycentric coordinate for the first triangle vertex.
+    v : float
+        The barycentric coordinate for the second triangle vertex.
+    w : float
+        The barycentric coordinate for the third triangle vertex
+    """
+    vertex_a = triangle_vertices[0, :]
+    vertex_b = triangle_vertices[1, :]
+    vertex_c = triangle_vertices[2, :]
+
+    v0 = vertex_b - vertex_a
+    v1 = vertex_c - vertex_a
+    v2 = point - vertex_a
+    d00 = np.dot(v0, v0)
+    d01 = np.dot(v0, v1)
+    d11 = np.dot(v1, v1)
+    d20 = np.dot(v2, v0)
+    d21 = np.dot(v2, v1)
+    denominator = d00 * d11 - d01 * d01
+    v = (d11 * d20 - d01 * d21) / denominator
+    w = (d00 * d21 - d01 * d20) / denominator
+    u = 1 - v - w
+    return u, v, w

--- a/napari/layers/surface/_tests/test_surface.py
+++ b/napari/layers/surface/_tests/test_surface.py
@@ -248,3 +248,41 @@ def test_get_value_3d(
     )
     assert index == expected_index
     np.testing.assert_allclose(value, expected_value)
+
+
+@pytest.mark.parametrize(
+    "ray_start,ray_direction,expected_value,expected_index",
+    [
+        ([0, 0, 1, 1], [0, 1, 0, 0], 2, 0),
+        ([0, 10, 1, 1], [0, -1, 0, 0], 2, 1),
+    ],
+)
+def test_get_value_3d_nd(
+    ray_start, ray_direction, expected_value, expected_index
+):
+    vertices = np.array(
+        [
+            [0, 3, 0, 0],
+            [0, 3, 0, 3],
+            [0, 3, 3, 0],
+            [0, 5, 0, 0],
+            [0, 5, 0, 3],
+            [0, 5, 3, 0],
+            [0, 2, 50, 50],
+            [0, 2, 50, 100],
+            [0, 2, 100, 50],
+        ]
+    )
+    faces = np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+    values = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+    surface_layer = Surface((vertices, faces, values))
+
+    surface_layer._slice_dims([0, 0, 0, 0], ndisplay=3)
+    value, index = surface_layer.get_value(
+        position=ray_start,
+        view_direction=ray_direction,
+        dims_displayed=[1, 2, 3],
+        world=False,
+    )
+    assert index == expected_index
+    np.testing.assert_allclose(value, expected_value)

--- a/napari/layers/surface/_tests/test_surface.py
+++ b/napari/layers/surface/_tests/test_surface.py
@@ -210,3 +210,41 @@ def test_shading():
     # set shading as keyword argument
     layer = Surface(data, shading=shading)
     assert layer.shading == shading
+
+
+@pytest.mark.parametrize(
+    "ray_start,ray_direction,expected_value,expected_index",
+    [
+        ([0, 1, 1], [1, 0, 0], 2, 0),
+        ([10, 1, 1], [-1, 0, 0], 2, 1),
+    ],
+)
+def test_get_value_3d(
+    ray_start, ray_direction, expected_value, expected_index
+):
+    vertices = np.array(
+        [
+            [3, 0, 0],
+            [3, 0, 3],
+            [3, 3, 0],
+            [5, 0, 0],
+            [5, 0, 3],
+            [5, 3, 0],
+            [2, 50, 50],
+            [2, 50, 100],
+            [2, 100, 50],
+        ]
+    )
+    faces = np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+    values = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+    surface_layer = Surface((vertices, faces, values))
+
+    surface_layer._slice_dims([0, 0, 0], ndisplay=3)
+    value, index = surface_layer.get_value(
+        position=ray_start,
+        view_direction=ray_direction,
+        dims_displayed=[0, 1, 2],
+        world=False,
+    )
+    assert index == expected_index
+    np.testing.assert_allclose(value, expected_value)

--- a/napari/layers/surface/_tests/test_surface_utils.py
+++ b/napari/layers/surface/_tests/test_surface_utils.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+
+from napari.layers.surface._surface_utils import (
+    calculate_barycentric_coordinates,
+)
+
+
+@pytest.mark.parametrize(
+    "point,expected_barycentric_coordinates",
+    [
+        ([5, 1, 1], [1 / 3, 1 / 3, 1 / 3]),
+        ([5, 0, 0], [1, 0, 0]),
+        ([5, 0, 3], [0, 1, 0]),
+        ([5, 3, 0], [0, 0, 1]),
+    ],
+)
+def test_calculate_barycentric_coordinates(
+    point, expected_barycentric_coordinates
+):
+    triangle_vertices = np.array(
+        [
+            [5, 0, 0],
+            [5, 0, 3],
+            [5, 3, 0],
+        ]
+    )
+    u, v, w = calculate_barycentric_coordinates(point, triangle_vertices)
+    np.testing.assert_allclose([u, v, w], expected_barycentric_coordinates)
+    np.testing.assert_allclose(u + v + w, 1)

--- a/napari/layers/surface/_tests/test_surface_utils.py
+++ b/napari/layers/surface/_tests/test_surface_utils.py
@@ -25,6 +25,10 @@ def test_calculate_barycentric_coordinates(
             [5, 3, 0],
         ]
     )
-    u, v, w = calculate_barycentric_coordinates(point, triangle_vertices)
-    np.testing.assert_allclose([u, v, w], expected_barycentric_coordinates)
-    np.testing.assert_allclose(u + v + w, 1)
+    barycentric_coordinates = calculate_barycentric_coordinates(
+        point, triangle_vertices
+    )
+    np.testing.assert_allclose(
+        barycentric_coordinates, expected_barycentric_coordinates
+    )
+    np.testing.assert_allclose(np.sum(barycentric_coordinates), 1)

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import List, Tuple, Union
 
 import numpy as np
 
@@ -448,3 +449,28 @@ class Surface(IntensityVisualizationMixin, Layer):
             Value of the data at the coord.
         """
         return None
+
+    def _get_value_3d(
+        self,
+        start_point: np.ndarray,
+        end_point: np.ndarray,
+        dims_displayed: List[int],
+    ) -> Tuple[Union[float, int], None]:
+        """Get the layer data value along a ray
+
+        Parameters
+        ----------
+        start_point : np.ndarray
+            The start position of the ray used to interrogate the data.
+        end_point : np.ndarray
+            The end position of the ray used to interrogate the data.
+        dims_displayed : List[int]
+            The indices of the dimensions currently displayed in the Viewer.
+
+        Returns
+        -------
+        value
+            The data value along the supplied ray.
+        vertex : None
+            Index of vertex if any that is at the coordinates. Always returns `None`.
+        """

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -9,7 +9,7 @@ from ...utils.geometry import find_nearest_triangle_intersection
 from ...utils.translations import trans
 from ..base import Layer
 from ..intensity_mixin import IntensityVisualizationMixin
-from ..utils.interactivity_utils import mouse_click_line_segment_to_ray
+from ..utils.interactivity_utils import nd_line_segment_to_displayed_data_ray
 from ..utils.layer_utils import calc_data_range
 from ._surface_constants import Shading
 from ._surface_utils import calculate_barycentric_coordinates
@@ -484,7 +484,7 @@ class Surface(IntensityVisualizationMixin, Layer):
             # return None if the ray doesn't intersect the data bounding box
             return None, None
 
-        start_position, ray_direction = mouse_click_line_segment_to_ray(
+        start_position, ray_direction = nd_line_segment_to_displayed_data_ray(
             start_point=start_point,
             end_point=end_point,
             dims_displayed=dims_displayed,

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -500,7 +500,7 @@ class Surface(IntensityVisualizationMixin, Layer):
             triangles=mesh_triangles,
         )
 
-        if (intersection_index is None) or (intersection is None):
+        if intersection_index is None:
             return None, None
 
         # add the full nD coords to intersection
@@ -510,10 +510,10 @@ class Surface(IntensityVisualizationMixin, Layer):
         # calculate the value from the intersection
         triangle_vertex_indices = self._view_faces[intersection_index]
         triangle_vertices = self._data_view[triangle_vertex_indices]
-        u, v, w = calculate_barycentric_coordinates(
+        barycentric_coordinates = calculate_barycentric_coordinates(
             intersection, triangle_vertices
         )
         vertex_values = self._view_vertex_values[triangle_vertex_indices]
-        intersection_value = (np.array([u, v, w]) * vertex_values).sum()
+        intersection_value = (barycentric_coordinates * vertex_values).sum()
 
         return intersection_value, intersection_index

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -491,7 +491,7 @@ class Surface(IntensityVisualizationMixin, Layer):
         )
 
         # get the mesh triangles
-        mesh_triangles = self.vertices[self.faces]
+        mesh_triangles = self._data_view[self._view_faces]
 
         # get the triangles intersection
         intersection_index, intersection = find_nearest_triangle_intersection(
@@ -508,12 +508,12 @@ class Surface(IntensityVisualizationMixin, Layer):
         intersection_point[dims_displayed] = intersection
 
         # calculate the value from the intersection
-        triangle_vertex_indices = self.faces[intersection_index]
-        triangle_vertices = self.vertices[triangle_vertex_indices]
+        triangle_vertex_indices = self._view_faces[intersection_index]
+        triangle_vertices = self._data_view[triangle_vertex_indices]
         u, v, w = calculate_barycentric_coordinates(
-            intersection_point, triangle_vertices
+            intersection, triangle_vertices
         )
-        vertex_values = self.vertex_values[triangle_vertex_indices]
+        vertex_values = self._view_vertex_values[triangle_vertex_indices]
         intersection_value = (np.array([u, v, w]) * vertex_values).sum()
 
         return intersection_value, intersection_index

--- a/napari/layers/utils/interactivity_utils.py
+++ b/napari/layers/utils/interactivity_utils.py
@@ -141,3 +141,40 @@ def orient_plane_normal_around_cursor(layer: Image, plane_normal: tuple):
     layer.plane.normal = layer._world_to_displayed_data_ray(
         plane_normal, dims_displayed=layer._dims_displayed
     )
+
+
+def mouse_click_line_segment_to_ray(
+    start_point: np.ndarray,
+    end_point: np.ndarray,
+    dims_displayed: Union[List[int], np.ndarray],
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Convert the start and end point of the line segment of a mouse click ray
+    intersecting a data cube to a ray (i.e., start position and direction).
+
+    Note: the ray starts 0.1 data units outside of the data volume.
+
+    Parameters
+    ----------
+    start_point : np.ndarray
+        The start position of the ray used to interrogate the data.
+    end_point : np.ndarray
+        The end position of the ray used to interrogate the data.
+    dims_displayed : List[int]
+        The indices of the dimensions currently displayed in the Viewer.
+
+    Returns
+    -------
+    start_position : np.ndarray
+        The start position of the ray in displayed data coordinates
+    ray_direction_normed : np.ndarray
+        The unit vector describing the ray direction.
+    """
+    # get the ray in the displayed data coordinates
+    start_position = start_point[dims_displayed]
+    end_position = end_point[dims_displayed]
+    ray_direction = end_position - start_position
+    ray_direction_normed = ray_direction / np.linalg.norm(ray_direction)
+    # step the start position back a little bit to be able to detect shapes
+    # that contain the start_position
+    start_position = start_position - 0.1 * ray_direction_normed
+    return start_position, ray_direction_normed

--- a/napari/layers/utils/interactivity_utils.py
+++ b/napari/layers/utils/interactivity_utils.py
@@ -143,13 +143,14 @@ def orient_plane_normal_around_cursor(layer: Image, plane_normal: tuple):
     )
 
 
-def mouse_click_line_segment_to_ray(
+def nd_line_segment_to_displayed_data_ray(
     start_point: np.ndarray,
     end_point: np.ndarray,
     dims_displayed: Union[List[int], np.ndarray],
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Convert the start and end point of the line segment of a mouse click ray
-    intersecting a data cube to a ray (i.e., start position and direction).
+    intersecting a data cube to a ray (i.e., start position and direction) in
+    displayed data coordinates
 
     Note: the ray starts 0.1 data units outside of the data volume.
 
@@ -166,15 +167,15 @@ def mouse_click_line_segment_to_ray(
     -------
     start_position : np.ndarray
         The start position of the ray in displayed data coordinates
-    ray_direction_normed : np.ndarray
+    ray_direction : np.ndarray
         The unit vector describing the ray direction.
     """
     # get the ray in the displayed data coordinates
     start_position = start_point[dims_displayed]
     end_position = end_point[dims_displayed]
     ray_direction = end_position - start_position
-    ray_direction_normed = ray_direction / np.linalg.norm(ray_direction)
+    ray_direction = ray_direction / np.linalg.norm(ray_direction)
     # step the start position back a little bit to be able to detect shapes
     # that contain the start_position
-    start_position = start_position - 0.1 * ray_direction_normed
-    return start_position, ray_direction_normed
+    start_position = start_position - 0.1 * ray_direction
+    return start_position, ray_direction

--- a/napari/utils/geometry.py
+++ b/napari/utils/geometry.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 import numpy as np
 
@@ -490,7 +490,7 @@ def intersect_line_with_multiple_planes_3d(
 
 def intersect_line_with_triangles(
     line_point: np.ndarray, line_direction: np.ndarray, triangles: np.ndarray
-):
+) -> np.ndarray:
     """Find the intersection of a ray with a set of triangles.
 
     This function does not test whether the ray intersects the triangles, so you should
@@ -783,3 +783,54 @@ def distance_between_point_and_line_3d(
     )
     distance = np.linalg.norm(point - closest_point_on_line)
     return distance
+
+
+def find_nearest_triangle_intersection(
+    ray_position: np.ndarray, ray_direction: np.ndarray, triangles: np.ndarray
+) -> Tuple[Optional[int], Optional[np.ndarray]]:
+    """Given an array of triangles, find the index and intersection location
+    of a ray and the nearest triangle.
+
+    This returns only the triangle closest to the the ray_position.
+
+    Parameters
+    ----------
+    ray_position : np.ndarray
+        The coordinate of the starting point of the ray.
+    ray_direction : np.ndarray
+        A unit vector describing the direction of the ray.
+    triangles : np.ndarray
+        (N, 3, 3) array containing the vertices of the triangles.
+
+    Returns
+    -------
+    closest_triangle_index : int
+        The index of the intersected triangle.
+    intersection : np.ndarray
+        The coordinate of where the ray intersects the triangle.
+    """
+    inside = line_in_triangles_3d(
+        line_point=ray_position,
+        line_direction=ray_direction,
+        triangles=triangles,
+    )
+
+    n_intersected_triangles = np.sum(inside)
+    if n_intersected_triangles == 0:
+        return None, None
+
+    # find the intersection points for the
+    intersected_triangles = triangles[inside]
+    intersection_points = intersect_line_with_triangles(
+        line_point=ray_position,
+        line_direction=ray_direction,
+        triangles=intersected_triangles,
+    )
+
+    # find the intersection closest to the start point of the ray and return
+    start_to_intersection = intersection_points - ray_position
+    distances = np.linalg.norm(start_to_intersection, axis=1)
+    closest_triangle_index = np.argmin(distances)
+    intersection = intersection_points[closest_triangle_index]
+
+    return closest_triangle_index, intersection

--- a/napari/utils/geometry.py
+++ b/napari/utils/geometry.py
@@ -804,7 +804,7 @@ def find_nearest_triangle_intersection(
 
     Returns
     -------
-    closest_triangle_index : int
+    closest_intersected_triangle_index : int
         The index of the intersected triangle.
     intersection : np.ndarray
         The coordinate of where the ray intersects the triangle.
@@ -831,6 +831,10 @@ def find_nearest_triangle_intersection(
     start_to_intersection = intersection_points - ray_position
     distances = np.linalg.norm(start_to_intersection, axis=1)
     closest_triangle_index = np.argmin(distances)
+    intersected_triangle_indices = np.argwhere(inside)
+    closest_intersected_triangle_index = intersected_triangle_indices[
+        closest_triangle_index
+    ][0]
     intersection = intersection_points[closest_triangle_index]
 
-    return closest_triangle_index, intersection
+    return closest_intersected_triangle_index, intersection


### PR DESCRIPTION
# Description
This PR adds the 3D interactivity machinery to the Surface layer. In particular, it implements `Surface._get_value_3d()`, which returns the value and index of the face intersected by a mouse click. The intersection is set as the first mesh triangle intersected.

The value is calculated using barycentric interpolation of the vertex values of the intersected triangle at the intersection point.

## Type of change
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?

- [x] added tests 
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
