### PR TITLE
Background box under scale bar to improve legibility

### DIFF
--- a/napari/_vispy/overlays/scale_bar.py
+++ b/napari/_vispy/overlays/scale_bar.py
@@ -2,7 +2,7 @@
 import bisect
 
 import numpy as np
-from vispy.scene.visuals import Rectangle, Line, Text
+from vispy.scene.visuals import Line, Rectangle, Text
 from vispy.visuals.transforms import STTransform
 
 from ...components._viewer_constants import Position
@@ -50,8 +50,12 @@ class VispyScaleBarOverlay:
         self.text_node.text = f"{1}px"
 
         self.rect_node = Rectangle(
-            center=[0.5, 0.5], width=1.1, height=36,
-            color='#00000099', parent=self.line_node)
+            center=[0.5, 0.5],
+            width=1.1,
+            height=36,
+            color='#00000099',
+            parent=self.line_node,
+        )
         self.rect_node.order = order
         self.rect_node.transform = STTransform()
 
@@ -208,7 +212,9 @@ class VispyScaleBarOverlay:
 
     def _on_visible_change(self):
         """Change visibility of scale bar."""
-        self.rect_node.visible = self._viewer.scale_bar.visible and self._viewer.scale_bar.box
+        self.rect_node.visible = (
+            self._viewer.scale_bar.visible and self._viewer.scale_bar.box
+        )
         self.line_node.visible = self._viewer.scale_bar.visible
         self.text_node.visible = self._viewer.scale_bar.visible
 

--- a/napari/_vispy/overlays/scale_bar.py
+++ b/napari/_vispy/overlays/scale_bar.py
@@ -29,7 +29,7 @@ class VispyScaleBarOverlay:
             ]
         )
         self._default_color = np.array([1, 0, 1, 1])
-        self._default_box_color = np.array([0, 0, 0, .6])
+        self._default_box_color = np.array([0, 0, 0, 0.6])
         self._target_length = 150
         self._scale = 1
         self._quantity = None
@@ -55,7 +55,7 @@ class VispyScaleBarOverlay:
             width=1.1,
             height=36,
             color=self._default_box_color,
-            parent=self.line_node
+            parent=self.line_node,
         )
         self.rect_node.order = order
         self.rect_node.transform = STTransform()

--- a/napari/components/scale_bar.py
+++ b/napari/components/scale_bar.py
@@ -51,5 +51,7 @@ class ScaleBar(EventedModel):
     position: Position = Position.BOTTOM_RIGHT
     font_size: float = 10
     box: bool = False
-    box_color: Optional[Union[str, Array[float, (3,)], Array[float, (4,)]]] = None
+    box_color: Optional[
+        Union[str, Array[float, (3,)], Array[float, (4,)]]
+    ] = None
     unit: Optional[str] = None

--- a/napari/components/scale_bar.py
+++ b/napari/components/scale_bar.py
@@ -1,7 +1,8 @@
 """Scale bar model."""
-from typing import Optional
+from typing import Optional, Union
 
 from ..utils.events import EventedModel
+from ..utils.events.custom_types import Array
 from ._viewer_constants import Position
 
 
@@ -17,6 +18,10 @@ class ScaleBar(EventedModel):
         default color is magenta. If not colored than
         scale bar color is the opposite of the canvas
         background.
+    color : Optional[str | array-like]
+        Scalebar and text color. Can be any color name recognized by vispy or
+        hex value if starting with `#`. If array-like must be 1-dimensional
+        array with 3 or 4 elements.
     ticks : bool
         If scale bar has ticks at ends or not.
     position : str
@@ -30,6 +35,10 @@ class ScaleBar(EventedModel):
         The font size (in points) of the text.
     box : bool
         If background box is visible or not.
+    box_color : Optional[str | array-like]
+        Box color. Can be any color name recognized by vispy or
+        hex value if starting with `#`. If array-like must be 1-dimensional
+        array with 3 or 4 elements.
     unit : Optional[str]
         Unit to be used by the scale bar. The value can be set
         to `None` to display no units.
@@ -37,8 +46,10 @@ class ScaleBar(EventedModel):
 
     visible: bool = False
     colored: bool = False
+    color: Optional[Union[str, Array[float, (3,)], Array[float, (4,)]]] = None
     ticks: bool = True
     position: Position = Position.BOTTOM_RIGHT
     font_size: float = 10
     box: bool = False
+    box_color: Optional[Union[str, Array[float, (3,)], Array[float, (4,)]]] = None
     unit: Optional[str] = None

--- a/napari/components/scale_bar.py
+++ b/napari/components/scale_bar.py
@@ -28,6 +28,8 @@ class ScaleBar(EventedModel):
         then it has the color opposite of this color.
     font_size : float
         The font size (in points) of the text.
+    box : bool
+        If background box is visible or not.
     unit : Optional[str]
         Unit to be used by the scale bar. The value can be set
         to `None` to display no units.
@@ -38,4 +40,5 @@ class ScaleBar(EventedModel):
     ticks: bool = True
     position: Position = Position.BOTTOM_RIGHT
     font_size: float = 10
+    box: bool = False
     unit: Optional[str] = None


### PR DESCRIPTION
# Description
This is a small cosmetic adjustment in the scale_bar code to add the option of showing a rectangle behind the scale bar to make it clearly visible even when the image behind is of a similar color to the scalebar.

![Before](https://user-images.githubusercontent.com/7880555/167707809-dedbba48-ceb2-4cdf-a8f1-d260f2c2e061.png)
![After](https://user-images.githubusercontent.com/7880555/167707836-af63d0be-0257-44cf-920d-63b7b854c284.png)

This box is invisible by default, but can be toggled with `Viewer.scale_bar.box = True`. The color of the box is hard-coded to `#00000099` (semi-transparent black).

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
Not tested thoroughly

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works