### PR TITLE
Add extra garbage collection for some viewer tests

### DIFF
--- a/napari/_tests/test_view_layers.py
+++ b/napari/_tests/test_view_layers.py
@@ -3,6 +3,7 @@ Ensure that layers and their convenience methods on the viewer
 have the same signatures and docstrings.
 """
 
+import gc
 import inspect
 import re
 from unittest.mock import MagicMock, call
@@ -190,6 +191,10 @@ def test_imshow_multichannel(qtbot, napari_plugin_manager):
     for i in range(data.shape[-1]):
         assert np.all(layers[i].data == data.take(i, axis=-1))
     viewer.close()
+    # Run a full garbage collection here so that any remaining viewer
+    # and related instances are removed for future tests that may use
+    # make_napari_viewer.
+    gc.collect()
 
 
 # plugin_manager fixture is added to prevent errors due to installed plugins


### PR DESCRIPTION
# Description
This adds a special call to `gc.collect` to one of the viewer tests, so that any `Viewer` and `QtViewer` instances should not be present in future tests. That's particularly important for tests that call `make_napari_viewer`, which asserts that there are no `QtViewer` instances.

The hope is that this fixes the failing py310-windows-pyside2 tests on `main`. I was able to reproduce that failure and this fix did fix it.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
- [ ] all tests pass with my change

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
