### PR TITLE
Make newly added points editable

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -18,6 +18,7 @@ from napari.layers.utils.color_encoding import ConstantColorEncoding
 from napari.layers.utils.color_manager import ColorProperties
 from napari.utils.colormaps.standardize_color import transform_color
 from napari.utils.transforms import CompositeAffine
+from napari.layers.points._points_constants import Mode
 
 
 def _make_cycled_properties(values, length):
@@ -2418,3 +2419,36 @@ def test_empty_data_from_tuple():
     layer = Points(name="points")
     layer2 = Points.create(*layer.as_layer_data_tuple())
     assert layer2.data.size == 0
+
+
+def test_new_point_size_editable():
+    layer = Points(name="Points")
+    layer.mode = Mode.ADD
+    layer.add((0,0))
+
+    current_size = layer.current_size
+
+    new_size = current_size + 10
+    layer.current_size = new_size
+    np.testing.assert_allclose(layer.size[0], [new_size, new_size])
+
+def test_new_point_face_color_editable():
+    layer = Points(name="Points")
+    layer.mode = Mode.ADD
+    layer.add((0,0))
+ 
+    new_color = np.asarray([0., 0., 1., 1.])
+    layer.current_face_color = new_color
+
+    np.testing.assert_allclose(layer.face_color[0], new_color)
+
+    
+def test_new_point_edge_color_editable():
+    layer = Points(name="Points")
+    layer.mode = Mode.ADD
+    layer.add((0,0))
+
+    new_color = np.asarray([0., 0., 1., 1.])
+    layer.current_edge_color = new_color
+
+    np.testing.assert_allclose(layer.edge_color[0], new_color)

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2420,35 +2420,39 @@ def test_empty_data_from_tuple():
     layer2 = Points.create(*layer.as_layer_data_tuple())
     assert layer2.data.size == 0
 
-
-def test_new_point_size_editable():
+@pytest.mark.parametrize(
+    'attribute, new_value',
+    [
+        ("size", [20, 20]),
+        ("face_color", np.asarray([0., 0., 1., 1.])),
+        ("edge_color", np.asarray([0., 0., 1., 1.]))
+    ]
+)
+def test_new_point_size_editable(attribute, new_value):
     layer = Points(name="Points")
     layer.mode = Mode.ADD
     layer.add((0,0))
 
-    current_size = layer.current_size
+    setattr(layer, f"current_{attribute}", new_value)
+    np.testing.assert_allclose(getattr(layer, attribute)[0], new_value)
 
-    new_size = current_size + 10
-    layer.current_size = new_size
-    np.testing.assert_allclose(layer.size[0], [new_size, new_size])
-
-def test_new_point_face_color_editable():
-    layer = Points(name="Points")
-    layer.mode = Mode.ADD
-    layer.add((0,0))
+# def test_new_point_face_color_editable():
+#     layer = Points(name="Points")
+#     layer.mode = Mode.ADD
+#     layer.add((0,0))
  
-    new_color = np.asarray([0., 0., 1., 1.])
-    layer.current_face_color = new_color
+#     new_color = np.asarray([0., 0., 1., 1.])
+#     layer.current_face_color = new_color
 
-    np.testing.assert_allclose(layer.face_color[0], new_color)
+#     np.testing.assert_allclose(layer.face_color[0], new_color)
 
     
-def test_new_point_edge_color_editable():
-    layer = Points(name="Points")
-    layer.mode = Mode.ADD
-    layer.add((0,0))
+# def test_new_point_edge_color_editable():
+#     layer = Points(name="Points")
+#     layer.mode = Mode.ADD
+#     layer.add((0,0))
 
-    new_color = np.asarray([0., 0., 1., 1.])
-    layer.current_edge_color = new_color
+#     new_color = np.asarray([0., 0., 1., 1.])
+#     layer.current_edge_color = new_color
 
-    np.testing.assert_allclose(layer.edge_color[0], new_color)
+#     np.testing.assert_allclose(layer.edge_color[0], new_color)

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2427,11 +2427,12 @@ def test_empty_data_from_tuple():
         ("size", [20, 20]),
         ("face_color", np.asarray([0.0, 0.0, 1.0, 1.0])),
         ("edge_color", np.asarray([0.0, 0.0, 1.0, 1.0])),
+        ("edge_width", np.asarray([0.2]))
     ],
 )
 def test_new_point_size_editable(attribute, new_value):
-    """tests the newly placed points may be edited without re-elescting"""
-    layer = Points(name="Points")
+    """tests the newly placed points may be edited without re-selecting"""
+    layer = Points()
     layer.mode = Mode.ADD
     layer.add((0, 0))
 

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -12,13 +12,13 @@ from napari._tests.utils import (
     check_layer_world_data_extent,
 )
 from napari.layers import Points
+from napari.layers.points._points_constants import Mode
 from napari.layers.points._points_utils import points_to_squares
 from napari.layers.utils._text_constants import Anchor
 from napari.layers.utils.color_encoding import ConstantColorEncoding
 from napari.layers.utils.color_manager import ColorProperties
 from napari.utils.colormaps.standardize_color import transform_color
 from napari.utils.transforms import CompositeAffine
-from napari.layers.points._points_constants import Mode
 
 
 def _make_cycled_properties(values, length):
@@ -2420,34 +2420,36 @@ def test_empty_data_from_tuple():
     layer2 = Points.create(*layer.as_layer_data_tuple())
     assert layer2.data.size == 0
 
+
 @pytest.mark.parametrize(
     'attribute, new_value',
     [
         ("size", [20, 20]),
-        ("face_color", np.asarray([0., 0., 1., 1.])),
-        ("edge_color", np.asarray([0., 0., 1., 1.]))
-    ]
+        ("face_color", np.asarray([0.0, 0.0, 1.0, 1.0])),
+        ("edge_color", np.asarray([0.0, 0.0, 1.0, 1.0])),
+    ],
 )
 def test_new_point_size_editable(attribute, new_value):
     """tests the newly placed points may be edited without re-elescting"""
     layer = Points(name="Points")
     layer.mode = Mode.ADD
-    layer.add((0,0))
+    layer.add((0, 0))
 
     setattr(layer, f"current_{attribute}", new_value)
     np.testing.assert_allclose(getattr(layer, attribute)[0], new_value)
+
 
 # def test_new_point_face_color_editable():
 #     layer = Points(name="Points")
 #     layer.mode = Mode.ADD
 #     layer.add((0,0))
- 
+
 #     new_color = np.asarray([0., 0., 1., 1.])
 #     layer.current_face_color = new_color
 
 #     np.testing.assert_allclose(layer.face_color[0], new_color)
 
-    
+
 # def test_new_point_edge_color_editable():
 #     layer = Points(name="Points")
 #     layer.mode = Mode.ADD

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2436,24 +2436,3 @@ def test_new_point_size_editable(attribute, new_value):
 
     setattr(layer, f"current_{attribute}", new_value)
     np.testing.assert_allclose(getattr(layer, attribute)[0], new_value)
-
-# def test_new_point_face_color_editable():
-#     layer = Points(name="Points")
-#     layer.mode = Mode.ADD
-#     layer.add((0,0))
- 
-#     new_color = np.asarray([0., 0., 1., 1.])
-#     layer.current_face_color = new_color
-
-#     np.testing.assert_allclose(layer.face_color[0], new_color)
-
-    
-# def test_new_point_edge_color_editable():
-#     layer = Points(name="Points")
-#     layer.mode = Mode.ADD
-#     layer.add((0,0))
-
-#     new_color = np.asarray([0., 0., 1., 1.])
-#     layer.current_edge_color = new_color
-
-#     np.testing.assert_allclose(layer.edge_color[0], new_color)

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2429,6 +2429,7 @@ def test_empty_data_from_tuple():
     ]
 )
 def test_new_point_size_editable(attribute, new_value):
+    """tests the newly placed points may be edited without re-elescting"""
     layer = Points(name="Points")
     layer.mode = Mode.ADD
     layer.add((0,0))

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2427,7 +2427,7 @@ def test_empty_data_from_tuple():
         ("size", [20, 20]),
         ("face_color", np.asarray([0.0, 0.0, 1.0, 1.0])),
         ("edge_color", np.asarray([0.0, 0.0, 1.0, 1.0])),
-        ("edge_width", np.asarray([0.2]))
+        ("edge_width", np.asarray([0.2])),
     ],
 )
 def test_new_point_size_editable(attribute, new_value):

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -626,7 +626,6 @@ class Points(Layer):
         if (
             self._update_properties
             and len(self.selected_data) > 0
-            and self._mode != Mode.ADD
         ):
             update_indices = list(self.selected_data)
         self._feature_table.set_currents(
@@ -753,8 +752,7 @@ class Points(Layer):
         self._current_size = size
         if (
             self._update_properties
-            and len(self.selected_data) > 0
-            and self._mode != Mode.ADD
+            and len(self.selected_data) > 0  
         ):
             for i in self.selected_data:
                 self.size[i, :] = (self.size[i, :] > 0) * size
@@ -859,7 +857,6 @@ class Points(Layer):
         if (
             self._update_properties
             and len(self.selected_data) > 0
-            and self._mode != Mode.ADD
         ):
             for i in self.selected_data:
                 self.edge_width[i] = (self.edge_width[i] > 0) * edge_width
@@ -931,7 +928,6 @@ class Points(Layer):
         if (
             self._update_properties
             and len(self.selected_data) > 0
-            and self._mode != Mode.ADD
         ):
             update_indices = list(self.selected_data)
         else:
@@ -1023,7 +1019,6 @@ class Points(Layer):
         if (
             self._update_properties
             and len(self.selected_data) > 0
-            and self._mode != Mode.ADD
         ):
             update_indices = list(self.selected_data)
         else:

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -623,10 +623,7 @@ class Points(Layer):
     @current_properties.setter
     def current_properties(self, current_properties):
         update_indices = None
-        if (
-            self._update_properties
-            and len(self.selected_data) > 0
-        ):
+        if self._update_properties and len(self.selected_data) > 0:
             update_indices = list(self.selected_data)
         self._feature_table.set_currents(
             current_properties, update_indices=update_indices
@@ -750,10 +747,7 @@ class Points(Layer):
     @current_size.setter
     def current_size(self, size: Union[None, float]) -> None:
         self._current_size = size
-        if (
-            self._update_properties
-            and len(self.selected_data) > 0  
-        ):
+        if self._update_properties and len(self.selected_data) > 0:
             for i in self.selected_data:
                 self.size[i, :] = (self.size[i, :] > 0) * size
             self.refresh()
@@ -854,10 +848,7 @@ class Points(Layer):
     @current_edge_width.setter
     def current_edge_width(self, edge_width: Union[None, float]) -> None:
         self._current_edge_width = edge_width
-        if (
-            self._update_properties
-            and len(self.selected_data) > 0
-        ):
+        if self._update_properties and len(self.selected_data) > 0:
             for i in self.selected_data:
                 self.edge_width[i] = (self.edge_width[i] > 0) * edge_width
             self.refresh()
@@ -925,10 +916,7 @@ class Points(Layer):
 
     @current_edge_color.setter
     def current_edge_color(self, edge_color: ColorType) -> None:
-        if (
-            self._update_properties
-            and len(self.selected_data) > 0
-        ):
+        if self._update_properties and len(self.selected_data) > 0:
             update_indices = list(self.selected_data)
         else:
             update_indices = []
@@ -1016,10 +1004,7 @@ class Points(Layer):
     @current_face_color.setter
     def current_face_color(self, face_color: ColorType) -> None:
 
-        if (
-            self._update_properties
-            and len(self.selected_data) > 0
-        ):
+        if self._update_properties and len(self.selected_data) > 0:
             update_indices = list(self.selected_data)
         else:
             update_indices = []


### PR DESCRIPTION
# Description
As per Issue #2234 , newly added points are now selected and able to have their size, face color and edge color changed without re-selecting the point.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #2234 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] the test suite for my feature covers cases regarding changing the following attributes on a newly placed point: `size, face_color, edge_color`
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality (tests are parameterized)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
