### PR TITLE
Return early when no slicing needed

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -722,6 +722,9 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     @property
     def _slice_indices(self):
         """(D, ) array: Slice indices in data coordinates."""
+        if len(self._slice_input.not_displayed) == 0:
+            # All dims are displayed dimensions
+            return (slice(None),) * self.ndim
         return self._slice_input.data_indices(
             self._data_to_world.inverse,
             getattr(self, '_round_index', True),


### PR DESCRIPTION
# Description

This fixes the slicing performance issues detected in #5194. These were caused by the refactor in #5003, which removed the case where we return early in `Layer._slice_indices` when no slicing is actually needed. 

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #5194

# How has this been tested?
- [x] all existing tests pass with my change

I ran some of the slicing benchmarks affected by this in #5194 at a few different commits.

First, at the commit on `main` corresponding to #5003 (256698021de3a8ff876d38e6f4462df4671efd3b).

```
(napari-dev) ➜  napari git:(256698021) asv run --bench "Image2DSuite.time_set_view_slice" --python=same
· Discovering benchmarks
· Running 2 total benchmarks (1 commits * 1 environments * 2 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_asweet_software_miniconda3_envs_napari-dev_bin_python
[ 25.00%] ··· Running (benchmark_image_layer.Image2DSuite.time_set_view_slice--)..
[ 75.00%] ··· benchmark_image_layer.Image2DSuite.time_set_view_slice                                                                                                                                                                                                      ok
[ 75.00%] ··· ======== ==========
               param1            
              -------- ----------
                 16     717±20μs 
                 32     714±10μs 
                 64     752±10μs 
                128     755±70μs 
                256     768±40μs 
                512     736±9μs  
                1024    743±10μs 
                2048    762±30μs 
                4096    720±30μs 
              ======== ==========

[100.00%] ··· benchmark_qt_slicing.AsyncImage2DSuite.time_set_view_slice                                                                                                                                                                                                  ok
[100.00%] ··· ======== ============ ======================
              --                      param2              
              -------- -----------------------------------
               param1   skin_data    jrc_hela-2 (scale 3) 
              ======== ============ ======================
                0.0     1.49±0.1ms        4.78±0.1ms      
                0.05     319±2ms           5.01±0s        
                0.1      616±2ms           9.78±0s        
              ======== ============ ======================
```

Then at the previous commit (e6ab7cda8d767a3d36e42362167c8384527dcce3) to show the regression.

```
(napari-dev) ➜  napari git:(e6ab7cda8) asv run --bench "Image2DSuite.time_set_view_slice" --python=same
· Discovering benchmarks
· Running 2 total benchmarks (1 commits * 1 environments * 2 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_asweet_software_miniconda3_envs_napari-dev_bin_python
[ 25.00%] ··· Running (benchmark_image_layer.Image2DSuite.time_set_view_slice--)..
[ 75.00%] ··· benchmark_image_layer.Image2DSuite.time_set_view_slice                                                                                                                                                                                                      ok
[ 75.00%] ··· ======== ===========
               param1             
              -------- -----------
                 16     92.1±30μs 
                 32      66.2±2μs 
                 64      66.3±3μs 
                128      64.3±5μs 
                256      66.3±2μs 
                512      65.3±2μs 
                1024     66.1±4μs 
                2048     72.0±6μs 
                4096     66.2±3μs 
              ======== ===========

[100.00%] ··· benchmark_qt_slicing.AsyncImage2DSuite.time_set_view_slice                                                                                                                                                                                                  ok
[100.00%] ··· ======== =========== ======================
              --                     param2              
              -------- ----------------------------------
               param1   skin_data   jrc_hela-2 (scale 3) 
              ======== =========== ======================
                0.0      736±60μs        4.85±0.3ms      
                0.05    320±0.9ms        5.06±0.01s      
                0.1     614±0.7ms        9.80±0.02s      
              ======== =========== ======================
```

Then with this PR, to show the fix.

```
(napari-dev) ➜  napari git:(fix-5194-early-return-slice) asv run --bench "Image2DSuite.time_set_view_slice" --python=same
· Discovering benchmarks
· Running 2 total benchmarks (1 commits * 1 environments * 2 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_asweet_software_miniconda3_envs_napari-dev_bin_python
[ 25.00%] ··· Running (benchmark_image_layer.Image2DSuite.time_set_view_slice--)..
[ 75.00%] ··· benchmark_image_layer.Image2DSuite.time_set_view_slice                                                                                                                                                                                                        ok
[ 75.00%] ··· ======== ============
               param1              
              -------- ------------
                 16      68.9±9μs  
                 32     67.6±0.7μs 
                 64      69.3±6μs  
                128      64.5±2μs  
                256      67.8±1μs  
                512      64.8±1μs  
                1024     67.7±2μs  
                2048     67.5±2μs  
                4096     70.3±3μs  
              ======== ============

[100.00%] ··· benchmark_qt_slicing.AsyncImage2DSuite.time_set_view_slice                                                                                                                                                                                                    ok
[100.00%] ··· ======== =========== ======================
              --                     param2              
              -------- ----------------------------------
               param1   skin_data   jrc_hela-2 (scale 3) 
              ======== =========== ======================
                0.0      700±8μs         5.15±0.8ms      
                0.05     320±1ms          5.03±0s        
                0.1     614±0.8ms        9.85±0.01s      
              ======== =========== ======================
```


## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
