### PR TITLE
Do not allow None when coercing encodings

### DIFF
--- a/napari/layers/utils/_color_encoding.py
+++ b/napari/layers/utils/_color_encoding.py
@@ -50,6 +50,65 @@ class ColorArray(np.ndarray):
 class ColorEncoding(StyleEncoding[ColorValue, ColorArray], Protocol):
     """Encodes colors from features."""
 
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(
+        cls, value: Union['ColorEncoding', dict, str, ColorType]
+    ) -> 'ColorEncoding':
+        """Validates and coerces a value to a ColorEncoding.
+
+        Parameters
+        ----------
+        value : ColorEncodingArgument
+            The value to validate and coerce.
+            If this is already a ColorEncoding, it is returned as is.
+            If this is a dict, then it should represent one of the built-in color encodings.
+            If this a string, then a DirectColorEncoding is returned.
+            If this a single color, a ConstantColorEncoding is returned.
+            If this is a sequence of colors, a ManualColorEncoding is returned.
+
+        Returns
+        -------
+        ColorEncoding
+
+        Raises
+        ------
+        TypeError
+            If the value is not a supported type.
+        ValidationError
+            If the value cannot be parsed into a ColorEncoding.
+        """
+        if isinstance(value, ColorEncoding):
+            return value
+        if isinstance(value, dict):
+            return parse_obj_as(
+                Union[
+                    ConstantColorEncoding,
+                    ManualColorEncoding,
+                    DirectColorEncoding,
+                    NominalColorEncoding,
+                    QuantitativeColorEncoding,
+                ],
+                value,
+            )
+        if isinstance(value, str):
+            return DirectColorEncoding(feature=value, fallback=DEFAULT_COLOR)
+        try:
+            color_array = ColorArray.validate_type(value)
+        except (ValueError, AttributeError, KeyError):
+            raise TypeError(
+                trans._(
+                    'value should be a ColorEncoding, a dict, a string, a color, a sequence of colors, or None',
+                    deferred=True,
+                )
+            )
+        if color_array.shape[0] == 1:
+            return ConstantColorEncoding(constant=value)
+        return ManualColorEncoding(array=color_array, default=DEFAULT_COLOR)
+
 
 """The default color to use, which may also be used a safe fallback color."""
 DEFAULT_COLOR = ColorValue.validate_type('cyan')
@@ -184,65 +243,6 @@ class QuantitativeColorEncoding(_DerivedStyleEncoding[ColorValue, ColorArray]):
                 'contrast_limits must be a strictly increasing pair of values'
             )
         return contrast_limits
-
-
-"""The types of arguments supported when setting a ColorEncoding field."""
-ColorEncodingArgument = Union[ColorEncoding, dict, str, ColorType, None]
-
-
-def validate_color_encoding(value: ColorEncodingArgument) -> ColorEncoding:
-    """Validates and coerces a value to a ColorEncoding.
-
-    Parameters
-    ----------
-    value : ColorEncodingArgument
-        The value to validate and coerce.
-        If this is already a ColorEncoding, it is returned as is.
-        If this is a dict, then it should represent one of the built-in color encodings.
-        If this a string, then a DirectColorEncoding is returned.
-        If this a single color, a ConstantColorEncoding is returned.
-        If this is a sequence of colors, a ManualColorEncoding is returned.
-
-    Returns
-    -------
-    ColorEncoding
-
-    Raises
-    ------
-    TypeError
-        If the value is not a supported type.
-    ValidationError
-        If the value cannot be parsed into a ColorEncoding.
-    """
-    if value is None:
-        return ConstantColorEncoding(constant=DEFAULT_COLOR)
-    if isinstance(value, ColorEncoding):
-        return value
-    if isinstance(value, dict):
-        return parse_obj_as(
-            Union[
-                ConstantColorEncoding,
-                ManualColorEncoding,
-                DirectColorEncoding,
-                NominalColorEncoding,
-                QuantitativeColorEncoding,
-            ],
-            value,
-        )
-    if isinstance(value, str):
-        return DirectColorEncoding(feature=value, fallback=DEFAULT_COLOR)
-    try:
-        color_array = ColorArray.validate_type(value)
-    except (ValueError, AttributeError, KeyError):
-        raise TypeError(
-            trans._(
-                'value should be a ColorEncoding, a dict, a string, a color, a sequence of colors, or None',
-                deferred=True,
-            )
-        )
-    if color_array.shape[0] == 1:
-        return ConstantColorEncoding(constant=value)
-    return ManualColorEncoding(array=color_array, default=DEFAULT_COLOR)
 
 
 def _calculate_contrast_limits(

--- a/napari/layers/utils/_tests/test_color_encoding.py
+++ b/napari/layers/utils/_tests/test_color_encoding.py
@@ -4,12 +4,12 @@ import pytest
 
 from napari.layers.utils._color_encoding import (
     ColorArray,
+    ColorEncoding,
     ConstantColorEncoding,
     DirectColorEncoding,
     ManualColorEncoding,
     NominalColorEncoding,
     QuantitativeColorEncoding,
-    validate_color_encoding,
 )
 
 
@@ -181,7 +181,7 @@ def test_validate_from_string():
     argument = 'class'
     expected = DirectColorEncoding(feature=argument)
 
-    actual = validate_color_encoding(argument)
+    actual = ColorEncoding.validate(argument)
 
     assert actual == expected
 
@@ -190,7 +190,7 @@ def test_validate_from_sequence():
     argument = ['red', 'green', 'cyan']
     expected = ManualColorEncoding(array=argument)
 
-    actual = validate_color_encoding(argument)
+    actual = ColorEncoding.validate(argument)
 
     assert actual == expected
 
@@ -200,7 +200,7 @@ def test_validate_from_constant_dict():
     argument = {'constant': constant}
     expected = ConstantColorEncoding(constant=constant)
 
-    actual = validate_color_encoding(argument)
+    actual = ColorEncoding.validate(argument)
 
     assert actual == expected
 
@@ -211,7 +211,7 @@ def test_validate_from_manual_dict():
     argument = {'array': array, 'default': default}
     expected = ManualColorEncoding(array=array, default=default)
 
-    actual = validate_color_encoding(argument)
+    actual = ColorEncoding.validate(argument)
 
     assert actual == expected
 
@@ -221,7 +221,7 @@ def test_validate_from_direct_dict():
     argument = {'feature': feature}
     expected = DirectColorEncoding(feature=feature)
 
-    actual = validate_color_encoding(argument)
+    actual = ColorEncoding.validate(argument)
 
     assert actual == expected
 
@@ -235,7 +235,7 @@ def test_validate_from_nominal_dict():
         colormap=colormap,
     )
 
-    actual = validate_color_encoding(argument)
+    actual = ColorEncoding.validate(argument)
 
     assert actual == expected
 
@@ -255,7 +255,7 @@ def test_validate_from_quantitative_dict(features):
         contrast_limits=contrast_limits,
     )
 
-    actual = validate_color_encoding(argument)
+    actual = ColorEncoding.validate(argument)
 
     assert actual == expected
 

--- a/napari/layers/utils/_tests/test_string_encoding.py
+++ b/napari/layers/utils/_tests/test_string_encoding.py
@@ -7,7 +7,7 @@ from napari.layers.utils.string_encoding import (
     DirectStringEncoding,
     FormatStringEncoding,
     ManualStringEncoding,
-    validate_string_encoding,
+    StringEncoding,
 )
 
 
@@ -137,7 +137,7 @@ def test_validate_from_format_string():
     argument = '{class}: {score:.2f}'
     expected = FormatStringEncoding(format=argument)
 
-    actual = validate_string_encoding(argument)
+    actual = StringEncoding.validate(argument)
 
     assert actual == expected
 
@@ -146,7 +146,7 @@ def test_validate_from_non_format_string():
     argument = 'abc'
     expected = DirectStringEncoding(feature=argument)
 
-    actual = validate_string_encoding(argument)
+    actual = StringEncoding.validate(argument)
 
     assert actual == expected
 
@@ -155,7 +155,7 @@ def test_validate_from_sequence():
     argument = ['a', 'b', 'c']
     expected = ManualStringEncoding(array=argument)
 
-    actual = validate_string_encoding(argument)
+    actual = StringEncoding.validate(argument)
 
     assert actual == expected
 
@@ -165,7 +165,7 @@ def test_validate_from_constant_dict():
     argument = {'constant': constant}
     expected = ConstantStringEncoding(constant=constant)
 
-    actual = validate_string_encoding(argument)
+    actual = StringEncoding.validate(argument)
 
     assert actual == expected
 
@@ -176,7 +176,7 @@ def test_validate_from_manual_dict():
     argument = {'array': array, 'default': default}
     expected = ManualStringEncoding(array=array, default=default)
 
-    actual = validate_string_encoding(argument)
+    actual = StringEncoding.validate(argument)
 
     assert actual == expected
 
@@ -186,7 +186,7 @@ def test_validate_from_direct_dict():
     argument = {'feature': feature}
     expected = DirectStringEncoding(feature=feature)
 
-    actual = validate_string_encoding(argument)
+    actual = StringEncoding.validate(argument)
 
     assert actual == expected
 
@@ -196,6 +196,6 @@ def test_validate_from_format_dict():
     argument = {'format': format}
     expected = FormatStringEncoding(format=format)
 
-    actual = validate_string_encoding(argument)
+    actual = StringEncoding.validate(argument)
 
     assert actual == expected

--- a/napari/layers/utils/_tests/test_text_manager.py
+++ b/napari/layers/utils/_tests/test_text_manager.py
@@ -298,6 +298,15 @@ def test_from_layer():
     assert not text_manager.visible
 
 
+def test_from_layer_with_no_text():
+    features = pd.DataFrame({})
+    text_manager = TextManager._from_layer(
+        text=None,
+        features=features,
+    )
+    assert text_manager.string == ConstantStringEncoding(constant='')
+
+
 def test_update_from_layer():
     text = {
         'string': 'class',
@@ -373,13 +382,6 @@ def test_update_from_layer_with_warning_only_one_emitted():
         )
 
     assert len(record) == 1
-
-
-def test_init_with_no_string():
-    text_manager = TextManager(string=None)
-
-    assert text_manager.string == ConstantStringEncoding(constant='')
-    np.testing.assert_array_equal(text_manager.values, '')
 
 
 def test_init_with_constant_string():

--- a/napari/layers/utils/text_manager.py
+++ b/napari/layers/utils/text_manager.py
@@ -18,8 +18,6 @@ from .string_encoding import (
     ConstantStringEncoding,
     StringArray,
     StringEncoding,
-    StringEncodingArgument,
-    validate_string_encoding,
 )
 from .style_encoding import _get_style_values
 
@@ -286,6 +284,8 @@ class TextManager(EventedModel):
             kwargs = text.dict()
         elif isinstance(text, dict):
             kwargs = deepcopy(text)
+        elif text is None:
+            kwargs = {'string': ConstantStringEncoding(constant='')}
         else:
             kwargs = {'string': text}
         kwargs['features'] = features
@@ -327,10 +327,6 @@ class TextManager(EventedModel):
         # Some of the encodings may have changed, so ensure they encode new
         # values if needed.
         self.apply(features)
-
-    @validator('string', pre=True, always=True)
-    def _check_string(cls, string: StringEncodingArgument):
-        return validate_string_encoding(string)
 
     @validator('color', pre=True, always=True)
     def _check_color(cls, color):


### PR DESCRIPTION
# Description

Currently, we allow `None` to be passed as a value assigned to string and color encodings, in which case it is parsed to a default value. Ideally, we want to attach encoding validation to the corresponding protocol, so that we can reduce validation boilerplate in models that have encodings. Unfortunately, Pydantic may also use `None` as a special sentinel value (see https://github.com/samuelcolvin/pydantic/issues/1624 for a similar bug), which prevents us from doing this.

There's no strong reason for us to support `None` as a value assigned to an encoding, so this PR removes that functionality. We still need to support `text` value of `None` passed from a `Layer`, but that can be done easily in `TextManager._from_layer`.

Note that this should ideally be included in v0.4.16 to prevent any usage of `string=None`. 

## Type of change

- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Related to #3992 

# How has this been tested?
- [ ] all existing tests pass with my change
- [ ] swapped a unit test to ensure `text=None` continues to work

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
