### PR TITLE
Fix creation `QtViewer` for `ViewerModel` with already added layers

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -669,4 +669,8 @@ def test_create_non_empty_viewer_model(qtbot):
 
     viewer.close()
     viewer.deleteLater()
+    # try to del local reference for gc.
+    del viewer_model
+    del viewer
     qtbot.wait(50)
+    gc.collect()

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -10,6 +10,7 @@ import pytest
 from qtpy.QtGui import QGuiApplication
 from qtpy.QtWidgets import QMessageBox
 
+from napari._qt.qt_viewer import QtViewer
 from napari._tests.utils import (
     add_layer_by_type,
     check_viewer_functioning,
@@ -18,6 +19,7 @@ from napari._tests.utils import (
     skip_on_win_ci,
 )
 from napari._vispy.utils.gl import fix_data_dtype
+from napari.components.viewer_model import ViewerModel
 from napari.layers import Points
 from napari.settings import get_settings
 from napari.utils.interactions import mouse_press_callbacks
@@ -657,3 +659,14 @@ def test_insert_layer_ordering(make_napari_viewer):
     pl2_vispy = viewer.window._qt_viewer.layer_to_visual[pl2].node
     assert pl1_vispy.order == 1
     assert pl2_vispy.order == 0
+
+
+def test_create_non_empty_viewer_model(qtbot):
+    viewer_model = ViewerModel()
+    viewer_model.add_points([(1, 2), (2, 3)])
+
+    viewer = QtViewer(viewer=viewer_model)
+
+    viewer.close()
+    viewer.deleteLater()
+    qtbot.wait(50)

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -295,9 +295,6 @@ class QtViewer(QSplitter):
 
         self.setAcceptDrops(True)
 
-        for layer in self.viewer.layers:
-            self._add_layer(layer)
-
         self.view = self.canvas.central_widget.add_view(border_width=0)
         self.camera = VispyCamera(
             self.view, self.viewer.camera, self.viewer.dims
@@ -328,6 +325,9 @@ class QtViewer(QSplitter):
 
         # bind shortcuts stored in settings last.
         self._bind_shortcuts()
+
+        for layer in self.viewer.layers:
+            self._add_layer(layer)
 
     def _leave_canvas(self):
         """disable status on canvas leave"""


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This PR fix bug that prevents the creation of QtViewer for models that already have added layers. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
