### PR TITLE
Fix throttled status updates by ensuring GUI updates occur on the main thread

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1173,6 +1173,7 @@ class Window:
         """
         self._qt_window.setWindowTitle(event.value)
 
+    @ensure_main_thread
     def _help_changed(self, event):
         """Update help message on status bar.
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -35,6 +35,7 @@ from qtpy.QtWidgets import (
     QToolTip,
     QWidget,
 )
+from superqt import ensure_main_thread
 
 from ..plugins import menu_item_template as plugin_menu_item_template
 from ..plugins import plugin_manager
@@ -1142,6 +1143,7 @@ class Window:
 
             self._qt_window.setStyleSheet(get_stylesheet(value))
 
+    @ensure_main_thread
     def _status_changed(self, event):
         """Update status bar.
 

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -785,7 +785,6 @@ def test_status_tooltip(Layer, data, ndim):
     layer = Layer(data)
     viewer.layers.append(layer)
     viewer.cursor.position = (1,) * ndim
-    viewer._on_cursor_position_change()
 
 
 def test_viewer_object_event_sources():

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -198,7 +198,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         self.dims.events.order.connect(self._update_layers)
         self.dims.events.order.connect(self.reset_view)
         self.dims.events.current_step.connect(self._update_layers)
-        self.cursor.events.position.connect(self._on_cursor_position_change)
         self.cursor.events.position.connect(
             throttled(self._update_status_bar_from_cursor, timeout=50)
         )
@@ -401,19 +400,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
     def _update_cursor_size(self, event):
         """Set the viewer cursor_size with the `event.cursor_size` int."""
         self.cursor.size = event.cursor_size
-
-    def _on_cursor_position_change(self):
-        """Set the layer cursor position."""
-        with warnings.catch_warnings():
-            # Catch the deprecation warning on layer.position
-            warnings.filterwarnings(
-                'ignore',
-                message=str(
-                    trans._('layer.position is deprecated', deferred=True)
-                ),
-            )
-            for layer in self.layers:
-                layer.position = self.cursor.position
 
     def _update_status_bar_from_cursor(self, event=None):
         """Update the status bar based on the current cursor position.

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -166,8 +166,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         Currently, this only applies to dask arrays.
     z_index : int
         Depth of the layer visual relative to other visuals in the scenecanvas.
-    coordinates : tuple of float
-        Cursor position in data coordinates.
     corner_pixels : array
         Coordinates of the top-left and bottom-right canvas pixels in the data
         coordinates of each layer. For multiscale data the coordinates are in

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -173,8 +173,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         coordinates of each layer. For multiscale data the coordinates are in
         the space of the currently viewed data level, not the highest resolution
         level.
-    position : tuple
-        Cursor position in world coordinates.
     ndim : int
         Dimensionality of the layer.
     thumbnail : (N, M, 4) array


### PR DESCRIPTION
# Description

This ensures that certain GUI updates happen on the main thread. Mostly, napari is a single-threaded app, but the use of `throttled` in `ViewerModel` means that we control the frequency of a callback using many threads. Ultimately this means that some callbacks will be executed on non-main threads and will eventually try to update `QWidgets` which is generally unsafe.

I only handled the updates to status and help. I'm unsure if we need to handle the tooltip too.

Alternatively, we could move the connection from `ViewerModel.cursor.events.position` to `ViewerModel._update_status_bar_from_cursor` to `QMainWindow` or `QtViewer` and use `qthrottled` to avoid use of multiple threads. I didn't do this here because I'm unsure if any headless napari users are depending being able to manually change the cursor position and expect updates to the status/help. My guess is no, but it is a public part of the viewer model, so the approach here seemed like a better quick fix. If someone wants to create a PR with this approach, it would be interesting to compare.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #4982 
Part of #4738 

# How has this been tested?
- [x] all tests pass with my change
- [x] with manual testing, I could no longer reproduce #4982 

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
