### PR TITLE
fix presentation and enablement of npe1 plugins

### DIFF
--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -526,7 +526,7 @@ class PluginListItem(QFrame):
             return
 
         for npe1_name, _, distname in plugin_manager.iter_available():
-            if distname and (distname == plugin_name):
+            if distname and (normalized_name(distname) == plugin_name):
                 plugin_manager.set_blocked(npe1_name, not enabled)
 
     def show_warning(self, message: str = ""):
@@ -825,7 +825,7 @@ class QtPluginDialog(QDialog):
             # not showing these in the plugin dialog
             if plugin_name in ('napari_plugin_engine',):
                 continue
-            if distname in self.already_installed:
+            if normalized_name(distname or '') in self.already_installed:
                 continue
             _add_to_installed(
                 distname, not plugin_manager.is_blocked(plugin_name)


### PR DESCRIPTION
# Description
fixes #4720, and also fixes a regression from #4223 in which packages with multiple entry points may show up multiple times.

Turns out this had less to do with multiple entry points, and more to do with inconsistent use of `normalized_name` in the plugin dialog.

cc @Czaki, i tried this with partseg and it seems to both fix the multi-line appearance of the plugin in the installer, as well as the inability to toggle enablement in the settings