### PR TITLE
Fix trailing comma fixes black formatting

### DIFF
--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -644,10 +644,9 @@ class Labels(_ImageBase):
     def color_mode(self, color_mode: Union[str, LabelColorMode]):
         color_mode = LabelColorMode(color_mode)
         if color_mode == LabelColorMode.DIRECT:
-            (
-                custom_colormap,
-                label_color_index,
-            ) = color_dict_to_colormap(self.color)
+            custom_colormap, label_color_index = color_dict_to_colormap(
+                self.color
+            )
             super()._set_colormap(custom_colormap)
             self._label_color_index = label_color_index
         elif color_mode == LabelColorMode.AUTO:


### PR DESCRIPTION
This was my go-to example for why black formatting is terrible, but it turns out it's been fixed! :tada: Removing the trailing comma and parentheses makes black do the right thing here now. (Note that black added them in the first place in a previous life, but I might be almost ready to forgive it. :joy:)
