### PR TITLE
Avoid possible divide-by-zero in Vectors layer thumbnail update

### DIFF
--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -665,49 +665,54 @@ class Vectors(Layer):
 
     def _update_thumbnail(self):
         """Update thumbnail with current vectors and colors."""
-        # calculate min vals for the vertices and pad with 0.5
-        # the offset is needed to ensure that the top left corner of the
-        # vectors corresponds to the top left corner of the thumbnail
-        de = self._extent_data
-        offset = (
-            np.array([de[0, d] for d in self._slice_input.displayed]) + 0.5
-        )[-2:]
-        # calculate range of values for the vertices and pad with 1
-        # padding ensures the entire vector can be represented in the thumbnail
-        # without getting clipped
-        shape = np.ceil(
-            [de[1, d] - de[0, d] + 1 for d in self._slice_input.displayed]
-        ).astype(int)[-2:]
-        zoom_factor = np.divide(self._thumbnail_shape[:2], shape).min()
-
-        # vectors = copy(self._data_view[:, :, -2:])
-        if self._view_data.shape[0] > self._max_vectors_thumbnail:
-            thumbnail_indices = np.random.randint(
-                0, self._view_data.shape[0], self._max_vectors_thumbnail
-            )
-            vectors = copy(self._view_data[thumbnail_indices, :, -2:])
-            thumbnail_color_indices = self._view_indices[thumbnail_indices]
-        else:
-            vectors = copy(self._view_data[:, :, -2:])
-            thumbnail_color_indices = self._view_indices
-        vectors[:, 1, :] = vectors[:, 0, :] + vectors[:, 1, :] * self.length
-        downsampled = (vectors - offset) * zoom_factor
-        downsampled = np.clip(
-            downsampled, 0, np.subtract(self._thumbnail_shape[:2], 1)
-        )
+        # Set the default thumbnail to black, opacity 1
         colormapped = np.zeros(self._thumbnail_shape)
         colormapped[..., 3] = 1
-        edge_colors = self._edge.colors[thumbnail_color_indices]
-        for v, ec in zip(downsampled, edge_colors):
-            start = v[0]
-            stop = v[1]
-            step = int(np.ceil(np.max(abs(stop - start))))
-            x_vals = np.linspace(start[0], stop[0], step)
-            y_vals = np.linspace(start[1], stop[1], step)
-            for x, y in zip(x_vals, y_vals):
-                colormapped[int(x), int(y), :] = ec
-        colormapped[..., 3] *= self.opacity
-        self.thumbnail = colormapped
+        if len(self.data) == 0:
+            self.thumbnail = colormapped
+        else:
+            # calculate min vals for the vertices and pad with 0.5
+            # the offset is needed to ensure that the top left corner of the
+            # vectors corresponds to the top left corner of the thumbnail
+            de = self._extent_data
+            offset = (
+                np.array([de[0, d] for d in self._slice_input.displayed]) + 0.5
+            )[-2:]
+            # calculate range of values for the vertices and pad with 1
+            # padding ensures the entire vector can be represented in the thumbnail
+            # without getting clipped
+            shape = np.ceil(
+                [de[1, d] - de[0, d] + 1 for d in self._slice_input.displayed]
+            ).astype(int)[-2:]
+            zoom_factor = np.divide(self._thumbnail_shape[:2], shape).min()
+
+            if self._view_data.shape[0] > self._max_vectors_thumbnail:
+                thumbnail_indices = np.random.randint(
+                    0, self._view_data.shape[0], self._max_vectors_thumbnail
+                )
+                vectors = copy(self._view_data[thumbnail_indices, :, -2:])
+                thumbnail_color_indices = self._view_indices[thumbnail_indices]
+            else:
+                vectors = copy(self._view_data[:, :, -2:])
+                thumbnail_color_indices = self._view_indices
+            vectors[:, 1, :] = (
+                vectors[:, 0, :] + vectors[:, 1, :] * self.length
+            )
+            downsampled = (vectors - offset) * zoom_factor
+            downsampled = np.clip(
+                downsampled, 0, np.subtract(self._thumbnail_shape[:2], 1)
+            )
+            edge_colors = self._edge.colors[thumbnail_color_indices]
+            for v, ec in zip(downsampled, edge_colors):
+                start = v[0]
+                stop = v[1]
+                step = int(np.ceil(np.max(abs(stop - start))))
+                x_vals = np.linspace(start[0], stop[0], step)
+                y_vals = np.linspace(start[1], stop[1], step)
+                for x, y in zip(x_vals, y_vals):
+                    colormapped[int(x), int(y), :] = ec
+            colormapped[..., 3] *= self.opacity
+            self.thumbnail = colormapped
 
     def _get_value(self, position):
         """Value of the data at a position in data coordinates.


### PR DESCRIPTION
# Description

Trying to run tests locally I ran into nine tests in `layers/vectors/_tests/test_vectors.py` tests consistently failing:
```
FAILED napari/layers/vectors/_tests/test_vectors.py::test_no_args_vectors - RuntimeWarning: divide by zero encountered in divide
FAILED napari/layers/vectors/_tests/test_vectors.py::test_no_data_vectors_with_ndim - RuntimeWarning: divide by zero encountered in divide
FAILED napari/layers/vectors/_tests/test_vectors.py::test_empty_vectors - RuntimeWarning: divide by zero encountered in divide
FAILED napari/layers/vectors/_tests/test_vectors.py::test_empty_vectors_with_property_choices - RuntimeWarning: divide by zero encountered in divide
FAILED napari/layers/vectors/_tests/test_vectors.py::test_empty_layer_with_edge_colormap - RuntimeWarning: divide by zero encountered in divide
FAILED napari/layers/vectors/_tests/test_vectors.py::test_empty_layer_with_edge_color_cycle - RuntimeWarning: divide by zero encountered in divide
FAILED napari/layers/vectors/_tests/test_vectors.py::test_no_data_3D_vectors_with_ndim - RuntimeWarning: divide by zero encountered in divide
FAILED napari/layers/vectors/_tests/test_vectors.py::test_empty_3D_vectors - RuntimeWarning: divide by zero encountered in divide
FAILED napari/layers/vectors/_tests/test_vectors.py::test_empty_data_from_tuple - RuntimeWarning: divide by zero encountered in divide
```

I will spare the repeated output because it was basically the same for each:
```
_________________________________________ test_no_args_vectors _________________________________________

    def test_no_args_vectors():
        """Test instantiating Vectors layer with no arguments"""
>       layer = Vectors()

napari/layers/vectors/_tests/test_vectors.py:40: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
napari/layers/vectors/vectors.py:248: in __init__
    self._update_dims()
napari/layers/base/base.py:704: in _update_dims
    self.refresh()  # This call is need for invalidate cache of extent in LayerList. If you remove it pleas ad another workaround.
napari/layers/base/base.py:1210: in refresh
    self._update_thumbnail()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <Vectors layer 'Vectors' at 0x287fdd7c0>

    def _update_thumbnail(self):
        """Update thumbnail with current vectors and colors."""
        # calculate min vals for the vertices and pad with 0.5
        # the offset is needed to ensure that the top left corner of the
        # vectors corresponds to the top left corner of the thumbnail
        de = self._extent_data
        offset = (np.array([de[0, d] for d in self._dims_displayed]) + 0.5)[
            -2:
        ]
        # calculate range of values for the vertices and pad with 1
        # padding ensures the entire vector can be represented in the thumbnail
        # without getting clipped
        shape = np.ceil(
            [de[1, d] - de[0, d] + 1 for d in self._dims_displayed]
        ).astype(int)[-2:]
>       zoom_factor = np.divide(self._thumbnail_shape[:2], shape).min()
E       RuntimeWarning: divide by zero encountered in divide

napari/layers/vectors/vectors.py:682: RuntimeWarning
```

The root of the problem is the undefined behavior in casting a `NaN` to `int` because `self._extent_data` is filled with `NaN` when the data is empty.
```
# natively on my Apple Silicon Mac
>>> np.float32("nan").astype(int)
0

# in an (emulated) x86-64 Ubuntu container on my machine
>>> np.float32("nan").astype(int)
-9223372036854775808
```

It looks like this or something like it was fixed or anticipated for the Shapes layer, so I copied the implementation style from there. I checked some of the other layer types and they look okay as well, though I'm still getting familiar with them.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
See https://github.com/numpy/numpy/issues/14412
I think this is actually set to emit a warning in a coming version of numpy, and potentially raise an error.

# How has this been tested?
Vector tests pass with my change on multiple platforms.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- N/A I have made corresponding changes to the documentation
- N/A I have added tests that prove my fix is effective or that my feature works
- N/A If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
