### PR TITLE
Refactor qt notification and its test solve problem of segfaults

### DIFF
--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -175,7 +175,7 @@ def test_notification_display(
     assert not dialog.property('expanded')
 
 
-@patch('napari._qt.dialogs.qt_notification.QDialog.show')
+@patch('napari._qt.dialogs.qt_notification.TracebackDialog.show')
 def test_notification_error(mock_show, monkeypatch, qtbot):
     from napari.settings import get_settings
 

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -192,8 +192,14 @@ def test_notification_error(mock_show, monkeypatch, qtbot):
     except ValueError as e:
         notif = ErrorNotification(e)
 
-    dialog = NapariQtNotification.from_notification(notif)
-    qtbot.add_widget(dialog)
+    # This test creates TracebackDialog which is not added to qtbot
+    # but its parent is same as parent of NapariQtNotification.
+    # so create dummy parent allow to not leak widget.
+    widget = QWidget()
+    qtbot.add_widget(widget)
+
+    dialog = NapariQtNotification.from_notification(notif, parent=widget)
+
     bttn = dialog.row2_widget.findChild(QPushButton)
     assert bttn.text() == 'View Traceback'
     mock_show.assert_not_called()

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -195,6 +195,10 @@ def test_notification_error(mock_show, monkeypatch, qtbot):
     # This test creates TracebackDialog which is not added to qtbot
     # but its parent is same as parent of NapariQtNotification.
     # so create dummy parent allow to not leak widget.
+    # Current parent structure, where QWidget is controled by qtbot:
+    # QWidget
+    # ├── NapariQtNotification
+    # └── TracebackDialog
     widget = QWidget()
     qtbot.add_widget(widget)
 

--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -32,7 +32,7 @@ from ...utils.translations import trans
 from ..code_syntax_highlight import Pylighter
 from ..qt_resources import QColoredSVGIcon
 
-ActionSequence = Sequence[Tuple[str, Callable[[], None]]]
+ActionSequence = Sequence[Tuple[str, Callable[['NapariQtNotification'], None]]]
 
 
 class NapariQtNotification(QDialog):

--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -357,8 +357,10 @@ class NapariQtNotification(QDialog):
 
         if isinstance(notification, ErrorNotification):
 
-            def show_tb(parent_):
-                tbdialog = TracebackDialog(notification, parent_.parent())
+            def show_tb(notification_dialog):
+                tbdialog = TracebackDialog(
+                    notification, notification_dialog.parent()
+                )
                 tbdialog.show()
 
             actions = tuple(notification.actions) + (


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

During investigate why the qt notifications test fails with segfaults, I found that there exists Qdialog that is created without setting Parent that may cause segfaults (this is my assumption) 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

Try to fix segfaults showed in #5137

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
