### PR TITLE
Make `builtins` default plugin for `viewer.open`

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -225,7 +225,7 @@ def parse_sys_argv():
 
 
 def _run():
-    from napari import run, view_path
+    from napari import Viewer, run
     from napari.settings import get_settings
 
     """Main program."""
@@ -301,13 +301,14 @@ def _run():
         splash = NapariSplashScreen()
         splash.close()  # will close once event loop starts
 
-        # viewer is unused but _must_  be kept around.
+        # viewer _must_  be kept around.
         # it will be referenced by the global window only
         # once napari has finished starting
         # but in the meantime if the garbage collector runs;
         # it will collect it and hang napari at start time.
         # in a way that is machine, os, time (and likely weather dependant).
-        viewer = view_path(  # noqa: F841
+        viewer = Viewer()
+        viewer._window._qt_viewer._qt_open(
             args.paths,
             stack=args.stack,
             plugin=args.plugin,

--- a/napari/_qt/dialogs/qt_reader_dialog.py
+++ b/napari/_qt/dialogs/qt_reader_dialog.py
@@ -117,6 +117,7 @@ def handle_gui_reading(
     stack: bool,
     plugin_name: Optional[str] = None,
     error: Optional[ReaderPluginError] = None,
+    **kwargs,
 ):
     """Present reader dialog to choose reader and open paths based on result.
 
@@ -160,6 +161,7 @@ def handle_gui_reading(
             paths,
             stack,
             qt_viewer,
+            **kwargs,
         )
 
 
@@ -218,6 +220,7 @@ def open_with_dialog_choices(
     paths: List[str],
     stack: bool,
     qt_viewer,
+    **kwargs,
 ):
     """Open paths with chosen plugin from reader dialog, persisting if chosen.
 
@@ -243,9 +246,7 @@ def open_with_dialog_choices(
         p_name for p_name, d_name in readers.items() if d_name == display_name
     ][0]
     # may throw error, but we let it this time
-    qt_viewer.viewer._add_layers_with_plugins(
-        paths, stack=stack, plugin=plugin_name
-    )
+    qt_viewer.viewer.open(paths, stack=stack, plugin=plugin_name, **kwargs)
 
     if persist:
         get_settings().plugins.extension2reader = {

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -730,7 +730,14 @@ class QtViewer(QSplitter):
             self._qt_open([folder], stack=False)
             update_open_history(folder)
 
-    def _qt_open(self, filenames: List[str], stack: bool):
+    def _qt_open(
+        self,
+        filenames: List[str],
+        stack: bool,
+        plugin: str = None,
+        layer_type: str = None,
+        **kwargs,
+    ):
         """Open files, potentially popping reader dialog for plugin selection.
 
         Call ViewerModel._open_or_raise_error and catch errors that could
@@ -744,11 +751,25 @@ class QtViewer(QSplitter):
             whether to stack files or not
         """
         try:
-            self.viewer._open_or_raise_error(filenames, stack=stack)
+            self.viewer.open(
+                filenames,
+                stack=stack,
+                plugin=plugin,
+                layer_type=layer_type,
+                **kwargs,
+            )
         except ReaderPluginError as e:
-            handle_gui_reading(filenames, self, stack, e.reader_plugin, e)
+            handle_gui_reading(
+                filenames,
+                self,
+                stack,
+                e.reader_plugin,
+                e,
+                layer_type=layer_type,
+                **kwargs,
+            )
         except MultipleReaderError:
-            handle_gui_reading(filenames, self, stack)
+            handle_gui_reading(filenames, self, stack, **kwargs)
 
     def _toggle_chunk_outlines(self):
         """Toggle whether we are drawing outlines around the chunks."""

--- a/napari/_tests/test_cli.py
+++ b/napari/_tests/test_cli.py
@@ -33,27 +33,33 @@ def test_cli_shows_plugins(napari_plugin_manager, monkeypatch, capsys):
     assert 'scikit-image' in str(capsys.readouterr())
 
 
-def test_cli_parses_unknowns(mock_run, monkeypatch):
+def test_cli_parses_unknowns(mock_run, monkeypatch, make_napari_viewer):
     """test that we can parse layer keyword arg variants"""
+    v = make_napari_viewer()  # our mock view_path will return this object
 
     def assert_kwargs(*args, **kwargs):
-        assert args == (["file"],)
+        assert ["file"] in args
         assert kwargs['contrast_limits'] == (0, 1)
 
     # testing all the variants of literal_evals
-    monkeypatch.setattr(napari, 'view_path', assert_kwargs)
-    with monkeypatch.context() as m:
-        m.setattr(sys, 'argv', ['n', 'file', '--contrast-limits', '(0, 1)'])
-        __main__._run()
-    with monkeypatch.context() as m:
-        m.setattr(sys, 'argv', ['n', 'file', '--contrast-limits', '(0,1)'])
-        __main__._run()
-    with monkeypatch.context() as m:
-        m.setattr(sys, 'argv', ['n', 'file', '--contrast-limits=(0, 1)'])
-        __main__._run()
-    with monkeypatch.context() as m:
-        m.setattr(sys, 'argv', ['n', 'file', '--contrast-limits=(0,1)'])
-        __main__._run()
+    with mock.patch('napari.Viewer', return_value=v):
+        monkeypatch.setattr(
+            napari.components.viewer_model.ViewerModel, 'open', assert_kwargs
+        )
+        with monkeypatch.context() as m:
+            m.setattr(
+                sys, 'argv', ['n', 'file', '--contrast-limits', '(0, 1)']
+            )
+            __main__._run()
+        with monkeypatch.context() as m:
+            m.setattr(sys, 'argv', ['n', 'file', '--contrast-limits', '(0,1)'])
+            __main__._run()
+        with monkeypatch.context() as m:
+            m.setattr(sys, 'argv', ['n', 'file', '--contrast-limits=(0, 1)'])
+            __main__._run()
+        with monkeypatch.context() as m:
+            m.setattr(sys, 'argv', ['n', 'file', '--contrast-limits=(0,1)'])
+            __main__._run()
 
 
 def test_cli_raises(monkeypatch):
@@ -84,15 +90,17 @@ def test_cli_runscript(run_path, monkeypatch, tmp_path):
     run_path.assert_called_once_with(str(script))
 
 
-@mock.patch('napari.view_path')
-def test_cli_passes_kwargs(view_path, mock_run, monkeypatch):
+@mock.patch('napari._qt.qt_viewer.QtViewer._qt_open')
+def test_cli_passes_kwargs(qt_open, mock_run, monkeypatch, make_napari_viewer):
     """test that we can parse layer keyword arg variants"""
+    v = make_napari_viewer()
 
-    with monkeypatch.context() as m:
-        m.setattr(sys, 'argv', ['n', 'file', '--name', 'some name'])
-        __main__._run()
+    with mock.patch('napari.Viewer', return_value=v):
+        with monkeypatch.context() as m:
+            m.setattr(sys, 'argv', ['n', 'file', '--name', 'some name'])
+            __main__._run()
 
-    view_path.assert_called_once_with(
+    qt_open.assert_called_once_with(
         ['file'],
         stack=False,
         plugin=None,
@@ -122,7 +130,12 @@ def test_cli_retains_viewer_ref(mock_run, monkeypatch, make_napari_viewer):
     with monkeypatch.context() as m:
         m.setattr(sys, 'argv', ['napari', 'path/to/file.tif'])
         # return our local v
-        with mock.patch('napari.view_path', return_value=v) as mock_vp:
+        with mock.patch('napari.Viewer', return_value=v) as mock_viewer:
             ref_count = sys.getrefcount(v)  # count current references
-            __main__._run()
-            mock_vp.assert_called_once()
+            # mock gui open so we're not opening dialogs/throwing errors on fake path
+            with mock.patch(
+                'napari._qt.qt_viewer.QtViewer._qt_open', return_value=None
+            ) as mock_viewer_open:
+                __main__._run()
+            mock_viewer.assert_called_once()
+            mock_viewer_open.assert_called_once()

--- a/napari/components/_tests/test_add_layers.py
+++ b/napari/components/_tests/test_add_layers.py
@@ -74,8 +74,9 @@ def test_viewer_open_no_plugin(tmp_path):
     fname = tmp_path / 'gibberish.gbrsh'
     fname.touch()
     with pytest.raises(ValueError) as e:
+        # will default to builtins
         viewer.open(fname)
-    assert 'No plugin found capable of reading' in str(e.value)
+    assert "Plugin 'builtins' does not support file(s)" in str(e.value)
 
 
 plugin_returns = [

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -866,7 +866,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         path: PathOrPaths,
         *,
         stack: bool = False,
-        plugin: Optional[str] = None,
+        plugin: Optional[str] = 'builtins',
         layer_type: Optional[str] = None,
         **kwargs,
     ) -> List[Layer]:
@@ -887,9 +887,11 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             ``False``, then the ``path`` list is broken up and passed to plugin
             readers one by one.  by default False.
         plugin : str, optional
-            Name of a plugin to use.  If provided, will force ``path`` to be
-            read with the specified ``plugin``.  If the requested plugin cannot
-            read ``path``, an exception will be raised.
+            Name of a plugin to use, by default builtins.  If provided, will
+            force ``path`` to be read with the specified ``plugin``.
+            If None, ``plugin`` will be read from preferences or inferred if just
+            one reader is compatible.
+            If the requested plugin cannot read ``path``, an exception will be raised.
         layer_type : str, optional
             If provided, will force data read from ``path`` to be passed to the
             corresponding ``add_<layer_type>`` method (along with any


### PR DESCRIPTION
# Description
This PR makes `builtins` the default plugin for `viewer.open`. Users must pass in `plugin=None` to "opt-in" to the inference behavior used by the GUI. Also updated the release notes to highlight the change.

#4569 should be merged first.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
