### PR TITLE
Add `error` color to themes and change application close/exit dialogs

### DIFF
--- a/napari/_qt/dialogs/confirm_close_dialog.py
+++ b/napari/_qt/dialogs/confirm_close_dialog.py
@@ -31,6 +31,7 @@ class ConfirmCloseDialog(QDialog):
                     QKeySequence.NativeText
                 ),
             )
+            close_btn.setObjectName("error_icon_btn")
             close_btn.setShortcut(QKeySequence('Ctrl+Q'))
             icon_label.setObjectName("error_icon_element")
         else:
@@ -41,6 +42,7 @@ class ConfirmCloseDialog(QDialog):
                     QKeySequence.NativeText
                 ),
             )
+            close_btn.setObjectName("warning_icon_btn")
             close_btn.setShortcut(QKeySequence('Ctrl+W'))
             icon_label.setObjectName("warning_icon_element")
 

--- a/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -183,7 +183,7 @@ QtModePushButton[mode="delete_shape"] {
 }
 
 QWidget[emphasized="true"] QtModePushButton[mode="delete_shape"]:pressed {
-  background-color: {{ warning }};
+  background-color: {{ error }};
 }
 
 
@@ -226,12 +226,12 @@ QtPlayButton[reverse=True]:hover, QtPlayButton[reverse=False]:hover {
 }
 
 QtPlayButton[playing=True]:hover {
-  background-color: {{ lighten(warning, 10) }};
+  background-color: {{ lighten(error, 10) }};
 }
 
 QtPlayButton[playing=True] {
     image: url("theme_{{ id }}:/square.svg");
-    background-color: {{ warning }};
+    background-color: {{ error }};
     height: 12px;
     width: 12px;
     padding: 2px;

--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -586,15 +586,15 @@ QPushButton#install_button:disabled {
 }
 
 QPushButton#remove_button {
-  background-color: {{ warning }}
+  background-color: {{ error }}
 }
 
 QPushButton#remove_button:hover {
-  background-color: {{ lighten(warning, 10) }}
+  background-color: {{ lighten(error, 10) }}
 }
 
 QPushButton#remove_button:pressed {
-  background-color: {{ darken(warning, 10) }}
+  background-color: {{ darken(error, 10) }}
 }
 
 QPushButton#busy_button:pressed {
@@ -814,6 +814,10 @@ QtLayerList::indicator:checked {
   image: url("theme_{{ id }}:/visibility.svg");
 }
 
+
+#error_icon_btn {
+  qproperty-icon: url("theme_{{ id }}:/error.svg");
+}
 
 #warning_icon_btn {
   qproperty-icon: url("theme_{{ id }}:/warning.svg");

--- a/napari/resources/_icons.py
+++ b/napari/resources/_icons.py
@@ -166,7 +166,11 @@ def build_theme_svgs(theme_name: str, source) -> str:
         svg_paths=ICONS.values(),
         colors=[(theme_name, 'icon')],
         opacities=(0.5, 1),
-        theme_override={'warning': 'warning', 'logo_silhouette': 'background'},
+        theme_override={
+            'warning': 'warning',
+            'error': 'error',
+            'logo_silhouette': 'background',
+        },
     )
     with (out / PLUGIN_FILE_NAME).open('w') as f:
         f.write(source)

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -57,7 +57,9 @@ class Theme(EventedModel):
     text : Color
         Color used to display text.
     warning : Color
-        Color used to indicate something is wrong.
+        Color used to indicate something needs attention.
+    error : Color
+        Color used to indicate something is wrong or could stop functionality.
     current : Color
         Color used to highlight Qt widget.
     """
@@ -75,6 +77,7 @@ class Theme(EventedModel):
     text: Color
     icon: Color
     warning: Color
+    error: Color
     current: Color
 
     @validator("syntax_style", pre=True)
@@ -335,7 +338,8 @@ DARK = Theme(
     highlight='rgb(106, 115, 128)',
     text='rgb(240, 241, 242)',
     icon='rgb(209, 210, 212)',
-    warning='rgb(153, 18, 31)',
+    warning='rgb(227, 182, 23)',
+    error='rgb(153, 18, 31)',
     current='rgb(0, 122, 204)',
     syntax_style='native',
     console='rgb(18, 18, 18)',
@@ -351,7 +355,8 @@ LIGHT = Theme(
     highlight='rgb(163, 158, 156)',
     text='rgb(59, 58, 57)',
     icon='rgb(107, 105, 103)',
-    warning='rgb(255, 18, 31)',
+    warning='rgb(227, 182, 23)',
+    error='rgb(255, 18, 31)',
     current='rgb(253, 240, 148)',
     syntax_style='default',
     console='rgb(255, 255, 255)',


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

* Adds `error` color to the themes (using the previously named color value set for the `warning` color) and changes `warning` color to use the one defined at: https://github.com/napari/napari/blob/e89bb038bbd864454364eee2af218f236f275fb4/napari/_qt/dialogs/qt_notification.py#L124

* Uses new colors definitions for the icons shown with the close confirmation dialog

## Preview

### Close window dialog
|Before|After|
|--|--|
|![imagen](https://user-images.githubusercontent.com/16781833/209380775-cfd916ee-8b27-4ea0-bbc1-e83406b5960a.png)|![imagen](https://user-images.githubusercontent.com/16781833/209379372-e457a116-0fcb-488d-bc08-abd4f68e49f4.png)|

### Close application dialog

|Before|After|
|--|--|
|![imagen](https://user-images.githubusercontent.com/16781833/209380905-c2639d2c-d8ea-4867-ba93-628f9f9a39ee.png)|![imagen](https://user-images.githubusercontent.com/16781833/209380272-0865e482-dbe7-4eac-982a-8f251488b5c5.png)|

## Notes

* Maybe is worthy to also use the `warning` color from the theme at https://github.com/napari/napari/blob/e89bb038bbd864454364eee2af218f236f275fb4/napari/_qt/dialogs/qt_notification.py#L120-L128

?

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
closes #5203 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] all tests pass with my change
- [ ] I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
