### PR TITLE
Add a public API for the setGeometry method of _qt_window

### DIFF
--- a/napari/_qt/_tests/test_qt_window.py
+++ b/napari/_qt/_tests/test_qt_window.py
@@ -48,6 +48,13 @@ def test_current_viewer(make_napari_viewer):
     assert _QtMainWindow.current() is None
 
 
+def test_set_geometry(make_napari_viewer):
+    viewer = make_napari_viewer()
+    values = (70, 70, 1000, 700)
+    viewer.window.set_geometry(*values)
+    assert viewer.window.geometry() == values
+
+
 @patch.object(Window, "_theme_icon_changed")
 @patch.object(Window, "_remove_theme")
 @patch.object(Window, "_add_theme")

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -19,7 +19,7 @@ from typing import (
 )
 from weakref import WeakValueDictionary
 
-from qtpy.QtCore import QEvent, QEventLoop, QPoint, QProcess, QSize, Qt, Slot
+from qtpy.QtCore import QEvent, QEventLoop, QPoint, QProcess, QSize, Qt, Slot, QRect
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (
     QApplication,
@@ -1023,6 +1023,7 @@ class Window:
         """Set the geometry of the widget
 
         Parameters
+        ----------
         left : int
             X coordinate of the upper left border.
         top : int
@@ -1033,6 +1034,16 @@ class Window:
             Height of the rectangle shape of the window.
         """
         self._qt_window.setGeometry(left, top, width, height)
+    
+    def geometry(self):
+        """Get the geometry of the widget
+
+        Returns
+        -------
+        qrect : QRect
+            Geometry of the window.
+        """
+        return self._qt_window.geometry()
 
     def show(self, *, block=False):
         """Resize, show, and bring forward the window.

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1019,7 +1019,7 @@ class Window:
         """
         self._qt_window.resize(width, height)
 
-    def setGeometry(self, left, top, width, height):
+    def set_geometry(self, left, top, width, height):
         """Set the Geometry of the widget
 
         Parameters

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1049,10 +1049,17 @@ class Window:
 
         Returns
         -------
-        qrect : QRect
-            Geometry of the window.
+        left : int
+            X coordinate of the upper left border.
+        top : int
+            Y coordinate of the upper left border.
+        width : int
+            Width of the rectangle shape of the window.
+        height : int
+            Height of the rectangle shape of the window.
         """
-        return self._qt_window.geometry()
+        rect = self._qt_window.geometry()
+        return rext.left(), rect.top(), rect.width(), rect.height()
 
     def show(self, *, block=False):
         """Resize, show, and bring forward the window.

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -24,7 +24,6 @@ from qtpy.QtCore import (
     QEventLoop,
     QPoint,
     QProcess,
-    QRect,
     QSize,
     Qt,
     Slot,

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1018,6 +1018,21 @@ class Window:
             Height in logical pixels.
         """
         self._qt_window.resize(width, height)
+        
+    def setGeometry(self, left, top, width, height):
+        """Set the Geometry of the widget
+        
+        Parameters
+        left : int
+            X coordinate of the upper left border.
+        top : int
+            Y coordinate of the upper left border.
+        width : int
+            Width of the rectangle shape of the window.
+        height : int
+            Height of the rectangle shape of the window.
+        """
+        self._qt_window.setGeometry(left, top, width, height)
 
     def show(self, *, block=False):
         """Resize, show, and bring forward the window.

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -19,7 +19,16 @@ from typing import (
 )
 from weakref import WeakValueDictionary
 
-from qtpy.QtCore import QEvent, QEventLoop, QPoint, QProcess, QSize, Qt, Slot, QRect
+from qtpy.QtCore import (
+    QEvent,
+    QEventLoop,
+    QPoint,
+    QProcess,
+    QRect,
+    QSize,
+    Qt,
+    Slot,
+)
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (
     QApplication,
@@ -1034,7 +1043,7 @@ class Window:
             Height of the rectangle shape of the window.
         """
         self._qt_window.setGeometry(left, top, width, height)
-    
+
     def geometry(self):
         """Get the geometry of the widget
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1059,7 +1059,7 @@ class Window:
             Height of the rectangle shape of the window.
         """
         rect = self._qt_window.geometry()
-        return rext.left(), rect.top(), rect.width(), rect.height()
+        return rect.left(), rect.top(), rect.width(), rect.height()
 
     def show(self, *, block=False):
         """Resize, show, and bring forward the window.

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1044,7 +1044,7 @@ class Window:
         """
         self._qt_window.setGeometry(left, top, width, height)
 
-    def geometry(self):
+    def geometry(self) -> Tuple[int, int, int, int]:
         """Get the geometry of the widget
 
         Returns

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -19,15 +19,7 @@ from typing import (
 )
 from weakref import WeakValueDictionary
 
-from qtpy.QtCore import (
-    QEvent,
-    QEventLoop,
-    QPoint,
-    QProcess,
-    QSize,
-    Qt,
-    Slot,
-)
+from qtpy.QtCore import QEvent, QEventLoop, QPoint, QProcess, QSize, Qt, Slot
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (
     QApplication,

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1020,7 +1020,7 @@ class Window:
         self._qt_window.resize(width, height)
 
     def set_geometry(self, left, top, width, height):
-        """Set the Geometry of the widget
+        """Set the geometry of the widget
 
         Parameters
         left : int

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1018,10 +1018,10 @@ class Window:
             Height in logical pixels.
         """
         self._qt_window.resize(width, height)
-        
+
     def setGeometry(self, left, top, width, height):
         """Set the Geometry of the widget
-        
+
         Parameters
         left : int
             X coordinate of the upper left border.


### PR DESCRIPTION
Add a public API for the setGeometry method of _qt_window
This fixes #4434

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
