### PR TITLE
added description of how to save layers without compression

### DIFF
--- a/docs/howtos/layers/image.md
+++ b/docs/howtos/layers/image.md
@@ -293,3 +293,13 @@ can.
 
 Currently if you pass contrast limits as a keyword argument to a layer then full
 extent of the contrast limits range slider will be set to those values.
+
+## Saving without image compression
+
+When saving a labels layer, lossless zlib compression is applied by default. 
+ To save with a different level of compression, consider using 
+ [imageio.imwrite](https://imageio.readthedocs.io/en/stable/_autosummary/imageio.v3.imwrite.html).  
+Adjusting compression can be accomplished by including the appropriate kwargs 
+as outlined in the following locations for 
+[tiff](https://imageio.readthedocs.io/en/stable/_autosummary/imageio.plugins.tifffile.html#metadata-for-writing) or 
+[png](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#png) files. 

--- a/docs/howtos/layers/image.md
+++ b/docs/howtos/layers/image.md
@@ -296,7 +296,7 @@ extent of the contrast limits range slider will be set to those values.
 
 ## Saving without image compression
 
-When saving a labels layer, lossless zlib compression is applied by default. 
+When saving an image layer, lossless zlib compression is applied by default. 
  To save with a different level of compression, consider using 
  [imageio.imwrite](https://imageio.readthedocs.io/en/stable/_autosummary/imageio.v3.imwrite.html).  
 Adjusting compression can be accomplished by including the appropriate kwargs 

--- a/docs/howtos/layers/labels.md
+++ b/docs/howtos/layers/labels.md
@@ -113,18 +113,26 @@ layer button above the layers list. The shape of the new labels layer will match
 the size of any currently existing image layers, allowing you to paint on top of
 them.
 
+```{admonition} Want to save without compression?
+:class: tip
+
+When saving a labels layer, lossless zlib compression is applied by default. 
+ To save with a different level of compression, consider using imageio.imwrite.  
+Adjusting compression can be accomplished by including the apporoiate kwargs 
+as outlined in the following locations for 
+[tiff](https://imageio.readthedocs.io/en/stable/_autosummary/imageio.plugins.tifffile.html#metadata-for-writing) or 
+[png](https://imageio.readthedocs.io/en/stable/_autosummary/imageio.v3.imwrite.html) files. 
+```
+
 ## Saving labels layers
 
-When saving a labels layer, file size can be unnecessarily large when compression
+
+
 is not used.  By default, when saving a layer through the GUI no file 
 compression is applied.  The following commands will save a labels layer using 
 compression:
 
-```{code-cell} 
-from skimage.io import imsave
-data = viewer.layers['name_of_your_layer'].data
-imsave('path.tif', data, compress=1)
-```
+
 
 where `name_of_your_layer` represents the name of the layer being saved.  These commands
 can be implemented in a script or entered at an ipython command prompt.

--- a/docs/howtos/layers/labels.md
+++ b/docs/howtos/layers/labels.md
@@ -117,25 +117,13 @@ them.
 :class: tip
 
 When saving a labels layer, lossless zlib compression is applied by default. 
- To save with a different level of compression, consider using imageio.imwrite.  
-Adjusting compression can be accomplished by including the apporoiate kwargs 
+ To save with a different level of compression, consider using [imageio.imwrite]
+(https://imageio.readthedocs.io/en/stable/_autosummary/imageio.v3.imwrite.html).  
+Adjusting compression can be accomplished by including the appropriate kwargs 
 as outlined in the following locations for 
 [tiff](https://imageio.readthedocs.io/en/stable/_autosummary/imageio.plugins.tifffile.html#metadata-for-writing) or 
-[png](https://imageio.readthedocs.io/en/stable/_autosummary/imageio.v3.imwrite.html) files. 
+[png](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#png) files. 
 ```
-
-## Saving labels layers
-
-
-
-is not used.  By default, when saving a layer through the GUI no file 
-compression is applied.  The following commands will save a labels layer using 
-compression:
-
-
-
-where `name_of_your_layer` represents the name of the layer being saved.  These commands
-can be implemented in a script or entered at an ipython command prompt.
 
 ## Non-editable mode
 

--- a/docs/howtos/layers/labels.md
+++ b/docs/howtos/layers/labels.md
@@ -117,8 +117,8 @@ them.
 :class: tip
 
 When saving a labels layer, lossless zlib compression is applied by default. 
- To save with a different level of compression, consider using [imageio.imwrite]
-(https://imageio.readthedocs.io/en/stable/_autosummary/imageio.v3.imwrite.html).  
+ To save with a different level of compression, consider using 
+[imageio.imwrite](https://imageio.readthedocs.io/en/stable/_autosummary/imageio.v3.imwrite.html).  
 Adjusting compression can be accomplished by including the appropriate kwargs 
 as outlined in the following locations for 
 [tiff](https://imageio.readthedocs.io/en/stable/_autosummary/imageio.plugins.tifffile.html#metadata-for-writing) or 

--- a/docs/howtos/layers/labels.md
+++ b/docs/howtos/layers/labels.md
@@ -113,6 +113,22 @@ layer button above the layers list. The shape of the new labels layer will match
 the size of any currently existing image layers, allowing you to paint on top of
 them.
 
+## Saving labels layers
+
+When saving a labels layer, file size can be unnecessarily large when compression
+is not used.  By default, when saving a layer through the GUI no file 
+compression is applied.  The following commands will save a labels layer using 
+compression:
+
+```{code-cell} 
+from skimage.io import imsave
+data = viewer.layers['name_of_your_layer'].data
+imsave('path.tif', data, compress=1)
+```
+
+where `name_of_your_layer` represents the name of the layer being saved.  These commands
+can be implemented in a script or entered at an ipython command prompt.
+
 ## Non-editable mode
 
 If you want to disable editing of the labels layer you can set the `editable`


### PR DESCRIPTION
# Description
Adds a description to the tutorial explaining how to use compression when saving a layer.

## Type of change
- [x] Update to documentation.

# References
n/a

# How has this been tested?
Reviewed the tutorial section.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
