### PR TITLE
fix clim init for dask arrays

### DIFF
--- a/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -76,6 +76,9 @@ class QtBaseImageControls(QtLayerControls):
         self.layer.events.contrast_limits.connect(
             self._on_contrast_limits_change
         )
+        self.layer.events.contrast_limits_range.connect(
+            self._on_contrast_limits_range_change
+        )
 
         comboBox = QtColormapComboBox(self)
         comboBox.setObjectName("colormapComboBox")
@@ -142,15 +145,28 @@ class QtBaseImageControls(QtLayerControls):
     def _on_contrast_limits_change(self):
         """Receive layer model contrast limits change event and update slider."""
         with qt_signals_blocked(self.contrastLimitsSlider):
-            self.contrastLimitsSlider.setRange(
-                *self.layer.contrast_limits_range
-            )
             self.contrastLimitsSlider.setValue(self.layer.contrast_limits)
 
         if self.clim_popup:
-            self.clim_popup.slider.setRange(*self.layer.contrast_limits_range)
             with qt_signals_blocked(self.clim_popup.slider):
                 self.clim_popup.slider.setValue(self.layer.contrast_limits)
+
+    def _on_contrast_limits_range_change(self):
+        """Receive layer model contrast limits change event and update slider."""
+        with qt_signals_blocked(self.contrastLimitsSlider):
+            decimals = range_to_decimals(
+                self.layer.contrast_limits_range, self.layer.dtype
+            )
+            self.contrastLimitsSlider.setRange(
+                *self.layer.contrast_limits_range
+            )
+            self.contrastLimitsSlider.setSingleStep(10**-decimals)
+
+        if self.clim_popup:
+            with qt_signals_blocked(self.clim_popup.slider):
+                self.clim_popup.slider.setRange(
+                    *self.layer.contrast_limits_range
+                )
 
     def _on_colormap_change(self):
         """Receive layer model colormap change event and update dropdown menu."""

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -404,6 +404,10 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         return self._slice.image.view
 
     def _calc_data_range(self, mode='data'):
+        """
+        Calculate the range of the data values in the currently viewed slice
+        or full data array
+        """
         if mode == 'data':
             input_data = self.data[-1] if self.multiscale else self.data
         elif mode == 'slice':
@@ -759,9 +763,12 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
             self, image_indices, image, thumbnail_source
         )
         self._load_slice(data)
-        if self._keep_auto_contrast or self._should_calc_clims:
+        if self._should_calc_clims:
+            self.reset_contrast_limits_range()
             self.reset_contrast_limits()
             self._should_calc_clims = False
+        if self._keep_auto_contrast:
+            self.reset_contrast_limits()
 
     @property
     def _SliceDataClass(self):

--- a/napari/layers/intensity_mixin.py
+++ b/napari/layers/intensity_mixin.py
@@ -26,7 +26,12 @@ class IntensityVisualizationMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.events.add(contrast_limits=Event, gamma=Event, colormap=Event)
+        self.events.add(
+            contrast_limits=Event,
+            contrast_limits_range=Event,
+            gamma=Event,
+            colormap=Event,
+        )
         self._gamma = 1
         self._colormap_name = ''
         self._contrast_limits_msg = ''
@@ -40,15 +45,16 @@ class IntensityVisualizationMixin:
         mode = mode or self._auto_contrast_source
         self.contrast_limits = self._calc_data_range(mode)
 
-    def reset_contrast_limits_range(self):
-        """Scale contrast limits range to data type.
-
-        Currently, this only does something if the data type is an integer...
-        otherwise it's unclear what the full range should be.
+    def reset_contrast_limits_range(self, mode=None):
+        """Scale contrast limits range to data type if dtype is an integer,
+        or use the current maximum data range otherwise.
         """
         if np.issubdtype(self.dtype, np.integer):
             info = np.iinfo(self.dtype)
             self.contrast_limits_range = (info.min, info.max)
+        else:
+            mode = mode or self._auto_contrast_source
+            self.contrast_limits_range = self._calc_data_range(mode)
 
     @property
     def colormap(self):
@@ -109,6 +115,7 @@ class IntensityVisualizationMixin:
         for i in range(2):
             value[i] = current_range[i] if value[i] is None else value[i]
         self._contrast_limits_range = value
+        self.events.contrast_limits_range()
 
         # make sure that the current values fit within the new range
         # this also serves the purpose of emitting events.contrast_limits()
@@ -118,7 +125,6 @@ class IntensityVisualizationMixin:
             new_min = min(max(value[0], cur_min), value[1])
             new_max = max(min(value[1], cur_max), value[0])
             self.contrast_limits = (new_min, new_max)
-            self.events.contrast_limits()
 
     @property
     def gamma(self):


### PR DESCRIPTION
# Description
Fixes #3698 by:
- also running `reset_contrast_limits_range()` on the first slice loaded
- making `reset_contrast_limits_range()` do the same as `reset_contrast_limits()` for non-integer dtype, rather than noop.

Also fixes some issues with events and gui.

It's breaking because the behaviour of `reset_contrast_limits_range()` changed. This could be avoided by separating out the logic, but it seemed reasonable to me.
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
