### PR TITLE
Remove unnecessary uses of make_napari_viewer (replace with ViewerModel)

### DIFF
--- a/napari/_qt/_tests/test_app.py
+++ b/napari/_qt/_tests/test_app.py
@@ -8,7 +8,7 @@ from napari._qt.qt_event_loop import _ipython_has_eventloop, run, set_app_id
 
 
 @pytest.mark.skipif(os.name != "Windows", reason="Windows specific")
-def test_windows_grouping_overwrite(make_napari_viewer):
+def test_windows_grouping_overwrite(qapp):
     import ctypes
 
     def get_app_id():

--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from napari_plugin_engine import napari_hook_implementation
@@ -6,6 +6,7 @@ from qtpy.QtWidgets import QWidget
 
 import napari
 from napari import Viewer
+from napari._qt.menus import PluginsMenu
 from napari._qt.qt_main_window import _instantiate_dock_widget
 from napari.utils._proxies import PublicOnlyProxy
 
@@ -87,14 +88,16 @@ def test_plugin_widgets(monkeypatch, napari_plugin_manager):
     yield
 
 
-def test_plugin_widgets_menus(test_plugin_widgets, make_napari_viewer):
+def test_plugin_widgets_menus(test_plugin_widgets, qtbot):
     """Test the plugin widgets get added to the window menu correctly."""
-    viewer = make_napari_viewer()
     # only take the plugin actions
-    actions = viewer.window.plugins_menu.actions()
+    window = Mock()
+    qtwin = QWidget()
+    qtbot.addWidget(qtwin)
+    with patch.object(window, '_qt_window', qtwin):
+        actions = PluginsMenu(window=window).actions()
     for cnt, action in enumerate(actions):
         if action.text() == "":
-            # this is the separator
             break
     actions = actions[cnt + 1 :]
     texts = [a.text() for a in actions]

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -181,11 +181,13 @@ def test_notification_error(mock_show, monkeypatch, clean_current):
 
 
 @pytest.mark.sync_only
-def test_notifications_error_with_threading():
+def test_notifications_error_with_threading(make_napari_viewer):
     """Test notifications of `threading` threads, using a dask example."""
+    random_image = da.random.random((10, 10))
     with notification_manager:
-        random_image = da.random.random((10, 10))
+        viewer = make_napari_viewer()
+        viewer.add_image(random_image)
         result = da.divide(random_image, da.zeros((10, 10)))
-        result.compute()
+        viewer.add_image(result)
         assert len(notification_manager.records) >= 1
         notification_manager.records = []

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -181,13 +181,11 @@ def test_notification_error(mock_show, monkeypatch, clean_current):
 
 
 @pytest.mark.sync_only
-def test_notifications_error_with_threading(make_napari_viewer):
+def test_notifications_error_with_threading():
     """Test notifications of `threading` threads, using a dask example."""
-    random_image = da.random.random((50, 50))
     with notification_manager:
-        viewer = make_napari_viewer()
-        viewer.add_image(random_image)
-        result = da.divide(random_image, da.zeros((50, 50)))
-        viewer.add_image(result)
+        random_image = da.random.random((10, 10))
+        result = da.divide(random_image, da.zeros((10, 10)))
+        result.compute()
         assert len(notification_manager.records) >= 1
         notification_manager.records = []

--- a/napari/_qt/_tests/test_qt_window.py
+++ b/napari/_qt/_tests/test_qt_window.py
@@ -9,7 +9,7 @@ from napari.utils.theme import (
 )
 
 
-def test_current_viewer(make_napari_viewer, qapp):
+def test_current_viewer(make_napari_viewer):
     """Test that we can retrieve the "current" viewer window easily.
 
     ... where "current" means it was the last viewer the user interacted with.

--- a/napari/_qt/widgets/_tests/test_qt_dims_sorter.py
+++ b/napari/_qt/widgets/_tests/test_qt_dims_sorter.py
@@ -1,9 +1,11 @@
 from napari._qt.widgets.qt_dims_sorter import QtDimsSorter
+from napari.components.viewer_model import ViewerModel
 
 
-def test_dims_sorter(make_napari_viewer):
-    viewer = make_napari_viewer()
+def test_dims_sorter(qtbot):
+    viewer = ViewerModel()
     dim_sorter = QtDimsSorter(viewer)
+    qtbot.addWidget(dim_sorter)
     assert tuple(dim_sorter.axes_list) == (0, 1)
 
     viewer.dims.axis_labels = ('y', 'x')
@@ -14,9 +16,10 @@ def test_dims_sorter(make_napari_viewer):
     assert tuple(viewer.dims.order) == (1, 0)
 
 
-def test_dims_sorter_with_reordered_init(make_napari_viewer):
-    viewer = make_napari_viewer()
+def test_dims_sorter_with_reordered_init(qtbot):
+    viewer = ViewerModel()
     viewer.dims.order = (1, 0)
 
     dim_sorter = QtDimsSorter(viewer)
+    qtbot.addWidget(dim_sorter)
     assert tuple(dim_sorter.axes_list) == tuple(viewer.dims.order)

--- a/napari/_tests/test_dtypes.py
+++ b/napari/_tests/test_dtypes.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from napari.components.viewer_model import ViewerModel
+
 dtypes = [
     np.dtype(bool),
     np.dtype(np.int8),
@@ -18,10 +20,10 @@ dtypes = [
 
 
 @pytest.mark.parametrize('dtype', dtypes)
-def test_image_dytpes(make_napari_viewer, dtype):
+def test_image_dytpes(dtype):
     """Test different dtype images."""
     np.random.seed(0)
-    viewer = make_napari_viewer()
+    viewer = ViewerModel()
 
     # add dtype image data
     data = np.random.randint(20, size=(30, 40)).astype(dtype)

--- a/napari/_tests/test_numpy_like.py
+++ b/napari/_tests/test_numpy_like.py
@@ -3,10 +3,12 @@ import numpy as np
 import xarray as xr
 import zarr
 
+from napari.components.viewer_model import ViewerModel
 
-def test_dask_2D(make_napari_viewer):
+
+def test_dask_2D():
     """Test adding 2D dask image."""
-    viewer = make_napari_viewer()
+    viewer = ViewerModel()
 
     da.random.seed(0)
     data = da.random.random((10, 15))
@@ -14,9 +16,9 @@ def test_dask_2D(make_napari_viewer):
     assert np.all(viewer.layers[0].data == data)
 
 
-def test_dask_nD(make_napari_viewer):
+def test_dask_nD():
     """Test adding nD dask image."""
-    viewer = make_napari_viewer()
+    viewer = ViewerModel()
 
     da.random.seed(0)
     data = da.random.random((10, 15, 6, 16))
@@ -24,9 +26,9 @@ def test_dask_nD(make_napari_viewer):
     assert np.all(viewer.layers[0].data == data)
 
 
-def test_zarr_2D(make_napari_viewer):
+def test_zarr_2D():
     """Test adding 2D zarr image."""
-    viewer = make_napari_viewer()
+    viewer = ViewerModel()
 
     data = zarr.zeros((200, 100), chunks=(40, 20))
     data[53:63, 10:20] = 1
@@ -35,9 +37,9 @@ def test_zarr_2D(make_napari_viewer):
     assert np.all(viewer.layers[0].data == data)
 
 
-def test_zarr_nD(make_napari_viewer):
+def test_zarr_nD():
     """Test adding nD zarr image."""
-    viewer = make_napari_viewer()
+    viewer = ViewerModel()
 
     data = zarr.zeros((200, 100, 50), chunks=(40, 20, 10))
     data[53:63, 10:20, :] = 1
@@ -46,9 +48,9 @@ def test_zarr_nD(make_napari_viewer):
     assert np.all(viewer.layers[0].data == data)
 
 
-def test_zarr_dask_2D(make_napari_viewer):
+def test_zarr_dask_2D():
     """Test adding 2D dask image."""
-    viewer = make_napari_viewer()
+    viewer = ViewerModel()
 
     data = zarr.zeros((200, 100), chunks=(40, 20))
     data[53:63, 10:20] = 1
@@ -57,9 +59,9 @@ def test_zarr_dask_2D(make_napari_viewer):
     assert np.all(viewer.layers[0].data == zdata)
 
 
-def test_zarr_dask_nD(make_napari_viewer):
+def test_zarr_dask_nD():
     """Test adding nD zarr image."""
-    viewer = make_napari_viewer()
+    viewer = ViewerModel()
 
     data = zarr.zeros((200, 100, 50), chunks=(40, 20, 10))
     data[53:63, 10:20, :] = 1
@@ -68,9 +70,9 @@ def test_zarr_dask_nD(make_napari_viewer):
     assert np.all(viewer.layers[0].data == zdata)
 
 
-def test_xarray_2D(make_napari_viewer):
+def test_xarray_2D():
     """Test adding 2D xarray image."""
-    viewer = make_napari_viewer()
+    viewer = ViewerModel()
 
     np.random.seed(0)
     data = np.random.random((10, 15))
@@ -79,9 +81,9 @@ def test_xarray_2D(make_napari_viewer):
     assert np.all(viewer.layers[0].data == xdata)
 
 
-def test_xarray_nD(make_napari_viewer):
+def test_xarray_nD():
     """Test adding nD xarray image."""
-    viewer = make_napari_viewer()
+    viewer = ViewerModel()
 
     np.random.seed(0)
     data = np.random.random((10, 15, 6, 16))

--- a/napari/components/experimental/chunk/_commands/_tests/test_loader.py
+++ b/napari/components/experimental/chunk/_commands/_tests/test_loader.py
@@ -2,13 +2,14 @@ import numpy as np
 import pytest
 
 from napari.components.experimental.chunk._commands import LoaderCommands
+from napari.viewer import ViewerModel
 
 
 @pytest.mark.async_only
-def test_help(make_napari_viewer, capsys):
+def test_help(capsys):
     """Test loader.help."""
-    viewer = make_napari_viewer()
-    loader = loader = viewer.experimental.cmds.loader
+    viewer = ViewerModel()
+    loader = viewer.experimental.cmds.loader
 
     loader.help
     out, _ = capsys.readouterr()
@@ -16,9 +17,9 @@ def test_help(make_napari_viewer, capsys):
 
 
 @pytest.mark.async_only
-def test_no_layers(make_napari_viewer, capsys):
+def test_no_layers(capsys):
     """Test loader.layers with no layers."""
-    viewer = make_napari_viewer()
+    viewer = ViewerModel()
     LoaderCommands(viewer.layers).layers
     out, _ = capsys.readouterr()
     for x in ["ID", "NAME", "LAYER"]:  # Just check a few.
@@ -26,9 +27,9 @@ def test_no_layers(make_napari_viewer, capsys):
 
 
 @pytest.mark.async_only
-def test_one_layer(make_napari_viewer, capsys):
+def test_one_layer(capsys):
     """Test loader.layer with one layer."""
-    viewer = make_napari_viewer()
+    viewer = ViewerModel()
     loader = viewer.experimental.cmds.loader
 
     data = np.random.random((10, 15))
@@ -40,13 +41,13 @@ def test_one_layer(make_napari_viewer, capsys):
 
 
 @pytest.mark.async_only
-def test_many_layers(make_napari_viewer, capsys):
+def test_many_layers(capsys):
     """Test loader.layer with many layers."""
-    viewer = make_napari_viewer()
+    viewer = ViewerModel()
     loader = viewer.experimental.cmds.loader
 
     num_images = 10
-    for i in range(num_images):
+    for _ in range(num_images):
         data = np.random.random((10, 15))
         viewer.add_image(data)
     loader.layers
@@ -55,9 +56,9 @@ def test_many_layers(make_napari_viewer, capsys):
 
 
 @pytest.mark.async_only
-def test_levels(make_napari_viewer, capsys):
+def test_levels(capsys):
     """Test loader.levels."""
-    viewer = make_napari_viewer()
+    viewer = ViewerModel()
     loader = viewer.experimental.cmds.loader
 
     data = np.random.random((10, 15))


### PR DESCRIPTION
# Description
Found a number of places where the full `make_napari_viewer` fixture was easily replaced with ViewerModel... which should speed up tests more.