### PR TITLE
Add "select all" to points and shapes layer

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_points_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_points_layer.py
@@ -14,3 +14,46 @@ def test_out_of_slice_display_checkbox(qtbot):
     assert layer.out_of_slice_display is False
     combo.setChecked(True)
     assert layer.out_of_slice_display is True
+
+
+def test_select_all_selects_value_change(qtbot):
+    layer = Points(
+        np.random.rand(10, 2), size=5, edge_color='red', face_color='red'
+    )
+    qtctrl = QtPointsControls(layer)
+    qtbot.addWidget(qtctrl)
+    size_ctrl = qtctrl.sizeSlider
+    face_ctrl = qtctrl.faceColorEdit
+    edge_ctrl = qtctrl.edgeColorEdit
+    select_all_ctrl = qtctrl.selectAllCheckBox
+
+    np.testing.assert_array_equal(layer.size, [[5] * 2] * 10)
+    assert layer.current_size == 5
+    np.testing.assert_almost_equal(layer.edge_color, [[1, 0, 0, 1]] * 10)
+    assert layer.current_edge_color == 'red'
+    np.testing.assert_almost_equal(layer.face_color, [[1, 0, 0, 1]] * 10)
+    assert layer.current_face_color == 'red'
+
+    size_ctrl.setValue(10)
+    face_ctrl.setColor('green')
+    edge_ctrl.setColor('green')
+
+    np.testing.assert_array_equal(layer.size, [[5] * 2] * 10)
+    assert layer.current_size == 10
+    np.testing.assert_almost_equal(layer.face_color, [[1, 0, 0, 1]] * 10)
+    assert layer.current_face_color == 'green'
+    np.testing.assert_almost_equal(layer.edge_color, [[1, 0, 0, 1]] * 10)
+    assert layer.current_edge_color == 'green'
+
+    select_all_ctrl.setChecked(True)
+
+    size_ctrl.setValue(15)
+    face_ctrl.setColor('blue')
+    edge_ctrl.setColor('blue')
+
+    np.testing.assert_array_equal(layer.size, [[15] * 2] * 10)
+    assert layer.current_size == 15
+    np.testing.assert_almost_equal(layer.face_color, [[0, 0, 1, 1]] * 10)
+    assert layer.current_face_color == 'blue'
+    np.testing.assert_almost_equal(layer.edge_color, [[0, 0, 1, 1]] * 10)
+    assert layer.current_edge_color == 'blue'

--- a/napari/_qt/layer_controls/_tests/test_qt_shapes_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_shapes_layer.py
@@ -33,3 +33,51 @@ def test_shape_controls_edge_color(qtbot):
     layer.current_edge_color = 'red'
     target_color = transform_color(layer.current_edge_color)[0]
     np.testing.assert_almost_equal(qtctrl.edgeColorEdit.color, target_color)
+
+
+def test_select_all_selects_value_change(qtbot):
+    layer = Shapes(
+        _SHAPES,
+        shape_type='polygon',
+        edge_width=5,
+        edge_color='red',
+        face_color='red',
+    )
+
+    qtctrl = QtShapesControls(layer)
+    qtbot.addWidget(qtctrl)
+    size_ctrl = qtctrl.widthSlider
+    face_ctrl = qtctrl.faceColorEdit
+    edge_ctrl = qtctrl.edgeColorEdit
+    select_all_ctrl = qtctrl.selectAllCheckBox
+
+    np.testing.assert_array_equal(layer.edge_width, [5] * 10)
+    assert layer.current_edge_width == 5
+    np.testing.assert_almost_equal(layer.edge_color, [[1, 0, 0, 1]] * 10)
+    assert layer.current_edge_color == 'red'
+    np.testing.assert_almost_equal(layer.face_color, [[1, 0, 0, 1]] * 10)
+    assert layer.current_face_color == 'red'
+
+    size_ctrl.setValue(10)
+    face_ctrl.setColor('green')
+    edge_ctrl.setColor('green')
+
+    np.testing.assert_array_equal(layer.edge_width, [5] * 10)
+    assert layer.current_edge_width == 10
+    np.testing.assert_almost_equal(layer.face_color, [[1, 0, 0, 1]] * 10)
+    assert layer.current_face_color == 'green'
+    np.testing.assert_almost_equal(layer.edge_color, [[1, 0, 0, 1]] * 10)
+    assert layer.current_edge_color == 'green'
+
+    select_all_ctrl.setChecked(True)
+
+    size_ctrl.setValue(15)
+    face_ctrl.setColor('blue')
+    edge_ctrl.setColor('blue')
+
+    np.testing.assert_array_equal(layer.edge_width, [15] * 10)
+    assert layer.current_edge_width == 15
+    np.testing.assert_almost_equal(layer.face_color, [[0, 0, 1, 1]] * 10)
+    assert layer.current_face_color == 'blue'
+    np.testing.assert_almost_equal(layer.edge_color, [[0, 0, 1, 1]] * 10)
+    assert layer.current_edge_color == 'blue'

--- a/napari/_qt/layer_controls/_tests/test_qt_shapes_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_shapes_layer.py
@@ -38,7 +38,6 @@ def test_shape_controls_edge_color(qtbot):
 def test_select_all_selects_value_change(qtbot):
     layer = Shapes(
         _SHAPES,
-        shape_type='polygon',
         edge_width=5,
         edge_color='red',
         face_color='red',

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -48,6 +48,8 @@ class QtPointsControls(QtLayerControls):
         An instance of a napari Points layer.
     outOfSliceCheckBox : qtpy.QtWidgets.QCheckBox
         Checkbox to indicate whether to render out of slice.
+    selectAllCheckBox : qtpy.QtWidgets.QCheckBox
+        Checkbox to indicate whether to influence all components
     panzoom_button : qtpy.QtWidgets.QtModeRadioButton
         Button for pan/zoom mode.
     select_button : qtpy.QtWidgets.QtModeRadioButton

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -135,6 +135,10 @@ class QtPointsControls(QtLayerControls):
         out_of_slice_cb.stateChanged.connect(self.change_out_of_slice)
         self.outOfSliceCheckBox = out_of_slice_cb
 
+        select_all_cb = QCheckBox()
+        select_all_cb.setToolTip(trans._('Select all'))
+        self.selectAllCheckBox = select_all_cb
+
         self.select_button = QtModeRadioButton(
             layer,
             'select_points',
@@ -193,6 +197,7 @@ class QtPointsControls(QtLayerControls):
         self.layout().addRow(trans._('edge color:'), self.edgeColorEdit)
         self.layout().addRow(trans._('display text:'), self.textDispCheckBox)
         self.layout().addRow(trans._('out of slice:'), self.outOfSliceCheckBox)
+        self.layout().addRow(trans._('select all:'), self.selectAllCheckBox)
 
     def _on_mode_change(self, event):
         """Update ticks in checkbox widgets when points layer mode is changed.
@@ -243,6 +248,8 @@ class QtPointsControls(QtLayerControls):
             Size of points.
         """
         self.layer.current_size = value
+        if self.selectAllCheckBox.isChecked():
+            self.layer.size = value
 
     def change_out_of_slice(self, state):
         """Toggleout of slice display of points layer.
@@ -292,12 +299,16 @@ class QtPointsControls(QtLayerControls):
         """Update face color of layer model from color picker user input."""
         with self.layer.events.current_face_color.blocker():
             self.layer.current_face_color = color
+            if self.selectAllCheckBox.isChecked():
+                self.layer.face_color = color
 
     @Slot(np.ndarray)
     def changeEdgeColor(self, color: np.ndarray):
         """Update edge color of layer model from color picker user input."""
         with self.layer.events.current_edge_color.blocker():
             self.layer.current_edge_color = color
+            if self.selectAllCheckBox.isChecked():
+                self.layer.edge_color = color
 
     def _on_current_face_color_change(self):
         """Receive layer.current_face_color() change event and update view."""

--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -74,6 +74,8 @@ class QtShapesControls(QtLayerControls):
         Button to remove vertex from shapes.
     widthSlider : qtpy.QtWidgets.QSlider
         Slider controlling line edge width of shapes.
+    selectAllCheckBox : qtpy.QtWidgets.QCheckBox
+        Checkbox to indicate whether to influence all components
 
     Raises
     ------

--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -293,6 +293,10 @@ class QtShapesControls(QtLayerControls):
         text_disp_cb.stateChanged.connect(self.change_text_visibility)
         self.textDispCheckBox = text_disp_cb
 
+        select_all_cb = QCheckBox()
+        select_all_cb.setToolTip(trans._('Select all'))
+        self.selectAllCheckBox = select_all_cb
+
         self.layout().addRow(button_grid)
         self.layout().addRow(trans._('opacity:'), self.opacitySlider)
         self.layout().addRow(trans._('edge width:'), self.widthSlider)
@@ -300,6 +304,7 @@ class QtShapesControls(QtLayerControls):
         self.layout().addRow(trans._('face color:'), self.faceColorEdit)
         self.layout().addRow(trans._('edge color:'), self.edgeColorEdit)
         self.layout().addRow(trans._('display text:'), self.textDispCheckBox)
+        self.layout().addRow(trans._('select all:'), self.selectAllCheckBox)
 
     def _on_mode_change(self, event):
         """Update ticks in checkbox widgets when shapes layer mode changed.
@@ -359,6 +364,8 @@ class QtShapesControls(QtLayerControls):
         """
         with self.layer.events.current_face_color.blocker():
             self.layer.current_face_color = color
+            if self.selectAllCheckBox.isChecked():
+                self.layer.face_color = color
 
     def changeEdgeColor(self, color: np.ndarray):
         """Change edge color of shapes.
@@ -371,6 +378,8 @@ class QtShapesControls(QtLayerControls):
         """
         with self.layer.events.current_edge_color.blocker():
             self.layer.current_edge_color = color
+            if self.selectAllCheckBox.isChecked():
+                self.layer.edge_color = color
 
     def changeWidth(self, value):
         """Change edge line width of shapes on the layer model.
@@ -381,6 +390,8 @@ class QtShapesControls(QtLayerControls):
             Line width of shapes.
         """
         self.layer.current_edge_width = float(value)
+        if self.selectAllCheckBox.isChecked():
+            self.layer.edge_width = float(value)
 
     def change_text_visibility(self, state):
         """Toggle the visibility of the text.


### PR DESCRIPTION
# Description

I propose to add a new checkbox "select all" for the points and shapes layer.
If checked, changes to the colors, size, and edge_width are propagated to influence all points/shapes of the respective layer. 

![image](https://user-images.githubusercontent.com/18047816/178867985-31f716ea-f4f5-4951-962e-823de8b3593a.png)
![image](https://user-images.githubusercontent.com/18047816/178868022-b962ad76-5e36-4580-9d2d-2f1e8776fc0b.png)


## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# References

Similar ideas have been mentioned here:
https://github.com/napari/napari/issues/702
https://github.com/napari/product-heuristics-2020/issues/19
closes https://github.com/napari/napari/issues/2353

<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [X] the test suite for my feature covers all properties of Shapes and Points covered by my change
- [X] all tests pass with my change

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
