### PR TITLE
Do not run `asv` on push

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -125,6 +125,20 @@ jobs:
               exit 1
           fi
 
+      - name: Report Failures
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && failure() }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PLATFORM: ${{ matrix.runs-on }}
+          PYTHON: "3.9"
+          BACKEND: ${{ matrix.benchmark-name }}
+          RUN_ID: ${{ github.run_id }}
+          TITLE: "[test-bot] Benchmark tests failing"
+        with:
+          filename: .github/TEST_FAIL_TEMPLATE.md
+          update_existing: true
+
       - name: Add more info to artifact
         if: always()
         run: |

--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -142,39 +142,3 @@ jobs:
         uses: GabrielBB/xvfb-action@v1
         with:
           run: python -m pytest --pyargs napari --color=yes
-
-  asv-checks:
-    name: asv checks
-    runs-on:
-      macos-latest
-      # We use a macOS runner to avoid having to deal with Xvfb
-      # derived problems on Ubuntu. Xvfb allows us to run the Qt
-      # benchmarks, but causes segfaults in some cases! :shrug:
-    steps:
-      # We need the full repo to avoid this issue
-      # https://github.com/actions/checkout/issues/23
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v3
-        name: Install Python
-        with:
-          python-version: "3.9"
-
-      - name: Install this commit
-        run: |
-          pip install --upgrade pip
-          pip install ".[all,testing]" asv
-
-      - name: Register machine
-        run: asv machine --yes
-
-      - name: Check asv config is correct
-        run: asv check -v -E existing
-
-      - name: Ensure benchmarking tests can run
-        # this does NOT run the benchmarks properly
-        # it only runs each function once to ensure the code is correct
-        # but there's no statistical meaning to it
-        run: asv dev


### PR DESCRIPTION
# Description

`asv dev` takes too long, even for single pass runs, hogging the CI resources when a lot of PRs are merged at the same time. They also use macOS runners, which are less numerous. Since we also have a weekly cronjob, I think it's ok to disable this test (which is only there to catch API breakage updates that didn't make it to the `asv`). The cronjobs will also take that, even if with some delays.

I am also adding a step to report failures in an issue so we stay up-to-date with those potential failures (or regressions!).

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References

Closes #4653 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
