### PR TITLE
Disable napari-console if napari launched from vanilla python REPL

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -60,7 +60,12 @@ from napari.settings import get_settings
 from napari.utils import perf
 from napari.utils._proxies import PublicOnlyProxy
 from napari.utils.io import imsave
-from napari.utils.misc import in_ipython, in_jupyter, running_as_bundled_app
+from napari.utils.misc import (
+    in_ipython,
+    in_jupyter,
+    in_python_REPL,
+    running_as_bundled_app,
+)
 from napari.utils.notifications import Notification
 from napari.utils.theme import _themes, get_system_theme
 from napari.utils.translations import trans
@@ -276,7 +281,7 @@ class _QtMainWindow(QMainWindow):
 
         # Toggling the console visibility is disabled when it is not
         # available, so ensure that it is hidden.
-        if in_ipython() or in_jupyter():
+        if in_ipython() or in_jupyter() or in_python_REPL():
             self._qt_viewer.dockConsole.setVisible(False)
 
         if window_fullscreen:

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -63,7 +63,7 @@ from napari.utils.io import imsave
 from napari.utils.misc import (
     in_ipython,
     in_jupyter,
-    in_python_REPL,
+    in_python_repl,
     running_as_bundled_app,
 )
 from napari.utils.notifications import Notification
@@ -281,7 +281,7 @@ class _QtMainWindow(QMainWindow):
 
         # Toggling the console visibility is disabled when it is not
         # available, so ensure that it is hidden.
-        if in_ipython() or in_jupyter() or in_python_REPL():
+        if in_ipython() or in_jupyter() or in_python_repl():
             self._qt_viewer.dockConsole.setVisible(False)
 
         if window_fullscreen:

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -19,7 +19,7 @@ from napari._qt.widgets.qt_spinbox import QtSpinBox
 from napari._qt.widgets.qt_tooltip import QtToolTipLabel
 from napari.utils.action_manager import action_manager
 from napari.utils.interactions import Shortcut
-from napari.utils.misc import in_ipython, in_jupyter, in_python_REPL
+from napari.utils.misc import in_ipython, in_jupyter, in_python_repl
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
@@ -121,7 +121,7 @@ class QtViewerButtons(QFrame):
             'console', action='napari:toggle_console_visibility'
         )
         self.consoleButton.setProperty('expanded', False)
-        if in_ipython() or in_jupyter() or in_python_REPL():
+        if in_ipython() or in_jupyter() or in_python_repl():
             self.consoleButton.setEnabled(False)
 
         rdb = QtViewerPushButton('roll', action='napari:roll_axes')

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -19,7 +19,7 @@ from napari._qt.widgets.qt_spinbox import QtSpinBox
 from napari._qt.widgets.qt_tooltip import QtToolTipLabel
 from napari.utils.action_manager import action_manager
 from napari.utils.interactions import Shortcut
-from napari.utils.misc import in_ipython, in_jupyter
+from napari.utils.misc import in_ipython, in_jupyter, in_python_REPL
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
@@ -121,7 +121,7 @@ class QtViewerButtons(QFrame):
             'console', action='napari:toggle_console_visibility'
         )
         self.consoleButton.setProperty('expanded', False)
-        if in_ipython() or in_jupyter():
+        if in_ipython() or in_jupyter() or in_python_REPL():
             self.consoleButton.setEnabled(False)
 
         rdb = QtViewerPushButton('roll', action='napari:roll_axes')

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -109,7 +109,7 @@ def in_ipython() -> bool:
     return False
 
 
-def in_python_REPL() -> bool:
+def in_python_repl() -> bool:
     """Return true if we're running in a Python REPL."""
     try:
         from IPython import get_ipython

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -110,7 +110,7 @@ def in_ipython() -> bool:
 
 
 def in_python_REPL() -> bool:
-    """Return true if we're running in an Python REPL."""
+    """Return true if we're running in a Python REPL."""
     try:
         from IPython import get_ipython
 

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -109,6 +109,19 @@ def in_ipython() -> bool:
     return False
 
 
+def in_python_REPL() -> bool:
+    """Return true if we're running in an Python REPL."""
+    try:
+        from IPython import get_ipython
+
+        return get_ipython().__class__.__name__ == 'NoneType' and hasattr(
+            sys, 'ps1'
+        )
+    except Exception:
+        pass
+    return False
+
+
 def str_to_rgb(arg):
     """Convert an rgb string 'rgb(x,y,z)' to a list of ints [x,y,z]."""
     return list(


### PR DESCRIPTION
# Description
This PR disables the napari-console if napari is launched from the vanilla python REPL.
For the case of ipython and jupyter this is already the case, so this is adding a function to check that it's the vanilla REPL and then disable the console and the button.
`sys.ps1` is the prompt string of the REPL, see: https://docs.python.org/3/library/sys.html#sys.ps1

This PR aims to prevent that bug from triggering and make the behavior consistent with the other interactive consoles.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
The vanilla REPL is equally interactive plus there is a serious if the napari-console is opened: https://github.com/napari/napari/issues/3338
Fixes https://github.com/napari/napari/issues/3338
See also: https://github.com/napari/napari/pull/4240 and https://github.com/napari/napari/pull/5213


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation: see: https://github.com/napari/docs/pull/53
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
