### PR TITLE
Set keyboard focus on console when opened

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -85,6 +85,12 @@ jobs:
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
           if (Test-Path -Path "C:\Windows\system32\opengl32.dll" -PathType Leaf) {Exit 0} else {Exit 1}
 
+      # run a minimal wm for linux tests that depend on UI events (e.g. setFocus)
+      # see https://github.com/pytest-dev/pytest-qt/issues/206
+      - name: Install WM on Linux
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y herbstluftwm
+
       - name: Install dependencies
         run: |
           pip install --upgrade pip
@@ -144,6 +150,10 @@ jobs:
           cache-dependency-path: napari-from-github/setup.cfg
 
       - uses: tlambert03/setup-qt-libs@v1
+
+      - name: Install WM
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y herbstluftwm
 
       - name: Install this commit
         run: |

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -39,6 +39,12 @@ jobs:
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
           if (Test-Path -Path "C:\Windows\system32\opengl32.dll" -PathType Leaf) {Exit 0} else {Exit 1}
 
+      # run a minimal wm for linux tests that depend on UI events (e.g. setFocus)
+      # see https://github.com/pytest-dev/pytest-qt/issues/206
+      - name: Install WM on Linux
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y herbstluftwm
+
       - name: Install dependencies
         run: |
           pip install --upgrade pip

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -110,6 +110,12 @@ jobs:
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
           if (Test-Path -Path "C:\Windows\system32\opengl32.dll" -PathType Leaf) {Exit 0} else {Exit 1}
 
+      # run a minimal wm for linux tests that depend on UI events (e.g. setFocus)
+      # see https://github.com/pytest-dev/pytest-qt/issues/206
+      - name: Install WM on Linux
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y herbstluftwm
+
       # tox and tox-gh-actions will take care of the "actual" installation
       # of python dependendencies into a virtualenv.  see tox.ini for more
       - name: Install dependencies
@@ -165,6 +171,12 @@ jobs:
           cache-dependency-path: napari-from-github/setup.cfg
 
       - uses: tlambert03/setup-qt-libs@v1
+
+      # run a minimal wm for linux tests that depend on UI events (e.g. setFocus)
+      # see https://github.com/pytest-dev/pytest-qt/issues/206
+      - name: Install WM
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y herbstluftwm
 
       - name: Install this commit
         run: |

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -66,8 +66,8 @@ def test_qt_viewer_toggle_console(make_napari_viewer):
 
 
 @skip_local_popups
-def test_qt_viewer_console_focus(qtbot, make_napari_viewer):
-    """Test instantiating console from viewer."""
+def test_qt_viewer_console_focus(qtbot, make_napari_viewer, linux_wm):
+    """Test console has focus when instantiating from viewer."""
     viewer = make_napari_viewer(show=True)
     view = viewer.window._qt_viewer
     assert not view.console.hasFocus(), "console has focus before being shown"

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -65,6 +65,23 @@ def test_qt_viewer_toggle_console(make_napari_viewer):
     assert view.dockConsole.widget() is view.console
 
 
+@skip_local_popups
+def test_qt_viewer_console_focus(qtbot, make_napari_viewer):
+    """Test instantiating console from viewer."""
+    viewer = make_napari_viewer(show=True)
+    view = viewer.window._qt_viewer
+    assert not view.console.hasFocus(), "console has focus before being shown"
+
+    view.toggle_console_visibility(None)
+
+    def console_has_focus():
+        assert (
+            view.console.hasFocus()
+        ), "console does not have focus when shown"
+
+    qtbot.waitUntil(console_has_focus)
+
+
 @pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)
 def test_add_layer(make_napari_viewer, layer_class, data, ndim):
 

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -916,6 +916,7 @@ class QtViewer(QSplitter):
 
         if viz:
             self.dockConsole.raise_()
+            self.dockConsole.setFocus()
 
         self.viewerButtons.consoleButton.setProperty(
             'expanded', self.dockConsole.isVisible()

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -285,6 +285,7 @@ class QtViewerDockWidget(QDockWidget):
 
     def setWidget(self, widget):
         widget._parent = self
+        self.setFocusProxy(widget)
         super().setWidget(widget)
 
 

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -39,6 +39,9 @@ except ModuleNotFoundError:
     pass
 
 import os
+import platform
+import subprocess
+import time
 from itertools import chain
 from multiprocessing.pool import ThreadPool
 from typing import TYPE_CHECKING

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -39,9 +39,6 @@ except ModuleNotFoundError:
     pass
 
 import os
-import platform
-import subprocess
-import time
 from itertools import chain
 from multiprocessing.pool import ThreadPool
 from typing import TYPE_CHECKING

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -1,7 +1,10 @@
 import collections
 import gc
 import os
+import platform
+import subprocess
 import sys
+import time
 import warnings
 from contextlib import suppress
 from typing import TYPE_CHECKING
@@ -345,3 +348,41 @@ def MouseEvent():
             'dims_point',
         ],
     )
+
+
+@pytest.fixture
+def linux_wm():
+    """Start a WM in the background for tests that need a WM.
+
+    This is required for tests that depend on UI events (e.g. setFocus).
+    See https://github.com/pytest-dev/pytest-qt/issues/206.
+
+    This will only run on Linux and in CI (determined by CI env var) - this is
+    unnecessary/irrelevant on macOS and Windows.
+
+    The window manager start command can be set via env var `WM_START_CMD`
+    (default is `herbstluftwm` - make sure it's installed).
+    """
+    wm_start_cmd = os.environ.get("WM_START_CMD", "herbstluftwm")
+    proc = None
+    if platform.system() == "Linux" and os.environ.get("CI"):
+        proc = subprocess.Popen([wm_start_cmd])
+        # give the WM 1s to start up and check it's still running
+        time.sleep(1)
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"window manager '{wm_start_cmd}' process [{proc.pid}] exited, "
+                f"return code: {proc.returncode}"
+            )
+
+    yield proc
+
+    if proc:
+        proc.terminate()
+        try:
+            proc.wait(timeout=20)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            raise RuntimeError(
+                f"failed to terminate window manager '{wm_start_cmd}'"
+            )


### PR DESCRIPTION
# Description
This adds a `setFocus` call when showing the console, giving keyboard focus to the console and allowing immediate user input.

See discussion in https://github.com/napari/napari-console/pull/23 for more on the changes to the GitHub Actions workflows and test fixture. I'll leave some review comments with my thoughts on these changes - feedback is appreciated!

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# References
Closes #5166 
Requires https://github.com/napari/napari-console/pull/23 to work (but harmless without it)

# How has this been tested?
- [x] all tests pass with my change
- [x] added a test (requires popup/window manager)
- [x] tested manually with and without https://github.com/napari/napari-console/pull/23 to test backward-compatibility

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works