### PR TITLE
Fix chackable menu entries when using PySide2 backend

### DIFF
--- a/napari/_qt/menus/_tests/test_util.py
+++ b/napari/_qt/menus/_tests/test_util.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock
+
+from qtpy.QtWidgets import QMenu
+
+from napari._qt.menus._util import populate_menu
+
+
+def test_populate_menu_create(qtbot):
+    """Test the populate_menu function."""
+
+    mock = MagicMock()
+    menu = QMenu()
+    populate_menu(menu, [{"text": "test", "slot": mock}])
+    assert len(menu.actions()) == 1
+    assert menu.actions()[0].text() == "test"
+    assert menu.actions()[0].isCheckable() is False
+    with qtbot.waitSignal(menu.actions()[0].triggered):
+        menu.actions()[0].trigger()
+    mock.assert_called_once_with(False)
+
+
+def test_populate_menu_create_checkable(qtbot):
+    """Test the populate_menu function with checkable actions."""
+
+    mock = MagicMock()
+    menu = QMenu()
+    populate_menu(menu, [{"text": "test", "slot": mock, "checkable": True}])
+    assert len(menu.actions()) == 1
+    assert menu.actions()[0].text() == "test"
+    assert menu.actions()[0].isCheckable() is True
+    with qtbot.waitSignal(menu.actions()[0].triggered):
+        menu.actions()[0].trigger()
+    mock.assert_called_once_with(True)
+    mock.reset_mock()
+    with qtbot.waitSignal(menu.actions()[0].triggered):
+        menu.actions()[0].trigger()
+    mock.assert_called_once_with(False)

--- a/napari/_qt/menus/_tests/test_util.py
+++ b/napari/_qt/menus/_tests/test_util.py
@@ -16,7 +16,7 @@ def test_populate_menu_create(qtbot):
     assert menu.actions()[0].isCheckable() is False
     with qtbot.waitSignal(menu.actions()[0].triggered):
         menu.actions()[0].trigger()
-    mock.assert_called_once_with(False)
+    mock.assert_called_once()
 
 
 def test_populate_menu_create_checkable(qtbot):

--- a/napari/_qt/menus/_util.py
+++ b/napari/_qt/menus/_util.py
@@ -87,7 +87,10 @@ def populate_menu(menu: QMenu, actions: List['MenuItem']):
             continue
         action: QAction = menu.addAction(ax['text'])
         if 'slot' in ax:
-            action.triggered[bool].connect(ax['slot'])
+            if ax.get("checkable"):
+                action.toggled.connect(ax['slot'])
+            else:
+                action.triggered.connect(ax['slot'])
         action.setShortcut(ax.get('shortcut', ''))
         action.setStatusTip(ax.get('statusTip', ''))
         if 'menuRole' in ax:

--- a/napari/_qt/menus/_util.py
+++ b/napari/_qt/menus/_util.py
@@ -87,7 +87,7 @@ def populate_menu(menu: QMenu, actions: List['MenuItem']):
             continue
         action: QAction = menu.addAction(ax['text'])
         if 'slot' in ax:
-            action.triggered.connect(ax['slot'])
+            action.triggered[bool].connect(ax['slot'])
         action.setShortcut(ax.get('shortcut', ''))
         action.setStatusTip(ax.get('statusTip', ''))
         if 'menuRole' in ax:


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

By default `QAction.triggered` signal do pass `checked` value in PyQt5 and not pass in PySide2. This PR ensures that it is propagated.

In the current main try to change the visibility of the scale bar ends with:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
TypeError: setattr expected 3 arguments, got 2
```
That provides no information on what happens. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
