### PR TITLE
Make LayerData a namedtuple

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
 from contextlib import contextmanager
 from functools import cached_property
-from typing import List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import magicgui as mgui
 import numpy as np
@@ -48,6 +48,9 @@ from napari.utils.naming import magic_name
 from napari.utils.status_messages import generate_layer_coords_status
 from napari.utils.transforms import Affine, CompositeAffine, TransformChain
 from napari.utils.translations import trans
+
+if TYPE_CHECKING:
+    from napari.types import FullLayerData
 
 Extent = namedtuple('Extent', 'data world step')
 
@@ -869,7 +872,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     def _type_string(self):
         return self.__class__.__name__.lower()
 
-    def as_layer_data_tuple(self):
+    def as_layer_data_tuple(self) -> FullLayerData:
         state = self._get_state()
         state.pop('data', None)
         return self.data, state, self._type_string

--- a/napari/plugins/io.py
+++ b/napari/plugins/io.py
@@ -77,7 +77,7 @@ def read_data_with_plugins(
     res = _npe2.read(paths, plugin, stack=stack)
     if res is not None:
         _ld, hookimpl = res
-        return [] if _is_null_layer_sentinel(_ld) else _ld, hookimpl  # type: ignore [return-value]
+        return [] if _is_null_layer_sentinel(_ld) else _ld, hookimpl
 
     hook_caller = plugin_manager.hook.napari_get_reader
     paths = [abspath_or_url(p, must_exist=True) for p in paths]

--- a/napari/types.py
+++ b/napari/types.py
@@ -8,6 +8,8 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
+    NamedTuple,
     NewType,
     Optional,
     Sequence,
@@ -37,10 +39,14 @@ if TYPE_CHECKING:
 # since it includes all valid arguments for np.array() ( int, float, str...)
 ArrayLike = Union[np.ndarray, 'dask.array.Array', 'zarr.Array']
 
+LayerTypeName = Literal[
+    "image", "labels", "points", "shapes", "surface", "tracks", "vectors"
+]
+
 
 # layer data may be: (data,) (data, meta), or (data, meta, layer_type)
 # using "Any" for the data type until ArrayLike is more mature.
-FullLayerData = Tuple[Any, Dict, str]
+FullLayerData = Tuple[Any, Dict, LayerTypeName]
 LayerData = Union[Tuple[Any], Tuple[Any, Dict], FullLayerData]
 
 PathLike = Union[str, Path]
@@ -97,6 +103,13 @@ _LayerData = Union[
 ]
 
 LayerDataTuple = NewType("LayerDataTuple", tuple)
+
+
+# This namedtuple increases code readability, but is only for internal use
+class LayerDataTupleNamed(NamedTuple):
+    data: Union[ArrayLike, Sequence[ArrayLike]]
+    attributes: Dict
+    layer_type: LayerTypeName
 
 
 def image_reader_to_layerdata_reader(

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -31,6 +31,7 @@ from typing import (
 
 import numpy as np
 
+from napari.types import LayerDataTupleNamed
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
@@ -470,11 +471,15 @@ def ensure_layer_data_tuple(val):
     return val
 
 
-def ensure_list_of_layer_data_tuple(val) -> List[tuple]:
-    # allow empty list to be returned but do nothing in that case
+def ensure_list_of_named_layer_data_tuple(val) -> List[LayerDataTupleNamed]:
+    """
+    Make sure *val* is a list of LayerDataTupleNamed objects.
+    """
     if isinstance(val, list):
         with contextlib.suppress(TypeError):
-            return [ensure_layer_data_tuple(v) for v in val]
+            return [
+                LayerDataTupleNamed(ensure_layer_data_tuple(v)) for v in val
+            ]
     raise TypeError(
         trans._('Not a valid list of layer data tuples!', deferred=True)
     )


### PR DESCRIPTION
# Description
This makes it possible to use named attributes to access the different bits of a `LayerDataTuple`. Fixes https://github.com/napari/napari/issues/3492

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes https://github.com/napari/napari/issues/3492

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] The test suite should already cover changed lines

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
