### PR TITLE
Deprecate layers.move_selected

### DIFF
--- a/napari/components/_tests/test_layers_list.py
+++ b/napari/components/_tests/test_layers_list.py
@@ -158,6 +158,7 @@ def test_remove_selected():
     assert len(layers) == 0
 
 
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 def test_move_selected():
     """
     Test removing selected layers

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -134,31 +134,6 @@ class LayerList(SelectableEventedList[Layer]):
         new_layer.events.set_data.connect(self._clean_cache)
         super().insert(index, new_layer)
 
-    def move_selected(self, index, insert):
-        """Reorder list by moving the item at index and inserting it
-        at the insert index. If additional items are selected these will
-        get inserted at the insert index too. This allows for rearranging
-        the list based on dragging and dropping a selection of items, where
-        index is the index of the primary item being dragged, and insert is
-        the index of the drop location, and the selection indicates if
-        multiple items are being dragged. If the moved layer is not selected
-        select it.
-
-        Parameters
-        ----------
-        index : int
-            Index of primary item to be moved
-        insert : int
-            Index that item(s) will be inserted at
-        """
-        if self[index] not in self.selection:
-            self.selection.select_only(self[index])
-            moving = [index]
-        else:
-            moving = [i for i, x in enumerate(self) if x in self.selection]
-        offset = insert >= index
-        self.move_multiple(moving, insert + offset)
-
     def toggle_selected_visibility(self):
         """Toggle visibility of selected layers"""
         for layer in self.selection:

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -97,7 +97,7 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
         the index of the drop location, and the selection indicates if
         multiple items are being dragged. If the moved layer is not selected
         select it.
-        
+
         This method is deprecated. Please use layers.move_multiple
         with layers.selection instead.
 

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import TypeVar
 
 from ...translations import trans
@@ -77,9 +78,47 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
         for i in list(self.selection):
             idx = self.index(i)
             self.remove(i)
-        new = max(0, (idx - 1))
-        if len(self) > new:
+        if isinstance(idx, int):
+            new = max(0, (idx - 1))
+            do_add = len(self) > new
+        else:
+            *root, _idx = idx
+            new = tuple(root) + (_idx - 1,) if _idx >= 1 else tuple(root)
+            do_add = len(self) > new[0]
+        if do_add:
             self.selection.add(self[new])
+
+    def move_selected(self, index: int, insert: int):
+        """Reorder list by moving the item at index and inserting it
+        at the insert index. If additional items are selected these will
+        get inserted at the insert index too. This allows for rearranging
+        the list based on dragging and dropping a selection of items, where
+        index is the index of the primary item being dragged, and insert is
+        the index of the drop location, and the selection indicates if
+        multiple items are being dragged. If the moved layer is not selected
+        select it.
+
+        Parameters
+        ----------
+        index : int
+            Index of primary item to be moved
+        insert : int
+            Index that item(s) will be inserted at
+        """
+        # this is just here for now to support the old layerlist API
+        warnings.warn(
+            "move_selected is deprecated. Please use layers.move_multiple "
+            "with layers.selection instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        if self[index] not in self.selection:
+            self.selection.select_only(self[index])
+            moving = [index]
+        else:
+            moving = [i for i, x in enumerate(self) if x in self.selection]
+        offset = insert >= index
+        self.move_multiple(moving, insert + offset)
 
     def select_next(self, step=1, shift=False):
         """Selects next item from list."""

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -97,6 +97,9 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
         the index of the drop location, and the selection indicates if
         multiple items are being dragged. If the moved layer is not selected
         select it.
+        
+        This method is deprecated. Please use layers.move_multiple
+        with layers.selection instead.
 
         Parameters
         ----------


### PR DESCRIPTION
# Description
This PR moves `layers.move_selected` to `SelectableEventedList` and deprecates it.  I think it's always had a bit of a strange API (since it's not strictly moving selected layers) and seems to have been there for the purpose of drag-and-drop, which is now handled by Qt (read old docstring for more).

Preferred usage now would be

```python
indices = [i for i, x in enumerate(viewer.layers) if x in viewer.layers.selection]
viewer.layers.move_multiple(indices, new_index)
```

(we don't _have_ to deprecate it, but at the very least, I would change the API to get rid of the dual `index` and `insert` parameters, in favor of a single `dest_index`)

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
