### PR TITLE
Try to upload pytest json report as artifact.

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -144,7 +144,7 @@ jobs:
         with:
           name: upload pytest timing reports as json
           path: |
-            ~/report-*.json
+            ./report-*.json
       # this steps display the cached folder size for debug and
       # remove the biggest contenders.
       - name: Display Cache size, and remove largest files from cache.

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -140,6 +140,11 @@ jobs:
           NUMPY_EXPERIMENTAL_ARRAY_FUNCTION: ${{ matrix.MIN_REQ || 1 }}
           PYVISTA_OFF_SCREEN: True
           MIN_REQ: ${{ matrix.MIN_REQ }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: upload pytest timing reports as json
+          path: |
+            ~/report-*.json
       # this steps display the cached folder size for debug and
       # remove the biggest contenders.
       - name: Display Cache size, and remove largest files from cache.

--- a/tox.ini
+++ b/tox.ini
@@ -81,10 +81,10 @@ commands_pre =
     # the rest is for good measure
     headless: pip uninstall -y pytest-qt qtpy pyqt5 pyside2
 commands =
-    !headless: python -m pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir} --cov-report=xml --cov={env:PYTEST_PATH:napari} --ignore tools  --json-report --json-report-file={env:HOME}/report-{envname}.json {posargs}  --maxfail=2
+    !headless: python -m pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir} --cov-report=xml --cov={env:PYTEST_PATH:napari} --ignore tools  --json-report --json-report-file={toxinidir}/report-{envname}.json {posargs}  --maxfail=2
     # do not add ignores to this line just to make headless tests pass.
     # nothing outside of _qt or _vispy should require Qt or make_napari_viewer
-    headless: python -m pytest --color=yes --basetemp={envtmpdir} --ignore napari/_vispy --ignore napari/_qt --ignore napari/_tests --ignore tools  --json-report --json-report-file={env:HOME}/report-{envname}.json  {posargs}
+    headless: python -m pytest --color=yes --basetemp={envtmpdir} --ignore napari/_vispy --ignore napari/_qt --ignore napari/_tests --ignore tools  --json-report --json-report-file={toxinidir}/report-{envname}.json  {posargs}
 
 
 [testenv:isort]

--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,7 @@ setenv =
     async: PYTEST_PATH = napari
 deps =
     pytest-cov
+    pytest-json-report
 # use extras specified in setup.cfg for certain test envs
 extras =
     testing
@@ -80,10 +81,10 @@ commands_pre =
     # the rest is for good measure
     headless: pip uninstall -y pytest-qt qtpy pyqt5 pyside2
 commands =
-    !headless: python -m pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir} --cov-report=xml --cov={env:PYTEST_PATH:napari} --ignore tools {posargs}  --maxfail=2
+    !headless: python -m pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir} --cov-report=xml --cov={env:PYTEST_PATH:napari} --ignore tools  --json-report --json-report-file={env:HOME}/report-{envname}.json {posargs}  --maxfail=2
     # do not add ignores to this line just to make headless tests pass.
     # nothing outside of _qt or _vispy should require Qt or make_napari_viewer
-    headless: python -m pytest --color=yes --basetemp={envtmpdir} --ignore napari/_vispy --ignore napari/_qt --ignore napari/_tests --ignore tools {posargs}
+    headless: python -m pytest --color=yes --basetemp={envtmpdir} --ignore napari/_vispy --ignore napari/_qt --ignore napari/_tests --ignore tools  --json-report --json-report-file={env:HOME}/report-{envname}.json  {posargs}
 
 
 [testenv:isort]


### PR DESCRIPTION
Mostly I want to investigate why tests are taking forever on CI,
like up to 45 minutes. It's hard with just printing the slowest 10
durations, as this may be dues to some test having for example many
parameters.

With this I should be able to download the artifact and analyse them.
