### PR TITLE
Apply disabled widgets style only for menus and set menus styles for `QModelMenu`  and `QMenu` instances

### DIFF
--- a/napari/_qt/qt_resources/styles/00_base.qss
+++ b/napari/_qt/qt_resources/styles/00_base.qss
@@ -43,14 +43,6 @@ QWidget[emphasized="true"] > QFrame {
     background-color: {{ foreground }};
 }
 
-QWidget:disabled {
-  background-color: {{ background }};
-  selection-background-color: transparent;
-  border: 1px solid;
-  border-color: {{ foreground }};
-  color: {{ opacity(text, 90) }};
-}
-
 /* ------------ QAbstractScrollArea ------------- */
 
 /* QAbstractScrollArea is the superclass */ 

--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -833,7 +833,7 @@ QtLayerList::indicator:checked {
 
 /* --------------- Menus (application and context menus) ---------------- */
 
-QModelMenu::separator {
+QMenu::separator, QModelMenu::separator {
 	height: 1 px;
 	background: {{ opacity(text, 90) }};
 	margin-left: 17 px;
@@ -842,6 +842,14 @@ QModelMenu::separator {
 	margin-bottom: 3 px;
 }
 
-QModelMenu {
+QMenu:disabled, QModelMenu:disabled {
+  background-color: {{ background }};
+  selection-background-color: transparent;
+  border: 1px solid;
+  border-color: {{ foreground }};
+  color: {{ opacity(text, 90) }};
+}
+
+QMenu, QModelMenu {
 	padding: 6 px;
 }


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Apply disabled widgets style only for menus (`QModelMenu`  or `QMenu` instances).

## Preview (Windows):

![menus](https://user-images.githubusercontent.com/16781833/209562743-25bcf778-3761-4b78-b32b-f7646e50d547.gif)



## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
closes #5445 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change
- [x] I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
