### PR TITLE
Respect background color when calculating scale bar color

### DIFF
--- a/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
+++ b/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
@@ -3,7 +3,9 @@ import numpy as np
 import pytest
 from pint import UndefinedUnitError
 
+from napari.components import ViewerModel
 from napari.components._viewer_constants import CanvasPosition
+from napari.qt import QtViewer
 
 
 def test_vispy_text_visual(make_napari_viewer):
@@ -88,3 +90,23 @@ def test_vispy_text_visual(make_napari_viewer):
         np.testing.assert_equal(viewer.scale_bar.box_color, np.asarray(rgba))
 
     del qt_widget
+
+
+def test_box_color_with_background_color_override(qtbot):
+    viewer_model = ViewerModel()
+    qt_viewer = QtViewer(viewer_model)
+    qtbot.addWidget(qt_viewer)
+
+    qt_viewer.canvas.background_color_override = [1, 0, 0]
+    qt_viewer.scale_bar.reset()
+
+    np.testing.assert_equal(
+        qt_viewer.scale_bar.node.text.color.rgb, [[0, 1, 1]]
+    )
+
+    qt_viewer.canvas.background_color_override = [0, 1, 0]
+    qt_viewer.scale_bar.reset()
+
+    np.testing.assert_equal(
+        qt_viewer.scale_bar.node.text.color.rgb, [[1, 0, 1]]
+    )

--- a/napari/_vispy/overlays/scale_bar.py
+++ b/napari/_vispy/overlays/scale_bar.py
@@ -120,13 +120,9 @@ class VispyScaleBarOverlay(VispyCanvasOverlay):
                 # set scale color negative of theme background.
                 # the reason for using the `as_hex` here is to avoid
                 # `UserWarning` which is emitted when RGB values are above 1
-                if (
-                    hasattr(self.viewer, 'window')
-                    and hasattr(self.viewer.window, "_qt_viewer")
-                    and self.viewer.window._qt_viewer.canvas.background_color_override
-                ):
+                if self.node.parent.parent.canvas.background_color_override:
                     background_color = transform_color(
-                        self.viewer.window._qt_viewer.canvas.background_color_override
+                        self.node.parent.parent.canvas.background_color_override
                     )[0]
                 else:
                     background_color = get_theme(

--- a/napari/_vispy/overlays/scale_bar.py
+++ b/napari/_vispy/overlays/scale_bar.py
@@ -121,7 +121,8 @@ class VispyScaleBarOverlay(VispyCanvasOverlay):
                 # the reason for using the `as_hex` here is to avoid
                 # `UserWarning` which is emitted when RGB values are above 1
                 if (
-                    hasattr(self.viewer.window, "_qt_viewer")
+                    hasattr(self.viewer, 'window')
+                    and hasattr(self.viewer.window, "_qt_viewer")
                     and self.viewer.window._qt_viewer.canvas.background_color_override
                 ):
                     background_color = transform_color(

--- a/napari/_vispy/overlays/scale_bar.py
+++ b/napari/_vispy/overlays/scale_bar.py
@@ -120,10 +120,18 @@ class VispyScaleBarOverlay(VispyCanvasOverlay):
                 # set scale color negative of theme background.
                 # the reason for using the `as_hex` here is to avoid
                 # `UserWarning` which is emitted when RGB values are above 1
-                background_color = get_theme(
-                    self.viewer.theme, False
-                ).canvas.as_hex()
-                background_color = transform_color(background_color)[0]
+                if (
+                    hasattr(self.viewer.window, "_qt_viewer")
+                    and self.viewer.window._qt_viewer.canvas.background_color_override
+                ):
+                    background_color = transform_color(
+                        self.viewer.window._qt_viewer.canvas.background_color_override
+                    )[0]
+                else:
+                    background_color = get_theme(
+                        self.viewer.theme, False
+                    ).canvas.as_hex()
+                    background_color = transform_color(background_color)[0]
                 color = np.subtract(1, background_color)
                 color[-1] = background_color[-1]
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Currently color of the scale bar is calculated base on the canvas color assigned in the theme. But since #2270 is possible to overwrite background color. In this PR I add support to respect this option (used for example, in PartSeg). 

![obraz](https://user-images.githubusercontent.com/3826210/198134630-32f0bbd5-1570-434c-91cf-160fc85a1604.png)


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
