### PR TITLE
`EventedModel`: fix validation of parametrized evented fields

### DIFF
--- a/napari/utils/events/containers/_evented_dict.py
+++ b/napari/utils/events/containers/_evented_dict.py
@@ -1,10 +1,13 @@
 """MutableMapping that emits events when altered."""
-from typing import Mapping, Sequence, Type, Union
+from typing import TYPE_CHECKING, Mapping, Sequence, Type, Union
 
 from ....utils.translations import trans
 from ..event import EmitterGroup, Event
 from ..types import SupportsEvents
 from ._dict import _K, _T, TypedMutableMapping
+
+if TYPE_CHECKING:
+    from pydantic.fields import ModelField
 
 
 class EventedDict(TypedMutableMapping[_K, _T]):
@@ -115,7 +118,7 @@ class EventedDict(TypedMutableMapping[_K, _T]):
         yield cls.validate
 
     @classmethod
-    def validate(cls, value, field):
+    def validate(cls, value: Mapping, field: 'ModelField'):
         """Pydantic validator."""
         if not isinstance(value, Mapping):
             raise TypeError(

--- a/napari/utils/events/containers/_evented_dict.py
+++ b/napari/utils/events/containers/_evented_dict.py
@@ -126,26 +126,26 @@ class EventedDict(TypedMutableMapping[_K, _T]):
                 )
             )
 
-        if field.key_field:
-            validated = {}
-            errors = []
-            for i, (k, v) in enumerate(value.items()):
-                valid_key, error = field.key_field[0].validate(
-                    k, {}, loc=f'[{i}]'
-                )
-                if error:
-                    errors.append(error)
-                valid_item, error = field.key_field[1].validate(
-                    v, {}, loc=f'[{i}]'
-                )
-                if error:
-                    errors.append(error)
-                validated[valid_key] = valid_item
-            if errors:
-                from pydantic import ValidationError
+        if not field.key_field:
+            return cls(value)
 
-                raise ValidationError(errors, cls)  # type: ignore
-            return cls(validated)
+        validated = {}
+        errors = []
+        for i, (k, v) in enumerate(value.items()):
+            valid_key, error = field.key_field[0].validate(k, {}, loc=f'[{i}]')
+            if error:
+                errors.append(error)
+            valid_item, error = field.key_field[1].validate(
+                v, {}, loc=f'[{i}]'
+            )
+            if error:
+                errors.append(error)
+            validated[valid_key] = valid_item
+        if errors:
+            from pydantic import ValidationError
+
+            raise ValidationError(errors, cls)  # type: ignore
+        return cls(validated)
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}({repr(self._dict)})"

--- a/napari/utils/events/containers/_evented_list.py
+++ b/napari/utils/events/containers/_evented_list.py
@@ -24,8 +24,8 @@ cover this in test_evented_list.py)
 
 import logging
 from typing import (
+    TYPE_CHECKING,
     Callable,
-    Collection,
     Dict,
     Iterable,
     List,
@@ -41,6 +41,9 @@ from ..types import SupportsEvents
 from ._typed import _L, _T, Index, TypedMutableSequence
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from pydantic.fields import ModelField
 
 
 class EventedList(TypedMutableSequence[_T]):
@@ -368,12 +371,12 @@ class EventedList(TypedMutableSequence[_T]):
         yield cls.validate
 
     @classmethod
-    def validate(cls, value, field):
+    def validate(cls, value: Iterable, field: 'ModelField'):
         """Pydantic validator."""
-        if not isinstance(value, Collection):
+        if not isinstance(value, Iterable):
             raise TypeError(
                 trans._(
-                    'Value is not a valid collection: {value}',
+                    'Value is not a valid iterable: {value}',
                     deferred=True,
                     value=value,
                 )

--- a/napari/utils/events/containers/_evented_list.py
+++ b/napari/utils/events/containers/_evented_list.py
@@ -379,19 +379,21 @@ class EventedList(TypedMutableSequence[_T]):
                 )
             )
 
-        if field.key_field:
-            validated = []
-            errors = []
-            for i, v in enumerate(value):
-                valid, error = field.key_field.validate(v, {}, loc=f'[{i}]')
-                validated.append(valid)
-                if error:
-                    errors.append(error)
-            if errors:
-                from pydantic import ValidationError
+        if not field.key_field:
+            return cls(value)
 
-                raise ValidationError(errors, cls)  # type: ignore
-            return cls(validated)
+        validated = []
+        errors = []
+        for i, v in enumerate(value):
+            valid, error = field.key_field.validate(v, {}, loc=f'[{i}]')
+            validated.append(valid)
+            if error:
+                errors.append(error)
+        if errors:
+            from pydantic import ValidationError
+
+            raise ValidationError(errors, cls)  # type: ignore
+        return cls(validated)
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}({repr(self._list)})"

--- a/napari/utils/events/containers/_set.py
+++ b/napari/utils/events/containers/_set.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import Any, Collection, Iterable, Iterator, MutableSet, TypeVar
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, MutableSet, TypeVar
 
 from ....utils.events import EmitterGroup
 from ....utils.translations import trans
 
 _T = TypeVar("_T")
+
+if TYPE_CHECKING:
+    from pydantic.fields import ModelField
 
 
 class EventedSet(MutableSet[_T]):
@@ -157,12 +160,12 @@ class EventedSet(MutableSet[_T]):
         yield cls.validate
 
     @classmethod
-    def validate(cls, value, field):
+    def validate(cls, value: Iterable, field: ModelField):
         """Pydantic validator."""
-        if not isinstance(value, Collection):
+        if not isinstance(value, Iterable):
             raise TypeError(
                 trans._(
-                    'Value is not a valid collection: {value}',
+                    'Value is not a valid iterable: {value}',
                     deferred=True,
                     value=value,
                 )

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -118,18 +118,24 @@ class EventedMetaclass(main.ModelMetaclass):
             # hijacking the key_field (cannot make new ones because of __slots__)
             # which is otherwise unused
             if f.type_ is EventedList:
-                f.key_field = f._create_sub_type(
-                    get_args(annotations[n])[0], 'i_' + f.name
-                )
+                hint = get_args(annotations[n])
+                if hint:
+                    f.key_field = f._create_sub_type(
+                        get_args(annotations[n])[0], 'i_' + f.name
+                    )
             if f.type_ is EventedDict:
-                f.key_field = [
-                    f._create_sub_type(
-                        get_args(annotations[n])[0], 'k_' + f.name
-                    ),
-                    f._create_sub_type(
-                        get_args(annotations[n])[1], 'i_' + f.name
-                    ),
-                ]
+                hint = get_args(annotations[n])
+                if hint:
+                    if len(hint) != 2:
+                        raise TypeError('Dict annotation must be a 2-tuple')
+                    f.key_field = [
+                        f._create_sub_type(
+                            get_args(annotations[n])[0], 'k_' + f.name
+                        ),
+                        f._create_sub_type(
+                            get_args(annotations[n])[1], 'i_' + f.name
+                        ),
+                    ]
 
         # check for @_.setters defined on the class, so we can allow them
         # in EventedModel.__setattr__

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -95,7 +95,9 @@ class EventedMetaclass(main.ModelMetaclass):
         annotations = namespace.get('__annotations__', {}).copy()
         for k, v in annotations.items():
             origin = get_origin(v)
-            if origin in (EventedList, EventedDict):
+            if isinstance(origin, type) and issubclass(
+                origin, (EventedList, EventedDict)
+            ):
                 namespace['__annotations__'][k] = origin
 
         with no_class_attributes():


### PR DESCRIPTION
# Description
While working on #4597 and #4522, I doscovered that pydantic (and therefore our `EventedModel`) was failing in a few ways when dealing with our `EvendedList` and `EvendetDict`.

In short:
1. using parametrized evented list or dict would not fire custom validators from `__get_validators__`, preventing us from coercing it to the class itself (you would just get a normal `list` out of validation)
2. using parametrized evented list or Set would fail if passing an evented object to be validated
3. using non-parametrized versions would not let you validate the types of the element
4. using non-parametrized versions would mean giving up on all the `mypy` checks

This PR fixes 1, 2 and 4 by automatically removing annotations in the `EventedModel` metaclass so that pydantic isn't spooked, then fixed 3 by reintroducing type-checking in a (now properly recognized) `__get_validators__` class validator and hijacking a bit pydantic by using a field `__slot__` which is otherwise unused for our two types.

This now means we can do:

```python
from napari.utils.events import EventedModel, EventedList, EventedDict, EventedSet, TypedMutableSequence

class M(EventedModel):
    ls: EventedList[float]
    s: EventedSet[str]
    d: EventedDict[float, str]

m = M(ls=[1,2,3], s={1,2}, d={1: 2})  # these could be any list/set/dict-like

# M(ls=EventedList([1.0, 2.0, 3.0]), s=EventedSet({'2', '1'}), d=EventedDict({1.0: '2'}))
```
cc @tlambert03 

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
