### PR TITLE
Patch scikit-image cells3d data function when testing examples

### DIFF
--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -2,8 +2,10 @@ import os
 import runpy
 from pathlib import Path
 
+import numpy as np
 import pytest
 from qtpy import API_NAME
+import skimage.data
 
 import napari
 from napari._qt.qt_main_window import Window
@@ -55,6 +57,8 @@ def test_examples(fname, monkeypatch):
     monkeypatch.setattr(Window, 'show', lambda *a: None)
     # prevent running the event loop
     monkeypatch.setattr(napari, 'run', lambda *a, **k: None)
+    # Prevent downloading example data because this sometimes fails.
+    monkeypatch.setattr(skimage.data, 'cells3d', lambda: np.zeros((60, 2, 256, 256), dtype=np.uint16))
 
     # make sure our sys.excepthook override doesn't hide errors
     def raise_errors(etype, value, tb):


### PR DESCRIPTION
# Description

This patches `skimage.data.cells3d` when testing the examples because that needs to download data, which sometimes fails. For example, see a recent run of [macos-11 3.9 pyqt](https://github.com/napari/napari/runs/6611791183?check_suite_focus=true#step:9:269).

Instead of downloading the data and returning that data as a numpy array, as `skimage.data.cells3d` typically does, this just returns a numpy array of zeros with the same shape and dtype.

Typically, I don't like mocking/faking things. But I see the example tests as sanity tests that check successful execution rather than correctness of result, so I think it seems like a good idea here.

We might need to add similar patches for other data, but it seems like most of the scikit-image data examples are included in the package, so have not identified any others yet. Thanks to @tlambert03 for checking that.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
- [ ] the example test passes

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
