### PR TITLE
Revert raising of PySide6 version error

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -80,10 +80,6 @@ jobs:
           - python: 3.9
             platform: ubuntu-latest
             backend: pyside6
-# uncoment when new qtpy is released
-#          - python: '3.10'
-#            platform: ubuntu-latest
-#            backend: pyside6
 
     steps:
       - name: Cancel Previous Runs

--- a/docs/release/release_0_4_17.md
+++ b/docs/release/release_0_4_17.md
@@ -44,6 +44,8 @@ See the docstring of `napari.imshow` for more details.
 
 We added some basic support for PyQt6 and PySide6 in #3707, though we expect some issues.
 If you need or want to use Qt6, please try this out and report any bugs you find.
+If you plan to use PySide6 specifically, please use Python 3.10 to avoid issues with older
+versions of Python.
 
 ### Multi-color text
 

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -436,10 +436,6 @@ def _maybe_rerun_with_macos_fixes():
        This requires relaunching the app from a symlink to the
        desired python executable, conveniently named 'napari'.
     """
-    from napari._qt import API_NAME
-
-    # This import mus be here to raise exception about PySide6 problem
-
     if sys.platform != "darwin":
         return
 
@@ -454,6 +450,8 @@ def _maybe_rerun_with_macos_fixes():
     import platform
     import subprocess
     from tempfile import mkdtemp
+
+    from qtpy import API_NAME
 
     # In principle, we will relaunch to the same python we were using
     executable = sys.executable

--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -6,7 +6,7 @@ from warnings import warn
 from ..utils.translations import trans
 
 try:
-    from qtpy import API_NAME, QT_VERSION, QtCore
+    from qtpy import API_NAME, QtCore
 except Exception as e:
     if 'No Qt bindings could be found' in str(e):
         raise type(e)(
@@ -26,17 +26,6 @@ if API_NAME == 'PySide2':
     os.environ['QT_PLUGIN_PATH'] = str(
         Path(PySide2.__file__).parent / 'Qt' / 'plugins'
     )
-
-if API_NAME == 'PySide6' and sys.version_info[:2] < (3, 10):
-    from packaging import version
-
-    if version.parse(QT_VERSION) > version.parse("6.3.1"):
-        raise RuntimeError(
-            trans._(
-                "Napari is not expected to work with PySide6 >= 6.3.2 on Python < 3.10",
-                deferred=True,
-            )
-        )
 
 
 # When QT is not the specific version, we raise a warning:

--- a/napari/_vispy/__init__.py
+++ b/napari/_vispy/__init__.py
@@ -1,11 +1,10 @@
 import logging
 
+import qtpy
 from vispy import app
 
-from napari._qt import API_NAME
-
 # set vispy application to the appropriate qt backend
-app.use_app(API_NAME)
+app.use_app(qtpy.API_NAME)
 del app
 
 # set vispy logger to show warning and errors only

--- a/tox.ini
+++ b/tox.ini
@@ -73,9 +73,9 @@ setenv =
 deps =
     pytest-cov
     pyqt6: PyQt6
-    pyside6: PySide6 < 6.3.2 ; python_version < '3.10'
-    pyside6: PySide6 ; python_version >= '3.10'
+    pyside6: PySide6
     pytest-json-report
+    pyside6: shiboken6!=6.3.2
 # use extras specified in setup.cfg for certain test envs
 extras =
     testing

--- a/tox.ini
+++ b/tox.ini
@@ -70,12 +70,15 @@ setenv =
     async: NAPARI_ASYNC = 1
     async: PYTEST_ADDOPTS = --async_only
     async: PYTEST_PATH = napari
+# PySide6 6.4.0 broke Python 3.9 and under.
+# See the napari issue for more details:
+# https://github.com/napari/napari/issues/5217
 deps =
     pytest-cov
     pyqt6: PyQt6
-    pyside6: PySide6
+    pyside6: PySide6 < 6.3.2 ; python_version < '3.10'
+    pyside6: PySide6 ; python_version >= '3.10'
     pytest-json-report
-    pyside6: shiboken6!=6.3.2
 # use extras specified in setup.cfg for certain test envs
 extras =
     testing


### PR DESCRIPTION
# Description
This reverts most of the changes in #5244 because reordering the imports can cause circular imports. For example, try running `pytest napari/_vispy/_tests`. See [the Zulip release discussion](https://napari.zulipchat.com/#narrow/stream/215289-release/topic/0.2E4.2E17/near/306229665) for more details.

This PR keeps the change to the `tox.ini` change, so that #5217 remains fixed.

It also adds a short detail to the release notes to help users of PySide6.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Fixes #5217
