### PR TITLE
Ignore tags directory generated by Sphinx build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ docs/source/api/
 docs/source/release/
 docs/source/releases.rst
 docs/build/
+docs/_tags
 
 # PyBuilder
 target/


### PR DESCRIPTION
# Description

This ignores the `docs/_tags` directory in the git repo. I believe this directory and its contents are automatically generated during the Sphinx build process.
