### PR TITLE
Avoid setting corner pixels for empty layers

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1545,12 +1545,16 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
         else:
             # The stored corner_pixels attribute must contain valid indices.
-            displayed_extent = self.extent.data[:, displayed_axes]
-            data_bbox_clipped = np.clip(
-                data_bbox_int, displayed_extent[0], displayed_extent[1]
-            )
             corners = np.zeros((2, self.ndim), dtype=int)
-            corners[:, displayed_axes] = data_bbox_clipped
+            # Some empty layers (e.g. Points) may have a data extent that only
+            # contains nans, in which case the integer valued corner pixels
+            # cannot be meaningfully set.
+            displayed_extent = self.extent.data[:, displayed_axes]
+            if not np.all(np.isnan(displayed_extent)):
+                data_bbox_clipped = np.clip(
+                    data_bbox_int, displayed_extent[0], displayed_extent[1]
+                )
+                corners[:, displayed_axes] = data_bbox_clipped
             self.corner_pixels = corners
 
     def _get_source_info(self):


### PR DESCRIPTION
# Description
This avoids trying to set `Layer.corner_pixels` (which should be integer indices in the data space of the layer) when a layer is empty. For all non-image layers, this causes a warning to be raised from numpy (see #5420) because `Layer._data_extent` is a (2, `Layer.ndim`) array of all nans. For image layers, if `Layer.data` is empty (which seems much less likely) we get all kinds of other errors before even reaching this warning.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #5420

# How has this been tested?
- [x] all existing tests pass with my change
