### PR TITLE
Standardise file extension when reading

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -745,6 +745,8 @@ class QtViewer(QSplitter):
 
         if (filenames != []) and (filenames is not None):
             for filename in filenames:
+                ext = str(Path(filename).suffix).lower()
+                filename = str(Path(filename).with_suffix(ext))
                 self._qt_open(
                     [filename], stack=False, choose_plugin=choose_plugin
                 )

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -745,8 +745,6 @@ class QtViewer(QSplitter):
 
         if (filenames != []) and (filenames is not None):
             for filename in filenames:
-                ext = str(Path(filename).suffix).lower()
-                filename = str(Path(filename).with_suffix(ext))
                 self._qt_open(
                     [filename], stack=False, choose_plugin=choose_plugin
                 )

--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -198,6 +198,15 @@ def test_get_potential_readers_finds_readers(tmp_plugin: DynamicPlugin):
     assert len(readers) == 2
 
 
+def test_get_potential_readers_extension_case(tmp_plugin: DynamicPlugin):
+    @tmp_plugin.contribute.reader(filename_patterns=['*.tif'])
+    def read_tif(path):
+        ...
+
+    readers = get_potential_readers('my_file.TIF')
+    assert len(readers) == 2
+
+
 def test_get_potential_readers_none_available():
     assert not get_potential_readers('my_file.fake')
 

--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -204,7 +204,7 @@ def test_get_potential_readers_extension_case(tmp_plugin: DynamicPlugin):
         ...
 
     readers = get_potential_readers('my_file.TIF')
-    assert len(readers) == 2
+    assert len(readers) == 1
 
 
 def test_get_potential_readers_none_available():

--- a/napari/plugins/utils.py
+++ b/napari/plugins/utils.py
@@ -4,6 +4,7 @@ import re
 from enum import IntFlag
 from fnmatch import fnmatch
 from functools import lru_cache
+from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from npe2 import PluginManifest
@@ -130,6 +131,9 @@ def get_potential_readers(filename: str) -> Dict[str, str]:
     """
     readers = {}
     hook_caller = plugin_manager.hook.napari_get_reader
+    # lower case file extension
+    ext = str(Path(filename).suffix).lower()
+    filename = str(Path(filename).with_suffix(ext))
     for impl in hook_caller.get_hookimpls():
         reader = hook_caller._call_plugin(impl.plugin_name, path=filename)
         if callable(reader):


### PR DESCRIPTION
# Description
fixes #4986

Use lower case file extension when we read, as suggested: https://github.com/napari/napari/issues/4986#issuecomment-1227825943

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
