### PR TITLE
Allow layers control section to resize to contents

### DIFF
--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -13,7 +13,7 @@ from napari._qt.dialogs.qt_notification import (
     NapariQtNotification,
     TracebackDialog,
 )
-from napari._tests.utils import DEFAULT_TIMEOUT_SECS
+from napari._tests.utils import DEFAULT_TIMEOUT_SECS, skip_on_win_ci
 from napari.utils.notifications import (
     ErrorNotification,
     Notification,
@@ -267,6 +267,7 @@ def test_notification_error(count_show, monkeypatch):
     assert count_show.show_traceback_count == 1
 
 
+@skip_on_win_ci
 @pytest.mark.sync_only
 def test_notifications_error_with_threading(
     make_napari_viewer, clean_current, monkeypatch

--- a/napari/_qt/_tests/test_qt_provide_theme.py
+++ b/napari/_qt/_tests/test_qt_provide_theme.py
@@ -6,10 +6,12 @@ from napari_plugin_engine import napari_hook_implementation
 
 from napari import Viewer
 from napari._qt import Window
+from napari._tests.utils import skip_on_win_ci
 from napari.settings import get_settings
 from napari.utils.theme import Theme, get_theme
 
 
+@skip_on_win_ci
 @patch.object(Window, "_remove_theme")
 @patch.object(Window, "_add_theme")
 def test_provide_theme_hook_registered_correctly(

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -515,6 +515,7 @@ def test_memory_leaking(qtbot, make_napari_viewer):
     assert labels() is None
 
 
+@skip_on_win_ci
 @skip_local_popups
 def test_leaks_image(qtbot, make_napari_viewer):
 
@@ -530,6 +531,7 @@ def test_leaks_image(qtbot, make_napari_viewer):
     assert not dr()
 
 
+@skip_on_win_ci
 @skip_local_popups
 def test_leaks_labels(qtbot, make_napari_viewer):
     viewer = make_napari_viewer(show=True)

--- a/napari/_qt/layer_controls/qt_layer_controls_container.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_container.py
@@ -101,6 +101,7 @@ class QtLayerControlsContainer(QStackedWidget):
 
         self.setMouseTracking(True)
         self.empty_widget = QFrame()
+        self.empty_widget.setObjectName("empty_controls_widget")
         self.widgets = {}
         self.addWidget(self.empty_widget)
         self.setCurrentWidget(self.empty_widget)

--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -267,12 +267,15 @@ QLabel#logo_silhouette {
 
 /* ------------------------------------------------------ */
 
+QFrame#empty_controls_widget {
+    min-height: 295px;
+    min-width: 240px;
+}
+
 QtLayerControlsContainer {
     border-radius: 2px;
     padding: 0px;
     margin: 10px;
-    min-height: 295px;
-    min-width: 240px;
     margin-left: 10px;
     margin-right: 8px;
     margin-bottom: 4px;

--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -268,7 +268,7 @@ QLabel#logo_silhouette {
 /* ------------------------------------------------------ */
 
 QFrame#empty_controls_widget {
-    min-height: 295px;
+    min-height: 225px;
     min-width: 240px;
 }
 

--- a/napari/layers/image/experimental/_tests/test_octree_import.py
+++ b/napari/layers/image/experimental/_tests/test_octree_import.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 import sys
 
+from napari._tests.utils import skip_on_win_ci
+
 CREATE_VIEWER_SCRIPT = """
 import numpy as np
 import napari
@@ -9,6 +11,7 @@ v = napari.view_image(np.random.rand(512, 512))
 """
 
 
+@skip_on_win_ci
 def test_octree_import():
     """Test we can create a viewer with NAPARI_OCTREE."""
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Set `min-height` and `min-width` to the empty widget used by the layers controls container widget instead of the widget itself to allow it to resize dependending on the controls being shown

## Preview

![resize2](https://user-images.githubusercontent.com/16781833/212175360-8e6446dd-dd39-4d16-9216-d7f3a6de61c2.gif)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
closes #2337 
closes #5472 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change
- [x] I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
