### PR TITLE
Ensure surface normals and wireframes are using Models internally

### DIFF
--- a/napari/layers/surface/_tests/test_surface.py
+++ b/napari/layers/surface/_tests/test_surface.py
@@ -291,6 +291,10 @@ def test_get_value_3d_nd(
 
 
 def test_surface_normals():
+    """Ensure that normals can be set both with dict and SurfaceNormals.
+
+    The model should internally always use SurfaceNormals.
+    """
     vertices = np.array(
         [
             [3, 0, 0],
@@ -322,6 +326,10 @@ def test_surface_normals():
 
 
 def test_surface_wireframe():
+    """Ensure that wireframe can be set both with dict and SurfaceWireframe.
+
+    The model should internally always use SurfaceWireframe.
+    """
     vertices = np.array(
         [
             [3, 0, 0],

--- a/napari/layers/surface/_tests/test_surface.py
+++ b/napari/layers/surface/_tests/test_surface.py
@@ -3,6 +3,8 @@ import pytest
 
 from napari._tests.utils import check_layer_world_data_extent
 from napari.layers import Surface
+from napari.layers.surface.normals import SurfaceNormals
+from napari.layers.surface.wireframe import SurfaceWireframe
 
 
 def test_random_surface():
@@ -286,3 +288,65 @@ def test_get_value_3d_nd(
     )
     assert index == expected_index
     np.testing.assert_allclose(value, expected_value)
+
+
+def test_surface_normals():
+    vertices = np.array(
+        [
+            [3, 0, 0],
+            [3, 0, 3],
+            [3, 3, 0],
+            [5, 0, 0],
+            [5, 0, 3],
+            [5, 3, 0],
+            [2, 50, 50],
+            [2, 50, 100],
+            [2, 100, 50],
+        ]
+    )
+    faces = np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+    values = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+
+    normals = dict(face=dict(visible=True, color='red'))
+    surface_layer = Surface((vertices, faces, values), normals=normals)
+    assert isinstance(surface_layer.normals, SurfaceNormals)
+    assert surface_layer.normals.face.visible is True
+    assert np.all(surface_layer.normals.face.color == (1, 0, 0, 1))
+
+    surface_layer = Surface(
+        (vertices, faces, values), normals=SurfaceNormals(**normals)
+    )
+    assert isinstance(surface_layer.normals, SurfaceNormals)
+    assert surface_layer.normals.face.visible is True
+    assert np.all(surface_layer.normals.face.color == (1, 0, 0, 1))
+
+
+def test_surface_wireframe():
+    vertices = np.array(
+        [
+            [3, 0, 0],
+            [3, 0, 3],
+            [3, 3, 0],
+            [5, 0, 0],
+            [5, 0, 3],
+            [5, 3, 0],
+            [2, 50, 50],
+            [2, 50, 100],
+            [2, 100, 50],
+        ]
+    )
+    faces = np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+    values = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+
+    wireframe = dict(visible=True, color='red')
+    surface_layer = Surface((vertices, faces, values), wireframe=wireframe)
+    assert isinstance(surface_layer.wireframe, SurfaceWireframe)
+    assert surface_layer.wireframe.visible is True
+    assert np.all(surface_layer.wireframe.color == (1, 0, 0, 1))
+
+    surface_layer = Surface(
+        (vertices, faces, values), wireframe=SurfaceWireframe(**wireframe)
+    )
+    assert isinstance(surface_layer.wireframe, SurfaceWireframe)
+    assert surface_layer.wireframe.visible is True
+    assert np.all(surface_layer.wireframe.color == (1, 0, 0, 1))

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -361,11 +361,11 @@ class Surface(IntensityVisualizationMixin, Layer):
         self.events.shading(value=self._shading)
 
     @property
-    def wireframe(self):
+    def wireframe(self) -> SurfaceWireframe:
         return self._wireframe
 
     @wireframe.setter
-    def wireframe(self, wireframe):
+    def wireframe(self, wireframe: Union[dict, SurfaceWireframe, None]):
         if wireframe is None:
             self._wireframe.reset()
         elif isinstance(wireframe, SurfaceWireframe):
@@ -379,11 +379,11 @@ class Surface(IntensityVisualizationMixin, Layer):
         self.events.wireframe(value=self._wireframe)
 
     @property
-    def normals(self):
+    def normals(self) -> SurfaceNormals:
         return self._normals
 
     @normals.setter
-    def normals(self, normals):
+    def normals(self, normals: Union[dict, SurfaceNormals, None]):
         if normals is None:
             self._normals.reset()
         elif isinstance(normals, SurfaceNormals):

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -197,6 +197,8 @@ class Surface(IntensityVisualizationMixin, Layer):
             interpolation=Event,
             rendering=Event,
             shading=Event,
+            wireframe=Event,
+            normals=Event,
         )
 
         # assign mesh data and establish default behavior
@@ -238,8 +240,11 @@ class Surface(IntensityVisualizationMixin, Layer):
         # Shading mode
         self._shading = shading
 
-        self.wireframe = wireframe or SurfaceWireframe()
-        self.normals = normals or SurfaceNormals()
+        self._wireframe = SurfaceWireframe()
+        self._normals = SurfaceNormals()
+
+        self.wireframe = wireframe
+        self.normals = normals
 
     def _calc_data_range(self, mode='data'):
         return calc_data_range(self.vertex_values)
@@ -354,6 +359,42 @@ class Surface(IntensityVisualizationMixin, Layer):
         else:
             self._shading = Shading(shading)
         self.events.shading(value=self._shading)
+
+    @property
+    def wireframe(self):
+        return self._wireframe
+
+    @wireframe.setter
+    def wireframe(self, wireframe):
+        if wireframe is None:
+            self._wireframe.reset()
+        elif isinstance(wireframe, SurfaceWireframe):
+            self._wireframe = wireframe
+        elif isinstance(wireframe, dict):
+            self._wireframe = SurfaceWireframe(**wireframe)
+        else:
+            raise ValueError(
+                f'wireframe should be a dict or SurfaceWireframe, got {type(wireframe)}'
+            )
+        self.events.wireframe(value=self._wireframe)
+
+    @property
+    def normals(self):
+        return self._normals
+
+    @normals.setter
+    def normals(self, normals):
+        if normals is None:
+            self._normals.reset()
+        elif isinstance(normals, SurfaceNormals):
+            self._normals = normals
+        elif isinstance(normals, dict):
+            self._normals = SurfaceNormals(**normals)
+        else:
+            raise ValueError(
+                f'normals should be a dict or SurfaceNormals, got {type(normals)}'
+            )
+        self.events.normals(value=self._normals)
 
     def _get_state(self):
         """Get dictionary of layer state.

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -92,9 +92,9 @@ class Surface(IntensityVisualizationMixin, Layer):
     cache : bool
         Whether slices of out-of-core datasets should be cached upon retrieval.
         Currently, this only applies to dask arrays.
-    wireframe : dict or SurfaceWireframe
+    wireframe : None, dict or SurfaceWireframe
         Whether and how to display the edges of the surface mesh with a wireframe.
-    normals : dict or SurfaceNormals
+    normals : None, dict or SurfaceNormals
         Whether and how to display the face and vertex normals of the surface mesh.
 
     Attributes
@@ -374,7 +374,7 @@ class Surface(IntensityVisualizationMixin, Layer):
             self._wireframe = SurfaceWireframe(**wireframe)
         else:
             raise ValueError(
-                f'wireframe should be a dict or SurfaceWireframe, got {type(wireframe)}'
+                f'wireframe should be None, a dict, or SurfaceWireframe; got {type(wireframe)}'
             )
         self.events.wireframe(value=self._wireframe)
 
@@ -392,7 +392,7 @@ class Surface(IntensityVisualizationMixin, Layer):
             self._normals = SurfaceNormals(**normals)
         else:
             raise ValueError(
-                f'normals should be a dict or SurfaceNormals, got {type(normals)}'
+                f'normals should be None, a dict, or SurfaceNormals; got {type(normals)}'
             )
         self.events.normals(value=self._normals)
 


### PR DESCRIPTION
# Description
Make sure that surface normals are always using the `SurfaceNormal` model internally (now they can sometimes be dict, which breaks a few assumptions in other parts of the codebase). See napari/napari-animation#145.

I also took the chance to add an event for them, and do the same fix for the wireframe.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
