### PR TITLE
Add duplicated event and emit on duplicate

### DIFF
--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -25,7 +25,9 @@ def _duplicate_layer(ll: LayerList, *, name: str = ''):
         data, state, type_str = lay.as_layer_data_tuple()
         state["name"] = trans._('{name} copy', name=lay.name)
         new = Layer.create(deepcopy(data), state, type_str)
-        ll.insert(ll.index(lay) + 1, new)
+        index = ll.index(lay) + 1
+        ll.insert(index, new)
+        ll.events.duplicated(index=index, value=new)
 
 
 def _split_stack(ll: LayerList, axis: int = 0):

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -27,7 +27,7 @@ def _duplicate_layer(ll: LayerList, *, name: str = ''):
         new = Layer.create(deepcopy(data), state, type_str)
         index = ll.index(lay) + 1
         ll.insert(index, new)
-        ll.events.duplicated(index=index, value=new)
+        ll.events.duplicated(index=index, old=lay, value=new)
 
 
 def _split_stack(ll: LayerList, axis: int = 0):

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -27,7 +27,7 @@ def _duplicate_layer(ll: LayerList, *, name: str = ''):
         new = Layer.create(deepcopy(data), state, type_str)
         index = ll.index(lay) + 1
         ll.insert(index, new)
-        ll.events.duplicated(index=index, old=lay, value=new)
+        ll.events.duplicated(index=index, old_value=lay, value=new)
 
 
 def _split_stack(ll: LayerList, axis: int = 0):

--- a/napari/layers/_tests/test_layer_actions.py
+++ b/napari/layers/_tests/test_layer_actions.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import numpy as np
 import pytest
 
@@ -16,12 +18,18 @@ def test_duplicate_layers():
         pass
 
     layer_list = LayerList()
+
+    layer_list.events = Mock(wraps=layer_list.events)
+
     layer_list.append(Points([[0, 0]], name="test"))
     layer_list.selection.active = layer_list[0]
     layer_list[0].events.data.connect(_dummy)
     assert len(layer_list[0].events.data.callbacks) == 2
     assert len(layer_list) == 1
     _duplicate_layer(layer_list)
+    layer_list.events.duplicated.assert_called_with(
+        index=1, old_value=layer_list[0], value=layer_list[1]
+    )
     assert len(layer_list) == 2
     assert layer_list[0].name == "test"
     assert layer_list[1].name == "test copy"

--- a/napari/utils/events/_tests/test_evented_list.py
+++ b/napari/utils/events/_tests/test_evented_list.py
@@ -118,6 +118,7 @@ def test_move(test_list):
     test_list.events.removed.connect(_fail)
     test_list.events.inserting.connect(_fail)
     test_list.events.inserted.connect(_fail)
+    test_list.events.duplicated.connect(_fail)
 
     before = list(test_list)
     assert before == [0, 1, 2, 3, 4]  # from fixture
@@ -176,6 +177,7 @@ def test_move_multiple(sources, dest, expectation):
     el.events.removed.connect(_fail)
     el.events.inserting.connect(_fail)
     el.events.inserted.connect(_fail)
+    el.events.duplicated.connect(_fail)
 
     el.move_multiple(sources, dest)
     assert el == expectation

--- a/napari/utils/events/containers/_evented_list.py
+++ b/napari/utils/events/containers/_evented_list.py
@@ -91,6 +91,7 @@ class EventedList(TypedMutableSequence[_T]):
             'moved': None,  # Tuple[Tuple[int, int], Any]
             'changed': None,  # Tuple[int, Any, Any] - (idx, old, new)
             'reordered': None,  # None
+            'duplicated': None,  # Tuple[int, Any] - (idx, value)
         }
 
         # For inheritance: If the mro already provides an EmitterGroup, add...

--- a/napari/utils/events/containers/_evented_list.py
+++ b/napari/utils/events/containers/_evented_list.py
@@ -71,6 +71,8 @@ class EventedList(TypedMutableSequence[_T]):
         emitted when ``index`` is set from ``old_value`` to ``value``
     reordered (value: self)
         emitted when the list is reordered (eg. moved/reversed).
+    duplicated (index: int, old_value: T, value: T)
+        emitted after the duplicate ``value`` of ``old_value`` was created and inserted at ``index``.
     """
 
     events: EmitterGroup
@@ -91,7 +93,7 @@ class EventedList(TypedMutableSequence[_T]):
             'moved': None,  # Tuple[Tuple[int, int], Any]
             'changed': None,  # Tuple[int, Any, Any] - (idx, old, new)
             'reordered': None,  # None
-            'duplicated': None,  # Tuple[int, Any] - (idx, value)
+            'duplicated': None,  # Tuple[int, Any, Any] - (idx, old, new)
         }
 
         # For inheritance: If the mro already provides an EmitterGroup, add...

--- a/napari/utils/events/containers/_evented_list.py
+++ b/napari/utils/events/containers/_evented_list.py
@@ -72,7 +72,7 @@ class EventedList(TypedMutableSequence[_T]):
     reordered (value: self)
         emitted when the list is reordered (eg. moved/reversed).
     duplicated (index: int, old_value: T, value: T)
-        emitted after the duplicate ``value`` of ``old_value`` was created and inserted at ``index``.
+        emitted after the duplicate ``value`` of ``old_value`` was created and inserted at ``index``. This event is emitted after the respective ``inserted`` event.
     """
 
     events: EmitterGroup


### PR DESCRIPTION
# Description

For the plugin I create, it would be great to have an event indicating that a specific layer has been duplicated rather then just inserted to adjust some metadata for further processing. 
Therefore, I propose to add a new event: `duplicated` that is emitted when a layer is duplicated.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How has this been tested?
- [X] all tests pass with my change
- [X] Added test for the duplicated event

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have made corresponding changes to the documentation