### PR TITLE
MAINT: Follow Nep29, bump minimum numpy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![Development Status](https://img.shields.io/pypi/status/napari.svg)](https://en.wikipedia.org/wiki/Software_release_life_cycle#Alpha)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 [![DOI](https://zenodo.org/badge/144513571.svg)](https://zenodo.org/badge/latestdoi/144513571)
+[![NEP29](https://raster.shields.io/badge/Follows-NEP29-brightgreen.png)](https://numpy.org/neps/nep-0029-deprecation_policy.html)
 
 **napari** is a fast, interactive, multi-dimensional image viewer for Python. It's designed for browsing, annotating, and analyzing large multi-dimensional images. It's built on top of Qt (for the GUI), vispy (for performant GPU-based rendering), and the scientific Python stack (numpy, scipy).
 

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -145,11 +145,6 @@ def are_objects_equal(object1, object2):
         items = [(object1, object2)]
 
     # equal_nan does not exist in array_equal in old numpy
-    npy_major_version = tuple(int(v) for v in np.__version__.split('.')[:2])
-    if npy_major_version < (1, 19):
-        fixed = [(np.nan_to_num(a1), np.nan_to_num(a2)) for a1, a2 in items]
-        return np.all([np.all(a1 == a2) for a1, a2 in fixed])
-
     try:
         return np.all(
             [np.array_equal(a1, a2, equal_nan=True) for a1, a2 in items]

--- a/napari/components/_tests/test_layer_slicer.py
+++ b/napari/components/_tests/test_layer_slicer.py
@@ -6,13 +6,13 @@ from typing import Any, Tuple, Union
 
 import numpy as np
 import pytest
+from numpy.typing import DTypeLike
 
 from napari._tests.utils import DEFAULT_TIMEOUT_SECS
 from napari.components import Dims
 from napari.components._layer_slicer import _LayerSlicer
 from napari.layers import Image, Points
 from napari.layers._data_protocols import Index, LayerDataProtocol
-from napari.types import DTypeLike
 
 # The following fakes are used to control execution of slicing across
 # multiple threads, while also allowing us to mimic real classes

--- a/napari/layers/_data_protocols.py
+++ b/napari/layers/_data_protocols.py
@@ -19,7 +19,7 @@ _OBJ_NAMES.update({'__annotations__', '__dict__', '__weakref__'})
 if TYPE_CHECKING:
     from enum import Enum
 
-    from napari.types import DTypeLike
+    from numpy.typing import DTypeLike
 
     # https://github.com/python/typing/issues/684#issuecomment-548203158
     class ellipsis(Enum):

--- a/napari/types.py
+++ b/napari/types.py
@@ -24,29 +24,6 @@ if TYPE_CHECKING:
     from magicgui.widgets import FunctionGui
     from qtpy.QtWidgets import QWidget
 
-try:
-    from numpy.typing import DTypeLike  # requires numpy 1.20
-except ImportError:
-    # Anything that can be coerced into numpy.dtype.
-    # Reference: https://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html
-    from typing import Protocol, TypeVar
-
-    _DType_co = TypeVar("_DType_co", covariant=True, bound=np.dtype)
-
-    # A protocol for anything with the dtype attribute
-    class _SupportsDType(Protocol[_DType_co]):
-        @property
-        def dtype(self) -> _DType_co:
-            ...
-
-    DTypeLike = Union[  # type: ignore
-        np.dtype,  # default data type (float64)
-        None,
-        type,  # array-scalar types and generic types
-        _SupportsDType[np.dtype],  # anything with a dtype attribute
-        str,  # character codes, type strings, e.g. 'float64'
-    ]
-
 
 # This is a WOEFULLY inadequate stub for a duck-array type.
 # Mostly, just a placeholder for the concept of needing an ArrayLike type.
@@ -95,16 +72,7 @@ class SampleDict(TypedDict):
 # while their names should not change (without deprecation), their typing
 # implementations may... or may be rolled over to napari/image-types
 
-if tuple(np.__version__.split('.')) < ('1', '20'):
-    # this hack is because NewType doesn't allow `Any` as a base type
-    # and numpy <=1.20 didn't provide type stubs for np.ndarray
-    # https://github.com/python/mypy/issues/6701#issuecomment-609638202
-    class ArrayBase(np.ndarray):
-        def __getattr__(self, name: str) -> Any:
-            return object.__getattribute__(self, name)
-
-else:
-    ArrayBase = np.ndarray  # type: ignore
+ArrayBase = np.ndarray
 
 
 ImageData = NewType("ImageData", ArrayBase)

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     napari-plugin-engine>=0.1.9
     napari-svg>=0.1.6
     npe2>=0.5.2
-    numpy>=1.20
+    numpy>=1.21
     numpydoc>=0.9.2
     pandas>=1.1.0 ; python_version < '3.9'
     pandas>=1.3.0 ; python_version >= '3.9'


### PR DESCRIPTION
As usual this is open for discussion.
See previous thread in #5089.

Also add a Nep29 badge to the readme.

for info Nep29 suggests:

> On Jan 31, 2023 drop support for NumPy 1.20 (initially released on Jan 31, 2021)

This also remove any conditional branching based on numpy version.


Note that this is _technically_ a change of API ad DTypeLiike is not exposed by `napari.types` anymore. I did not manage to keep it there as `ruff` is removing is as an unused import. I think that's ok as this was likely only used internally.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References

https://numpy.org/neps/nep-0029-deprecation_policy.html


## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
