### PR TITLE
Set focus on `QtViewer` object after creating main window

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -125,7 +125,6 @@ class _QtMainWindow(QMainWindow):
             handle.screenChanged.connect(
                 self._qt_viewer.canvas._backend.screen_changed
             )
-        self._qt_viewer.setFocus()
 
     def statusBar(self) -> 'ViewerStatusBar':
         return super().statusBar()
@@ -295,6 +294,7 @@ class _QtMainWindow(QMainWindow):
 
     def show(self, block=False):
         super().show()
+        self._qt_viewer.setFocus()
         if block:
             self._ev = QEventLoop()
             self._ev.exec()

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -125,6 +125,7 @@ class _QtMainWindow(QMainWindow):
             handle.screenChanged.connect(
                 self._qt_viewer.canvas._backend.screen_changed
             )
+        self._qt_viewer.setFocus()
 
     def statusBar(self) -> 'ViewerStatusBar':
         return super().statusBar()


### PR DESCRIPTION
# Description
Initially noted in #4628, our custom keybindings don't work when napari first launches, unless you first click on something inside the window. @ctrueden was investigating a separate issue [in this zulip thread](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/More.20keyboard.20focus.20fun) and found that it's actually the activity dialog button in the status bar that has focus. 

I initially tried just clearing the focus from the button, the status bar and the activity dialog, but for some reason that doesn't work? So instead I've set the focus at the end of `_QtMainWindow.__init__` to the `QtViewer`. I've confirmed this addresses the issue with our custom shortcuts not working. I have no idea if this is a sane thing to do though, so I'm opening in draft and pinging @tlambert03.

@ctrueden @gselzer does this fix your issue with the search bar of your plugin?

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
