### PR TITLE
Add modal dialogs for window/application closure

### DIFF
--- a/napari/_qt/menus/_tests/test_file_menu.py
+++ b/napari/_qt/menus/_tests/test_file_menu.py
@@ -3,11 +3,9 @@ from unittest import mock
 from npe2 import DynamicPlugin
 from npe2.manifest.contributions import SampleDataURI
 
-
 from napari._qt.menus import file_menu
 from napari.settings import get_settings
 from napari.utils.action_manager import action_manager
-
 
 
 def test_sample_data_triggers_reader_dialog(
@@ -109,7 +107,8 @@ def test_close_app_ok(make_napari_viewer):
             v.window.file_menu._close_app()
             message_mock.assert_called_once()
             close_mock.assert_called_once_with(quit_app=True)
-      
+
+
 def test_show_shortcuts_actions(make_napari_viewer):
     viewer = make_napari_viewer()
     assert viewer.window.file_menu._pref_dialog is None

--- a/napari/_qt/menus/_tests/test_file_menu.py
+++ b/napari/_qt/menus/_tests/test_file_menu.py
@@ -3,6 +3,9 @@ from unittest import mock
 from npe2 import DynamicPlugin
 from npe2.manifest.contributions import SampleDataURI
 
+from napari._qt.menus import file_menu
+from napari.settings import get_settings
+
 
 def test_sample_data_triggers_reader_dialog(
     mock_npe2_pm, tmp_reader, make_napari_viewer
@@ -31,3 +34,75 @@ def test_sample_data_triggers_reader_dialog(
 
     # assert that handle gui reading was called
     mock_read.assert_called_once()
+
+
+def test_close_window_cancel(make_napari_viewer):
+    v = make_napari_viewer()
+    with mock.patch(
+        'napari._qt.qt_main_window._QtMainWindow.close'
+    ) as close_mock:
+        with mock.patch(
+            "napari._qt.menus.file_menu.QMessageBox.exec_",
+            return_value=file_menu.QMessageBox.StandardButton.Cancel,
+        ) as message_mock:
+            v.window.file_menu._close_window()
+            message_mock.assert_called_once()
+            close_mock.assert_not_called()
+
+
+def test_close_window_ok(make_napari_viewer):
+    v = make_napari_viewer()
+    with mock.patch(
+        'napari._qt.qt_main_window._QtMainWindow.close'
+    ) as close_mock:
+        with mock.patch(
+            "napari._qt.menus.file_menu.QMessageBox.exec_",
+            return_value=file_menu.QMessageBox.StandardButton.Ok,
+        ) as message_mock:
+            v.window.file_menu._close_window()
+            message_mock.assert_called_once()
+            close_mock.assert_called_once_with(quit_app=False)
+
+
+def test_close_window_no_confirm(make_napari_viewer, monkeypatch):
+    v = make_napari_viewer()
+    with mock.patch(
+        'napari._qt.qt_main_window._QtMainWindow.close'
+    ) as close_mock:
+        monkeypatch.setattr(
+            get_settings().application, "confirm_close_window", False
+        )
+        with mock.patch(
+            "napari._qt.menus.file_menu.QMessageBox.exec_"
+        ) as message_mock:
+            v.window.file_menu._close_window()
+            message_mock.assert_not_called()
+            close_mock.assert_called_once_with(quit_app=False)
+
+
+def test_close_app_cancel(make_napari_viewer):
+    v = make_napari_viewer()
+    with mock.patch(
+        'napari._qt.qt_main_window._QtMainWindow.close'
+    ) as close_mock:
+        with mock.patch(
+            "napari._qt.menus.file_menu.QMessageBox.exec_",
+            return_value=file_menu.QMessageBox.StandardButton.Cancel,
+        ) as message_mock:
+            v.window.file_menu._close_app()
+            message_mock.assert_called_once()
+            close_mock.assert_not_called()
+
+
+def test_close_app_ok(make_napari_viewer):
+    v = make_napari_viewer()
+    with mock.patch(
+        'napari._qt.qt_main_window._QtMainWindow.close'
+    ) as close_mock:
+        with mock.patch(
+            "napari._qt.menus.file_menu.QMessageBox.exec_",
+            return_value=file_menu.QMessageBox.StandardButton.Ok,
+        ) as message_mock:
+            v.window.file_menu._close_app()
+            message_mock.assert_called_once()
+            close_mock.assert_called_once_with(quit_app=True)

--- a/napari/_qt/menus/_util.py
+++ b/napari/_qt/menus/_util.py
@@ -1,3 +1,4 @@
+import contextlib
 from typing import TYPE_CHECKING, Callable, List, Union
 
 from qtpy.QtWidgets import QAction, QMenu
@@ -125,18 +126,14 @@ class NapariMenu(QMenu):
         for ax in self.actions():
             ax.setData(None)
 
-            try:
+            with contextlib.suppress(AttributeError):
                 ax._destroy()
-            except AttributeError:
-                pass
-
         if self in self._INSTANCES:
             self._INSTANCES.remove(self)
 
     def update(self, event=None):
         """Update action enabled/disabled state based on action data."""
         for ax in self.actions():
-            data = ax.data()
-            if data:
+            if data := ax.data():
                 enabled_func = data.get('enabled', lambda event: True)
                 ax.setEnabled(bool(enabled_func(event)))

--- a/napari/_qt/menus/file_menu.py
+++ b/napari/_qt/menus/file_menu.py
@@ -148,7 +148,7 @@ class FileMenu(NapariMenu):
     def _close_window(self):
         message = QMessageBox(
             QMessageBox.Icon.Warning,
-            "Close window",
+            "Close window?",
             "Confirm to close window (or press 'Ctrl+W')",
             QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
             self._win._qt_window,

--- a/napari/_qt/menus/file_menu.py
+++ b/napari/_qt/menus/file_menu.py
@@ -137,7 +137,10 @@ class FileMenu(NapariMenu):
             QMessageBox.Icon.Warning,
             trans._("Close application?"),
             trans._(
-                "Do you want to close the application? ('Ctrl+Q' to confirm). This will close all Qt Windows in this process"
+                "Do you want to close the application? ('{shortcut}' to confirm). This will close all Qt Windows in this process",
+                shortcut=QKeySequence('Ctrl+Q').toString(
+                    QKeySequence.NativeText
+                ),
             ),
             QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
             self._win._qt_window,
@@ -154,7 +157,12 @@ class FileMenu(NapariMenu):
         message = QMessageBox(
             QMessageBox.Icon.Question,
             trans._("Close window?"),
-            trans._("Confirm to close window (or press 'Ctrl+W')"),
+            trans._(
+                "Confirm to close window (or press '{shortcut}')",
+                shortcut=QKeySequence('Ctrl+W').toString(
+                    QKeySequence.NativeText
+                ),
+            ),
             QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
             self._win._qt_window,
         )

--- a/napari/_qt/menus/file_menu.py
+++ b/napari/_qt/menus/file_menu.py
@@ -136,7 +136,9 @@ class FileMenu(NapariMenu):
         message = QMessageBox(
             QMessageBox.Icon.Warning,
             trans._("Close application?"),
-            trans._("Confirm to close application (or press 'Ctrl+Q')"),
+            trans._(
+                "Confirm to close application (or press 'Ctrl+Q'). This will close all Qt Windows in this process"
+            ),
             QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
             self._win._qt_window,
         )

--- a/napari/_qt/menus/file_menu.py
+++ b/napari/_qt/menus/file_menu.py
@@ -135,8 +135,8 @@ class FileMenu(NapariMenu):
     def _close_app(self):
         message = QMessageBox(
             QMessageBox.Icon.Warning,
-            "Close confirm",
-            "Confirm to close application (could confirm with 'Ctrl+Q')",
+            "Close application?",
+            "Confirm to close application (or press 'Ctrl+Q')",
             QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
             self._win._qt_window,
         )
@@ -148,8 +148,8 @@ class FileMenu(NapariMenu):
     def _close_window(self):
         message = QMessageBox(
             QMessageBox.Icon.Warning,
-            "Close confirm",
-            "Confirm to close window (could confirm with 'Ctrl+W')",
+            "Close window",
+            "Confirm to close window (or press 'Ctrl+W')",
             QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
             self._win._qt_window,
         )

--- a/napari/_qt/menus/file_menu.py
+++ b/napari/_qt/menus/file_menu.py
@@ -148,6 +148,9 @@ class FileMenu(NapariMenu):
             self._win._qt_window.close(quit_app=True)
 
     def _close_window(self):
+        if not get_settings().application.confirm_close_window:
+            self._win._qt_window.close(quit_app=False)
+            return
         message = QMessageBox(
             QMessageBox.Icon.Question,
             trans._("Close window?"),
@@ -158,7 +161,7 @@ class FileMenu(NapariMenu):
         close_btn = message.button(QMessageBox.StandardButton.Ok)
         close_btn.setShortcut(QKeySequence('Ctrl+W'))
         if message.exec_() == QMessageBox.StandardButton.Ok:
-            self._win._qt_window.close()
+            self._win._qt_window.close(quit_app=False)
 
     def _layer_count(self, event=None):
         return len(self._win._qt_viewer.viewer.layers)

--- a/napari/_qt/menus/file_menu.py
+++ b/napari/_qt/menus/file_menu.py
@@ -135,8 +135,8 @@ class FileMenu(NapariMenu):
     def _close_app(self):
         message = QMessageBox(
             QMessageBox.Icon.Warning,
-            "Close application?",
-            "Confirm to close application (or press 'Ctrl+Q')",
+            trans._("Close application?"),
+            trans._("Confirm to close application (or press 'Ctrl+Q')"),
             QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
             self._win._qt_window,
         )
@@ -148,8 +148,8 @@ class FileMenu(NapariMenu):
     def _close_window(self):
         message = QMessageBox(
             QMessageBox.Icon.Warning,
-            "Close window?",
-            "Confirm to close window (or press 'Ctrl+W')",
+            trans._("Close window?"),
+            trans._("Confirm to close window (or press 'Ctrl+W')"),
             QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
             self._win._qt_window,
         )

--- a/napari/_qt/menus/file_menu.py
+++ b/napari/_qt/menus/file_menu.py
@@ -137,7 +137,7 @@ class FileMenu(NapariMenu):
             QMessageBox.Icon.Warning,
             trans._("Close application?"),
             trans._(
-                "Confirm to close application (or press 'Ctrl+Q'). This will close all Qt Windows in this process"
+                "Do you want to close the application? ('Ctrl+Q' to confirm). This will close all Qt Windows in this process"
             ),
             QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
             self._win._qt_window,

--- a/napari/_qt/menus/file_menu.py
+++ b/napari/_qt/menus/file_menu.py
@@ -149,7 +149,7 @@ class FileMenu(NapariMenu):
 
     def _close_window(self):
         message = QMessageBox(
-            QMessageBox.Icon.Warning,
+            QMessageBox.Icon.Question,
             trans._("Close window?"),
             trans._("Confirm to close window (or press 'Ctrl+W')"),
             QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,

--- a/napari/settings/_application.py
+++ b/napari/settings/_application.py
@@ -7,6 +7,7 @@ from pydantic import Field, validator
 from ..utils._base import _DEFAULT_LOCALE
 from ..utils.events.custom_types import conint
 from ..utils.events.evented_model import EventedModel
+from ..utils.interactions import Shortcut
 from ..utils.notifications import NotificationSeverity
 from ..utils.translations import trans
 from ._constants import LoopMode
@@ -159,7 +160,8 @@ class ApplicationSettings(EventedModel):
         default=True,
         title=trans._("Window close confirmation"),
         description=trans._(
-            "Ask for confirmation before close window with Ctrl+W"
+            "Ask for confirmation before close window with {shortcut}",
+            shortcut=Shortcut("Control-W").platform,
         ),
     )
 

--- a/napari/settings/_application.py
+++ b/napari/settings/_application.py
@@ -155,6 +155,13 @@ class ApplicationSettings(EventedModel):
         title=trans._("Grid Height"),
         description=trans._("Number of rows in the grid."),
     )
+    confirm_close_window: bool = Field(
+        default=True,
+        title=trans._("Window close confirmation"),
+        description=trans._(
+            "Ask for confirmation before close window with Ctrl+W"
+        ),
+    )
 
     @validator('window_state')
     def _validate_qbtye(cls, v):

--- a/napari/settings/_application.py
+++ b/napari/settings/_application.py
@@ -158,9 +158,9 @@ class ApplicationSettings(EventedModel):
     )
     confirm_close_window: bool = Field(
         default=True,
-        title=trans._("Window close confirmation"),
+        title=trans._("Confirm window closing"),
         description=trans._(
-            "Ask for confirmation before close window with {shortcut}",
+            "Ask for confirmation before closing window with {shortcut}",
             shortcut=Shortcut("Control-W").platform,
         ),
     )


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This PR adds dialogs with confirmation of the close window. To simplify the life of the power user the confirmation could be done using the same shortcut again. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

close #4626

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
