### PR TITLE
change default blending mode on image layer to translucent no depth

### DIFF
--- a/napari/components/_tests/test_multichannel.py
+++ b/napari/components/_tests/test_multichannel.py
@@ -120,7 +120,7 @@ def test_multichannel(shape, kwargs):
                 assert viewer.layers[i].colormap.name == base_colormaps[i]
         if 'blending' not in kwargs:
             assert (
-                viewer.layers[i].blending == 'translucent'
+                viewer.layers[i].blending == 'translucent_no_depth'
                 if i == 0
                 else 'additive'
             )

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -551,7 +551,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         shear=None,
         affine=None,
         opacity=1,
-        blending=None,
+        blending='translucent_no_depth',
         visible=True,
         multiscale=None,
         cache=True,
@@ -740,7 +740,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
         if channel_axis is None:
             kwargs['colormap'] = kwargs['colormap'] or 'gray'
-            kwargs['blending'] = kwargs['blending'] or 'translucent'
+            kwargs['blending'] = kwargs['blending'] or 'translucent_no_depth'
             # Helpful message if someone tries to add mulit-channel kwargs,
             # but forget the channel_axis arg
             for k, v in kwargs.items():

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -297,7 +297,7 @@ def test_blending():
     np.random.seed(0)
     data = np.random.random((10, 15))
     layer = Image(data)
-    assert layer.blending == 'translucent'
+    assert layer.blending == 'translucent_no_depth'
 
     layer.blending = 'additive'
     assert layer.blending == 'additive'

--- a/napari/layers/image/_tests/test_multiscale.py
+++ b/napari/layers/image/_tests/test_multiscale.py
@@ -205,7 +205,7 @@ def test_blending():
     np.random.seed(0)
     data = [np.random.random(s) for s in shapes]
     layer = Image(data, multiscale=True)
-    assert layer.blending == 'translucent'
+    assert layer.blending == 'translucent_no_depth'
 
     layer.blending = 'additive'
     assert layer.blending == 'additive'

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -229,7 +229,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         shear=None,
         affine=None,
         opacity=1,
-        blending='translucent',
+        blending='translucent_no_depth',
         visible=True,
         multiscale=None,
         cache=True,


### PR DESCRIPTION
# Description
The addition of explicit depth checking in the image visual in vispy (vispy/vispy#2305) means that points on top of volume layers in 3D are sometimes partially hidden behind low intensity voxels near the front face. This happens along rays cast which contain only low intensity voxels.

This PR changes the default blending mode to 'translucent no depth' so that the visual appears as it always has in napari whilst we work on discarding low intensity fragments :)

cc @jni this is what broke your example

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
