### PR TITLE
Feature: making the Help menu more helpful via weblinks (re-do of #5094)

### DIFF
--- a/napari/_app_model/_app.py
+++ b/napari/_app_model/_app.py
@@ -7,6 +7,7 @@ from typing import Dict
 from app_model import Application
 
 from napari._app_model._submenus import SUBMENUS
+from napari._app_model.actions._help_actions import HELP_ACTIONS
 from napari._app_model.actions._layer_actions import LAYER_ACTIONS
 from napari._app_model.actions._view_actions import VIEW_ACTIONS
 from napari._app_model.injection._processors import PROCESSORS
@@ -31,7 +32,7 @@ class NapariApplication(Application):
             providers=PROVIDERS, processors=PROCESSORS
         )
 
-        for action in chain(LAYER_ACTIONS, VIEW_ACTIONS):
+        for action in chain(HELP_ACTIONS, LAYER_ACTIONS, VIEW_ACTIONS):
             self.register_action(action)
 
         self.menus.append_menu_items(SUBMENUS)

--- a/napari/_app_model/_tests/test_help_menu_urls.py
+++ b/napari/_app_model/_tests/test_help_menu_urls.py
@@ -1,0 +1,15 @@
+"""For testing the URLs in the Help menu"""
+
+import pytest
+import requests
+
+from napari._app_model.actions._help_actions import HELP_URLS
+
+
+@pytest.mark.parametrize('url', HELP_URLS.keys())
+def test_help_urls(url):
+    if url == 'release_notes':
+        pytest.skip("No release notes for dev version")
+
+    r = requests.head(HELP_URLS[url])
+    r.raise_for_status()

--- a/napari/_app_model/actions/_help_actions.py
+++ b/napari/_app_model/actions/_help_actions.py
@@ -34,6 +34,14 @@ HELP_ACTIONS: List[Action] = [
         menus=[{'id': MenuId.MENUBAR_HELP}],
     ),
     Action(
+        id=CommandId.NAPARI_LAYERS_GUIDE,
+        title=CommandId.NAPARI_LAYERS_GUIDE.title,
+        callback=lambda: webbrowser.open(
+            f'https://napari.org/{VERSION}/howtos/layers/index.html'
+        ),
+        menus=[{'id': MenuId.MENUBAR_HELP}],
+    ),
+    Action(
         id=CommandId.NAPARI_EXAMPLES,
         title=CommandId.NAPARI_EXAMPLES.title,
         callback=lambda: webbrowser.open(

--- a/napari/_app_model/actions/_help_actions.py
+++ b/napari/_app_model/actions/_help_actions.py
@@ -27,12 +27,6 @@ HELP_URLS = {
 
 HELP_ACTIONS: List[Action] = [
     Action(
-        id=CommandId.NAPARI_HOMEPAGE,
-        title=CommandId.NAPARI_HOMEPAGE.title,
-        callback=lambda: webbrowser.open(HELP_URLS['homepage']),
-        menus=[{'id': MenuId.MENUBAR_HELP}],
-    ),
-    Action(
         id=CommandId.NAPARI_GETTING_STARTED,
         title=CommandId.NAPARI_GETTING_STARTED.title,
         callback=lambda: webbrowser.open(HELP_URLS['getting_started']),
@@ -71,5 +65,11 @@ HELP_ACTIONS: List[Action] = [
             HELP_URLS['github_issue'],
         ),
         menus=[{'id': MenuId.MENUBAR_HELP, 'when': VERSION == "dev"}],
+    ),
+    Action(
+        id=CommandId.NAPARI_HOMEPAGE,
+        title=CommandId.NAPARI_HOMEPAGE.title,
+        callback=lambda: webbrowser.open(HELP_URLS['homepage']),
+        menus=[{'id': MenuId.MENUBAR_HELP}],
     ),
 ]

--- a/napari/_app_model/actions/_help_actions.py
+++ b/napari/_app_model/actions/_help_actions.py
@@ -21,10 +21,17 @@ HELP_URLS = {
     "layers_guide": f'https://napari.org/{VERSION}/howtos/layers/index.html',
     "examples_gallery": f'https://napari.org/{VERSION}/gallery.html',
     "release_notes": f'https://napari.org/{VERSION}/release/release_{VERSION.replace(".", "_")}.html',
+    "github_issue": 'https://github.com/napari/napari/issues',
     "homepage": 'https://napari.org',
 }
 
 HELP_ACTIONS: List[Action] = [
+    Action(
+        id=CommandId.NAPARI_HOMEPAGE,
+        title=CommandId.NAPARI_HOMEPAGE.title,
+        callback=lambda: webbrowser.open(HELP_URLS['homepage']),
+        menus=[{'id': MenuId.MENUBAR_HELP}],
+    ),
     Action(
         id=CommandId.NAPARI_GETTING_STARTED,
         title=CommandId.NAPARI_GETTING_STARTED.title,
@@ -55,13 +62,14 @@ HELP_ACTIONS: List[Action] = [
         callback=lambda: webbrowser.open(
             HELP_URLS['release_notes'],
         ),
-        menus=[{'id': MenuId.MENUBAR_HELP}],
-        enablement=VERSION != "dev",
+        menus=[{'id': MenuId.MENUBAR_HELP, 'when': VERSION != "dev"}],
     ),
     Action(
-        id=CommandId.NAPARI_HOMEPAGE,
-        title=CommandId.NAPARI_HOMEPAGE.title,
-        callback=lambda: webbrowser.open(HELP_URLS['homepage']),
-        menus=[{'id': MenuId.MENUBAR_HELP}],
+        id=CommandId.NAPARI_GITHUB_ISSUE,
+        title=CommandId.NAPARI_GITHUB_ISSUE.title,
+        callback=lambda: webbrowser.open(
+            HELP_URLS['github_issue'],
+        ),
+        menus=[{'id': MenuId.MENUBAR_HELP, 'when': VERSION == "dev"}],
     ),
 ]

--- a/napari/_app_model/actions/_help_actions.py
+++ b/napari/_app_model/actions/_help_actions.py
@@ -1,0 +1,30 @@
+"""Actions related to the 'Help' menu that do not require Qt.
+
+View actions that do require Qt should go in
+`napari/_qt/_qapp_model/qactions/_help.py`.
+"""
+import webbrowser
+from typing import List
+
+from app_model.types import Action
+from packaging.version import parse
+
+from napari import __version__
+from napari._app_model.constants import CommandId, MenuId
+
+v = parse(__version__)
+VERSION = "dev" if v.is_devrelease else str(v)
+
+
+def _open_getting_started():
+    webbrowser.open(f'https://napari.org/{VERSION}/tutorials/start_index.html')
+
+
+HELP_ACTIONS: List[Action] = [
+    Action(
+        id=CommandId.NAPARI_GETTING_STARTED,
+        title=CommandId.NAPARI_GETTING_STARTED.title,
+        callback=_open_getting_started,
+        menus=[{'id': MenuId.MENUBAR_HELP}],
+    ),
+]

--- a/napari/_app_model/actions/_help_actions.py
+++ b/napari/_app_model/actions/_help_actions.py
@@ -16,15 +16,43 @@ v = parse(__version__)
 VERSION = "dev" if v.is_devrelease else str(v)
 
 
-def _open_getting_started():
-    webbrowser.open(f'https://napari.org/{VERSION}/tutorials/start_index.html')
-
-
 HELP_ACTIONS: List[Action] = [
     Action(
         id=CommandId.NAPARI_GETTING_STARTED,
         title=CommandId.NAPARI_GETTING_STARTED.title,
-        callback=_open_getting_started,
+        callback=lambda: webbrowser.open(
+            f'https://napari.org/{VERSION}/tutorials/start_index.html'
+        ),
+        menus=[{'id': MenuId.MENUBAR_HELP}],
+    ),
+    Action(
+        id=CommandId.NAPARI_TUTORIALS,
+        title=CommandId.NAPARI_TUTORIALS.title,
+        callback=lambda: webbrowser.open(
+            f'https://napari.org/{VERSION}/tutorials/index.html'
+        ),
+        menus=[{'id': MenuId.MENUBAR_HELP}],
+    ),
+    Action(
+        id=CommandId.NAPARI_EXAMPLES,
+        title=CommandId.NAPARI_EXAMPLES.title,
+        callback=lambda: webbrowser.open(
+            f'https://napari.org/{VERSION}/gallery.html'
+        ),
+        menus=[{'id': MenuId.MENUBAR_HELP}],
+    ),
+    Action(
+        id=CommandId.NAPARI_RELEASE_NOTES,
+        title=CommandId.NAPARI_RELEASE_NOTES.title,
+        callback=lambda: webbrowser.open(
+            f'https://napari.org/{VERSION}/release/release_{VERSION.replace(".", "_")}.html'
+        ),
+        menus=[{'id': MenuId.MENUBAR_HELP}],
+    ),
+    Action(
+        id=CommandId.NAPARI_HOMEPAGE,
+        title=CommandId.NAPARI_HOMEPAGE.title,
+        callback=lambda: webbrowser.open('https://napari.org'),
         menus=[{'id': MenuId.MENUBAR_HELP}],
     ),
 ]

--- a/napari/_app_model/actions/_help_actions.py
+++ b/napari/_app_model/actions/_help_actions.py
@@ -10,7 +10,7 @@ from app_model.types import Action
 from packaging.version import parse
 
 from napari import __version__
-from napari._app_model.constants import CommandId, MenuId
+from napari._app_model.constants import CommandId, MenuGroup, MenuId
 
 v = parse(__version__)
 VERSION = "dev" if v.is_devrelease else str(v)
@@ -56,7 +56,13 @@ HELP_ACTIONS: List[Action] = [
         callback=lambda: webbrowser.open(
             HELP_URLS['release_notes'],
         ),
-        menus=[{'id': MenuId.MENUBAR_HELP, 'when': VERSION != "dev"}],
+        menus=[
+            {
+                'id': MenuId.MENUBAR_HELP,
+                'when': VERSION != "dev",
+                'group': MenuGroup.NAVIGATION,
+            }
+        ],
     ),
     Action(
         id=CommandId.NAPARI_GITHUB_ISSUE,
@@ -64,12 +70,18 @@ HELP_ACTIONS: List[Action] = [
         callback=lambda: webbrowser.open(
             HELP_URLS['github_issue'],
         ),
-        menus=[{'id': MenuId.MENUBAR_HELP, 'when': VERSION == "dev"}],
+        menus=[
+            {
+                'id': MenuId.MENUBAR_HELP,
+                'when': VERSION == "dev",
+                'group': MenuGroup.NAVIGATION,
+            }
+        ],
     ),
     Action(
         id=CommandId.NAPARI_HOMEPAGE,
         title=CommandId.NAPARI_HOMEPAGE.title,
         callback=lambda: webbrowser.open(HELP_URLS['homepage']),
-        menus=[{'id': MenuId.MENUBAR_HELP}],
+        menus=[{'id': MenuId.MENUBAR_HELP, 'group': MenuGroup.NAVIGATION}],
     ),
 ]

--- a/napari/_app_model/actions/_help_actions.py
+++ b/napari/_app_model/actions/_help_actions.py
@@ -15,45 +15,45 @@ from napari._app_model.constants import CommandId, MenuId
 v = parse(__version__)
 VERSION = "dev" if v.is_devrelease else str(v)
 
+HELP_URLS = {
+    "getting_started": f'https://napari.org/{VERSION}/tutorials/start_index.html',
+    "tutorials": f'https://napari.org/{VERSION}/tutorials/index.html',
+    "layers_guide": f'https://napari.org/{VERSION}/howtos/layers/index.html',
+    "examples_gallery": f'https://napari.org/{VERSION}/gallery.html',
+    "release_notes": f'https://napari.org/{VERSION}/release/release_{VERSION.replace(".", "_")}.html',
+    "homepage": 'https://napari.org',
+}
 
 HELP_ACTIONS: List[Action] = [
     Action(
         id=CommandId.NAPARI_GETTING_STARTED,
         title=CommandId.NAPARI_GETTING_STARTED.title,
-        callback=lambda: webbrowser.open(
-            f'https://napari.org/{VERSION}/tutorials/start_index.html'
-        ),
+        callback=lambda: webbrowser.open(HELP_URLS['getting_started']),
         menus=[{'id': MenuId.MENUBAR_HELP}],
     ),
     Action(
         id=CommandId.NAPARI_TUTORIALS,
         title=CommandId.NAPARI_TUTORIALS.title,
-        callback=lambda: webbrowser.open(
-            f'https://napari.org/{VERSION}/tutorials/index.html'
-        ),
+        callback=lambda: webbrowser.open(HELP_URLS['tutorials']),
         menus=[{'id': MenuId.MENUBAR_HELP}],
     ),
     Action(
         id=CommandId.NAPARI_LAYERS_GUIDE,
         title=CommandId.NAPARI_LAYERS_GUIDE.title,
-        callback=lambda: webbrowser.open(
-            f'https://napari.org/{VERSION}/howtos/layers/index.html'
-        ),
+        callback=lambda: webbrowser.open(HELP_URLS['layers_guide']),
         menus=[{'id': MenuId.MENUBAR_HELP}],
     ),
     Action(
         id=CommandId.NAPARI_EXAMPLES,
         title=CommandId.NAPARI_EXAMPLES.title,
-        callback=lambda: webbrowser.open(
-            f'https://napari.org/{VERSION}/gallery.html'
-        ),
+        callback=lambda: webbrowser.open(HELP_URLS['examples_gallery']),
         menus=[{'id': MenuId.MENUBAR_HELP}],
     ),
     Action(
         id=CommandId.NAPARI_RELEASE_NOTES,
         title=CommandId.NAPARI_RELEASE_NOTES.title,
         callback=lambda: webbrowser.open(
-            f'https://napari.org/{VERSION}/release/release_{VERSION.replace(".", "_")}.html'
+            HELP_URLS['release_notes'],
         ),
         menus=[{'id': MenuId.MENUBAR_HELP}],
         enablement=VERSION != "dev",
@@ -61,7 +61,7 @@ HELP_ACTIONS: List[Action] = [
     Action(
         id=CommandId.NAPARI_HOMEPAGE,
         title=CommandId.NAPARI_HOMEPAGE.title,
-        callback=lambda: webbrowser.open('https://napari.org'),
+        callback=lambda: webbrowser.open(HELP_URLS['homepage']),
         menus=[{'id': MenuId.MENUBAR_HELP}],
     ),
 ]

--- a/napari/_app_model/actions/_help_actions.py
+++ b/napari/_app_model/actions/_help_actions.py
@@ -48,6 +48,7 @@ HELP_ACTIONS: List[Action] = [
             f'https://napari.org/{VERSION}/release/release_{VERSION.replace(".", "_")}.html'
         ),
         menus=[{'id': MenuId.MENUBAR_HELP}],
+        enablement=VERSION != "dev",
     ),
     Action(
         id=CommandId.NAPARI_HOMEPAGE,

--- a/napari/_app_model/constants/_commands.py
+++ b/napari/_app_model/constants/_commands.py
@@ -38,6 +38,7 @@ class CommandId(str, Enum):
     # Help menubar
     NAPARI_GETTING_STARTED = 'napari:window:help:getting_started'
     NAPARI_TUTORIALS = 'napari:window:help:tutorials'
+    NAPARI_LAYERS_GUIDE = 'napari:window:help:layers_guide'
     NAPARI_EXAMPLES = 'napari:window:help:examples'
     NAPARI_RELEASE_NOTES = 'napari:window:help:release_notes'
     NAPARI_HOMEPAGE = 'napari:window:help:homepage'
@@ -110,6 +111,7 @@ _COMMAND_INFO = {
     # Help menubar
     CommandId.NAPARI_GETTING_STARTED: _i(trans._('Getting started'), ),
     CommandId.NAPARI_TUTORIALS: _i(trans._('Tutorials'), ),
+    CommandId.NAPARI_LAYERS_GUIDE: _i(trans._('Using Layers Guides'), ),
     CommandId.NAPARI_EXAMPLES: _i(trans._('Examples Gallery'), ),
     CommandId.NAPARI_RELEASE_NOTES: _i(trans._('Release Notes'), ),
     CommandId.NAPARI_HOMEPAGE: _i(trans._('napari homepage'), ),

--- a/napari/_app_model/constants/_commands.py
+++ b/napari/_app_model/constants/_commands.py
@@ -43,6 +43,7 @@ class CommandId(str, Enum):
     NAPARI_RELEASE_NOTES = 'napari:window:help:release_notes'
     NAPARI_HOMEPAGE = 'napari:window:help:homepage'
     NAPARI_INFO = 'napari:window:help:info'
+    NAPARI_GITHUB_ISSUE = 'napari:window:help:github_issue'
     TOGGLE_BUG_REPORT_OPT_IN = 'napari:window:help:bug_report_opt_in'
 
     # Layer menubar
@@ -116,6 +117,7 @@ _COMMAND_INFO = {
     CommandId.NAPARI_RELEASE_NOTES: _i(trans._('Release Notes'), ),
     CommandId.NAPARI_HOMEPAGE: _i(trans._('napari homepage'), ),
     CommandId.NAPARI_INFO: _i(trans._('napari Info'), ),
+    CommandId.NAPARI_GITHUB_ISSUE: _i(trans._('Report a bug on GitHub'), ),
     CommandId.TOGGLE_BUG_REPORT_OPT_IN: _i(trans._('Bug Reporting Opt In/Out...'), ),
 
     # Layer menubar

--- a/napari/_app_model/constants/_commands.py
+++ b/napari/_app_model/constants/_commands.py
@@ -36,6 +36,11 @@ class CommandId(str, Enum):
     TOGGLE_VIEWER_SCALE_BAR_TICKS = 'napari:window:view:toggle_viewer_scale_bar_ticks'
 
     # Help menubar
+    NAPARI_GETTING_STARTED = 'napari:window:help:getting_started'
+    NAPARI_TUTORIALS = 'napari:window:help:tutorials'
+    NAPARI_EXAMPLES = 'napari:window:help:examples'
+    NAPARI_RELEASE_NOTES = 'napari:window:help:release_notes'
+    NAPARI_HOMEPAGE = 'napari:window:help:homepage'
     NAPARI_INFO = 'napari:window:help:info'
     TOGGLE_BUG_REPORT_OPT_IN = 'napari:window:help:bug_report_opt_in'
 
@@ -103,6 +108,11 @@ _COMMAND_INFO = {
     CommandId.TOGGLE_VIEWER_SCALE_BAR_TICKS: _i(trans._('Scale Bar Ticks')),
 
     # Help menubar
+    CommandId.NAPARI_GETTING_STARTED: _i(trans._('Getting started'), ),
+    CommandId.NAPARI_TUTORIALS: _i(trans._('Tutorials'), ),
+    CommandId.NAPARI_EXAMPLES: _i(trans._('Examples Gallery'), ),
+    CommandId.NAPARI_RELEASE_NOTES: _i(trans._('Release Notes'), ),
+    CommandId.NAPARI_HOMEPAGE: _i(trans._('napari homepage'), ),
     CommandId.NAPARI_INFO: _i(trans._('napari Info'), ),
     CommandId.TOGGLE_BUG_REPORT_OPT_IN: _i(trans._('Bug Reporting Opt In/Out...'), ),
 

--- a/napari/_app_model/constants/_commands.py
+++ b/napari/_app_model/constants/_commands.py
@@ -117,7 +117,7 @@ _COMMAND_INFO = {
     CommandId.NAPARI_RELEASE_NOTES: _i(trans._('Release Notes'), ),
     CommandId.NAPARI_HOMEPAGE: _i(trans._('napari homepage'), ),
     CommandId.NAPARI_INFO: _i(trans._('napari Info'), ),
-    CommandId.NAPARI_GITHUB_ISSUE: _i(trans._('Report a bug on GitHub'), ),
+    CommandId.NAPARI_GITHUB_ISSUE: _i(trans._('Report an issue on GitHub'), ),
     CommandId.TOGGLE_BUG_REPORT_OPT_IN: _i(trans._('Bug Reporting Opt In/Out...'), ),
 
     # Layer menubar

--- a/napari/_qt/_qapp_model/qactions/_help.py
+++ b/napari/_qt/_qapp_model/qactions/_help.py
@@ -8,7 +8,7 @@ from typing import List
 
 from app_model.types import Action, KeyBindingRule, KeyCode, KeyMod
 
-from napari._app_model.constants import CommandId, MenuId
+from napari._app_model.constants import CommandId, MenuGroup, MenuId
 from napari._qt.dialogs.qt_about import QtAbout
 from napari._qt.qt_main_window import Window
 from napari.utils.translations import trans
@@ -28,7 +28,7 @@ Q_HELP_ACTIONS: List[Action] = [
         id=CommandId.NAPARI_INFO,
         title=CommandId.NAPARI_INFO.title,
         callback=_show_about,
-        menus=[{"id": MenuId.MENUBAR_HELP}],
+        menus=[{"id": MenuId.MENUBAR_HELP, 'group': MenuGroup.RENDER}],
         status_tip=trans._('About napari'),
         keybindings=[KeyBindingRule(primary=KeyMod.CtrlCmd | KeyCode.Slash)],
     )


### PR DESCRIPTION
# Description
This PR is a re-do of #5096 due to the move to app-model.
It populates the Help menu with links to helpful resources, including the Getting started guide, Layers guides, examples, and release notes (for releases only, disable for dev):
<img width="370" alt="image" src="https://user-images.githubusercontent.com/76622105/206897567-7b974c32-4a1e-4c30-850b-99395705e2ba.png">

While having access to some of these resources within napari could be nice, it seems common across programs I use (e.g. VS Code) for the Help menu to just link out to webpages.
I'm kind of tempted to add: Report Issue linking to GitHub issues?

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes https://github.com/napari/napari/issues/5094

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
