### PR TITLE
Remove meshzoo from napari

### DIFF
--- a/examples/clipping_planes_interactive_.py
+++ b/examples/clipping_planes_interactive_.py
@@ -44,7 +44,7 @@ points_layer = viewer.add_points(
 
 # SPHERE
 mesh = create_sphere(method='ico')
-sphere_vert = mesh.get_vertices * 20
+sphere_vert = mesh.get_vertices() * 20
 sphere_vert += 32
 surface_layer = viewer.add_surface(
     (sphere_vert, mesh.get_faces()),

--- a/examples/clipping_planes_interactive_.py
+++ b/examples/clipping_planes_interactive_.py
@@ -9,15 +9,7 @@ import napari
 import numpy as np
 from skimage import data
 from scipy import ndimage
-
-try:
-    from meshzoo import icosa_sphere
-except ModuleNotFoundError as e:
-    raise ModuleNotFoundError(
-        "This example uses a meshzoo but meshzoo is not installed. "
-        "To install try 'pip install meshzoo'."
-    ) from e
-
+from vispy.geometry import create_sphere
 
 viewer = napari.Viewer(ndisplay=3)
 
@@ -51,11 +43,11 @@ points_layer = viewer.add_points(
 )
 
 # SPHERE
-sphere_vert, sphere_faces = icosa_sphere(10)
-sphere_vert *= 20
+mesh = create_sphere(method='ico')
+sphere_vert = mesh.get_vertices * 20
 sphere_vert += 32
 surface_layer = viewer.add_surface(
-    (sphere_vert, sphere_faces),
+    (sphere_vert, mesh.get_faces()),
     experimental_clipping_planes=[plane_parameters],
 )
 

--- a/examples/spheres_.py
+++ b/examples/spheres_.py
@@ -5,19 +5,13 @@ Spheres
 Display two spheres with Surface layers
 """
 
-try:
-    from meshzoo import icosa_sphere
-except ModuleNotFoundError as e:
-    raise ModuleNotFoundError(
-        "This example uses a meshzoo but meshzoo is not installed. "
-        "To install try 'pip install meshzoo'."
-    ) from e
 import napari
+from vispy.geometry import create_sphere
 
+mesh = create_sphere(method='ico')
 
-vert, faces = icosa_sphere(10)
-
-vert *= 100
+faces = mesh.get_faces()
+vert = mesh.get_vertices() * 100
 
 sphere1 = (vert + 30, faces)
 sphere2 = (vert - 30, faces)

--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -23,16 +23,7 @@ skip = [
     'custom_key_bindings.py',  # breaks EXPECTED_NUMBER_OF_VIEWER_METHODS later
     'new_theme.py',  # testing theme is extremely slow on CI
     'dynamic-projections-dask.py',  # extremely slow / does not finish
-    'spheres_.py',  # needs meshzoo
-    'clipping_planes_interactive_.py',  # needs meshzoo
 ]
-
-try:
-    import meshzoo
-except ModuleNotFoundError:
-    # this should be restored once numpy min req is
-    skip.extend(['spheres.py', 'clipping_planes_interactive.py'])
-
 
 EXAMPLE_DIR = Path(napari.__file__).parent.parent / 'examples'
 # using f.name here and re-joining at `run_path()` for test key presentation

--- a/setup.cfg
+++ b/setup.cfg
@@ -118,7 +118,6 @@ testing =
     semgrep
     tensorstore>=0.1.13 ; python_version < '3.10'
     torch>=1.7 ; python_version < '3.10'
-    meshzoo
     lxml!=4.9.0
 release = 
     PyGithub>=1.44.1

--- a/tools/minreq.py
+++ b/tools/minreq.py
@@ -10,7 +10,6 @@ other than '1'.
 """
 
 import os
-import sys
 from configparser import ConfigParser
 
 
@@ -18,13 +17,6 @@ def pin_config_minimum_requirements(config_filename):
     # read it with configparser
     config = ConfigParser()
     config.read(config_filename)
-
-    if 'numpy>=1.20' in config['options.extras_require']:
-        sys.exit('please restore meshzoo install in minreq.py, ')
-    else:
-        config['options.extras_require']['testing'] = config[
-            'options.extras_require'
-        ]['testing'].replace('meshzoo', '')
 
     # swap out >= requirements for ==
     config['options']['install_requires'] = config['options'][


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

As mentioned in https://github.com/napari/napari/issues/4324, `meshzoo` recently switched from being a small clean library to one with opaque source code and dependencies on *binary only* libraries which seem to serve no purpose, namely [`x21`](https://pypi.org/project/x21/) and  [`kgt`](https://pypi.org/project/kgt/).

These libraries prevented `pip install -e .[dev]` from working on `arm64`. (Beyond that, I find it unnerving that a binary-only library with zero documentation was being installed when we set up a development environment.)

I was able to maintain the examples by using `vispy.geometry import create_sphere`. As a bonus, we no longer need to check for `meshzoo` when testing these example.

h/t to @Czaki and @psobolewskiPhD on Zulip.

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
