### PR TITLE
Do not use keyword argument for `QListWidgetItem` parent set in constructor

### DIFF
--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -566,8 +566,8 @@ class QPluginList(QListWidget):
             return
 
         # including summary here for sake of filtering below.
-        searchable_text = pkg_name + " " + project_info.summary
-        item = QListWidgetItem(searchable_text, parent=self)
+        searchable_text = f"{pkg_name} {project_info.summary}"
+        item = QListWidgetItem(searchable_text, self)
         item.version = project_info.version
         super().addItem(item)
         widg = PluginListItem(

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -207,7 +207,7 @@ class QtHookImplementationListWidget(QListWidget):
         hook_implementation : HookImplementation
             The hook implementation object to add to the list.
         """
-        item = QListWidgetItem(parent=self)
+        item = QListWidgetItem(self)
         item.hook_implementation = hook_implementation
         self.addItem(item)
         widg = ImplementationListItem(item, parent=self)


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

PySide2 from conda (5.15.4) does not accept keyword `parent` as argument of `QListWidgetItem`
constructor. If using a keyword there is a need to use [listview](https://doc.qt.io/qtforpython-5/PySide2/QtWidgets/QListWidgetItem.html#PySide2.QtWidgets.PySide2.QtWidgets.QListWidgetItem). 

pypi version of PySide accepts both `listview` and `parent`. `PyQt5` accept only the `parent` keyword.  

But checking the signature suggests that it is enough to use positional only arguments. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" --> close  #4658

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] manumaly tested for conda and pypi on Ubuntu Linux 21.10

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
