### PR TITLE
Fixes broken links in latest docs version

### DIFF
--- a/docs/plugins/best_practices.md
+++ b/docs/plugins/best_practices.md
@@ -277,7 +277,8 @@ class MyWidget(QWidget):
 
 If there is a particular reason that you need to use a separate window that
 inherits from `QWidget`, not `QDialog`, then you could use the `get_current_stylesheet` 
-and [`get_stylesheet`](/api/napari.qt.html#napari.qt.get_stylesheet) functions from the [`napari.qt`](/api/napari.qt.html) module.
+and {func}`get_stylesheet <napari.qt.get_stylesheet>` functions from the
+{mod}`napari.qt <napari.qt>` module.
 
 Here is a `magicgui` example (but could be easily generalised to native `qt` based widgets):
 

--- a/docs/tutorials/annotation/annotate_points.md
+++ b/docs/tutorials/annotation/annotate_points.md
@@ -177,7 +177,7 @@ def point_annotator(
 First, we load the movie to be annotated.
 Since behavior movies can be quite long, we will use a lazy loading strategy (i.e., we will only load the frames as they are used).
 Using [`dask-image`](https://github.com/dask/dask-image), we can construct an object that we can pass to napari for lazy loading in just one line.
-For more explanation on using dask to lazily load images in napari, see [this](https://napari.org/tutorials/applications/dask) tutorial.
+For more explanation on using dask to lazily load images in napari, see [this](../processing/dask) tutorial.
 
 ```python
 stack = imread(im_path)


### PR DESCRIPTION
# Description
Fixes a few broken links in the documentation (in the Best Practices docs for plugins, and the Annotation tutorial).

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes napari/napari.github.io#364

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
