### PR TITLE
Add user agent environment variable for pip installations

### DIFF
--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -129,7 +129,6 @@ class Installer(QObject):
                 "CONDA_PINNED_PACKAGES",
                 f"napari={napari_version}{system_pins}",
             )
-            env.insert("PIP_USER_AGENT_USER_DATA", _user_agent())
             if os.name == "nt":
                 # workaround https://github.com/napari/napari/issues/4247, 4484
                 if not env.contains("TEMP"):

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -42,7 +42,7 @@ import napari.resources
 
 from ...plugins import plugin_manager
 from ...plugins.hub import iter_hub_plugin_info
-from ...plugins.pypi import iter_napari_plugin_info, _user_agent
+from ...plugins.pypi import _user_agent, iter_napari_plugin_info
 from ...plugins.utils import normalized_name
 from ...settings import get_settings
 from ...utils._appdirs import user_plugin_dir, user_site_packages

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -42,7 +42,7 @@ import napari.resources
 
 from ...plugins import plugin_manager
 from ...plugins.hub import iter_hub_plugin_info
-from ...plugins.pypi import iter_napari_plugin_info
+from ...plugins.pypi import iter_napari_plugin_info, _user_agent
 from ...plugins.utils import normalized_name
 from ...settings import get_settings
 from ...utils._appdirs import user_plugin_dir, user_site_packages
@@ -105,6 +105,7 @@ class Installer(QObject):
                 ]
             )
             env.insert("PYTHONPATH", combined_paths)
+            env.insert("PIP_USER_AGENT_USER_DATA", _user_agent())
         else:
             process.setProgram(installer)
 
@@ -128,6 +129,7 @@ class Installer(QObject):
                 "CONDA_PINNED_PACKAGES",
                 f"napari={napari_version}{system_pins}",
             )
+            env.insert("PIP_USER_AGENT_USER_DATA", _user_agent())
             if os.name == "nt":
                 # workaround https://github.com/napari/napari/issues/4247, 4484
                 if not env.contains("TEMP"):


### PR DESCRIPTION
This allows pip to report the environment where the plugin installation happens

# Description
see discussion in zulip: https://napari.zulipchat.com/#narrow/stream/212875-general/topic/detecting.20plugin.20downloads.20in.20the.20viewer

tldr: we want napari to report that the plugin installation is done from napari plugin installer when it is the case

## Type of change
New feature (non-breaking change which adds functionality)

# References
https://pip.pypa.io/en/stable/user_guide/#using-a-proxy-server


## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
