### PR TITLE
Populate Help menu with weblinks to docs

### DIFF
--- a/napari/_qt/menus/help_menu.py
+++ b/napari/_qt/menus/help_menu.py
@@ -28,15 +28,6 @@ class HelpMenu(NapariMenu):
         super().__init__(trans._('&Help'), window._qt_window)
         ACTIONS = [
             {
-                'text': trans._('napari Info'),
-                'slot': lambda e: QtAbout.showAbout(window._qt_window),
-                'shortcut': 'Ctrl+/',
-                'statusTip': trans._('About napari'),
-                # on macOS this will be properly placed in the napari menu as:
-                # About napari
-                'menuRole': QAction.AboutRole,
-            },
-            {
                 'text': trans._('Getting started'),
                 'slot': lambda e: webbrowser.open(
                     f'https://napari.org/{VERSION}/tutorials/start_index.html'
@@ -69,6 +60,16 @@ class HelpMenu(NapariMenu):
                 'text': trans._('napari homepage'),
                 'slot': lambda e: webbrowser.open('https://napari.org'),
                 'statusTip': trans._('Open napari.org webpage'),
+            },
+            {},
+            {
+                'text': trans._('napari info'),
+                'slot': lambda e: QtAbout.showAbout(window._qt_window),
+                'shortcut': 'Ctrl+/',
+                'statusTip': trans._('About napari'),
+                # on macOS this will be properly placed in the napari menu as:
+                # About napari
+                'menuRole': QAction.AboutRole,
             },
         ]
         if ask_opt_in is not None:

--- a/napari/_qt/menus/help_menu.py
+++ b/napari/_qt/menus/help_menu.py
@@ -58,6 +58,14 @@ class HelpMenu(NapariMenu):
                 'statusTip': trans._('Open Examples Gallery webpage'),
             },
             {
+                'when': VERSION != "dev",
+                'text': trans._('Release Notes'),
+                'slot': lambda e: webbrowser.open(
+                    f'https://napari.org/{VERSION}/release/release_{VERSION.replace(".", "_")}.html'
+                ),
+                'statusTip': trans._('Open Examples Gallery webpage'),
+            },
+            {
                 'text': trans._('napari homepage'),
                 'slot': lambda e: webbrowser.open('https://napari.org'),
                 'statusTip': trans._('Open napari.org webpage'),

--- a/napari/_qt/menus/help_menu.py
+++ b/napari/_qt/menus/help_menu.py
@@ -63,7 +63,7 @@ class HelpMenu(NapariMenu):
                 'slot': lambda e: webbrowser.open(
                     f'https://napari.org/{VERSION}/release/release_{VERSION.replace(".", "_")}.html'
                 ),
-                'statusTip': trans._('Open Examples Gallery webpage'),
+                'statusTip': trans._('Open Release Notes webpage'),
             },
             {
                 'text': trans._('napari homepage'),

--- a/napari/_qt/menus/help_menu.py
+++ b/napari/_qt/menus/help_menu.py
@@ -1,4 +1,7 @@
+import webbrowser
 from typing import TYPE_CHECKING
+
+from qtpy.QtWidgets import QAction
 
 from ...utils.translations import trans
 from ..dialogs.qt_about import QtAbout
@@ -22,7 +25,36 @@ class HelpMenu(NapariMenu):
                 'slot': lambda e: QtAbout.showAbout(window._qt_window),
                 'shortcut': 'Ctrl+/',
                 'statusTip': trans._('About napari'),
-            }
+                # on macOS this will be properly placed in the napari menu as:
+                # About napari
+                'menuRole': QAction.AboutRole,
+            },
+            {
+                'text': trans._('Getting started'),
+                'slot': lambda e: webbrowser.open(
+                    'https://napari.org/stable/tutorials/start_index.html'
+                ),
+                'statusTip': trans._('Open Getting started webpage'),
+            },
+            {
+                'text': trans._('Tutorials'),
+                'slot': lambda e: webbrowser.open(
+                    'https://napari.org/stable/tutorials/index.html'
+                ),
+                'statusTip': trans._('Open Tutorials webpage'),
+            },
+            {
+                'text': trans._('Examples Gallery'),
+                'slot': lambda e: webbrowser.open(
+                    'https://napari.org/stable/gallery.html'
+                ),
+                'statusTip': trans._('Open Examples Gallery webpage'),
+            },
+            {
+                'text': trans._('napari website'),
+                'slot': lambda e: webbrowser.open('https://napari.org'),
+                'statusTip': trans._('Open napari.org webpage'),
+            },
         ]
         if ask_opt_in is not None:
             ACTIONS.append(

--- a/napari/_qt/menus/help_menu.py
+++ b/napari/_qt/menus/help_menu.py
@@ -1,7 +1,10 @@
 import webbrowser
 from typing import TYPE_CHECKING
 
+from packaging.version import parse
 from qtpy.QtWidgets import QAction
+
+from napari import __version__
 
 from ...utils.translations import trans
 from ..dialogs.qt_about import QtAbout
@@ -14,6 +17,10 @@ try:
     from napari_error_reporter import ask_opt_in
 except ModuleNotFoundError:
     ask_opt_in = None
+
+# Get the version for proper links to documentation
+v = parse(__version__)
+VERSION = "dev" if v.is_devrelease else str(v)
 
 
 class HelpMenu(NapariMenu):
@@ -32,26 +39,26 @@ class HelpMenu(NapariMenu):
             {
                 'text': trans._('Getting started'),
                 'slot': lambda e: webbrowser.open(
-                    'https://napari.org/stable/tutorials/start_index.html'
+                    f'https://napari.org/{VERSION}/tutorials/start_index.html'
                 ),
                 'statusTip': trans._('Open Getting started webpage'),
             },
             {
                 'text': trans._('Tutorials'),
                 'slot': lambda e: webbrowser.open(
-                    'https://napari.org/stable/tutorials/index.html'
+                    f'https://napari.org/{VERSION}/tutorials/index.html'
                 ),
                 'statusTip': trans._('Open Tutorials webpage'),
             },
             {
                 'text': trans._('Examples Gallery'),
                 'slot': lambda e: webbrowser.open(
-                    'https://napari.org/stable/gallery.html'
+                    f'https://napari.org/{VERSION}/gallery.html'
                 ),
                 'statusTip': trans._('Open Examples Gallery webpage'),
             },
             {
-                'text': trans._('napari website'),
+                'text': trans._('napari homepage'),
                 'slot': lambda e: webbrowser.open('https://napari.org'),
                 'statusTip': trans._('Open napari.org webpage'),
             },


### PR DESCRIPTION
# Description
This is a stab at fixing #5094 
For now, the Help menu is populated with weblinks to:
Getting started, Tutorials, Examples Gallery, and napari.org
While it might be nice to open a widget or something similar to provide help & documentation *within* napari, I think this is a good start to making that info more accessible from within napari. In VS Code the Help menu also has a `Documentation` item that just opens the default web browser to the docs page, so a similar approach using the standard module `webbrowser` was used here.
Also by populating the menu, the `napari info` menu item now uses `QAction.AboutRole` to properly place it the `napari` menu on macOS.
<img width="392" alt="image" src="https://user-images.githubusercontent.com/76622105/190875618-02ed9580-068c-480b-aa73-3944f5b39e9e.png">
<img width="241" alt="image" src="https://user-images.githubusercontent.com/76622105/190875623-80e4dad7-1a10-49bb-a522-850617d31a17.png">


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
#5094 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
