### PR TITLE
Add a "New image layer" button to the layer list

### DIFF
--- a/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -19,6 +19,10 @@ QtViewerPushButton{
    
 }
 
+QtViewerPushButton[mode="new_image"] {
+  image: url(":/themes/{{ name }}/new_image.svg");
+}
+
 QtViewerPushButton[mode="new_points"] {
   image: url(":/themes/{{ name }}/new_points.svg");
 }

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -62,11 +62,14 @@ class QtLayerButtons(QFrame):
             from magicgui import magicgui
 
             class BackingData(Enum):
-                NumPy = ('NumPy',)
-                Dask = ('Dask',)
+                NumPy = 'NumPy'
+                Zarr = 'Zarr'
 
-            @magicgui(call_button="Create")
+            name_options = {'tooltip': "If blank, a name will be generated"}
+
+            @magicgui(call_button="Create", name=name_options)
             def _new_image_widget(
+                name: str = "",
                 dimensions: List[int] = [512, 512],
                 data_type: BackingData = BackingData.NumPy,
                 fill_value: float = 0.0,
@@ -76,18 +79,18 @@ class QtLayerButtons(QFrame):
                     import numpy as np
 
                     data = np.full(tuple(dimensions), fill_value)
-                elif data_type is BackingData.Dask:
-                    import dask
+                elif data_type is BackingData.Zarr:
+                    # Zarr is not shipped by default, but we can support it sometimes
+                    import zarr
 
-                    data = dask.array.from_delayed(fill_value, dimensions)
-                self.viewer.add_image(data=data)
+                    data = zarr.full(dimensions, fill_value)
 
-            widget = self.viewer.window.add_dock_widget(
-                _new_image_widget,
-                name="Add new image",
-                area='left',
-            )
-            _new_image_widget.called.connect(widget.destroyOnClose)
+                if name == "":
+                    name = None
+                self.viewer.add_image(name=name, data=data)
+
+            _new_image_widget.show()
+            _new_image_widget.called.connect(_new_image_widget.close)
 
         self.newImageButton = QtViewerPushButton(
             'new_image',

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -1,6 +1,6 @@
 import warnings
 from functools import wraps
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from qtpy.QtCore import QPoint, Qt
 from qtpy.QtWidgets import (
@@ -53,6 +53,27 @@ class QtLayerButtons(QFrame):
 
         self.viewer = viewer
         self.deleteButton = QtDeleteButton(self.viewer)
+
+        def _Add_new_image(
+            dimensions: List[int] = [512, 512], fill_value: float = 0.0
+        ) -> None:
+            import numpy as np
+
+            data = np.full(tuple(dimensions), fill_value)
+            self.viewer.add_image(data=data)
+
+        self.newImageButton = QtViewerPushButton(
+            'new_image',
+            trans._('New image layer'),
+            lambda: self.viewer.window.add_function_widget(
+                function=_Add_new_image,
+                magic_kwargs={
+                    'auto_call': False,
+                    'call_button': "Create",
+                    'layout': 'vertical',
+                },
+            ),
+        )
         self.newPointsButton = QtViewerPushButton(
             'new_points',
             trans._('New points layer'),
@@ -78,6 +99,7 @@ class QtLayerButtons(QFrame):
 
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.newImageButton)
         layout.addWidget(self.newPointsButton)
         layout.addWidget(self.newShapesButton)
         layout.addWidget(self.newLabelsButton)

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -54,25 +54,30 @@ class QtLayerButtons(QFrame):
         self.viewer = viewer
         self.deleteButton = QtDeleteButton(self.viewer)
 
-        def _Add_new_image(
-            dimensions: List[int] = [512, 512], fill_value: float = 0.0
+        def _new_image_widget(
+            dimensions: List[int] = [512, 512],
+            fill_value: float = 0.0,
         ) -> None:
             import numpy as np
 
             data = np.full(tuple(dimensions), fill_value)
             self.viewer.add_image(data=data)
 
+        def _spawn_new_image_widget() -> None:
+            from magicgui import magicgui
+
+            widget = magicgui(function=_new_image_widget, call_button="Create")
+            widget.called.connect(widget.close)
+            widget = self.viewer.window.add_dock_widget(
+                widget,
+                name="Add new image",
+                area='left',
+            )
+
         self.newImageButton = QtViewerPushButton(
             'new_image',
             trans._('New image layer'),
-            lambda: self.viewer.window.add_function_widget(
-                function=_Add_new_image,
-                magic_kwargs={
-                    'auto_call': False,
-                    'call_button': "Create",
-                    'layout': 'vertical',
-                },
-            ),
+            _spawn_new_image_widget,
         )
         self.newPointsButton = QtViewerPushButton(
             'new_points',


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This PR adds a "New image layer" button next to the points, shapes, and labels buttons in the layer list.

Upon clicking the "New image layer" button, an external dialog pops up allowing the user to set various parameters of the new layer. **This is a major difference from the other layer buttons, and should be discussed**. Once the "Create" button has been pressed, the image layer is created and added to the viewer, and the dialog is destroyed.

![NewImageEarlyDemo](https://user-images.githubusercontent.com/29754838/171476172-7ddc94d0-b13c-4117-87ef-905a870cb82f.gif)

My selfish use case of this behavior is for napari-imagej, where we have lots of algorithms that store results into a preallocated output. This button would make creating those preallocated outputs significantly easier.

I am very open to changes in this functionality.

Points of discussion:
* Should the dialog pop up in another layer, or should it show up in the main window? If it shows up in another layer, can/*should* it disable the main window until the "Create" button is pressed? My vote is no, as we generally do not adhere to such behavior in napari.
* Which array types should be supported? I currently support numpy arrays and zarr arrays, but I assume that others should be added. Of the array types, numpy is the only one that is always shipped with napari (zarr, for example, is not); how should we handle array types that are not imported? Should we just raise the `ImportError`, or try to disable the array types that are not available? I prefer the former.
* How do we handle the data type of the array? The `fill_value` must also be tied to this.

This is still a work in progress; here are the things I plan to do before converting this draft:
* [ ] Clean the code, add comments.
* [ ] Write tests for the new button
* [ ] Document the new button where appropriate

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# References

Please see the [zulip thread](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/Creating.20new.20images/near/284064534) for much discussion. 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
