### PR TITLE
Much faster FormatStringEncoding

### DIFF
--- a/napari/layers/utils/string_encoding.py
+++ b/napari/layers/utils/string_encoding.py
@@ -1,12 +1,5 @@
 from string import Formatter
-from typing import (
-    Any,
-    Literal,
-    Protocol,
-    Sequence,
-    Union,
-    runtime_checkable,
-)
+from typing import Any, Literal, Protocol, Sequence, Union, runtime_checkable
 
 import numpy as np
 from pydantic import parse_obj_as

--- a/napari/layers/utils/string_encoding.py
+++ b/napari/layers/utils/string_encoding.py
@@ -173,16 +173,12 @@ class FormatStringEncoding(_DerivedStyleEncoding[StringValue, StringArray]):
     encoding_type: Literal['FormatStringEncoding'] = 'FormatStringEncoding'
 
     def __call__(self, features: Any) -> StringArray:
+        feature_names = features.columns.to_list()
         values = [
-            self.format.format(**_get_feature_row(features, i))
-            for i in range(len(features))
+            self.format.format(**dict(zip(feature_names, tuple_)))
+            for tuple_ in features.itertuples(index=False, name=None)
         ]
         return np.array(values, dtype=str)
-
-
-def _get_feature_row(features: Any, index: int) -> Dict[str, Any]:
-    """Returns one row of the features table as a dictionary."""
-    return {name: values.iloc[index] for name, values in features.items()}
 
 
 def _is_format_string(string: str) -> bool:

--- a/napari/layers/utils/string_encoding.py
+++ b/napari/layers/utils/string_encoding.py
@@ -1,7 +1,6 @@
 from string import Formatter
 from typing import (
     Any,
-    Dict,
     Literal,
     Protocol,
     Sequence,

--- a/napari/layers/utils/string_encoding.py
+++ b/napari/layers/utils/string_encoding.py
@@ -167,8 +167,8 @@ class FormatStringEncoding(_DerivedStyleEncoding[StringValue, StringArray]):
     def __call__(self, features: Any) -> StringArray:
         feature_names = features.columns.to_list()
         values = [
-            self.format.format(**dict(zip(feature_names, tuple_)))
-            for tuple_ in features.itertuples(index=False, name=None)
+            self.format.format(**dict(zip(feature_names, row)))
+            for row in features.itertuples(index=False, name=None)
         ]
         return np.array(values, dtype=str)
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Loading a large pose estimation data file with a simple "{id}–{label}" format (using the napari-deeplabcut plugin; resulting feature table with >6M rows and four columns) lasted 3+ min.
While I first thought it had something to do with rendering the keypoints, a bit of profiling (see pink lines below) indicated that 92% of the time it took to load the annotations (177 s!) was spent in the TextManager, and specifically in `_get_feature_row`.

<img width="1440" alt="Screenshot 2022-11-08 at 6 12 17 PM" src="https://user-images.githubusercontent.com/30733203/200637972-a6999eda-973c-478e-b3ff-cc50f143f033.png">

<img width="1440" alt="Screenshot 2022-11-08 at 6 12 30 PM" src="https://user-images.githubusercontent.com/30733203/200638035-9228b977-5435-448c-a431-0d20de54fee2.png">

I substituted df.iloc with df.itertuples, and loading now takes only roughly 5 s (~35x speedup).

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [x] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x]  I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
