### PR TITLE
Fix styles for LayerControlsContainer and Console on Qt6

### DIFF
--- a/napari/_qt/qt_resources/styles/00_base.qss
+++ b/napari/_qt/qt_resources/styles/00_base.qss
@@ -35,10 +35,6 @@ QWidget {
   selection-color: {{ text }};
 }
 
-QWidget[emphasized="true"] {
-    background-color: {{ foreground }};
-}
-
 QWidget[emphasized="true"] > QFrame {
     background-color: {{ foreground }};
 }

--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -111,7 +111,7 @@ QtConsole {
 
 QtConsole > QTextEdit {
   background-color: {{ console }};
-  background-clip: padding;
+  background-clip: border-box;
   color: {{ text }};
   selection-background-color: {{ highlight }};
   margin: 10px;
@@ -272,18 +272,12 @@ QFrame#empty_controls_widget {
     min-width: 240px;
 }
 
-QtLayerControlsContainer {
-    border-radius: 2px;
-    padding: 0px;
-    margin: 10px;
-    margin-left: 10px;
-    margin-right: 8px;
-    margin-bottom: 4px;
-}
-
 QtLayerControlsContainer > QFrame {
-  padding: 5px;
-  padding-right: 8px;
+  padding: 5;
+  margin: 10px;
+  margin-left: 10px;
+  margin-right: 8px;
+  margin-bottom: 4px;
   border-radius: 2px;
 }
 

--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -273,7 +273,7 @@ QFrame#empty_controls_widget {
 }
 
 QtLayerControlsContainer > QFrame {
-  padding: 5;
+  padding: 5px;
   margin: 10px;
   margin-left: 10px;
   margin-right: 8px;

--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -111,10 +111,10 @@ QtConsole {
 
 QtConsole > QTextEdit {
   background-color: {{ console }};
-  background-clip: border-box;
+  background-clip: padding;
   color: {{ text }};
   selection-background-color: {{ highlight }};
-  margin: 10px;
+  padding: 5px;
 }
 .inverted {
   background-color: {{ background }};

--- a/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/napari/_qt/qt_resources/styles/02_custom.qss
@@ -114,8 +114,9 @@ QtConsole > QTextEdit {
   background-clip: padding;
   color: {{ text }};
   selection-background-color: {{ highlight }};
-  padding: 5px;
+  margin: 10px;
 }
+
 .inverted {
   background-color: {{ background }};
   color: {{ foreground }};

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -81,6 +81,8 @@ class QtViewerDockWidget(QDockWidget):
     ) -> None:
         self._ref_qt_viewer: 'ReferenceType[QtViewer]' = ref(qt_viewer)
         super().__init__(name)
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground)
+
         self._parent = qt_viewer
         self.name = name
         self._close_btn = close_btn


### PR DESCRIPTION
# Description
This fixes a couple visual bugs on macOS when using Qt6. I tested as well on Qt5 and don't notice any issues. Unfortunately I don't have simple access to many platforms to do more extensive testing.

I appreciate review from anyone with more Qt experience on whether these fixes make sense. 

## Qt6 main
<img width="900" alt="Screenshot 2023-02-02 at 4 16 36 PM" src="https://user-images.githubusercontent.com/1231828/216451940-c8fb0703-8739-4440-8865-ccd124a15c62.png">

## Qt5 main
<img width="900" alt="Screenshot 2023-02-02 at 4 30 12 PM" src="https://user-images.githubusercontent.com/1231828/216454008-216d16f1-d3f5-4c31-a204-a148f11cb4ad.png">

## Qt6 this branch (PyQt)

<img width="900" alt="Screenshot 2023-02-04 at 2 12 59 PM" src="https://user-images.githubusercontent.com/1231828/216785501-b564f217-2665-4422-b2e5-99356ed632dc.png">
<img width="900" alt="Screenshot 2023-02-04 at 2 13 02 PM" src="https://user-images.githubusercontent.com/1231828/216785504-0988966a-92fd-4115-9faf-4b29667cf86e.png">

### Previous iterations from this branch
<img width="256" alt="Screenshot 2023-02-02 at 4 14 37 PM" src="https://user-images.githubusercontent.com/1231828/216452022-879da65a-1feb-4956-9b13-45f28604c01b.png">


<img width="256" alt="Screenshot 2023-02-02 at 4 23 15 PM" src="https://user-images.githubusercontent.com/1231828/216452705-3d52314b-c071-414e-aa10-bbbe42dd0a14.png">

<img width="256" alt="Screenshot 2023-02-02 at 4 14 41 PM" src="https://user-images.githubusercontent.com/1231828/216451967-9f82587d-a9d7-430b-80f0-3c7d4f222674.png">

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
#3880
Closes #5529

# How has this been tested?
- [x] Tested changes with PyQt5 and PyQt6, PySide6 (macOS) and PyQt5 (linux)

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality lo