### PR TITLE
Explicit convert color to string when compile resources

### DIFF
--- a/napari/_qt/qt_resources/_svg.py
+++ b/napari/_qt/qt_resources/_svg.py
@@ -83,7 +83,7 @@ class QColoredSVGIcon(QIcon):
         if not color and theme:
             from ...utils.theme import get_theme
 
-            color = getattr(get_theme(theme, False), theme_key)
+            color = str(getattr(get_theme(theme, False), theme_key))
 
         return QColoredSVGIcon(self._svg, color, opacity)
 

--- a/napari/_qt/qt_resources/_svg.py
+++ b/napari/_qt/qt_resources/_svg.py
@@ -83,7 +83,7 @@ class QColoredSVGIcon(QIcon):
         if not color and theme:
             from ...utils.theme import get_theme
 
-            color = str(getattr(get_theme(theme, False), theme_key))
+            color = getattr(get_theme(theme, False), theme_key).as_hex()
 
         return QColoredSVGIcon(self._svg, color, opacity)
 

--- a/napari/resources/_icons.py
+++ b/napari/resources/_icons.py
@@ -124,7 +124,8 @@ def generate_colorized_svgs(
 
             clrkey, theme_key = color
             theme_key = theme_override.get(svg_stem, theme_key)
-            color = getattr(get_theme(clrkey, False), theme_key)
+            color = str(getattr(get_theme(clrkey, False), theme_key))
+            # convert color to string to fit get_colorized_svg signature
 
         op_key = "" if op == 1 else f"_{op * 100:.0f}"
         alias = ALIAS_T.format(color=clrkey, svg_stem=svg_stem, opacity=op_key)

--- a/napari/resources/_icons.py
+++ b/napari/resources/_icons.py
@@ -124,7 +124,7 @@ def generate_colorized_svgs(
 
             clrkey, theme_key = color
             theme_key = theme_override.get(svg_stem, theme_key)
-            color = str(getattr(get_theme(clrkey, False), theme_key))
+            color = getattr(get_theme(clrkey, False), theme_key).as_hex()
             # convert color to string to fit get_colorized_svg signature
 
         op_key = "" if op == 1 else f"_{op * 100:.0f}"


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

One of the big problems when debugging #4995 for me was that `get_colorized_svg` signature expects color to be a string, and we pass `pydantic.color.Color` to it. So I lost time digging into what could go wrong and why we passed unexpected arguments. 

As follow up we could simply convert color to string before this phase (what is done in this PR) or update the signature of `get_colorized_svg` to assume that we could accept `Color` class also to convert it into a string later. 

I personally prefer the conversion way, but if you think of another way, the signature update is also ok. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Refactor

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
