### PR TITLE
move disable_notification_dismiss_timer

### DIFF
--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -1,7 +1,6 @@
 import threading
 import warnings
 from concurrent.futures import Future
-from contextlib import suppress
 from dataclasses import dataclass
 from unittest.mock import MagicMock
 
@@ -41,26 +40,6 @@ def _threading_raise():
 
 def _raise():
     raise ValueError("error!")
-
-
-@pytest.fixture(autouse=True)
-def disable_notification_dismiss_timer(monkeypatch):
-    """
-    This fixture disables starting timer for closing notification
-    by setting the value of `NapariQtNotification.DISMISS_AFTER` to 0.
-
-    As Qt timer is realised by thread and keep reference to the object,
-    without increase of reference counter object could be garbage collected and
-    cause segmentation fault error when Qt (C++) code try to access it without
-    checking if Python object exists.
-    """
-
-    with suppress(ImportError):
-        from napari._qt.dialogs.qt_notification import NapariQtNotification
-
-        monkeypatch.setattr(NapariQtNotification, "DISMISS_AFTER", 0)
-        monkeypatch.setattr(NapariQtNotification, "FADE_IN_RATE", 0)
-        monkeypatch.setattr(NapariQtNotification, "FADE_OUT_RATE", 0)
 
 
 @pytest.fixture

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -1,6 +1,7 @@
 import threading
 import warnings
 from concurrent.futures import Future
+from contextlib import suppress
 from dataclasses import dataclass
 from unittest.mock import MagicMock
 
@@ -40,6 +41,26 @@ def _threading_raise():
 
 def _raise():
     raise ValueError("error!")
+
+
+@pytest.fixture(autouse=True)
+def disable_notification_dismiss_timer(monkeypatch):
+    """
+    This fixture disables starting timer for closing notification
+    by setting the value of `NapariQtNotification.DISMISS_AFTER` to 0.
+
+    As Qt timer is realised by thread and keep reference to the object,
+    without increase of reference counter object could be garbage collected and
+    cause segmentation fault error when Qt (C++) code try to access it without
+    checking if Python object exists.
+    """
+
+    with suppress(ImportError):
+        from napari._qt.dialogs.qt_notification import NapariQtNotification
+
+        monkeypatch.setattr(NapariQtNotification, "DISMISS_AFTER", 0)
+        monkeypatch.setattr(NapariQtNotification, "FADE_IN_RATE", 0)
+        monkeypatch.setattr(NapariQtNotification, "FADE_OUT_RATE", 0)
 
 
 @pytest.fixture

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -31,7 +31,6 @@ Notes for using the plugin-related fixtures here:
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import suppress
 
 try:
     __import__('dotenv').load_dotenv()
@@ -415,26 +414,6 @@ def pytest_collection_modifyitems(session, config, items):
                 index = i
         test_order[index].append(item)
     items[:] = list(chain(*test_order))
-
-
-@pytest.fixture(autouse=True)
-def disable_notification_dismiss_timer(monkeypatch):
-    """
-    This fixture disables starting timer for closing notification
-    by setting the value of `NapariQtNotification.DISMISS_AFTER` to 0.
-
-    As Qt timer is realised by thread and keep reference to the object,
-    without increase of reference counter object could be garbage collected and
-    cause segmentation fault error when Qt (C++) code try to access it without
-    checking if Python object exists.
-    """
-
-    with suppress(ImportError):
-        from napari._qt.dialogs.qt_notification import NapariQtNotification
-
-        monkeypatch.setattr(NapariQtNotification, "DISMISS_AFTER", 0)
-        monkeypatch.setattr(NapariQtNotification, "FADE_IN_RATE", 0)
-        monkeypatch.setattr(NapariQtNotification, "FADE_OUT_RATE", 0)
 
 
 @pytest.fixture()

--- a/napari/utils/_tests/test_notification_manager.py
+++ b/napari/utils/_tests/test_notification_manager.py
@@ -1,7 +1,6 @@
 import sys
 import threading
 import warnings
-from contextlib import suppress
 from typing import List
 
 import pytest
@@ -14,26 +13,6 @@ from napari.utils.notifications import (
     show_info,
     show_warning,
 )
-
-
-@pytest.fixture(autouse=True)
-def disable_notification_dismiss_timer(monkeypatch):
-    """
-    This fixture disables starting timer for closing notification
-    by setting the value of `NapariQtNotification.DISMISS_AFTER` to 0.
-
-    As Qt timer is realised by thread and keep reference to the object,
-    without increase of reference counter object could be garbage collected and
-    cause segmentation fault error when Qt (C++) code try to access it without
-    checking if Python object exists.
-    """
-
-    with suppress(ImportError):
-        from napari._qt.dialogs.qt_notification import NapariQtNotification
-
-        monkeypatch.setattr(NapariQtNotification, "DISMISS_AFTER", 0)
-        monkeypatch.setattr(NapariQtNotification, "FADE_IN_RATE", 0)
-        monkeypatch.setattr(NapariQtNotification, "FADE_OUT_RATE", 0)
 
 
 # capsys fixture comes from pytest

--- a/napari/utils/_tests/test_notification_manager.py
+++ b/napari/utils/_tests/test_notification_manager.py
@@ -1,6 +1,7 @@
 import sys
 import threading
 import warnings
+from contextlib import suppress
 from typing import List
 
 import pytest
@@ -13,6 +14,26 @@ from napari.utils.notifications import (
     show_info,
     show_warning,
 )
+
+
+@pytest.fixture(autouse=True)
+def disable_notification_dismiss_timer(monkeypatch):
+    """
+    This fixture disables starting timer for closing notification
+    by setting the value of `NapariQtNotification.DISMISS_AFTER` to 0.
+
+    As Qt timer is realised by thread and keep reference to the object,
+    without increase of reference counter object could be garbage collected and
+    cause segmentation fault error when Qt (C++) code try to access it without
+    checking if Python object exists.
+    """
+
+    with suppress(ImportError):
+        from napari._qt.dialogs.qt_notification import NapariQtNotification
+
+        monkeypatch.setattr(NapariQtNotification, "DISMISS_AFTER", 0)
+        monkeypatch.setattr(NapariQtNotification, "FADE_IN_RATE", 0)
+        monkeypatch.setattr(NapariQtNotification, "FADE_OUT_RATE", 0)
 
 
 # capsys fixture comes from pytest


### PR DESCRIPTION
# Description

`npe2` has checks to ensure a subset of napari tests pass, but this has been breaking lately (see napari/npe2#255 and [this comment](https://github.com/napari/npe2/pull/255#pullrequestreview-1181754313)).

There's a qt dependency getting pulled in when it shouldn't be due to an `autouse` fixture. This PR moves that fixture to `test_qt_notifications.py` which seems more appropriate.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
- [x] all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
