### PR TITLE
Reduce canvas margin

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -263,10 +263,10 @@ class QtViewer(QSplitter):
 
         main_widget = QWidget()
         main_layout = QVBoxLayout()
-        main_layout.setContentsMargins(10, 22, 10, 2)
+        main_layout.setContentsMargins(0, 2, 0, 2)
         main_layout.addWidget(self._canvas_overlay)
         main_layout.addWidget(self.dims)
-        main_layout.setSpacing(10)
+        main_layout.setSpacing(0)
         main_widget.setLayout(main_layout)
 
         self.setOrientation(Qt.Vertical)


### PR DESCRIPTION
# Description

This is a minor esthetic PR increasing the canvas size by reducing the canvas margin. Space is rare on a Windows FullHD screen (1920x1080) with zoom level 150%, which is default after operating system installation. The screenshots below show napari in full screen mode.

The margins around the canvas appear quite wide. Especially the thick margin on top of the canvas appears not reasonable.

![image](https://user-images.githubusercontent.com/12660498/167306573-cf963107-f5d0-4fa2-9b4a-aa22abf66d03.png)

This PR reduces the margins, makes them more symmetric around the "..." buttons and increases space to look at images :-)

![image](https://user-images.githubusercontent.com/12660498/167306611-8b530e6c-fda2-425a-9b97-9321a07ef6f3.png)

## Type of change
- [x] Minor layout change

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
- [x] I tested manually, on Windows only

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
