### PR TITLE
Fix docs for shape/points layer properties

### DIFF
--- a/docs/guides/layers.md
+++ b/docs/guides/layers.md
@@ -43,8 +43,8 @@ to adjust the layer opacity between 0, fully invisible and 1, fully visible.
 globally to all the points in the layer, and so you don't need to have any
 points selected for it to have an effect.
 * For the [shapes layer](napari.layers.Shapes), the opacity value applies
-individually to each shape in the layer, and so you must have shapes selected
-for it to have an effect.
+globally to all shapes in the layer, and so you don't need to have any
+shape selected for it to have an effect.
 * For the [vectors layer](napari.layers.Vectors), the opacity value applies
 globally to all the vectors in the layer.
 * For the [tracks layer](napari.layers.Tracks), the opacity value applies globally to all the tracks in the layer.

--- a/docs/howtos/layers/points.md
+++ b/docs/howtos/layers/points.md
@@ -171,8 +171,8 @@ Each point can have a different size. You can pass a list or 1-dimensional array
 of points through the size keyword argument to initialize the layer with points
 of different sizes. These sizes are then accessible through the `size`
 property. If you pass a single size then all points will get initialized with
-that size. Points can be pseduo-visualized as n-dimensionsal if the
-`n-dimensional` property is set to `True` or the `n-dimensional` checkbox is
+that size. Points can be pseudo-visualized as n-dimensional if the
+`out_of_slice_display` property is set to `True` or the `out of slice` checkbox is
 checked. In this setting when viewing different slices of the layer points will
 appear in the neighbouring slices to the ones in which they are located with a
 size scaled by the distance from their center to that slice. This feature can be

--- a/docs/howtos/layers/points.md
+++ b/docs/howtos/layers/points.md
@@ -169,7 +169,7 @@ your selection.
 
 Each point can have a different size. You can pass a list or 1-dimensional array
 of points through the size keyword argument to initialize the layer with points
-of different sizes. These sizes are then accessible through the `sizes`
+of different sizes. These sizes are then accessible through the `size`
 property. If you pass a single size then all points will get initialized with
 that size. Points can be pseduo-visualized as n-dimensionsal if the
 `n-dimensional` property is set to `True` or the `n-dimensional` checkbox is
@@ -183,8 +183,8 @@ Points can also be resized within the GUI by first selecting them and then
 adjusting the point size slider. If no points are selected, then adjusting the
 slider value will only serve to initialize the size for new points that are
 about to be added. The value of the size of the next point to be added can be
-found in the `layer.size` property. Note this property is different from
-`layer.sizes` which contains the current sizes of all the points.
+found in the `layer.current_size` property. Note this property is different from
+`layer.size` which contains the current sizes of all the points.
 
 ## Changing points edge and face color
 
@@ -192,10 +192,11 @@ Individual points can each have different edge and face colors. You can
 initially set these colors by providing a list of colors to the `edge_color` or
 `face_color` keyword arguments respectively, or you can edit them from the GUI.
 The colors of each of the points are available as lists under the
-`layer.edge_colors` and `layer.face_colors` properties. Similar to the `sizes`
-and `size` properties these properties are different from the `layer.edge_color`
-and `layer.face_color` properties that will determine the color of the next
-point to be added or any currently selected points.
+`layer.edge_color` and `layer.face_color` properties. Similar to the `size`
+and `current_size` properties these properties are different from the
+`layer.current_edge_color` and `layer.current_face_color` properties that will
+determine the color of the next point to be added or any currently selected
+points.
 
 To change the point color properties from the GUI you must first select the
 points whose properties you want to change, otherwise you will just be

--- a/docs/howtos/layers/shapes.md
+++ b/docs/howtos/layers/shapes.md
@@ -366,10 +366,10 @@ Individual shapes can each have different edge and face colors. You can
 initially set these colors by providing a list of colors to the `edge_color` or
 `face_color` keyword arguments respectively, or you can edit them from the GUI.
 The colors of each of the shapes are available as lists under the
-`layer.edge_colors` and `layer.face_colors` properties. These properties are
-different from the `layer.edge_color` and `layer.face_color` properties that
-will determine the color of the next shape to be added or any currently selected
-shapes.
+`layer.edge_color` and `layer.face_color` properties. These properties are
+different from the `layer.current_edge_color` and `layer.current_face_color`
+properties that will determine the color of the next shape to be added or any 
+currently selected shapes.
 
 To change the shape color properties from the GUI you must first select the
 shape whose properties you want to change, otherwise you will just be
@@ -380,10 +380,10 @@ initializing the property for the next shape you add.
 Individual shapes can each have different edge widths. You can initially set the
 edge widths by providing a list of values to the `edge_width` keyword arguments
 respectively, or you can edit them from the GUI. The widths of each of the
-shapes are available as a list under the `layer.edge_widths` property. Similar
+shapes are available as a list under the `layer.edge_width` property. Similar
 to the edge and face colors, these property is different from the
-`layer.edge_width` property that will determine the edge width of the next shape
-to be added or any currently selected shapes.
+`layer.current_edge_width` property that will determine the edge width of the
+next shape to be added or any currently selected shapes.
 
 To change the edge with property from the GUI you must first select the shape
 whose properties you want to change, otherwise you will just be initializing the

--- a/docs/howtos/layers/shapes.md
+++ b/docs/howtos/layers/shapes.md
@@ -407,14 +407,12 @@ will be updated with the new slice values.
 
 ## Shapes layer opacity
 
-The {ref}`opacity value <layer_opacity>` applies individually to each shape in
-the layer, and so you must have shapes selected for it to have an effect. You
-can initialize the shape opacities using the `opacity` keyword argument which
-accepts either a list of opacities or a single opacity value that will be
-applied globally. You can then access the opacity of every shape using the
-`layer.opacities` property. Note that this property is different from the
-`layer.opacity` property that determines the opacity of the next shape to be
-added.
+The {ref}`opacity value <layer_opacity>` applies to all shapes. You can 
+initialize the shape opacities using the `opacity` keyword argument which
+accepts a single opacity value that will be applied globally. You can then
+access the opacity using the `layer.opacity` property. In order to adjust the
+opacity of individual shapes you need to adjust the alpha value in the
+`layer.edge_color` and `layer.face_color` properties.
 
 ## Putting it all together
 

--- a/examples/shapes_to_labels.py
+++ b/examples/shapes_to_labels.py
@@ -75,7 +75,7 @@ layer = viewer.add_shapes(
 # change some attributes of the layer
 layer.selected_data = set(range(layer.nshapes))
 layer.current_edge_width = 5
-layer.current_opacity = 0.75
+layer.opacity = 0.75
 layer.selected_data = set()
 
 # add an ellipse to the layer

--- a/examples/to_screenshot.py
+++ b/examples/to_screenshot.py
@@ -76,7 +76,7 @@ layer = viewer.add_shapes(
 # change some attributes of the layer
 layer.selected_data = set(range(layer.nshapes))
 layer.current_edge_width = 5
-layer.current_opacity = 0.75
+layer.opacity = 0.75
 layer.selected_data = set()
 
 # add an ellipse to the layer


### PR DESCRIPTION
# Description
Some of the docs in the How-to on shape and points layers seem to be outdated. For multiple properties (`edge_width` `face_color` etc) it is indicated that there's also a corresponding "plural" property (`edge_widths` `face_colors` etc) which doesn't actually exist (see e.g. https://napari.org/howtos/layers/shapes.html#changing-shape-edge-and-face-colors). From the source code it looks like there are:
- properties like ```face_color``` that contain a list of colors for each shape/point
- properties like ```current_face_color``` that contain a single color that will be used for the next shape/point

I tried to fix all the places where variable definition was wrong. There's one place where I'm not sure if this is a bug or not. The docs specify very precisely that the opacity for the shape layer is adjusted **per shape** when one is selected but this doesn't seem to be true (see [here](https://napari.org/howtos/layers/shapes.html#shapes-layer-opacity) and there's even a note [here](https://napari.org/guides/layers.html#layer-opacity)). The ```layer.opacity``` is a single value and not a list, and there's no ```current_opacity``` variable, so it really does look like opacity applies to all shapes. I'll complete this PR by fixing this opacity issue if nobody knows better.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ x] Bug-fix (non-breaking change which fixes an issue)

# References
Discussed [here](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/face_colors/near/285504543)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
