### PR TITLE
Accessor refactor

### DIFF
--- a/napari/utils/_injection.py
+++ b/napari/utils/_injection.py
@@ -66,7 +66,7 @@ class set_accessor:
         a map of type -> accessor function, where each value is a function
         that is capable of retrieving an instance of the associated key/type.
     clobber : bool, optional
-        Whether to override any existing accessor function, by default True.
+        Whether to override any existing accessor function, by default False.
 
     Raises
     ------
@@ -76,11 +76,11 @@ class set_accessor:
     """
 
     def __init__(
-        self, mapping: Dict[Type[T], Callable[..., Optional[T]]], clobber=True
+        self, mapping: Dict[Type[T], Callable[..., Optional[T]]], clobber=False
     ):
         self._before = {}
-        for k, v in mapping.items():
-            if k in _ACCESSORS and clobber is False:
+        for k in mapping:
+            if k in _ACCESSORS and not clobber:
                 raise ValueError(
                     f"Class {k} already has an accessor and clobber is False"
                 )
@@ -99,6 +99,7 @@ class set_accessor:
 
 
 def napari_type_hints(obj: Any) -> Dict[str, Any]:
+    """variant of get_type_hints with napari namespace awareness."""
     import napari
 
     return get_type_hints(

--- a/napari/utils/_injection.py
+++ b/napari/utils/_injection.py
@@ -21,7 +21,7 @@ def _get_active_layer_list() -> Optional[components.LayerList]:
 
 # registry of Type -> "accessor function"
 # where each value is a function that is capable
-# of retrieving an instance of it's corresponding key type.
+# of retrieving an instance of its corresponding key type.
 _ACCESSORS: Dict[Type, Callable[..., Optional[object]]] = {
     layers.Layer: _get_active_layer,
     viewer.Viewer: current_viewer,

--- a/napari/utils/_injection.py
+++ b/napari/utils/_injection.py
@@ -5,30 +5,31 @@ from typing import Any, Callable, Dict, Optional, Type, TypeVar
 from typing_extensions import get_type_hints
 
 from .. import components, layers, viewer
+from ..viewer import current_viewer
 
 T = TypeVar("T")
+_NULL = object()
 
 
 def _get_active_layer() -> Optional[layers.Layer]:
-    if cur_viewer := viewer.current_viewer():
-        return cur_viewer.layers.selection.active
-    return None
+    return v.layers.selection.active if (v := current_viewer()) else None
 
 
 def _get_active_layer_list() -> Optional[components.LayerList]:
-    if cur_viewer := viewer.current_viewer():
-        return cur_viewer.layers
-    return None
+    return v.layers if (v := current_viewer()) else None
 
 
-_ACCESSORS: Dict[Type, Callable[[], Optional[object]]] = {
+# registry of Type -> "accessor function"
+# where each value is a function that is capable
+# of retrieving an instance of it's corresponding key type.
+_ACCESSORS: Dict[Type, Callable[..., Optional[object]]] = {
     layers.Layer: _get_active_layer,
-    viewer.Viewer: viewer.current_viewer,
+    viewer.Viewer: current_viewer,
     components.LayerList: _get_active_layer_list,
 }
 
 
-def get_accessor(type_: Type[T]) -> Optional[Callable[[], Optional[T]]]:
+def get_accessor(type_: Type[T]) -> Optional[Callable[..., Optional[T]]]:
     """Return object accessor function given a type.
 
     An object accessor is a function that returns an instance of a
@@ -39,11 +40,62 @@ def get_accessor(type_: Type[T]) -> Optional[Callable[[], Optional[T]]]:
     `inject_napari_dependencies`, allows us to inject current napari objects
     into functions based on type hints.
     """
+    if type_ in _ACCESSORS:
+        return _ACCESSORS[type_]
+
     if isinstance(type_, type):
         for key, val in _ACCESSORS.items():
             if issubclass(type, key):
                 return val  # type: ignore [return-type]
     return None
+
+
+class set_accessor:
+    """Set accessor(s) for given type(s).
+
+    "Acessors" are functions that can retrieve an instance of a given type.
+    For instance, `napari.viewer.current_viewer` is a function that can
+    retrieve an instance of `napari.Viewer`.
+
+    This is a class that behaves as a function or a context manager, that
+    allows one to set an accessor function for a given type.
+
+    Parameters
+    ----------
+    mapping : Dict[Type[T], Callable[..., Optional[T]]]
+        a map of type -> accessor function, where each value is a function
+        that is capable of retrieving an instance of the associated key/type.
+    clobber : bool, optional
+        Whether to override any existing accessor function, by default True.
+
+    Raises
+    ------
+    ValueError
+        if clobber is `True` and one of the keys in `mapping` is already
+        registered.
+    """
+
+    def __init__(
+        self, mapping: Dict[Type[T], Callable[..., Optional[T]]], clobber=True
+    ):
+        self._before = {}
+        for k, v in mapping.items():
+            if k in _ACCESSORS and clobber is False:
+                raise ValueError(
+                    f"Class {k} already has an accessor and clobber is False"
+                )
+            self._before[k] = _ACCESSORS.get(k, _NULL)
+        _ACCESSORS.update(mapping)
+
+    def __enter__(self):
+        return None
+
+    def __exit__(self, *_):
+        for key, val in self._before.items():
+            if val is _NULL:
+                del _ACCESSORS[key]
+            else:
+                _ACCESSORS[key] = val
 
 
 def napari_type_hints(obj: Any) -> Dict[str, Any]:
@@ -97,18 +149,16 @@ def inject_napari_dependencies(func: Callable) -> Callable:
     # get type hints for the object, with forward refs of napari hints resolved
     hints = napari_type_hints(func)
     # get accessor functions for each required parameter
-    accessors = {}
+    required = {}
     for name, hint in hints.items():
         if sig.parameters[name].default is sig.empty:
-            accessor = get_accessor(hint)
-            if accessor:
-                accessors[name] = accessor
+            required[name] = hint
 
     @wraps(func)
     def _exec(*args, **kwargs):
         # when we call the function, we call the accessor functions to get
         # the current napari objects
-        _kwargs = {k: accessor() for k, accessor in accessors.items()}
+        _kwargs = {n: get_accessor(hint)() for n, hint in required.items()}
         # but we use bind_partial to allow the caller to still provide
         # their own objects if desired.
         # (i.e. the injected deps are only used if needed)
@@ -129,7 +179,7 @@ def inject_napari_dependencies(func: Callable) -> Callable:
     # update the signature
     p = [
         p.replace(default=None, annotation=Optional[hints[p.name]])
-        if p.name in accessors and p.default is p.empty
+        if p.name in required
         else p
         for p in sig.parameters.values()
     ]

--- a/napari/utils/_injection.py
+++ b/napari/utils/_injection.py
@@ -45,7 +45,7 @@ def get_accessor(type_: Type[T]) -> Optional[Callable[..., Optional[T]]]:
 
     if isinstance(type_, type):
         for key, val in _ACCESSORS.items():
-            if issubclass(type, key):
+            if issubclass(type_, key):
                 return val  # type: ignore [return-type]
     return None
 

--- a/napari/utils/_injection.py
+++ b/napari/utils/_injection.py
@@ -71,7 +71,7 @@ class set_accessor:
     Raises
     ------
     ValueError
-        if clobber is `True` and one of the keys in `mapping` is already
+        if clobber is `False` and one of the keys in `mapping` is already
         registered.
     """
 

--- a/napari/utils/_injection.py
+++ b/napari/utils/_injection.py
@@ -158,7 +158,11 @@ def inject_napari_dependencies(func: Callable) -> Callable:
     def _exec(*args, **kwargs):
         # when we call the function, we call the accessor functions to get
         # the current napari objects
-        _kwargs = {n: get_accessor(hint)() for n, hint in required.items()}
+        _kwargs = {}
+        for n, hint in required.items():
+            if accessor := get_accessor(hint):
+                _kwargs[n] = accessor()
+
         # but we use bind_partial to allow the caller to still provide
         # their own objects if desired.
         # (i.e. the injected deps are only used if needed)

--- a/napari/utils/_injection.py
+++ b/napari/utils/_injection.py
@@ -53,7 +53,7 @@ def get_accessor(type_: Type[T]) -> Optional[Callable[..., Optional[T]]]:
 class set_accessor:
     """Set accessor(s) for given type(s).
 
-    "Acessors" are functions that can retrieve an instance of a given type.
+    "Accessors" are functions that can retrieve an instance of a given type.
     For instance, `napari.viewer.current_viewer` is a function that can
     retrieve an instance of `napari.Viewer`.
 

--- a/napari/utils/_tests/test_injection.py
+++ b/napari/utils/_tests/test_injection.py
@@ -8,5 +8,10 @@ def test_napari_injection():
         return ll
 
     some_layers = LayerList()
+
+    assert f() is None
+
     with set_accessor({LayerList: lambda: some_layers}):
         assert f() is some_layers
+
+    assert f() is None

--- a/napari/utils/_tests/test_injection.py
+++ b/napari/utils/_tests/test_injection.py
@@ -13,7 +13,7 @@ def test_napari_injection():
 
     assert f() is None
 
-    with set_accessor({LayerList: lambda: some_layers}):
+    with set_accessor({LayerList: lambda: some_layers}, clobber=True):
         assert f() is some_layers
 
     assert f() is None

--- a/napari/utils/_tests/test_injection.py
+++ b/napari/utils/_tests/test_injection.py
@@ -1,0 +1,12 @@
+from napari.components import LayerList
+from napari.utils._injection import inject_napari_dependencies, set_accessor
+
+
+def test_napari_injection():
+    @inject_napari_dependencies
+    def f(ll: LayerList):
+        return ll
+
+    some_layers = LayerList()
+    with set_accessor({LayerList: lambda: some_layers}):
+        assert f() is some_layers

--- a/napari/utils/_tests/test_injection.py
+++ b/napari/utils/_tests/test_injection.py
@@ -1,3 +1,5 @@
+import pytest
+
 from napari.components import LayerList
 from napari.utils._injection import inject_napari_dependencies, set_accessor
 
@@ -15,3 +17,17 @@ def test_napari_injection():
         assert f() is some_layers
 
     assert f() is None
+
+
+def test_napari_injection_missing():
+    @inject_napari_dependencies
+    def f(x: int):
+        return x
+
+    assert f(4) == 4
+
+    with pytest.raises(TypeError):
+        f()
+
+    with set_accessor({int: lambda: 1}):
+        assert f() == 1

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -8,7 +8,6 @@ from inspect import isgeneratorfunction
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Set, Union
 
 from ..utils.events import EmitterGroup
-from ._injection import inject_napari_dependencies
 from .interactions import Shortcut
 from .translations import trans
 
@@ -47,6 +46,8 @@ class Action:
         layer into the commands.  See :func:`inject_napari_dependencies` for
         details.
         """
+        from ._injection import inject_napari_dependencies
+
         return inject_napari_dependencies(self.command)
 
 


### PR DESCRIPTION
# Description
This is a minor refactor/revision that starts on https://github.com/napari/napari/issues/4532

it does a few things
1. introduces a way to permanently, or temporarily in a context manager, _set_ an accessor that knows how to return an instance of some type.  
    
    ```python
    from napari.components import LayerList
    from napari.utils._injection import inject_napari_dependencies, set_accessor
    
    @inject_napari_dependencies
    def func(ll: LayerList):
        return ll
    
    some_layers = LayerList()
    # temporarily set the accessor function that gets an instance of `LayerList`
    with set_accessor({LayerList: lambda: some_layers}):
        assert func() is some_layers
    ```
2. delays the _retrieval_ of the accessor function to call-time of the function requiring the dependency injection.  For example, before this PR, `def func(viewer: napari.Viewer)` would _always_ use `napari.viewer.current_viewer` to inject the `Viewer` dependency into `func`... with this PR, that relationship won't be set at the moment a function is annotated with `inject_napari_dependencies`, but rather can change depending on the context.
3. makes a minor import change in `action_manager` to avoid a circular dependency while removing a ton of delayed imports in `_injection.py`