### PR TITLE
ci: fix tox factor names in tests

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -57,6 +57,11 @@ jobs:
 
 
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
       - uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -36,26 +36,25 @@ jobs:
       matrix:
         platform: [ubuntu-latest, windows-latest]
         python: ["3.8", "3.9", "3.10"]
+        backend: [pyqt5, pyside2]
         include:
-          # test big sur on 3.9.0
           - python: 3.9
-            platform: macos-11
-            toxenv: py39-macos-pyqt
+            platform: macos-latest
+            backend: pyqt5
           # test with minimum specified requirements
           - python: 3.8
             platform: ubuntu-18.04
+            backend: pyqt5
             MIN_REQ: 1
           # test with --async_only
           - python: 3.8
             platform: ubuntu-18.04
-            toxenv: async-py38-linux-pyqt
+            toxenv: async-py38-linux-pyqt5
           # test without any Qt backends
           - python: 3.8
             platform: ubuntu-18.04
             toxenv: headless-py38-linux
-          - python: "3.10"
-            platform: ubuntu-latest
-            toxenv: py310-linux-pyside
+
 
     steps:
       - uses: actions/checkout@v2
@@ -95,6 +94,7 @@ jobs:
           run: python -m tox
         env:
           PLATFORM: ${{ matrix.platform }}
+          BACKEND: ${{ matrix.backend }}
           TOXENV: ${{ matrix.toxenv }}
           NUMPY_EXPERIMENTAL_ARRAY_FUNCTION: ${{ matrix.MIN_REQ || 1 }}
           PYVISTA_OFF_SCREEN: True

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        python: [3.8]
-        backend: [pyqt, pyside]
+        python: [3.9]
+        backend: [pyqt5, pyside2]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes the name of fox factors in the comprehensive and --pre tests after #4646 

closes #4651 