### PR TITLE
Fix `_n_selected_points` in _layerlist_context.py

### DIFF
--- a/napari/_app_model/context/_layerlist_context.py
+++ b/napari/_app_model/context/_layerlist_context.py
@@ -59,7 +59,7 @@ def _only_points(s: LayerSel) -> bool:
 
 
 def _n_selected_points(s: LayerSel) -> int:
-    return sum(x._type_string == "labels" for x in s)
+    return sum(x._type_string == "points" for x in s)
 
 
 def _only_shapes(s: LayerSel) -> bool:


### PR DESCRIPTION
# Description

While going through the source code, I noticed that `_n_selected_points` counts the number of labels layers instead of the number of points layers (likely a copy-paste mistake). This minimal PR rectifies that.

## Type of change

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References

None

# How has this been tested?

I have NOT tested this.

## Final checklist:

- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
