### PR TITLE
Bugfix: POLL_INTERVAL_MS used in QTimer needs to be an int on python 3.10

### DIFF
--- a/napari/_qt/experimental/qt_poll.py
+++ b/napari/_qt/experimental/qt_poll.py
@@ -11,7 +11,7 @@ from qtpy.QtCore import QEvent, QObject, QTimer
 from napari.utils.events import EmitterGroup
 
 # When running a timer we use this interval.
-POLL_INTERVAL_MS = 16.666  # About 60HZ
+POLL_INTERVAL_MS = 16  # About 60HZ, needs to be an int for QTimer setInterval
 
 # If called more often than this we ignore it. Our _on_camera() method can
 # be called multiple times in on frame. It can get called because the


### PR DESCRIPTION
# Description
Python 3.10 no longer casts floats to ints
https://github.com/python/cpython/issues/82180

The variable `POLL_INTERVAL_MS` is used by QTimer and the `setInterval()` needs an int (in milliseconds), see:
https://doc.qt.io/qt-5/qtimer.html

This means that in python 3.10 the existing value (16.666) results in a TypeError (see #5415 ) and napari doesn't even launch. 

Note: This is part of the experimental async/octree and apparently not tested on 3.10 CI.

`POLL_INTERVAL_MS` is fairly arbitrary and unused anywhere else, so in this PR I simply assign an int to it, `16` rather than the `16.666` (~1/60).



## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References

Closes #5415 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [x] example: If I enable the experimental features in settings, then napari won't launch on main (as in the issue) but will launch with this branch.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
