### PR TITLE
Add versioned API docs workflow

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -3,7 +3,7 @@ name: Build and Deploy Docs
 on:
   push:
     branches:
-      - enable-versioned-api
+      - main
     tags:
       - 'v*'
   workflow_dispatch:
@@ -47,8 +47,8 @@ jobs:
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3
         with:
-          personal_token: ${{ secrets.DEPLOY_GHPAGES }}
-          external_repository: melissawm/napari.github.io
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          external_repository: napari/napari.github.io
           publish_dir: docs/_build
           publish_branch: gh-pages
           destination_dir: dev

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -3,7 +3,7 @@ name: Build and Deploy Docs
 on:
   push:
     branches:
-      - main
+      - enable-versioned-api
     tags:
       - 'v*'
   workflow_dispatch:
@@ -47,8 +47,9 @@ jobs:
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3
         with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          external_repository: napari/napari.github.io
+          personal_token: ${{ secrets.DEPLOY_GHPAGES }}
+          external_repository: melissawm/napari.github.io
           publish_dir: docs/_build
           publish_branch: gh-pages
+          destination_dir: dev
           cname: napari.org

--- a/docs/_static/redirects.js
+++ b/docs/_static/redirects.js
@@ -1,0 +1,11 @@
+// Will match any urls containing the strings
+// - "/dev/"
+// - "/stable/"
+// - "/X.Y.Z/"
+// where X.Y.Z is a version string and redirect the page to its stable version.
+
+let pattern = /\/dev\/|\/stable\/|\/\d+.\d+.\d+\//;
+
+if (!pattern.test(window.location.href.toLowerCase())) {
+   window.location.href = 'http://napari.org/stable'+window.location.pathname;
+}

--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -6,7 +6,12 @@
 	},
 	{
 		"name": "stable",
-		"version": "0.4.15",
+		"version": "0.4.16",
 		"url": "https://napari.org/stable/"
+	}
+	{
+		"name": "0.4.15",
+		"version": "0.4.15",
+		"url": "https://napari.org/0.4.15/"
 	}
 ]

--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -2,11 +2,11 @@
 	{
 		"name": "latest",
 		"version": "dev",
-		"url": "https://melissawm.github.io/napari.github.io/dev/"
+		"url": "https://napari.org/dev/"
 	},
 	{
 		"name": "stable",
 		"version": "0.4.15",
-		"url": "https://melissawm.github.io/napari.github.io/stable/"
+		"url": "https://napari.org/stable/"
 	}
 ]

--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -1,29 +1,12 @@
 [
 	{
-	  "version": "dev"
+		"name": "latest",
+		"version": "dev",
+		"url": "https://melissawm.github.io/napari.github.io/dev/"
 	},
 	{
-	  "version": "0.4.7"
-	},
-	{
-	  "version": "0.4.6"
-	},
-	{
-	  "version": "0.4.5"
-	},
-	{
-	  "version": "0.4.4"
-	},
-	{
-	  "version": "0.4.3"
-	},
-	{
-	  "version": "0.4.0"
-	},
-	{
-	  "version": "0.3.8"
-	},
-	{
-	  "version": "0.3.7"
-	},
+		"name": "stable",
+		"version": "0.4.15",
+		"url": "https://melissawm.github.io/napari.github.io/stable/"
+	}
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,13 +71,29 @@ external_toc_exclude_missing = False
 # a list of builtin themes.
 #
 html_theme = 'napari'
+
+# Define the json_url for our version switcher.
+#json_url = "https://napari.org/version_switcher.json"
+json_url = "https://melissawm.github.io/napari.github.io/version_switcher.json"
+
+if version == "dev":
+    version_match = "latest"
+else:
+    version_match = release
+
 html_theme_options = {
     "external_links": [
         {"name": "napari hub", "url": "https://napari-hub.org"}
     ],
     "github_url": "https://github.com/napari/napari",
     "navbar_start": ["navbar-project"],
-    "navbar_end": ["navbar-icon-links"],
+    "navbar_end": ["version-switcher", "navbar-icon-links"],
+    "switcher": {
+        #"json_url": "https://napari.org/version_switcher.json",
+        "json_url": "https://melissawm.github.io/napari.github.io/version_switcher.json",
+        "version_match": version_match,
+    },
+
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,6 +105,10 @@ html_css_files = [
     'custom.css',
 ]
 
+html_js_files = [
+    'redirects.js',
+]
+
 intersphinx_mapping = {
     'python': ['https://docs.python.org/3', None],
     'numpy': ['https://numpy.org/doc/stable/', None],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,8 +73,7 @@ external_toc_exclude_missing = False
 html_theme = 'napari'
 
 # Define the json_url for our version switcher.
-#json_url = "https://napari.org/version_switcher.json"
-json_url = "https://melissawm.github.io/napari.github.io/version_switcher.json"
+json_url = "https://napari.org/version_switcher.json"
 
 if version == "dev":
     version_match = "latest"
@@ -89,11 +88,9 @@ html_theme_options = {
     "navbar_start": ["navbar-project"],
     "navbar_end": ["version-switcher", "navbar-icon-links"],
     "switcher": {
-        #"json_url": "https://napari.org/version_switcher.json",
-        "json_url": "https://melissawm.github.io/napari.github.io/version_switcher.json",
+        "json_url": "https://napari.org/version_switcher.json",
         "version_match": version_match,
     },
-
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
# Description
This PR adds a version switcher dropdown to the docs, and a github action to deploy these docs to the `napari/napari.github.io` upon merge to main (EDIT: This is ready)

This should be merged first, followed by https://github.com/napari/napari.github.io/pull/350

The caveat here, as mentioned in #4593 , is that links to the docs pages will change due to the new folder structure pointing to `/dev`, `/stable` etc. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# References
Closes #4593

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
