### PR TITLE
Remove internal event connection on SelectableEventedList

### DIFF
--- a/napari/components/_tests/test_layers_list.py
+++ b/napari/components/_tests/test_layers_list.py
@@ -146,7 +146,7 @@ def test_remove_selected():
     layers.remove_selected()
     assert list(layers) == [layer_a, layer_b]
 
-    # select and remove all layersay
+    # select and remove all layers
     layers.select_all()
     layers.remove_selected()
     assert len(layers) == 0

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -93,6 +93,7 @@ class LayerList(SelectableEventedList[Layer]):
             layer._on_selection(False)
 
     def _process_delete_item(self, item: Layer):
+        super()._process_delete_item(item)
         item.events.set_data.disconnect(self._clean_cache)
         self._clean_cache()
 

--- a/napari/utils/events/_tests/test_selectable_list.py
+++ b/napari/utils/events/_tests/test_selectable_list.py
@@ -1,0 +1,33 @@
+from typing import Iterable, TypeVar
+
+from napari.utils.events.containers import SelectableEventedList
+
+T = TypeVar('T')
+
+
+def _make_selectable_list_and_select_first(
+    items: Iterable[T],
+) -> SelectableEventedList[T]:
+    selectable_list = SelectableEventedList(items)
+    first = selectable_list[0]
+    selectable_list.selection = [first]
+    assert first in selectable_list.selection
+    return selectable_list
+
+
+def test_remove_discards_from_selection():
+    selectable_list = _make_selectable_list_and_select_first(['a', 'b', 'c'])
+    selectable_list.remove('a')
+    assert 'a' not in selectable_list.selection
+
+
+def test_pop_discards_from_selection():
+    selectable_list = _make_selectable_list_and_select_first(['a', 'b', 'c'])
+    selectable_list.pop(0)
+    assert 'a' not in selectable_list.selection
+
+
+def test_del_discards_from_selection():
+    selectable_list = _make_selectable_list_and_select_first(['a', 'b', 'c'])
+    del selectable_list[0]
+    assert 'a' not in selectable_list.selection

--- a/napari/utils/events/containers/_evented_list.py
+++ b/napari/utils/events/containers/_evented_list.py
@@ -183,7 +183,7 @@ class EventedList(TypedMutableSequence[_T]):
             self._process_delete_item(item)
             parent.events.removed(index=index, value=item)
 
-    def _process_delete_item(self, item):
+    def _process_delete_item(self, item: _T):
         """Allow process item in inherited class before event was emitted"""
 
     def insert(self, index: int, value: _T):

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -45,9 +45,6 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
     def __init__(self, *args, **kwargs) -> None:
         self._activate_on_insert = True
         super().__init__(*args, **kwargs)
-        self.events.removed.connect(
-            lambda e: self.selection.discard(e.value)
-        )  # FIXME remove lambda
         self.selection._pre_add_hook = self._preselect_hook
 
     def _preselect_hook(self, value):
@@ -61,6 +58,9 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
                 )
             )
         return value
+
+    def _process_delete_item(self, item: _T):
+        self.selection.discard(item)
 
     def insert(self, index: int, value: _T):
         super().insert(index, value)


### PR DESCRIPTION
# Description

We try to avoid internal event connections, likely to avoid circular references. This PR removes such an internal event connection and also closes that particular TODO/FIXME.

It also adds tests to ensure we still get the desired behavior of removing a deleted item from the current selection.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
An alternative to #4534 

# How has this been tested?
- [x] added new tests to cover expected behavior
- [x] all existing tests pass with my change
