### PR TITLE
Fix error with "None" key press

### DIFF
--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -517,6 +517,7 @@ class KeymapHandler:
             The vispy key press event that triggered this method.
         """
         if event.key is None:
+            # TODO determine when None key could be sent. 
             return
 
         combo = normalize_key_combo(

--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -516,6 +516,9 @@ class KeymapHandler:
         event : vispy.util.event.Event
             The vispy key press event that triggered this method.
         """
+        if event.key is None:
+            return
+
         combo = normalize_key_combo(
             components_to_key_combo(event.key.name, event.modifiers)
         )

--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -517,7 +517,7 @@ class KeymapHandler:
             The vispy key press event that triggered this method.
         """
         if event.key is None:
-            # TODO determine when None key could be sent. 
+            # TODO determine when None key could be sent.
             return
 
         combo = normalize_key_combo(


### PR DESCRIPTION
# Description
Unfortunately I struggle to reproduce the error which I got during normal use, but one way to trigger it is to quickly close napari as soon as it opens:

```py
File ~/venv/test-napari/lib/python3.10/site-packages/napari/utils/key_bindings.py:520, in KeymapHandler.on_key_press(self=<napari.utils.key_bindings.KeymapHandler object>, event=<KeyEvent blocked=False handled=False key=None m...d80> source=None sources=[] text= type=key_press>)
    511 def on_key_press(self, event):
    512     """Called whenever key pressed in canvas.
    513
    514     Parameters
   (...)
    517         The vispy key press event that triggered this method.
    518     """
    519     combo = normalize_key_combo(
--> 520         components_to_key_combo(event.key.name, event.modifiers)
        event = <KeyEvent blocked=False handled=False key=None modifiers=() native=<PyQt5.QtGui.QKeyEvent object at 0x7f64380e1d80> source=None sources=[] text= type=key_press>
    521     )
    523     repeatables = {
    524         *action_manager._get_repeatable_shortcuts(self.keymap_chain),
    525         "Up",
   (...)
    528         "Right",
    529     }
    531     if (
    532         event.native is not None
    533         and event.native.isAutoRepeat()
   (...)
    537         # unless the combo being held down is one of the autorepeatables or
    538         # one of the navigation keys (helps with scrolling).

AttributeError: 'NoneType' object has no attribute 'name'
```

I'm not entirely sure this is the right fix, but it seems like a reasonable thing to do, and shouldn't be that expensive.

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
