### PR TITLE
Add missed dialogs to `qtbot` in `test_qt_notifications` to prevent segfaults

### DIFF
--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -141,11 +141,10 @@ def test_notification_manager_via_gui(
     warnButton.clicked.connect(warn_func)
     qtbot.addWidget(errButton)
     qtbot.addWidget(warnButton)
-
+    monkeypatch.setattr(
+        NapariQtNotification, "show_notification", lambda x: None
+    )
     with notification_manager:
-        monkeypatch.setattr(
-            NapariQtNotification, "show_notification", lambda x: None
-        )
         for btt, expected_message in [
             (errButton, 'error!'),
             (warnButton, 'warning!'),

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -129,7 +129,7 @@ def test_clean_current_path_exist(make_napari_viewer):
     [(_raise, _warn), (_threading_raise, _threading_warn)],
 )
 def test_notification_manager_via_gui(
-    qtbot, raise_func, warn_func, clean_current
+    count_show, qtbot, raise_func, warn_func, clean_current, monkeypatch
 ):
     """
     Test that the notification_manager intercepts `sys.excepthook`` and
@@ -143,6 +143,9 @@ def test_notification_manager_via_gui(
     qtbot.addWidget(warnButton)
 
     with notification_manager:
+        monkeypatch.setattr(
+            NapariQtNotification, "show_notification", lambda x: None
+        )
         for btt, expected_message in [
             (errButton, 'error!'),
             (warnButton, 'warning!'),
@@ -251,9 +254,14 @@ def test_notification_error(count_show, monkeypatch):
 
 
 @pytest.mark.sync_only
-def test_notifications_error_with_threading(make_napari_viewer, clean_current):
+def test_notifications_error_with_threading(
+    make_napari_viewer, clean_current, monkeypatch
+):
     """Test notifications of `threading` threads, using a dask example."""
     random_image = da.random.random((10, 10))
+    monkeypatch.setattr(
+        NapariQtNotification, "show_notification", lambda x: None
+    )
     with notification_manager:
         viewer = make_napari_viewer(strict_qt=False)
         viewer.add_image(random_image)

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -74,6 +74,15 @@ class ShowStatus:
     show_traceback_count: int = 0
 
 
+@pytest.fixture(autouse=True)
+def raise_on_show(monkeypatch, qtbot):
+    def _raise_on_show(self, *args, **kwargs):
+        raise RuntimeError('error!')
+
+    monkeypatch.setattr(NapariQtNotification, 'show', _raise_on_show)
+    monkeypatch.setattr(TracebackDialog, 'show', _raise_on_show)
+
+
 @pytest.fixture
 def count_show(monkeypatch, qtbot):
 

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -76,11 +76,23 @@ class ShowStatus:
 
 @pytest.fixture(autouse=True)
 def raise_on_show(monkeypatch, qtbot):
-    def _raise_on_show(self, *args, **kwargs):
-        raise RuntimeError('error!')
+    def raise_prepare(text):
+        def _raise_on_call(self, *args, **kwargs):
+            raise RuntimeError(text)
 
-    monkeypatch.setattr(NapariQtNotification, 'show', _raise_on_show)
-    monkeypatch.setattr(TracebackDialog, 'show', _raise_on_show)
+        return _raise_on_call
+
+    monkeypatch.setattr(
+        NapariQtNotification, 'show', raise_prepare("notification show")
+    )
+    monkeypatch.setattr(
+        TracebackDialog, 'show', raise_prepare("traceback show")
+    )
+    monkeypatch.setattr(
+        NapariQtNotification,
+        'close_with_fade',
+        raise_prepare("close_with_fade"),
+    )
 
 
 @pytest.fixture
@@ -233,6 +245,9 @@ def test_notification_error(count_show, monkeypatch):
     settings = get_settings()
 
     monkeypatch.delenv('NAPARI_CATCH_ERRORS', raising=False)
+    monkeypatch.setattr(
+        NapariQtNotification, "close_with_fade", lambda x, y: None
+    )
     monkeypatch.setattr(
         settings.application,
         'gui_notification_level',


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

update of `test_qt_notifications.py` to better guard Qt object. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
