### PR TITLE
Fix deepcopy for trans objects when passing args

### DIFF
--- a/napari/utils/_tests/test_translations.py
+++ b/napari/utils/_tests/test_translations.py
@@ -418,7 +418,7 @@ def test_deepcopy(kwargs):
 
     See:
       - https://github.com/napari/napari/issues/2911
-      - https://github.com/napari/napari/issues/4736    
+      - https://github.com/napari/napari/issues/4736
     """
     t = TranslationString(**kwargs)
     u = deepcopy(t)

--- a/napari/utils/_tests/test_translations.py
+++ b/napari/utils/_tests/test_translations.py
@@ -380,12 +380,54 @@ def test_bundle_exceptions(trans):
 
 
 def test_deepcopy():
-    """see https://github.com/napari/napari/issues/2911
+    """See https://github.com/napari/napari/issues/2911
 
     Object containing translation strings can't bee deep-copied.
     """
 
     t = TranslationString(msgid='huhu')
+    u = deepcopy(t)
+    assert t is not u
+    assert t == u
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            'msgid': 'Convert to {dtype}',
+            'dtype': 'uint16',
+        },
+        {
+            'msgid': 'Convert to {dtype}',
+            'dtype': 'uint16',
+            'deferred': True,
+        },
+        {
+            'msgid': 'Convert to {dtype}',
+            'dtype': 'uint16',
+            'deferred': False,
+        },
+        {
+            'msgid': 'Convert to {dtype}',
+            'msgid_plural': 'Convert to {dtype}s',
+            'n': 1,
+            'dtype': 'uint16',
+        },
+        {
+            'msgid': 'Convert to {dtype}',
+            'msgid_plural': 'Convert to {dtype}s',
+            'n': 2,
+            'dtype': 'uint16',
+        },
+    ],
+)
+def test_deepcopy_args(kwargs):
+    """See https://github.com/napari/napari/issues/4736
+
+    Object containing translation strings can't bee deep-copied when passing args.
+    """
+    t = TranslationString(**kwargs)
     u = deepcopy(t)
     assert t is not u
     assert t == u

--- a/napari/utils/_tests/test_translations.py
+++ b/napari/utils/_tests/test_translations.py
@@ -414,7 +414,7 @@ def test_bundle_exceptions(trans):
     ],
 )
 def test_deepcopy(kwargs):
-    """Object containing translation strings can't bee deep-copied.
+    """Object containing translation strings can't be deep-copied.
 
     See:
       - https://github.com/napari/napari/issues/2911

--- a/napari/utils/_tests/test_translations.py
+++ b/napari/utils/_tests/test_translations.py
@@ -379,21 +379,12 @@ def test_bundle_exceptions(trans):
         trans._dnpgettext()
 
 
-def test_deepcopy():
-    """See https://github.com/napari/napari/issues/2911
-
-    Object containing translation strings can't bee deep-copied.
-    """
-
-    t = TranslationString(msgid='huhu')
-    u = deepcopy(t)
-    assert t is not u
-    assert t == u
-
-
 @pytest.mark.parametrize(
     "kwargs",
     [
+        {
+            'msgid': 'huhu',
+        },
         {
             'msgid': 'Convert to {dtype}',
             'dtype': 'uint16',
@@ -422,10 +413,12 @@ def test_deepcopy():
         },
     ],
 )
-def test_deepcopy_args(kwargs):
-    """See https://github.com/napari/napari/issues/4736
+def test_deepcopy(kwargs):
+    """Object containing translation strings can't bee deep-copied.
 
-    Object containing translation strings can't bee deep-copied when passing args.
+    See:
+      - https://github.com/napari/napari/issues/2911
+      - https://github.com/napari/napari/issues/4736    
     """
     t = TranslationString(**kwargs)
     u = deepcopy(t)

--- a/napari/utils/translations.py
+++ b/napari/utils/translations.py
@@ -167,6 +167,10 @@ class TranslationString(str):
     def __deepcopy__(self, memo):
         from copy import deepcopy
 
+        kwargs = deepcopy(self._kwargs)
+        # Remove `n` from `kwargs` added in the initializer
+        # See https://github.com/napari/napari/issues/4736
+        kwargs.pop("n")
         return TranslationString(
             domain=self._domain,
             msgctxt=self._msgctxt,
@@ -174,7 +178,7 @@ class TranslationString(str):
             msgid_plural=self._msgid_plural,
             n=self._n,
             deferred=self._deferred,
-            kwargs=deepcopy(self._kwargs),
+            **kwargs,
         )
 
     def __new__(


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

Fixes #4736

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
