### PR TITLE
Add Google Calendar ID to directive

### DIFF
--- a/docs/community/meeting_schedule.md
+++ b/docs/community/meeting_schedule.md
@@ -2,9 +2,10 @@
 
 We hold regular meetings, the timings of which are available on our [public calendar](https://calendar.google.com/calendar/embed?src=c_35r93ec6vtp8smhm7dv5uot0v4%40group.calendar.google.com).
 
-```{napari-calendar}
+```{calendar}
 ---
 show-filters: true
+calendar-id: c_35r93ec6vtp8smhm7dv5uot0v4%40group.calendar.google.com
 ---
 ```
 


### PR DESCRIPTION
# Description

Forgot to add these changes after updating the calendar directive 

- Adds Google Calendar ID to the calendar directive 
- Uses updated `calendar` directive name

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
- https://github.com/napari/napari-sphinx-theme/issues/78
- https://github.com/napari/napari-sphinx-theme/pull/116