### PR TITLE
Mark NAP-2 as approved

### DIFF
--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -5,11 +5,11 @@
 ```{eval-rst}
 :Author: Jaime Rodríguez-Guerra, Gonzalo Peña-Castellanos
 :Created: 2022-05-05
-:Resolution: <url> (required for Accepted | Rejected | Withdrawn)
-:Resolved: <date resolved, in yyyy-mm-dd format>
+:Resolution: https://github.com/napari/napari/pull/4602#issuecomment-1184061072
+:Resolved: 2022-07-14
 :Status: Draft
-:Type: <Standards Track | Process>
-:Version effective: <version-number> (for accepted NAPs)
+:Type: Standards Track
+:Version effective: N/A
 ```
 
 ## Abstract


### PR DESCRIPTION
@jni as requested in https://github.com/napari/napari/pull/4602#issuecomment-1184061072, I am marking the NAP-2 as approved, with URL and date.

I am not 100% sure about the values for "Type" and "Version effective", so please feel free to fix it if it's not correct right now.

Thanks everyone!

