### PR TITLE
Improve using Qt flags by direct use enums.

### DIFF
--- a/napari/_qt/containers/_base_item_model.py
+++ b/napari/_qt/containers/_base_item_model.py
@@ -132,19 +132,21 @@ class _BaseEventedItemModel(QAbstractItemModel, Generic[ItemType]):
         """
         return 1
 
-    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:
+    def rowCount(self, parent: QModelIndex = None) -> int:
         """Returns the number of rows under the given parent.
 
         When the parent is valid it means that rowCount is returning the number
         of children of parent.
         """
+        if parent is None:
+            parent = QModelIndex()
         try:
             return len(self.getItem(parent))
         except TypeError:
             return 0
 
     def index(
-        self, row: int, column: int = 0, parent: QModelIndex = QModelIndex()
+        self, row: int, column: int = 0, parent: QModelIndex = None
     ) -> QModelIndex:
         """Return a QModelIndex for item at `row`, `column` and `parent`."""
 
@@ -169,6 +171,9 @@ class _BaseEventedItemModel(QAbstractItemModel, Generic[ItemType]):
         #
         # Unfortunately, all of those come at a cost... as this is a very
         # frequently called function :/
+
+        if parent is None:
+            parent = QModelIndex()
 
         return (
             self.createIndex(row, column, self.getItem(parent)[row])

--- a/napari/_qt/containers/_base_item_view.py
+++ b/napari/_qt/containers/_base_item_view.py
@@ -53,7 +53,7 @@ class _BaseEventedItemView(Generic[ItemType]):
 
     def keyPressEvent(self, e: QKeyEvent) -> None:
         """Delete items with delete key."""
-        if e.key() in (Qt.Key_Backspace, Qt.Key_Delete):
+        if e.key() in (Qt.Key.Key_Backspace, Qt.Key.Key_Delete):
             self._root.remove_selected()
             return
         return super().keyPressEvent(e)
@@ -123,8 +123,12 @@ class _BaseEventedItemView(Generic[ItemType]):
 
 def index_of(model: QAbstractItemModel, obj: ItemType) -> QModelIndex:
     """Find the `QModelIndex` for a given object in the model."""
-    fl = Qt.MatchExactly | Qt.MatchRecursive
+    fl = Qt.MatchFlag.MatchExactly | Qt.MatchFlag.MatchRecursive
     hits = model.match(
-        model.index(0, 0, QModelIndex()), Qt.UserRole, obj, hits=1, flags=fl
+        model.index(0, 0, QModelIndex()),
+        Qt.ItemDataRole.UserRole,
+        obj,
+        hits=1,
+        flags=fl,
     )
     return hits[0] if hits else QModelIndex()

--- a/napari/_qt/containers/_layer_delegate.py
+++ b/napari/_qt/containers/_layer_delegate.py
@@ -116,7 +116,7 @@ class LayerDelegate(QStyledItemDelegate):
         # MAGICNUMBER: numbers from the margin applied in the stylesheet to
         # QtLayerTreeView::item
         thumb_rect = option.rect.translated(-2, 2)
-        h = index.data(Qt.SizeHintRole).height() - 4
+        h = index.data(Qt.ItemDataRole.SizeHintRole).height() - 4
         thumb_rect.setWidth(h)
         thumb_rect.setHeight(h)
         image = index.data(ThumbnailRole)
@@ -133,7 +133,9 @@ class LayerDelegate(QStyledItemDelegate):
         self.get_layer_icon(option, index)
         editor = super().createEditor(parent, option, index)
         # make sure editor has same alignment as the display name
-        editor.setAlignment(Qt.Alignment(index.data(Qt.TextAlignmentRole)))
+        editor.setAlignment(
+            Qt.Alignment(index.data(Qt.ItemDataRole.TextAlignmentRole))
+        )
         return editor
 
     def editorEvent(
@@ -149,7 +151,7 @@ class LayerDelegate(QStyledItemDelegate):
         """
         if (
             event.type() == event.MouseButtonRelease
-            and event.button() == Qt.RightButton
+            and event.button() == Qt.MouseButton.RightButton
         ):
             self.show_context_menu(
                 index, model, event.globalPos(), option.widget
@@ -165,12 +167,18 @@ class LayerDelegate(QStyledItemDelegate):
                 style.SE_ItemViewItemCheckIndicator, option, option.widget
             )
             if check_rect.contains(event.pos()):
-                cur_state = index.data(Qt.CheckStateRole)
-                if model.flags(index) & Qt.ItemIsUserTristate:
+                cur_state = index.data(Qt.ItemDataRole.CheckStateRole)
+                if model.flags(index) & Qt.ItemFlag.ItemIsUserTristate:
                     state = Qt.CheckState((cur_state + 1) % 3)
                 else:
-                    state = Qt.Unchecked if cur_state else Qt.Checked
-                return model.setData(index, state, Qt.CheckStateRole)
+                    state = (
+                        Qt.CheckState.Unchecked
+                        if cur_state
+                        else Qt.CheckState.Checked
+                    )
+                return model.setData(
+                    index, state, Qt.ItemDataRole.CheckStateRole
+                )
         # refer all other events to the QStyledItemDelegate
         return super().editorEvent(event, model, option, index)
 

--- a/napari/_qt/containers/qt_layer_list.py
+++ b/napari/_qt/containers/qt_layer_list.py
@@ -24,7 +24,7 @@ class ReverseProxyModel(QSortFilterProxyModel):
         super().__init__()
         self.setSourceModel(model)
         self.setSortRole(SortRole)
-        self.sort(0, Qt.DescendingOrder)
+        self.sort(0, Qt.SortOrder.DescendingOrder)
 
     def dropMimeData(self, data, action, destRow, col, parent):
         """Handle destination row for dropping with reversed indices."""

--- a/napari/_qt/containers/qt_layer_model.py
+++ b/napari/_qt/containers/qt_layer_model.py
@@ -1,3 +1,5 @@
+import typing
+
 from qtpy.QtCore import QModelIndex, QSize, Qt
 from qtpy.QtGui import QImage
 
@@ -13,17 +15,20 @@ class QtLayerListModel(QtListModel[Layer]):
         if not index.isValid():
             return None
         layer = self.getItem(index)
-        if role == Qt.DisplayRole:  # used for item text
+        if role == Qt.ItemDataRole.DisplayRole:  # used for item text
             return layer.name
-        if role == Qt.TextAlignmentRole:  # alignment of the text
+        if role == Qt.ItemDataRole.TextAlignmentRole:  # alignment of the text
             return Qt.AlignCenter
-        if role == Qt.EditRole:  # used to populate line edit when editing
+        if role == Qt.ItemDataRole.EditRole:
+            # used to populate line edit when editing
             return layer.name
-        if role == Qt.ToolTipRole:  # for tooltip
+        if role == Qt.ItemDataRole.ToolTipRole:  # for tooltip
             return layer.name
-        if role == Qt.CheckStateRole:  # the "checked" state of this item
+        if (
+            role == Qt.ItemDataRole.CheckStateRole
+        ):  # the "checked" state of this item
             return Qt.Checked if layer.visible else Qt.Unchecked
-        if role == Qt.SizeHintRole:  # determines size of item
+        if role == Qt.ItemDataRole.SizeHintRole:  # determines size of item
             return QSize(200, 34)
         if role == ThumbnailRole:  # return the thumbnail
             thumbnail = layer.thumbnail
@@ -35,16 +40,21 @@ class QtLayerListModel(QtListModel[Layer]):
             )
         # normally you'd put the icon in DecorationRole, but we do that in the
         # # LayerDelegate which is aware of the theme.
-        # if role == Qt.DecorationRole:  # icon to show
+        # if role == Qt.ItemDataRole.DecorationRole:  # icon to show
         #     pass
         return super().data(index, role)
 
-    def setData(self, index: QModelIndex, value, role: int) -> bool:
-        if role == Qt.CheckStateRole:
+    def setData(
+        self,
+        index: QModelIndex,
+        value: typing.Any,
+        role: int = Qt.ItemDataRole.EditRole,
+    ) -> bool:
+        if role == Qt.ItemDataRole.CheckStateRole:
             self.getItem(index).visible = value
-        elif role == Qt.EditRole:
+        elif role == Qt.ItemDataRole.EditRole:
             self.getItem(index).name = value
-            role = Qt.DisplayRole
+            role = Qt.ItemDataRole.DisplayRole
         else:
             return super().setData(index, value, role=role)
 
@@ -59,9 +69,9 @@ class QtLayerListModel(QtListModel[Layer]):
             return
         role = {
             'thumbnail': ThumbnailRole,
-            'visible': Qt.CheckStateRole,
-            'name': Qt.DisplayRole,
-        }.get(event.type, None)
+            'visible': Qt.ItemDataRole.CheckStateRole,
+            'name': Qt.ItemDataRole.DisplayRole,
+        }.get(event.type)
         roles = [role] if role is not None else []
         row = self.index(event.index)
         self.dataChanged.emit(row, row, roles)

--- a/napari/_qt/containers/qt_list_model.py
+++ b/napari/_qt/containers/qt_list_model.py
@@ -59,7 +59,7 @@ class QtListModel(_BaseEventedItemModel[ItemType]):
         bool ``True`` if the `data` and `action` were handled by the model;
             otherwise returns ``False``.
         """
-        if not data or action != Qt.MoveAction:
+        if not data or action != Qt.DropAction.MoveAction:
             return False
         if not data.hasFormat(self.mimeTypes()[0]):
             return False

--- a/napari/_qt/containers/qt_tree_model.py
+++ b/napari/_qt/containers/qt_tree_model.py
@@ -34,9 +34,9 @@ class QtNodeTreeModel(_BaseEventedItemModel[NodeType]):
         its own "ItemDataRole".
         """
         item = self.getItem(index)
-        if role == Qt.DisplayRole:
+        if role == Qt.ItemDataRole.DisplayRole:
             return item._node_name()
-        if role == Qt.UserRole:
+        if role == Qt.ItemDataRole.UserRole:
             return self.getItem(index)
         return None
 
@@ -151,7 +151,7 @@ class QtNodeTreeModel(_BaseEventedItemModel[NodeType]):
         bool ``True`` if the `data` and `action` were handled by the model;
             otherwise returns ``False``.
         """
-        if not data or action != Qt.MoveAction:
+        if not data or action != Qt.DropAction.MoveAction:
             return False
         if not data.hasFormat(self.mimeTypes()[0]):
             return False

--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -70,7 +70,7 @@ class PreferencesDialog(QDialog):
         self._rebuild_dialog()
 
     def keyPressEvent(self, e: 'QKeyEvent'):
-        if e.key() == Qt.Key_Escape:
+        if e.key() == Qt.Key.Key_Escape:
             # escape key should just close the window
             # which implies "accept"
             e.accept()
@@ -146,7 +146,7 @@ class PreferencesDialog(QDialog):
         self._list.addItem(field.field_info.title or field.name)
         self._stack.addWidget(form)
 
-    def _get_page_dict(self, field: 'ModelField') -> Tuple[dict, dict, dict]:
+    def _get_page_dict(self, field: 'ModelField') -> Tuple[dict, dict]:
         """Provides the schema, set of values for each setting, and the
         properties for each setting."""
         ftype = cast('BaseModel', field.type_)

--- a/napari/_qt/dialogs/qt_about.py
+++ b/napari/_qt/dialogs/qt_about.py
@@ -51,19 +51,25 @@ class QtAbout(QDialog):
                 "<b>napari: a multi-dimensional image viewer for python</b>"
             )
         )
-        title_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        title_label.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
         self.layout.addWidget(title_label)
 
         # Add information
         self.infoTextBox = QTextEdit()
-        self.infoTextBox.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.infoTextBox.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
         self.infoTextBox.setLineWrapMode(QTextEdit.NoWrap)
         # Add text copy button
         self.infoCopyButton = QtCopyToClipboardButton(self.infoTextBox)
         self.info_layout = QHBoxLayout()
         self.info_layout.addWidget(self.infoTextBox, 1)
-        self.info_layout.addWidget(self.infoCopyButton, 0, Qt.AlignTop)
-        self.info_layout.setAlignment(Qt.AlignTop)
+        self.info_layout.addWidget(
+            self.infoCopyButton, 0, Qt.AlignmentFlag.AlignTop
+        )
+        self.info_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
         self.layout.addLayout(self.info_layout)
 
         self.infoTextBox.setText(sys_info(as_html=True))
@@ -78,7 +84,9 @@ class QtAbout(QDialog):
         self.citationCopyButton = QtCopyToClipboardButton(self.citationTextBox)
         self.citation_layout = QHBoxLayout()
         self.citation_layout.addWidget(self.citationTextBox, 1)
-        self.citation_layout.addWidget(self.citationCopyButton, 0, Qt.AlignTop)
+        self.citation_layout.addWidget(
+            self.citationCopyButton, 0, Qt.AlignmentFlag.AlignTop
+        )
         self.layout.addLayout(self.citation_layout)
 
         self.setLayout(self.layout)
@@ -96,7 +104,7 @@ class QtAbout(QDialog):
         d = QtAbout(parent)
         d.setObjectName('QtAbout')
         d.setWindowTitle(trans._('About'))
-        d.setWindowModality(Qt.ApplicationModal)
+        d.setWindowModality(Qt.WindowModality.ApplicationModal)
         d.exec_()
 
 

--- a/napari/_qt/dialogs/qt_activity_dialog.py
+++ b/napari/_qt/dialogs/qt_activity_dialog.py
@@ -36,8 +36,10 @@ class ActivityToggleItem(QWidget):
 
         self._activityBtn = QToolButton()
         self._activityBtn.setObjectName("QtActivityButton")
-        self._activityBtn.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
-        self._activityBtn.setArrowType(Qt.UpArrow)
+        self._activityBtn.setToolButtonStyle(
+            Qt.ToolButtonStyle.ToolButtonTextBesideIcon
+        )
+        self._activityBtn.setArrowType(Qt.ArrowType.UpArrow)
         self._activityBtn.setIconSize(QSize(11, 11))
         self._activityBtn.setText(trans._('activity'))
         self._activityBtn.setCheckable(True)
@@ -72,7 +74,9 @@ class QtActivityDialog(QDialog):
         self.setMinimumHeight(self.MIN_HEIGHT)
         self.setMaximumHeight(self.MIN_HEIGHT)
         self.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
-        self.setWindowFlags(Qt.SubWindow | Qt.WindowStaysOnTopHint)
+        self.setWindowFlags(
+            Qt.WindowType.SubWindow | Qt.WindowType.WindowStaysOnTopHint
+        )
         self.setModal(False)
 
         opacityEffect = QGraphicsOpacityEffect(self)
@@ -223,8 +227,7 @@ class QtActivityDialog(QDialog):
         QtLabeledProgressBar
             QtLabeledProgressBar widget associated with this progress object
         """
-        pbars = self._baseWidget.findChildren(QtLabeledProgressBar)
-        if pbars:
+        if pbars := self._baseWidget.findChildren(QtLabeledProgressBar):
             for potential_parent in pbars:
                 if potential_parent.progress is prog:
                     return potential_parent
@@ -265,9 +268,9 @@ class QtActivityDialog(QDialog):
         pbars = self._baseWidget.findChildren(QtLabeledProgressBar)
         pbar_groups = self._baseWidget.findChildren(QtProgressBarGroup)
 
-        progress_visible = any([pbar.isVisible() for pbar in pbars])
+        progress_visible = any(pbar.isVisible() for pbar in pbars)
         progress_group_visible = any(
-            [pbar_group.isVisible() for pbar_group in pbar_groups]
+            pbar_group.isVisible() for pbar_group in pbar_groups
         )
         if not progress_visible and not progress_group_visible:
             self._toggleButton._inProgressIndicator.movie().stop()
@@ -284,8 +287,7 @@ def remove_separators(current_pbars):
         parent and new progress bar to remove separators from
     """
     for current_pbar in current_pbars:
-        line_widg = current_pbar.findChild(QFrame, "QtCustomTitleBarLine")
-        if line_widg:
+        if line_widg := current_pbar.findChild(QFrame, "QtCustomTitleBarLine"):
             current_pbar.layout().removeWidget(line_widg)
             line_widg.hide()
             line_widg.deleteLater()

--- a/napari/_qt/dialogs/qt_modal.py
+++ b/napari/_qt/dialogs/qt_modal.py
@@ -30,8 +30,6 @@ class QtPopup(QDialog):
     ----------
     frame : qtpy.QtWidgets.QFrame
         Frame of the popup dialog box.
-    layout : qtpy.QtWidgets.QVBoxLayout
-        Layout of the popup dialog box.
     """
 
     def __init__(self, parent):
@@ -159,7 +157,7 @@ class QtPopup(QDialog):
         event : qtpy.QtCore.QEvent
             Event from the Qt context.
         """
-        if event.key() in (Qt.Key_Return, Qt.Key_Enter):
+        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
             self.close()
             return
         super().keyPressEvent(event)

--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -91,7 +91,7 @@ class NapariQtNotification(QDialog):
             canvas.resized.connect(self.move_to_bottom_right)
 
         self.setupUi()
-        self.setAttribute(Qt.WA_DeleteOnClose)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         self.setup_buttons(actions)
         self.setMouseTracking(True)
 
@@ -239,7 +239,7 @@ class NapariQtNotification(QDialog):
 
     def setupUi(self):
         """Set up the UI during initialization."""
-        self.setWindowFlags(Qt.SubWindow)
+        self.setWindowFlags(Qt.WindowType.SubWindow)
         self.setMinimumWidth(self.MIN_WIDTH)
         self.setMaximumWidth(self.MIN_WIDTH)
         self.setMinimumHeight(40)
@@ -257,7 +257,9 @@ class NapariQtNotification(QDialog):
         self.severity_icon.setObjectName("severity_icon")
         self.severity_icon.setMinimumWidth(30)
         self.severity_icon.setMaximumWidth(30)
-        self.row1.addWidget(self.severity_icon, alignment=Qt.AlignTop)
+        self.row1.addWidget(
+            self.severity_icon, alignment=Qt.AlignmentFlag.AlignTop
+        )
         self.message = QElidingLabel()
         self.message.setWordWrap(True)
         self.message.setTextInteractionFlags(Qt.TextSelectableByMouse)
@@ -265,28 +267,34 @@ class NapariQtNotification(QDialog):
         self.message.setSizePolicy(
             QSizePolicy.Expanding, QSizePolicy.Expanding
         )
-        self.row1.addWidget(self.message, alignment=Qt.AlignTop)
+        self.row1.addWidget(self.message, alignment=Qt.AlignmentFlag.AlignTop)
         self.expand_button = QPushButton(self.row1_widget)
         self.expand_button.setObjectName("expand_button")
         self.expand_button.setCursor(Qt.PointingHandCursor)
         self.expand_button.setMaximumWidth(20)
         self.expand_button.setFlat(True)
 
-        self.row1.addWidget(self.expand_button, alignment=Qt.AlignTop)
+        self.row1.addWidget(
+            self.expand_button, alignment=Qt.AlignmentFlag.AlignTop
+        )
         self.close_button = QPushButton(self.row1_widget)
         self.close_button.setObjectName("close_button")
         self.close_button.setCursor(Qt.PointingHandCursor)
         self.close_button.setMaximumWidth(20)
         self.close_button.setFlat(True)
 
-        self.row1.addWidget(self.close_button, alignment=Qt.AlignTop)
+        self.row1.addWidget(
+            self.close_button, alignment=Qt.AlignmentFlag.AlignTop
+        )
         self.verticalLayout.addWidget(self.row1_widget, 1)
         self.row2_widget = QWidget(self)
         self.row2_widget.hide()
         self.row2 = QHBoxLayout(self.row2_widget)
         self.source_label = QLabel(self.row2_widget)
         self.source_label.setObjectName("source_label")
-        self.row2.addWidget(self.source_label, alignment=Qt.AlignBottom)
+        self.row2.addWidget(
+            self.source_label, alignment=Qt.AlignmentFlag.AlignBottom
+        )
         self.row2.addStretch()
         self.row2.setContentsMargins(12, 2, 16, 12)
         self.row2_widget.setMaximumHeight(34)
@@ -351,8 +359,6 @@ class NapariQtNotification(QDialog):
 
         from ...utils.notifications import ErrorNotification
 
-        actions = notification.actions
-
         if isinstance(notification, ErrorNotification):
 
             def show_tb(parent):
@@ -385,7 +391,9 @@ class NapariQtNotification(QDialog):
 
                 btn.clicked.connect(_enter_debug_mode)
                 tbdialog.layout().addWidget(text)
-                tbdialog.layout().addWidget(btn, 0, Qt.AlignRight)
+                tbdialog.layout().addWidget(
+                    btn, 0, Qt.AlignmentFlag.AlignRight
+                )
                 tbdialog.show()
 
             actions = tuple(notification.actions) + (

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import sys
 from enum import Enum, auto
@@ -164,10 +165,11 @@ class Installer(QObject):
         if exit_code != 0:
             self._exit_code = 0
 
-        process_to_terminate = []
-        for pkg_list, proc in self._processes.items():
-            if proc == process:
-                process_to_terminate.append(pkg_list)
+        process_to_terminate = [
+            pkg_list
+            for pkg_list, proc in self._processes.items()
+            if proc == process
+        ]
 
         for pkg_list in process_to_terminate:
             process = self._processes.pop(pkg_list)
@@ -203,10 +205,10 @@ class Installer(QObject):
         installer = installer or self._installer_type
         self._queue.insert(
             0,
-            [
+            (
                 tuple(pkg_list),
                 lambda: self._install(pkg_list, installer, channels),
-            ],
+            ),
         )
         self._handle_action()
 
@@ -257,10 +259,10 @@ class Installer(QObject):
         installer = installer or self._installer_type
         self._queue.insert(
             0,
-            [
+            (
                 tuple(pkg_list),
                 lambda: self._uninstall(pkg_list, installer, channels),
-            ],
+            ),
         )
         self._handle_action()
 
@@ -306,11 +308,9 @@ class Installer(QObject):
 
             self._processes = {}
         else:
-            try:
+            with contextlib.suppress(KeyError):
                 process = self._processes.pop(tuple(pkg_list))
                 process.terminate()
-            except KeyError:
-                pass
 
     @staticmethod
     def _is_installed_with_conda():
@@ -328,16 +328,12 @@ class Installer(QObject):
         if conda_meta_path.is_dir():
             for file in conda_meta_path.iterdir():
                 fname = file.parts[-1]
-                if fname.startswith(napari_version_string) and fname.endswith(
-                    ".json"
-                ):
+                if (
+                    fname.startswith(napari_version_string)
+                    or fname.startswith(qt_version_string)
+                ) and fname.endswith(".json"):
                     return True
-                elif fname.startswith(qt_version_string) and fname.endswith(
-                    ".json"
-                ):
-                    return True
-            else:
-                return False
+        return False
 
 
 class PluginListItem(QFrame):
@@ -458,7 +454,9 @@ class PluginListItem(QFrame):
 
         self.package_name = QLabel(self)
         self.package_name.setAlignment(
-            Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter
+            Qt.AlignmentFlag.AlignRight
+            | Qt.AlignmentFlag.AlignTrailing
+            | Qt.AlignmentFlag.AlignVCenter
         )
         self.row1.addWidget(self.package_name)
 
@@ -488,7 +486,7 @@ class PluginListItem(QFrame):
         self.row2 = QHBoxLayout()
         self.error_indicator = QPushButton()
         self.error_indicator.setObjectName("warning_icon")
-        self.error_indicator.setCursor(Qt.PointingHandCursor)
+        self.error_indicator.setCursor(Qt.CursorShape.PointingHandCursor)
         self.error_indicator.hide()
         self.row2.addWidget(self.error_indicator)
         self.row2.setContentsMargins(-1, 4, 0, -1)
@@ -567,7 +565,10 @@ class QPluginList(QListWidget):
     ):
         pkg_name = project_info.name
         # don't add duplicates
-        if self.findItems(pkg_name, Qt.MatchFixedString) and not plugin_name:
+        if (
+            self.findItems(pkg_name, Qt.MatchFlag.MatchFixedString)
+            and not plugin_name
+        ):
             return
 
         # including summary here for sake of filtering below.
@@ -616,7 +617,7 @@ class QPluginList(QListWidget):
 
     def handle_action(self, item, pkg_name, action_name, update=False):
         widget = item.widget
-        item.setText("0-" + item.text())
+        item.setText(f"0-{item.text()}")
         method = getattr(self.installer, action_name)
         self._remove_list.append((pkg_name, item))
         self._warn_dialog = None
@@ -666,7 +667,9 @@ class QPluginList(QListWidget):
         if not is_available:
             return
 
-        for item in self.findItems(project_info.name, Qt.MatchStartsWith):
+        for item in self.findItems(
+            project_info.name, Qt.MatchFlag.MatchStartsWith
+        ):
             current = item.version
             latest = project_info.version
             if parse_version(current) >= parse_version(latest):
@@ -690,7 +693,9 @@ class QPluginList(QListWidget):
         This will disable the item and the install button and add a warning
         icon with a hover tooltip.
         """
-        for item in self.findItems(project_info.name, Qt.MatchStartsWith):
+        for item in self.findItems(
+            project_info.name, Qt.MatchFlag.MatchStartsWith
+        ):
             widget = self.itemWidget(item)
             widget.show_warning(
                 trans._(
@@ -708,7 +713,10 @@ class QPluginList(QListWidget):
         if text:
             # PySide has some issues, so we compare using id
             # See: https://bugreports.qt.io/browse/PYSIDE-74
-            shown = [id(it) for it in self.findItems(text, Qt.MatchContains)]
+            shown = [
+                id(it)
+                for it in self.findItems(text, Qt.MatchFlag.MatchContains)
+            ]
             for i in range(self.count()):
                 item = self.item(i)
                 item.setHidden(id(item) not in shown)
@@ -864,9 +872,9 @@ class QtPluginDialog(QDialog):
         vlay_1 = QVBoxLayout(self)
         self.h_splitter = QSplitter(self)
         vlay_1.addWidget(self.h_splitter)
-        self.h_splitter.setOrientation(Qt.Horizontal)
+        self.h_splitter.setOrientation(Qt.Orientation.Horizontal)
         self.v_splitter = QSplitter(self.h_splitter)
-        self.v_splitter.setOrientation(Qt.Vertical)
+        self.v_splitter.setOrientation(Qt.Orientation.Vertical)
         self.v_splitter.setMinimumWidth(500)
 
         installed = QWidget(self.v_splitter)

--- a/napari/_qt/dialogs/qt_plugin_report.py
+++ b/napari/_qt/dialogs/qt_plugin_report.py
@@ -66,7 +66,7 @@ class QtPluginErrReporter(QDialog):
         self.plugin_manager = plugin_manager
 
         self.setWindowTitle(trans._('Recorded Plugin Exceptions'))
-        self.setWindowModality(Qt.NonModal)
+        self.setWindowModality(Qt.WindowModality.NonModal)
         self.layout = QVBoxLayout()
         self.layout.setSpacing(0)
         self.layout.setContentsMargins(10, 10, 10, 10)
@@ -77,7 +77,9 @@ class QtPluginErrReporter(QDialog):
         self._highlight = Pylighter(
             self.text_area.document(), "python", theme.syntax_style
         )
-        self.text_area.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.text_area.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
         self.text_area.setMinimumWidth(360)
 
         # Create plugin dropdown menu
@@ -109,10 +111,12 @@ class QtPluginErrReporter(QDialog):
         # plugin_meta contains a URL to the home page, (and/or other details)
         self.plugin_meta = QLabel('', parent=self)
         self.plugin_meta.setObjectName("pluginInfo")
-        self.plugin_meta.setTextFormat(Qt.RichText)
-        self.plugin_meta.setTextInteractionFlags(Qt.TextBrowserInteraction)
+        self.plugin_meta.setTextFormat(Qt.TextFormat.RichText)
+        self.plugin_meta.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextBrowserInteraction
+        )
         self.plugin_meta.setOpenExternalLinks(True)
-        self.plugin_meta.setAlignment(Qt.AlignRight)
+        self.plugin_meta.setAlignment(Qt.AlignmentFlag.AlignRight)
 
         # make layout
         row_1_layout = QHBoxLayout()

--- a/napari/_qt/layer_controls/qt_image_controls.py
+++ b/napari/_qt/layer_controls/qt_image_controls.py
@@ -39,8 +39,6 @@ class QtImageControls(QtBaseImageControls):
         Slider controlling attenuation rate for `attenuated_mip` mode.
     attenuationLabel : qtpy.QtWidgets.QLabel
         Label for the attenuation slider widget.
-    grid_layout : qtpy.QtWidgets.QGridLayout
-        Layout of Qt widget controls for the layer.
     interpComboBox : qtpy.QtWidgets.QComboBox
         Dropdown menu to select the interpolation mode for image display.
     interpLabel : qtpy.QtWidgets.QLabel
@@ -85,7 +83,7 @@ class QtImageControls(QtBaseImageControls):
         rendering_options = [i.value for i in ImageRendering]
         renderComboBox.addItems(rendering_options)
         index = renderComboBox.findText(
-            self.layer.rendering, Qt.MatchFixedString
+            self.layer.rendering, Qt.MatchFlag.MatchFixedString
         )
         renderComboBox.setCurrentIndex(index)
         renderComboBox.activated[str].connect(self.changeRendering)
@@ -96,7 +94,7 @@ class QtImageControls(QtBaseImageControls):
         depiction_options = [d.value for d in VolumeDepiction]
         self.depictionComboBox.addItems(depiction_options)
         index = self.depictionComboBox.findText(
-            self.layer.depiction, Qt.MatchFixedString
+            self.layer.depiction, Qt.MatchFlag.MatchFixedString
         )
         self.depictionComboBox.setCurrentIndex(index)
         self.depictionComboBox.activated[str].connect(self.changeDepiction)
@@ -122,7 +120,9 @@ class QtImageControls(QtBaseImageControls):
             self.planeNormalButtons.obliqueButton,
         )
 
-        self.planeThicknessSlider = QLabeledDoubleSlider(Qt.Horizontal, self)
+        self.planeThicknessSlider = QLabeledDoubleSlider(
+            Qt.Orientation.Horizontal, self
+        )
         self.planeThicknessLabel = QLabel(trans._('plane thickness:'))
         self.planeThicknessSlider.setFocusPolicy(Qt.NoFocus)
         self.planeThicknessSlider.setMinimum(1)
@@ -132,8 +132,8 @@ class QtImageControls(QtBaseImageControls):
             self.changePlaneThickness
         )
 
-        sld = QSlider(Qt.Horizontal, parent=self)
-        sld.setFocusPolicy(Qt.NoFocus)
+        sld = QSlider(Qt.Orientation.Horizontal, parent=self)
+        sld.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         sld.setMinimum(0)
         sld.setMaximum(100)
         sld.setSingleStep(1)
@@ -142,8 +142,8 @@ class QtImageControls(QtBaseImageControls):
         self.isoThresholdSlider = sld
         self.isoThresholdLabel = QLabel(trans._('iso threshold:'))
 
-        sld = QSlider(Qt.Horizontal, parent=self)
-        sld.setFocusPolicy(Qt.NoFocus)
+        sld = QSlider(Qt.Orientation.Horizontal, parent=self)
+        sld.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         sld.setMinimum(0)
         sld.setMaximum(100)
         sld.setSingleStep(1)
@@ -284,7 +284,7 @@ class QtImageControls(QtBaseImageControls):
         """Receive layer model rendering change event and update dropdown menu."""
         with self.layer.events.rendering.blocker():
             index = self.renderComboBox.findText(
-                self.layer.rendering, Qt.MatchFixedString
+                self.layer.rendering, Qt.MatchFlag.MatchFixedString
             )
             self.renderComboBox.setCurrentIndex(index)
             self._toggle_rendering_parameter_visbility()
@@ -293,7 +293,7 @@ class QtImageControls(QtBaseImageControls):
         """Receive layer model depiction change event and update combobox."""
         with self.layer.events.depiction.blocker():
             index = self.depictionComboBox.findText(
-                self.layer.depiction, Qt.MatchFixedString
+                self.layer.depiction, Qt.MatchFlag.MatchFixedString
             )
             self.depictionComboBox.setCurrentIndex(index)
             self._toggle_plane_parameter_visibility()
@@ -345,7 +345,9 @@ class QtImageControls(QtBaseImageControls):
             if self.layer._ndisplay == 2
             else self.layer.interpolation3d
         )
-        index = self.interpComboBox.findText(interp, Qt.MatchFixedString)
+        index = self.interpComboBox.findText(
+            interp, Qt.MatchFlag.MatchFixedString
+        )
         self.interpComboBox.setCurrentIndex(index)
 
     def _on_ndisplay_change(self):

--- a/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -34,7 +34,7 @@ class _QDoubleRangeSlider(QDoubleRangeSlider):
         event : napari.utils.event.Event
             The napari event that triggered this method.
         """
-        if event.button() == Qt.RightButton:
+        if event.button() == Qt.MouseButton.RightButton:
             self.parent().show_clim_popupup()
         else:
             super().mousePressEvent(event)
@@ -92,7 +92,9 @@ class QtBaseImageControls(QtLayerControls):
         self.colormapComboBox = comboBox
 
         # Create contrast_limits slider
-        self.contrastLimitsSlider = _QDoubleRangeSlider(Qt.Horizontal, self)
+        self.contrastLimitsSlider = _QDoubleRangeSlider(
+            Qt.Orientation.Horizontal, self
+        )
         decimals = range_to_decimals(
             self.layer.contrast_limits_range, self.layer.dtype
         )
@@ -118,7 +120,7 @@ class QtBaseImageControls(QtLayerControls):
         self.autoScaleBar = AutoScaleButtons(layer, self)
 
         # gamma slider
-        sld = QDoubleSlider(Qt.Horizontal, parent=self)
+        sld = QDoubleSlider(Qt.Orientation.Horizontal, parent=self)
         sld.setMinimum(0.2)
         sld.setMaximum(2)
         sld.setSingleStep(0.02)
@@ -172,8 +174,7 @@ class QtBaseImageControls(QtLayerControls):
         """Receive layer model colormap change event and update dropdown menu."""
         name = self.layer.colormap.name
         if name not in self.colormapComboBox._allitems:
-            cm = AVAILABLE_COLORMAPS.get(name)
-            if cm:
+            if cm := AVAILABLE_COLORMAPS.get(name):
                 self.colormapComboBox._allitems.add(name)
                 self.colormapComboBox.addItem(cm._display_name, name)
 
@@ -216,11 +217,11 @@ class AutoScaleButtons(QWidget):
         self.layout().setSpacing(2)
         self.layout().setContentsMargins(0, 0, 0, 0)
         once_btn = QPushButton(trans._('once'))
-        once_btn.setFocusPolicy(Qt.NoFocus)
+        once_btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
 
         auto_btn = QPushButton(trans._('continuous'))
         auto_btn.setCheckable(True)
-        auto_btn.setFocusPolicy(Qt.NoFocus)
+        auto_btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         once_btn.clicked.connect(lambda: auto_btn.setChecked(False))
         connect_no_arg(once_btn.clicked, layer, "reset_contrast_limits")
         connect_setattr(auto_btn.toggled, layer, "_keep_auto_contrast")
@@ -258,7 +259,9 @@ class QContrastLimitsPopup(QRangeSliderPopup):
         reset_btn.setToolTip(trans._("autoscale contrast to data range"))
         reset_btn.setFixedWidth(45)
         reset_btn.clicked.connect(reset)
-        self._layout.addWidget(reset_btn, alignment=Qt.AlignBottom)
+        self._layout.addWidget(
+            reset_btn, alignment=Qt.AlignmentFlag.AlignBottom
+        )
 
         # the "full range" button doesn't do anything if it's not an
         # unsigned integer type (it's unclear what range should be set)
@@ -271,7 +274,9 @@ class QContrastLimitsPopup(QRangeSliderPopup):
             )
             range_btn.setFixedWidth(75)
             range_btn.clicked.connect(layer.reset_contrast_limits_range)
-            self._layout.addWidget(range_btn, alignment=Qt.AlignBottom)
+            self._layout.addWidget(
+                range_btn, alignment=Qt.AlignmentFlag.AlignBottom
+            )
 
 
 def range_to_decimals(range_, dtype):

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -56,8 +56,6 @@ class QtLabelsControls(QtLayerControls):
         Checkbox to control if label layer is contiguous.
     fill_button : qtpy.QtWidgets.QtModeRadioButton
         Button to select FILL mode on Labels layer.
-    grid_layout : qtpy.QtWidgets.QGridLayout
-        Layout of Qt widget controls for the layer.
     layer : napari.layers.Labels
         An instance of a napari Labels layer.
     ndimSpinBox : qtpy.QtWidgets.QSpinBox
@@ -110,11 +108,11 @@ class QtLabelsControls(QtLayerControls):
         self.selectionSpinBox.setRange(*dtype_lims)
         self.selectionSpinBox.setKeyboardTracking(False)
         self.selectionSpinBox.valueChanged.connect(self.changeSelection)
-        self.selectionSpinBox.setAlignment(Qt.AlignCenter)
+        self.selectionSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._on_selected_label_change()
 
-        sld = QSlider(Qt.Horizontal)
-        sld.setFocusPolicy(Qt.NoFocus)
+        sld = QSlider(Qt.Orientation.Horizontal)
+        sld.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         sld.setMinimum(1)
         sld.setMaximum(40)
         sld.setSingleStep(1)
@@ -135,7 +133,7 @@ class QtLabelsControls(QtLayerControls):
         ndim_sb.setMinimum(2)
         ndim_sb.setMaximum(self.layer.ndim)
         ndim_sb.setSingleStep(1)
-        ndim_sb.setAlignment(Qt.AlignCenter)
+        ndim_sb.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._on_n_edit_dimensions_change()
 
         self.contourSpinBox = QLargeIntSpinBox()
@@ -143,7 +141,7 @@ class QtLabelsControls(QtLayerControls):
         self.contourSpinBox.setToolTip(trans._('display contours of labels'))
         self.contourSpinBox.valueChanged.connect(self.change_contour)
         self.contourSpinBox.setKeyboardTracking(False)
-        self.contourSpinBox.setAlignment(Qt.AlignCenter)
+        self.contourSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._on_contour_change()
 
         preserve_labels_cb = QCheckBox()
@@ -163,7 +161,7 @@ class QtLabelsControls(QtLayerControls):
 
         # shuffle colormap button
         self.colormapUpdate = QtModePushButton(
-            None,
+            layer,
             'shuffle',
             slot=self.changeColor,
             tooltip=trans._('shuffle colors'),
@@ -242,7 +240,7 @@ class QtLabelsControls(QtLayerControls):
         rendering_options = [i.value for i in LabelsRendering]
         renderComboBox.addItems(rendering_options)
         index = renderComboBox.findText(
-            self.layer.rendering, Qt.MatchFixedString
+            self.layer.rendering, Qt.MatchFlag.MatchFixedString
         )
         renderComboBox.setCurrentIndex(index)
         renderComboBox.activated[str].connect(self.changeRendering)
@@ -311,9 +309,7 @@ class QtLabelsControls(QtLayerControls):
             self.fill_button.setChecked(True)
         elif mode == Mode.ERASE:
             self.erase_button.setChecked(True)
-        elif mode == Mode.TRANSFORM:
-            pass
-        else:
+        elif mode != Mode.TRANSFORM:
             raise ValueError(trans._("Mode not recognized"))
 
     def changeRendering(self, text):
@@ -351,10 +347,7 @@ class QtLabelsControls(QtLayerControls):
         self.setFocus()
 
     def toggle_selected_mode(self, state):
-        if state == Qt.Checked:
-            self.layer.show_selected_label = True
-        else:
-            self.layer.show_selected_label = False
+        self.layer.show_selected_label = state == Qt.CheckState.Checked
 
     def changeSize(self, value):
         """Change paint brush size.
@@ -374,10 +367,7 @@ class QtLabelsControls(QtLayerControls):
         state : QCheckBox
             Checkbox indicating if labels are contiguous.
         """
-        if state == Qt.Checked:
-            self.layer.contiguous = True
-        else:
-            self.layer.contiguous = False
+        self.layer.contiguous = state == Qt.CheckState.Checked
 
     def change_n_edit_dim(self, value):
         """Change the number of editable dimensions of label layer.
@@ -411,7 +401,7 @@ class QtLabelsControls(QtLayerControls):
         state : QCheckBox
             Checkbox indicating if overwriting label is enabled.
         """
-        self.layer.preserve_labels = state == Qt.Checked
+        self.layer.preserve_labels = state == Qt.CheckState.Checked
 
     def change_color_mode(self):
         """Change color mode of label layer"""
@@ -488,7 +478,7 @@ class QtLabelsControls(QtLayerControls):
         """Receive layer model rendering change event and update dropdown menu."""
         with self.layer.events.rendering.blocker():
             index = self.renderComboBox.findText(
-                self.layer.rendering, Qt.MatchFixedString
+                self.layer.rendering, Qt.MatchFlag.MatchFixedString
             )
             self.renderComboBox.setCurrentIndex(index)
 
@@ -527,7 +517,7 @@ class QtColorBox(QWidget):
         self.layer.events.opacity.connect(self._on_opacity_change)
         self.layer.events.colormap.connect(self._on_colormap_change)
 
-        self.setAttribute(Qt.WA_DeleteOnClose)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
 
         self._height = 24
         self.setFixedWidth(self._height)

--- a/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -29,9 +29,7 @@ class QtLayerControls(QFrame):
     Attributes
     ----------
     blendComboBox : qtpy.QtWidgets.QComboBox
-        Drowpdown widget to select blending mode of layer.
-    grid_layout : qtpy.QtWidgets.QGridLayout
-        Layout of Qt widget controls for the layer.
+        Dropdown widget to select blending mode of layer.
     layer : napari.layers.Layer
         An instance of a napari layer.
     opacitySlider : qtpy.QtWidgets.QSlider
@@ -50,8 +48,8 @@ class QtLayerControls(QFrame):
 
         self.setLayout(LayerFormLayout(self))
 
-        sld = QDoubleSlider(Qt.Horizontal, parent=self)
-        sld.setFocusPolicy(Qt.NoFocus)
+        sld = QDoubleSlider(Qt.Orientation.Horizontal, parent=self)
+        sld.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         sld.setMinimum(0)
         sld.setMaximum(1)
         sld.setSingleStep(0.01)

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -34,16 +34,10 @@ class QtPointsControls(QtLayerControls):
         Button group of points layer modes (ADD, PAN_ZOOM, SELECT).
     delete_button : qtpy.QtWidgets.QtModePushButton
         Button to delete points from layer.
-    edgeColorSwatch : qtpy.QtWidgets.QFrame
-        Color swatch showing shapes edge display color.
-    edgeComboBox : qtpy.QtWidgets.QComboBox
-        Dropdown widget to select display color for shape edges.
-    faceColorSwatch : qtpy.QtWidgets.QFrame
-        Color swatch showing shapes face display color.
-    faceComboBox : qtpy.QtWidgets.QComboBox
-        Dropdown widget to select display color for shape faces.
-    grid_layout : qtpy.QtWidgets.QGridLayout
-        Layout of Qt widget controls for the layer.
+    edgeColorEdit : QColorSwatchEdit
+        Widget to select display color for shape edges.
+    faceColorEdit : QColorSwatchEdit
+        Widget to select display color for shape faces.
     layer : napari.layers.Points
         An instance of a napari Points layer.
     outOfSliceCheckBox : qtpy.QtWidgets.QCheckBox
@@ -90,13 +84,13 @@ class QtPointsControls(QtLayerControls):
         self.layer.events.editable.connect(self._on_editable_change)
         self.layer.text.events.visible.connect(self._on_text_visibility_change)
 
-        sld = QSlider(Qt.Horizontal)
+        sld = QSlider(Qt.Orientation.Horizontal)
         sld.setToolTip(
             trans._(
                 "Change the size of currently selected points and any added afterwards."
             )
         )
-        sld.setFocusPolicy(Qt.NoFocus)
+        sld.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         sld.setMinimum(1)
         sld.setMaximum(100)
         sld.setSingleStep(1)
@@ -219,9 +213,7 @@ class QtPointsControls(QtLayerControls):
             self.select_button.setChecked(True)
         elif mode == Mode.PAN_ZOOM:
             self.panzoom_button.setChecked(True)
-        elif mode == Mode.TRANSFORM:
-            pass
-        else:
+        elif mode != Mode.TRANSFORM:
             raise ValueError(trans._("Mode not recognized {mode}", mode=mode))
 
     def changeSymbol(self, text):
@@ -252,7 +244,7 @@ class QtPointsControls(QtLayerControls):
         state : QCheckBox
             Checkbox indicating whether to render out of slice.
         """
-        self.layer.out_of_slice_display = state == Qt.Checked
+        self.layer.out_of_slice_display = state == Qt.CheckState.Checked
 
     def change_text_visibility(self, state):
         """Toggle the visibility of the text.
@@ -262,7 +254,7 @@ class QtPointsControls(QtLayerControls):
         state : QCheckBox
             Checkbox indicating if text is visible.
         """
-        self.layer.text.visible = state == Qt.Checked
+        self.layer.text.visible = state == Qt.CheckState.Checked
 
     def _on_text_visibility_change(self):
         """Receive layer model text visibiltiy change change event and update checkbox."""

--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -38,18 +38,12 @@ class QtShapesControls(QtLayerControls):
         Button to delete selected shapes
     direct_button : qtpy.QtWidgets.QtModeRadioButton
         Button to select individual vertices in shapes.
-    edgeColorSwatch : qtpy.QtWidgets.QFrame
-        Thumbnail display of points edge color.
-    edgeComboBox : qtpy.QtWidgets.QComboBox
-        Drop down list allowing user to set edge color of points.
+    edgeColorEdit : QColorSwatchEdit
+        Widget allowing user to set edge color of points.
     ellipse_button : qtpy.QtWidgets.QtModeRadioButton
         Button to add ellipses to shapes layer.
-    faceColorSwatch : qtpy.QtWidgets.QFrame
-        Thumbnail display of points face color.
-    faceComboBox : qtpy.QtWidgets.QComboBox
-        Drop down list allowing user to set face color of points.
-    grid_layout : qtpy.QtWidgets.QGridLayout
-        Layout of Qt widget controls for the layer.
+    faceColorEdit : QColorSwatchEdit
+        Widget allowing user to set face color of points.
     layer : napari.layers.Shapes
         An instance of a napari Shapes layer.
     line_button : qtpy.QtWidgets.QtModeRadioButton
@@ -97,8 +91,8 @@ class QtShapesControls(QtLayerControls):
         self.layer.events.editable.connect(self._on_editable_change)
         self.layer.text.events.visible.connect(self._on_text_visibility_change)
 
-        sld = QSlider(Qt.Horizontal)
-        sld.setFocusPolicy(Qt.NoFocus)
+        sld = QSlider(Qt.Orientation.Horizontal)
+        sld.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         sld.setMinimum(0)
         sld.setMaximum(40)
         sld.setSingleStep(1)
@@ -149,7 +143,7 @@ class QtShapesControls(QtLayerControls):
             When shortcuts are modifed/added/removed via the action manager, the
             tooltip will be updated to reflect the new shortcut.
             """
-            action_name = 'napari:' + action_name
+            action_name = f'napari:{action_name}'
             btn = QtModeRadioButton(parent, btn_name, mode, **kwargs)
             action_manager.bind_button(
                 action_name,
@@ -341,9 +335,7 @@ class QtShapesControls(QtLayerControls):
 
         if event.mode in mode_buttons:
             mode_buttons[event.mode].setChecked(True)
-        elif event.mode == Mode.TRANSFORM:
-            pass
-        else:
+        elif event.mode != Mode.TRANSFORM:
             raise ValueError(
                 trans._("Mode '{mode}'not recognized", mode=event.mode)
             )
@@ -390,10 +382,7 @@ class QtShapesControls(QtLayerControls):
         state : QCheckBox
             Checkbox indicating if text is visible.
         """
-        if state == Qt.Checked:
-            self.layer.text.visible = True
-        else:
-            self.layer.text.visible = False
+        self.layer.text.visible = state == Qt.CheckState.Checked
 
     def _on_text_visibility_change(self):
         """Receive layer model text visibiltiy change change event and update checkbox."""

--- a/napari/_qt/layer_controls/qt_surface_controls.py
+++ b/napari/_qt/layer_controls/qt_surface_controls.py
@@ -20,8 +20,6 @@ class QtSurfaceControls(QtBaseImageControls):
 
     Attributes
     ----------
-    grid_layout : qtpy.QtWidgets.QGridLayout
-        Layout of Qt widget controls for the layer.
     layer : napari.layers.Surface
         An instance of a napari Surface layer.
 

--- a/napari/_qt/layer_controls/qt_tracks_controls.py
+++ b/napari/_qt/layer_controls/qt_tracks_controls.py
@@ -22,8 +22,6 @@ class QtTracksControls(QtLayerControls):
 
     Attributes
     ----------
-    grid_layout : qtpy.QtWidgets.QGridLayout
-        Layout of Qt widget controls for the layer.
     layer : layers.Tracks
         An instance of a Tracks layer.
 
@@ -53,22 +51,22 @@ class QtTracksControls(QtLayerControls):
             self.colormap_combobox.addItem(display_name, name)
 
         # slider for track head length
-        self.head_length_slider = QSlider(Qt.Horizontal)
-        self.head_length_slider.setFocusPolicy(Qt.NoFocus)
+        self.head_length_slider = QSlider(Qt.Orientation.Horizontal)
+        self.head_length_slider.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self.head_length_slider.setMinimum(0)
         self.head_length_slider.setMaximum(self.layer._max_length)
         self.head_length_slider.setSingleStep(1)
 
         # slider for track tail length
-        self.tail_length_slider = QSlider(Qt.Horizontal)
-        self.tail_length_slider.setFocusPolicy(Qt.NoFocus)
+        self.tail_length_slider = QSlider(Qt.Orientation.Horizontal)
+        self.tail_length_slider.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self.tail_length_slider.setMinimum(1)
         self.tail_length_slider.setMaximum(self.layer._max_length)
         self.tail_length_slider.setSingleStep(1)
 
         # slider for track edge width
-        self.tail_width_slider = QSlider(Qt.Horizontal)
-        self.tail_width_slider.setFocusPolicy(Qt.NoFocus)
+        self.tail_width_slider = QSlider(Qt.Orientation.Horizontal)
+        self.tail_width_slider.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self.tail_width_slider.setMinimum(1)
         self.tail_width_slider.setMaximum(int(2 * self.layer._max_width))
         self.tail_width_slider.setSingleStep(1)
@@ -144,7 +142,7 @@ class QtTracksControls(QtLayerControls):
             color_by = self.layer.color_by
 
             idx = self.color_by_combobox.findText(
-                color_by, Qt.MatchFixedString
+                color_by, Qt.MatchFlag.MatchFixedString
             )
             self.color_by_combobox.setCurrentIndex(idx)
 

--- a/napari/_qt/layer_controls/qt_vectors_controls.py
+++ b/napari/_qt/layer_controls/qt_vectors_controls.py
@@ -26,18 +26,14 @@ class QtVectorsControls(QtLayerControls):
     ----------
     edge_color_label : qtpy.QtWidgets.QLabel
         Label for edgeColorSwatch
-    edgeColorSwatch : qtpy.QtWidgets.QFrame
-        Color swatch showing display color of vectors.
-    edgeComboBox : qtpy.QtWidgets.QComboBox
-        Dropdown widget to select display color for vectors.
+    edgeColorEdit : QColorSwatchEdit
+        Widget to select display color for vectors.
     color_mode_comboBox : qtpy.QtWidgets.QComboBox
         Dropdown widget to select edge_color_mode for the vectors.
     color_prop_box : qtpy.QtWidgets.QComboBox
         Dropdown widget to select _edge_color_property for the vectors.
     edge_prop_label : qtpy.QtWidgets.QLabel
         Label for color_prop_box
-    grid_layout : qtpy.QtWidgets.QGridLayout
-        Layout of Qt widget controls for the layer.
     layer : napari.layers.Vectors
         An instance of a napari Vectors layer.
     outOfSliceCheckBox : qtpy.QtWidgets.QCheckBox
@@ -208,10 +204,7 @@ class QtVectorsControls(QtLayerControls):
         state : QCheckBox
             Checkbox to indicate whether to render out of slice.
         """
-        if state == Qt.Checked:
-            self.layer.out_of_slice_display = True
-        else:
-            self.layer.out_of_slice_display = False
+        self.layer.out_of_slice_display = state == Qt.CheckState.Checked
 
     def _update_edge_color_gui(self, mode: str):
         """Update the GUI element associated with edge_color.
@@ -223,7 +216,7 @@ class QtVectorsControls(QtLayerControls):
             The new edge_color mode the GUI needs to be updated for.
             Should be: 'direct', 'cycle', 'colormap'
         """
-        if mode in ('cycle', 'colormap'):
+        if mode in {'cycle', 'colormap'}:
             self.edgeColorEdit.setHidden(True)
             self.edge_color_label.setHidden(True)
             self.color_prop_box.setHidden(False)

--- a/napari/_qt/perf/qt_performance.py
+++ b/napari/_qt/perf/qt_performance.py
@@ -36,8 +36,8 @@ class TextLog(QTextEdit):
         time_ms : float
             Duration of the timer in milliseconds.
         """
-        self.moveCursor(QTextCursor.End)
-        self.setTextColor(Qt.red)
+        self.moveCursor(QTextCursor.MoveOperation.End)
+        self.setTextColor(Qt.GlobalColor.red)
         self.insertPlainText(
             trans._("{time_ms:5.0f}ms {name}\n", time_ms=time_ms, name=name)
         )

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -136,8 +136,12 @@ def get_app(
         # automatically determine monitor DPI.
         # Note: this MUST be set before the QApplication is instantiated
         if PYQT5:
-            QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
-            QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps)
+            QApplication.setAttribute(
+                Qt.ApplicationAttribute.AA_EnableHighDpiScaling
+            )
+            QApplication.setAttribute(
+                Qt.ApplicationAttribute.AA_UseHighDpiPixmaps
+            )
 
         argv = sys.argv.copy()
         if sys.platform == "darwin" and not argv[0].endswith("napari"):

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -689,7 +689,7 @@ class Window:
             return dock_widget, wdg
 
         wdg = _instantiate_dock_widget(
-            Widget, cast(self._qt_viewer.viewer, Viewer)
+            Widget, cast('Viewer', self._qt_viewer.viewer)
         )
 
         # Add dock widget

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -722,7 +722,7 @@ class Window:
 
     def add_dock_widget(
         self,
-        widget: Union[QWidget, Widget],
+        widget: Union[QWidget, 'Widget'],
         *,
         name: str = '',
         area: str = 'right',

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -2,6 +2,8 @@
 Custom Qt widgets that serve as native objects that the public-facing elements
 wrap.
 """
+
+import contextlib
 import inspect
 import os
 import sys
@@ -16,6 +18,8 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    Union,
+    cast,
 )
 from weakref import WeakValueDictionary
 
@@ -58,6 +62,7 @@ from .widgets.qt_viewer_status_bar import ViewerStatusBar
 _sentinel = object()
 
 if TYPE_CHECKING:
+    from magicgui.widgets import Widget
     from qtpy.QtGui import QImage
 
     from ..viewer import Viewer
@@ -82,7 +87,7 @@ class _QtMainWindow(QMainWindow):
         self._quit_app = False
 
         self.setWindowIcon(QIcon(self._window_icon))
-        self.setAttribute(Qt.WA_DeleteOnClose)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         self.setUnifiedTitleAndToolBarOnMac(True)
         center = QWidget(self)
         center.setLayout(QHBoxLayout())
@@ -140,25 +145,21 @@ class _QtMainWindow(QMainWindow):
 
     def event(self, e):
         if (
-            e.type() == QEvent.ToolTip
+            e.type() == QEvent.Type.ToolTip
             and self._qt_viewer.viewer.tooltip.visible
         ):
             QToolTip.showText(
                 e.globalPos(), self._qt_viewer.viewer.tooltip.text, self
             )
-        if e.type() == QEvent.Close:
+        if e.type() == QEvent.Type.Close:
             # when we close the MainWindow, remove it from the instances list
-            try:
+            with contextlib.suppress(ValueError):
                 _QtMainWindow._instances.remove(self)
-            except ValueError:
-                pass
-        if e.type() in {QEvent.WindowActivate, QEvent.ZOrderChange}:
+        if e.type() in {QEvent.Type.WindowActivate, QEvent.Type.ZOrderChange}:
             # upon activation or raise_, put window at the end of _instances
-            try:
+            with contextlib.suppress(ValueError):
                 inst = _QtMainWindow._instances
                 inst.append(inst.pop(inst.index(self)))
-            except ValueError:
-                pass
         return super().event(e)
 
     def _load_window_settings(self):
@@ -221,7 +222,7 @@ class _QtMainWindow(QMainWindow):
         Symmetric to the 'get_window_settings' accessor.
         """
         self.setUpdatesEnabled(False)
-        self.setWindowState(Qt.WindowNoState)
+        self.setWindowState(Qt.WindowState.WindowNoState)
 
         if window_position:
             window_position = QPoint(*window_position)
@@ -240,10 +241,10 @@ class _QtMainWindow(QMainWindow):
             self._qt_viewer.dockConsole.setVisible(False)
 
         if window_fullscreen:
-            self.setWindowState(Qt.WindowFullScreen)
+            self.setWindowState(Qt.WindowState.WindowFullScreen)
             self._maximized_flag = window_maximized
         elif window_maximized:
-            self.setWindowState(Qt.WindowMaximized)
+            self.setWindowState(Qt.WindowState.WindowMaximized)
 
         self.setUpdatesEnabled(True)
 
@@ -289,7 +290,7 @@ class _QtMainWindow(QMainWindow):
 
             try:
                 parent = parent.parent()
-            except Exception:
+            except AttributeError:
                 parent = getattr(parent, "_parent", None)
 
     def show(self, block=False):
@@ -301,7 +302,7 @@ class _QtMainWindow(QMainWindow):
 
     def changeEvent(self, event):
         """Handle window state changes."""
-        if event.type() == QEvent.WindowStateChange:
+        if event.type() == QEvent.Type.WindowStateChange:
             # TODO: handle maximization issue. When double clicking on the
             # title bar on Mac the resizeEvent is called an varying amount
             # of times which makes it hard to track the original size before
@@ -349,7 +350,7 @@ class _QtMainWindow(QMainWindow):
 
         # Close any floating dockwidgets
         for dock in self.findChildren(QtViewerDockWidget):
-            if dock.isFloating():
+            if isinstance(dock, QWidget) and dock.isFloating():
                 dock.setFloating(False)
 
         self._save_current_window_settings()
@@ -359,7 +360,7 @@ class _QtMainWindow(QMainWindow):
         # test to complete its draw cycle, then pop back out of fullscreen.
         if self.isFullScreen():
             self.showNormal()
-            for _i in range(5):
+            for _ in range(5):
                 time.sleep(0.1)
                 QApplication.processEvents()
 
@@ -402,8 +403,7 @@ class Window:
         Help menu.
     main_menu : qtpy.QtWidgets.QMainWindow.menuBar
         Main menubar.
-    qt_viewer : QtViewer
-        Contained viewer widget.
+
     view_menu : qtpy.QtWidgets.QMenu
         View menu.
     window_menu : qtpy.QtWidgets.QMenu
@@ -468,7 +468,7 @@ class Window:
                     self._qt_viewer.dockLayerList,
                 ],
                 [self._qt_viewer.dockLayerControls.minimumHeight(), 10000],
-                Qt.Vertical,
+                Qt.Orientation.Vertical,
             )
 
     def _setup_existing_themes(self, connect: bool = True):
@@ -628,22 +628,14 @@ class Window:
         self.main_menu.setVisible(not self.main_menu.isVisible())
         self._main_menu_shortcut.setEnabled(not self.main_menu.isVisible())
 
-    def _tooltip_visibility_toggle(self, value):
-        get_settings().appearance.layer_tooltip_visibility = value
-
-    def _tooltip_visibility_toggled(self, event):
-        self.tooltip_menu.setChecked(
-            get_settings().appearance.layer_tooltip_visibility
-        )
-
-    def _toggle_fullscreen(self, event=None):
+    def _toggle_fullscreen(self):
         """Toggle fullscreen mode."""
         if self._qt_window.isFullScreen():
             self._qt_window.showNormal()
         else:
             self._qt_window.showFullScreen()
 
-    def _toggle_play(self, state=None):
+    def _toggle_play(self):
         """Toggle play."""
         if self._qt_viewer.dims.is_playing:
             self._qt_viewer.dims.stop()
@@ -676,8 +668,7 @@ class Window:
         Widget = None
         dock_kwargs = {}
 
-        result = _npe2.get_widget_contribution(plugin_name, widget_name)
-        if result:
+        if result := _npe2.get_widget_contribution(plugin_name, widget_name):
             Widget, widget_name = result
 
         if Widget is None:
@@ -697,7 +688,9 @@ class Window:
                 wdg = wdg._magic_widget
             return dock_widget, wdg
 
-        wdg = _instantiate_dock_widget(Widget, self._qt_viewer.viewer)
+        wdg = _instantiate_dock_widget(
+            Widget, cast(self._qt_viewer.viewer, Viewer)
+        )
 
         # Add dock widget
         dock_kwargs.pop('name', None)
@@ -729,7 +722,7 @@ class Window:
 
     def add_dock_widget(
         self,
-        widget: QWidget,
+        widget: Union[QWidget, Widget],
         *,
         name: str = '',
         area: str = 'right',
@@ -775,11 +768,8 @@ class Window:
             `dock_widget` that can pass viewer events.
         """
         if not name:
-            try:
+            with contextlib.suppress(AttributeError):
                 name = widget.objectName()
-            except AttributeError:
-                pass
-
             name = name or trans._(
                 "Dock widget {number}",
                 number=self._unnamed_dockwidget_count,
@@ -862,7 +852,9 @@ class Window:
                 _wdg = current_dws_in_area + [dock_widget]
                 # add sizes to push lower widgets up
                 sizes = list(range(1, len(_wdg) * 4, 4))
-                self._qt_window.resizeDocks(_wdg, sizes, Qt.Vertical)
+                self._qt_window.resizeDocks(
+                    _wdg, sizes, Qt.Orientation.Vertical
+                )
 
         if menu:
             action = dock_widget.toggleViewAction()
@@ -909,6 +901,7 @@ class Window:
             return
 
         if not isinstance(widget, QDockWidget):
+            dw: QDockWidget
             for dw in self._qt_window.findChildren(QDockWidget):
                 if dw.widget() is widget:
                     _dw: QDockWidget = dw
@@ -1130,21 +1123,19 @@ class Window:
     def _update_theme(self, event=None):
         """Update widget color theme."""
         settings = get_settings()
-        try:
+        with contextlib.suppress(AttributeError, RuntimeError):
             if event:
                 value = event.value
                 self._qt_viewer.viewer.theme = value
                 settings.appearance.theme = value
             else:
-                if settings.appearance.theme == "system":
-                    value = get_system_theme()
-                else:
-                    value = self._qt_viewer.viewer.theme
+                value = (
+                    get_system_theme()
+                    if settings.appearance.theme == "system"
+                    else self._qt_viewer.viewer.theme
+                )
 
             self._qt_window.setStyleSheet(get_stylesheet(value))
-        except (AttributeError, RuntimeError):
-            # wrapped C/C++ object may have been deleted?
-            pass
 
     def _status_changed(self, event):
         """Update status bar.
@@ -1295,10 +1286,8 @@ class Window:
         _themes.events.removed.disconnect(self._remove_theme)
         self._qt_viewer.viewer.layers.events.disconnect(self.file_menu.update)
         for menu in self.file_menu._INSTANCES:
-            try:
+            with contextlib.suppress(RuntimeError):
                 menu._destroy()
-            except RuntimeError:
-                pass
 
     def close(self):
         """Close the viewer window and cleanup sub-widgets."""

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -805,9 +805,7 @@ class QtViewer(QSplitter):
         size = int(size)
         if cursor == 'square':
             # make sure the square fits within the current canvas
-            if size < 8 or size > (
-                min(*self.viewer.window._qt_viewer.canvas.size) - 4
-            ):
+            if size < 8 or size > (min(*self.canvas.size) - 4):
                 q_cursor = self._cursors['cross']
             else:
                 q_cursor = QCursor(square_pixmap(size))
@@ -1077,7 +1075,7 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : qtpy.QtCore.QDragEvent
             Event from the Qt context.
         """
         if event.mimeData().hasUrls():

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -162,8 +162,6 @@ class QtViewer(QSplitter):
         Dimension sliders; Qt View for Dims model.
     dockConsole : QtViewerDockWidget
         QWidget wrapped in a QDockWidget with forwarded viewer events.
-    aboutKeybindings : QtAboutKeybindings
-        Key bindings for the 'About' Qt dialog.
     dockLayerControls : QtViewerDockWidget
         QWidget wrapped in a QDockWidget with forwarded viewer events.
     dockLayerList : QtViewerDockWidget
@@ -190,7 +188,7 @@ class QtViewer(QSplitter):
 
         super().__init__()
         self._instances.add(self)
-        self.setAttribute(Qt.WA_DeleteOnClose)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
 
         self._show_welcome_screen = show_welcome_screen
 
@@ -272,14 +270,14 @@ class QtViewer(QSplitter):
         main_layout.setSpacing(0)
         main_widget.setLayout(main_layout)
 
-        self.setOrientation(Qt.Vertical)
+        self.setOrientation(Qt.Orientation.Vertical)
         self.addWidget(main_widget)
 
         self._cursors = {
-            'cross': Qt.CrossCursor,
-            'forbidden': Qt.ForbiddenCursor,
-            'pointing': Qt.PointingHandCursor,
-            'standard': QCursor(),
+            'cross': Qt.CursorShape.CrossCursor,
+            'forbidden': Qt.CursorShape.ForbiddenCursor,
+            'pointing': Qt.CursorShape.PointingHandCursor,
+            'standard': Qt.CursorShape.ArrowCursor,
         }
 
         self._on_active_change()
@@ -804,7 +802,7 @@ class QtViewer(QSplitter):
             size = self.viewer.cursor.size * self.viewer.camera.zoom
         else:
             size = self.viewer.cursor.size
-
+        size = int(size)
         if cursor == 'square':
             # make sure the square fits within the current canvas
             if size < 8 or size > (
@@ -1098,10 +1096,13 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : qtpy.QtCore.QDropEvent
             Event from the Qt context.
         """
-        shift_down = QGuiApplication.keyboardModifiers() & Qt.ShiftModifier
+        shift_down = (
+            QGuiApplication.keyboardModifiers()
+            & Qt.KeyboardModifier.ShiftModifier
+        )
         filenames = []
         for url in event.mimeData().urls():
             if url.isLocalFile():
@@ -1123,7 +1124,7 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : qtpy.QtCore.QCloseEvent
             Event from the Qt context.
         """
         self.layers.close()

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -82,7 +82,7 @@ def str_to_qbytearray(string: str) -> QByteArray:
     return QByteArray.fromBase64(string[len(QBYTE_FLAG) :].encode())
 
 
-def QImg2array(img):
+def QImg2array(img) -> np.ndarray:
     """Convert QImage to an array.
 
     Parameters

--- a/napari/_qt/widgets/qt_color_swatch.py
+++ b/napari/_qt/widgets/qt_color_swatch.py
@@ -3,7 +3,7 @@ from typing import Optional, Union
 
 import numpy as np
 from qtpy.QtCore import QEvent, Qt, Signal, Slot
-from qtpy.QtGui import QColor, QKeyEvent
+from qtpy.QtGui import QColor, QKeyEvent, QMouseEvent
 from qtpy.QtWidgets import (
     QColorDialog,
     QCompleter,
@@ -154,7 +154,7 @@ class QColorSwatch(QFrame):
         super().__init__(parent)
         self.setObjectName('colorSwatch')
         self.setToolTip(tooltip or trans._('click to set color'))
-        self.setCursor(Qt.PointingHandCursor)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
 
         self.color_changed.connect(self._update_swatch_style)
         self._color: np.ndarray = TRANSPARENT
@@ -172,9 +172,9 @@ class QColorSwatch(QFrame):
         rgba = f'rgba({",".join(map(lambda x: str(int(x*255)), self._color))})'
         self.setStyleSheet('#colorSwatch {background-color: ' + rgba + ';}')
 
-    def mouseReleaseEvent(self, event: QEvent):
+    def mouseReleaseEvent(self, event: QMouseEvent):
         """Show QColorPopup picker when the user clicks on the swatch."""
-        if event.button() == Qt.LeftButton:
+        if event.button() == Qt.MouseButton.LeftButton:
             initial = QColor(*(255 * self._color).astype('int'))
             popup = QColorPopup(self, initial)
             popup.colorSelected.connect(self.setColor)
@@ -306,8 +306,8 @@ class QColorPopup(QtPopup):
         event : QKeyEvent
             The keypress event that triggered this method.
         """
-        if event.key() in (Qt.Key_Return, Qt.Key_Enter):
+        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
             return self.color_dialog.accept()
-        if event.key() == Qt.Key_Escape:
+        if event.key() == Qt.Key.Key_Escape:
             return self.color_dialog.reject()
         self.color_dialog.keyPressEvent(event)

--- a/napari/_qt/widgets/qt_dims_slider.py
+++ b/napari/_qt/widgets/qt_dims_slider.py
@@ -97,7 +97,7 @@ class QtDimSliderWidget(QWidget):
         layout.addWidget(self.totslice_label)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(2)
-        layout.setAlignment(Qt.AlignVCenter)
+        layout.setAlignment(Qt.AlignmentFlag.AlignVCenter)
         self.setLayout(layout)
         self.dims.events.axis_labels.connect(self._pull_label)
 
@@ -127,7 +127,7 @@ class QtDimSliderWidget(QWidget):
         label.setToolTip(trans._('Edit to change axis label'))
         label.setAcceptDrops(False)
         label.setEnabled(True)
-        label.setAlignment(Qt.AlignRight)
+        label.setAlignment(Qt.AlignmentFlag.AlignRight)
         label.setContentsMargins(0, 0, 2, 0)
         label.textChanged.connect(self._update_label)
         label.editingFinished.connect(self._clear_label_focus)
@@ -145,8 +145,8 @@ class QtDimSliderWidget(QWidget):
         # Set the maximum values of the range slider to be one step less than
         # the range of the layer as otherwise the slider can move beyond the
         # shape of the layer as the endpoint is included
-        slider = ModifiedScrollBar(Qt.Horizontal)
-        slider.setFocusPolicy(Qt.NoFocus)
+        slider = ModifiedScrollBar(Qt.Orientation.Horizontal)
+        slider.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         slider.setMinimum(0)
         slider.setMaximum(self.dims.nsteps[self.axis] - 1)
         slider.setSingleStep(1)
@@ -227,7 +227,7 @@ class QtDimSliderWidget(QWidget):
             self.slider.setPageStep(1)
             self.slider.setValue(self.dims.current_step[self.axis])
             self.totslice_label.setText(str(nsteps))
-            self.totslice_label.setAlignment(Qt.AlignLeft)
+            self.totslice_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
             self._update_slice_labels()
 
     def _update_slider(self):
@@ -238,7 +238,7 @@ class QtDimSliderWidget(QWidget):
     def _update_slice_labels(self):
         """Update slice labels to match current dimension slider position."""
         self.curslice_label.setText(str(self.dims.current_step[self.axis]))
-        self.curslice_label.setAlignment(Qt.AlignRight)
+        self.curslice_label.setAlignment(Qt.AlignmentFlag.AlignRight)
 
     @property
     def fps(self):
@@ -326,7 +326,7 @@ class QtDimSliderWidget(QWidget):
                 trans._('frame_range value must be a list or tuple')
             )
 
-        if value and not len(value) == 2:
+        if value and len(value) != 2:
             raise ValueError(trans._('frame_range must have a length of 2'))
 
         if value is None:
@@ -444,7 +444,7 @@ class QtCustomDoubleSpinBox(QDoubleSpinBox):
         value : float
             The value of this custom double spin box.
         """
-        if QApplication.mouseButtons() & Qt.LeftButton:
+        if QApplication.mouseButtons() & Qt.MouseButton.LeftButton:
             self.editingFinished.emit()
 
     def textFromValue(self, value):
@@ -464,7 +464,7 @@ class QtCustomDoubleSpinBox(QDoubleSpinBox):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : qtpy.QtCore.QKeyEvent
             Event from the Qt context.
         """
         # this is here to intercept Return/Enter keys when editing the FPS
@@ -472,7 +472,7 @@ class QtCustomDoubleSpinBox(QDoubleSpinBox):
         # but if the user is editing the FPS spinbox, we simply want to
         # register the change and lose focus on the lineEdit, in case they
         # want to make an additional change (without reopening the popup)
-        if event.key() in (Qt.Key_Return, Qt.Key_Enter):
+        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
             self.editingFinished.emit()
             self.clearFocus()
             return
@@ -505,7 +505,7 @@ class QtPlayButton(QPushButton):
 
         fpsspin = QtCustomDoubleSpinBox(self.popup)
         fpsspin.setObjectName("fpsSpinBox")
-        fpsspin.setAlignment(Qt.AlignCenter)
+        fpsspin.setAlignment(Qt.AlignmentFlag.AlignCenter)
         fpsspin.setValue(self.fps)
         if hasattr(fpsspin, 'setStepType'):
             # this was introduced in Qt 5.12.  Totally optional, just nice.
@@ -539,15 +539,15 @@ class QtPlayButton(QPushButton):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : qtpy.QtCore.QMouseEvent
             Event from the qt context.
         """
         # using this instead of self.customContextMenuRequested.connect and
         # clicked.connect because the latter was not sending the
         # rightMouseButton release event.
-        if event.button() == Qt.RightButton:
+        if event.button() == Qt.MouseButton.RightButton:
             self.popup.show_above_mouse()
-        elif event.button() == Qt.LeftButton:
+        elif event.button() == Qt.MouseButton.LeftButton:
             self._on_click()
 
     def _on_click(self):

--- a/napari/_qt/widgets/qt_extension2reader.py
+++ b/napari/_qt/widgets/qt_extension2reader.py
@@ -146,7 +146,7 @@ class Extension2ReaderTable(QWidget):
     def _display_no_preferences_found(self):
         self._table.setRowCount(1)
         item = QTableWidgetItem(trans._('No filename preferences found.'))
-        item.setFlags(Qt.NoItemFlags)
+        item.setFlags(Qt.ItemFlag.NoItemFlags)
         self._table.setItem(self._fn_pattern_col, 0, item)
 
     def _add_reader_choice(self, i, plugin_name, display_name):
@@ -166,7 +166,7 @@ class Extension2ReaderTable(QWidget):
             )
             tooltip_text = f'Accepts: {reader_patterns_formatted}'
         self._new_reader_dropdown.setItemData(
-            i, tooltip_text, role=Qt.ToolTipRole
+            i, tooltip_text, role=Qt.ItemDataRole.ToolTipRole
         )
 
     def _filter_compatible_readers(self, new_pattern):
@@ -235,7 +235,7 @@ class Extension2ReaderTable(QWidget):
 
         self._table.insertRow(last_row)
         item = QTableWidgetItem(fn_pattern)
-        item.setFlags(Qt.NoItemFlags)
+        item.setFlags(Qt.ItemFlag.NoItemFlags)
         self._table.setItem(last_row, self._fn_pattern_col, item)
 
         plugin_widg = QWidget()

--- a/napari/_qt/widgets/qt_highlight_preview.py
+++ b/napari/_qt/widgets/qt_highlight_preview.py
@@ -92,12 +92,7 @@ class QtStar(QFrame):
         star_center_x = width / 2
         star_center_y = height / 2
         # make sure the star equal no matter the size of the qframe
-        if width < height:
-            # not taking it all the way to the edge so the star has room to grow
-            radius_outer = width * 0.35
-        else:
-            radius_outer = height * 0.35
-
+        radius_outer = width * 0.35 if width < height else height * 0.35
         # start at the top point of the star and move counter clockwise to draw the path.
         # every other point is the shorter radius (1/(1+golden_ratio)) of the larger radius
         golden_ratio = (1 + np.sqrt(5)) / 2
@@ -188,7 +183,6 @@ class QtTriangle(QFrame):
         qp : QPainter object
         """
         width = self.rect().width()
-        height = self.rect().height()
 
         col = QColor(135, 206, 235)
         qp.setPen(QPen(col, 1))
@@ -255,8 +249,7 @@ class QtTriangle(QFrame):
             Minimum value of triangle.
         """
         self._min_value = value
-        if self._value < value:
-            self._value = value
+        self._value = max(self._value, value)
 
     def setMaximum(self, value: int):
         """Set maximum value.
@@ -268,8 +261,7 @@ class QtTriangle(QFrame):
         """
         self._max_value = value
 
-        if self._value > value:
-            self._value = value
+        self._value = min(self._value, value)
 
     def drawLine(self, qp, value: int):
         """Draw line on triangle indicating value.
@@ -324,7 +316,7 @@ class QtHighlightSizePreviewWidget(QWidget):
         super().__init__(parent)
 
         self.setGeometry(300, 300, 125, 110)
-        self._value = value if value else self.fontMetrics().height()
+        self._value = value or self.fontMetrics().height()
         self._min_value = min_value
         self._max_value = max_value
 
@@ -332,7 +324,7 @@ class QtHighlightSizePreviewWidget(QWidget):
         self._lineedit = QLineEdit()
         self._description = QLabel(self)
         self._unit = QLabel(self)
-        self._slider = QSlider(Qt.Horizontal)
+        self._slider = QSlider(Qt.Orientation.Horizontal)
         self._triangle = QtTriangle(self)
         self._slider_min_label = QLabel(self)
         self._slider_max_label = QLabel(self)
@@ -344,14 +336,14 @@ class QtHighlightSizePreviewWidget(QWidget):
         self._description.setText(description)
         self._description.setWordWrap(True)
         self._unit.setText(unit)
-        self._unit.setAlignment(Qt.AlignBottom)
+        self._unit.setAlignment(Qt.AlignmentFlag.AlignBottom)
         self._lineedit.setValidator(self._validator)
-        self._lineedit.setAlignment(Qt.AlignRight)
-        self._lineedit.setAlignment(Qt.AlignBottom)
+        self._lineedit.setAlignment(Qt.AlignmentFlag.AlignRight)
+        self._lineedit.setAlignment(Qt.AlignmentFlag.AlignBottom)
         self._slider_min_label.setText(str(min_value))
-        self._slider_min_label.setAlignment(Qt.AlignBottom)
+        self._slider_min_label.setAlignment(Qt.AlignmentFlag.AlignBottom)
         self._slider_max_label.setText(str(max_value))
-        self._slider_max_label.setAlignment(Qt.AlignBottom)
+        self._slider_max_label.setAlignment(Qt.AlignmentFlag.AlignBottom)
         self._slider.setMinimum(min_value)
         self._slider.setMaximum(max_value)
         self._preview.setValue(value)
@@ -359,8 +351,8 @@ class QtHighlightSizePreviewWidget(QWidget):
         self._triangle.setMinimum(min_value)
         self._triangle.setMaximum(max_value)
         self._preview_label.setText(trans._("Preview"))
-        self._preview_label.setAlignment(Qt.AlignHCenter)
-        self._preview_label.setAlignment(Qt.AlignBottom)
+        self._preview_label.setAlignment(Qt.AlignmentFlag.AlignHCenter)
+        self._preview_label.setAlignment(Qt.AlignmentFlag.AlignBottom)
         self._preview.setStyleSheet('border: 1px solid white;')
 
         # Signals
@@ -376,33 +368,33 @@ class QtHighlightSizePreviewWidget(QWidget):
         triangle_slider_layout.addLayout(triangle_layout)
         triangle_slider_layout.setContentsMargins(0, 0, 0, 0)
         triangle_slider_layout.addWidget(self._slider)
-        triangle_slider_layout.setAlignment(Qt.AlignVCenter)
+        triangle_slider_layout.setAlignment(Qt.AlignmentFlag.AlignVCenter)
 
         # Bottom row layout
         lineedit_layout = QHBoxLayout()
         lineedit_layout.addWidget(self._lineedit)
-        lineedit_layout.setAlignment(Qt.AlignBottom)
+        lineedit_layout.setAlignment(Qt.AlignmentFlag.AlignBottom)
         bottom_left_layout = QHBoxLayout()
         bottom_left_layout.addLayout(lineedit_layout)
         bottom_left_layout.addWidget(self._unit)
         bottom_left_layout.addWidget(self._slider_min_label)
         bottom_left_layout.addLayout(triangle_slider_layout)
         bottom_left_layout.addWidget(self._slider_max_label)
-        bottom_left_layout.setAlignment(Qt.AlignBottom)
+        bottom_left_layout.setAlignment(Qt.AlignmentFlag.AlignBottom)
 
         left_layout = QVBoxLayout()
         left_layout.addWidget(self._description)
         left_layout.addLayout(bottom_left_layout)
-        left_layout.setAlignment(Qt.AlignLeft)
+        left_layout.setAlignment(Qt.AlignmentFlag.AlignLeft)
 
         preview_label_layout = QHBoxLayout()
         preview_label_layout.addWidget(self._preview_label)
-        preview_label_layout.setAlignment(Qt.AlignHCenter)
+        preview_label_layout.setAlignment(Qt.AlignmentFlag.AlignHCenter)
 
         preview_layout = QVBoxLayout()
         preview_layout.addWidget(self._preview)
         preview_layout.addLayout(preview_label_layout)
-        preview_layout.setAlignment(Qt.AlignCenter)
+        preview_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         layout = QHBoxLayout()
         layout.addLayout(left_layout)
@@ -509,18 +501,7 @@ class QtHighlightSizePreviewWidget(QWidget):
             Minimum highlight value.
         """
         value = int(value)
-        if value < self._max_value:
-            self._min_value = value
-            self._slider_min_label.setText(str(value))
-            self._slider.setMinimum(value)
-            self._triangle.setMinimum(value)
-            self._value = (
-                self._min_value
-                if self._value < self._min_value
-                else self._value
-            )
-            self._refresh()
-        else:
+        if value >= self._max_value:
             raise ValueError(
                 trans._(
                     "Minimum value must be smaller than {max_value}",
@@ -528,6 +509,12 @@ class QtHighlightSizePreviewWidget(QWidget):
                     max_value=self._max_value,
                 )
             )
+        self._min_value = value
+        self._slider_min_label.setText(str(value))
+        self._slider.setMinimum(value)
+        self._triangle.setMinimum(value)
+        self._value = max(self._value, self._min_value)
+        self._refresh()
 
     def minimum(self):
         """Return minimum highlight value.
@@ -548,18 +535,7 @@ class QtHighlightSizePreviewWidget(QWidget):
             Maximum highlight value.
         """
         value = int(value)
-        if value > self._min_value:
-            self._max_value = value
-            self._slider_max_label.setText(str(value))
-            self._slider.setMaximum(value)
-            self._triangle.setMaximum(value)
-            self._value = (
-                self._max_value
-                if self._value > self._max_value
-                else self._value
-            )
-            self._refresh()
-        else:
+        if value <= self._min_value:
             raise ValueError(
                 trans._(
                     "Maximum value must be larger than {min_value}",
@@ -567,6 +543,12 @@ class QtHighlightSizePreviewWidget(QWidget):
                     min_value=self._min_value,
                 )
             )
+        self._max_value = value
+        self._slider_max_label.setText(str(value))
+        self._slider.setMaximum(value)
+        self._triangle.setMaximum(value)
+        self._value = min(self._value, self._max_value)
+        self._refresh()
 
     def maximum(self):
         """Return maximum highlight value.

--- a/napari/_qt/widgets/qt_message_popup.py
+++ b/napari/_qt/widgets/qt_message_popup.py
@@ -15,7 +15,7 @@ class WarnPopup(QDialog):
     ):
         super().__init__(parent)
 
-        self.setWindowFlags(Qt.FramelessWindowHint)
+        self.setWindowFlags(Qt.WindowType.FramelessWindowHint)
 
         # Widgets
         self._message = QLabel()

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -43,8 +43,8 @@ def rst2html(text):
         _text, _link = match.groups()[0].split('<')
         return f'<a href="{_link.rstrip(">")}">{_text.strip()}</a>'
 
-    text = re.sub(r'\*\*([^\*]+)\*\*', '<strong>\\1</strong>', text)
-    text = re.sub(r'\*([^\*]+)\*', '<em>\\1</em>', text)
+    text = re.sub(r'\*\*([^*]+)\*\*', '<strong>\\1</strong>', text)
+    text = re.sub(r'\*([^*]+)\*', '<em>\\1</em>', text)
     text = re.sub(r':[a-z]+:`([^`]+)`', ref, text, re.DOTALL)
     text = re.sub(r'`([^`]+)`_', link, text, re.DOTALL)
     text = re.sub(r'``([^`]+)``', '<code>\\1</code>', text)
@@ -146,7 +146,7 @@ class QtHookImplementationListWidget(QListWidget):
     ----------
     parent : QWidget, optional
         Optional parent widget, by default None
-    hook : HookCaller, optional
+    hook_caller : HookCaller, optional
         The ``HookCaller`` for which to show implementations. by default None
         (i.e. no hooks shown)
 
@@ -165,7 +165,7 @@ class QtHookImplementationListWidget(QListWidget):
         hook_caller: Optional[HookCaller] = None,
     ):
         super().__init__(parent)
-        self.setDefaultDropAction(Qt.MoveAction)
+        self.setDefaultDropAction(Qt.DropAction.MoveAction)
         self.setDragEnabled(True)
         self.setDragDropMode(self.InternalMove)
         self.setSelectionMode(self.SingleSelection)
@@ -228,9 +228,9 @@ class QtHookImplementationListWidget(QListWidget):
         order = [self.item(r).hook_implementation for r in range(self.count())]
         self.order_changed.emit(order)
 
-    def startDrag(self, supportedActions: Qt.DropActions):
+    def startDrag(self, supported_actions):
         drag = drag_with_pixmap(self)
-        drag.exec_(supportedActions, Qt.MoveAction)
+        drag.exec_(supported_actions, Qt.DropAction.MoveAction)
 
     @Slot(list)
     def permute_hook(self, order: List[HookImplementation]):
@@ -305,12 +305,13 @@ class QtPluginSorter(QWidget):
             if not hook_caller.spec:
                 continue
 
-            if firstresult_only:
-                # if the firstresult_only option is set
-                # we only want to include hook_specifications that declare the
-                # "firstresult" option as True.
-                if not hook_caller.spec.opts.get('firstresult', False):
-                    continue
+            # if the firstresult_only option is set
+            # we only want to include hook_specifications that declare the
+            # "firstresult" option as True.
+            if firstresult_only and not hook_caller.spec.opts.get(
+                'firstresult', False
+            ):
+                continue
             self.hook_combo_box.addItem(
                 name.replace("napari_", ""), hook_caller
             )

--- a/napari/_qt/widgets/qt_progress_bar.py
+++ b/napari/_qt/widgets/qt_progress_bar.py
@@ -21,7 +21,7 @@ class QtLabeledProgressBar(QWidget):
         self, parent: Optional[QWidget] = None, prog: progress = None
     ) -> None:
         super().__init__(parent)
-        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
 
         self.progress = prog
 
@@ -84,7 +84,7 @@ class QtProgressBarGroup(QWidget):
         parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(parent)
-        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
 
         pbr_group_layout = QVBoxLayout()
         pbr_group_layout.addWidget(qt_progress_bar)

--- a/napari/_qt/widgets/qt_range_slider_popup.py
+++ b/napari/_qt/widgets/qt_range_slider_popup.py
@@ -6,24 +6,27 @@ from ..dialogs.qt_modal import QtPopup
 
 
 class QRangeSliderPopup(QtPopup):
+    """A popup window that contains a labeled range slider and buttons.
+
+    Parameters
+    ----------
+    parent : QWidget, optional
+        Will like be an instance of QtLayerControls.  Note, providing
+        parent can be useful to inherit stylesheets.
+
+    Attributes
+    ----------
+    slider : QLabeledRangeSlider
+        Slider widget.
+    """
+
     def __init__(self, parent=None):
-        """A popup window that contains a labeled range slider and buttons.
-
-        Parameters
-        ----------
-        parent : QWidget, optional
-            Will like be an instance of QtLayerControls.  Note, providing
-            parent can be useful to inherit stylesheets.
-
-        Attributes
-        ----------
-        slider : QLabeledRangeSlider
-            Slider widget.
-        """
         super().__init__(parent)
 
         # create slider
-        self.slider = QLabeledDoubleRangeSlider(Qt.Horizontal, parent)
+        self.slider = QLabeledDoubleRangeSlider(
+            Qt.Orientation.Horizontal, parent
+        )
         self.slider.label_shift_x = 2
         self.slider.label_shift_y = 2
         self.slider.setFocus()
@@ -41,12 +44,12 @@ class QRangeSliderPopup(QtPopup):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : qtpy.QtCore.QKeyEvent
             Event from the Qt context.
         """
         # we override the parent keyPressEvent so that hitting enter does not
         # hide the window... but we do want to lose focus on the lineEdits
-        if event.key() in (Qt.Key_Return, Qt.Key_Enter):
+        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
             self.slider.setFocus()
             return
         super().keyPressEvent(event)

--- a/napari/_qt/widgets/qt_scrollbar.py
+++ b/napari/_qt/widgets/qt_scrollbar.py
@@ -20,47 +20,48 @@ class ModifiedScrollBar(QScrollBar):
         control = self.style().hitTestComplexControl(
             QStyle.CC_ScrollBar, opt, event.pos(), self
         )
-        if (
-            control == QStyle.SC_ScrollBarAddPage
-            or control == QStyle.SC_ScrollBarSubPage
-        ):
-            # scroll here
-            gr = self.style().subControlRect(
-                QStyle.CC_ScrollBar, opt, QStyle.SC_ScrollBarGroove, self
+        if control not in [
+            QStyle.SC_ScrollBarAddPage,
+            QStyle.SC_ScrollBarSubPage,
+        ]:
+            return
+        # scroll here
+        gr = self.style().subControlRect(
+            QStyle.CC_ScrollBar, opt, QStyle.SC_ScrollBarGroove, self
+        )
+        sr = self.style().subControlRect(
+            QStyle.CC_ScrollBar, opt, QStyle.SC_ScrollBarSlider, self
+        )
+        if self.orientation() == Qt.Horizontal:
+            pos = event.pos().x()
+            slider_length = sr.width()
+            slider_min = gr.x()
+            slider_max = gr.right() - slider_length + 1
+            if self.layoutDirection() == Qt.RightToLeft:
+                opt.upsideDown = not opt.upsideDown
+        else:
+            pos = event.pos().y()
+            slider_length = sr.height()
+            slider_min = gr.y()
+            slider_max = gr.bottom() - slider_length + 1
+        self.setValue(
+            QStyle.sliderValueFromPosition(
+                self.minimum(),
+                self.maximum(),
+                pos - slider_min - slider_length // 2,
+                slider_max - slider_min,
+                opt.upsideDown,
             )
-            sr = self.style().subControlRect(
-                QStyle.CC_ScrollBar, opt, QStyle.SC_ScrollBarSlider, self
-            )
-            if self.orientation() == Qt.Horizontal:
-                pos = event.pos().x()
-                sliderLength = sr.width()
-                sliderMin = gr.x()
-                sliderMax = gr.right() - sliderLength + 1
-                if self.layoutDirection() == Qt.RightToLeft:
-                    opt.upsideDown = not opt.upsideDown
-            else:
-                pos = event.pos().y()
-                sliderLength = sr.height()
-                sliderMin = gr.y()
-                sliderMax = gr.bottom() - sliderLength + 1
-            self.setValue(
-                QStyle.sliderValueFromPosition(
-                    self.minimum(),
-                    self.maximum(),
-                    pos - sliderMin - sliderLength // 2,
-                    sliderMax - sliderMin,
-                    opt.upsideDown,
-                )
-            )
+        )
 
     def mouseMoveEvent(self, event):
-        if event.buttons() & Qt.LeftButton:
+        if event.buttons() & Qt.MouseButton.LeftButton:
             # dragging with the mouse button down should move the slider
             self._move_to_mouse_position(event)
         return super().mouseMoveEvent(event)
 
     def mousePressEvent(self, event):
-        if event.button() == Qt.LeftButton:
+        if event.button() == Qt.MouseButton.LeftButton:
             # clicking the mouse button should move slider to the clicked point
             self._move_to_mouse_position(event)
         return super().mousePressEvent(event)

--- a/napari/_qt/widgets/qt_splash_screen.py
+++ b/napari/_qt/widgets/qt_splash_screen.py
@@ -9,7 +9,10 @@ class NapariSplashScreen(QSplashScreen):
     def __init__(self, width=360):
         get_app()
         pm = QPixmap(NAPARI_ICON_PATH).scaled(
-            width, width, Qt.KeepAspectRatio, Qt.SmoothTransformation
+            width,
+            width,
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.SmoothTransformation,
         )
         super().__init__(pm)
         self.show()

--- a/napari/_qt/widgets/qt_theme_sample.py
+++ b/napari/_qt/widgets/qt_theme_sample.py
@@ -11,7 +11,7 @@ $ python -m napari._qt.theme_sample
 
 To generate a screenshot within python:
 
->>> from napari._qt.theme_sample import SampleWidget
+>>> from napari._qt.widgets.qt_theme_sample import SampleWidget
 >>> widg = SampleWidget(theme='dark')
 >>> screenshot = widg.screenshot()
 """
@@ -104,7 +104,7 @@ class SampleWidget(QWidget):
         chk = QCheckBox('tristate')
         chk.setToolTip('I am a tooltip')
         chk.setTristate(True)
-        chk.setCheckState(Qt.PartiallyChecked)
+        chk.setCheckState(Qt.CheckState.PartiallyChecked)
         chk3 = QCheckBox('checked')
         chk3.setChecked(True)
         hbox.addWidget(QCheckBox('unchecked'))
@@ -114,13 +114,13 @@ class SampleWidget(QWidget):
 
         lay.addWidget(TabDemo(emphasized=emphasized))
 
-        sld = QSlider(Qt.Horizontal)
+        sld = QSlider(Qt.Orientation.Horizontal)
         sld.setValue(50)
         lay.addWidget(sld)
-        scroll = QScrollBar(Qt.Horizontal)
+        scroll = QScrollBar(Qt.Orientation.Horizontal)
         scroll.setValue(50)
         lay.addWidget(scroll)
-        lay.addWidget(QRangeSlider(Qt.Horizontal, self))
+        lay.addWidget(QRangeSlider(Qt.Orientation.Horizontal, self))
         text = QTextEdit()
         text.setMaximumHeight(100)
         text.setHtml(blurb)
@@ -133,7 +133,7 @@ class SampleWidget(QWidget):
         prog = QProgressBar()
         prog.setValue(50)
         lay.addWidget(prog)
-        groupBox = QGroupBox("Exclusive Radio Buttons")
+        group_box = QGroupBox("Exclusive Radio Buttons")
         radio1 = QRadioButton("&Radio button 1")
         radio2 = QRadioButton("R&adio button 2")
         radio3 = QRadioButton("Ra&dio button 3")
@@ -143,8 +143,8 @@ class SampleWidget(QWidget):
         hbox.addWidget(radio2)
         hbox.addWidget(radio3)
         hbox.addStretch(1)
-        groupBox.setLayout(hbox)
-        lay.addWidget(groupBox)
+        group_box.setLayout(hbox)
+        lay.addWidget(group_box)
 
     def screenshot(self, path=None):
         img = self.grab().toImage()

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -23,7 +23,7 @@ from .qt_spinbox import QtSpinBox
 from .qt_tooltip import QtToolTipLabel
 
 if TYPE_CHECKING:
-    from ...viewer import Viewer
+    from ...viewer import ViewerModel
 
 
 class QtLayerButtons(QFrame):
@@ -48,7 +48,7 @@ class QtLayerButtons(QFrame):
         Napari viewer containing the rendered scene, layers, and controls.
     """
 
-    def __init__(self, viewer: 'Viewer'):
+    def __init__(self, viewer: 'ViewerModel'):
         super().__init__()
 
         self.viewer = viewer
@@ -112,7 +112,7 @@ class QtViewerButtons(QFrame):
         Napari viewer containing the rendered scene, layers, and controls.
     """
 
-    def __init__(self, viewer: 'Viewer'):
+    def __init__(self, viewer: 'ViewerModel'):
         super().__init__()
 
         self.viewer = viewer
@@ -126,7 +126,7 @@ class QtViewerButtons(QFrame):
 
         rdb = QtViewerPushButton('roll', action='napari:roll_axes')
         self.rollDimsButton = rdb
-        rdb.setContextMenuPolicy(Qt.CustomContextMenu)
+        rdb.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         rdb.customContextMenuRequested.connect(self._open_roll_popup)
 
         self.transposeDimsButton = QtViewerPushButton(
@@ -141,7 +141,7 @@ class QtViewerButtons(QFrame):
         self.gridViewButton = gvb
         gvb.setCheckable(True)
         gvb.setChecked(viewer.grid.enabled)
-        gvb.setContextMenuPolicy(Qt.CustomContextMenu)
+        gvb.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         gvb.customContextMenuRequested.connect(self._open_grid_popup)
 
         @self.viewer.grid.events.enabled.connect
@@ -154,7 +154,7 @@ class QtViewerButtons(QFrame):
         self.ndisplayButton = ndb
         ndb.setCheckable(True)
         ndb.setChecked(self.viewer.dims.ndisplay == 3)
-        ndb.setContextMenuPolicy(Qt.CustomContextMenu)
+        ndb.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         ndb.customContextMenuRequested.connect(self.open_perspective_popup)
 
         @self.viewer.dims.events.ndisplay.connect
@@ -178,8 +178,8 @@ class QtViewerButtons(QFrame):
             return
 
         # make slider connected to perspective parameter
-        sld = QSlider(Qt.Horizontal, self)
-        sld.setRange(0, max(90, self.viewer.camera.perspective))
+        sld = QSlider(Qt.Orientation.Horizontal, self)
+        sld.setRange(0, max(90, int(self.viewer.camera.perspective)))
         sld.setValue(self.viewer.camera.perspective)
         sld.valueChanged.connect(
             lambda v: setattr(self.viewer.camera, 'perspective', v)
@@ -237,7 +237,7 @@ class QtViewerButtons(QFrame):
         stride_max = self.viewer.grid.__fields__['stride'].type_.le
         stride_not = self.viewer.grid.__fields__['stride'].type_.ne
         grid_stride.setObjectName("gridStrideBox")
-        grid_stride.setAlignment(Qt.AlignCenter)
+        grid_stride.setAlignment(Qt.AlignmentFlag.AlignCenter)
         grid_stride.setRange(stride_min, stride_max)
         grid_stride.setProhibitValue(stride_not)
         grid_stride.setValue(self.viewer.grid.stride)
@@ -247,7 +247,7 @@ class QtViewerButtons(QFrame):
         width_min = self.viewer.grid.__fields__['shape'].sub_fields[1].type_.ge
         width_not = self.viewer.grid.__fields__['shape'].sub_fields[1].type_.ne
         grid_width.setObjectName("gridWidthBox")
-        grid_width.setAlignment(Qt.AlignCenter)
+        grid_width.setAlignment(Qt.AlignmentFlag.AlignCenter)
         grid_width.setMinimum(width_min)
         grid_width.setProhibitValue(width_not)
         grid_width.setValue(self.viewer.grid.shape[1])
@@ -261,7 +261,7 @@ class QtViewerButtons(QFrame):
             self.viewer.grid.__fields__['shape'].sub_fields[0].type_.ne
         )
         grid_height.setObjectName("gridStrideBox")
-        grid_height.setAlignment(Qt.AlignCenter)
+        grid_height.setAlignment(Qt.AlignmentFlag.AlignCenter)
         grid_height.setMinimum(height_min)
         grid_height.setProhibitValue(height_not)
         grid_height.setValue(self.viewer.grid.shape[0])
@@ -399,7 +399,7 @@ class QtDeleteButton(QPushButton):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : qtpy.QtCore.QDropEvent
             Event from the Qt context.
         """
         event.accept()
@@ -450,11 +450,6 @@ class QtViewerPushButton(QPushButton):
         callable to be triggered on button click
     action : str
         action name to be triggered on button click
-
-    Attributes
-    ----------
-    viewer : napari.components.ViewerModel
-        Napari viewer containing the rendered scene, layers, and controls.
     """
 
     @_omit_viewer_args
@@ -522,10 +517,7 @@ class QtStateButton(QtViewerPushButton):
 
     def change(self):
         """Toggle between the multiple states of this button."""
-        if self.isChecked():
-            newstate = self._onstate
-        else:
-            newstate = self._offstate
+        newstate = self._onstate if self.isChecked() else self._offstate
         setattr(self._target, self._attribute, newstate)
 
     def _on_change(self, event=None):

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -2,7 +2,7 @@ import warnings
 from functools import reduce
 from itertools import count
 from operator import ior
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Union
 from weakref import ReferenceType, ref
 
 from qtpy.QtCore import Qt
@@ -21,6 +21,8 @@ from ...utils.translations import trans
 from ..utils import combine_widgets, qt_signals_blocked
 
 if TYPE_CHECKING:
+    from magicgui.widgets import Widget
+
     from ..qt_viewer import QtViewer
 
 counter = count()
@@ -39,7 +41,7 @@ class QtViewerDockWidget(QDockWidget):
     ----------
     qt_viewer : QtViewer
         The QtViewer instance that this dock widget will belong to.
-    widget : QWidget
+    widget : QWidget or magicgui.widgets.Widget
         `widget` that will be added as QDockWidget's main widget.
     name : str
         Name of dock widget.
@@ -66,7 +68,7 @@ class QtViewerDockWidget(QDockWidget):
     def __init__(
         self,
         qt_viewer,
-        widget: QWidget,
+        widget: Union[QWidget, Widget],
         *,
         name: str = '',
         area: str = 'right',
@@ -83,10 +85,10 @@ class QtViewerDockWidget(QDockWidget):
         self._close_btn = close_btn
 
         areas = {
-            'left': Qt.LeftDockWidgetArea,
-            'right': Qt.RightDockWidgetArea,
-            'top': Qt.TopDockWidgetArea,
-            'bottom': Qt.BottomDockWidgetArea,
+            'left': Qt.DockWidgetArea.LeftDockWidgetArea,
+            'right': Qt.DockWidgetArea.RightDockWidgetArea,
+            'top': Qt.DockWidgetArea.TopDockWidgetArea,
+            'bottom': Qt.DockWidgetArea.BottomDockWidgetArea,
         }
         if area not in areas:
             raise ValueError(
@@ -127,7 +129,7 @@ class QtViewerDockWidget(QDockWidget):
                 )
             allowed_areas = reduce(ior, [areas[a] for a in allowed_areas])
         else:
-            allowed_areas = Qt.AllDockWidgetAreas
+            allowed_areas = Qt.DockWidgetArea.AllDockWidgetAreas
         self.setAllowedAreas(allowed_areas)
         self.setMinimumHeight(50)
         self.setMinimumWidth(50)
@@ -223,7 +225,10 @@ class QtViewerDockWidget(QDockWidget):
         return self._ref_qt_viewer().keyPressEvent(event)
 
     def _set_title_orientation(self, area):
-        if area in (Qt.LeftDockWidgetArea, Qt.RightDockWidgetArea):
+        if area in (
+            Qt.DockWidgetArea.LeftDockWidgetArea,
+            Qt.DockWidgetArea.RightDockWidgetArea,
+        ):
             features = self._features
             if features & self.DockWidgetVerticalTitleBar:
                 features = features ^ self.DockWidgetVerticalTitleBar
@@ -237,8 +242,8 @@ class QtViewerDockWidget(QDockWidget):
             par = self.parent()
             if par and hasattr(par, 'dockWidgetArea'):
                 return par.dockWidgetArea(self) in (
-                    Qt.LeftDockWidgetArea,
-                    Qt.RightDockWidgetArea,
+                    Qt.DockWidgetArea.LeftDockWidgetArea,
+                    Qt.DockWidgetArea.RightDockWidgetArea,
                 )
         return self.size().height() > self.size().width()
 
@@ -309,17 +314,17 @@ class QtCustomTitleBar(QLabel):
         self.hide_button = QPushButton(self)
         self.hide_button.setToolTip(trans._('hide this panel'))
         self.hide_button.setObjectName("QTitleBarHideButton")
-        self.hide_button.setCursor(Qt.ArrowCursor)
+        self.hide_button.setCursor(Qt.CursorShape.ArrowCursor)
         self.hide_button.clicked.connect(lambda: self.parent().close())
 
         self.float_button = QPushButton(self)
         self.float_button.setToolTip(trans._('float this panel'))
         self.float_button.setObjectName("QTitleBarFloatButton")
-        self.float_button.setCursor(Qt.ArrowCursor)
+        self.float_button.setCursor(Qt.CursorShape.ArrowCursor)
         self.float_button.clicked.connect(
             lambda: self.parent().setFloating(not self.parent().isFloating())
         )
-        self.title = QLabel(title, self)
+        self.title: QLabel = QLabel(title, self)
         self.title.setSizePolicy(
             QSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Maximum)
         )
@@ -328,7 +333,7 @@ class QtCustomTitleBar(QLabel):
             self.close_button = QPushButton(self)
             self.close_button.setToolTip(trans._('close this panel'))
             self.close_button.setObjectName("QTitleBarCloseButton")
-            self.close_button.setCursor(Qt.ArrowCursor)
+            self.close_button.setCursor(Qt.CursorShape.ArrowCursor)
             self.close_button.clicked.connect(
                 lambda: self.parent().destroyOnClose()
             )
@@ -339,10 +344,16 @@ class QtCustomTitleBar(QLabel):
             layout.setContentsMargins(0, 8, 0, 8)
             line.setFixedWidth(1)
             if close_btn:
-                layout.addWidget(self.close_button, 0, Qt.AlignHCenter)
-            layout.addWidget(self.hide_button, 0, Qt.AlignHCenter)
-            layout.addWidget(self.float_button, 0, Qt.AlignHCenter)
-            layout.addWidget(line, 0, Qt.AlignHCenter)
+                layout.addWidget(
+                    self.close_button, 0, Qt.AlignmentFlag.AlignHCenter
+                )
+            layout.addWidget(
+                self.hide_button, 0, Qt.AlignmentFlag.AlignHCenter
+            )
+            layout.addWidget(
+                self.float_button, 0, Qt.AlignmentFlag.AlignHCenter
+            )
+            layout.addWidget(line, 0, Qt.AlignmentFlag.AlignHCenter)
             self.title.hide()
 
         else:
@@ -359,7 +370,7 @@ class QtCustomTitleBar(QLabel):
             layout.addWidget(self.title)
 
         self.setLayout(layout)
-        self.setCursor(Qt.OpenHandCursor)
+        self.setCursor(Qt.CursorShape.OpenHandCursor)
 
     def sizeHint(self):
         # this seems to be the correct way to set the height of the titlebar

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -69,7 +69,7 @@ class QtViewerDockWidget(QDockWidget):
     def __init__(
         self,
         qt_viewer,
-        widget: Union[QWidget, Widget],
+        widget: Union[QWidget, 'Widget'],
         *,
         name: str = '',
         area: str = 'right',

--- a/napari/_qt/widgets/qt_viewer_status_bar.py
+++ b/napari/_qt/widgets/qt_viewer_status_bar.py
@@ -35,7 +35,9 @@ class ViewerStatusBar(QStatusBar):
         if visible:
             par._activity_dialog.show()
             par._activity_dialog.raise_()
-            self._activity_item._activityBtn.setArrowType(Qt.DownArrow)
+            self._activity_item._activityBtn.setArrowType(
+                Qt.ArrowType.DownArrow
+            )
         else:
             par._activity_dialog.hide()
-            self._activity_item._activityBtn.setArrowType(Qt.UpArrow)
+            self._activity_item._activityBtn.setArrowType(Qt.ArrowType.UpArrow)

--- a/napari/_qt/widgets/qt_welcome.py
+++ b/napari/_qt/widgets/qt_welcome.py
@@ -46,8 +46,8 @@ class QtWelcomeWidget(QWidget):
         # Widget setup
         self.setAutoFillBackground(True)
         self.setAcceptDrops(True)
-        self._image.setAlignment(Qt.AlignCenter)
-        self._label.setAlignment(Qt.AlignCenter)
+        self._image.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         # Layout
         text_layout = QVBoxLayout()
@@ -125,7 +125,7 @@ class QtWelcomeWidget(QWidget):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : qtpy.QtCore.QDragEnterEvent
             Event from the Qt context.
         """
         self._update_property("drag", True)
@@ -141,7 +141,7 @@ class QtWelcomeWidget(QWidget):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : qtpy.QtCore.QDragLeaveEvent
             Event from the Qt context.
         """
         self._update_property("drag", False)
@@ -153,7 +153,7 @@ class QtWelcomeWidget(QWidget):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : qtpy.QtCore.QDropEvent
             Event from the Qt context.
         """
         self._update_property("drag", False)

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -327,7 +327,7 @@ class ActionManager:
 
         return layer_shortcuts
 
-    def _get_layer_actions(self, layer):
+    def _get_layer_actions(self, layer) -> dict:
         """
         Get actions filtered by the given layers.
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

In this PR I change the usage of Qt enums from `Qt.enum_item` to `Qt.Enum_Name.enum_item`. this reduces warnings in PyCharm and improves readability by additional context. 

Also, there are minor fixes by updating docstrings, and simplifying code. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Refactor

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
