### PR TITLE
Add CZI as an Institutional and Funding Partner

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,7 @@ We're a community partner on the [image.sc forum](https://forum.image.sc/tags/na
 
 Bug reports should be made on our [github issues](https://github.com/napari/napari/issues/new?template=bug_report.md) using
 the bug report template. If you think something isn't working, don't hesitate to reach out - it is probably us and not you!
+
+## insitutional and funding partners
+
+![CZI logo](https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg)

--- a/docs/community/team.md
+++ b/docs/community/team.md
@@ -39,16 +39,17 @@ Over time, napari has grown to over 80 direct contributors. Talley Lambert, from
 
 Read more about napari’s [mission and values](https://napari.org/community/mission_and_values.html), how to get started as a [contributor](https://napari.org/developers/contributing.html) or join us in our [zulip chat](https://napari.zulipchat.com/login/) for a more synchronous conversation. You can also follow us on [twitter](https://twitter.com/napari_imaging).
 
-## Funding and support
+## Institutional and funding Partners
 
-The napari project and community have been generously supported by the [CZI Science Imaging Program.](https://chanzuckerberg.com/science/programs-resources/imaging/)
+- [Chan Zuckberg Initiative Foundation.](https://chanzuckerberg.com/science) Representative [Nicholas Sofroniew](https://github.com/sofroniewn).
 
-![](https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg)
+    - The napari project and community have been generously supported by the [CZI Science Imaging Program.](https://chanzuckerberg.com/science/programs-resources/imaging/)
+    - Since late 2018, Juan Nunez-Iglesias has been supported by a CZI Imaging Software Fellowship.
+    - The CZI Imaging Technology Team, under the leadership of Nicholas Sofroniew and engineering management of Justine Larsen, has been making direct engineering and design contributions to improve and expand napari.
+    - The CZI Imaging Tech Team has supported [Quansight Labs](https://www.quansight.com/labs) and independent contractors to improve and expand napari.
+    - The CZI Imaging Tech Team, through an effort led by Justin Kiggins, has created [napari-hub.org](https://www.napari-hub.org/), a site to make discovering and sharing napari plugins easier.
+    - CZI has launched a [grant program](https://chanzuckerberg.com/rfa/napari-plugin-accelerator-grants/) to help accelerate the napari plugin developer community.
 
-- Since late 2018, Juan Nunez-Iglesias has been supported by a CZI Imaging Software Fellowship.
-- The CZI Imaging Technology Team, under the leadership of Nicholas Sofroniew and engineering management of Justine Larsen, has been making direct engineering and design contributions to improve and expand napari.
-- The CZI Imaging Tech Team has supported [Quansight Labs](https://www.quansight.com/labs) and independent contractors to improve and expand napari.
-- The CZI Imaging Tech Team, through an effort led by Justin Kiggins, has created [napari-hub.org](https://www.napari-hub.org/), a site to make discovering and sharing napari plugins easier.
-- CZI has launched a [grant program](https://chanzuckerberg.com/rfa/napari-plugin-accelerator-grants/) to help accelerate the napari plugin developer community.
+The current representative of the Insitutional and Funding Partner Advisory Council on the napari steering council is Nicholas Sofroniew.
 
-If you or your organization are interested in also supporting the napari project, please email the napari steering council at `napari-steering-council@googlegroups.com`.
+If you or your organization are interested in also supporting the napari project and becoming an Institutional and Funding Partner, please email the napari steering council at `napari-steering-council@googlegroups.com`.

--- a/docs/community/team.md
+++ b/docs/community/team.md
@@ -45,7 +45,7 @@ Read more about napari’s [mission and values](https://napari.org/community/mis
 
     - The napari project and community have been generously supported by the [CZI Science Imaging Program.](https://chanzuckerberg.com/science/programs-resources/imaging/)
     - Since late 2018, Juan Nunez-Iglesias has been supported by a CZI Imaging Software Fellowship.
-    - The CZI Imaging Technology Team, under the leadership of Nicholas Sofroniew and engineering management of Justine Larsen, has been making direct engineering and design contributions to improve and expand napari.
+    - The CZI Imaging Tech Team, under the leadership of Nicholas Sofroniew and engineering management of Justine Larsen, has been making direct engineering and design contributions to improve and expand napari.
     - The CZI Imaging Tech Team has supported [Quansight Labs](https://www.quansight.com/labs) and independent contractors to improve and expand napari.
     - The CZI Imaging Tech Team, through an effort led by Justin Kiggins, has created [napari-hub.org](https://www.napari-hub.org/), a site to make discovering and sharing napari plugins easier.
     - CZI has launched a [grant program](https://chanzuckerberg.com/rfa/napari-plugin-accelerator-grants/) to help accelerate the napari plugin developer community.


### PR DESCRIPTION
# Description
Following NAP-1 added in #4458 and discussion of the @napari/steering-council we will be adding CZI as napari's first institutional and funding partner - and with agreement of the necessary CZI leadership I @sofroniewn will be it's IFP representative - cc @neuromusic @justinelarsen 

We will transition my seat on the napari steering council to be the first IFP seat, I will become the first holder of the IFP seat and first member of the IFP advisory council.

In the immediate sense this means nothing is changing, but in the longer term it might lead to the following changes. For example if the CZI Leadership were to feel I was no longer representing CZI's interests or if I were to leave CZI then CZI could replace me on the IFP Advisory Council with a new representative - triggering a process of redetermining the holder of the IFP seat on the SC. If the napari SC is still only three people, then at this point, the napari SC could nominate me to hold a seat on the SC again if the project felt it was in its best interests - but that would be their choice. I would retain my core developer status if I was still active in the project.

As the first member of the IFP AC I promise to work in good faith with subsequent members of the IFP AC to determine the process for selecting the IFP AC representative on the SC. I think we can wait until new IFPs are seeking to join napari before determining any rules, but I imagine that some form of vote weighting proportional to the level of investment of the IFP would be appropriate.

Please let me know any concerns or feedback - thanks!!