### PR TITLE
Fix missing slice from dims

### DIFF
--- a/napari/components/_tests/test_dims.py
+++ b/napari/components/_tests/test_dims.py
@@ -294,3 +294,10 @@ def test_changing_focus():
     assert dims.last_used == 0
     dims._focus_down()
     assert dims.last_used == 2
+
+
+def test_floating_point_edge_case():
+    # see #4889
+    dims = Dims(ndim=2)
+    dims.set_range(0, (0.0, 17.665, 3.533))
+    assert dims.nsteps[0] == 5

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -155,7 +155,7 @@ class Dims(EventedModel):
     def nsteps(self) -> Tuple[int, ...]:
         """Tuple of int: Number of slider steps for each dimension."""
         return tuple(
-            int((max_val - min_val) // step_size)
+            int((max_val - min_val) / step_size)
             for min_val, max_val, step_size in self.range
         )
 


### PR DESCRIPTION
# Description
Fixes #4861. I'm not 100% sure that this does not introduce the *opposite* problem (adding one more slice than necessary), but I *think* it shouldn't. Even if it does, it's less critical than the current issue.

As mentioned in the original issue, the problem can be boiled down to this floating point precision example:

```py
(17.665-0.0) // 3.533 == 4.0  # what we do in `Dims.nsteps`
(17.665-0.0) / 3.533 == 5.0  # what apparently we should do
```

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
