### PR TITLE
Make sure reader dialog pops open if File -> Open Sample is compatible with multiple readers

### DIFF
--- a/napari/_qt/menus/_tests/test_file_menu.py
+++ b/napari/_qt/menus/_tests/test_file_menu.py
@@ -1,0 +1,33 @@
+from unittest import mock
+
+from npe2 import DynamicPlugin
+from npe2.manifest.contributions import SampleDataURI
+
+
+def test_sample_data_triggers_reader_dialog(
+    mock_npe2_pm, tmp_reader, make_napari_viewer
+):
+    """Sample data pops reader dialog if multiple compatible readers"""
+    # make two tmp readers that take tif files
+    tmp_reader(mock_npe2_pm, 'tif-reader', filename_patterns=['*.tif'])
+    tmp_reader(mock_npe2_pm, 'other-tif-reader', filename_patterns=['*.tif'])
+
+    # make a sample data reader for tif file
+    tmp_sample_plugin = DynamicPlugin('sample-plugin', mock_npe2_pm)
+    my_sample = SampleDataURI(
+        key='tmp-sample',
+        display_name='Temp Sample',
+        uri='some-path/some-file.tif',
+    )
+    tmp_sample_plugin.manifest.contributions.sample_data = [my_sample]
+    tmp_sample_plugin.register()
+
+    viewer = make_napari_viewer()
+    sample_action = viewer.window.file_menu.open_sample_menu.actions()[0]
+    with mock.patch(
+        'napari._qt.menus.file_menu.handle_gui_reading'
+    ) as mock_read:
+        sample_action.trigger()
+
+    # assert that handle gui reading was called
+    mock_read.assert_called_once()

--- a/napari/_qt/menus/file_menu.py
+++ b/napari/_qt/menus/file_menu.py
@@ -4,6 +4,9 @@ from typing import TYPE_CHECKING
 from qtpy.QtCore import QSize
 from qtpy.QtWidgets import QAction
 
+from napari._qt.dialogs.qt_reader_dialog import handle_gui_reading
+from napari.errors.reader_errors import MultipleReaderError
+
 from ...settings import get_settings
 from ...utils.history import get_save_history, update_save_history
 from ...utils.misc import running_as_bundled_app
@@ -187,7 +190,15 @@ class FileMenu(NapariMenu):
                     action = QAction(full_name, parent=self)
 
                 def _add_sample(*args, plg=plugin_name, smp=samp_name):
-                    self._win._qt_viewer.viewer.open_sample(plg, smp)
+                    try:
+                        self._win._qt_viewer.viewer.open_sample(plg, smp)
+                    except MultipleReaderError as e:
+                        handle_gui_reading(
+                            e.paths,
+                            self._win._qt_viewer,
+                            plugin_name=plugin_name,
+                            stack=False,
+                        )
 
                 menu.addAction(action)
                 action.triggered.connect(_add_sample)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -807,9 +807,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
         # try with npe2
         data, available = _npe2.get_sample_data(plugin, sample)
-        if hasattr(data.__self__, 'uri'):
-            data = data.__self__.uri
-        print(data)
 
         # then try with npe1
         if data is None:
@@ -817,6 +814,9 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
                 data = plugin_manager._sample_data[plugin][sample]['data']
             except KeyError:
                 available += list(plugin_manager.available_samples())
+        # npe2 uri sample data, extract the path so we can use viewer.open
+        elif hasattr(data.__self__, 'uri'):
+            data = data.__self__.uri
 
         if data is None:
             msg = trans._(

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -807,6 +807,9 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
         # try with npe2
         data, available = _npe2.get_sample_data(plugin, sample)
+        if hasattr(data.__self__, 'uri'):
+            data = data.__self__.uri
+        print(data)
 
         # then try with npe1
         if data is None:

--- a/napari/plugins/utils.py
+++ b/napari/plugins/utils.py
@@ -28,7 +28,6 @@ def get_potential_readers(filename: str) -> Dict[str, str]:
         dictionary of registered name to display_name
     """
     readers = _npe2.get_readers(filename)
-
     npe1_readers = {}
     for spec, hook_caller in plugin_manager.hooks.items():
         if spec == 'napari_get_reader':


### PR DESCRIPTION
# Description
This PR ensures that if a sample plugin provides data via URI *and* we are in the GUI *and* multiple plugins are available to read the file, the reader dialog pops up for user to select among them.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #4495

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added test for npe2 plugins
- [x] manually confirmed this addresses #4495

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
