### PR TITLE
Handle case when QtDims play thread is partially deleted 

### DIFF
--- a/napari/_qt/_tests/test_threading_progress.py
+++ b/napari/_qt/_tests/test_threading_progress.py
@@ -52,20 +52,23 @@ def test_worker_may_exceed_total(qtbot):
 
     def test_yield(v):
         test_val[0] += 1
-
-    thread_func = qthreading.thread_worker(
-        func,
-        connect={'yielded': test_yield},
-        progress={'total': 1},
-        start_thread=False,
-    )
-    worker = thread_func()
-    with qtbot.waitSignal(worker.yielded):
-        worker.start()
         if test_val[0] < 2:
             assert worker.pbar.n == test_val[0]
         else:
             assert worker.pbar.total == 0
+
+    thread_func = qthreading.thread_worker(
+        func,
+        progress={'total': 1},
+        start_thread=False,
+    )
+    worker = thread_func()
+    worker.yielded.connect(test_yield)
+    with qtbot.waitSignal(worker.yielded) and qtbot.waitSignal(
+        worker.finished
+    ):
+        worker.start()
+    assert test_val[0] == 2
 
 
 def test_generator_worker_with_description():

--- a/napari/_qt/widgets/qt_dims.py
+++ b/napari/_qt/widgets/qt_dims.py
@@ -320,7 +320,7 @@ class QtDims(QWidget):
             return (
                 self._animation_thread and self._animation_thread.isRunning()
             )
-        except RuntimeError as e:
+        except RuntimeError as e:  # pragma: no cover
             if (
                 "wrapped C/C++ object of type" not in e.args[0]
                 and "Internal C++ object" not in e.args[0]

--- a/napari/_qt/widgets/qt_dims.py
+++ b/napari/_qt/widgets/qt_dims.py
@@ -325,6 +325,9 @@ class QtDims(QWidget):
                 "wrapped C/C++ object of type" not in e.args[0]
                 and "Internal C++ object" not in e.args[0]
             ):
+                # checking if threat is partially deleted. Otherwise
+                # reraise exception. For more details see:
+                # https://github.com/napari/napari/pull/5499
                 raise
             return False
 

--- a/napari/_qt/widgets/qt_dims.py
+++ b/napari/_qt/widgets/qt_dims.py
@@ -316,7 +316,17 @@ class QtDims(QWidget):
     @property
     def is_playing(self):
         """Return True if any axis is currently animated."""
-        return self._animation_thread and self._animation_thread.isRunning()
+        try:
+            return (
+                self._animation_thread and self._animation_thread.isRunning()
+            )
+        except RuntimeError as e:
+            if (
+                "wrapped C/C++ object of type" not in e.args[0]
+                and "Internal C++ object" not in e.args[0]
+            ):
+                raise
+            return False
 
     def _set_frame(self, axis, frame):
         """Safely tries to set `axis` to the requested `point`.


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

It is possible that `QtDims._animation_thread` is already deleted, but an event that will clean a reference is not processed yet. This PR update code with the catch of runtime exception and process it. 

Fix bug observed here 
https://github.com/napari/napari/actions/runs/3983769894/jobs/6829367267#step:8:408

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
