### PR TITLE
Update layer list context keys

### DIFF
--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -242,8 +242,9 @@ def _labeltypedict(key) -> ContextAction:
     return {
         'description': key,
         'action': partial(_convert_dtype, mode=key),
-        'enable_when': LLCK.only_labels_selected
-        & (LLCK.active_layer_dtype != key),
+        'enable_when': (
+            LLCK.only_labels_layers_selected & (LLCK.active_layer_dtype != key)
+        ),
         'show_when': True,
     }
 
@@ -260,14 +261,15 @@ _LAYER_ACTIONS: Sequence[MenuItem] = [
             'description': trans._('Convert to Labels'),
             'action': _convert_to_labels,
             'enable_when': (
-                LLCK.only_images_selected | LLCK.only_shapes_selected
+                LLCK.only_image_layers_selected
+                | LLCK.only_shapes_layers_selected
             ),
             'show_when': True,
         },
         'napari:convert_to_image': {
             'description': trans._('Convert to Image'),
             'action': _convert_to_image,
-            'enable_when': LLCK.only_labels_selected,
+            'enable_when': LLCK.only_labels_layers_selected,
             'show_when': True,
         },
         'napari:toggle_visibility': {
@@ -281,7 +283,7 @@ _LAYER_ACTIONS: Sequence[MenuItem] = [
     {
         'napari:group:convert_type': {
             'description': trans._('Convert datatype'),
-            'enable_when': LLCK.only_labels_selected,
+            'enable_when': LLCK.only_labels_layers_selected,
             'show_when': True,
             'action_group': {
                 'napari:to_int8': _labeltypedict('int8'),
@@ -330,8 +332,8 @@ _LAYER_ACTIONS: Sequence[MenuItem] = [
             'description': trans._('Merge to Stack'),
             'action': _merge_stack,
             'enable_when': (
-                (LLCK.layers_selection_count > 1)
-                & LLCK.only_images_selected
+                (LLCK.num_selected_layers > 1)
+                & LLCK.only_image_layers_selected
                 & LLCK.all_layers_same_shape
             ),
             'show_when': True,
@@ -342,7 +344,7 @@ _LAYER_ACTIONS: Sequence[MenuItem] = [
             'description': trans._('Link Layers'),
             'action': lambda ll: ll.link_layers(ll.selection),
             'enable_when': (
-                (LLCK.layers_selection_count > 1) & ~LLCK.all_layers_linked
+                (LLCK.num_selected_layers > 1) & ~LLCK.all_layers_linked
             ),
             'show_when': ~LLCK.all_layers_linked,
         },
@@ -355,7 +357,7 @@ _LAYER_ACTIONS: Sequence[MenuItem] = [
         'napari:select_linked_layers': {
             'description': trans._('Select Linked Layers'),
             'action': _select_linked_layers,
-            'enable_when': LLCK.unselected_linked_layers,
+            'enable_when': LLCK.num_unselected_linked_layers,
             'show_when': True,
         },
     },

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -274,8 +274,8 @@ _LAYER_ACTIONS: Sequence[MenuItem] = [
             'description': trans._('Convert to Image'),
             'action': _convert_to_image,
             'enable_when': (
-                LLCK.num_selected_labels_layers
-                >= 1 & LLCK.all_selected_layers_same_type
+                (LLCK.num_selected_labels_layers >= 1)
+                & LLCK.all_selected_layers_same_type
             ),
             'show_when': True,
         },
@@ -291,8 +291,8 @@ _LAYER_ACTIONS: Sequence[MenuItem] = [
         'napari:group:convert_type': {
             'description': trans._('Convert datatype'),
             'enable_when': (
-                LLCK.num_selected_labels_layers
-                >= 1 & LLCK.all_selected_layers_same_type
+                (LLCK.num_selected_labels_layers >= 1)
+                & LLCK.all_selected_layers_same_type
             ),
             'show_when': True,
             'action_group': {

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -262,17 +262,21 @@ _LAYER_ACTIONS: Sequence[MenuItem] = [
             'description': trans._('Convert to Labels'),
             'action': _convert_to_labels,
             'enable_when': (
-                LLCK.num_selected_image_layers
-                == LLCK.num_selected_layers | LLCK.num_selected_shapes_layers
-                == LLCK.num_selected_layers
+                (
+                    (LLCK.num_selected_image_layers >= 1)
+                    | (LLCK.num_selected_shapes_layers >= 1)
+                )
+                & LLCK.all_selected_layers_same_type
             ),
             'show_when': True,
         },
         'napari:convert_to_image': {
             'description': trans._('Convert to Image'),
             'action': _convert_to_image,
-            'enable_when': LLCK.num_selected_labels_layers
-            == LLCK.num_selected_layers,
+            'enable_when': (
+                LLCK.num_selected_labels_layers
+                >= 1 & LLCK.all_selected_layers_same_type
+            ),
             'show_when': True,
         },
         'napari:toggle_visibility': {
@@ -286,8 +290,10 @@ _LAYER_ACTIONS: Sequence[MenuItem] = [
     {
         'napari:group:convert_type': {
             'description': trans._('Convert datatype'),
-            'enable_when': LLCK.num_selected_labels_layers
-            == LLCK.num_selected_layers,
+            'enable_when': (
+                LLCK.num_selected_labels_layers
+                >= 1 & LLCK.all_selected_layers_same_type
+            ),
             'show_when': True,
             'action_group': {
                 'napari:to_int8': _labeltypedict('int8'),

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -337,7 +337,7 @@ _LAYER_ACTIONS: Sequence[MenuItem] = [
             'enable_when': (
                 (LLCK.num_selected_layers > 1)
                 & (LLCK.num_selected_image_layers == LLCK.num_selected_layers)
-                & LLCK.all_layers_same_shape
+                & LLCK.all_selected_layers_same_shape
             ),
             'show_when': True,
         },

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -347,15 +347,16 @@ _LAYER_ACTIONS: Sequence[MenuItem] = [
             'description': trans._('Link Layers'),
             'action': lambda ll: ll.link_layers(ll.selection),
             'enable_when': (
-                (LLCK.num_selected_layers > 1) & ~LLCK.all_layers_linked
+                (LLCK.num_selected_layers > 1)
+                & ~LLCK.num_selected_layers_linked
             ),
-            'show_when': ~LLCK.all_layers_linked,
+            'show_when': ~LLCK.num_selected_layers_linked,
         },
         'napari:unlink_selected_layers': {
             'description': trans._('Unlink Layers'),
             'action': lambda ll: ll.unlink_layers(ll.selection),
-            'enable_when': LLCK.all_layers_linked,
-            'show_when': LLCK.all_layers_linked,
+            'enable_when': LLCK.num_selected_layers_linked,
+            'show_when': LLCK.num_selected_layers_linked,
         },
         'napari:select_linked_layers': {
             'description': trans._('Select Linked Layers'),

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -286,7 +286,8 @@ _LAYER_ACTIONS: Sequence[MenuItem] = [
     {
         'napari:group:convert_type': {
             'description': trans._('Convert datatype'),
-            'enable_when': LLCK.only_labels_layers_selected,
+            'enable_when': LLCK.num_selected_labels_layers
+            == LLCK.num_selected_layers,
             'show_when': True,
             'action_group': {
                 'napari:to_int8': _labeltypedict('int8'),

--- a/napari/utils/context/_layerlist_context.py
+++ b/napari/utils/context/_layerlist_context.py
@@ -124,9 +124,9 @@ class LayerListContextKeys(ContextNamespace['LayerSel']):
     current value from layers.selection
     """
 
-    layers_selection_count = ContextKey(
+    num_selected_layers = ContextKey(
         0,
-        trans._("Number of layers currently selected"),
+        trans._("Number of currently selected layers."),
         _len,
     )
     all_layers_linked = ContextKey(
@@ -134,14 +134,14 @@ class LayerListContextKeys(ContextNamespace['LayerSel']):
         trans._("True when all selected layers are linked."),
         _all_linked,
     )
-    unselected_linked_layers = ContextKey(
+    num_unselected_linked_layers = ContextKey(
         0,
-        trans._("Number of unselected layers linked to selected layer(s)"),
+        trans._("Number of unselected layers linked to selected layer(s)."),
         _n_unselected_links,
     )
     active_layer_is_rgb = ContextKey(
         False,
-        trans._("True when the active layer is RGB"),
+        trans._("True when the active layer is RGB."),
         _is_rgb,
     )
     active_layer_type = ContextKey['LayerSel', Optional[str]](
@@ -154,86 +154,86 @@ class LayerListContextKeys(ContextNamespace['LayerSel']):
     # TODO: try to reduce these `only_x_selected` to a single set of strings
     # or something... however, this would require that our context expressions
     # support Sets, tuples, lists, etc...  which they currently do not.
-    only_images_selected = ContextKey(
+    only_image_layers_selected = ContextKey(
         False,
         trans._(
             "True when there is at least one selected layer and all selected layers are images"
         ),
         _only_img,
     )
-    selected_images = ContextKey(
+    num_selected_image_layers = ContextKey(
         0,
         trans._("Number of selected image layers."),
         _n_selected_imgs,
     )
-    only_labels_selected = ContextKey(
+    only_labels_layers_selected = ContextKey(
         False,
         trans._(
             "True when there is at least one selected layer and all selected layers are labels"
         ),
         _only_labels,
     )
-    selected_labels = ContextKey(
+    num_selected_labels_layers = ContextKey(
         0,
         trans._("Number of selected labels layers."),
         _n_selected_labels,
     )
-    only_points_selected = ContextKey(
+    only_points_layers_selected = ContextKey(
         False,
         trans._(
             "True when there is at least one selected layer and all selected layers are points"
         ),
         _only_points,
     )
-    selected_points = ContextKey(
+    num_selected_points_layers = ContextKey(
         0,
         trans._("Number of selected points layers."),
         _n_selected_points,
     )
-    only_shapes_selected = ContextKey(
+    only_shapes_layers_selected = ContextKey(
         False,
         trans._(
             "True when there is at least one selected layer and all selected layers are shapes"
         ),
         _only_shapes,
     )
-    selected_shapes = ContextKey(
+    num_selected_shapes_layers = ContextKey(
         0,
         trans._("Number of selected shapes layers."),
         _n_selected_shapes,
     )
-    only_surface_selected = ContextKey(
+    only_surface_layers_selected = ContextKey(
         False,
         trans._(
             "True when there is at least one selected layer and all selected layers are surfaces"
         ),
         _only_surface,
     )
-    selected_surfaces = ContextKey(
+    num_selected_surface_layers = ContextKey(
         0,
         trans._("Number of selected surface layers."),
         _n_selected_surfaces,
     )
-    only_vectors_selected = ContextKey(
+    only_vectors_layers_selected = ContextKey(
         False,
         trans._(
             "True when there is at least one selected layer and all selected layers are vectors"
         ),
         _only_vectors,
     )
-    selected_vectors = ContextKey(
+    num_selected_vectors_layers = ContextKey(
         0,
         trans._("Number of selected vectors layers."),
         _n_selected_vectors,
     )
-    only_vectors_tracks = ContextKey(
+    only_tracks_layers_selected = ContextKey(
         False,
         trans._(
             "True when there is at least one selected layer and all selected layers are tracks"
         ),
         _only_tracks,
     )
-    selected_tracks = ContextKey(
+    num_selected_tracks_layers = ContextKey(
         0,
         trans._("Number of selected tracks layers."),
         _n_selected_tracks,
@@ -241,7 +241,7 @@ class LayerListContextKeys(ContextNamespace['LayerSel']):
     active_layer_ndim = ContextKey['LayerSel', Optional[int]](
         None,
         trans._(
-            "Number of dimensions in the active layer, or `None` if nothing is active"
+            "Number of dimensions in the active layer, or `None` if nothing is active."
         ),
         _active_ndim,
     )
@@ -257,6 +257,6 @@ class LayerListContextKeys(ContextNamespace['LayerSel']):
     )
     all_layers_same_shape = ContextKey(
         False,
-        trans._("True when all selected layers have the same shape"),
+        trans._("True when all selected layers have the same shape."),
         _same_shape,
     )

--- a/napari/utils/context/_layerlist_context.py
+++ b/napari/utils/context/_layerlist_context.py
@@ -206,7 +206,7 @@ class LayerListContextKeys(ContextNamespace['LayerSel']):
         trans._("Dtype of the active layer, or `None` if nothing is active."),
         _active_dtype,
     )
-    all_layers_same_shape = ContextKey(
+    all_selected_layers_same_shape = ContextKey(
         False,
         trans._("True when all selected layers have the same shape."),
         _same_shape,

--- a/napari/utils/context/_layerlist_context.py
+++ b/napari/utils/context/_layerlist_context.py
@@ -117,8 +117,9 @@ def _active_dtype(s: LayerSel) -> DTypeLike:
     return dtype
 
 
-def _same_dtype(s: LayerSel) -> bool:
-    for idx, layer in enumerate(list(s)):
+def _same_type(s: LayerSel) -> bool:
+    s = list(s)
+    for idx, layer in enumerate(s):
         next_layer = s[idx + 1] if idx < (len(s) - 1) else None
         if (type(layer) != type(next_layer)) and (next_layer is not None):
             return False
@@ -218,4 +219,9 @@ class LayerListContextKeys(ContextNamespace['LayerSel']):
         False,
         trans._("True when all selected layers have the same shape."),
         _same_shape,
+    )
+    all_selected_layers_same_type = ContextKey(
+        False,
+        trans._("True when all selected layers are of the same type."),
+        _same_type,
     )

--- a/napari/utils/context/_layerlist_context.py
+++ b/napari/utils/context/_layerlist_context.py
@@ -118,14 +118,7 @@ def _active_dtype(s: LayerSel) -> DTypeLike:
 
 
 def _same_type(s: LayerSel) -> bool:
-    s = list(s)
-    if len(s) == 0:
-        return False
-    for idx, layer in enumerate(s):
-        next_layer = s[idx + 1] if idx < (len(s) - 1) else None
-        if (type(layer) != type(next_layer)) and (next_layer is not None):
-            return False
-    return True
+    return len({x._type_string for x in s}) == 1
 
 
 class LayerListContextKeys(ContextNamespace['LayerSel']):

--- a/napari/utils/context/_layerlist_context.py
+++ b/napari/utils/context/_layerlist_context.py
@@ -117,6 +117,14 @@ def _active_dtype(s: LayerSel) -> DTypeLike:
     return dtype
 
 
+def _same_dtype(s: LayerSel) -> bool:
+    for idx, layer in enumerate(list(s)):
+        next_layer = s[idx + 1] if idx < (len(s) - 1) else None
+        if (type(layer) != type(next_layer)) and (next_layer is not None):
+            return False
+    return True
+
+
 class LayerListContextKeys(ContextNamespace['LayerSel']):
     """These are the available context keys relating to a LayerList.
 

--- a/napari/utils/context/_layerlist_context.py
+++ b/napari/utils/context/_layerlist_context.py
@@ -154,84 +154,35 @@ class LayerListContextKeys(ContextNamespace['LayerSel']):
     # TODO: try to reduce these `only_x_selected` to a single set of strings
     # or something... however, this would require that our context expressions
     # support Sets, tuples, lists, etc...  which they currently do not.
-    only_image_layers_selected = ContextKey(
-        False,
-        trans._(
-            "True when there is at least one selected layer and all selected layers are images"
-        ),
-        _only_img,
-    )
     num_selected_image_layers = ContextKey(
         0,
         trans._("Number of selected image layers."),
         _n_selected_imgs,
-    )
-    only_labels_layers_selected = ContextKey(
-        False,
-        trans._(
-            "True when there is at least one selected layer and all selected layers are labels"
-        ),
-        _only_labels,
     )
     num_selected_labels_layers = ContextKey(
         0,
         trans._("Number of selected labels layers."),
         _n_selected_labels,
     )
-    only_points_layers_selected = ContextKey(
-        False,
-        trans._(
-            "True when there is at least one selected layer and all selected layers are points"
-        ),
-        _only_points,
-    )
     num_selected_points_layers = ContextKey(
         0,
         trans._("Number of selected points layers."),
         _n_selected_points,
-    )
-    only_shapes_layers_selected = ContextKey(
-        False,
-        trans._(
-            "True when there is at least one selected layer and all selected layers are shapes"
-        ),
-        _only_shapes,
     )
     num_selected_shapes_layers = ContextKey(
         0,
         trans._("Number of selected shapes layers."),
         _n_selected_shapes,
     )
-    only_surface_layers_selected = ContextKey(
-        False,
-        trans._(
-            "True when there is at least one selected layer and all selected layers are surfaces"
-        ),
-        _only_surface,
-    )
     num_selected_surface_layers = ContextKey(
         0,
         trans._("Number of selected surface layers."),
         _n_selected_surfaces,
     )
-    only_vectors_layers_selected = ContextKey(
-        False,
-        trans._(
-            "True when there is at least one selected layer and all selected layers are vectors"
-        ),
-        _only_vectors,
-    )
     num_selected_vectors_layers = ContextKey(
         0,
         trans._("Number of selected vectors layers."),
         _n_selected_vectors,
-    )
-    only_tracks_layers_selected = ContextKey(
-        False,
-        trans._(
-            "True when there is at least one selected layer and all selected layers are tracks"
-        ),
-        _only_tracks,
     )
     num_selected_tracks_layers = ContextKey(
         0,

--- a/napari/utils/context/_layerlist_context.py
+++ b/napari/utils/context/_layerlist_context.py
@@ -39,12 +39,56 @@ def _only_img(s: LayerSel) -> bool:
     return bool(s and all(x._type_string == "image" for x in s))
 
 
+def _n_selected_imgs(s: LayerSel) -> int:
+    return sum(1 for x in s if x._type_string == "image")
+
+
 def _only_labels(s: LayerSel) -> bool:
     return bool(s and all(x._type_string == "labels" for x in s))
 
 
+def _n_selected_labels(s: LayerSel) -> int:
+    return sum(1 for x in s if x._type_string == "labels")
+
+
+def _only_points(s: LayerSel) -> bool:
+    return bool(s and all(x._type_string == "points" for x in s))
+
+
+def _n_selected_points(s: LayerSel) -> int:
+    return sum(1 for x in s if x._type_string == "labels")
+
+
 def _only_shapes(s: LayerSel) -> bool:
     return bool(s and all(x._type_string == "shapes" for x in s))
+
+
+def _n_selected_shapes(s: LayerSel) -> int:
+    return sum(1 for x in s if x._type_string == "shapes")
+
+
+def _only_surface(s: LayerSel) -> bool:
+    return bool(s and all(x._type_string == "surface" for x in s))
+
+
+def _n_selected_surfaces(s: LayerSel) -> int:
+    return sum(1 for x in s if x._type_string == "surface")
+
+
+def _only_vectors(s: LayerSel) -> bool:
+    return bool(s and all(x._type_string == "vectors" for x in s))
+
+
+def _n_selected_vectors(s: LayerSel) -> int:
+    return sum(1 for x in s if x._type_string == "vectors")
+
+
+def _only_tracks(s: LayerSel) -> bool:
+    return bool(s and all(x._type_string == "tracks" for x in s))
+
+
+def _n_selected_tracks(s: LayerSel) -> int:
+    return sum(1 for x in s if x._type_string == "tracks")
 
 
 def _active_type(s: LayerSel) -> Optional[str]:

--- a/napari/utils/context/_layerlist_context.py
+++ b/napari/utils/context/_layerlist_context.py
@@ -119,6 +119,8 @@ def _active_dtype(s: LayerSel) -> DTypeLike:
 
 def _same_type(s: LayerSel) -> bool:
     s = list(s)
+    if len(s) == 0:
+        return False
     for idx, layer in enumerate(s):
         next_layer = s[idx + 1] if idx < (len(s) - 1) else None
         if (type(layer) != type(next_layer)) and (next_layer is not None):
@@ -160,7 +162,7 @@ class LayerListContextKeys(ContextNamespace['LayerSel']):
         ),
         _active_type,
     )
-    # TODO: try to reduce these `only_x_selected` to a single set of strings
+    # TODO: try to reduce these `num_selected_x_layers` to a single set of strings
     # or something... however, this would require that our context expressions
     # support Sets, tuples, lists, etc...  which they currently do not.
     num_selected_image_layers = ContextKey(

--- a/napari/utils/context/_layerlist_context.py
+++ b/napari/utils/context/_layerlist_context.py
@@ -161,6 +161,11 @@ class LayerListContextKeys(ContextNamespace['LayerSel']):
         ),
         _only_img,
     )
+    selected_images = ContextKey(
+        0,
+        trans._("Number of selected image layers."),
+        _n_selected_imgs,
+    )
     only_labels_selected = ContextKey(
         False,
         trans._(
@@ -168,12 +173,70 @@ class LayerListContextKeys(ContextNamespace['LayerSel']):
         ),
         _only_labels,
     )
+    selected_labels = ContextKey(
+        0,
+        trans._("Number of selected labels layers."),
+        _n_selected_labels,
+    )
+    only_points_selected = ContextKey(
+        False,
+        trans._(
+            "True when there is at least one selected layer and all selected layers are points"
+        ),
+        _only_points,
+    )
+    selected_points = ContextKey(
+        0,
+        trans._("Number of selected points layers."),
+        _n_selected_points,
+    )
     only_shapes_selected = ContextKey(
         False,
         trans._(
             "True when there is at least one selected layer and all selected layers are shapes"
         ),
         _only_shapes,
+    )
+    selected_shapes = ContextKey(
+        0,
+        trans._("Number of selected shapes layers."),
+        _n_selected_shapes,
+    )
+    only_surface_selected = ContextKey(
+        False,
+        trans._(
+            "True when there is at least one selected layer and all selected layers are surfaces"
+        ),
+        _only_surface,
+    )
+    selected_surfaces = ContextKey(
+        0,
+        trans._("Number of selected surface layers."),
+        _n_selected_surfaces,
+    )
+    only_vectors_selected = ContextKey(
+        False,
+        trans._(
+            "True when there is at least one selected layer and all selected layers are vectors"
+        ),
+        _only_vectors,
+    )
+    selected_vectors = ContextKey(
+        0,
+        trans._("Number of selected vectors layers."),
+        _n_selected_vectors,
+    )
+    only_vectors_tracks = ContextKey(
+        False,
+        trans._(
+            "True when there is at least one selected layer and all selected layers are tracks"
+        ),
+        _only_tracks,
+    )
+    selected_tracks = ContextKey(
+        0,
+        trans._("Number of selected tracks layers."),
+        _n_selected_tracks,
     )
     active_layer_ndim = ContextKey['LayerSel', Optional[int]](
         None,

--- a/napari/utils/context/_layerlist_context.py
+++ b/napari/utils/context/_layerlist_context.py
@@ -129,7 +129,7 @@ class LayerListContextKeys(ContextNamespace['LayerSel']):
         trans._("Number of currently selected layers."),
         _len,
     )
-    all_layers_linked = ContextKey(
+    num_selected_layers_linked = ContextKey(
         False,
         trans._("True when all selected layers are linked."),
         _all_linked,

--- a/napari/utils/context/_tests/conftest.py
+++ b/napari/utils/context/_tests/conftest.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+
+from napari.components.layerlist import LayerList
+from napari.layers import Image, Points
+
+
+@pytest.fixture
+def layer_list():
+    return LayerList()
+
+
+@pytest.fixture
+def points_layer():
+    return Points()
+
+
+@pytest.fixture
+def image_layer():
+    data = np.ones((10, 10))
+    data[::2, ::2] = 0
+    return Image(data)

--- a/napari/utils/context/_tests/test_layerlist_context.py
+++ b/napari/utils/context/_tests/test_layerlist_context.py
@@ -4,16 +4,16 @@ from napari.utils.context import LayerListContextKeys
 
 
 def test_layerlist_context():
-    assert 'layers_selection_count' in LayerListContextKeys.__members__
+    assert 'num_selected_layers' in LayerListContextKeys.__members__
 
     ctx = {}
     llc = LayerListContextKeys(ctx)
-    assert llc.layers_selection_count == 0
-    assert ctx['layers_selection_count'] == 0
+    assert llc.num_selected_layers == 0
+    assert ctx['num_selected_layers'] == 0
 
     layers = LayerList()
 
     layers.selection.events.changed.connect(llc.update)
     layers.append(Points())
-    assert llc.layers_selection_count == 1
-    assert ctx['layers_selection_count'] == 1
+    assert llc.num_selected_layers == 1
+    assert ctx['num_selected_layers'] == 1

--- a/napari/utils/context/_tests/test_layerlist_context.py
+++ b/napari/utils/context/_tests/test_layerlist_context.py
@@ -1,19 +1,40 @@
-from napari.components.layerlist import LayerList
-from napari.layers import Points
 from napari.utils.context import LayerListContextKeys
 
 
-def test_layerlist_context():
+def test_layerlist_context(layer_list, points_layer):
     assert 'num_selected_layers' in LayerListContextKeys.__members__
 
     ctx = {}
-    llc = LayerListContextKeys(ctx)
-    assert llc.num_selected_layers == 0
+    LLCK = LayerListContextKeys(ctx)
+    assert LLCK.num_selected_layers == 0
     assert ctx['num_selected_layers'] == 0
 
-    layers = LayerList()
-
-    layers.selection.events.changed.connect(llc.update)
-    layers.append(Points())
-    assert llc.num_selected_layers == 1
+    layer_list.selection.events.changed.connect(LLCK.update)
+    layer_list.append(points_layer)
+    assert LLCK.num_selected_layers == 1
     assert ctx['num_selected_layers'] == 1
+
+
+def test_all_selected_layers_same_type(layer_list, points_layer, image_layer):
+    assert 'all_selected_layers_same_type' in LayerListContextKeys.__members__
+
+    ctx = {}
+    LLCK = LayerListContextKeys(ctx)
+    assert LLCK.all_selected_layers_same_type is False
+    assert ctx['all_selected_layers_same_type'] is False
+
+    layer_list.selection.events.changed.connect(LLCK.update)
+    layer_list.append(points_layer)
+    layer_list.append(points_layer)
+    layer_list.append(image_layer)
+
+    layer_list.selection = layer_list[:2]  # two points layers selected
+    assert LLCK.all_selected_layers_same_type is True
+    assert ctx['all_selected_layers_same_type'] is True
+
+    layer_list.selection = [
+        layer_list[0],
+        layer_list[2],
+    ]  # one points + one image
+    assert LLCK.all_selected_layers_same_type is False
+    assert ctx['all_selected_layers_same_type'] is False


### PR DESCRIPTION
# Description
This PR updates the context keys available on the `LayerList`, increasing the scope of what can be inferred from our `LayerList` context

- missing `only_<layer_class>_selected` context keys added
- `num_<layer_class>_selected` context keys added
- updated some keys to unify naming style

Internal usages of layer list context keys have been updated to reflect the new names. @tlambert03 assures me that these shouldn't be being used by others yet and changing the names to unify is okay at this stage.

@napari/core-devs could you take a look at these `ContextKey` names? Once these get out in the open any changes will be hard to revert 👀 

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# References
@tlambert03 + https://napari.org/guides/contexts_expressions.html

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
