### PR TITLE
Warn user when preferred plugin for a file is missing

### DIFF
--- a/docs/release/release_0_4_16.md
+++ b/docs/release/release_0_4_16.md
@@ -28,6 +28,7 @@ After discussion in [#4102](https://github.com/napari/napari/pull/4102) and [#41
 - Calling `viewer.open` *without* passing a plugin will result in an error if you have not saved a reader preference for that file pattern *and* multiple plugins can claim the file
     - You can address this error by associating a preference for the file pattern, or calling `viewer.open(file_path, plugin=...)
 - A preferred reader failing to read your file will result in an error
+- A preferred reader missing from current plugins will trigger a warning, but the preference will be otherwise ignored
 - When opening a file through a GUI pathway (drag & drop, File -> Open, Open Sample) you are provided with a dialog allowing you to choose among the various plugins that are compatible with your file
     - This dialog also allows you to save a preference for files with extensions
     - This dialog also pops up if a preferred reader fails to open your file
@@ -141,6 +142,7 @@ We have thought carefully about these choices, but there are still some open que
 
 ## API Changes
 - Update file opening behavior to ensure consistency across command line and GUI. (#4347)
+- Warn user when preferred plugin for a file is missing (#4545)
 
 
 ## UI Changes

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -11,8 +11,6 @@ from qtpy.QtCore import QCoreApplication, QObject, Qt
 from qtpy.QtGui import QCursor, QGuiApplication
 from qtpy.QtWidgets import QFileDialog, QSplitter, QVBoxLayout, QWidget
 
-from napari.errors.reader_errors import MissingAssociatedReaderError
-
 from ..components._interaction_box_mouse_bindings import (
     InteractionBoxMouseBindings,
 )
@@ -746,7 +744,7 @@ class QtViewer(QSplitter):
         """
         try:
             self.viewer._open_or_raise_error(filenames, stack=stack)
-        except (ReaderPluginError, MissingAssociatedReaderError) as e:
+        except ReaderPluginError as e:
             handle_gui_reading(filenames, self, stack, e.reader_plugin, e)
         except MultipleReaderError:
             handle_gui_reading(filenames, self, stack)

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -10,10 +10,7 @@ from napari._tests.utils import (
 )
 from napari.components import ViewerModel
 from napari.errors import MultipleReaderError, ReaderPluginError
-from napari.errors.reader_errors import (
-    MissingAssociatedReaderError,
-    NoAvailableReaderError,
-)
+from napari.errors.reader_errors import NoAvailableReaderError
 from napari.layers import Image
 from napari.settings import get_settings
 from napari.utils.colormaps import AVAILABLE_COLORMAPS, Colormap
@@ -857,19 +854,46 @@ def test_open_or_get_error_prefered_plugin(mock_npe2_pm, tmp_reader, tmp_path):
         assert added[0].source.reader_plugin == 'builtins'
 
 
-def test_open_or_get_error_cant_find_plugin(mock_npe2_pm, tmp_reader):
-    """Test correct error message is returned when prefered plugin is missing."""
+def test_open_or_get_error_cant_find_plugin(
+    tmp_path, mock_npe2_pm, tmp_reader
+):
+    """Test user is warned and only plugin used if preferred plugin missing."""
+    viewer = ViewerModel()
+    pth = tmp_path / 'my-file.npy'
+    np.save(pth, np.random.random((10, 10)))
+
+    with restore_settings_on_exit():
+        get_settings().plugins.extension2reader = {'*.npy': 'fake-reader'}
+
+        with pytest.warns(
+            RuntimeWarning, match="Can't find fake-reader plugin"
+        ):
+            added = viewer._open_or_raise_error([str(pth)])
+        assert len(added) == 1
+        assert added[0].source.reader_plugin == 'builtins'
+
+
+def test_open_or_get_error_no_prefered_plugin_many_available(
+    mock_npe2_pm, tmp_reader
+):
+    """Test MultipleReaderError raised if preferred plugin missing."""
     viewer = ViewerModel()
 
     with restore_settings_on_exit():
-        get_settings().plugins.extension2reader = {'*.fake': 'fake-reader'}
+        get_settings().plugins.extension2reader = {'*.fake': 'not-a-plugin'}
 
-        tmp_reader(mock_npe2_pm, 'other-fake-reader')
+        tmp_reader(mock_npe2_pm, 'fake-reader', filename_patterns=['*.fake'])
+        tmp_reader(
+            mock_npe2_pm, 'other-fake-reader', filename_patterns=['*.fake']
+        )
 
-        with pytest.raises(
-            MissingAssociatedReaderError, match="Can't find fake-reader plugin"
+        with pytest.warns(
+            RuntimeWarning, match="Can't find not-a-plugin plugin"
         ):
-            viewer._open_or_raise_error(['my_file.fake'])
+            with pytest.raises(
+                MultipleReaderError, match='Multiple plugins found capable'
+            ):
+                viewer._open_or_raise_error(['my_file.fake'])
 
 
 def test_open_or_get_error_preferred_fails(tmp_path):

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1032,7 +1032,17 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         if plugin and plugin not in readers:
             warnings.warn(
                 RuntimeWarning(
-                    f"Can't find {plugin} plugin associated with {path_message} files."
+                    trans._(
+                        f"Can't find {plugin} plugin associated with {path_message} files. ",
+                        plugin=plugin,
+                        path_message=path_message,
+                    )
+                    + trans._(
+                        "This may be because you've switched environments, or have uninstalled the plugin without updating the reader preference. "
+                    )
+                    + trans._(
+                        "You can remove this preference in the preference dialog, or by editing `settings.plugins.extension2reader`."
+                    )
                 )
             )
             plugin = None

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -24,7 +24,6 @@ from pydantic import Extra, Field, validator
 
 from .. import layers
 from ..errors import (
-    MissingAssociatedReaderError,
     MultipleReaderError,
     NoAvailableReaderError,
     ReaderPluginError,
@@ -1030,9 +1029,16 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             )
 
         plugin = get_preferred_reader(_path)
+        if plugin and plugin not in readers:
+            warnings.warn(
+                RuntimeWarning(
+                    f"Can't find {plugin} plugin associated with {path_message} files."
+                )
+            )
+            plugin = None
 
         # preferred plugin exists, or we just have one plugin available
-        if plugin in readers or (not plugin and len(readers) == 1):
+        if plugin or len(readers) == 1:
             plugin = plugin or next(iter(readers.keys()))
             try:
                 added = self._add_layers_with_plugins(
@@ -1053,19 +1059,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
                     plugin,
                     paths,
                 ) from e
-
-        # preferred plugin doesn't exist
-        elif plugin:
-            raise MissingAssociatedReaderError(
-                trans._(
-                    "Can't find {plugin} plugin associated with {extension} files.",
-                    plugin=plugin,
-                    extension=os.path.splitext(paths[0])[1],
-                    deferred=True,
-                ),
-                plugin,
-                paths,
-            )
         # multiple plugins
         else:
             raise MultipleReaderError(

--- a/napari/errors/__init__.py
+++ b/napari/errors/__init__.py
@@ -1,5 +1,4 @@
 from .reader_errors import (
-    MissingAssociatedReaderError,
     MultipleReaderError,
     NoAvailableReaderError,
     ReaderPluginError,

--- a/napari/errors/reader_errors.py
+++ b/napari/errors/reader_errors.py
@@ -74,36 +74,6 @@ class ReaderPluginError(ValueError):
         self.paths = paths
 
 
-class MissingAssociatedReaderError(RuntimeError):
-    """The reader plugin associated with paths' extension is not available.
-
-    Parameters
-    ----------
-    message: str
-        error description
-    reader_plugin : str
-        plugin that was tried
-    paths: List[str]
-        file paths for reading
-
-    Attributes
-    ----------
-    message: str
-        error description
-    reader_plugin : str
-        plugin that was tried
-    paths: List[str]
-        file paths for reading
-    """
-
-    def __init__(
-        self, message: str, reader_plugin: str, paths: List[str], *args: object
-    ) -> None:
-        super().__init__(message, *args)
-        self.reader_plugin = reader_plugin
-        self.paths = paths
-
-
 class NoAvailableReaderError(ValueError):
     """No reader plugins are available to open the chosen file
 


### PR DESCRIPTION
# Description
@jni pointed out [here](https://github.com/napari/napari/pull/4535#discussion_r875448629) that since our preferences are not environment dependent, raising an error when a preferred plugin for a file is missing may be problematic. This PR instead warns user when a preferred plugin is missing, but otherwise proceeds with the standard opening behavior, ignoring the preference.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
