### PR TITLE
Fix warning when fail to import qt binding.

### DIFF
--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -9,7 +9,7 @@ try:
     from qtpy import API_NAME, QT_VERSION, QtCore
 except Exception as e:
     if 'No Qt bindings could be found' in str(e):
-        raise type(e)(
+        raise ImportError(
             trans._(
                 "No Qt bindings could be found.\n\nnapari requires either PyQt5 or PySide2 to be installed in the environment.\nTo install the default backend (currently PyQt5), run \"pip install napari[all]\" \nYou may also use \"pip install napari[pyside2]\"for Pyside2, or \"pip install napari[pyqt5]\" for PyQt5",
                 deferred=True,

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -428,6 +428,10 @@ def disable_notification_dismiss_timer(monkeypatch):
     without increase of reference counter object could be garbage collected and
     cause segmentation fault error when Qt (C++) code try to access it without
     checking if Python object exists.
+
+    This fixture is used in all exceptions because it is not possible to call Qt code
+    from non Qt test by connection of `NapariQtNotification.show_notification` to
+    `NotificationManager` global instance.
     """
 
     with suppress(ImportError):

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -429,7 +429,7 @@ def disable_notification_dismiss_timer(monkeypatch):
     cause segmentation fault error when Qt (C++) code try to access it without
     checking if Python object exists.
 
-    This fixture is used in all exceptions because it is not possible to call Qt code
+    This fixture is used in all tests because it is possible to call Qt code
     from non Qt test by connection of `NapariQtNotification.show_notification` to
     `NotificationManager` global instance.
     """


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

In this PR, I fix raising exceptions when failing to import qt binding (see https://github.com/napari/napari/pull/5376#issuecomment-1335660126)

I also add a comment explaining why the fixture is global. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

alternative to #5376

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
