### PR TITLE
Add test for QtPerformance widget

### DIFF
--- a/napari/_qt/perf/_tests/test_perf.py
+++ b/napari/_qt/perf/_tests/test_perf.py
@@ -1,9 +1,12 @@
+import dataclasses
 import json
 import os
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
+from napari._qt.perf import qt_performance
 from napari._tests.utils import skip_local_popups, skip_on_win_ci
 
 # NOTE:
@@ -55,3 +58,31 @@ def test_trace_on_start(tmp_path: Path):
         for event in data:
             for field in ['pid', 'tid', 'name', 'ph', 'ts', 'args']:
                 assert field in event
+
+
+def test_qt_performance(qtbot, monkeypatch):
+    widget = qt_performance.QtPerformance()
+    widget.timer.stop()
+    qtbot.addWidget(widget)
+    mock = MagicMock()
+    data = [
+        ("test1", MockTimer(1, 1)),
+        ("test2", MockTimer(20, 120)),
+        ("test1", MockTimer(70, 90)),
+        ("test2", MockTimer(50, 220)),
+    ]
+    mock.timers.items = MagicMock(return_value=data)
+    monkeypatch.setattr(qt_performance.perf, 'timers', mock)
+    assert widget.log.toPlainText() == ""
+    widget.update()
+    assert widget.log.toPlainText() == '  120ms test2\n  220ms test2\n'
+    widget._change_thresh("150")
+    assert widget.log.toPlainText() == ""
+    widget.update()
+    assert widget.log.toPlainText() == '  220ms test2\n'
+
+
+@dataclasses.dataclass
+class MockTimer:
+    average: float
+    max: float


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Currently, there happens information about coverage changes depending on the speed of the test runner:

![Zrzut ekranu z 2022-05-30 16-10-44](https://user-images.githubusercontent.com/3826210/171009722-7e3cdaa3-9c8a-4a50-94e8-cd0ec0d0d5d0.png)

This PR adds direct tests of `QtPerformance` 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Add tests

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes work with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
