### PR TITLE
Maint: Typing and ImportError -> ModuleNotFoundError.

### DIFF
--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -43,7 +43,7 @@ def fail_obj_graph(Klass):
 
     try:
         import objgraph
-    except ImportError:
+    except ModuleNotFoundError:
         return
 
     if not len(Klass._instances) == 0:

--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -35,6 +35,7 @@ To create a keymap that will block others, ``bind_key(..., ...)```.
 
 import contextlib
 import inspect
+import sys
 import time
 from collections import ChainMap
 from types import MethodType
@@ -45,9 +46,9 @@ from vispy.util import keys
 
 from napari.utils.translations import trans
 
-try:  # remove after min py version 3.10+
+if sys.version_info >= (3, 10):
     from types import EllipsisType
-except ImportError:
+else:
     EllipsisType = type(Ellipsis)
 
 KeyBindingLike = Union[KeyBinding, str, int]

--- a/napari/utils/naming.py
+++ b/napari/utils/naming.py
@@ -3,6 +3,8 @@
 import inspect
 import re
 from collections import ChainMap
+from types import FrameType
+from typing import Any, Callable, Optional
 
 from napari.utils.misc import ROOT_DIR, formatdoc
 
@@ -28,7 +30,7 @@ def _inc_name_count_sub(match):
 
 
 @formatdoc
-def inc_name_count(name):
+def inc_name_count(name: str) -> str:
     """Increase a name's count matching `{numbered_patt}` by ``1``.
 
     If the name is not already numbered, append '{sep}[{start}]'.
@@ -82,7 +84,7 @@ class CallerFrame:
 
     """
 
-    def __init__(self, skip_predicate):
+    def __init__(self, skip_predicate: Callable[[int, FrameType], bool]):
         self.predicate = skip_predicate
         self.namespace = {}
         self.names = ()
@@ -132,7 +134,7 @@ class CallerFrame:
         del self.names
 
 
-def magic_name(value, *, path_prefix=ROOT_DIR):
+def magic_name(value: Any, *, path_prefix: str = ROOT_DIR) -> Optional[str]:
     """Fetch the name of the variable with the given value passed to the calling function.
 
     Parameters

--- a/napari/utils/translations.py
+++ b/napari/utils/translations.py
@@ -51,7 +51,7 @@ def _get_display_name(
         )
         loc = babel.Locale.parse(locale)
         dislay_name = loc.get_display_name(display_locale).capitalize()
-    except ImportError:
+    except ModuleNotFoundError:
         dislay_name = display_locale.capitalize()
 
     return dislay_name
@@ -88,7 +88,7 @@ def _is_valid_locale(locale: str) -> bool:
 
         babel.Locale.parse(locale)
         valid = True
-    except ImportError:
+    except ModuleNotFoundError:
         valid = True
     except ValueError:
         pass

--- a/napari_builtins/io/_read.py
+++ b/napari_builtins/io/_read.py
@@ -19,7 +19,7 @@ from napari.utils.translations import trans
 
 try:
     import imageio.v2 as imageio
-except ImportError:
+except ModuleNotFoundError:
     import imageio  # type: ignore
 
 IMAGEIO_EXTENSIONS = {x for f in imageio.formats for x in f.extensions}


### PR DESCRIPTION
Module not found is more specific than Import Error, and allows to bubble errors when the issue is not that the module is not installed.

In the same vein it is an anti pattern to use try/except for conditional import, as it may hide errors in Python install, using a explicit compare with sys.version_info, can allow some tools (like pyupgrade) to detect dead branches.
