### PR TITLE
Docs for adding LayerData tuple to viewer

### DIFF
--- a/docs/plugins/_layer_data_guide.md
+++ b/docs/plugins/_layer_data_guide.md
@@ -126,5 +126,5 @@ To add a `LayerData` tuple to the napari viewer, use :meth:`Layer.create`:
 ```python
 >>> image_layer_data = (data, {'name': 'My Image', 'colormap': 'red'}, 'image')
 >>> viewer = napari.current_viewer()
->>> viewer.add_layer(Layer(*image_layer_data))
+>>> viewer.add_layer(napari.layers.Layer.create(*image_layer_data))
 ```

--- a/docs/plugins/_layer_data_guide.md
+++ b/docs/plugins/_layer_data_guide.md
@@ -118,3 +118,13 @@ Out[7]:
     'image'
 )
 ```
+
+### Adding to the viewer
+
+To add a `LayerData` tuple to the napari viewer, use :meth:`Layer.create`:
+
+```python
+>>> image_layer_data = (data, {'name': 'My Image', 'colormap': 'red'}, 'image')
+>>> viewer = napari.current_viewer()
+>>> viewer.add_layer(Layer(*image_layer_data))
+```


### PR DESCRIPTION
# Description
This adds some short docs for adding a LayerData tuple to the `napari` viewer.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
