### PR TITLE
Remove preliminary admonition for last two release notes

### DIFF
--- a/docs/release/release_0_4_15.md
+++ b/docs/release/release_0_4_15.md
@@ -1,10 +1,5 @@
 # napari 0.4.15
 
-```{note}
-These are preliminary release notes until 0.4.15 is released. Currently this is
-slated to occur on 2022-03-08.
-```
-
 We're happy to announce the release of napari 0.4.15!
 napari is a fast, interactive, multi-dimensional image viewer for Python.
 It's designed for browsing, annotating, and analyzing large multi-dimensional

--- a/docs/release/release_0_4_16.md
+++ b/docs/release/release_0_4_16.md
@@ -1,10 +1,5 @@
 # napari 0.4.16
 
-```{note}
-These are the preliminary release notes for 0.4.16 release candidates. The
-final release notes will be posted with the release on 2022-05-31.
-```
-
 We're happy to announce the release of napari 0.4.16!
 napari is a fast, interactive, multi-dimensional image viewer for Python.
 It's designed for browsing, annotating, and analyzing large multi-dimensional


### PR DESCRIPTION
# Description

I noticed these admonitions while looking at the release notes for 0.4.15 on napari.org. I have to assume these are not preliminary anymore, given that both 0.4.15 and 0.4.16 have been released for a while, so have removed them here.