### PR TITLE
Replace GabrielBB/xvfb-action

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -49,7 +49,7 @@ jobs:
           python -c 'import napari.layers; print(napari.layers.__doc__)'
 
       - name: Build Docs
-        uses: GabrielBB/xvfb-action@v1
+        uses: aganders3/headless-gui@v1
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}

--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -85,12 +85,6 @@ jobs:
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
           if (Test-Path -Path "C:\Windows\system32\opengl32.dll" -PathType Leaf) {Exit 0} else {Exit 1}
 
-      # run a minimal wm for linux tests that depend on UI events (e.g. setFocus)
-      # see https://github.com/pytest-dev/pytest-qt/issues/206
-      - name: Install WM on Linux
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y herbstluftwm
-
       - name: Install dependencies
         run: |
           pip install --upgrade pip
@@ -106,7 +100,7 @@ jobs:
       # in which case we are declaring one specific tox environment to run.
       # see tox.ini for more
       - name: Test with tox
-        uses: GabrielBB/xvfb-action@v1
+        uses: aganders3/headless-gui@v1
         with:
           run: python -m tox
         env:
@@ -151,17 +145,13 @@ jobs:
 
       - uses: tlambert03/setup-qt-libs@v1
 
-      - name: Install WM
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y herbstluftwm
-
       - name: Install this commit
         run: |
           pip install --upgrade pip
           pip install ./napari-from-github[all,testing]
 
       - name: Test
-        uses: GabrielBB/xvfb-action@v1
+        uses: aganders3/headless-gui@v1
         with:
           run: python -m pytest --pyargs napari --color=yes
 
@@ -180,6 +170,6 @@ jobs:
           pip install setuptools tox tox-gh-actions
 
       - name: Test
-        uses: GabrielBB/xvfb-action@v1
+        uses: aganders3/headless-gui@v1
         with:
           run: tox -e py39-linux-pyside2-examples

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -39,12 +39,6 @@ jobs:
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
           if (Test-Path -Path "C:\Windows\system32\opengl32.dll" -PathType Leaf) {Exit 0} else {Exit 1}
 
-      # run a minimal wm for linux tests that depend on UI events (e.g. setFocus)
-      # see https://github.com/pytest-dev/pytest-qt/issues/206
-      - name: Install WM on Linux
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y herbstluftwm
-
       - name: Install dependencies
         run: |
           pip install --upgrade pip
@@ -52,7 +46,7 @@ jobs:
 
       - name: Test with tox
         # run tests using pip install --pre
-        uses: GabrielBB/xvfb-action@v1
+        uses: aganders3/headless-gui@v1
         with:
           run: python -m tox -v --pre
         env:

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -114,12 +114,6 @@ jobs:
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
           if (Test-Path -Path "C:\Windows\system32\opengl32.dll" -PathType Leaf) {Exit 0} else {Exit 1}
 
-      # run a minimal wm for linux tests that depend on UI events (e.g. setFocus)
-      # see https://github.com/pytest-dev/pytest-qt/issues/206
-      - name: Install WM on Linux
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y herbstluftwm
-
       # tox and tox-gh-actions will take care of the "actual" installation
       # of python dependendencies into a virtualenv.  see tox.ini for more
       - name: Install dependencies
@@ -140,7 +134,7 @@ jobs:
       # `tox -e py38-linux-pyqt,py38-linux-pyside`
       # see tox.ini for more
       - name: Test with tox
-        uses: GabrielBB/xvfb-action@v1
+        uses: aganders3/headless-gui@v1
         with:
           run: python -m tox
         env:
@@ -176,19 +170,13 @@ jobs:
 
       - uses: tlambert03/setup-qt-libs@v1
 
-      # run a minimal wm for linux tests that depend on UI events (e.g. setFocus)
-      # see https://github.com/pytest-dev/pytest-qt/issues/206
-      - name: Install WM
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y herbstluftwm
-
       - name: Install this commit
         run: |
           pip install --upgrade pip
           pip install ./napari-from-github[all,testing]
 
       - name: Test
-        uses: GabrielBB/xvfb-action@v1
+        uses: aganders3/headless-gui@v1
         with:
           run: |
             python -m pytest --pyargs napari --color=yes
@@ -210,6 +198,6 @@ jobs:
           pip install setuptools tox tox-gh-actions
 
       - name: Test
-        uses: GabrielBB/xvfb-action@v1
+        uses: aganders3/headless-gui@v1
         with:
           run: tox -e py39-linux-pyside2-examples

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,5 +43,7 @@ repos:
     hooks:
     - id: import-linter
       stages: [manual]
-
-
+-   repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.20.0
+    hooks:
+      - id: check-github-workflows

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -66,7 +66,7 @@ def test_qt_viewer_toggle_console(make_napari_viewer):
 
 
 @skip_local_popups
-def test_qt_viewer_console_focus(qtbot, make_napari_viewer, linux_wm):
+def test_qt_viewer_console_focus(qtbot, make_napari_viewer):
     """Test console has focus when instantiating from viewer."""
     viewer = make_napari_viewer(show=True)
     view = viewer.window._qt_viewer

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -1,10 +1,7 @@
 import collections
 import gc
 import os
-import platform
-import subprocess
 import sys
-import time
 import warnings
 from contextlib import suppress
 from typing import TYPE_CHECKING
@@ -362,41 +359,3 @@ def MouseEvent():
             'dims_point',
         ],
     )
-
-
-@pytest.fixture
-def linux_wm():
-    """Start a WM in the background for tests that need a WM.
-
-    This is required for tests that depend on UI events (e.g. setFocus).
-    See https://github.com/pytest-dev/pytest-qt/issues/206.
-
-    This will only run on Linux and in CI (determined by CI env var) - this is
-    unnecessary/irrelevant on macOS and Windows.
-
-    The window manager start command can be set via env var `WM_START_CMD`
-    (default is `herbstluftwm` - make sure it's installed).
-    """
-    wm_start_cmd = os.environ.get("WM_START_CMD", "herbstluftwm")
-    proc = None
-    if platform.system() == "Linux" and os.environ.get("CI"):
-        proc = subprocess.Popen([wm_start_cmd])
-        # give the WM 1s to start up and check it's still running
-        time.sleep(1)
-        if proc.poll() is not None:
-            raise RuntimeError(
-                f"window manager '{wm_start_cmd}' process [{proc.pid}] exited, "
-                f"return code: {proc.returncode}"
-            )
-
-    yield proc
-
-    if proc:
-        proc.terminate()
-        try:
-            proc.wait(timeout=20)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            raise RuntimeError(
-                f"failed to terminate window manager '{wm_start_cmd}'"
-            )


### PR DESCRIPTION
This (potentially) closes #5476 by replacing https://github.com/GabrielBB/xvfb-action with https://github.com/aganders3/headless-gui.

I am also happy to move this action into the napari org if the community prefers to maintain it collectively.

The purpose of this action is to run the same commands on multiple platforms (Windows, macOS, Linux) for consistency, but Linux requires a bit of extra setup:
* For GUI tests we need a display server, so we run [Xvfb](https://en.wikipedia.org/wiki/Xvfb)
* [Some GUI tests additionally require a window manager](https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#xvfb-assertionerror-timeouterror-when-using-waituntil-waitexposed-and-ui-events), so this runs [herbstluftwm](https://herbstluftwm.org/) (though this is configurable)

Adding the WM startup in here also removes the need for the `linux_wm` test fixture added in #5208.

Other options:
* Put more logic into the GitHub Actions Workflow file(s) to install dependencies and modify commands for Linux
* (Maybe?) put more logic into `tox.ini` and other cross-platform command runners
*  Use another existing action e.g. https://github.com/coactions/setup-xvfb

As part of testing I also added a pre-commit hook to check GitHub Actions Workflows against a schema. I am happy to remove this or put it in a separate PR if it's muddying the scope here.

## Type of change
- [x] Bug-fix/CI change

# References
* Prior discussions:
  * https://github.com/napari/napari/pull/5208#discussion_r993585379
  * #5476 
* Old action currently in use: https://github.com/GabrielBB/xvfb-action
* New action proposed by this PR: https://github.com/aganders3/headless-gui

# How has this been tested?
- [x] PR tests pass with this change in my fork
