### PR TITLE
Fix the wrong guardian for the build tooltip when bind button

### DIFF
--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -211,7 +211,7 @@ class ActionManager:
                 )
 
         button.clicked.connect(lambda: self.trigger(name))
-        if name in self._shortcuts:
+        if name in self._actions:
             button.setToolTip(
                 f'{self._build_tooltip(name)} {extra_tooltip_text}'
             )


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Fix the wrong guardian for the build tooltip when bind button.

Even if `self._actions` is used

https://github.com/napari/napari/blob/6d32e9ee83de393ed67ab30895a7c4e617cc48a4/napari/utils/action_manager.py#L301

The guard `if` is using. `self._shortcuts`

https://github.com/napari/napari/blob/6d32e9ee83de393ed67ab30895a7c4e617cc48a4/napari/utils/action_manager.py#L214

this PR update guard to use `self._actions`

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

Introduced by me in #5018 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
