### PR TITLE
PERF: Event emissions and perf regression.

### DIFF
--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -764,7 +764,6 @@ class EventEmitter:
         finally:
             self._emitting = False
             ps = event._pop_source()
-            assert isinstance(ps, EventEmitter), ps
             if ps is not self.source:
 
                 raise RuntimeError(

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -764,8 +764,6 @@ class EventEmitter:
         finally:
             self._emitting = False
             ps = event._pop_source()
-            # test for identity before equality is faster, and can
-            # shave a non-negligible amount of time.
             assert isinstance(ps, EventEmitter), ps
             if ps is not self.source:
 

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -764,10 +764,8 @@ class EventEmitter:
         finally:
             self._emitting = False
             ps = event._pop_source()
-            # INFO: As far as I understand the Python interpreter _should_
-            # test for identity before equality and _if identical_ not test
-            # for equality as identical objects are always equal.
-            # Though it does not appear to be the case here.
+            # test for identity before equality is faster, and can
+            # shave a non-negligible amount of time.
             if ps is not self.source:
                 if ps != self.source:
                     raise RuntimeError(

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -763,13 +763,19 @@ class EventEmitter:
                 self.disconnect(cb)
         finally:
             self._emitting = False
-            if event._pop_source() != self.source:
-                raise RuntimeError(
-                    trans._(
-                        "Event source-stack mismatch.",
-                        deferred=True,
+            ps = event._pop_source()
+            # INFO: As far as I understand the Python interpreter _should_
+            # test for identity before equality and _if identical_ not test
+            # for equality as identical objects are always equal.
+            # Though it does not appear to be the case here.
+            if ps is not self.source:
+                if ps != self.source:
+                    raise RuntimeError(
+                        trans._(
+                            "Event source-stack mismatch.",
+                            deferred=True,
+                        )
                     )
-                )
 
         return event
 

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -766,8 +766,8 @@ class EventEmitter:
             ps = event._pop_source()
             # test for identity before equality is faster, and can
             # shave a non-negligible amount of time.
-            if ps != self.source:
-                assert isinstance(ps, EventEmitter), ps
+            assert isinstance(ps, EventEmitter), ps
+            if ps is not self.source:
 
                 raise RuntimeError(
                     trans._(

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -766,14 +766,15 @@ class EventEmitter:
             ps = event._pop_source()
             # test for identity before equality is faster, and can
             # shave a non-negligible amount of time.
-            if ps is not self.source:
-                if ps != self.source:
-                    raise RuntimeError(
-                        trans._(
-                            "Event source-stack mismatch.",
-                            deferred=True,
-                        )
+            if ps != self.source:
+                assert isinstance(ps, EventEmitter), ps
+
+                raise RuntimeError(
+                    trans._(
+                        "Event source-stack mismatch.",
+                        deferred=True,
                     )
+                )
 
         return event
 

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -330,6 +330,8 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
         like arrays, whose truth value is often ambiguous. ``__eq_operators__``
         is constructed in ``EqualityMetaclass.__new__``
         """
+        if self is other:
+            return True
         if not isinstance(other, EventedModel):
             return self.dict() == other
 


### PR DESCRIPTION
Working on #5263, I came across this weird things where a lot of time is spent checking the non-equality of two empty dict, that actually are the same instance.

It does create a 20% improvement in `TextManager.__init__`, which apply directly trigger the event mechanism:

    def apply(self, features: Any):
        self.string._apply(features)
        # this line is a call to __call__ and represent ~99% of time
        # spent in this method regardless of before/after patch.
        self.events.values()
        self.color._apply(features)

I'm not sure why the interpreter does not check for identity first. I'm adding the

After patch:

```
(HEAD) $ time python -m kernprof -l -v bench.py
Wrote profile results to bench.py.lprof
Timer unit: 1e-06 s

Total time: 0.001366 s
File: /Users/bussonniermatthias/dev/napari/napari/layers/utils/text_manager.py
Function: __init__ at line 89

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
class TextManager(EventedModel)
    89                                               @profile
    90                                               def __init__(
    91                                                   self, text=None, properties=None, n_text=None, features=None, **kwargs
    92                                               ):
    93         1          1.0      1.0      0.1          if ...:
    94                                                       ...
    95         1          0.0      0.0      0.0          if ...:
    96                                                       ...
    97                                                       ...
    98                                                   else:
    99         1        114.0    114.0      8.3              features = _validate_features(features)
   100         1          1.0      1.0      0.1          if ...:
   101                                                       ...
   102                                                       ...
   103                                                       ...
   104                                                           ...
   105         1          0.0      0.0      0.0          if ...:
   106                                                       _warn_about_deprecated_text_parameter()
   107                                                       kwargs['string'] = text
   108         1       1224.0   1224.0     89.6          super().__init__(**kwargs)
   109         1         11.0     11.0      0.8          self.events.add(values=Event)
   110         1         15.0     15.0      1.1          self.apply(features)

==============================================================
and  in __call__:

   766         5          2.0      0.4      2.9              self._emitting = False
   767         5          6.0      1.2      8.6              ps = event._pop_source()
   768         5          5.0      1.0      7.1              if ps is not self.source :
   769                                                           if ps != self.source:
   770                                                               raise RuntimeError(
   771                                                                   trans._(
   772                                                                       "Event source-stack mismatch.",
   773                                                                       deferred=True,
   774                                                                   )
   775                                                               )

```

And master baseline for info:

```
(|nap6) napari[main ✗]  $ time python -m kernprof -l -v bench.py
Wrote profile results to bench.py.lprof
Timer unit: 1e-06 s

Total time: 0.001803 s
File: /Users/bussonniermatthias/dev/napari/napari/layers/utils/text_manager.py
Function: __init__ at line 89

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    89                                               @profile
    90                                               def __init__(
    91                                                   self, text=None, properties=None, n_text=None, features=None, **kwargs
    92                                               ):
    93         1          1.0      1.0      0.1          if ...:
    94                                                       ...
    95         1          0.0      0.0      0.0          if ...:
    96                                                       ...
    97                                                       ...
    98                                                   else:
    99         1        112.0    112.0      6.2              features = _validate_features(features)
   100         1          0.0      0.0      0.0          if ...:
   101                                                       ...
   102                                                       ...
   103                                                       if 'string' not in kwargs:
   104                                                           ...
   105         1          1.0      1.0      0.1          if ...:
   106                                                       ...
   107                                                       ...
   108         1       1268.0   1268.0     70.3          super().__init__(**kwargs)
   109         1         11.0     11.0      0.6          self.events.add(values=Event)
   110         1        410.0    410.0     22.7          self.apply(features)

==============================================================
and in __call__:

   767         5        441.0     88.2     87.3              if event._pop_source() != self.source:
   768                                                           raise RuntimeError(
   769                                                               trans._(
   770                                                                   "Event source-stack mismatch.",
   771                                                                   deferred=True,
   772                                                               )
   773                                                           )

python -m kernprof -l -v bench.py  1.35s user 0.61s system 113% cpu 1.721 total
```

I'd love for someone to confirm I"m not crazy and Python does not text for identity.

And here is my bench script, from the slow benchmarks:

```
from napari.layers.utils.text_manager import TextManager
import numpy as np

import pandas as pd

categories = ('cat', 'car')
n= 64

features = pd.DataFrame(
            {
                'string_property': pd.Series(
                    np.random.choice(categories, n),
                    dtype=pd.CategoricalDtype(categories),
                ),
                'float_property': np.random.rand(n),
            }
        )

def f():
    string = {'constant': 'test'}
    TextManager(string=string, features=features)
f()



