### PR TITLE
Bugfix: Fix test_get_system_theme test for `name` to `id` change

### DIFF
--- a/examples/new_theme.py
+++ b/examples/new_theme.py
@@ -19,7 +19,7 @@ viewer = napari.view_image(data.astronaut(), rgb=True, name='astronaut')
 print('Originally themes', available_themes())
 
 blue_theme = get_theme('dark', False)
-blue_theme.name = "blue"
+blue_theme.id = "blue"
 blue_theme.icon = (
     'rgb(0, 255, 255)'  # you can provide colors as rgb(XXX, YYY, ZZZ)
 )

--- a/napari/utils/_tests/test_theme.py
+++ b/napari/utils/_tests/test_theme.py
@@ -37,7 +37,7 @@ def test_get_system_theme(monkeypatch):
     monkeypatch.setattr('napari.utils.theme.get_system_theme', lambda: 'light')
     theme = get_theme('system', as_dict=False)
     # should return the theme specified by get_system_theme
-    assert theme.name == 'light'
+    assert theme.id == 'light'
 
 
 def test_register_theme():


### PR DESCRIPTION
# Description

https://github.com/napari/napari/pull/5412 changed `theme.name` to `theme.id`
I failed to account for that PR being merged in https://github.com/napari/napari/pull/5143
As a result, the `test_get_system_theme` test fails:
**https://github.com/napari/napari/issues/5455**

This PR fixes the test and also the `new_theme.py` example which also uses `theme.name`

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
closes https://github.com/napari/napari/issues/5455

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
