### PR TITLE
Update build_docs workflow

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           # the napari-docs repo is cloned into a docs/ folder, hence the
           # invocation below. Locally, you should simply run make docs
-          run: make -C docs docs
+          run: make -C docs docs GALLERY_PATH=../examples/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
# Description
This updates the Build PR Docs workflow to match [recent changes in `napari/docs`](https://github.com/napari/docs/pull/5).

Maybe there's a better way to sync these workflows between repos - e.g. this repo can get the workflow from the docs repo - but for now this should fix CI.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
Tested workflow in my fork with a successful run: https://github.com/aganders3/napari/actions/runs/3686819198

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
