### PR TITLE
Show platform specific shortcut while editing.

### DIFF
--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -388,7 +388,7 @@ class ShortcutEditor(QWidget):
 
             # get the current item from shortcuts column
             current_item = self._table.currentItem()
-            new_shortcut = current_item.text()
+            new_shortcut = Shortcut.parse_platform(current_item.text())
             if new_shortcut:
                 new_shortcut = new_shortcut[0].upper() + new_shortcut[1:]
 
@@ -587,7 +587,7 @@ class EditorWidget(QLineEdit):
             Qt.Key.Key_Meta,
             Qt.Key.Key_Delete,
         ):
-            self.setText(str(qkey2modelkey(event_key)))
+            self.setText(Shortcut(qkey2modelkey(event_key)).platform)
             return
 
         if event_key in {
@@ -603,8 +603,7 @@ class EditorWidget(QLineEdit):
         translator = ShortcutTranslator()
         event_keyseq = translator.keyevent_to_keyseq(event)
         kb = qkeysequence2modelkeybinding(event_keyseq)
-
-        self.setText(str(kb))
+        self.setText(Shortcut(kb).platform)
 
 
 class ShortcutTranslator(QKeySequenceEdit):

--- a/napari/utils/_tests/test_interactions.py
+++ b/napari/utils/_tests/test_interactions.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from napari.utils.interactions import Shortcut
@@ -27,3 +29,22 @@ def test_minus_shortcut():
 
 def test_shortcut_qt():
     assert Shortcut('Control-A').qt == 'Ctrl+A'
+
+
+@pytest.mark.skipif(
+    sys.platform != 'darwin', reason='Parsing macos specific keys'
+)
+@pytest.mark.parametrize(
+    'expected, shortcut',
+    [
+        ('␣', 'Space'),
+        ('⌥', 'Alt'),
+        ('⌥-', 'Alt--'),
+        ('⌘', 'Meta'),
+        ('⌘-', 'Meta--'),
+        ('⌘⌥', 'Meta-Alt'),
+        ('⌥⌘P', 'Meta-Alt-P'),
+    ],
+)
+def test_partial_shortcuts(shortcut, expected):
+    assert str(Shortcut(shortcut)) == expected

--- a/napari/utils/interactions.py
+++ b/napari/utils/interactions.py
@@ -291,7 +291,7 @@ class Shortcut:
             shortcut to format
         """
         error_msg = trans._(
-            "{shortcut} does not seem to be a valid shortcut Key.",
+            "`{shortcut}` does not seem to be a valid shortcut Key.",
             shortcut=shortcut,
         )
         error = False
@@ -308,6 +308,33 @@ class Shortcut:
 
         if error:
             warnings.warn(error_msg, UserWarning, stacklevel=2)
+
+    @staticmethod
+    def parse_platform(text: str) -> str:
+        """
+        Parse a current_platform_specific shortcut, and return a canonical
+        version separated with dashes.
+
+        This replace platform specific symbols, like ↵ by Enter,  ⌘ by Command on MacOS....
+        """
+        # edge case, shortcut combinaison where `+` is a key.
+        # this should be rare as on english keyboard + is Shift-Minus.
+        # but not unheard of. In those case `+` is always at the end with `++`
+        # as you can't get two non-modifier keys,  or alone.
+        if text == '+':
+            return text
+        if joinchar == "+":
+            text.replace('++', '+Plus')
+            text.replace('+', '')
+            text.replace('Plus', '+')
+        for k, v in KEY_SYMBOLS.items():
+            if text.endswith(v):
+                text = text.replace(v, k)
+                assert v not in text
+            else:
+                text = text.replace(v, k + '-')
+
+        return text
 
     @property
     def qt(self) -> str:


### PR DESCRIPTION
As the text in the text field is used to bind the shortcut later introduce a utility function to parse back from platform specific to canonical representation

Closes #5047

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  


Manually on Macos, checking that I can set shortcuts to things like Ctrl-Meta-Alt-Shift-N
I'm not sure extra tests are needed here. Maybe they will if we find edge cases.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
