### PR TITLE
Color edit without tooltip fix

### DIFF
--- a/napari/_qt/widgets/_tests/test_qt_color_swatch.py
+++ b/napari/_qt/widgets/_tests/test_qt_color_swatch.py
@@ -2,7 +2,7 @@ import itertools
 
 from qtpy.QtWidgets import QWidget
 
-from napari._qt.widgets.qt_color_swatch import QColorSwatchEdit
+from napari._qt.widgets.qt_color_swatch import QColorSwatch, QColorSwatchEdit
 
 
 def test_succesfull_create_qcolorswatchedit(qtbot):
@@ -21,3 +21,21 @@ def test_succesfull_create_qcolorswatchedit(qtbot):
 
     for parent, color, tooltip in itertools.product(parents, colors, tooltips):
         QColorSwatchEdit(parent, initial_color=color, tooltip=tooltip)
+
+
+def test_succesfull_create_qcolorswatch(qtbot):
+    parents = [
+        None,
+        QWidget(),
+    ]
+    colors = [
+        None,
+        [1, 1, 1, 1],
+    ]
+    tooltips = [
+        None,
+        'This is a test',
+    ]
+
+    for parent, color, tooltip in itertools.product(parents, colors, tooltips):
+        QColorSwatch(parent, initial_color=color, tooltip=tooltip)

--- a/napari/_qt/widgets/_tests/test_qt_color_swatch.py
+++ b/napari/_qt/widgets/_tests/test_qt_color_swatch.py
@@ -1,0 +1,23 @@
+import itertools
+
+from qtpy.QtWidgets import QWidget
+
+from napari._qt.widgets.qt_color_swatch import QColorSwatchEdit
+
+
+def test_succesfull_create_qcolorswatchedit(qtbot):
+    parents = [
+        None,
+        QWidget(),
+    ]
+    colors = [
+        None,
+        [1, 1, 1, 1],
+    ]
+    tooltips = [
+        None,
+        'This is a test',
+    ]
+
+    for parent, color, tooltip in itertools.product(parents, colors, tooltips):
+        QColorSwatchEdit(parent, initial_color=color, tooltip=tooltip)

--- a/napari/_qt/widgets/_tests/test_qt_color_swatch.py
+++ b/napari/_qt/widgets/_tests/test_qt_color_swatch.py
@@ -13,15 +13,9 @@ from napari._qt.widgets.qt_color_swatch import (
 def test_succesfull_create_qcolorswatchedit(qtbot, color, tooltip):
     widget = QColorSwatchEdit(initial_color=color, tooltip=tooltip)
     qtbot.add_widget(widget)
-    if color is None:
-        test_color = TRANSPARENT
-    else:
-        test_color = color
 
-    if tooltip is None:
-        test_tooltip = 'click to set color'
-    else:
-        test_tooltip = tooltip
+    test_color = color or TRANSPARENT
+    test_tooltip = tooltip or 'click to set color'
 
     assert widget.color_swatch.toolTip() == test_tooltip
     numpy.testing.assert_array_equal(widget.color, test_color)
@@ -32,15 +26,9 @@ def test_succesfull_create_qcolorswatchedit(qtbot, color, tooltip):
 def test_succesfull_create_qcolorswatch(qtbot, color, tooltip):
     widget = QColorSwatch(initial_color=color, tooltip=tooltip)
     qtbot.add_widget(widget)
-    if color is None:
-        test_color = TRANSPARENT
-    else:
-        test_color = color
 
-    if tooltip is None:
-        test_tooltip = 'click to set color'
-    else:
-        test_tooltip = tooltip
+    test_color = color or TRANSPARENT
+    test_tooltip = tooltip or 'click to set color'
 
     assert widget.toolTip() == test_tooltip
     numpy.testing.assert_array_equal(widget.color, test_color)

--- a/napari/_qt/widgets/_tests/test_qt_color_swatch.py
+++ b/napari/_qt/widgets/_tests/test_qt_color_swatch.py
@@ -1,41 +1,28 @@
-import itertools
-
+import pytest
 from qtpy.QtWidgets import QWidget
 
 from napari._qt.widgets.qt_color_swatch import QColorSwatch, QColorSwatchEdit
 
 
-def test_succesfull_create_qcolorswatchedit(qtbot):
-    parents = [
-        None,
-        QWidget(),
-    ]
-    colors = [
-        None,
-        [1, 1, 1, 1],
-    ]
-    tooltips = [
-        None,
-        'This is a test',
-    ]
-
-    for parent, color, tooltip in itertools.product(parents, colors, tooltips):
+@pytest.mark.parametrize('parent', [None, True])
+@pytest.mark.parametrize('color', [None, [1, 1, 1, 1]])
+@pytest.mark.parametrize('tooltip', [None, 'This is a test'])
+def test_succesfull_create_qcolorswatchedit(qtbot, parent, color, tooltip):
+    if parent:
+        parent = QWidget()
+        qtbot.add_widget(parent)
+    qtbot.add_widget(
         QColorSwatchEdit(parent, initial_color=color, tooltip=tooltip)
+    )
 
 
-def test_succesfull_create_qcolorswatch(qtbot):
-    parents = [
-        None,
-        QWidget(),
-    ]
-    colors = [
-        None,
-        [1, 1, 1, 1],
-    ]
-    tooltips = [
-        None,
-        'This is a test',
-    ]
-
-    for parent, color, tooltip in itertools.product(parents, colors, tooltips):
+@pytest.mark.parametrize('parent', [None, True])
+@pytest.mark.parametrize('color', [None, [1, 1, 1, 1]])
+@pytest.mark.parametrize('tooltip', [None, 'This is a test'])
+def test_succesfull_create_qcolorswatch(qtbot, parent, color, tooltip):
+    if parent:
+        parent = QWidget()
+        qtbot.add_widget(parent)
+    qtbot.add_widget(
         QColorSwatch(parent, initial_color=color, tooltip=tooltip)
+    )

--- a/napari/_qt/widgets/_tests/test_qt_color_swatch.py
+++ b/napari/_qt/widgets/_tests/test_qt_color_swatch.py
@@ -1,28 +1,46 @@
+import numpy
 import pytest
-from qtpy.QtWidgets import QWidget
 
-from napari._qt.widgets.qt_color_swatch import QColorSwatch, QColorSwatchEdit
+from napari._qt.widgets.qt_color_swatch import (
+    TRANSPARENT,
+    QColorSwatch,
+    QColorSwatchEdit,
+)
 
 
-@pytest.mark.parametrize('parent', [None, True])
 @pytest.mark.parametrize('color', [None, [1, 1, 1, 1]])
 @pytest.mark.parametrize('tooltip', [None, 'This is a test'])
-def test_succesfull_create_qcolorswatchedit(qtbot, parent, color, tooltip):
-    if parent:
-        parent = QWidget()
-        qtbot.add_widget(parent)
-    qtbot.add_widget(
-        QColorSwatchEdit(parent, initial_color=color, tooltip=tooltip)
-    )
+def test_succesfull_create_qcolorswatchedit(qtbot, color, tooltip):
+    widget = QColorSwatchEdit(initial_color=color, tooltip=tooltip)
+    qtbot.add_widget(widget)
+    if color is None:
+        test_color = TRANSPARENT
+    else:
+        test_color = color
+
+    if tooltip is None:
+        test_tooltip = 'click to set color'
+    else:
+        test_tooltip = tooltip
+
+    assert widget.color_swatch.toolTip() == test_tooltip
+    numpy.testing.assert_array_equal(widget.color, test_color)
 
 
-@pytest.mark.parametrize('parent', [None, True])
 @pytest.mark.parametrize('color', [None, [1, 1, 1, 1]])
 @pytest.mark.parametrize('tooltip', [None, 'This is a test'])
-def test_succesfull_create_qcolorswatch(qtbot, parent, color, tooltip):
-    if parent:
-        parent = QWidget()
-        qtbot.add_widget(parent)
-    qtbot.add_widget(
-        QColorSwatch(parent, initial_color=color, tooltip=tooltip)
-    )
+def test_succesfull_create_qcolorswatch(qtbot, color, tooltip):
+    widget = QColorSwatch(initial_color=color, tooltip=tooltip)
+    qtbot.add_widget(widget)
+    if color is None:
+        test_color = TRANSPARENT
+    else:
+        test_color = color
+
+    if tooltip is None:
+        test_tooltip = 'click to set color'
+    else:
+        test_tooltip = tooltip
+
+    assert widget.toolTip() == test_tooltip
+    numpy.testing.assert_array_equal(widget.color, test_color)

--- a/napari/_qt/widgets/qt_color_swatch.py
+++ b/napari/_qt/widgets/qt_color_swatch.py
@@ -153,7 +153,7 @@ class QColorSwatch(QFrame):
     ):
         super().__init__(parent)
         self.setObjectName('colorSwatch')
-        self.setToolTip(tooltip or trans.__('click to set color'))
+        self.setToolTip(tooltip or trans._('click to set color'))
         self.setCursor(Qt.PointingHandCursor)
 
         self.color_changed.connect(self._update_swatch_style)


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
The QColorSwatch class had a typo in the assignment of the tooltip if no explicit tooltip was provided.
<!-- Tell us about your new feature, improvement, or fix! -->
I fixed the typo by removing the second underscore

```
self.setToolTip(tooltip or trans.__('click to set color'))
to
self.setToolTip(tooltip or trans._('click to set color'))
```
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
None
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [X] I wrote two tests creating the respective classes with default values and explicitly provided values 
- [X] all tests pass with my change

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have added tests that prove my fix is effective or that my feature works
