### PR TITLE
Forward port further 0.4.16 release note changes

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -119,6 +119,7 @@ subtrees:
       - file: release/index
         subtrees:
         - entries:
+          - file: release/release_0_4_16
           - file: release/release_0_4_15
           - file: release/release_0_4_14
           - file: release/release_0_4_13

--- a/docs/release/release_0_4_16.md
+++ b/docs/release/release_0_4_16.md
@@ -233,6 +233,7 @@ We have thought carefully about these choices, but there are still some open que
 - Fix make-typestubs: use union for type hint instead of '|' (#4476)
 - [conda] rework how plugin install/remove subprocesses receive the parent environment (#4520)
 - [conda] revert default installation path (#4525)
+- Pin vispy to <0.11 to prevent future breakages (#4594)
 
 ## Other Pull Requests
 

--- a/docs/release/release_0_4_16.md
+++ b/docs/release/release_0_4_16.md
@@ -153,6 +153,7 @@ We have thought carefully about these choices, but there are still some open que
 - Fix AttributeError: 'LayerList' object has no attribute 'name' (#4276)
 - Fix _BaseEventedItemModel.flags (#4558)
 - Bug fix: blending multichannel images and 3D points (#4567)
+- Fix checkable menu entries when using PySide2 backend (#4581)
 
 ## Documentation
 


### PR DESCRIPTION
This ports the following two changes from the v0.4.16x branch to main.

- Add #4581 to release notes
- Add 0.4.16 release notes to TOC
