### PR TITLE
Bug fix: blending multichannel images and 3D points

### DIFF
--- a/napari/components/_tests/test_multichannel.py
+++ b/napari/components/_tests/test_multichannel.py
@@ -120,7 +120,7 @@ def test_multichannel(shape, kwargs):
                 assert viewer.layers[i].colormap.name == base_colormaps[i]
         if 'blending' not in kwargs:
             assert (
-                viewer.layers[i].blending == 'translucent'
+                viewer.layers[i].blending == 'translucent_no_depth'
                 if i == 0
                 else 'additive'
             )

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -739,7 +739,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
         if channel_axis is None:
             kwargs['colormap'] = kwargs['colormap'] or 'gray'
-            kwargs['blending'] = kwargs['blending'] or 'translucent'
+            kwargs['blending'] = kwargs['blending'] or 'translucent_no_depth'
             # Helpful message if someone tries to add mulit-channel kwargs,
             # but forget the channel_axis arg
             for k, v in kwargs.items():

--- a/napari/layers/utils/_tests/test_stack_utils.py
+++ b/napari/layers/utils/_tests/test_stack_utils.py
@@ -227,7 +227,9 @@ def test_split_channels_missing_keywords():
     for chan, layer in enumerate(result_list):
         assert layer[0].shape == (128, 128)
         assert (
-            layer[1]['blending'] == 'translucent' if chan == 0 else 'additive'
+            layer[1]['blending'] == 'translucent_no_depth'
+            if chan == 0
+            else 'additive'
         )
 
 

--- a/napari/layers/utils/stack_utils.py
+++ b/napari/layers/utils/stack_utils.py
@@ -81,7 +81,7 @@ def split_channels(
 
     n_channels = (data[0] if multiscale else data).shape[channel_axis]
     # Use original blending mode or for multichannel use translucent for first channel then additive
-    kwargs['blending'] = kwargs.get('blending') or ['translucent'] + [
+    kwargs['blending'] = kwargs.get('blending') or ['translucent_no_depth'] + [
         'additive'
     ] * (n_channels - 1)
     kwargs.setdefault('colormap', None)


### PR DESCRIPTION
# Description
This is a different approach related to https://github.com/napari/napari/pull/4523
Instead of making the default blending `translucent_no_depth` in `viewer_model.py` (inherited when `kwargs['blending'] = kwargs['blending'] or ...`) this PR sets blending to `translucent_no_depth` if *no blending* is specified for `channel_axis is None` and to `translucent_no_depth` for the first layer when splitting channels.
This mimics the current approach—importantly, it specifies a blending if the user doesn't, but then allows single channel and multichannel images to follow their own logic.

This PR fixes the issue demonstrated by @jni here:
https://github.com/napari/napari/pull/4523#issuecomment-1125579866
where points get clipped.

Here's what it looks like with this PR:
<img width="1228" alt="image" src="https://user-images.githubusercontent.com/76622105/170121663-7d984a7f-4a91-4989-a7f4-5abd9869074b.png">
Note that `nuclei` blending is still *additive* with respect to `membranes`. 
And all points are rendered correctly.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
This is a different approach to PR: https://github.com/napari/napari/pull/4523
as identified in comment: https://github.com/napari/napari/pull/4523#issuecomment-1128835292
Also, some discussion on zulip:
https://napari.zulipchat.com/#narrow/stream/270578-reviews

# How has this been tested?
- [x] example: the test suite has been adjusted to account for the change
- [x] example: locally the fix works, as compared to `main`

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have adjusted tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
