### PR TITLE
revert adding delta to colormap

### DIFF
--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -286,9 +286,11 @@ def color_dict_to_colormap(colors):
         for color, control_point in zip(colormap.colors, colormap.controls)
     }
 
-    control_small_delta = 0.5 / len(control_colors)
+    # control_small_delta = 0.5 / len(control_colors)
     label_color_index = {
-        label: np.float32(control2index[tuple(color)] + control_small_delta)
+        label: np.float32(
+            control2index[tuple(color)]
+        )  # + control_small_delta)
         for label, color in colors.items()
     }
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

I do not understand why, but reverting adds a small delta fix #5199. 
Based on my and @perlman work, this delta improves 2D work with multiple custom labels. 

So this is only reverting part of #4935, so the previous error will be present. 

Because of this, I would like to merge this only to 0.4.17 release branch and not put it in main branch. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->



# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).

@psobolewskiPhD could you check this? 
