### PR TITLE
Add paint event to labels layer emitting last history item

### DIFF
--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -77,6 +77,8 @@ def draw(layer, event):
     undo_item = layer._undo_history[-1]
     if len(undo_item) == 1 and len(undo_item[0][0][0]) == 0:
         layer._undo_history.pop()
+    else:
+        layer.events.paint(value=undo_item)
 
 
 def pick(layer, event):

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -297,6 +297,7 @@ class Labels(_ImageBase):
             brush_shape=Event,
             contour=Event,
             features=Event,
+            paint=Event,
         )
 
         self._feature_table = _FeatureTable.from_layer(


### PR DESCRIPTION
# Description
@kephale and I are at the CellMap hackathon and came across #4194 which discusses the addition of a paint event to the Labels layer. Kyle is currently having to implement a tedious workaround to get access to the latest changes, and based on @jni's suggestion  in #4194 I think this minimal change would be sufficient to emit the event without affecting performance, as we only emit on mouse release if the `undo_item` is not empty.

I've had a think about any issues this could introduce but haven't been able to come up with any. Would love any feedback on the implementation, or if there's a better way to do it, some insight into what that would look like!

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #4194

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
