### PR TITLE
add 'napari-xpra' target to dockerfile

### DIFF
--- a/.github/workflows/docker-singularity-publish.yml
+++ b/.github/workflows/docker-singularity-publish.yml
@@ -14,7 +14,6 @@ on:
     branches: [ main ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
-  pull_request:
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/docker-singularity-publish.yml
+++ b/.github/workflows/docker-singularity-publish.yml
@@ -14,6 +14,7 @@ on:
     branches: [ main ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
+  pull_request:
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/docker-singularity-publish.yml
+++ b/.github/workflows/docker-singularity-publish.yml
@@ -18,13 +18,9 @@ on:
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
-
 
 jobs:
   build1:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -32,7 +28,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        recipe: ["Docker"]
+        include:
+          - recipe: Docker
+            target: napari
+            image-name: napari/napari
+          - recipe: Docker
+            target: napari-xpra
+            image-name: napari/napari-xpra
 
     steps:
       - name: Checkout repository
@@ -56,10 +58,10 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           # list of Docker images to use as base name for tags
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-#          images: |
-#            name/app
-#            ghcr.io/username/app
+          images: ${{ env.REGISTRY }}/${{ matrix.image-name }}
+          #          images: |
+          #            name/app
+          #            ghcr.io/username/app
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule
@@ -70,7 +72,7 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
             latest
-#            oras://ghcr.io is tagged latest too, and seems to override the docker://ghcr.io tag -> race condition?
+          # oras://ghcr.io is tagged latest too, and seems to override the docker://ghcr.io tag -> race condition?
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -82,11 +84,12 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: "dockerfile"
+          target: ${{ matrix.target }}
 
       - name: Check out code for the container build
         uses: actions/checkout@v2
 
-# ----
+  # ----
 
   build2:
     needs: build1
@@ -110,28 +113,30 @@ jobs:
         run: |
           if [[ -f "${{ matrix.recipe }}" ]]; then
             echo "keepgoing=true" >> $GITHUB_ENV
-          fi          
+          fi
 
       - name: Build Container
         if: ${{ env.keepgoing == 'true' }}
         env:
           recipe: ${{ matrix.recipe }}
         run: |
+          ls
          ls 
-         if [ -f "${{ matrix.recipe }}" ]; then
-            singularity build container.sif ${{ matrix.recipe }}
-            tag=latest
-         fi
-         # Build the container and name by tag
-         echo "Tag is $tag."
-         echo "tag=$tag" >> $GITHUB_ENV
+          ls
+          if [ -f "${{ matrix.recipe }}" ]; then
+             singularity build container.sif ${{ matrix.recipe }}
+             tag=latest
+          fi
+          # Build the container and name by tag
+          echo "Tag is $tag."
+          echo "tag=$tag" >> $GITHUB_ENV
 
       - name: Login and Deploy Container
         if: (github.event_name != 'pull_request')
         env:
           keepgoing: ${{ env.keepgoing }}
-        run: |         
-            if [[ "${keepgoing}" == "true" ]]; then
-                echo ${{ secrets.GITHUB_TOKEN }} | singularity remote login -u ${{ secrets.GHCR_USERNAME }} --password-stdin oras://ghcr.io
-                singularity push container.sif oras://ghcr.io/${GITHUB_REPOSITORY}:${tag}
-            fi
+        run: |
+          if [[ "${keepgoing}" == "true" ]]; then
+              echo ${{ secrets.GITHUB_TOKEN }} | singularity remote login -u ${{ secrets.GHCR_USERNAME }} --password-stdin oras://ghcr.io
+              singularity push container.sif oras://ghcr.io/${GITHUB_REPOSITORY}:${tag}
+          fi

--- a/.github/workflows/docker-singularity-publish.yml
+++ b/.github/workflows/docker-singularity-publish.yml
@@ -122,8 +122,6 @@ jobs:
           recipe: ${{ matrix.recipe }}
         run: |
           ls
-         ls 
-          ls
           if [ -f "${{ matrix.recipe }}" ]; then
              singularity build container.sif ${{ matrix.recipe }}
              tag=latest

--- a/dockerfile
+++ b/dockerfile
@@ -1,23 +1,77 @@
-FROM ubuntu:20.04
-
-# install python resources
-RUN apt-get update && apt-get install -qqy build-essential python3.8 python3-pip
+FROM --platform=linux/amd64 ubuntu:20.04 AS napari
 
 # below env var required to install libglib2.0-0 non-interactively
-ENV TZ America/Los_Angeles
-ENV DEBIAN_FRONTEND noninteractive
+ENV TZ=America/Los_Angeles
+ARG DEBIAN_FRONTEND=noninteractive
 
-# install graphical libraries used by qt and vispy
-RUN apt-get install -qqy mesa-utils libgl1-mesa-glx  libglib2.0-0
-RUN apt-get install -qqy libfontconfig1 libxrender1 libdbus-1-3 libxkbcommon-x11-0 libxi6
-RUN apt-get install -qqy libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0
-RUN apt-get install -qqy libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0
+# install python resources + graphical libraries used by qt and vispy
+RUN apt-get update && \
+    apt-get install -qqy  \
+        build-essential \
+        python3.8 \
+        python3-pip \
+        mesa-utils \
+        libgl1-mesa-glx \
+        libglib2.0-0 \
+        libfontconfig1 \
+        libxrender1 \
+        libdbus-1-3 \
+        libxkbcommon-x11-0 \
+        libxi6 \
+        libxcb-icccm4 \
+        libxcb-image0 \
+        libxcb-keysyms1 \
+        libxcb-randr0 \
+        libxcb-render-util0 \
+        libxcb-xinerama0 \
+        libxcb-xinput0 \
+        libxcb-xfixes0 \
+        libxcb-shape0
 
-# install napari release version
-RUN pip3 install napari[all]
-
-# install scikit image for examples
-RUN pip3 install scikit-image
+# install napari release version + scikit-image (for examples)
+RUN pip3 install napari[all] scikit-image
 COPY examples /tmp/examples
 
 ENTRYPOINT ["python3", "-m", "napari"]
+
+#########################################################
+# Extend napari with a preconfigured Xpra server target #
+#########################################################
+
+FROM napari AS napari-xpra
+
+# Install Xpra and dependencies
+RUN apt-get install -y wget gnupg2 apt-transport-https && \
+    wget -O - https://xpra.org/gpg.asc | apt-key add - && \
+    echo "deb https://xpra.org/ focal main" > /etc/apt/sources.list.d/xpra.list
+
+RUN apt-get update && \
+    apt-get install -yqq \
+        xpra \
+        xvfb \
+        xterm \
+        sshfs && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV DISPLAY=:100
+ENV XPRA_PORT=9876
+ENV XPRA_START="python3 -m napari"
+ENV XPRA_EXIT_WITH_CLIENT="yes"
+ENV XPRA_XVFB_SCREEN="1920x1080x24+32"
+EXPOSE 9876
+
+CMD echo "Launching napari on Xpra. Connect via http://localhost:$XPRA_PORT"; \
+    xpra start \
+    --bind-tcp=0.0.0.0:$XPRA_PORT \
+    --html=on \
+    --start="$XPRA_START" \
+    --exit-with-client="$XPRA_EXIT_WITH_CLIENT" \
+    --daemon=no \
+    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 $XPRA_XVFB_SCREEN -nolisten tcp -noreset" \
+    --pulseaudio=no \
+    --notifications=no \
+    --bell=no \
+    $DISPLAY
+
+ENTRYPOINT []

--- a/dockerfile
+++ b/dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
         build-essential \
         python3.8 \
         python3-pip \
+        git \
         mesa-utils \
         libgl1-mesa-glx \
         libglib2.0-0 \

--- a/dockerfile
+++ b/dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update && \
         libxcb-xfixes0 \
         libxcb-shape0
 
-# install napari release version + scikit-image (for examples)
-RUN pip3 install napari[all] scikit-image
+# install napari release version
+RUN pip3 install napari[all]
 COPY examples /tmp/examples
 
 ENTRYPOINT ["python3", "-m", "napari"]

--- a/docs/howtos/docker.md
+++ b/docs/howtos/docker.md
@@ -4,22 +4,81 @@
 
 Builds are avilable through [dockerhub](https://hub.docker.com/repository/docker/napari/napari)
 
-A dockerfile is added to napari root to allow build of a docker image using official napari release. 
-Note that napari in docker is still in alpha stage and not working universally, feedback and contribution also welcomed.
+A dockerfile is added to napari root to allow build of a docker image using official napari release.
+It contains two targets built on top of Ubuntu 20.04:
 
-To build the image, run from napari root
+* `napari`: The result of `pip install napari[all] scikit-image` for Python 3.8, including all the system libraries required by PyQt.
+* `napari-xpra`: Same as above, plus a preconfigured Xpra server.
+
+Note that napari in Docker is still in alpha stage and not working universally. Feedback and contributions are welcomed!
+
+To build the image, run one of these commands from napari root:
+
+```bash
+# build napari image
+docker build --target napari -t napari/napari:<version> .
+# build napari + xpra image
+docker build --target napari-xpra -t napari/napari-xpra:<version> .
 ```
-docker build -t napari/napari:<version> .
-```
-which would build a docker image tagged with napari version
+
+which would build a Docker image tagged with napari version.
 
 ## Usage
 
-Enable XServer on the host machine, these can be useful if you are looking for options:
+### Base `napari` image
+
+First, make sure there's a running X server on the host machine.
+These can be useful if you are looking for options:
 * Windows: [vcxsrc](https://sourceforge.net/projects/vcxsrv/)
 * MacOS: [xquartz](https://www.xquartz.org/) (may not work due to graphical driver issue with opengl)
 
 To run a container with external mapping of display, an example being:
+
 ```
-docker run -d  -e DISPLAY=host.docker.internal:0 napari/napari:0.3.6 python3 /tmp/examples/add_image.py
+docker run -it --rm -e DISPLAY=host.docker.internal:0 napari/napari
 ```
+
+### `napari-xpra` image
+
+With this image you don't need X running on the host. A browser is sufficient!
+
+```
+docker run -it --rm -p 9876:9876 napari/napari-xpra
+```
+
+Once that's running, you can open a tab on your browser of choice and go to [localhost:9876](http://localhost:9876).
+You'll be presented with a virtual desktop already running running napari.
+The desktop features a basic menu at the top with some extra items, like a `Xterm` terminal.
+
+This image features a series of environment variables you can use to customize its behaviour:
+
+* `XPRA_PORT=9876`: Port where Xpra will publish the display feed (if you change this, make sure to use the new port in your  `docker run`)
+* `XPRA_START="python3 -m napari"`: Xpra will run this command once it has started
+* `XPRA_EXIT_WITH_CLIENT="yes"`: By default, Xpra will exit if you close the browser tab
+* `XPRA_XVFB_SCREEN="1920x1080x24+32"`: The resolution and bit depth of the virtual display created by Xvfb
+
+## Troubleshooting
+
+Making the Docker image run seamlessly with your host graphical stack can be tricky.
+You might find issues like these:
+
+* napari seems to be running, but no window appears at all
+* napari does run and the UI works as intended, but the viewer portion is completely black
+* napari does not start due to missing libraries or mismatched ABIs (e.g. drivers in host are incompatible with guest)
+
+In these cases, the best option is to stop relying on the host graphics and let the guest handle
+everything. To do this, we need several pieces in place:
+
+* A headless X server running on the guest; e.g. `Xvfb` (X virtual frame buffer)
+* A way of "seeing" that X server from the host. Some options include:
+    * VNC (might have issues with OpenGL)
+    * NX (NoMachine;, [should work](https://github.com/napari/napari/issues/886#issuecomment-873178682))
+    * Microsoft Remote Desktop Protocol (e.g. XRDP; [should work](https://github.com/napari/napari/issues/886#issuecomment-875959941))
+    * Chrome Remote Desktop ([should work](https://github.com/napari/napari/issues/886#issue-551159225))
+    * Xpra (part of the Docker image detailed above)
+
+Since napari relies on OpenGL for its (hardware) accelerated parts, we need to ensure that the piece we choose are OpenGL compatible.
+Xvfb itself is compatible, but the display "exporter" needs to know how to deal with that part of the graphics too!
+
+You must also note that Docker won't probably have access to the host GPU, so everything will be rendered in the CPU.
+Expect some performance overhead!

--- a/docs/howtos/docker.md
+++ b/docs/howtos/docker.md
@@ -2,7 +2,7 @@
 
 ## Build
 
-Builds are avilable through [dockerhub](https://hub.docker.com/repository/docker/napari/napari)
+Builds are available in the [GitHub Container Registry](https://github.com/orgs/napari/packages).
 
 A dockerfile is added to napari root to allow build of a docker image using official napari release.
 It contains two targets built on top of Ubuntu 20.04:
@@ -16,9 +16,9 @@ To build the image, run one of these commands from napari root:
 
 ```bash
 # build napari image
-docker build --target napari -t napari/napari:<version> .
+docker build --target napari -t ghcr.io/napari/napari:<version> .
 # build napari + xpra image
-docker build --target napari-xpra -t napari/napari-xpra:<version> .
+docker build --target napari-xpra -t ghcr.io/napari/napari-xpra:<version> .
 ```
 
 which would build a Docker image tagged with napari version.
@@ -35,7 +35,7 @@ These can be useful if you are looking for options:
 To run a container with external mapping of display, an example being:
 
 ```
-docker run -it --rm -e DISPLAY=host.docker.internal:0 napari/napari
+docker run -it --rm -e DISPLAY=host.docker.internal:0 ghcr.io/napari/napari
 ```
 
 ### `napari-xpra` image
@@ -43,7 +43,7 @@ docker run -it --rm -e DISPLAY=host.docker.internal:0 napari/napari
 With this image you don't need X running on the host. A browser is sufficient!
 
 ```
-docker run -it --rm -p 9876:9876 napari/napari-xpra
+docker run -it --rm -p 9876:9876 ghcr.io/napari/napari-xpra
 ```
 
 Once that's running, you can open a tab on your browser of choice and go to [localhost:9876](http://localhost:9876).
@@ -56,6 +56,30 @@ This image features a series of environment variables you can use to customize i
 * `XPRA_START="python3 -m napari"`: Xpra will run this command once it has started
 * `XPRA_EXIT_WITH_CLIENT="yes"`: By default, Xpra will exit if you close the browser tab
 * `XPRA_XVFB_SCREEN="1920x1080x24+32"`: The resolution and bit depth of the virtual display created by Xvfb
+
+## For development
+
+The Docker images are also useful for developers who need to debug issues on Linux.
+The images include the latest napari version published on PyPI by default, but you can also install your own local version of napari if needed.
+For this, you need to mount a volume as part of the `docker run` command and make sure you land in a `bash` session:
+
+```bash
+# base napari image, we replace entry point (python3 -m napari) with a bash session
+docker run -it --rm -e DISPLAY=host.docker.internal:0 -v ~/devel/napari:/opt/napari --entrypoint /bin/bash ghcr.io/napari/napari
+# napari-xpra image, we replace the command Xpra will run on start (python3 -m napari) to a bash session running on xterm
+docker run -it --rm -p 9876:9876 -v ~/devel/napari:/opt/napari -e XPRA_START=xterm ghcr.io/napari/napari-xpra
+```
+
+> Change `~/devel/napari` to your local copy of the napari repository, which will be visible in the image as `/opt/napari`.
+
+In both cases you'll have a running shell session where you can run these commands:
+
+```bash
+# Install local napari
+$ python3 -m pip install /opt/napari[all]
+# Run napari
+$ python3 -m napari
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION
# Description

Add a new Docker target to our `dockerfile` that extends the existing image with a set of layers implementing a preconfigured Xpra server. This allows users to run X on the guest image and forward the display to a browser tab under `localhost:9876` with full OpenGL compatibility.

This is a solution for users experiencing OpenGL/X issues when forwarding DISPLAY directly to the host. Performance is not stellar but at least it works! It's also useful for developers who want to debug issues on Linux.

![napari_xpra](https://user-images.githubusercontent.com/2559438/174055345-213e89b6-836f-4751-a9e5-ba7456960144.jpg)

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

Closes napari/napari#2014 

Related issues: napari/docs#29 (might close this one), napari/napari#886

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] The docker CI passes successfully
- [ ] The commands mentioned in the documentation work as expected

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).


---

Note: Images at dockerhub haven't been updated in a while. Images in the Github Packages Registry are private. We might want to make them public?