### PR TITLE
Check strictly increasing values when clipping contrast limits to a new range

### DIFF
--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -104,6 +104,21 @@ def test_add_multiscale():
     assert viewer.dims.ndim == 2
 
 
+def test_add_multiscale_image_with_negative_floats():
+    """See https://github.com/napari/napari/issues/5257"""
+    viewer = ViewerModel()
+    shapes = [(20, 10), (10, 5)]
+    data = [np.zeros(s, dtype=np.float64) for s in shapes]
+    data[0][-4:, -2:] = -1
+    data[1][-2:, -1:] = -1
+
+    viewer.add_image(data, multiscale=True)
+
+    assert len(viewer.layers) == 1
+    assert np.all(viewer.layers[0].data == data)
+    assert viewer.dims.ndim == 2
+
+
 def test_add_labels():
     """Test adding labels image."""
     viewer = ViewerModel()

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -432,6 +432,24 @@ def test_set_contrast_limits_range():
     assert layer.contrast_limits == [60, 100]
 
 
+@pytest.mark.parametrize(
+    'contrast_limits_range',
+    (
+        [-2, -1],  # range below lower boundary of (0, 1)
+        [-1, 0],  # range on lower boundary of (0, 1)
+        [1, 2],  # range on upper boundary of (0, 1)
+        [2, 3],  # range above upper boundary of (0, 1)
+    ),
+)
+def test_set_contrast_limits_range_at_boundary_of_contrast_limits(
+    contrast_limits_range,
+):
+    """See https://github.com/napari/napari/issues/5257"""
+    layer = Image(np.zeros((6, 5)), contrast_limits=[0, 1])
+    layer.contrast_limits_range = contrast_limits_range
+    assert layer.contrast_limits == contrast_limits_range
+
+
 def test_gamma():
     """Test setting gamma."""
     np.random.seed(0)

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -435,10 +435,10 @@ def test_set_contrast_limits_range():
 @pytest.mark.parametrize(
     'contrast_limits_range',
     (
-        [-2, -1],  # range below lower boundary of (0, 1)
-        [-1, 0],  # range on lower boundary of (0, 1)
-        [1, 2],  # range on upper boundary of (0, 1)
-        [2, 3],  # range above upper boundary of (0, 1)
+        [-2, -1],  # range below lower boundary of [0, 1]
+        [-1, 0],  # range on lower boundary of [0, 1]
+        [1, 2],  # range on upper boundary of [0, 1]
+        [2, 3],  # range above upper boundary of [0, 1]
     ),
 )
 def test_set_contrast_limits_range_at_boundary_of_contrast_limits(

--- a/napari/layers/intensity_mixin.py
+++ b/napari/layers/intensity_mixin.py
@@ -131,19 +131,15 @@ class IntensityVisualizationMixin:
         self._contrast_limits_range = value
         self.events.contrast_limits_range()
 
-        # make sure that the current values fit within the new range
+        # make sure that the contrast limits fit within the new range
         # this also serves the purpose of emitting events.contrast_limits()
         # and updating the views/controllers
         if hasattr(self, '_contrast_limits') and any(self._contrast_limits):
-            cur_min, cur_max = self.contrast_limits
-            # if range limits are outside of current limits, override
-            if value[0] > cur_max or value[1] < cur_min:
-                self.contrast_limits = tuple(value)
-            # if there is some overlap, clip to range
+            clipped_limits = np.clip(self.contrast_limits, *value)
+            if clipped_limits[0] < clipped_limits[1]:
+                self.contrast_limits = tuple(clipped_limits)
             else:
-                new_min = min(max(value[0], cur_min), value[1])
-                new_max = max(min(value[1], cur_max), value[0])
-                self.contrast_limits = (new_min, new_max)
+                self.contrast_limits = tuple(value)
 
     @property
     def gamma(self):


### PR DESCRIPTION
# Description
When we change `contrast_limits_range`, we clip `contrast_limits` to fit in that new range. If the current limits have no real overlap with the new range, then we set them to the new range. We previously had some logic to handle that, but missed the case when the overlap between the current limits and new range had no length (i.e. the clipped limits were equal and therefore not strictly increasing). In this PR, I fixed and simplified that logic to make it clearer.

The example described in #5257 shows one way of reaching this buggy case, though it is caused by some fairly complex logic around how we automatically determine `contrast_limits` on `Image` initialization. In short when passing any data that is not an `ndarray` without `contrast_limits`, we set the `contrast_limits` to be `[0, 1]` if the inferred `dtype` is not an integer. In that case, the data had a min of -1 and a max of 0, so when automatically calculated the limits on slicing, we failed.

I added a test to cover the example in #5257, then added a finer grained unit test to check what happens when setting a new range around the boundary of the current limits.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #5257 

# How has this been tested?
- [ ] added tests to cover buggy behavior pass
- [ ] all tests pass with my change
