### PR TITLE
Apply shown mask to points._view_size_scale

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2346,3 +2346,77 @@ def test_selected_data_with_non_uniform_sizes():
     # should change to that mean.
     layer.selected_data = (0, 2)
     assert layer.current_size == 2
+
+
+def test_shown_view_size_and_view_data_have_the_same_dimension():
+    data = [[0, 0, 0], [1, 1, 1]]
+    # Data with default settings
+    layer = Points(
+        data, out_of_slice_display=False, shown=[True, True], size=3
+    )
+    assert layer._view_size.shape[0] == layer._view_data.shape[0]
+
+    # shown == [True, False]
+    layer = Points(
+        data, out_of_slice_display=False, shown=[True, False], size=3
+    )
+    assert layer._view_size.shape[0] == layer._view_data.shape[0]
+
+    # shown == [False, True]
+    layer = Points(
+        data, out_of_slice_display=False, shown=[False, True], size=3
+    )
+    assert layer._view_size.shape[0] == layer._view_data.shape[0]
+
+    # Out of slice display == True
+    layer = Points(data, out_of_slice_display=True, shown=[True, True], size=3)
+    assert layer._view_size.shape[0] == layer._view_data.shape[0]
+
+    # Out of slice display == True && shown == [True, False]
+    layer = Points(
+        data, out_of_slice_display=True, shown=[True, False], size=3
+    )
+    assert layer._view_size.shape[0] == layer._view_data.shape[0]
+
+    # Out of slice display == True && shown == [False, True]
+    layer = Points(
+        data, out_of_slice_display=True, shown=[False, True], size=3
+    )
+    assert layer._view_size.shape[0] == layer._view_data.shape[0]
+
+
+def test_shown_view_size_has_the_correct_values():
+    data = [[0, 0, 0], [1, 1, 1]]
+    # Data with default settings
+    layer = Points(
+        data, out_of_slice_display=False, shown=[True, True], size=3
+    )
+    assert np.array_equal(layer._view_size, [3])
+
+    # shown == [True, False]
+    layer = Points(
+        data, out_of_slice_display=False, shown=[True, False], size=3
+    )
+    assert np.array_equal(layer._view_size, [3])
+
+    # shown == [False, True]
+    layer = Points(
+        data, out_of_slice_display=False, shown=[False, True], size=3
+    )
+    assert np.array_equal(layer._view_size, [])
+
+    # Out of slice display == True
+    layer = Points(data, out_of_slice_display=True, shown=[True, True], size=3)
+    assert np.array_equal(layer._view_size, [3, 1])
+
+    # Out of slice display == True && shown == [True, False]
+    layer = Points(
+        data, out_of_slice_display=True, shown=[True, False], size=3
+    )
+    assert np.array_equal(layer._view_size, [3])
+
+    # Out of slice display == True && shown == [False, True]
+    layer = Points(
+        data, out_of_slice_display=True, shown=[False, True], size=3
+    )
+    assert np.array_equal(layer._view_size, [1])

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2368,6 +2368,12 @@ def test_shown_view_size_and_view_data_have_the_same_dimension():
     )
     assert layer._view_size.shape[0] == layer._view_data.shape[0]
 
+    # shown == [False, False]
+    layer = Points(
+        data, out_of_slice_display=False, shown=[False, False], size=3
+    )
+    assert layer._view_size.shape[0] == layer._view_data.shape[0]
+
     # Out of slice display == True
     layer = Points(data, out_of_slice_display=True, shown=[True, True], size=3)
     assert layer._view_size.shape[0] == layer._view_data.shape[0]
@@ -2381,6 +2387,12 @@ def test_shown_view_size_and_view_data_have_the_same_dimension():
     # Out of slice display == True && shown == [False, True]
     layer = Points(
         data, out_of_slice_display=True, shown=[False, True], size=3
+    )
+    assert layer._view_size.shape[0] == layer._view_data.shape[0]
+
+    # Out of slice display == True && shown == [False, False]
+    layer = Points(
+        data, out_of_slice_display=True, shown=[False, False], size=3
     )
     assert layer._view_size.shape[0] == layer._view_data.shape[0]
 
@@ -2405,6 +2417,12 @@ def test_shown_view_size_has_the_correct_values():
     )
     assert np.array_equal(layer._view_size, [])
 
+    # shown == [False, False]
+    layer = Points(
+        data, out_of_slice_display=False, shown=[False, False], size=3
+    )
+    assert np.array_equal(layer._view_size, [])
+
     # Out of slice display == True
     layer = Points(data, out_of_slice_display=True, shown=[True, True], size=3)
     assert np.array_equal(layer._view_size, [3, 1])
@@ -2420,3 +2438,9 @@ def test_shown_view_size_has_the_correct_values():
         data, out_of_slice_display=True, shown=[False, True], size=3
     )
     assert np.array_equal(layer._view_size, [1])
+
+    # Out of slice display == True && shown == [False, False]
+    layer = Points(
+        data, out_of_slice_display=True, shown=[False, False], size=3
+    )
+    assert np.array_equal(layer._view_size, [])

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2355,46 +2355,54 @@ def test_shown_view_size_and_view_data_have_the_same_dimension():
         data, out_of_slice_display=False, shown=[True, True], size=3
     )
     assert layer._view_size.shape[0] == layer._view_data.shape[0]
+    assert layer._view_size.shape[0] == 1
 
     # shown == [True, False]
     layer = Points(
         data, out_of_slice_display=False, shown=[True, False], size=3
     )
     assert layer._view_size.shape[0] == layer._view_data.shape[0]
+    assert layer._view_size.shape[0] == 1
 
     # shown == [False, True]
     layer = Points(
         data, out_of_slice_display=False, shown=[False, True], size=3
     )
     assert layer._view_size.shape[0] == layer._view_data.shape[0]
+    assert layer._view_size.shape[0] == 0
 
     # shown == [False, False]
     layer = Points(
         data, out_of_slice_display=False, shown=[False, False], size=3
     )
     assert layer._view_size.shape[0] == layer._view_data.shape[0]
+    assert layer._view_size.shape[0] == 0
 
     # Out of slice display == True
     layer = Points(data, out_of_slice_display=True, shown=[True, True], size=3)
     assert layer._view_size.shape[0] == layer._view_data.shape[0]
+    assert layer._view_size.shape[0] == 2
 
     # Out of slice display == True && shown == [True, False]
     layer = Points(
         data, out_of_slice_display=True, shown=[True, False], size=3
     )
     assert layer._view_size.shape[0] == layer._view_data.shape[0]
+    assert layer._view_size.shape[0] == 1
 
     # Out of slice display == True && shown == [False, True]
     layer = Points(
         data, out_of_slice_display=True, shown=[False, True], size=3
     )
     assert layer._view_size.shape[0] == layer._view_data.shape[0]
+    assert layer._view_size.shape[0] == 1
 
     # Out of slice display == True && shown == [False, False]
     layer = Points(
         data, out_of_slice_display=True, shown=[False, False], size=3
     )
     assert layer._view_size.shape[0] == layer._view_data.shape[0]
+    assert layer._view_size.shape[0] == 0
 
 
 def test_shown_view_size_has_the_correct_values():

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2356,6 +2356,7 @@ def test_shown_view_size_and_view_data_have_the_same_dimension():
     )
     assert layer._view_size.shape[0] == layer._view_data.shape[0]
     assert layer._view_size.shape[0] == 1
+    assert np.array_equal(layer._view_size, [3])
 
     # shown == [True, False]
     layer = Points(
@@ -2363,6 +2364,7 @@ def test_shown_view_size_and_view_data_have_the_same_dimension():
     )
     assert layer._view_size.shape[0] == layer._view_data.shape[0]
     assert layer._view_size.shape[0] == 1
+    assert np.array_equal(layer._view_size, [3])
 
     # shown == [False, True]
     layer = Points(
@@ -2370,6 +2372,7 @@ def test_shown_view_size_and_view_data_have_the_same_dimension():
     )
     assert layer._view_size.shape[0] == layer._view_data.shape[0]
     assert layer._view_size.shape[0] == 0
+    assert np.array_equal(layer._view_size, [])
 
     # shown == [False, False]
     layer = Points(
@@ -2377,78 +2380,34 @@ def test_shown_view_size_and_view_data_have_the_same_dimension():
     )
     assert layer._view_size.shape[0] == layer._view_data.shape[0]
     assert layer._view_size.shape[0] == 0
+    assert np.array_equal(layer._view_size, [])
 
     # Out of slice display == True
     layer = Points(data, out_of_slice_display=True, shown=[True, True], size=3)
     assert layer._view_size.shape[0] == layer._view_data.shape[0]
     assert layer._view_size.shape[0] == 2
-
-    # Out of slice display == True && shown == [True, False]
-    layer = Points(
-        data, out_of_slice_display=True, shown=[True, False], size=3
-    )
-    assert layer._view_size.shape[0] == layer._view_data.shape[0]
-    assert layer._view_size.shape[0] == 1
-
-    # Out of slice display == True && shown == [False, True]
-    layer = Points(
-        data, out_of_slice_display=True, shown=[False, True], size=3
-    )
-    assert layer._view_size.shape[0] == layer._view_data.shape[0]
-    assert layer._view_size.shape[0] == 1
-
-    # Out of slice display == True && shown == [False, False]
-    layer = Points(
-        data, out_of_slice_display=True, shown=[False, False], size=3
-    )
-    assert layer._view_size.shape[0] == layer._view_data.shape[0]
-    assert layer._view_size.shape[0] == 0
-
-
-def test_shown_view_size_has_the_correct_values():
-    data = [[0, 0, 0], [1, 1, 1]]
-    # Data with default settings
-    layer = Points(
-        data, out_of_slice_display=False, shown=[True, True], size=3
-    )
-    assert np.array_equal(layer._view_size, [3])
-
-    # shown == [True, False]
-    layer = Points(
-        data, out_of_slice_display=False, shown=[True, False], size=3
-    )
-    assert np.array_equal(layer._view_size, [3])
-
-    # shown == [False, True]
-    layer = Points(
-        data, out_of_slice_display=False, shown=[False, True], size=3
-    )
-    assert np.array_equal(layer._view_size, [])
-
-    # shown == [False, False]
-    layer = Points(
-        data, out_of_slice_display=False, shown=[False, False], size=3
-    )
-    assert np.array_equal(layer._view_size, [])
-
-    # Out of slice display == True
-    layer = Points(data, out_of_slice_display=True, shown=[True, True], size=3)
     assert np.array_equal(layer._view_size, [3, 1])
 
     # Out of slice display == True && shown == [True, False]
     layer = Points(
         data, out_of_slice_display=True, shown=[True, False], size=3
     )
+    assert layer._view_size.shape[0] == layer._view_data.shape[0]
+    assert layer._view_size.shape[0] == 1
     assert np.array_equal(layer._view_size, [3])
 
     # Out of slice display == True && shown == [False, True]
     layer = Points(
         data, out_of_slice_display=True, shown=[False, True], size=3
     )
+    assert layer._view_size.shape[0] == layer._view_data.shape[0]
+    assert layer._view_size.shape[0] == 1
     assert np.array_equal(layer._view_size, [1])
 
     # Out of slice display == True && shown == [False, False]
     layer = Points(
         data, out_of_slice_display=True, shown=[False, False], size=3
     )
+    assert layer._view_size.shape[0] == layer._view_data.shape[0]
+    assert layer._view_size.shape[0] == 0
     assert np.array_equal(layer._view_size, [])

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1669,6 +1669,10 @@ class Points(Layer):
         # get the indices of points in view
         indices, scale = self._slice_data(self._slice_indices)
 
+        # Update the _view_size_scale in accordance to the self._indices_view setter.
+        # If out_of_slice_display is False, scale is a number and not an array.
+        # Therefore we have an additional if statement checking for
+        # self._view_size_scale being an integer.
         if not isinstance(scale, np.ndarray):
             self._view_size_scale = scale
         elif len(self._shown) == 0:

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1668,7 +1668,14 @@ class Points(Layer):
         """Sets the view given the indices to slice with."""
         # get the indices of points in view
         indices, scale = self._slice_data(self._slice_indices)
-        self._view_size_scale = scale
+
+        if not isinstance(scale, np.ndarray):
+            self._view_size_scale = scale
+        elif len(self._shown) == 0:
+            self._view_size_scale = np.empty(0, int)
+        else:
+            self._view_size_scale = scale[self.shown[indices]]
+
         self._indices_view = np.array(indices, dtype=int)
         # get the selected points that are in view
         self._selected_view = list(


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
This pull request tackles the issue of a dimensional mismatch between `Points._view_size_scale` and `Points._indices_view` in combination with the `Points.shown` property and `Points.out_of_slice_display`.

Steps to reproduce:
1. Open Napari 
2. Open the napari console
3. Type: `viewer.add_points([[0, 0, 0], [1,1,1]], out_of_slice_display=True, shown=[True, False], size=3)`

```
...
File /opt/user_software/miniconda3/envs/napari-tomotwin-debug2/lib/python3.9/site-packages/vispy/visuals/markers.py:725, in MarkersVisual.set_data(self, pos, size, edge_width, edge_width_rel, edge_color, face_color, symbol, scaling)
    723     data['a_edgewidth'] = edge_width
    724 else:
--> 725     data['a_edgewidth'] = size * edge_width_rel
    726 data['a_position'][:, :pos.shape[1]] = pos
    727 data['a_size'] = size

ValueError: could not broadcast input array from shape (2,) into shape (1,)
/opt/user_software/miniconda3/envs/napari-tomotwin-debug2/lib/python3.9/site-packages/ipykernel/kernelbase.py:757: RuntimeWarning: coroutine 'InProcessKernel._abort_queues' was never awaited!
```

The reason for that is that the `Points._indices_view` array is properly adjusted by `shown`, but `Points._view_size_scale` is not, leading to dimensional mismatch in the `Points._view_size` function.

<!-- Tell us about your new feature, improvement, or fix! -->

The fix I propose is that the `Points._view_size_scale` array is adjusted in the same way the `Points._indices_view`.

<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
---

<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->
---

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
---

<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
---

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [X] example: all tests pass with my change

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).

I would like to request some help how to add a test for the desired behavior :) 
Edit: Thanks for the help!