### PR TITLE
Set fixpoint before move for shapes

### DIFF
--- a/napari/layers/points/_points_mouse_bindings.py
+++ b/napari/layers/points/_points_mouse_bindings.py
@@ -47,6 +47,9 @@ def select(layer, event):
             layer.selected_data = set()
     layer._set_highlight()
 
+    layer._set_drag_start(
+        layer.selected_data, layer.world_to_data(event.position)
+    )
     yield
 
     is_moving = False

--- a/napari/layers/points/_points_mouse_bindings.py
+++ b/napari/layers/points/_points_mouse_bindings.py
@@ -47,6 +47,8 @@ def select(layer, event):
             layer.selected_data = set()
     layer._set_highlight()
 
+    # Set _drag_start value here to prevent an offset when mouse_move happens
+    # https://github.com/napari/napari/pull/4999
     layer._set_drag_start(
         layer.selected_data, layer.world_to_data(event.position)
     )

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2458,3 +2458,19 @@ def test_antialiasing_value_clipping():
     with pytest.warns(RuntimeWarning):
         layer.antialiasing = -1
     assert layer.antialiasing == 0
+
+
+def test_set_drag_start():
+    """Drag start should only change when currently None."""
+    data = [[0, 0], [1, 1]]
+    layer = Points(data)
+    assert layer._drag_start is None
+    position = (0, 1)
+    layer._set_drag_start({0}, position=position)
+    assert all(
+        layer._drag_start[i] == position[i] for i in layer._dims_displayed
+    )
+    layer._set_drag_start({0}, position=(1, 2))
+    assert all(
+        layer._drag_start[i] == position[i] for i in layer._dims_displayed
+    )

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1844,31 +1844,35 @@ class Points(Layer):
             self.data = np.delete(self.data, index, axis=0)
             self.selected_data = set()
 
-    def _move(self, index, coord):
-        """Moves points relative drag start location.
+    def _move(
+        self,
+        selection_indices: Sequence[int],
+        position: Sequence[Union[int, float]],
+    ) -> None:
+        """Move points relative to drag start location.
 
         Parameters
         ----------
-        index : list
-            Integer indices of points to move
-        coord : tuple
-            Coordinates to move points to
+        selection_indices : Sequence[int]
+            Integer indices of points to move in self.data
+        position : tuple
+            Position to move points to in data coordinates.
         """
-        if len(index) > 0:
-            index = list(index)
+        if len(selection_indices) > 0:
+            selection_indices = list(selection_indices)
             disp = list(self._dims_displayed)
-            self._set_drag_start(index, coord)
-            center = self.data[np.ix_(index, disp)].mean(axis=0)
-            shift = np.array(coord)[disp] - center - self._drag_start
-            self.data[np.ix_(index, disp)] = (
-                self.data[np.ix_(index, disp)] + shift
+            self._set_drag_start(selection_indices, position)
+            center = self.data[np.ix_(selection_indices, disp)].mean(axis=0)
+            shift = np.array(position)[disp] - center - self._drag_start
+            self.data[np.ix_(selection_indices, disp)] = (
+                self.data[np.ix_(selection_indices, disp)] + shift
             )
             self.refresh()
         self.events.data(value=self.data)
 
     def _set_drag_start(
         self,
-        selection_indices: set[int],
+        selection_indices: Sequence[int],
         position: Sequence[Union[int, float]],
     ) -> None:
         """Store the initial position at the start of a drag event.

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -2,7 +2,7 @@ import numbers
 import warnings
 from copy import copy, deepcopy
 from itertools import cycle
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -1866,13 +1866,28 @@ class Points(Layer):
             self.refresh()
         self.events.data(value=self.data)
 
-    def _set_drag_start(self, index, coord):
-        if len(index) > 0:
-            index = list(index)
-            disp = list(self._dims_displayed)
+    def _set_drag_start(
+        self,
+        selection_indices: set[int],
+        position: Sequence[Union[int, float]],
+    ) -> None:
+        """Store the initial position at the start of a drag event.
+
+        Parameters
+        ----------
+        selection_indices : set of int
+            integer indices of selected data used to index into self.data
+        position : Sequence of numbers
+            position of the drag start in data coordinates.
+        """
+        if len(selection_indices) > 0:
+            selection_indices = list(selection_indices)
+            dims_displayed = list(self._dims_displayed)
             if self._drag_start is None:
-                center = self.data[np.ix_(index, disp)].mean(axis=0)
-                self._drag_start = np.array(coord)[disp] - center
+                center = self.data[
+                    np.ix_(selection_indices, dims_displayed)
+                ].mean(axis=0)
+                self._drag_start = np.array(position)[dims_displayed] - center
 
     def _paste_data(self):
         """Paste any point from clipboard and select them."""

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1857,9 +1857,7 @@ class Points(Layer):
         if len(index) > 0:
             index = list(index)
             disp = list(self._dims_displayed)
-            if self._drag_start is None:
-                center = self.data[np.ix_(index, disp)].mean(axis=0)
-                self._drag_start = np.array(coord)[disp] - center
+            self._set_drag_start(index, coord)
             center = self.data[np.ix_(index, disp)].mean(axis=0)
             shift = np.array(coord)[disp] - center - self._drag_start
             self.data[np.ix_(index, disp)] = (
@@ -1867,6 +1865,14 @@ class Points(Layer):
             )
             self.refresh()
         self.events.data(value=self.data)
+
+    def _set_drag_start(self, index, coord):
+        if len(index) > 0:
+            index = list(index)
+            disp = list(self._dims_displayed)
+            if self._drag_start is None:
+                center = self.data[np.ix_(index, disp)].mean(axis=0)
+                self._drag_start = np.array(coord)[disp] - center
 
     def _paste_data(self):
         """Paste any point from clipboard and select them."""

--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -368,6 +368,7 @@ def _set_drag_start(layer, coordinates):
     if layer._drag_start is None and len(layer.selected_data) > 0:
         center = layer._selected_box[Box.CENTER]
         layer._drag_start = coord - center
+    return coord
 
 
 def _move(layer, coordinates):
@@ -389,14 +390,11 @@ def _move(layer, coordinates):
     if layer._mode in (
         [Mode.SELECT, Mode.ADD_RECTANGLE, Mode.ADD_ELLIPSE, Mode.ADD_LINE]
     ):
-        coord = [coordinates[i] for i in layer._dims_displayed]
+        coord = _set_drag_start(layer, coordinates)
         layer._moving_coordinates = coordinates
         layer._is_moving = True
         if vertex is None:
             # Check where dragging box from to move whole object
-            if layer._drag_start is None:
-                center = layer._selected_box[Box.CENTER]
-                layer._drag_start = coord - center
             center = layer._selected_box[Box.CENTER]
             shift = coord - center - layer._drag_start
             for index in layer.selected_data:

--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -44,6 +44,7 @@ def select(layer, event):
 
     # we don't update the thumbnail unless a shape has been moved
     update_thumbnail = False
+    _set_drag_start(layer, layer.world_to_data(event.position))
     yield
 
     # on move
@@ -357,6 +358,13 @@ def _drag_selection_box(layer, coordinates):
         layer._drag_start = coord
     layer._drag_box = np.array([layer._drag_start, coord])
     layer._set_highlight()
+
+
+def _set_drag_start(layer, coordinates):
+    coord = [coordinates[i] for i in layer._dims_displayed]
+    if layer._drag_start is None and len(layer.selected_data) > 0:
+        center = layer._selected_box[Box.CENTER]
+        layer._drag_start = coord - center
 
 
 def _move(layer, coordinates):

--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -44,6 +44,9 @@ def select(layer, event):
 
     # we don't update the thumbnail unless a shape has been moved
     update_thumbnail = False
+
+    # Set _drag_start value here to prevent an offset when mouse_move happens
+    # https://github.com/napari/napari/pull/4999
     _set_drag_start(layer, layer.world_to_data(event.position))
     yield
 


### PR DESCRIPTION
# Description
There is a small delay between selecting a point/shape and actually moving the point/shape.
This delay leads to an offset between mouse and object.

By calculating the relative point on mouse_press, rather than on mouse_move fixes this issue.

Before:
![broken](https://user-images.githubusercontent.com/18047816/187690393-41102044-23ac-4f83-b0e3-e6981e66fcad.gif)

After:
![fixed](https://user-images.githubusercontent.com/18047816/187690420-1e83174e-77ec-4291-b1c6-e7caf5eabc0f.gif)

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
