### PR TITLE
Ensure non-negative edge width

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -933,9 +933,7 @@ def test_edge_width_types_negative(edge_width):
     np.random.seed(0)
     data = 20 * np.random.random(shape)
     with pytest.raises(ValueError):
-        Points(
-            data, edge_width=edge_width, edge_width_is_relative=False
-        )
+        Points(data, edge_width=edge_width, edge_width_is_relative=False)
 
 
 def test_out_of_slice_display():

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -906,6 +906,28 @@ def test_edge_width():
     layer = Points(data, edge_width=3, edge_width_is_relative=False)
     np.testing.assert_array_equal(layer.edge_width, 3)
     assert layer.edge_width_is_relative is False
+    with pytest.raises(ValueError):
+        layer.edge_width = -2
+
+
+@pytest.mark.parametrize("edge_width", [int(1), float(1), np.array([1, 2, 3, 4, 5]), [1, 2, 3, 4, 5]])
+def test_edge_width_types(edge_width):
+    """Test edge_width dtypes with valid values"""
+    shape = (5, 2)
+    np.random.seed(0)
+    data = 20 * np.random.random(shape)
+    layer = Points(data, edge_width=edge_width, edge_width_is_relative=False)
+    np.testing.assert_array_equal(layer.edge_width, edge_width)
+
+
+@pytest.mark.parametrize("edge_width", [int(-1), float(-1), np.array([-1, 2, 3, 4, 5]), [-1, 2, 3, 4, 5]])
+def test_edge_width_types_negative(edge_width):
+    """Test negative values in all edge_width dtypes"""
+    shape = (5, 2)
+    np.random.seed(0)
+    data = 20 * np.random.random(shape)
+    with pytest.raises(ValueError):
+        layer = Points(data, edge_width=edge_width, edge_width_is_relative=False)
 
 
 def test_out_of_slice_display():

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -933,7 +933,7 @@ def test_edge_width_types_negative(edge_width):
     np.random.seed(0)
     data = 20 * np.random.random(shape)
     with pytest.raises(ValueError):
-        layer = Points(  # noqa: F841
+        Points(
             data, edge_width=edge_width, edge_width_is_relative=False
         )
 

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -910,7 +910,10 @@ def test_edge_width():
         layer.edge_width = -2
 
 
-@pytest.mark.parametrize("edge_width", [int(1), float(1), np.array([1, 2, 3, 4, 5]), [1, 2, 3, 4, 5]])
+@pytest.mark.parametrize(
+    "edge_width",
+    [int(1), float(1), np.array([1, 2, 3, 4, 5]), [1, 2, 3, 4, 5]],
+)
 def test_edge_width_types(edge_width):
     """Test edge_width dtypes with valid values"""
     shape = (5, 2)
@@ -920,14 +923,19 @@ def test_edge_width_types(edge_width):
     np.testing.assert_array_equal(layer.edge_width, edge_width)
 
 
-@pytest.mark.parametrize("edge_width", [int(-1), float(-1), np.array([-1, 2, 3, 4, 5]), [-1, 2, 3, 4, 5]])
+@pytest.mark.parametrize(
+    "edge_width",
+    [int(-1), float(-1), np.array([-1, 2, 3, 4, 5]), [-1, 2, 3, 4, 5]],
+)
 def test_edge_width_types_negative(edge_width):
     """Test negative values in all edge_width dtypes"""
     shape = (5, 2)
     np.random.seed(0)
     data = 20 * np.random.random(shape)
     with pytest.raises(ValueError):
-        layer = Points(data, edge_width=edge_width, edge_width_is_relative=False)
+        layer = Points(
+            data, edge_width=edge_width, edge_width_is_relative=False
+        )
 
 
 def test_out_of_slice_display():

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -933,7 +933,7 @@ def test_edge_width_types_negative(edge_width):
     np.random.seed(0)
     data = 20 * np.random.random(shape)
     with pytest.raises(ValueError):
-        layer = Points(
+        layer = Points(  # noqa: F841
             data, edge_width=edge_width, edge_width_is_relative=False
         )
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -838,7 +838,7 @@ class Points(Layer):
         if np.any(edge_width < 0):
             raise ValueError(
                 trans._(
-                    'edge_width must be > 0',
+                    'All edge_width must be > 0',
                     deferred=True,
                 )
             )
@@ -846,7 +846,7 @@ class Points(Layer):
         if self.edge_width_is_relative and np.any(edge_width > 1):
             raise ValueError(
                 trans._(
-                    'edge_width must be between 0 and 1 if edge_width_is_relative is enabled',
+                    'All edge_width must be between 0 and 1 if edge_width_is_relative is enabled',
                     deferred=True,
                 )
             )

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -840,7 +840,8 @@ class Points(Layer):
                 trans._(
                     'edge_width must be > 0',
                     deferred=True,
-                ))
+                )
+            )
         # if relative edge width is enabled, edge_width must be between 0 and 1
         if self.edge_width_is_relative and np.any(edge_width > 1):
             raise ValueError(

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -831,16 +831,25 @@ class Points(Layer):
     def edge_width(
         self, edge_width: Union[int, float, np.ndarray, list]
     ) -> None:
+        # broadcast to np.array
         edge_width = np.broadcast_to(edge_width, self.data.shape[0]).copy()
-        if self.edge_width_is_relative and np.any(
-            (edge_width > 1) | (edge_width < 0)
-        ):
+
+        # edge width cannot be negative
+        if np.any(edge_width < 0):
+            raise ValueError(
+                trans._(
+                    'edge_width must be > 0',
+                    deferred=True,
+                ))
+        # if relative edge width is enabled, edge_width must be between 0 and 1
+        if self.edge_width_is_relative and np.any(edge_width > 1):
             raise ValueError(
                 trans._(
                     'edge_width must be between 0 and 1 if edge_width_is_relative is enabled',
                     deferred=True,
                 )
             )
+
         self._edge_width = edge_width
         self.refresh()
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->
Edge_width cannot be negative. There was a catch in place in napari.layers, but it only caught for `edge_width_is_relative = True`. There was a secondary catch in vispy. This was working, but its more appropriate to catch on assignment rather than visualization

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)


# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
Resolves #3752

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
