### PR TITLE
MAINT: Update Future Warning.

### DIFF
--- a/napari/_qt/_tests/test_qt_provide_theme.py
+++ b/napari/_qt/_tests/test_qt_provide_theme.py
@@ -15,9 +15,8 @@ def test_provide_theme_hook_registered_correctly(
     make_napari_viewer,
     napari_plugin_manager,
 ):
-    with pytest.warns(FutureWarning):
-        dark = get_theme("dark")
-        dark["name"] = "dark-test-2"
+    dark = get_theme("dark", True)
+    dark["name"] = "dark-test-2"
 
     class TestPlugin:
         @napari_hook_implementation

--- a/napari/plugins/_tests/test_provide_theme.py
+++ b/napari/plugins/_tests/test_provide_theme.py
@@ -13,9 +13,8 @@ if TYPE_CHECKING:
 
 
 def test_provide_theme_hook(napari_plugin_manager: "NapariPluginManager"):
-    with pytest.warns(FutureWarning):
-        dark = get_theme("dark")
-        dark["name"] = "dark-test"
+    dark = get_theme("dark", True)
+    dark["name"] = "dark-test"
 
     class TestPlugin:
         @napari_hook_implementation
@@ -40,10 +39,9 @@ def test_provide_theme_hook(napari_plugin_manager: "NapariPluginManager"):
 def test_provide_theme_hook_bad(napari_plugin_manager: "NapariPluginManager"):
     napari_plugin_manager.discover_themes()
 
-    with pytest.warns(FutureWarning):
-        dark = get_theme("dark")
-        dark.pop("foreground")
-        dark["name"] = "dark-bad"
+    dark = get_theme("dark", True)
+    dark.pop("foreground")
+    dark["name"] = "dark-bad"
 
     class TestPluginBad:
         @napari_hook_implementation
@@ -86,9 +84,8 @@ def test_provide_theme_hook_not_dict(
 def test_provide_theme_hook_unregister(
     napari_plugin_manager: "NapariPluginManager",
 ):
-    with pytest.warns(FutureWarning):
-        dark = get_theme("dark")
-        dark["name"] = "dark-test"
+    dark = get_theme("dark", True)
+    dark["name"] = "dark-test"
 
     class TestPlugin:
         @napari_hook_implementation

--- a/napari/settings/_tests/test_settings.py
+++ b/napari/settings/_tests/test_settings.py
@@ -162,7 +162,7 @@ def test_custom_theme_settings(test_settings):
     with pytest.raises(pydantic.error_wrappers.ValidationError):
         test_settings.appearance.theme = custom_theme_name
 
-    blue_theme = get_theme('dark')
+    blue_theme = get_theme('dark', True)
     blue_theme.update(
         background='rgb(28, 31, 48)',
         foreground='rgb(45, 52, 71)',

--- a/napari/utils/_tests/test_theme.py
+++ b/napari/utils/_tests/test_theme.py
@@ -21,12 +21,8 @@ def test_default_themes():
 
 
 def test_get_theme():
-    theme = get_theme('dark')
-    assert isinstance(theme, dict)
-    assert theme['name'] == 'dark'
-
     # get theme in the old-style dict format
-    theme = get_theme("dark")
+    theme = get_theme("dark", True)
     assert isinstance(theme, dict)
 
     # get theme in the new model-based format
@@ -40,7 +36,7 @@ def test_register_theme():
     assert 'test_blue' not in themes
 
     # Create new blue theme based on dark theme
-    blue_theme = get_theme('dark')
+    blue_theme = get_theme('dark', True)
     blue_theme.update(
         background='rgb(28, 31, 48)',
         foreground='rgb(45, 52, 71)',
@@ -56,11 +52,11 @@ def test_register_theme():
     assert 'test_blue' in themes
 
     # Check that the dark theme has not been overwritten
-    dark_theme = get_theme('dark')
+    dark_theme = get_theme('dark', True)
     assert not dark_theme['background'] == blue_theme['background']
 
     # Check that blue theme can be gotten from available themes
-    theme = get_theme('test_blue')
+    theme = get_theme('test_blue', True)
     assert theme['background'] == blue_theme['background']
 
     theme = get_theme("test_blue", False)
@@ -69,7 +65,7 @@ def test_register_theme():
 
 def test_unregister_theme():
     # Create new blue theme based on dark theme
-    blue_theme = get_theme('dark')
+    blue_theme = get_theme('dark', True)
     blue_theme.update(
         background='rgb(28, 31, 48)',
         foreground='rgb(45, 52, 71)',
@@ -96,7 +92,7 @@ def test_rebuild_theme_settings():
     # theme is not updated
     with pytest.raises(ValidationError):
         settings.appearance.theme = "another-theme"
-    blue_theme = get_theme("dark")
+    blue_theme = get_theme("dark", True)
     register_theme("another-theme", blue_theme)
     settings.appearance.theme = "another-theme"
 

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -213,13 +213,14 @@ def get_theme(name, as_dict=None):
     if as_dict is None:
         warnings.warn(
             trans._(
-                "Themes were changed to use evented model with Pydantic's color type rather than the `rgb(x, y, z)`. The `as_dict=True` option will be changed to `as_dict=False` in 0.4.15",
+                "The `as_dict` kwarg default to False` since Napari 0.4.17, "
+                "and will become a mandatory parameter in the future.",
                 deferred=True,
             ),
             category=FutureWarning,
             stacklevel=2,
         )
-        as_dict = True
+        as_dict = False
     if as_dict:
         _theme = _theme.dict()
         _theme = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ filterwarnings = [
   "ignore:numpy.ufunc size changed:RuntimeWarning",
   "ignore:Multiscale rendering is only supported in 2D. In 3D, only the lowest resolution scale is displayed",
   "ignore:Alternative shading modes are only available in 3D, defaulting to none",
-  "ignore:.*Themes were changed to use evented model",  # specifying the full is not working here so glob pattern is used instead
   "ignore:distutils Version classes are deprecated::",
   "ignore:There is no current event loop:DeprecationWarning:",
 ]


### PR DESCRIPTION
With #4967 merged, we can now finally switch the default, as we should have done 2 release ago.

I just want to note that this is one of the reason I prefer not to put future version numbers with promise of removal/change, as those are rarely followed.
