### PR TITLE
Fix source of copied layer events by use `layer.as_layer_data_tuple`

### DIFF
--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -36,13 +36,9 @@ def _duplicate_layer(ll: LayerList):
     from copy import deepcopy
 
     for lay in list(ll.selection):
-        new = deepcopy(lay)
-        new.events.disconnect()
-        new.events.source = new
-        for emitter in new.events.emitters.values():
-            emitter.disconnect()
-            emitter.source = new
-        new.name += trans._(' copy')
+        data, state, type_str = lay.as_layer_data_tuple()
+        state["name"] = trans._('{name} copy', name=lay.name)
+        new = Layer.create(deepcopy(data), state, type_str)
         ll.insert(ll.index(lay) + 1, new)
 
 

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -37,10 +37,10 @@ def _duplicate_layer(ll: LayerList):
 
     for lay in list(ll.selection):
         new = deepcopy(lay)
-        # new.events.disconnect()
+        new.events.disconnect()
         new.events.source = new
         for emitter in new.events.emitters.values():
-            # emitter.disconnect()
+            emitter.disconnect()
             emitter.source = new
         new.name += trans._(' copy')
         ll.insert(ll.index(lay) + 1, new)

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -37,7 +37,12 @@ def _duplicate_layer(ll: LayerList):
 
     for lay in list(ll.selection):
         new = deepcopy(lay)
-        new.name += ' copy'
+        # new.events.disconnect()
+        new.events.source = new
+        for emitter in new.events.emitters.values():
+            # emitter.disconnect()
+            emitter.source = new
+        new.name += trans._(' copy')
         ll.insert(ll.index(lay) + 1, new)
 
 

--- a/napari/layers/_tests/test_layer_actions.py
+++ b/napari/layers/_tests/test_layer_actions.py
@@ -52,15 +52,23 @@ def test_layer_actions():
 
 
 def test_duplicate_layers():
+    def _dummy():
+        pass
+
     layer_list = LayerList()
     layer_list.append(Points(name="test"))
     layer_list.selection.active = layer_list[0]
+    layer_list[0].events.data.connect(_dummy)
+    assert len(layer_list[0].events.data.callbacks) == 2
     assert len(layer_list) == 1
     _duplicate_layer(layer_list)
     assert len(layer_list) == 2
     assert layer_list[0].name == "test"
     assert layer_list[1].name == "test copy"
     assert layer_list[1].events.source is layer_list[1]
+    assert (
+        len(layer_list[1].events.data.callbacks) == 1
+    )  # `events` Event Emitter
 
 
 @pytest.mark.parametrize(

--- a/napari/layers/_tests/test_layer_actions.py
+++ b/napari/layers/_tests/test_layer_actions.py
@@ -56,7 +56,7 @@ def test_duplicate_layers():
         pass
 
     layer_list = LayerList()
-    layer_list.append(Points(name="test"))
+    layer_list.append(Points([[0, 0]], name="test"))
     layer_list.selection.active = layer_list[0]
     layer_list[0].events.data.connect(_dummy)
     assert len(layer_list[0].events.data.callbacks) == 2

--- a/napari/layers/_tests/test_layer_actions.py
+++ b/napari/layers/_tests/test_layer_actions.py
@@ -4,13 +4,14 @@ import numpy as np
 import pytest
 
 from napari.components.layerlist import LayerList
-from napari.layers import Image, Labels, Shapes
+from napari.layers import Image, Labels, Points, Shapes
 from napari.layers._layer_actions import (
     _LAYER_ACTIONS,
     ContextAction,
     SubMenu,
     _convert,
     _convert_dtype,
+    _duplicate_layer,
     _project,
 )
 from napari.utils.context._expressions import Expr
@@ -48,6 +49,18 @@ def test_layer_actions():
             expr = action.get('show_when', None)
             if isinstance(expr, Expr):
                 assert_expression_variables(expr, names)
+
+
+def test_duplicate_layers():
+    layer_list = LayerList()
+    layer_list.append(Points(name="test"))
+    layer_list.selection.active = layer_list[0]
+    assert len(layer_list) == 1
+    _duplicate_layer(layer_list)
+    assert len(layer_list) == 2
+    assert layer_list[0].name == "test"
+    assert layer_list[1].name == "test copy"
+    assert layer_list[1].events.source is layer_list[1]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Currently copied layer emits all events as source layer because source in EventEmitter is stored as weak reference https://github.com/napari/napari/blob/7d27d9f0f5bbcad9be1924cf1937bfab878f2121/napari/utils/events/event.py#L370

and deepcopy does not go through weekref.  

This PR also disconnects all events from the copied object. Internal napari events will be connected to insert operation. If a user connects something to a given layer, then he should not expect that such callback will be also connected to the new one. 

Disconnection is a breaking change, but as we do not have reports about problems with events sources I think that it will not break anything in real life.  

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

taken from #4665

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] added additional test for verify if everything works as expected

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
