### PR TITLE
use python 3.9 for mac tests until numcodecs 3.10 wheels are available

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -57,7 +57,7 @@ jobs:
           - python: 3.8
             platform: windows-latest
             backend: pyside2
-          - python: "3.10"
+          - python: 3.9
             platform: macos-latest
             backend: pyqt5
           # minimum specified requirements


### PR DESCRIPTION
perhaps one way to fix tests for mac?