### PR TITLE
Raise error when rgb True but data not correct dims

### DIFF
--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -203,7 +203,7 @@ def test_non_rgb_image():
 def test_error_non_rgb_image(shape):
     """Test error on trying non rgb as rgb."""
     # If rgb is set to be True in constructor but the last dim has a
-    # size > 4 or len(shape) < 3 then data cannot actually be rgb
+    # size > 4 or ndim not >= 3 then data cannot actually be rgb
     np.random.seed(0)
     data = np.random.random(shape)
     with pytest.raises(ValueError):

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -204,9 +204,8 @@ def test_error_non_rgb_image(shape):
     """Test error on trying non rgb as rgb."""
     # If rgb is set to be True in constructor but the last dim has a
     # size > 4 or ndim not >= 3 then data cannot actually be rgb
-    np.random.seed(0)
-    data = np.random.random(shape)
-    with pytest.raises(ValueError):
+    data = np.empty(shape)
+    with pytest.raises(ValueError, match="'rgb' was set to True but"):
         Image(data, rgb=True)
 
 

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -199,11 +199,11 @@ def test_non_rgb_image():
     assert layer._data_view.shape == shape[-2:]
 
 
-def test_error_non_rgb_image():
+@pytest.mark.parametrize("shape", [(10, 15, 6), (10, 10)])
+def test_error_non_rgb_image(shape):
     """Test error on trying non rgb as rgb."""
     # If rgb is set to be True in constructor but the last dim has a
-    # size > 4 then data cannot actually be rgb
-    shape = (10, 15, 6)
+    # size > 4 or len(shape) < 3 then data cannot actually be rgb
     np.random.seed(0)
     data = np.random.random(shape)
     with pytest.raises(ValueError):

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -260,7 +260,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         if rgb and not rgb_guess:
             raise ValueError(
                 trans._(
-                    "'rgb' was set to True but last dim of data was not 3 or 4."
+                    "'rgb' was set to True but data does not have suitable dimensions."
                 )
             )
         elif rgb is None:

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -256,8 +256,15 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
             data = MultiScaleData(data)
 
         # Determine if rgb
-        if rgb is None:
-            rgb = guess_rgb(data.shape)
+        rgb_guess = guess_rgb(data.shape)
+        if rgb and not rgb_guess:
+            raise ValueError(
+                trans._(
+                    "'rgb' was set to True but last dim of data was not 3 or 4."
+                )
+            )
+        elif rgb is None:
+            rgb = rgb_guess
 
         # Determine dimensionality of the data
         ndim = len(data.shape)


### PR DESCRIPTION
# Description
Raise error when rgb True but data not correct dims. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #3923

Not sure if test required for this change, happy to add one.
 