### PR TITLE
Discuss the approval of NAP-2 (conda-based packaging for napari)

### DIFF
--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -7,7 +7,7 @@
 :Created: 2022-05-05
 :Resolution: <url> (required for Accepted | Rejected | Withdrawn)
 :Resolved: <date resolved, in yyyy-mm-dd format>
-:Status: Approved
+:Status: Accepted
 :Type: <Standards Track | Process>
 :Version effective: <version-number> (for accepted NAPs)
 ```

--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -79,6 +79,9 @@ In contrast, `conda`-based packaging offers some benefits in those points:
   more developers are aware of them and familiar with them, and how to create
   packages for them. Conda in contrast presents a community education
   challenge.
+* Even with a well-developed community of practice among napari and napari
+  plugin developers, some significant industry-provided packages, such as
+  Apple's tensorflow-metal, may *never* be available no conda-forge.
 * Although the conda-forge review process is an advantage with regards to
   correctness and reliability, it presents a scalability challenge in the
   absence of broader community education about conda packaging.
@@ -96,8 +99,10 @@ application and plugins, supported by five key milestones:
 4. Enabling in-app napari version updates
 5. Deprecating Briefcase-based installers
 
-Throughout the process, we will try to minimize conda's downsides by providing
+Throughout the process, we will aim to minimize conda's downsides by providing
 local conda-based installation options and documentation about how to use them.
+We will also provide users an opt-in, "use at your own risk" method to install
+pip packages where they do not exist on conda-forge.
 
 ## Detailed Description
 

--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -644,7 +644,7 @@ CC0+BY [^cc0by].
 
 [^conda-pip-issue-comment]: https://github.com/napari/napari/issues/3223#issuecomment-972189348
 
-[^pamba]: https://gist.github.com/tlambert03/cdc63d68f4fd1bce20f8f3e769217759
+[^pamba]: https://github.com/tlambert03/pamba
 
 [^napari-installer-class]: https://github.com/napari/napari/blob/5c10022337601f350ad64ce56eddf6664306e40e/napari/_qt/dialogs/qt_plugin_dialog.py#L64
 

--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -108,7 +108,7 @@ The details for each milestone will be discussed in subsections.
 napari 0.2.12 was submitted to conda-forge [^staged-recipes-napari] in Oct 2019 and the PR was
 merged some months later. As a result, napari is available on conda-forge since Feb 2020
 [^napari-feedstock-creation]. The conda-forge bots auto-submit PRs to build the new versions
-once detected on PyPI. This means that releases on conda-forge can be slightly lag behind PyPI.
+once detected on PyPI. This means that releases on conda-forge can slightly lag behind PyPI.
 To avoid accidental delays in the releases, conda-forge packaging needs to be considered part
 of the release guide [^release-guide].
 
@@ -116,21 +116,22 @@ Pre-release packages are additionally built in our CI by cloning the conda-forge
 patching it to use the local source. The artifacts are uploaded to the `napari` channel at
 Anaconda.org [^napari-channel].
 
-While napari itself is on conda-forge for some years now, the plugin ecosystem was still
-relying on PyPI. In the case of napari users that relied on conda packages, that means that the
+While napari itself has been on conda-forge for some years now, until recently, the plugin
+ecosystem still broadly
+relied on PyPI. In the case of napari users that relied on conda packages, that means that the
 plugin manager would use `pip` to install the plugin and its dependencies in the conda
 environment, potentially mixing PyPI packages with conda-forge packages and causing conflicts
 due to binary incompatibilities.
 
-To avoid this risk, the recommended way forward is to package all existing napari plugins (and
-their dependencies!) on conda-forge too. This (ongoing) effort started in Jan 2022, resulting
-in ~200 PRs to date [^staged-recipes-all-plugins].
+To avoid this risk, this NAP recommends packaging all existing napari plugins (and
+their dependencies) on conda-forge too. This (ongoing) effort started in Jan 2022, resulting
+in ~200 pull requests (PRs) to date [^staged-recipes-all-plugins].
 
 That said, that is only the initial migration. We need a way to ensure that new plugins are also
 packaged on conda-forge. We recommend adding it to the plugin development documentation, as well
 as adding support for the relevant metadata on napari hub.
 
-Lastly, in order to get the maximum compatibility across plugins, the napari project should also
+Lastly, in order to ensure maximum compatibility across plugins, the napari project should also
 provide documentation and guidelines on what versions of major scientific packages are supported
 on each napari release. For example, we should control the version bounds for `numpy`,
 `scikit-image` and similar members of the PyData ecosystem. Otherwise, we might arrive to a

--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -7,7 +7,7 @@
 :Created: 2022-05-05
 :Resolution: <url> (required for Accepted | Rejected | Withdrawn)
 :Resolved: <date resolved, in yyyy-mm-dd format>
-:Status: Draft
+:Status: Approved
 :Type: <Standards Track | Process>
 :Version effective: <version-number> (for accepted NAPs)
 ```

--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -526,6 +526,9 @@ deciding to use the currently proposed one. Namely:
 - [PR #4404](https://github.com/napari/napari/pull/4404) (Switch to a more declarative configuration
   for conda packaging)
 - [PR #4519](https://github.com/napari/napari/pull/4519) (Initial draft of this NAP and discussion)
+- [PR #4602](https://github.com/napari/napari/pull/4602) (PR to discuss the approval this NAP)
+- [Zulip thread](https://napari.zulipchat.com/#narrow/stream/322105-naps/topic/Proposal.20to.20accept.20NAP-2)
+  to discuss the approval of this NAP
 
 ## References and Footnotes
 

--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -531,7 +531,7 @@ the future, if it makes sense, we can talk about adding a UI on top.
 For Milestone 4 "Enabling in-app napari version updates", we considered other options before
 deciding to use the currently proposed one. Namely:
 
-* Each napari installation only contains a single conda environemnt and version. Users can update
+* Each napari installation only contains a single conda environment and version. Users can update
   by downloading the newer installer, possibly after having received a notification in a running
   napari instance. This was discarded because it required too many user actions to succeed.
 * Each napari installation contains several environments, one per napari version. Each napari

--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -52,8 +52,9 @@ however, presents a series of limitations for the napari ecosystem:
   restricting the packaging options to a language-specific repository can be limiting.
 * PyPI only provides Python _packages_. It does not distribute Python itself, leaving that to the
   installer infrastructure. In the case of Briefcase, this is obtained via their own distribution
-  mechanisms [^briefcase-python]. One more moving piece that can result in incompatibilities with
-  the target system if not controlled properly (see issues [^appimage-crash][^appimage-crash2]).
+  mechanisms [^briefcase-python]. This presents one more moving piece that can
+  result in incompatibilities with the target system if not controlled properly
+  (see issues [^appimage-crash][^appimage-crash2]).
 
 In contrast, `conda`-based packaging offers some benefits in those points:
 
@@ -67,7 +68,7 @@ In contrast, `conda`-based packaging offers some benefits in those points:
   automated way that ensures binary compatibility across packages and languages. Every
   submission needs to be reviewed and approved by humans after successfully passing the CI.
   This adds guarantees for provenance, transparency and debugging.
-* `conda` has the notion of optional version constrains. A package can provide constrains for other
+* `conda` has the notion of optional version constrains. A package can provide constraints for other
   packages that _could_ be installed alongside, without depending on them. This offers a lot of
   flexibility to manage a plugin ecosystem with potentially wildly different requirements, which
   would risk conflicts.

--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -186,25 +186,24 @@ developers to alleviate these issues.
 
 Anaconda releases their Anaconda and Miniconda distributions with platform specific installers:
 
-* On Windows, the offer an EXE built with NSIS
+* On Windows, they offer an EXE built with NSIS
 * On Linux, a text-based installer is offered as a fat SH script
 * On macOS, a native, graphical PKG installer is provided in addition to the text-based option
 
 These three products are created using `constructor` [^constructor], their own tool to gather
 the required conda dependencies and add the logic to install them on the target machine.
-However, `constructor` hasn't been well maintained during the last years (only small fixes),
-which means that some work will be needed to make it behave the way we want and need. More
-specifically:
+However, `constructor` hasn't been well maintained in recent years (only small fixes),
+which means that some work is needed to meet our needs. More specifically:
 
-* Shortcut creation is only supported on Windows
+* Application shortcut creation is only supported on Windows
 * PKG installers are created with hardcoded Anaconda branding
 * Some conda-specific options cannot be removed (only disabled by default), which might distract
   users in the installers
 
 In order to have `constructor` cover our needs, we need to add the features ourselves. Upstream
-maintenance is meant to be improve over the year, but for now the reviews are coming in slow. As
+maintenance is expected to improve in the coming years, but for now the reviews are coming in slow. As
 a result, we are temporarily forking the project and developing the features as needed while
-submitting PRs to upstream [^constructor-upstream] to keep things tidy. Our improved `constructor`
+submitting PRs upstream [^constructor-upstream] to keep things tidy. Our improved `constructor`
 fork has the following features:
 
 * Cross-platform shortcut creation for the distributed application thanks to a complete `menuinst`

--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -7,7 +7,7 @@
 :Created: 2022-05-05
 :Resolution: <url> (required for Accepted | Rejected | Withdrawn)
 :Resolved: <date resolved, in yyyy-mm-dd format>
-:Status: Accepted
+:Status: Draft
 :Type: <Standards Track | Process>
 :Version effective: <version-number> (for accepted NAPs)
 ```

--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -179,7 +179,7 @@ at napari can help here, but this will not scale if the plugin ecosystem keeps g
 
 As a result, some plugins might end up being available on PyPI but not on conda-forge. This further
 reinforces the idea that conda-forge packaging is a second-class citizen for the plugin ecosystem.
-We would recommend including some packaging guidelines as part of the documentation for plugin
+This NAP recommends including packaging guidelines as part of the documentation for plugin
 developers to alleviate these issues.
 
 ### Milestone 2: Building conda-based installers for napari

--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -73,14 +73,31 @@ In contrast, `conda`-based packaging offers some benefits in those points:
   flexibility to manage a plugin ecosystem with potentially wildly different requirements, which
   would risk conflicts.
 
-This NAP proposes to add a `conda`-based distribution mechanism for napari, supported by five key
-milestones:
+`conda` packaging also has its own downsides compared to `pip`, though:
+
+* pip and PyPI are the *de facto* standard in Python packaging, which means
+  more developers are aware of them and familiar with them, and how to create
+  packages for them. Conda in contrast presents a community education
+  challenge.
+* Although the conda-forge review process is an advantage with regards to
+  correctness and reliability, it presents a scalability challenge in the
+  absence of broader community education about conda packaging.
+* pip can install packages from a simple local directory, from a zip file, or
+  from a GitHub repository. These simple installation methods are favored by
+  small labs and institutions that want to create plugins for internal use,
+  rather than for broad distribution.
+
+This NAP proposes to add a `conda`-based distribution mechanism for the napari
+application and plugins, supported by five key milestones:
 
 1. Distributing napari and plugins on conda-forge
 2. Building conda-based installers for napari
 3. Adding support for conda packages in the plugin manager
 4. Enabling in-app napari version updates
 5. Deprecating Briefcase-based installers
+
+Throughout the process, we will try to minimize conda's downsides by providing
+local conda-based installation options and documentation about how to use them.
 
 ## Detailed Description
 

--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -36,9 +36,11 @@ however, presents a series of limitations for the napari ecosystem:
 * No standardized building infrastructure. PyPI accepts submissions from any user without requiring
   any validation or review. As a result, packages can be built using arbitrary toolchains or
   expecting different libraries in the system. `cibuildwheel` [^cibuildwheel] and related tools
-  [^audithwheel] [^delocate] [^delvewheel] can definitely help users who want to do it in the right
-  way, but again, there's no guarantee is being used. This can result in ABI incompatibilities with
-  the target system and within the plugin ecosystem, specially when some packages vendor specific
+  [^audithwheel] [^delocate] [^delvewheel] can definitely help users who want
+  to follow community packaging practices,
+  but there is no guarantee of it being used by individual packages.
+  This can result in ABI incompatibilities with
+  the target system and within the plugin ecosystem, especially when some packages vendor specific
   libraries [^pypi-parallelism-abi].
 * PyPI metadata is often not detailed enough. This is a byproduct of the previous point, which
   makes it difficult for the different clients (pip, poetry, etc) to guarantee that the

--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -295,7 +295,7 @@ are multiple:
   explicitly (thus overriding the historic preference). For napari, this means that every plugin
   installation will be recorded in the history file, accumulating over time. If we compound this
   with `napari` updates, the problem gets larger with every new release.
-* Guarantee of success: updating an environment to the latest napari release might now work right
+* Guarantee of success: updating an environment to the latest napari release might not work right
   away, specially if the user has installed plugins that have conflicting packaging metadata. Even
   if the installation succeeds, insufficient/incorrect metadata might result in the wrong packages
   being installed, rendering the napari installation non-operational!


### PR DESCRIPTION
#4519 added a [NAP draft](https://napari.org/naps/2-conda-based-packaging.html) to discuss strategies around using `conda` packaging within `napari`, at different levels. We (@goanpeca and I) proposed five milestones to split the discussion:

1. Distributing napari and plugins on conda-forge
2. Building conda-based installers for napari
3. Adding support for conda packages in the plugin manager
4. Enabling in-app napari version updates
5. Deprecating Briefcase-based installers

The discussion already started in the first PR, and some feedback was already incorporated in the text. However, there are many points we still need to discuss before marking this NAP as approved.

This is what I've gathered so far, but please let me know if I should add more talking points and/or action items to the list below.

# Summary of the discussion so far

## Milestone 1 -  Distributing napari and plugins on conda-forge

* We seem to have good agreement on napari being distributed on conda-forge, but we should cover it explicitly in the release guide.
* However, asking plugin developers to submit to conda-forge on their own seems to be too big of a requirement. Better documentation on our end might help, as well as some kind of support in the cookiecutter template, but ultimately this means we can't consider conda-forge the only data source for plugins (at least in the current state, and possibly in the foreseeable future). See milestone 3 for action items.

Action items:

* [ ] Add documentation about conda-forge in the release guide
* [ ] Add documentation about conda-forge in the plugin developer guide
* [ ] Ensure the cookiecutter template has some notion of conda packaging.

## Milestone 2 -  Building conda-based installers for napari

* I think almost everyone agrees that the current `constructor` stack satisfies the installer needs for `napari`
* The multi-environment approach seems to be well received, but we need to ensure that the packaging documentation covers this in a detailed way, since it uses a lot of conda concepts that might be foreign to some devs. This might involve contributing some docs to upstream.
* Creating `napari/packaging` looks like a good idea to keep things tidy and uncoupled

Action items:

* [ ] Add detailed documentation about how the installers are structured and how they work internally
* [ ] Create `napari/packaging` and migrate the conda bundle CI there, along with the relevant metadata 
* [ ] Add PyPI-conda consistency checks to ensure `napari/napari` and `napari/packaging` match

## Milestone 3 -  Adding support for conda packages in the plugin manager

* Supporting `conda` packages exclusively sounds like too big of an ask (see milestone 1)
* Instead, the plugin manager on the bundle should support other plugin sources, like PyPI packages, custom conda channels or local sources.
* Allowing users to install non-conda-forge packages involves some risks we should be prepared for. For example,  via simulated installs to alert users of potential problems, metadata analysis, or recovery mechanisms via `napari-updater`.
* Some comments point out that the plugin manager could become a plugin itself.

_I feel this milestone is one of the most controversial changes, so the discussion here is not over yet._

Action items:

* [ ] Add hybrid support for conda-forge _and_ PyPI packaging. Conda sources are preferred if available; PyPI sources might be marked with warnings or locked unless "advanced mode" is enabled. Some heuristics might anticipate problems or devise a hybrid conda-pip plan where dependencies are satisfied with conda whenever possible first, leaving the rest to pip.
* [ ] Add support for custom conda channels in the UI.
* [ ] Add support for local sources via drag&drop.


## Milestone 4 -  Enabling in-app napari version updates

* If we agree to use multi-environment installations like the infrastructure currently proposes,
  we can implement updates by creating new environments for each version. Multi-env installs would
  allow for different napari "flavors" or "collections" too (not just different versions).
* This is delegated to an external tool (codenamed `napari-updater`) so the logic can be kept
  separate from napari across versions. This tool would also help manage existing installations,
  like reparation tasks ("oh no I installed a plugin and everything broke, what do I do?") and
  cleaning up old installations.
* The development on this tool will happen on `napari/packaging` at first while we prototype
  something quickly, but it will eventually live on its own repo (`napari/updater` or similar) where
  we can make it available for other projects too.

Action items:

- [x] Agree on multi-envs install (e.g. evaluate the balance between flexibility and complexity)
- [ ] Prototype something on `napari/packaging`
- [ ] Refactor prototype into `napari/updater` or equivalent

## Milestone 5 -  Deprecating Briefcase-based installers

* Once we are satisfied with the feature set of the new installers (e.g. pip-install compatibility),
  we can deprecate these pipelines.
* When that's decided, announce in one release, and make it effective for the next one.

Action items:

- [ ] Decide the minimum feature set needed in the conda-based installers so they can replace
      the Briefcase installers. So far, I think it comes down to:
    - [X] Cross-platform compatibility
    - [X] Functional shortcuts in all platforms
    - [ ] Plugin manager support:
        - [X] conda-forge sources
        - [ ] custom conda channels (local or remote, also private)
        - [ ] pypi sources (in a safe way)
        - [ ] local wheels (in a safe way)