### PR TITLE
Update screenshot in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ import napari
 viewer = napari.view_image(data.cells3d(), channel_axis=1, ndisplay=3)
 ```
 
-![napari viewer showing an image of an astronaut.](https://github.com/napari/docs/blob/main/docs/images/screenshot-add-image.png)
+<img width="1198" alt="napari viewer showing cells in 3d." src="https://user-images.githubusercontent.com/44469195/209934762-aba0c2c0-5829-43ac-96f1-ce55707860b4.png">
+
 
 To use napari from inside a script, use `napari.run()`:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import napari
 viewer = napari.view_image(data.cells3d(), channel_axis=1, ndisplay=3)
 ```
 
-<img width="1198" alt="napari viewer showing cells in 3d." src="https://user-images.githubusercontent.com/44469195/209934762-aba0c2c0-5829-43ac-96f1-ce55707860b4.png">
+![napari viewer with a multichannel image of cells displayed as two image layers: nuclei and membrane.](https://github.com/napari/docs/blob/main/docs/images/multichannel_cells.png)
 
 
 To use napari from inside a script, use `napari.run()`:


### PR DESCRIPTION
In the readme, there is currently a picture showing an astronaut in the napari viewer, but the script generates cells in 3d.
Therefore, I've changed the image to a screenshot that I get when I run the example script in the latest napari version.
I've used the GitHub markdown drag and drop to add this image, so this image lives in the GitHub image database, and does not live in this repo. This might be a good idea, as the screenshot does not use repo space that way.
The outdated screenshot got originally readded in https://github.com/napari/napari/pull/5220