### PR TITLE
Fix flaky dims playback test by waiting for playing condition

### DIFF
--- a/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -279,15 +279,19 @@ def test_play_button(qtbot):
     ndim = 3
     view = QtDims(Dims(ndim=ndim))
     qtbot.addWidget(view)
-    button = view.slider_widgets[0].play_button
+    slider = view.slider_widgets[0]
+    button = slider.play_button
 
-    # Cannot wait for the view._animation_thread.started signal here because
-    # _animation_thread will be None before the mouse is clicked.
+    # Need looping playback so that it does not stop before we can assert that.
+    assert slider.loop_mode == 'loop'
     assert not view.is_playing
-    qtbot.mouseClick(button, Qt.LeftButton)
-    qtbot.waitUntil(lambda: view.is_playing)
 
-    with qtbot.waitSignal(view._animation_thread.finished):
+    with qtbot.waitSignal(slider.play_started):
+        qtbot.mouseClick(button, Qt.LeftButton)
+
+    assert view.is_playing
+
+    with qtbot.waitSignal(slider.play_stopped):
         qtbot.mouseClick(button, Qt.LeftButton)
 
     assert not view.is_playing

--- a/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -287,7 +287,7 @@ def test_play_button(qtbot):
     assert not view.is_playing
 
     qtbot.mouseClick(button, Qt.LeftButton)
-    qtbot.waitUntil(view.is_playing)
+    qtbot.waitUntil(lambda: view.is_playing)
 
     qtbot.mouseClick(button, Qt.LeftButton)
     qtbot.waitUntil(lambda: not view.is_playing)

--- a/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -287,7 +287,7 @@ def test_play_button(qtbot):
     assert not view.is_playing
 
     qtbot.mouseClick(button, Qt.LeftButton)
-    qtbot.waitUntil(lambda: view.is_playing)
+    qtbot.waitUntil(view.is_playing)
 
     qtbot.mouseClick(button, Qt.LeftButton)
     qtbot.waitUntil(lambda: not view.is_playing)

--- a/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -280,10 +280,14 @@ def test_play_button(qtbot):
     view = QtDims(Dims(ndim=ndim))
     qtbot.addWidget(view)
     button = view.slider_widgets[0].play_button
-    qtbot.mouseClick(button, Qt.LeftButton)
-    qtbot.waitSignal(view._animation_thread.started, timeout=5000)
 
-    with qtbot.waitSignal(view._animation_thread.finished, timeout=7000):
+    # Cannot wait for the view._animation_thread.started signal here because
+    # _animation_thread will be None before the mouse is clicked.
+    assert not view.is_playing
+    qtbot.mouseClick(button, Qt.LeftButton)
+    qtbot.waitUntil(lambda: view.is_playing)
+
+    with qtbot.waitSignal(view._animation_thread.finished):
         qtbot.mouseClick(button, Qt.LeftButton)
 
     assert not view.is_playing

--- a/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -291,6 +291,7 @@ def test_play_button(qtbot):
 
     qtbot.mouseClick(button, Qt.LeftButton)
     qtbot.waitUntil(lambda: not view.is_playing)
+    qtbot.waitUntil(lambda: view._animation_worker is None)
 
     with patch.object(button.popup, 'show_above_mouse') as mock_popup:
         qtbot.mouseClick(button, Qt.RightButton)

--- a/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -286,15 +286,11 @@ def test_play_button(qtbot):
     assert slider.loop_mode == 'loop'
     assert not view.is_playing
 
-    with qtbot.waitSignal(slider.play_started):
-        qtbot.mouseClick(button, Qt.LeftButton)
+    qtbot.mouseClick(button, Qt.LeftButton)
+    qtbot.waitUntil(lambda: view.is_playing)
 
-    assert view.is_playing
-
-    with qtbot.waitSignal(slider.play_stopped):
-        qtbot.mouseClick(button, Qt.LeftButton)
-
-    assert not view.is_playing
+    qtbot.mouseClick(button, Qt.LeftButton)
+    qtbot.waitUntil(lambda: not view.is_playing)
 
     with patch.object(button.popup, 'show_above_mouse') as mock_popup:
         qtbot.mouseClick(button, Qt.RightButton)

--- a/napari/_qt/widgets/qt_dims.py
+++ b/napari/_qt/widgets/qt_dims.py
@@ -309,7 +309,6 @@ class QtDims(QWidget):
 
     @Slot()
     def cleaned_worker(self):
-        print("aaaa")
         self._animation_thread = None
         self._animation_worker = None
         self.enable_play()

--- a/napari/_qt/widgets/qt_dims_slider.py
+++ b/napari/_qt/widgets/qt_dims_slider.py
@@ -739,8 +739,6 @@ class AnimationWorker(QObject):
                 return self.finish()
         with self.dims.events.current_step.blocker(self._on_axis_changed):
             self.frame_requested.emit(self.axis, self.current)
-        # using a singleShot timer here instead of timer.start() because
-        # it makes it easier to update the interval using signals/slots
         self.timer.start()
 
     def finish(self):


### PR DESCRIPTION
# Description
Before this change `test_qt_dims.py::test_play_button` tried to wait for `QtDims._animation_thread.started`, which had a few issues.

1. `waitSignal` returns a `SignalBlocker`, but does not actually wait. Based on [the `pytest-qt` docs](https://pytest-qt.readthedocs.io/en/latest/signals.html#) you should typically use that as a context manager to wait, where the code with in the context should eventually cause the signal to be emitted.
2. The intent is to start waiting after mouse click has occurred, but it's possible (though unlikely) that the signal has already been emitted.
3. `QtDims._animation_thread` is `None` before the button has been clicked.

This recently caused [a failure on what should be an unrelated PR](https://github.com/napari/napari/actions/runs/3709270881/jobs/6287719643#step:8:379). I don't know enough about `pytest-qt` to confidently explain the failure - but my guess is that the two mouse clicks are being registered as one that starts playback, but does not stop it.

The fix here is to use `waitUntil` to wait on `QtDims.is_playing` instead. This makes the test slightly less inefficient, but also makes it simpler and less dependent on implementation details.

I also removed a couple of timeout values because the default is 5000 (milliseconds) anyway - if waiting 5 seconds didn't work, waiting another 2 seconds is almost always just wishful thinking.

Finally, I removed some other leftovers from https://github.com/napari/napari/pull/5373

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)