### PR TITLE
Add Talley to the steering council

### DIFF
--- a/docs/community/team.md
+++ b/docs/community/team.md
@@ -17,7 +17,7 @@ napari is a consensus-based community project. Anyone with an interest in the pr
 - [Loic Royer](https://github.com/napari/napari/commits?author=royerloic) - [@royerloic](https://github.com/royerloic)*
 - [Lorenzo Gaifas](https://github.com/napari/napari/commits?author=brisvag) - [@brisvag](https://github.com/brisvag)
 - [Nicholas Sofroniew](https://github.com/napari/napari/commits?author=sofroniewn) - [@sofroniewn](https://github.com/sofroniewn)*
-- [Talley Lambert](https://github.com/napari/napari/commits?author=tlambert03) - [@tlambert03](https://github.com/tlambert03)
+- [Talley Lambert](https://github.com/napari/napari/commits?author=tlambert03) - [@tlambert03](https://github.com/tlambert03)*
 - [Ziyang Liu](https://github.com/napari/napari/commits?author=ziyangczi) - [@ziyangczi](https://github.com/ziyangczi)
 
 <sub>* on the napari [steering council](https://napari.org/community/governance.html#steering-council).</sub>


### PR DESCRIPTION
I love how tiny this PR turned out to be. 😂 

As the core devs already know, @tlambert03 recently joined the napari steering council after a nomination by @alisterburt. 🎉 This PR merely reflects that in our docs. 😊 

Thanks @tlambert03!