### PR TITLE
Bugfix: Ensure layer._fixed_vertex is set when rotating

### DIFF
--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -488,12 +488,9 @@ def _move(layer, coordinates):
         elif vertex == 8:
             # Rotation handle is being dragged so rotate object
             handle = layer._selected_box[Box.HANDLE]
-            if layer._drag_start is None:
-                layer._fixed_vertex = layer._selected_box[Box.CENTER]
-                offset = handle - layer._fixed_vertex
-                layer._drag_start = -np.degrees(
-                    np.arctan2(offset[0], -offset[1])
-                )
+            layer._fixed_vertex = layer._selected_box[Box.CENTER]
+            offset = handle - layer._fixed_vertex
+            layer._drag_start = -np.degrees(np.arctan2(offset[0], -offset[1]))
 
             new_offset = coord - layer._fixed_vertex
             new_angle = -np.degrees(np.arctan2(new_offset[0], -new_offset[1]))

--- a/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
@@ -396,6 +396,65 @@ def test_drag_shape(create_known_shapes_layer, Event):
     np.testing.assert_allclose(layer.data[0], orig_data + [10, 5])
 
 
+def test_rotate_shape(create_known_shapes_layer, Event):
+    """Select and drag handle to rotate shape."""
+    layer, n_shapes, _ = create_known_shapes_layer
+
+    layer.mode = 'select'
+    layer.selected_data = {1}
+    # get the position of the rotation handle
+    position = tuple(layer._selected_box[9])
+    # get the vertexes
+    original_data = layer.data[1].copy()
+
+    # Simulate click
+    event = ReadOnlyWrapper(
+        Event(
+            type='mouse_press',
+            is_dragging=True,
+            modifiers=[],
+            position=position,
+        )
+    )
+    mouse_press_callbacks(layer, event)
+    # start drag event
+    event = ReadOnlyWrapper(
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            modifiers=[],
+            position=position,
+        )
+    )
+    mouse_move_callbacks(layer, event)
+
+    # drag in the handle to bottom midpoint vertex to rotate 180 degrees
+    position = tuple(tuple(layer._selected_box[3]))
+    # Simulate move, click, and release
+    event = ReadOnlyWrapper(
+        Event(
+            type='mouse_move',
+            is_dragging=True,
+            modifiers=[],
+            position=position,
+        )
+    )
+    mouse_move_callbacks(layer, event)
+    # Simulate release
+    event = ReadOnlyWrapper(
+        Event(
+            type='mouse_release',
+            is_dragging=True,
+            modifiers=[],
+            position=position,
+        )
+    )
+    mouse_release_callbacks(layer, event)
+
+    # Check shape was rotated
+    np.testing.assert_allclose(layer.data[1][2], original_data[0])
+
+
 def test_drag_vertex(create_known_shapes_layer, Event):
     """Select and drag vertex."""
     layer, n_shapes, _ = create_known_shapes_layer


### PR DESCRIPTION
# Description

This PR attempts to fix: https://github.com/napari/napari/issues/5448
In https://github.com/napari/napari/pull/4999 a change was made so that
`layer._drag_start` is now set initially by a new function:
https://github.com/napari/napari/blob/562cc7f8cd7ff70e3ff567f258af209fbd15b00d/napari/layers/shapes/_shapes_mouse_bindings.py#L372-L377
Called at the top of `_move`:
https://github.com/napari/napari/blob/562cc7f8cd7ff70e3ff567f258af209fbd15b00d/napari/layers/shapes/_shapes_mouse_bindings.py#L396-L399

This means that the check `if layer._drag_start is None:` for rotation never fires and the `layer._fixed_vertex` is never set:
https://github.com/napari/napari/blob/562cc7f8cd7ff70e3ff567f258af209fbd15b00d/napari/layers/shapes/_shapes_mouse_bindings.py#L489-L503

So in this PR I remove that check, analogous to what was done in the original PR where the check was removed for dragging.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References

Fixes issue: https://github.com/napari/napari/issues/5448
Related to changes in previous PR: #4999 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
