### PR TITLE
Remove osx-arm64 from conda bundle

### DIFF
--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -15,3 +15,4 @@ jobs:
     secrets: inherit
     with:
       event_name: ${{ github.event_name }}
+      installer_platforms: 'linux-64,win-64,osx-64' # Do not target osx-arm64 as there are issues with PySide2


### PR DESCRIPTION
# Description
An alternative to #5252 that is based off the v0.4.17x branch.

Installing napari from conda-forge with PySide2 for macOS ARM64 has some issues (i.e. it won't work right now), so the simplest solution for v0.4.17 is to disable it.

See #5231 and [zulip topic](https://napari.zulipchat.com/#narrow/stream/215289-release/topic/0.2E4.2E17/near/304343534) for more details.

## Type of change

- [x] Bug-fix (non-breaking change which fixes an issue)

# References

Related to #5231.
