### PR TITLE
Fix theme reference to get image for `success_label` style

### DIFF
--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -673,7 +673,7 @@ QPushButton#close_button:disabled {
 }
 
 #success_label {
-  image: url("theme_{{ name }}:/check.svg");
+  image: url("theme_{{ id }}:/check.svg");
   max-width: 18px;
   max-height: 18px;
   min-width: 18px;


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Use `id` instead of `name` to get the image for `success_label`. Without that when updating other open PRs with the latest main branch I was getting the following warning interacting with the plugins dialog:

```
WARNING: Cannot open file '...napari/theme_{{ name }}:/check.svg'
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change
- [x] I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
