### PR TITLE
Fix exception when rendering colorbar from a label_colormap

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -386,7 +386,7 @@ def test_label_colormap():
     assert not np.any(colormap.map([0.0]))
 
     # Test that out-of-range values map to last value
-    assert np.all(colormap.map([1.0, 1.1, 2.0]) == colormap.colors[3])
+    assert np.all(colormap.map([1.0, 1.1, 2.0]) == colormap.colors[4])
 
 
 def test_custom_color_dict():

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -386,7 +386,7 @@ def test_label_colormap():
     assert not np.any(colormap.map([0.0]))
 
     # Test that out-of-range values map to last value
-    assert np.all(colormap.map([1.0, 1.1, 2.0]) == colormap.colors[4])
+    assert np.all(colormap.map([1.0, 1.1, 2.0]) == colormap.colors[-1])
 
 
 def test_custom_color_dict():

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -19,7 +19,7 @@ from napari.components import ViewerModel
 from napari.layers import Labels
 from napari.layers.labels._labels_constants import LabelsRendering
 from napari.utils import Colormap
-from napari.utils.colormaps import low_discrepancy_image
+from napari.utils.colormaps import label_colormap, low_discrepancy_image
 
 
 def test_random_labels():
@@ -376,6 +376,17 @@ def test_colormap():
     layer.new_colormap()
     assert isinstance(layer.colormap, Colormap)
     assert layer.colormap.name == 'label_colormap'
+
+
+def test_label_colormap():
+    """Test a label colormap."""
+    colormap = label_colormap(num_colors=4)
+
+    # Make sure color 0 is transparent
+    assert not np.any(colormap.map([0.0]))
+
+    # Test that out-of-range values map to last value
+    assert np.all(colormap.map([1.0, 1.1, 2.0]) == colormap.colors[3])
 
 
 def test_custom_color_dict():

--- a/napari/utils/colormaps/colormap.py
+++ b/napari/utils/colormaps/colormap.py
@@ -121,10 +121,11 @@ class Colormap(EventedModel):
             cols = np.stack(cols, axis=1)
         elif self.interpolation == ColormapInterpolationMode.ZERO:
             # One color per bin
+            # Colors beyond max clipped to final bin
             indices = np.clip(
                 np.searchsorted(self.controls, values, side="right") - 1,
                 0,
-                len(self.colors),
+                len(self.colors) - 1,
             )
             cols = self.colors[indices.astype(np.int32)]
         else:

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -370,13 +370,14 @@ def label_colormap(num_colors=256, seed=0.5):
     ----------
     num_colors : int, optional
         Number of unique colors to use. Default used if not given.
+        Colors are in addition to a transparent color 0.
     seed : float or array of float, length 3
         The seed for the random color generator.
 
     Returns
     -------
     colormap : napari.utils.Colormap
-        A colormap for use with labels are remapped to [0, 1].
+        A colormap for use with labels remapped to [0, 1].
 
     Notes
     -----
@@ -384,14 +385,15 @@ def label_colormap(num_colors=256, seed=0.5):
     """
     # Starting the control points slightly above 0 and below 1 is necessary
     # to ensure that the background pixel 0 is transparent
-    midpoints = np.linspace(0.00001, 1 - 0.00001, num_colors - 1)
+    midpoints = np.linspace(0.00001, 1 - 0.00001, num_colors)
     control_points = np.concatenate(([0], midpoints, [1.0]))
     # make sure to add an alpha channel to the colors
     colors = np.concatenate(
         (_color_random(num_colors, seed=seed), np.full((num_colors, 1), 1)),
         axis=1,
     )
-    colors[0, :] = 0  # ensure alpha is 0 for label 0
+    # Insert alpha at layer 0
+    colors = np.concatenate((np.full((1, 4), 0.0), colors))
     return Colormap(
         name='label_colormap',
         display_name=trans._p('colormap', 'low discrepancy colors'),

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -389,11 +389,15 @@ def label_colormap(num_colors=256, seed=0.5):
     control_points = np.concatenate(([0], midpoints, [1.0]))
     # make sure to add an alpha channel to the colors
     colors = np.concatenate(
-        (_color_random(num_colors, seed=seed), np.full((num_colors, 1), 1)),
+        (
+            _color_random(num_colors + 1, seed=seed),
+            np.full((num_colors + 1, 1), 1),
+        ),
         axis=1,
     )
     # Insert alpha at layer 0
-    colors = np.concatenate((np.full((1, 4), 0.0), colors))
+    colors[0, :] = 0  # ensure alpha is 0 for label 0
+
     return Colormap(
         name='label_colormap',
         display_name=trans._p('colormap', 'low discrepancy colors'),


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This fixes an exception found by @psobolewskiPhD and reported on [zulip](https://napari.zulipchat.com/#narrow/stream/215289-release/topic/0.2E4.2E17rc3/near/301510059).

This was triggered by the rendering of a color box on a surface layer. Doing so mapped a number of values, including 1.0, which was then assigned an index beyond the length of colors.

This was introduced by me in d4b28364a2d1cc832b1eba06cc33ab5849514f62 (also identified by @psobolewskiPhD) when changing the logic used to identify a control point. (I was expecting data in the range `[0,1.0)` & missed the effectively useless range clipping.)

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
