### PR TITLE
fix theme id not being used correctly

### DIFF
--- a/napari/_qt/_tests/test_qt_window.py
+++ b/napari/_qt/_tests/test_qt_window.py
@@ -67,7 +67,7 @@ def test_update_theme(
     viewer = make_napari_viewer()
 
     blue = get_theme("dark", False)
-    blue.name = "blue"
+    blue.id = "blue"
     register_theme("blue", blue, "test")
 
     # triggered when theme was added

--- a/napari/_qt/qt_resources/__init__.py
+++ b/napari/_qt/qt_resources/__init__.py
@@ -12,7 +12,7 @@ STYLES = {x.stem: str(x) for x in STYLE_PATH.iterdir() if x.suffix == '.qss'}
 
 
 def get_stylesheet(
-    theme: str = None, extra: Optional[List[str]] = None
+    theme_id: str = None, extra: Optional[List[str]] = None
 ) -> str:
     """Combine all qss files into single, possibly pre-themed, style string.
 
@@ -41,10 +41,10 @@ def get_stylesheet(
             with open(file) as f:
                 stylesheet += f.read()
 
-    if theme:
+    if theme_id:
         from napari.utils.theme import get_theme, template
 
-        return template(stylesheet, **get_theme(theme, as_dict=True))
+        return template(stylesheet, **get_theme(theme_id, as_dict=True))
 
     return stylesheet
 

--- a/napari/_qt/qt_resources/styles/00_base.qss
+++ b/napari/_qt/qt_resources/styles/00_base.qss
@@ -130,7 +130,7 @@ QComboBox::drop-down {
 }
 
 QComboBox::down-arrow {
-   image: url("theme_{{ name }}:/drop_down_50.svg");
+   image: url("theme_{{ id }}:/drop_down_50.svg");
    width: 14px;
    height: 14px;
 }
@@ -241,11 +241,11 @@ QAbstractSpinBox::down-arrow {
 }
 
 QAbstractSpinBox::up-arrow {
-   image: url("theme_{{ name }}:/plus_50.svg");
+   image: url("theme_{{ id }}:/plus_50.svg");
 }
 
 QAbstractSpinBox::down-arrow {
-   image: url("theme_{{ name }}:/minus_50.svg");
+   image: url("theme_{{ id }}:/minus_50.svg");
 }
 
 QLabeledRangeSlider > QAbstractSpinBox {
@@ -278,11 +278,11 @@ QCheckBox::indicator:unchecked {
 }
 
 QCheckBox::indicator:checked {
-  image: url("theme_{{ name }}:/check.svg");
+  image: url("theme_{{ id }}:/check.svg");
 }
 
 QCheckBox::indicator:indeterminate {
-  image: url("theme_{{ name }}:/minus.svg");
+  image: url("theme_{{ id }}:/minus.svg");
   padding: 2px;
   width: 14px;
   height: 14px;
@@ -329,7 +329,7 @@ QRadioButton::indicator::checked {
 }
 
 QRadioButton::indicator::checked {
-  image: url("theme_{{ name }}:/circle.svg");
+  image: url("theme_{{ id }}:/circle.svg");
   height: 6px;
   width: 6px;
   padding: 5px;
@@ -498,19 +498,19 @@ QWidget[emphasized="true"] QScrollBar::sub-line:horizontal:pressed {
 }
 
 QScrollBar:left-arrow:horizontal {
-    image: url("theme_{{ name }}:/left_arrow.svg");
+    image: url("theme_{{ id }}:/left_arrow.svg");
 }
 
 QScrollBar::right-arrow:horizontal {
-    image: url("theme_{{ name }}:/right_arrow.svg");
+    image: url("theme_{{ id }}:/right_arrow.svg");
 }
 
 QScrollBar:up-arrow:vertical {
-    image: url("theme_{{ name }}:/up_arrow.svg");
+    image: url("theme_{{ id }}:/up_arrow.svg");
 }
 
 QScrollBar::down-arrow:vertical {
-    image: url("theme_{{ name }}:/down_arrow.svg");
+    image: url("theme_{{ id }}:/down_arrow.svg");
 }
 
 QScrollBar::left-arrow,

--- a/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -2,7 +2,7 @@
 /* ----------------- Buttons -------------------- */
 
 QtDeleteButton {
-   image: url("theme_{{ name }}:/delete.svg");
+   image: url("theme_{{ id }}:/delete.svg");
    min-width : 28px;
    max-width : 28px;
    min-height : 28px;
@@ -20,51 +20,51 @@ QtViewerPushButton{
 }
 
 QtViewerPushButton[mode="new_points"] {
-  image: url("theme_{{ name }}:/new_points.svg");
+  image: url("theme_{{ id }}:/new_points.svg");
 }
 
 QtViewerPushButton[mode="new_shapes"] {
-  image: url("theme_{{ name }}:/new_shapes.svg");
+  image: url("theme_{{ id }}:/new_shapes.svg");
 }
 
 QtViewerPushButton[mode="warning"] {
-  image: url("theme_{{ name }}:/warning.svg");
+  image: url("theme_{{ id }}:/warning.svg");
 }
 
 QtViewerPushButton[mode="new_labels"] {
-  image: url("theme_{{ name }}:/new_labels.svg");
+  image: url("theme_{{ id }}:/new_labels.svg");
 }
 
 QtViewerPushButton[mode="console"] {
-  image: url("theme_{{ name }}:/console.svg");
+  image: url("theme_{{ id }}:/console.svg");
 }
 
 QtViewerPushButton[mode="roll"] {
-  image: url("theme_{{ name }}:/roll.svg");
+  image: url("theme_{{ id }}:/roll.svg");
 }
 
 QtViewerPushButton[mode="transpose"] {
-  image: url("theme_{{ name }}:/transpose.svg");
+  image: url("theme_{{ id }}:/transpose.svg");
 }
 
 QtViewerPushButton[mode="home"] {
-  image: url("theme_{{ name }}:/home.svg");
+  image: url("theme_{{ id }}:/home.svg");
 }
 
 QtViewerPushButton[mode="ndisplay_button"]:checked {
-  image: url("theme_{{ name }}:/3D.svg");
+  image: url("theme_{{ id }}:/3D.svg");
 }
 
 QtViewerPushButton[mode="ndisplay_button"] {
-  image: url("theme_{{ name }}:/2D.svg");
+  image: url("theme_{{ id }}:/2D.svg");
 }
 
 QtViewerPushButton[mode="grid_view_button"]:checked {
-  image: url("theme_{{ name }}:/square.svg");
+  image: url("theme_{{ id }}:/square.svg");
 }
 
 QtViewerPushButton[mode="grid_view_button"] {
-  image: url("theme_{{ name }}:/grid.svg");
+  image: url("theme_{{ id }}:/grid.svg");
 }
 
 QtModeRadioButton {
@@ -98,88 +98,88 @@ QtModeRadioButton::indicator:unchecked:hover {
 }
 
 QtModeRadioButton[mode="zoom"]::indicator {
-  image: url("theme_{{ name }}:/zoom.svg");
+  image: url("theme_{{ id }}:/zoom.svg");
 }
 
 QtModeRadioButton[mode="select"]::indicator {
-  image: url("theme_{{ name }}:/select.svg");
+  image: url("theme_{{ id }}:/select.svg");
 }
 
 QtModeRadioButton[mode="direct"]::indicator {
-  image: url("theme_{{ name }}:/direct.svg");
+  image: url("theme_{{ id }}:/direct.svg");
 }
 
 QtModeRadioButton[mode="rectangle"]::indicator {
-  image: url("theme_{{ name }}:/rectangle.svg");
+  image: url("theme_{{ id }}:/rectangle.svg");
 }
 
 QtModeRadioButton[mode="ellipse"]::indicator {
-  image: url("theme_{{ name }}:/ellipse.svg");
+  image: url("theme_{{ id }}:/ellipse.svg");
   color: red;
 }
 
 QtModeRadioButton[mode="line"]::indicator {
-  image: url("theme_{{ name }}:/line.svg");
+  image: url("theme_{{ id }}:/line.svg");
 }
 
 QtModeRadioButton[mode="path"]::indicator {
-  image: url("theme_{{ name }}:/path.svg");
+  image: url("theme_{{ id }}:/path.svg");
 }
 
 QtModeRadioButton[mode="polygon"]::indicator {
-  image: url("theme_{{ name }}:/polygon.svg");
+  image: url("theme_{{ id }}:/polygon.svg");
 }
 
 QtModeRadioButton[mode="vertex_insert"]::indicator {
-  image: url("theme_{{ name }}:/vertex_insert.svg");
+  image: url("theme_{{ id }}:/vertex_insert.svg");
 }
 
 QtModeRadioButton[mode="vertex_remove"]::indicator {
-  image: url("theme_{{ name }}:/vertex_remove.svg");
+  image: url("theme_{{ id }}:/vertex_remove.svg");
 }
 
 QtModeRadioButton[mode="paint"]::indicator {
-  image: url("theme_{{ name }}:/paint.svg");
+  image: url("theme_{{ id }}:/paint.svg");
 }
 
 QtModeRadioButton[mode="fill"]::indicator {
-  image: url("theme_{{ name }}:/fill.svg");
+  image: url("theme_{{ id }}:/fill.svg");
 }
 
 QtModeRadioButton[mode="picker"]::indicator {
-  image: url("theme_{{ name }}:/picker.svg");
+  image: url("theme_{{ id }}:/picker.svg");
 }
 
 QtModeRadioButton[mode="erase"]::indicator {
-    image: url("theme_{{ name }}:/erase.svg");
+    image: url("theme_{{ id }}:/erase.svg");
 }
 
 QtModeRadioButton[mode="pan_zoom"]::indicator {
-    image: url("theme_{{ name }}:/zoom.svg");
+    image: url("theme_{{ id }}:/zoom.svg");
 }
 
 QtModeRadioButton[mode="select_points"]::indicator {
-    image: url("theme_{{ name }}:/select.svg");
+    image: url("theme_{{ id }}:/select.svg");
 }
 
 QtModeRadioButton[mode="add_points"]::indicator {
-    image: url("theme_{{ name }}:/add.svg");
+    image: url("theme_{{ id }}:/add.svg");
 }
 
 QtModePushButton[mode="shuffle"] {
-   image: url("theme_{{ name }}:/shuffle.svg");
+   image: url("theme_{{ id }}:/shuffle.svg");
 }
 
 QtModePushButton[mode="move_back"] {
-   image: url("theme_{{ name }}:/move_back.svg");
+   image: url("theme_{{ id }}:/move_back.svg");
 }
 
 QtModePushButton[mode="move_front"] {
-   image: url("theme_{{ name }}:/move_front.svg");
+   image: url("theme_{{ id }}:/move_front.svg");
 }
 
 QtModePushButton[mode="delete_shape"] {
-   image: url("theme_{{ name }}:/delete_shape.svg");
+   image: url("theme_{{ id }}:/delete_shape.svg");
 }
 
 QWidget[emphasized="true"] QtModePushButton[mode="delete_shape"]:pressed {
@@ -200,7 +200,7 @@ QtCopyToClipboardButton {
 }
 
 #QtCopyToClipboardButton {
-  image: url("theme_{{ name }}:/copy_to_clipboard.svg");
+  image: url("theme_{{ id }}:/copy_to_clipboard.svg");
 }
 
 QtPlayButton {
@@ -213,12 +213,12 @@ QtPlayButton {
 }
 
 QtPlayButton[reverse=True] {
-    image: url("theme_{{ name }}:/left_arrow.svg");
+    image: url("theme_{{ id }}:/left_arrow.svg");
 }
 
 QtPlayButton[reverse=False] {
   background: {{ foreground }};
-  image: url("theme_{{ name }}:/right_arrow.svg");
+  image: url("theme_{{ id }}:/right_arrow.svg");
 }
 
 QtPlayButton[reverse=True]:hover, QtPlayButton[reverse=False]:hover {
@@ -230,7 +230,7 @@ QtPlayButton[playing=True]:hover {
 }
 
 QtPlayButton[playing=True] {
-    image: url("theme_{{ name }}:/square.svg");
+    image: url("theme_{{ id }}:/square.svg");
     background-color: {{ warning }};
     height: 12px;
     width: 12px;

--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -44,11 +44,11 @@ QMainWindow::separator:hover {
 }
 
 QMainWindow::separator:horizontal {
-  image: url("theme_{{ name }}:/horizontal_separator.svg");
+  image: url("theme_{{ id }}:/horizontal_separator.svg");
 }
 
 QMainWindow::separator:vertical {
-  image: url("theme_{{ name }}:/vertical_separator.svg");
+  image: url("theme_{{ id }}:/vertical_separator.svg");
 }
 
 /* ------------- DockWidgets --------- */
@@ -85,19 +85,19 @@ QMainWindow::separator:vertical {
     width: 12px;
     height: 12px;
     padding: 0;
-    image: url("theme_{{ name }}:/delete_shape.svg");
+    image: url("theme_{{ id }}:/delete_shape.svg");
 }
 
 
 #QTitleBarFloatButton{
-    image: url("theme_{{ name }}:/pop_out.svg");
+    image: url("theme_{{ id }}:/pop_out.svg");
     width: 10px;
     height: 8px;
     padding: 2 1 2 1;
 }
 
 #QTitleBarHideButton{
-    image: url("theme_{{ name }}:/visibility_off.svg");
+    image: url("theme_{{ id }}:/visibility_off.svg");
     width: 10px;
     height: 8px;
     padding: 2 1 2 1;
@@ -216,11 +216,11 @@ QtLayerWidget > QCheckBox#visibility::indicator{
 }
 
 QtLayerWidget > QCheckBox#visibility::indicator:unchecked {
-  image: url("theme_{{ name }}:/visibility_off_50.svg");
+  image: url("theme_{{ id }}:/visibility_off_50.svg");
 }
 
 QtLayerWidget > QCheckBox#visibility::indicator:checked {
-  image: url("theme_{{ name }}:/visibility.svg");
+  image: url("theme_{{ id }}:/visibility.svg");
 }
 
 
@@ -233,35 +233,35 @@ QLabel[layer_type_label="true"] {
 }
 
 QLabel#Shapes {
-  image: url("theme_{{ name }}:/new_shapes.svg");
+  image: url("theme_{{ id }}:/new_shapes.svg");
 }
 
 QLabel#Points {
-  image: url("theme_{{ name }}:/new_points.svg");
+  image: url("theme_{{ id }}:/new_points.svg");
 }
 
 QLabel#Labels {
-  image: url("theme_{{ name }}:/new_labels.svg");
+  image: url("theme_{{ id }}:/new_labels.svg");
 }
 
 QLabel#Image {
-  image: url("theme_{{ name }}:/new_image.svg");
+  image: url("theme_{{ id }}:/new_image.svg");
 }
 
 QLabel#Multiscale {
-  image: url("theme_{{ name }}:/new_image.svg");
+  image: url("theme_{{ id }}:/new_image.svg");
 }
 
 QLabel#Surface {
-  image: url("theme_{{ name }}:/new_surface.svg");
+  image: url("theme_{{ id }}:/new_surface.svg");
 }
 
 QLabel#Vectors {
-  image: url("theme_{{ name }}:/new_vectors.svg");
+  image: url("theme_{{ id }}:/new_vectors.svg");
 }
 
 QLabel#logo_silhouette {
-  image: url("theme_{{ name }}:/logo_silhouette.svg");
+  image: url("theme_{{ id }}:/logo_silhouette.svg");
 }
 
 
@@ -344,11 +344,11 @@ QtDimSliderWidget > QScrollBar::handle[last_used=true]:horizontal {
 }
 
 QtDimSliderWidget > QScrollBar:left-arrow:horizontal {
-    image: url("theme_{{ name }}:/step_left.svg");
+    image: url("theme_{{ id }}:/step_left.svg");
 }
 
 QtDimSliderWidget > QScrollBar::right-arrow:horizontal {
-    image: url("theme_{{ name }}:/step_right.svg");
+    image: url("theme_{{ id }}:/step_right.svg");
 }
 
 QtDimSliderWidget > QLineEdit {
@@ -372,7 +372,7 @@ QtDimSliderWidget > QLineEdit {
 }
 
 #playDirectionCheckBox::indicator {
-   image: url("theme_{{ name }}:/long_right_arrow.svg");
+   image: url("theme_{{ id }}:/long_right_arrow.svg");
    width: 22px;
    height: 22px;
    padding: 0 6px;
@@ -384,7 +384,7 @@ QtDimSliderWidget > QLineEdit {
 }
 
 #playDirectionCheckBox::indicator:checked {
-   image: url("theme_{{ name }}:/long_left_arrow.svg");
+   image: url("theme_{{ id }}:/long_left_arrow.svg");
 }
 
 #playDirectionCheckBox::indicator:pressed {
@@ -503,17 +503,17 @@ NapariQtNotification #expand_button {
 }
 
 NapariQtNotification[expanded="false"] #expand_button {
-  image: url("theme_{{ name }}:/chevron_up.svg");
+  image: url("theme_{{ id }}:/chevron_up.svg");
 }
 
 NapariQtNotification[expanded="true"] #expand_button {
-  image: url("theme_{{ name }}:/chevron_down.svg");
+  image: url("theme_{{ id }}:/chevron_down.svg");
 }
 
 
 NapariQtNotification #close_button {
   background: none;
-  image: url("theme_{{ name }}:/delete_shape.svg");
+  image: url("theme_{{ id }}:/delete_shape.svg");
   padding: 0px;
   margin: 0px;
   max-width: 20px;
@@ -566,7 +566,7 @@ PluginListItem#unavailable {
 
 PluginListItem QCheckBox::indicator:disabled {
   background-color: {{ opacity(foreground, 127) }};
-  image: url("theme_{{ name }}:/check_50.svg");
+  image: url("theme_{{ id }}:/check_50.svg");
 }
 
 QPushButton#install_button {
@@ -635,14 +635,14 @@ QPushButton#close_button:disabled {
 }
 
 #info_icon {
-  image: url("theme_{{ name }}:/info.svg");
+  image: url("theme_{{ id }}:/info.svg");
   min-width: 18px;
   min-height: 18px;
   margin: 2px;
 }
 
 #warning_icon {
-  image: url("theme_{{ name }}:/warning.svg");
+  image: url("theme_{{ id }}:/warning.svg");
   max-width: 14px;
   max-height: 14px;
   min-width: 14px;
@@ -662,7 +662,7 @@ QPushButton#close_button:disabled {
 }
 
 #error_label {
-  image: url("theme_{{ name }}:/warning.svg");
+  image: url("theme_{{ id }}:/warning.svg");
   max-width: 18px;
   max-height: 18px;
   min-width: 18px;
@@ -673,7 +673,7 @@ QPushButton#close_button:disabled {
 }
 
 #help_label {
-  image: url("theme_{{ name }}:/help.svg");
+  image: url("theme_{{ id }}:/help.svg");
   max-width: 18px;
   max-height: 18px;
   min-width: 18px;
@@ -791,31 +791,31 @@ QtLayerList::indicator {
   height: 16px;
   position: absolute;
   left: 0px;
-  image: url("theme_{{ name }}:/visibility_off.svg");
+  image: url("theme_{{ id }}:/visibility_off.svg");
 }
 
 QtLayerList::indicator:unchecked {
-  image: url("theme_{{ name }}:/visibility_off_50.svg");
+  image: url("theme_{{ id }}:/visibility_off_50.svg");
   
 }
 
 QtLayerList::indicator:checked {
-  image: url("theme_{{ name }}:/visibility.svg");
+  image: url("theme_{{ id }}:/visibility.svg");
 }
 
 
 #warning_icon_btn {
-  qproperty-icon: url("theme_{{ name }}:/warning.svg");
+  qproperty-icon: url("theme_{{ id }}:/warning.svg");
 }
 
 #warning_icon_element {
-  image: url("theme_{{ name }}:/warning.svg");
+  image: url("theme_{{ id }}:/warning.svg");
   min-height: 36px;
   min-width: 36px;
 }
 
 #error_icon_element {
-  image: url("theme_{{ name }}:/error.svg");
+  image: url("theme_{{ id }}:/error.svg");
   min-height: 36px;
   min-width: 36px;
 }

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -368,11 +368,12 @@ class NapariPluginManager(PluginManager):
             return
 
         _data = {}
-        for theme_name, theme_colors in data.items():
+        for theme_id, theme_colors in data.items():
+            print(theme_colors)
             try:
                 theme = Theme.parse_obj(theme_colors)
-                register_theme(theme_name, theme, plugin_name)
-                _data[theme_name] = theme
+                register_theme(theme_id, theme, plugin_name)
+                _data[theme_id] = theme
             except (KeyError, ValidationError) as err:
                 warn_msg = trans._(
                     "In {hook_name!r}, plugin {plugin_name!r} provided an invalid dict object for creating themes. {err!r}",
@@ -394,8 +395,8 @@ class NapariPluginManager(PluginManager):
             return
 
         # unregister all themes that were provided by the plugins
-        for theme_name in self._theme_data[plugin_name]:
-            unregister_theme(theme_name)
+        for theme_id in self._theme_data[plugin_name]:
+            unregister_theme(theme_id)
 
         # since its possible that disabled/removed plugin was providing the
         # current theme, we check for this explicitly and if this the case,

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -369,7 +369,6 @@ class NapariPluginManager(PluginManager):
 
         _data = {}
         for theme_id, theme_colors in data.items():
-            print(theme_colors)
             try:
                 theme = Theme.parse_obj(theme_colors)
                 register_theme(theme_id, theme, plugin_name)

--- a/napari/utils/_tests/test_theme.py
+++ b/napari/utils/_tests/test_theme.py
@@ -127,26 +127,28 @@ def test_theme_syntax_highlight():
 
 
 def test_is_theme_available(tmp_path, monkeypatch):
-    (tmp_path / "blue").mkdir()
+    (tmp_path / "test_blue").mkdir()
     (tmp_path / "yellow").mkdir()
-    (tmp_path / "blue" / PLUGIN_FILE_NAME).write_text("test-blue")
+    (tmp_path / "test_blue" / PLUGIN_FILE_NAME).write_text("test-blue")
     monkeypatch.setattr(
         "napari.utils.theme._theme_path", lambda x: tmp_path / x
     )
 
+    n_themes = len(available_themes())
+
     def mock_install_theme(_themes):
         theme_dict = _themes["dark"].dict()
-        theme_dict["name"] = "blue"
-        register_theme("blue", theme_dict, "test")
+        theme_dict["id"] = "test_blue"
+        register_theme("test_blue", theme_dict, "test")
 
     monkeypatch.setattr(
         "napari.utils.theme._install_npe2_themes", mock_install_theme
     )
 
-    assert len(available_themes()) == 3
+    assert len(available_themes()) == n_themes
     assert is_theme_available("dark")
     assert not is_theme_available("green")
     assert not is_theme_available("yellow")
-    assert is_theme_available("blue")
-    assert len(available_themes()) == 4
-    assert "blue" in available_themes()
+    assert is_theme_available("test_blue")
+    assert len(available_themes()) == n_themes + 1
+    assert "test_blue" in available_themes()

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -60,6 +60,7 @@ class Theme(EventedModel):
     """
 
     id: str
+    label: str
     syntax_style: str
     canvas: Color
     console: Color
@@ -323,6 +324,7 @@ def rebuild_theme_settings():
 
 DARK = Theme(
     id='dark',
+    label='Default Dark',
     background='rgb(38, 41, 48)',
     foreground='rgb(65, 72, 81)',
     primary='rgb(90, 98, 108)',
@@ -338,6 +340,7 @@ DARK = Theme(
 )
 LIGHT = Theme(
     id='light',
+    label='Default Light',
     background='rgb(239, 235, 233)',
     foreground='rgb(214, 208, 206)',
     primary='rgb(188, 184, 181)',

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -34,7 +34,7 @@ class Theme(EventedModel):
 
     Attributes
     ----------
-    name : str
+    id : str
         Name of the virtual folder where icons will be saved to.
     syntax_style : str
         Name of the console style.
@@ -59,7 +59,7 @@ class Theme(EventedModel):
         Color used to highlight Qt widget.
     """
 
-    name: str
+    id: str
     syntax_style: str
     canvas: Color
     console: Color
@@ -173,15 +173,15 @@ def template(css: str, **theme):
 def get_system_theme() -> str:
     """Return the system default theme, either 'dark', or 'light'."""
     try:
-        name = darkdetect.theme().lower()
+        id = darkdetect.theme().lower()
     except Exception:
-        name = "dark"
+        id = "dark"
 
-    return name
+    return id
 
 
-def get_theme(name, as_dict=None):
-    """Get a copy of theme based on it's name.
+def get_theme(id, as_dict=None):
+    """Get a copy of theme based on it's id.
 
     If you get a copy of the theme, changes to the theme model will not be
     reflected in the UI unless you replace or add the modified theme to
@@ -189,8 +189,8 @@ def get_theme(name, as_dict=None):
 
     Parameters
     ----------
-    name : str
-        Name of requested theme.
+    id : str
+        ID of requested theme.
     as_dict : bool
         Flag to indicate that the old-style dictionary
         should be returned. This will emit deprecation warning.
@@ -202,19 +202,19 @@ def get_theme(name, as_dict=None):
         so that manipulating this theme can be done without
         side effects.
     """
-    if name == "system":
-        name = get_system_theme()
+    if id == "system":
+        id = get_system_theme()
 
-    if name not in _themes:
+    if id not in _themes:
         raise ValueError(
             trans._(
-                "Unrecognized theme {name}. Available themes are {themes}",
+                "Unrecognized theme {id}. Available themes are {themes}",
                 deferred=True,
-                name=name,
+                id=id,
                 themes=available_themes(),
             )
         )
-    theme = _themes[name]
+    theme = _themes[id]
     _theme = theme.copy()
     if as_dict is None:
         warnings.warn(
@@ -240,13 +240,13 @@ def get_theme(name, as_dict=None):
 _themes: EventedDict[str, Theme] = EventedDict(basetype=Theme)
 
 
-def register_theme(name, theme, source):
+def register_theme(id, theme, source):
     """Register a new or updated theme.
 
     Parameters
     ----------
-    name : str
-        Name of requested theme.
+    id : str
+        id of requested theme.
     theme : dict of str: str, Theme
         Theme mapping elements to colors.
     source : str
@@ -255,20 +255,20 @@ def register_theme(name, theme, source):
     if isinstance(theme, dict):
         theme = Theme(**theme)
     assert isinstance(theme, Theme)
-    _themes[name] = theme
+    _themes[id] = theme
 
-    build_theme_svgs(name, source)
+    build_theme_svgs(id, source)
 
 
-def unregister_theme(name):
+def unregister_theme(id):
     """Remove existing theme.
 
     Parameters
     ----------
-    name : str
-        Name of the theme to be removed.
+    id : str
+        id of the theme to be removed.
     """
-    _themes.pop(name, None)
+    _themes.pop(id, None)
 
 
 def available_themes():
@@ -277,28 +277,28 @@ def available_themes():
     Returns
     -------
     list of str
-        Names of available themes.
+        ids of available themes.
     """
     return tuple(_themes) + ("system",)
 
 
-def is_theme_available(name):
+def is_theme_available(id):
     """Check if a theme is available.
 
     Parameters
     ----------
-    name : str
-        Name of requested theme.
+    id : str
+        id of requested theme.
 
     Returns
     -------
     bool
         True if the theme is available, False otherwise.
     """
-    if name == "system":
+    if id == "system":
         return True
-    if name not in _themes and _theme_path(name).exists():
-        plugin_name_file = _theme_path(name) / PLUGIN_FILE_NAME
+    if id not in _themes and _theme_path(id).exists():
+        plugin_name_file = _theme_path(id) / PLUGIN_FILE_NAME
         if not plugin_name_file.exists():
             return False
         plugin_name = plugin_name_file.read_text()
@@ -306,7 +306,7 @@ def is_theme_available(name):
             npe2.PluginManager.instance().register(plugin_name)
         _install_npe2_themes(_themes)
 
-    return name in _themes
+    return id in _themes
 
 
 def rebuild_theme_settings():
@@ -322,7 +322,7 @@ def rebuild_theme_settings():
 
 
 DARK = Theme(
-    name='dark',
+    id='dark',
     background='rgb(38, 41, 48)',
     foreground='rgb(65, 72, 81)',
     primary='rgb(90, 98, 108)',
@@ -337,7 +337,7 @@ DARK = Theme(
     canvas='black',
 )
 LIGHT = Theme(
-    name='light',
+    id='light',
     background='rgb(239, 235, 233)',
     foreground='rgb(214, 208, 206)',
     primary='rgb(188, 184, 181)',
@@ -366,8 +366,13 @@ def _install_npe2_themes(themes=None):
         disabled=False
     ):
         for theme in manifest.contributions.themes or ():
+            # get fallback values
             theme_dict = themes[theme.type].dict()
-            theme_dict.update(theme.colors.dict(exclude_unset=True))
+            # update available values
+            theme_info = theme.dict(exclude={'colors'}, exclude_unset=True)
+            theme_colors = theme.colors.dict(exclude_unset=True)
+            theme_dict.update(theme_info)
+            theme_dict.update(theme_colors)
             register_theme(theme.id, theme_dict, manifest.name)
 
 

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -35,7 +35,10 @@ class Theme(EventedModel):
     Attributes
     ----------
     id : str
-        Name of the virtual folder where icons will be saved to.
+        id of the theme and name of the virtual folder where icons
+        will be saved to.
+    label : str
+        Name of the theme as it should be shown in the ui.
     syntax_style : str
         Name of the console style.
         See for more details: https://pygments.org/docs/styles/


### PR DESCRIPTION
As discussed in [this zulip conversation](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/theme.20not.20respected.20in.20qss), napari is currently not respecting icons when it comes to theme contributions.

Turns out, the `theme_dict` was constructed by updating the base theme of the same type (`dark` or `light`) with the new values, but only the colors were being updated, leaving any non-color contribution the same (such as the theme `name` [which I renamed `id` for consistency with the schema; this made it harder to debug]). Since `name` was left to `dark`, and this was the field used to pick the correct generated icons, we ended up with a half theme.

The only "real" changes here (among the many variable renames) are inside `utils/theme.py`:
- `label` is now read from the contribution instead of ignored (though it's not used anywhere in napari yet)
- the dict is updated with all the contribution info, see at the bottom of the file

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
