### PR TITLE
Remove `print("aaaa")` from `QtDims.cleaned_worker`

### DIFF
--- a/napari/_qt/widgets/qt_dims.py
+++ b/napari/_qt/widgets/qt_dims.py
@@ -309,7 +309,6 @@ class QtDims(QWidget):
 
     @Slot()
     def cleaned_worker(self):
-        print("aaaa")
         self._animation_thread = None
         self._animation_worker = None
         self.enable_play()


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Hi, after updating to the latest `main` and using and stopping the playback option in the viewer you can see an `"aaaa"` being printed in the console/terminal from where you are running Napari. Seems like a `print` statement (``print("aaaa")`) was left at some point, which most proably was not intended. This PR removes it.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
