### PR TITLE
Add tags to recently added examples

### DIFF
--- a/examples/inherit_viewer_style.py
+++ b/examples/inherit_viewer_style.py
@@ -4,6 +4,8 @@ Method to get napari style in magicgui based windows
 
 Example how to embed magicgui widget in dialog to inherit style
 from main napari window.
+
+.. tags::  gui, interactivity
 """
 
 from qtpy.QtWidgets import QDialog, QWidget, QVBoxLayout, QPushButton, QGridLayout, QLabel, QSpinBox

--- a/examples/minimum_blending.py
+++ b/examples/minimum_blending.py
@@ -11,7 +11,7 @@ values, as opposed to the more conventional black [0, 0, 0]. For example, try th
 colormaps prefixed with *I*, such as *I Forest* or *I Bordeaux*, from 
 ChrisLUTs: https://github.com/cleterrier/ChrisLUTs .
 
-.. tags:: visualization-advanced
+.. tags:: visualization-basic
 """
 
 from skimage import data

--- a/examples/minimum_blending.py
+++ b/examples/minimum_blending.py
@@ -10,6 +10,8 @@ An inverted colormap is one where white [1, 1, 1] is used to represent the lowes
 values, as opposed to the more conventional black [0, 0, 0]. For example, try the
 colormaps prefixed with *I*, such as *I Forest* or *I Bordeaux*, from 
 ChrisLUTs: https://github.com/cleterrier/ChrisLUTs .
+
+.. tags:: visualization-advanced
 """
 
 from skimage import data


### PR DESCRIPTION
# Description

Two new examples have been recently added to the gallery. However, because they don't have tags associated with them, they are not showing in the rendered gallery since we have removed the full example list from the ToC sidebar. This can be seen in https://napari.org/dev/gallery.html

When building the docs, this can be seen with the current warning:

```
napari-docs/docs/gallery/inherit_viewer_style.rst: WARNING: document isn't included in any toctree
napari-docs/docs/gallery/minimum_blending.rst: WARNING: document isn't included in any toctree
```

If different tags are preferred for these examples, please let me know.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
--

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
