### PR TITLE
fix icon urls for close dialog

### DIFF
--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -79,7 +79,7 @@ Icons are typically used inside of one of our `stylesheet.qss` files, with the
 
 ```css
 QtDeleteButton {
-   image: url(":/themes/{{ folder }}/delete.svg");
+   image: url("theme_{{ name }}:/delete.svg");
 }
 ```
 

--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -789,17 +789,17 @@ QtLayerList::indicator:checked {
 
 
 #warning_icon_btn {
-  qproperty-icon: url(":/themes/{{ name }}/warning.svg");
+  qproperty-icon: url("theme_{{ name }}:/warning.svg");
 }
 
 #warning_icon_element {
-  image: url(":/themes/{{ name }}/warning.svg");
+  image: url("theme_{{ name }}:/warning.svg");
   min-height: 36px;
   min-width: 36px;
 }
 
 #error_icon_element {
-  image: url(":/themes/{{ name }}/error.svg");
+  image: url("theme_{{ name }}:/error.svg");
   min-height: 36px;
   min-width: 36px;
 }


### PR DESCRIPTION
# Description
just merged #4820, but missed that the icon styles used the old pattern (pre pyqt6 support).  This fixes that and updates the contributing docs