### PR TITLE
Initialize plugins before validating widget in `napari -w {plugin}`

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -266,10 +266,11 @@ def _run():
 
     else:
         if args.with_:
-            from .plugins import _npe2, plugin_manager
+            from .plugins import _npe2, plugin_manager, _initialize_plugins
 
             # if a plugin widget has been requested, this will fail immediately
             # if the requested plugin/widget is not available.
+            _initialize_plugins()
             plugin_manager.discover_widgets()
             pname, *wnames = args.with_
             if wnames:

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -266,7 +266,7 @@ def _run():
 
     else:
         if args.with_:
-            from .plugins import _npe2, plugin_manager, _initialize_plugins
+            from .plugins import _initialize_plugins, _npe2, plugin_manager
 
             # if a plugin widget has been requested, this will fail immediately
             # if the requested plugin/widget is not available.


### PR DESCRIPTION
# Description
Fixes #4941 by making sure the plugin system is initialized before checking that user passed in a valid plugin name and widget name. 

We could move the check after the creation of the `Viewer` instead, but this method is faster for invalid input, so I think it's still worth it.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #4941

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
