### PR TITLE
Add saving folders to preferences

### DIFF
--- a/napari/_qt/dialogs/_tests/test_reader_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_reader_dialog.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pytest
 from npe2 import DynamicPlugin
@@ -61,7 +63,7 @@ def test_reader_dir(tmpdir, reader_dialog):
     widg = reader_dialog(pth=dir, readers={'p1': 'p1', 'p2': 'p2'})
     assert (
         widg._persist_text
-        == f'Remember this choice for folders labeled as {dir}/.'
+        == f'Remember this choice for folders labeled as {dir}{os.sep}.'
     )
 
 

--- a/napari/_qt/dialogs/_tests/test_reader_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_reader_dialog.py
@@ -55,6 +55,16 @@ def test_reader_dir_with_extension(tmpdir, reader_dialog):
     )
 
 
+def test_reader_dir(tmpdir, reader_dialog):
+
+    dir = tmpdir.mkdir('my_dir')
+    widg = reader_dialog(pth=dir, readers={'p1': 'p1', 'p2': 'p2'})
+    assert (
+        widg._persist_text
+        == 'Remember this choice for folders labeled as ' + str(dir) + '/.'
+    )
+
+
 def test_get_plugin_choice(tmpdir, reader_dialog):
     file_pth = tmpdir.join('my_file.tif')
     widg = reader_dialog(pth=file_pth, readers={'p1': 'p1', 'p2': 'p2'})

--- a/napari/_qt/dialogs/_tests/test_reader_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_reader_dialog.py
@@ -61,7 +61,7 @@ def test_reader_dir(tmpdir, reader_dialog):
     widg = reader_dialog(pth=dir, readers={'p1': 'p1', 'p2': 'p2'})
     assert (
         widg._persist_text
-        == 'Remember this choice for folders labeled as ' + str(dir) + '/.'
+        == f'Remember this choice for folders labeled as {dir}/.'
     )
 
 

--- a/napari/_qt/dialogs/_tests/test_reader_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_reader_dialog.py
@@ -45,13 +45,6 @@ def test_reader_with_error_message(reader_dialog):
     assert widg.findChild(QLabel).text().startswith('Test Error')
 
 
-def test_reader_dir(tmpdir, reader_dialog):
-    dir = tmpdir.mkdir('my_dir')
-    widg = reader_dialog(pth=dir, readers={'p1': 'p1', 'p2': 'p2'})
-
-    assert not hasattr(widg, 'persist_checkbox')
-
-
 def test_reader_dir_with_extension(tmpdir, reader_dialog):
     dir = tmpdir.mkdir('my_dir.zarr')
     widg = reader_dialog(pth=dir, readers={'p1': 'p1', 'p2': 'p2'})

--- a/napari/_qt/dialogs/qt_reader_dialog.py
+++ b/napari/_qt/dialogs/qt_reader_dialog.py
@@ -292,7 +292,7 @@ def open_with_dialog_choices(
     qt_viewer.viewer.open(paths, stack=stack, plugin=plugin_name, **kwargs)
 
     if persist:
-        if not os.path.isdir(extension):
+        if not extension.endswith(os.sep):
             extension = '*' + extension
         get_settings().plugins.extension2reader = {
             **get_settings().plugins.extension2reader,

--- a/napari/_qt/dialogs/qt_reader_dialog.py
+++ b/napari/_qt/dialogs/qt_reader_dialog.py
@@ -44,7 +44,7 @@ class QtReaderDialog(QDialog):
                 '.zarr'
             ) and not self._extension.endswith('/'):
                 self._extension = self._extension + '/'
-                self._persist_text = f'Remember this choice for folders labeled as {self._extension}.'
+                self._persist_text = f'Remember this choice for folders named {self._extension}.'
 
         self._reader_buttons = []
         self.setup_ui(error_message, readers, persist_checked)

--- a/napari/_qt/dialogs/qt_reader_dialog.py
+++ b/napari/_qt/dialogs/qt_reader_dialog.py
@@ -275,6 +275,7 @@ def open_with_dialog_choices(
     qt_viewer.viewer.open(paths, stack=stack, plugin=plugin_name, **kwargs)
 
     if persist:
+        print(extension)
         get_settings().plugins.extension2reader = {
             **get_settings().plugins.extension2reader,
             f'{extension}': plugin_name,

--- a/napari/_qt/dialogs/qt_reader_dialog.py
+++ b/napari/_qt/dialogs/qt_reader_dialog.py
@@ -42,12 +42,10 @@ class QtReaderDialog(QDialog):
             self._extension = os.path.realpath(pth)
             if not self._extension.endswith(
                 '.zarr'
-            ) and not self._extension.endswith('/'):
+            ) and not self._extension.endswith(os.sep):
                 self._extension = self._extension + os.sep
                 self._persist_text = f'Remember this choice for folders labeled as {self._extension}.'
 
-        else:
-            self._extension = '*' + self._extension
         self._reader_buttons = []
         self.setup_ui(error_message, readers, persist_checked)
 
@@ -275,6 +273,8 @@ def open_with_dialog_choices(
     qt_viewer.viewer.open(paths, stack=stack, plugin=plugin_name, **kwargs)
 
     if persist:
+        if not os.path.isdir(extension):
+            extension = '*' + extension
         get_settings().plugins.extension2reader = {
             **get_settings().plugins.extension2reader,
             f'{extension}': plugin_name,

--- a/napari/_qt/dialogs/qt_reader_dialog.py
+++ b/napari/_qt/dialogs/qt_reader_dialog.py
@@ -296,5 +296,5 @@ def open_with_dialog_choices(
             extension = '*' + extension
         get_settings().plugins.extension2reader = {
             **get_settings().plugins.extension2reader,
-            f'{extension}': plugin_name,
+            extension: plugin_name,
         }

--- a/napari/_qt/dialogs/qt_reader_dialog.py
+++ b/napari/_qt/dialogs/qt_reader_dialog.py
@@ -275,7 +275,6 @@ def open_with_dialog_choices(
     qt_viewer.viewer.open(paths, stack=stack, plugin=plugin_name, **kwargs)
 
     if persist:
-        print(extension)
         get_settings().plugins.extension2reader = {
             **get_settings().plugins.extension2reader,
             f'{extension}': plugin_name,

--- a/napari/_qt/dialogs/qt_reader_dialog.py
+++ b/napari/_qt/dialogs/qt_reader_dialog.py
@@ -35,9 +35,13 @@ class QtReaderDialog(QDialog):
         self.setWindowTitle(trans._('Choose reader'))
         self._current_file = pth
 
-        if os.path.isdir(pth) and str(pth).endswith('/'):
-            pth = os.path.dirname(pth)
-        self._extension = os.path.splitext(pth)[1]
+        if os.path.isdir(pth):
+            self._extension = os.path.basename(pth)
+            if not self._extension.endswith('/'):
+                self._extension = self._extension + '/'
+
+        else:
+            self._extension = '*' + os.path.splitext(pth)[1]
 
         self._reader_buttons = []
         self.setup_ui(error_message, readers, persist_checked)
@@ -66,27 +70,27 @@ class QtReaderDialog(QDialog):
         self.btn_box.accepted.connect(self.accept)
         self.btn_box.rejected.connect(self.reject)
 
-        # checkbox to remember the choice (doesn't pop up for folders with no extension)
-        if self._extension:
+        # checkbox to remember the choice 
 
-            existing_pref = get_settings().plugins.extension2reader.get(
-                '*' + self._extension
+        existing_pref = get_settings().plugins.extension2reader.get(
+            '*' + self._extension
+        )
+        if existing_pref:
+            warn_message = trans._(
+                'Override existing preference for files with a {extension} extension: {pref}',
+                extension=self._extension,
+                pref=existing_pref,
             )
-            if existing_pref:
-                warn_message = trans._(
-                    'Override existing preference for files with a {extension} extension: {pref}',
-                    extension=self._extension,
-                    pref=existing_pref,
-                )
-            else:
-                warn_message = trans._(
-                    'Remember this choice for files with a {extension} extension',
-                    extension=self._extension,
-                )
+        else:
+            warn_message = trans._(
+                'Remember this choice for files with a {extension} extension',
+                extension=self._extension,
+            )
 
-            self.persist_checkbox = QCheckBox(warn_message)
-            self.persist_checkbox.setChecked(persist_checked)
-            layout.addWidget(self.persist_checkbox)
+        self.persist_checkbox = QCheckBox(warn_message)
+        self.persist_checkbox.toggle()
+        self.persist_checkbox.setChecked(persist_checked)
+        layout.addWidget(self.persist_checkbox)
 
         layout.addWidget(self.btn_box)
         self.setLayout(layout)
@@ -271,5 +275,5 @@ def open_with_dialog_choices(
     if persist:
         get_settings().plugins.extension2reader = {
             **get_settings().plugins.extension2reader,
-            f'*{extension}': plugin_name,
+            f'{extension}': plugin_name,
         }

--- a/napari/_qt/dialogs/qt_reader_dialog.py
+++ b/napari/_qt/dialogs/qt_reader_dialog.py
@@ -87,11 +87,6 @@ class QtReaderDialog(QDialog):
                 extension=self._extension,
                 pref=existing_pref,
             )
-        else:
-            self._persist_text = trans._(
-                'Remember this choice for files with a {extension} extension',
-                extension=self._extension,
-            )
 
         self.persist_checkbox = QCheckBox(self._persist_text)
         self.persist_checkbox.toggle()

--- a/napari/_qt/dialogs/qt_reader_dialog.py
+++ b/napari/_qt/dialogs/qt_reader_dialog.py
@@ -36,7 +36,10 @@ class QtReaderDialog(QDialog):
         self._current_file = pth
 
         self._extension = os.path.splitext(pth)[1]
-        self._persist_text = f'Remember this choice for files with a {self._extension} extension'
+        self._persist_text = trans._(
+            'Remember this choice for files with a {extension} extension',
+            extension=self._extension,
+        )
 
         if os.path.isdir(pth):
             self._extension = os.path.realpath(pth)
@@ -44,7 +47,10 @@ class QtReaderDialog(QDialog):
                 '.zarr'
             ) and not self._extension.endswith(os.sep):
                 self._extension = self._extension + os.sep
-                self._persist_text = f'Remember this choice for folders labeled as {self._extension}.'
+                self._persist_text = trans._(
+                    'Remember this choice for folders labeled as {extension}.',
+                    extension=self._extension,
+                )
 
         self._reader_buttons = []
         self.setup_ui(error_message, readers, persist_checked)
@@ -73,25 +79,38 @@ class QtReaderDialog(QDialog):
         self.btn_box.accepted.connect(self.accept)
         self.btn_box.rejected.connect(self.reject)
 
-        # checkbox to remember the choice 
+        # checkbox to remember the choice
         if os.path.isdir(self._current_file):
-            existing_pref = get_settings().plugins.extension2reader.get(self._extension)
+            existing_pref = get_settings().plugins.extension2reader.get(
+                self._extension
+            )
+            isdir = True
         else:
             existing_pref = get_settings().plugins.extension2reader.get(
-            '*' + self._extension)
+                '*' + self._extension
+            )
+            isdir = False
 
         if existing_pref:
-            self._persist_text = trans._(
-                'Override existing preference for files with a {extension} extension: {pref}',
-                extension=self._extension,
-                pref=existing_pref,
-            )
+            if isdir:
+                self._persist_text = trans._(
+                    'Override existing preference for folders labeled as {extension}: {pref}',
+                    extension=self._extension,
+                    pref=existing_pref,
+                )
+
+            else:
+                self._persist_text = trans._(
+                    'Override existing preference for files with a {extension} extension: {pref}',
+                    extension=self._extension,
+                    pref=existing_pref,
+                )
 
         self.persist_checkbox = QCheckBox(self._persist_text)
         self.persist_checkbox.toggle()
         self.persist_checkbox.setChecked(persist_checked)
         layout.addWidget(self.persist_checkbox)
-        
+
         layout.addWidget(self.btn_box)
         self.setLayout(layout)
 

--- a/napari/_qt/dialogs/qt_reader_dialog.py
+++ b/napari/_qt/dialogs/qt_reader_dialog.py
@@ -39,13 +39,15 @@ class QtReaderDialog(QDialog):
         self._persist_text = f'Remember this choice for files with a {self._extension} extension'
 
         if os.path.isdir(pth):
-            self._extension = os.path.basename(pth)
+            self._extension = os.path.realpath(pth)
             if not self._extension.endswith(
                 '.zarr'
             ) and not self._extension.endswith('/'):
-                self._extension = self._extension + '/'
-                self._persist_text = f'Remember this choice for folders named {self._extension}.'
+                self._extension = self._extension + os.sep
+                self._persist_text = f'Remember this choice for folders labeled as {self._extension}.'
 
+        else:
+            self._extension = '*' + self._extension
         self._reader_buttons = []
         self.setup_ui(error_message, readers, persist_checked)
 
@@ -74,7 +76,6 @@ class QtReaderDialog(QDialog):
         self.btn_box.rejected.connect(self.reject)
 
         # checkbox to remember the choice 
-
         if os.path.isdir(self._current_file):
             existing_pref = get_settings().plugins.extension2reader.get(self._extension)
         else:
@@ -276,5 +277,5 @@ def open_with_dialog_choices(
     if persist:
         get_settings().plugins.extension2reader = {
             **get_settings().plugins.extension2reader,
-            f'*{extension}': plugin_name,
+            f'{extension}': plugin_name,
         }

--- a/napari/_qt/widgets/qt_extension2reader.py
+++ b/napari/_qt/widgets/qt_extension2reader.py
@@ -52,16 +52,10 @@ class Extension2ReaderTable(QWidget):
 
         instructions = QLabel(
             trans._(
-                'Enter a filename pattern to associate with a reader e.g. "*.tif" for all TIFF files.'
-            )
-            + trans._(
-                'Available readers will be filtered to those compatible with your pattern. Hover over a reader to see what patterns it accepts.'
-            )
-            + trans._(
-                '\n\nYou can save a preference for a specific folder by listing the folder name with a "/" at the end (for example, "/test_images/").'
-            )
-            + trans._(
-                '\n\nFor documentation on valid filename patterns, see https://docs.python.org/3/library/fnmatch.html'
+                'Enter a filename pattern to associate with a reader e.g. "*.tif" for all TIFF files. '
+                + 'Available readers will be filtered to those compatible with your pattern. Hover over a reader to see what patterns it accepts.'
+                + '\n\nYou can save a preference for a specific folder by listing the folder name with a "/" at the end (for example, "/test_images/").'
+                + '\n\nFor documentation on valid filename patterns, see https://docs.python.org/3/library/fnmatch.html'
             )
         )
         instructions.setWordWrap(True)

--- a/napari/_qt/widgets/qt_extension2reader.py
+++ b/napari/_qt/widgets/qt_extension2reader.py
@@ -1,3 +1,5 @@
+import os
+
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import (
     QComboBox,
@@ -235,7 +237,7 @@ class Extension2ReaderTable(QWidget):
 
         self._table.insertRow(last_row)
         item = QTableWidgetItem(fn_pattern)
-        if fn_pattern.endswith('/'):
+        if fn_pattern.endswith(os.sep):
             item.setTextAlignment(Qt.AlignLeft)
         item.setFlags(Qt.ItemFlag.NoItemFlags)
         self._table.setItem(last_row, self._fn_pattern_col, item)

--- a/napari/_qt/widgets/qt_extension2reader.py
+++ b/napari/_qt/widgets/qt_extension2reader.py
@@ -56,7 +56,7 @@ class Extension2ReaderTable(QWidget):
                 'Available readers will be filtered to those compatible with your pattern. Hover over a reader to see what patterns it accepts.'
             )
             + trans._(
-                '\n\nYou can save a preference for a specific folder by listing the folder name with a "/" at the end (for example, "test_images/").'
+                '\n\nYou can save a preference for a specific folder by listing the folder name with a "/" at the end (for example, "/test_images/").'
             )
             + trans._(
                 '\n\nFor documentation on valid filename patterns, see https://docs.python.org/3/library/fnmatch.html'
@@ -235,6 +235,8 @@ class Extension2ReaderTable(QWidget):
 
         self._table.insertRow(last_row)
         item = QTableWidgetItem(fn_pattern)
+        if fn_pattern.endswith('/'):
+            item.setTextAlignment(Qt.AlignLeft)
         item.setFlags(Qt.ItemFlag.NoItemFlags)
         self._table.setItem(last_row, self._fn_pattern_col, item)
 

--- a/napari/_qt/widgets/qt_extension2reader.py
+++ b/napari/_qt/widgets/qt_extension2reader.py
@@ -56,7 +56,7 @@ class Extension2ReaderTable(QWidget):
                 'Available readers will be filtered to those compatible with your pattern. Hover over a reader to see what patterns it accepts.'
             )
             + trans._(
-                '\n\nPreference saving for folder readers is not supported, so these readers are not shown.'
+                '\n\nYou can save a preference for a specific folder by listing the folder name with a "/" at the end (for example, "test_images/").'
             )
             + trans._(
                 '\n\nFor documentation on valid filename patterns, see https://docs.python.org/3/library/fnmatch.html'
@@ -175,7 +175,6 @@ class Extension2ReaderTable(QWidget):
 
         readers = self._npe2_readers.copy()
         to_delete = []
-
         compatible_readers = get_potential_readers(new_pattern)
         for plugin_name, display_name in readers.items():
             if plugin_name not in compatible_readers:
@@ -183,6 +182,7 @@ class Extension2ReaderTable(QWidget):
 
         for reader in to_delete:
             del readers[reader]
+
         readers.update(self._npe1_readers)
 
         if not readers:

--- a/napari/_qt/widgets/qt_extension2reader.py
+++ b/napari/_qt/widgets/qt_extension2reader.py
@@ -52,10 +52,7 @@ class Extension2ReaderTable(QWidget):
 
         instructions = QLabel(
             trans._(
-                'Enter a filename pattern to associate with a reader e.g. "*.tif" for all TIFF files. '
-                + 'Available readers will be filtered to those compatible with your pattern. Hover over a reader to see what patterns it accepts.'
-                + '\n\nYou can save a preference for a specific folder by listing the folder name with a "/" at the end (for example, "/test_images/").'
-                + '\n\nFor documentation on valid filename patterns, see https://docs.python.org/3/library/fnmatch.html'
+                'Enter a filename pattern to associate with a reader e.g. "*.tif" for all TIFF files.  Available readers will be filtered to those compatible with your pattern. Hover over a reader to see what patterns it accepts. \n\nYou can save a preference for a specific folder by listing the folder name with a "/" at the end (for example, "/test_images/"). \n\nFor documentation on valid filename patterns, see https://docs.python.org/3/library/fnmatch.html'
             )
         )
         instructions.setWordWrap(True)

--- a/napari/_qt/widgets/qt_extension2reader.py
+++ b/napari/_qt/widgets/qt_extension2reader.py
@@ -238,7 +238,7 @@ class Extension2ReaderTable(QWidget):
         self._table.insertRow(last_row)
         item = QTableWidgetItem(fn_pattern)
         if fn_pattern.endswith(os.sep):
-            item.setTextAlignment(Qt.AlignLeft)
+            item.setTextAlignment(Qt.AlignmentFlag.AlignLeft)
         item.setFlags(Qt.ItemFlag.NoItemFlags)
         self._table.setItem(last_row, self._fn_pattern_col, item)
 

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1078,13 +1078,11 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             when multiple readers are available to read the path
         """
         paths = [os.fspath(path) for path in paths]  # PathObjects -> str
-
         added = []
         plugin = None
         _path = paths[0]
         # we want to display the paths nicely so make a help string here
         path_message = f"[{_path}], ...]" if len(paths) > 1 else _path
-
         readers = get_potential_readers(_path)
         if not readers:
             raise NoAvailableReaderError(

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -207,17 +207,8 @@ def get_readers(path: Optional[str] = None) -> Dict[str, str]:
     Dict[str, str]
         Dictionary of plugin_name to display name
     """
-    readers = {}
 
     if path:
-        if path.endswith('/'):
-            for manifest in pm.iter_manifests():
-                if manifest.contributions.readers:
-                    for reader in manifest.contributions.readers:
-                        if reader.accepts_directories:
-                            readers[manifest.name] = manifest.display_name
-                            break
-            return readers
         return {
             reader.plugin_name: pm.get_manifest(reader.command).display_name
             for reader in pm.iter_compatible_readers([path])

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -207,7 +207,17 @@ def get_readers(path: Optional[str] = None) -> Dict[str, str]:
     Dict[str, str]
         Dictionary of plugin_name to display name
     """
+    readers = {}
+
     if path:
+        if path.endswith('/'):
+            for manifest in pm.iter_manifests():
+                if manifest.contributions.readers:
+                    for reader in manifest.contributions.readers:
+                        if reader.accepts_directories:
+                            readers[manifest.name] = manifest.display_name
+                            break
+            return readers
         return {
             reader.plugin_name: pm.get_manifest(reader.command).display_name
             for reader in pm.iter_compatible_readers([path])

--- a/napari/plugins/utils.py
+++ b/napari/plugins/utils.py
@@ -82,8 +82,12 @@ def _get_preferred_readers(path: str) -> Iterable[Tuple[str, str]]:
     filtered_preferences : Iterable[Tuple[str, str]]
         Filtered patterns and their corresponding readers.
     """
-    reader_settings = get_settings().plugins.extension2reader
 
+    if osp.isdir(path):
+        path = osp.basename(path)
+        if not path.endswith('/'):
+            path = path + '/'
+    reader_settings = get_settings().plugins.extension2reader
     return filter(lambda kv: fnmatch(path, kv[0]), reader_settings.items())
 
 
@@ -103,7 +107,6 @@ def get_preferred_reader(path: str) -> Optional[str]:
     readers = sorted(
         _get_preferred_readers(path), key=lambda kv: score_specificity(kv[0])
     )
-
     if readers:
         preferred = readers[0]
         _, reader = preferred

--- a/napari/plugins/utils.py
+++ b/napari/plugins/utils.py
@@ -89,13 +89,6 @@ def _get_preferred_readers(path: str) -> Iterable[Tuple[str, str]]:
             path = path + os.sep
 
     reader_settings = get_settings().plugins.extension2reader
-    print('reader settings', reader_settings)
-    print(
-        'result',
-        str(filter(lambda kv: fnmatch(path, kv[0]), reader_settings.items())),
-    )
-    for kv in reader_settings.items():
-        print('matching', path, kv, fnmatch(path, kv[0]))
     return filter(lambda kv: fnmatch(path, kv[0]), reader_settings.items())
 
 

--- a/napari/plugins/utils.py
+++ b/napari/plugins/utils.py
@@ -108,11 +108,9 @@ def get_preferred_reader(path: str) -> Optional[str]:
     readers = sorted(
         _get_preferred_readers(path), key=lambda kv: score_specificity(kv[0])
     )
-    print('readers', readers)
     if readers:
         preferred = readers[0]
         _, reader = preferred
-        print(reader)
         return reader
 
     return None

--- a/napari/plugins/utils.py
+++ b/napari/plugins/utils.py
@@ -86,7 +86,7 @@ def _get_preferred_readers(path: str) -> Iterable[Tuple[str, str]]:
 
     if osp.isdir(path):
         path = osp.basename(path)
-        if not path.endswith('/'):
+        if not path.endswith(os.sep):
             path = path + os.sep
     reader_settings = get_settings().plugins.extension2reader
     return filter(lambda kv: fnmatch(path, kv[0]), reader_settings.items())

--- a/napari/plugins/utils.py
+++ b/napari/plugins/utils.py
@@ -1,3 +1,4 @@
+import os
 import os.path as osp
 import re
 from enum import IntFlag
@@ -86,7 +87,7 @@ def _get_preferred_readers(path: str) -> Iterable[Tuple[str, str]]:
     if osp.isdir(path):
         path = osp.basename(path)
         if not path.endswith('/'):
-            path = path + '/'
+            path = path + os.sep
     reader_settings = get_settings().plugins.extension2reader
     return filter(lambda kv: fnmatch(path, kv[0]), reader_settings.items())
 

--- a/napari/plugins/utils.py
+++ b/napari/plugins/utils.py
@@ -85,10 +85,17 @@ def _get_preferred_readers(path: str) -> Iterable[Tuple[str, str]]:
     """
 
     if osp.isdir(path):
-        path = osp.basename(path)
         if not path.endswith(os.sep):
             path = path + os.sep
+
     reader_settings = get_settings().plugins.extension2reader
+    print('reader settings', reader_settings)
+    print(
+        'result',
+        str(filter(lambda kv: fnmatch(path, kv[0]), reader_settings.items())),
+    )
+    for kv in reader_settings.items():
+        print('matching', path, kv, fnmatch(path, kv[0]))
     return filter(lambda kv: fnmatch(path, kv[0]), reader_settings.items())
 
 
@@ -108,9 +115,11 @@ def get_preferred_reader(path: str) -> Optional[str]:
     readers = sorted(
         _get_preferred_readers(path), key=lambda kv: score_specificity(kv[0])
     )
+    print('readers', readers)
     if readers:
         preferred = readers[0]
         _, reader = preferred
+        print(reader)
         return reader
 
     return None


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
From issue #4613, #4.
This PR will allow a user to save a file reader preference for a specific folder name.

If you try to open a folder, and no preference is saved, it will ask the user to pick a plugin.  The option is now given to save that preference.  

https://user-images.githubusercontent.com/54282105/182483982-0705dc4c-434b-4610-b3f2-1400f8eaadef.mov


