### PR TITLE
Do not inform about coverage untill all CI jobs are done

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -28,5 +28,9 @@ coverage:
     patch:
       threshold: 1%
       target: 0%
+codecov:
+  notify:
+    after_n_builds: 12
 comment:
   require_changes: true  # if true: only post the PR comment if coverage changes
+  after_n_builds: 12

--- a/codecov.yml
+++ b/codecov.yml
@@ -31,7 +31,7 @@ coverage:
         target: 0%
 codecov:
   notify:
-    after_n_builds: 12
+    after_n_builds: 11
 comment:
   require_changes: true  # if true: only post the PR comment if coverage changes
-  after_n_builds: 12
+  after_n_builds: 11

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,8 +26,9 @@ coverage:
         paths: ['.*/_tests/.*']
         threshold: 1%  # coverage can drop by up to 1% while still posting success
     patch:
-      threshold: 1%
-      target: 0%
+      default:
+        threshold: 1%
+        target: 0%
 codecov:
   notify:
     after_n_builds: 12


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Currently, coverage publishes comment just after the first result from CI is sent. 
But part of the tests are executed only on macOS, so we got false negative information from coverage. This information is corrected after CI job is done, but may create "what I broke" reaction in first-time contributors. 

If I good calculate the current number of tests for PR is 12 and for main branch is 16. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Improve coverage report.

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

https://docs.codecov.com/docs/notifications#section-preventing-notifications-until-after-n-builds

# How has this been tested?
After fixing the coverage file there is only one edit from codecov bot. 

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
