### PR TITLE
[conda] revert default installation path

### DIFF
--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -389,9 +389,9 @@ jobs:
       - name: Test installation (Linux)
         if: runner.os == 'Linux'
         run: |
-          bash napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }} -bfp "${{ runner.temp }}/napari-app-${{ env.installer_version }}"
-          . "${{ runner.temp }}/napari-app-${{ env.installer_version }}/etc/profile.d/conda.sh"
-          conda activate "${{ runner.temp }}/napari-app-${{ env.installer_version }}/envs/napari-${{ env.version }}"
+          bash napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }} -bfp "${{ runner.temp }}/napari-${{ env.version }}"
+          . "${{ runner.temp }}/napari-${{ env.version }}/etc/profile.d/conda.sh"
+          conda activate "${{ runner.temp }}/napari-${{ env.version }}/envs/napari-${{ env.version }}"
           conda config --show-sources
           conda config --show
           xvfb-run --auto-servernum napari --info
@@ -401,8 +401,8 @@ jobs:
         run: |
           set -x
           installer -pkg napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }} -target CurrentUserHomeDirectory -dumplog
-          . "/Users/runner/Library/napari-app-${{ env.installer_version }}/etc/profile.d/conda.sh"
-          conda activate "/Users/runner/Library/napari-app-${{ env.installer_version }}/envs/napari-${{ env.version }}"
+          . "/Users/runner/Library/napari-${{ env.version }}/etc/profile.d/conda.sh"
+          conda activate "/Users/runner/Library/napari-${{ env.version }}/envs/napari-${{ env.version }}"
           conda config --show-sources
           conda config --show
           napari --info
@@ -411,8 +411,8 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd /C call {0}
         run: |
-          cmd.exe /c start /wait napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }} /S /D=${{ runner.temp }}\napari-app-${{ env.installer_version }}
-          CALL ${{ runner.temp }}\napari-app-${{ env.installer_version }}\Scripts\activate ${{ runner.temp }}\napari-app-${{ env.installer_version }}\envs\napari-${{ env.version }}
+          cmd.exe /c start /wait napari-${{ env.version }}-${{ runner.os }}-${{ env.arch-suffix }}.${{ env.extension }} /S /D=${{ runner.temp }}\napari-${{ env.version }}
+          CALL ${{ runner.temp }}\napari-${{ env.version }}\Scripts\activate ${{ runner.temp }}\napari-${{ env.version }}\envs\napari-${{ env.version }}
           CALL conda config --show-sources
           CALL conda config --show
           napari --info

--- a/bundle_conda.py
+++ b/bundle_conda.py
@@ -13,10 +13,11 @@ CONSTRUCTOR_APP_NAME:
     named `napari`
 CONSTRUCTOR_INSTALLER_DEFAULT_PATH_STEM:
     The last component of the default installation path. Defaults to
-    {CONSTRUCTOR_APP_NAME}-app-{CONSTRUCTOR_INSTALLER_VERSION}
+    {CONSTRUCTOR_APP_NAME}-{_version()}
 CONSTRUCTOR_INSTALLER_VERSION:
     Version for the installer, separate from the app being installed.
-    This has an effect on the default install locations!
+    This will have an effect on the default install locations in future
+    releases.
 CONSTRUCTOR_TARGET_PLATFORM:
     conda-style platform (as in `platform` in `conda info -a` output)
 CONSTRUCTOR_USE_LOCAL:

--- a/bundle_conda.py
+++ b/bundle_conda.py
@@ -57,9 +57,6 @@ APP = os.environ.get("CONSTRUCTOR_APP_NAME", "napari")
 # bump this when something in the installer infrastructure changes
 # note that this will affect the default installation path across platforms!
 INSTALLER_VERSION = os.environ.get("CONSTRUCTOR_INSTALLER_VERSION", "0.1")
-INSTALLER_DEFAULT_PATH_STEM = os.environ.get(
-    "CONSTRUCTOR_INSTALLER_DEFAULT_PATH_STEM", f"{APP}-app-{INSTALLER_VERSION}"
-)
 HERE = os.path.abspath(os.path.dirname(__file__))
 WINDOWS = os.name == 'nt'
 MACOS = sys.platform == 'darwin'
@@ -86,6 +83,9 @@ def _version():
 
 
 OUTPUT_FILENAME = f"{APP}-{_version()}-{OS}-{ARCH}.{EXT}"
+INSTALLER_DEFAULT_PATH_STEM = os.environ.get(
+    "CONSTRUCTOR_INSTALLER_DEFAULT_PATH_STEM", f"{APP}-{_version()}"
+)
 clean_these_files = []
 
 


### PR DESCRIPTION
# Description

PR #4444 changed the default installation path for the conda installers in preparation of in-app updates suggested in #4422. Since it looks that it won't be merged for this release, we need to rollback those changes so the default path still uses the napari version.

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] CI installation works and uses the "old path"

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
