### PR TITLE
Remove unused points _color state

### DIFF
--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -8,11 +8,7 @@ import pandas as pd
 from scipy.stats import gmean
 
 from ...utils.colormaps import Colormap, ValidColormapArg
-from ...utils.colormaps.standardize_color import (
-    get_color_namelist,
-    hex_to_name,
-    rgb_to_hex,
-)
+from ...utils.colormaps.standardize_color import hex_to_name, rgb_to_hex
 from ...utils.events import Event
 from ...utils.events.custom_types import Array
 from ...utils.geometry import project_points_onto_plane, rotate_points
@@ -362,8 +358,6 @@ class Points(Layer):
             features=Event,
             feature_defaults=Event,
         )
-
-        self._colors = get_color_namelist()
 
         # Save the point coordinates
         self._data = np.asarray(data)

--- a/napari/utils/colormaps/standardize_color.py
+++ b/napari/utils/colormaps/standardize_color.py
@@ -405,9 +405,6 @@ def _create_hex_to_name_dict():
     return hex_to_name
 
 
-hex_to_name = _create_hex_to_name_dict()
-
-
 def get_color_namelist():
     """Gets all the color names supported by napari.
 
@@ -417,6 +414,9 @@ def get_color_namelist():
         All the color names supported by napari.
     """
     return get_color_names()
+
+
+hex_to_name = _create_hex_to_name_dict()
 
 
 def _check_color_dim(val):

--- a/napari/utils/colormaps/standardize_color.py
+++ b/napari/utils/colormaps/standardize_color.py
@@ -24,7 +24,7 @@ import warnings
 from typing import Any, Callable, Dict, Sequence
 
 import numpy as np
-from vispy.color import ColorArray, get_color_dict, get_color_names
+from vispy.color import ColorArray, get_color_dict
 from vispy.color.color_array import _string_to_rgb
 
 from ..translations import trans
@@ -404,23 +404,6 @@ def _create_hex_to_name_dict():
     hex_to_name = {f"{v.lower()}ff": k for k, v in colordict.items()}
     hex_to_name["#00000000"] = "transparent"
     return hex_to_name
-
-
-def get_color_namelist():
-    """A wrapper around vispy's get_color_names designed to add a
-    "transparent" (alpha = 0) color to it.
-
-    Once https://github.com/vispy/vispy/pull/1794 is merged this
-    function is no longer necessary.
-
-    Returns
-    -------
-    color_dict : list
-        A list of all valid vispy color names plus "transparent".
-    """
-    names = get_color_names()
-    names.append('transparent')
-    return names
 
 
 hex_to_name = _create_hex_to_name_dict()

--- a/napari/utils/colormaps/standardize_color.py
+++ b/napari/utils/colormaps/standardize_color.py
@@ -402,7 +402,6 @@ def _create_hex_to_name_dict():
     """
     colordict = get_color_dict()
     hex_to_name = {f"{v.lower()}ff": k for k, v in colordict.items()}
-    hex_to_name["#00000000"] = "transparent"
     return hex_to_name
 
 

--- a/napari/utils/colormaps/standardize_color.py
+++ b/napari/utils/colormaps/standardize_color.py
@@ -24,7 +24,7 @@ import warnings
 from typing import Any, Callable, Dict, Sequence
 
 import numpy as np
-from vispy.color import ColorArray, get_color_dict
+from vispy.color import ColorArray, get_color_dict, get_color_names
 from vispy.color.color_array import _string_to_rgb
 
 from ..translations import trans
@@ -406,6 +406,17 @@ def _create_hex_to_name_dict():
 
 
 hex_to_name = _create_hex_to_name_dict()
+
+
+def get_color_namelist():
+    """Gets all the color names supported by napari.
+
+    Returns
+    -------
+    list[str]
+        All the color names supported by napari.
+    """
+    return get_color_names()
 
 
 def _check_color_dim(val):


### PR DESCRIPTION
# Description

Not sure when this was used/needed, but after https://github.com/vispy/vispy/pull/1794 was merged and used by napari, I don't think it's necessary anymore. I also cleaned up some function implementations based on that PR merge. We could remove `get_color_namelist`, though that would technically be a breaking change. That function does provide useful functionality, but likely would be better defined as a constant in a higher level module (e.g. `napari.utils.colors.COLOR_NAMES`) that we could define in a follow-up PR.

FYI, I found this while making notes on the current state in `Points`.

## Type of change
Clean up

# How has this been tested?
- [x] all existing tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
