### PR TITLE
Fix blending presets.

### DIFF
--- a/napari/_vispy/utils/gl.py
+++ b/napari/_vispy/utils/gl.py
@@ -112,8 +112,20 @@ def fix_data_dtype(data):
 
 
 BLENDING_MODES = {
-    'opaque': dict(preset='opaque'),
-    'translucent': dict(preset='translucent'),
+    'opaque': dict(
+        depth_test=True,
+        cull_face=False,
+        blend=False,
+        blend_func=('one', 'zero'),
+        blend_equation='func_add',
+    ),
+    'translucent': dict(
+        depth_test=True,
+        cull_face=False,
+        blend=True,
+        blend_func=('src_alpha', 'one_minus_src_alpha', 'zero', 'one'),
+        blend_equation='func_add',
+    ),
     'translucent_no_depth': dict(
         depth_test=False,
         cull_face=False,
@@ -121,8 +133,18 @@ BLENDING_MODES = {
         blend_func=('src_alpha', 'one_minus_src_alpha', 'zero', 'one'),
         blend_equation='func_add',  # see vispy/vispy#2324
     ),
-    'additive': dict(preset='additive'),
+    'additive': dict(
+        depth_test=False,
+        cull_face=False,
+        blend=True,
+        blend_func=('src_alpha', 'one'),
+        blend_equation='func_add',
+    ),
     'minimum': dict(
-        depth_test=False, cull_face=False, blend=True, blend_equation='min'
+        depth_test=False,
+        cull_face=False,
+        blend=True,
+        blend_func=('one', 'one'),
+        blend_equation='min',
     ),
 }


### PR DESCRIPTION
# Description
Fix #5076.

I'm still not sure what the underlyign issue is; it's almost as if `blend=False` is straight up ignored? Maybe @djhoese can help us here.

For the time being, I went fully explicit on all the blending modes, and set a simple `('one', 'zero'), 'func_add'` blending for `opaque`, which results in what we want.

@VolkerH and @psobolewskiPhD, could you check it out and see if it solves your issues?

@kevinyamauchi and @perlman, any insights?

# Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
