### PR TITLE
Fix broken link in EmitterGroup docstring

### DIFF
--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -1089,8 +1089,8 @@ class EmitterGroup(EventEmitter):
     def unblock_all(self):
         """
         Unblock all emitters in this group, by decrease counter of semaphores for each event emitter.
-        if block is called twice and unblock is called once, then events will be still blocked
-        https://en.wikipedia.org/wiki/Semaphore_(programming)
+        if block is called twice and unblock is called once, then events will be still blocked.
+        See `Semaphore (programming) <https://en.wikipedia.org/wiki/Semaphore_(programming)>`__.
         """
         self.unblock()
         for em in self._emitters.values():


### PR DESCRIPTION
# Description
Fixes a broken link in the EmitterGroup docstring.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
None

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
