### PR TITLE
deprecate channel_axis argument to viewer.add_image

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -810,6 +810,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
             return layer
         else:
+            from ..utils.stack_utils import split_channels
+
             warnings.warn(
                 trans._(
                     "\nThe 'channel_axis' argument is deprecated and will be removed in v0.5.1.\nTo achieve the same behavior, you may use 'napari.utils.split_channels':\n\n```\nfrom napari.utils import split_channels\n\nfor (ch, kw, _) in split_channels(data, channel_axis, **kwargs):\n    viewer.add_image(ch, **kw)\n```\n",

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -47,7 +47,6 @@ from ..utils.migrations import rename_argument
 from ..utils.misc import is_sequence
 from ..utils.mouse_bindings import MousemapProvider
 from ..utils.progress import progress
-from ..utils.stack_utils import split_channels
 from ..utils.theme import available_themes
 from ..utils.translations import trans
 from ._viewer_mouse_bindings import dims_scroll

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -34,7 +34,6 @@ from ..layers.image._image_utils import guess_labels
 from ..layers.labels._labels_key_bindings import labels_fun_to_mode
 from ..layers.points._points_key_bindings import points_fun_to_mode
 from ..layers.shapes._shapes_key_bindings import shapes_fun_to_mode
-from ..layers.utils.stack_utils import split_channels
 from ..plugins.utils import get_potential_readers, get_preferred_reader
 from ..settings import get_settings
 from ..utils._register import create_func as create_add_method

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -47,6 +47,7 @@ from ..utils.migrations import rename_argument
 from ..utils.misc import is_sequence
 from ..utils.mouse_bindings import MousemapProvider
 from ..utils.progress import progress
+from ..utils.stack_utils import split_channels
 from ..utils.theme import available_themes
 from ..utils.translations import trans
 from ._viewer_mouse_bindings import dims_scroll
@@ -810,6 +811,14 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
             return layer
         else:
+            warnings.warn(
+                trans._(
+                    "\nThe 'channel_axis' argument is deprecated and will be removed in v0.5.1.\nTo achieve the same behavior, you may use 'napari.utils.split_channels':\n\n```\nfrom napari.utils import split_channels\n\nfor (ch, kw, _) in split_channels(data, channel_axis, **kwargs):\n    viewer.add_image(ch, **kw)\n```\n",
+                    deferred=True,
+                ),
+                category=DeprecationWarning,
+                stacklevel=3,
+            )
             layerdata_list = split_channels(data, channel_axis, **kwargs)
 
             layer_list = list()

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -19,11 +19,11 @@ from typing import (
 import numpy as np
 from typing_extensions import TypedDict
 
-from ..utils import stack_utils
 from ..utils._injection import inject_napari_dependencies
 from ..utils.context._layerlist_context import LayerListContextKeys as LLCK
 from ..utils.translations import trans
 from .base.base import Layer
+from .utils import stack_utils
 from .utils._link_layers import get_linked_layers
 
 if TYPE_CHECKING:

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -23,7 +23,6 @@ from ..utils._injection import inject_napari_dependencies
 from ..utils.context._layerlist_context import LayerListContextKeys as LLCK
 from ..utils.translations import trans
 from .base.base import Layer
-from .utils import stack_utils
 from .utils._link_layers import get_linked_layers
 
 if TYPE_CHECKING:
@@ -44,6 +43,8 @@ def _duplicate_layer(ll: LayerList):
 
 @inject_napari_dependencies
 def _split_stack(ll: LayerList, axis: int = 0):
+    from ..utils import stack_utils
+
     layer = ll.selection.active
     if not layer:
         return
@@ -148,6 +149,8 @@ def _convert_to_image(ll: LayerList):
 
 @inject_napari_dependencies
 def _merge_stack(ll: LayerList, rgb=False):
+    from ..utils import stack_utils
+
     # force selection to follow LayerList ordering
     selection = [layer for layer in ll if layer in ll.selection]
     for layer in selection:

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -19,11 +19,11 @@ from typing import (
 import numpy as np
 from typing_extensions import TypedDict
 
+from ..utils import stack_utils
 from ..utils._injection import inject_napari_dependencies
 from ..utils.context._layerlist_context import LayerListContextKeys as LLCK
 from ..utils.translations import trans
 from .base.base import Layer
-from .utils import stack_utils
 from .utils._link_layers import get_linked_layers
 
 if TYPE_CHECKING:

--- a/napari/layers/utils/_tests/test_stack_utils.py
+++ b/napari/layers/utils/_tests/test_stack_utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from napari.layers import Image
-from napari.layers.utils.stack_utils import (
+from napari.utils.stack_utils import (
     images_to_stack,
     split_channels,
     stack_to_images,

--- a/napari/layers/utils/_tests/test_stack_utils.py
+++ b/napari/layers/utils/_tests/test_stack_utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from napari.layers import Image
-from napari.utils.stack_utils import (
+from napari.layers.utils.stack_utils import (
     images_to_stack,
     split_channels,
     stack_to_images,

--- a/napari/layers/utils/stack_utils.py
+++ b/napari/layers/utils/stack_utils.py
@@ -5,14 +5,14 @@ from typing import TYPE_CHECKING, List
 
 import numpy as np
 
-from ..layers import Image
-from ..layers.image._image_utils import guess_multiscale
-from .colormaps import CYMRGB, MAGENTA_GREEN, Colormap
-from .misc import ensure_iterable, ensure_sequence_of_iterables
-from .translations import trans
+from ...utils.colormaps import CYMRGB, MAGENTA_GREEN, Colormap
+from ...utils.misc import ensure_iterable, ensure_sequence_of_iterables
+from ...utils.translations import trans
+from .. import Image
+from ..image._image_utils import guess_multiscale
 
 if TYPE_CHECKING:
-    from ..types import FullLayerData
+    from ...types import FullLayerData
 
 
 def slice_from_axis(array, *, axis, element):

--- a/napari/utils/__init__.py
+++ b/napari/utils/__init__.py
@@ -3,3 +3,15 @@ from .colormaps import Colormap
 from .info import citation_text, sys_info
 from .notebook_display import nbscreenshot
 from .progress import progrange, progress
+from .stack_utils import split_channels
+
+__all__ = [
+    'Colormap',
+    'citation_text',
+    'nbscreenshot',
+    'progrange',
+    'progress',
+    'resize_dask_cache',
+    'split_channels',
+    'sys_info',
+]

--- a/napari/utils/__init__.py
+++ b/napari/utils/__init__.py
@@ -3,11 +3,10 @@ from .colormaps import Colormap
 from .info import citation_text, sys_info
 from .notebook_display import nbscreenshot
 from .progress import progrange, progress
-from .stack_utils import split_channels
 
 __all__ = [
-    'Colormap',
     'citation_text',
+    'Colormap',
     'nbscreenshot',
     'progrange',
     'progress',
@@ -15,3 +14,13 @@ __all__ = [
     'split_channels',
     'sys_info',
 ]
+
+
+def __getattr__(name):
+    # prefer to export here, but moving it from layers.utils causes a circular import
+    if name != 'split_channels':
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    from ..layers.utils.stack_utils import split_channels
+
+    return split_channels

--- a/napari/utils/__init__.py
+++ b/napari/utils/__init__.py
@@ -3,6 +3,7 @@ from .colormaps import Colormap
 from .info import citation_text, sys_info
 from .notebook_display import nbscreenshot
 from .progress import progrange, progress
+from .stack_utils import split_channels
 
 __all__ = [
     'citation_text',
@@ -14,13 +15,3 @@ __all__ = [
     'split_channels',
     'sys_info',
 ]
-
-
-def __getattr__(name):
-    # prefer to export here, but moving it from layers.utils causes a circular import
-    if name != 'split_channels':
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-    from ..layers.utils.stack_utils import split_channels
-
-    return split_channels

--- a/napari/utils/stack_utils.py
+++ b/napari/utils/stack_utils.py
@@ -5,14 +5,13 @@ from typing import TYPE_CHECKING, List
 
 import numpy as np
 
-from ...utils.colormaps import CYMRGB, MAGENTA_GREEN, Colormap
-from ...utils.misc import ensure_iterable, ensure_sequence_of_iterables
-from ...utils.translations import trans
-from .. import Image
-from ..image._image_utils import guess_multiscale
+from .colormaps import CYMRGB, MAGENTA_GREEN, Colormap
+from .misc import ensure_iterable, ensure_sequence_of_iterables
+from .translations import trans
 
 if TYPE_CHECKING:
-    from ...types import FullLayerData
+    from ..layers import Image
+    from ..types import FullLayerData
 
 
 def slice_from_axis(array, *, axis, element):
@@ -72,6 +71,7 @@ def split_channels(
     -------
     List of LayerData tuples: [(data: array, meta: Dict, type: str )]
     """
+    from ..layers.image._image_utils import guess_multiscale
 
     # Determine if data is a multiscale
     multiscale = kwargs.get('multiscale')
@@ -272,6 +272,7 @@ def images_to_stack(images: List[Image], axis: int = 0, **kwargs) -> Image:
     stack : napari.layers.Image
         Combined image stack
     """
+    from ..layers import Image
 
     if not images:
         raise IndexError(trans._("images list is empty", deferred=True))

--- a/napari/utils/stack_utils.py
+++ b/napari/utils/stack_utils.py
@@ -5,14 +5,14 @@ from typing import TYPE_CHECKING, List
 
 import numpy as np
 
-from ...layers import Image
-from ...layers.image._image_utils import guess_multiscale
-from ...utils.colormaps import CYMRGB, MAGENTA_GREEN, Colormap
-from ...utils.misc import ensure_iterable, ensure_sequence_of_iterables
-from ...utils.translations import trans
+from ..layers import Image
+from ..layers.image._image_utils import guess_multiscale
+from .colormaps import CYMRGB, MAGENTA_GREEN, Colormap
+from .misc import ensure_iterable, ensure_sequence_of_iterables
+from .translations import trans
 
 if TYPE_CHECKING:
-    from ...types import FullLayerData
+    from ..types import FullLayerData
 
 
 def slice_from_axis(array, *, axis, element):

--- a/napari/utils/stack_utils.py
+++ b/napari/utils/stack_utils.py
@@ -181,6 +181,7 @@ def stack_to_images(stack: Image, axis: int, **kwargs) -> List[Image]:
     imagelist: list
         List of Image objects
     """
+    from ..layers import Image
 
     data, meta, _ = stack.as_layer_data_tuple()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,8 @@ filterwarnings = [
   "ignore:.*Themes were changed to use evented model",  # specifying the full is not working here so glob pattern is used instead
   "ignore:distutils Version classes are deprecated::",
   "ignore:There is no current event loop:DeprecationWarning:",
+  # REMOVE me once we drop channel_axis.  Much easier to put here than to decorate every test.
+  "ignore:\\nThe 'channel_axis' argument is deprecated:DeprecationWarning",
 ]
 markers = [
     "sync_only: Test should only be run synchronously",


### PR DESCRIPTION
# Description
This closes #3019 and deprecates the channel_axis argument to viewer.add_image.  The deprecation warning looks like this:

````python
DeprecationWarning:
The 'channel_axis' argument is deprecated and will be removed in v0.5.1.
To achieve the same behavior, you may use 'napari.utils.split_channels':

```
from napari.utils import split_channels

for (ch, kw, _) in split_channels(data, channel_axis, **kwargs):
    viewer.add_image(ch, **kw)
```
````

happy to change the removal target to anything else.  I just picked that one out of thin air (but we should probably give one).

### rationale

`viewer.add_image(..., channel_axis=)` is the _only_ case in which any call to `viewer.add_*` results in the addition of multiple layers.  It makes for lots of problems from a API perspective, because it means that, technically, everyone would need to check whether `viewer.add_image` returns a Layer or a list of Layer before operating on it with type safety.  It is the only thing in the way of the  `Layer.create` class method working for all layer data tuples.  it's problematic from a typing perspective, etc...