### PR TITLE
MAINT: Unnecessary formatting of constant.

### DIFF
--- a/napari/_vispy/overlays/axes.py
+++ b/napari/_vispy/overlays/axes.py
@@ -202,7 +202,7 @@ class VispyAxesOverlay:
         self.text_node = self.node._subvisuals[2]
         self.text_node.font_size = 10
         self.text_node.anchors = ('center', 'center')
-        self.text_node.text = f'{1}'
+        self.text_node.text = '1'
 
         self.node.canvas._backend.destroyed.connect(self._set_canvas_none)
         # End Note

--- a/napari/_vispy/overlays/scale_bar.py
+++ b/napari/_vispy/overlays/scale_bar.py
@@ -46,7 +46,7 @@ class VispyScaleBarOverlay:
         self.text_node.transform = STTransform()
         self.text_node.font_size = 10
         self.text_node.anchors = ("center", "center")
-        self.text_node.text = f"{1}px"
+        self.text_node.text = "1px"
 
         self.rect_node = Rectangle(
             center=[0.5, 0.5],


### PR DESCRIPTION
I'm quite unsure about this one,
f"{1}" is "1", it's the same.
Was this supposed to not have the f, because maybe Qt interpolate a first arguments or some kind later on, or is this supposed to actually contain a varaible like f"{font_size}" ?
