### PR TITLE
Menu model

### DIFF
--- a/napari/_qt/menus/__init__.py
+++ b/napari/_qt/menus/__init__.py
@@ -2,6 +2,7 @@ from .debug_menu import DebugMenu
 from .file_menu import FileMenu
 from .help_menu import HelpMenu
 from .plugins_menu import PluginsMenu
+from .tools_menu import ToolsMenu
 from .view_menu import ViewMenu
 from .window_menu import WindowMenu
 
@@ -12,4 +13,5 @@ __all__ = [
     'PluginsMenu',
     'ViewMenu',
     'WindowMenu',
+    'ToolsMenu',
 ]

--- a/napari/_qt/menus/_util.py
+++ b/napari/_qt/menus/_util.py
@@ -2,10 +2,11 @@ from typing import TYPE_CHECKING, Callable, List, Union
 
 from qtpy.QtWidgets import QAction, QMenu
 
+from ...components.menu import ActionMenuItem, CheckableMenuItem, Menu
+
 if TYPE_CHECKING:
     from typing_extensions import TypedDict
 
-    from ...components.menu import ActionMenuItem, CheckableMenuItem, Menu
     from ...utils.events import EventEmitter
 
     try:

--- a/napari/_qt/menus/_util.py
+++ b/napari/_qt/menus/_util.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Callable, List, Union
 
 from qtpy.QtWidgets import QAction, QMenu
 
-from ...components.menu import ActionMenuItem, CheckableMenuItem, Menu
+from ...utils.menus import ActionMenuItem, CheckableMenuItem, Menu
 
 if TYPE_CHECKING:
     from typing_extensions import TypedDict

--- a/napari/_qt/menus/_util.py
+++ b/napari/_qt/menus/_util.py
@@ -115,11 +115,11 @@ def populate_menu_view(view: QMenu, model: Menu):
     ----------
     view : qtpy.QtWidgets.QMenu
         Qt view to populate.
-    menu : napari.components.menu.Menu
+    model : napari.components.menu.Menu
         Menu model to populate from.
     """
     for child in model.children:
-        if isinstance(model, Menu):
+        if isinstance(child, Menu):
             if child.enabled:
                 # in case of a submenu, recurse
                 submenu: QMenu = view.addMenu(child.label)
@@ -131,9 +131,10 @@ def populate_menu_view(view: QMenu, model: Menu):
         else:
             # common attributes
             action: QAction = view.addAction(child.label)
-            action.setShortcut(
-                convert_keybinding_to_shortcut(child.keybinding)
-            )
+            if child.keybinding:
+                action.setShortcut(
+                    convert_keybinding_to_shortcut(child.keybinding)
+                )
             action.setStatusTip(child.description)
             action.setEnabled(child.enabled)
 

--- a/napari/_qt/menus/tools_menu.py
+++ b/napari/_qt/menus/tools_menu.py
@@ -8,8 +8,8 @@ if TYPE_CHECKING:
 
 
 class ToolsMenu(NapariMenu):
-    def __init__(self, window: Window):
-        self._win
+    def __init__(self, window: 'Window'):
+        self._win = window
         super().__init__('&Tools', window._qt_window)
         self._build()
 

--- a/napari/_qt/menus/tools_menu.py
+++ b/napari/_qt/menus/tools_menu.py
@@ -1,0 +1,19 @@
+from typing import TYPE_CHECKING
+
+from ...plugins import _npe2
+from ._util import NapariMenu, populate_menu_view
+
+if TYPE_CHECKING:
+    from ..qt_main_window import Window
+
+
+class ToolsMenu(NapariMenu):
+    def __init__(self, window: Window):
+        self._win
+        super().__init__('&Tools', window._qt_window)
+        self._build()
+
+    def _build(self):
+        self.clear()
+        model = _npe2.build_tools_menu()
+        populate_menu_view(self, model)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -608,6 +608,8 @@ class Window:
         self.main_menu.addMenu(self.view_menu)
         self.window_menu = menus.WindowMenu(self)
         self.main_menu.addMenu(self.window_menu)
+        self.tools_menu = menus.ToolsMenu(self)
+        self.main_menu.addMenu(self.tools_menu)
         self.plugins_menu = menus.PluginsMenu(self)
         self.main_menu.addMenu(self.plugins_menu)
         self.help_menu = menus.HelpMenu(self)

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -481,3 +481,19 @@ def qt_might_be_rich_text(text) -> bool:
         return _Qt.mightBeRichText(text)
     except Exception:
         return bool(RICH_TEXT_PATTERN.search(text))
+
+
+def convert_keybinding_to_shortcut(keybinding: str) -> str:
+    """Convert a napari keybinding to a Qt shortcut.
+
+    Parameters
+    ----------
+    keybinding : str
+        Key combination to convert.
+
+    Returns
+    -------
+    shortcut : str
+        Equivalent Qt shortcut.
+    """
+    return keybinding.replace('-', '+').replace('Control', 'Ctrl')

--- a/napari/components/menu.py
+++ b/napari/components/menu.py
@@ -1,24 +1,43 @@
 from typing import Callable, List, Optional
 
+from pydantic import Field
+
 from ..utils.events import EventedModel
 
 
 class MenuItem(EventedModel):
-    label: str
-    id: str
-    description: Optional[str]
+    label: str = Field(..., description='Text of the menu item.')
+    id: str = Field(
+        ...,
+        description='Internal identifier of the menu item, to be used when accessing programmatically.',
+    )
+    description: Optional[str] = Field(
+        description='Description to be shown in the status bar when hovered.'
+    )
     # TODO: add validation to keybinding
-    keybinding: Optional[str]
+    keybinding: Optional[str] = Field(
+        description='Keyboard shortcut which activates this item.'
+    )
+    enabled: bool = Field(
+        True, description='Whether or not to allow this item to be clickable.'
+    )
 
 
 class ActionMenuItem(MenuItem):
-    action: Callable[[], None]
+    action: Callable[[], None] = Field(
+        ..., description='Callback to trigger when the menu item is clicked.'
+    )
 
 
 class CheckableMenuItem(MenuItem):
-    checked: bool
+    checked: bool = Field(
+        ..., description='Whether the current menu item is checked.'
+    )
 
 
 class Menu(MenuItem):
-    # should this be an EventedList?
-    children: List[MenuItem]
+    children: List[MenuItem] = Field(
+        ...,
+        description='Children menu items of this menu.',
+        allow_mutation=False,
+    )

--- a/napari/components/menu.py
+++ b/napari/components/menu.py
@@ -1,0 +1,24 @@
+from typing import Callable, List, Optional
+
+from ..utils.events import EventedModel
+
+
+class MenuItem(EventedModel):
+    label: str
+    id: str
+    description: Optional[str]
+    # TODO: add validation to keybinding
+    keybinding: Optional[str]
+
+
+class ActionMenuItem(MenuItem):
+    action: Callable[[], None]
+
+
+class CheckableMenuItem(MenuItem):
+    checked: bool
+
+
+class Menu(MenuItem):
+    # should this be an EventedList?
+    children: List[MenuItem]

--- a/napari/components/menu.py
+++ b/napari/components/menu.py
@@ -41,3 +41,20 @@ class Menu(MenuItem):
         description='Children menu items of this menu.',
         allow_mutation=False,
     )
+
+    def get(self, id: str) -> Optional[MenuItem]:
+        """Get a child by its id.
+
+        Parameters
+        ----------
+        id : str
+            Id of the menu item to fetch.
+
+        Returns
+        -------
+        menu_item : MenuItem, optional
+            Fetched menu item, if found.
+        """
+        for child in self.children:
+            if child.id == id:
+                return child

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -37,16 +37,16 @@ class _FakeHookimpl:
 
 
 napari_menus = {
-    "/napari/layer_context": "Process Layer",
-    "/napari/layer_context/projections": "Make Projection",
-    "/napari/layer_context/convert_type": "Convert datatype",
-    "/napari/tools/acquisition": "Acquisition",
-    "/napari/tools/classification": "Classification",
-    "/napari/tools/measurement": "Measurement",
-    "/napari/tools/segmentation": "Segmentation",
-    "/napari/tools/transform": "Transform",
-    "/napari/tools/utilities": "Utilities",
-    "/napari/tools/visualization": "Visualization",
+    ("/napari/layer_context", "Process Layer"),
+    ("/napari/layer_context/projections", "Make Projection"),
+    ("/napari/layer_context/convert_type", "Convert datatype"),
+    ("/napari/tools/acquisition", "Acquisition"),
+    ("/napari/tools/classification", "Classification"),
+    ("/napari/tools/measurement", "Measurement"),
+    ("/napari/tools/segmentation", "Segmentation"),
+    ("/napari/tools/transform", "Transform"),
+    ("/napari/tools/utilities", "Utilities"),
+    ("/napari/tools/visualization", "Visualization"),
 }
 
 TOOLS_PATH_PREFIX = '/napari/tools/'
@@ -256,10 +256,18 @@ def build_tools_menu() -> Menu:
         Built tools menu.
     """
     submenus = []
-    for path, title in napari_menus.items():
+    for path, title in napari_menus:
         if not path.startswith(TOOLS_PATH_PREFIX):
             continue
-        submenus.append(Menu(label=title, id=path, children=build_menus(path)))
+        children = build_menus(path)
+        submenus.append(
+            Menu(
+                label=title,
+                id=path.removeprefix(TOOLS_PATH_PREFIX),
+                children=children,
+                enabled=len(children) > 0,
+            )
+        )
 
     return Menu(label='Tools', id=TOOLS_PATH_PREFIX, children=submenus)
 

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -415,9 +415,7 @@ def _on_plugin_enablement_change(enabled: Set[str], disabled: Set[str]):
     to_disable.update(disabled)
     plugin_settings.disabled_plugins = to_disable
 
-    # tools_menu = build_tools_menu()
-    # populate qmenu wtih tools menu
-
     for v in Viewer._instances:
+        v.window.tools_menu._build()
         v.window.plugins_menu._build()
         v.window.file_menu._rebuild_samples_menu()

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -25,7 +25,9 @@ from ..utils.translations import trans
 if TYPE_CHECKING:
     from npe2.manifest.contributions import MenuItem as MenuEntry
     from npe2.manifest.contributions import WriterContribution
+    from npe2.types import LayerData, SampleDataCreator, WidgetCreator
 
+    from ..layers import Layer
     from ..types import SampleDict
 
 

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -36,6 +36,22 @@ class _FakeHookimpl:
         self.plugin_name = name
 
 
+napari_menus = {
+    "/napari/layer_context": "Process Layer",
+    "/napari/layer_context/projections": "Make Projection",
+    "/napari/layer_context/convert_type": "Convert datatype",
+    "/napari/tools/acquisition": "Acquisition",
+    "/napari/tools/classification": "Classification",
+    "/napari/tools/measurement": "Measurement",
+    "/napari/tools/segmentation": "Segmentation",
+    "/napari/tools/transform": "Transform",
+    "/napari/tools/utilities": "Utilities",
+    "/napari/tools/visualization": "Visualization",
+}
+
+TOOLS_PATH_PREFIX = '/napari/tools/'
+
+
 def read(
     paths: Sequence[str], plugin: Optional[str] = None, *, stack: bool
 ) -> Optional[Tuple[List[LayerData], _FakeHookimpl]]:
@@ -231,6 +247,23 @@ def build_menus(menu_key: str) -> List[MenuItem]:
     return _build_menus(pm.iter_menu(menu_key))
 
 
+def build_tools_menu() -> Menu:
+    """Build the tools menu.
+
+    Returns
+    -------
+    tools_menu : napari.components.menu.Menu
+        Built tools menu.
+    """
+    submenus = []
+    for path, title in napari_menus.items():
+        if not path.startswith(TOOLS_PATH_PREFIX):
+            continue
+        submenus.append(Menu(label=title, id=path, children=build_menus(path)))
+
+    return Menu(label='Tools', id=TOOLS_PATH_PREFIX, children=submenus)
+
+
 def file_extensions_string_for_layers(
     layers: Sequence[Layer],
 ) -> Tuple[Optional[str], List[WriterContribution]]:
@@ -373,6 +406,9 @@ def _on_plugin_enablement_change(enabled: Set[str], disabled: Set[str]):
     to_disable.difference_update(enabled)
     to_disable.update(disabled)
     plugin_settings.disabled_plugins = to_disable
+
+    # tools_menu = build_tools_menu()
+    # populate qmenu wtih tools menu
 
     for v in Viewer._instances:
         v.window.plugins_menu._build()

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -126,7 +126,7 @@ def get_widget_contribution(
     return None
 
 
-def _build_menu(entries: Iterable[MenuEntry]) -> List[MenuItem]:
+def _build_menus(entries: Iterable[MenuEntry]) -> List[MenuItem]:
     """Build napari native menus from npe2 menu entries.
 
     Parameters
@@ -169,7 +169,7 @@ def build_submenu(submenu_key: str) -> Menu:
     pm = npe2.PluginManager.instance()
 
     entry = pm.get_submenu(submenu_key)
-    children = _build_menu(entry.contents)
+    children = _build_menus(entry.contents)
     return Menu(id=entry.id, label=entry.label, children=children)
 
 
@@ -206,7 +206,7 @@ def build_menu_item(menu_entry: MenuEntry) -> MenuItem:
         )
 
 
-def build_menu(menu_key: str) -> List[MenuItem]:
+def build_menus(menu_key: str) -> List[MenuItem]:
     """Build napari native menus from npe2 menu entries given the relevant menu key.
 
     Parameters
@@ -226,7 +226,7 @@ def build_menu(menu_key: str) -> List[MenuItem]:
     """
     pm = npe2.PluginManager.instance()
 
-    return _build_menu(pm.iter_menu(menu_key))
+    return _build_menus(pm.iter_menu(menu_key))
 
 
 def file_extensions_string_for_layers(

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -19,7 +19,7 @@ from npe2.io_utils import read_get_reader
 from npe2.manifest import PluginManifest
 from npe2.manifest.contributions import MenuCommand, Submenu
 
-from ..components.menu import ActionMenuItem, Menu, MenuItem
+from ..utils.menus import ActionMenuItem, Menu, MenuItem
 from ..utils.translations import trans
 
 if TYPE_CHECKING:

--- a/napari/plugins/_tests/test_npe2.py
+++ b/napari/plugins/_tests/test_npe2.py
@@ -202,12 +202,12 @@ def test_build_menu(mock_pm):
 
     assert submenu.label == 'My SubMenu'
     assert submenu.id == 'my-plugin.mysubmenu'
-    
-    command1, nested_submenu = submenu.contents
+
+    command1, nested_submenu = submenu.children
     assert command1 == command
-    
+
     assert nested_submenu.label == 'My Nested SubMenu'
     assert nested_submenu.id == 'my-plugin.mynestedsubmenu'
 
-    command2, = nested_submenu.contents
+    (command2,) = nested_submenu.children
     assert command2 == command

--- a/napari/plugins/_tests/test_npe2.py
+++ b/napari/plugins/_tests/test_npe2.py
@@ -37,7 +37,7 @@ contributions:
     - command: {0}.some_widget
       display_name: My Widget
   menus:
-    /napari/layer_context:
+    /napari/tools/acquisition:
       - submenu: {0}.mysubmenu
       - command: {0}.hello_world
   submenus:
@@ -194,7 +194,7 @@ def test_widget_iterator(mock_pm):
 
 
 def test_build_menu(mock_pm):
-    menus = _npe2.build_menus('/napari/layer_context')
+    menus = _npe2.build_menus('/napari/tools/acquisition')
     submenu, command = menus
 
     assert command.label == 'Hello World'
@@ -211,3 +211,17 @@ def test_build_menu(mock_pm):
 
     (command2,) = nested_submenu.children
     assert command2 == command
+
+
+def test_build_tools_menu(mock_pm):
+    tools_menu = _npe2.build_tools_menu()
+
+    acq = tools_menu.get('acquisition')
+    assert acq.label == 'Acquisition'
+    assert acq.enabled is True
+    assert len(acq.children) == 2
+
+    util = tools_menu.get('utilities')
+    assert util.label == 'Utilities'
+    assert util.enabled is False
+    assert len(util.children) == 0

--- a/napari/utils/menus.py
+++ b/napari/utils/menus.py
@@ -2,7 +2,7 @@ from typing import Callable, List, Optional
 
 from pydantic import Field
 
-from ..utils.events import EventedModel
+from .events import EventedModel
 
 
 class MenuItem(EventedModel):


### PR DESCRIPTION
# Description
Adds an internal menu model and populates menus from the npe2 spec. TODO: directly adds these menu items to their corresponding locations in the UI

Future refactors (currently out of scope) will use this class to represent menus while being view/Qt-agnostic.

Note: uses an npe2 version that is still in development