### PR TITLE
Fully specify cache path in pip install job

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           python-version: 3.9
           cache: "pip"
-          cache-dependency-path: setup.cfg
+          cache-dependency-path: napari-from-github/setup.cfg
 
       - uses: tlambert03/setup-qt-libs@v1
 


### PR DESCRIPTION
# Description
This updates the cache path for the `setup-python` step of the pip install job in the comprehensive workflow that runs on each commit on `main`. That job has been failing since #5234 was merged.

Based on a quick look at the job and `setup-python` action docs, I think this commit should fix things, though I'm fairly unfamiliar with things here.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
