### PR TITLE
Fix NAP-1 status/type

### DIFF
--- a/docs/naps/1-institutional-funding-partners.md
+++ b/docs/naps/1-institutional-funding-partners.md
@@ -6,8 +6,8 @@
 :Author: "Juan Nunez-Iglesias <mailto:jni@fastmail.com>"
 :Author: "Nicholas Sofroniew <mailto:sofroniewn@gmail.com>"
 :Created: '2022-04-21'
-:Status: Draft
-:Type: Accepted
+:Status: Accepted
+:Type: Process
 ```
 
 ## Abstract


### PR DESCRIPTION
# Description

The wrong like was edited when accepting NAP-1, which left us with:

```
:Status: Draft
:Type: Accepted
```

instead of:

```
:Status: Accepted
:Type: Process
```
