### PR TITLE
Bugfix: ensure Checkbox state comparisons are correct by using Qt.CheckState(state)

### DIFF
--- a/napari/_qt/containers/qt_layer_model.py
+++ b/napari/_qt/containers/qt_layer_model.py
@@ -59,7 +59,9 @@ class QtLayerListModel(QtListModel[Layer]):
             # partially checked, but we only use the unchecked and checked
             # to correspond to the layer's visibility.
             # https://doc.qt.io/qt-5/qt.html#CheckState-enum
-            self.getItem(index).visible = value == Qt.CheckState.Checked
+            self.getItem(index).visible = (
+                Qt.CheckState(value) == Qt.CheckState.Checked
+            )
         elif role == Qt.ItemDataRole.EditRole:
             self.getItem(index).name = value
             role = Qt.ItemDataRole.DisplayRole

--- a/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
@@ -63,3 +63,22 @@ def test_changing_colormap_updates_colorbox(qtbot):
         color_box.color,
         np.round(np.asarray(layer._selected_color) * 255 * layer.opacity),
     )
+
+
+def test_layercontrols_checkboxes(qtbot):
+    """Tests that the Labels LayerControl checkboxes actually set properties properly."""
+    layer = Labels(_LABELS)
+    qtctrl = QtLabelsControls(layer)
+    qtbot.add_widget(qtctrl)
+    qtctrl.selectedColorCheckbox.setChecked(True)
+    assert layer.show_selected_label
+    qtctrl.selectedColorCheckbox.setChecked(False)
+    assert not layer.show_selected_label
+    qtctrl.contigCheckBox.setChecked(True)
+    assert layer.contiguous
+    qtctrl.contigCheckBox.setChecked(False)
+    assert not layer.contiguous
+    qtctrl.preserveLabelsCheckBox.setChecked(True)
+    assert layer.preserve_labels
+    qtctrl.preserveLabelsCheckBox.setChecked(False)
+    assert not layer.preserve_labels

--- a/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from napari._qt.layer_controls.qt_labels_controls import QtLabelsControls
 from napari.layers import Labels
@@ -9,11 +10,20 @@ _LABELS = np.random.randint(5, size=(10, 15))
 _COLOR = {1: 'white', 2: 'blue', 3: 'green', 4: 'red', 5: 'yellow'}
 
 
-def test_changing_layer_color_mode_updates_combo_box(qtbot):
+@pytest.fixture
+def make_labels_controls(qtbot, color=None):
+    def _make_labels_controls(color=color):
+        layer = Labels(_LABELS, color=color)
+        qtctrl = QtLabelsControls(layer)
+        qtbot.add_widget(qtctrl)
+        return layer, qtctrl
+
+    return _make_labels_controls
+
+
+def test_changing_layer_color_mode_updates_combo_box(make_labels_controls):
     """Updating layer color mode changes the combo box selection"""
-    layer = Labels(_LABELS, color=_COLOR)
-    qtctrl = QtLabelsControls(layer)
-    qtbot.addWidget(qtctrl)
+    layer, qtctrl = make_labels_controls(color=_COLOR)
 
     original_color_mode = layer.color_mode
     assert original_color_mode == qtctrl.colorModeComboBox.currentText()
@@ -22,11 +32,9 @@ def test_changing_layer_color_mode_updates_combo_box(qtbot):
     assert layer.color_mode == qtctrl.colorModeComboBox.currentText()
 
 
-def test_rendering_combobox(qtbot):
+def test_rendering_combobox(make_labels_controls):
     """Changing the model attribute should update the view"""
-    layer = Labels(_LABELS)
-    qtctrl = QtLabelsControls(layer)
-    qtbot.addWidget(qtctrl)
+    layer, qtctrl = make_labels_controls()
     combo = qtctrl.renderComboBox
     opts = {combo.itemText(i) for i in range(combo.count())}
     rendering_options = {'translucent', 'iso_categorical'}
@@ -37,11 +45,9 @@ def test_rendering_combobox(qtbot):
     assert combo.findText(new_mode) == combo.currentIndex()
 
 
-def test_changing_colormap_updates_colorbox(qtbot):
+def test_changing_colormap_updates_colorbox(make_labels_controls):
     """Test that changing the colormap on a layer will update color swatch in the combo box"""
-    layer = Labels(_LABELS, color=_COLOR)
-    qtctrl = QtLabelsControls(layer)
-    qtbot.addWidget(qtctrl)
+    layer, qtctrl = make_labels_controls(color=_COLOR)
     color_box = qtctrl.colorBox
 
     layer.selected_label = 1
@@ -65,20 +71,34 @@ def test_changing_colormap_updates_colorbox(qtbot):
     )
 
 
-def test_layercontrols_checkboxes(qtbot):
-    """Tests that the Labels LayerControl checkboxes actually set properties properly."""
-    layer = Labels(_LABELS)
-    qtctrl = QtLabelsControls(layer)
-    qtbot.add_widget(qtctrl)
+def test_selected_color_checkbox(make_labels_controls):
+    """Tests that the 'selected color' checkbox sets the 'show_selected_label' property properly."""
+    layer, qtctrl = make_labels_controls()
     qtctrl.selectedColorCheckbox.setChecked(True)
     assert layer.show_selected_label
     qtctrl.selectedColorCheckbox.setChecked(False)
     assert not layer.show_selected_label
+    qtctrl.selectedColorCheckbox.setChecked(True)
+    assert layer.show_selected_label
+
+
+def test_contiguous_labels_checkbox(make_labels_controls):
+    """Tests that the 'contiguous' checkbox sets the 'contiguous' property properly."""
+    layer, qtctrl = make_labels_controls()
     qtctrl.contigCheckBox.setChecked(True)
     assert layer.contiguous
     qtctrl.contigCheckBox.setChecked(False)
     assert not layer.contiguous
+    qtctrl.contigCheckBox.setChecked(True)
+    assert layer.contiguous
+
+
+def test_preserve_labels_checkbox(make_labels_controls):
+    """Tests that the 'preserve labels' checkbox sets the 'preserve_labels' property properly."""
+    layer, qtctrl = make_labels_controls()
     qtctrl.preserveLabelsCheckBox.setChecked(True)
     assert layer.preserve_labels
     qtctrl.preserveLabelsCheckBox.setChecked(False)
     assert not layer.preserve_labels
+    qtctrl.preserveLabelsCheckBox.setChecked(True)
+    assert layer.preserve_labels

--- a/napari/_qt/layer_controls/_tests/test_qt_shapes_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_shapes_layer.py
@@ -39,6 +39,8 @@ def test_text_visible_checkbox(qtbot):
     layer = Shapes(_SHAPES)
     qtctrl = QtShapesControls(layer)
     qtbot.addWidget(qtctrl)
+    qtctrl.textDispCheckBox.setChecked(True)
+    assert layer.text.visible
     qtctrl.textDispCheckBox.setChecked(False)
     assert not layer.text.visible
     qtctrl.textDispCheckBox.setChecked(True)

--- a/napari/_qt/layer_controls/_tests/test_qt_shapes_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_shapes_layer.py
@@ -33,3 +33,13 @@ def test_shape_controls_edge_color(qtbot):
     layer.current_edge_color = 'red'
     target_color = transform_color(layer.current_edge_color)[0]
     np.testing.assert_almost_equal(qtctrl.edgeColorEdit.color, target_color)
+
+
+def test_text_visible_checkbox(qtbot):
+    layer = Shapes(_SHAPES)
+    qtctrl = QtShapesControls(layer)
+    qtbot.addWidget(qtctrl)
+    qtctrl.textDispCheckBox.setChecked(False)
+    assert not layer.text.visible
+    qtctrl.textDispCheckBox.setChecked(True)
+    assert layer.text.visible

--- a/napari/_qt/layer_controls/_tests/test_qt_vectors_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_vectors_layer.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from napari._qt.layer_controls.qt_vectors_controls import QtVectorsControls
+from napari.layers import Vectors
+
+_VECTORS = np.zeros((2, 2, 2))
+
+
+def test_out_of_slice_display_checkbox(qtbot):
+    layer = Vectors(_VECTORS)
+    qtctrl = QtVectorsControls(layer)
+    qtbot.addWidget(qtctrl)
+    qtctrl.outOfSliceCheckBox.setChecked(True)
+    assert layer.out_of_slice_display
+    qtctrl.outOfSliceCheckBox.setChecked(False)
+    assert not layer.out_of_slice_display

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -353,7 +353,7 @@ class QtLabelsControls(QtLayerControls):
         self.setFocus()
 
     def toggle_selected_mode(self, state):
-        """Toggle contiguous state of label layer.
+        """Toggle display of selected label only.
 
         Parameters
         ----------

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -349,7 +349,9 @@ class QtLabelsControls(QtLayerControls):
         self.setFocus()
 
     def toggle_selected_mode(self, state):
-        self.layer.show_selected_label = state == Qt.CheckState.Checked
+        self.layer.show_selected_label = (
+            Qt.CheckState(state) == Qt.CheckState.Checked
+        )
 
     def changeSize(self, value):
         """Change paint brush size.
@@ -369,7 +371,7 @@ class QtLabelsControls(QtLayerControls):
         state : QCheckBox
             Checkbox indicating if labels are contiguous.
         """
-        self.layer.contiguous = state == Qt.CheckState.Checked
+        self.layer.contiguous = Qt.CheckState(state) == Qt.CheckState.Checked
 
     def change_n_edit_dim(self, value):
         """Change the number of editable dimensions of label layer.
@@ -403,7 +405,9 @@ class QtLabelsControls(QtLayerControls):
         state : QCheckBox
             Checkbox indicating if overwriting label is enabled.
         """
-        self.layer.preserve_labels = state == Qt.CheckState.Checked
+        self.layer.preserve_labels = (
+            Qt.CheckState(state) == Qt.CheckState.Checked
+        )
 
     def change_color_mode(self):
         """Change color mode of label layer"""

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -368,8 +368,8 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        state : QCheckBox
-            Checkbox indicating if labels are contiguous.
+        state : int
+            Integer value of Qt.CheckState that indicates the check state of contigCheckBox
         """
         self.layer.contiguous = Qt.CheckState(state) == Qt.CheckState.Checked
 

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -68,11 +68,15 @@ class QtLabelsControls(QtLayerControls):
         Button to select PAN_ZOOM mode on Labels layer.
     pick_button : qtpy.QtWidgets.QtModeRadioButton
         Button to select PICKER mode on Labels layer.
+    preserveLabelsCheckBox : qtpy.QtWidgets.QCheckBox
+        Checkbox to control if existing labels are preserved
     erase_button : qtpy.QtWidgets.QtModeRadioButton
         Button to select ERASE mode on Labels layer.
     selectionSpinBox : superqt.QLargeIntSpinBox
         Widget to select a specific label by its index.
         N.B. cannot represent labels > 2**53.
+    selectedColorCheckbox : qtpy.QtWidgets.QCheckBox
+        Checkbox to control if only currently selected label is shown.
 
     Raises
     ------
@@ -349,6 +353,13 @@ class QtLabelsControls(QtLayerControls):
         self.setFocus()
 
     def toggle_selected_mode(self, state):
+        """Toggle contiguous state of label layer.
+
+        Parameters
+        ----------
+        state : int
+            Integer value of Qt.CheckState that indicates the check state of selectedColorCheckbox
+        """
         self.layer.show_selected_label = (
             Qt.CheckState(state) == Qt.CheckState.Checked
         )
@@ -402,8 +413,8 @@ class QtLabelsControls(QtLayerControls):
 
         Parameters
         ----------
-        state : QCheckBox
-            Checkbox indicating if overwriting label is enabled.
+        state : int
+            Integer value of Qt.CheckState that indicates the check state of preserveLabelsCheckBox
         """
         self.layer.preserve_labels = (
             Qt.CheckState(state) == Qt.CheckState.Checked

--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -68,6 +68,8 @@ class QtShapesControls(QtLayerControls):
         Button to add rectangles to shapes layer.
     select_button : qtpy.QtWidgets.QtModeRadioButton
         Button to select shapes.
+    textDispCheckBox : qtpy.QtWidgets.QCheckBox
+        Checkbox to control if text should be displayed
     vertex_insert_button : qtpy.QtWidgets.QtModeRadioButton
         Button to insert vertex into shape.
     vertex_remove_button : qtpy.QtWidgets.QtModeRadioButton
@@ -402,8 +404,8 @@ class QtShapesControls(QtLayerControls):
 
         Parameters
         ----------
-        state : QCheckBox
-            Checkbox indicating if text is visible.
+        state : int
+            Integer value of Qt.CheckState that indicates the check state of textDispCheckBox
         """
         self.layer.text.visible = Qt.CheckState(state) == Qt.CheckState.Checked
 

--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -405,7 +405,7 @@ class QtShapesControls(QtLayerControls):
         state : QCheckBox
             Checkbox indicating if text is visible.
         """
-        self.layer.text.visible = state == Qt.CheckState.Checked
+        self.layer.text.visible = Qt.CheckState(state) == Qt.CheckState.Checked
 
     def _on_text_visibility_change(self):
         """Receive layer model text visibiltiy change change event and update checkbox."""

--- a/napari/_qt/layer_controls/qt_vectors_controls.py
+++ b/napari/_qt/layer_controls/qt_vectors_controls.py
@@ -204,8 +204,8 @@ class QtVectorsControls(QtLayerControls):
 
         Parameters
         ----------
-        state : QCheckBox
-            Checkbox to indicate whether to render out of slice.
+        state : int
+             Integer value of Qt.CheckState that indicates the check state of outOfSliceCheckBox
         """
         self.layer.out_of_slice_display = (
             Qt.CheckState(state) == Qt.CheckState.Checked

--- a/napari/_qt/layer_controls/qt_vectors_controls.py
+++ b/napari/_qt/layer_controls/qt_vectors_controls.py
@@ -207,7 +207,9 @@ class QtVectorsControls(QtLayerControls):
         state : QCheckBox
             Checkbox to indicate whether to render out of slice.
         """
-        self.layer.out_of_slice_display = state == Qt.CheckState.Checked
+        self.layer.out_of_slice_display = (
+            Qt.CheckState(state) == Qt.CheckState.Checked
+        )
 
     def _update_edge_color_gui(self, mode: str):
         """Update the GUI element associated with edge_color.


### PR DESCRIPTION
# Description

This PR fixes #5540 
Basically, the existing Checkbox comparisons fail on Qt6 because we compare the returned `state`, which is 0 or 2, with the enum Qt.CheckState.Checked. This always fails.
Now instead of using `state`, I make the comparison with `Qt.CheckState(state)`.
See pyside6 docs:
https://doc.qt.io/qtforpython/PySide6/QtCore/Qt.html#PySide6.QtCore.PySide6.QtCore.Qt.CheckState
And here's QT5 docs:
https://doc.qt.io/qt-5/qt.html#CheckState-enum

Note I also found 2 other places in the code where I fixed this, outside of labels layer checkboxes.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References

closes #5540 
closes #5556

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
