### PR TITLE
Fixes/modifications to nested list model and Group in prep for layergroups

### DIFF
--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -134,31 +134,6 @@ class LayerList(SelectableEventedList[Layer]):
         new_layer.events.set_data.connect(self._clean_cache)
         super().insert(index, new_layer)
 
-    def move_selected(self, index, insert):
-        """Reorder list by moving the item at index and inserting it
-        at the insert index. If additional items are selected these will
-        get inserted at the insert index too. This allows for rearranging
-        the list based on dragging and dropping a selection of items, where
-        index is the index of the primary item being dragged, and insert is
-        the index of the drop location, and the selection indicates if
-        multiple items are being dragged. If the moved layer is not selected
-        select it.
-
-        Parameters
-        ----------
-        index : int
-            Index of primary item to be moved
-        insert : int
-            Index that item(s) will be inserted at
-        """
-        if self[index] not in self.selection:
-            self.selection.select_only(self[index])
-            moving = [index]
-        else:
-            moving = [i for i, x in enumerate(self) if x in self.selection]
-        offset = insert >= index
-        self.move_multiple(moving, insert + offset)
-
     def toggle_selected_visibility(self):
         """Toggle visibility of selected layers"""
         for layer in self.selection:

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -134,6 +134,31 @@ class LayerList(SelectableEventedList[Layer]):
         new_layer.events.set_data.connect(self._clean_cache)
         super().insert(index, new_layer)
 
+    def move_selected(self, index, insert):
+        """Reorder list by moving the item at index and inserting it
+        at the insert index. If additional items are selected these will
+        get inserted at the insert index too. This allows for rearranging
+        the list based on dragging and dropping a selection of items, where
+        index is the index of the primary item being dragged, and insert is
+        the index of the drop location, and the selection indicates if
+        multiple items are being dragged. If the moved layer is not selected
+        select it.
+
+        Parameters
+        ----------
+        index : int
+            Index of primary item to be moved
+        insert : int
+            Index that item(s) will be inserted at
+        """
+        if self[index] not in self.selection:
+            self.selection.select_only(self[index])
+            moving = [index]
+        else:
+            moving = [i for i, x in enumerate(self) if x in self.selection]
+        offset = insert >= index
+        self.move_multiple(moving, insert + offset)
+
     def toggle_selected_visibility(self):
         """Toggle visibility of selected layers"""
         for layer in self.selection:

--- a/napari/utils/events/_tests/test_evented_list.py
+++ b/napari/utils/events/_tests/test_evented_list.py
@@ -257,6 +257,14 @@ def test_nested_indexing():
     for index in indices:
         assert ne_list[index] == int("".join(map(str, index)))
 
+    assert ne_list.has_index(1)
+    assert ne_list.has_index((1,))
+    assert ne_list.has_index((1, 2))
+    assert ne_list.has_index((1, 1, 2))
+    assert not ne_list.has_index((1, 1, 3))
+    assert not ne_list.has_index((1, 1, 2, 3, 4))
+    assert not ne_list.has_index(100)
+
 
 # indices in NEST that are themselves lists
 @pytest.mark.parametrize(
@@ -306,8 +314,9 @@ def test_nested_events(meth, group_index):
 
     method_name, args, expected_events = meth
     method = getattr(ne_list[group_index], method_name)
-    if method_name == 'index' and group_index != (1, 1):
-        # the expected value only occurs in index (1, 1)
+    if method_name == 'index' and group_index == (1, 1, 1):
+        # the expected value of '110' (in the pytest parameters)
+        # is not present in any child of ne_list[1, 1, 1]
         with pytest.raises(ValueError):
             method(*args)
     else:

--- a/napari/utils/events/_tests/test_typed_list.py
+++ b/napari/utils/events/_tests/test_typed_list.py
@@ -148,7 +148,7 @@ def test_nested_custom_lookup():
     a = NestableEventedList(
         [c, c1, [c2, [c3]]],
         basetype=Custom,
-        lookup={str: lambda x: x.name},
+        lookup={str: lambda x: getattr(x, 'name', object())},
     )
     # first level
     assert a[1].name == 'c1'  # index with integer as usual

--- a/napari/utils/events/_tests/test_typed_list.py
+++ b/napari/utils/events/_tests/test_typed_list.py
@@ -145,10 +145,10 @@ def test_nested_custom_lookup():
     c2 = Custom(name='c2')
     c3 = Custom(name='c3')
 
-    a = NestableEventedList(
+    a: NestableEventedList[Custom] = NestableEventedList(
         [c, c1, [c2, [c3]]],
         basetype=Custom,
-        lookup={str: lambda x: getattr(x, 'name', object())},
+        lookup={str: lambda x: getattr(x, 'name', '')},
     )
     # first level
     assert a[1].name == 'c1'  # index with integer as usual

--- a/napari/utils/events/containers/_evented_list.py
+++ b/napari/utils/events/containers/_evented_list.py
@@ -317,8 +317,9 @@ class EventedList(TypedMutableSequence[_T]):
             else:
                 raise TypeError(
                     trans._(
-                        "Can only move integer or slice indices",
+                        "Can only move integer or slice indices, not {t}",
                         deferred=True,
+                        t=type(idx),
                     )
                 )
 

--- a/napari/utils/events/containers/_nested_list.py
+++ b/napari/utils/events/containers/_nested_list.py
@@ -474,4 +474,4 @@ class NestableEventedList(EventedList[_T]):
                 return True
             except IndexError:
                 return False
-        return False
+        raise TypeError(f"Not supported index type {type(index)}")

--- a/napari/utils/events/containers/_nested_list.py
+++ b/napari/utils/events/containers/_nested_list.py
@@ -10,6 +10,7 @@ from typing import (
     DefaultDict,
     Generator,
     Iterable,
+    MutableSequence,
     NewType,
     Tuple,
     TypeVar,
@@ -184,7 +185,9 @@ class NestableEventedList(EventedList[_T]):
         if isinstance(key, tuple):
             item: NestableEventedList[_T] = self
             for idx in key:
-                item = item[idx]  # type: ignore
+                if not isinstance(item, MutableSequence):
+                    raise IndexError(f'index out of range: {key}')
+                item = item[idx]
             return item
         return super().__getitem__(key)
 
@@ -250,13 +253,12 @@ class NestableEventedList(EventedList[_T]):
         """Make sure dest_index is a positive index inside parent_index."""
         destination_group = self[parent_index]
         # not handling slice indexes
-        if isinstance(dest_index, int):
-            if dest_index < 0:
-                dest_index += len(destination_group) + 1
+        if isinstance(dest_index, int) and dest_index < 0:
+            dest_index += len(destination_group) + 1
         return dest_index
 
     def _move_plan(
-        self, sources: Iterable[NestedIndex], dest_index: NestedIndex
+        self, sources: Iterable[MaybeNestedIndex], dest_index: NestedIndex
     ) -> Generator[tuple[NestedIndex, NestedIndex], None, None]:
         """Prepared indices for a complicated nested multi-move.
 
@@ -309,6 +311,8 @@ class NestableEventedList(EventedList[_T]):
 
         # we iterate indices from the end first, so pop() always works
         for idx in sorted(sources, reverse=True):
+            if isinstance(idx, (int, slice)):
+                idx = (idx,)
             if idx == ():
                 raise IndexError(
                     trans._(
@@ -416,16 +420,17 @@ class NestableEventedList(EventedList[_T]):
                 )
             )
 
-        if src_par_i == dest_par_i:
-            if isinstance(dest_i, int):
-                if dest_i > src_i:
-                    dest_i -= 1
-                if src_i == dest_i:
-                    return False
+        if src_par_i == dest_par_i and isinstance(dest_i, int):
+            if dest_i > src_i:
+                dest_i -= 1
+            if src_i == dest_i:
+                return False
 
         self.events.moving(index=src_index, new_index=dest_index)
+
+        dest_par = self[dest_par_i]  # grab this before popping src_i
+
         with self.events.blocker_all():
-            dest_par = self[dest_par_i]  # grab this before popping src_i
             value = self[src_par_i].pop(src_i)
             dest_par.insert(dest_i, value)
 
@@ -437,8 +442,8 @@ class NestableEventedList(EventedList[_T]):
         if isinstance(e, list):
             return self.__newlike__(e)
         if self._basetypes:
-            _types = set(self._basetypes) | {NestableEventedList}
-            if not any(isinstance(e, t) for t in _types):
+            _types = tuple(self._basetypes) + (NestableEventedList,)
+            if not isinstance(e, _types):
                 raise TypeError(
                     trans._(
                         'Cannot add object with type {dtype!r} to TypedList expecting type {types_!r}',
@@ -449,21 +454,24 @@ class NestableEventedList(EventedList[_T]):
                 )
         return e
 
-    def _iter_indices(self, start=0, stop=None, root=(), deep=False):
+    def _iter_indices(self, start=0, stop=None, root=()):
         """Iter indices from start to stop.
 
         Depth first traversal of the tree
         """
-        if deep:
-            for i in range(start, len(self) if stop is None else stop):
-                if isinstance(self[i], NestableEventedList):
-                    yield from self[i]._iter_indices(  # type: ignore
-                        root=root + (i,), deep=deep
-                    )
-                else:
-                    if root:
-                        yield root + (i,)
-                    else:
-                        yield i
-        else:
-            yield from super()._iter_indices(start, stop)
+        for i, item in enumerate(self[:stop]):
+            yield root + (i,) if root else i
+            if isinstance(item, NestableEventedList):
+                yield from item._iter_indices(root=root + (i,))
+
+    def has_index(self, index: Union[int, Tuple[int, ...]]) -> bool:
+        """Return true if `index` is valid for this nestable list."""
+        if isinstance(index, int):
+            return -len(self) <= index < len(self)
+        if isinstance(index, tuple):
+            try:
+                self[index]
+                return True
+            except IndexError:
+                return False
+        return False

--- a/napari/utils/events/containers/_nested_list.py
+++ b/napari/utils/events/containers/_nested_list.py
@@ -459,7 +459,7 @@ class NestableEventedList(EventedList[_T]):
 
         Depth first traversal of the tree
         """
-        for i, item in enumerate(self[:stop]):
+        for i, item in enumerate(self[start:stop]):
             yield root + (i,) if root else i
             if isinstance(item, NestableEventedList):
                 yield from item._iter_indices(root=root + (i,))

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import TypeVar
 
 from ...translations import trans
@@ -77,9 +78,47 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
         for i in list(self.selection):
             idx = self.index(i)
             self.remove(i)
-        new = max(0, (idx - 1))
-        if len(self) > new:
+        if isinstance(idx, int):
+            new = max(0, (idx - 1))
+            do_add = len(self) > new
+        else:
+            *root, _idx = idx
+            new = tuple(root) + (_idx - 1,) if _idx >= 1 else tuple(root)
+            do_add = len(self) > new[0]
+        if do_add:
             self.selection.add(self[new])
+
+    def move_selected(self, index: int, insert: int):
+        """Reorder list by moving the item at index and inserting it
+        at the insert index. If additional items are selected these will
+        get inserted at the insert index too. This allows for rearranging
+        the list based on dragging and dropping a selection of items, where
+        index is the index of the primary item being dragged, and insert is
+        the index of the drop location, and the selection indicates if
+        multiple items are being dragged. If the moved layer is not selected
+        select it.
+
+        Parameters
+        ----------
+        index : int
+            Index of primary item to be moved
+        insert : int
+            Index that item(s) will be inserted at
+        """
+        # this is just here for now to support the old layerlist API
+        warnings.warn(
+            "move_selected is deprecated.  Please use layers.move_multiple "
+            "with layers.selection instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        if self[index] not in self.selection:
+            self.selection.select_only(self[index])
+            moving = [index]
+        else:
+            moving = [i for i, x in enumerate(self) if x in self.selection]
+        offset = insert >= index
+        self.move_multiple(moving, insert + offset)
 
     def select_next(self, step=1, shift=False):
         """Selects next item from list."""

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import TypeVar
 
 from ...translations import trans
@@ -78,47 +77,9 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
         for i in list(self.selection):
             idx = self.index(i)
             self.remove(i)
-        if isinstance(idx, int):
-            new = max(0, (idx - 1))
-            do_add = len(self) > new
-        else:
-            *root, _idx = idx
-            new = tuple(root) + (_idx - 1,) if _idx >= 1 else tuple(root)
-            do_add = len(self) > new[0]
-        if do_add:
+        new = max(0, (idx - 1))
+        if len(self) > new:
             self.selection.add(self[new])
-
-    def move_selected(self, index: int, insert: int):
-        """Reorder list by moving the item at index and inserting it
-        at the insert index. If additional items are selected these will
-        get inserted at the insert index too. This allows for rearranging
-        the list based on dragging and dropping a selection of items, where
-        index is the index of the primary item being dragged, and insert is
-        the index of the drop location, and the selection indicates if
-        multiple items are being dragged. If the moved layer is not selected
-        select it.
-
-        Parameters
-        ----------
-        index : int
-            Index of primary item to be moved
-        insert : int
-            Index that item(s) will be inserted at
-        """
-        # this is just here for now to support the old layerlist API
-        warnings.warn(
-            "move_selected is deprecated.  Please use layers.move_multiple "
-            "with layers.selection instead.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        if self[index] not in self.selection:
-            self.selection.select_only(self[index])
-            moving = [index]
-        else:
-            moving = [i for i, x in enumerate(self) if x in self.selection]
-        offset = insert >= index
-        self.move_multiple(moving, insert + offset)
 
     def select_next(self, step=1, shift=False):
         """Selects next item from list."""

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -77,8 +77,14 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
         for i in list(self.selection):
             idx = self.index(i)
             self.remove(i)
-        new = max(0, (idx - 1))
-        if len(self) > new:
+        if isinstance(idx, int):
+            new = max(0, (idx - 1))
+            do_add = len(self) > new
+        else:
+            *root, _idx = idx
+            new = tuple(root) + (_idx - 1,) if _idx >= 1 else tuple(root)
+            do_add = len(self) > new[0]
+        if do_add:
             self.selection.add(self[new])
 
     def select_next(self, step=1, shift=False):

--- a/napari/utils/events/containers/_typed.py
+++ b/napari/utils/events/containers/_typed.py
@@ -24,11 +24,6 @@ _T = TypeVar("_T")
 _L = TypeVar("_L")
 
 
-class B(MutableSequence[int]):
-    def __new__(self, data):
-        self._data = data
-
-
 class TypedMutableSequence(MutableSequence[_T]):
     """List mixin that enforces item type, and enables custom indexing.
 
@@ -224,13 +219,8 @@ class TypedMutableSequence(MutableSequence[_T]):
             stop += len(self)
 
         convert = self._lookup.get(type(value), _noop)
-        special_lookup = type(value) in self._lookup
-        # A "special lookup" means that they type of the value being searched
-        # is in the `self._lookups` dict.  The most common internal use of this
-        # pattern is `layers['name']`.  So we do a "deep" traversal in that
-        # case, which will let the nestable variant search throughout.
-        # we may or may not want that behavior?
-        for i in self._iter_indices(start, stop, deep=special_lookup):
+
+        for i in self._iter_indices(start, stop):
             v = convert(self[i])
             if v is value or v == value:
                 return i
@@ -243,7 +233,7 @@ class TypedMutableSequence(MutableSequence[_T]):
             )
         )
 
-    def _iter_indices(self, start=0, stop=None, deep=False):
+    def _iter_indices(self, start=0, stop=None):
         """Iter indices from start to stop.
 
         While this is trivial for this basic sequence type, this method lets
@@ -253,7 +243,7 @@ class TypedMutableSequence(MutableSequence[_T]):
 
     def _ipython_key_completions_(self):
         if str in self._lookup:
-            return (self._lookup[str](x) for x in self)
+            return (self._lookup[str](x) for x in self)  # type: ignore
 
 
 def _noop(x):

--- a/napari/utils/tree/group.py
+++ b/napari/utils/tree/group.py
@@ -1,4 +1,6 @@
-from typing import Generator, Iterable, List, TypeVar
+from __future__ import annotations
+
+from typing import Generator, Iterable, List, TypeVar, Union
 
 from ..events.containers._nested_list import MaybeNestedIndex
 from ..events.containers._selectable_list import SelectableNestableEventedList
@@ -38,8 +40,32 @@ class Group(Node, SelectableNestableEventedList[NodeType]):
     ):
         Node.__init__(self, name=name)
         SelectableNestableEventedList.__init__(
-            self, data=children, basetype=basetype
+            self,
+            data=children,
+            basetype=basetype,
+            lookup={str: lambda e: e.name},
         )
+
+    def __newlike__(self, iterable: Iterable):
+        from copy import copy
+
+        # NOTE: TRICKY!
+        # whenever we slice into a group with group[start:end],
+        # the super().__newlike__() call is going to create a new object
+        # of the same type (Group), and then populate it with items in iterable
+        # ...
+        # However, `Group.insert` changes the parent of each item as
+        # it gets inserted.  (The implication is that no Node can live in
+        # multiple groups at the same time). This means that simply slicing
+        # into a group will actually reparent *all* items in that group
+        # (even if the resulting slice goes unused...).
+        #
+        # So, we call `copy()` here to avoid that reparenting.  Though this
+        # may have it's own negative consequences?
+        return super().__newlike__(copy(i) for i in iterable)
+
+    def __getitem__(self, key) -> Union[NodeType, Group[NodeType]]:
+        return super().__getitem__(key)
 
     def __delitem__(self, key: MaybeNestedIndex):
         """Remove item at ``key``, and unparent."""
@@ -63,11 +89,14 @@ class Group(Node, SelectableNestableEventedList[NodeType]):
         """Return true if ``other`` appears anywhere under this group."""
         return any(item is other for item in self.traverse())
 
-    def traverse(self, leaves_only=False) -> Generator[NodeType, None, None]:
+    def traverse(
+        self, leaves_only=False, with_ancestors=False
+    ) -> Generator[NodeType, None, None]:
         """Recursive all nodes and leaves of the Group tree."""
+        obj = self.root() if with_ancestors else self
         if not leaves_only:
-            yield self
-        for child in self:
+            yield obj
+        for child in obj:
             yield from child.traverse(leaves_only)
 
     def _render(self) -> List[str]:

--- a/napari/utils/tree/group.py
+++ b/napari/utils/tree/group.py
@@ -47,8 +47,6 @@ class Group(Node, SelectableNestableEventedList[NodeType]):
         )
 
     def __newlike__(self, iterable: Iterable):
-        from copy import copy
-
         # NOTE: TRICKY!
         # whenever we slice into a group with group[start:end],
         # the super().__newlike__() call is going to create a new object
@@ -60,9 +58,13 @@ class Group(Node, SelectableNestableEventedList[NodeType]):
         # into a group will actually reparent *all* items in that group
         # (even if the resulting slice goes unused...).
         #
-        # So, we call `copy()` here to avoid that reparenting.  Though this
-        # may have it's own negative consequences?
-        return super().__newlike__(copy(i) for i in iterable)
+        # So, we call new._list.extend here to avoid that reparenting.
+        # Though this may have its own negative consequences for typing/events?
+        new = type(self)()
+        new._basetypes = self._basetypes
+        new._lookup = self._lookup.copy()
+        new._list.extend(iterable)
+        return new
 
     def __getitem__(self, key) -> Union[NodeType, Group[NodeType]]:
         return super().__getitem__(key)

--- a/napari/utils/tree/node.py
+++ b/napari/utils/tree/node.py
@@ -30,7 +30,15 @@ class Node:
 
     def __init__(self, name: str = "Node"):
         self.parent: Optional[Group] = None
-        self.name = name
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
 
     def is_group(self) -> bool:
         """Return True if this Node is a composite.
@@ -41,9 +49,7 @@ class Node:
 
     def index_in_parent(self) -> Optional[int]:
         """Return index of this Node in its parent, or None if no parent."""
-        if self.parent is not None:
-            return self.parent.index(self)
-        return None
+        return self.parent.index(self) if self.parent is not None else None
 
     def index_from_root(self) -> Tuple[int, ...]:
         """Return index of this Node relative to root.
@@ -57,7 +63,21 @@ class Node:
             item = item.parent
         return tuple(indices)
 
-    def traverse(self, leaves_only=False) -> Generator['Node', None, None]:
+    def iter_parents(self):
+        """Iterate the parent chain, starting with nearest relatives"""
+        obj = self.parent
+        while obj:
+            yield obj
+            obj = obj.parent
+
+    def root(self) -> 'Node':
+        """Get the root parent."""
+        parents = list(self.iter_parents())
+        return parents[-1] if parents else self
+
+    def traverse(
+        self, leaves_only=False, with_ancestors=False
+    ) -> Generator['Node', None, None]:
         """Recursive all nodes and leaves of the Node.
 
         This is mostly used by :class:`~napari.utils.tree.Group`, which can


### PR DESCRIPTION
# Description
pulling out a few components from #4018, so as to test them independently.

Nothing very consequential:
- adds a `with_ancestors` parameter convenience when traversing a `Group`
- adds `root` and `iter_parents` methods to `Node` (to get the root and iter_parents :)
- removes the `deep` parameter from `NestedList._iter_indices` (which was strange and unused anyway)
- cleans up some syntax
- adds more tests

There was one slightly tricky thing I came across and added a note to the code, copied here for convenience:


> `Group.insert` changes the parent of each item as
it gets inserted.  (The implication is that no `Node` can be a child of
multiple `Groups` at the same time). 
>
>  However, whenever we slice into a group with group[start:end],
the `super().__newlike__()` call is going to create a new object
of the same type (Group), and then populate it with items in in the slice.
>This means that simply slicing into a group will actually reparent *all*
items in that group (even if the resulting slice goes unused...).
>
> So, we call `new._list.extend` here to avoid that reparenting.
Though this may have its own negative consequences for typing/events?
