### PR TITLE
Option to load all dock widgets

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -144,6 +144,13 @@ def parse_sys_argv():
         ),
     )
     parser.add_argument(
+        '-t',
+        '--tabify',
+        dest='tabify_',
+        action='store_true',
+        help='When multiple dock widgets are loaded start them as tabs.',
+    )
+    parser.add_argument(
         '--version',
         action='version',
         version=f'napari version {__version__}',
@@ -273,6 +280,12 @@ def _run():
             _initialize_plugins()
             plugin_manager.discover_widgets()
             pname, *wnames = args.with_
+            if '__all__' in wnames:
+                for name, (_pname, _wnames) in _npe2.widget_iterator():
+                    if name != 'dock' and pname != _pname:
+                        continue
+                    wnames = _wnames
+
             if wnames:
                 for wname in wnames:
                     _npe2.get_widget_contribution(
@@ -318,11 +331,19 @@ def _run():
 
         if args.with_:
             pname, *wnames = args.with_
+            if '__all__' in wnames:
+                for name, (_pname, _wnames) in _npe2.widget_iterator():
+                    if name != 'dock' and pname != _pname:
+                        continue
+                    wnames = _wnames
+
             if wnames:
                 for wname in wnames:
-                    viewer.window.add_plugin_dock_widget(pname, wname)
+                    viewer.window.add_plugin_dock_widget(
+                        pname, wname, args.tabify_
+                    )
             else:
-                viewer.window.add_plugin_dock_widget(pname)
+                viewer.window.add_plugin_dock_widget(pname, args.tabify_)
 
         # only necessary in bundled app, but see #3596
         from napari.utils.misc import (

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -144,16 +144,16 @@ def parse_sys_argv():
             "open napari with dock widget from specified plugin name."
             "(If plugin provides multiple dock widgets, widget name must also "
             "be provided). Use __all__ to open all dock widgets of a "
-            "specified plugin."
+            "specified plugin. Multiple widgets are opened in tabs."
         ),
     )
-    parser.add_argument(
-        '-t',
-        '--tabify',
-        dest='tabify_',
-        action='store_true',
-        help='When multiple dock widgets are loaded start them as tabs.',
-    )
+    # parser.add_argument(
+    #    '-t',
+    #    '--tabify',
+    #    dest='tabify_',
+    #    action='store_true',
+    #    help='When multiple dock widgets are loaded start them as tabs.',
+    # )
     parser.add_argument(
         '--version',
         action='version',
@@ -301,14 +301,13 @@ def _run():
                         if '__all__' in wnames:
                             # Plugin_manager iter_widgets return wnames as dict keys
                             wnames = list(_wnames.keys())
-                        if args.tabify_:
-                            print(
-                                trans._(
-                                    'Non-npe2 plugin {pname} in combination with -t/--tabify detected. Disable tabify for this plugin.',
-                                    deferred=True,
-                                    pname=pname,
-                                )
+                        print(
+                            trans._(
+                                'Non-npe2 plugin {pname} detected. Disable tabify for this plugin.',
+                                deferred=True,
+                                pname=pname,
                             )
+                        )
                         break
 
                 if wnames:
@@ -358,7 +357,7 @@ def _run():
             # Non-npe2 plugins disappear on tabify or if tabified npe2 plugins are loaded after them.
             # Therefore, read npe2 plugins first and do not tabify for non-npe2 plugins.
             for plugin, tabify in chain(
-                zip(npe2_plugins, repeat(args.tabify_)),
+                zip(npe2_plugins, repeat(True)),
                 zip(plugin_manager_plugins, repeat(False)),
             ):
                 pname, *wnames = plugin

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -142,7 +142,8 @@ def parse_sys_argv():
         help=(
             "open napari with dock widget from specified plugin name."
             "(If plugin provides multiple dock widgets, widget name must also "
-            "be provided)"
+            "be provided). Use __all__ to open all dock widgets of a "
+            "specified plugin."
         ),
     )
     parser.add_argument(

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -147,13 +147,6 @@ def parse_sys_argv():
             "specified plugin. Multiple widgets are opened in tabs."
         ),
     )
-    # parser.add_argument(
-    #    '-t',
-    #    '--tabify',
-    #    dest='tabify_',
-    #    action='store_true',
-    #    help='When multiple dock widgets are loaded start them as tabs.',
-    # )
     parser.add_argument(
         '--version',
         action='version',

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -8,6 +8,7 @@ import runpy
 import sys
 import warnings
 from ast import literal_eval
+from itertools import chain
 from pathlib import Path
 from textwrap import wrap
 from typing import Any, Dict, List
@@ -285,10 +286,12 @@ def _run():
             for plugin in args.with_:
                 pname, *wnames = plugin
                 if '__all__' in wnames:
-                    for name, (_pname, _wnames) in _npe2.widget_iterator():
-                        if name != 'dock' or pname != _pname:
-                            continue
-                        wnames = _wnames
+                    for name, (_pname, _wnames) in chain(
+                        _npe2.widget_iterator(), plugin_manager.iter_widgets()
+                    ):
+                        if name == 'dock' and pname == _pname:
+                            wnames = _wnames
+                            break
 
                 if wnames:
                     for wname in wnames:
@@ -337,10 +340,12 @@ def _run():
             for plugin in args.with_:
                 pname, *wnames = plugin
                 if '__all__' in wnames:
-                    for name, (_pname, _wnames) in _npe2.widget_iterator():
-                        if name != 'dock' or pname != _pname:
-                            continue
-                        wnames = _wnames
+                    for name, (_pname, _wnames) in chain(
+                        _npe2.widget_iterator(), plugin_manager.iter_widgets()
+                    ):
+                        if name == 'dock' and pname == _pname:
+                            wnames = _wnames
+                            break
 
                 if wnames:
                     for wname in wnames:

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -649,7 +649,10 @@ class Window:
             self._qt_viewer.dims.play(axis)
 
     def add_plugin_dock_widget(
-        self, plugin_name: str, widget_name: str = None
+        self,
+        plugin_name: str,
+        widget_name: str = None,
+        tabify: bool = False,
     ) -> Tuple[QtViewerDockWidget, Any]:
         """Add plugin dock widget if not already added.
 
@@ -699,7 +702,9 @@ class Window:
 
         # Add dock widget
         dock_kwargs.pop('name', None)
-        dock_widget = self.add_dock_widget(wdg, name=full_name, **dock_kwargs)
+        dock_widget = self.add_dock_widget(
+            wdg, name=full_name, tabify=tabify, **dock_kwargs
+        )
         return dock_widget, wdg
 
     def _add_plugin_function_widget(self, plugin_name: str, widget_name: str):
@@ -735,6 +740,7 @@ class Window:
         shortcut=_sentinel,
         add_vertical_stretch=True,
         menu=None,
+        tabify: bool = False,
     ):
         """Convenience method to add a QDockWidget to the main window.
 
@@ -807,7 +813,7 @@ class Window:
                 add_vertical_stretch=add_vertical_stretch,
             )
 
-        self._add_viewer_dock_widget(dock_widget, menu=menu)
+        self._add_viewer_dock_widget(dock_widget, menu=menu, tabify=tabify)
 
         if hasattr(widget, 'reset_choices'):
             # Keep the dropdown menus in the widget in sync with the layer model

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -683,6 +683,7 @@ class Window:
             Widget, dock_kwargs = plugin_manager.get_widget(
                 plugin_name, widget_name
             )
+
         if not widget_name:
             # if widget_name wasn't provided, `get_widget` will have
             # ensured that there is a single widget available.


### PR DESCRIPTION
# Description
Sometimes we want to load all dock widgets of a certain plugin, or even have dock widgets of multiple dock widgets on startup.
Therefore, I propose a new method to start all dock widgets and provide multiple plugins:

```
napari -w plugin1 dock1 dock2 -w plugin2 __all__
```

I chose the keyword `__all__` here, but it could also be the default behavior when no dock widget is provided!?

![image](https://user-images.githubusercontent.com/18047816/185386355-1752b931-2d99-41f0-973f-76034cdc214c.png)


Since this might clutter the GUI, I also propse a new `-t` option that will lead to a tabified version:

```
napari -w plugin1 dock1 dock2 -w plugin2 __all__ -t
```
![image](https://user-images.githubusercontent.com/18047816/185386418-d790f7d5-2cbd-4348-b959-c13cc2b27089.png)


## Type of change
- [X] New feature (non-breaking change which adds functionality?

# How has this been tested?

## Final checklist:
