### PR TITLE
Quick silo dev version settings in a dev sub-directory

### DIFF
--- a/napari/utils/_base.py
+++ b/napari/utils/_base.py
@@ -7,8 +7,19 @@ the translator before the settings manager is created.
 
 from appdirs import user_config_dir
 
+from napari._version import __version_tuple__
+
+if 'dev' in str(__version_tuple__):
+    _dev_version_config_dir = 'dev'
+else:
+    _dev_version_config_dir = None
+
 _FILENAME = "settings.yaml"
 _APPNAME = "Napari"
 _APPAUTHOR = "Napari"
 _DEFAULT_LOCALE = "en"
-_DEFAULT_CONFIG_PATH = user_config_dir(_APPNAME, _APPAUTHOR, _FILENAME)
+_DEFAULT_CONFIG_PATH = (
+    user_config_dir(_APPNAME, _APPAUTHOR, _dev_version_config_dir)
+    + '/'
+    + _FILENAME
+)

--- a/napari/utils/_base.py
+++ b/napari/utils/_base.py
@@ -6,12 +6,13 @@ the translator before the settings manager is created.
 """
 
 from appdirs import user_config_dir
-
 from packaging import version
 
 from napari._version import __version__
 
-_dev_version_config_dir = 'dev' if version.parse(__version__).is_devrelease else None
+_dev_version_config_dir = (
+    'dev' if version.parse(__version__).is_devrelease else None
+)
 
 
 _FILENAME = "settings.yaml"

--- a/napari/utils/_base.py
+++ b/napari/utils/_base.py
@@ -7,12 +7,12 @@ the translator before the settings manager is created.
 
 from appdirs import user_config_dir
 
-from napari._version import __version_tuple__
+from packaging import version
 
-if 'dev' in str(__version_tuple__):
-    _dev_version_config_dir = 'dev'
-else:
-    _dev_version_config_dir = None
+from napari._version import __version__
+
+_dev_version_config_dir = 'dev' if version.parse(__version__).is_devrelease else None
+
 
 _FILENAME = "settings.yaml"
 _APPNAME = "Napari"


### PR DESCRIPTION
# Description
In this PR, there is a check to see if the version is a dev version (using `__version_tuple__`) and if so, define the _DEFAULT_CONFIG_PATH used to write settings to include a sub-directory named `dev`.
This effectively silos dev version settings:
- no accommodations are made for reading previous/other napari version settings 
- dev settings will not be read by non-dev napari versions

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
This is an alternative to https://github.com/napari/napari/pull/5306 for addressing https://github.com/napari/napari/issues/5314 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).


Extra note: the current behavior in `napari/utils/_base.py` behavior using `appdirs.user_config_dir` works, but is actually not proper. `appdirs.user_config_dir` is supposed to return a path to a **directory** and at the moment the `version` argument is being passed _FILENAME ("settings.yaml") rather than a version to force a file return.