### PR TITLE
Bugfix: Add missing Enums and Flags required by PySide6 > 6.4

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -84,10 +84,9 @@ jobs:
           - python: 3.9
             platform: ubuntu-latest
             backend: pyside6
-# uncoment when new qtpy is released
-#          - python: '3.10'
-#            platform: ubuntu-latest
-#            backend: pyside6
+          - python: '3.10'
+            platform: ubuntu-latest
+            backend: pyside6
 
     steps:
       - name: Cancel Previous Runs

--- a/napari/_qt/code_syntax_highlight.py
+++ b/napari/_qt/code_syntax_highlight.py
@@ -15,7 +15,7 @@ def get_text_char_format(style):
     """
 
     text_char_format = QtGui.QTextCharFormat()
-	try:
+    try:
         text_char_format.setFontFamilies(["monospace"])
     except AttributeError:
         text_char_format.setFontFamily("monospace") # backward compatibility for pyqt5 5.12.3 

--- a/napari/_qt/code_syntax_highlight.py
+++ b/napari/_qt/code_syntax_highlight.py
@@ -15,7 +15,10 @@ def get_text_char_format(style):
     """
 
     text_char_format = QtGui.QTextCharFormat()
-    text_char_format.setFontFamilies(["monospace"])
+	try:
+        text_char_format.setFontFamilies(["monospace"])
+    except AttributeError:
+        text_char_format.setFontFamily("monospace") # backward compatibility for pyqt5 5.12.3 
     if style.get('color'):
         text_char_format.setForeground(QtGui.QColor(f"#{style['color']}"))
 

--- a/napari/_qt/code_syntax_highlight.py
+++ b/napari/_qt/code_syntax_highlight.py
@@ -15,7 +15,7 @@ def get_text_char_format(style):
     """
 
     text_char_format = QtGui.QTextCharFormat()
-    text_char_format.setFontFamily("monospace")
+    text_char_format.setFontFamilies(["monospace"])
     if style.get('color'):
         text_char_format.setForeground(QtGui.QColor(f"#{style['color']}"))
 

--- a/napari/_qt/code_syntax_highlight.py
+++ b/napari/_qt/code_syntax_highlight.py
@@ -18,7 +18,9 @@ def get_text_char_format(style):
     try:
         text_char_format.setFontFamilies(["monospace"])
     except AttributeError:
-        text_char_format.setFontFamily("monospace") # backward compatibility for pyqt5 5.12.3 
+        text_char_format.setFontFamily(
+            "monospace"
+        )  # backward compatibility for pyqt5 5.12.3
     if style.get('color'):
         text_char_format.setForeground(QtGui.QColor(f"#{style['color']}"))
 

--- a/napari/_qt/containers/_base_item_view.py
+++ b/napari/_qt/containers/_base_item_view.py
@@ -98,7 +98,7 @@ class _BaseEventedItemView(Generic[ItemType]):
             sm.clearCurrentIndex()
         else:
             idx = index_of(self.model(), event.value)
-            sm.setCurrentIndex(idx, sm.Current)
+            sm.setCurrentIndex(idx, sm.SelectionFlag.Current)
 
     def _on_py_selection_change(self, event: Event):
         """The python model selection has changed. Update the Qt view."""

--- a/napari/_qt/containers/_base_item_view.py
+++ b/napari/_qt/containers/_base_item_view.py
@@ -118,7 +118,7 @@ class _BaseEventedItemView(Generic[ItemType]):
         for i in self._root.selection:
             idx = index_of(self.model(), i)
             selection.select(idx, idx)
-        sel_model.select(selection, sel_model.ClearAndSelect)
+        sel_model.select(selection, sel_model.SelectionFlag.ClearAndSelect)
 
 
 def index_of(model: QAbstractItemModel, obj: ItemType) -> QModelIndex:

--- a/napari/_qt/containers/_base_item_view.py
+++ b/napari/_qt/containers/_base_item_view.py
@@ -104,8 +104,8 @@ class _BaseEventedItemView(Generic[ItemType]):
         """The python model selection has changed. Update the Qt view."""
         sm = self.selectionModel()
         for is_selected, idx in chain(
-            zip(repeat(sm.Select), event.added),
-            zip(repeat(sm.Deselect), event.removed),
+            zip(repeat(sm.SelectionFlag.Select), event.added),
+            zip(repeat(sm.SelectionFlag.Deselect), event.removed),
         ):
             model_idx = index_of(self.model(), idx)
             if model_idx.isValid():

--- a/napari/_qt/containers/_layer_delegate.py
+++ b/napari/_qt/containers/_layer_delegate.py
@@ -109,7 +109,9 @@ class LayerDelegate(QStyledItemDelegate):
         bg = option.palette.color(option.palette.ColorRole.Window).red()
         option.icon = icon.colored(theme='dark' if bg < 128 else 'light')
         option.decorationSize = QSize(18, 18)
-        option.decorationPosition = option.Right  # put icon on the right
+        option.decorationPosition = (
+            option.Position.Right
+        )  # put icon on the right
         option.features |= option.HasDecoration
 
     def _paint_thumbnail(self, painter, option, index):

--- a/napari/_qt/containers/_layer_delegate.py
+++ b/napari/_qt/containers/_layer_delegate.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from qtpy.QtCore import QPoint, QSize, Qt
-from qtpy.QtGui import QPixmap
+from qtpy.QtGui import QMouseEvent, QPixmap
 from qtpy.QtWidgets import QStyledItemDelegate
 
 from napari._app_model.constants import MenuId
@@ -154,7 +154,7 @@ class LayerDelegate(QStyledItemDelegate):
         This can be used to customize how the delegate handles mouse/key events
         """
         if (
-            event.type() == event.MouseButtonRelease
+            event.type() == QMouseEvent.MouseButtonRelease
             and event.button() == Qt.MouseButton.RightButton
         ):
             pnt = (
@@ -168,11 +168,13 @@ class LayerDelegate(QStyledItemDelegate):
         # if the user clicks quickly on the visibility checkbox, we *don't*
         # want it to be interpreted as a double-click.  We want the visibilty
         # to simply be toggled.
-        if event.type() == event.MouseButtonDblClick:
+        if event.type() == QMouseEvent.MouseButtonDblClick:
             self.initStyleOption(option, index)
             style = option.widget.style()
             check_rect = style.subElementRect(
-                style.SE_ItemViewItemCheckIndicator, option, option.widget
+                style.SubElement.SE_ItemViewItemCheckIndicator,
+                option,
+                option.widget,
             )
             if check_rect.contains(event.pos()):
                 cur_state = index.data(Qt.ItemDataRole.CheckStateRole)

--- a/napari/_qt/containers/_layer_delegate.py
+++ b/napari/_qt/containers/_layer_delegate.py
@@ -112,7 +112,7 @@ class LayerDelegate(QStyledItemDelegate):
         option.decorationPosition = (
             option.Position.Right
         )  # put icon on the right
-        option.features |= option.HasDecoration
+        option.features |= option.ViewItemFeature.HasDecoration
 
     def _paint_thumbnail(self, painter, option, index):
         """paint the layer thumbnail."""

--- a/napari/_qt/containers/_tests/test_qt_list.py
+++ b/napari/_qt/containers/_tests/test_qt_list.py
@@ -75,7 +75,7 @@ def test_list_view(qtbot):
     assert qmodel.getItem(qsel.currentIndex()) == root[3]
 
     # clear current in Qt
-    qsel.setCurrentIndex(QModelIndex(), qsel.Current)
+    qsel.setCurrentIndex(QModelIndex(), qsel.SelectionFlag.Current)
     # check current in python
     assert root.selection._current is None
 

--- a/napari/_qt/containers/_tests/test_qt_tree.py
+++ b/napari/_qt/containers/_tests/test_qt_tree.py
@@ -145,7 +145,7 @@ def test_node_tree_view(qtbot):
     assert qmodel.getItem(qsel.currentIndex()).index_from_root() == (2, 1, 0)
 
     # clear current in Qt
-    qsel.setCurrentIndex(QModelIndex(), qsel.Current)
+    qsel.setCurrentIndex(QModelIndex(), qsel.SelectionFlag.Current)
     # check current in python
     assert root.selection._current is None
 

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, List, Optional, Union
 from napari_plugin_engine import HookCaller, HookImplementation
 from qtpy.QtCore import QEvent, Qt, Signal, Slot
 from qtpy.QtWidgets import (
+    QAbstractItemView,
     QCheckBox,
     QComboBox,
     QFrame,
@@ -169,7 +170,7 @@ class QtHookImplementationListWidget(QListWidget):
         self.setDefaultDropAction(Qt.DropAction.MoveAction)
         self.setDragEnabled(True)
         self.setDragDropMode(QListView.InternalMove)
-        self.setSelectionMode(self.SingleSelection)
+        self.setSelectionMode(QAbstractItemView.SingleSelection)
         self.setAcceptDrops(True)
         self.setSpacing(1)
         self.setMinimumHeight(1)

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -14,6 +14,7 @@ from qtpy.QtWidgets import (
     QGraphicsOpacityEffect,
     QHBoxLayout,
     QLabel,
+    QListView,
     QListWidget,
     QListWidgetItem,
     QSizePolicy,
@@ -167,7 +168,7 @@ class QtHookImplementationListWidget(QListWidget):
         super().__init__(parent)
         self.setDefaultDropAction(Qt.DropAction.MoveAction)
         self.setDragEnabled(True)
-        self.setDragDropMode(self.InternalMove)
+        self.setDragDropMode(QListView.InternalMove)
         self.setSelectionMode(self.SingleSelection)
         self.setAcceptDrops(True)
         self.setSpacing(1)

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -235,10 +235,16 @@ class QtViewerDockWidget(QDockWidget):
             Qt.DockWidgetArea.RightDockWidgetArea,
         ):
             features = self._features
-            if features & self.DockWidgetVerticalTitleBar:
-                features = features ^ self.DockWidgetVerticalTitleBar
+            if features & self.DockWidgetFeature.DockWidgetVerticalTitleBar:
+                features = (
+                    features
+                    ^ self.DockWidgetFeature.DockWidgetVerticalTitleBar
+                )
         else:
-            features = self._features | self.DockWidgetVerticalTitleBar
+            features = (
+                self._features
+                | self.DockWidgetFeature.DockWidgetVerticalTitleBar
+            )
         self.setFeatures(features)
 
     @property


### PR DESCRIPTION
# Description

This PR is a fix for the change in PySide6 to Enums in PySide6 6.4:
https://doc.qt.io/qtforpython/considerations.html#the-new-python-enums

Basically shortcuts related to flags and enums are not allowed anymore, so for example `SelectionFlag` needs to be explicitly accessed.

I checked the python Qt5 docs and the same approach was present there, so it's backwards compatible. My local tests with PyQt5 pass and I also made a PR in my fork to ensure tests pass on CI: https://github.com/psobolewskiPhD/napari/actions/runs/3918510705

This wasn't caught by tests because our PySide 6.4 test was commented out, pending a qtpy release. I uncommented it and the tests caught a few more cases, other than the original breaking one from the issue.
Also there is a deprecated setFontFamily issue, which should keep working, but test fails with DeprecationWarning. It affects pyqt5 min req, because the new setFontFamilies is Qt >= 5.13. Instead of bumping out min req on pyqt5, which has historical significance and may exist in the wild—per @Czaki—instead we just try/except.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References

Closes #5479 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my changes
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
