### PR TITLE
Make references to examples link there

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ napari.run()  # start the "event loop" and show the viewer
 
 ## features
 
-Check out the scripts in our `examples` folder to see some of the functionality we're developing!
+Check out the scripts in our [`examples` folder](examples) to see some of the functionality we're developing!
 
 **napari** supports six main different layer types, `Image`, `Labels`, `Points`, `Vectors`, `Shapes`, and `Surface`, each corresponding to a different data type, visualization, and interactivity. You can add multiple layers of different types into the viewer and then start working with them, adjusting their properties.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,9 +48,9 @@ theme:
 ## Multi-dimensional image viewer for python
 
 [![image.sc forum](https://img.shields.io/badge/dynamic/json.svg?label=forum&url=https%3A%2F%2Fforum.image.sc%2Ftags%2Fnapari.json&query=%24.topic_list.tags.0.topic_count&colorB=brightgreen&suffix=%20topics&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAABPklEQVR42m3SyyqFURTA8Y2BER0TDyExZ+aSPIKUlPIITFzKeQWXwhBlQrmFgUzMMFLKZeguBu5y+//17dP3nc5vuPdee6299gohUYYaDGOyyACq4JmQVoFujOMR77hNfOAGM+hBOQqB9TjHD36xhAa04RCuuXeKOvwHVWIKL9jCK2bRiV284QgL8MwEjAneeo9VNOEaBhzALGtoRy02cIcWhE34jj5YxgW+E5Z4iTPkMYpPLCNY3hdOYEfNbKYdmNngZ1jyEzw7h7AIb3fRTQ95OAZ6yQpGYHMMtOTgouktYwxuXsHgWLLl+4x++Kx1FJrjLTagA77bTPvYgw1rRqY56e+w7GNYsqX6JfPwi7aR+Y5SA+BXtKIRfkfJAYgj14tpOF6+I46c4/cAM3UhM3JxyKsxiOIhH0IO6SH/A1Kb1WBeUjbkAAAAAElFTkSuQmCC)](https://forum.image.sc/tag/napari)
-[![License](https://img.shields.io/pypi/l/napari.svg)](https://github.com/napari/napari/raw/master/LICENSE)
+[![License](https://img.shields.io/pypi/l/napari.svg)](https://github.com/napari/napari/raw/main/LICENSE)
 [![Build Status](https://api.cirrus-ci.com/github/Napari/napari.svg)](https://cirrus-ci.com/napari/napari)
-[![codecov](https://codecov.io/gh/napari/napari/branch/master/graph/badge.svg)](https://codecov.io/gh/napari/napari)
+[![codecov](https://codecov.io/gh/napari/napari/branch/main/graph/badge.svg)](https://codecov.io/gh/napari/napari)
 [![Python Version](https://img.shields.io/pypi/pyversions/napari.svg)](https://python.org)
 [![PyPI](https://img.shields.io/pypi/v/napari.svg)](https://pypi.org/project/napari)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/napari.svg)](https://pypistats.org/packages/napari)

--- a/docs/index.md
+++ b/docs/index.md
@@ -194,8 +194,9 @@ napari.run()  # start the event loop and show viewer
 
 ## Features
 
-Check out the scripts in our `examples` folder to see some of the functionality
-we're developing!
+Check out the scripts in our
+[`examples` folder](https://github.com/napari/napari/tree/main/examples)
+to see some of the functionality we're developing!
 
 **napari** supports six main different layer types, `Image`, `Labels`, `Points`,
 `Vectors`, `Shapes`, and `Surface`, each corresponding to a different data type,


### PR DESCRIPTION
- docs/index: fix references to main branch
- Make references to examples folder link there

# Description
This branch updates the documentation to link to the examples folder. In particular, https://napari.org/#features suggests to check this folder, but there is no link from there, unlike the following Tutorials section, which does have a link. Tangentially, I also noticed a couple of references to the old master branch, which was renamed to main, and fixed those accordingly.

## Type of change
Improvement to the documentation.

# How has this been tested?
Not yet tested.

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
