### PR TITLE
Reroute key events

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -1137,7 +1137,7 @@ class QtViewer(QSplitter):
         event : qtpy.QtCore.QEvent
             Event from the Qt context.
         """
-        self.canvas._backend._keyEvent(self.canvas.events.key_press, event)
+        self._key_map_handler._on_key_press(event)
         event.accept()
 
     def keyReleaseEvent(self, event):
@@ -1148,7 +1148,7 @@ class QtViewer(QSplitter):
         event : qtpy.QtCore.QEvent
             Event from the Qt context.
         """
-        self.canvas._backend._keyEvent(self.canvas.events.key_release, event)
+        self._key_map_handler._on_key_release(event)
         event.accept()
 
     def dragEnterEvent(self, event):

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -8,8 +8,10 @@ from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple, Union
 from weakref import WeakSet
 
 import numpy as np
+from app_model.backends.qt import qkey2modelkey, qmods2modelmods
+from app_model.types import KeyBinding
 from qtpy.QtCore import QCoreApplication, QObject, Qt
-from qtpy.QtGui import QCursor, QGuiApplication
+from qtpy.QtGui import QCursor, QGuiApplication, QKeyEvent
 from qtpy.QtWidgets import QFileDialog, QSplitter, QVBoxLayout, QWidget
 
 from napari._qt.containers import QtLayerList
@@ -146,6 +148,24 @@ def _extension_string_for_layers(
         # multiple layers.
         ext_str = trans._("All Files (*);;")
     return ext_str, []
+
+
+def _qkeyevent2keybinding(event: QKeyEvent) -> KeyBinding:
+    """Extract a Qt key event's information into an app-model keybinding.
+
+    Parameters
+    ----------
+    event : QKeyEvent
+        Triggering event.
+
+    Returns
+    -------
+    KeyBinding
+        Key combination extracted from the event.
+    """
+    return KeyBinding.from_int(
+        qmods2modelmods(event.modifiers()) | qkey2modelkey(event.key())
+    )
 
 
 class QtViewer(QSplitter):
@@ -421,12 +441,8 @@ class QtViewer(QSplitter):
         self.canvas.events.mouse_move.connect(self.on_mouse_move)
         self.canvas.events.mouse_press.connect(self.on_mouse_press)
         self.canvas.events.mouse_release.connect(self.on_mouse_release)
-        self.canvas.events.key_press.connect(
-            self._key_map_handler.on_key_press
-        )
-        self.canvas.events.key_release.connect(
-            self._key_map_handler.on_key_release
-        )
+        self.canvas.events.key_press.connect(self._on_key_press)
+        self.canvas.events.key_release.connect(self._on_key_release)
         self.canvas.events.mouse_wheel.connect(self.on_mouse_wheel)
         self.canvas.events.draw.connect(self.on_draw)
         self.canvas.events.resize.connect(self.on_resize)
@@ -897,6 +913,28 @@ class QtViewer(QSplitter):
 
         self.canvas.native.setCursor(q_cursor)
 
+    def _on_key_press(self, event):
+        """Called whenever key pressed in canvas.
+
+        Parameters
+        ----------
+        event : vispy.util.event.Event
+            The vispy key press event that triggered this method.
+        """
+        if event.native is not None:
+            self.keyPressEvent(event.native)
+
+    def _on_key_release(self, event):
+        """Called whenever key released in canvas.
+
+        Parameters
+        ----------
+        event : vispy.util.event.Event
+            The vispy key release event that triggered this method.
+        """
+        if event.native is not None:
+            self.keyReleaseEvent(event.native)
+
     def toggle_console_visibility(self, event=None):
         """Toggle console visible and not visible.
 
@@ -1134,10 +1172,15 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : qtpy.QtGui.QKeyEvent
             Event from the Qt context.
         """
-        self._key_map_handler._on_key_press(event)
+        if event.key() == Qt.Key.Key_unknown:
+            return
+
+        key_bind = _qkeyevent2keybinding(event)
+
+        self._key_map_handler.press_key(key_bind, event.isAutoRepeat())
         event.accept()
 
     def keyReleaseEvent(self, event):
@@ -1145,10 +1188,16 @@ class QtViewer(QSplitter):
 
         Parameters
         ----------
-        event : qtpy.QtCore.QEvent
+        event : qtpy.QtGui.QKeyEvent
             Event from the Qt context.
         """
-        self._key_map_handler._on_key_release(event)
+        if event.key == Qt.Key.Key_unknown or event.isAutoRepeat():
+            # on linux press down is treated as multiple press and release
+            return
+
+        key_bind = _qkeyevent2keybinding(event)
+
+        self._key_map_handler.release_key(key_bind)
         event.accept()
 
     def dragEnterEvent(self, event):

--- a/napari/_tests/test_interactive_transforms.py
+++ b/napari/_tests/test_interactive_transforms.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from vispy import keys
+from app_model.types import KeyCode
 
 from napari.components.overlays._interaction_box_constants import Box
 from napari.utils.transforms import Affine
@@ -119,7 +119,7 @@ def test_panzoom_on_space(make_napari_viewer):
     layer = viewer.add_image(data)
 
     layer.mode = 'transform'
-    view.canvas.events.key_press(key=keys.Key('Space'))
+    view._key_map_handler.press_key(KeyCode.Space)
     assert layer.mode == 'pan_zoom'
     assert viewer.overlays.interaction_box.show is False
 

--- a/napari/_tests/test_key_bindings.py
+++ b/napari/_tests/test_key_bindings.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock
 
 import numpy as np
-from vispy import keys
+from app_model.types import KeyCode, KeyMod
 
 
 def test_viewer_key_bindings(make_napari_viewer):
@@ -40,7 +40,7 @@ def test_viewer_key_bindings(make_napari_viewer):
         mock_shift_release.method()
 
     # Simulate press only
-    view.canvas.events.key_press(key=keys.Key('F'))
+    view._key_map_handler.press_key(KeyCode.KeyF)
     mock_press.method.assert_called_once()
     mock_press.reset_mock()
     mock_release.method.assert_not_called()
@@ -48,7 +48,7 @@ def test_viewer_key_bindings(make_napari_viewer):
     mock_shift_release.method.assert_not_called()
 
     # Simulate release only
-    view.canvas.events.key_release(key=keys.Key('F'))
+    view._key_map_handler.release_key(KeyCode.KeyF)
     mock_press.method.assert_not_called()
     mock_release.method.assert_called_once()
     mock_release.reset_mock()
@@ -56,7 +56,7 @@ def test_viewer_key_bindings(make_napari_viewer):
     mock_shift_release.method.assert_not_called()
 
     # Simulate press only
-    view.canvas.events.key_press(key=keys.Key('F'), modifiers=[keys.SHIFT])
+    view._key_map_handler.press_key(KeyMod.Shift | KeyCode.KeyF)
     mock_press.method.assert_not_called()
     mock_release.method.assert_not_called()
     mock_shift_press.method.assert_called_once()
@@ -64,7 +64,7 @@ def test_viewer_key_bindings(make_napari_viewer):
     mock_shift_release.method.assert_not_called()
 
     # Simulate release only
-    view.canvas.events.key_release(key=keys.Key('F'), modifiers=[keys.SHIFT])
+    view._key_map_handler.release_key(KeyMod.Shift | KeyCode.KeyF)
     mock_press.method.assert_not_called()
     mock_release.method.assert_not_called()
     mock_shift_press.method.assert_not_called()
@@ -108,7 +108,7 @@ def test_layer_key_bindings(make_napari_viewer):
         mock_shift_release.method()
 
     # Simulate press only
-    view.canvas.events.key_press(key=keys.Key('F'))
+    view._key_map_handler.press_key(KeyCode.KeyF)
     mock_press.method.assert_called_once()
     mock_press.reset_mock()
     mock_release.method.assert_not_called()
@@ -116,7 +116,7 @@ def test_layer_key_bindings(make_napari_viewer):
     mock_shift_release.method.assert_not_called()
 
     # Simulate release only
-    view.canvas.events.key_release(key=keys.Key('F'))
+    view._key_map_handler.release_key(KeyCode.KeyF)
     mock_press.method.assert_not_called()
     mock_release.method.assert_called_once()
     mock_release.reset_mock()
@@ -124,7 +124,7 @@ def test_layer_key_bindings(make_napari_viewer):
     mock_shift_release.method.assert_not_called()
 
     # Simulate press only
-    view.canvas.events.key_press(key=keys.Key('F'), modifiers=[keys.SHIFT])
+    view._key_map_handler.press_key(KeyMod.Shift | KeyCode.KeyF)
     mock_press.method.assert_not_called()
     mock_release.method.assert_not_called()
     mock_shift_press.method.assert_called_once()
@@ -132,7 +132,7 @@ def test_layer_key_bindings(make_napari_viewer):
     mock_shift_release.method.assert_not_called()
 
     # Simulate release only
-    view.canvas.events.key_release(key=keys.Key('F'), modifiers=[keys.SHIFT])
+    view._key_map_handler.release_key(KeyMod.Shift | KeyCode.KeyF)
     mock_press.method.assert_not_called()
     mock_release.method.assert_not_called()
     mock_shift_press.method.assert_not_called()
@@ -146,9 +146,9 @@ def test_reset_scroll_progress(make_napari_viewer):
     view = viewer.window._qt_viewer
     assert viewer.dims._scroll_progress == 0
 
-    view.canvas.events.key_press(key=keys.Key('Control'))
+    view._key_map_handler.press_key(KeyCode.Ctrl)
     viewer.dims._scroll_progress = 10
     assert viewer.dims._scroll_progress == 10
 
-    view.canvas.events.key_release(key=keys.Key('Control'))
+    view._key_map_handler.release_key(KeyCode.Ctrl)
     assert viewer.dims._scroll_progress == 0

--- a/napari/utils/interactions.py
+++ b/napari/utils/interactions.py
@@ -242,7 +242,7 @@ KEY_SYMBOLS = {
 
 joinchar = '+'
 if sys.platform.startswith('darwin'):
-    KEY_SYMBOLS.update({'Ctrl': '⌘', 'Alt': '⌥', 'Meta': '⌃'})
+    KEY_SYMBOLS.update({'Meta': '⌘', 'Alt': '⌥', 'Ctrl': '⌃'})
     joinchar = ''
 elif sys.platform.startswith('linux'):
     KEY_SYMBOLS.update({'Meta': 'Super'})

--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -351,7 +351,7 @@ class KeymapHandler:
         is_auto_repeat : bool, optional
             If this key press was triggered by holding down a key.
         """
-        from ..utils.action_manager import action_manager
+        from napari.utils.action_manager import action_manager
 
         key_bind = coerce_keybinding(key_bind)
 

--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -40,10 +40,7 @@ from collections import ChainMap
 from types import MethodType
 from typing import Callable, Mapping, Union
 
-from app_model.backends.qt import qkey2modelkey, qmods2modelmods
 from app_model.types import KeyBinding, KeyCode
-from qtpy.QtCore import Qt
-from qtpy.QtGui import QKeyEvent
 
 from napari.utils.translations import trans
 
@@ -69,24 +66,6 @@ _UNDEFINED = object()
 
 # TODO: add this to app-model instead
 KeyBinding.__hash__ = lambda self: hash(str(self))
-
-
-def _qkeyevent2keybinding(event: QKeyEvent) -> KeyBinding:
-    """Extract a Qt key event's information into an app-model keybinding.
-
-    Parameters
-    ----------
-    event : QKeyEvent
-        Triggering event.
-
-    Returns
-    -------
-    KeyBinding
-        Key combination extracted from the event.
-    """
-    return KeyBinding.from_int(
-        qmods2modelmods(event.modifiers()) | qkey2modelkey(event.key())
-    )
 
 
 def coerce_keybinding(key_bind: KeyBindingLike) -> KeyBinding:
@@ -451,56 +430,3 @@ class KeymapHandler:
                     callback()
             else:
                 next(val)  # call function
-
-    def _on_key_press(self, event: QKeyEvent):
-        """Event handler for Qt's key press events.
-
-        Parameters
-        ----------
-        event : QKeyEvent
-            Triggering event.
-        """
-        if event.key() == Qt.Key.Key_unknown:
-            return
-
-        key_bind = _qkeyevent2keybinding(event)
-
-        self.press_key(key_bind, event.isAutoRepeat())
-
-    def _on_key_release(self, event: QKeyEvent):
-        """Event handler for Qt's key release events.
-
-        Parameters
-        ----------
-        event : QKeyEvent
-            Triggering event.
-        """
-        if event.key == Qt.Key.Key_unknown or event.isAutoRepeat():
-            # on linux press down is treated as multiple press and release
-            return
-
-        key_bind = _qkeyevent2keybinding(event)
-
-        self.release_key(key_bind)
-
-    def on_key_press(self, event):
-        """Called whenever key pressed in canvas.
-
-        Parameters
-        ----------
-        event : vispy.util.event.Event
-            The vispy key press event that triggered this method.
-        """
-        if event.native is not None:
-            self._on_key_press(event.native)
-
-    def on_key_release(self, event):
-        """Called whenever key released in canvas.
-
-        Parameters
-        ----------
-        event : vispy.util.event.Event
-            The vispy key release event that triggered this method.
-        """
-        if event.native is not None:
-            self._on_key_release(event.native)

--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -41,10 +41,9 @@ from types import MethodType
 from typing import Callable, Mapping, Union
 
 from app_model.backends.qt import qkey2modelkey, qmods2modelmods
-from app_model.types import KeyBinding, KeyCode, KeyMod
+from app_model.types import KeyBinding, KeyCode
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QKeyEvent
-from vispy.util import keys
 
 from napari.utils.translations import trans
 
@@ -68,54 +67,25 @@ KEY_SUBS = {
 
 _UNDEFINED = object()
 
-_VISPY_SPECIAL_KEYS = [
-    keys.SHIFT,
-    keys.CONTROL,
-    keys.ALT,
-    keys.META,
-    keys.UP,
-    keys.DOWN,
-    keys.LEFT,
-    keys.RIGHT,
-    keys.PAGEUP,
-    keys.PAGEDOWN,
-    keys.INSERT,
-    keys.DELETE,
-    keys.HOME,
-    keys.END,
-    keys.ESCAPE,
-    keys.BACKSPACE,
-    keys.F1,
-    keys.F2,
-    keys.F3,
-    keys.F4,
-    keys.F5,
-    keys.F6,
-    keys.F7,
-    keys.F8,
-    keys.F9,
-    keys.F10,
-    keys.F11,
-    keys.F12,
-    keys.SPACE,
-    keys.ENTER,
-    keys.TAB,
-]
-
-_VISPY_MODS = {
-    keys.CONTROL: KeyMod.CtrlCmd,
-    keys.SHIFT: KeyMod.Shift,
-    keys.ALT: KeyMod.Alt,
-    keys.META: KeyMod.WinCtrl,
-}
-
 # TODO: add this to app-model instead
 KeyBinding.__hash__ = lambda self: hash(str(self))
 
 
 def _qkeyevent2keybinding(event: QKeyEvent) -> KeyBinding:
+    """Extract a Qt key event's information into an app-model keybinding.
+
+    Parameters
+    ----------
+    event : QKeyEvent
+        Triggering event.
+
+    Returns
+    -------
+    KeyBinding
+        Key combination extracted from the event.
+    """
     return KeyBinding.from_int(
-        qmods2modelmods(event.modifiers() | qkey2modelkey(event.key()))
+        qmods2modelmods(event.modifiers()) | qkey2modelkey(event.key())
     )
 
 
@@ -136,7 +106,20 @@ def coerce_keybinding(key_bind: KeyBindingLike) -> KeyBinding:
         for k, v in KEY_SUBS.items():
             key_bind = key_bind.replace(k, v)
 
-    return KeyBinding.validate(key_bind)
+    key_bind = KeyBinding.validate(key_bind)
+
+    # remove redundant modifiers e.g. Shift+Shift
+    for part in key_bind.parts:
+        if part.key == KeyCode.Ctrl:
+            part.ctrl = False
+        elif part.key == KeyCode.Shift:
+            part.shift = False
+        elif part.key == KeyCode.Alt:
+            part.alt = False
+        elif part.key == KeyCode.Meta:
+            part.meta = False
+
+    return key_bind
 
 
 def bind_key(
@@ -259,30 +242,6 @@ def _bind_user_key(
     See ``bind_key`` docs for details.
     """
     return bind_key(_get_user_keymap(), key_bind, func, overwrite=overwrite)
-
-
-def _vispy2appmodel(event) -> KeyBinding:
-    key, modifiers = event.key.name, event.modifiers
-    if len(key) == 1 and key.isalpha():  # it's a letter
-        key = key.upper()
-        cond = lambda m: True  # noqa: E731
-    elif key in _VISPY_SPECIAL_KEYS:
-        # remove redundant information i.e. an output of 'Shift-Shift'
-        cond = lambda m: m != key  # noqa: E731
-    else:
-        # Shift is consumed to transform key
-
-        # bug found on OSX: Command will cause Shift to not
-        # transform the key so do not consume it
-        # note: 'Control' is OSX Command key
-        cond = lambda m: m != 'Shift' or 'Control' in modifiers  # noqa: E731
-
-    kb = KeyCode.from_string(KEY_SUBS.get(key, key))
-
-    for key in filter(lambda key: key in modifiers and cond(key), _VISPY_MODS):
-        kb |= _VISPY_MODS[key]
-
-    return coerce_keybinding(kb)
 
 
 class KeybindingDescriptor:
@@ -494,6 +453,13 @@ class KeymapHandler:
                 next(val)  # call function
 
     def _on_key_press(self, event: QKeyEvent):
+        """Event handler for Qt's key press events.
+
+        Parameters
+        ----------
+        event : QKeyEvent
+            Triggering event.
+        """
         if event.key() == Qt.Key.Key_unknown:
             return
 
@@ -502,6 +468,13 @@ class KeymapHandler:
         self.press_key(key_bind, event.isAutoRepeat())
 
     def _on_key_release(self, event: QKeyEvent):
+        """Event handler for Qt's key release events.
+
+        Parameters
+        ----------
+        event : QKeyEvent
+            Triggering event.
+        """
         if event.key == Qt.Key.Key_unknown or event.isAutoRepeat():
             # on linux press down is treated as multiple press and release
             return

--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -40,7 +40,10 @@ from collections import ChainMap
 from types import MethodType
 from typing import Callable, Mapping, Union
 
+from app_model.backends.qt import qkey2modelkey, qmods2modelmods
 from app_model.types import KeyBinding, KeyCode, KeyMod
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QKeyEvent
 from vispy.util import keys
 
 from napari.utils.translations import trans
@@ -108,6 +111,12 @@ _VISPY_MODS = {
 
 # TODO: add this to app-model instead
 KeyBinding.__hash__ = lambda self: hash(str(self))
+
+
+def _qkeyevent2keybinding(event: QKeyEvent) -> KeyBinding:
+    return KeyBinding.from_int(
+        qmods2modelmods(event.modifiers() | qkey2modelkey(event.key()))
+    )
 
 
 def coerce_keybinding(key_bind: KeyBindingLike) -> KeyBinding:
@@ -405,11 +414,11 @@ class KeymapHandler:
             If this key press was triggered by holding down a key.
         """
         from ..utils.action_manager import action_manager
-        
+
         key_bind = coerce_keybinding(key_bind)
 
         repeatables = {
-            *action_manager._get_repeatable_shortcuts(self.keymap_chain),
+            *action_manager._get_repeatable_shortcuts(self.active_keymap),
             "Up",
             "Down",
             "Left",
@@ -484,6 +493,23 @@ class KeymapHandler:
             else:
                 next(val)  # call function
 
+    def _on_key_press(self, event: QKeyEvent):
+        if event.key() == Qt.Key.Key_unknown:
+            return
+
+        key_bind = _qkeyevent2keybinding(event)
+
+        self.press_key(key_bind, event.isAutoRepeat())
+
+    def _on_key_release(self, event: QKeyEvent):
+        if event.key == Qt.Key.Key_unknown or event.isAutoRepeat():
+            # on linux press down is treated as multiple press and release
+            return
+
+        key_bind = _qkeyevent2keybinding(event)
+
+        self.release_key(key_bind)
+
     def on_key_press(self, event):
         """Called whenever key pressed in canvas.
 
@@ -492,17 +518,8 @@ class KeymapHandler:
         event : vispy.util.event.Event
             The vispy key press event that triggered this method.
         """
-        if event.key is None:
-            # TODO determine when None key could be sent.
-            return
-
-        kb = _vispy2appmodel(event)
-
-        is_auto_repeat = (
-            event.native.isAutoRepeat() if event.native is not None else False
-        )
-
-        self.press_key(kb, is_auto_repeat)
+        if event.native is not None:
+            self._on_key_press(event.native)
 
     def on_key_release(self, event):
         """Called whenever key released in canvas.
@@ -512,11 +529,5 @@ class KeymapHandler:
         event : vispy.util.event.Event
             The vispy key release event that triggered this method.
         """
-        if event.key is None or (
-            # on linux press down is treated as multiple press and release
-            event.native is not None
-            and event.native.isAutoRepeat()
-        ):
-            return
-        kb = _vispy2appmodel(event)
-        self.release_key(kb)
+        if event.native is not None:
+            self._on_key_release(event.native)


### PR DESCRIPTION
# Description
Reroutes key events to be translated into `app-model` keybindings from `Qt` events. This is done so that we are no longer handing off everything to be processed by vispy's event system before being sent to us.

Closes #3087