### PR TITLE
Reader preferences specificity

### DIFF
--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -28,6 +28,9 @@ def test_get_preferred_reader_complex_pattern():
     reader = get_preferred_reader('my-specific-folder/my_file.tif')
     assert reader == 'fake-plugin'
 
+    reader = get_preferred_reader('../my-specific-folder/my_file.tif')
+    assert reader == 'fake-plugin'
+
 
 def test_get_preferred_reader_higher_specificity():
     get_settings().plugins.extension2reader = {
@@ -35,10 +38,12 @@ def test_get_preferred_reader_higher_specificity():
         '*.tif': 'generic-tif-plugin',
         # more nested so higher specificity
         'my-specific-folder/*.tif': 'fake-plugin',
+        # even more nested so even higher specificity
+        'my-specific-folder/nested/*.tif': 'very-specific-plugin',
     }
 
-    reader = get_preferred_reader('my-specific-folder/my_file.tif')
-    assert reader == 'fake-plugin'
+    reader = get_preferred_reader('my-specific-folder/nested/my_file.tif')
+    assert reader == 'very-specific-plugin'
 
 
 def test_get_preferred_reader_no_extension():

--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -29,6 +29,18 @@ def test_get_preferred_reader_complex_pattern():
     assert reader == 'fake-plugin'
 
 
+def test_get_preferred_reader_higher_specificity():
+    get_settings().plugins.extension2reader = {
+        # less nested so less specificity
+        '*.tif': 'generic-tif-plugin',
+        # more nested so higher specificity
+        'my-specific-folder/*.tif': 'fake-plugin',
+    }
+
+    reader = get_preferred_reader('my-specific-folder/my_file.tif')
+    assert reader == 'fake-plugin'
+
+
 def test_get_preferred_reader_no_extension():
     assert get_preferred_reader('my_file') is None
 

--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -28,7 +28,7 @@ def test_get_preferred_reader_complex_pattern():
     reader = get_preferred_reader('my-specific-folder/my_file.tif')
     assert reader == 'fake-plugin'
 
-    reader = get_preferred_reader('../my-specific-folder/my_file.tif')
+    reader = get_preferred_reader('foo/my-specific-folder/my_file.tif')
     assert reader == 'fake-plugin'
 
 

--- a/napari/plugins/utils.py
+++ b/napari/plugins/utils.py
@@ -1,3 +1,4 @@
+import pathlib
 import re
 from typing import Dict, Set, Tuple, Union
 
@@ -25,7 +26,9 @@ def _get_preferred_readers(path):
     reader_settings = get_settings().plugins.extension2reader
 
     return filter(
-        lambda kv: wildmatch(kv[0], path, any_depth=True),
+        lambda kv: wildmatch(
+            kv[0], str(pathlib.Path(path).as_posix()), any_depth=True
+        ),
         reader_settings.items(),
     )
 

--- a/napari/plugins/utils.py
+++ b/napari/plugins/utils.py
@@ -9,14 +9,57 @@ from napari.settings import get_settings
 from . import _npe2, plugin_manager
 
 
-def get_preferred_reader(_path):
-    """Return preferred reader for _path from settings, if one exists."""
+def _get_preferred_readers(path):
+    """Given filepath, find matching readers from preferences.
+
+    Parameters
+    ----------
+    path : str
+        Path of the file.
+
+    Returns
+    -------
+    filtered_preferences : Iterable[Tuple[str, str]]
+        Filtered patterns and their corresponding readers.
+    """
     reader_settings = get_settings().plugins.extension2reader
-    for pattern, reader in reader_settings.items():
+
+    return filter(lambda kv: fnmatch(path, kv[0]), reader_settings.items())
+
+
+def get_preferred_readers(path):
+    """Given filepath, find matching readers from preferences.
+
+    Parameters
+    ----------
+    path : str
+        Path of the file.
+
+    Returns
+    -------
+    filtered_readers : List[str]
+        Preferred readers which match the given filepath.
+    """
+    return [reader for (pattern, reader) in _get_preferred_readers(path)]
+
+
+def get_preferred_reader(path):
+    """Given filepath, find the best matching reader from the preferences.
+
+    Parameters
+    ----------
+    path : str
+        Path of the file.
+
+    Returns
+    -------
+    reader : str
+        Best matching reader, if found.
+    """
+    for pattern, reader in _get_preferred_readers(path):
         # TODO: we return the first one we find - more work should be done here
         # in case other patterns would match - do we return the most specific?
-        if fnmatch(_path, pattern):
-            return reader
+        return reader
 
 
 def get_potential_readers(filename: str) -> Dict[str, str]:

--- a/napari/utils/_tests/test_wildmatch.py
+++ b/napari/utils/_tests/test_wildmatch.py
@@ -1,0 +1,211 @@
+from ..wildmatch import Match, score_key, score_pattern_specificity, wildmatch
+
+
+def test_match_literal():
+    assert wildmatch('a', 'a')
+    assert not wildmatch('a', 'b')
+    assert wildmatch('\\(', '(')
+    assert not wildmatch('abc', 'a')
+
+
+def test_match_any():
+    assert wildmatch('?', 'b')
+    assert wildmatch('a?c', 'abc')
+    assert not wildmatch('a?c', 'abdc')
+    assert wildmatch('file_??', 'file_01')
+
+
+def test_match_star_simple():
+    assert wildmatch('*', 'abc')
+    assert not wildmatch('*', 'a/bc')
+    assert wildmatch('a*d', 'ad')
+    assert wildmatch('a*d', 'abcd')
+    assert wildmatch('a*cd', 'abcd')
+    assert wildmatch('a*cd', 'acdeabcd')
+    assert not wildmatch('a*d', 'abcde')
+    assert wildmatch('a*d', 'abcdabcd')
+    assert not wildmatch('a*d', 'abcdeabcde')
+    assert wildmatch('file_*', 'file_100')
+    assert wildmatch('a*', 'a')
+
+
+def test_match_star_complex():
+    assert wildmatch('a/*/d', 'a/bc/d')
+    assert wildmatch('a/b*g/z', 'a/bcdefg/z')
+    assert not wildmatch('a/*/d', 'a/b/c/d')
+    assert not wildmatch('a/*/d', 'a/d')
+
+
+def test_match_doublestar_collapse():
+    assert wildmatch('a/**/d', 'a/d')
+    assert wildmatch('a/**/d', 'a/bc/d')
+    assert wildmatch('a/**/d', 'a/b/c/d')
+    assert not wildmatch('a/**/d', 'a/b/c/d/e')
+    assert wildmatch('a/**/d/e', 'a/b/c/d/e')
+    assert wildmatch('a/**/d', 'a/b/c/d/a/b/c/d')
+    assert not wildmatch('a/**/d', 'a/b/c/d/a/b/c/d/e')
+    assert not wildmatch('a/**/b', 'a/')
+    assert not wildmatch('a/**/', 'a/b')
+
+
+def test_match_doublestar_expand():
+    assert wildmatch('a/b**/e', 'a/b/c/d/e')
+    assert wildmatch('a/b**/e', 'a/bc/d/e')
+    assert not wildmatch('a/b**/e', 'a/bc/de')
+    assert wildmatch('a/b**e', 'a/b/c/d/e')
+    assert not wildmatch('a/**c/e', 'a/b/c/d/e')
+    assert wildmatch('**.zarr', 'a/b/c/d/efg.zarr')
+    assert not wildmatch('a/**b/', 'a/')
+    assert wildmatch('a**', 'a')
+    assert wildmatch('**', 'a/b/c')
+
+
+def test_match_set():
+    assert wildmatch('[abcd]', 'c')
+    assert not wildmatch('[abcd]', 'f')
+
+    assert wildmatch('[a-c]', 'c')
+    assert not wildmatch('[a-c]', 'd')
+    assert wildmatch('[0-9]', '0')
+    assert not wildmatch('[3-5]', '1')
+    assert wildmatch('[!3-5]', '1')
+    assert wildmatch('[!0-9]', 'A')
+    assert not wildmatch('[!0-9]', '9')
+
+    assert wildmatch('[[:space:]]', ' ')
+    assert wildmatch('[[:]', '[')
+    assert wildmatch('[[:]', ':')
+    assert wildmatch('[[:abc]', 'c')
+    assert not wildmatch('[[:abc]', 'd')
+    assert wildmatch('[[:graph:]]', 'A')
+    assert wildmatch('[[:upper:][:space:]]', ' ')
+    assert wildmatch('[[:upper:][:space:]]', 'A')
+    assert wildmatch('[[:cntrl:]]', '\0')
+    assert wildmatch('[[:cntrl:]]', '\x1F')
+    assert wildmatch('[[:cntrl:]]', '\x0F')
+    assert wildmatch('[[:cntrl:]]', '\x7F')
+    assert not wildmatch('[[:cntrl:]]', '\x5F')
+
+
+def test_match_paren():
+    assert wildmatch('a(?bc)', 'a')
+    assert wildmatch('a(?bc)', 'abc')
+    assert wildmatch('a(?b)c', 'ac')
+    assert wildmatch('a(?b)c', 'abc')
+    assert not wildmatch('a(?b)c', 'a')
+
+
+def test_match_paren_subpatt():
+    assert wildmatch('(?[a-f])', 'd')
+    assert not wildmatch('(?[a-f])', 'z')
+    assert wildmatch('(?[a-f])', '')
+
+    assert wildmatch('a(?*)b', 'ab')
+    assert wildmatch('a(?b*)c', 'ac')
+    assert wildmatch('a(?b*)c', 'abc')
+    assert wildmatch('a(?b*)c', 'abwer2341243c')
+    assert not wildmatch('a(?b*)c', 'abcd')
+
+
+def test_match_folder():
+    assert wildmatch('**.zarr/', 'a/b/c/d/efg.zarr/')
+    assert not wildmatch('**.zarr/', 'a/b/c/d/efg.zarr')
+
+    assert wildmatch('*/', 'abcdefg.zarr/')
+    assert not wildmatch('*/', 'abcdefg.zarr')
+
+    assert wildmatch('**.zarr(?/)', 'a/b/c/d/efg.zarr')
+    assert wildmatch('**.zarr(?/)', 'a/b/c/d/efg.zarr/')
+
+    assert wildmatch('**/', 'a/b/c/d/efg.zarr/')
+    assert wildmatch('a**/', 'a/b/c/d/efg.zarr/')
+
+    assert not wildmatch('a/**/', 'a/')
+    assert wildmatch('a/**/', 'a/b/c/d/efg.zarr/')
+
+    assert not wildmatch('a/**/', 'a/c/d/e/b')
+    assert wildmatch('a/**/', 'a/b/c/d/e/')
+
+
+def test_match_casefold():
+    assert wildmatch('abcde', 'AbCdE', casefold=True)
+    assert not wildmatch('abcde', 'AbCdE', casefold=False)
+
+    assert not wildmatch('\\Dockerfile', 'dockerfile', casefold=True)
+    assert wildmatch('\\Dockerfile', 'Dockerfile', casefold=True)
+
+    assert wildmatch('[a-z]', 'g', casefold=False)
+    assert not wildmatch('[a-z]', 'G', casefold=False)
+    assert wildmatch('[a-zA-Z]', 'G', casefold=False)
+    assert not wildmatch('[a-zA-Z]', '0', casefold=False)
+
+    assert not wildmatch('[[:upper:][:space:]]', 'a', casefold=False)
+    assert wildmatch('[[:upper:][:space:]]', 'a', casefold=True)
+
+
+def test_match_any_depth():
+    assert wildmatch('*.zarr', 'a/b/c/d/efg.zarr', any_depth=True)
+    assert wildmatch('.zarr', 'a/b/c/d/efg.zarr', any_depth=True)
+    assert not wildmatch('/*.zarr', 'a/b/c/d/efg.zarr', any_depth=True)
+    assert wildmatch('!/*.zarr', 'a/b/c/d/efg.zarr', any_depth=True)
+
+
+def test_specificity_individual():
+    assert score_pattern_specificity('\\*') == [Match.NONE]
+    assert score_pattern_specificity('(?abc)') == [Match.MAYBE]
+    assert score_pattern_specificity('[:upper:]') == [Match.SET]
+    assert score_pattern_specificity('a*') == [Match.STAR]
+    assert score_pattern_specificity('**') == [Match.DOUBLESTAR]
+
+
+def test_specificity_complex():
+    assert score_pattern_specificity('**abc') == [Match.DOUBLESTAR, Match.STAR]
+    assert score_pattern_specificity('**abc/d') == [
+        Match.DOUBLESTAR,
+        Match.STAR,
+        Match.NONE,
+    ]
+    assert score_pattern_specificity('(?ab*c)') == [Match.STAR | Match.MAYBE]
+
+    assert score_pattern_specificity('(?ab/c)') == [Match.MAYBE]
+    assert score_pattern_specificity('/abc') == [Match.NONE, Match.NONE]
+
+    assert score_pattern_specificity('**/**/**/**a(?b)c') == [
+        Match.DOUBLESTAR,
+        Match.STAR | Match.MAYBE,
+    ]
+    assert score_pattern_specificity('****foo') == [
+        Match.DOUBLESTAR,
+        Match.STAR,
+    ]
+
+
+def test_sort_by_specificity():
+    paths = [
+        'foo',
+        '/foo',
+        '/foo/',
+        '/foo/bar',
+        '/foo/bar/',
+        '/foo/*.txt',
+        '*.txt',
+        'foo/bar',
+        'foo/*.txt',
+        '**foo',
+        '*foo',
+    ]
+    paths_ordered = [
+        '/foo/bar/',
+        '/foo/',
+        '/foo/bar',
+        '/foo/*.txt',
+        '/foo',
+        'foo/bar',
+        'foo/*.txt',
+        'foo',
+        '*.txt',
+        '**foo',
+        '*foo',
+    ]
+
+    assert sorted(paths, key=score_key) == paths_ordered

--- a/napari/utils/wildmatch.py
+++ b/napari/utils/wildmatch.py
@@ -1,0 +1,486 @@
+"""Wildmatching based off of git's implementation.
+
+See https://github.com/git/git/blob/master/wildmatch.c
+"""
+
+import string
+from enum import IntFlag
+
+LITERAL_ERROR = "invalid pattern: no character followed by literal symbol '\\'"
+BRACKET_ERROR = "invalid pattern: no closing bracket ']'"
+PAREN_ERROR = "invalid pattern: no closing parenthesis ')'"
+PAREN_OP_ERROR = "missing parenthesis operator '?'"
+
+POSIX_CLASSES = {
+    'alnum': str.isalnum,
+    'alpha': str.isalpha,
+    'ascii': str.isascii,
+    'blank': lambda c: c == ' ' or c == '\t',
+    'cntrl': lambda c: '\x00' <= c <= '\x1F' or c == '\x7F',
+    'digit': str.isdigit,
+    'graph': lambda c: POSIX_CLASSES['print'](c)
+    and not POSIX_CLASSES['space'](c),
+    'lower': str.islower,
+    'print': str.isprintable,
+    'punct': lambda c: c in string.punctuation,
+    'space': str.isspace,
+    'upper': str.isupper,
+    'word': lambda c: c == '_' or POSIX_CLASSES['alnum'](c),
+    'xdigit': lambda c: c in string.hexdigits,
+}
+
+
+def _wildmatch(pattern, text, casefold):
+    pattern_left = True
+
+    if not pattern and text:
+        return False
+
+    p_ch = pattern[(p_i := 0)]
+
+    if len(text) > (t_i := 0):
+        t_ch = text[t_i]
+    else:
+        t_ch = None
+
+    def p():
+        nonlocal p_ch, p_i
+        if (p_i := p_i + 1) >= len(pattern):
+            return (p_ch := None)
+        return (p_ch := pattern[p_i])
+
+    def t():
+        nonlocal t_ch, t_i
+        if (t_i := t_i + 1) >= len(text):
+            return (t_ch := None)
+        return (t_ch := text[t_i])
+
+    while pattern_left:
+
+        # TODO: replace with case matching in 3.10
+        if t_ch is None and p_ch != '*' and p_ch != '(':
+            return False
+
+        if p_ch == '\\':
+            # literal match, skip to next character
+            if p() is None:
+                raise ValueError(LITERAL_ERROR)
+
+            # do not apply lower casing in literal comparisons
+
+            if t_ch != p_ch:
+                return False
+        elif p_ch == '?':
+            # matches one character
+            if t_ch == '/':
+                # that is not /
+                return False
+        elif p_ch == '*':
+            # one asterisk
+            doublestar = False
+            if p() is None:
+                # pattern ends in singular *, match all files non-recursively
+                return '/' not in text[t_i:]
+            elif p_ch == '*':
+                # two or more asterisks
+                doublestar = True
+                prev_p_i = p_i - 2
+                while p() == '*':
+                    pass  # advance until next non-asterisk character reached
+                if p_ch is None:  # end of pattern, match everything
+                    return True
+                elif (
+                    prev_p_i < 0 or pattern[prev_p_i] == '/'
+                ) and p_ch == '/':  # equivalent to /**/
+                    if p_i + 1 < len(pattern) and _wildmatch(
+                        pattern[p_i + 1 :], text[t_i:], casefold
+                    ):
+                        # check if **/ can be collapsed as it can match nothing
+                        return True
+
+            while t_ch is not None:
+                if not doublestar and t_ch == '/':
+                    break
+
+                if _wildmatch(pattern[p_i:], text[t_i:], casefold):
+                    return True
+
+                t()
+            else:
+                return False
+
+        elif p_ch == '[':
+            p()
+            if negated := p_ch == '!':
+                p()
+
+            needs_end_bracket = True
+
+            prev_ord = 0
+            matched = False
+
+            while needs_end_bracket:
+                if p_ch is None:
+                    raise ValueError(BRACKET_ERROR)
+
+                if p_ch == '\\':
+                    if p() is None:
+                        raise ValueError(LITERAL_ERROR)
+                    if t_ch == p_ch:
+                        matched = True
+                elif (
+                    p_ch == '-'
+                    and prev_ord
+                    and p_i + 1 < len(pattern)
+                    and pattern[p_i + 1] != ']'
+                ):
+                    if p() == '\\':
+                        if p() is None:
+                            raise ValueError(LITERAL_ERROR)
+                    if ord(t_ch) <= ord(p_ch) and ord(t_ch) >= prev_ord:
+                        matched = True
+                    elif casefold and t_ch.islower():
+                        t_ch_upper = t_ch.upper()
+                        if (
+                            ord(t_ch_upper) <= ord(p_ch)
+                            and ord(t_ch_upper) >= prev_ord
+                        ):
+                            matched = True
+                    else:
+                        p_ch = '\0'  # resets prev_ord to 0
+                elif (
+                    p_ch == '['
+                    and p_i + 1 < len(pattern)
+                    and pattern[p_i + 1] == ':'
+                ):
+                    s = p_i + 2  # skip past '[:'
+                    i = pattern.find(']', s)
+
+                    if i < 0:  # end bracket not found
+                        raise ValueError(BRACKET_ERROR)
+
+                    if i - s - 1 < 0 or pattern[i - 1] != ':':
+                        # didn't find ':]', treat like normal set
+                        assert p_ch == '['
+
+                        if t_ch == p_ch:
+                            matched = True
+                    else:
+                        p_i = i
+
+                        if (
+                            posix_class := pattern[s : i - 1]
+                        ) not in POSIX_CLASSES:
+                            raise ValueError(
+                                f"invalid pattern: malformed posix class '{posix_class}'"
+                            )
+
+                        if casefold and posix_class == 'upper':
+                            if t_ch in string.ascii_letters:
+                                matched = True
+                        elif POSIX_CLASSES[posix_class](t_ch):
+                            matched = True
+
+                        p_ch = '\0'  # resets prev_ord to 0
+
+                elif t_ch == p_ch:
+                    matched = True
+
+                prev_ord = ord(p_ch)
+                needs_end_bracket = p() != ']'
+
+            if matched == negated or t_ch == '/':
+                return False
+
+        elif p_ch == '(':
+            if p() != '?':
+                # TODO: add other operators e.g. +, *, {a,b}
+                raise ValueError(PAREN_OP_ERROR)
+
+            # match zero or one times
+
+            patt = ''
+
+            while True:
+                if p() is None:
+                    raise ValueError(PAREN_ERROR)
+                if p_ch == '\\':
+                    if p() is None:
+                        raise ValueError(LITERAL_ERROR)
+                    patt += '\\' + p_ch
+                elif p_ch == ')':
+                    break
+                else:
+                    patt += p_ch
+
+            if p() is None and t_i >= len(text):
+                return True
+
+            if _wildmatch(pattern[p_i:], text[t_i:], casefold):
+                # check for zero time match
+                return True
+
+            return _wildmatch(patt + pattern[p_i:], text[t_i:], casefold)
+
+        else:  # default case
+            if casefold:
+                p_ch = p_ch.lower()
+                t_ch = t_ch.lower()
+
+            if t_ch != p_ch:
+                return False
+
+        pattern_left = p() is not None
+        t()
+
+    return t_i >= len(text)  # is there remaining text?
+
+
+def wildmatch(pattern, path, *, casefold=True, any_depth=False):
+    """Match a pattern against a path. Path delimiters are always '/'.
+
+    Special Characters:
+    - ! at the beginning of the pattern negates it
+    - \\ marks the following character as a literal
+    - ? matches any non-slash character
+    - * matches multiple non-slash characters
+    - ** matches multiple characters with infinite depth
+
+    Sub-patterns:
+    - brackets [] denote a set of characters that can be matched:
+        - loose set of characters, e.g. [cake] which matches the characters c, a, k, and e
+        - range of characters, e.g. [0-5] which matches all numbers from 0 to 5
+        - posix class, e.g. [[:word:]] which match certain pre-defined rules
+        - ! at the beginning of the set inverts it, e.g. [!.] matches anything that isn't a period
+    - parentheses () denote a certain amount of matches:
+        - ? matches 0 or 1 times
+        - TODO: * matches 0 or more times
+        - TODO: + matches 1 or more times
+        - TODO: {a,b} matches between a and b times, e.g. {3,5} matches 3-5 times
+
+    Parameters
+    ----------
+    pattern : str
+        Pattern to match with.
+    path : str
+        Path to match against.
+    casefold : bool, optional, kwonly
+        Whether to ignore case when matching, does not apply to sets
+        except for the posix class `upper`.
+    any_depth : bool, optional, kwonly
+        Whether relative paths can be matched at any depth (effectively pre-pends **).
+
+    Returns
+    -------
+    match : bool
+        Whether the pattern matches the path provided.
+
+    Raises
+    ------
+    ValueError
+        When the pattern is invalid.
+    """
+    if pattern.startswith('!'):
+        return not wildmatch(
+            pattern[1:], path, casefold=casefold, any_depth=any_depth
+        )
+    if any_depth and not pattern.startswith('/'):
+        pattern = '**' + pattern
+    return _wildmatch(pattern, path, casefold)
+
+
+class Match(IntFlag):
+    NONE = 0
+    MAYBE = 1
+    SET = 2
+    ANY = 4
+    MULTI_RANGE = 8  # e.g. ({3,5}pattern), to be implemented
+    MULTI = 16  # e.g. (+pattern) or (*pattern), to be implemented
+    STAR = 32
+    DOUBLESTAR = 64
+
+
+def score_pattern_specificity(pattern):
+    """Score a pattern's segments' specificities. Lower score means higher specificity.
+
+    Parameters
+    ----------
+    pattern : str
+        Pattern to score.
+
+    Returns
+    -------
+    score : list of int
+        Specificity scores for each pattern segment.
+
+    Raises
+    ------
+    ValueError
+        When the pattern is invalid.
+    """
+    if not pattern:
+        return []
+
+    score = [Match.NONE]
+
+    p_ch = pattern[(p_i := 0)]
+
+    def p():
+        nonlocal p_ch, p_i
+        if (p_i := p_i + 1) >= len(pattern):
+            return (p_ch := None)
+        return (p_ch := pattern[p_i])
+
+    pattern_left = True
+
+    while pattern_left:
+        # TODO: replace with case matching in 3.10
+        if p_ch == '\\':
+            # literal match, skip to next character
+            if p() is None:
+                raise ValueError(LITERAL_ERROR)
+
+        elif p_ch == '/':
+            score.append(Match.NONE)
+
+        elif p_ch == '?':
+            # matches one character
+            score[-1] |= Match.ANY
+
+        elif p_ch == '*':
+            if p() == '*':
+                # two or more asterisks
+                prev_p_i = p_i - 2
+                while p() == '*':
+                    pass  # advance until next non-asterisk character reached
+                if (
+                    not score[-1] & Match.DOUBLESTAR
+                    and prev_p_i >= 0
+                    and pattern[prev_p_i] == '/'
+                ):
+                    score.append(Match.NONE)
+                score[-1] |= Match.DOUBLESTAR
+                if p_ch == '/':
+                    s = score_pattern_specificity(pattern[p_i + 1 :])
+                    if not s[0] & Match.DOUBLESTAR:
+                        score.append(Match.NONE)
+                elif p_ch is not None:
+                    score.append(Match.STAR)
+            else:
+                # one asterisk
+                score[-1] |= Match.STAR
+
+        elif p_ch == '[':
+            if p() == '!':
+                p()
+
+            needs_end_bracket = True
+
+            prev_ord = False
+
+            while needs_end_bracket:
+                if p_ch is None:
+                    raise ValueError(BRACKET_ERROR)
+
+                if p_ch == '\\':
+                    if p() is None:
+                        raise ValueError(LITERAL_ERROR)
+                elif (
+                    p_ch == '-'
+                    and prev_ord
+                    and p_i + 1 < len(pattern)
+                    and pattern[p_i + 1] != ']'
+                ):
+                    if p() == '\\':
+                        if p() is None:
+                            raise ValueError(LITERAL_ERROR)
+
+                elif (
+                    p_ch == '['
+                    and p_i + 1 < len(pattern)
+                    and pattern[p_i + 1] == ':'
+                ):
+                    s = p_i + 2  # skip past '[:'
+                    i = pattern.find(']', s)
+
+                    if i < 0:  # end bracket not found
+                        raise ValueError(BRACKET_ERROR)
+
+                    if i - s - 1 < 0 or pattern[i - 1] != ':':
+                        # didn't find ':]', treat like normal set
+                        assert p_ch == '['
+                    else:
+                        p_i = i
+
+                        if (
+                            posix_class := pattern[s : i - 1]
+                        ) not in POSIX_CLASSES:
+                            raise ValueError(
+                                f"invalid pattern: malformed posix class '{posix_class}'"
+                            )
+
+                prev_ord = True
+                needs_end_bracket = p() != ']'
+
+            score[-1] |= Match.SET
+
+        elif p_ch == '(':
+            if p() != '?':
+                # TODO: add other operators e.g. +, *, {a,b}
+                raise ValueError("missing parenthesis operator '?'")
+
+            # match zero or one times
+
+            patt = ''
+
+            while True:
+                if p() is None:
+                    raise ValueError(PAREN_ERROR)
+                if p_ch == '\\':
+                    if p() is None:
+                        raise ValueError(LITERAL_ERROR)
+                    patt += '\\' + p_ch
+                elif p_ch == ')':
+                    break
+                else:
+                    patt += p_ch
+
+            score[-1] |= Match.MAYBE
+
+            for e in score_pattern_specificity(patt):
+                score[-1] |= e
+
+        pattern_left = p() is not None
+
+    return score
+
+
+def score_key(pattern):
+    """Extracts a comparable specificity score key from a pattern.
+    Lower score means more specificity.
+
+    Absolute paths have highest specificity,
+    followed by paths with the most nesting,
+    followed by path segments broken down by the least ambiguous.
+
+    Parameters
+    ----------
+    pattern : str
+        Pattern to score.
+
+    Returns
+    -------
+    score : list of int
+        Comparable score.
+
+    Raises
+    ------
+    ValueError
+        When the pattern is invalid.
+    """
+    rel_path = False
+    if not pattern.startswith('/'):
+        pattern = '**/' + pattern
+        rel_path = True
+    score = score_pattern_specificity(pattern)
+    return [rel_path, -len(score)] + score

--- a/napari/utils/wildmatch.py
+++ b/napari/utils/wildmatch.py
@@ -461,7 +461,7 @@ def score_key(pattern):
 
     Absolute paths have highest specificity,
     followed by paths with the most nesting,
-    followed by path segments broken down by the least ambiguous.
+    then by path segments with the least ambiguity.
 
     Parameters
     ----------


### PR DESCRIPTION
# Description
Implements wildmatching (what git uses for .gitignore) with some improvements and scores patterns for their specificities. Path delimiters are always '/'.

```
Special Characters:
- ! at the beginning of the pattern negates it
- \ marks the following character as a literal
- ? matches any non-slash character
- * matches multiple non-slash characters
- ** matches multiple characters with infinite depth

Sub-patterns:
- brackets [] denote a set of characters that can be matched:
    - loose set of characters, e.g. [cake] which matches the characters c, a, k, and e
    - range of characters, e.g. [0-5] which matches all numbers from 0 to 5
    - posix class, e.g. [[:word:]] which match certain pre-defined rules
    - ! at the beginning of the set inverts it, e.g. [!.] matches anything that isn't a period
- parentheses () denote a certain amount of matches:
    - ? matches 0 or 1 times
    - TODO: * matches 0 or more times
    - TODO: + matches 1 or more times
    - TODO: {a,b} matches between a and b times, e.g. {3,5} matches 3-5 times
```

Absolute paths have highest specificity, followed by paths with the most nesting, then by path segments with the least ambiguity.