### PR TITLE
Removed unused private Layer._position

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -282,7 +282,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             ]
         )
 
-        self._position = (0,) * ndim
         self._dims_point = [0] * ndim
         self.corner_pixels = np.zeros((2, ndim), dtype=int)
         self._editable = True
@@ -657,7 +656,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             self._dims_order = list(
                 reorder_after_dim_reduction(self._dims_order[-ndim:])
             )
-            self._position = self._position[-ndim:]
         elif old_ndim < ndim:
             new_axes = range(ndim - old_ndim)
             self._transforms = self._transforms.expand_dims(new_axes)
@@ -665,7 +663,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             self._dims_order = list(range(ndim - old_ndim)) + [
                 o + ndim - old_ndim for o in self._dims_order
             ]
-            self._position = (0,) * (ndim - old_ndim) + self._position
 
         self._ndim = ndim
         if 'extent' in self.__dict__:


### PR DESCRIPTION
# Description

This removes `Layer._position`, which is private and never read internally. It is only written in `Layer`.

If something external relied on this private state, they can simply use `Layer._dims_point` which is the list equivalent and can convert with `tuple()` if they really need to.

I found this while writing up some notes on how slicing is performed, so thought it was worth removing early so I don't have to explain what it is.

# How has this been tested?

- [ ] all existing tests pass with my change

## Final checklist:

- [x] My PR is the minimum possible work for the desired functionality
