### PR TITLE
Prevent obsolete reports about failure of cleaning viewer instances

### DIFF
--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -101,6 +101,19 @@ def napari_plugin_manager(monkeypatch):
 GCPASS = 0
 
 
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    # https://docs.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures
+    # execute all other hooks to obtain the report object
+    outcome = yield
+    rep = outcome.get_result()
+
+    # set a report attribute for each phase of a call, which can
+    # be "setup", "call", "teardown"
+
+    setattr(item, f"rep_{rep.when}", rep)
+
+
 @pytest.fixture
 def make_napari_viewer(
     qtbot, request: 'FixtureRequest', napari_plugin_manager
@@ -228,7 +241,14 @@ def make_napari_viewer(
     if request.config.getoption(_SAVE_GRAPH_OPNAME):
         fail_obj_graph(QtViewer)
 
+    if request.node.rep_call.failed:
+        # IF test failed do not check for leaks
+        QtViewer._instances.clear()
+
     _do_not_inline_below = len(QtViewer._instances)
+
+    QtViewer._instances.clear()  # clear to prevent fail of next test
+
     # do not inline to avoid pytest trying to compute repr of expression.
     # it fails if C++ object gone but not Python object.
     assert _do_not_inline_below == 0


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This is often the thing that if the test is failed, then cleaning of the viewer is failed. At the `make_napari_viewer` fixture is long, most of the error log is occupied by information of failure in the fixture, not the actual error message. 

We also do not clean instances, so the next test crash because of the previous test crash. I have added a clean step to prevent this. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
