### PR TITLE
Feature: register a keyboard shortcut for `preserve_labels` checkbox

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -101,7 +101,7 @@ EXPECTED_NUMBER_OF_LAYER_METHODS = {
     'Surface': 0,
     'Tracks': 0,
     'Points': 9,
-    'Labels': 11,
+    'Labels': 12,
     'Shapes': 17,
 }
 

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -90,8 +90,8 @@ def increase_label_id(layer: Labels):
     layer.selected_label += 1
 
 
-@register_label_action(
-    trans._("Toggle preserve labels"),
+@register_layer_attr_action(
+    Labels, trans._("Toggle preserve labels"), "preserve_labels"
 )
 def toggle_preserve_labels(layer: Labels):
     layer.preserve_labels = not layer.preserve_labels

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -90,7 +90,9 @@ def increase_label_id(layer: Labels):
     layer.selected_label += 1
 
 
-@register_label_mode_action(trans._("Toggle preserve labels"))
+@register_label_action(
+    trans._("Toggle preserve labels"),
+)
 def toggle_preserve_labels(layer: Labels):
     layer.preserve_labels = not layer.preserve_labels
 

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -90,6 +90,11 @@ def increase_label_id(layer: Labels):
     layer.selected_label += 1
 
 
+@register_label_mode_action(trans._("Toggle preserve labels"))
+def toggle_preserve_labels(layer: Labels):
+    layer.preserve_labels = not layer.preserve_labels
+
+
 @Labels.bind_key('Control-Z')
 def undo(layer: Labels):
     """Undo the last paint or fill action since the view slice has changed."""

--- a/napari/utils/shortcuts.py
+++ b/napari/utils/shortcuts.py
@@ -21,7 +21,7 @@ default_shortcuts = {
     'napari:new_label': ['M'],
     'napari:decrease_label_id': ['-'],
     'napari:increase_label_id': ['='],
-    'napari:toggle_preserve_labels': ['Shift'],
+    'napari:toggle_preserve_labels': ['P'],
     'napari:activate_points_add_mode': ['2'],
     'napari:activate_points_select_mode': ['3'],
     'napari:activate_points_pan_zoom_mode': ['4'],

--- a/napari/utils/shortcuts.py
+++ b/napari/utils/shortcuts.py
@@ -21,6 +21,7 @@ default_shortcuts = {
     'napari:new_label': ['M'],
     'napari:decrease_label_id': ['-'],
     'napari:increase_label_id': ['='],
+    'napari:toggle_preserve_labels': ['Shift'],
     'napari:activate_points_add_mode': ['2'],
     'napari:activate_points_select_mode': ['3'],
     'napari:activate_points_pan_zoom_mode': ['4'],


### PR DESCRIPTION
# Description
This PR registers a keyboard shortcut/keybinding for `preserve_labels` checkbox of the Labels layer. By default, it uses `P`. Thanks to @Czaki https://github.com/napari/napari/pull/4814 *any* keybind can function as either a selector or on-hold conditional, but alas, Shift, which was the old on-hold keybind prior to https://github.com/napari/napari/issues/5016 is not possible at the moment, see: https://github.com/napari/napari/issues/5016#issuecomment-1237416747

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
This is also relevant to the `Auto-Fill` PR: https://github.com/napari/napari/pull/5006 because it would make choosing the `preserve_labels` feature much easier.
Partially addresses https://github.com/napari/napari/issues/4813 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change: I edited the test to account for the extra layer method
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
