### PR TITLE
Fix viewer.reset() throws TypeError

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -360,13 +360,19 @@ def test_current_viewer(make_napari_viewer):
 
 
 def test_reset_empty(make_napari_viewer):
-    """Test that resetting an empty viewer doesn't crash"""
+    """
+    Test that resetting an empty viewer doesn't crash
+    https://github.com/napari/napari/issues/4867
+    """
     viewer = make_napari_viewer()
     viewer.reset()
 
 
 def test_reset_non_empty(make_napari_viewer):
-    """Test that resetting a non-empty viewer doesn't crash"""
+    """
+    Test that resetting a non-empty viewer doesn't crash
+    https://github.com/napari/napari/issues/4867
+    """
     viewer = make_napari_viewer()
     viewer.add_points([(0, 1), (2, 3)])
     viewer.reset()

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -357,3 +357,16 @@ def test_current_viewer(make_napari_viewer):
 
     assert current_viewer() is viewer1
     assert current_viewer() is not viewer2
+
+
+def test_reset_empty(make_napari_viewer):
+    """Test that resetting an empty viewer doesn't crash"""
+    viewer = make_napari_viewer()
+    viewer.reset()
+
+
+def test_reset_non_empty(make_napari_viewer):
+    """Test that resetting an empty viewer doesn't crash"""
+    viewer = make_napari_viewer()
+    viewer.add_points([(0, 1), (2, 3)])
+    viewer.reset()

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -366,7 +366,7 @@ def test_reset_empty(make_napari_viewer):
 
 
 def test_reset_non_empty(make_napari_viewer):
-    """Test that resetting an empty viewer doesn't crash"""
+    """Test that resetting a non-empty viewer doesn't crash"""
     viewer = make_napari_viewer()
     viewer.add_points([(0, 1), (2, 3)])
     viewer.reset()

--- a/napari/components/_interaction_box_mouse_bindings.py
+++ b/napari/components/_interaction_box_mouse_bindings.py
@@ -196,7 +196,7 @@ class InteractionBoxMouseBindings:
 
         layer_affine_transform = event.value.compose(
             self._initial_transform_inverse
-        )
+        ) if self._initial_transform_inverse is not None else event.value
 
         active_layer.affine = active_layer.affine.replace_slice(
             layer_dims_displayed, layer_affine_transform

--- a/napari/components/_interaction_box_mouse_bindings.py
+++ b/napari/components/_interaction_box_mouse_bindings.py
@@ -191,7 +191,7 @@ class InteractionBoxMouseBindings:
         layer_dims_displayed = dims_displayed_world_to_layer(
             list(self._ref_viewer().dims.displayed),
             viewer.dims.ndim,
-            active_layer.ndim if active_layer is not None else 2,
+            active_layer.ndim,
         )
 
         layer_affine_transform = event.value.compose(

--- a/napari/components/_interaction_box_mouse_bindings.py
+++ b/napari/components/_interaction_box_mouse_bindings.py
@@ -183,20 +183,23 @@ class InteractionBoxMouseBindings:
     def _on_transform_change(self, event):
         """Gets called when the interaction box is transformed to update transform of the layer"""
 
+        viewer = self._ref_viewer()
+        active_layer = viewer.layers.selection.active
+        if active_layer is None:
+            return
+
         layer_dims_displayed = dims_displayed_world_to_layer(
             list(self._ref_viewer().dims.displayed),
-            self._ref_viewer().dims.ndim,
-            self._ref_viewer().layers.selection.active.ndim,
+            viewer.dims.ndim,
+            active_layer.ndim if active_layer is not None else 2,
         )
 
         layer_affine_transform = event.value.compose(
             self._initial_transform_inverse
         )
 
-        self._ref_viewer().layers.selection.active.affine = (
-            self._ref_viewer().layers.selection.active.affine.replace_slice(
-                layer_dims_displayed, layer_affine_transform
-            )
+        active_layer.affine = active_layer.affine.replace_slice(
+            layer_dims_displayed, layer_affine_transform
         )
 
     def initialize_key_events(self, viewer):

--- a/napari/components/_interaction_box_mouse_bindings.py
+++ b/napari/components/_interaction_box_mouse_bindings.py
@@ -194,9 +194,11 @@ class InteractionBoxMouseBindings:
             active_layer.ndim,
         )
 
-        layer_affine_transform = event.value.compose(
-            self._initial_transform_inverse
-        ) if self._initial_transform_inverse is not None else event.value
+        layer_affine_transform = (
+            event.value.compose(self._initial_transform_inverse)
+            if self._initial_transform_inverse is not None
+            else event.value
+        )
 
         active_layer.affine = active_layer.affine.replace_slice(
             layer_dims_displayed, layer_affine_transform

--- a/napari/utils/events/containers/_evented_list.py
+++ b/napari/utils/events/containers/_evented_list.py
@@ -22,6 +22,7 @@ MUST make sure that all the appropriate events are emitted.  (Tests should
 cover this in test_evented_list.py)
 """
 
+import contextlib
 import logging
 from typing import Callable, Dict, Iterable, List, Sequence, Tuple, Type, Union
 
@@ -190,10 +191,8 @@ class EventedList(TypedMutableSequence[_T]):
     def _reemit_child_event(self, event: Event):
         """An item in the list emitted an event.  Re-emit with index"""
         if not hasattr(event, 'index'):
-            try:
+            with contextlib.suppress(ValueError):
                 setattr(event, 'index', self.index(event.source))
-            except ValueError:
-                pass
         # reemit with this object's EventEmitter of the same type if present
         # otherwise just emit with the EmitterGroup itself
         getattr(self.events, event.type, self.events)(event)

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import Optional, Sequence
+from typing import Sequence
 
 import numpy as np
 import toolz as tz

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -57,7 +57,7 @@ class Transform:
 
     def compose(self, transform: Optional['Transform']) -> 'Transform':
         """Return the composite of this transform and the provided one."""
-        return self if transform is None else TransformChain([self, transform])
+        return TransformChain([self, transform])
 
     def set_slice(self, axes: Sequence[int]) -> 'Transform':
         """Return a transform subset to the visible dimensions.

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -55,7 +55,7 @@ class Transform:
                 trans._('Inverse function was not provided.', deferred=True)
             )
 
-    def compose(self, transform: Optional['Transform']) -> 'Transform':
+    def compose(self, transform: 'Transform') -> 'Transform':
         """Return the composite of this transform and the provided one."""
         return TransformChain([self, transform])
 

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import Sequence
+from typing import Optional, Sequence
 
 import numpy as np
 import toolz as tz
@@ -55,9 +55,9 @@ class Transform:
                 trans._('Inverse function was not provided.', deferred=True)
             )
 
-    def compose(self, transform: 'Transform') -> 'Transform':
+    def compose(self, transform: Optional['Transform']) -> 'Transform':
         """Return the composite of this transform and the provided one."""
-        return TransformChain([self, transform])
+        return self if transform is None else TransformChain([self, transform])
 
     def set_slice(self, axes: Sequence[int]) -> 'Transform':
         """Return a transform subset to the visible dimensions.


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Fix raising error in napari Viewer on call `reset` method. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

close #4867

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
