### PR TITLE
Tracks tail update fix beyond _max_length

### DIFF
--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -183,6 +183,7 @@ def test_tracks_float_time_index():
     data = np.concatenate((track_id, time, coords), axis=1)
     Tracks(data)
 
+
 def test_tracks_length_change():
     """Test changing length properties of tracks"""
     track_length = 1000

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -182,3 +182,17 @@ def test_tracks_float_time_index():
     track_id[50:] = 1
     data = np.concatenate((track_id, time, coords), axis=1)
     Tracks(data)
+
+def test_tracks_length_change():
+    """Test changing length properties of tracks"""
+    track_length = 1000
+    data = np.zeros((track_length, 4))
+    layer = Tracks(data)
+    layer.tail_length = track_length
+    assert layer.tail_length == track_length
+    assert layer._max_length == track_length
+
+    layer = Tracks(data)
+    layer.head_length = track_length
+    assert layer.head_length == track_length
+    assert layer._max_length == track_length

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -471,7 +471,9 @@ class Tracks(Layer):
 
     @head_length.setter
     def head_length(self, head_length: Union[int, float]):
-        self._head_length = np.clip(head_length, 0, self._max_length)
+        if head_length > self._max_length:
+            self._max_length = head_length
+        self._head_length = head_length
         self.events.head_length()
 
     @property

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -460,7 +460,7 @@ class Tracks(Layer):
     def tail_length(self, tail_length: Union[int, float]):
         if tail_length > self._max_length:
             self._max_length = tail_length
-        self._tail_length = np.clip(tail_length, 1, self._max_length)
+        self._tail_length = tail_length
         self.events.tail_length()
 
     @property

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -93,8 +93,6 @@ class Tracks(Layer):
     # The max number of tracks that will ever be used to render the thumbnail
     # If more tracks are present then they are randomly subsampled
     _max_tracks_thumbnail = 1024
-    _max_length = 300
-    _max_width = 20
 
     def __init__(
         self,
@@ -173,6 +171,10 @@ class Tracks(Layer):
 
         # use this to update shaders when the displayed dims change
         self._current_displayed_dims = None
+
+        # track display default limits
+        self._max_length = 300
+        self._max_width = 20
 
         # track display properties
         self.tail_width = tail_width

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -458,6 +458,8 @@ class Tracks(Layer):
 
     @tail_length.setter
     def tail_length(self, tail_length: Union[int, float]):
+        if tail_length > self._max_length:
+            self._max_length = tail_length
         self._tail_length = np.clip(tail_length, 1, self._max_length)
         self.events.tail_length()
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
- Improve the intuitiveness while trying to set `tail_length` attribute of Tracks layer to beyond the hard set `_max_length`
- As a follow-up from suggestions by @alisterburt either we can auto-update `_max_length` upon change in `tail_length` or warn the user if they exceed `_max_length`.
<!-- Tell us about your new feature, improvement, or fix! -->
- I chose the former as for the latter option I had to do the reassignment in this order to make it update in the viewer: `_max_length` -> `tail_length` -> again `tail_length`. It doesn't just seem to apply by just doing one reassignment of `tail_length`.
    - This change however seems to render `_max_length` of no use (need more discussion).
    - Along the same lines, `head_length` (which also uses `_max_length`) & `tail_width` (unable to update beyond 20) updates need to be considered

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
