### PR TITLE
napari.viewer.current_viewer fallback ancestor

### DIFF
--- a/napari/_tests/test_magicgui.py
+++ b/napari/_tests/test_magicgui.py
@@ -229,19 +229,36 @@ def test_magicgui_data_updated(make_napari_viewer):
 
 def test_magicgui_get_viewer(make_napari_viewer):
     """Test that annotating with napari.Viewer gets the Viewer"""
-    viewer = make_napari_viewer()
+    # Make two DIFFERENT viewers
+    viewer1 = make_napari_viewer()
+    viewer2 = make_napari_viewer()
+    assert viewer2 is not viewer1
+    # Ensure one is returned by napari.current_viewer()
+    from napari import current_viewer
+
+    assert current_viewer() is viewer2
 
     @magicgui
     def func(v: Viewer):
         return v
 
-    assert func() is None
-    viewer.window.add_dock_widget(func)
-    v = func()
-    assert isinstance(v, PublicOnlyProxy)
-    assert v.__wrapped__ is viewer
+    def func_returns(v: Viewer) -> bool:
+        """Helper function determining whether func() returns v"""
+        func_viewer = func()
+        assert isinstance(func_viewer, PublicOnlyProxy)
+        return func_viewer.__wrapped__ is v
+
+    # We expect func's Viewer to be current_viewer, not viewer
+    assert func_returns(viewer2)
+    assert not func_returns(viewer1)
+    # With viewer as parent, it should be returned instead
+    viewer1.window.add_dock_widget(func)
+    assert func_returns(viewer1)
+    assert not func_returns(viewer2)
     # no widget should be shown
     assert not func.v.visible
+    # ensure that viewer2 is still the current viewer
+    assert current_viewer() is viewer2
 
 
 MGUI_EXPORTS = ['napari.layers.Layer', 'napari.Viewer']

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -339,3 +339,21 @@ def test_empty_shapes_dims(make_napari_viewer):
     viewer = make_napari_viewer(show=True)
     viewer.add_shapes(None)
     viewer.dims.ndisplay = 3
+
+
+def test_current_viewer(make_napari_viewer):
+    """Test that the viewer made last is the "current_viewer()" until another is activated"""
+    # Make two DIFFERENT viewers
+    viewer1: Viewer = make_napari_viewer()
+    viewer2: Viewer = make_napari_viewer()
+    assert viewer2 is not viewer1
+    # Ensure one is returned by napari.current_viewer()
+    from napari import current_viewer
+
+    assert current_viewer() is viewer2
+    assert current_viewer() is not viewer1
+
+    viewer1.window.activate()
+
+    assert current_viewer() is viewer1
+    assert current_viewer() is not viewer2

--- a/napari/utils/_magicgui.py
+++ b/napari/utils/_magicgui.py
@@ -199,7 +199,11 @@ def add_future_data(gui, future: Future, return_type, _from_tuple=True):
 
 
 def find_viewer_ancestor(widget) -> Optional[Viewer]:
-    """Return the Viewer object if it is an ancestor of ``widget``, else None.
+    """Return the closest parent Viewer of ``widget``.
+
+    Priority is given to `Viewer` ancestors of ``widget``.
+    `napari.current_viewer()` is called for Widgets without a
+    Viewer ancestor.
 
     Parameters
     ----------
@@ -209,7 +213,7 @@ def find_viewer_ancestor(widget) -> Optional[Viewer]:
     Returns
     -------
     viewer : napari.Viewer or None
-        Viewer instance if one exists, else None.
+        Viewer ancestor if it exists, else `napari.current_viewer()`
     """
     from .._qt.widgets.qt_viewer_dock_widget import QtViewerDockWidget
 
@@ -219,6 +223,8 @@ def find_viewer_ancestor(widget) -> Optional[Viewer]:
         parent = widget.native.parent()
     else:
         parent = widget.parent()
+    from napari.viewer import current_viewer
+
     while parent:
         if hasattr(parent, '_qt_viewer'):  # QMainWindow
             return parent._qt_viewer.viewer
@@ -226,9 +232,9 @@ def find_viewer_ancestor(widget) -> Optional[Viewer]:
             qt_viewer = parent._ref_qt_viewer()
             if qt_viewer is not None:
                 return qt_viewer.viewer
-            return None
+            return current_viewer()
         parent = parent.parent()
-    return None
+    return current_viewer()
 
 
 def proxy_viewer_ancestor(widget) -> Optional[PublicOnlyProxy[Viewer]]:


### PR DESCRIPTION
# Description
This PR provides a `Viewer` fallback of `napari.current_viewer()` for widgets that are not a direct descendant of some `Viewer`. The fallback is `napari.current_viewer()`.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

Please see [this zulip thread](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/magicgui.2Erequest_values.20layers/near/286252222)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

I have tested that this change works with my plugin. I could not find any tests for `find_viewer_ancestor`, so I added no tests. 

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
