### PR TITLE
Accelerate adding large numbers of points

### DIFF
--- a/napari/benchmarks/benchmark_points_layer.py
+++ b/napari/benchmarks/benchmark_points_layer.py
@@ -37,6 +37,9 @@ class Points2DSuite:
         """Time to get current value."""
         self.layer.get_value((0,) * 2)
 
+    def time_add(self, n):
+        self.layer.add(self.data)
+
     def mem_layer(self, n):
         """Memory used by layer."""
         return self.layer

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2327,3 +2327,21 @@ def test_shown():
     assert np.all(layer.shown[:-2] == True)  # noqa
     assert layer.shown[-2] == False  # noqa
     assert layer.shown[-1] == True  # noqa
+
+
+def test_selected_data_with_non_uniform_sizes():
+    data = np.zeros((3, 2))
+    size = [[1, 3], [1, 4], [1, 3]]
+    layer = Points(data, size=size)
+    # Current size is the default 10 because passed size is not a scalar.
+    assert layer.current_size == 10
+
+    # The first two points have different mean sizes, so the current size
+    # should not change.
+    layer.selected_data = (0, 1)
+    assert layer.current_size == 10
+
+    # The first and last point have the same mean size, so the current size
+    # should change to that mean.
+    layer.selected_data = (0, 2)
+    assert layer.current_size == 2

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1207,7 +1207,8 @@ class Points(Layer):
             with self.block_update_properties():
                 self.current_face_color = face_color
 
-        size = list({self.size[i, self._dims_displayed].mean() for i in index})
+        size_indices = np.ix_(index, list(self._dims_displayed))
+        size = np.unique(np.mean(self.size[size_indices], axis=0))
         if len(size) == 1:
             size = size[0]
             with self.block_update_properties():

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1207,8 +1207,8 @@ class Points(Layer):
             with self.block_update_properties():
                 self.current_face_color = face_color
 
-        size_indices = np.ix_(index, list(self._dims_displayed))
-        size = np.unique(np.mean(self.size[size_indices], axis=0))
+        size_index = np.ix_(index, self._dims_displayed)
+        size = np.unique(np.mean(self.size[size_index], axis=0))
         if len(size) == 1:
             size = size[0]
             with self.block_update_properties():

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1207,8 +1207,12 @@ class Points(Layer):
             with self.block_update_properties():
                 self.current_face_color = face_color
 
-        size_index = np.ix_(index, self._dims_displayed)
-        size = np.unique(np.mean(self.size[size_index], axis=0))
+        # Calculate the mean size across the displayed dimensions for
+        # each point to be consistent with `_view_size`.
+        mean_size = np.mean(
+            self.size[np.ix_(index, self._dims_displayed)], axis=1
+        )
+        size = np.unique(mean_size)
         if len(size) == 1:
             size = size[0]
             with self.block_update_properties():

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -398,6 +398,7 @@ def test_feature_table_resize_smaller():
 
 def test_feature_table_resize_larger():
     feature_table = _make_feature_table()
+    expected_dtypes = feature_table.values.dtypes
 
     feature_table.resize(6)
 
@@ -411,6 +412,7 @@ def test_feature_table_resize_larger():
         features['confidence'],
         [0.2, 0.5, 1, 0.8, 0.8, 0.8],
     )
+    np.testing.assert_array_equal(features.dtypes, expected_dtypes)
 
 
 def test_feature_table_append():

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -807,9 +807,7 @@ class _FeatureTable:
         if size < current_size:
             self.remove(range(size, current_size))
         elif size > current_size:
-            to_append = self._defaults.reindex(
-                index=range(size - current_size), method='pad'
-            )
+            to_append = self._defaults.iloc[np.zeros(size - current_size)]
             self.append(to_append)
 
     def append(self, to_append: pd.DataFrame) -> None:

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -807,7 +807,9 @@ class _FeatureTable:
         if size < current_size:
             self.remove(range(size, current_size))
         elif size > current_size:
-            to_append = pd.concat([self._defaults] * (size - current_size))
+            to_append = self._defaults.reindex(
+                index=range(size - current_size), method='pad'
+            )
             self.append(to_append)
 
     def append(self, to_append: pd.DataFrame) -> None:
@@ -828,11 +830,6 @@ class _FeatureTable:
         indices : Any
             The indices of the rows to remove. Must be usable as the labels parameter
             to pandas.DataFrame.drop.
-
-        Returns
-        -------
-        pd.DataFrame
-            The resulting features table, which contain copies of the existing data.
         """
         self._values = self._values.drop(labels=indices, axis=0).reset_index(
             drop=True


### PR DESCRIPTION
# Description

This speeds up two particularly slow lines that get executed as a result of `Points.add`. In both cases, we were originally doing python-based iteration, but both cases can be replaced by more efficient numpy/pandas-specific functions that should behave identically.

## Type of change

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References

[Original Zulip discussion]((https://napari.zulipchat.com/#narrow/stream/212875-general/topic/Adding.20of.20points.20slow).

# How has this been tested?

- [ ] modified a test to check that dtypes are as expected for added rows (an alternative optimization broke this test)
- [ ] all existing tests pass

I also tested this manually with the usage described in the original zulip thread, where it works as expected and much faster after this PR.

I also ran the benchmark added here before and after this change. Before, we have the following results.

```
(napari-dev) ➜  napari git:(main) ✗ asv run --bench Points2DSuite.time_add --python=same
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_asweet_software_miniconda3_envs_napari-dev_bin_python
[ 50.00%] ··· Running (benchmark_points_layer.Points2DSuite.time_add--).
[100.00%] ··· benchmark_points_layer.Points2DSuite.time_add                                                                                                                                                                                                           ok
[100.00%] ··· ======== =============
               param1               
              -------- -------------
                 16     3.74±0.09ms 
                 64       5.38±1ms  
                256      9.45±0.3ms 
                1024     26.5±0.5ms 
                4096     92.9±0.4ms 
               16384      376±9ms   
               65536     1.52±0.01s 
              ======== =============
```

And after we have speed ups of ~5x for large numbers of points without making things worse for small numbers.

```
(napari-dev) ➜  napari git:(add-points-faster) ✗ asv run --bench Points2DSuite.time_add --python=same
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_asweet_software_miniconda3_envs_napari-dev_bin_python
[ 50.00%] ··· Running (benchmark_points_layer.Points2DSuite.time_add--).
[100.00%] ··· benchmark_points_layer.Points2DSuite.time_add                                                                                                                                                                                                           ok
[100.00%] ··· ======== ============
               param1              
              -------- ------------
                 16     3.49±0.1ms 
                 64     3.64±0.2ms 
                256     4.43±0.1ms 
                1024    7.19±0.2ms 
                4096    16.4±0.3ms 
               16384    61.7±0.4ms 
               65536     267±3ms   
              ======== ============
```

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
