### PR TITLE
Set PYTHONEXECUTABLE as part of macos fixes on (re)startup

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -537,6 +537,10 @@ def _maybe_rerun_with_macos_fixes():
         else:  # we assume it must have been launched via '-m' syntax
             cmd = [executable, "-m", "napari"]
 
+        # this fixes issues running from a venv/virtualenv based virtual
+        # environment with certain python distributions (e.g. pyenv, asdf)
+        env["PYTHONEXECUTABLE"] = sys.executable
+
         # Append original command line arguments.
         if len(sys.argv) > 1:
             cmd.extend(sys.argv[1:])


### PR DESCRIPTION
# Description
Fixes #5454.

I believe this is a problem caused by a combination of our symlink hack to change the executable name (name in the menu bar) on macOS, and certain Python distributions like [pyenv](https://github.com/pyenv/pyenv) or [asdf](https://github.com/asdf-community/asdf-python) that use "shims" to dynamically figure out which version of Python to run. Setting this env var allows Python to find the correct import paths for the virtual environment.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
https://docs.python.org/3/using/cmdline.html?highlight=pythonexecutable#envvar-PYTHONEXECUTABLE

# How has this been tested?
- [x] Tested with both venv-based (Python installed via asdf) and conda-based virtual environments

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
