### PR TITLE
Bugfix:  disable opacity slider for opaque blending

### DIFF
--- a/docs/guides/layers.md
+++ b/docs/guides/layers.md
@@ -56,7 +56,7 @@ All our layers support three blending modes: `translucent`, `additive`, and
 `opaque`. These modes determine how the visuals for this layer get mixed with
 the visuals from the other layers.
 
-* An `opaque` layer renders all the other layers below it invisible.
+* An `opaque` layer hides any layer data below it.
 * A `translucent` setting will cause the layer to blend with the layers below
 it if you decrease its opacity but will fully block those layers if its opacity
 is `1`. This is a reasonable default, useful for many applications.

--- a/docs/guides/layers.md
+++ b/docs/guides/layers.md
@@ -56,8 +56,7 @@ All our layers support three blending modes: `translucent`, `additive`, and
 `opaque`. These modes determine how the visuals for this layer get mixed with
 the visuals from the other layers.
 
-* An `opaque` layer renders all the other layers below it invisible and will
-fade to black as you decrease its opacity.
+* An `opaque` layer renders all the other layers below it invisible.
 * A `translucent` setting will cause the layer to blend with the layers below
 it if you decrease its opacity but will fully block those layers if its opacity
 is `1`. This is a reasonable default, useful for many applications.

--- a/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
@@ -146,11 +146,11 @@ def test_blending_opacity_slider(qtbot):
     # set minimum blending, the opacity slider should be disabled
     layer.blending = 'minimum'
     assert not qtctrl.opacitySlider.isEnabled()
-    # set the blending back to 'translucent' confirm the slider is enabled
-    layer.blending = 'translucent'
-    assert layer.blending == 'translucent'
+    # set the blending to 'additive' confirm the slider is enabled
+    layer.blending = 'additive'
+    assert layer.blending == 'additive'
     assert qtctrl.opacitySlider.isEnabled()
-    # set minimum blending, the opacity slider should be disabled
+    # set opaque blending, the opacity slider should be disabled
     layer.blending = 'opaque'
     assert layer.blending == 'opaque'
     assert not qtctrl.opacitySlider.isEnabled()

--- a/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
@@ -135,8 +135,8 @@ def test_tensorstore_clim_popup():
     QContrastLimitsPopup(layer)
 
 
-def test_min_blending_opacity_slider(qtbot):
-    """Tests whether opacity slider is disabled for minimum blending."""
+def test_blending_opacity_slider(qtbot):
+    """Tests whether opacity slider is disabled for minimum and opaque blending."""
     layer = Image(np.random.rand(8, 8))
     qtctrl = QtLayerControls(layer)
     qtbot.addWidget(qtctrl)
@@ -145,6 +145,14 @@ def test_min_blending_opacity_slider(qtbot):
     assert qtctrl.opacitySlider.isEnabled()
     # set minimum blending, the opacity slider should be disabled
     layer.blending = 'minimum'
+    assert not qtctrl.opacitySlider.isEnabled()
+    # set the blending back to 'translucent' confirm the slider is enabled
+    layer.blending = 'translucent'
+    assert layer.blending == 'translucent'
+    assert qtctrl.opacitySlider.isEnabled()
+    # set minimum blending, the opacity slider should be disabled
+    layer.blending = 'opaque'
+    assert layer.blending == 'opaque'
     assert not qtctrl.opacitySlider.isEnabled()
     # set the blending back to 'translucent' confirm the slider is enabled
     layer.blending = 'translucent'

--- a/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -1,7 +1,7 @@
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QComboBox, QFormLayout, QFrame, QLabel
 
-from ...layers.base._base_constants import BLENDING_TRANSLATIONS, Blending 
+from ...layers.base._base_constants import BLENDING_TRANSLATIONS, Blending
 from ...utils.events import disconnect_events
 from ...utils.translations import trans
 from ..widgets._slider_compat import QDoubleSlider

--- a/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -105,8 +105,7 @@ class QtLayerControls(QFrame):
             self.layer.blending not in {'minimum', 'opaque'}
         )
         self.opacityLabel.setEnabled(
-            self.layer.blending != 'minimum'
-            and self.layer.blending != 'opaque'
+            self.layer.blending not in {'minimum', 'opaque'}
         )
 
         self.blendComboBox.setToolTip(

--- a/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -1,7 +1,7 @@
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QComboBox, QFormLayout, QFrame, QLabel
 
-from ...layers.base._base_constants import BLENDING_TRANSLATIONS
+from ...layers.base._base_constants import BLENDING_TRANSLATIONS, Blending 
 from ...utils.events import disconnect_events
 from ...utils.translations import trans
 from ..widgets._slider_compat import QDoubleSlider

--- a/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -76,8 +76,7 @@ class QtLayerControls(QFrame):
             self.layer.blending not in {'minimum', 'opaque'}
         )
         self.opacityLabel.setEnabled(
-            self.layer.blending != 'minimum'
-            and self.layer.blending != 'opaque'
+            self.layer.blending not in {'minimum', 'opaque'}
         )
 
     def changeOpacity(self, value):

--- a/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -73,8 +73,7 @@ class QtLayerControls(QFrame):
         self.blendComboBox = blend_comboBox
         # opaque and minimum blending do not support changing alpha
         self.opacitySlider.setEnabled(
-            self.layer.blending != 'minimum'
-            and self.layer.blending != 'opaque'
+            self.layer.blending not in {'minimum', 'opaque'}
         )
         self.opacityLabel.setEnabled(
             self.layer.blending != 'minimum'

--- a/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -102,8 +102,7 @@ class QtLayerControls(QFrame):
         self.layer.blending = self.blendComboBox.currentData()
         # opaque and minimum blending do not support changing alpha
         self.opacitySlider.setEnabled(
-            self.layer.blending != 'minimum'
-            and self.layer.blending != 'opaque'
+            self.layer.blending not in {'minimum', 'opaque'}
         )
         self.opacityLabel.setEnabled(
             self.layer.blending != 'minimum'

--- a/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -71,9 +71,15 @@ class QtLayerControls(QFrame):
 
         blend_comboBox.currentTextChanged.connect(self.changeBlending)
         self.blendComboBox = blend_comboBox
-        # GL minimum blending does not support changing alpha
-        self.opacitySlider.setEnabled(self.layer.blending != 'minimum')
-        self.opacityLabel.setEnabled(self.layer.blending != 'minimum')
+        # opaque and minimum blending do not support changing alpha
+        self.opacitySlider.setEnabled(
+            self.layer.blending != 'minimum'
+            and self.layer.blending != 'opaque'
+        )
+        self.opacityLabel.setEnabled(
+            self.layer.blending != 'minimum'
+            and self.layer.blending != 'opaque'
+        )
 
     def changeOpacity(self, value):
         """Change opacity value on the layer model.
@@ -96,9 +102,15 @@ class QtLayerControls(QFrame):
             Name of blending mode, eg: 'translucent', 'additive', 'opaque'.
         """
         self.layer.blending = self.blendComboBox.currentData()
-        # GL minimum blending does not support changing alpha
-        self.opacitySlider.setEnabled(self.layer.blending != 'minimum')
-        self.opacityLabel.setEnabled(self.layer.blending != 'minimum')
+        # opaque and minimum blending do not support changing alpha
+        self.opacitySlider.setEnabled(
+            self.layer.blending != 'minimum'
+            and self.layer.blending != 'opaque'
+        )
+        self.opacityLabel.setEnabled(
+            self.layer.blending != 'minimum'
+            and self.layer.blending != 'opaque'
+        )
 
         self.blendComboBox.setToolTip(
             "`minimum` blending mode works best with inverted colormaps with a white background."

--- a/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -6,6 +6,9 @@ from ...utils.events import disconnect_events
 from ...utils.translations import trans
 from ..widgets._slider_compat import QDoubleSlider
 
+# opaque and minimum blending do not support changing alpha (opacity)
+NO_OPACITY_BLENDING_MODES = {'minimum', 'opaque'}
+
 
 class LayerFormLayout(QFormLayout):
     """Reusable form layout for subwidgets in each QtLayerControls class"""
@@ -73,10 +76,10 @@ class QtLayerControls(QFrame):
         self.blendComboBox = blend_comboBox
         # opaque and minimum blending do not support changing alpha
         self.opacitySlider.setEnabled(
-            self.layer.blending not in {'minimum', 'opaque'}
+            self.layer.blending not in NO_OPACITY_BLENDING_MODES
         )
         self.opacityLabel.setEnabled(
-            self.layer.blending not in {'minimum', 'opaque'}
+            self.layer.blending not in NO_OPACITY_BLENDING_MODES
         )
 
     def changeOpacity(self, value):
@@ -102,10 +105,10 @@ class QtLayerControls(QFrame):
         self.layer.blending = self.blendComboBox.currentData()
         # opaque and minimum blending do not support changing alpha
         self.opacitySlider.setEnabled(
-            self.layer.blending not in {'minimum', 'opaque'}
+            self.layer.blending not in NO_OPACITY_BLENDING_MODES
         )
         self.opacityLabel.setEnabled(
-            self.layer.blending not in {'minimum', 'opaque'}
+            self.layer.blending not in NO_OPACITY_BLENDING_MODES
         )
 
         self.blendComboBox.setToolTip(

--- a/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -7,7 +7,7 @@ from ...utils.translations import trans
 from ..widgets._slider_compat import QDoubleSlider
 
 # opaque and minimum blending do not support changing alpha (opacity)
-NO_OPACITY_BLENDING_MODES = {'minimum', 'opaque'}
+NO_OPACITY_BLENDING_MODES = {str(Blending.MINIMUM), str(Blending.OPAQUE)}
 
 
 class LayerFormLayout(QFormLayout):


### PR DESCRIPTION
# Description
Fixes https://github.com/napari/napari/issues/5074
Disables the opacity slider for `opaque` blending, because by definition an opaque layer is fully opaque and the slider does nothing. Also corrects the misleading docs noted by @VolkerH 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
see also https://github.com/napari/napari/pull/5087 for blending details

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: updated the test for the new behavior
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have updated tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
