### PR TITLE
Fix Image parameter docs

### DIFF
--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -1079,6 +1079,9 @@ if config.async_octree:
         pass
 
 
+Image.__doc__ = _ImageBase.__doc__
+
+
 class _weakref_hide:
     def __init__(self, obj):
         import weakref


### PR DESCRIPTION
Because the docstring is actually in `_ImageBase` whichis a private class, the `__doc__` attribute needs manually assigning. I tested this locally and it works. Fixes https://github.com/napari/napari/issues/4553