### PR TITLE
Refine and cleanup DeprecationWarnings.

### DIFF
--- a/napari/_qt/_tests/test_qt_provide_theme.py
+++ b/napari/_qt/_tests/test_qt_provide_theme.py
@@ -15,9 +15,8 @@ def test_provide_theme_hook_registered_correctly(
     make_napari_viewer,
     napari_plugin_manager,
 ):
-    with pytest.warns(FutureWarning):
-        dark = get_theme("dark")
-        dark["name"] = "dark-test-2"
+    dark = get_theme("dark", as_dict=True)
+    dark["name"] = "dark-test-2"
 
     class TestPlugin:
         @napari_hook_implementation

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -417,7 +417,7 @@ def _omit_viewer_args(constructor):
         if len(args) > 1 and not isinstance(args[1], str):
             warnings.warn(
                 trans._(
-                    "viewer argument is deprecated and should not be used"
+                    "viewer argument is deprecated since 0.4.14 and should not be used"
                 ),
                 category=FutureWarning,
                 stacklevel=2,
@@ -426,7 +426,7 @@ def _omit_viewer_args(constructor):
         if "viewer" in kwargs:
             warnings.warn(
                 trans._(
-                    "viewer argument is deprecated and should not be used"
+                    "viewer argument is deprecated since 0.4.14 and should not be used"
                 ),
                 category=FutureWarning,
                 stacklevel=2,
@@ -469,74 +469,3 @@ class QtViewerPushButton(QPushButton):
             self.clicked.connect(slot)
         if action:
             action_manager.bind_button(action, self)
-
-
-class QtStateButton(QtViewerPushButton):
-    """Button to toggle between two states.
-    Parameters
-    ----------
-    button_name : str
-        A string that will be used in qss to style the button with the
-        QtStateButton[mode=...] selector,
-    target : object
-        object on which you want to change the property when button pressed.
-    attribute:
-        name of attribute on `object` you wish to change.
-    events: EventEmitter
-        event emitter that will trigger when value is changed
-    onstate: Any
-        value to use for ``setattr(object, attribute, onstate)`` when clicking
-        this button
-    offstate: Any
-        value to use for ``setattr(object, attribute, offstate)`` when clicking
-        this button.
-    """
-
-    def __init__(
-        self,
-        button_name,
-        target,
-        attribute,
-        events,
-        onstate=True,
-        offstate=False,
-    ):
-        warnings.warn(
-            trans._(
-                "QtStateButton is deprecated and will be removed in 0.4.14"
-            ),
-            stacklevel=2,
-            category=FutureWarning,
-        )
-        super().__init__(button_name)
-        self.setCheckable(True)
-
-        self._target = target
-        self._attribute = attribute
-        self._onstate = onstate
-        self._offstate = offstate
-        self._events = events
-        self._events.connect(self._on_change)
-        self.clicked.connect(self.change)
-        self._on_change()
-
-    def change(self):
-        """Toggle between the multiple states of this button."""
-        if self.isChecked():
-            newstate = self._onstate
-        else:
-            newstate = self._offstate
-        setattr(self._target, self._attribute, newstate)
-
-    def _on_change(self, event=None):
-        """Called wen mirrored value changes
-        Parameters
-        ----------
-        event : qtpy.QtCore.QEvent
-            Event from the Qt context.
-        """
-        with self._events.blocker():
-            if self.isChecked() != (
-                getattr(self._target, self._attribute) == self._onstate
-            ):
-                self.toggle()

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -564,28 +564,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         self.events.affine()
 
     @property
-    def translate_grid(self):
-        warnings.warn(
-            trans._(
-                "translate_grid will become private in v0.4.14. See Layer.translate or Layer.data_to_world() instead.",
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._translate_grid
-
-    @translate_grid.setter
-    def translate_grid(self, translate_grid):
-        warnings.warn(
-            trans._(
-                "translate_grid will become private in v0.4.14. See Layer.translate or Layer.data_to_world() instead.",
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self._translate_grid = translate_grid
-
-    @property
     def _translate_grid(self):
         """list: Factors to shift the layer by."""
         return self._transforms['world2grid'].translate

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -536,7 +536,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         """
         warnings.warn(
             trans._(
-                "Interpolation attribute is deprecated. Please use interpolation2d or interpolation3d",
+                "Interpolation attribute is deprecated since 0.4.16. Please use interpolation2d or interpolation3d",
             ),
             category=DeprecationWarning,
             stacklevel=2,
@@ -552,7 +552,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         """Set current interpolation mode."""
         warnings.warn(
             trans._(
-                "Interpolation setting is deprecated. Please use interpolation2d or interpolation3d",
+                "Interpolation setting is deprecated since 0.4.16. Please use interpolation2d or interpolation3d",
             ),
             category=DeprecationWarning,
             stacklevel=2,

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import dask
@@ -278,15 +277,9 @@ def prepare_properties(
     """
     # If there is no data, non-empty properties represent choices as a deprecated behavior.
     if num_data == 0 and properties:
-        warnings.warn(
-            trans._(
-                "Property choices should be passed as property_choices, not properties. This warning will become an error in version 0.4.11.",
-            ),
-            DeprecationWarning,
-            stacklevel=2,
+        raise ValueError(
+            "Property choices should be passed as property_choices, not properties."
         )
-        choices = properties
-        properties = {}
 
     properties = validate_properties(properties, expected_len=num_data)
     choices = _validate_property_choices(choices)

--- a/napari/layers/utils/text_manager.py
+++ b/napari/layers/utils/text_manager.py
@@ -144,7 +144,7 @@ class TextManager(EventedModel):
         """
         warnings.warn(
             trans._(
-                'TextManager.refresh_text is deprecated. Use TextManager.refresh instead.'
+                'TextManager.refresh_text is deprecated since 0.4.16. Use TextManager.refresh instead.'
             ),
             DeprecationWarning,
             stacklevel=2,
@@ -164,7 +164,7 @@ class TextManager(EventedModel):
         """
         warnings.warn(
             trans._(
-                'TextManager.add is deprecated. Use TextManager.apply instead.'
+                'TextManager.add is deprecated since 0.4.16. Use TextManager.apply instead.'
             ),
             DeprecationWarning,
             stacklevel=2,
@@ -363,7 +363,9 @@ class TextManager(EventedModel):
 
 def _warn_about_deprecated_text_parameter():
     warnings.warn(
-        trans._('text is a deprecated parameter. Use string instead.'),
+        trans._(
+            'text is a deprecated parameter since 0.4.16. Use string instead.'
+        ),
         DeprecationWarning,
         stacklevel=2,
     )
@@ -371,7 +373,9 @@ def _warn_about_deprecated_text_parameter():
 
 def _warn_about_deprecated_properties_parameter():
     warnings.warn(
-        trans._('properties is a deprecated parameter. Use features instead.'),
+        trans._(
+            'properties is a deprecated parameter since 0.4.16. Use features instead.'
+        ),
         DeprecationWarning,
         stacklevel=2,
     )
@@ -379,7 +383,9 @@ def _warn_about_deprecated_properties_parameter():
 
 def _warn_about_deprecated_n_text_parameter():
     warnings.warn(
-        trans._('n_text is a deprecated parameter. Use features instead.'),
+        trans._(
+            'n_text is a deprecated parameter since 0.4.16. Use features instead.'
+        ),
         DeprecationWarning,
         stacklevel=2,
     )
@@ -387,7 +393,9 @@ def _warn_about_deprecated_n_text_parameter():
 
 def _warn_about_deprecated_values_parameter():
     warnings.warn(
-        trans._('values is a deprecated parameter. Use string instead.'),
+        trans._(
+            'values is a deprecated parameter since 0.4.16. Use string instead.'
+        ),
         DeprecationWarning,
         stacklevel=2,
     )

--- a/napari/plugins/_tests/test_provide_theme.py
+++ b/napari/plugins/_tests/test_provide_theme.py
@@ -13,9 +13,8 @@ if TYPE_CHECKING:
 
 
 def test_provide_theme_hook(napari_plugin_manager: "NapariPluginManager"):
-    with pytest.warns(FutureWarning):
-        dark = get_theme("dark")
-        dark["name"] = "dark-test"
+    dark = get_theme("dark", as_dict=True)
+    dark["name"] = "dark-test"
 
     class TestPlugin:
         @napari_hook_implementation
@@ -40,10 +39,9 @@ def test_provide_theme_hook(napari_plugin_manager: "NapariPluginManager"):
 def test_provide_theme_hook_bad(napari_plugin_manager: "NapariPluginManager"):
     napari_plugin_manager.discover_themes()
 
-    with pytest.warns(FutureWarning):
-        dark = get_theme("dark")
-        dark.pop("foreground")
-        dark["name"] = "dark-bad"
+    dark = get_theme("dark", as_dict=True)
+    dark.pop("foreground")
+    dark["name"] = "dark-bad"
 
     class TestPluginBad:
         @napari_hook_implementation
@@ -86,9 +84,8 @@ def test_provide_theme_hook_not_dict(
 def test_provide_theme_hook_unregister(
     napari_plugin_manager: "NapariPluginManager",
 ):
-    with pytest.warns(FutureWarning):
-        dark = get_theme("dark")
-        dark["name"] = "dark-test"
+    dark = get_theme("dark", as_dict=True)
+    dark["name"] = "dark-test"
 
     class TestPlugin:
         @napari_hook_implementation

--- a/napari/qt/__init__.py
+++ b/napari/qt/__init__.py
@@ -5,14 +5,13 @@ from .._qt.qt_main_window import Window
 from .._qt.qt_resources import compile_qt_svgs, get_stylesheet
 from .._qt.qt_viewer import QtViewer
 from .._qt.widgets.qt_tooltip import QtToolTipLabel
-from .._qt.widgets.qt_viewer_buttons import QtStateButton, QtViewerButtons
+from .._qt.widgets.qt_viewer_buttons import QtViewerButtons
 from ..utils.translations import trans
 from .threading import create_worker, thread_worker
 
 __all__ = (
     'compile_qt_svgs',
     'create_worker',
-    'QtStateButton',
     'QtToolTipLabel',
     'QtViewer',
     'QtViewerButtons',

--- a/napari/qt/progress.py
+++ b/napari/qt/progress.py
@@ -4,7 +4,7 @@ from ..utils.translations import trans
 
 warnings.warn(
     trans._(
-        'progress has moved from qt. Use `from napari.utils import progress` instead',
+        'progress has moved from qt since 0.4.11. Use `from napari.utils import progress` instead',
         deferred=True,
     ),
     category=FutureWarning,

--- a/napari/resources/__init__.py
+++ b/napari/resources/__init__.py
@@ -4,20 +4,3 @@ from ..utils.translations import trans
 from ._icons import ICON_PATH, ICONS, get_colorized_svg, get_icon_path
 
 __all__ = ['get_colorized_svg', 'get_icon_path', 'ICON_PATH', 'ICONS']
-
-
-def get_stylesheet(extra: Optional[List[str]] = None) -> str:
-    """For backward compatibility"""
-    import warnings
-
-    warnings.warn(
-        trans._(
-            "Moved to module napari._qt.qt_resources. Will be removed after version 0.4.6.",
-            deferred=True,
-        ),
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
-    from .._qt.qt_resources import get_stylesheet as qt_get_stylesheet
-
-    return qt_get_stylesheet(extra)

--- a/napari/settings/_tests/test_settings.py
+++ b/napari/settings/_tests/test_settings.py
@@ -162,7 +162,7 @@ def test_custom_theme_settings(test_settings):
     with pytest.raises(pydantic.error_wrappers.ValidationError):
         test_settings.appearance.theme = custom_theme_name
 
-    blue_theme = get_theme('dark')
+    blue_theme = get_theme('dark', as_dict=True)
     blue_theme.update(
         background='rgb(28, 31, 48)',
         foreground='rgb(45, 52, 71)',
@@ -312,14 +312,6 @@ def test_get_settings_fails(monkeypatch, tmp_path):
 def test_first_time():
     """This test just confirms that we don't load an existing file (locally)"""
     assert NapariSettings().application.first_time is True
-
-
-# def test_deprecated_SETTINGS():
-#     """Test that direct access of SETTINGS warns."""
-#     from napari.settings import SETTINGS
-
-#     with pytest.warns(FutureWarning):
-#         assert SETTINGS.appearance.theme == 'dark'
 
 
 def test_no_save_path():

--- a/napari/utils/_tests/test_theme.py
+++ b/napari/utils/_tests/test_theme.py
@@ -21,16 +21,16 @@ def test_default_themes():
 
 
 def test_get_theme():
-    theme = get_theme('dark')
+    # get theme in the old-style dict format
+    theme = get_theme('dark', as_dict=True)
     assert isinstance(theme, dict)
     assert theme['name'] == 'dark'
 
-    # get theme in the old-style dict format
     theme = get_theme("dark")
-    assert isinstance(theme, dict)
+    assert isinstance(theme, Theme)
 
     # get theme in the new model-based format
-    theme = get_theme("dark", False)
+    theme = get_theme("dark", as_dict=False)
     assert isinstance(theme, Theme)
 
 
@@ -40,7 +40,7 @@ def test_register_theme():
     assert 'test_blue' not in themes
 
     # Create new blue theme based on dark theme
-    blue_theme = get_theme('dark')
+    blue_theme = get_theme('dark', as_dict=True)
     blue_theme.update(
         background='rgb(28, 31, 48)',
         foreground='rgb(45, 52, 71)',
@@ -56,20 +56,20 @@ def test_register_theme():
     assert 'test_blue' in themes
 
     # Check that the dark theme has not been overwritten
-    dark_theme = get_theme('dark')
+    dark_theme = get_theme('dark', as_dict=True)
     assert not dark_theme['background'] == blue_theme['background']
 
     # Check that blue theme can be gotten from available themes
-    theme = get_theme('test_blue')
+    theme = get_theme('test_blue', as_dict=True)
     assert theme['background'] == blue_theme['background']
 
-    theme = get_theme("test_blue", False)
+    theme = get_theme("test_blue", as_dict=False)
     assert theme.background.as_rgb() == blue_theme["background"]
 
 
 def test_unregister_theme():
     # Create new blue theme based on dark theme
-    blue_theme = get_theme('dark')
+    blue_theme = get_theme('dark', as_dict=True)
     blue_theme.update(
         background='rgb(28, 31, 48)',
         foreground='rgb(45, 52, 71)',

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -110,7 +110,7 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
         """
         # this is just here for now to support the old layerlist API
         warnings.warn(
-            "move_selected is deprecated. Please use layers.move_multiple "
+            "move_selected is deprecated since 0.4.16. Please use layers.move_multiple "
             "with layers.selection instead.",
             FutureWarning,
             stacklevel=2,

--- a/napari/utils/settings/__init__.py
+++ b/napari/utils/settings/__init__.py
@@ -5,7 +5,7 @@ from ..translations import trans
 
 warnings.warn(
     trans._(
-        "'napari.utils.settings' has moved to 'napari.settings'. This will raise an ImportError in a future version",
+        "'napari.utils.settings' has moved to 'napari.settings' in 0.4.11. This will raise an ImportError in a future version",
         deferred=True,
     ),
     FutureWarning,

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -1,7 +1,6 @@
 # syntax_style for the console must be one of the supported styles from
 # pygments - see here for examples https://help.farbox.com/pygments.html
 import re
-import warnings
 from ast import literal_eval
 from typing import Union
 
@@ -163,7 +162,7 @@ def template(css: str, **theme):
     return css
 
 
-def get_system_theme():
+def get_system_theme() -> str:
     """Return the system default theme, either 'dark', or 'light'."""
     try:
         name = darkdetect.theme().lower()
@@ -173,7 +172,7 @@ def get_system_theme():
     return name
 
 
-def get_theme(name, as_dict=None):
+def get_theme(name, as_dict=False):
     """Get a copy of theme based on it's name.
 
     If you get a copy of the theme, changes to the theme model will not be
@@ -209,16 +208,8 @@ def get_theme(name, as_dict=None):
         )
     theme = _themes[name]
     _theme = theme.copy()
-    if as_dict is None:
-        warnings.warn(
-            trans._(
-                "Themes were changed to use evented model with Pydantic's color type rather than the `rgb(x, y, z)`. The `as_dict=True` option will be changed to `as_dict=False` in 0.4.15",
-                deferred=True,
-            ),
-            category=FutureWarning,
-            stacklevel=2,
-        )
-        as_dict = True
+    assert as_dict in (True, False)
+    assert isinstance(_theme, Theme)
     if as_dict:
         _theme = _theme.dict()
         _theme = {


### PR DESCRIPTION
1) all warnings should mention a version, either since when things are
   deprecated, or when they will be removed. Otherwise they are not
   actionable by users or future devs without looking through git
   history, which nobody does and then get never cleaned up.

2) Things that we say we would removed have not been removed, and thus
   removing them.

(2) seem to indicate that in (1) we should not try to say things about
the future, and it's better to use version when things are deprecated as
this is factual and we can change our mind
