### PR TITLE
Volume rendering updates for isosurface and attenuated MIP

### DIFF
--- a/napari/_qt/layer_controls/qt_image_controls.py
+++ b/napari/_qt/layer_controls/qt_image_controls.py
@@ -137,10 +137,10 @@ class QtImageControls(QtBaseImageControls):
 
         sld = QDoubleSlider(Qt.Orientation.Horizontal, parent=self)
         sld.setFocusPolicy(Qt.FocusPolicy.NoFocus)
-        cmin, cmax = self.layer.contrast_limits
+        cmin, cmax = self.layer.contrast_limits_range
         sld.setMinimum(cmin)
         sld.setMaximum(cmax)
-        sld.setValue(cmin + (cmax - cmin) / 2)
+        sld.setValue(self.layer.iso_threshold)
         sld.valueChanged.connect(self.changeIsoThreshold)
         self.isoThresholdSlider = sld
         self.isoThresholdLabel = QLabel(trans._('iso threshold:'))
@@ -247,7 +247,7 @@ class QtImageControls(QtBaseImageControls):
 
     def _on_contrast_limits_change(self):
         with self.layer.events.blocker(self._on_iso_threshold_change):
-            cmin, cmax = self.layer.contrast_limits
+            cmin, cmax = self.layer.contrast_limits_range
             self.isoThresholdSlider.setMinimum(cmin)
             self.isoThresholdSlider.setMaximum(cmax)
         return super()._on_contrast_limits_change()

--- a/napari/_qt/layer_controls/qt_image_controls.py
+++ b/napari/_qt/layer_controls/qt_image_controls.py
@@ -19,6 +19,7 @@ from ...layers.image._image_constants import (
 from ...utils.action_manager import action_manager
 from ...utils.translations import trans
 from ..utils import qt_signals_blocked
+from ..widgets._slider_compat import QDoubleSlider
 from .qt_image_controls_base import QtBaseImageControls
 
 if TYPE_CHECKING:
@@ -134,12 +135,12 @@ class QtImageControls(QtBaseImageControls):
             self.changePlaneThickness
         )
 
-        sld = QSlider(Qt.Orientation.Horizontal, parent=self)
+        sld = QDoubleSlider(Qt.Orientation.Horizontal, parent=self)
         sld.setFocusPolicy(Qt.FocusPolicy.NoFocus)
-        sld.setMinimum(0)
-        sld.setMaximum(100)
-        sld.setSingleStep(1)
-        sld.setValue(int(self.layer.iso_threshold * 100))
+        cmin, cmax = self.layer.contrast_limits
+        sld.setMinimum(cmin)
+        sld.setMaximum(cmax)
+        sld.setValue(cmin + (cmax - cmin) / 2)
         sld.valueChanged.connect(self.changeIsoThreshold)
         self.isoThresholdSlider = sld
         self.isoThresholdLabel = QLabel(trans._('iso threshold:'))
@@ -242,14 +243,19 @@ class QtImageControls(QtBaseImageControls):
             Threshold for isosurface.
         """
         with self.layer.events.blocker(self._on_iso_threshold_change):
-            self.layer.iso_threshold = value / 100
+            self.layer.iso_threshold = value
+
+    def _on_contrast_limits_change(self):
+        with self.layer.events.blocker(self._on_iso_threshold_change):
+            cmin, cmax = self.layer.contrast_limits
+            self.isoThresholdSlider.setMinimum(cmin)
+            self.isoThresholdSlider.setMaximum(cmax)
+        return super()._on_contrast_limits_change()
 
     def _on_iso_threshold_change(self):
         """Receive layer model isosurface change event and update the slider."""
         with self.layer.events.iso_threshold.blocker():
-            self.isoThresholdSlider.setValue(
-                int(self.layer.iso_threshold * 100)
-            )
+            self.isoThresholdSlider.setValue(self.layer.iso_threshold)
 
     def changeAttenuation(self, value):
         """Change attenuation rate for attenuated maximum intensity projection.

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -203,7 +203,9 @@ class VispyImageLayer(VispyBaseLayer):
         if isinstance(self.node, VolumeNode):
             if self.node._texture.is_normalized:
                 cmin, cmax = self.layer.contrast_limits_range
-                self.node.threshold = self.layer.iso_threshold / (cmax - cmin)
+                self.node.threshold = (self.layer.iso_threshold - cmin) / (
+                    cmax - cmin
+                )
             else:
                 self.node.threshold = self.layer.iso_threshold
 

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -186,9 +186,8 @@ class VispyImageLayer(VispyBaseLayer):
         self.node.clim = self.layer.contrast_limits
         # cutoffs must be updated after clims, so we can set them to the new values
         self._update_mip_minip_cutoff()
-        # iso and attenuated_mip both also (may) depend on contrast limit values
+        # iso also may depend on contrast limit values
         self._on_iso_threshold_change()
-        self._on_attenuation_change()
 
     def _on_blending_change(self):
         super()._on_blending_change()
@@ -210,13 +209,7 @@ class VispyImageLayer(VispyBaseLayer):
 
     def _on_attenuation_change(self):
         if isinstance(self.node, VolumeNode):
-            if self.node._texture.is_normalized:
-                self.node.attenuation = self.layer.attenuation
-            else:
-                crange_min, crange_max = self.layer.contrast_limits_range
-                self.node.attenuation = self.layer.attenuation / (
-                    crange_max - crange_min
-                )
+            self.node.attenuation = self.layer.attenuation
 
     def _on_plane_thickness_change(self):
         if isinstance(self.node, VolumeNode):

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -199,7 +199,13 @@ class VispyImageLayer(VispyBaseLayer):
 
     def _on_iso_threshold_change(self):
         if isinstance(self.node, VolumeNode):
-            self.node.threshold = self.layer.iso_threshold
+            if self.node._texture.is_normalized:
+                self.node.threshold = self.layer.iso_threshold
+            else:
+                cmin, cmax = self.node._texture.clim
+                self.node.threshold = (
+                    self.layer.iso_threshold * (cmax - cmin) + cmin
+                )
 
     def _on_attenuation_change(self):
         if isinstance(self.node, VolumeNode):

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -203,12 +203,10 @@ class VispyImageLayer(VispyBaseLayer):
     def _on_iso_threshold_change(self):
         if isinstance(self.node, VolumeNode):
             if self.node._texture.is_normalized:
-                self.node.threshold = self.layer.iso_threshold
+                cmin, cmax = self.layer.contrast_limits_range
+                self.node.threshold = self.layer.iso_threshold / (cmax - cmin)
             else:
-                cmin, cmax = self.node._texture.clim
-                self.node.threshold = (
-                    self.layer.iso_threshold * (cmax - cmin) + cmin
-                )
+                self.node.threshold = self.layer.iso_threshold
 
     def _on_attenuation_change(self):
         if isinstance(self.node, VolumeNode):

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -209,7 +209,13 @@ class VispyImageLayer(VispyBaseLayer):
 
     def _on_attenuation_change(self):
         if isinstance(self.node, VolumeNode):
-            self.node.attenuation = self.layer.attenuation
+            if self.node._texture.is_normalized:
+                self.node.attenuation = self.layer.attenuation
+            else:
+                crange_min, crange_max = self.layer.contrast_limits_range
+                self.node.attenuation = self.layer.attenuation / (
+                    crange_max - crange_min
+                )
 
     def _on_plane_thickness_change(self):
         if isinstance(self.node, VolumeNode):

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -186,6 +186,9 @@ class VispyImageLayer(VispyBaseLayer):
         self.node.clim = self.layer.contrast_limits
         # cutoffs must be updated after clims, so we can set them to the new values
         self._update_mip_minip_cutoff()
+        # iso and attenuated_mip both also (may) depend on contrast limit values
+        self._on_iso_threshold_change()
+        self._on_attenuation_change()
 
     def _on_blending_change(self):
         super()._on_blending_change()

--- a/napari/_vispy/visuals/volume.py
+++ b/napari/_vispy/visuals/volume.py
@@ -113,6 +113,34 @@ vec4 calculateCategoricalColor(vec4 betterColor, vec3 loc, vec3 step)
 }
 """
 
+ATTENUATED_MIP_SNIPPETS = dict(
+    before_loop="""
+        float maxval = u_mip_cutoff; // The maximum encountered value
+        float scaled_sumval = 0.0; // The sum of the encountered values
+        float scaled = 0.0; // The scaled value
+        int maxi = -1;  // Where the maximum value was encountered
+        vec3 max_loc_tex = vec3(0.0);  // Location where the maximum value was encountered
+        """,
+    in_loop="""
+        scaled_sumval += (val - clim.x) / (clim.y - clim.x);
+        scaled = val * exp(-u_attenuation * (scaled_sumval - 1) / u_relative_step_size);
+        if( scaled > maxval ) {
+            maxval = scaled;
+            maxi = iter;
+            max_loc_tex = loc;
+        }
+        """,
+    after_loop="""
+        if ( maxi > -1 ) {
+            frag_depth_point = max_loc_tex * u_shape;
+            gl_FragColor = applyColormap(maxval);
+        }
+        else {
+            discard;
+        }
+        """,
+)
+
 ISO_CATEGORICAL_SNIPPETS = dict(
     before_loop="""
         vec4 color3 = vec4(0.0);  // final color
@@ -157,6 +185,7 @@ shaders['fragment'] = before + FUNCTION_DEFINITIONS + 'void main()' + after
 
 rendering_methods = BaseVolume._rendering_methods.copy()
 rendering_methods['iso_categorical'] = ISO_CATEGORICAL_SNIPPETS
+rendering_methods['attenuated_mip'] = ATTENUATED_MIP_SNIPPETS
 
 
 class Volume(BaseVolume):

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -598,7 +598,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         interpolation3d='linear',
         rendering='mip',
         depiction='volume',
-        iso_threshold=0.5,
+        iso_threshold=None,
         attenuation=0.05,
         name=None,
         metadata=None,

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -496,7 +496,7 @@ def test_iso_threshold():
     np.random.seed(0)
     data = np.random.random((10, 15))
     layer = Image(data)
-    assert layer.iso_threshold == 0.5
+    assert np.min(data) <= layer.iso_threshold <= np.max(data)
 
     # Change iso_threshold property
     iso_threshold = 0.7

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -361,7 +361,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
             self.contrast_limits_range = contrast_limits
         self._contrast_limits = tuple(self.contrast_limits_range)
         if iso_threshold is None:
-            cmin, cmax = self.contrast_limits
+            cmin, cmax = self.contrast_limits_range
             self._iso_threshold = cmin + (cmax - cmin) / 2
         else:
             self._iso_threshold = iso_threshold

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -224,7 +224,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         interpolation2d='nearest',
         interpolation3d='linear',
         rendering='mip',
-        iso_threshold=0.5,
+        iso_threshold=None,
         attenuation=0.05,
         name=None,
         metadata=None,
@@ -342,7 +342,6 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
 
         # Set contrast limits, colormaps and plane parameters
         self._gamma = gamma
-        self._iso_threshold = iso_threshold
         self._attenuation = attenuation
         self._plane = SlicingPlane(thickness=1, enabled=False, draggable=True)
         self._mode = Mode.PAN_ZOOM
@@ -361,6 +360,11 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         else:
             self.contrast_limits_range = contrast_limits
         self._contrast_limits = tuple(self.contrast_limits_range)
+        if iso_threshold is None:
+            cmin, cmax = self.contrast_limits
+            self._iso_threshold = cmin + (cmax - cmin) / 2
+        else:
+            self._iso_threshold = iso_threshold
         # using self.colormap = colormap uses the setter in *derived* classes,
         # where the intention here is to use the base setter, so we use the
         # _set_colormap method. This is important for Labels layers, because

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -226,7 +226,7 @@ def imshow(
     interpolation3d='linear',
     rendering='mip',
     depiction='volume',
-    iso_threshold=0.5,
+    iso_threshold=None,
     attenuation=0.05,
     name=None,
     metadata=None,


### PR DESCRIPTION
# Description
This is meant to fix some ugly volume rendering issues with certain data types when using `iso` or `attenuated_mip` modes. In my investigation it seemed to mostly be a result of certain data types not being normalized in the GPU memory when using `texture_format = 'auto'`.

Here's what it can look like now with 16 bit signed ints (from a directory of DICOM files):

https://user-images.githubusercontent.com/1231828/195733682-5364fe26-22ea-4547-be5b-7839ac264db7.mov

With these changes, this is how it behaves:

https://user-images.githubusercontent.com/1231828/195734045-c28537e3-918f-4dd0-8ca1-fd0f9be1bf22.mov

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
[Discussion in Zulip](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/3D.20attenuated_mip.20and.20iso.20not.20working)
[Visual Human Project CT Data](https://medicine.uiowa.edu/mri/facility-resources/images/visible-human-project-ct-datasets)

# How has this been tested?
Tested with some of the sample data that comes with Napari (e.g. Brain (3D)) and some CT data from the Visual Human Project. I would appreciate others testing this as it seems like "tuning" parameters and I don't have a huge collection of relevant data. Suggestions from the Zulip stream were split into separate commits for easy testing.

Any input on possible automated tests is also appreciated.

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
