### PR TITLE
test: fix ability to use posargs with tox

### DIFF
--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -1,11 +1,17 @@
+import sys
+
+import pytest
+
+if '--test-examples' not in sys.argv:
+    pytest.skip('Use `--test-examples` to test examples', allow_module_level=True)
+
 import os
 import runpy
 from pathlib import Path
 
 import numpy as np
-import pytest
-from qtpy import API_NAME
 import skimage.data
+from qtpy import API_NAME
 
 import napari
 from napari._qt.qt_main_window import Window
@@ -37,7 +43,6 @@ if os.getenv("CI") and os.name == 'nt' and 'to_screenshot.py' in examples:
     examples.remove('to_screenshot.py')
 
 
-@pytest.mark.examples
 @pytest.mark.filterwarnings("ignore")
 @pytest.mark.skipif(not examples, reason="No examples were found.")
 @pytest.mark.parametrize("fname", examples)

--- a/napari/_tests/test_examples.py
+++ b/napari/_tests/test_examples.py
@@ -1,11 +1,15 @@
 import sys
+import os
 
 import pytest
 
-if '--test-examples' not in sys.argv:
-    pytest.skip('Use `--test-examples` to test examples', allow_module_level=True)
+# check if this module has been explicitly requested or `--test-examples` is included
+fpath = os.path.join(*__file__.split(os.path.sep)[-3:])
+if '--test-examples' not in sys.argv and fpath not in sys.argv:
+    pytest.skip(
+        'Use `--test-examples` to test examples', allow_module_level=True
+    )
 
-import os
 import runpy
 from pathlib import Path
 
@@ -54,7 +58,11 @@ def test_examples(builtins, fname, monkeypatch):
     # prevent running the event loop
     monkeypatch.setattr(napari, 'run', lambda *a, **k: None)
     # Prevent downloading example data because this sometimes fails.
-    monkeypatch.setattr(skimage.data, 'cells3d', lambda: np.zeros((60, 2, 256, 256), dtype=np.uint16))
+    monkeypatch.setattr(
+        skimage.data,
+        'cells3d',
+        lambda: np.zeros((60, 2, 256, 256), dtype=np.uint16),
+    )
 
     # make sure our sys.excepthook override doesn't hide errors
     def raise_errors(etype, value, tb):

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -102,12 +102,6 @@ def pytest_addoption(parser):
         default=False,
         help="run only asynchronous tests",
     )
-    parser.addoption(
-        "--skip_examples",
-        action="store_true",
-        default=False,
-        help="run only asynchronous tests",
-    )
 
 
 @pytest.fixture(

--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,7 @@ commands_pre =
     # the rest is for good measure
     headless: pip uninstall -y pytest-qt qtpy pyqt5 pyside2
 commands =
-    !headless: python -m pytest napari --color=yes --basetemp={envtmpdir} \
+    !headless: python -m pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir} \
         --cov-report=xml --cov={env:PYTEST_PATH:napari} --ignore tools --maxfail=5 \
         --json-report --json-report-file={toxinidir}/report-{envname}.json \
         --skip_examples {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,7 @@ commands =
     !headless: python -m pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir} \
         --cov-report=xml --cov={env:PYTEST_PATH:napari} --ignore tools --maxfail=5 \
         --json-report --json-report-file={toxinidir}/report-{envname}.json \
-        --skip_examples {posargs}
+        {posargs}
 
     # do not add ignores to this line just to make headless tests pass.
     # nothing outside of _qt or _vispy should require Qt or make_napari_viewer
@@ -94,7 +94,7 @@ commands =
 
 [testenv:py{38,39,310}-{linux,macos,windows}-{pyqt5,pyside2}-examples]
 commands =
-    python -m pytest napari/_tests/test_examples.py -v --color=yes --basetemp={envtmpdir} {posargs}
+    python -m pytest napari/_tests/test_examples.py -v --test-examples --color=yes --basetemp={envtmpdir} {posargs}
 
 [testenv:isort]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,7 @@ commands =
 
 [testenv:py{38,39,310}-{linux,macos,windows}-{pyqt5,pyside2}-examples]
 commands =
-    python -m pytest napari/_tests/test_examples.py -v --test-examples --color=yes --basetemp={envtmpdir} {posargs}
+    python -m pytest napari/_tests/test_examples.py -v --color=yes --basetemp={envtmpdir} {posargs}
 
 [testenv:isort]
 skip_install = True


### PR DESCRIPTION
# Description
reverts a change from #4725 that prevents the ability to invoke tox with `tox -- some/path`

@Czaki, let me know what the original rationale was for that and maybe we can figure something out that works for both cases