### PR TITLE
Add the ability to return a List[Layer] in magicgui

### DIFF
--- a/docs/guides/magicgui.md
+++ b/docs/guides/magicgui.md
@@ -205,6 +205,7 @@ each type is described below:
 - any of the `<LayerType>Data` types from {mod}`napari.types`, such as
   {attr}`napari.types.ImageData` or  {attr}`napari.types.LabelsData`
 - {attr}`napari.types.LayerDataTuple`
+- `List`s of {class}`napari.layers.Layer` or {attr}`napari.types.LayerDataTuple`
 
 ### Returning a `Layer` subclass
 
@@ -250,6 +251,27 @@ nbscreenshot(viewer, alt_text="A magicgui widget using an image layer return ann
 With this method, a new layer will be added to the layer list each time the
 function is called.  To update an existing layer, you must use the
 `LayerDataTuple` approach described below
+```
+
+### Returning `List[napari.layers.Layer]`
+
+You can create multiple layers by returning a list of
+{class}`~napari.layers.Layer`.
+
+```python
+from typing import List
+
+@magicgui
+def make_points(...) -> List[napari.layers.Layer]:
+  ...
+```
+
+```{note}
+Note: the `List[]` syntax here is optional from the perspective of `napari`.  You
+can return either a single Layer or a list of Layers and they will all be added
+to the viewer as long as you use either `List[napari.layers.Layer]` or 
+`napari.layers.Layer`.  If you want your code to be properly typed, however,
+your return type must match your return annotation.
 ```
 
 (returning-napari-types-data)=

--- a/napari/_tests/test_magicgui.py
+++ b/napari/_tests/test_magicgui.py
@@ -161,6 +161,25 @@ def test_magicgui_add_layer(make_napari_viewer, LayerType, data, ndim):
     assert viewer.layers[0].source.widget == add_layer
 
 
+def test_magicgui_add_layer_list(make_napari_viewer):
+    viewer = make_napari_viewer()
+
+    @magicgui
+    def add_layer() -> List[Layer]:
+        a = Image(data=np.random.randint(0, 10, size=(10, 10)))
+        b = Labels(data=np.random.randint(0, 10, size=(10, 10)))
+        return [a, b]
+
+    viewer.window.add_dock_widget(add_layer)
+    add_layer()
+    assert len(viewer.layers) == 2
+    assert isinstance(viewer.layers[0], Image)
+    assert isinstance(viewer.layers[1], Labels)
+
+    assert viewer.layers[0].source.widget == add_layer
+    assert viewer.layers[1].source.widget == add_layer
+
+
 def test_magicgui_add_layer_data_tuple(make_napari_viewer):
     viewer = make_napari_viewer()
 

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -12,7 +12,11 @@ import magicgui as mgui
 import numpy as np
 
 from ...utils._dask_utils import configure_dask
-from ...utils._magicgui import add_layer_to_viewer, get_layers
+from ...utils._magicgui import (
+    add_layer_to_viewer,
+    add_layers_to_viewer,
+    get_layers,
+)
 from ...utils.events import EmitterGroup, Event
 from ...utils.events.event import WarningEmitter
 from ...utils.geometry import (
@@ -1779,3 +1783,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
                     layer_type=layer_type,
                 )
             ) from exc
+
+
+mgui.register_type(type_=List[Layer], return_callback=add_layers_to_viewer)

--- a/napari/utils/_magicgui.py
+++ b/napari/utils/_magicgui.py
@@ -358,7 +358,37 @@ def add_layer_to_viewer(gui, result: Any, return_type: Type[Layer]) -> None:
     ...     return napari.layers.Image(np.random.rand(64, 64))
 
     """
+    add_layers_to_viewer(gui, [result], List[return_type])
+
+
+def add_layers_to_viewer(gui, result: Any, return_type: List[Layer]) -> None:
+    """Show a magicgui result in the viewer.
+
+    Parameters
+    ----------
+    gui : MagicGui or QWidget
+        The instantiated MagicGui widget.  May or may not be docked in a
+        dock widget.
+    result : Any
+        The result of the function call.
+    return_type : type
+        The return annotation that was used in the decorated function.
+
+    Examples
+    --------
+    This allows the user to do this, and add the resulting layer to the viewer.
+
+    >>> @magicgui
+    ... def make_layer() -> List[napari.layers.Layer]:
+    ...     return napari.layers.Image(np.random.rand(64, 64))
+
+    """
     from ..utils._injection._processors import _add_layer_to_viewer
 
-    if result is not None and (viewer := find_viewer_ancestor(gui)):
-        _add_layer_to_viewer(result, viewer=viewer, source={'widget': gui})
+    viewer = find_viewer_ancestor(gui)
+    if not viewer:
+        return
+
+    for item in result:
+        if item is not None:
+            _add_layer_to_viewer(item, viewer=viewer, source={'widget': gui})


### PR DESCRIPTION
# Description
This PR adds the ability for a plugin to return a `List[Layer]`. Returns of `Layer`, `LayerDataTuple` and `List[LayerDataTuple]`, so I don't know why `List[Layer]` shouldn't be supported.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# References

@tlambert03 pointed me in the right direction in [this zulip thread](https://napari.zulipchat.com/#narrow/stream/309872-plugins/topic/Giving.20a.20layer.20a.20unique.20name/near/290256372)

# How has this been tested?
I modified a copy of [this test](https://github.com/napari/napari/blob/5827a55f18d02fc65958766db4d5457549c63cb0/napari/_tests/test_magicgui.py#L150) such that the return was `List[Layer]`. It passes on my machine.

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).