### PR TITLE
Maint: fix comprehensive test-suite

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           python-version: 3.9
           cache: "pip"
-          cache-dependency-path: setup.cfg
+          cache-dependency-path: napari-from-github/setup.cfg
 
       - uses: tlambert03/setup-qt-libs@v1
 


### PR DESCRIPTION
The cache key was updated for test_pull_request, but not for test comprehensive, leading to main to fail CI for this item.
