### PR TITLE
Make `viewer.events.layers_change` event deprecated

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -184,7 +184,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         self.events.add(
             layers_change=WarningEmitter(
                 "This event will be removed in 0.5.0. "
-                "Please use viewer.layers.events instead"
+                "Please use viewer.layers.events instead",
+                type="layers_change",
             ),
             reset_view=Event,
         )

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -42,6 +42,7 @@ from ..utils._register import create_func as create_add_method
 from ..utils.action_manager import action_manager
 from ..utils.colormaps import ensure_colormap
 from ..utils.events import Event, EventedModel, disconnect_events
+from ..utils.events.event import WarningEmitter
 from ..utils.key_bindings import KeymapProvider
 from ..utils.migrations import rename_argument
 from ..utils.misc import is_sequence
@@ -180,7 +181,13 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         )
 
         # Add extra events - ideally these will be removed too!
-        self.events.add(layers_change=Event, reset_view=Event)
+        self.events.add(
+            layers_change=WarningEmitter(
+                "This event will be removed in 0.5.0. "
+                "Please use viewer.layers.events instead"
+            ),
+            reset_view=Event,
+        )
 
         # Connect events
         self.grid.events.connect(self.reset_view)


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Requested by @sofroniewn in #4469

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
