### PR TITLE
Allow empty tuple layer to be returned #4571

### DIFF
--- a/napari/utils/_tests/test_misc.py
+++ b/napari/utils/_tests/test_misc.py
@@ -213,19 +213,23 @@ def test_is_array_type_with_xarray():
     assert not _is_array_type([], 'xarray.DataArray')
     assert not _is_array_type(np.array([]), 'xarray.DataArray')
 
+
 @pytest.mark.parametrize(
     'input, expected',
     [
-        ([ ([1,10], )], [ ([1,10], )]),
-        ([([1,10] , {'name': 'hi'})], [([1,10], {'name': 'hi'})]),
-        ([([1,10] , {'name': 'hi'}, "image")], [([1,10], {'name': 'hi'}, "image")]),
-        ([] , []),
+        ([([1, 10],)], [([1, 10],)]),
+        ([([1, 10], {'name': 'hi'})], [([1, 10], {'name': 'hi'})]),
+        (
+            [([1, 10], {'name': 'hi'}, "image")],
+            [([1, 10], {'name': 'hi'}, "image")],
+        ),
+        ([], []),
     ],
 )
 def test_ensure_list_of_layer_data_tuple(input, expected):
     """Ensure that when given layer data that a tuple can be generated.
 
     When data with a name is supplied a layer should be created and named.
-    When an empty dataset is supplied no layer is created and no errors are produced. 
+    When an empty dataset is supplied no layer is created and no errors are produced.
     """
     assert ensure_list_of_layer_data_tuple(input) == expected

--- a/napari/utils/_tests/test_misc.py
+++ b/napari/utils/_tests/test_misc.py
@@ -10,6 +10,7 @@ from napari.utils.misc import (
     _quiet_array_equal,
     abspath_or_url,
     ensure_iterable,
+    ensure_list_of_layer_data_tuple,
     ensure_sequence_of_iterables,
     pick_equality_operator,
 )
@@ -211,3 +212,20 @@ def test_is_array_type_with_xarray():
     )
     assert not _is_array_type([], 'xarray.DataArray')
     assert not _is_array_type(np.array([]), 'xarray.DataArray')
+
+@pytest.mark.parametrize(
+    'input, expected',
+    [
+        ([ ([1,10], )], [ ([1,10], )]),
+        ([([1,10] , {'name': 'hi'})], [([1,10], {'name': 'hi'})]),
+        ([([1,10] , {'name': 'hi'}, "image")], [([1,10], {'name': 'hi'}, "image")]),
+        ([] , []),
+    ],
+)
+def test_ensure_list_of_layer_data_tuple(input, expected):
+    """Ensure that when given layer data that a tuple can be generated.
+
+    When data with a name is supplied a layer should be created and named.
+    When an empty dataset is supplied no layer is created and no errors are produced. 
+    """
+    assert ensure_list_of_layer_data_tuple(input) == expected

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -457,7 +457,8 @@ def ensure_layer_data_tuple(val):
 
 
 def ensure_list_of_layer_data_tuple(val) -> List[tuple]:
-    if isinstance(val, list) and len(val):
+    # allow empty list to be returned but do nothing in that case
+    if isinstance(val, list):
         with contextlib.suppress(TypeError):
             return [ensure_layer_data_tuple(v) for v in val]
     raise TypeError(


### PR DESCRIPTION
An empty list can sometimes be returned from adding a layer.

This PR closes #4571 

# Description
If an empty list is returned from adding a layer an error is no longer raised.

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
- [X] example: the test suite for my feature covers cases x, y, and z
Tested that original functionality remains unchanged and then tested an empty list returned.

 ```
@magic_factory
def make_layer() -> napari.types.LayerDataTuple:
    return []
my_magic_widget = make_layer()
viewer = napari.Viewer()
viewer.window.add_dock_widget(my_magic_widget)
napari.run()
```

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
