### PR TITLE
honor confirm close settings when quitting

### DIFF
--- a/napari/_qt/menus/file_menu.py
+++ b/napari/_qt/menus/file_menu.py
@@ -135,6 +135,9 @@ class FileMenu(NapariMenu):
         self.update()
 
     def _close_app(self):
+        if not get_settings().application.confirm_close_window:
+            self._win._qt_window.close(quit_app=True)
+            return
         message = QMessageBox(
             QMessageBox.Icon.Warning,
             trans._("Close application?"),

--- a/napari/settings/_application.py
+++ b/napari/settings/_application.py
@@ -157,7 +157,7 @@ class ApplicationSettings(EventedModel):
     )
     confirm_close_window: bool = Field(
         default=True,
-        title=trans._("Confirm window closing"),
+        title=trans._("Confirm window or application closing"),
         description=trans._(
             "Ask for confirmation before closing a napari window.",
         ),

--- a/napari/settings/_application.py
+++ b/napari/settings/_application.py
@@ -7,7 +7,6 @@ from pydantic import Field, validator
 from ..utils._base import _DEFAULT_LOCALE
 from ..utils.events.custom_types import conint
 from ..utils.events.evented_model import EventedModel
-from ..utils.interactions import Shortcut
 from ..utils.notifications import NotificationSeverity
 from ..utils.translations import trans
 from ._constants import LoopMode
@@ -160,8 +159,7 @@ class ApplicationSettings(EventedModel):
         default=True,
         title=trans._("Confirm window closing"),
         description=trans._(
-            "Ask for confirmation before closing window with {shortcut}",
-            shortcut=Shortcut("Control-W").platform,
+            "Ask for confirmation before closing a napari window.",
         ),
     )
 

--- a/napari/settings/_application.py
+++ b/napari/settings/_application.py
@@ -159,7 +159,7 @@ class ApplicationSettings(EventedModel):
         default=True,
         title=trans._("Confirm window or application closing"),
         description=trans._(
-            "Ask for confirmation before closing a napari window.",
+            "Ask for confirmation before closing a napari window or application (all napari windows).",
         ),
     )
 


### PR DESCRIPTION
# Description
We need to have a way to quit napari without having to confirm every time (particularly when there's nothing to save anyway, but in general: if I have selected in the settings not to confirm on close, it shouldn't confirm on close).  If a follow up PR is desired that adds a separate setting to differentiate between command W and command Q, that's fine.  But there needs to be a preference.
