### PR TITLE
Optimization: convert point slice indices to floats

### DIFF
--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1465,10 +1465,15 @@ class Points(Layer):
         """
         # Get a list of the data for the points in this slice
         not_disp = list(self._dims_not_displayed)
-        indices = np.array(dims_indices)
+        # We want a numpy array so we can use fancy indexing with the non-displayed
+        # indices, but as dims_indices can (and often/always does) contain slice
+        # objects, the array has dtype=object which is then very slow for the
+        # arithmetic below. As Points._round_index is always False, we can safely
+        # convert to float to get a major performance improvement.
+        not_disp_indices = np.array(dims_indices)[not_disp].astype(float)
         if len(self.data) > 0:
             if self.out_of_slice_display is True and self.ndim > 2:
-                distances = abs(self.data[:, not_disp] - indices[not_disp])
+                distances = abs(self.data[:, not_disp] - not_disp_indices)
                 sizes = self.size[:, not_disp] / 2
                 matches = np.all(distances <= sizes, axis=1)
                 size_match = sizes[matches]
@@ -1480,7 +1485,7 @@ class Points(Layer):
                 return slice_indices, scale
             else:
                 data = self.data[:, not_disp]
-                distances = np.abs(data - indices[not_disp])
+                distances = np.abs(data - not_disp_indices)
                 matches = np.all(distances <= 0.5, axis=1)
                 slice_indices = np.where(matches)[0].astype(int)
                 return slice_indices, 1


### PR DESCRIPTION
# Description

This ensures that the array of indices used to find which points are in the current slice (in `Points._slice_data`) has `dtype=float`, which gives us a significant performance improvement when slicing with millions of points. I added an explanatory implementation comment in the code to describe what's going on and why it should be safe.

I discovered this when profiling `Points._slice_data` as part of the async slicing project, though it took me a while to understand why that method was so slow compared to a similar function written independently of the `Points` class.

## Type of change

Performance optimization.

# How has this been tested?

- [x] all existing tests pass with my change

I also ran two relevant asv benchmarks: `benchmark_points_layer.Points3DSuite.time_set_view_slice` and `PointsSlicingSuite.time_slice_points`. As the number of points grows, we see that this branch is **almost 10x faster**, which has a significant impact on napari's behavior when you're slicing millions of 3D points in 2D.

Results on `main`.

```
(napari-dev) ➜  napari git:(main) asv run --python=same --bench Points3DSuite.time_set_view_slice                                                                   
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_asweet_software_miniconda3_envs_napari-dev_bin_python
[ 50.00%] ··· Running (benchmark_points_layer.Points3DSuite.time_set_view_slice--).
[100.00%] ··· benchmark_points_layer.Points3DSuite.time_set_view_slice                                                                                                                                                                                                      ok
[100.00%] ··· ======== =============
               param1               
              -------- -------------
                 16       492±30μs  
                 64       491±20μs  
                256       524±20μs  
                1024      669±80μs  
                4096    1.16±0.06ms 
               16384     3.20±0.1ms 
               65536     13.5±0.5ms 
              ======== =============

(napari-dev) ➜  napari git:(main) asv run --python=same --bench PointsSlicingSuite               
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_asweet_software_miniconda3_envs_napari-dev_bin_python
[ 50.00%] ··· Running (benchmark_points_layer.PointsSlicingSuite.time_slice_points--).
[100.00%] ··· benchmark_points_layer.PointsSlicingSuite.time_slice_points                                                                                                                                                                                                   ok
[100.00%] ··· ======== ============
               param1              
              -------- ------------
                True    2.25±0.01s 
               False    2.26±0.01s 
              ======== ============
```

Results on this branch.

```
(napari-dev) ➜  napari git:(faster-points-slice) ✗ asv run --python=same --bench Points3DSuite.time_set_view_slice
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_asweet_software_miniconda3_envs_napari-dev_bin_python
[ 50.00%] ··· Running (benchmark_points_layer.Points3DSuite.time_set_view_slice--).
[100.00%] ··· benchmark_points_layer.Points3DSuite.time_set_view_slice                                                                                                                                                                                                      ok
[100.00%] ··· ======== ============
               param1              
              -------- ------------
                 16      431±10μs  
                 64      454±20μs  
                256      463±20μs  
                1024     491±10μs  
                4096     513±10μs  
               16384     739±50μs  
               65536    1.64±0.3ms 
              ======== ============

(napari-dev) ➜  napari git:(faster-points-slice) ✗ asv run --python=same --bench PointsSlicingSuite               
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_asweet_software_miniconda3_envs_napari-dev_bin_python
[ 50.00%] ··· Running (benchmark_points_layer.PointsSlicingSuite.time_slice_points--).
[100.00%] ··· benchmark_points_layer.PointsSlicingSuite.time_slice_points                                                                                                                                                                                                   ok
[100.00%] ··· ======== ==========
               param1            
              -------- ----------
                True    316±10ms 
               False    301±10ms 
              ======== ==========
```

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
