### PR TITLE
Explicitly set test array data to fix a flaky test

### DIFF
--- a/napari/_vispy/_tests/test_vispy_multiscale.py
+++ b/napari/_vispy/_tests/test_vispy_multiscale.py
@@ -164,7 +164,7 @@ def test_multiscale_zoomed_out(make_napari_viewer):
     # get set appropriately.
     viewer = make_napari_viewer(show=True)
     shapes = [(3200, 3200), (1600, 1600), (800, 800)]
-    data = [np.empty(s) for s in shapes]
+    data = [np.zeros(s, dtype=np.uint8) for s in shapes]
     layer = viewer.add_image(data, multiscale=True)
     qt_viewer = viewer.window._qt_viewer
     # Canvas size is in screen pixels.


### PR DESCRIPTION
# Description
One of [the existing tests](https://github.com/napari/napari/blob/main/napari/_vispy/_tests/test_vispy_multiscale.py#L167) (that I wrote...) uses `np.empty` for layer data. That was to avoid a fairly expensive allocation, but it also means we have no guarantees about the values in that array (i.e. the test is not deterministic).

That [test failed on the last merge to main](https://github.com/napari/napari/actions/runs/3282377478/jobs/5405701771#step:8:380) (unrelated to the branch being merged) and I think I've seen it fail sometimes elsewhere to. The issue is that sometimes we need to calculate contrast limits, which sometimes needs the data to be defined.

This PR fixes the issue by explicitly assigning data as zeros with `dtype=np.uint8`. Using `uint8` means that the allocation is relatively cheap and it also means that the data range is implied for contrast limits, which is where the issue was occurring. I guess we could use `np.empty(shape, dtype=np.uint8)`, but that might cause other issues when the data is accessed.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
- [ ] all tests pass with my change
