### PR TITLE
MAINT: re-enable type checking workflow

### DIFF
--- a/.github/workflows/test_typing.yml
+++ b/.github/workflows/test_typing.yml
@@ -16,8 +16,7 @@ jobs:
       - name: Install napari
         run: |
           pip install mypy types-PyYAML types-setuptools
-          pip install -e .[all]
+          SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install -e .[all]
 
       - name: Run mypy on typed modules
-        if: ${{ false }}
         run: make typecheck


### PR DESCRIPTION
This reverts https://github.com/napari/napari/pull/4950 and adds a workaround to get type checking back in after it mysteriously broke.

After some digging, I found the cause of the breakage was new (>=64) setuptools, which changed the way editable installs work. Unfortunately the new method is not compatible with static type checkers (mypy). I think generally the new editable install mechanism is good, so rather than restrict setuptools to < 64 (e.g. in `pyproject.toml`) I just fixed it in the type checking workflow. The drawback is anyone wanting to run mypy locally may still run into this issue.

Relevant issues for tracking:
https://github.com/python/mypy/issues/13392
https://github.com/pypa/setuptools/issues/3518