### PR TITLE
Allow dunder methods use in `PublicOnlyProxy`

### DIFF
--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -43,7 +43,9 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
     __wrapped__: _T
 
     def __getattr__(self, name: str):
-        if name.startswith("_"):
+        if name.startswith("_") and not (
+            name.startswith('__') and name.endswith('__')
+        ):
             # allow napari to access private attributes and get an non-proxy
             frame = sys._getframe(1) if hasattr(sys, "_getframe") else None
             if frame.f_code.co_filename.startswith(misc.ROOT_DIR):


### PR DESCRIPTION
# Description
If something tries to access dunder methods in a `PublicOnlyProxy`, it will raise errors. I think we should differentiate this from actual napari private methods. Here's a case where I think it shouldn't happen:


```py
import napari
from magicgui import magicgui
from rich import print

@magicgui
def print_viewer(viewer: napari.Viewer):
    print(viewer)

v = napari.Viewer()
v.window.add_dock_widget(print_viewer)

print_viewer()
```

`rich` uses some dunder methods, and makes a mess:

```py
/home/lorenzo/venv/napari-spaces/lib/python3.10/site-packages/rich/protocol.py:31: FutureWarning: Private attribute access ('Viewer.__rich__') in this context (e.g. inside a plugin widget or dock widget) is deprecated and will be unavailable in version 0.5.0
  while hasattr(renderable, "__rich__") and not isclass(renderable):
/usr/lib/python3.10/typing.py:1505: FutureWarning: Private attribute access ('Viewer.__rich_console__') in this context (e.g. inside a plugin widget or dock widget) is deprecated and will be unavailable in version 0.5.0
  if all(hasattr(instance, attr) and
/home/lorenzo/venv/napari-spaces/lib/python3.10/site-packages/rich/pretty.py:396: FutureWarning: Private attribute access ('Viewer.__rich_repr__') in this context (e.g. inside a plugin widget or dock widget) is deprecated and will be unavailable in version 0.5.0
  or (hasattr(obj, "__rich_repr__"))
```

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
