### PR TITLE
DOC Update docstring of `add_dock_widget` & `_add_viewer_dock_widget`

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -23,6 +23,7 @@ from typing import (
 )
 from weakref import WeakValueDictionary
 
+from app_model.backends.qt import QModelMenu
 from qtpy.QtCore import QEvent, QEventLoop, QPoint, QProcess, QSize, Qt, Slot
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (
@@ -51,6 +52,7 @@ from . import menus
 from .dialogs.confirm_close_dialog import ConfirmCloseDialog
 from .dialogs.qt_activity_dialog import QtActivityDialog
 from .dialogs.qt_notification import NapariQtNotification
+from .menus._util import NapariMenu
 from .qt_event_loop import NAPARI_ICON_PATH, get_app, quit_app
 from .qt_resources import get_stylesheet
 from .qt_viewer import QtViewer
@@ -758,7 +760,7 @@ class Window:
         shortcut=_sentinel,
         add_vertical_stretch=True,
         tabify: bool = False,
-        menu: Optional[] = None,
+        menu: Optional[Union[QModelMenu, NapariMenu]] = None,
     ):
         """Convenience method to add a QDockWidget to the main window.
 
@@ -790,9 +792,10 @@ class Window:
                 The shortcut parameter is deprecated since version 0.4.8, please use
                 the action and shortcut manager APIs. The new action manager and
                 shortcut API allow user configuration and localisation.
-        menu : Optional[]
         tabify : bool
             Flag to tabify dockwidget or not.
+        menu : QModelMenu, NapariMenu, optional
+            Menu bar to add toggle action to. If `None` nothing added to menu.
 
         Returns
         -------
@@ -851,7 +854,10 @@ class Window:
         return dock_widget
 
     def _add_viewer_dock_widget(
-        self, dock_widget: QtViewerDockWidget, tabify: bool = False, menu: Optional[] =None,
+        self,
+        dock_widget: QtViewerDockWidget,
+        tabify: bool = False,
+        menu: Optional[Union[QModelMenu, NapariMenu]] = None,
     ):
         """Add a QtViewerDockWidget to the main window
 
@@ -863,9 +869,8 @@ class Window:
             `dock_widget` will be added to the main window.
         tabify : bool
             Flag to tabify dockwidget or not.
-        menu : Optional[]
-            If `None` action not added to menu.
-
+        menu : QModelMenu, NapariMenu, optional
+            Menu bar to add toggle action to. If `None` nothing added to menu.
         """
         # Find if any othe dock widgets are currently in area
         current_dws_in_area = [

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -757,8 +757,8 @@ class Window:
         allowed_areas: Optional[Sequence[str]] = None,
         shortcut=_sentinel,
         add_vertical_stretch=True,
-        menu=None,
         tabify: bool = False,
+        menu: Optional[] = None,
     ):
         """Convenience method to add a QDockWidget to the main window.
 
@@ -790,6 +790,9 @@ class Window:
                 The shortcut parameter is deprecated since version 0.4.8, please use
                 the action and shortcut manager APIs. The new action manager and
                 shortcut API allow user configuration and localisation.
+        menu : Optional[]
+        tabify : bool
+            Flag to tabify dockwidget or not.
 
         Returns
         -------
@@ -831,7 +834,7 @@ class Window:
                 add_vertical_stretch=add_vertical_stretch,
             )
 
-        self._add_viewer_dock_widget(dock_widget, menu=menu, tabify=tabify)
+        self._add_viewer_dock_widget(dock_widget, tabify=tabify, menu=menu)
 
         if hasattr(widget, 'reset_choices'):
             # Keep the dropdown menus in the widget in sync with the layer model
@@ -848,7 +851,7 @@ class Window:
         return dock_widget
 
     def _add_viewer_dock_widget(
-        self, dock_widget: QtViewerDockWidget, tabify=False, menu=None
+        self, dock_widget: QtViewerDockWidget, tabify: bool = False, menu: Optional[] =None,
     ):
         """Add a QtViewerDockWidget to the main window
 
@@ -860,6 +863,9 @@ class Window:
             `dock_widget` will be added to the main window.
         tabify : bool
             Flag to tabify dockwidget or not.
+        menu : Optional[]
+            If `None` action not added to menu.
+
         """
         # Find if any othe dock widgets are currently in area
         current_dws_in_area = [
@@ -899,7 +905,6 @@ class Window:
                 action.setShortcut(shortcut)
 
             menu.addAction(action)
-        # self.window_menu.addAction(action)
 
         # see #3663, to fix #3624 more generally
         dock_widget.setFloating(False)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -23,7 +23,6 @@ from typing import (
 )
 from weakref import WeakValueDictionary
 
-from app_model.backends.qt import QModelMenu
 from qtpy.QtCore import QEvent, QEventLoop, QPoint, QProcess, QSize, Qt, Slot
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (
@@ -32,6 +31,7 @@ from qtpy.QtWidgets import (
     QDockWidget,
     QHBoxLayout,
     QMainWindow,
+    QMenu,
     QShortcut,
     QToolTip,
     QWidget,
@@ -52,7 +52,6 @@ from . import menus
 from .dialogs.confirm_close_dialog import ConfirmCloseDialog
 from .dialogs.qt_activity_dialog import QtActivityDialog
 from .dialogs.qt_notification import NapariQtNotification
-from .menus._util import NapariMenu
 from .qt_event_loop import NAPARI_ICON_PATH, get_app, quit_app
 from .qt_resources import get_stylesheet
 from .qt_viewer import QtViewer
@@ -760,7 +759,7 @@ class Window:
         shortcut=_sentinel,
         add_vertical_stretch=True,
         tabify: bool = False,
-        menu: Optional[Union[QModelMenu, NapariMenu]] = None,
+        menu: Optional[QMenu] = None,
     ):
         """Convenience method to add a QDockWidget to the main window.
 
@@ -794,7 +793,7 @@ class Window:
                 shortcut API allow user configuration and localisation.
         tabify : bool
             Flag to tabify dockwidget or not.
-        menu : QModelMenu, NapariMenu, optional
+        menu : QMenu, optional
             Menu bar to add toggle action to. If `None` nothing added to menu.
 
         Returns
@@ -857,7 +856,7 @@ class Window:
         self,
         dock_widget: QtViewerDockWidget,
         tabify: bool = False,
-        menu: Optional[Union[QModelMenu, NapariMenu]] = None,
+        menu: Optional[QMenu] = None,
     ):
         """Add a QtViewerDockWidget to the main window
 
@@ -869,7 +868,7 @@ class Window:
             `dock_widget` will be added to the main window.
         tabify : bool
             Flag to tabify dockwidget or not.
-        menu : QModelMenu, NapariMenu, optional
+        menu : QMenu, optional
             Menu bar to add toggle action to. If `None` nothing added to menu.
         """
         # Find if any othe dock widgets are currently in area


### PR DESCRIPTION
# Description
Update docstring to add missing parameter. I am not confident the types of `menu` parameter is correct.

Note with the migration to the use of app-model to register menu items, it raises the question: do we still want to keep the functionality to add to the menu bar in `_add_viewer_dock_widget`?

cc @DragaDoncila @nclack 

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
