### PR TITLE
Fix track ids features ordering for unordered tracks

### DIFF
--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -202,10 +202,10 @@ def test_tracks_length_change():
 def test_track_ids_ordering() -> None:
     """Check if tracks ids are correctly set to features when given not-sorted tracks."""
     # track_id, t, y, x
-    data = np.asarray(
+    unsorted_data = np.asarray(
         [[1, 1, 0, 0], [0, 1, 0, 0], [2, 0, 0, 0], [0, 0, 0, 0], [1, 0, 0, 0]]
     )
-    track_ids = [0, 0, 1, 1, 2]  # track_ids after sorting
+    sorted_track_ids = [0, 0, 1, 1, 2]  # track_ids after sorting
 
-    layer = Tracks(data)
-    assert np.all(track_ids == layer.features["track_id"])
+    layer = Tracks(unsorted_data)
+    assert np.all(sorted_track_ids == layer.features["track_id"])

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -197,3 +197,15 @@ def test_tracks_length_change():
     layer.head_length = track_length
     assert layer.head_length == track_length
     assert layer._max_length == track_length
+
+
+def test_track_ids_ordering() -> None:
+    """Check if tracks ids are correctly set to features when given not-sorted tracks."""
+    # track_id, t, y, x
+    data = np.asarray(
+        [[1, 1, 0, 0], [0, 1, 0, 0], [2, 0, 0, 0], [0, 0, 0, 0], [1, 0, 0, 0]]
+    )
+    track_ids = [0, 0, 1, 1, 2]  # track_ids after sorting
+
+    layer = Tracks(data)
+    assert np.all(track_ids == layer.features["track_id"])

--- a/napari/layers/tracks/_track_utils.py
+++ b/napari/layers/tracks/_track_utils.py
@@ -166,9 +166,9 @@ class TrackManager:
         features: Union[Dict[str, np.ndarray], pd.DataFrame],
     ) -> None:
         self._feature_table.set_values(features, num_data=len(self.data))
+        self._feature_table.reorder(self._order)
         if 'track_id' not in self._feature_table.values:
             self._feature_table.values['track_id'] = self.track_ids
-        self._feature_table.reorder(self._order)
 
     @property
     def properties(self) -> Dict[str, np.ndarray]:


### PR DESCRIPTION
# Description

The tracks layer automatically adds the `track_id` as a feature. This functionality was broken when the provided tracks were not sorted by `track_id` and `time`.

For example, the `example/tracks_2d.py` colored by `track_id` with unsorted data.

https://user-images.githubusercontent.com/21022743/200822355-2adb8c76-ad66-4243-8b37-354a8a7f9624.mp4

## Note

A track layer features are still not idempotent:
```python3
layer = viewer.add_tracks(...)
layer.features   # corrected result
layer.features = layer.features  # sets ordered features
layer.features  # wrong values
```
because the `features` getter returns the ordered features while `features` setter expected the original ordering.
This should be fixed in another PR.

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
- [x] added a regression test for this use case;
- [x] tracks tests pass with my change.

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
