### PR TITLE
MAINT: increase min numpy version.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     napari-plugin-engine>=0.1.9
     napari-svg>=0.1.6
     npe2>=0.5.2
-    numpy>=1.18.5
+    numpy>=1.20
     numpydoc>=0.9.2
     pandas>=1.1.0 ; python_version < '3.9'
     pandas>=1.3.0 ; python_version >= '3.9'


### PR DESCRIPTION
Nep 29 suggests:

> On Jun 21, 2022 drop support for NumPy 1.19 (initially released on Jun 20, 2020)

It roughly looks like Napari is following nep 29 for Python version. I was wondering if we would like to follow it for numpy versions as well.
