### PR TITLE
Clean status message after leave canvas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,5 @@ napari/settings/napari.schema.json
 docs/jupyter_execute/
 docs/.jupyter_cache/
 docs/gallery/
+
+report*.json

--- a/.gitignore
+++ b/.gitignore
@@ -160,4 +160,5 @@ docs/jupyter_execute/
 docs/.jupyter_cache/
 docs/gallery/
 
+# pytest reports in json format https://github.com/napari/napari/pull/4518
 report*.json

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -261,8 +261,8 @@ class QtViewer(QSplitter):
         self._canvas_overlay = QtWidgetOverlay(self, self.canvas.native)
         self._canvas_overlay.set_welcome_visible(show_welcome_screen)
         self._canvas_overlay.sig_dropped.connect(self.dropEvent)
-        self._canvas_overlay.leave.connect(self._canvas_leave)
-        self._canvas_overlay.enter.connect(self._canvas_enter)
+        self._canvas_overlay.leave.connect(self._leave_canvas)
+        self._canvas_overlay.enter.connect(self._enter_canvas)
 
         main_widget = QWidget()
         main_layout = QVBoxLayout()
@@ -331,12 +331,12 @@ class QtViewer(QSplitter):
         # bind shortcuts stored in settings last.
         self._bind_shortcuts()
 
-    def _canvas_leave(self):
+    def _leave_canvas(self):
         """disable status on canvas leave"""
         self.viewer.status = ""
         self.viewer._mouse_over_canvas = False
 
-    def _canvas_enter(self):
+    def _enter_canvas(self):
         """enable status on canvas enter"""
         self.viewer.status = "Ready"
         self.viewer._mouse_over_canvas = True

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -261,6 +261,8 @@ class QtViewer(QSplitter):
         self._canvas_overlay = QtWidgetOverlay(self, self.canvas.native)
         self._canvas_overlay.set_welcome_visible(show_welcome_screen)
         self._canvas_overlay.sig_dropped.connect(self.dropEvent)
+        self._canvas_overlay.leave.connect(self._canvas_leave)
+        self._canvas_overlay.enter.connect(self._canvas_enter)
 
         main_widget = QWidget()
         main_layout = QVBoxLayout()
@@ -328,6 +330,16 @@ class QtViewer(QSplitter):
 
         # bind shortcuts stored in settings last.
         self._bind_shortcuts()
+
+    def _canvas_leave(self):
+        """disable status on canvas leave"""
+        self.viewer.status = ""
+        self.viewer._mouse_over_canvas = False
+
+    def _canvas_enter(self):
+        """enable status on canvas enter"""
+        self.viewer.status = "Ready"
+        self.viewer._mouse_over_canvas = True
 
     def _ensure_connect(self):
         # lazy load console

--- a/napari/_qt/widgets/qt_welcome.py
+++ b/napari/_qt/widgets/qt_welcome.py
@@ -182,6 +182,6 @@ class QtWidgetOverlay(QStackedWidget):
         super().enterEvent(event)
 
     def leaveEvent(self, event):
-        """Emmit our own event when mouse leave canvas."""
+        """Emit our own event when mouse leaves the canvas."""
         self.leave.emit()
         super().leaveEvent(event)

--- a/napari/_qt/widgets/qt_welcome.py
+++ b/napari/_qt/widgets/qt_welcome.py
@@ -172,7 +172,7 @@ class QtWidgetOverlay(QStackedWidget):
         self.setCurrentIndex(int(visible))
 
     def resizeEvent(self, event):
-        """Emmit our own event when canvas was resized."""
+        """Emit our own event when canvas was resized."""
         self.resized.emit()
         return super().resizeEvent(event)
 

--- a/napari/_qt/widgets/qt_welcome.py
+++ b/napari/_qt/widgets/qt_welcome.py
@@ -151,6 +151,8 @@ class QtWidgetOverlay(QStackedWidget):
 
     sig_dropped = Signal("QEvent")
     resized = Signal()
+    leave = Signal()
+    enter = Signal()
 
     def __init__(self, parent, widget):
         super().__init__(parent)
@@ -172,3 +174,11 @@ class QtWidgetOverlay(QStackedWidget):
     def resizeEvent(self, event):
         self.resized.emit()
         return super().resizeEvent(event)
+
+    def enterEvent(self, event):
+        self.enter.emit()
+        super().enterEvent(event)
+
+    def leaveEvent(self, event):
+        self.leave.emit()
+        super().leaveEvent(event)

--- a/napari/_qt/widgets/qt_welcome.py
+++ b/napari/_qt/widgets/qt_welcome.py
@@ -177,7 +177,7 @@ class QtWidgetOverlay(QStackedWidget):
         return super().resizeEvent(event)
 
     def enterEvent(self, event):
-        """Emmit our own event when mouse enter canvas."""
+        """Emit our own event when mouse enters the canvas."""
         self.enter.emit()
         super().enterEvent(event)
 

--- a/napari/_qt/widgets/qt_welcome.py
+++ b/napari/_qt/widgets/qt_welcome.py
@@ -172,13 +172,16 @@ class QtWidgetOverlay(QStackedWidget):
         self.setCurrentIndex(int(visible))
 
     def resizeEvent(self, event):
+        """Emmit our own event when canvas was resized."""
         self.resized.emit()
         return super().resizeEvent(event)
 
     def enterEvent(self, event):
+        """Emmit our own event when mouse enter canvas."""
         self.enter.emit()
         super().enterEvent(event)
 
     def leaveEvent(self, event):
+        """Emmit our own event when mouse leave canvas."""
         self.leave.emit()
         super().leaveEvent(event)

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -319,6 +319,7 @@ def test_emitting_data_doesnt_change_points_value(make_napari_viewer):
     viewer.layers.selection.active = layer
 
     assert layer._value is None
+    viewer._mouse_over_canvas = True
     viewer.cursor.position = tuple(layer.data[1])
     assert layer._value == 1
 

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -583,6 +583,7 @@ def test_active_layer_status_update():
 
     # wait 1 s to avoid the cursor event throttling
     time.sleep(1)
+    viewer._mouse_over_canvas = True
     viewer.cursor.position = [1, 1, 1, 1, 1]
     assert viewer.status == viewer.layers.selection.active.get_status(
         viewer.cursor.position, world=True

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -134,6 +134,9 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
     # 2-tuple indicating height and width
     _canvas_size: Tuple[int, int] = (600, 800)
     _ctx: Context
+    # To check if mouse is over canvas to avoid race conditions between
+    # different events systems
+    _mouse_over_canvas: bool = False
 
     def __init__(self, title='napari', ndisplay=2, order=(), axis_labels=()):
         # max_depth=0 means don't look for parent contexts.
@@ -397,6 +400,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         This is generally used as a callback when cursor.position is updated.
         """
         # Update status and help bar based on active layer
+        if not self._mouse_over_canvas:
+            return
         active = self.layers.selection.active
         if active is not None:
             self.status = active.get_status(

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -331,7 +331,10 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             layer._slice_dims(
                 self.dims.point, self.dims.ndisplay, self.dims.order
             )
-        self._update_status_bar_from_cursor()
+        position = list(self.cursor.position)
+        for ind in self.dims.order[: -self.dims.ndisplay]:
+            position[ind] = self.dims.point[ind]
+        self.cursor.position = position
 
     def _on_active_layer(self, event):
         """Update viewer state for a new active layer."""

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -331,6 +331,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             layer._slice_dims(
                 self.dims.point, self.dims.ndisplay, self.dims.order
             )
+        self._update_status_bar_from_cursor()
 
     def _on_active_layer(self, event):
         """Update viewer state for a new active layer."""

--- a/napari/utils/status_messages.py
+++ b/napari/utils/status_messages.py
@@ -60,9 +60,9 @@ def generate_layer_status(name, position, value):
     msg : string
         String containing a message that can be used as a status update.
     """
-    full_coord = np.round(position).astype(int)
+    full_coord = map(str, np.round(position).astype(int))
 
-    msg = f'{name} {full_coord}'
+    msg = f"{name} [{' '.join(full_coord)}]"
 
     if value is not None:
         if isinstance(value, tuple) and value != (None, None):


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This PR fix lack of update of status bar when mouse leave canvas or dim slider was updated

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

fix #4606

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
