### PR TITLE
tests: remove private magicgui access in tests

### DIFF
--- a/napari/_tests/test_magicgui.py
+++ b/napari/_tests/test_magicgui.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from magicgui import magicgui
 
-from napari import Viewer, layers, types
+from napari import Viewer, types
 from napari._tests.utils import layer_test_data
 from napari.layers import Image, Labels, Layer
 from napari.utils._proxies import PublicOnlyProxy
@@ -278,38 +278,6 @@ def test_magicgui_get_viewer(make_napari_viewer):
     assert not func.v.visible
     # ensure that viewer2 is still the current viewer
     assert current_viewer() is viewer2
-
-
-MGUI_EXPORTS = ['napari.layers.Layer', 'napari.Viewer']
-MGUI_EXPORTS += [f'napari.types.{nm.title()}Data' for nm in layers.NAMES]
-NAMES = ('Image', 'Labels', 'Layer', 'Points', 'Shapes', 'Surface')
-
-
-@pytest.mark.parametrize('name', sorted(MGUI_EXPORTS))
-def test_mgui_forward_refs(name, monkeypatch):
-    """Test magicgui forward ref annotations
-
-    make sure that calling
-    `magicgui.type_map.pick_widget_type` with the string version of a napari
-    object triggers the appropriate imports to resolve the class in time.
-    """
-    import magicgui.type_map
-
-    monkeypatch.delitem(sys.modules, 'napari')
-    monkeypatch.delitem(sys.modules, 'napari.viewer')
-    monkeypatch.delitem(sys.modules, 'napari.types')
-    # need to clear all of these submodules too, otherise the layers are oddly not
-    # subclasses of napari.layers.Layer, and napari.layers.NAMES
-    # oddly ends up as an empty set
-    for m in list(sys.modules):
-        if m.startswith('napari.layers') and 'utils' not in m:
-            monkeypatch.delitem(sys.modules, m)
-
-    wdg, options = magicgui.type_map.pick_widget_type(annotation=name)
-    if name == 'napari.Viewer':
-        assert wdg == magicgui.widgets.EmptyWidget and 'bind' in options
-    else:
-        assert wdg == magicgui.widgets.Combobox
 
 
 def test_layers_populate_immediately(make_napari_viewer):

--- a/napari/_tests/test_magicgui.py
+++ b/napari/_tests/test_magicgui.py
@@ -295,10 +295,6 @@ def test_mgui_forward_refs(name, monkeypatch):
     """
     import magicgui.type_map
 
-    # clearing out the loaded modules that call magicgui.register_type,
-    # to make sure that when the forward ref is evaluated, those modules get imported
-    # again.
-    monkeypatch.setattr(magicgui.type_map, '_TYPE_DEFS', {})
     monkeypatch.delitem(sys.modules, 'napari')
     monkeypatch.delitem(sys.modules, 'napari.viewer')
     monkeypatch.delitem(sys.modules, 'napari.types')
@@ -309,7 +305,6 @@ def test_mgui_forward_refs(name, monkeypatch):
         if m.startswith('napari.layers') and 'utils' not in m:
             monkeypatch.delitem(sys.modules, m)
 
-    assert magicgui.type_map._TYPE_DEFS == {}
     wdg, options = magicgui.type_map.pick_widget_type(annotation=name)
     if name == 'napari.Viewer':
         assert wdg == magicgui.widgets.EmptyWidget and 'bind' in options

--- a/napari/_tests/test_magicgui.py
+++ b/napari/_tests/test_magicgui.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from magicgui import magicgui
 
-from napari import Viewer, types
+from napari import Viewer, layers, types
 from napari._tests.utils import layer_test_data
 from napari.layers import Image, Labels, Layer
 from napari.utils._proxies import PublicOnlyProxy
@@ -278,6 +278,38 @@ def test_magicgui_get_viewer(make_napari_viewer):
     assert not func.v.visible
     # ensure that viewer2 is still the current viewer
     assert current_viewer() is viewer2
+
+
+MGUI_EXPORTS = ['napari.layers.Layer', 'napari.Viewer']
+MGUI_EXPORTS += [f'napari.types.{nm.title()}Data' for nm in layers.NAMES]
+NAMES = ('Image', 'Labels', 'Layer', 'Points', 'Shapes', 'Surface')
+
+
+@pytest.mark.parametrize('name', sorted(MGUI_EXPORTS))
+def test_mgui_forward_refs(name, monkeypatch):
+    """Test magicgui forward ref annotations
+
+    make sure that calling
+    `magicgui.type_map.pick_widget_type` with the string version of a napari
+    object triggers the appropriate imports to resolve the class in time.
+    """
+    import magicgui.type_map
+
+    monkeypatch.delitem(sys.modules, 'napari')
+    monkeypatch.delitem(sys.modules, 'napari.viewer')
+    monkeypatch.delitem(sys.modules, 'napari.types')
+    # need to clear all of these submodules too, otherise the layers are oddly not
+    # subclasses of napari.layers.Layer, and napari.layers.NAMES
+    # oddly ends up as an empty set
+    for m in list(sys.modules):
+        if m.startswith('napari.layers') and 'utils' not in m:
+            monkeypatch.delitem(sys.modules, m)
+
+    wdg, options = magicgui.type_map.pick_widget_type(annotation=name)
+    if name == 'napari.Viewer':
+        assert wdg == magicgui.widgets.EmptyWidget and 'bind' in options
+    else:
+        assert wdg == magicgui.widgets.Combobox
 
 
 def test_layers_populate_immediately(make_napari_viewer):

--- a/napari/_tests/test_magicgui.py
+++ b/napari/_tests/test_magicgui.py
@@ -290,10 +290,11 @@ def test_mgui_forward_refs(name, monkeypatch):
     """Test magicgui forward ref annotations
 
     make sure that calling
-    `magicgui.type_map.pick_widget_type` with the string version of a napari
+    `magicgui.type_map.get_widget_class` with the string version of a napari
     object triggers the appropriate imports to resolve the class in time.
     """
-    import magicgui.type_map
+    import magicgui.widgets
+    from magicgui.type_map import get_widget_class
 
     monkeypatch.delitem(sys.modules, 'napari')
     monkeypatch.delitem(sys.modules, 'napari.viewer')
@@ -305,7 +306,7 @@ def test_mgui_forward_refs(name, monkeypatch):
         if m.startswith('napari.layers') and 'utils' not in m:
             monkeypatch.delitem(sys.modules, m)
 
-    wdg, options = magicgui.type_map.pick_widget_type(annotation=name)
+    wdg, options = get_widget_class(annotation=name)
     if name == 'napari.Viewer':
         assert wdg == magicgui.widgets.EmptyWidget and 'bind' in options
     else:

--- a/napari/_tests/test_magicgui.py
+++ b/napari/_tests/test_magicgui.py
@@ -287,11 +287,8 @@ NAMES = ('Image', 'Labels', 'Layer', 'Points', 'Shapes', 'Surface')
 
 @pytest.mark.parametrize('name', sorted(MGUI_EXPORTS))
 def test_mgui_forward_refs(name, monkeypatch):
-    """Test magicgui forward ref annotations
-
-    make sure that calling
-    `magicgui.type_map.get_widget_class` with the string version of a napari
-    object triggers the appropriate imports to resolve the class in time.
+    """make sure that magicgui's `get_widget_class` returns the right widget type
+    for the various napari types... even when expressed as strings.
     """
     import magicgui.widgets
     from magicgui.type_map import get_widget_class


### PR DESCRIPTION
# Description
This removes a reference to a private module-level variable in magicgui that is going to be moved in https://github.com/pyapp-kit/magicgui/pull/497/.  It's only used in the tests, and the specific test (resolution of forward references) is well tested on the magicgui side at this point.  So simply removing it is fine