### PR TITLE
Enabe tags in gallery examples.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,9 +1,10 @@
 .PHONY: typestubs pre watch dist settings-schema
 
 clean:
-	rm -rf docs/_build/
-	rm -rf docs/api/napari*.rst
-	rm -rf docs/gallery/*
+	rm -rf _build/
+	rm -rf api/napari*.rst
+	rm -rf gallery/*
+	rm -rf _tags
 
 docs:
 	python _scripts/prep_docs.py

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -70,6 +70,9 @@ subtrees:
           - file: guides/events_reference
       - file: further-resources/glossary
       - file: gallery
+        subtrees:
+        - entries:
+          - file: _tags/tagsindex
   - file: plugins/index
     subtrees:
     - entries:

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -70,9 +70,6 @@ subtrees:
           - file: guides/events_reference
       - file: further-resources/glossary
       - file: gallery
-        subtrees:
-        - entries:
-          - file: _tags/tagsindex
   - file: plugins/index
     subtrees:
     - entries:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,10 +60,15 @@ extensions = [
     "sphinx_panels",
     "sphinx.ext.viewcode",
     "sphinx_gallery.gen_gallery",
+    "sphinx_tags",
 ]
 
 external_toc_path = "_toc.yml"
 external_toc_exclude_missing = False
+
+tags_create_tags = True
+tags_output_dir = "_tags"
+tags_extension = ["md", "rst"]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,7 @@ external_toc_exclude_missing = False
 
 tags_create_tags = True
 tags_output_dir = "_tags"
+tags_overview_title = "Tags"
 tags_extension = ["md", "rst"]
 
 # -- Options for HTML output -------------------------------------------------

--- a/examples/3D_paths.py
+++ b/examples/3D_paths.py
@@ -7,7 +7,7 @@ layers is 3D and "sliced" with a different set of vectors appearing on
 different 3D slices. Another is 2D and "broadcast" with the same vectors
 appearing on each slice.
 
-.. tags:: layers, visualization-nD
+.. tags:: visualization-advanced, layers
 """
 
 import numpy as np

--- a/examples/3D_paths.py
+++ b/examples/3D_paths.py
@@ -5,7 +5,9 @@
 Display two vectors layers ontop of a 4-D image layer. One of the vectors
 layers is 3D and "sliced" with a different set of vectors appearing on
 different 3D slices. Another is 2D and "broadcast" with the same vectors
-apprearing on each slice.
+appearing on each slice.
+
+.. tags:: layers, visualization-nD
 """
 
 import numpy as np

--- a/examples/3Dimage_plane_rendering.py
+++ b/examples/3Dimage_plane_rendering.py
@@ -5,7 +5,7 @@
 Display one 3D image layer and display it as a plane
 with a simple widget for modifying plane parameters.
 
-.. tags:: layers, visualization-nD, gui
+.. tags:: visualization-advanced, gui, layers
 """
 import napari
 import numpy as np

--- a/examples/3Dimage_plane_rendering.py
+++ b/examples/3Dimage_plane_rendering.py
@@ -4,6 +4,8 @@
 
 Display one 3D image layer and display it as a plane
 with a simple widget for modifying plane parameters.
+
+.. tags:: layers, visualization-nD, gui
 """
 import napari
 import numpy as np

--- a/examples/3d_kymograph_.py
+++ b/examples/3d_kymograph_.py
@@ -5,6 +5,7 @@
 This example demonstrates that the volume rendering capabilities of napari
 can also be used to render 2d timelapse acquisitions as kymographs.
 
+.. tags:: experimental
 """
 from typing import Dict, List, Tuple
 import numpy as np

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,7 +1,6 @@
 Examples of napari usage.
 
 .. toctree::
-    :caption: Tags
     :maxdepth: 1
 
     ../_tags/tagsindex

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,1 +1,7 @@
 Examples of napari usage.
+
+.. toctree::
+    :caption: Tags
+    :maxdepth: 1
+
+    ../_tags/tagsindex

--- a/examples/action_manager.py
+++ b/examples/action_manager.py
@@ -2,6 +2,7 @@
 Action manager
 ==============
 
+.. tags:: gui
 """
 from random import shuffle
 

--- a/examples/action_manager.py
+++ b/examples/action_manager.py
@@ -2,7 +2,7 @@
 Action manager
 ==============
 
-.. tags:: gui
+.. tags:: gui, experimental
 """
 from random import shuffle
 

--- a/examples/add_3D_image.py
+++ b/examples/add_3D_image.py
@@ -4,7 +4,7 @@ Add 3D image
 
 Display a 3D image layer using the :meth:`add_image` API.
 
-.. tags:: layers, visualization-nD
+.. tags:: visualization-nD, layers
 """
 
 from skimage import data

--- a/examples/add_3D_image.py
+++ b/examples/add_3D_image.py
@@ -3,6 +3,8 @@ Add 3D image
 ============
 
 Display a 3D image layer using the :meth:`add_image` API.
+
+.. tags:: layers, visualization-nD
 """
 
 from skimage import data

--- a/examples/add_grayscale_image.py
+++ b/examples/add_grayscale_image.py
@@ -3,6 +3,8 @@ Add grayscale image
 ===================
 
 Display one grayscale image using the add_image API.
+
+.. tags:: visualization-basic
 """
 
 from skimage import data

--- a/examples/add_image.py
+++ b/examples/add_image.py
@@ -3,6 +3,8 @@ Add image
 =========
 
 Display one image using the :func:`view_image` API.
+
+.. tags:: visualization-basic
 """
 
 from skimage import data

--- a/examples/add_image_transformed.py
+++ b/examples/add_image_transformed.py
@@ -3,6 +3,8 @@ Add image transformed
 =====================
 
 Display one image and transform it using the :func:`view_image` API.
+
+.. tags:: visualization-basic
 """
 
 from skimage import data

--- a/examples/add_labels.py
+++ b/examples/add_labels.py
@@ -4,6 +4,8 @@ Add labels
 
 Display a labels layer above of an image layer using the ``add_labels`` and
 ``add_image`` APIs
+
+.. tags:: layers, visualization-advanced
 """
 
 from skimage import data

--- a/examples/add_labels.py
+++ b/examples/add_labels.py
@@ -5,7 +5,7 @@ Add labels
 Display a labels layer above of an image layer using the ``add_labels`` and
 ``add_image`` APIs
 
-.. tags:: layers, visualization-advanced
+.. tags:: layers, visualization-basic
 """
 
 from skimage import data

--- a/examples/add_labels_with_features.py
+++ b/examples/add_labels_with_features.py
@@ -4,7 +4,7 @@ Add labels with features
 
 Display a labels layer with various features
 
-.. tags:: layers, visualization-advanced
+.. tags:: layers, analysis
 """
 
 

--- a/examples/add_labels_with_features.py
+++ b/examples/add_labels_with_features.py
@@ -3,6 +3,8 @@ Add labels with features
 ========================
 
 Display a labels layer with various features
+
+.. tags:: layers, visualization-advanced
 """
 
 

--- a/examples/add_multiscale_image.py
+++ b/examples/add_multiscale_image.py
@@ -3,6 +3,8 @@ Add multiscale image
 ====================
 
 Displays a multiscale image
+
+.. tags:: visualization-advanced
 """
 
 from skimage import data

--- a/examples/add_points.py
+++ b/examples/add_points.py
@@ -4,6 +4,8 @@ Add points
 
 Display a points layer on top of an image layer using the ``add_points`` and
 ``add_image`` APIs
+
+.. tags:: visualization-basic
 """
 
 import numpy as np

--- a/examples/add_points_on_nD_shapes.py
+++ b/examples/add_points_on_nD_shapes.py
@@ -4,6 +4,7 @@ Add points on nD shapes
 
 Add points on nD shapes in 3D using a mouse callback
 
+.. tags:: visualization-nD
 """
 
 import napari

--- a/examples/add_points_with_features.py
+++ b/examples/add_points_with_features.py
@@ -2,8 +2,10 @@
 Add points with features
 ========================
 
-Display a points layer on top of an image layer using the add_points and
-add_image APIs
+Display a points layer on top of an image layer using the ``add_points`` and
+``add_image`` APIs
+
+.. tags:: visualization-basic
 """
 
 import numpy as np

--- a/examples/add_points_with_multicolor_text.py
+++ b/examples/add_points_with_multicolor_text.py
@@ -4,6 +4,8 @@ Add points with multicolor text
 
 Display a points layer on top of an image layer with text using
 multiple face colors mapped from features for the points and text.
+
+.. tags:: visualization-basic
 """
 
 import numpy as np

--- a/examples/add_points_with_text.py
+++ b/examples/add_points_with_text.py
@@ -2,8 +2,10 @@
 Add points with text
 ====================
 
-Display a points layer on top of an image layer using the add_points and
-add_image APIs
+Display a points layer on top of an image layer using the ``add_points`` and
+``add_image`` APIs
+
+.. tags:: visualization-basic
 """
 
 import numpy as np

--- a/examples/add_shapes.py
+++ b/examples/add_shapes.py
@@ -2,9 +2,11 @@
 Add shapes
 ==========
 
-Display one shapes layer ontop of one image layer using the add_shapes and
-add_image APIs. When the window is closed it will print the coordinates of
+Display one shapes layer ontop of one image layer using the ``add_shapes`` and
+``add_image`` APIs. When the window is closed it will print the coordinates of
 your shapes.
+
+.. tags:: visualization-basic
 """
 
 import numpy as np

--- a/examples/add_shapes_with_features.py
+++ b/examples/add_shapes_with_features.py
@@ -2,9 +2,11 @@
 Add shapes with features
 ========================
 
-Display one shapes layer ontop of one image layer using the add_shapes and
-add_image APIs. When the window is closed it will print the coordinates of
+Display one shapes layer ontop of one image layer using the ``add_shapes`` and
+``add_image`` APIs. When the window is closed it will print the coordinates of
 your shapes.
+
+.. tags:: visualization-basic
 """
 
 import numpy as np

--- a/examples/add_shapes_with_text.py
+++ b/examples/add_shapes_with_text.py
@@ -2,9 +2,11 @@
 Add shapes with text
 ====================
 
-Display one shapes layer ontop of one image layer using the add_shapes and
-add_image APIs. When the window is closed it will print the coordinates of
+Display one shapes layer ontop of one image layer using the ``add_shapes`` and
+``add_image`` APIs. When the window is closed it will print the coordinates of
 your shapes.
+
+.. tags:: visualization-basic
 """
 
 import numpy as np

--- a/examples/add_surface_2D.py
+++ b/examples/add_surface_2D.py
@@ -3,6 +3,8 @@ Add surface 2D
 ==============
 
 Display a 2D surface
+
+.. tags:: visualization-basic
 """
 
 import numpy as np

--- a/examples/add_vectors.py
+++ b/examples/add_vectors.py
@@ -8,6 +8,7 @@ Each vector position is defined by an (x, y, x-proj, y-proj) element where
 * x and y are the center points
 * x-proj and y-proj are the vector projections at each center
 
+.. tags:: visualization-basic
 """
 
 import napari

--- a/examples/add_vectors_color_by_angle.py
+++ b/examples/add_vectors_color_by_angle.py
@@ -5,6 +5,7 @@ Add vectors color by angle
 This example generates a set of vectors in a spiral pattern.
 The color of the vectors is mapped to their 'angle' feature.
 
+.. tags:: visualization-advanced
 """
 
 import napari

--- a/examples/add_vectors_image.py
+++ b/examples/add_vectors_image.py
@@ -7,6 +7,8 @@ Vector data is an array of shape (N, M, 2)
 Each vector position is defined by an (x-proj, y-proj) element where
 * x-proj and y-proj are the vector projections at each center
 * each vector is centered on a pixel of the NxM grid
+
+.. tags:: visualization-basic
 """
 
 import napari

--- a/examples/affine_transforms.py
+++ b/examples/affine_transforms.py
@@ -3,6 +3,8 @@ Affine transforms
 =================
 
 Display an image and its corners before and after an affine transform
+
+.. tags:: visualization-advanced
 """
 import numpy as np
 import napari

--- a/examples/annotate-2d.py
+++ b/examples/annotate-2d.py
@@ -2,8 +2,10 @@
 Annotate 2D
 ===========
 
-Display one points layer ontop of one image layer using the add_points and
-add_image APIs
+Display one points layer ontop of one image layer using the ``add_points`` and
+``add_image`` APIs
+
+.. tags:: analysis
 """
 
 import numpy as np

--- a/examples/annotate_segmentation_with_text.py
+++ b/examples/annotate_segmentation_with_text.py
@@ -4,6 +4,8 @@ Annotate segmentation with text
 
 Perform a segmentation and annotate the results with
 bounding boxes and text
+
+.. tags:: analysis
 """
 import numpy as np
 from skimage import data

--- a/examples/bbox_annotator.py
+++ b/examples/bbox_annotator.py
@@ -2,6 +2,7 @@
 bbox annotator
 ==============
 
+.. tags:: gui
 """
 
 from magicgui.widgets import ComboBox, Container

--- a/examples/clipboard_.py
+++ b/examples/clipboard_.py
@@ -4,6 +4,7 @@ Clipboard
 
 Copy screenshot of the canvas or the whole viewer to clipboard.
 
+.. tags:: gui
 """
 
 from skimage import data

--- a/examples/clipping_planes_interactive_.py
+++ b/examples/clipping_planes_interactive_.py
@@ -4,6 +4,8 @@ Clipping planes interactive
 
 Display a 3D image (plus labels) with a clipping plane and interactive controls
 for moving the plane
+
+.. tags:: experimental
 """
 import napari
 import numpy as np

--- a/examples/cursor_position.py
+++ b/examples/cursor_position.py
@@ -3,6 +3,8 @@ Cursor position
 ===============
 
 Add small data to examine cursor positions
+
+.. tags:: interactivity
 """
 
 import numpy as np

--- a/examples/cursor_ray.py
+++ b/examples/cursor_ray.py
@@ -3,6 +3,8 @@ Cursor ray
 ==========
 
 Depict a ray through a layer in 3D to demonstrate interactive 3D functionality
+
+.. tags:: interactivity
 """
 import numpy as np
 import napari

--- a/examples/custom_key_bindings.py
+++ b/examples/custom_key_bindings.py
@@ -2,7 +2,9 @@
 Custom key bindings
 ===================
 
-Display one 4-D image layer using the add_image API
+Display one 4-D image layer using the ``add_image`` API
+
+.. tags:: gui
 """
 
 from skimage import data

--- a/examples/custom_mouse_functions.py
+++ b/examples/custom_mouse_functions.py
@@ -2,7 +2,9 @@
 Custom mouse functions
 ======================
 
-Display one 4-D image layer using the add_image API
+Display one 4-D image layer using the ``add_image`` API
+
+.. tags:: gui
 """
 
 from skimage import data

--- a/examples/dask_nD_image.py
+++ b/examples/dask_nD_image.py
@@ -3,6 +3,8 @@ Dask nD image
 =============
 
 Display a dask array
+
+.. tags:: visualization-nD
 """
 
 try:

--- a/examples/dynamic-projections-dask.py
+++ b/examples/dynamic-projections-dask.py
@@ -6,6 +6,8 @@ Using dask array operations, one can dynamically take arbitrary slices
 and computations of a source dask array and display the results in napari.
 When the computation takes one or more parameters, one can tie a UI to
 them using magicgui.
+
+.. tags:: visualization-advanced
 """
 
 import numpy as np

--- a/examples/embed_ipython_.py
+++ b/examples/embed_ipython_.py
@@ -9,6 +9,8 @@ such as shown in https://github.com/napari/napari/blob/main/examples/update_cons
 
 However, differently from `update_console`, this will start an independent
 ipython console which can outlive the viewer.
+
+.. tags:: gui
 """
 
 import napari

--- a/examples/get_current_viewer.py
+++ b/examples/get_current_viewer.py
@@ -6,6 +6,8 @@ Get a reference to the current napari viewer.
 
 Whilst this example is contrived, it can be useful to get a reference to the
 viewer when the viewer is out of scope.
+
+.. tags:: gui
 """
 
 import napari

--- a/examples/image_depth.py
+++ b/examples/image_depth.py
@@ -2,6 +2,7 @@
 Image depth
 ===========
 
+.. tags:: visualization-basic
 """
 
 import napari

--- a/examples/interaction_box_image.py
+++ b/examples/interaction_box_image.py
@@ -5,6 +5,8 @@ Interaction box image
 This example demonstrates activating 'transform' mode on the image layer.
 This allows the user to manipulate the image via the interaction box
 (blue box and points around the image).
+
+.. tags:: experimental
 """
 
 from skimage import data

--- a/examples/interaction_box_points.py
+++ b/examples/interaction_box_points.py
@@ -3,6 +3,8 @@ Interaction box points
 ======================
 
 Demonstrate interaction box on points layer
+
+.. tags:: experimental
 """
 
 from skimage import data

--- a/examples/interactive_move_point_3d.py
+++ b/examples/interactive_move_point_3d.py
@@ -3,6 +3,8 @@ Interactive move point
 ======================
 
 3D click and drag interactivity demo
+
+.. tags:: experimental
 """
 from copy import copy
 

--- a/examples/interactive_move_rectangle_3d.py
+++ b/examples/interactive_move_rectangle_3d.py
@@ -4,6 +4,7 @@ Interactive move rectangle
 
 Shift a rectangle along its normal vector in 3D
 
+.. tags:: experimental
 """
 
 import napari

--- a/examples/interactive_scripting.py
+++ b/examples/interactive_scripting.py
@@ -2,6 +2,7 @@
 Interactive scripting
 =====================
 
+.. tags:: interactivity
 """
 
 import numpy as np

--- a/examples/labels-2d.py
+++ b/examples/labels-2d.py
@@ -2,8 +2,10 @@
 Labels 2D
 =========
 
-Display a labels layer above of an image layer using the add_labels and
-add_image APIs
+Display a labels layer above of an image layer using the ``add_labels`` and
+``add_image`` APIs
+
+.. tags:: visualization-basic
 """
 
 from skimage import data

--- a/examples/layers.py
+++ b/examples/layers.py
@@ -2,8 +2,10 @@
 Layers
 ======
 
-Display multiple image layers using the add_image API and then reorder them
+Display multiple image layers using the ``add_image`` API and then reorder them
 using the layers swap method and remove one
+
+.. tags:: visualization-basic
 """
 
 from skimage import data

--- a/examples/linked_layers.py
+++ b/examples/linked_layers.py
@@ -7,6 +7,8 @@ Demonstrates the `link_layers` function.
 This function takes a list of layers and an optional list of attributes, and
 links them such that when one of the linked attributes changes on any of the
 linked layers, all of the other layers follow.
+
+.. tags:: experimental
 """
 import napari
 from napari.experimental import link_layers

--- a/examples/live_tiffs_.py
+++ b/examples/live_tiffs_.py
@@ -5,6 +5,8 @@ Live tiffs
 Loads and Displays tiffs as they get generated in the specific directory.
 Trying to simulate the live display of data as it gets acquired by microscope.
 This script should be run together with live_tiffs_generator.py
+
+.. tags:: experimental
 """
 
 import os

--- a/examples/live_tiffs_generator_.py
+++ b/examples/live_tiffs_generator_.py
@@ -4,6 +4,8 @@ Live tiffs generator
 
 Simulation of microscope acquisition. This code generates time series tiffs in
 an output directory (must be supplied by the user).
+
+.. tags:: experimental
 """
 
 

--- a/examples/magic_image_arithmetic.py
+++ b/examples/magic_image_arithmetic.py
@@ -4,6 +4,7 @@ magicgui Image Arithmetic
 
 Basic example of using magicgui to create an Image Arithmetic GUI in napari.
 
+.. tags:: gui
 """
 
 import enum

--- a/examples/magic_parameter_sweep.py
+++ b/examples/magic_parameter_sweep.py
@@ -7,6 +7,8 @@ Example showing how to accomplish a napari parameter sweep with magicgui.
 It demonstrates:
 1. overriding the default widget type with a custom class
 2. the `auto_call` option, which calls the function whenever a parameter changes
+
+.. tags:: gui
 """
 import skimage.data
 import skimage.filters

--- a/examples/magic_viewer.py
+++ b/examples/magic_viewer.py
@@ -4,6 +4,7 @@ magicgui viewer
 
 Example showing how to access the current viewer from a function widget.
 
+.. tags:: gui
 """
 
 import napari

--- a/examples/mgui_dask_delayed_.py
+++ b/examples/mgui_dask_delayed_.py
@@ -4,6 +4,8 @@ magicgui dask delayed
 
 An example of calling a threaded function from a magicgui dock_widget.
 Note: this example requires python >= 3.9
+
+.. tags:: gui
 """
 import time
 from concurrent.futures import Future

--- a/examples/mgui_with_threadpoolexec_.py
+++ b/examples/mgui_with_threadpoolexec_.py
@@ -6,6 +6,8 @@ An example of calling a threaded function from a magicgui ``dock_widget``.
 
 using ``ThreadPoolExecutor``
 Note: this example requires python >= 3.9
+
+.. tags:: gui
 """
 import sys
 from concurrent.futures import Future, ThreadPoolExecutor

--- a/examples/mgui_with_threadworker_.py
+++ b/examples/mgui_with_threadworker_.py
@@ -4,6 +4,8 @@ magicgui with threadworker
 
 An example of calling a threaded function from a magicgui ``dock_widget``.
 Note: this example requires python >= 3.9
+
+.. tags:: gui
 """
 from magicgui import magic_factory, widgets
 from skimage import data

--- a/examples/mixed-dimensions-labels.py
+++ b/examples/mixed-dimensions-labels.py
@@ -11,6 +11,8 @@ we slice through the dataset, the segmentation stays unchanged, but is visible
 on every slice.
 
 .. [1] https://numpy.org/doc/stable/user/basics.broadcasting.html
+
+.. tags:: visualization-nD
 """
 
 from skimage.data import binary_blobs

--- a/examples/mouse_drag_callback.py
+++ b/examples/mouse_drag_callback.py
@@ -4,6 +4,8 @@ Mouse drag callback
 
 Example updating the status bar with line profile info while dragging
 lines around in a shapes layer.
+
+.. tags:: gui
 """
 
 from skimage import data

--- a/examples/mpl_plot_.py
+++ b/examples/mpl_plot_.py
@@ -2,6 +2,7 @@
 Matplotlib plot
 ===============
 
+.. tags:: gui
 """
 
 import matplotlib.pyplot as plt

--- a/examples/multiple_viewer_widget.py
+++ b/examples/multiple_viewer_widget.py
@@ -8,6 +8,8 @@ Switching to 3D display will only impact the main viewer.
 
 This example also contain option to enable cross that will be moved to the
 current dims point (`viewer.dims.point`).
+
+.. tags:: gui
 """
 
 from copy import deepcopy

--- a/examples/multiple_viewers.py
+++ b/examples/multiple_viewers.py
@@ -3,6 +3,8 @@ Multiple viewers
 ================
 
 Create multiple viewers from the same script
+
+.. tags:: gui
 """
 
 from skimage import data

--- a/examples/multithreading_simple_.py
+++ b/examples/multithreading_simple_.py
@@ -2,6 +2,7 @@
 Multithreading simple
 =====================
 
+.. tags:: interactivity
 """
 
 from qtpy.QtWidgets import QApplication, QWidget, QHBoxLayout, QLabel

--- a/examples/multithreading_two_way_.py
+++ b/examples/multithreading_two_way_.py
@@ -2,6 +2,7 @@
 Multithreading two-way
 ======================
 
+.. tags:: interactivity
 """
 import time
 

--- a/examples/nD_image.py
+++ b/examples/nD_image.py
@@ -3,6 +3,8 @@ nD image
 ========
 
 Display one 4-D image layer using the :func:`view_image` API.
+
+.. tags:: visualization-nD
 """
 
 import numpy as np

--- a/examples/nD_labels.py
+++ b/examples/nD_labels.py
@@ -2,8 +2,10 @@
 nD labels
 =========
 
-Display a labels layer above of an image layer using the add_labels and
-add_image APIs
+Display a labels layer above of an image layer using the ``add_labels`` and
+``add_image`` APIs
+
+.. tags:: visualization-nD
 """
 
 from skimage import data

--- a/examples/nD_multiscale_image.py
+++ b/examples/nD_multiscale_image.py
@@ -3,6 +3,8 @@ nD multiscale image
 ===================
 
 Displays an nD multiscale image
+
+.. tags:: visualization-advanced
 """
 
 from skimage.transform import pyramid_gaussian

--- a/examples/nD_multiscale_image_non_uniform.py
+++ b/examples/nD_multiscale_image_non_uniform.py
@@ -3,6 +3,8 @@ nD multiscale image non-uniform
 ===============================
 
 Displays an nD multiscale image
+
+.. tags:: visualization-advanced
 """
 
 from skimage import data

--- a/examples/nD_points.py
+++ b/examples/nD_points.py
@@ -5,6 +5,8 @@ nD points
 Display one points layer on top of one 4-D image layer using the
 add_points and add_image APIs, where the markes are visible as nD objects
 across the dimensions, specified by their size
+
+.. tags:: visualization-nD
 """
 
 import numpy as np

--- a/examples/nD_points_with_features.py
+++ b/examples/nD_points_with_features.py
@@ -5,6 +5,8 @@ nD points with features
 Display one points layer ontop of one 4-D image layer using the
 add_points and add_image APIs, where the markes are visible as nD objects
 across the dimensions, specified by their size
+
+.. tags:: visualization-nD
 """
 
 import numpy as np

--- a/examples/nD_shapes.py
+++ b/examples/nD_shapes.py
@@ -2,7 +2,9 @@
 nD shapes
 =========
 
-Display one 4-D image layer using the add_image API
+Display one 4-D image layer using the ``add_image`` API
+
+.. tags:: visualization-nD
 """
 
 import numpy as np

--- a/examples/nD_shapes_with_text.py
+++ b/examples/nD_shapes_with_text.py
@@ -2,6 +2,7 @@
 nD shapes with text
 ===================
 
+.. tags:: visualization-nD
 """
 from skimage import data
 import napari

--- a/examples/nD_surface.py
+++ b/examples/nD_surface.py
@@ -3,6 +3,8 @@ nD surface
 ==========
 
 Display a 3D surface
+
+.. tags:: visualization-nD
 """
 
 import numpy as np

--- a/examples/nD_vectors.py
+++ b/examples/nD_vectors.py
@@ -6,6 +6,8 @@ Display two vectors layers ontop of a 4-D image layer. One of the vectors
 layers is 3D and "sliced" with a different set of vectors appearing on
 different 3D slices. Another is 2D and "broadcast" with the same vectors
 apprearing on each slice.
+
+.. tags:: visualization-nD
 """
 
 import numpy as np

--- a/examples/nD_vectors_image.py
+++ b/examples/nD_vectors_image.py
@@ -7,6 +7,7 @@ Vector data is an array of shape (M, N, P, 3)
 Each vector position is defined by an (x-proj, y-proj, z-proj) element
 which are vector projections centered on a pixel of the MxNxP grid
 
+.. tags:: visualization-nD
 """
 
 import napari

--- a/examples/new_theme.py
+++ b/examples/new_theme.py
@@ -4,6 +4,7 @@ New theme
 
 Displays an image and sets the theme to new custom theme.
 
+.. tags:: experimental
 """
 
 from skimage import data

--- a/examples/paint-nd.py
+++ b/examples/paint-nd.py
@@ -6,6 +6,7 @@ Display a 4D labels layer and paint only in 3D.
 
 This is useful e.g. when proofreading segmentations within a time series.
 
+.. tags:: analysis
 """
 
 import numpy as np

--- a/examples/pass_colormaps.py
+++ b/examples/pass_colormaps.py
@@ -4,6 +4,7 @@ Pass colormaps
 
 Add named or unnamed vispy colormaps to existing layers.
 
+.. tags:: visualization-basic
 """
 
 import numpy as np

--- a/examples/points-over-time.py
+++ b/examples/points-over-time.py
@@ -2,6 +2,7 @@
 Points over time
 ================
 
+.. tags:: visualization-advanced
 """
 import napari
 import numpy as np

--- a/examples/progress_bar_minimal_.py
+++ b/examples/progress_bar_minimal_.py
@@ -5,6 +5,7 @@ Progress bar minimal
 This file provides minimal working examples of progress bars in
 the napari viewer.
 
+.. tags:: gui
 """
 
 import napari

--- a/examples/progress_bar_segmentation_.py
+++ b/examples/progress_bar_segmentation_.py
@@ -5,6 +5,7 @@ Progress bar segmentation
 Use napari's tqdm wrapper to display the progress of long-running operations
 in the viewer.
 
+.. tags:: gui
 """
 import numpy as np
 import napari

--- a/examples/progress_bar_threading_.py
+++ b/examples/progress_bar_threading_.py
@@ -5,6 +5,7 @@ Progress bar threading
 This file provides a minimal working example using a progress bar alongside
 ``@thread_worker`` to report progress.
 
+.. tags:: interactivity
 """
 from time import sleep
 from qtpy.QtWidgets import QPushButton, QVBoxLayout, QWidget

--- a/examples/reader_plugin.py
+++ b/examples/reader_plugin.py
@@ -4,6 +4,7 @@ Reader plugin
 
 Barebones reader plugin example, using ``imageio.imread```
 
+.. tags:: historical
 """
 from napari_plugin_engine import napari_hook_implementation
 from imageio import formats, imread

--- a/examples/scale_bar.py
+++ b/examples/scale_bar.py
@@ -3,6 +3,8 @@ Scale bar
 =========
 
 Display a 3D volume and the scale bar
+
+.. tags:: experimental
 """
 import numpy as np
 import napari

--- a/examples/set_colormaps.py
+++ b/examples/set_colormaps.py
@@ -3,6 +3,8 @@ Set colormaps
 =============
 
 Add named or unnamed vispy colormaps to existing layers.
+
+.. tags:: visualization-basic
 """
 
 import numpy as np

--- a/examples/set_theme.py
+++ b/examples/set_theme.py
@@ -3,6 +3,8 @@ Set theme
 =========
 
 Displays an image and sets the theme to 'light'.
+
+.. tags:: gui
 """
 
 from skimage import data

--- a/examples/shapes_to_labels.py
+++ b/examples/shapes_to_labels.py
@@ -5,6 +5,8 @@ Shapes to labels
 Display one shapes layer ontop of one image layer using the ``add_shapes`` and
 ``add_image`` APIs. When the window is closed it will print the coordinates of
 your shapes.
+
+.. tags:: historical
 """
 
 import numpy as np

--- a/examples/show_points_based_on_feature.py
+++ b/examples/show_points_based_on_feature.py
@@ -2,6 +2,7 @@
 Show points based on feature
 ============================
 
+.. tags:: visualization-advanced
 """
 #!/usr/bin/env python3
 

--- a/examples/spheres_.py
+++ b/examples/spheres_.py
@@ -3,6 +3,8 @@ Spheres
 =======
 
 Display two spheres with Surface layers
+
+.. tags:: visualization-advanced
 """
 
 import napari

--- a/examples/spherical_points.py
+++ b/examples/spherical_points.py
@@ -2,6 +2,7 @@
 Spherical points
 ================
 
+.. tags:: experimental
 """
 import napari
 import numpy as np

--- a/examples/surface_normals_wireframe.py
+++ b/examples/surface_normals_wireframe.py
@@ -3,6 +3,8 @@ Surface normals wireframe
 =========================
 
 Display a 3D mesh with normals and wireframe
+
+.. tags:: experimental
 """
 
 from vispy.io import read_mesh, load_data_file

--- a/examples/surface_timeseries_.py
+++ b/examples/surface_timeseries_.py
@@ -3,6 +3,8 @@ Surface timeseries
 ==================
 
 Display a surface timeseries using data from nilearn
+
+.. tags:: experimental
 """
 
 try:

--- a/examples/swap_dims.py
+++ b/examples/swap_dims.py
@@ -3,6 +3,8 @@ Swap dims
 =========
 
 Display a 4-D image and points layer and swap the displayed dimensions
+
+.. tags:: visualization-nD
 """
 
 import numpy as np

--- a/examples/tiled-rendering-2d_.py
+++ b/examples/tiled-rendering-2d_.py
@@ -15,6 +15,8 @@ If octree support is *not* enabled, napari will try to load the entire image,
 which may not fit in memory and may bring your computer to a halt. Oops! So, we
 make sure that we enable octree support by setting the NAPARI_OCTREE
 environment variable to 1 if it is not set by the user.
+
+.. tags:: experimental
 """
 
 import os

--- a/examples/to_screenshot.py
+++ b/examples/to_screenshot.py
@@ -5,6 +5,8 @@ To screenshot
 Display one shapes layer ontop of one image layer using the ``add_shapes`` and
 ``add_image`` APIs. When the window is closed it will print the coordinates of
 your shapes.
+
+.. tags:: visualization-advanced
 """
 
 import numpy as np

--- a/examples/tracks_2d.py
+++ b/examples/tracks_2d.py
@@ -2,6 +2,7 @@
 Tracks 2D
 =========
 
+.. tags:: visualization-basic
 """
 
 import napari

--- a/examples/tracks_3d.py
+++ b/examples/tracks_3d.py
@@ -2,6 +2,7 @@
 Tracks 3D
 =========
 
+.. tags:: visualization-advanced
 """
 
 import napari

--- a/examples/tracks_3d_with_graph.py
+++ b/examples/tracks_3d_with_graph.py
@@ -2,6 +2,7 @@
 Tracks 3D with graph
 ====================
 
+.. tags:: visualization-advanced
 """
 
 import napari

--- a/examples/update_console.py
+++ b/examples/update_console.py
@@ -5,6 +5,8 @@ Update console
 Display one shapes layer ontop of one image layer using the add_shapes and
 add_image APIs. When the window is closed it will print the coordinates of
 your shapes.
+
+.. tags:: historical
 """
 
 import numpy as np

--- a/examples/viewer_fps_label.py
+++ b/examples/viewer_fps_label.py
@@ -3,6 +3,8 @@ Viewer FPS label
 ================
 
 Display a 3D volume and the fps label.
+
+.. tags:: experimental
 """
 import numpy as np
 import napari

--- a/examples/viewer_loop_reproducible_screenshots.md
+++ b/examples/viewer_loop_reproducible_screenshots.md
@@ -12,7 +12,8 @@ kernelspec:
   name: python3
 ---
 
-+++ {"tags": []}
+```{tags} gui
+```
 
 # Creating reproducible screenshots with a viewer loop
 

--- a/examples/without_gui_qt.py
+++ b/examples/without_gui_qt.py
@@ -6,6 +6,8 @@ Alternative to using napari.gui_qt() context manager.
 
 This is here for historical purposes, to the transition away from
 the "gui_qt()" context manager.
+
+.. tags:: historical
 """
 
 from skimage import data

--- a/examples/xarray_nD_image_.py
+++ b/examples/xarray_nD_image_.py
@@ -3,6 +3,8 @@ Xarray example
 ==============
 
 Displays an xarray
+
+.. tags:: visualization-nD
 """
 
 try:

--- a/examples/zarr_nD_image_.py
+++ b/examples/zarr_nD_image_.py
@@ -3,6 +3,8 @@ Zarr array
 ==========
 
 Display a zarr array
+
+.. tags:: visualization-nD
 """
 
 try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -138,7 +138,7 @@ docs =
     %(all)s
     sphinx<5
     sphinx-tabs
-    sphinx-tags==0.1
+    sphinx-tags==0.1.1
     sphinx-panels
     sphinx-external-toc
     sphinx-gallery

--- a/setup.cfg
+++ b/setup.cfg
@@ -138,6 +138,7 @@ docs =
     %(all)s
     sphinx<5
     sphinx-tabs
+    sphinx-tags==0.1
     sphinx-panels
     sphinx-external-toc
     sphinx-gallery

--- a/setup.cfg
+++ b/setup.cfg
@@ -138,7 +138,7 @@ docs =
     %(all)s
     sphinx<5
     sphinx-tabs
-    sphinx-tags==0.1.1
+    sphinx-tags
     sphinx-panels
     sphinx-external-toc
     sphinx-gallery


### PR DESCRIPTION
# Description

This PR enables tags for the examples in the gallery using the [sphinx-tags extension](https://github.com/melissawm/sphinx-tags).

Co-authored-by: chili-chiu <89602983+chili-chiu@users.noreply.github.com>

EDIT: Here's the link to the built artifacts https://github.com/napari/napari/suites/7950693509/artifacts/339488705

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Reference

Supersedes #4372

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
