### PR TITLE
Add .to_rgb_dict() to Theme class.

### DIFF
--- a/examples/new_theme.py
+++ b/examples/new_theme.py
@@ -18,7 +18,7 @@ viewer = napari.view_image(data.astronaut(), rgb=True, name='astronaut')
 # List themes
 print('Originally themes', available_themes())
 
-blue_theme = get_theme('dark', False)
+blue_theme = get_theme('dark')
 blue_theme.id = "blue"
 blue_theme.icon = (
     'rgb(0, 255, 255)'  # you can provide colors as rgb(XXX, YYY, ZZZ)

--- a/napari/_qt/_tests/test_qt_provide_theme.py
+++ b/napari/_qt/_tests/test_qt_provide_theme.py
@@ -75,7 +75,7 @@ def test_plugin_provide_theme_hook_set_settings_correctly(
 def make_napari_viewer_with_plugin_theme(
     make_napari_viewer, napari_plugin_manager, *, theme_type: str, name: str
 ) -> Viewer:
-    theme = get_theme(theme_type, True)
+    theme = get_theme(theme_type).dict()
     theme["name"] = name
 
     class TestPlugin:

--- a/napari/_qt/_tests/test_qt_provide_theme.py
+++ b/napari/_qt/_tests/test_qt_provide_theme.py
@@ -75,7 +75,7 @@ def test_plugin_provide_theme_hook_set_settings_correctly(
 def make_napari_viewer_with_plugin_theme(
     make_napari_viewer, napari_plugin_manager, *, theme_type: str, name: str
 ) -> Viewer:
-    theme = get_theme(theme_type).to_dict()
+    theme = get_theme(theme_type).to_rgb_dict()
     theme["name"] = name
 
     class TestPlugin:

--- a/napari/_qt/_tests/test_qt_provide_theme.py
+++ b/napari/_qt/_tests/test_qt_provide_theme.py
@@ -75,7 +75,7 @@ def test_plugin_provide_theme_hook_set_settings_correctly(
 def make_napari_viewer_with_plugin_theme(
     make_napari_viewer, napari_plugin_manager, *, theme_type: str, name: str
 ) -> Viewer:
-    theme = get_theme(theme_type).dict()
+    theme = get_theme(theme_type).to_dict()
     theme["name"] = name
 
     class TestPlugin:

--- a/napari/_qt/_tests/test_qt_window.py
+++ b/napari/_qt/_tests/test_qt_window.py
@@ -70,7 +70,7 @@ def test_update_theme(
 ):
     viewer = make_napari_viewer()
 
-    blue = get_theme("dark", False)
+    blue = get_theme("dark")
     blue.id = "blue"
     register_theme("blue", blue, "test")
 

--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -115,7 +115,7 @@ class NapariQtNotification(QDialog):
 
         settings = get_settings()
         theme = settings.appearance.theme
-        default_color = get_theme(theme, False).icon
+        default_color = get_theme(theme).icon
 
         # FIXME: Should these be defined at the theme level?
         # Currently there is a warning one
@@ -417,7 +417,7 @@ class TracebackDialog(QDialog):
         self.setLayout(QVBoxLayout())
         self.resize(650, 270)
         text = QTextEdit()
-        theme = get_theme(get_settings().appearance.theme, as_dict=False)
+        theme = get_theme(get_settings().appearance.theme)
         _highlight = Pylighter(text.document(), "python", theme.syntax_style)
         text.setText(exception.as_text())
         text.setReadOnly(True)

--- a/napari/_qt/dialogs/qt_plugin_report.py
+++ b/napari/_qt/dialogs/qt_plugin_report.py
@@ -75,7 +75,7 @@ class QtPluginErrReporter(QDialog):
         self.setLayout(self.layout)
 
         self.text_area = QTextEdit()
-        theme = get_theme(get_settings().appearance.theme, as_dict=False)
+        theme = get_theme(get_settings().appearance.theme)
         self._highlight = Pylighter(
             self.text_area.document(), "python", theme.syntax_style
         )

--- a/napari/_qt/qt_resources/__init__.py
+++ b/napari/_qt/qt_resources/__init__.py
@@ -44,7 +44,7 @@ def get_stylesheet(
     if theme_id:
         from napari.utils.theme import get_theme, template
 
-        return template(stylesheet, **get_theme(theme_id).to_dict())
+        return template(stylesheet, **get_theme(theme_id).to_rgb_dict())
 
     return stylesheet
 

--- a/napari/_qt/qt_resources/__init__.py
+++ b/napari/_qt/qt_resources/__init__.py
@@ -44,7 +44,9 @@ def get_stylesheet(
     if theme_id:
         from napari.utils.theme import get_theme, template
 
-        return template(stylesheet, **get_theme(theme_id, as_dict=True))
+        return template(
+            stylesheet, **get_theme(theme_id, as_dict=False).dict()
+        )
 
     return stylesheet
 

--- a/napari/_qt/qt_resources/__init__.py
+++ b/napari/_qt/qt_resources/__init__.py
@@ -45,7 +45,7 @@ def get_stylesheet(
         from napari.utils.theme import get_theme, template
 
         return template(
-            stylesheet, **get_theme(theme_id, as_dict=False).dict()
+            stylesheet, **get_theme(theme_id, as_dict=False).to_dict()
         )
 
     return stylesheet

--- a/napari/_qt/qt_resources/__init__.py
+++ b/napari/_qt/qt_resources/__init__.py
@@ -44,9 +44,7 @@ def get_stylesheet(
     if theme_id:
         from napari.utils.theme import get_theme, template
 
-        return template(
-            stylesheet, **get_theme(theme_id, as_dict=False).to_dict()
-        )
+        return template(stylesheet, **get_theme(theme_id).to_dict())
 
     return stylesheet
 

--- a/napari/_qt/qt_resources/_svg.py
+++ b/napari/_qt/qt_resources/_svg.py
@@ -81,7 +81,7 @@ class QColoredSVGIcon(QIcon):
         if not color and theme:
             from napari.utils.theme import get_theme
 
-            color = getattr(get_theme(theme, False), theme_key).as_hex()
+            color = getattr(get_theme(theme), theme_key).as_hex()
 
         return QColoredSVGIcon(self._svg, color, opacity)
 

--- a/napari/_vispy/canvas.py
+++ b/napari/_vispy/canvas.py
@@ -204,7 +204,7 @@ class VispyCanvas:
         # Note 2. the reason for using the `as_hex` here is to avoid
         # `UserWarning` which is emitted when RGB values are above 1
         self._last_theme_color = transform_color(
-            get_theme(theme, False).canvas.as_hex()
+            get_theme(theme).canvas.as_hex()
         )[0]
         self.bgcolor = self._last_theme_color
 

--- a/napari/_vispy/overlays/axes.py
+++ b/napari/_vispy/overlays/axes.py
@@ -46,7 +46,7 @@ class VispyAxesOverlay(ViewerOverlayMixin, VispySceneOverlay):
             axes=axes,
             reversed_axes=reversed_axes,
             colored=self.overlay.colored,
-            bg_color=get_theme(self.viewer.theme, False).canvas,
+            bg_color=get_theme(self.viewer.theme).canvas,
             dashed=self.overlay.dashed,
             arrows=self.overlay.arrows,
         )

--- a/napari/_vispy/overlays/scale_bar.py
+++ b/napari/_vispy/overlays/scale_bar.py
@@ -126,7 +126,7 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
                     background_color = self.node.parent.bgcolor.rgba
                 else:
                     background_color = get_theme(
-                        self.viewer.theme, False
+                        self.viewer.theme
                     ).canvas.as_hex()
                     background_color = transform_color(background_color)[0]
                 color = np.subtract(1, background_color)

--- a/napari/plugins/_tests/test_provide_theme.py
+++ b/napari/plugins/_tests/test_provide_theme.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 def test_provide_theme_hook(napari_plugin_manager: "NapariPluginManager"):
-    dark = get_theme("dark").dict()
+    dark = get_theme("dark").to_dict()
     dark["name"] = "dark-test"
 
     class TestPlugin:
@@ -39,7 +39,7 @@ def test_provide_theme_hook(napari_plugin_manager: "NapariPluginManager"):
 def test_provide_theme_hook_bad(napari_plugin_manager: "NapariPluginManager"):
     napari_plugin_manager.discover_themes()
 
-    dark = get_theme("dark").dict()
+    dark = get_theme("dark").to_dict()
     dark.pop("foreground")
     dark["name"] = "dark-bad"
 
@@ -84,7 +84,7 @@ def test_provide_theme_hook_not_dict(
 def test_provide_theme_hook_unregister(
     napari_plugin_manager: "NapariPluginManager",
 ):
-    dark = get_theme("dark").dict()
+    dark = get_theme("dark").to_dict()
     dark["name"] = "dark-test"
 
     class TestPlugin:

--- a/napari/plugins/_tests/test_provide_theme.py
+++ b/napari/plugins/_tests/test_provide_theme.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 def test_provide_theme_hook(napari_plugin_manager: "NapariPluginManager"):
-    dark = get_theme("dark").to_dict()
+    dark = get_theme("dark").to_rgb_dict()
     dark["name"] = "dark-test"
 
     class TestPlugin:
@@ -39,7 +39,7 @@ def test_provide_theme_hook(napari_plugin_manager: "NapariPluginManager"):
 def test_provide_theme_hook_bad(napari_plugin_manager: "NapariPluginManager"):
     napari_plugin_manager.discover_themes()
 
-    dark = get_theme("dark").to_dict()
+    dark = get_theme("dark").to_rgb_dict()
     dark.pop("foreground")
     dark["name"] = "dark-bad"
 
@@ -84,7 +84,7 @@ def test_provide_theme_hook_not_dict(
 def test_provide_theme_hook_unregister(
     napari_plugin_manager: "NapariPluginManager",
 ):
-    dark = get_theme("dark").to_dict()
+    dark = get_theme("dark").to_rgb_dict()
     dark["name"] = "dark-test"
 
     class TestPlugin:

--- a/napari/plugins/_tests/test_provide_theme.py
+++ b/napari/plugins/_tests/test_provide_theme.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 def test_provide_theme_hook(napari_plugin_manager: "NapariPluginManager"):
-    dark = get_theme("dark", True)
+    dark = get_theme("dark").dict()
     dark["name"] = "dark-test"
 
     class TestPlugin:
@@ -39,7 +39,7 @@ def test_provide_theme_hook(napari_plugin_manager: "NapariPluginManager"):
 def test_provide_theme_hook_bad(napari_plugin_manager: "NapariPluginManager"):
     napari_plugin_manager.discover_themes()
 
-    dark = get_theme("dark", True)
+    dark = get_theme("dark").dict()
     dark.pop("foreground")
     dark["name"] = "dark-bad"
 
@@ -84,7 +84,7 @@ def test_provide_theme_hook_not_dict(
 def test_provide_theme_hook_unregister(
     napari_plugin_manager: "NapariPluginManager",
 ):
-    dark = get_theme("dark", True)
+    dark = get_theme("dark").dict()
     dark["name"] = "dark-test"
 
     class TestPlugin:

--- a/napari/resources/_icons.py
+++ b/napari/resources/_icons.py
@@ -126,7 +126,7 @@ def generate_colorized_svgs(
 
             clrkey, theme_key = color
             theme_key = theme_override.get(svg_stem, theme_key)
-            color = getattr(get_theme(clrkey, False), theme_key).as_hex()
+            color = getattr(get_theme(clrkey), theme_key).as_hex()
             # convert color to string to fit get_colorized_svg signature
 
         op_key = "" if op == 1 else f"_{op * 100:.0f}"

--- a/napari/settings/_tests/test_settings.py
+++ b/napari/settings/_tests/test_settings.py
@@ -162,7 +162,7 @@ def test_custom_theme_settings(test_settings):
     with pytest.raises(pydantic.error_wrappers.ValidationError):
         test_settings.appearance.theme = custom_theme_name
 
-    blue_theme = get_theme('dark').dict()
+    blue_theme = get_theme('dark').to_dict()
     blue_theme.update(
         background='rgb(28, 31, 48)',
         foreground='rgb(45, 52, 71)',

--- a/napari/settings/_tests/test_settings.py
+++ b/napari/settings/_tests/test_settings.py
@@ -162,7 +162,7 @@ def test_custom_theme_settings(test_settings):
     with pytest.raises(pydantic.error_wrappers.ValidationError):
         test_settings.appearance.theme = custom_theme_name
 
-    blue_theme = get_theme('dark', True)
+    blue_theme = get_theme('dark').dict()
     blue_theme.update(
         background='rgb(28, 31, 48)',
         foreground='rgb(45, 52, 71)',

--- a/napari/settings/_tests/test_settings.py
+++ b/napari/settings/_tests/test_settings.py
@@ -162,7 +162,7 @@ def test_custom_theme_settings(test_settings):
     with pytest.raises(pydantic.error_wrappers.ValidationError):
         test_settings.appearance.theme = custom_theme_name
 
-    blue_theme = get_theme('dark').to_dict()
+    blue_theme = get_theme('dark').to_rgb_dict()
     blue_theme.update(
         background='rgb(28, 31, 48)',
         foreground='rgb(45, 52, 71)',

--- a/napari/utils/_tests/test_theme.py
+++ b/napari/utils/_tests/test_theme.py
@@ -29,17 +29,17 @@ def test_default_themes():
 
 def test_get_theme():
     # get theme in the old-style dict format
-    theme = get_theme("dark", True)
+    theme = get_theme("dark").to_dict()
     assert isinstance(theme, dict)
 
     # get theme in the new model-based format
-    theme = get_theme("dark", False)
+    theme = get_theme("dark")
     assert isinstance(theme, Theme)
 
 
 def test_get_system_theme(monkeypatch):
     monkeypatch.setattr('napari.utils.theme.get_system_theme', lambda: 'light')
-    theme = get_theme('system', as_dict=False)
+    theme = get_theme('system')
     # should return the theme specified by get_system_theme
     assert theme.id == 'light'
 
@@ -50,7 +50,7 @@ def test_register_theme():
     assert 'test_blue' not in themes
 
     # Create new blue theme based on dark theme
-    blue_theme = get_theme('dark', True)
+    blue_theme = get_theme('dark').to_dict()
     blue_theme.update(
         background='rgb(28, 31, 48)',
         foreground='rgb(45, 52, 71)',
@@ -66,20 +66,20 @@ def test_register_theme():
     assert 'test_blue' in themes
 
     # Check that the dark theme has not been overwritten
-    dark_theme = get_theme('dark', True)
+    dark_theme = get_theme('dark').to_dict()
     assert dark_theme['background'] != blue_theme['background']
 
     # Check that blue theme can be gotten from available themes
-    theme = get_theme('test_blue', True)
+    theme = get_theme('test_blue').to_dict()
     assert theme['background'] == blue_theme['background']
 
-    theme = get_theme("test_blue", False)
+    theme = get_theme("test_blue")
     assert theme.background.as_rgb() == blue_theme["background"]
 
 
 def test_unregister_theme():
     # Create new blue theme based on dark theme
-    blue_theme = get_theme('dark', True)
+    blue_theme = get_theme('dark').to_dict()
     blue_theme.update(
         background='rgb(28, 31, 48)',
         foreground='rgb(45, 52, 71)',
@@ -106,7 +106,7 @@ def test_rebuild_theme_settings():
     # theme is not updated
     with pytest.raises(ValidationError):
         settings.appearance.theme = "another-theme"
-    blue_theme = get_theme("dark", True)
+    blue_theme = get_theme("dark").to_dict()
     register_theme("another-theme", blue_theme, "test")
     settings.appearance.theme = "another-theme"
 
@@ -128,12 +128,12 @@ def test_rebuild_theme_settings():
     ],
 )
 def test_theme(color):
-    theme = get_theme("dark", False)
+    theme = get_theme("dark")
     theme.background = color
 
 
 def test_theme_syntax_highlight():
-    theme = get_theme("dark", False)
+    theme = get_theme("dark")
     with pytest.raises(ValidationError):
         theme.syntax_style = "invalid"
 
@@ -149,7 +149,7 @@ def test_is_theme_available(tmp_path, monkeypatch):
     n_themes = len(available_themes())
 
     def mock_install_theme(_themes):
-        theme_dict = _themes["dark"].dict()
+        theme_dict = _themes["dark"].to_dict()
         theme_dict["id"] = "test_blue"
         register_theme("test_blue", theme_dict, "test")
 
@@ -171,7 +171,7 @@ def test_is_theme_available(tmp_path, monkeypatch):
     reason="requires npe2 0.6.2 for syntax style contributions",
 )
 def test_theme_registration(monkeypatch, caplog):
-    data = {"dark": get_theme("dark", as_dict=False)}
+    data = {"dark": get_theme("dark")}
 
     manifest = PluginManifest(
         name="theme_test",

--- a/napari/utils/_tests/test_theme.py
+++ b/napari/utils/_tests/test_theme.py
@@ -29,7 +29,7 @@ def test_default_themes():
 
 def test_get_theme():
     # get theme in the old-style dict format
-    theme = get_theme("dark").to_dict()
+    theme = get_theme("dark").to_rgb_dict()
     assert isinstance(theme, dict)
 
     # get theme in the new model-based format
@@ -50,7 +50,7 @@ def test_register_theme():
     assert 'test_blue' not in themes
 
     # Create new blue theme based on dark theme
-    blue_theme = get_theme('dark').to_dict()
+    blue_theme = get_theme('dark').to_rgb_dict()
     blue_theme.update(
         background='rgb(28, 31, 48)',
         foreground='rgb(45, 52, 71)',
@@ -66,11 +66,11 @@ def test_register_theme():
     assert 'test_blue' in themes
 
     # Check that the dark theme has not been overwritten
-    dark_theme = get_theme('dark').to_dict()
+    dark_theme = get_theme('dark').to_rgb_dict()
     assert dark_theme['background'] != blue_theme['background']
 
     # Check that blue theme can be gotten from available themes
-    theme = get_theme('test_blue').to_dict()
+    theme = get_theme('test_blue').to_rgb_dict()
     assert theme['background'] == blue_theme['background']
 
     theme = get_theme("test_blue")
@@ -79,7 +79,7 @@ def test_register_theme():
 
 def test_unregister_theme():
     # Create new blue theme based on dark theme
-    blue_theme = get_theme('dark').to_dict()
+    blue_theme = get_theme('dark').to_rgb_dict()
     blue_theme.update(
         background='rgb(28, 31, 48)',
         foreground='rgb(45, 52, 71)',
@@ -106,7 +106,7 @@ def test_rebuild_theme_settings():
     # theme is not updated
     with pytest.raises(ValidationError):
         settings.appearance.theme = "another-theme"
-    blue_theme = get_theme("dark").to_dict()
+    blue_theme = get_theme("dark").to_rgb_dict()
     register_theme("another-theme", blue_theme, "test")
     settings.appearance.theme = "another-theme"
 
@@ -149,7 +149,7 @@ def test_is_theme_available(tmp_path, monkeypatch):
     n_themes = len(available_themes())
 
     def mock_install_theme(_themes):
-        theme_dict = _themes["dark"].to_dict()
+        theme_dict = _themes["dark"].to_rgb_dict()
         theme_dict["id"] = "test_blue"
         register_theme("test_blue", theme_dict, "test")
 

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -5,7 +5,7 @@ import re
 import warnings
 from ast import literal_eval
 from contextlib import suppress
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Literal, Union, overload
 
 import npe2
 from pydantic import validator
@@ -200,7 +200,17 @@ def get_system_theme() -> str:
     return id_
 
 
-def get_theme(theme_id, as_dict=None) -> Union[Theme, Dict[str, Any]]:
+@overload
+def get_theme(theme_id: str, as_dict: Literal[False]) -> Theme:
+    ...
+
+
+@overload
+def get_theme(theme_id: str, as_dict: Literal[True]) -> Dict[str, Any]:
+    ...
+
+
+def get_theme(theme_id, as_dict=None):
     """Get a copy of theme based on it's id.
 
     If you get a copy of the theme, changes to the theme model will not be
@@ -212,6 +222,10 @@ def get_theme(theme_id, as_dict=None) -> Union[Theme, Dict[str, Any]]:
     theme_id : str
         ID of requested theme.
     as_dict : bool
+        .. deprecated:: 0.5.0
+
+            Use ``get_theme(...).to_dict()``
+
         Flag to indicate that the old-style dictionary
         should be returned. This will emit deprecation warning.
 

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -94,7 +94,7 @@ class Theme(EventedModel):
         )
         return value
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_rgb_dict(self) -> Dict[str, Any]:
         """
         This differs from baseclass `dict()` by converting colors to rgb.
         """
@@ -224,7 +224,7 @@ def get_theme(theme_id, as_dict=None):
     as_dict : bool
         .. deprecated:: 0.5.0
 
-            Use ``get_theme(...).to_dict()``
+            Use ``get_theme(...).to_rgb_dict()``
 
         Flag to indicate that the old-style dictionary
         should be returned. This will emit deprecation warning.
@@ -253,14 +253,14 @@ def get_theme(theme_id, as_dict=None):
         warnings.warn(
             trans._(
                 "The `as_dict` kwarg has been deprecated since Napari 0.5.0 and "
-                "will be removed in future version. You can use `get_theme(...).to_dict()`",
+                "will be removed in future version. You can use `get_theme(...).to_rgb_dict()`",
                 deferred=True,
             ),
             category=FutureWarning,
             stacklevel=2,
         )
     if as_dict:
-        return theme.to_dict()
+        return theme.to_rgb_dict()
     return theme
 
 

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -94,7 +94,10 @@ class Theme(EventedModel):
         )
         return value
 
-    def dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        This differs from baseclass `dict()` by converting colors to rgb.
+        """
         th = super().dict()
         return {
             k: v if not isinstance(v, Color) else v.as_rgb()
@@ -244,7 +247,7 @@ def get_theme(theme_id, as_dict=None) -> Union[Theme, Dict[str, Any]]:
         )
         as_dict = False
     if as_dict:
-        return theme.dict()
+        return theme.to_dict()
     return theme
 
 

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -235,17 +235,16 @@ def get_theme(theme_id, as_dict=None) -> Union[Theme, Dict[str, Any]]:
             )
         )
     theme = _themes[theme_id].copy()
-    if as_dict is None:
+    if as_dict is not None:
         warnings.warn(
             trans._(
-                "The `as_dict` kwarg default to False` since Napari 0.4.17, "
-                "and will become a mandatory parameter in the future.",
+                "The `as_dict` kwarg has been deprecated since Napari 0.5.0 and "
+                "will be removed in future version. You can use `get_theme(...).to_dict()`",
                 deferred=True,
             ),
             category=FutureWarning,
             stacklevel=2,
         )
-        as_dict = False
     if as_dict:
         return theme.to_dict()
     return theme


### PR DESCRIPTION
Using a method to convert the theme to a dict is better than having get_theme(..., as_dict=True), as
now you can call `.to_rgb_dict()` to any `Theme` anywhere.

This should also make function type-stable.

Pros:
 - get_theme is type stable, 
 - user can use `as_dict` on any theme, anywhere, not only where calling `get_theme()`

Cons:
 - We already had a deprecation of not passing `as_dict=` in `0.4.17`, it makes two opposite deprecation (force keyword, then remove keyword) in a row.
 - `to_dict` can be confusing/confused with `dict(...)`/`.dict()` which do not convert `Colors`. This could be mitigated by a custom NewType for def `to_rgb_dict(self) -> Dict[str, Any]`, but maybe overkill.


