### PR TITLE
split Image `interpolation` on two properties, `interpoltion2d` and `interpolation3d` 

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_image_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_image_layer.py
@@ -13,7 +13,7 @@ def test_interpolation_combobox(qtbot):
     opts = {combo.itemText(i) for i in range(combo.count())}
     assert opts == {'bicubic', 'bilinear', 'kaiser', 'nearest', 'spline36'}
     # programmatically adding approved interpolation works
-    layer.interpolation = 'lanczos'
+    layer.interpolation2d = 'lanczos'
     assert combo.findText('lanczos') == 5
 
 

--- a/napari/_qt/layer_controls/qt_image_controls.py
+++ b/napari/_qt/layer_controls/qt_image_controls.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QComboBox,
@@ -18,6 +20,9 @@ from ...layers.image._image_constants import (
 from ...utils.action_manager import action_manager
 from ...utils.translations import trans
 from .qt_image_controls_base import QtBaseImageControls
+
+if TYPE_CHECKING:
+    import napari.layers
 
 
 class QtImageControls(QtBaseImageControls):
@@ -51,6 +56,8 @@ class QtImageControls(QtBaseImageControls):
     renderLabel : qtpy.QtWidgets.QLabel
         Label for the rendering mode dropdown menu.
     """
+
+    layer: 'napari.layers.Image'
 
     def __init__(self, layer):
         super().__init__(layer)
@@ -186,7 +193,10 @@ class QtImageControls(QtBaseImageControls):
             'hamming', 'hanning', 'hermite', 'kaiser', 'lanczos', 'mitchell',
             'nearest', 'spline16', 'spline36'
         """
-        self.layer.interpolation = text
+        if self.layer._ndisplay == 2:
+            self.layer.interpolation2d = text
+        else:
+            self.layer.interpolation3d = text
 
     def changeRendering(self, text):
         """Change rendering mode for image display.
@@ -330,9 +340,12 @@ class QtImageControls(QtBaseImageControls):
             else [i.value for i in Interpolation.view_subset()]
         )
         self.interpComboBox.addItems(interp_names)
-        index = self.interpComboBox.findText(
-            self.layer.interpolation, Qt.MatchFixedString
+        interp = (
+            self.layer.interpolation2d
+            if self.layer._ndisplay == 2
+            else self.layer.interpolation3d
         )
+        index = self.interpComboBox.findText(interp, Qt.MatchFixedString)
         self.interpComboBox.setCurrentIndex(index)
 
     def _on_ndisplay_change(self):

--- a/napari/_qt/layer_controls/qt_image_controls.py
+++ b/napari/_qt/layer_controls/qt_image_controls.py
@@ -55,7 +55,12 @@ class QtImageControls(QtBaseImageControls):
     def __init__(self, layer):
         super().__init__(layer)
 
-        self.layer.events.interpolation.connect(self._on_interpolation_change)
+        self.layer.events.interpolation2d.connect(
+            self._on_interpolation_change
+        )
+        self.layer.events.interpolation3d.connect(
+            self._on_interpolation_change
+        )
         self.layer.events.rendering.connect(self._on_rendering_change)
         self.layer.events.iso_threshold.connect(self._on_iso_threshold_change)
         self.layer.events.attenuation.connect(self._on_attenuation_change)
@@ -260,7 +265,7 @@ class QtImageControls(QtBaseImageControls):
         """
         interp_string = event.value.value
 
-        with self.layer.events.interpolation.blocker():
+        with self.layer.events.interpolation.blocker(), self.layer.events.interpolation2d.blocker(), self.layer.events.interpolation3d.blocker():
             if self.interpComboBox.findText(interp_string) == -1:
                 self.interpComboBox.addItem(interp_string)
             self.interpComboBox.setCurrentText(interp_string)

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import numpy as np
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor, QPainter
@@ -27,6 +29,10 @@ from ..utils import disable_with_opacity
 from ..widgets._slider_compat import QSlider
 from ..widgets.qt_mode_buttons import QtModePushButton, QtModeRadioButton
 from .qt_layer_controls_base import QtLayerControls
+
+if TYPE_CHECKING:
+    import napari.layers
+
 
 INT32_MAX = 2**31 - 1
 
@@ -74,6 +80,8 @@ class QtLabelsControls(QtLayerControls):
         Raise error if label mode is not PAN_ZOOM, PICKER, PAINT, ERASE, or
         FILL.
     """
+
+    layer: 'napari.layers.Labels'
 
     def __init__(self, layer):
         super().__init__(layer)

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import numpy as np
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import QButtonGroup, QCheckBox, QComboBox, QHBoxLayout
@@ -11,6 +13,9 @@ from ..widgets._slider_compat import QSlider
 from ..widgets.qt_color_swatch import QColorSwatchEdit
 from ..widgets.qt_mode_buttons import QtModePushButton, QtModeRadioButton
 from .qt_layer_controls_base import QtLayerControls
+
+if TYPE_CHECKING:
+    import napari.layers
 
 
 class QtPointsControls(QtLayerControls):
@@ -58,6 +63,8 @@ class QtPointsControls(QtLayerControls):
         Raise error if points mode is not recognized.
         Points mode must be one of: ADD, PAN_ZOOM, or SELECT.
     """
+
+    layer: 'napari.layers.Points'
 
     def __init__(self, layer):
         super().__init__(layer)

--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import numpy as np
 from qtpy.QtCore import Qt
@@ -14,6 +15,9 @@ from ..widgets._slider_compat import QSlider
 from ..widgets.qt_color_swatch import QColorSwatchEdit
 from ..widgets.qt_mode_buttons import QtModePushButton, QtModeRadioButton
 from .qt_layer_controls_base import QtLayerControls
+
+if TYPE_CHECKING:
+    import napari.layers
 
 
 class QtShapesControls(QtLayerControls):
@@ -76,6 +80,8 @@ class QtShapesControls(QtLayerControls):
     ValueError
         Raise error if shapes mode is not recognized.
     """
+
+    layer: 'napari.layers.Shapes'
 
     def __init__(self, layer):
         super().__init__(layer)

--- a/napari/_qt/layer_controls/qt_surface_controls.py
+++ b/napari/_qt/layer_controls/qt_surface_controls.py
@@ -1,8 +1,13 @@
+from typing import TYPE_CHECKING
+
 from qtpy.QtWidgets import QComboBox, QHBoxLayout
 
 from ...layers.surface._surface_constants import SHADING_TRANSLATION
 from ...utils.translations import trans
 from .qt_image_controls_base import QtBaseImageControls
+
+if TYPE_CHECKING:
+    import napari.layers
 
 
 class QtSurfaceControls(QtBaseImageControls):
@@ -21,6 +26,8 @@ class QtSurfaceControls(QtBaseImageControls):
         An instance of a napari Surface layer.
 
     """
+
+    layer: 'napari.layers.Surface'
 
     def __init__(self, layer):
         super().__init__(layer)

--- a/napari/_qt/layer_controls/qt_tracks_controls.py
+++ b/napari/_qt/layer_controls/qt_tracks_controls.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QCheckBox, QComboBox, QSlider
 
@@ -5,6 +7,9 @@ from ...utils.colormaps import AVAILABLE_COLORMAPS
 from ...utils.translations import trans
 from ..utils import qt_signals_blocked
 from .qt_layer_controls_base import QtLayerControls
+
+if TYPE_CHECKING:
+    import napari.layers
 
 
 class QtTracksControls(QtLayerControls):
@@ -23,6 +28,8 @@ class QtTracksControls(QtLayerControls):
         An instance of a Tracks layer.
 
     """
+
+    layer: 'napari.layers.Tracks'
 
     def __init__(self, layer):
         super().__init__(layer)

--- a/napari/_qt/layer_controls/qt_vectors_controls.py
+++ b/napari/_qt/layer_controls/qt_vectors_controls.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import numpy as np
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QCheckBox, QComboBox, QDoubleSpinBox, QLabel
@@ -7,6 +9,9 @@ from ...utils.translations import trans
 from ..utils import qt_signals_blocked
 from ..widgets.qt_color_swatch import QColorSwatchEdit
 from .qt_layer_controls_base import QtLayerControls
+
+if TYPE_CHECKING:
+    import napari.layers
 
 
 class QtVectorsControls(QtLayerControls):
@@ -43,6 +48,8 @@ class QtVectorsControls(QtLayerControls):
     widthSpinBox : qtpy.QtWidgets.QDoubleSpinBox
         Spin box widget controlling edge line width of vectors.
     """
+
+    layer: 'napari.layers.Tracks'
 
     def __init__(self, layer):
         super().__init__(layer)

--- a/napari/_vispy/_tests/test_image_rendering.py
+++ b/napari/_vispy/_tests/test_image_rendering.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from napari._tests.utils import skip_on_win_ci
 from napari._vispy.layers.image import VispyImageLayer
@@ -17,8 +18,11 @@ def test_image_rendering(make_napari_viewer):
     assert layer.rendering == 'mip'
 
     # Change the interpolation property
-    layer.interpolation = 'linear'
+    with pytest.warns(FutureWarning):
+        layer.interpolation = 'linear'
+    assert layer.interpolation2d == 'nearest'
     assert layer.interpolation == 'linear'
+    assert layer.interpolation3d == 'linear'
 
     # Change rendering property
     layer.rendering = 'translucent'

--- a/napari/_vispy/_tests/test_image_rendering.py
+++ b/napari/_vispy/_tests/test_image_rendering.py
@@ -18,7 +18,7 @@ def test_image_rendering(make_napari_viewer):
     assert layer.rendering == 'mip'
 
     # Change the interpolation property
-    with pytest.warns(FutureWarning):
+    with pytest.deprecated_call():
         layer.interpolation = 'linear'
     assert layer.interpolation2d == 'nearest'
     assert layer.interpolation == 'linear'

--- a/napari/_vispy/_tests/test_image_rendering.py
+++ b/napari/_vispy/_tests/test_image_rendering.py
@@ -21,7 +21,8 @@ def test_image_rendering(make_napari_viewer):
     with pytest.deprecated_call():
         layer.interpolation = 'linear'
     assert layer.interpolation2d == 'nearest'
-    assert layer.interpolation == 'linear'
+    with pytest.deprecated_call():
+        assert layer.interpolation == 'linear'
     assert layer.interpolation3d == 'linear'
 
     # Change rendering property

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -150,7 +150,11 @@ class VispyImageLayer(VispyBaseLayer):
         node.update()
 
     def _on_interpolation_change(self):
-        self.node.interpolation = self.layer.interpolation
+        self.node.interpolation = (
+            self.layer.interpolation2d
+            if self.layer._ndisplay == 2
+            else self.layer.interpolation3d
+        )
 
     def _on_rendering_change(self):
         if isinstance(self.node, VolumeNode):

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -59,7 +59,12 @@ class VispyImageLayer(VispyBaseLayer):
 
         self.layer.events.rendering.connect(self._on_rendering_change)
         self.layer.events.depiction.connect(self._on_depiction_change)
-        self.layer.events.interpolation.connect(self._on_interpolation_change)
+        self.layer.events.interpolation2d.connect(
+            self._on_interpolation_change
+        )
+        self.layer.events.interpolation3d.connect(
+            self._on_interpolation_change
+        )
         self.layer.events.colormap.connect(self._on_colormap_change)
         self.layer.events.contrast_limits.connect(
             self._on_contrast_limits_change

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -538,7 +538,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         self.layers.append(layer)
         return layer
 
-    @rename_argument("interpolation", "interpolation2d")
+    @rename_argument("interpolation", "interpolation2d", "0.6.0")
     def add_image(
         self,
         data=None,

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -39,6 +39,7 @@ from ..utils.colormaps import ensure_colormap
 from ..utils.context import Context, create_context
 from ..utils.events import Event, EventedModel, disconnect_events
 from ..utils.key_bindings import KeymapProvider
+from ..utils.migrations import rename_argument
 from ..utils.misc import is_sequence
 from ..utils.mouse_bindings import MousemapProvider
 from ..utils.progress import progress
@@ -537,6 +538,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         self.layers.append(layer)
         return layer
 
+    @rename_argument("interpolation", "interpolation2d")
     def add_image(
         self,
         data=None,
@@ -546,7 +548,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         colormap=None,
         contrast_limits=None,
         gamma=1,
-        interpolation='nearest',
+        interpolation2d='nearest',
+        interpolation3d='linear',
         rendering='mip',
         depiction='volume',
         iso_threshold=0.5,
@@ -713,7 +716,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             'colormap': colormap,
             'contrast_limits': contrast_limits,
             'gamma': gamma,
-            'interpolation': interpolation,
+            'interpolation2d': interpolation2d,
+            'interpolation3d': interpolation3d,
             'rendering': rendering,
             'depiction': depiction,
             'iso_threshold': iso_threshold,

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -313,15 +313,20 @@ def test_interpolation():
     np.random.seed(0)
     data = np.random.random((10, 15))
     layer = Image(data)
-    assert layer.interpolation == 'nearest'
+    with pytest.deprecated_call():
+        assert layer.interpolation == 'nearest'
+    assert layer.interpolation2d == 'nearest'
+    assert layer.interpolation3d == 'linear'
 
     layer = Image(data, interpolation2d='bicubic')
     assert layer.interpolation2d == 'bicubic'
-    assert layer.interpolation == 'bicubic'
+    with pytest.deprecated_call():
+        assert layer.interpolation == 'bicubic'
 
     layer.interpolation2d = 'bilinear'
     assert layer.interpolation2d == 'bilinear'
-    assert layer.interpolation == 'bilinear'
+    with pytest.deprecated_call():
+        assert layer.interpolation == 'bilinear'
 
 
 def test_colormaps():

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -315,10 +315,12 @@ def test_interpolation():
     layer = Image(data)
     assert layer.interpolation == 'nearest'
 
-    layer = Image(data, interpolation='bicubic')
+    layer = Image(data, interpolation2d='bicubic')
+    assert layer.interpolation2d == 'bicubic'
     assert layer.interpolation == 'bicubic'
 
-    layer.interpolation = 'bilinear'
+    layer.interpolation2d = 'bilinear'
+    assert layer.interpolation2d == 'bilinear'
     assert layer.interpolation == 'bilinear'
 
 

--- a/napari/layers/image/_tests/test_multiscale.py
+++ b/napari/layers/image/_tests/test_multiscale.py
@@ -225,11 +225,13 @@ def test_interpolation():
     layer = Image(data, multiscale=True)
     assert layer.interpolation == 'nearest'
 
-    layer = Image(data, multiscale=True, interpolation='bicubic')
+    layer = Image(data, multiscale=True, interpolation2d='bicubic')
+    assert layer.interpolation2d == 'bicubic'
     assert layer.interpolation == 'bicubic'
 
-    layer.interpolation = 'bilinear'
+    layer.interpolation2d = 'bilinear'
     assert layer.interpolation == 'bilinear'
+    assert layer.interpolation2d == 'bilinear'
 
 
 def test_colormaps():

--- a/napari/layers/image/_tests/test_multiscale.py
+++ b/napari/layers/image/_tests/test_multiscale.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import skimage
 from skimage.transform import pyramid_gaussian
 
@@ -223,14 +224,19 @@ def test_interpolation():
     np.random.seed(0)
     data = [np.random.random(s) for s in shapes]
     layer = Image(data, multiscale=True)
-    assert layer.interpolation == 'nearest'
+    with pytest.deprecated_call():
+        assert layer.interpolation == 'nearest'
+    assert layer.interpolation2d == 'nearest'
+    assert layer.interpolation3d == 'linear'
 
     layer = Image(data, multiscale=True, interpolation2d='bicubic')
     assert layer.interpolation2d == 'bicubic'
-    assert layer.interpolation == 'bicubic'
+    with pytest.deprecated_call():
+        assert layer.interpolation == 'bicubic'
 
     layer.interpolation2d = 'bilinear'
-    assert layer.interpolation == 'bilinear'
+    with pytest.deprecated_call():
+        assert layer.interpolation == 'bilinear'
     assert layer.interpolation2d == 'bilinear'
 
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -547,7 +547,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
             trans._(
                 "Interpolation setting is deprecated. Please use interpolation2d or interpolation3d",
             ),
-            category=FutureWarning,
+            category=DeprecationWarning,
             stacklevel=2,
         )
         if self._ndisplay == 3:

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -559,10 +559,8 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         )
         if self._ndisplay == 3:
             self.interpolation3d = interpolation
-            self.events.interpolation(value=self.interpolation3d)
         else:
             self.interpolation2d = interpolation
-            self.events.interpolation(value=self.interpolation2d)
 
     @property
     def interpolation2d(self):
@@ -572,6 +570,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
     def interpolation2d(self, value):
         self._interpolation2d = Interpolation(value)
         self.events.interpolation2d(value=self._interpolation2d)
+        self.events.interpolation(value=self._interpolation2d)
 
     @property
     def interpolation3d(self):
@@ -581,6 +580,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
     def interpolation3d(self, value):
         self._interpolation3d = Interpolation3D(value)
         self.events.interpolation3d(value=self._interpolation3d)
+        self.events.interpolation(value=self._interpolation3d)
 
     @property
     def depiction(self):

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -211,7 +211,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
 
     _colormaps = AVAILABLE_COLORMAPS
 
-    @rename_argument("interpolation", "interpolation2d")
+    @rename_argument("interpolation", "interpolation2d", "0.6.0")
     def __init__(
         self,
         data,

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -534,6 +534,13 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         str
             The current interpolation mode
         """
+        warnings.warn(
+            trans._(
+                "Interpolation attribute is deprecated. Please use interpolation2d or interpolation3d",
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return str(
             self._interpolation2d
             if self._ndisplay == 2

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -13,6 +13,7 @@ from ...utils import config
 from ...utils._dtype import get_dtype_limits, normalize_dtype
 from ...utils.colormaps import AVAILABLE_COLORMAPS
 from ...utils.events import Event
+from ...utils.events.event import WarningEmitter
 from ...utils.migrations import rename_argument
 from ...utils.naming import magic_name
 from ...utils.translations import trans
@@ -294,7 +295,13 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
 
         self.events.add(
             mode=Event,
-            interpolation=Event,
+            interpolation=WarningEmitter(
+                trans._(
+                    "'layer.events.interpolation' is deprecated please use `interpolation2d` and `interpolation3d`",
+                    deferred=True,
+                ),
+                type='select',
+            ),
             interpolation2d=Event,
             interpolation3d=Event,
             rendering=Event,

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -266,7 +266,8 @@ class Labels(_ImageBase):
             rgb=False,
             colormap=self._random_colormap,
             contrast_limits=[0.0, 1.0],
-            interpolation='nearest',
+            interpolation2d='nearest',
+            interpolation3d='nearest',
             rendering=rendering,
             depiction=depiction,
             iso_threshold=0,
@@ -773,10 +774,7 @@ class Labels(_ImageBase):
     def _set_editable(self, editable=None):
         """Set editable mode based on layer properties."""
         if editable is None:
-            if self.multiscale:
-                self.editable = False
-            else:
-                self.editable = True
+            self.editable = not self.multiscale
 
         if not self.editable:
             self.mode = Mode.PAN_ZOOM

--- a/napari/layers/utils/_tests/test_link_layers.py
+++ b/napari/layers/utils/_tests/test_link_layers.py
@@ -20,7 +20,7 @@ BASE_ATTRS = {
 IM_ATTRS = {
     'rendering': 'translucent',
     'iso_threshold': 0.34,
-    'interpolation': 'bilinear',
+    'interpolation2d': 'bilinear',
     'contrast_limits': [0.25, 0.75],
     'gamma': 0.5,
 }

--- a/napari/utils/_tests/test_migrations.py
+++ b/napari/utils/_tests/test_migrations.py
@@ -10,7 +10,7 @@ def test_simple():
 
     assert sample_fun(1) == 1
     assert sample_fun(b=1) == 1
-    with pytest.warns(FutureWarning):
+    with pytest.deprecated_call():
         assert sample_fun(a=1) == 1
     with pytest.raises(ValueError):
         sample_fun(b=1, a=1)
@@ -24,5 +24,5 @@ def test_constructor():
 
     assert Sample(1).b == 1
     assert Sample(b=1).b == 1
-    with pytest.warns(FutureWarning):
+    with pytest.deprecated_call():
         assert Sample(a=1).b == 1

--- a/napari/utils/_tests/test_migrations.py
+++ b/napari/utils/_tests/test_migrations.py
@@ -1,0 +1,26 @@
+import pytest
+
+from napari.utils.migrations import rename_argument
+
+
+def test_simple():
+    @rename_argument("a", "b")
+    def sample_fun(b):
+        return b
+
+    assert sample_fun(1) == 1
+    assert sample_fun(b=1) == 1
+    with pytest.warns(FutureWarning):
+        assert sample_fun(a=1) == 1
+
+
+def test_constructor():
+    class Sample:
+        @rename_argument("a", "b")
+        def __init__(self, b):
+            self.b = b
+
+    assert Sample(1).b == 1
+    assert Sample(b=1).b == 1
+    with pytest.warns(FutureWarning):
+        assert Sample(a=1).b == 1

--- a/napari/utils/_tests/test_migrations.py
+++ b/napari/utils/_tests/test_migrations.py
@@ -4,7 +4,7 @@ from napari.utils.migrations import rename_argument
 
 
 def test_simple():
-    @rename_argument("a", "b")
+    @rename_argument("a", "b", "1")
     def sample_fun(b):
         return b
 
@@ -16,7 +16,7 @@ def test_simple():
 
 def test_constructor():
     class Sample:
-        @rename_argument("a", "b")
+        @rename_argument("a", "b", "1")
         def __init__(self, b):
             self.b = b
 

--- a/napari/utils/_tests/test_migrations.py
+++ b/napari/utils/_tests/test_migrations.py
@@ -12,6 +12,8 @@ def test_simple():
     assert sample_fun(b=1) == 1
     with pytest.warns(FutureWarning):
         assert sample_fun(a=1) == 1
+    with pytest.raises(ValueError):
+        sample_fun(b=1, a=1)
 
 
 def test_constructor():

--- a/napari/utils/migrations.py
+++ b/napari/utils/migrations.py
@@ -4,7 +4,7 @@ from functools import wraps
 from napari.utils.translations import trans
 
 
-def rename_argument(from_name: str, to_name: str):
+def rename_argument(from_name: str, to_name: str, version: str):
     """
     This is decorator for simple rename function argument
     without break backward compatibility.
@@ -23,9 +23,10 @@ def rename_argument(from_name: str, to_name: str):
             if from_name in kwargs:
                 warnings.warn(
                     trans._(
-                        "Argument {from_name} is deprecated, please use {to_name} instead.",
+                        "Argument {from_name} is deprecated, please use {to_name} instead. It will be removed in {version}.",
                         from_name=from_name,
                         to_name=to_name,
+                        version=version,
                     ),
                     category=FutureWarning,
                     stacklevel=2,

--- a/napari/utils/migrations.py
+++ b/napari/utils/migrations.py
@@ -21,6 +21,14 @@ def rename_argument(from_name: str, to_name: str, version: str):
         @wraps(func)
         def _update_from_dict(*args, **kwargs):
             if from_name in kwargs:
+                if to_name in kwargs:
+                    raise ValueError(
+                        trans._(
+                            "Argument {to_name} already defined, please do not mix {from_name} and {to_name} in one call.",
+                            from_name=from_name,
+                            to_name=to_name,
+                        )
+                    )
                 warnings.warn(
                     trans._(
                         "Argument {from_name} is deprecated, please use {to_name} instead. It will be removed in {version}.",

--- a/napari/utils/migrations.py
+++ b/napari/utils/migrations.py
@@ -36,7 +36,7 @@ def rename_argument(from_name: str, to_name: str, version: str):
                         to_name=to_name,
                         version=version,
                     ),
-                    category=FutureWarning,
+                    category=DeprecationWarning,
                     stacklevel=2,
                 )
                 kwargs = kwargs.copy()

--- a/napari/utils/migrations.py
+++ b/napari/utils/migrations.py
@@ -1,0 +1,39 @@
+import warnings
+from functools import wraps
+
+from napari.utils.translations import trans
+
+
+def rename_argument(from_name: str, to_name: str):
+    """
+    This is decorator for simple rename function argument
+    without break backward compatibility.
+
+    Parameters
+    ----------
+    from_name : str
+        old name of argument
+    to_name : str
+        new name of argument
+    """
+
+    def _wrapper(func):
+        @wraps(func)
+        def _update_from_dict(*args, **kwargs):
+            if from_name in kwargs:
+                warnings.warn(
+                    trans._(
+                        "Argument {from_name} is deprecated, please use {to_name} instead.",
+                        from_name=from_name,
+                        to_name=to_name,
+                    ),
+                    category=FutureWarning,
+                    stacklevel=2,
+                )
+                kwargs = kwargs.copy()
+                kwargs[to_name] = kwargs.pop(from_name)
+            return func(*args, **kwargs)
+
+        return _update_from_dict
+
+    return _wrapper

--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,7 @@ commands_pre =
     # the rest is for good measure
     headless: pip uninstall -y pytest-qt qtpy pyqt5 pyside2
 commands =
-    !headless: python -m pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir} \
+    !headless: python -m pytest . --color=yes --basetemp={envtmpdir} \
         --cov-report=xml --cov={env:PYTEST_PATH:napari} --ignore tools --maxfail=5 \
         --json-report --json-report-file={toxinidir}/report-{envname}.json {posargs} \
         --skip_examples

--- a/tox.ini
+++ b/tox.ini
@@ -80,10 +80,10 @@ commands_pre =
     # the rest is for good measure
     headless: pip uninstall -y pytest-qt qtpy pyqt5 pyside2
 commands =
-    !headless: python -m pytest . --color=yes --basetemp={envtmpdir} \
+    !headless: python -m pytest napari --color=yes --basetemp={envtmpdir} \
         --cov-report=xml --cov={env:PYTEST_PATH:napari} --ignore tools --maxfail=5 \
-        --json-report --json-report-file={toxinidir}/report-{envname}.json {posargs} \
-        --skip_examples
+        --json-report --json-report-file={toxinidir}/report-{envname}.json \
+        --skip_examples {posargs}
 
     # do not add ignores to this line just to make headless tests pass.
     # nothing outside of _qt or _vispy should require Qt or make_napari_viewer

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,7 @@ commands_pre =
 commands =
     !headless: python -m pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir} \
         --cov-report=xml --cov={env:PYTEST_PATH:napari} --ignore tools --maxfail=5 \
-        --json-report --json-report-file={toxinidir}/report-{envname}.json {posargs}
+        --json-report --json-report-file={toxinidir}/report-{envname}.json {posargs} \
         --skip_examples
 
     # do not add ignores to this line just to make headless tests pass.


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This PR simplifies access to interpolation of the Image layer by splitting it into two properties, one for each method of visualization. This allows to set interpolation of 3d mode without changing dimensions to 3d and simplifies the coping layer. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

closes #3551

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
