### PR TITLE
Installation: don't include pyqt5 (from [all]) in [dev] installs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,7 @@
 	"forwardPorts": [5900, 5901, 6080],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip install -U pip && pip install -e .[dev] && pre-commit install",
+	"postCreateCommand": "pip install -U pip && pip install -e .[pyqt, dev] && pre-commit install",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",

--- a/setup.cfg
+++ b/setup.cfg
@@ -134,7 +134,6 @@ dev =
     pre-commit>=2.9.0
     pydantic[dotenv]
     rich
-    %(all)s
     %(testing)s
 build =
     black


### PR DESCRIPTION
# Description

At present, installing `napari[dev]`, such as in the case of `pip install -e .[dev]` includes [all]:
https://github.com/napari/napari/blob/86567150d35625a7c3ea88c32d9958924998f8ad/setup.cfg#L129-L138
and [all] is just [pyqt5]:
https://github.com/napari/napari/blob/86567150d35625a7c3ea88c32d9958924998f8ad/setup.cfg#L105-L106
This means that [dev] always installs pyqt5, which makes it really annoying to make a dev env with a Qt backend other than pyqt5. For example, if someone wants to use pyside2 or Qt6. This is not ideal in terms of catching bugs etc. In the case of devs on arm64 macOS there are no pyqt5 wheels on pypi, so  `pip install -e .[dev]` fails.

This PR removes [all] from [dev] so that you can install [dev] with any Qt backend, including a pre-existing one. For example, for the default pyqt:
`pip install -e ".[pyqt, dev]"`
Or to use a preexisting one:
`pip install -e ".[dev]"`

I've made a parallel PR to the contribution docs to clarify this change.


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# References
See also: https://napari.zulipchat.com/#narrow/stream/212875-general/topic/qt.20and.20dev.20installs
See also docs PR: https://github.com/napari/docs/pull/78

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
