### PR TITLE
Fix sys.path issue with subprocess relaunch in macOS

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -471,8 +471,8 @@ def _maybe_rerun_with_macos_fixes():
     if sys.executable != executable:
         env["_NAPARI_RERUN_WITH_FIXES"] = "1"
         if Path(sys.argv[0]).name == "napari":
-            # launched through entry point, we do that again to
-            # avoid issues with working directory getting into sys.path
+            # launched through entry point, we do that again to avoid 
+            # issues with working directory getting into sys.path (#5007)
             cmd = [executable, sys.argv[0]]
         else:  # we assume it must have been launched via '-m' syntax
             cmd = [executable, "-m", "napari"]

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -470,7 +470,13 @@ def _maybe_rerun_with_macos_fixes():
     # need to launch the subprocess to apply the fixes
     if sys.executable != executable:
         env["_NAPARI_RERUN_WITH_FIXES"] = "1"
-        cmd = [executable, '-m', 'napari']
+        if Path(sys.argv[0]).name == "napari":  
+            # launched through entry point, we do that again to
+            # avoid issues with working directory getting into sys.path
+            cmd = [executable, sys.argv[0]]
+        else:  # we assume it must have been launched via '-m' syntax
+            cmd = [executable, "-m", "napari"]
+
         # Append original command line arguments.
         if len(sys.argv) > 1:
             cmd.extend(sys.argv[1:])

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -470,7 +470,7 @@ def _maybe_rerun_with_macos_fixes():
     # need to launch the subprocess to apply the fixes
     if sys.executable != executable:
         env["_NAPARI_RERUN_WITH_FIXES"] = "1"
-        if Path(sys.argv[0]).name == "napari":  
+        if Path(sys.argv[0]).name == "napari":
             # launched through entry point, we do that again to
             # avoid issues with working directory getting into sys.path
             cmd = [executable, sys.argv[0]]

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -471,7 +471,7 @@ def _maybe_rerun_with_macos_fixes():
     if sys.executable != executable:
         env["_NAPARI_RERUN_WITH_FIXES"] = "1"
         if Path(sys.argv[0]).name == "napari":
-            # launched through entry point, we do that again to avoid 
+            # launched through entry point, we do that again to avoid
             # issues with working directory getting into sys.path (#5007)
             cmd = [executable, sys.argv[0]]
         else:  # we assume it must have been launched via '-m' syntax


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

First reported in https://napari.zulipchat.com/#narrow/stream/212875-general/topic/Unable.20to.20launch.20napari.20on.20main

This problem only occurs in some specific cases, and it was present already before #4989, but now we can see it more often since the subprocess relaunches are seen more often. 

We were seeing this error:

```
ImportError: cannot import name 'run' from 'napari' (unknown location)
```

which shows that our `napari` is not importable. Something else got in `sys.path`.

This only happens if:

1. User runs napari from a directory containing a `napari` directory that is NOT the `napari` package. For example, my napari repo is in `~/devel/napari`, but I am running napari from `~/devel`.
2. The Python version recognizes the napari repo as a `Namespace`. Python 3.9.6 didn't do this, but 3.9.12 does.
3. The user runs `napari` (the entry point) instead of `python -m napari`.
 
The entry point does not add the working directory to `sys.path`, but the `-m` syntax does! If the user had been running `python -m napari`, this issue would have come up earlier. However, since the subprocess reruns napari with `python -m napari`, the working directory gets inserted into `sys.path` (first position), clobbering the installed directory. 


This is hardly a bug, but more like "unfortunate behaviour". However, I think we should respect the launching method. So the fix is to detect whether we ran from the entry point, and run the subprocess using the same approach. If not, we assume it was using `-m napari`.

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [X] Local tests reproduced the original problem and show that this fix solves it.

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).


cc/ @psobolewskiPhD 