### PR TITLE
Feature: add Label brush size keybinds that can be held down 

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -101,7 +101,7 @@ EXPECTED_NUMBER_OF_LAYER_METHODS = {
     'Surface': 0,
     'Tracks': 0,
     'Points': 9,
-    'Labels': 11,
+    'Labels': 13,
     'Shapes': 17,
 }
 

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -100,3 +100,13 @@ def undo(layer: Labels):
 def redo(layer: Labels):
     """Redo any previously undone actions."""
     layer.redo()
+
+
+@Labels.bind_key('[')
+def decrease_brush_size(layer: Labels):
+    layer.brush_size -= 1
+
+
+@Labels.bind_key(']')
+def increase_brush_size(layer: Labels):
+    layer.brush_size += 1

--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -518,7 +518,7 @@ class KeymapHandler:
         if (
             event.native is not None
             and event.native.isAutoRepeat()
-            and event.key.name not in ['Up', 'Down', 'Left', 'Right']
+            and event.key.name not in ['Up', 'Down', 'Left', 'Right', '[', ']']
         ) or event.key is None:
             # pass if no key is present or if key is held down, unless the
             # key being held down is one of the navigation keys

--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -518,6 +518,7 @@ class KeymapHandler:
         if (
             event.native is not None
             and event.native.isAutoRepeat()
+            # Adding [, ] here for hard-coded Labels brush size press & hold keybind
             and event.key.name not in ['Up', 'Down', 'Left', 'Right', '[', ']']
         ) or event.key is None:
             # pass if no key is present or if key is held down, unless the


### PR DESCRIPTION
# Description
This PR adds [ and ] (from Photoshop) as keybinds for decreasing and increasing the Labels brush size. If they are held down, the size keeps increasing/decreasing. 
However, at the moment, to make the hold-down to increase/decrease work, the keybinds are hard-coded, so they are not registered (because if the user changed them, then the hold-down behavior wouldn't work.)

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
closes https://github.com/napari/napari/issues/3994
Uses the methodology by @RobAnKo to white-list [ and ] for repeating/hold-down behavior, see https://github.com/napari/napari/issues/3994#issuecomment-1025713296
The hold-down behavior (and white-list for arrow keys) is here:
https://github.com/napari/napari/blob/6a3e11aa717e7928a0a5a3c7693577729a466ef1/napari/utils/key_bindings.py#L471-L490



# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change: I edited the test to account for the 2 extra layer method
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
