### PR TITLE
Update config directory paths for perfmon tools

### DIFF
--- a/tools/perfmon/README.md
+++ b/tools/perfmon/README.md
@@ -10,11 +10,54 @@ Users can then be encouraged to use this tool to help developers better understa
 ## Usage
 
 From the root of the napari repo:
+
 ```shell
-% python tools/perfmon/run.py CONFIG EXAMPLE_SCRIPT
+python tools/perfmon/run.py CONFIG EXAMPLE_SCRIPT
 ```
 
-For example, to measure slicing performance one of the built-in examples:
+To take a specific example, let's say that we want to monitor `Layer.refresh`
+while interacting with a multi-scale image in napari.
+
+First, we would call the run command with the slicing config and one of the
+built-in example scripts:
+
 ```shell
-% python tools/perfmon/run.py slicing examples/add_multiscale_image.py
+python tools/perfmon/run.py slicing examples/add_multiscale_image.py
 ```
+
+After interacting with napari then quitting the application either through
+the application menu or keyboard shortcut, a traces JSON file should be
+output to the slicing subdirectory:
+
+```shell
+cat tools/perfmon/slicing/traces-latest.json
+```
+
+You can then plot the distribution of the `Layer.refresh` callable defined
+in the slicing config:
+
+```shell
+python tools/perfmon/plot_callable.py slicing Layer.refresh
+```
+
+Next, you might want to switch to a branch, repeat a similar interaction
+with the same configuration to measure a potential improvement to napari:
+
+```shell
+python tools/perfmon/run.py slicing examples/add_multiscale_image.py --output=test
+```
+
+By specifying the `output` argument, the trace JSON file is written to a
+different location to avoid overwriting the first file:
+
+```shell
+cat tools/perfmon/slicing/traces-test.json
+```
+
+We can then generate a comparison of the two runs to understand if there
+was an improvement:
+
+```shell
+python tools/perfmon/compare_callable.py slicing Layer.refresh latest test
+```
+

--- a/tools/perfmon/README.md
+++ b/tools/perfmon/README.md
@@ -11,10 +11,10 @@ Users can then be encouraged to use this tool to help developers better understa
 
 From the root of the napari repo:
 ```shell
-% python tools/perfmon/run.py CONFIG NAPARI_ARGS 
+% python tools/perfmon/run.py CONFIG EXAMPLE_SCRIPT
 ```
 
-For example, to measure slicing performance on an image:
+For example, to measure slicing performance one of the built-in examples:
 ```shell
-% python tools/perfmon/run.py slicing docs/images/multichannel_cells.png
+% python tools/perfmon/run.py slicing examples/add_multiscale_image.py
 ```

--- a/tools/perfmon/compare_callable.py
+++ b/tools/perfmon/compare_callable.py
@@ -38,7 +38,7 @@ logging.info(
 {args}'''
 )
 
-perfmon_dir = pathlib.Path(__file__).parent.parent.resolve(strict=True)
+perfmon_dir = pathlib.Path(__file__).parent.resolve(strict=True)
 config_dir = perfmon_dir / args.config
 
 

--- a/tools/perfmon/plot_callable.py
+++ b/tools/perfmon/plot_callable.py
@@ -31,7 +31,7 @@ logging.info(
 {args}'''
 )
 
-perfmon_dir = pathlib.Path(__file__).parent.parent.resolve(strict=True)
+perfmon_dir = pathlib.Path(__file__).parent.resolve(strict=True)
 
 traces_path = perfmon_dir / args.config / f'traces-{args.output}.json'
 

--- a/tools/perfmon/run.py
+++ b/tools/perfmon/run.py
@@ -18,12 +18,12 @@ parser.add_argument(
     help='The name of the sub-directory that contains the perfmon configuration file (e.g. slicing).',
 )
 parser.add_argument(
+    'example_script', help='The example script that should run napari.'
+)
+parser.add_argument(
     '--output',
     default='latest',
     help='The name to add to the output traces file.',
-)
-parser.add_argument(
-    'napari_args', nargs="*", help='The arguments to pass to napari.'
 )
 args = parser.parse_args()
 
@@ -40,9 +40,8 @@ env = os.environ.copy()
 env['NAPARI_PERFMON'] = config_path
 
 subprocess.check_call(
-    'napari ' + ' '.join(args.napari_args),
+    ['python', args.example_script],
     env=env,
-    shell=True,
 )
 
 original_output_path = str(config_dir / 'traces-latest.json')


### PR DESCRIPTION
# Description

This fixes the perfmon tools we're planning to use to help measure changes in performance due to the async slicing project in a few ways.

1\. Fixes the path resolution for `config_dir` in `plot_callable.py` and `compare_callable.py`.
 
This was needed as these tools were moved. It might suggest adding more structure to avoid these kinds of breakages in the future, but may not be worth it yet.

2\. Changes the `run.py` script to use a single `example_script` argument (e.g. `examples/add_multiscale_image.py`), which is then run with `python` instead of capturing the rest of the arguments and passing them to `napari`.

This is one way to make the tool work with the built-in examples, which will only call `napari.run()` when `__name__ == '__main__'`, which is not true when passing an example to `napari`. Better suggestions are appreciated!

3\. Update the README to clarify intended usage of all scripts.

## Type of change

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References

Related to #4795 

# How has this been tested?

- [x] Tested the steps in the README manually.

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
