### PR TITLE
Add mini interactive prompt to edit string_list.json

### DIFF
--- a/tools/string_list.json
+++ b/tools/string_list.json
@@ -29,7 +29,30 @@
       "plugins.io",
       "utils.notifications",
       "view_layers",
-      "viewer"
+      "viewer",
+      "__version__",
+      "components",
+      "experimental",
+      "layers",
+      "qt",
+      "types",
+      "utils",
+      "gui_qt",
+      "run",
+      "save_layers",
+      "utils",
+      "sys_info",
+      "notification_manager",
+      "view_image",
+      "view_labels",
+      "view_path",
+      "view_points",
+      "view_shapes",
+      "view_surface",
+      "view_tracks",
+      "view_vectors",
+      "Viewer",
+      "current_viewer"
     ],
     "napari/_event_loop.py": [],
     "napari/_qt/__init__.py": [
@@ -40,7 +63,26 @@
       "plugins"
     ],
     "napari/_qt/_constants.py": [],
-    "napari/_qt/containers/__init__.py": [],
+    "napari/_qt/code_syntax_highlight.py": [
+      "monospace",
+      "color",
+      "#{style['color']}",
+      "bgcolor",
+      "bgcolor",
+      "bold",
+      "italic",
+      "underline"
+    ],
+    "napari/_qt/containers/__init__.py": [
+      "create_model",
+      "create_view",
+      "QtLayerList",
+      "QtLayerListModel",
+      "QtListModel",
+      "QtListView",
+      "QtNodeTreeModel",
+      "QtNodeTreeView"
+    ],
     "napari/_qt/containers/_base_item_model.py": [
       "ItemType",
       "_root"
@@ -152,7 +194,11 @@
       "icon",
       "info",
       "none",
-      "warning"
+      "warning",
+      "opacity",
+      "geometry",
+      "QPushButton{padding: 4px 12px 4px 12px; font-size: 11px;min-height: 18px; border-radius: 0;}",
+      "python"
     ],
     "napari/_qt/dialogs/qt_plugin_dialog.py": [
       "-c",
@@ -198,14 +244,39 @@
       "uninstall",
       "url",
       "version",
-      "warning_icon"
+      "warning_icon",
+      "CONDA_PINNED_PACKAGES",
+      "&{env.value('CONDA_PINNED_PACKAGES')}",
+      "CONDA_PINNED_PACKAGES",
+      "napari={napari_version}{system_pins}",
+      "nt",
+      "TEMP",
+      "TMP",
+      "TEMP",
+      "USERPROFILE",
+      "HOME",
+      "~",
+      "USERPROFILE",
+      "~",
+      "shim",
+      "shim",
+      "warning",
+      "#E3B617",
+      "{pkg_name} {project_info.summary}",
+      "latest_version",
+      "=={item.latest_version}",
+      "1.0",
+      "shim",
+      "napari_hub"
     ],
     "napari/_qt/dialogs/qt_plugin_report.py": [
       "QtCopyToClipboardButton",
       "github.com",
       "pluginInfo",
       "url",
-      "{meta.get(\"url\")}/issues/new?&body={err}"
+      "{meta.get(\"url\")}/issues/new?&body={err}",
+      "python",
+      "NoColor"
     ],
     "napari/_qt/dialogs/qt_reader_dialog.py": [
       "Choose reader",
@@ -709,7 +780,6 @@
       "_QtMainWindow"
     ],
     "napari/_qt/widgets/qt_welcome.py": [
-      "Ctrl+Alt+/",
       "Ctrl+O",
       "QEvent",
       "drag",
@@ -964,8 +1034,6 @@
     "napari/benchmarks/benchmark_qt_viewer.py": [],
     "napari/benchmarks/benchmark_qt_viewer_image.py": [],
     "napari/benchmarks/benchmark_qt_viewer_labels.py": [
-      "Event",
-      "is_dragging",
       "paint"
     ],
     "napari/benchmarks/benchmark_shapes_layer.py": [
@@ -1016,9 +1084,7 @@
       "bottom_center",
       "crosshair"
     ],
-    "napari/components/_viewer_key_bindings.py": [
-      "napari:"
-    ],
+    "napari/components/_viewer_key_bindings.py": [],
     "napari/components/_viewer_mouse_bindings.py": [
       "Control"
     ],
@@ -1939,7 +2005,6 @@
       "builtins",
       "index",
       "name",
-      "napari_write_{layer_type}",
       "properties",
       "rectangle",
       "shape-type",
@@ -1960,7 +2025,6 @@
     "napari/plugins/_plugin_manager.py": [
       "`napari_experimental_provide_dock_widget`",
       "`napari_experimental_provide_function`",
-      "builtins",
       "data",
       "display_name",
       "dock",
@@ -1972,8 +2036,6 @@
       "napari.plugin",
       "napari_provide_sample_data",
       "plugin",
-      "scikit-image",
-      "skimage",
       ".{extension}",
       ".{ext}",
       "_extension2{type_}",
@@ -2076,7 +2138,6 @@
       "{url}{page}"
     ],
     "napari/plugins/utils.py": [
-      "builtins",
       "napari_get_reader"
     ],
     "napari/qt/__init__.py": [],
@@ -2180,7 +2241,6 @@
       "VectorsData",
       "dask.array.Array",
       "zarr.Array",
-      "{layer_name.title()}Data",
       "_DType_co"
     ],
     "napari/utils/__init__.py": [],
@@ -2206,8 +2266,6 @@
     ],
     "napari/utils/_magicgui.py": [
       "Data",
-      "add_{layer_type}",
-      "name",
       "native",
       "parent",
       "_qt_viewer",
@@ -2783,7 +2841,6 @@
     ],
     "napari/utils/notebook_display.py": [
       "png",
-      "<img src=\"{url}\"></img>",
       "data:image/png;base64,",
       "utf-8"
     ],
@@ -2917,7 +2974,6 @@
       ": {status_format(value[0])}",
       "[",
       "]",
-      "{name} {full_coord}",
       "{value:0.3g}"
     ],
     "napari/utils/temporary_file.py": [],


### PR DESCRIPTION
This adds a mini TUI that ask for each non translated string whether to
ignore it or not, allowing to quickly update string_list.json.

This implements a quick getch() function that read stdin for a single
character, but will only work on unix.

This roughly looks like this in a loop.

```
    i : ignore –  add to ignored localised strings
    q : quit –  quit w/o saving
    s : save and quit

    napari/_qt/dialogs/qt_plugin_dialog.py:700 'unavailable'

                      )
                  )
    >             widget.setObjectName("unavailable")
                  widget.style().unpolish(widget)
                  widget.style().polish(widget)
                  widget.action_button.setEnabled(False)
```

Alternate/addition to #4732

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
