### PR TITLE
Fix macos release version comparison in __main__

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -400,10 +400,12 @@ def main():
     import platform
 
     _MACOS_AT_LEAST_CATALINA = (
-        sys.platform == "darwin" and int(platform.release().split('.')[0]) > 19
+        sys.platform == "darwin"
+        and int(platform.release().split('.')[0]) >= 19
     )
     _MACOS_AT_LEAST_BIG_SUR = (
-        sys.platform == "darwin" and int(platform.release().split('.')[0]) > 20
+        sys.platform == "darwin"
+        and int(platform.release().split('.')[0]) >= 20
     )
 
     _RUNNING_CONDA = "CONDA_PREFIX" in os.environ


### PR DESCRIPTION
# Description
Fixes a bug introduced by a change in #3894.

There, the following change was made:

```python
    _MACOS_AT_LEAST_CATALINA = sys.platform == "darwin" and StrictVersion(
        platform.release()
    ) > StrictVersion('19.0.0')
```
became:
```python
    _MACOS_AT_LEAST_CATALINA = (
        sys.platform == "darwin" and int(platform.release().split('.')[0]) > 19
    )
```

but the StrictVersion comparison went all the way out to the `PATCH` and the new one was just the major version, so it needs to be `>=`

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
