### PR TITLE
Use Source object to track if a layer is duplicated

### DIFF
--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from ..utils.translations import trans
 from . import Image, Labels, Layer
+from ._source import layer_source
 from .utils import stack_utils
 from .utils._link_layers import get_linked_layers
 
@@ -24,8 +25,8 @@ def _duplicate_layer(ll: LayerList, *, name: str = ''):
     for lay in list(ll.selection):
         data, state, type_str = lay.as_layer_data_tuple()
         state["name"] = trans._('{name} copy', name=lay.name)
-        new = Layer.create(deepcopy(data), state, type_str)
-        new._source = new.source.copy(update={'parent': lay})
+        with layer_source(parent=lay):
+            new = Layer.create(deepcopy(data), state, type_str)
         ll.insert(ll.index(lay) + 1, new)
 
 

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -25,6 +25,7 @@ def _duplicate_layer(ll: LayerList, *, name: str = ''):
         data, state, type_str = lay.as_layer_data_tuple()
         state["name"] = trans._('{name} copy', name=lay.name)
         new = Layer.create(deepcopy(data), state, type_str)
+        new._source = new.source.copy(update={'parent': lay})
         ll.insert(ll.index(lay) + 1, new)
 
 

--- a/napari/layers/_source.py
+++ b/napari/layers/_source.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from magicgui.widgets import FunctionGui
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from .base.base import Layer
 
 
 class Source(BaseModel):
@@ -28,6 +31,7 @@ class Source(BaseModel):
     reader_plugin: Optional[str] = None
     sample: Optional[Tuple[str, str]] = None
     widget: Optional[FunctionGui] = None
+    parent: Optional[Layer] = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/napari/layers/_source.py
+++ b/napari/layers/_source.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import weakref
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import Optional, Tuple
 
 from magicgui.widgets import FunctionGui
 from pydantic import BaseModel, validator

--- a/napari/layers/_source.py
+++ b/napari/layers/_source.py
@@ -8,7 +8,8 @@ from typing import Optional, Tuple, TYPE_CHECKING
 from magicgui.widgets import FunctionGui
 from pydantic import BaseModel, validator
 
-from .base.base import Layer
+if TYPE_CHECKING:
+    from .base.base import Layer
 
 
 class Source(BaseModel):

--- a/napari/layers/_source.py
+++ b/napari/layers/_source.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import weakref
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Optional, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from magicgui.widgets import FunctionGui
 from pydantic import BaseModel, validator

--- a/napari/layers/_source.py
+++ b/napari/layers/_source.py
@@ -25,6 +25,8 @@ class Source(BaseModel):
         `viewer.open_sample`.
     widget: FunctionGui, optional
         magicgui widget, if the layer was added via a magicgui widget.
+    parent: Layer, optional
+        parent layer if the layer is a duplicate.
     """
 
     path: Optional[str] = None

--- a/napari/layers/_source.py
+++ b/napari/layers/_source.py
@@ -8,8 +8,7 @@ from typing import Optional, Tuple
 from magicgui.widgets import FunctionGui
 from pydantic import BaseModel, validator
 
-if TYPE_CHECKING:
-    from .base.base import Layer
+from .base.base import Layer
 
 
 class Source(BaseModel):

--- a/napari/layers/_source.py
+++ b/napari/layers/_source.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
+import weakref
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import Optional, Tuple
 
 from magicgui.widgets import FunctionGui
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
-if TYPE_CHECKING:
-    from .base.base import Layer
+from .base.base import Layer
 
 
 class Source(BaseModel):
@@ -38,6 +38,10 @@ class Source(BaseModel):
     class Config:
         arbitrary_types_allowed = True
         frozen = True
+
+    @validator('parent')
+    def make_weakref(cls, layer: Layer):
+        return weakref.ref(layer)
 
     def __deepcopy__(self, memo):
         """Custom deepcopy implementation.

--- a/napari/layers/_source.py
+++ b/napari/layers/_source.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import weakref
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Optional, Tuple
+from typing import Optional, Tuple, TYPE_CHECKING
 
 from magicgui.widgets import FunctionGui
 from pydantic import BaseModel, validator

--- a/napari/layers/_tests/test_layer_actions.py
+++ b/napari/layers/_tests/test_layer_actions.py
@@ -29,6 +29,7 @@ def test_duplicate_layers():
     assert (
         len(layer_list[1].events.data.callbacks) == 1
     )  # `events` Event Emitter
+    assert layer_list[1].source.parent == layer_list[0]
 
 
 @pytest.mark.parametrize(

--- a/napari/layers/_tests/test_layer_actions.py
+++ b/napari/layers/_tests/test_layer_actions.py
@@ -29,7 +29,7 @@ def test_duplicate_layers():
     assert (
         len(layer_list[1].events.data.callbacks) == 1
     )  # `events` Event Emitter
-    assert layer_list[1].source.parent == layer_list[0]
+    assert layer_list[1].source.parent() is layer_list[0]
 
 
 @pytest.mark.parametrize(

--- a/napari/layers/_tests/test_source.py
+++ b/napari/layers/_tests/test_source.py
@@ -1,3 +1,6 @@
+import pydantic
+import pytest
+
 from napari.layers import Points
 from napari.layers._source import Source, current_source, layer_source
 
@@ -32,4 +35,18 @@ def test_source_context():
                 path='a', reader_plugin='plug', sample=('samp', 'name')
             )
         assert current_source() == Source(sample=('samp', 'name'))
+
+        point = Points()
+        with layer_source(parent=point):
+            assert current_source() == Source(
+                sample=('samp', 'name'), parent=point
+            )
+    assert current_source() == Source()
+
+
+def test_source_assert_parent():
+    assert current_source() == Source()
+    with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with layer_source(parent=''):
+            current_source()
     assert current_source() == Source()

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -31,7 +31,6 @@ from ...utils.naming import magic_name
 from ...utils.status_messages import generate_layer_coords_status
 from ...utils.transforms import Affine, CompositeAffine, TransformChain
 from ...utils.translations import trans
-from .._source import current_source
 from ..utils.interactivity_utils import drag_data_to_projected_distance
 from ..utils.layer_utils import (
     coerce_affine,
@@ -232,6 +231,9 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             raise ValueError(
                 f"Layer {name!r} is invalid because it has scale values of 0. The layer's scale is currently {scale!r}"
             )
+
+        # Needs to be imported here to avoid circular import in _source
+        from .._source import current_source
 
         self._source = current_source()
         self.dask_optimized_slicing = configure_dask(data, cache)


### PR DESCRIPTION
# Description

As suggested by https://github.com/napari/napari/issues/5023 after https://github.com/napari/napari/pull/5010 the Source object could keep track of a potential parent.
Here I propose a draft how this could look like :) 

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] New feature (non-breaking change which adds functionality)
