### PR TITLE
Add option to edit second shortcut in settings

### DIFF
--- a/examples/action_manager.py
+++ b/examples/action_manager.py
@@ -45,7 +45,7 @@ layer_buttons = viewer.window.qt_viewer.layerButtons
 # Button do not need to do anything, just need to be pretty; all the action
 # binding and (un) binding will be done with the action manager, idem for
 # setting the tooltip.
-rot_button = QtViewerPushButton(None, 'warning')
+rot_button = QtViewerPushButton('warning')
 layer_buttons.layout().insertWidget(3, rot_button)
 
 

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -23,7 +23,6 @@ from ...layers.labels._labels_utils import get_dtype
 from ...utils._dtype import get_dtype_limits
 from ...utils.action_manager import action_manager
 from ...utils.events import disconnect_events
-from ...utils.interactions import Shortcut
 from ...utils.translations import trans
 from ..utils import disable_with_opacity
 from ..widgets._slider_compat import QSlider
@@ -195,10 +194,6 @@ class QtLabelsControls(QtLayerControls):
         action_manager.bind_button(
             'napari:activate_fill_mode',
             self.fill_button,
-            extra_tooltip_text=trans._(
-                "Toggle with {shortcut}",
-                shortcut=Shortcut("Control"),
-            ),
         )
 
         self.erase_button = QtModeRadioButton(
@@ -209,10 +204,6 @@ class QtLabelsControls(QtLayerControls):
         action_manager.bind_button(
             'napari:activate_label_erase_mode',
             self.erase_button,
-            extra_tooltip_text=trans._(
-                "Toggle with {shortcut}",
-                shortcut=Shortcut("Alt"),
-            ),
         )
 
         # don't bind with action manager as this would remove "Toggle with {shortcut}"

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 import pytest
 
-from napari._qt.widgets.qt_keyboard_settings import ShortcutEditor
+from napari._qt.widgets.qt_keyboard_settings import ShortcutEditor, WarnPopup
+from napari.utils.action_manager import action_manager
 
 
 @pytest.fixture
@@ -19,3 +22,25 @@ def test_shortcut_editor_defaults(
     shortcut_editor_widget,
 ):
     shortcut_editor_widget()
+
+
+def test_layer_actions(shortcut_editor_widget):
+    widget = shortcut_editor_widget()
+    assert widget.layer_combo_box.currentText() == widget.VIEWER_KEYBINDINGS
+    actions1 = widget._get_layer_actions()
+    assert actions1 == widget.key_bindings_strs[widget.VIEWER_KEYBINDINGS]
+    widget.layer_combo_box.setCurrentText("Labels layer")
+    actions2 = widget._get_layer_actions()
+    assert actions2 == {**widget.key_bindings_strs["Labels layer"], **actions1}
+
+
+def test_mark_conflicts(shortcut_editor_widget):
+    widget = shortcut_editor_widget()
+    widget._table.item(0, widget._shortcut_col).setText("U")
+    act = widget._table.item(0, widget._action_col).text()
+    assert action_manager._shortcuts[act][0] == "U"
+    with patch.object(WarnPopup, "exec_") as mock:
+        assert not widget._mark_conflicts(action_manager._shortcuts[act][0], 1)
+        assert mock.called
+    assert widget._mark_conflicts("Y", 1)
+    # "Y" is arbitrary chosen and on conflict with existing shortcut should be changed

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -34,7 +34,7 @@ def test_layer_actions(shortcut_editor_widget):
     assert actions2 == {**widget.key_bindings_strs["Labels layer"], **actions1}
 
 
-def test_mark_conflicts(shortcut_editor_widget):
+def test_mark_conflicts(shortcut_editor_widget, qtbot):
     widget = shortcut_editor_widget()
     widget._table.item(0, widget._shortcut_col).setText("U")
     act = widget._table.item(0, widget._action_col).text()
@@ -44,3 +44,4 @@ def test_mark_conflicts(shortcut_editor_widget):
         assert mock.called
     assert widget._mark_conflicts("Y", 1)
     # "Y" is arbitrary chosen and on conflict with existing shortcut should be changed
+    qtbot.add_widget(widget._warn_dialog)

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -287,8 +287,9 @@ class ShortcutEditor(QWidget):
                 else ""
             )
 
-    def _mark_conflicts(self, new_shortcut, current_action, row) -> bool:
+    def _mark_conflicts(self, new_shortcut, row) -> bool:
         # Go through all layer actions to determine if the new shortcut is already here.
+        current_action = self._table.item(row, self._action_col).text()
         actions_all = self._get_layer_actions()
         current_item = self._table.currentItem()
         for row1, (action_name, action) in enumerate(actions_all.items()):
@@ -360,6 +361,8 @@ class ShortcutEditor(QWidget):
         if self._skip:
             return
 
+        self._table.setCurrentItem(self._table.item(row, col))
+
         if col in {self._shortcut_col, self._shortcut_col2}:
             # Get all layer actions and viewer actions in order to determine
             # the new shortcut is not already set to an action.
@@ -389,15 +392,14 @@ class ShortcutEditor(QWidget):
             )
 
             # Flag to indicate whether to set the new shortcut.
-            replace = self._mark_conflicts(new_shortcut, current_action, row)
+            replace = self._mark_conflicts(new_shortcut, row)
 
             if replace is True:
                 # This shortcut is not taken.
 
                 #  Unbind current action from shortcuts in action manager.
-                shortcuts_list = list(
-                    action_manager.unbind_shortcut(current_action)
-                )
+                action_manager.unbind_shortcut(current_action)
+                shortcuts_list = list(current_shortcuts)
                 ind = col - self._shortcut_col
                 if new_shortcut != "":
                     if ind < len(shortcuts_list):

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -326,7 +326,7 @@ class ShortcutEditor(QWidget):
     def _show_bind_shortcut_error(
         self, current_action, current_shortcuts, row, new_shortcut
     ):
-        action_manager._shortcuts[current_action] = set()
+        action_manager._shortcuts[current_action] = []
         # need to rebind the old shortcut
         action_manager.unbind_shortcut(current_action)
         for short in current_shortcuts:
@@ -582,11 +582,18 @@ class EditorWidget(QLineEdit):
         if not event_key or event_key == Qt.Key.Key_unknown:
             return
 
+        key_map = {
+            Qt.Key.Key_Control: 'Control',
+            Qt.Key.Key_Shift: 'Shift',
+            Qt.Key.Key_Alt: 'Alt',
+            Qt.Key.Key_Meta: 'Meta',
+        }
+
+        if event_key in key_map:
+            self.setText(key_map[event_key])
+            return
+
         if event_key in [
-            Qt.Key.Key_Control,
-            Qt.Key.Key_Shift,
-            Qt.Key.Key_Alt,
-            Qt.Key.Key_Meta,
             Qt.Key.Key_Return,
             Qt.Key.Key_Tab,
             Qt.Key.Key_CapsLock,

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -580,11 +580,11 @@ class EditorWidget(QLineEdit):
             return
 
         key_map = {
-            Qt.Key.Key_Control: keys.CONTROL,
-            Qt.Key.Key_Shift: keys.SHIFT,
-            Qt.Key.Key_Alt: keys.ALT,
-            Qt.Key.Key_Meta: keys.META,
-            Qt.Key.Key_Delete: keys.DELETE,
+            Qt.Key.Key_Control: keys.CONTROL.name,
+            Qt.Key.Key_Shift: keys.SHIFT.name,
+            Qt.Key.Key_Alt: keys.ALT.name,
+            Qt.Key.Key_Meta: keys.META.name,
+            Qt.Key.Key_Delete: keys.DELETE.name,
         }
 
         if event_key in key_map:

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -522,6 +522,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
                 continue
             action_name = f"napari:{fun.__name__}"
             desc = action_manager._actions[action_name].description.lower()
+            if not shortcuts[action_name]:
+                continue
             help_li.append(
                 trans._(
                     "use <{shortcut}> for {desc}",

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -120,6 +120,8 @@ def register_layer_attr_action(
 
             return _callback
 
+        _wrapper._hold_button_delay = True
+
         register_layer_action(keymapprovider, description, shortcuts)(_wrapper)
         return func
 

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -120,8 +120,6 @@ def register_layer_attr_action(
 
             return _callback
 
-        _wrapper._hold_button_delay = True
-
         register_layer_action(keymapprovider, description, shortcuts)(_wrapper)
         return func
 

--- a/napari/settings/_shortcuts.py
+++ b/napari/settings/_shortcuts.py
@@ -1,6 +1,6 @@
 from typing import Dict, List
 
-from pydantic import Field
+from pydantic import Field, validator
 
 from ..utils.events.evented_model import EventedModel
 from ..utils.shortcuts import default_shortcuts
@@ -20,3 +20,10 @@ class ShortcutsSettings(EventedModel):
     class NapariConfig:
         # Napari specific configuration
         preferences_exclude = ['schema_version']
+
+    @validator('shortcuts')
+    def shortcut_validate(cls, v):
+        for name, value in default_shortcuts.items():
+            if name not in v:
+                v[name] = value
+        return v

--- a/napari/utils/_tests/test_action_manager.py
+++ b/napari/utils/_tests/test_action_manager.py
@@ -37,7 +37,7 @@ def test_bind_multiple_action(action_manager):
 
     action_manager.bind_shortcut('napari:test_action_2', 'X')
     action_manager.bind_shortcut('napari:test_action_2', 'Y')
-    assert action_manager._shortcuts['napari:test_action_2'] == {'X', 'Y'}
+    assert action_manager._shortcuts['napari:test_action_2'] == ['X', 'Y']
 
 
 def test_bind_unbind_existing_action(action_manager):
@@ -47,5 +47,5 @@ def test_bind_unbind_existing_action(action_manager):
     )
 
     assert action_manager.bind_shortcut('napari:test_action_1', 'X') is None
-    assert action_manager.unbind_shortcut('napari:test_action_1') == {'X'}
+    assert action_manager.unbind_shortcut('napari:test_action_1') == ['X']
     assert action_manager._shortcuts['napari:test_action_1'] == set()

--- a/napari/utils/_tests/test_action_manager.py
+++ b/napari/utils/_tests/test_action_manager.py
@@ -48,4 +48,4 @@ def test_bind_unbind_existing_action(action_manager):
 
     assert action_manager.bind_shortcut('napari:test_action_1', 'X') is None
     assert action_manager.unbind_shortcut('napari:test_action_1') == ['X']
-    assert action_manager._shortcuts['napari:test_action_1'] == set()
+    assert action_manager._shortcuts['napari:test_action_1'] == []

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -303,10 +303,6 @@ class ActionManager:
             ttip += f' ({shorts})'
 
         ttip += f'[{name}]' if self._tooltip_include_action_name else ''
-
-        if getattr(self._actions[name].command, '_hold_button_delay', False):
-            ttip += trans._(' (hold to temporary activate)')
-
         return ttip
 
     def _get_layer_shortcuts(self, layers):

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -211,6 +211,7 @@ class ActionManager:
                 )
 
         button.clicked.connect(lambda: self.trigger(name))
+        button.setToolTip(f'{self._build_tooltip(name)} {extra_tooltip_text}')
 
         def _update_tt(event: ShortcutEvent):
             if event.name == name:
@@ -299,7 +300,7 @@ class ActionManager:
         if name in self._shortcuts:
             jstr = ' ' + trans._p('<keysequence> or <keysequence>', 'or') + ' '
             shorts = jstr.join(f"{Shortcut(s)}" for s in self._shortcuts[name])
-            ttip += f'({shorts})'
+            ttip += f' ({shorts})'
 
         ttip += f'[{name}]' if self._tooltip_include_action_name else ''
         return ttip

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -303,6 +303,10 @@ class ActionManager:
             ttip += f' ({shorts})'
 
         ttip += f'[{name}]' if self._tooltip_include_action_name else ''
+
+        if getattr(self._actions[name].command, '_hold_button_delay', False):
+            ttip += trans._(' (hold to temporary activate)')
+
         return ttip
 
     def _get_layer_shortcuts(self, layers):

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -211,7 +211,10 @@ class ActionManager:
                 )
 
         button.clicked.connect(lambda: self.trigger(name))
-        button.setToolTip(f'{self._build_tooltip(name)} {extra_tooltip_text}')
+        if name in self._shortcuts:
+            button.setToolTip(
+                f'{self._build_tooltip(name)} {extra_tooltip_text}'
+            )
 
         def _update_tt(event: ShortcutEvent):
             if event.name == name:

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from functools import cached_property
 from inspect import isgeneratorfunction
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Set, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 from ..utils.events import EmitterGroup
 from .interactions import Shortcut
@@ -245,7 +245,7 @@ class ActionManager:
         self._update_shortcut_bindings(name)
         self._emit_shortcut_change(name, shortcut)
 
-    def unbind_shortcut(self, name: str) -> Union[Set[str], None]:
+    def unbind_shortcut(self, name: str) -> Optional[List[str]]:
         """
         Unbind all shortcuts for a given action name.
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

![image](https://user-images.githubusercontent.com/3826210/188629023-d4f4a7c4-2cd2-4514-9206-25be0aa52afa.png)


add the option to edit the second shortcut in settings. Preserve multiple shortcuts if edit (currently delete the second one)

List of changes:
1) add a second column for edit or preview shortcuts
2) change actions storage from set to list to preserve order after loading from disc
3) split code for validation of new shortcuts on more functions to increase readability
4) allow Ctrl, Shift, Alt, and Meta to be shortcuts
5) if the user has edited shortcuts and new action is added, then it will be added to user shortcut storage. 
6) add basic tests

Known issue found while reading the code: 
When editing the Viewer shortcut, one could simply set the shortcut already used by some layer. 
Oppositely, there is a protection. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

closes #5016
closes #3926
closes #4813

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).

This is the only draft with a known problem that shortcuts order may change after restarting napari, and sometimes a shortcut is overwritten instead of added next. 

I open it to get initial feedback. @psobolewskiPhD ? 
