### PR TITLE
Move mesh generation to vispy

### DIFF
--- a/napari/_vispy/layers/vectors.py
+++ b/napari/_vispy/layers/vectors.py
@@ -1,3 +1,5 @@
+from copy import copy
+
 import numpy as np
 
 from ..visuals.vectors import VectorsVisual
@@ -15,24 +17,27 @@ class VispyVectorsLayer(VispyBaseLayer):
         self._on_data_change()
 
     def _on_data_change(self):
-        if (
-            len(self.layer._view_vertices) == 0
-            or len(self.layer._view_faces) == 0
-        ):
-            vertices = np.zeros((3, self.layer._ndisplay))
+
+        # Make meshes
+        vertices, faces = generate_vector_meshes(
+            self.layer._view_data,
+            self.layer.edge_width,
+            self.layer.length,
+        )
+        face_color = self.layer._view_face_color
+        ndisplay = self.layer._ndisplay
+        ndim = self.layer.ndim
+
+        if len(vertices) == 0 or len(faces) == 0:
+            vertices = np.zeros((3, ndisplay))
             faces = np.array([[0, 1, 2]])
             face_color = np.array([[0, 0, 0, 0]])
         else:
-            vertices = self.layer._view_vertices[:, ::-1]
-            faces = self.layer._view_faces
-            face_color = self.layer._view_face_color
+            vertices = vertices[:, ::-1]
 
-        if self.layer._ndisplay == 3 and self.layer.ndim == 2:
+        if ndisplay == 3 and ndim == 2:
             vertices = np.pad(vertices, ((0, 0), (0, 1)), mode='constant')
 
-        # self.node.set_data(
-        #     vertices=vertices, faces=faces, color=self.layer.current_edge_color
-        # )
         self.node.set_data(
             vertices=vertices,
             faces=faces,
@@ -42,3 +47,127 @@ class VispyVectorsLayer(VispyBaseLayer):
         self.node.update()
         # Call to update order of translation values with new dims:
         self._on_matrix_change()
+
+
+def generate_vector_meshes(vectors, width, length):
+    """Generates list of mesh vertices and triangles from a list of vectors
+
+    Parameters
+    ----------
+    vectors : (N, 2, D) array
+        A list of N vectors with start point and projections of the vector
+        in D dimensions, where D is 2 or 3.
+    width : float
+        width of the line to be drawn
+    length : float
+        length multiplier of the line to be drawn
+
+    Returns
+    -------
+    vertices : (4N, D) array
+        Vertices of all triangles for the lines
+    triangles : (2N, 3) array
+        Vertex indices that form the mesh triangles
+    """
+    ndim = vectors.shape[2]
+    if ndim == 2:
+        vertices, triangles = generate_vector_meshes_2D(vectors, width, length)
+    else:
+        v_a, t_a = generate_vector_meshes_2D(
+            vectors, width, length, p=(0, 0, 1)
+        )
+        v_b, t_b = generate_vector_meshes_2D(
+            vectors, width, length, p=(1, 0, 0)
+        )
+        vertices = np.concatenate([v_a, v_b], axis=0)
+        triangles = np.concatenate([t_a, len(v_a) + t_b], axis=0)
+
+    return vertices, triangles
+
+
+def generate_vector_meshes_2D(vectors, width, length, p=(0, 0, 1)):
+    """Generates list of mesh vertices and triangles from a list of vectors
+
+    Parameters
+    ----------
+    vectors : (N, 2, D) array
+        A list of N vectors with start point and projections of the vector
+        in D dimensions, where D is 2 or 3.
+    width : float
+        width of the line to be drawn
+    length : float
+        length multiplier of the line to be drawn
+    p : 3-tuple, optional
+        orthogonal vector for segment calculation in 3D.
+
+    Returns
+    -------
+    vertices : (4N, D) array
+        Vertices of all triangles for the lines
+    triangles : (2N, 3) array
+        Vertex indices that form the mesh triangles
+    """
+    ndim = vectors.shape[2]
+    vectors = np.reshape(copy(vectors), (-1, ndim))
+    vectors[1::2] = vectors[::2] + length * vectors[1::2]
+
+    centers = np.repeat(vectors, 2, axis=0)
+    offsets = segment_normal(vectors[::2, :], vectors[1::2, :], p=p)
+    offsets = np.repeat(offsets, 4, axis=0)
+    signs = np.ones((len(offsets), ndim))
+    signs[::2] = -1
+    offsets = offsets * signs
+
+    vertices = centers + width * offsets / 2
+    triangles = np.array(
+        [
+            [2 * i, 2 * i + 1, 2 * i + 2]
+            if i % 2 == 0
+            else [2 * i - 1, 2 * i, 2 * i + 1]
+            for i in range(len(vectors))
+        ]
+    ).astype(np.uint32)
+
+    return vertices, triangles
+
+
+def segment_normal(a, b, p=(0, 0, 1)):
+    """Determines the unit normal of the vector from a to b.
+
+    Parameters
+    ----------
+    a : np.ndarray
+        Length 2 array of first point or Nx2 array of points
+    b : np.ndarray
+        Length 2 array of second point or Nx2 array of points
+    p : 3-tuple, optional
+        orthogonal vector for segment calculation in 3D.
+
+    Returns
+    -------
+    unit_norm : np.ndarray
+        Length the unit normal of the vector from a to b. If a == b,
+        then returns [0, 0] or Nx2 array of vectors
+    """
+    d = b - a
+
+    if d.ndim == 1:
+        if len(d) == 2:
+            normal = np.array([d[1], -d[0]])
+        else:
+            normal = np.cross(d, p)
+        norm = np.linalg.norm(normal)
+        if norm == 0:
+            norm = 1
+    else:
+        if d.shape[1] == 2:
+            normal = np.stack([d[:, 1], -d[:, 0]], axis=0).transpose(1, 0)
+        else:
+            normal = np.cross(d, p)
+
+        norm = np.linalg.norm(normal, axis=1, keepdims=True)
+        ind = norm == 0
+        norm[ind] = 1
+    unit_norm = normal / norm
+
+    return unit_norm

--- a/napari/benchmarks/benchmark_qt_viewer_vectors.py
+++ b/napari/benchmarks/benchmark_qt_viewer_vectors.py
@@ -7,6 +7,7 @@ from qtpy.QtWidgets import QApplication
 
 import napari
 
+
 class QtViewerViewVectorSuite:
     """Benchmarks for viewing vectors in the viewer."""
 

--- a/napari/benchmarks/benchmark_qt_viewer_vectors.py
+++ b/napari/benchmarks/benchmark_qt_viewer_vectors.py
@@ -1,0 +1,30 @@
+# See "Writing benchmarks" in the asv docs for more information.
+# https://asv.readthedocs.io/en/latest/writing_benchmarks.html
+# or the napari documentation on benchmarking
+# https://github.com/napari/napari/blob/main/docs/BENCHMARKS.md
+import numpy as np
+from qtpy.QtWidgets import QApplication
+
+import napari
+
+class QtViewerViewVectorSuite:
+    """Benchmarks for viewing vectors in the viewer."""
+
+    params = [2**i for i in range(4, 18, 2)]
+
+    def setup(self, n):
+        _ = QApplication.instance() or QApplication([])
+        np.random.seed(0)
+        self.data = np.random.random((n, 2, 3))
+        self.viewer = napari.Viewer()
+        self.layer = self.viewer.add_vectors(self.data)
+        self.visual = self.viewer.window._qt_viewer.layer_to_visual[self.layer]
+
+    def teardown(self, n):
+        self.viewer.window.close()
+
+    def time_vectors_refresh(self, n):
+        """Time to view a vector."""
+        self.viewer.layers[0].refresh()
+        self.viewer.layers[0].refresh()
+        self.viewer.layers[0].refresh()

--- a/napari/layers/vectors/_vector_utils.py
+++ b/napari/layers/vectors/_vector_utils.py
@@ -1,10 +1,8 @@
-from copy import copy
 from typing import Optional, Tuple
 
 import numpy as np
 
 from ...utils.translations import trans
-from ..utils.layer_utils import segment_normal
 
 
 def convert_image_to_coordinates(vectors):
@@ -38,88 +36,6 @@ def convert_image_to_coordinates(vectors):
     coords[:, 1, :] = np.reshape(vectors, (-1, vectors.ndim - 1))
 
     return coords
-
-
-def generate_vector_meshes(vectors, width, length):
-    """Generates list of mesh vertices and triangles from a list of vectors
-
-    Parameters
-    ----------
-    vectors : (N, 2, D) array
-        A list of N vectors with start point and projections of the vector
-        in D dimensions, where D is 2 or 3.
-    width : float
-        width of the line to be drawn
-    length : float
-        length multiplier of the line to be drawn
-
-    Returns
-    -------
-    vertices : (4N, D) array
-        Vertices of all triangles for the lines
-    triangles : (2N, 3) array
-        Vertex indices that form the mesh triangles
-    """
-    ndim = vectors.shape[2]
-    if ndim == 2:
-        vertices, triangles = generate_vector_meshes_2D(vectors, width, length)
-    else:
-        v_a, t_a = generate_vector_meshes_2D(
-            vectors, width, length, p=(0, 0, 1)
-        )
-        v_b, t_b = generate_vector_meshes_2D(
-            vectors, width, length, p=(1, 0, 0)
-        )
-        vertices = np.concatenate([v_a, v_b], axis=0)
-        triangles = np.concatenate([t_a, len(v_a) + t_b], axis=0)
-
-    return vertices, triangles
-
-
-def generate_vector_meshes_2D(vectors, width, length, p=(0, 0, 1)):
-    """Generates list of mesh vertices and triangles from a list of vectors
-
-    Parameters
-    ----------
-    vectors : (N, 2, D) array
-        A list of N vectors with start point and projections of the vector
-        in D dimensions, where D is 2 or 3.
-    width : float
-        width of the line to be drawn
-    length : float
-        length multiplier of the line to be drawn
-    p : 3-tuple, optional
-        orthogonal vector for segment calculation in 3D.
-
-    Returns
-    -------
-    vertices : (4N, D) array
-        Vertices of all triangles for the lines
-    triangles : (2N, 3) array
-        Vertex indices that form the mesh triangles
-    """
-    ndim = vectors.shape[2]
-    vectors = np.reshape(copy(vectors), (-1, ndim))
-    vectors[1::2] = vectors[::2] + length * vectors[1::2]
-
-    centers = np.repeat(vectors, 2, axis=0)
-    offsets = segment_normal(vectors[::2, :], vectors[1::2, :], p=p)
-    offsets = np.repeat(offsets, 4, axis=0)
-    signs = np.ones((len(offsets), ndim))
-    signs[::2] = -1
-    offsets = offsets * signs
-
-    vertices = centers + width * offsets / 2
-    triangles = np.array(
-        [
-            [2 * i, 2 * i + 1, 2 * i + 2]
-            if i % 2 == 0
-            else [2 * i - 1, 2 * i, 2 * i + 1]
-            for i in range(len(vectors))
-        ]
-    ).astype(np.uint32)
-
-    return vertices, triangles
 
 
 def fix_data_vectors(

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -14,7 +14,7 @@ from ..utils._color_manager_constants import ColorMode
 from ..utils.color_manager import ColorManager
 from ..utils.color_transformations import ColorType
 from ..utils.layer_utils import _FeatureTable
-from ._vector_utils import fix_data_vectors, generate_vector_meshes
+from ._vector_utils import fix_data_vectors
 
 
 class Vectors(Layer):
@@ -135,21 +135,10 @@ class Vectors(Layer):
         colors for the M in view vectors
     _view_indices : (1, M) array
         indices for the M in view vectors
-    _view_vertices : (4M, 2) or (8M, 2) np.ndarray
-        the corner points for the M in view faces. Shape is (4M, 2) for 2D and (8M, 2) for 3D.
-    _view_faces : (2M, 3) or (4M, 3) np.ndarray
-        indices of the _mesh_vertices that form the faces of the M in view vectors.
-        Shape is (2M, 2) for 2D and (4M, 2) for 3D.
     _view_alphas : (M,) or float
         relative opacity for the M in view vectors
     _property_choices : dict {str: array (N,)}
         Possible values for the properties in Vectors.properties.
-    _mesh_vertices : (4N, 2) array
-        The four corner points for the mesh representation of each vector as as
-        rectangle in the slice that it starts in.
-    _mesh_triangles : (2N, 3) array
-        The integer indices of the `_mesh_vertices` that form the two triangles
-        for the mesh representation of the vectors.
     _max_vectors_thumbnail : int
         The maximum number of vectors that will ever be used to render the
         thumbnail. If more vectors are present then they are randomly
@@ -229,10 +218,7 @@ class Vectors(Layer):
         self._length = float(length)
 
         self._data = data
-        self._mesh_vertices = None
-        self._mesh_triangles = None
         self._displayed_stored = None
-        self._update_mesh()
 
         self._feature_table = _FeatureTable.from_layer(
             features=features,
@@ -255,8 +241,6 @@ class Vectors(Layer):
         # Data containing vectors in the currently viewed slice
         self._view_data = np.empty((0, 2, 2))
         self._displayed_stored = []
-        self._view_vertices = []
-        self._view_faces = []
         self._view_indices = []
         self._view_alphas = []
 
@@ -275,8 +259,6 @@ class Vectors(Layer):
 
         self._data, _ = fix_data_vectors(vectors, self.ndim)
         n_vectors = len(self.data)
-
-        self._update_mesh()
 
         # Adjust the props/color arrays when the number of vectors has changed
         with self.events.blocker_all():
@@ -439,8 +421,6 @@ class Vectors(Layer):
     def edge_width(self, edge_width: Union[int, float]):
         self._edge_width = edge_width
 
-        self._update_mesh()
-
         self.events.edge_width()
         self.refresh()
 
@@ -452,8 +432,6 @@ class Vectors(Layer):
     @length.setter
     def length(self, length: Union[int, float]):
         self._length = float(length)
-
-        self._update_mesh()
 
         self.events.length()
         self.refresh()
@@ -656,14 +634,10 @@ class Vectors(Layer):
         """Sets the view given the indices to slice with."""
 
         indices, alphas = self._slice_data(self._slice_indices)
-        if not self._dims_displayed == self._displayed_stored:
-            self._update_mesh()
 
-        vertices = self._mesh_vertices
         disp = list(self._dims_displayed)
 
         if len(self.data) == 0:
-            faces = []
             self._view_data = np.empty((0, 2, 2))
             self._view_indices = []
         elif self.ndim > 2:
@@ -671,32 +645,10 @@ class Vectors(Layer):
             self._view_indices = indices
             self._view_alphas = alphas
             self._view_data = self.data[np.ix_(indices, [0, 1], disp)]
-            if len(indices) == 0:
-                faces = []
-            else:
-                keep_inds = np.repeat(2 * indices, 2)
-                keep_inds[1::2] = keep_inds[1::2] + 1
-                if self._ndisplay == 3:
-                    keep_inds = np.concatenate(
-                        [
-                            keep_inds,
-                            len(self._mesh_triangles) // 2 + keep_inds,
-                        ],
-                        axis=0,
-                    )
-                faces = self._mesh_triangles[keep_inds]
         else:
-            faces = self._mesh_triangles
             self._view_data = self.data[:, :, disp]
             self._view_indices = np.arange(self.data.shape[0])
             self._view_alphas = 1.0
-
-        if len(faces) == 0:
-            self._view_vertices = []
-            self._view_faces = []
-        else:
-            self._view_vertices = vertices
-            self._view_faces = faces
 
     def _update_thumbnail(self):
         """Update thumbnail with current vectors and colors."""
@@ -758,16 +710,3 @@ class Vectors(Layer):
             Value of the data at the coord.
         """
         return None
-
-    def _update_mesh(self):
-        """Generate a new vector mesh and update the stored vertices and
-        trianges for the mesh.
-        """
-        vertices, triangles = generate_vector_meshes(
-            self.data[:, :, list(self._dims_displayed)],
-            self.edge_width,
-            self.length,
-        )
-        self._mesh_vertices = vertices
-        self._mesh_triangles = triangles
-        self._displayed_stored = copy(self._dims_displayed)


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->
I've added a benchmark to check for regressions when switching to updating the mesh with every slice event. 

Based on my understanding, calling `refresh` should trigger both `on_data_change` _and_ `set_view_slice`. This means that `refresh` should encompass the mesh code in both locations and be as close to apples to apples as possible. 

That said, I'm not certain whether `refresh` should be called more than once in order to capture the additional burden of recalculating the mesh with every slice. I believe that in the old code, there was basically a check to see if anything had changed and if not, the mesh wasn't recalculated. This would mean that running refresh multiple times on the old code should be less computationally expensive than the new code _unless_ the reduction to only generate the mesh in the slice subset is sufficiently efficient. 

TLDR - I benchmarked against calling refresh in the test function once, and again with three consecutive calls to refresh.

**RESULTS:**


**call refresh once**
```
**old code**
[100.00%] ··· ======== =============
               param1               
              -------- -------------
                 16     2.81±0.02ms 
                 64     4.67±0.09ms 
                256      10.2±0.1ms 
                1024     36.3±0.8ms 
                4096     74.6±0.2ms 
               16384      110±1ms   
               65536      250±3ms   
              ======== =============


**new code**
[100.00%] ··· ======== =============
               param1               
              -------- -------------
                 16     2.93±0.03ms 
                 64     4.70±0.06ms 
                256      10.5±0.1ms 
                1024     38.1±0.9ms 
                4096     75.8±0.4ms 
               16384     122±0.8ms  
               65536      298±2ms   
              ======== =============
```

**call refresh 3 times**
```
**old code**
[100.00%] ··· ======== =============
               param1               
              -------- -------------
                 16      8.30±0.1ms 
                 64     13.9±0.07ms 
                256      31.2±0.3ms 
                1024     105±0.6ms  
                4096      216±1ms   
               16384      326±6ms   
               65536      756±9ms   
              ======== =============

**new code**
[100.00%] ··· ======== =============
               param1               
              -------- -------------
                 16     8.63±0.02ms 
                 64     14.3±0.09ms 
                256      32.0±0.2ms 
                1024     106±0.7ms  
                4096      224±2ms   
               16384     358±0.8ms  
               65536      896±4ms   
              ======== =============
```   



## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

I added this benchmark as a qt benchmark because otherwise, the benchmark wasn't getting into `on_data_change`. It was strange because when I ran the same commands through pytest, I could have gotten away with not instantiating the viewer (I think). If there is a better approach, I'm happy to hear it! 


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
