### PR TITLE
Remove leading b from briefcase macOS support build numbers

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -32,7 +32,7 @@ jobs:
           - platform: ubuntu-18.04
             python-version: "3.9"
           - platform: macos-latest
-            python-version: "3.9"
+            python-version: "3.9.1"
           - platform: windows-latest
             python-version: "3.8"
     steps:

--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -32,7 +32,7 @@ jobs:
           - platform: ubuntu-18.04
             python-version: "3.9"
           - platform: macos-latest
-            python-version: "3.9.1"
+            python-version: "3.9"
           - platform: windows-latest
             python-version: "3.8"
     steps:

--- a/bundle.py
+++ b/bundle.py
@@ -107,10 +107,10 @@ def patched_toml():
         # Workaround https://github.com/napari/napari/issues/2965
         # Pin revisions to releases _before_ they switched to static libs
         revision = {
-            (3, 6): 'b11',
-            (3, 7): 'b5',
-            (3, 8): 'b4',
-            (3, 9): 'b1',
+            (3, 6): '11',
+            (3, 7): '5',
+            (3, 8): '4',
+            (3, 9): '1',
         }[sys.version_info[:2]]
         app_table = toml['tool']['briefcase']['app'][APP]
         app_table.add('macOS', tomlkit.table())

--- a/bundle.py
+++ b/bundle.py
@@ -116,42 +116,8 @@ def patched_toml():
         app_table.add('macOS', tomlkit.table())
         app_table['macOS']['support_revision'] = revision
         print(
-            "patching pyproject.toml to pin support package revision:",
+            "patching pyproject.toml to pin support package to revision:",
             revision,
-        )
-        # See https://github.com/napari/napari/pull/5152/#issuecomment-1263385953
-        # and following comments - we can't use `template_branch` because that
-        # is only available in a later briefcase version; we pin to 0.3.1 due to
-        # https://github.com/napari/napari/pull/2980
-        # so we can only use 'template', which supports git urls, archive urls and
-        # paths; we can't use direct URLs because the launcher loses the
-        # executable bits (chmod+x)... so we need to clone and checkout
-        # ourselves, and then provide a path :/
-        # normally we would use the pyver and revision from the dict above, but 3.9b1
-        # has a bug and... whatever comes before b9 works with the pydantic bug :shrug:
-        # b1 to b4: crash with no error
-        # b5 to b8: "Distribution {name!r} exists but does not provide a napari manifest"
-        #   note it does work if launched with the bundled python3 -m napari approach
-        #   (PYTHONPATH needs to be patched though)
-        # b8 and up: pydantic error :/
-        template_path = os.path.join(HERE, 'macOS', 'template')
-        os.makedirs(template_path, exist_ok=True)
-        template_tag = f"3.9-b5"
-        print(f"fetchin template {template_tag}...")
-        subprocess.check_output(
-            [
-                "git",
-                "clone",
-                "--branch",
-                template_tag,
-                "https://github.com/beeware/briefcase-macOS-app-template",
-                template_path,
-            ]
-        )
-        app_table['macOS']['template'] = template_path
-        print(
-            "patching pyproject.toml to pin template to:",
-            template_path,
         )
 
     with open(PYPROJECT_TOML, 'w') as f:

--- a/bundle.py
+++ b/bundle.py
@@ -310,20 +310,20 @@ def bundle():
         elif MACOS:
             patch_python_lib_location()
 
-        # # build
-        # cmd = ['briefcase', 'build', '-v'] + (['--no-docker'] if LINUX else [])
-        # subprocess.check_call(cmd)
+        # build
+        cmd = ['briefcase', 'build', '-v'] + (['--no-docker'] if LINUX else [])
+        subprocess.check_call(cmd)
 
-        # # package
-        # cmd = ['briefcase', 'package', '-v']
-        # cmd += ['--no-sign'] if MACOS else (['--no-docker'] if LINUX else [])
-        # subprocess.check_call(cmd)
+        # package
+        cmd = ['briefcase', 'package', '-v']
+        cmd += ['--no-sign'] if MACOS else (['--no-docker'] if LINUX else [])
+        subprocess.check_call(cmd)
 
-        # # compress
-        # dest = make_zip()
-        # clean()
+        # compress
+        dest = make_zip()
+        clean()
 
-        # return dest
+        return dest
 
 
 if __name__ == "__main__":

--- a/bundle.py
+++ b/bundle.py
@@ -119,13 +119,13 @@ def patched_toml():
             "patching pyproject.toml to pin support package revision:",
             revision,
         )
-        # See https://github.com/napari/napari/pull/5152/#issuecomment-1263385953 
+        # See https://github.com/napari/napari/pull/5152/#issuecomment-1263385953
         # and following comments - we can't use `template_branch` because that
         # is only available in a later briefcase version; we pin to 0.3.1 due to
         # https://github.com/napari/napari/pull/2980
         # so we can only use 'template', which supports git urls, archive urls and
-        # paths; we can't use direct URLs because the launcher loses the 
-        # executable bits (chmod+x)... so we need to clone and checkout 
+        # paths; we can't use direct URLs because the launcher loses the
+        # executable bits (chmod+x)... so we need to clone and checkout
         # ourselves, and then provide a path :/
         # normally we would use the pyver and revision from the dict above, but 3.9b1
         # has a bug and... whatever comes before b9 works with the pydantic bug :shrug:
@@ -140,12 +140,12 @@ def patched_toml():
         print(f"fetchin template {template_tag}...")
         subprocess.check_output(
             [
-                "git", 
+                "git",
                 "clone",
-                "--branch", 
-                template_tag, 
+                "--branch",
+                template_tag,
                 "https://github.com/beeware/briefcase-macOS-app-template",
-                template_path
+                template_path,
             ]
         )
         app_table['macOS']['template'] = template_path
@@ -297,7 +297,9 @@ def bundle():
     # the briefcase calls need to happen while the pyproject toml is patched
     with patched_toml(), patched_dmgbuild():
         # create
-        cmd = ['briefcase', 'create', '-v'] + (['--no-docker'] if LINUX else [])
+        cmd = ['briefcase', 'create', '-v'] + (
+            ['--no-docker'] if LINUX else []
+        )
         subprocess.check_call(cmd)
 
         time.sleep(0.5)


### PR DESCRIPTION
# Description

This fixes the recent failing actions related to the briefcase-based bundled app.

It seems like the briefcase URL forwarder to AWS changed recently (though I'm not sure where that is configured), which meant that an extra `b` was being added to the S3 URL.

The fix is to remove the `b` prefix from the build numbers in our utility. This may be fragile, but should work for now. If the URL forwarder changes again, we can update accordingly.

## Type of change

- [x] Bug-fix (non-breaking change which fixes an issue)

# References

Alternative to #5144 

# How has this been tested?
- [x] I tested the URL forwarding with each of the version/revision combos.
- [ ] I ran `python bundle.py` locally on my mac (Intel, 12.5) with success, then ran the associated bundled app successfully.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
