### PR TITLE
Layer bounding box

### DIFF
--- a/napari/_vispy/layers/base.py
+++ b/napari/_vispy/layers/base.py
@@ -49,8 +49,7 @@ class VispyBaseLayer(ABC):
         self.layer = layer
         self._array_like = False
         self.node = node
-        self.bounding_box_2D = BoundingBox(parent=self.node)
-        self.bounding_box_3D = BoundingBox(parent=self.node)
+        self.bounding_box = BoundingBox(parent=self.node)
 
         (
             self.MAX_TEXTURE_SIZE_2D,
@@ -117,10 +116,7 @@ class VispyBaseLayer(ABC):
         self._reset_bounding_box()
 
     def _reset_bounding_box(self):
-        if self.layer._ndisplay == 3:
-            self.bounding_box_3D.set_bounds(self.node, 3)
-        else:
-            self.bounding_box_2D.set_bounds(self.node, 2)
+        self.bounding_box.set_bounds(self.node, self.layer._ndisplay)
 
     def _on_refresh_change(self):
         self.node.update()

--- a/napari/_vispy/layers/base.py
+++ b/napari/_vispy/layers/base.py
@@ -117,7 +117,6 @@ class VispyBaseLayer(ABC):
         self._reset_bounding_box()
 
     def _reset_bounding_box(self):
-        print(self.layer.data.shape, self.layer._ndisplay, self.node.bounds(0))
         if self.layer._ndisplay == 3:
             self.bounding_box_3D.set_bounds(self.node, 3)
         else:

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -55,9 +55,6 @@ class VispyImageLayer(VispyBaseLayer):
         # Default to 2D (image) node.
         super().__init__(layer, self._layer_node.get_node(2))
 
-        self.bounding_box_2D.parent = self._layer_node._image_node
-        self.bounding_box_3D.parent = self._layer_node._volume_node
-
         self._array_like = True
 
         self.layer.events.rendering.connect(self._on_rendering_change)
@@ -109,6 +106,7 @@ class VispyImageLayer(VispyBaseLayer):
 
         self.node.parent = parent
         self.node.order = self.order
+        self.bounding_box.parent = self.node
         self.reset()
 
     def _on_data_change(self):

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -55,6 +55,9 @@ class VispyImageLayer(VispyBaseLayer):
         # Default to 2D (image) node.
         super().__init__(layer, self._layer_node.get_node(2))
 
+        self.bounding_box_2D.parent = self._layer_node._image_node
+        self.bounding_box_3D.parent = self._layer_node._volume_node
+
         self._array_like = True
 
         self.layer.events.rendering.connect(self._on_rendering_change)

--- a/napari/_vispy/visuals/bounding_box.py
+++ b/napari/_vispy/visuals/bounding_box.py
@@ -1,0 +1,69 @@
+from itertools import product
+
+import numpy as np
+from vispy.scene.visuals import Compound, Line
+
+from ..visuals.markers import Markers
+
+
+class BoundingBox(Compound):
+    def __init__(self, *args, **kwargs):
+        super().__init__([Line(), Markers(antialias=0)], *args, **kwargs)
+
+    def set_bounds(self, node, ndim=2):
+        """
+        Takes another node to generate its bounding box.
+        """
+
+        if ndim not in (2, 3):
+            raise ValueError(
+                f'Can only compute 2 or 3-dimensional bounds, not {ndim}'
+            )
+
+        node._bounds_changed()
+        bounds = [node.bounds(i, self) for i in range(ndim)]
+
+        if any(b is None for b in bounds):
+            return
+        print(1)
+
+        vertices = np.array(list(product(*bounds)))
+        if ndim == 3:
+            vertices = vertices - 0.5
+
+        # vertices are generated according to the following scheme:
+        #    5-------7
+        #   /|      /|
+        #  1-------3 |
+        #  | |     | |
+        #  | 4-----|-6
+        #  |/      |/
+        #  0-------2
+
+        edges = np.array(
+            [
+                [0, 1],
+                [1, 3],
+                [3, 2],
+                [2, 0],
+                [0, 4],
+                [1, 5],
+                [2, 6],
+                [3, 7],
+                [4, 5],
+                [5, 7],
+                [7, 6],
+                [6, 4],
+            ]
+        )
+
+        # only the front face is needed for 2D
+        if ndim == 2:
+            edges = edges[:4]
+
+        self._subvisuals[0].set_data(
+            pos=vertices, connect=edges, color='red', width=2
+        )
+        self._subvisuals[1].set_data(
+            pos=vertices, face_color='red', edge_width=1, edge_color='black'
+        )

--- a/napari/_vispy/visuals/bounding_box.py
+++ b/napari/_vispy/visuals/bounding_box.py
@@ -7,8 +7,74 @@ from ..visuals.markers import Markers
 
 
 class BoundingBox(Compound):
+    # vertices are generated according to the following scheme:
+    #    5-------7
+    #   /|      /|
+    #  1-------3 |
+    #  | |     | |
+    #  | 4-----|-6
+    #  |/      |/
+    #  0-------2
+    _edges = np.array(
+        [
+            [0, 1],
+            [1, 3],
+            [3, 2],
+            [2, 0],
+            [0, 4],
+            [1, 5],
+            [2, 6],
+            [3, 7],
+            [4, 5],
+            [5, 7],
+            [7, 6],
+            [6, 4],
+        ]
+    )
+
     def __init__(self, *args, **kwargs):
-        super().__init__([Line(), Markers(antialias=0)], *args, **kwargs)
+        super().__init__(
+            [Line(), Line(), Markers(antialias=0)], *args, **kwargs
+        )
+
+    @property
+    def line2d(self):
+        return self._subvisuals[0]
+
+    @property
+    def line3d(self):
+        return self._subvisuals[1]
+
+    @property
+    def markers(self):
+        return self._subvisuals[2]
+
+    def _set_bounds_2d(self, vertices):
+        # only the front face is needed for 2D
+        edges = self._edges[:4]
+
+        self.line2d.set_data(pos=vertices, connect=edges, color='red', width=2)
+        self.line2d.visible = True
+        self.line3d.visible = False
+
+        self.markers.set_data(
+            pos=vertices, face_color='red', edge_width=1, edge_color='black'
+        )
+
+    def _set_bounds_3d(self, vertices):
+        # pixels in 3D are shifted by half in napari compared to vispy
+        # TODO: find exactly where this difference is and write it here
+        vertices = vertices - 0.5
+
+        self.line3d.set_data(
+            pos=vertices, connect=self._edges.copy(), color='red', width=2
+        )
+        self.line3d.visible = True
+        self.line2d.visible = False
+
+        self.markers.set_data(
+            pos=vertices, face_color='red', edge_width=1, edge_color='black'
+        )
 
     def set_bounds(self, node, ndim=2):
         """
@@ -20,50 +86,18 @@ class BoundingBox(Compound):
                 f'Can only compute 2 or 3-dimensional bounds, not {ndim}'
             )
 
+        # vispy caches bounds for visuals for some reason; if they change, we won't know,
+        # so we force cache cleaning
+        # this is particularly bad for cases like image layer where we initialize the Volume
+        # with a 1 pixel texture, which makes bounds permanently stuck at (0, 1)
         node._bounds_changed()
         bounds = [node.bounds(i, self) for i in range(ndim)]
+        vertices = np.array(list(product(*bounds)))
 
         if any(b is None for b in bounds):
             return
-        print(1)
 
-        vertices = np.array(list(product(*bounds)))
-        if ndim == 3:
-            vertices = vertices - 0.5
-
-        # vertices are generated according to the following scheme:
-        #    5-------7
-        #   /|      /|
-        #  1-------3 |
-        #  | |     | |
-        #  | 4-----|-6
-        #  |/      |/
-        #  0-------2
-
-        edges = np.array(
-            [
-                [0, 1],
-                [1, 3],
-                [3, 2],
-                [2, 0],
-                [0, 4],
-                [1, 5],
-                [2, 6],
-                [3, 7],
-                [4, 5],
-                [5, 7],
-                [7, 6],
-                [6, 4],
-            ]
-        )
-
-        # only the front face is needed for 2D
         if ndim == 2:
-            edges = edges[:4]
-
-        self._subvisuals[0].set_data(
-            pos=vertices, connect=edges, color='red', width=2
-        )
-        self._subvisuals[1].set_data(
-            pos=vertices, face_color='red', edge_width=1, edge_color='black'
-        )
+            self._set_bounds_2d(vertices)
+        else:
+            self._set_bounds_3d(vertices)

--- a/napari/_vispy/visuals/bounding_box.py
+++ b/napari/_vispy/visuals/bounding_box.py
@@ -76,28 +76,16 @@ class BoundingBox(Compound):
             pos=vertices, face_color='red', edge_width=1, edge_color='black'
         )
 
-    def set_bounds(self, node, ndim=2):
+    def set_bounds(self, bounds):
         """
         Takes another node to generate its bounding box.
         """
-
-        if ndim not in (2, 3):
-            raise ValueError(
-                f'Can only compute 2 or 3-dimensional bounds, not {ndim}'
-            )
-
-        # vispy caches bounds for visuals for some reason; if they change, we won't know,
-        # so we force cache cleaning
-        # this is particularly bad for cases like image layer where we initialize the Volume
-        # with a 1 pixel texture, which makes bounds permanently stuck at (0, 1)
-        node._bounds_changed()
-        bounds = [node.bounds(i, self) for i in range(ndim)]
         vertices = np.array(list(product(*bounds)))
 
         if any(b is None for b in bounds):
             return
 
-        if ndim == 2:
+        if len(bounds) == 2:
             self._set_bounds_2d(vertices)
         else:
             self._set_bounds_3d(vertices)

--- a/napari/_vispy/visuals/points.py
+++ b/napari/_vispy/visuals/points.py
@@ -61,6 +61,3 @@ class PointsVisual(ClippingPlanesMixin, Compound):
     @spherical.setter
     def spherical(self, value):
         self._subvisuals[0].spherical = value
-
-    def bounds(self, axis, view=None):
-        return self._subvisuals[0]._compute_bounds(axis, self._subvisuals[0])

--- a/napari/_vispy/visuals/points.py
+++ b/napari/_vispy/visuals/points.py
@@ -1,6 +1,7 @@
-from vispy.scene.visuals import Compound, Line, Markers, Text
+from vispy.scene.visuals import Compound, Line, Text
 
 from ..filters.points_clamp_size import ClampSizeFilter
+from ..visuals.markers import Markers
 from .clipping_planes_mixin import ClippingPlanesMixin
 
 
@@ -60,3 +61,6 @@ class PointsVisual(ClippingPlanesMixin, Compound):
     @spherical.setter
     def spherical(self, value):
         self._subvisuals[0].spherical = value
+
+    def bounds(self, axis, view=None):
+        return self._subvisuals[0]._compute_bounds(axis, self._subvisuals[0])


### PR DESCRIPTION
# Description
I often found myself wanting a bounding box around the layer, especially when using the `plane` rendering mode fore volumes. Without it, I lose track of where I am in the volume and I'm always slicing back and forth to the extremes just to make sure I'm not forgetting parts of the volume.

This PR is an attempt at implementing a bounding box visual that can be used by any layer. There are a few quirks, but the gist is this:

- get the bounds of the visual from vispy
- generate a rectangle or cuboid made of lines and markers

The annoying stuff mainly comes from juggling 2d and 3d and making sure things are up to date.

This is a WIP and I only made it work-ish for image and points, to get some feedback. To test it, try:

```py
import napari
import numpy as np

v = napari.Viewer(ndisplay=3)

img = v.add_image(np.random.rand(10, 20, 15), translate=(30, 50, 12), scale=(10, 12, 13))
pts = v.add_points(np.random.rand(10, 3) * 200)
```
![image](https://user-images.githubusercontent.com/23482191/179932472-349ae2de-7cbf-4c4a-aa56-e0600290669a.png)


The cool thing of this approach is that it inherits the transform of its parent, so we get all of that for free.

Something that's worth discussing in relation to this:
- how should we interface with this from the napari side?
- can we join this with other "world space overlays" (need better name :P) and share some functionality? I'm thinking for example @Czaki's "technical layers" or @alisterburt and @kevinyamauchi's `napari-threedee`'s depictors/manipulators.

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
