### PR TITLE
Fix test keybinding for layer actions

### DIFF
--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -83,7 +83,7 @@ class ShortcutEditor(QWidget):
             if len(layer.class_keymap) == 0:
                 actions = {}
             else:
-                actions = action_manager._get_layer_actions(layer)
+                actions = action_manager._get_provider_actions(layer)
                 for name in actions.keys():
                     all_actions.pop(name)
             self.key_bindings_strs[f"{layer.__name__} layer"] = actions

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -16,29 +16,29 @@ from napari.utils._tests.test_naming import eval_with_filename
 from napari.utils.action_manager import action_manager
 
 
-def _get_all_keybinding_methods(type_):
-    obj_methods = set(super(type_, type_).class_keymap.values())
-    obj_methods.update({v.__name__ for v in type_.class_keymap.values()})
-    obj_methods.update(
+def _get_all_keybinding_actions(type_):
+    obj_actions = set(super(type_, type_).class_keymap.values())
+    obj_actions.update({v.__name__ for v in type_.class_keymap.values()})
+    obj_actions.update(
         {
             a.command.__name__
             for a in action_manager._get_layer_actions(type_).values()
         }
     )
-    return obj_methods
+    return obj_actions
 
 
-viewer_methods = _get_all_keybinding_methods(Viewer)
-EXPECTED_NUMBER_OF_VIEWER_METHODS = 14
+viewer_actions = _get_all_keybinding_actions(Viewer)
+EXPECTED_NUMBER_OF_VIEWER_ACTIONS = 14
 
 
-def test_len_methods_viewer(make_napari_viewer):
+def test_len_actions_viewer(make_napari_viewer):
     """
-    Make sure we do find all the methods attached to a viewer via keybindings
+    Make sure we do find all the actions attached to a viewer via keybindings
     """
     _ = make_napari_viewer()
-    viewer_methods = _get_all_keybinding_methods(Viewer)
-    assert len(viewer_methods) == EXPECTED_NUMBER_OF_VIEWER_METHODS
+    viewer_actions = _get_all_keybinding_actions(Viewer)
+    assert len(viewer_actions) == EXPECTED_NUMBER_OF_VIEWER_ACTIONS
 
 
 @pytest.mark.xfail
@@ -47,12 +47,12 @@ def test_non_existing_bindings():
     Those are condition tested in next unittest; but do not exists; this is
     likely due to an oversight somewhere.
     """
-    assert 'play' in [x.__name__ for x in viewer_methods]
-    assert 'toggle_fullscreen' in [x.__name__ for x in viewer_methods]
+    assert 'play' in [x.__name__ for x in viewer_actions]
+    assert 'toggle_fullscreen' in [x.__name__ for x in viewer_actions]
 
 
-@pytest.mark.parametrize('func', viewer_methods)
-def test_viewer_methods(make_napari_viewer, func):
+@pytest.mark.parametrize('func', viewer_actions)
+def test_viewer_actions(make_napari_viewer, func):
     """Test instantiating viewer."""
     viewer = make_napari_viewer()
 
@@ -95,7 +95,7 @@ def test_add_layer(make_napari_viewer, layer_class, data, ndim):
         func(layer)
 
 
-EXPECTED_NUMBER_OF_LAYER_METHODS = {
+EXPECTED_NUMBER_OF_LAYER_ACTIONS = {
     'Image': 5,
     'Vectors': 0,
     'Surface': 0,
@@ -107,14 +107,17 @@ EXPECTED_NUMBER_OF_LAYER_METHODS = {
 
 
 @pytest.mark.parametrize(
-    'cls, expectation', EXPECTED_NUMBER_OF_LAYER_METHODS.items()
+    'cls, expectation', EXPECTED_NUMBER_OF_LAYER_ACTIONS.items()
 )
-def test_expected_number_of_layer_methods(cls, expectation):
+def test_expected_number_of_layer_actions(cls, expectation):
     """
-    Make sure we do find all the methods attached to a layer via keybindings
+    Make sure we do find all the actions attached to a layer via keybindings
     """
-    layer_methods = _get_all_keybinding_methods(getattr(layers, cls))
-    assert len(layer_methods) == expectation
+    layer_actions = _get_all_keybinding_actions(getattr(layers, cls))
+    assert len(layer_actions) == expectation, (
+        # chr(10) is "\n", which can't be used directly in fstrings
+        f'expected {expectation} actions, but got the following:\n{chr(10).join(layer_actions)}'
+    )
 
 
 @pytest.mark.parametrize('layer_class, a_unique_name, ndim', layer_test_data)

--- a/napari/layers/image/_image_key_bindings.py
+++ b/napari/layers/image/_image_key_bindings.py
@@ -34,18 +34,9 @@ def orient_plane_normal_along_x(layer: Image):
     orient_plane_normal_around_cursor(layer, plane_normal=(0, 0, 1))
 
 
+@Image.bind_key(KeyCode.KeyO)
 @register_image_action(trans._('orient plane normal along view direction'))
 def orient_plane_normal_along_view_direction(layer: Image):
-    viewer = napari.viewer.current_viewer()
-    if viewer.dims.ndisplay != 3:
-        return
-    layer.plane.normal = layer._world_to_displayed_data_ray(
-        viewer.camera.view_direction, dims_displayed=[-3, -2, -1]
-    )
-
-
-@Image.bind_key(KeyCode.KeyO)
-def synchronise_plane_normal_with_view_direction(layer: Image):
     viewer = napari.viewer.current_viewer()
     if viewer.dims.ndisplay != 3:
         return
@@ -81,7 +72,7 @@ def hold_to_pan_zoom(layer):
 
 
 @register_image_action(trans._('Transform'))
-def activate_image_select_mode(layer):
+def activate_image_transform_mode(layer):
     layer.mode = Mode.TRANSFORM
 
 

--- a/napari/layers/utils/stack_utils.py
+++ b/napari/layers/utils/stack_utils.py
@@ -94,6 +94,7 @@ def split_channels(
         'metadata',
         'plane',
         'experimental_clipping_planes',
+        'custom_interpolation_kernel',
     }
 
     # turn the kwargs dict into a mapping of {key: iterator}

--- a/napari/layers/utils/stack_utils.py
+++ b/napari/layers/utils/stack_utils.py
@@ -94,7 +94,6 @@ def split_channels(
         'metadata',
         'plane',
         'experimental_clipping_planes',
-        'custom_interpolation_kernel',
     }
 
     # turn the kwargs dict into a mapping of {key: iterator}

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -351,25 +351,25 @@ class ActionManager:
 
         return layer_shortcuts
 
-    def _get_layer_actions(self, layer) -> dict:
+    def _get_provider_actions(self, provider) -> dict:
         """
-        Get actions filtered by the given layer.
+        Get actions filtered by the given provider.
 
         Parameters
         ----------
-        layer : Layer
-            Layer to use for actions filtering.
+        provider : KeymapProvider
+            Provider to use for actions filtering.
 
         Returns
         -------
-        layer_actions: dict
-            Dictionary of names of actions with action values for a layer.
+        provider_actions: dict
+            Dictionary of names of actions with action values for a provider.
 
         """
         return {
             name: action
             for name, action in self._actions.items()
-            if action and layer == action.keymapprovider
+            if action and provider == action.keymapprovider
         }
 
     def _get_active_shortcuts(self, active_keymap):

--- a/napari/utils/shortcuts.py
+++ b/napari/utils/shortcuts.py
@@ -53,6 +53,8 @@ default_shortcuts = {
     'napari:activate_vertex_remove_mode': [KeyCode.Digit1],
     'napari:copy_selected_shapes': [KeyMod.CtrlCmd | KeyCode.KeyC],
     'napari:paste_shape': [KeyMod.CtrlCmd | KeyCode.KeyV],
+    'napari:move_shapes_selection_to_front': [KeyCode.KeyF],
+    'napari:move_shapes_selection_to_back': [KeyCode.KeyB],
     'napari:select_all_shapes': [KeyCode.KeyA],
     'napari:delete_selected_shapes': [
         KeyCode.Backspace,
@@ -66,6 +68,8 @@ default_shortcuts = {
     'napari:transform_active_layer': [
         KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA
     ],
+    'napari:activate_image_pan_zoom_mode': [KeyCode.Digit2],
+    'napari:activate_image_transform_mode': [KeyCode.Digit1],
 }
 
 default_shortcuts = {


### PR DESCRIPTION
# Description
Fixes #5404.

I changed the test so they actually do what they were intended to: ensuring that keybinding existed for each action (rather than having hardcoded numbers like we have now).

To do so I had to programmatically find all relevant actions and shortcuts.

This fixes a few things:
- the result helped me track down a couple of missing shortcuts (which the test was meant to catch) and a quasi-duplicated shortcut for `Image.plane`.
- I found out what the issue was with #5404: layers need to be first instantiated once in order to be correctly populated. Now the test is deterministic. Not sure if we need to somehow fix the behaviour so that instantiation is not required, but that's out of scope for this PR.
- tests are hopefully clearer in intent now that I renamed and restructed them a bit

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
