### PR TITLE
add path specificity scoring

### DIFF
--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -28,6 +28,9 @@ def test_get_preferred_reader_complex_pattern():
     reader = get_preferred_reader('my-specific-folder/my_file.tif')
     assert reader == 'fake-plugin'
 
+    reader = get_preferred_reader('../my-specific-folder/my_file.tif')
+    assert reader == 'fake-plugin'
+
 
 def test_get_preferred_reader_higher_specificity():
     get_settings().plugins.extension2reader = {
@@ -35,10 +38,12 @@ def test_get_preferred_reader_higher_specificity():
         '*.tif': 'generic-tif-plugin',
         # more nested so higher specificity
         'my-specific-folder/*.tif': 'fake-plugin',
+        # even more nested so even higher specificity
+        'my-specific-folder/nested/*.tif': 'very-specific-plugin',
     }
 
-    reader = get_preferred_reader('my-specific-folder/my_file.tif')
-    assert reader == 'fake-plugin'
+    reader = get_preferred_reader('my-specific-folder/nested/my_file.tif')
+    assert reader == 'very-specific-plugin'
 
 
 def test_get_preferred_reader_no_extension():

--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -157,6 +157,11 @@ def test_score_specificity_collapse_star():
     assert nested == -1
     assert score == [MatchFlag.STAR, MatchFlag.STAR | MatchFlag.ANY]
 
+    relpath, nested, score = score_specificity('*/*/*a?c.tif')
+    assert relpath is True
+    assert nested == 0
+    assert score == [MatchFlag.STAR | MatchFlag.ANY]
+
     relpath, nested, score = score_specificity('*/*/*.tif')
     assert relpath is True
     assert nested == 0

--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -29,6 +29,18 @@ def test_get_preferred_reader_complex_pattern():
     assert reader == 'fake-plugin'
 
 
+def test_get_preferred_reader_higher_specificity():
+    get_settings().plugins.extension2reader = {
+        # less nested so less specificity
+        '*.tif': 'generic-tif-plugin',
+        # more nested so higher specificity
+        'my-specific-folder/*.tif': 'fake-plugin',
+    }
+
+    reader = get_preferred_reader('my-specific-folder/my_file.tif')
+    assert reader == 'fake-plugin'
+
+
 def test_get_preferred_reader_no_extension():
     assert get_preferred_reader('my_file') is None
 

--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -95,87 +95,59 @@ def test_get_preferred_reader_abs_path():
 
 
 def test_score_specificity_simple():
-    relpath, nested, score = score_specificity('')
-    assert relpath is True
-    assert nested == 0
-    assert score == [MatchFlag.NONE]
-
-    relpath, nested, score = score_specificity('a')
-    assert relpath is True
-    assert nested == 0
-    assert score == [MatchFlag.NONE]
-
-    relpath, nested, score = score_specificity('ab*c')
-    assert relpath is True
-    assert nested == 0
-    assert score == [MatchFlag.STAR]
-
-    relpath, nested, score = score_specificity('a?c')
-    assert relpath is True
-    assert nested == 0
-    assert score == [MatchFlag.ANY]
-
-    relpath, nested, score = score_specificity('a[a-zA-Z]c')
-    assert relpath is True
-    assert nested == 0
-    assert score == [MatchFlag.SET]
-
-    relpath, nested, score = score_specificity('*[a-zA-Z]*a?c')
-    assert relpath is True
-    assert nested == 0
-    assert score == [MatchFlag.STAR | MatchFlag.ANY | MatchFlag.SET]
+    assert score_specificity('') == (True, 0, [MatchFlag.NONE])
+    assert score_specificity('a') == (True, 0, [MatchFlag.NONE])
+    assert score_specificity('ab*c') == (True, 0, [MatchFlag.STAR])
+    assert score_specificity('a?c') == (True, 0, [MatchFlag.ANY])
+    assert score_specificity('a[a-zA-Z]c') == (True, 0, [MatchFlag.SET])
+    assert score_specificity('*[a-zA-Z]*a?c') == (
+        True,
+        0,
+        [MatchFlag.STAR | MatchFlag.ANY | MatchFlag.SET],
+    )
 
 
 def test_score_specificity_complex():
-    relpath, nested, score = score_specificity(
-        '*/my-specific-folder/[nested]/*?.tif'
+    assert score_specificity('*/my-specific-folder/[nested]/*?.tif') == (
+        True,
+        -3,
+        [
+            MatchFlag.STAR,
+            MatchFlag.NONE,
+            MatchFlag.SET,
+            MatchFlag.STAR | MatchFlag.ANY,
+        ],
     )
-    assert relpath is True
-    assert nested == -3
-    assert score == [
-        MatchFlag.STAR,
-        MatchFlag.NONE,
-        MatchFlag.SET,
-        MatchFlag.STAR | MatchFlag.ANY,
-    ]
 
-    relpath, nested, score = score_specificity(
-        '/my-specific-folder/[nested]/*?.tif'
+    assert score_specificity('/my-specific-folder/[nested]/*?.tif') == (
+        False,
+        -2,
+        [
+            MatchFlag.NONE,
+            MatchFlag.SET,
+            MatchFlag.STAR | MatchFlag.ANY,
+        ],
     )
-    assert relpath is False
-    assert nested == -2
-    assert score == [
-        MatchFlag.NONE,
-        MatchFlag.SET,
-        MatchFlag.STAR | MatchFlag.ANY,
-    ]
 
 
 def test_score_specificity_collapse_star():
-    relpath, nested, score = score_specificity('*/*/?*.tif')
-    assert relpath is True
-    assert nested == -1
-    assert score == [MatchFlag.STAR, MatchFlag.STAR | MatchFlag.ANY]
-
-    relpath, nested, score = score_specificity('*/*/*a?c.tif')
-    assert relpath is True
-    assert nested == 0
-    assert score == [MatchFlag.STAR | MatchFlag.ANY]
-
-    relpath, nested, score = score_specificity('*/*/*.tif')
-    assert relpath is True
-    assert nested == 0
-    assert score == [MatchFlag.STAR]
-
-    relpath, nested, score = score_specificity('*/abc*/*.tif')
-    assert relpath is True
-    assert nested == -1
-    assert score == [MatchFlag.STAR, MatchFlag.STAR]
-
-    relpath, nested, score = score_specificity('/abc*/*.tif')
-    assert relpath is False
-    assert nested == 0
-    assert score == [MatchFlag.STAR]
+    assert score_specificity('*/*/?*.tif') == (
+        True,
+        -1,
+        [MatchFlag.STAR, MatchFlag.STAR | MatchFlag.ANY],
+    )
+    assert score_specificity('*/*/*a?c.tif') == (
+        True,
+        0,
+        [MatchFlag.STAR | MatchFlag.ANY],
+    )
+    assert score_specificity('*/*/*.tif') == (True, 0, [MatchFlag.STAR])
+    assert score_specificity('*/abc*/*.tif') == (
+        True,
+        -1,
+        [MatchFlag.STAR, MatchFlag.STAR],
+    )
+    assert score_specificity('/abc*/*.tif') == (False, 0, [MatchFlag.STAR])
 
 
 def test_score_specificity_range():

--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -28,7 +28,7 @@ def test_get_preferred_reader_complex_pattern():
     reader = get_preferred_reader('my-specific-folder/my_file.tif')
     assert reader == 'fake-plugin'
 
-    reader = get_preferred_reader('../my-specific-folder/my_file.tif')
+    reader = get_preferred_reader('foo/my-specific-folder/my_file.tif')
     assert reader == 'fake-plugin'
 
 

--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -34,7 +34,27 @@ def test_get_preferred_reader_complex_pattern():
     assert reader == 'fake-plugin'
 
 
-def test_get_preferred_reader_higher_specificity():
+def test_get_preferred_reader_match_less_ambiguous():
+    get_settings().plugins.extension2reader = {
+        # generic star so least specificity
+        '*.tif': 'generic-tif-plugin',
+        # specific file so most specificity
+        '*/foo.tif': 'very-specific-plugin',
+        # set so less specificity
+        '*/file_[0-9][0-9].tif': 'set-plugin',
+    }
+
+    reader = get_preferred_reader('/asdf/a.tif')
+    assert reader == 'generic-tif-plugin'
+
+    reader = get_preferred_reader('/asdf/foo.tif')
+    assert reader == 'very-specific-plugin'
+
+    reader = get_preferred_reader('/asdf/file_01.tif')
+    assert reader == 'set-plugin'
+
+
+def test_get_preferred_reader_more_nested():
     get_settings().plugins.extension2reader = {
         # less nested so less specificity
         '*.tif': 'generic-tif-plugin',
@@ -43,6 +63,12 @@ def test_get_preferred_reader_higher_specificity():
         # even more nested so even higher specificity
         '*/my-specific-folder/nested/*.tif': 'very-specific-plugin',
     }
+
+    reader = get_preferred_reader('/asdf/nested/1/2/3/my_file.tif')
+    assert reader == 'generic-tif-plugin'
+
+    reader = get_preferred_reader('/asdf/my-specific-folder/my_file.tif')
+    assert reader == 'fake-plugin'
 
     reader = get_preferred_reader(
         '/asdf/my-specific-folder/nested/my_file.tif'

--- a/napari/plugins/utils.py
+++ b/napari/plugins/utils.py
@@ -9,14 +9,57 @@ from napari.settings import get_settings
 from . import _npe2, plugin_manager
 
 
-def get_preferred_reader(_path):
-    """Return preferred reader for _path from settings, if one exists."""
+def _get_preferred_readers(path):
+    """Given filepath, find matching readers from preferences.
+
+    Parameters
+    ----------
+    path : str
+        Path of the file.
+
+    Returns
+    -------
+    filtered_preferences : Iterable[Tuple[str, str]]
+        Filtered patterns and their corresponding readers.
+    """
     reader_settings = get_settings().plugins.extension2reader
-    for pattern, reader in reader_settings.items():
+
+    return filter(lambda kv: fnmatch(path, kv[0]), reader_settings.items())
+
+
+def get_preferred_readers(path):
+    """Given filepath, find matching readers from preferences.
+
+    Parameters
+    ----------
+    path : str
+        Path of the file.
+
+    Returns
+    -------
+    filtered_readers : List[str]
+        Preferred readers which match the given filepath.
+    """
+    return [reader for (pattern, reader) in _get_preferred_readers(path)]
+
+
+def get_preferred_reader(path):
+    """Given filepath, find the best matching reader from the preferences.
+
+    Parameters
+    ----------
+    path : str
+        Path of the file.
+
+    Returns
+    -------
+    reader : str
+        Best matching reader, if found.
+    """
+    for pattern, reader in _get_preferred_readers(path):
         # TODO: we return the first one we find - more work should be done here
         # in case other patterns would match - do we return the most specific?
-        if fnmatch(_path, pattern):
-            return reader
+        return reader
 
 
 def get_potential_readers(filename: str) -> Dict[str, str]:

--- a/napari/plugins/utils.py
+++ b/napari/plugins/utils.py
@@ -43,11 +43,7 @@ def score_specificity(pattern):
     """
     pattern = osp.normpath(pattern)
 
-    sep = '/'
-
-    abspath = pattern.startswith(sep)
-
-    segments = pattern.split(sep)
+    segments = pattern.split(osp.sep)
     score = []
     ends_with_star = False
 
@@ -70,7 +66,7 @@ def score_specificity(pattern):
 
         ends_with_star = segment and segment[-1] == '*'
 
-    return not abspath, 1 - len(score), score
+    return not osp.isabs(pattern), 1 - len(score), score
 
 
 def _get_preferred_readers(path):

--- a/napari/plugins/utils.py
+++ b/napari/plugins/utils.py
@@ -64,7 +64,7 @@ def score_specificity(pattern: str) -> Tuple[bool, int, List[MatchFlag]]:
         if '[' in segment and ']' in segment[segment.index('[') :]:
             add(MatchFlag.SET)
 
-        ends_with_star = segment != '' and segment[-1] == '*'
+        ends_with_star = segment.endswith('*')
 
     return not osp.isabs(pattern), 1 - len(score), score
 


### PR DESCRIPTION
# Description
Score an fnmatch pattern, with higher specificities having lower scores.

Absolute paths have highest specificity, followed by paths with the most nesting, then by path segments with the least ambiguity.

replaces #4802

see #4613 