### PR TITLE
Workaround for PySide6 problem

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -78,6 +78,9 @@ jobs:
           - python: 3.9
             platform: ubuntu-latest
             backend: pyside6
+          - python: '3.10'
+            platform: ubuntu-latest
+            backend: pyside6
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -78,9 +78,10 @@ jobs:
           - python: 3.9
             platform: ubuntu-latest
             backend: pyside6
-          - python: '3.10'
-            platform: ubuntu-latest
-            backend: pyside6
+# uncoment when new qtpy is released
+#          - python: '3.10'
+#            platform: ubuntu-latest
+#            backend: pyside6
 
     steps:
       - name: Cancel Previous Runs

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -436,6 +436,10 @@ def _maybe_rerun_with_macos_fixes():
        This requires relaunching the app from a symlink to the
        desired python executable, conveniently named 'napari'.
     """
+    from napari._qt import API_NAME
+
+    # This import mus be here to raise exception about PySide6 problem
+
     if sys.platform != "darwin":
         return
 
@@ -450,8 +454,6 @@ def _maybe_rerun_with_macos_fixes():
     import platform
     import subprocess
     from tempfile import mkdtemp
-
-    from qtpy import API_NAME
 
     # In principle, we will relaunch to the same python we were using
     executable = sys.executable

--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -6,7 +6,7 @@ from warnings import warn
 from ..utils.translations import trans
 
 try:
-    from qtpy import API_NAME, QtCore
+    from qtpy import API_NAME, QT_VERSION, QtCore
 except Exception as e:
     if 'No Qt bindings could be found' in str(e):
         raise type(e)(
@@ -26,6 +26,17 @@ if API_NAME == 'PySide2':
     os.environ['QT_PLUGIN_PATH'] = str(
         Path(PySide2.__file__).parent / 'Qt' / 'plugins'
     )
+
+if API_NAME == 'PySide6' and sys.version_info[:2] < (3, 10):
+    from packaging import version
+
+    if version.parse(QT_VERSION) > version.parse("6.3.1"):
+        raise RuntimeError(
+            trans._(
+                "Napari is not expected to work with PySide6 >= 6.3.2 on Python < 3.10",
+                deferred=True,
+            )
+        )
 
 
 # When QT is not the specific version, we raise a warning:

--- a/napari/_vispy/__init__.py
+++ b/napari/_vispy/__init__.py
@@ -1,10 +1,11 @@
 import logging
 
-import qtpy
 from vispy import app
 
+from napari._qt import API_NAME
+
 # set vispy application to the appropriate qt backend
-app.use_app(qtpy.API_NAME)
+app.use_app(API_NAME)
 del app
 
 # set vispy logger to show warning and errors only

--- a/tox.ini
+++ b/tox.ini
@@ -73,9 +73,9 @@ setenv =
 deps =
     pytest-cov
     pyqt6: PyQt6
-    pyside6: PySide6
+    pyside6: PySide6 < 6.3.2 ; python_version < '3.10'
+    pyside6: PySide6 ; python_version >= '3.10'
     pytest-json-report
-    pyside6: shiboken6!=6.3.2
 # use extras specified in setup.cfg for certain test envs
 extras =
     testing


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Workaround for problem from #5217. 

As PySide maintainers decide to monkeypatch enum module for python bellow 3.10 on import of PySide and napari is not only an application but also a library, and there is no possibility to guarantee that PySide will be the first imported library we cannot support using PySide6 > 6.3.1 on python < 3.10. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
