### PR TITLE
Fix key error issue of action manager

### DIFF
--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -176,17 +176,17 @@ class QtLabelsControls(QtLayerControls):
             checked=True,
         )
         action_manager.bind_button(
-            'napari:activate_label_pan_zoom_mode', self.panzoom_button
+            'napari:activate_labels_pan_zoom_mode', self.panzoom_button
         )
 
         self.pick_button = QtModeRadioButton(layer, 'picker', Mode.PICK)
         action_manager.bind_button(
-            'napari:activate_label_picker_mode', self.pick_button
+            'napari:activate_labels_picker_mode', self.pick_button
         )
 
         self.paint_button = QtModeRadioButton(layer, 'paint', Mode.PAINT)
         action_manager.bind_button(
-            'napari:activate_paint_mode', self.paint_button
+            'napari:activate_labels_paint_mode', self.paint_button
         )
 
         self.fill_button = QtModeRadioButton(
@@ -195,7 +195,7 @@ class QtLabelsControls(QtLayerControls):
             Mode.FILL,
         )
         action_manager.bind_button(
-            'napari:activate_fill_mode',
+            'napari:activate_labels_fill_mode',
             self.fill_button,
         )
 
@@ -205,7 +205,7 @@ class QtLabelsControls(QtLayerControls):
             Mode.ERASE,
         )
         action_manager.bind_button(
-            'napari:activate_label_erase_mode',
+            'napari:activate_labels_erase_mode',
             self.erase_button,
         )
 

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -22,12 +22,12 @@ def register_label_mode_action(description):
 
 
 @register_label_mode_action(trans._('Transform'))
-def activate_labels_transform_mode(layer):
+def activate_labels_transform_mode(layer: Labels):
     layer.mode = Mode.TRANSFORM
 
 
 @register_label_mode_action(trans._('Pan/zoom'))
-def activate_labels_pan_zoom_mode(layer):
+def activate_labels_pan_zoom_mode(layer: Labels):
     layer.mode = Mode.PAN_ZOOM
 
 


### PR DESCRIPTION
# Description
Fixes the issue described in #5535. Due to the action manager bindings being incorrect, key errors were thrown when using the functionality of the labels layer.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
#5535 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
Passed the tests in napari.layers and manually tested

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
