### PR TITLE
MAINT: update issue failing template

### DIFF
--- a/.github/TEST_FAIL_TEMPLATE.md
+++ b/.github/TEST_FAIL_TEMPLATE.md
@@ -7,6 +7,6 @@ The {{ workflow }} workflow failed on {{ date | date("YYYY-MM-DD HH:mm") }} UTC
 The most recent failing test was on {{ env.PLATFORM }} py{{ env.PYTHON }} {{ env.BACKEND }}
 with commit: {{ sha }}
 
-Full run: https://github.com/{{ payload.repository.full_name }}/actions/runs/{{ env.RUN_ID }}
+Full run: https://github.com/napari/napari/actions/runs/{{ env.RUN_ID }}
 
 (This post will be updated if another test fails, as long as this issue remains open.)


### PR DESCRIPTION
The varaible {{ payload.repository.full_name }} does not exists,
This will fix the links to the failing test when the issue are
autoposted by a bot.

See for example issues #4796 and #4629 which have broken links. 