### PR TITLE
Use plugin display_name for widget parent menu

### DIFF
--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -233,16 +233,14 @@ def iter_manifests(
 
 def widget_iterator() -> Iterator[Tuple[str, Tuple[str, Sequence[str]]]]:
     # eg ('dock', ('my_plugin', ('My widget', MyWidget)))
-    # Make a dict of display_name matching plugin_name
-    plugin_names = {}
-    for plugin in pm.iter_manifests():
-        plugin_names[plugin.name] = plugin.display_name
-
     wdgs: DefaultDict[str, List[str]] = DefaultDict(list)
     for wdg_contrib in pm.iter_widgets():
-        wdgs[plugin_names[wdg_contrib.plugin_name]].append(
-            wdg_contrib.display_name
-        )
+        # The plugin_display_name is distinct from the wdg_contrib.display_name
+        # One plugin might have many widgets.
+        plugin_display_name = pm.get_manifest(
+            wdg_contrib.plugin_name
+        ).display_name
+        wdgs[plugin_display_name].append(wdg_contrib.display_name)
     return (('dock', x) for x in wdgs.items())
 
 

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -233,9 +233,16 @@ def iter_manifests(
 
 def widget_iterator() -> Iterator[Tuple[str, Tuple[str, Sequence[str]]]]:
     # eg ('dock', ('my_plugin', ('My widget', MyWidget)))
+    # Make a dict of display_name matching plugin_name
+    plugin_names = {}
+    for plugin in pm.iter_manifests():
+        plugin_names[plugin.name] = plugin.display_name
+
     wdgs: DefaultDict[str, List[str]] = DefaultDict(list)
     for wdg_contrib in pm.iter_widgets():
-        wdgs[wdg_contrib.plugin_name].append(wdg_contrib.display_name)
+        wdgs[plugin_names[wdg_contrib.plugin_name]].append(
+            wdg_contrib.display_name
+        )
     return (('dock', x) for x in wdgs.items())
 
 

--- a/napari/plugins/_tests/test_npe2.py
+++ b/napari/plugins/_tests/test_npe2.py
@@ -14,6 +14,7 @@ from napari.layers import Image, Points
 from napari.plugins import _npe2
 
 PLUGIN_NAME = 'my-plugin'  # this matches the sample_manifest
+PLUGIN_DISPLAY_NAME = 'My Plugin'  # this matches the sample_manifest
 MANIFEST_PATH = Path(__file__).parent / '_sample_manifest.yaml'
 
 
@@ -145,7 +146,7 @@ def test_sample_iterator(mock_pm):
 
 def test_widget_iterator(mock_pm):
     wdgs = list(_npe2.widget_iterator())
-    assert wdgs == [('dock', (PLUGIN_NAME, ['My Widget']))]
+    assert wdgs == [('dock', (PLUGIN_DISPLAY_NAME, ['My Widget']))]
 
 
 def test_plugin_actions(mock_pm: 'TestPluginManager'):


### PR DESCRIPTION
# Description
When a plugin has multiple widgets, the `display_name` provided by the plugin will be used for the parent Plugin menu item.
For example, if the `napari.yaml` first two lines are:
```
name: napari-first-try
display_name: Hello Plugin
```
Then the Plugin menu will show:
<img width="540" alt="image" src="https://user-images.githubusercontent.com/76622105/200123512-ca42573b-33be-4ea8-bbec-ea3ceb388174.png">

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Fixes half https://github.com/napari/napari/issues/5304 (the plugin menu part)
Also partially addresses: https://github.com/napari/cookiecutter-napari-plugin/issues/126
Once this is merged (or fixed in another way) will make a PR there too to alter the `display_name` prompt to be more clear.


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: fixed `test_npe2.py` to account for the new behavior
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
