### PR TITLE
Limit comprehensive test concurrency to 1.

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -11,6 +11,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: comprehensive-test
+
 jobs:
   manifest:
     name: Check Manifest


### PR DESCRIPTION
Just to make sure we don't block testing PRs with main

Mitigate #4653
