### PR TITLE
Fix shift selection for points

### DIFF
--- a/napari/layers/points/_points_mouse_bindings.py
+++ b/napari/layers/points/_points_mouse_bindings.py
@@ -50,7 +50,9 @@ def select(layer, event):
     # Set _drag_start value here to prevent an offset when mouse_move happens
     # https://github.com/napari/napari/pull/4999
     layer._set_drag_start(
-        layer.selected_data, layer.world_to_data(event.position)
+        layer.selected_data,
+        layer.world_to_data(event.position),
+        center_by_data=not modify_selection,
     )
     yield
 
@@ -67,8 +69,6 @@ def select(layer, event):
             # while dragging, update the drag box
             coord = [coordinates[i] for i in layer._dims_displayed]
             layer._is_selecting = True
-            if layer._drag_start is None:
-                layer._drag_start = coord
             layer._drag_box = np.array([layer._drag_start, coord])
 
             # update the drag up and normal vectors on the layer

--- a/napari/layers/points/_points_mouse_bindings.py
+++ b/napari/layers/points/_points_mouse_bindings.py
@@ -56,6 +56,10 @@ def select(layer, event):
     )
     yield
 
+    # Undo the toggle selected in case of a mouse move with modifiers
+    if modify_selection and value is not None and event.type == 'mouse_move':
+        layer.selected_data = _toggle_selected(layer.selected_data, value)
+
     is_moving = False
     # on move
     while event.type == 'mouse_move':
@@ -94,6 +98,7 @@ def select(layer, event):
         )
 
     # reset the selection box data and highlights
+    layer._drag_box = None
     layer._drag_normal = None
     layer._drag_up = None
     layer._set_highlight(force=True)

--- a/napari/layers/points/_tests/test_points_mouse_bindings.py
+++ b/napari/layers/points/_tests/test_points_mouse_bindings.py
@@ -681,3 +681,194 @@ def test_selecting_no_points_with_drag_3d(create_known_points_layer_3d):
 
     # Check all points selected as drag box contains them
     assert len(layer.selected_data) == 0
+
+
+@pytest.mark.parametrize(
+    'pre_selection,on_point,modifier',
+    [
+        (set(), True, []),
+        ({0}, True, []),
+        ({0, 1, 2}, True, []),
+        ({1, 2}, True, []),
+        (set(), True, ['Shift']),
+        ({0}, True, ['Shift']),
+        ({0, 1, 2}, True, ['Shift']),
+        ({1, 2}, True, ['Shift']),
+        (set(), False, []),
+        ({0}, False, []),
+        ({0, 1, 2}, False, []),
+        ({1, 2}, False, []),
+        (set(), False, ['Shift']),
+        ({0}, False, ['Shift']),
+        ({0, 1, 2}, False, ['Shift']),
+        ({1, 2}, False, ['Shift']),
+    ],
+)
+def test_drag_start_selection(
+    create_known_points_layer_2d, pre_selection, on_point, modifier
+):
+    layer, n_points, known_non_point = create_known_points_layer_2d
+    layer.mode = 'select'
+    layer.selected_data = pre_selection
+
+    if on_point:
+        initial_position = tuple(layer.data[0])
+    else:
+        initial_position = tuple(known_non_point)
+    zero_pos = [0, 0]
+    initial_position_1 = tuple(layer.data[1])
+    diff_data_1 = [
+        layer.data[1, 0] - layer.data[0, 0],
+        layer.data[1, 1] - layer.data[0, 1],
+    ]
+
+    assert layer._drag_start is None
+    assert layer._drag_box is None
+
+    # Simulate click
+    event = ReadOnlyWrapper(
+        Event(
+            type='mouse_press', position=initial_position, modifiers=modifier
+        )
+    )
+    mouse_press_callbacks(layer, event)
+
+    if modifier:
+        if not on_point:
+            assert layer.selected_data == pre_selection
+        elif 0 in pre_selection:
+            assert layer.selected_data == pre_selection - {0}
+        else:
+            assert layer.selected_data == pre_selection | {0}
+    elif not on_point:
+        assert layer.selected_data == set()
+    elif 0 in pre_selection:
+        assert layer.selected_data == pre_selection
+    else:
+        assert layer.selected_data == {0}
+
+    if len(layer.selected_data) > 0:
+        center = layer.data[list(layer.selected_data), :].mean(axis=0)
+    else:
+        center = [0, 0]
+
+    if not modifier:
+        start_position = [
+            initial_position[0] - center[0],
+            initial_position[1] - center[1],
+        ]
+    else:
+        start_position = initial_position
+
+    is_point_move = len(layer.selected_data) > 0 and on_point and not modifier
+
+    np.testing.assert_array_equal(layer._drag_start, start_position)
+
+    # Simulate drag start on a different position
+    offset_position = [initial_position[0] + 20, initial_position[1] + 20]
+    event = ReadOnlyWrapper(
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            position=offset_position,
+            modifiers=modifier,
+        )
+    )
+    mouse_move_callbacks(layer, event)
+
+    # Initial mouse_move is already considered a move and not a press.
+    # Therefore, the _drag_start value should be identical and the data or drag_box should reflect
+    # the mouse position.
+    np.testing.assert_array_equal(layer._drag_start, start_position)
+    if is_point_move:
+        if 1 in layer.selected_data and 0 in layer.selected_data:
+            np.testing.assert_array_equal(
+                layer.data[1],
+                [
+                    offset_position[0] + diff_data_1[0],
+                    offset_position[1] + diff_data_1[1],
+                ],
+            )
+        elif 1 not in layer.selected_data:
+            np.testing.assert_array_equal(layer.data[1], initial_position_1)
+
+        if 0 in layer.selected_data:
+            np.testing.assert_array_equal(
+                layer.data[0], [offset_position[0], offset_position[1]]
+            )
+        else:
+            assert False, 'Unreachable code'  # pragma: no cover
+    else:
+        np.testing.assert_array_equal(
+            layer._drag_box, [initial_position, offset_position]
+        )
+
+    # Simulate drag start on new different position
+    offset_position = zero_pos
+    event = ReadOnlyWrapper(
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            position=offset_position,
+            modifiers=modifier,
+        )
+    )
+    mouse_move_callbacks(layer, event)
+
+    # Initial mouse_move is already considered a move and not a press.
+    # Therefore, the _drag_start value should be identical and the data or drag_box should reflect
+    # the mouse position.
+    np.testing.assert_array_equal(layer._drag_start, start_position)
+    if is_point_move:
+        if 1 in layer.selected_data and 0 in layer.selected_data:
+            np.testing.assert_array_equal(
+                layer.data[1],
+                [
+                    offset_position[0] + diff_data_1[0],
+                    offset_position[1] + diff_data_1[1],
+                ],
+            )
+        elif 1 not in layer.selected_data:
+            np.testing.assert_array_equal(layer.data[1], initial_position_1)
+
+        if 0 in layer.selected_data:
+            np.testing.assert_array_equal(
+                layer.data[0], [offset_position[0], offset_position[1]]
+            )
+        else:
+            assert False, 'Unreachable code'  # pragma: no cover
+    else:
+        np.testing.assert_array_equal(
+            layer._drag_box, [initial_position, offset_position]
+        )
+
+    # Simulate release
+    event = ReadOnlyWrapper(
+        Event(type='mouse_release', is_dragging=True, modifiers=modifier)
+    )
+    mouse_release_callbacks(layer, event)
+
+    if on_point and 0 in pre_selection and modifier:
+        assert layer.selected_data == pre_selection - {0}
+    elif on_point and 0 in pre_selection and not modifier:
+        assert layer.selected_data == pre_selection
+    elif on_point and 0 not in pre_selection and modifier:
+        assert layer.selected_data == pre_selection | {0}
+    elif on_point and 0 not in pre_selection and not modifier:
+        assert layer.selected_data == {0}
+    elif 0 in pre_selection and modifier:
+        assert 0 not in layer.selected_data
+        assert layer.selected_data == (set(range(n_points)) - pre_selection)
+    elif 0 in pre_selection and not modifier:
+        assert 0 in layer.selected_data
+        assert layer.selected_data == set(range(n_points))
+    elif 0 not in pre_selection and modifier:
+        assert 0 in layer.selected_data
+        assert layer.selected_data == (set(range(n_points)) - pre_selection)
+    elif 0 not in pre_selection and not modifier:
+        assert 0 in layer.selected_data
+        assert layer.selected_data == set(range(n_points))
+    else:
+        assert False, 'Unreachable code'  # pragma: no cover
+    assert layer._drag_box is None
+    assert layer._drag_start is None

--- a/napari/layers/points/_tests/test_points_mouse_bindings.py
+++ b/napari/layers/points/_tests/test_points_mouse_bindings.py
@@ -707,6 +707,7 @@ def test_selecting_no_points_with_drag_3d(create_known_points_layer_3d):
 def test_drag_start_selection(
     create_known_points_layer_2d, pre_selection, on_point, modifier
 ):
+"""Check layer drag start and drag box behave as expected."""
     layer, n_points, known_non_point = create_known_points_layer_2d
     layer.mode = 'select'
     layer.selected_data = pre_selection

--- a/napari/layers/points/_tests/test_points_mouse_bindings.py
+++ b/napari/layers/points/_tests/test_points_mouse_bindings.py
@@ -707,7 +707,7 @@ def test_selecting_no_points_with_drag_3d(create_known_points_layer_3d):
 def test_drag_start_selection(
     create_known_points_layer_2d, pre_selection, on_point, modifier
 ):
-"""Check layer drag start and drag box behave as expected."""
+    """Check layer drag start and drag box behave as expected."""
     layer, n_points, known_non_point = create_known_points_layer_2d
     layer.mode = 'select'
     layer.selected_data = pre_selection

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1891,7 +1891,7 @@ class Points(Layer):
         selection_indices = list(selection_indices)
         dims_displayed = list(self._dims_displayed)
         if self._drag_start is None:
-            self._drag_start = np.array(position)[dims_displayed]
+            self._drag_start = np.array(position, dtype=float)[dims_displayed]
             if len(selection_indices) > 0 and center_by_data:
                 center = self.data[
                     np.ix_(selection_indices, dims_displayed)

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1874,6 +1874,7 @@ class Points(Layer):
         self,
         selection_indices: Sequence[int],
         position: Sequence[Union[int, float]],
+        center_by_data: bool = True,
     ) -> None:
         """Store the initial position at the start of a drag event.
 
@@ -1883,15 +1884,19 @@ class Points(Layer):
             integer indices of selected data used to index into self.data
         position : Sequence of numbers
             position of the drag start in data coordinates.
+        center_by_data: bool
+            Center the drag start based on the selected data.
+            Used for modifier drag_box selection.
         """
-        if len(selection_indices) > 0:
-            selection_indices = list(selection_indices)
-            dims_displayed = list(self._dims_displayed)
-            if self._drag_start is None:
+        selection_indices = list(selection_indices)
+        dims_displayed = list(self._dims_displayed)
+        if self._drag_start is None:
+            self._drag_start = np.array(position)[dims_displayed]
+            if len(selection_indices) > 0 and center_by_data:
                 center = self.data[
                     np.ix_(selection_indices, dims_displayed)
                 ].mean(axis=0)
-                self._drag_start = np.array(position)[dims_displayed] - center
+                self._drag_start -= center
 
     def _paste_data(self):
         """Paste any point from clipboard and select them."""

--- a/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
@@ -726,7 +726,7 @@ def test_all_modes_covered(attr):
 def test_drag_start_selection(
     create_known_shapes_layer, Event, pre_selection, on_point, modifier
 ):
-"""Check layer drag start and drag box behave as expected."""
+    """Check layer drag start and drag box behave as expected."""
     layer, n_points, known_non_point = create_known_shapes_layer
     layer.mode = 'select'
     layer.selected_data = pre_selection

--- a/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
@@ -720,21 +720,7 @@ def test_all_modes_covered(attr):
     'pre_selection,on_point,modifier',
     [
         (set(), True, []),
-        ({0}, True, []),
-        ({0, 1}, True, []),
         ({1}, True, []),
-        (set(), True, ['Shift']),
-        ({0}, True, ['Shift']),
-        ({0, 1}, True, ['Shift']),
-        ({1}, True, ['Shift']),
-        (set(), False, []),
-        ({0}, False, []),
-        ({0, 1}, False, []),
-        ({1}, False, []),
-        (set(), False, ['Shift']),
-        ({0}, False, ['Shift']),
-        ({0, 1}, False, ['Shift']),
-        ({1}, False, ['Shift']),
     ],
 )
 def test_drag_start_selection(
@@ -750,8 +736,11 @@ def test_drag_start_selection(
         initial_position = tuple(known_non_point)
     zero_pos = [0, 0]
 
+    value = layer.get_value(initial_position, world=True)
+    assert value[0] == 0
     assert layer._drag_start is None
     assert layer._drag_box is None
+    assert layer.selected_data == pre_selection
 
     # Simulate click
     event = ReadOnlyWrapper(

--- a/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
@@ -714,3 +714,180 @@ def test_all_modes_covered(attr):
     """
     mode_dict = getattr(Shapes, attr)
     assert {k.value for k in mode_dict.keys()} == set(Mode.keys())
+
+
+@pytest.mark.parametrize(
+    'pre_selection,on_point,modifier',
+    [
+        (set(), True, []),
+        ({0}, True, []),
+        ({0, 1}, True, []),
+        ({1}, True, []),
+        (set(), True, ['Shift']),
+        ({0}, True, ['Shift']),
+        ({0, 1}, True, ['Shift']),
+        ({1}, True, ['Shift']),
+        (set(), False, []),
+        ({0}, False, []),
+        ({0, 1}, False, []),
+        ({1}, False, []),
+        (set(), False, ['Shift']),
+        ({0}, False, ['Shift']),
+        ({0, 1}, False, ['Shift']),
+        ({1}, False, ['Shift']),
+    ],
+)
+def test_drag_start_selection(
+    create_known_shapes_layer, Event, pre_selection, on_point, modifier
+):
+    layer, n_points, known_non_point = create_known_shapes_layer
+    layer.mode = 'select'
+    layer.selected_data = pre_selection
+
+    if on_point:
+        initial_position = tuple(layer.data[0].mean(axis=0))
+    else:
+        initial_position = tuple(known_non_point)
+    zero_pos = [0, 0]
+
+    assert layer._drag_start is None
+    assert layer._drag_box is None
+
+    # Simulate click
+    event = ReadOnlyWrapper(
+        Event(
+            type='mouse_press',
+            position=initial_position,
+            modifiers=modifier,
+            is_dragging=True,
+        )
+    )
+    mouse_press_callbacks(layer, event)
+
+    if modifier:
+        if not on_point:
+            assert layer.selected_data == pre_selection
+        elif 0 in pre_selection:
+            assert layer.selected_data == pre_selection - {0}
+        else:
+            assert layer.selected_data == pre_selection | {0}
+    elif not on_point:
+        assert layer.selected_data == set()
+    elif 0 in pre_selection:
+        assert layer.selected_data == pre_selection
+    else:
+        assert layer.selected_data == {0}
+
+    if len(layer.selected_data) > 0:
+        center_list = []
+        for idx in layer.selected_data:
+            center_list.append(layer.data[idx].mean(axis=0))
+        center = np.mean(center_list, axis=0)
+    else:
+        center = [0, 0]
+
+    if not modifier:
+        start_position = [
+            initial_position[0] - center[0],
+            initial_position[1] - center[1],
+        ]
+    else:
+        start_position = initial_position
+
+    is_point_move = len(layer.selected_data) > 0 and on_point and not modifier
+
+    np.testing.assert_array_equal(layer._drag_start, start_position)
+
+    # Simulate drag start on a different position
+    offset_position = [initial_position[0] + 20, initial_position[1] + 20]
+    event = ReadOnlyWrapper(
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            position=offset_position,
+            modifiers=modifier,
+        )
+    )
+    mouse_move_callbacks(layer, event)
+
+    # Initial mouse_move is already considered a move and not a press.
+    # Therefore, the _drag_start value should be identical and the data or drag_box should reflect
+    # the mouse position.
+    np.testing.assert_array_equal(layer._drag_start, start_position)
+    if is_point_move:
+        if 0 in layer.selected_data:
+            np.testing.assert_array_equal(
+                layer.data[0].mean(axis=0),
+                [offset_position[0], offset_position[1]],
+            )
+        else:
+            assert False, 'Unreachable code'  # pragma: no cover
+    else:
+        np.testing.assert_array_equal(
+            layer._drag_box, [initial_position, offset_position]
+        )
+
+    # Simulate drag start on new different position
+    offset_position = zero_pos
+    event = ReadOnlyWrapper(
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            position=offset_position,
+            modifiers=modifier,
+        )
+    )
+    mouse_move_callbacks(layer, event)
+
+    # Initial mouse_move is already considered a move and not a press.
+    # Therefore, the _drag_start value should be identical and the data or drag_box should reflect
+    # the mouse position.
+    np.testing.assert_array_equal(layer._drag_start, start_position)
+    if is_point_move:
+        if 0 in layer.selected_data:
+            np.testing.assert_array_equal(
+                layer.data[0].mean(axis=0),
+                [offset_position[0], offset_position[1]],
+            )
+        else:
+            assert False, 'Unreachable code'  # pragma: no cover
+    else:
+        np.testing.assert_array_equal(
+            layer._drag_box, [initial_position, offset_position]
+        )
+
+    # Simulate release
+    event = ReadOnlyWrapper(
+        Event(
+            type='mouse_release',
+            is_dragging=True,
+            modifiers=modifier,
+            position=offset_position,
+        )
+    )
+    mouse_release_callbacks(layer, event)
+
+    if on_point and 0 in pre_selection and modifier:
+        assert layer.selected_data == pre_selection - {0}
+    elif on_point and 0 in pre_selection and not modifier:
+        assert layer.selected_data == pre_selection
+    elif on_point and 0 not in pre_selection and modifier:
+        assert layer.selected_data == pre_selection | {0}
+    elif on_point and 0 not in pre_selection and not modifier:
+        assert layer.selected_data == {0}
+    elif 0 in pre_selection and modifier:
+        assert 0 not in layer.selected_data
+        assert layer.selected_data == (set(range(n_points)) - pre_selection)
+    elif 0 in pre_selection and not modifier:
+        assert 0 in layer.selected_data
+        assert layer.selected_data == set(range(n_points))
+    elif 0 not in pre_selection and modifier:
+        assert 0 in layer.selected_data
+        assert layer.selected_data == (set(range(n_points)) - pre_selection)
+    elif 0 not in pre_selection and not modifier:
+        assert 0 in layer.selected_data
+        assert layer.selected_data == set(range(n_points))
+    else:
+        assert False, 'Unreachable code'  # pragma: no cover
+    assert layer._drag_box is None
+    assert layer._drag_start is None

--- a/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
@@ -726,6 +726,7 @@ def test_all_modes_covered(attr):
 def test_drag_start_selection(
     create_known_shapes_layer, Event, pre_selection, on_point, modifier
 ):
+"""Check layer drag start and drag box behave as expected."""
     layer, n_points, known_non_point = create_known_shapes_layer
     layer.mode = 'select'
     layer.selected_data = pre_selection


### PR DESCRIPTION
# Description

Fixing a weird behavior with the fixpoint when shift is pressed during selection drag and points are already selected.
This happened, because the selection drag does not use centering of the data, but the newly created function did not 

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
