### PR TITLE
Fix broken links in Napari Code of Conduct

### DIFF
--- a/docs/community/code_of_conduct.md
+++ b/docs/community/code_of_conduct.md
@@ -63,7 +63,7 @@ If your report involves any members of the committee, or if they feel they have 
 
 ## Incident reporting resolution & Code of Conduct enforcement
 
-*This section summarizes the most important points, more details can be found in [napari Code of Conduct - How to follow up on a report.](/code-of-conduct-reporting)*
+*This section summarizes the most important points, more details can be found in [napari Code of Conduct - How to follow up on a report.](coc-reporting)*
 
 We will investigate and respond to all complaints. The napari Code of Conduct Committee will protect the identity of the reporter, and treat the content of complaints as confidential (unless the reporter agrees otherwise).
 
@@ -77,7 +77,7 @@ In cases not involving clear severe and obvious breaches of this code of conduct
 
 3. mediation (if feedback didn’t help, and only if both reporter and reportee agree to this)
 
-4. enforcement via transparent decision (see [Resolutions](/code-of-conduct-reporting#resolutions)) by the Code of Conduct Committee
+4. enforcement via transparent decision (see [Resolutions](coc-reporting#resolutions)) by the Code of Conduct Committee
 
 The committee will respond to any report as soon as possible, and at most within 72 hours.
 

--- a/docs/community/code_of_conduct.md
+++ b/docs/community/code_of_conduct.md
@@ -85,5 +85,5 @@ The committee will respond to any report as soon as possible, and at most within
 
 We are thankful to the groups behind the following documents, from which we drew content and inspiration:
 
-* [The SciPy Code of Conduct](https://scipy.github.io/devdocs/dev/conduct/code_of_conduct.html)
+* [The SciPy Code of Conduct](https://docs.scipy.org/doc/scipy/dev/conduct/code_of_conduct.html)
 * [The Numpy Code of Conduct](https://numpy.org/code-of-conduct/)

--- a/docs/community/code_of_conduct.md
+++ b/docs/community/code_of_conduct.md
@@ -77,7 +77,7 @@ In cases not involving clear severe and obvious breaches of this code of conduct
 
 3. mediation (if feedback didn’t help, and only if both reporter and reportee agree to this)
 
-4. enforcement via transparent decision (see [Resolutions](coc-reporting#resolutions)) by the Code of Conduct Committee
+4. enforcement via transparent decision (see [Resolutions](code_of_conduct_reporting.md#resolutions)) by the Code of Conduct Committee
 
 The committee will respond to any report as soon as possible, and at most within 72 hours.
 

--- a/docs/community/code_of_conduct.md
+++ b/docs/community/code_of_conduct.md
@@ -63,7 +63,7 @@ If your report involves any members of the committee, or if they feel they have 
 
 ## Incident reporting resolution & Code of Conduct enforcement
 
-*This section summarizes the most important points, more details can be found in [napari Code of Conduct - How to follow up on a report.](https://github.com/napari/napari/blob/main/docs/developers/code_of_conduct_reporting.md)*
+*This section summarizes the most important points, more details can be found in [napari Code of Conduct - How to follow up on a report.](/code-of-conduct-reporting)*
 
 We will investigate and respond to all complaints. The napari Code of Conduct Committee will protect the identity of the reporter, and treat the content of complaints as confidential (unless the reporter agrees otherwise).
 
@@ -77,7 +77,7 @@ In cases not involving clear severe and obvious breaches of this code of conduct
 
 3. mediation (if feedback didn’t help, and only if both reporter and reportee agree to this)
 
-4. enforcement via transparent decision (see [Resolutions](https://github.com/napari/napari/blob/main/docs/REPORT_HANDLING_MANUAL.md#resolutions)) by the Code of Conduct Committee
+4. enforcement via transparent decision (see [Resolutions](/code-of-conduct-reporting#resolutions)) by the Code of Conduct Committee
 
 The committee will respond to any report as soon as possible, and at most within 72 hours.
 
@@ -85,5 +85,5 @@ The committee will respond to any report as soon as possible, and at most within
 
 We are thankful to the groups behind the following documents, from which we drew content and inspiration:
 
-* [The SciPy Code of Conduct](https://docs.scipy.org/doc/scipy/reference/dev/conduct/code_of_conduct.html)
+* [The SciPy Code of Conduct](https://scipy.github.io/devdocs/dev/conduct/code_of_conduct.html)
 * [The Numpy Code of Conduct](https://numpy.org/code-of-conduct/)

--- a/docs/community/code_of_conduct_reporting.md
+++ b/docs/community/code_of_conduct_reporting.md
@@ -1,3 +1,4 @@
+(coc-reporting)=
 # Handling Code of Conduct reports
 
 This is the manual followed by napari's Code of Conduct Committee. It’s used when we respond to an issue to make sure we’re consistent and fair.


### PR DESCRIPTION
Fixes https://github.com/napari/napari/issues/5001

Switch to using internal links rather than URLs (and currently broken) links to the internal stuff.
Fix the external link to SciPy Code of Conduct, by using the link from SciPy Community page:
https://scipy.org/community/


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality) N/A
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) N/A
- [ ] This change requires a documentation update N/A

# References
Fixes https://github.com/napari/napari/issues/5001

The external link to SciPy Code of Conduct is from SciPy Community page:
https://scipy.org/community/


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z N/A
- [ ] example: all tests pass with my change N/A
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  N/A

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas N/A
- [ ] I have made corresponding changes to the documentation N/A
- [ ] I have added tests that prove my fix is effective or that my feature works N/A
- [ ] If I included new strings, I have used `trans.` to make them localizable. N/A
      For more information see our [translations guide](https://napari.org/developers/translations.html).
