### PR TITLE
Public API for dock widgets 

### DIFF
--- a/napari/qt/__init__.py
+++ b/napari/qt/__init__.py
@@ -4,9 +4,11 @@ from napari._qt.qt_resources import get_current_stylesheet, get_stylesheet
 from napari._qt.qt_viewer import QtViewer
 from napari._qt.widgets.qt_tooltip import QtToolTipLabel
 from napari._qt.widgets.qt_viewer_buttons import QtViewerButtons
+from napari.qt.dock_widget import DockWidget
 from napari.qt.threading import create_worker, thread_worker
 
 __all__ = (
+    'DockWidget',
     'create_worker',
     'QtToolTipLabel',
     'QtViewer',

--- a/napari/qt/dock_widget.py
+++ b/napari/qt/dock_widget.py
@@ -1,0 +1,107 @@
+"""
+Currently just passes some dock_widget methods to the main window.
+"""
+from typing import TYPE_CHECKING, Optional, Sequence, Union
+
+from qtpy.QtWidgets import QMenu, QWidget
+
+from napari.viewer import current_viewer
+
+if TYPE_CHECKING:
+    from magicgui.widgets import Widget
+
+
+class DockWidget:
+    @staticmethod
+    def add_dock_widget(
+        widget: Union[QWidget, 'Widget'],
+        *,
+        name: str = '',
+        area: str = 'right',
+        allowed_areas: Optional[Sequence[str]] = None,
+        add_vertical_stretch=True,
+        tabify: bool = False,
+        menu: Optional[QMenu] = None,
+    ):
+        """Add a widget to the napari dock area.
+
+        Parameters
+        ----------
+        widget : QWidget or magicgui.Widget
+            The widget to add to the dock area.
+        name : str, optional
+            The name of the widget, by default ''
+        area : str, optional
+            The area to add the widget to, by default 'right'
+        allowed_areas : Sequence[str], optional
+            A list of areas where the widget can be moved, by default None
+        add_vertical_stretch : bool, optional
+            Whether to add a vertical stretch to the widget, by default True
+        tabify : bool, optional
+            Whether to tabify the widget with any existing widgets, by default False
+        menu : QMenu, optional
+            A menu to add the widget to, by default None
+        """
+        current_viewer().window.add_dock_widget(
+            widget,
+            name=name,
+            area=area,
+            allowed_areas=allowed_areas,
+            add_vertical_stretch=add_vertical_stretch,
+            tabify=tabify,
+            menu=menu,
+        )
+
+    @staticmethod
+    def add_function_widget(
+        function,
+        *,
+        magic_kwargs=None,
+        name: str = '',
+        area=None,
+        allowed_areas=None,
+        shortcut=None,
+    ):
+        """Turn a function into a dock widget via magicgui and adds it to the napari dock area.
+
+        Parameters
+        ----------
+        function : callable
+            The function to add to the dock area.
+        magic_kwargs : dict, optional
+            Keyword arguments to pass to magicgui, by default None
+        name : str, optional
+            The name of the widget, by default ''
+        area : str, optional
+            The area to add the widget to, by default None
+        allowed_areas : list[str], optional
+            A list of areas where the widget can be moved, by default None
+        shortcut : str, optional
+            A keyboard shortcut to call the function, by default None
+        """
+        current_viewer().window.add_function_widget(
+            function,
+            magic_kwargs=magic_kwargs,
+            name=name,
+            area=area,
+            allowed_areas=allowed_areas,
+            shortcut=shortcut,
+        )
+
+    @staticmethod
+    def remove_dock_widget(widget: QWidget, menu=None):
+        """Remove a widget from the napari dock area.
+
+        Parameters
+        ----------
+        widget : QWidget | str
+            The widget to remove from the dock area. If widget == 'all', all docked widgets will be removed.
+        menu : QMenu, optional
+            A menu to remove the widget from, by default None
+        """
+        current_viewer().window.remove_dock_widget(widget, menu=menu)
+
+    @staticmethod
+    def get_dock_widgets():
+        """A dict of all dock widgets."""
+        return current_viewer().window._dock_widgets


### PR DESCRIPTION
# Description

This PR is motivated in part by #23, #2203, #3944, and #5407. The goal is to have a public API for handling dock widgets. Currently, functionality is handled by the napari._qt module and there has been a need to create a public-facing API for dock widgets in the `napari.qt` module.

To get started, I've created a simple dock_widgets file that just exposes some of the dock_widget methods from the private window class. The goal is to have a `DockWidget` class that handles all public elements of the dock widgets API, including all the current functionality under the private `napari._qt` module, as well as some new features mentioned in the above issues/PRs.

I'm unsure _who_ should own the `DockWidget` class right now so I've implemented it as an uninstantiated class with staticmethods. In the future, it may be beneficial for the Viewer to own the instance of `DockWidget`. If anyone has advice or thoughts on how we could best implement this public dock widgets API, comment away!

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
