### PR TITLE
Don't build bundle in PRs on doc changes

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
   schedule:
     - cron: "0 0 * * *"
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
   schedule:
     - cron: "0 0 * * *"
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
See #4555

This is again trying to consume less CI hours and have a faster PR turnaround time.