### PR TITLE
MAINT: Fix vendoring script and track closest commit.

### DIFF
--- a/napari/utils/colormaps/vendored/_cm_listed.py
+++ b/napari/utils/colormaps/vendored/_cm_listed.py
@@ -1,3 +1,4 @@
+# closest mpl commit is 3fda6a719d, except it is missing turbo data
 from napari.utils.colormaps.vendored.colors import ListedColormap
 
 _magma_data = [

--- a/napari/utils/colormaps/vendored/cm.py
+++ b/napari/utils/colormaps/vendored/cm.py
@@ -1,3 +1,4 @@
+# closes commit to this file is matplotlib's e9cda7fbfb
 """
 Builtin colormaps, colormap handling utilities, and the `ScalarMappable` mixin.
 

--- a/tools/check_vendored_modules.py
+++ b/tools/check_vendored_modules.py
@@ -100,7 +100,7 @@ def main():
         ),
     ]:
         print(f"\n * Checking '{org}/{reponame}'\n")
-        if not source:
+        if source is None:
             diff = check_vendored_module(org, reponame, tag)
         else:
             diff = check_vendored_files(


### PR DESCRIPTION
For two on the vendored file, try to track the closes version. None of the files are exact match, in particular imports were modified by absolute importify, but this should allow to at least track the modification that were done in a later pass, and later update them.

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
