### PR TITLE
Add Minimize on macOS (Window menu)

### DIFF
--- a/napari/_qt/menus/window_menu.py
+++ b/napari/_qt/menus/window_menu.py
@@ -1,3 +1,4 @@
+import platform
 from typing import TYPE_CHECKING
 
 from ...utils.translations import trans
@@ -10,5 +11,14 @@ if TYPE_CHECKING:
 class WindowMenu(NapariMenu):
     def __init__(self, window: 'Window'):
         super().__init__(trans._('&Window'), window._qt_window)
-        ACTIONS = []
+        ACTIONS = [
+            {
+                'when': platform.system() == "Darwin",
+                'text': trans._('Minimize'),
+                'slot': window._minimize,
+                'shortcut': 'Ctrl+M',
+                'statusTip': trans._('Minimize'),
+            },
+            {},
+        ]
         populate_menu(self, ACTIONS)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -657,6 +657,10 @@ class Window:
         else:
             self._qt_window.showFullScreen()
 
+    def _minimize(self):
+        """Minimize"""
+        self._qt_window.showMinimized()
+
     def _toggle_play(self):
         """Toggle play."""
         if self._qt_viewer.dims.is_playing:


### PR DESCRIPTION
# Description
fixes #5092 
Adds `_minimize` to Window class and then a menu item and keybind in the Window menu on macOS, where this function normally lives.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
I'm not sure why this menu item doesn't exist when the native `Enter Full Screen` does exist in the bottom of View menu on macOS, despite not being in view_menu.py
Edit: for more context: https://github.com/napari/napari/issues/5092#issuecomment-1250075960
To summarize Control-M is a keybind only on != Darwin for `hide menubar`, so at present it's unused on macOS. So adding this on macOS makes it more native, without harm, so to speak.


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass locally with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
