### PR TITLE
MAINT: Unused attribute.

### DIFF
--- a/napari/_qt/widgets/qt_dims_slider.py
+++ b/napari/_qt/widgets/qt_dims_slider.py
@@ -416,7 +416,6 @@ class QtDimSliderWidget(QWidget):
         worker.finished.connect(self.qt_dims.cleaned_worker)
         thread.finished.connect(self.play_stopped)
         self.play_started.emit()
-        self.thread = thread
         return worker, thread
 
 


### PR DESCRIPTION
I'm unsure if this is related to #5443 and could lead to non-gc of thread? but nothing seem to be using it, and it's always better to have a single owner for a thread, to manage it's state in a single place.
