### PR TITLE
Remove some sleepy tests, wait with timeout instead

### DIFF
--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -1,5 +1,4 @@
 import threading
-import time
 import warnings
 from concurrent.futures import Future
 from unittest.mock import patch
@@ -10,6 +9,7 @@ from qtpy.QtCore import Qt, QThread
 from qtpy.QtWidgets import QPushButton
 
 from napari._qt.dialogs.qt_notification import NapariQtNotification
+from napari._tests.utils import DEFAULT_TIMEOUT_SECS
 from napari.utils.notifications import (
     ErrorNotification,
     Notification,
@@ -21,20 +21,20 @@ from napari.utils.notifications import (
 def _threading_warn():
     thr = threading.Thread(target=_warn)
     thr.start()
+    thr.join(timeout=DEFAULT_TIMEOUT_SECS)
 
 
 def _warn():
-    time.sleep(0.1)
     warnings.warn('warning!')
 
 
 def _threading_raise():
     thr = threading.Thread(target=_raise)
     thr.start()
+    thr.join(timeout=DEFAULT_TIMEOUT_SECS)
 
 
 def _raise():
-    time.sleep(0.1)
     raise ValueError("error!")
 
 
@@ -79,7 +79,6 @@ def test_notification_manager_via_gui(
         ]:
             notification_manager.records = []
             qtbot.mouseClick(btt, Qt.LeftButton)
-            qtbot.wait(500)
             assert len(notification_manager.records) == 1
             assert notification_manager.records[0].message == expected_message
             notification_manager.records = []
@@ -106,7 +105,7 @@ def test_show_notification_from_thread(mock_show, monkeypatch, qtbot):
             )
             res = NapariQtNotification.show_notification(notif)
             assert isinstance(res, Future)
-            assert res.result() is None
+            assert res.result(timeout=DEFAULT_TIMEOUT_SECS) is None
             mock_show.assert_called_once()
 
     thread = CustomThread()

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -31,6 +31,12 @@ skip_local_popups = pytest.mark.skipif(
     ' Set NAPARI_POPUP_TESTS=1 environment variable to enable.',
 )
 
+"""
+The default timeout duration in seconds when waiting on tasks running in non-main threads.
+The value was chosen to be consistent with `QtBot.waitSignal` and `QtBot.waitUntil`.
+"""
+DEFAULT_TIMEOUT_SECS: float = 5
+
 
 """
 Used as pytest params for testing layer add and view functionality (Layer class, data, ndim)

--- a/napari/utils/_tests/test_notification_manager.py
+++ b/napari/utils/_tests/test_notification_manager.py
@@ -1,11 +1,11 @@
 import sys
 import threading
-import time
 import warnings
 from typing import List
 
 import pytest
 
+from napari._tests.utils import DEFAULT_TIMEOUT_SECS
 from napari.utils.notifications import (
     Notification,
     notification_manager,
@@ -112,11 +112,9 @@ def test_notification_manager_no_gui_with_threading():
     """
 
     def _warn():
-        time.sleep(0.01)
         warnings.showwarning('this is a warning', UserWarning, '', 0)
 
     def _raise():
-        time.sleep(0.01)
         with pytest.raises(PurposefulException):
             raise PurposefulException("this is an exception")
 
@@ -135,7 +133,7 @@ def test_notification_manager_no_gui_with_threading():
 
         exception_thread = threading.Thread(target=_raise)
         exception_thread.start()
-        time.sleep(0.02)
+        exception_thread.join(timeout=DEFAULT_TIMEOUT_SECS)
 
         try:
             raise ValueError("a")
@@ -149,16 +147,10 @@ def test_notification_manager_no_gui_with_threading():
         assert warnings.showwarning == notification_manager.receive_warning
         warning_thread = threading.Thread(target=_warn)
         warning_thread.start()
+        warning_thread.join(timeout=DEFAULT_TIMEOUT_SECS)
 
-        for _ in range(100):
-            time.sleep(0.01)
-            if (
-                len(notification_manager.records) == 2
-                and store[-1].type == 'warning'
-            ):
-                break
-        else:
-            raise AssertionError("Thread notification not received in time")
+        assert len(notification_manager.records) == 2
+        assert store[-1].type == 'warning'
 
     # make sure we've restored the threading except hook
     assert threading.excepthook == previous_threading_exhook


### PR DESCRIPTION
# Description

This removes calls to `time.sleep` and `QtBot.wait` in the notification tests and instead waits for tasks to finish on other threads with a long default timeout that matches `QtBot.waitSignal`.

Waiting for short fixed durations in tests that deal with multiple threads is rarely a good idea and could explain some of the recent flaky [test failures on `main`](https://github.com/napari/napari/runs/6771162918?check_suite_focus=true#step:7:287) and occasionally on PRs.

We have some other tests like this that I'm looking at fixing in https://github.com/andy-sweet/napari/pull/11, but I haven't seen those explicitly cause issues, so I'm splitting this smaller PR off first.

If someone can provide more context on why these specific durations were chosen or if these changes fundamentally change the behavior under test here, then I'd consider modifying this or closing this PR.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
- [ ] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
