### PR TITLE
DOC: Fix some incorrect parameters names.

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -665,7 +665,13 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             If a list then must be same length as the axis that is being
             expanded as channels.
         interpolation : str or list
-            Interpolation mode used by vispy. Must be one of our supported
+            Deprecated, to be removed in 0.6.0
+        interpolation2d : str or list
+            Interpolation mode used by vispy in D2. Must be one of our supported
+            modes. If a list then must be same length as the axis that is being
+            expanded as channels.
+        interpolation3d : str or list
+            Interpolation mode used by vispy in D2. Must be one of our supported
             modes. If a list then must be same length as the axis that is being
             expanded as channels.
         rendering : str or list

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -667,11 +667,11 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         interpolation : str or list
             Deprecated, to be removed in 0.6.0
         interpolation2d : str or list
-            Interpolation mode used by vispy in D2. Must be one of our supported
+            Interpolation mode used by vispy in 2D. Must be one of our supported
             modes. If a list then must be same length as the axis that is being
             expanded as channels.
         interpolation3d : str or list
-            Interpolation mode used by vispy in D2. Must be one of our supported
+            Interpolation mode used by vispy in 3D. Must be one of our supported
             modes. If a list then must be same length as the axis that is being
             expanded as channels.
         rendering : str or list

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -75,15 +75,14 @@ def write_layers(
     ----------
     path : str
         The path (file, directory, url) to write.
-    layer_type : str
+    layers : list of Layers
         All lower-class name of the layer class to be written.
     plugin_name : str, optional
         Name of the plugin to write data with. If None then all plugins
         corresponding to appropriate hook specification will be looped
         through to find the first one that can write the data.
-    command_id : str, optional
-        npe2 command identifier that uniquely identifies the command to ivoke
-        to save layers. If specified, overrides, the plugin_name.
+    writer : WriterContribution, optional
+        writer contribution to use to write given layer, autodetedect if None.
 
     Returns
     -------

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -76,13 +76,13 @@ def write_layers(
     path : str
         The path (file, directory, url) to write.
     layers : list of Layers
-        All lower-class name of the layer class to be written.
+        The layers to write.
     plugin_name : str, optional
         Name of the plugin to write data with. If None then all plugins
         corresponding to appropriate hook specification will be looped
         through to find the first one that can write the data.
     writer : WriterContribution, optional
-        writer contribution to use to write given layer, autodetedect if None.
+        Writer contribution to use to write given layers, autodetect if None.
 
     Returns
     -------


### PR DESCRIPTION
1) interpolation is deprecated and split into interpolation2d/3d.
2) writer's doc seem to not have been updated, and parameter names did
   not match signature

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
