### PR TITLE
[conda] rework how plugin install/remove subprocesses receive the parent environment

### DIFF
--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -99,7 +99,10 @@ class Installer(QObject):
             process.setProgram(self._sys_executable_or_bundled_python())
             # patch process path
             combined_paths = os.pathsep.join(
-                [user_site_packages(), env.systemEnvironment().value("PYTHONPATH")]
+                [
+                    user_site_packages(),
+                    env.systemEnvironment().value("PYTHONPATH"),
+                ]
             )
             env.insert("PYTHONPATH", combined_paths)
         else:
@@ -107,6 +110,7 @@ class Installer(QObject):
 
         if installer == "mamba":
             from ..._version import version_tuple
+
             # To avoid napari version changing when installing a plugin, we
             # add a pin to the current napari version, that way we can
             # restrict any changes to the actual napari application.
@@ -121,7 +125,8 @@ class Installer(QObject):
             else:
                 system_pins = ""
             env.insert(
-                "CONDA_PINNED_PACKAGES", f"napari={napari_version}{system_pins}"
+                "CONDA_PINNED_PACKAGES",
+                f"napari={napari_version}{system_pins}",
             )
             if os.name == "nt":
                 # workaround https://github.com/napari/napari/issues/4247, 4484

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -219,6 +219,7 @@ class Installer(QObject):
                 '-y',
                 '--prefix',
                 self._conda_env_path,
+                '--no-shortcuts',
             ]
             for channel in channels:
                 cmd.extend(["-c", channel])
@@ -274,6 +275,7 @@ class Installer(QObject):
                 '-y',
                 '--prefix',
                 self._conda_env_path,
+                '--no-shortcuts',
             ]
 
             for channel in channels:

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -89,36 +89,49 @@ class Installer(QObject):
         installer: InstallerTypes = "pip",
     ):
         process = QProcess()
-        if installer != "pip":
-            process.setProgram(installer)
-        else:
-            process.setProgram(self._sys_executable_or_bundled_python())
-
         process.setProcessChannelMode(QProcess.MergedChannels)
         process.readyReadStandardOutput.connect(
             lambda process=process: self._on_stdout_ready(process)
         )
+        env = QProcessEnvironment.systemEnvironment()
 
-        # setup process path
-        env = QProcessEnvironment()
-        combined_paths = os.pathsep.join(
-            [user_site_packages(), env.systemEnvironment().value("PYTHONPATH")]
-        )
-        env.insert("PYTHONPATH", combined_paths)
-        # use path of parent process
-        env.insert(
-            "PATH", QProcessEnvironment.systemEnvironment().value("PATH")
-        )
+        if installer == "pip":
+            process.setProgram(self._sys_executable_or_bundled_python())
+            # patch process path
+            combined_paths = os.pathsep.join(
+                [user_site_packages(), env.systemEnvironment().value("PYTHONPATH")]
+            )
+            env.insert("PYTHONPATH", combined_paths)
+        else:
+            process.setProgram(installer)
 
-        # workaround https://github.com/napari/napari/issues/4247
-        if (
-            installer == "mamba"
-            and os.name == "nt"
-            and not QProcessEnvironment.systemEnvironment().contains("TEMP")
-        ):
-            temp = gettempdir()
-            env.insert("TMP", temp)
-            env.insert("TEMP", temp)
+        if installer == "mamba":
+            from ..._version import version_tuple
+            # To avoid napari version changing when installing a plugin, we
+            # add a pin to the current napari version, that way we can
+            # restrict any changes to the actual napari application.
+            # Conda/mamba also pin python by default, so we effectively
+            # constrain python and napari versions from changing, when
+            # installing plugins inside the constructor bundled application.
+            # See: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-pkgs.html#preventing-packages-from-updating-pinning
+            napari_version = ".".join(str(v) for v in version_tuple[:3])
+            if env.contains("CONDA_PINNED_PACKAGES"):
+                # str delimiter is '&'
+                system_pins = f"&{env.value('CONDA_PINNED_PACKAGES')}"
+            else:
+                system_pins = ""
+            env.insert(
+                "CONDA_PINNED_PACKAGES", f"napari={napari_version}{system_pins}"
+            )
+            if os.name == "nt":
+                # workaround https://github.com/napari/napari/issues/4247, 4484
+                if not env.contains("TEMP"):
+                    temp = gettempdir()
+                    env.insert("TMP", temp)
+                    env.insert("TEMP", temp)
+                if not env.contains("USERPROFILE"):
+                    env.insert("HOME", os.path.expanduser("~"))
+                    env.insert("USERPROFILE", os.path.expanduser("~"))
 
         process.setProcessEnvironment(env)
         self.set_output_widget(self._output_widget)
@@ -199,27 +212,13 @@ class Installer(QObject):
         channels: Sequence[str] = ("conda-forge",),
     ):
         installer = installer or self._installer_type
-        process_environment = QProcessEnvironment.systemEnvironment()
+        process = self._create_process(installer)
         if installer != "pip":
-            from ..._version import version_tuple
-
-            # To avoid napari version changing when installing a plugin, we
-            # add a pin to the current napari version, that way we can
-            # restrict any changes to the actual napari application.
-            # Conda/mamba also pin python by default, so we effectively
-            # constrain python and napari versions from changing, when
-            # installing plugins inside the constructor bundled application.
-            # See: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-pkgs.html#preventing-packages-from-updating-pinning
-            napari_version = ".".join(str(v) for v in version_tuple[:3])
-            process_environment.insert(
-                "CONDA_PINNED_PACKAGES", f"napari={napari_version}"
-            )
             cmd = [
                 'install',
                 '-y',
                 '--prefix',
                 self._conda_env_path,
-                '--no-shortcuts',
             ]
             for channel in channels:
                 cmd.extend(["-c", channel])
@@ -237,8 +236,6 @@ class Installer(QObject):
                 user_plugin_dir(),
             ]
 
-        process = self._create_process(installer)
-        process.setProcessEnvironment(process_environment)
         process.setArguments(cmd + list(pkg_list))
         if self._output_widget and self._queue:
             self._output_widget.clear()
@@ -275,7 +272,6 @@ class Installer(QObject):
                 '-y',
                 '--prefix',
                 self._conda_env_path,
-                '--no-shortcuts',
             ]
 
             for channel in channels:


### PR DESCRIPTION
# Description

Some Windows installations (cough cough, AWS Workspace) have unusual settings for the user directories, which results in `mamba` running into issues with `pywin32` when a plugin is installed on this platform from the bundled napari.

We thought #4462 would be enough to fix it, but #4427 has re-emerged as #4484. Let's see if adding this flag helps.

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

Closes #4484

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] The bug cannot be reproduced on Windows anymore

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
