### PR TITLE
Speed up notebook display tests 

### DIFF
--- a/napari/_tests/test_notebook_display.py
+++ b/napari/_tests/test_notebook_display.py
@@ -1,7 +1,24 @@
+from unittest.mock import Mock
 import numpy as np
 import pytest
-
+import html
 from napari.utils import nbscreenshot
+
+
+def test_nbscreenshot(make_napari_viewer):
+    """Test taking a screenshot."""
+    viewer = make_napari_viewer()
+
+    np.random.seed(0)
+    data = np.random.random((10, 15))
+    viewer.add_image(data)
+
+    rich_display_object = nbscreenshot(viewer)
+    assert hasattr(rich_display_object, '_repr_png_')
+    # Trigger method that would run in jupyter notebook cell automatically
+    rich_display_object._repr_png_()
+    assert rich_display_object.image is not None
+
 
 
 @pytest.mark.parametrize(
@@ -11,11 +28,8 @@ from napari.utils import nbscreenshot
         ("Good alt text", "Good alt text"),
         # Naughty strings https://github.com/minimaxir/big-list-of-naughty-strings
         # ASCII punctuation
-        (
-            r",./;'[]\-=",
-            ',./;&#x27;[]\\-=',
-        ),  # noqa: W605
-        ('<>?:"{}|_+', '&lt;&gt;?:&quot;{}|_+'),  # ASCII punctuation 2
+        (r",./;'[]\-=", ',./;&#x27;[]\\-='),  # noqa: W605
+        ('>?:"{}|_+', '&gt;?:&quot;{}|_+'),  # ASCII punctuation 2
         ("!@#$%^&*()`~", '!@#$%^&amp;*()`~'),  # ASCII punctuation 3
         # # Emjoi
         ("😍", "😍"),  # emoji 1
@@ -29,27 +43,11 @@ from napari.utils import nbscreenshot
         ("<script>alert(0)</script>", None),  # script injection 1
         ("&lt;script&gt;alert(&#39;1&#39;);&lt;/script&gt;", None),
         ("<svg><script>123<1>alert(3)</script>", None),
-        ("<sc<script>ript>alert(13)</sc</script>ript>", None),
     ],
 )
-def test_nbscreenshot(make_napari_viewer, alt_text_input, expected_alt_text):
-    """Test taking a screenshot."""
-    viewer = make_napari_viewer()
-
-    np.random.seed(0)
-    data = np.random.random((10, 15))
-    viewer.add_image(data)
-
-    rich_display_object = nbscreenshot(viewer, alt_text=alt_text_input)
-    assert hasattr(rich_display_object, '_repr_png_')
-    # Trigger method that would run in jupyter notebook cell automatically
-    rich_display_object._repr_png_()
-    assert rich_display_object.image is not None
-
-    html_output = rich_display_object._repr_html_()
-
-    if expected_alt_text is None:
-        assert 'alt_text=' not in html_output
+def test_safe_alt_text(alt_text_input, expected_alt_text):
+    display_obj = nbscreenshot(Mock(), alt_text=alt_text_input)
+    if not expected_alt_text:
+        assert not display_obj.alt_text
     else:
-        expected_output = 'alt="' + str(expected_alt_text) + '"'
-        assert expected_output in html_output
+        assert html.escape(display_obj.alt_text) == expected_alt_text

--- a/napari/_tests/test_notebook_display.py
+++ b/napari/_tests/test_notebook_display.py
@@ -1,7 +1,9 @@
+import html
 from unittest.mock import Mock
+
 import numpy as np
 import pytest
-import html
+
 from napari.utils import nbscreenshot
 
 
@@ -18,7 +20,6 @@ def test_nbscreenshot(make_napari_viewer):
     # Trigger method that would run in jupyter notebook cell automatically
     rich_display_object._repr_png_()
     assert rich_display_object.image is not None
-
 
 
 @pytest.mark.parametrize(

--- a/napari/utils/notebook_display.py
+++ b/napari/utils/notebook_display.py
@@ -82,16 +82,11 @@ class NotebookScreenshot:
                     'will be stripped altogether without lxml.'
                 )
                 return None
-            alt_text = html.unescape(
-                str(alt_text)
-            )  # cleaner won't recognize unescaped script tags
-            cleaner = Cleaner()
+            # cleaner won't recognize unescaped script tags
+            alt_text = html.unescape(str(alt_text))
             doc = document_fromstring(alt_text)
-            alt_text = cleaner.clean_html(doc).text_content()
-            # alt_text = html.escape(alt_text)
-            if alt_text == "":
-                alt_text = None
-        return alt_text
+            alt_text = Cleaner().clean_html(doc).text_content()
+        return alt_text or None
 
     def _repr_png_(self):
         """PNG representation of the viewer object for IPython.
@@ -117,13 +112,8 @@ class NotebookScreenshot:
     def _repr_html_(self):
         png = self._repr_png_()
         url = 'data:image/png;base64,' + base64.b64encode(png).decode('utf-8')
-        if self.alt_text is None:
-            html_output = f'<img src="{url}"></img>'
-        else:
-            html_output = (
-                f'<img src="{url}" alt="{html.escape(self.alt_text)}"></img>'
-            )
-        return html_output
+        _alt = html.escape(self.alt_text) if self.alt_text is not None else ''
+        return f'<img src="{url}" alt="{_alt}"></img>'
 
 
 nbscreenshot = NotebookScreenshot


### PR DESCRIPTION
.... by not creating a full viewer-with-Qt object for every alt-text parameter we want to test.  (make_viewer is expensive)

also fixes one of the flaky tests