### PR TITLE
Disconnect a removed slider's _pull_label callback from the axis label change event 

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -657,3 +657,18 @@ def test_insert_layer_ordering(make_napari_viewer):
     pl2_vispy = viewer.window._qt_viewer.layer_to_visual[pl2].node
     assert pl1_vispy.order == 1
     assert pl2_vispy.order == 0
+
+
+def test_set_axis_labels_after_clearing_3d_layer(make_napari_viewer):
+    """See https://github.com/napari/napari/issues/3753"""
+    viewer = make_napari_viewer()
+    viewer.add_image(np.zeros((7, 6, 5)))
+    # Clearing the layerlist to be empty makes viewer.dims 2D.
+    viewer.layers.clear()
+
+    viewer.dims.axis_labels = ['y', 'x']
+
+    sliders = viewer.window._qt_viewer.dims.slider_widgets
+    assert len(sliders) == 2
+    assert sliders[0].axis_label.text() == 'y'
+    assert sliders[1].axis_label.text() == 'x'

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -657,18 +657,3 @@ def test_insert_layer_ordering(make_napari_viewer):
     pl2_vispy = viewer.window._qt_viewer.layer_to_visual[pl2].node
     assert pl1_vispy.order == 1
     assert pl2_vispy.order == 0
-
-
-def test_set_axis_labels_after_clearing_3d_layer(make_napari_viewer):
-    """See https://github.com/napari/napari/issues/3753"""
-    viewer = make_napari_viewer()
-    viewer.add_image(np.zeros((7, 6, 5)))
-    # Clearing the layerlist to be empty makes viewer.dims 2D.
-    viewer.layers.clear()
-
-    viewer.dims.axis_labels = ['y', 'x']
-
-    sliders = viewer.window._qt_viewer.dims.slider_widgets
-    assert len(sliders) == 2
-    assert sliders[0].axis_label.text() == 'y'
-    assert sliders[1].axis_label.text() == 'x'

--- a/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -313,3 +313,17 @@ def test_slice_labels(qtbot):
     label_edit.setText(str(8))
     label_edit.editingFinished.emit()
     assert dims.point[0] == 8
+
+
+def test_set_axis_labels_after_ndim_changes(qtbot):
+    """See https://github.com/napari/napari/issues/3753"""
+    dims = Dims(ndim=3, ndisplay=2)
+    view = QtDims(dims)
+    qtbot.addWidget(view)
+
+    dims.ndim = 2
+    dims.axis_labels = ['y', 'x']
+
+    assert len(view.slider_widgets) == 2
+    assert view.slider_widgets[0].axis_label.text() == 'y'
+    assert view.slider_widgets[1].axis_label.text() == 'x'

--- a/napari/_qt/widgets/qt_dims.py
+++ b/napari/_qt/widgets/qt_dims.py
@@ -217,6 +217,10 @@ class QtDims(QWidget):
         slider_widget = self.slider_widgets.pop(index)
         self._displayed_sliders.pop(index)
         self.layout().removeWidget(slider_widget)
+        # As we delete this widget later, callbacks with a weak reference
+        # to it may successfully grab the instance, but may be incompatible
+        # with other update state like dims.
+        self.dims.events.axis_labels.disconnect(slider_widget._pull_label)
         slider_widget.deleteLater()
         nsliders = np.sum(self._displayed_sliders)
         self.setMinimumHeight(int(nsliders * self.SLIDERHEIGHT))


### PR DESCRIPTION
# Description

When `Viewer.dims.ndim` changes `QtDims._update_sliders` is called which removes all the existing `QtDimSliderWidget` objects from `QtDims` and creates `ndim` new ones. Some events are connected to methods in `QtDimSliderWidget`, where the callback holds a weak reference to the object.

This PR disconnects `QtDimSliderWidget._pull_label` from `Dims.axis_labels` after an instance of that widget has been removed from `QtDims`. If I understand correctly, not doing this means that the callbacks associated with an old/removed instance will be executed if the instance has not actually been deleted yet, which can be problematic because other state like `Viewer.dims` is not longer compatible with that instance.

In the case of #3753, we go from 3D to 2D. If the third slider is still alive when `dims.axis_labels` is changed, then its `_pull_label` will be called when `self.axis == 2`, which is then used as a index for `dims.axis_labels` causing the index error described in that bug. This is likely why we don't see the error when the commands are run individually in the built-in console - because the instance has been deleted.

There may be other related bugs lurking (e.g. #3998), but this PR does not try to anticipate and fix those.

I haven't worked much with the slider code before, so it would be great to check and correct my logic here!

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #3753

# How has this been tested?
- [ ] all existing test pass
- [ ] new test to cover bug passes

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
