### PR TITLE
Move theme files to cache dir

### DIFF
--- a/napari/resources/_icons.py
+++ b/napari/resources/_icons.py
@@ -4,7 +4,8 @@ from itertools import product
 from pathlib import Path
 from typing import Dict, Iterable, Iterator, Optional, Tuple, Union
 
-from ..utils.translations import trans
+from napari.utils._appdirs import user_cache_dir
+from napari.utils.translations import trans
 
 ICON_PATH = (Path(__file__).parent / 'icons').resolve()
 ICONS = {x.stem: str(x) for x in ICON_PATH.iterdir() if x.suffix == '.svg'}
@@ -112,7 +113,7 @@ def generate_colorized_svgs(
     """
 
     # mapping of svg_stem to theme_key
-    theme_override = theme_override or dict()
+    theme_override = theme_override or {}
 
     ALIAS_T = '{color}/{svg_stem}{opacity}.svg'
 
@@ -129,7 +130,7 @@ def generate_colorized_svgs(
 
         op_key = "" if op == 1 else f"_{op * 100:.0f}"
         alias = ALIAS_T.format(color=clrkey, svg_stem=svg_stem, opacity=op_key)
-        yield (alias, get_colorized_svg(path, color, op))
+        yield alias, get_colorized_svg(path, color, op)
 
 
 def write_colorized_svgs(
@@ -138,7 +139,7 @@ def write_colorized_svgs(
     colors: Iterable[Union[str, Tuple[str, str]]],
     opacities: Iterable[float] = (1.0,),
     theme_override: Optional[Dict[str, str]] = None,
-) -> Iterator[Tuple[str, str]]:
+):
 
     dest = Path(dest)
     dest.mkdir(parents=True, exist_ok=True)
@@ -154,7 +155,7 @@ def write_colorized_svgs(
 
 
 def _theme_path(theme_name: str) -> Path:
-    return ICON_PATH / '_themes' / theme_name
+    return Path(user_cache_dir()) / '_themes' / theme_name
 
 
 def build_theme_svgs(theme_name: str) -> str:

--- a/napari/utils/_appdirs.py
+++ b/napari/utils/_appdirs.py
@@ -5,8 +5,13 @@ from typing import Callable, Optional
 
 import appdirs
 
+from napari._version import __version_tuple__
+
 _appname = 'napari'
 _appauthor = False
+
+version_string = '.'.join(str(x) for x in __version_tuple__[:3])
+
 
 # all of these also take an optional "version" argument ... but if we want
 # to be able to update napari while using data (e.g. plugins, settings) from
@@ -19,7 +24,7 @@ user_config_dir: Callable[[], str] = partial(
     appdirs.user_config_dir, _appname, _appauthor
 )
 user_cache_dir: Callable[[], str] = partial(
-    appdirs.user_cache_dir, _appname, _appauthor
+    appdirs.user_cache_dir, _appname, _appauthor, version_string
 )
 user_state_dir: Callable[[], str] = partial(
     appdirs.user_state_dir, _appname, _appauthor


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This PR will move `_themes` from `site-package/napari/resources/icons/_themes` to `cache-dir/napari/_themes`.

This should solve the problem of preventing napari from running after accidentally installing napari without `-e` option and then trying to use it in editable mode.


Minor fixes in formating

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
