### PR TITLE
Removes deprecated configuration options for notebooks from docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,9 +118,6 @@ intersphinx_mapping = {
     ],
 }
 
-jupyter_cache = ''
-jupyter_execute_notebooks = 'auto'
-
 myst_enable_extensions = [
     'colon_fence',
     'dollarmath',


### PR DESCRIPTION
# Description
When building the documentation, we see two mystnb configuration options showing deprecation messages:

```
WARNING: 'jupyter_execute_notebooks' is deprecated for 'nb_execution_mode' [mystnb.config]
WARNING: 'jupyter_cache' is deprecated for 'nb_execution_cache_path' [mystnb.config]
```

This PR cleans up these unused options. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
