### PR TITLE
Revert "Fix sys.path issue with subprocess relaunch in macOS"

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -470,13 +470,7 @@ def _maybe_rerun_with_macos_fixes():
     # need to launch the subprocess to apply the fixes
     if sys.executable != executable:
         env["_NAPARI_RERUN_WITH_FIXES"] = "1"
-        if Path(sys.argv[0]).name == "napari":
-            # launched through entry point, we do that again to avoid
-            # issues with working directory getting into sys.path (#5007)
-            cmd = [executable, sys.argv[0]]
-        else:  # we assume it must have been launched via '-m' syntax
-            cmd = [executable, "-m", "napari"]
-
+        cmd = [executable, '-m', 'napari']
         # Append original command line arguments.
         if len(sys.argv) > 1:
             cmd.extend(sys.argv[1:])


### PR DESCRIPTION
Reverts napari/napari#5007 due to #5026 