### PR TITLE
Docker: Update xpra's apt too

### DIFF
--- a/.github/workflows/docker-singularity-publish.yml
+++ b/.github/workflows/docker-singularity-publish.yml
@@ -14,6 +14,7 @@ on:
     branches: [ main ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
+  pull_request:  # temporary for PR testing only; REMOVE
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/docker-singularity-publish.yml
+++ b/.github/workflows/docker-singularity-publish.yml
@@ -14,7 +14,6 @@ on:
     branches: [ main ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
-  pull_request:  # temporary for PR testing only; REMOVE
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,7 @@
 FROM --platform=linux/amd64 ubuntu:22.04 AS napari
-
+# if you change the Ubuntu version, remember to update
+# the APT definitions for Xpra below so it reflects the
+# new codename (e.g. 20.04 was focal, 22.04 had jammy)
 
 # below env var required to install libglib2.0-0 non-interactively
 ENV TZ=America/Los_Angeles

--- a/dockerfile
+++ b/dockerfile
@@ -48,7 +48,7 @@ FROM napari AS napari-xpra
 # Install Xpra and dependencies
 RUN apt-get install -y wget gnupg2 apt-transport-https && \
     wget -O - https://xpra.org/gpg.asc | apt-key add - && \
-    echo "deb https://xpra.org/ focal main" > /etc/apt/sources.list.d/xpra.list
+    echo "deb https://xpra.org/ jammy main" > /etc/apt/sources.list.d/xpra.list
 
 RUN apt-get update && \
     apt-get install -yqq \


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

Docker jobs are failing on `main`.

Follow up to https://github.com/napari/napari/pull/4568, where Ubuntu's image was updated from v20 to v22. Unfortunately, this means that the codename changed from `focal` to `jammy`, and that needs to be reflected in the Xpra APT definitions below.

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] CI passes on PR.
- [ ] Removed temporary CI triggers for PR.

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
