### PR TITLE
Raise exception when layer created with a scale value of 0

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -376,16 +376,3 @@ def test_reset_non_empty(make_napari_viewer):
     viewer = make_napari_viewer()
     viewer.add_points([(0, 1), (2, 3)])
     viewer.reset()
-
-
-def test_zero_scale_layer(make_napari_viewer):
-    """
-    Test that creating a layers with scale 0 for any
-    dimension throws an exception
-    https://github.com/napari/napari/issues/2569
-    """
-    viewer = make_napari_viewer()
-    try:
-        viewer.add_image(np.random.rand(64, 64), scale=(0, 1))
-    except Exception as e:
-        assert 'scale values of 0' in str(e)

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -376,3 +376,16 @@ def test_reset_non_empty(make_napari_viewer):
     viewer = make_napari_viewer()
     viewer.add_points([(0, 1), (2, 3)])
     viewer.reset()
+
+
+def test_zero_scale_layer(make_napari_viewer):
+    """
+    Test that creating a layers with scale 0 for any
+    dimension throws an exception
+    https://github.com/napari/napari/issues/2569
+    """
+    viewer = make_napari_viewer()
+    try:
+        viewer.add_image(np.random.rand(64, 64), scale=(0, 1))
+    except Exception as e:
+        assert 'scale values of 0' in str(e)

--- a/napari/layers/_tests/test_layer_attributes.py
+++ b/napari/layers/_tests/test_layer_attributes.py
@@ -123,3 +123,8 @@ def test_get_value_3d_view_of_2d_image(ImageClass):
         (1, 1): data[(1, 1)],
     }
     _check_subpixel_values(layer, val_dict)
+
+
+def test_zero_scale_layer():
+    with pytest.raises(ValueError, match='scale values of 0'):
+        Image(np.random.rand(64, 64), scale=(0, 1))

--- a/napari/layers/_tests/test_layer_attributes.py
+++ b/napari/layers/_tests/test_layer_attributes.py
@@ -127,4 +127,4 @@ def test_get_value_3d_view_of_2d_image(ImageClass):
 
 def test_zero_scale_layer():
     with pytest.raises(ValueError, match='scale values of 0'):
-        Image(np.random.rand(64, 64), scale=(0, 1))
+        Image(np.zeros((64, 64)), scale=(0, 1))

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -230,7 +230,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         if name is None and data is not None:
             name = magic_name(data)
 
-        if scale and 0 in scale:
+        if scale is not None and not np.all(scale):
             raise Exception(
                 f'Layer "{name}" is invalid because it has scale values of 0. The layer\'s scale is currently "{scale}"'
             )

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -231,7 +231,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             name = magic_name(data)
 
         if scale is not None and not np.all(scale):
-            raise Exception(
+            raise ValueError(
                 f'Layer "{name}" is invalid because it has scale values of 0. The layer\'s scale is currently "{scale}"'
             )
 

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -230,7 +230,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         if name is None and data is not None:
             name = magic_name(data)
 
-        if 0 in scale:
+        if scale and 0 in scale:
             raise Exception(
                 f'Layer "{name}" is invalid because it has scale values of 0. The layer\'s scale is currently "{scale}"'
             )

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -230,6 +230,11 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         if name is None and data is not None:
             name = magic_name(data)
 
+        if 0 in scale:
+            raise Exception(
+                f'Layer "{name}" is invalid because it has scale values of 0. The layer\'s scale is currently "{scale}"'
+            )
+
         self._source = current_source()
         self.dask_optimized_slicing = configure_dask(data, cache)
         self._metadata = dict(metadata or {})

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -232,7 +232,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
         if scale is not None and not np.all(scale):
             raise ValueError(
-                f'Layer "{name}" is invalid because it has scale values of 0. The layer\'s scale is currently "{scale}"'
+                f"Layer {name!r} is invalid because it has scale values of 0. The layer's scale is currently {scale!r}"
             )
 
         self._source = current_source()


### PR DESCRIPTION
# Description

This PR adds an exception when a layer is created with a scale value of 0 (which is invalid). This addresses issue https://github.com/napari/napari/issues/2569. 

Previously when a layer was added with scale of 0 the error (reported in the above issue). Raises a LinAlg exception in a different part of the code that would be hard to interpret as a problem with scale values of 0.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes https://github.com/napari/napari/issues/2569

# How has this been tested?

A test was added to confirm that the exception is thrown https://github.com/kephale/napari/blob/9afc02bed20aec407680c5eddd6f760c50d05c70/napari/_tests/test_viewer.py#L381

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable. (N/A)
      For more information see our [translations guide](https://napari.org/developers/translations.html).
