### PR TITLE
Use imageio v2 api to silence Deprecation Warning

### DIFF
--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import List, Optional, Tuple, Union
 from urllib.error import HTTPError, URLError
 
-import imageio
 import numpy as np
 from dask import array as da
 from dask import delayed
@@ -19,6 +18,11 @@ from dask import delayed
 from ..types import FullLayerData
 from ..utils.misc import abspath_or_url
 from ..utils.translations import trans
+
+try:
+    import imageio.v2 as imageio
+except ImportError:
+    import imageio
 
 IMAGEIO_EXTENSIONS = {x for f in imageio.formats for x in f.extensions}
 READER_EXTENSIONS = IMAGEIO_EXTENSIONS.union({'.zarr', '.lsm'})
@@ -143,8 +147,6 @@ def imread(filename: str) -> np.ndarray:
         with file_or_url_context(filename) as filename:
             return tifffile.imread(filename)
     else:
-        import imageio
-
         return imageio.imread(filename)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -107,8 +107,7 @@ optional =
     triangle
 testing =
     babel>=2.9.0
-    pytest
-    pytest-faulthandler
+    pytest>=7.0.0
     pytest-qt
     hypothesis>=6.8.0
     xarray


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This PR switch to directly use imageio v2 API to prevent test fail because of deprecation warnings. 
```
  E       DeprecationWarning: Starting with ImageIO v3 the behavior of this function will switch to that of iio.v3.imread. To keep the current behavior (and make this warning dissapear) use `import imageio.v2 as imageio` or call `imageio.v2.imread` directly.
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

https://github.com/napari/napari/runs/6449319602?check_suite_focus=true#step:9:101

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
