### PR TITLE
Wait until a blocked test task is actually running

### DIFF
--- a/napari/components/_tests/test_layer_slicer.py
+++ b/napari/components/_tests/test_layer_slicer.py
@@ -312,7 +312,7 @@ def test_slice_layers_exception_subthread_on_result(layer_slicer):
     layer = FakeAsyncLayerError()
     future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
 
-    done, _ = wait([future], timeout=5)
+    done, _ = wait([future], timeout=DEFAULT_TIMEOUT_SECS)
     assert done, 'Test future did not complete within timeout.'
     with pytest.raises(RuntimeError, match='FakeSliceRequestError'):
         _wait_for_result(future)

--- a/napari/components/_tests/test_layer_slicer.py
+++ b/napari/components/_tests/test_layer_slicer.py
@@ -2,11 +2,12 @@ import time
 from concurrent.futures import Future, wait
 from dataclasses import dataclass
 from threading import RLock, current_thread, main_thread
-from typing import Tuple, Union
+from typing import Any, Tuple, Union
 
 import numpy as np
 import pytest
 
+from napari._tests.utils import DEFAULT_TIMEOUT_SECS
 from napari.components import Dims
 from napari.components._layer_slicer import _LayerSlicer
 from napari.layers import Image, Points
@@ -119,7 +120,8 @@ def test_slice_layers_async_with_one_async_layer_no_block(layer_slicer):
 
     future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
 
-    assert future.result()[layer].id == 1
+    assert _wait_for_result(future)[layer].id == 1
+    assert _wait_for_result(future)[layer].id == 1
 
 
 def test_slice_layers_async_with_multiple_async_layer_no_block(layer_slicer):
@@ -130,8 +132,8 @@ def test_slice_layers_async_with_multiple_async_layer_no_block(layer_slicer):
         layers=[layer1, layer2], dims=Dims()
     )
 
-    assert future.result()[layer1].id == 1
-    assert future.result()[layer2].id == 1
+    assert _wait_for_result(future)[layer1].id == 1
+    assert _wait_for_result(future)[layer2].id == 1
 
 
 def test_slice_layers_async_emits_ready_event_when_done(layer_slicer):
@@ -145,7 +147,7 @@ def test_slice_layers_async_emits_ready_event_when_done(layer_slicer):
     layer_slicer.events.ready.connect(on_done)
 
     future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
-    actual_result = future.result()
+    actual_result = _wait_for_result(future)
 
     assert actual_result is event_result
 
@@ -157,7 +159,7 @@ def test_slice_layers_async_with_one_sync_layer(layer_slicer):
     future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
 
     assert layer.slice_count == 1
-    assert future.result() == {}
+    assert _wait_for_result(future) == {}
 
 
 def test_slice_layers_async_with_multiple_sync_layer(layer_slicer):
@@ -172,7 +174,7 @@ def test_slice_layers_async_with_multiple_sync_layer(layer_slicer):
 
     assert layer1.slice_count == 1
     assert layer2.slice_count == 1
-    assert not future.result()
+    assert not _wait_for_result(future)
 
 
 def test_slice_layers_async_with_mixed_layers(layer_slicer):
@@ -187,8 +189,8 @@ def test_slice_layers_async_with_mixed_layers(layer_slicer):
 
     assert layer1.slice_count == 1
     assert layer2.slice_count == 1
-    assert future.result()[layer1].id == 1
-    assert layer2 not in future.result()
+    assert _wait_for_result(future)[layer1].id == 1
+    assert layer2 not in _wait_for_result(future)
 
 
 def test_slice_layers_async_lock_blocking(layer_slicer):
@@ -200,7 +202,7 @@ def test_slice_layers_async_lock_blocking(layer_slicer):
         blocked = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
         assert not blocked.done()
 
-    assert blocked.result()[layer].id == 1
+    assert _wait_for_result(blocked)[layer].id == 1
 
 
 def test_slice_layers_async_multiple_calls_cancels_pending(layer_slicer):
@@ -229,7 +231,7 @@ def test_slice_layers_mixed_allows_sync_to_run(layer_slicer):
         assert layer2.slice_count == 1
         assert not blocked.done()
 
-    assert blocked.result()[layer1].id == 1
+    assert _wait_for_result(blocked)[layer1].id == 1
 
 
 def test_slice_layers_mixed_allows_sync_to_run_one_slicer_call(layer_slicer):
@@ -245,7 +247,7 @@ def test_slice_layers_mixed_allows_sync_to_run_one_slicer_call(layer_slicer):
         assert layer2.slice_count == 1
         assert not blocked.done()
 
-    assert blocked.result()[layer1].id == 1
+    assert _wait_for_result(blocked)[layer1].id == 1
 
 
 def test_slice_layers_async_with_multiple_async_layer_with_all_locked(
@@ -262,8 +264,8 @@ def test_slice_layers_async_with_multiple_async_layer_with_all_locked(
         )
         assert not blocked.done()
 
-    assert blocked.result()[layer1].id == 1
-    assert blocked.result()[layer2].id == 1
+    assert _wait_for_result(blocked)[layer1].id == 1
+    assert _wait_for_result(blocked)[layer2].id == 1
 
 
 def test_slice_layers_async_task_to_layers_lock(layer_slicer):
@@ -276,7 +278,7 @@ def test_slice_layers_async_task_to_layers_lock(layer_slicer):
         task = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
         assert task in layer_slicer._layers_to_task.values()
 
-    assert task.result()[layer].id == 1
+    assert _wait_for_result(task)[layer].id == 1
     assert task not in layer_slicer._layers_to_task
 
 
@@ -313,7 +315,7 @@ def test_slice_layers_exception_subthread_on_result(layer_slicer):
     done, _ = wait([future], timeout=5)
     assert done, 'Test future did not complete within timeout.'
     with pytest.raises(RuntimeError, match='FakeSliceRequestError'):
-        future.result()
+        _wait_for_result(future)
 
 
 def test_wait_until_idle(layer_slicer, single_threaded_executor):
@@ -332,11 +334,12 @@ def test_wait_until_idle(layer_slicer, single_threaded_executor):
         # holding the layer's slice lock, so submit it to be executed
         # on another thread and also wait for it to start.
         wait_future = single_threaded_executor.submit(
-            layer_slicer.wait_until_idle
+            layer_slicer.wait_until_idle,
+            timeout=5,
         )
         _wait_until_running(wait_future)
 
-    wait_future.result()
+    _wait_for_result(wait_future)
     assert len(layer_slicer._layers_to_task) == 0
 
 
@@ -348,7 +351,7 @@ def test_layer_slicer_force_sync_on_sync_layer(layer_slicer):
         future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
 
     assert layer.slice_count == 1
-    assert future.result() == {}
+    assert _wait_for_result(future) == {}
     assert not layer_slicer._force_sync
 
 
@@ -360,7 +363,7 @@ def test_layer_slicer_force_sync_on_async_layer(layer_slicer):
         future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
 
     assert layer.slice_count == 1
-    assert future.result() == {}
+    assert _wait_for_result(future) == {}
 
 
 def test_slice_layers_async_with_one_3d_image(layer_slicer):
@@ -379,7 +382,7 @@ def test_slice_layers_async_with_one_3d_image(layer_slicer):
         future = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
         assert not future.done()
 
-    layer_result = future.result()[layer]
+    layer_result = _wait_for_result(future)[layer]
     np.testing.assert_equal(layer_result.data, data[2, :, :])
 
 
@@ -407,13 +410,19 @@ def test_slice_layers_async_with_one_3d_points(layer_slicer):
         assert not future.done()
 
 
-def _wait_until_running(future: Future, timeout_milliseconds: int = 5000):
-    sleep_milliseconds = 10
-    total_sleep_milliseconds = 0
+def _wait_until_running(future: Future):
+    """Waits until the given future is running using a default finite timeout."""
+    sleep_secs = 0.01
+    total_sleep_secs = 0
     while not future.running():
-        time.sleep(sleep_milliseconds / 1000)
-        total_sleep_milliseconds += sleep_milliseconds
-        if total_sleep_milliseconds > timeout_milliseconds:
+        time.sleep(sleep_secs)
+        total_sleep_secs += sleep_secs
+        if total_sleep_secs > DEFAULT_TIMEOUT_SECS:
             raise TimeoutError(
-                f'Future did not start running after the given timeout of {timeout_milliseconds}ms.'
+                f'Future did not start running after a timeout of {DEFAULT_TIMEOUT_SECS} seconds.'
             )
+
+
+def _wait_for_result(future: Future) -> Any:
+    """Waits until the given future is finished using a default finite timeout, and returns its result."""
+    return future.result(timeout=DEFAULT_TIMEOUT_SECS)

--- a/napari/components/_tests/test_layer_slicer.py
+++ b/napari/components/_tests/test_layer_slicer.py
@@ -335,7 +335,7 @@ def test_wait_until_idle(layer_slicer, single_threaded_executor):
         # on another thread and also wait for it to start.
         wait_future = single_threaded_executor.submit(
             layer_slicer.wait_until_idle,
-            timeout=5,
+            timeout=DEFAULT_TIMEOUT_SECS,
         )
         _wait_until_running(wait_future)
 


### PR DESCRIPTION
# Description
The `test_slice_layers_async_multiple_calls_cancels_pending` test [failed](https://github.com/napari/napari/actions/runs/3714126707/jobs/6297620663#step:8:306) in [an unrelated PR](https://github.com/napari/napari/pull/5412).

That test uses a lock to block a layer from finishing slicing, then submits two slicing tasks to the same layer to check that the middle one is actually cancelled. But it does not actually check to see if that task is running, which is a required precondition for the cancellation behavior under test. That's the only explanation of the failure above I could come up with.

Therefore, I fixed that test by using the local `_wait_until_running` function to wait for the task to start running before submitting the second one.

I also added the default timeout to all waits in these tests to ensure we don't have an accidental/unexpected deadlock somewhere. I've seen some recent test runs hang indefinitely and want to rule out these tests as explanations.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
