### PR TITLE
Forward port of release note updates for 0.4.16rc2 and rc3

### DIFF
--- a/docs/release/release_0_4_16.md
+++ b/docs/release/release_0_4_16.md
@@ -2,7 +2,7 @@
 
 ```{note}
 These are the preliminary release notes for 0.4.16 release candidates. The
-final release notes will be posted with the release on 2022-05-10.
+final release notes will be posted with the release on 2022-05-31.
 ```
 
 We're happy to announce the release of napari 0.4.16!
@@ -118,6 +118,11 @@ We have thought carefully about these choices, but there are still some open que
 - Split_channel makes base channel translucent, rest additive (#4394)
 - Vispy 0.10 (#4401)
 - Use syntax highlighter when printing stacktrace in GUI (#4414)
+- Accelerate adding large numbers of points (#4549)
+- use mip minip cutoff (#4556)
+- Warn user when preferred plugin for a file is missing (#4545)
+- Add preference saving from dialog for folders with extensions (#4535)
+- Add filename pattern to reader associations to preference dialog (#4459)
 
 ## Bug Fixes
 
@@ -140,6 +145,10 @@ We have thought carefully about these choices, but there are still some open que
 - napari --info: list npe2 plugins (#4445)
 - Bugfix/Add affine to base_dict via _get_base_state() (#4453)
 - Fix layer control pop-up issue (#4460)
+- fix Re-setting shapes data to initial data fails, but only in 3D (#4550)
+- Make sure we pass plugin through if opening file as stack (#4515)
+- Fix update of plugins and disable update button if not available on conda forge (for bundle) (#4512)
+- Connect napari events first to EventEmitter (#4480)
 
 ## Documentation
 
@@ -180,8 +189,10 @@ We have thought carefully about these choices, but there are still some open que
 - Fix events rendering in docs for components.LayerList (#4442)
 - Add NAP1: institutional and funding partners (#4446)
 - Update to the documentation: add viewer.dims.current_step tips (#4454)
+- Add information about new file opening behaviour (#4516)
 
 ## API Changes
+
 - Update file opening behavior to ensure consistency across command line and GUI. (#4347)
 - Warn user when preferred plugin for a file is missing (#4545)
 - Make `builtins` default plugin for `viewer.open` (#4574)
@@ -215,6 +226,8 @@ We have thought carefully about these choices, but there are still some open que
 - Set `TMP` on Windows+Mamba subprocesses if not set (#4462)
 - Update test_typing.yml (#4475)
 - Fix make-typestubs: use union for type hint instead of '|' (#4476)
+- [conda] rework how plugin install/remove subprocesses receive the parent environment (#4520)
+- [conda] revert default installation path (#4525)
 
 ## Other Pull Requests
 
@@ -241,7 +254,7 @@ We have thought carefully about these choices, but there are still some open que
 - Fix mypy error in CI (#4439)
 - Make npe2 writer test more lenient (#4457)
 
-## 32 authors added to this release (alphabetical)
+## 33 authors added to this release (alphabetical)
 
 - [aeisenbarth](https://github.com/napari/napari/commits?author=aeisenbarth) - @aeisenbarth
 - [alisterburt](https://github.com/napari/napari/commits?author=alisterburt) - @alisterburt
@@ -253,6 +266,7 @@ We have thought carefully about these choices, but there are still some open que
 - [Draga Doncila Pop](https://github.com/napari/napari/commits?author=DragaDoncila) - @DragaDoncila
 - [Eric Perlman](https://github.com/napari/napari/commits?author=perlman) - @perlman
 - [Genevieve Buckley](https://github.com/napari/napari/commits?author=GenevieveBuckley) - @GenevieveBuckley
+- [Gonzalo Peña-Castellanos](https://github.com/napari/napari/commits?author=goanpeca) - @goanpeca
 - [Gregory Lee](https://github.com/napari/napari/commits?author=grlee77) - @grlee77
 - [Grzegorz Bokota](https://github.com/napari/napari/commits?author=Czaki) - @Czaki
 - [Isabela Presedo-Floyd](https://github.com/napari/napari/commits?author=isabela-pf) - @isabela-pf
@@ -275,7 +289,6 @@ We have thought carefully about these choices, but there are still some open que
 - [Tru Huynh](https://github.com/napari/napari/commits?author=truatpasteurdotfr) - @truatpasteurdotfr
 - [Yuki Mochizuki](https://github.com/napari/napari/commits?author=2dx) - @2dx
 - [Ziyang Liu](https://github.com/napari/napari/commits?author=potating-potato) - @potating-potato
-
 
 ## 42 reviewers added to this release (alphabetical)
 

--- a/docs/release/release_0_4_16.md
+++ b/docs/release/release_0_4_16.md
@@ -123,6 +123,7 @@ We have thought carefully about these choices, but there are still some open que
 - Warn user when preferred plugin for a file is missing (#4545)
 - Add preference saving from dialog for folders with extensions (#4535)
 - Add filename pattern to reader associations to preference dialog (#4459)
+- use imageio v2 api (#4537)
 
 ## Bug Fixes
 
@@ -149,6 +150,9 @@ We have thought carefully about these choices, but there are still some open que
 - Make sure we pass plugin through if opening file as stack (#4515)
 - Fix update of plugins and disable update button if not available on conda forge (for bundle) (#4512)
 - Connect napari events first to EventEmitter (#4480)
+- Fix AttributeError: 'LayerList' object has no attribute 'name' (#4276)
+- Fix _BaseEventedItemModel.flags (#4558)
+- Bug fix: blending multichannel images and 3D points (#4567)
 
 ## Documentation
 


### PR DESCRIPTION
I made these changes in the v0.4.16x branch made for the 0.4.16 release (see discussion in [this Zulip thread](https://napari.zulipchat.com/#narrow/stream/215289-release/topic/0.2E4.2E16.20schedule/near/280157582)), this brings them forward to main.
