### PR TITLE
Keep order of layers when select to save multiple selected layers

### DIFF
--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -432,7 +432,11 @@ class LayerList(SelectableEventedList[Layer]):
         """
         from ..plugins.io import save_layers
 
-        layers = list(self.selection) if selected else list(self)
+        layers = (
+            [x for x in self if x in self.selection]
+            if selected
+            else list(self)
+        )
 
         if selected:
             msg = trans._("No layers selected", deferred=True)


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This is bugfix requested by @cnstt on zulip thread https://napari.zulipchat.com/#narrow/stream/309872-plugins/topic/Writer.20.3A.20layers.20order.20in.20data.20list/near/285949108

When saving multiple layers using a writer that could handle multiple layers these layers should be served in order from `layerlist` but are served in "random" order as `layerlist.selection` is set. This PR fix this problem. 



## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

https://napari.zulipchat.com/#narrow/stream/309872-plugins/topic/Writer.20.3A.20layers.20order.20in.20data.20list/near/285949108

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
