### PR TITLE
Pin vispy to <0.11 to prevent future breakages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ install_requires =
     typing_extensions
     toolz>=0.10.0
     tqdm>=4.56.0
-    vispy>=0.10.0
+    vispy>=0.10.0,<0.11
     wrapt>=1.11.1
 
 [options.package_data]


### PR DESCRIPTION
This makes our vispy dependency `>=0.10.0,<0.11` as proposed by @brisvag and @Czaki.

Fixes #4587
Fixes #4589

Note that I'm assuming re #4589 that any upcoming VisPy release will actually be 0.11, not 0.10.1, unless it's a bug fix release. CC @djhoese?
