### PR TITLE
Make sure npe2 and npe1 builtins are available in dialogs

### DIFF
--- a/docs/release/release_0_4_16.md
+++ b/docs/release/release_0_4_16.md
@@ -177,6 +177,7 @@ We have thought carefully about these choices, but there are still some open que
 - Allow resizing left dock widgets (#4368)
 - Add filename pattern to reader associations to preference dialog (#4459)
 - Add preference saving from dialog for folders with extensions #4535
+- Make sure npe2 and npe1 builtins are available in dialogs (#4575)
 
 ## Deprecations
 

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -901,7 +901,7 @@ def test_open_or_get_error_preferred_fails(tmp_path):
     pth = tmp_path / 'my-file.npy'
 
     with restore_settings_on_exit():
-        get_settings().plugins.extension2reader = {'.npy': 'napari'}
+        get_settings().plugins.extension2reader = {'*.npy': 'napari'}
 
         with pytest.raises(
             ReaderPluginError, match='Tried opening with napari, but failed.'

--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -52,7 +52,9 @@ def test_get_potential_readers_gives_napari(mock_npe2_pm, tmp_reader):
     tmp_reader(mock_npe2_pm, 'napari', ['*.tif'])
     readers = get_potential_readers(pth)
     assert 'napari' in readers
-    assert 'builtins' not in readers
+    assert 'builtins' in readers
+    assert readers['napari'] == 'napari (npe2)'
+    assert readers['builtins'] == 'builtins (npe1)'
 
 
 def test_get_potential_readers_finds_readers(mock_npe2_pm, tmp_reader):
@@ -91,9 +93,12 @@ def test_get_all_readers_gives_npe1(mock_npe2_pm):
 
 def test_get_all_readers_gives_napari():
     npe2_readers, npe1_readers = get_all_readers()
-    assert len(npe1_readers) == 0
+    assert len(npe1_readers) == 1
     assert len(npe2_readers) == 1
     assert 'napari' in npe2_readers
+    assert npe2_readers['napari'] == 'napari (npe2)'
+    assert 'builtins' in npe1_readers
+    assert npe1_readers['builtins'] == 'builtins (npe1)'
 
 
 def test_get_all_readers(mock_npe2_pm, tmp_reader):

--- a/napari/plugins/utils.py
+++ b/napari/plugins/utils.py
@@ -46,9 +46,11 @@ def get_potential_readers(filename: str) -> Dict[str, str]:
                     ] = get_reader.plugin_name
     readers.update(npe1_readers)
 
-    # if npe2 is present, remove npe1 builtins
-    if 'napari' in readers and 'builtins' in readers:
-        del readers['builtins']
+    # if npe1 and npe2 builtins are present, disambiguate
+    if 'napari' in readers:
+        readers['napari'] = 'napari (npe2)'
+    if 'builtins' in readers:
+        readers['builtins'] = 'builtins (npe1)'
 
     return readers
 
@@ -69,9 +71,11 @@ def get_all_readers() -> Tuple[Dict[str, str], Dict[str, str]]:
             for get_reader in potential_readers:
                 npe1_readers[get_reader.plugin_name] = get_reader.plugin_name
 
-    # if npe2 is present, remove npe1 builtins
-    if 'napari' in npe2_readers and 'builtins' in npe1_readers:
-        del npe1_readers['builtins']
+    # if npe1 and npe2 builtins are present, disambiguate
+    if 'napari' in npe2_readers:
+        npe2_readers['napari'] = 'napari (npe2)'
+    if 'builtins' in npe1_readers:
+        npe1_readers['builtins'] = 'builtins (npe1)'
 
     return npe2_readers, npe1_readers
 


### PR DESCRIPTION
# Description
@jni and I noticed today that while we have an `npe2` builtins (called `napari`), it only declares `['*.csv', '*.npy']` as valid filename patterns, so we still need original `builtins` to support opening other filetypes. Prior to this PR, I was removing `builtins` from options in dialogs if `napari` was present. Since they're not quite equivalent, this PR makes sure both are shown to the user, and disambiguated slightly with "(npe1)" and "(npe2)" in brackets.

Example in preference dialog:

![image](https://user-images.githubusercontent.com/17995243/170426640-92ed5500-69cf-4a22-a610-1de1b82de7ce.png)

Usually when opening a file you just get one option or the other, but if you are, say, opening a numpy file, you might get both:

![image](https://user-images.githubusercontent.com/17995243/170427036-688a9465-4ebc-4ef6-801f-213cca89b8fe.png)


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
