### PR TITLE
Conda: fix MacOS signing

### DIFF
--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -289,6 +289,12 @@ jobs:
           echo "CONSTRUCTOR_SIGNING_IDENTITY=${signing_identity}" >> $GITHUB_ENV
           echo "CONSTRUCTOR_NOTARIZATION_IDENTITY=${notarization_identity}" >> $GITHUB_ENV
 
+          # The conda environment might contain a different codesign!
+          _codesign=$(which codesign)
+          if [[ $_codesign =~ ${CONDA_PREFIX}.* ]]; then
+            mv "${_codesign}" "${_codesign}.in_conda_env"
+          fi
+
       - name: Load signing certificate (Windows)
         # We only sign pushes to main, nightlies, RCs and final releases
         if: runner.os == 'Windows' && (github.event_name == 'schedule' || github.event_name == 'push')

--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
   schedule:
     - cron: "0 0 * * *"
   # Allows you to run this workflow manually from the Actions tab
@@ -256,7 +256,7 @@ jobs:
       - name: Load signing certificate (MacOS)
         shell: bash -l {0}
         # We only sign pushes to main, nightlies, RCs and final releases
-        if: runner.os == 'macOS' && (github.event_name == 'schedule' || github.event_name == 'push')
+        if: runner.os == 'macOS' # && (github.event_name == 'schedule' || github.event_name == 'push')
         env:
           APPLE_APPLICATION_CERTIFICATE_BASE64: ${{ secrets.APPLE_APPLICATION_CERTIFICATE_BASE64 }}
           APPLE_INSTALLER_CERTIFICATE_BASE64: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_BASE64 }}
@@ -289,7 +289,8 @@ jobs:
           echo "CONSTRUCTOR_SIGNING_IDENTITY=${signing_identity}" >> $GITHUB_ENV
           echo "CONSTRUCTOR_NOTARIZATION_IDENTITY=${notarization_identity}" >> $GITHUB_ENV
 
-          # The conda environment might contain a different codesign!
+          # The conda environment might contain a totally different codesign
+          # which would clobber the Apple's codesign (the one we need)
           _codesign=$(which codesign)
           if [[ $_codesign =~ ${CONDA_PREFIX}.* ]]; then
             mv "${_codesign}" "${_codesign}.in_conda_env"

--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -256,7 +256,7 @@ jobs:
       - name: Load signing certificate (MacOS)
         shell: bash -l {0}
         # We only sign pushes to main, nightlies, RCs and final releases
-        if: runner.os == 'macOS' # && (github.event_name == 'schedule' || github.event_name == 'push')
+        if: runner.os == 'macOS' && (github.event_name == 'schedule' || github.event_name == 'push')
         env:
           APPLE_APPLICATION_CERTIFICATE_BASE64: ${{ secrets.APPLE_APPLICATION_CERTIFICATE_BASE64 }}
           APPLE_INSTALLER_CERTIFICATE_BASE64: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_BASE64 }}


### PR DESCRIPTION
# Description

Supersedes https://github.com/napari/napari/pull/4903 (need to run from a branch, not fork)

See https://github.com/napari/packaging/issues/11 for description of the error. A non-Apple `codesign` is now being shipped in our environment (a secondary dependency must be bringing that in), which clobbers Apple's one (the one we need). Hence why we obtain an undocumented error 109 - the CLI is totally different!

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] Enable PR triggers for CI, temporarily
- [x] Signing works
- [x] Remove PR triggers from CI 

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
