### PR TITLE
Maint: Fix sporadic QtDims garbage collection failures by converting some stray references to weakrefs

### DIFF
--- a/napari/_qt/widgets/qt_dims_slider.py
+++ b/napari/_qt/widgets/qt_dims_slider.py
@@ -556,8 +556,8 @@ class QtPlayButton(QPushButton):
     def _on_click(self):
         """Toggle play/stop animation control."""
         qt_dims = self.qt_dims_ref()
-        if not qt_dims:
-            return None
+        if not qt_dims:  # pragma: no cover
+            return
         if self.property('playing') == "True":
             return qt_dims.stop()
         self.play_requested.emit(self.axis)


### PR DESCRIPTION
As far as I can tell this is due to issue with garbage collection issue
between the worker and thread. Mostly between the garbage collection and
the worker cleanup if the last reference to the thread is set to None
and collected while the thread is still active it causes a crash.

This has two side:
1) changes to make this crash more reliably, by removing unused
   reference to the thread, and using weakrefs to make sure we free up
   things faster. Freeing things faster mean we crash more reliably.
2) actually fix the cleanup to be done after thread termination and not
   worker termination. Due to 1) we are more confident this fixes
   things.

In particular, the animation thread, has a worker that refers to the
dims via a callback/slot.

We also remove the local reference to thread, to make sure there is not
a standing, unused reference to thread, thus self._animation_thread will
be the last standing reference.

That is to say we currently have:

 - worker stop
    - delete last thread reference
 (if GC, crash)
 - Thread stops.

Now we have
 - worker stop
 - Thread stops.
    - delete last thread (and worker) reference

This should fix some issues with thread/garbage collection/cycle (#5443)