### PR TITLE
Fix `python` name in macOS menu bar

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -366,111 +366,74 @@ def _run_plugin_module(mod, plugin_name):
     run()
 
 
-def _run_pythonw(python_path):
-    """Execute this script again through pythonw.
-
-    This can be used to ensure we're using a framework
-    build of Python on macOS, which fixes frozen menubar issues.
-
-    Parameters
-    ----------
-    python_path : pathlib.Path
-        Path to python framework build.
+def _maybe_rerun_with_macos_fixes():
     """
-    import subprocess
+    Apply some fixes needed in macOS, which might involve
+    running this script again using a different sys.executable.
 
-    cwd = Path.cwd()
-    cmd = [python_path, '-m', 'napari']
-    env = os.environ.copy()
-
-    # Append command line arguments.
-    if len(sys.argv) > 1:
-        cmd.extend(sys.argv[1:])
-
-    result = subprocess.run(cmd, env=env, cwd=cwd)
-    sys.exit(result.returncode)
-
-
-def _run_as_napari_app():
+    1) Quick fix for Big Sur Python 3.9 and Qt 5.
+       No relaunch needed.
+    1) Using `pythonw` instead of `python`.
+       This can be used to ensure we're using a framework
+       build of Python on macOS, which fixes frozen menubar issues
+       in some macOS versions.
+    2) Make sure the menu bar uses 'napari' as the display name.
+       This requires relaunching the app from a symlink to the
+       desired python executable, conveniently named 'napari'.
     """
-    Fixes the app name on MacOS menu bar
-    See https://github.com/napari/napari/issues/4910
-    for details
-    """
-    if "_RUNNING_AS_NAPARI_APP" in os.environ:
+    if sys.platform != "darwin":
+        return
+
+    if "_NAPARI_RERUN_WITH_FIXES" in os.environ:
         # This function already ran, do not recurse!
-        # We also restore sys.executable to its initial value
-        if exe := os.environ.pop("_NAPARI_OLD_SYS_EXECUTABLE", ""):
+        # We also restore sys.executable to its initial value,
+        # if we used a symlink
+        if exe := os.environ.pop("_NAPARI_SYMLINKED_EXECUTABLE", ""):
             sys.executable = exe
         return
 
-    if os.path.basename(sys.executable) == "napari":
-        # If this is true, macOS should have picked the right name
-        # and we do not need workarounds
-        return
-
-    import subprocess
-    from tempfile import TemporaryDirectory
-
-    cwd = Path.cwd()
-    env = os.environ.copy()
-    # Sentinel var to prevent a recursion
-    env["_RUNNING_AS_NAPARI_APP"] = "1"
-    # Pass original sys.executable to the subprocess so it can restore it later
-    env["_NAPARI_OLD_SYS_EXECUTABLE"] = sys.executable
-    with TemporaryDirectory(prefix="symlink-to-fix-macos-menu-name-") as tmp:
-        # By using a symlink with basename napari
-        # we make macOS take 'napari' as the program name
-        napari_link = os.path.join(tmp, "napari")
-        os.symlink(sys.executable, napari_link)
-        cmd = [napari_link, '-m', 'napari']
-        # Append command line arguments.
-        if len(sys.argv) > 1:
-            cmd.extend(sys.argv[1:])
-
-        result = subprocess.run(cmd, env=env, cwd=cwd)
-        sys.exit(result.returncode)
-
-
-def main():
-    # Ensure we're always using a "framework build" on the latest
-    # macOS to ensure menubar works without needing to refocus napari.
-    # We try this for macOS later than the Catelina release
-    # See https://github.com/napari/napari/pull/1554 and
-    # https://github.com/napari/napari/issues/380#issuecomment-659656775
-    # and https://github.com/ContinuumIO/anaconda-issues/issues/199
     import platform
+    import subprocess
+    from tempfile import mkdtemp
 
     from qtpy import API_NAME
 
-    _MACOS_AT_LEAST_CATALINA = (
-        sys.platform == "darwin"
-        and int(platform.release().split('.')[0]) >= 19
-    )
-    _MACOS_AT_LEAST_BIG_SUR = (
-        sys.platform == "darwin"
-        and int(platform.release().split('.')[0]) >= 20
-    )
+    # In principle, we will relaunch to the same python we were using
+    executable = sys.executable
+    cwd = Path.cwd()
 
+    _MACOS_AT_LEAST_CATALINA = int(platform.release().split('.')[0]) >= 19
+    _MACOS_AT_LEAST_BIG_SUR = int(platform.release().split('.')[0]) >= 20
     _RUNNING_CONDA = "CONDA_PREFIX" in os.environ
     _RUNNING_PYTHONW = "PYTHONEXECUTABLE" in os.environ
 
-    # quick fix for Big Sur py3.9 and qt 5
+    # 1) quick fix for Big Sur py3.9 and qt 5
+    # https://github.com/napari/napari/pull/1894
     if _MACOS_AT_LEAST_BIG_SUR and '6' not in API_NAME:
         os.environ['QT_MAC_WANTS_LAYER'] = '1'
 
+    # Create the env copy now because the following changes
+    # should not persist in the current process in case
+    # we do not run the subprocess!
+    env = os.environ.copy()
+
+    # 2) Ensure we're always using a "framework build" on the latest
+    # macOS to ensure menubar works without needing to refocus napari.
+    # We try this for macOS later than the Catalina release
+    # See https://github.com/napari/napari/pull/1554 and
+    # https://github.com/napari/napari/issues/380#issuecomment-659656775
+    # and https://github.com/ContinuumIO/anaconda-issues/issues/199
     if (
         _MACOS_AT_LEAST_CATALINA
         and not _MACOS_AT_LEAST_BIG_SUR
         and _RUNNING_CONDA
         and not _RUNNING_PYTHONW
     ):
-        python_path = Path(sys.exec_prefix) / 'bin' / 'pythonw'
-
-        if python_path.exists():
-            # Running again with pythonw will exit this script
-            # and use the framework build of python.
-            _run_pythonw(python_path)
+        pythonw_path = Path(sys.exec_prefix) / 'bin' / 'pythonw'
+        if pythonw_path.exists():
+            # Use this one instead of sys.executable to relaunch
+            # the subprocess
+            executable = pythonw_path
         else:
             msg = (
                 'pythonw executable not found.\n'
@@ -482,18 +445,57 @@ def main():
             )
             warnings.warn(msg)
 
+    # 3) Make sure the app name in the menu bar is 'napari', not 'python'
+    tempdir = None
+    _NEEDS_SYMLINK = (
+        # When napari is launched from the conda bundle shortcut
+        # it already has the right 'napari' name in the app title
+        # and __CFBundleIdentifier is set to 'com.napari._(<version>)'
+        "napari" not in os.environ.get("__CFBundleIdentifier", "")
+        # with a sys.executable named napari,
+        # macOS should have picked the right name already
+        or os.path.basename(executable) != "napari"
+    )
+    if _NEEDS_SYMLINK:
+        tempdir = mkdtemp(prefix="symlink-to-fix-macos-menu-name-")
+        # By using a symlink with basename napari
+        # we make macOS take 'napari' as the program name
+        napari_link = os.path.join(tempdir, "napari")
+        os.symlink(executable, napari_link)
+        # Pass original executable to the subprocess so it can restore it later
+        env["_NAPARI_SYMLINKED_EXECUTABLE"] = executable
+        executable = napari_link
+
+    # if at this point 'executable' is different from 'sys.executable', we
+    # need to launch the subprocess to apply the fixes
+    if sys.executable != executable:
+        env["_NAPARI_RERUN_WITH_FIXES"] = "1"
+        cmd = [executable, '-m', 'napari']
+        # Append original command line arguments.
+        if len(sys.argv) > 1:
+            cmd.extend(sys.argv[1:])
+        try:
+            result = subprocess.run(cmd, env=env, cwd=cwd)
+            sys.exit(result.returncode)
+        finally:
+            if tempdir is not None:
+                import shutil
+
+                shutil.rmtree(tempdir)
+
+
+def main():
+    # There a number of macOS issues we can fix with env vars
+    # and/or relaunching a subprocess
+    _maybe_rerun_with_macos_fixes()
+
+    # Prevent https://github.com/napari/napari/issues/3415
+    # This one fix is needed _after_ a potential relaunch,
+    # that's why it's here and not in _maybe_rerun_with_macos_fixes()
     if sys.platform == "darwin":
-        # Prevent https://github.com/napari/napari/issues/3415
         import multiprocessing
 
         multiprocessing.set_start_method('fork')
-
-        # Make sure menu bar in macOS uses 'napari' as the app name
-        if "napari" not in os.environ.get("__CFBundleIdentifier", ""):
-            # When napari is launched from the bundle shortcut
-            # it already has the right 'napari' name in the app title
-            # and __CFBundleIdentifier is set to 'com.napari._(<version>)'
-            _run_as_napari_app()
 
     _run()
 

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -373,11 +373,11 @@ def _maybe_rerun_with_macos_fixes():
 
     1) Quick fix for Big Sur Python 3.9 and Qt 5.
        No relaunch needed.
-    1) Using `pythonw` instead of `python`.
+    2) Using `pythonw` instead of `python`.
        This can be used to ensure we're using a framework
        build of Python on macOS, which fixes frozen menubar issues
        in some macOS versions.
-    2) Make sure the menu bar uses 'napari' as the display name.
+    3) Make sure the menu bar uses 'napari' as the display name.
        This requires relaunching the app from a symlink to the
        desired python executable, conveniently named 'napari'.
     """


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

My favourite kind of change! Hacky and workaround-y!

In macOS, having `python3.9` (or whatever version) in the menu bar when launched from the console is not pretty. macOS takes this title from the base name of running process (e.g. `/usr/bin/python3.9` -> `python3.9`), without resolving symlinks!

That means we can sneak in whatever name we want if we craft a symlink to `sys.executable` and relaunch the process, right? Say no more.

This PR creates a temporary symlink to `sys.executable`, intentionally named `napari`. We then restore the original `sys.executable` value to whatever it was before the relaunch.

Questions:
* We are already using the subprocess approach to launch `pythonw` if available. This would add a second subprocess. Is that too much of an overhead?
* Any reason we are not using `os.exec(ve)` to replace the process instead of running a subprocess?

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

Closes #4910 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [X] Locally, running `napari` or `python -m napari` makes the menu bar show the right name.

Current main:

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/2559438/187028881-be31df8b-024a-49f5-b75a-10d843798d8f.png">

This PR:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/2559438/187028937-fd1e3b32-c4e6-41cf-97ff-d102ca6b9e8e.png">



## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
