### PR TITLE
Add options to toggle QtCustomTitleBar

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -933,7 +933,7 @@ class Window:
                 allowed_areas=allowed_areas,
                 shortcut=shortcut,
                 add_vertical_stretch=add_vertical_stretch,
-                add_custom_title_bar=add_custom_title_bar,
+                use_napari_title_bar=use_napari_title_bar,
             )
         else:
             dock_widget = QtViewerDockWidget(

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -943,7 +943,7 @@ class Window:
                 area=area,
                 allowed_areas=allowed_areas,
                 add_vertical_stretch=add_vertical_stretch,
-                add_custom_title_bar=add_custom_title_bar,
+                use_napari_title_bar=use_napari_title_bar,
             )
 
         self._add_viewer_dock_widget(dock_widget, tabify=tabify, menu=menu)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -797,6 +797,7 @@ class Window:
         allowed_areas: Optional[Sequence[str]] = None,
         shortcut=_sentinel,
         add_vertical_stretch=True,
+        add_custom_title_bar=True,
         tabify: bool = False,
         menu: Optional[QMenu] = None,
     ):
@@ -830,6 +831,8 @@ class Window:
                 The shortcut parameter is deprecated since version 0.4.8, please use
                 the action and shortcut manager APIs. The new action manager and
                 shortcut API allow user configuration and localisation.
+        add_custom_title_bar : bool, optional
+            Whether to add a custom title bar with buttons for closing, hiding, and floating the dock widget. By default, True.
         tabify : bool
             Flag to tabify dockwidget or not.
         menu : QMenu, optional
@@ -864,6 +867,7 @@ class Window:
                 allowed_areas=allowed_areas,
                 shortcut=shortcut,
                 add_vertical_stretch=add_vertical_stretch,
+                add_custom_title_bar=add_custom_title_bar,
             )
         else:
             dock_widget = QtViewerDockWidget(
@@ -873,6 +877,7 @@ class Window:
                 area=area,
                 allowed_areas=allowed_areas,
                 add_vertical_stretch=add_vertical_stretch,
+                add_custom_title_bar=add_custom_title_bar,
             )
 
         self._add_viewer_dock_widget(dock_widget, tabify=tabify, menu=menu)

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -897,7 +897,7 @@ class Window:
                 The shortcut parameter is deprecated since version 0.4.8, please use
                 the action and shortcut manager APIs. The new action manager and
                 shortcut API allow user configuration and localisation.
-        add_custom_title_bar : bool, optional
+        use_napari_title_bar : bool, optional
             Whether to add a custom title bar with buttons for closing, hiding, and floating the dock widget. By default, True.
         tabify : bool
             Flag to tabify dockwidget or not.

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -863,7 +863,7 @@ class Window:
         allowed_areas: Optional[Sequence[str]] = None,
         shortcut=_sentinel,
         add_vertical_stretch=True,
-        add_custom_title_bar=True,
+        use_napari_title_bar=True,
         tabify: bool = False,
         menu: Optional[QMenu] = None,
     ):

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -82,8 +82,6 @@ class QtViewerDockWidget(QDockWidget):
         add_vertical_stretch=True,
         add_custom_title_bar=True,
         close_btn=True,
-        hide_btn=True,
-        float_btn=True,
     ):
         self._ref_qt_viewer: 'ReferenceType[QtViewer]' = ref(qt_viewer)
         super().__init__(name)
@@ -91,8 +89,6 @@ class QtViewerDockWidget(QDockWidget):
         self.name = name
         self.add_custom_title_bar = add_custom_title_bar
         self._close_btn = close_btn
-        self._hide_btn = hide_btn
-        self._float_btn = float_btn
 
         areas = {
             'left': Qt.DockWidgetArea.LeftDockWidgetArea,
@@ -161,8 +157,6 @@ class QtViewerDockWidget(QDockWidget):
                 self,
                 title=self.name,
                 close_btn=close_btn,
-                hide_btn=hide_btn,
-                float_btn=float_btn,
             )
             self.setTitleBarWidget(self.title)
         self.visibilityChanged.connect(self._on_visibility_changed)
@@ -293,8 +287,6 @@ class QtViewerDockWidget(QDockWidget):
                     title=self.name,
                     vertical=not self.is_vertical,
                     close_btn=self._close_btn,
-                    hide_btn=self._hide_btn,
-                    float_btn=self._float_btn,
                 )
                 self.setTitleBarWidget(self.title)
 
@@ -325,8 +317,6 @@ class QtCustomTitleBar(QLabel):
         title: str = '',
         vertical=False,
         close_btn=True,
-        hide_btn=True,
-        float_btn=True,
     ):
         super().__init__(parent)
         self.setObjectName("QtCustomTitleBar")
@@ -336,24 +326,6 @@ class QtCustomTitleBar(QLabel):
 
         line = QFrame(self)
         line.setObjectName("QtCustomTitleBarLine")
-
-        if hide_btn:
-            self.hide_button = QPushButton(self)
-            self.hide_button.setToolTip(trans._('hide this panel'))
-            self.hide_button.setObjectName("QTitleBarHideButton")
-            self.hide_button.setCursor(Qt.CursorShape.ArrowCursor)
-            self.hide_button.clicked.connect(lambda: self.parent().close())
-
-        if float_btn:
-            self.float_button = QPushButton(self)
-            self.float_button.setToolTip(trans._('float this panel'))
-            self.float_button.setObjectName("QTitleBarFloatButton")
-            self.float_button.setCursor(Qt.CursorShape.ArrowCursor)
-            self.float_button.clicked.connect(
-                lambda: self.parent().setFloating(
-                    not self.parent().isFloating()
-                )
-            )
 
         self.title: QLabel = QLabel(title, self)
         self.title.setSizePolicy(
@@ -378,14 +350,6 @@ class QtCustomTitleBar(QLabel):
                 layout.addWidget(
                     self.close_button, 0, Qt.AlignmentFlag.AlignHCenter
                 )
-            if hide_btn:
-                layout.addWidget(
-                    self.hide_button, 0, Qt.AlignmentFlag.AlignHCenter
-                )
-            if float_btn:
-                layout.addWidget(
-                    self.float_button, 0, Qt.AlignmentFlag.AlignHCenter
-                )
             layout.addWidget(line, 0, Qt.AlignmentFlag.AlignHCenter)
             self.title.hide()
 
@@ -396,10 +360,6 @@ class QtCustomTitleBar(QLabel):
             line.setFixedHeight(1)
             if close_btn:
                 layout.addWidget(self.close_button)
-            if hide_btn:
-                layout.addWidget(self.hide_button)
-            if float_btn:
-                layout.addWidget(self.float_button)
             layout.addWidget(line)
             layout.addWidget(self.title)
 

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -80,7 +80,7 @@ class QtViewerDockWidget(QDockWidget):
         shortcut=_sentinel,
         object_name: str = '',
         add_vertical_stretch=True,
-        add_custom_title_bar=True,
+        use_napari_title_bar=True,
         close_btn=True,
     ):
         self._ref_qt_viewer: 'ReferenceType[QtViewer]' = ref(qt_viewer)

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -64,6 +64,9 @@ class QtViewerDockWidget(QDockWidget):
         Whether to add stretch to the bottom of vertical widgets (pushing
         widgets up towards the top of the allotted area, instead of letting
         them distribute across the vertical space).  By default, True.
+    add_custom_title_bar : bool, optional
+        Whether to add a custom title bar containing the widget name and
+        buttons for closing, hiding, and floating the dock widget. By default, True.
     """
 
     def __init__(
@@ -77,6 +80,7 @@ class QtViewerDockWidget(QDockWidget):
         shortcut=_sentinel,
         object_name: str = '',
         add_vertical_stretch=True,
+        add_custom_title_bar=True,
         close_btn=True,
         hide_btn=True,
         float_btn=True,
@@ -85,6 +89,7 @@ class QtViewerDockWidget(QDockWidget):
         super().__init__(name)
         self._parent = qt_viewer
         self.name = name
+        self.add_custom_title_bar = add_custom_title_bar
         self._close_btn = close_btn
         self._hide_btn = hide_btn
         self._float_btn = float_btn
@@ -150,15 +155,16 @@ class QtViewerDockWidget(QDockWidget):
         self._features = self.features()
         self.dockLocationChanged.connect(self._set_title_orientation)
 
-        # custom title bar
-        self.title = QtCustomTitleBar(
-            self,
-            title=self.name,
-            close_btn=close_btn,
-            hide_btn=hide_btn,
-            float_btn=float_btn,
-        )
-        self.setTitleBarWidget(self.title)
+        # add custom title bar
+        if add_custom_title_bar:
+            self.title = QtCustomTitleBar(
+                self,
+                title=self.name,
+                close_btn=close_btn,
+                hide_btn=hide_btn,
+                float_btn=float_btn,
+            )
+            self.setTitleBarWidget(self.title)
         self.visibilityChanged.connect(self._on_visibility_changed)
 
     @property
@@ -282,7 +288,7 @@ class QtViewerDockWidget(QDockWidget):
             return
         with qt_signals_blocked(self):
             self.setTitleBarWidget(None)
-            if not self.isFloating():
+            if not self.isFloating() and self.add_custom_title_bar:
                 self.title = QtCustomTitleBar(
                     self,
                     title=self.name,

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -64,7 +64,7 @@ class QtViewerDockWidget(QDockWidget):
         Whether to add stretch to the bottom of vertical widgets (pushing
         widgets up towards the top of the allotted area, instead of letting
         them distribute across the vertical space).  By default, True.
-    add_custom_title_bar : bool, optional
+    use_napari_title_bar : bool, optional
         Whether to add a custom title bar containing the widget name and
         buttons for closing, hiding, and floating the dock widget. By default, True.
     """

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -78,12 +78,16 @@ class QtViewerDockWidget(QDockWidget):
         object_name: str = '',
         add_vertical_stretch=True,
         close_btn=True,
+        hide_btn=True,
+        float_btn=True,
     ):
         self._ref_qt_viewer: 'ReferenceType[QtViewer]' = ref(qt_viewer)
         super().__init__(name)
         self._parent = qt_viewer
         self.name = name
         self._close_btn = close_btn
+        self._hide_btn = hide_btn
+        self._float_btn = float_btn
 
         areas = {
             'left': Qt.DockWidgetArea.LeftDockWidgetArea,
@@ -148,7 +152,11 @@ class QtViewerDockWidget(QDockWidget):
 
         # custom title bar
         self.title = QtCustomTitleBar(
-            self, title=self.name, close_btn=close_btn
+            self,
+            title=self.name,
+            close_btn=close_btn,
+            hide_btn=hide_btn,
+            float_btn=float_btn,
         )
         self.setTitleBarWidget(self.title)
         self.visibilityChanged.connect(self._on_visibility_changed)
@@ -280,6 +288,8 @@ class QtViewerDockWidget(QDockWidget):
                     title=self.name,
                     vertical=not self.is_vertical,
                     close_btn=self._close_btn,
+                    hide_btn=self._hide_btn,
+                    float_btn=self._float_btn,
                 )
                 self.setTitleBarWidget(self.title)
 
@@ -305,7 +315,13 @@ class QtCustomTitleBar(QLabel):
     """
 
     def __init__(
-        self, parent, title: str = '', vertical=False, close_btn=True
+        self,
+        parent,
+        title: str = '',
+        vertical=False,
+        close_btn=True,
+        hide_btn=True,
+        float_btn=True,
     ):
         super().__init__(parent)
         self.setObjectName("QtCustomTitleBar")
@@ -316,19 +332,24 @@ class QtCustomTitleBar(QLabel):
         line = QFrame(self)
         line.setObjectName("QtCustomTitleBarLine")
 
-        self.hide_button = QPushButton(self)
-        self.hide_button.setToolTip(trans._('hide this panel'))
-        self.hide_button.setObjectName("QTitleBarHideButton")
-        self.hide_button.setCursor(Qt.CursorShape.ArrowCursor)
-        self.hide_button.clicked.connect(lambda: self.parent().close())
+        if hide_btn:
+            self.hide_button = QPushButton(self)
+            self.hide_button.setToolTip(trans._('hide this panel'))
+            self.hide_button.setObjectName("QTitleBarHideButton")
+            self.hide_button.setCursor(Qt.CursorShape.ArrowCursor)
+            self.hide_button.clicked.connect(lambda: self.parent().close())
 
-        self.float_button = QPushButton(self)
-        self.float_button.setToolTip(trans._('float this panel'))
-        self.float_button.setObjectName("QTitleBarFloatButton")
-        self.float_button.setCursor(Qt.CursorShape.ArrowCursor)
-        self.float_button.clicked.connect(
-            lambda: self.parent().setFloating(not self.parent().isFloating())
-        )
+        if float_btn:
+            self.float_button = QPushButton(self)
+            self.float_button.setToolTip(trans._('float this panel'))
+            self.float_button.setObjectName("QTitleBarFloatButton")
+            self.float_button.setCursor(Qt.CursorShape.ArrowCursor)
+            self.float_button.clicked.connect(
+                lambda: self.parent().setFloating(
+                    not self.parent().isFloating()
+                )
+            )
+
         self.title: QLabel = QLabel(title, self)
         self.title.setSizePolicy(
             QSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Maximum)
@@ -352,12 +373,14 @@ class QtCustomTitleBar(QLabel):
                 layout.addWidget(
                     self.close_button, 0, Qt.AlignmentFlag.AlignHCenter
                 )
-            layout.addWidget(
-                self.hide_button, 0, Qt.AlignmentFlag.AlignHCenter
-            )
-            layout.addWidget(
-                self.float_button, 0, Qt.AlignmentFlag.AlignHCenter
-            )
+            if hide_btn:
+                layout.addWidget(
+                    self.hide_button, 0, Qt.AlignmentFlag.AlignHCenter
+                )
+            if float_btn:
+                layout.addWidget(
+                    self.float_button, 0, Qt.AlignmentFlag.AlignHCenter
+                )
             layout.addWidget(line, 0, Qt.AlignmentFlag.AlignHCenter)
             self.title.hide()
 
@@ -368,9 +391,10 @@ class QtCustomTitleBar(QLabel):
             line.setFixedHeight(1)
             if close_btn:
                 layout.addWidget(self.close_button)
-
-            layout.addWidget(self.hide_button)
-            layout.addWidget(self.float_button)
+            if hide_btn:
+                layout.addWidget(self.hide_button)
+            if float_btn:
+                layout.addWidget(self.float_button)
             layout.addWidget(line)
             layout.addWidget(self.title)
 

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -169,11 +169,10 @@ class QtViewerDockWidget(QDockWidget):
 
     @property
     def _parent(self):
-        """
-        Let's make sure parent always a weakref:
+        """Let's make sure parent always a weakref:
 
             1) parent is likely to always exists after child
-            2) even if not strictly necessary it make it easier to view reference cycles.
+            2) even if not strictly necessary it makes it easier to view reference cycles.
         """
         return self._ref_parent()
 

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -87,7 +87,7 @@ class QtViewerDockWidget(QDockWidget):
         super().__init__(name)
         self._parent = qt_viewer
         self.name = name
-        self.add_custom_title_bar = add_custom_title_bar
+        self.use_napari_title_bar = use_napari_title_bar
         self._close_btn = close_btn
 
         areas = {

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -171,8 +171,8 @@ class QtViewerDockWidget(QDockWidget):
     def _parent(self):
         """Let's make sure parent always a weakref:
 
-            1) parent is likely to always exists after child
-            2) even if not strictly necessary it makes it easier to view reference cycles.
+        1) parent is likely to always exists after child
+        2) even if not strictly necessary it makes it easier to view reference cycles.
         """
         return self._ref_parent()
 

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -152,13 +152,15 @@ class QtViewerDockWidget(QDockWidget):
         self.dockLocationChanged.connect(self._set_title_orientation)
 
         # add custom title bar
-        if add_custom_title_bar:
+        if use_napari_title_bar:
             self.title = QtCustomTitleBar(
                 self,
                 title=self.name,
                 close_btn=close_btn,
             )
             self.setTitleBarWidget(self.title)
+        else:
+            self.title = None
         self.visibilityChanged.connect(self._on_visibility_changed)
 
     @property

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -318,6 +318,8 @@ class QtCustomTitleBar(QLabel):
         parent,
         title: str = '',
         vertical=False,
+        hide_btn=True,
+        float_btn=True,
         close_btn=True,
     ):
         super().__init__(parent)
@@ -334,6 +336,20 @@ class QtCustomTitleBar(QLabel):
             QSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Maximum)
         )
 
+        self.hide_button = QPushButton(self)
+        self.hide_button.setToolTip(trans._('hide this panel'))
+        self.hide_button.setObjectName("QTitleBarHideButton")
+        self.hide_button.setCursor(Qt.CursorShape.ArrowCursor)
+        self.hide_button.clicked.connect(lambda: self.parent().close())
+
+        self.float_button = QPushButton(self)
+        self.float_button.setToolTip(trans._('float this panel'))
+        self.float_button.setObjectName("QTitleBarFloatButton")
+        self.float_button.setCursor(Qt.CursorShape.ArrowCursor)
+        self.float_button.clicked.connect(
+            lambda: self.parent().setFloating(not self.parent().isFloating())
+        )
+
         if close_btn:
             self.close_button = QPushButton(self)
             self.close_button.setToolTip(trans._('close this panel'))
@@ -348,10 +364,16 @@ class QtCustomTitleBar(QLabel):
             layout.setSpacing(4)
             layout.setContentsMargins(0, 8, 0, 8)
             line.setFixedWidth(1)
-            if close_btn:
+            if hide_btn:
                 layout.addWidget(
-                    self.close_button, 0, Qt.AlignmentFlag.AlignHCenter
+                    self.hide_button, 0, Qt.AlignmentFlag.AlignHCenter
                 )
+            layout.addWidget(
+                self.float_button, 0, Qt.AlignmentFlag.AlignHCenter
+            )
+            layout.addWidget(
+                self.close_button, 0, Qt.AlignmentFlag.AlignHCenter
+            )
             layout.addWidget(line, 0, Qt.AlignmentFlag.AlignHCenter)
             self.title.hide()
 
@@ -360,6 +382,8 @@ class QtCustomTitleBar(QLabel):
             layout.setSpacing(4)
             layout.setContentsMargins(8, 1, 8, 0)
             line.setFixedHeight(1)
+            layout.addWidget(self.hide_button)
+            layout.addWidget(self.float_button)
             if close_btn:
                 layout.addWidget(self.close_button)
             layout.addWidget(line)


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
Adds the option to not render the `hide_btn` and `float_btn` in the QtCustomTitleBar of any widget. Previously this was only possible for the `close_btn`
<!-- Tell us about your new feature, improvement, or fix! -->
Users can now toggle the rendering of `hide_btn` and `float_btn` in QtCustomTitleBar of any widget. For example: 
``` Python
from qtpy import QtWidgets
import napari

viewer = napari.Viewer()
myWidget = QtWidgets.QWidget()
w1 = viewer.window.add_dock_widget(myWidget)

# toggle by setting the respective button to True or False
w1._close_btn = False
w1._hide_btn = True
w1._float_btn = False
```
#4027 added support for the `close_btn` and the feature was also mentioned on [image.sc](https://forum.image.sc/t/can-i-remove-the-close-icon-when-i-create-a-dock-widget-in-the-viewer-with-add-dock-widget/67369/4)

<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->

<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
normal
![all](https://user-images.githubusercontent.com/81212794/207494563-e99996f9-9679-4152-8d41-cebaecfdd031.png)
`_close_btn` hidden
![Screenshot 2022-12-13 194325](https://user-images.githubusercontent.com/81212794/207494564-c7bb7a60-bc63-401e-be6f-3378a86cc932.png)
`_close_btn`  and `_hide_btn` hidden
![Screenshot 2022-12-13 194354](https://user-images.githubusercontent.com/81212794/207494567-f9bb671f-fa8d-44cc-9314-fe7c70451627.png)
`_close_btn`,`_hide_btn`, and `_float_btn` hidden
![Screenshot 2022-12-13 194423](https://user-images.githubusercontent.com/81212794/207494569-e91a24ca-d521-4171-9147-7fdae7095cc5.png)

<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
