### PR TITLE
Add HIP workshop to documentation/workshops

### DIFF
--- a/docs/further-resources/napari-workshops.md
+++ b/docs/further-resources/napari-workshops.md
@@ -10,6 +10,10 @@ You can find more videos of talks, tutorials and demos on the
 
 *Workshops are listed from newest to oldest.*
 
+* September 2022, Helmholtz Imaging Summer Academy
+  * [Image analysis with Python and Napari](https://biapol.github.io/HIP_Introduction_to_Napari_and_image_processing_with_Python_2022/intro.html) 
+  * [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7102242.svg)](https://doi.org/10.5281/zenodo.7102242)
+
 * July 2022, SciPy 2022
   * [watch it here](https://www.youtube.com/watch?v=vismuuc4y1I&list=PLYx7XA2nY5Gfxu98P_HL1MnFb_BSkpxLV&index=10)
   * [Workshop materials available here](https://alisterburt.github.io/napari-workshops/SciPy-0722/intro.html) 


### PR DESCRIPTION
# Description
Hi all, this adds a link to a 1-day Napari/Python/Jupyter workshop we are running in Germany

## Type of change
- [x] This change _is_ a documentation update

# References

# How has this been tested?
I clicked on the links.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
