### PR TITLE
disable mip and minip cutoffs if opaque blending

### DIFF
--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -4,6 +4,7 @@ import numpy as np
 from vispy.color import Colormap as VispyColormap
 from vispy.scene.node import Node
 
+from ...layers.base._base_constants import Blending
 from ...utils.translations import trans
 from ..utils.gl import fix_data_dtype, get_gl_extensions
 from ..visuals.image import Image as ImageNode
@@ -170,8 +171,12 @@ class VispyImageLayer(VispyBaseLayer):
         self.node.cmap = VispyColormap(*self.layer.colormap)
 
     def _update_mip_minip_cutoff(self):
+        # discard fragments beyond contrast limits, but only with translucent blending
         if isinstance(self.node, VolumeNode):
-            if self.layer.blending != 'opaque':
+            if self.layer.blending in {
+                Blending.TRANSLUCENT,
+                Blending.TRANSLUCENT_NO_DEPTH,
+            }:
                 self.node.mip_cutoff = self.node._texture.clim_normalized[0]
                 self.node.minip_cutoff = self.node._texture.clim_normalized[1]
             else:

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -185,10 +185,13 @@ class VispyImageLayer(VispyBaseLayer):
 
     def _on_contrast_limits_change(self):
         self.node.clim = self.layer.contrast_limits
+        # cutoffs must be updated after clims, so we can set them to the new values
         self._update_mip_minip_cutoff()
 
     def _on_blending_change(self):
         super()._on_blending_change()
+        # cutoffs must be updated after blending, so we can know if
+        # the new blending is a translucent one
         self._update_mip_minip_cutoff()
 
     def _on_gamma_change(self):

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -169,11 +169,22 @@ class VispyImageLayer(VispyBaseLayer):
     def _on_colormap_change(self):
         self.node.cmap = VispyColormap(*self.layer.colormap)
 
+    def _update_mip_minip_cutoff(self):
+        if isinstance(self.node, VolumeNode):
+            if self.layer.blending != 'opaque':
+                self.node.mip_cutoff = self.node._texture.clim_normalized[0]
+                self.node.minip_cutoff = self.node._texture.clim_normalized[1]
+            else:
+                self.node.mip_cutoff = None
+                self.node.minip_cutoff = None
+
     def _on_contrast_limits_change(self):
         self.node.clim = self.layer.contrast_limits
-        if isinstance(self.node, VolumeNode):
-            self.node.mip_cutoff = self.node._texture.clim_normalized[0]
-            self.node.minip_cutoff = self.node._texture.clim_normalized[1]
+        self._update_mip_minip_cutoff()
+
+    def _on_blending_change(self):
+        super()._on_blending_change()
+        self._update_mip_minip_cutoff()
 
     def _on_gamma_change(self):
         if len(self.node.shared_program.frag._set_items) > 0:


### PR DESCRIPTION
# Description
Fix #5002. @tlambert03, try out this and tell me if it looks like what you expected:

```py
import numpy as np
import napari

x = np.zeros((20,20,20), np.float32)
x[10,10,10] = 100

y = np.zeros((20,20,20), np.float32)
y[1:-1,1:-1,1:-1]  = 100

v = napari.Viewer(ndisplay=3)
v.add_image(y, colormap='cyan')
v.add_image(x, colormap='red', contrast_limits=(25, 75))
```

And change all the blending mode combinations. Don't forget that the default is `translucent_no_depth` for both.

cc @alisterburt

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
