### PR TITLE
mock npe1 plugin manager during tests (fix tests with npe1 plugins installed)

### DIFF
--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -467,8 +467,11 @@ def _no_error_reports():
 
 
 @pytest.fixture(autouse=True)
-def _npe2pm(npe2pm):
+def _npe2pm(npe2pm, monkeypatch):
     """Autouse the npe2 mock plugin manager with no registered plugins."""
+    from napari.plugins import NapariPluginManager
+
+    monkeypatch.setattr(NapariPluginManager, 'discover', lambda *_, **__: None)
     return npe2pm
 
 


### PR DESCRIPTION
# Description
This doesn't show up on CI, since we don't install npe1 plugins... but this fixes the case of testing locally with some npe1 plugins installed.  (I think we had this before, but then might have removed it when fully converting our builtins to npe2)