### PR TITLE
Fix docs dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,11 @@
-sphinx_autodoc_typehints==1.12.0
-Jinja2
+sphinx<5
 sphinx-tabs
 sphinx-panels
-myst-nb
-napari-sphinx-theme
 sphinx-external-toc
 sphinx-gallery
+sphinx_autodoc_typehints==1.12.0
+myst-nb
+napari-sphinx-theme
 matplotlib
 qtgallery
+lxml

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ install_requires =
     scikit-image>=0.19.1
     scipy>=1.4.1 ; python_version < '3.9'
     scipy>=1.5.4 ; python_version >= '3.9'
+    sphinx<5
     superqt>=0.2.5
     tifffile>=2020.2.16
     toolz>=0.10.0
@@ -135,15 +136,14 @@ dev =
     %(testing)s
 docs =
     %(all)s
-    sphinx_autodoc_typehints==1.12.0
-    Jinja2
-    jupytext
+    sphinx<5
     sphinx-tabs
     sphinx-panels
-    myst-nb
-    napari-sphinx-theme
     sphinx-external-toc
     sphinx-gallery
+    sphinx_autodoc_typehints==1.12.0
+    myst-nb
+    napari-sphinx-theme
     matplotlib
     qtgallery
     lxml

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ install_requires =
     scikit-image>=0.19.1
     scipy>=1.4.1 ; python_version < '3.9'
     scipy>=1.5.4 ; python_version >= '3.9'
-    sphinx<5
+    sphinx<5  # numpydoc dependency. sphinx>=5 breaks the docs build; see https://github.com/napari/napari/pull/4915
     superqt>=0.2.5
     tifffile>=2020.2.16
     toolz>=0.10.0


### PR DESCRIPTION
Fixes a few conflicts which were preventing the docs build - specifically preventing Sphinx>=5 from being installed.

Also syncs the `docs/requirements.txt` to agree with `setup.cfg`.

# Description

When creating a fresh conda environment with napari from main, pip is flagging some package conflicts.

```
$ python -m pip install -e ".[all]"
```

<details>
<summary>Output</summary>

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
virtualenv 20.13.0 requires distlib<1,>=0.3.1, which is not installed.
virtualenv 20.13.0 requires platformdirs<3,>=2, which is not installed.
napari-sphinx-theme 0.1.1 requires beautifulsoup4, which is not installed.
myst-nb 0.15.0 requires importlib_metadata, which is not installed.
myst-nb 0.15.0 requires nbclient, which is not installed.
myst-nb 0.15.0 requires nbformat~=5.0, which is not installed.
jupyter-cache 0.5.0 requires importlib-metadata, which is not installed.
jupyter-cache 0.5.0 requires nbclient<0.6,>=0.2, which is not installed.
jupyter-cache 0.5.0 requires nbformat, which is not installed.
furo 2022.4.7 requires beautifulsoup4, which is not installed.
pre-commit 2.19.0 requires toml, which is not installed.
sphinx-panels 0.6.0 requires sphinx<5,>=2, but you have sphinx 5.1.1 which is incompatible.
sphinx-external-toc 0.3.0 requires sphinx<5,>=3, but you have sphinx 5.1.1 which is incompatible.
myst-parser 0.17.2 requires sphinx<5,>=3.1, but you have sphinx 5.1.1 which is incompatible.
myst-nb 0.15.0 requires sphinx<5,>=3.5, but you have sphinx 5.1.1 which is incompatible.
furo 2022.4.7 requires sphinx~=4.0, but you have sphinx 5.1.1 which is incompatible.
```
</details>

In this state, trying to `make docs` fails:

<details>
<summary>Output of make docs</summary>

```
$ make docs
rm -rf docs/_build/
rm -rf docs/api/napari*.rst
rm -rf docs/gallery/*
pip install -qr docs/requirements.txt
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
furo 2022.4.7 requires sphinx~=4.0, but you have sphinx 3.5.3 which is incompatible.
python docs/_scripts/prep_docs.py
Cloning into 'npe2'...
remote: Enumerating objects: 1959, done.
remote: Counting objects: 100% (127/127), done.
remote: Compressing objects: 100% (98/98), done.
remote: Total 1959 (delta 49), reused 69 (delta 28), pack-reused 1832
Receiving objects: 100% (1959/1959), 555.66 KiB | 3.94 MiB/s, done.
Resolving deltas: 100% (1276/1276), done.
Rendered /home/melissa/projects/napari/docs/plugins/_npe2_contributions.md
Rendered /home/melissa/projects/napari/docs/plugins/_npe2_manifest.md
Rendered /home/melissa/projects/napari/docs/plugins/_npe2_writers_guide.md
Rendered /home/melissa/projects/napari/docs/plugins/_npe2_readers_guide.md
Rendered /home/melissa/projects/napari/docs/plugins/_npe2_widgets_guide.md
Rendered /home/melissa/projects/napari/docs/plugins/_npe2_sample_data_guide.md
Traceback (most recent call last):
  File "/home/melissa/projects/napari/docs/_scripts/prep_docs.py", line 29, in <module>
    main()
  File "/home/melissa/projects/napari/docs/_scripts/prep_docs.py", line 24, in main
    __import__('update_preference_docs').main()
  File "/home/melissa/projects/napari/docs/_scripts/update_preference_docs.py", line 8, in <module>
    from napari._qt.dialogs.preferences_dialog import PreferencesDialog
  File "/home/melissa/projects/napari/napari/_qt/__init__.py", line 53, in <module>
    from .qt_event_loop import get_app, gui_qt, quit_app, run
  File "/home/melissa/projects/napari/napari/_qt/qt_event_loop.py", line 14, in <module>
    from .. import Viewer, __version__
  File "<frozen importlib._bootstrap>", line 1075, in _handle_fromlist
  File "/home/melissa/projects/napari/napari/_lazy.py", line 48, in __getattr__
    submod = import_module(
  File "/opt/miniconda/envs/napari-teste/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/home/melissa/projects/napari/napari/viewer.py", line 8, in <module>
    from .components.viewer_model import ViewerModel
  File "/home/melissa/projects/napari/napari/components/__init__.py", line 19, in <module>
    from .layerlist import LayerList
  File "/home/melissa/projects/napari/napari/components/layerlist.py", line 9, in <module>
    from ..layers import Layer
  File "/home/melissa/projects/napari/napari/layers/__init__.py", line 11, in <module>
    from .base import Layer
  File "/home/melissa/projects/napari/napari/layers/base/__init__.py", line 1, in <module>
    from .base import Layer, no_op
  File "/home/melissa/projects/napari/napari/layers/base/base.py", line 34, in <module>
    from ..utils.layer_utils import (
  File "/home/melissa/projects/napari/napari/layers/utils/layer_utils.py", line 12, in <module>
    from ...utils.action_manager import action_manager
  File "/home/melissa/projects/napari/napari/utils/action_manager.py", line 11, in <module>
    from .interactions import Shortcut
  File "/home/melissa/projects/napari/napari/utils/interactions.py", line 6, in <module>
    from numpydoc.docscrape import FunctionDoc
  File "/home/melissa/.local/lib/python3.10/site-packages/numpydoc/__init__.py", line 30, in <module>
    _verify_sphinx_jinja()
  File "/home/melissa/.local/lib/python3.10/site-packages/numpydoc/__init__.py", line 23, in _verify_sphinx_jinja
    raise VersionRequirementError(
sphinx.errors.VersionRequirementError: 

Sphinx<4.0.2 is incompatible with Jinja2>=3.1.
If you wish to continue using sphinx<4.0.2 you need to pin Jinja2<3.1.
make: *** [Makefile:8: docs] Erro 1
```
</details>

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
