### PR TITLE
Small shortcuts preference pane wording update after #5018

### DIFF
--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -117,7 +117,7 @@ class ShortcutEditor(QWidget):
         layout.addWidget(
             QLabel(
                 trans._(
-                    "To clean shortcut use Backspace or Delete. To set one of this as shortcut, first clean previous shortcut."
+                    "To edit, double-click the keybinding. To unbind a key, use Backspace or Delete. To set Backspace or Delete, first unbind."
                 )
             )
         )

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -117,7 +117,7 @@ class ShortcutEditor(QWidget):
         layout.addWidget(
             QLabel(
                 trans._(
-                    "To edit, double-click the keybinding. To unbind a key, use Backspace or Delete. To set Backspace or Delete, first unbind."
+                    "To edit, double-click the keybinding. To unbind a shortcut, use Backspace or Delete. To set Backspace or Delete, first unbind."
                 )
             )
         )


### PR DESCRIPTION
# Description
Small wording change to fix grammar and clarify, for the keyboard shortcuts preference pane that I messed up when #5018 was in the works.
CC: @alisterburt @Czaki 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
[PR #5018 ](https://github.com/napari/napari/pull/5018#pullrequestreview-1098750350)

# How has this been tested?
N/A wording only.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
