### PR TITLE
Fix bug in deepcopy of utils.context.Expr

### DIFF
--- a/napari/utils/context/__init__.py
+++ b/napari/utils/context/__init__.py
@@ -1,4 +1,12 @@
 from ._context import Context, create_context, get_context
+from ._expressions import Expr, parse_expression
 from ._layerlist_context import LayerListContextKeys
 
-__all__ = ['Context', 'create_context', 'get_context', 'LayerListContextKeys']
+__all__ = [
+    'Context',
+    'create_context',
+    'Expr',
+    'get_context',
+    'LayerListContextKeys',
+    'parse_expression',
+]

--- a/napari/utils/context/_expressions.py
+++ b/napari/utils/context/_expressions.py
@@ -36,6 +36,8 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    SupportsIndex,
+    Tuple,
     Type,
     TypeVar,
     Union,
@@ -315,7 +317,7 @@ class Expr(ast.AST, Generic[T]):
         # note: we're using the invert operator `~` to mean "not ___"
         return UnaryOp(ast.Not(), self)
 
-    def __reduce_ex__(self, protocol: int) -> Tuple[Any, ...]:
+    def __reduce_ex__(self, protocol: SupportsIndex) -> Tuple[Any, ...]:
         rv = list(super().__reduce_ex__(protocol))
         rv[1] = tuple(getattr(self, f) for f in self._fields)
         return tuple(rv)

--- a/napari/utils/context/_expressions.py
+++ b/napari/utils/context/_expressions.py
@@ -315,6 +315,11 @@ class Expr(ast.AST, Generic[T]):
         # note: we're using the invert operator `~` to mean "not ___"
         return UnaryOp(ast.Not(), self)
 
+    def __reduce_ex__(self, protocol: int) -> None:
+        rv = list(super().__reduce_ex__(protocol))
+        rv[1] = tuple(getattr(self, f) for f in self._fields)
+        return tuple(rv)
+
 
 class Name(Expr[T], ast.Name):
     """A variable name.
@@ -322,7 +327,9 @@ class Name(Expr[T], ast.Name):
     `id` holds the name as a string.
     """
 
-    def __init__(self, id: str, **kwargs: Any) -> None:
+    def __init__(
+        self, id: str, ctx: ast.expr_context = ast.Load(), **kwargs: Any
+    ) -> None:
         kwargs['ctx'] = ast.Load()
         super().__init__(id, **kwargs)
 
@@ -339,7 +346,9 @@ class Constant(Expr[V], ast.Constant):
 
     value: V
 
-    def __init__(self, value: V, **kwargs: Any) -> None:
+    def __init__(
+        self, value: V, kind: Optional[str] = None, **kwargs: Any
+    ) -> None:
         _valid_type = (type(None), str, bytes, bool, int, float)
         if not isinstance(value, _valid_type):
             raise TypeError(
@@ -349,7 +358,7 @@ class Constant(Expr[V], ast.Constant):
                     _valid_type=_valid_type,
                 )
             )
-        super().__init__(value, **kwargs)
+        super().__init__(value, kind, **kwargs)
 
 
 class Compare(Expr[bool], ast.Compare):

--- a/napari/utils/context/_expressions.py
+++ b/napari/utils/context/_expressions.py
@@ -315,7 +315,7 @@ class Expr(ast.AST, Generic[T]):
         # note: we're using the invert operator `~` to mean "not ___"
         return UnaryOp(ast.Not(), self)
 
-    def __reduce_ex__(self, protocol: int) -> None:
+    def __reduce_ex__(self, protocol: int) -> Tuple[Any, ...]:
         rv = list(super().__reduce_ex__(protocol))
         rv[1] = tuple(getattr(self, f) for f in self._fields)
         return tuple(rv)

--- a/napari/utils/context/_tests/test_expressions.py
+++ b/napari/utils/context/_tests/test_expressions.py
@@ -39,7 +39,7 @@ def test_constants():
     assert Constant(False).eval() is False
     assert Constant(None).eval() is None
 
-    if sys.version_info > (3, 8):
+    if sys.version_info >= (3, 9):
         assert repr(Constant(1)) == 'Constant(value=1)'
     else:
         assert repr(Constant(1)) == 'Constant(value=1, kind=None)'

--- a/napari/utils/context/_tests/test_expressions.py
+++ b/napari/utils/context/_tests/test_expressions.py
@@ -1,4 +1,5 @@
 import ast
+import sys
 from copy import deepcopy
 
 import pytest
@@ -38,7 +39,10 @@ def test_constants():
     assert Constant(False).eval() is False
     assert Constant(None).eval() is None
 
-    assert repr(Constant(1)) == 'Constant(value=1)'
+    if sys.version_info > (3, 8):
+        assert repr(Constant(1)) == 'Constant(value=1)'
+    else:
+        assert repr(Constant(1)) == 'Constant(value=1, kind=None)'
 
     # only {None, str, bytes, bool, int, float} allowed
     with pytest.raises(TypeError):

--- a/napari/utils/context/_tests/test_expressions.py
+++ b/napari/utils/context/_tests/test_expressions.py
@@ -1,4 +1,5 @@
 import ast
+from copy import deepcopy
 
 import pytest
 
@@ -202,3 +203,13 @@ def test_serdes(expr):
 def test_bad_serdes(expr):
     with pytest.raises(SyntaxError):
         parse_expression(expr)
+
+
+def test_deepcopy_expression():
+    deepcopy(parse_expression('1'))
+    deepcopy(parse_expression('1 > 2'))
+    deepcopy(parse_expression('1 & 2'))
+    deepcopy(parse_expression('1 or 2'))
+    deepcopy(parse_expression('not 1'))
+    deepcopy(parse_expression('~x'))
+    deepcopy(parse_expression('2 if x else 3'))


### PR DESCRIPTION
# Description
found a little issue with deepcopy on an `Expr` object while working on menus/contexts/keybindings ...

certainly not something that would have been a problem anywhere yet.  but will be eventually :)
This fixes and adds tests