### PR TITLE
test: speed up magicgui forward ref tests

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -96,13 +96,13 @@ def test_add_layer(make_napari_viewer, layer_class, data, ndim):
 
 
 EXPECTED_NUMBER_OF_LAYER_METHODS = {
-    'Image': 8,
+    'Image': 5,
     'Vectors': 0,
     'Surface': 0,
     'Tracks': 0,
     'Points': 8,
     'Labels': 11,
-    'Shapes': 19,
+    'Shapes': 17,
 }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -81,7 +81,7 @@ commands_pre =
     headless: pip uninstall -y pytest-qt qtpy pyqt5 pyside2
 commands =
     !headless: python -m pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir} \
-        --cov-report=xml --cov={env:PYTEST_PATH:napari} --ignore tools --maxfail=2 \
+        --cov-report=xml --cov={env:PYTEST_PATH:napari} --ignore tools --maxfail=5 \
         --json-report --json-report-file={toxinidir}/report-{envname}.json {posargs}
     # do not add ignores to this line just to make headless tests pass.
     # nothing outside of _qt or _vispy should require Qt or make_napari_viewer


### PR DESCRIPTION
# Description
This dramatically speeds up the magicgui `ForwardRef` tests by avoiding the use of subprocesses.

The use of subprocess was to mimic a clean slate when magicgui reaches a forward ref pointing to a napari type name.  Here we create that clean slate by mocking/clearing `sys.modules` instead