### PR TITLE
MAINT: Remove deprecated events and methods.

### DIFF
--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -78,20 +78,6 @@ class LayerList(SelectableEventedList[Layer]):
 
             self.selection.events.changed.connect(self._ctx_keys.update)
 
-        # temporary: see note in _on_selection_event
-        self.selection.events.changed.connect(self._on_selection_changed)
-
-    def _on_selection_changed(self, event):
-        # This method is a temporary workaround to the fact that the Points
-        # layer needs to know when its selection state changes so that it can
-        # update the highlight state.  This (and the layer._on_selection
-        # method) can be removed once highlighting logic has been removed from
-        # the layer model.
-        for layer in event.added:
-            layer._on_selection(True)
-        for layer in event.removed:
-            layer._on_selection(False)
-
     def _process_delete_item(self, item: Layer):
         super()._process_delete_item(item)
         item.events.extent.disconnect(self._clean_cache)

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -38,7 +38,6 @@ from napari.utils._magicgui import (
     get_layers,
 )
 from napari.utils.events import EmitterGroup, Event, EventedDict
-from napari.utils.events.event import WarningEmitter
 from napari.utils.geometry import (
     find_front_back_face,
     intersect_line_with_axis_aligned_bounding_box_3d,
@@ -391,24 +390,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             cursor_size=Event,
             editable=Event,
             loaded=Event,
-            reload=Event,
-            extent=Event,
-            _overlays=Event,
-            select=WarningEmitter(
-                trans._(
-                    "'layer.events.select' is deprecated and will be removed in napari v0.4.9, use 'viewer.layers.selection.events.changed' instead, and inspect the 'added' attribute on the event.",
-                    deferred=True,
-                ),
-                type_name='select',
-            ),
-            deselect=WarningEmitter(
-                trans._(
-                    "'layer.events.deselect' is deprecated and will be removed in napari v0.4.9, use 'viewer.layers.selection.events.changed' instead, and inspect the 'removed' attribute on the event.",
-                    deferred=True,
-                ),
-                type_name='deselect',
-            ),
-            mode=Event,
+            _ndisplay=Event,
         )
         self.name = name
         self.mode = mode
@@ -698,28 +680,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         )
         self._clear_extent()
         self.events.affine()
-
-    @property
-    def translate_grid(self):
-        warnings.warn(
-            trans._(
-                "translate_grid will become private in v0.4.14. See Layer.translate or Layer.data_to_world() instead.",
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._translate_grid
-
-    @translate_grid.setter
-    def translate_grid(self, translate_grid):
-        warnings.warn(
-            trans._(
-                "translate_grid will become private in v0.4.14. See Layer.translate or Layer.data_to_world() instead.",
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self._translate_grid = translate_grid
 
     @property
     def _translate_grid(self):

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -38,6 +38,7 @@ from napari.utils._magicgui import (
     get_layers,
 )
 from napari.utils.events import EmitterGroup, Event, EventedDict
+from napari.utils.events.event import WarningEmitter
 from napari.utils.geometry import (
     find_front_back_face,
     intersect_line_with_axis_aligned_bounding_box_3d,
@@ -390,7 +391,10 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             cursor_size=Event,
             editable=Event,
             loaded=Event,
-            _ndisplay=Event,
+            reload=Event,
+            extent=Event,
+            _overlays=Event,
+            mode=Event,
         )
         self.name = name
         self.mode = mode
@@ -1798,18 +1802,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         from napari.plugins.io import save_layers
 
         return save_layers(path, [self], plugin=plugin)
-
-    def _on_selection(self, selected: bool):
-        # This method is a temporary workaround to the fact that the Points
-        # layer needs to know when its selection state changes so that it can
-        # update the highlight state.  This, along with the events.select and
-        # events.deselect emitters, (and the LayerList._on_selection_event
-        # method) can be removed once highlighting logic has been removed from
-        # the layer model.
-        if selected:
-            self.events.select()
-        else:
-            self.events.deselect()
 
     @classmethod
     def create(


### PR DESCRIPTION
select and deselect events were supposed to be removed in 0.4.9, and two functions were supposed to be private in 0.4.11.

Remove them.
