### PR TITLE
Clean up layer slicer before integration with viewer

### DIFF
--- a/napari/components/_layer_slicer.py
+++ b/napari/components/_layer_slicer.py
@@ -81,6 +81,7 @@ class _LayerSlicer:
     @contextmanager
     def force_sync(self):
         """Context manager to temporarily force slicing to be synchronous.
+
         This should only be used from the main thread.
 
         >>> layer_slicer = _LayerSlicer()

--- a/napari/components/_layer_slicer.py
+++ b/napari/components/_layer_slicer.py
@@ -239,7 +239,7 @@ class _LayerSlicer:
 
     def _find_existing_task(
         self, layers: Iterable[Layer]
-    ) -> Optional[Future[dict]]:
+    ) -> Optional[Future[Dict]]:
         """Find the task associated with a list of layers. Returns the first
         task found for which the layers of the task are a subset of the input
         layers.

--- a/napari/components/_tests/test_layer_slicer.py
+++ b/napari/components/_tests/test_layer_slicer.py
@@ -14,31 +14,11 @@ from napari.layers import Image, Points
 from napari.layers._data_protocols import Index, LayerDataProtocol
 from napari.types import DTypeLike
 
-"""
-Cases to consider
-- single + multiple layers that supports async (all of layers do support async)
-- single + multiple layers that don't support async (all of layers do not support async)
-- mix of layers that do and don't support async
-
-Behaviors we want to test:
-scheduling logic of the slicer (and not correctness of the slice response value)
-
-- for layers that support async, the slice task should not be run on the main
-  thread (we don't want to block the calling)
-- for layers that do not support async, slicing should always be done once
-  the method returns
-- slice requests should be run on the main thread
-- pending tasks are cancelled (at least when the new task will slice all
-  layers for the pending task)
-
-The fake request, response, and layers exist to give structure against which to
-test (class instances and attributes) and to remain isolated from the existing
-codebase. They represent what will become real classes in the codebase which
-have additional methods and properties that don't currently exist.
-
-Run all tests with:
-pytest napari/components/_tests/test_layer_slicer.py -svv
-"""
+# The following fakes are used to control execution of slicing across
+# multiple threads, while also allowing us to mimic real classes
+# (like layers) in the code base. This allows us to assert state and
+# conditions that may only be temporarily true at different stages of
+# an asynchronous task.
 
 
 @dataclass(frozen=True)

--- a/napari/components/_tests/test_layer_slicer.py
+++ b/napari/components/_tests/test_layer_slicer.py
@@ -58,13 +58,17 @@ class FakeSliceRequest:
 
 class FakeAsyncLayer:
     def __init__(self):
-        self.slice_count = 0
-        self.lock = RLock()
+        self._slice_request_count: int = 0
+        self.slice_count: int = 0
+        self.lock: RLock = RLock()
 
-    def _make_slice_request(self, dims) -> FakeSliceRequest:
+    def _make_slice_request(self, dims: Dims) -> FakeSliceRequest:
         assert current_thread() == main_thread()
-        self.slice_count += 1
-        return FakeSliceRequest(id=self.slice_count, lock=self.lock)
+        self._slice_request_count += 1
+        return FakeSliceRequest(id=self._slice_request_count, lock=self.lock)
+
+    def _update_slice_response(self, response: FakeSliceResponse):
+        self.slice_count = response.id
 
     def _slice_dims(self, *args, **kwargs) -> None:
         self.slice_count += 1
@@ -114,27 +118,25 @@ def layer_slicer():
     layer_slicer.shutdown()
 
 
-def test_slice_layers_async_with_one_async_layer_no_block(layer_slicer):
+def test_submit_with_one_async_layer_no_block(layer_slicer):
     layer = FakeAsyncLayer()
 
-    future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
+    future = layer_slicer.submit(layers=[layer], dims=Dims())
 
     assert future.result()[layer].id == 1
 
 
-def test_slice_layers_async_with_multiple_async_layer_no_block(layer_slicer):
+def test_submit_with_multiple_async_layer_no_block(layer_slicer):
     layer1 = FakeAsyncLayer()
     layer2 = FakeAsyncLayer()
 
-    future = layer_slicer.slice_layers_async(
-        layers=[layer1, layer2], dims=Dims()
-    )
+    future = layer_slicer.submit(layers=[layer1, layer2], dims=Dims())
 
     assert future.result()[layer1].id == 1
     assert future.result()[layer2].id == 1
 
 
-def test_slice_layers_async_emits_ready_event_when_done(layer_slicer):
+def test_submit_emits_ready_event_when_done(layer_slicer):
     layer = FakeAsyncLayer()
     event_result = None
 
@@ -144,74 +146,69 @@ def test_slice_layers_async_emits_ready_event_when_done(layer_slicer):
 
     layer_slicer.events.ready.connect(on_done)
 
-    future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
+    future = layer_slicer.submit(layers=[layer], dims=Dims())
     actual_result = future.result()
 
     assert actual_result is event_result
 
 
-def test_slice_layers_async_with_one_sync_layer(layer_slicer):
+def test_submit_with_one_sync_layer(layer_slicer):
     layer = FakeSyncLayer()
     assert layer.slice_count == 0
 
-    future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
+    future = layer_slicer.submit(layers=[layer], dims=Dims())
 
     assert layer.slice_count == 1
-    assert future.result() == {}
+    assert future is None
 
 
-def test_slice_layers_async_with_multiple_sync_layer(layer_slicer):
+def test_submit_with_multiple_sync_layer(layer_slicer):
     layer1 = FakeSyncLayer()
     layer2 = FakeSyncLayer()
     assert layer1.slice_count == 0
     assert layer2.slice_count == 0
 
-    future = layer_slicer.slice_layers_async(
-        layers=[layer1, layer2], dims=Dims()
-    )
+    future = layer_slicer.submit(layers=[layer1, layer2], dims=Dims())
 
     assert layer1.slice_count == 1
     assert layer2.slice_count == 1
-    assert not future.result()
+    assert future is None
 
 
-def test_slice_layers_async_with_mixed_layers(layer_slicer):
+def test_submit_with_mixed_layers(layer_slicer):
     layer1 = FakeAsyncLayer()
     layer2 = FakeSyncLayer()
     assert layer1.slice_count == 0
     assert layer2.slice_count == 0
 
-    future = layer_slicer.slice_layers_async(
-        layers=[layer1, layer2], dims=Dims()
-    )
+    future = layer_slicer.submit(layers=[layer1, layer2], dims=Dims())
 
-    assert layer1.slice_count == 1
     assert layer2.slice_count == 1
     assert future.result()[layer1].id == 1
     assert layer2 not in future.result()
 
 
-def test_slice_layers_async_lock_blocking(layer_slicer):
+def test_submit_lock_blocking(layer_slicer):
     dims = Dims()
     layer = FakeAsyncLayer()
 
     assert layer.slice_count == 0
     with layer.lock:
-        blocked = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
+        blocked = layer_slicer.submit(layers=[layer], dims=dims)
         assert not blocked.done()
 
     assert blocked.result()[layer].id == 1
 
 
-def test_slice_layers_async_multiple_calls_cancels_pending(layer_slicer):
+def test_submit_multiple_calls_cancels_pending(layer_slicer):
     dims = Dims()
     layer = FakeAsyncLayer()
 
     with layer.lock:
-        blocked = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
-        pending = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
+        blocked = layer_slicer.submit(layers=[layer], dims=dims)
+        pending = layer_slicer.submit(layers=[layer], dims=dims)
         assert not pending.running()
-        layer_slicer.slice_layers_async(layers=[layer], dims=dims)
+        layer_slicer.submit(layers=[layer], dims=dims)
         assert not blocked.done()
 
     assert pending.cancelled()
@@ -223,8 +220,8 @@ def test_slice_layers_mixed_allows_sync_to_run(layer_slicer):
     layer1 = FakeAsyncLayer()
     layer2 = FakeSyncLayer()
     with layer1.lock:
-        blocked = layer_slicer.slice_layers_async(layers=[layer1], dims=dims)
-        layer_slicer.slice_layers_async(layers=[layer2], dims=dims)
+        blocked = layer_slicer.submit(layers=[layer1], dims=dims)
+        layer_slicer.submit(layers=[layer2], dims=dims)
         assert layer2.slice_count == 1
         assert not blocked.done()
 
@@ -237,9 +234,7 @@ def test_slice_layers_mixed_allows_sync_to_run_one_slicer_call(layer_slicer):
     layer1 = FakeAsyncLayer()
     layer2 = FakeSyncLayer()
     with layer1.lock:
-        blocked = layer_slicer.slice_layers_async(
-            layers=[layer1, layer2], dims=dims
-        )
+        blocked = layer_slicer.submit(layers=[layer1, layer2], dims=dims)
 
         assert layer2.slice_count == 1
         assert not blocked.done()
@@ -247,7 +242,7 @@ def test_slice_layers_mixed_allows_sync_to_run_one_slicer_call(layer_slicer):
     assert blocked.result()[layer1].id == 1
 
 
-def test_slice_layers_async_with_multiple_async_layer_with_all_locked(
+def test_submit_with_multiple_async_layer_with_all_locked(
     layer_slicer,
 ):
     """ensure that if only all layers are locked, none continue"""
@@ -256,23 +251,21 @@ def test_slice_layers_async_with_multiple_async_layer_with_all_locked(
     layer2 = FakeAsyncLayer()
 
     with layer1.lock, layer2.lock:
-        blocked = layer_slicer.slice_layers_async(
-            layers=[layer1, layer2], dims=dims
-        )
+        blocked = layer_slicer.submit(layers=[layer1, layer2], dims=dims)
         assert not blocked.done()
 
     assert blocked.result()[layer1].id == 1
     assert blocked.result()[layer2].id == 1
 
 
-def test_slice_layers_async_task_to_layers_lock(layer_slicer):
+def test_submit_task_to_layers_lock(layer_slicer):
     """ensure that if only one layer has a lock, the non-locked layer
     can continue"""
     dims = Dims()
     layer = FakeAsyncLayer()
 
     with layer.lock:
-        task = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
+        task = layer_slicer.submit(layers=[layer], dims=dims)
         assert task in layer_slicer._layers_to_task.values()
 
     assert task.result()[layer].id == 1
@@ -289,7 +282,7 @@ def test_slice_layers_exception_main_thread(layer_slicer):
 
     layer = FakeAsyncLayerError()
     with pytest.raises(RuntimeError, match='_make_slice_request'):
-        layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
+        layer_slicer.submit(layers=[layer], dims=Dims())
 
 
 def test_slice_layers_exception_subthread_on_result(layer_slicer):
@@ -303,11 +296,14 @@ def test_slice_layers_exception_subthread_on_result(layer_slicer):
             raise RuntimeError('FakeSliceRequestError')
 
     class FakeAsyncLayerError(FakeAsyncLayer):
-        def _make_slice_request(self, dims) -> FakeSliceRequestError:
-            return FakeSliceRequestError(id=self.slice_count, lock=self.lock)
+        def _make_slice_request(self, dims: Dims) -> FakeSliceRequestError:
+            self._slice_request_count += 1
+            return FakeSliceRequestError(
+                id=self._slice_request_count, lock=self.lock
+            )
 
     layer = FakeAsyncLayerError()
-    future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
+    future = layer_slicer.submit(layers=[layer], dims=Dims())
 
     done, _ = wait([future], timeout=5)
     assert done, 'Test future did not complete within timeout.'
@@ -320,9 +316,7 @@ def test_wait_until_idle(layer_slicer, single_threaded_executor):
     layer = FakeAsyncLayer()
 
     with layer.lock:
-        slice_future = layer_slicer.slice_layers_async(
-            layers=[layer], dims=dims
-        )
+        slice_future = layer_slicer.submit(layers=[layer], dims=dims)
         _wait_until_running(slice_future)
         # The slice task has started, but has not finished yet
         # because we are holding the layer's slicing lock.
@@ -349,10 +343,10 @@ def test_layer_slicer_force_sync_on_sync_layer(layer_slicer):
 
     with layer_slicer.force_sync():
         assert layer_slicer._force_sync
-        future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
+        future = layer_slicer.submit(layers=[layer], dims=Dims())
 
     assert layer.slice_count == 1
-    assert future.result() == {}
+    assert future is None
     assert not layer_slicer._force_sync
 
 
@@ -361,13 +355,13 @@ def test_layer_slicer_force_sync_on_async_layer(layer_slicer):
 
     with layer_slicer.force_sync():
         assert layer_slicer._force_sync
-        future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
+        future = layer_slicer.submit(layers=[layer], dims=Dims())
 
     assert layer.slice_count == 1
-    assert future.result() == {}
+    assert future is None
 
 
-def test_slice_layers_async_with_one_3d_image(layer_slicer):
+def test_submit_with_one_3d_image(layer_slicer):
     np.random.seed(0)
     data = np.random.rand(8, 7, 6)
     lockable_data = LockableData(data)
@@ -380,14 +374,14 @@ def test_slice_layers_async_with_one_3d_image(layer_slicer):
     )
 
     with lockable_data.lock:
-        future = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
+        future = layer_slicer.submit(layers=[layer], dims=dims)
         assert not future.done()
 
     layer_result = future.result()[layer]
     np.testing.assert_equal(layer_result.data, data[2, :, :])
 
 
-def test_slice_layers_async_with_one_3d_points(layer_slicer):
+def test_submit_with_one_3d_points(layer_slicer):
     """ensure that async slicing of points does not block"""
     np.random.seed(0)
     num_points = 100
@@ -407,5 +401,13 @@ def test_slice_layers_async_with_one_3d_points(layer_slicer):
     )
 
     with lockable_internal_data.lock:
-        future = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
+        future = layer_slicer.submit(layers=[layer], dims=dims)
         assert not future.done()
+
+
+def test_submit_after_shutdown_raises():
+    layer_slicer = _LayerSlicer()
+    layer_slicer._force_sync = False
+    layer_slicer.shutdown()
+    with pytest.raises(RuntimeError):
+        layer_slicer.submit(layers=[FakeAsyncLayer()], dims=Dims())

--- a/napari/components/_tests/test_layer_slicer.py
+++ b/napari/components/_tests/test_layer_slicer.py
@@ -197,7 +197,7 @@ def test_submit_multiple_calls_cancels_pending(layer_slicer):
     assert pending.cancelled()
 
 
-def test_slice_layers_mixed_allows_sync_to_run(layer_slicer):
+def test_submit_mixed_allows_sync_to_run(layer_slicer):
     """ensure that a blocked async slice doesn't block sync slicing"""
     dims = Dims()
     layer1 = FakeAsyncLayer()
@@ -211,7 +211,7 @@ def test_slice_layers_mixed_allows_sync_to_run(layer_slicer):
     assert _wait_for_result(blocked)[layer1].id == 1
 
 
-def test_slice_layers_mixed_allows_sync_to_run_one_slicer_call(layer_slicer):
+def test_submit_mixed_allows_sync_to_run_one_slicer_call(layer_slicer):
     """ensure that a blocked async slice doesn't block sync slicing"""
     dims = Dims()
     layer1 = FakeAsyncLayer()
@@ -255,7 +255,7 @@ def test_submit_task_to_layers_lock(layer_slicer):
     assert task not in layer_slicer._layers_to_task
 
 
-def test_slice_layers_exception_main_thread(layer_slicer):
+def test_submit_exception_main_thread(layer_slicer):
     """Exception is raised on the main thread from an error on the main
     thread immediately when the task is created."""
 
@@ -268,7 +268,7 @@ def test_slice_layers_exception_main_thread(layer_slicer):
         layer_slicer.submit(layers=[layer], dims=Dims())
 
 
-def test_slice_layers_exception_subthread_on_result(layer_slicer):
+def test_submit_exception_subthread_on_result(layer_slicer):
     """Exception is raised on the main thread from an error on a subthread
     only after result is called, not upon submission of the task."""
 
@@ -317,7 +317,7 @@ def test_wait_until_idle(layer_slicer, single_threaded_executor):
     assert len(layer_slicer._layers_to_task) == 0
 
 
-def test_layer_slicer_force_sync_on_sync_layer(layer_slicer):
+def test_force_sync_on_sync_layer(layer_slicer):
     layer = FakeSyncLayer()
 
     with layer_slicer.force_sync():
@@ -329,7 +329,7 @@ def test_layer_slicer_force_sync_on_sync_layer(layer_slicer):
     assert not layer_slicer._force_sync
 
 
-def test_layer_slicer_force_sync_on_async_layer(layer_slicer):
+def test_force_sync_on_async_layer(layer_slicer):
     layer = FakeAsyncLayer()
 
     with layer_slicer.force_sync():

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import types
 import warnings
+from contextlib import nullcontext
 from typing import TYPE_CHECKING, List, Sequence, Tuple, Union
 
 import numpy as np
@@ -33,6 +34,7 @@ from napari.layers.utils._slice_input import _SliceInput
 from napari.layers.utils.layer_utils import calc_data_range
 from napari.layers.utils.plane import SlicingPlane
 from napari.utils import config
+from napari.utils._dask_utils import DaskIndexer
 from napari.utils._dtype import get_dtype_limits, normalize_dtype
 from napari.utils.colormaps import AVAILABLE_COLORMAPS
 from napari.utils.events import Event
@@ -764,28 +766,41 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         # The new slicing code makes a request from the existing state and
         # executes the request on the calling thread directly.
         # For async slicing, the calling thread will not be the main thread.
-        request = self._make_slice_request_internal(self._slice_input, indices)
+        request = self._make_slice_request_internal(
+            slice_input=self._slice_input,
+            indices=indices,
+            lazy=True,
+            dask_indexer=nullcontext,
+        )
         response = request()
-        self._update_slice_response(response, indices)
+        self._update_slice_response(response)
 
     def _make_slice_request(self, dims: Dims) -> _ImageSliceRequest:
         """Make an image slice request based on the given dims and this image."""
         slice_input = self._make_slice_input(
             dims.point, dims.ndisplay, dims.order
         )
-        # TODO: for the existing sync slicing, slice_indices is passed through
+        # TODO: for the existing sync slicing, indices is passed through
         # to avoid some performance issues related to the evaluation of the
         # data-to-world transform and its inverse. Async slicing currently
         # absorbs these performance issues here, but we can likely improve
         # things either by caching the world-to-data transform on the layer
         # or by lazily evaluating it in the slice task itself.
-        slice_indices = slice_input.data_indices(self._data_to_world.inverse)
-        return self._make_slice_request_internal(slice_input, slice_indices)
+        indices = slice_input.data_indices(self._data_to_world.inverse)
+        return self._make_slice_request_internal(
+            slice_input=slice_input,
+            indices=indices,
+            lazy=False,
+            dask_indexer=self.dask_optimized_slicing,
+        )
 
     def _make_slice_request_internal(
         self,
+        *,
         slice_input: _SliceInput,
-        slice_indices,
+        indices: Tuple[Union[int, slice], ...],
+        lazy: bool,
+        dask_indexer: DaskIndexer,
     ) -> _ImageSliceRequest:
         """Needed to support old-style sync slicing through _slice_dims and
         _set_view_slice.
@@ -796,7 +811,8 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         return _ImageSliceRequest(
             dims=slice_input,
             data=self.data,
-            slice_indices=slice_indices,
+            dask_indexer=dask_indexer,
+            indices=indices,
             multiscale=self.multiscale,
             corner_pixels=self.corner_pixels,
             rgb=self.rgb,
@@ -804,17 +820,18 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
             thumbnail_level=self._thumbnail_level,
             level_shapes=self.level_shapes,
             downsample_factors=self.downsample_factors,
-            lazy=True,
+            lazy=lazy,
         )
 
-    def _update_slice_response(
-        self, response: _ImageSliceResponse, indices
-    ) -> None:
+    def _update_slice_response(self, response: _ImageSliceResponse) -> None:
         """Update the slice output state currently on the layer."""
+        self._slice_input = response.dims
+
         # For the old experimental async code.
+        self._empty = False
         slice_data = self._SliceDataClass(
             layer=self,
-            indices=indices,
+            indices=response.indices,
             image=response.data,
             thumbnail_source=response.thumbnail,
         )

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1695,7 +1695,7 @@ class Points(Layer):
             self._slice_input, self._slice_indices
         )
         response = request()
-        self._set_slice_response(response)
+        self._update_slice_response(response)
 
     def _make_slice_request(self, dims) -> _PointSliceRequest:
         """Make a Points slice request based on the given dims and these data."""
@@ -1723,8 +1723,9 @@ class Points(Layer):
             size=self.size,
         )
 
-    def _set_slice_response(self, response: _PointSliceResponse):
+    def _update_slice_response(self, response: _PointSliceResponse):
         """Handle a slicing response."""
+        self._slice_input = response.dims
         indices = response.indices
         scale = response.scale
 

--- a/napari/utils/_dask_utils.py
+++ b/napari/utils/_dask_utils.py
@@ -15,6 +15,8 @@ from dask.cache import Cache
 _DASK_CACHE = Cache(1)
 _DEFAULT_MEM_FRACTION = 0.25
 
+DaskIndexer = Callable[[], ContextManager[Optional[Tuple[dict, Cache]]]]
+
 
 def resize_dask_cache(
     nbytes: Optional[int] = None, mem_fraction: Optional[float] = None
@@ -82,9 +84,7 @@ def _is_dask_data(data) -> bool:
     )
 
 
-def configure_dask(
-    data, cache=True
-) -> Callable[[], ContextManager[Optional[Tuple[dict, Cache]]]]:
+def configure_dask(data, cache=True) -> DaskIndexer:
     """Spin up cache and return context manager that optimizes Dask indexing.
 
     This function determines whether data is a dask array or list of dask


### PR DESCRIPTION
# Description
This cherry picks the simpler changes over from the more complex integration PR (#5377), which include the following.

- Rename `LayerSlicer.slice_layers_async` to `LayerSlicer.submit`. Also make the parameters keyword only for extra clarity.
- Don't submit an empty request to the executor and return `None` in this case.
- Clarify and add to some of the `LayerSlicer` docstrings.
- Test and implement `LayerSlicer.shutdown` to cancel and wait for all futures.
- Some other fixes that were picked up during integration.

## Type of change
This mostly a private API refactor/rename.

# How has this been tested?
- [x] all tests pass with my change
