### PR TITLE
Make sure we pass plugin through if opening file as stack

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -910,9 +910,18 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         paths = [path] if isinstance(path, (Path, str)) else path
 
         if stack:
-            layers = self._open_or_raise_error(
-                paths, kwargs, layer_type, stack
-            )
+            if plugin:
+                layers = self._add_layers_with_plugins(
+                    paths,
+                    kwargs=kwargs,
+                    plugin=plugin,
+                    layer_type=layer_type,
+                    stack=stack,
+                )
+            else:
+                layers = self._open_or_raise_error(
+                    paths, kwargs, layer_type, stack
+                )
             return layers
 
         added: List[Layer] = []  # for layers that get added

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -907,7 +907,11 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             A list of any layers that were added to the viewer.
         """
 
-        paths = [path] if isinstance(path, (Path, str)) else path
+        paths: List[str | Path] = (
+            [os.fspath(path)]
+            if isinstance(path, (Path, str))
+            else [os.fspath(p) for p in path]
+        )
 
         if stack:
             if plugin:
@@ -1125,6 +1129,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         assert stack is not None
         assert isinstance(paths, list)
         assert not isinstance(paths, str)
+        for p in paths:
+            assert isinstance(p, str)
 
         if stack:
             layer_data, hookimpl = read_data_with_plugins(


### PR DESCRIPTION
# Description
I missed this change in #4347 - when opening file as a stack we weren't checking whether the user had passed a plugin. This PR makes sure if the user has given us a plugin, we use that plugin to open files.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
