### PR TITLE
Un-set unified title and tool bar on mac (Qt property)

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -114,7 +114,6 @@ class _QtMainWindow(QMainWindow):
 
         self.setWindowIcon(QIcon(self._window_icon))
         self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
-        self.setUnifiedTitleAndToolBarOnMac(True)
         center = QWidget(self)
         center.setLayout(QHBoxLayout())
         center.layout().addWidget(self._qt_viewer)


### PR DESCRIPTION
# Description
This one is a bit weird, but here goes. This fixes the background "behind" the QtViewerDockWidgets being the wrong color (something from the system theme). I think this was actually the root cause of the issues seen in #5529 and addressed separately in #5526. I could go either way then on whether to include the changes in #5526 as well.

Anyway this removes a property that was set to fix an intermittent problem quite a while ago. It seems the behavior of this property actually changed in Qt5, and it is supposedly not compatible with windows that contain Open GL content.

### Before this change
![Screenshot 2023-02-06 at 12 12 18 PM](https://user-images.githubusercontent.com/1231828/217045566-eb330839-4496-4cb4-883e-2f58788ef68a.png)

### After this change
![Screenshot 2023-02-06 at 12 24 58 PM](https://user-images.githubusercontent.com/1231828/217045560-0d593d26-9cea-48ee-8838-864b8ef265fb.png)

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
https://github.com/napari/napari/pull/245
https://github.com/napari/napari/issues/239
https://github.com/napari/napari/issues/5529
#5526

# How has this been tested?
- [x] I checked my changes work with both PySide and PyQt backends on Qt6, and PyQt on Qt5

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality