### PR TITLE
Refactor label painting by moving code from mouse bindings onto layer, adding staged history and paint event

### DIFF
--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -33,15 +33,15 @@ def draw(layer, event):
     else:
         new_label = layer.selected_label
 
-    layer._start_painting(coordinates, new_label)
-    last_cursor_coord = coordinates
+    layer._draw(new_label, coordinates, coordinates)
     yield
 
+    last_cursor_coord = coordinates
     # on move
     while event.type == 'mouse_move':
         coordinates = mouse_event_to_labels_coordinate(layer, event)
         if coordinates is not None or last_cursor_coord is not None:
-            layer._paint(new_label, last_cursor_coord, coordinates)
+            layer._draw(new_label, last_cursor_coord, coordinates)
         last_cursor_coord = coordinates
         yield
 

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from ._labels_constants import Mode
 from ._labels_utils import (
-    interpolate_coordinates,
     mouse_event_to_labels_coordinate,
 )
 
@@ -26,7 +25,6 @@ def draw(layer, event):
     pixels will be changed to background and this tool functions like an
     eraser
     """
-    ndisplay = len(layer._dims_displayed)
     coordinates = mouse_event_to_labels_coordinate(layer, event)
 
     # on press
@@ -55,20 +53,7 @@ def draw(layer, event):
     while event.type == 'mouse_move':
         coordinates = mouse_event_to_labels_coordinate(layer, event)
         if coordinates is not None or last_cursor_coord is not None:
-            interp_coord = interpolate_coordinates(
-                last_cursor_coord, coordinates, layer.brush_size
-            )
-            for c in interp_coord:
-                if (
-                    ndisplay == 3
-                    and layer.data[tuple(np.round(c).astype(int))] == 0
-                ):
-                    continue
-                if layer._mode in [Mode.PAINT, Mode.ERASE]:
-                    layer.paint(c, new_label, refresh=False)
-                elif layer._mode == Mode.FILL:
-                    layer.fill(c, new_label, refresh=False)
-            layer.refresh()
+            layer._paint(new_label, last_cursor_coord, coordinates)
         last_cursor_coord = coordinates
         yield
 

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -24,25 +24,23 @@ def draw(layer, event):
     coordinates = mouse_event_to_labels_coordinate(layer, event)
 
     # on press
-    if layer._mode == Mode.ERASE:
-        new_label = layer._background_label
-    else:
-        new_label = layer.selected_label
+    with layer.block_history():
+        if layer._mode == Mode.ERASE:
+            new_label = layer._background_label
+        else:
+            new_label = layer.selected_label
 
-    layer._draw(new_label, coordinates, coordinates)
-    yield
-
-    last_cursor_coord = coordinates
-    # on move
-    while event.type == 'mouse_move':
-        coordinates = mouse_event_to_labels_coordinate(layer, event)
-        if coordinates is not None or last_cursor_coord is not None:
-            layer._draw(new_label, last_cursor_coord, coordinates)
-        last_cursor_coord = coordinates
+        layer._draw(new_label, coordinates, coordinates)
         yield
 
-    # on release
-    layer._finish_painting()
+        last_cursor_coord = coordinates
+        # on move
+        while event.type == 'mouse_move':
+            coordinates = mouse_event_to_labels_coordinate(layer, event)
+            if coordinates is not None or last_cursor_coord is not None:
+                layer._draw(new_label, last_cursor_coord, coordinates)
+            last_cursor_coord = coordinates
+            yield
 
 
 def pick(layer, event):

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -1,9 +1,7 @@
 import numpy as np
 
 from ._labels_constants import Mode
-from ._labels_utils import (
-    mouse_event_to_labels_coordinate,
-)
+from ._labels_utils import mouse_event_to_labels_coordinate
 
 
 def draw(layer, event):

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -22,13 +22,13 @@ def draw(layer, event):
     eraser
     """
     coordinates = mouse_event_to_labels_coordinate(layer, event)
+    if layer._mode == Mode.ERASE:
+        new_label = layer._background_label
+    else:
+        new_label = layer.selected_label
 
     # on press
     with layer.block_history():
-        if layer._mode == Mode.ERASE:
-            new_label = layer._background_label
-        else:
-            new_label = layer.selected_label
 
         layer._draw(new_label, coordinates, coordinates)
         yield

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from ._labels_constants import Mode
 from ._labels_utils import mouse_event_to_labels_coordinate
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -28,7 +28,7 @@ from ..utils.color_transformations import transform_color
 from ..utils.layer_utils import _FeatureTable
 from ._labels_constants import LabelColorMode, LabelsRendering, Mode
 from ._labels_mouse_bindings import draw, pick
-from ._labels_utils import indices_in_shape, sphere_indices
+from ._labels_utils import indices_in_shape, sphere_indices, interpolate_coordinates
 
 _REV_SHAPE_HELP = {
     trans._('enter paint or fill mode to edit labels'): {
@@ -1224,6 +1224,29 @@ class Labels(_ImageBase):
 
         if refresh is True:
             self.refresh()
+
+    def _start_painting(self):
+        pass
+
+    def _paint(self, new_label, last_cursor_coord, coordinates):
+        ndisplay = len(self._dims_displayed)
+        interp_coord = interpolate_coordinates(
+            last_cursor_coord, coordinates, self.brush_size
+        )
+        for c in interp_coord:
+            if (
+                ndisplay == 3
+                and self.data[tuple(np.round(c).astype(int))] == 0
+            ):
+                continue
+            if self._mode in [Mode.PAINT, Mode.ERASE]:
+                self.paint(c, new_label, refresh=False)
+            elif self._mode == Mode.FILL:
+                self.fill(c, new_label, refresh=False)
+        self.refresh()
+
+    def _finish_painting(self):
+        pass
 
     def paint(self, coord, new_label, refresh=True):
         """Paint over existing labels with a new label, using the selected

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1,6 +1,6 @@
-from contextlib import contextmanager
 import warnings
 from collections import deque
+from contextlib import contextmanager
 from typing import Dict, List, Optional, Union
 
 import numpy as np
@@ -1269,7 +1269,7 @@ class Labels(_ImageBase):
         self._block_history = True
         try:
             yield
-        finally: 
+        finally:
             self._finish_painting()
             self._block_history = prev
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1088,6 +1088,13 @@ class Labels(_ImageBase):
 
     @contextmanager
     def block_history(self):
+        """Context manager to group history-editing operations together.
+
+        While in the context, history atoms are grouped together into a
+        "staged" history. When exiting the context, that staged history is
+        committed to the undo history queue, and an event is emitted
+        containing the change.
+        """
         prev = self._block_history
         self._block_history = True
         try:
@@ -1103,12 +1110,12 @@ class Labels(_ImageBase):
             self._staged_history = []
 
     def _append_to_undo_history(self, item):
-        """Append item to history and emit paint event
+        """Append item to history and emit paint event.
 
         Parameters
         ----------
         item : List[Tuple[ndarray, ndarray, int]]
-            list of history atoms to append to undo history
+            list of history atoms to append to undo history.
         """
         self._undo_history.append(item)
         self.events.paint(value=item)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1140,7 +1140,7 @@ class Labels(_ImageBase):
             - the values corresponding to those elements before the change
             - the value(s) after the change
         """
-        self._redo_history = deque()
+        self._redo_history.clear()
         if not self._block_history:
             self._append_to_undo_history([value])
         else:

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1099,10 +1099,10 @@ class Labels(_ImageBase):
     def _commit_staged_history(self):
         """Save staged history to undo history and clear it."""
         if self._staged_history:
-            self._undo_append(self._staged_history)
+            self._append_to_undo_history(self._staged_history)
             self._staged_history = []
 
-    def _undo_append(self, item):
+    def _append_to_undo_history(self, item):
         """Append item to history and emit paint event
 
         Parameters
@@ -1135,7 +1135,7 @@ class Labels(_ImageBase):
         """
         self._redo_history = deque()
         if not self._block_history:
-            self._undo_append([value])
+            self._append_to_undo_history([value])
         else:
             self._staged_history.append(value)
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1248,8 +1248,9 @@ class Labels(_ImageBase):
         self.data_setitem(match_indices, new_label, refresh)
 
     def _draw(self, new_label, last_cursor_coord, coordinates):
-        """Paint new label into layer at given coordinates,
-        interpolating from the last cursor coordinate.
+        """Paint into coordinates, accounting for mode and cursor movement.
+
+        The draw operation depends on the current mode of the layer.
 
         Parameters
         ----------
@@ -1347,16 +1348,22 @@ class Labels(_ImageBase):
         self.data_setitem(slice_coord, new_label, refresh)
 
     def data_setitem(self, indices, value, refresh=True):
-        """Set `indices` in `data` to `value`.
+        """Set `indices` in `data` to `value`, while writing to edit history.
 
         Parameters
         ----------
-        indices : sequence of int
-            indices in data to overwrite
-        value : int
-            new label value
-        refresh : bool, optional
+        indices : tuple of int, slice, or sequence of int
+            Indices in data to overwrite. Can be any valid NumPy indexing
+            expression [1]_.
+        value : int or array of int
+            New label value(s). If more than one value, must match or
+            broadcast with the given indices.
+        refresh : bool, default True
             whether to refresh the view, by default True
+
+        References
+        ----------
+        ..[1] https://numpy.org/doc/stable/user/basics.indexing.html
         """
         self._save_history(
             (

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1141,10 +1141,10 @@ class Labels(_ImageBase):
             - the value(s) after the change
         """
         self._redo_history.clear()
-        if not self._block_history:
-            self._append_to_undo_history([value])
-        else:
+        if self._block_history:
             self._staged_history.append(value)
+        else:
+            self._append_to_undo_history([value])
 
     def _load_history(self, before, after, undoing=True):
         """Load a history item and apply it to the array.

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -302,7 +302,6 @@ class Labels(_ImageBase):
             brush_shape=Event,
             contour=Event,
             features=Event,
-            paint=Event,
         )
 
         self._feature_table = _FeatureTable.from_layer(
@@ -1269,15 +1268,14 @@ class Labels(_ImageBase):
         self._block_history = True
         try:
             yield
-        finally:
             self._finish_painting()
+        finally:
             self._block_history = prev
 
     def _finish_painting(self):
         """Save staged history to undo history and emit paint event."""
         if self._staged_history:
             self._undo_history.append(self._staged_history)
-            self.events.paint(value=self._staged_history)
             self._staged_history = []
 
     def paint(self, coord, new_label, refresh=True):

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -28,7 +28,11 @@ from ..utils.color_transformations import transform_color
 from ..utils.layer_utils import _FeatureTable
 from ._labels_constants import LabelColorMode, LabelsRendering, Mode
 from ._labels_mouse_bindings import draw, pick
-from ._labels_utils import indices_in_shape, sphere_indices, interpolate_coordinates
+from ._labels_utils import (
+    indices_in_shape,
+    interpolate_coordinates,
+    sphere_indices,
+)
 
 _REV_SHAPE_HELP = {
     trans._('enter paint or fill mode to edit labels'): {
@@ -1159,7 +1163,7 @@ class Labels(_ImageBase):
             Whether to refresh view slice or not. Set to False to batch paint
             calls.
         save_history : bool
-            Whether to save painted coords to history or now. Set to False to 
+            Whether to save painted coords to history or now. Set to False to
             batch fill calls, which will save painted coords to staged history.
         """
         int_coord = tuple(np.round(coord).astype(int))
@@ -1213,10 +1217,10 @@ class Labels(_ImageBase):
         )
 
         history_atom = (
-                match_indices,
-                np.array(self.data[match_indices], copy=True),
-                new_label,
-            )
+            match_indices,
+            np.array(self.data[match_indices], copy=True),
+            new_label,
+        )
         if save_history:
             self._save_history(history_atom)
         else:
@@ -1260,8 +1264,7 @@ class Labels(_ImageBase):
         self.refresh()
 
     def _finish_painting(self):
-        """Save staged history to undo history and emit paint event.
-        """
+        """Save staged history to undo history and emit paint event."""
         if self._staged_history:
             self._undo_history.append(self._staged_history)
             self.events.paint(value=self._staged_history)
@@ -1282,7 +1285,7 @@ class Labels(_ImageBase):
             Whether to refresh view slice or not. Set to False to batch paint
             calls.
         save_history : bool
-            Whether to save painted coords to history or now. Set to False to 
+            Whether to save painted coords to history or now. Set to False to
             batch paint calls, which will save painted coords to staged history.
         """
         shape = self.data.shape
@@ -1338,10 +1341,10 @@ class Labels(_ImageBase):
 
         # save the existing values to the history
         history_atom = (
-                    slice_coord,
-                    np.array(self.data[slice_coord], copy=True),
-                    new_label,
-                )
+            slice_coord,
+            np.array(self.data[slice_coord], copy=True),
+            new_label,
+        )
         if save_history:
             self._save_history(history_atom)
         else:


### PR DESCRIPTION
# Description
After some conversations on #4663 and with @jni and @tlambert03, I'm opening this draft PR to refactor some of the painting and history saving for the labels layer, also adding a paint event but this time in a more appropriate spot, on the layer itself.

The `labels_mouse_bindings` `draw` function was doing a *lot* of work checking layer attributes and computing coordinates, and this work really belongs on the layer itself. This PR moves some of that code into a private `_draw` method on the layer.

The `draw` function was also setting `layer._block_saving` as a way to let the layer know whether it should save one history atom, or start a new item. This led to some issues e.g. having to have a workaround for when the user started painting outside the canvas, and made it impossible to know, in the layer, when a larger mouse drag had finished. This PR therefore uses a `_staged_history` list to store history atoms, and adds a new `_finish_painting` method, whose job is to save staged history to real history, and emit the `paint` event with the history item. 

It may seem like we are now injecting "gui" logic into the layer, but I would say that the original `_block_saving` attribute was doing the same thing, but in a decentralised way. This PR at least makes sure that layer computations are not done in the mouse bindings, and that the layer has access to all the information it needs to emit its event. The `_finish_painting` method could also be used to support batch calls to `paint`, which otherwise would've needed toggling of the much more esoteric `_block_saving` attribute. We can also make `_finish_painting` a public method if we want to really support this.

This doesn't address @jni's concern on #4663 about emitting an event when someone splits labels or otherwise programmatically calls `paint`. I think we could address this by emitting in `paint`, but blocking the emission in `labels_mouse_bindings` `draw` until we call `_finish_painting`? Alternatively we could have two separate events e.g. `paint` and `painted` (or something more informative), but that may lead to performance issues - a concern originally raised in issue #4194.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
