### PR TITLE
For npe2 plugin, use manifest display_name for File > Open Samples

### DIFF
--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -247,7 +247,8 @@ def widget_iterator() -> Iterator[Tuple[str, Tuple[str, Sequence[str]]]]:
 def sample_iterator() -> Iterator[Tuple[str, Dict[str, SampleDict]]]:
     return (
         (
-            plugin_name,
+            # use display_name for user facing display
+            pm.get_manifest(plugin_name).display_name,
             {
                 c.key: {'data': c.open, 'display_name': c.display_name}
                 for c in contribs

--- a/napari/plugins/_tests/test_npe2.py
+++ b/napari/plugins/_tests/test_npe2.py
@@ -138,6 +138,8 @@ def test_sample_iterator(mock_pm):
     for plugin, contribs in samples:
         assert isinstance(plugin, str)
         assert isinstance(contribs, dict)
+        # check that the manifest display_name is used
+        assert plugin == PLUGIN_DISPLAY_NAME
         assert contribs
         for i in contribs.values():
             assert 'data' in i


### PR DESCRIPTION
# Description
This PR is the 2nd half to https://github.com/napari/napari/pull/5305 aiming to fix: https://github.com/napari/napari/issues/5304
It uses the `display_name` from the npe2 plugin manifest for the name of the plugin shown in the File > Open Sample menu. See:
<img width="486" alt="image" src="https://user-images.githubusercontent.com/76622105/202913755-57106bbb-dbe5-4fbe-b788-92fd6805c6a1.png">
"Hello plugin" is shown instead of `napari-first-try`

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Fixes https://github.com/napari/napari/issues/5304
See also the discussion here: https://github.com/napari/cookiecutter-napari-plugin/issues/126
Also note that the napari-hub has started to use the `display_name` as well:
https://github.com/chanzuckerberg/napari-hub/issues/759#issuecomment-1319221129

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: the test suite for my feature covers cases x, y, and z: I added a check to existing test
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
