### PR TITLE
Remove internal event connection on `SelectableEventedList`

### DIFF
--- a/napari/utils/events/_tests/test_selectable_list.py
+++ b/napari/utils/events/_tests/test_selectable_list.py
@@ -1,0 +1,12 @@
+from napari.utils.events.containers import SelectableEventedList
+
+
+def test_remove_discards_from_selection():
+    """Removing from the list should also discard from the selection."""
+    selectable_list = SelectableEventedList(['a', 'b', 'c'])
+    selectable_list.selection = ['a']
+
+    assert 'a' in selectable_list.selection
+    selectable_list.remove('a')
+    assert 'a' not in selectable_list
+    assert 'a' not in selectable_list.selection

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -44,9 +44,6 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
     def __init__(self, *args, **kwargs) -> None:
         self._activate_on_insert = True
         super().__init__(*args, **kwargs)
-        self.events.removed.connect(
-            lambda e: self.selection.discard(e.value)
-        )  # FIXME remove lambda
         self.selection._pre_add_hook = self._preselect_hook
 
     def _preselect_hook(self, value):
@@ -66,6 +63,11 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
         if self._activate_on_insert:
             # Make layer selected and unselect all others
             self.selection.active = value
+
+    def remove(self, value: _T) -> None:
+        """Remove, discarding from selection after removing."""
+        super().remove(value)
+        self.selection.discard(value)
 
     def select_all(self):
         """Select all items in the list."""


### PR DESCRIPTION
# Description
This PR removes an internal event connection on our `SelectableEventedList` object - I can't remember exactly in what situation this is bad but I know it's something we've aimed to avoid. cc @tlambert03 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] added new test
- [x] existing tests pass with the change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
