### PR TITLE
MAINT: bump napari-console to 0.0.6.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     imageio>=2.5.0,!=2.11.0
     jsonschema>=3.2.0
     magicgui>=0.3.6
-    napari-console>=0.0.4
+    napari-console>=0.0.5
     napari-plugin-engine>=0.1.9
     napari-svg>=0.1.6
     npe2>=0.5.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     imageio>=2.5.0,!=2.11.0
     jsonschema>=3.2.0
     magicgui>=0.3.6
-    napari-console>=0.0.5
+    napari-console>=0.0.6
     napari-plugin-engine>=0.1.9
     napari-svg>=0.1.6
     npe2>=0.5.2


### PR DESCRIPTION
It does not exists yet, but will need to be published at some point.
In particular please see napari/napari-console#19 that tries to update
napari-console

Out of interest is bumping the minimum version of Python to 3.8,
and removal of deprecated napari API so that we can remove them from
napari.


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->



## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
