### PR TITLE
Move layer editable change from slicing to controls

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
@@ -86,22 +86,41 @@ def test_set_text_then_set_visible_updates_checkbox(
 
 @pytest.mark.parametrize(('ndim', 'editable_after'), ((2, False), (3, True)))
 def test_set_3d_display_with_points(qtbot, ndim, editable_after):
-    """Interactivity only work for 2D points layers
-    being rendered in 2D and not 3D. Verify that layer.editable
-    is set appropriately upon switching to 3D rendering mode.
+    """Interactivity only works for 2D points layers rendered in 2D and not
+    in 3D. Verify that layer.editable is set appropriately upon switching to
+    3D rendering mode.
 
     See: https://github.com/napari/napari/pull/4184
     """
     viewer = ViewerModel()
     container = QtLayerControlsContainer(viewer)
     qtbot.addWidget(container)
-    layer = viewer.add_points(np.zeros((4, ndim)))
+    layer = viewer.add_points(np.zeros((0, ndim)), ndim=ndim)
     assert viewer.dims.ndisplay == 2
     assert layer.editable
 
     viewer.dims.ndisplay = 3
 
     assert layer.editable == editable_after
+
+
+def test_set_3d_display_with_shapes(qtbot):
+    """Interactivity only works for shapes layers rendered in 2D and not
+    in 3D. Verify that layer.editable is set appropriately upon switching to
+    3D rendering mode.
+
+    See: https://github.com/napari/napari/pull/4184
+    """
+    viewer = ViewerModel()
+    container = QtLayerControlsContainer(viewer)
+    qtbot.addWidget(container)
+    layer = viewer.add_shapes(np.zeros((0, 2, 4)))
+    assert viewer.dims.ndisplay == 2
+    assert layer.editable
+
+    viewer.dims.ndisplay = 3
+
+    assert not layer.editable
 
 
 # The following tests handle changes to the layer's visible and

--- a/napari/_qt/layer_controls/qt_layer_controls_container.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_container.py
@@ -148,7 +148,7 @@ class QtLayerControlsContainer(QStackedWidget):
         """
         layer = event.value
         controls = create_qt_layer_controls(layer)
-        controls.ndisplay = 3
+        controls.ndisplay = self.viewer.dims.ndisplay
         self.addWidget(controls)
         self.widgets[layer] = controls
 

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -339,6 +339,10 @@ class QtPointsControls(QtLayerControls):
         with qt_signals_blocked(self.edgeColorEdit):
             self.edgeColorEdit.setColor(self.layer.current_edge_color)
 
+    def _on_ndisplay_changed(self):
+        # interaction currently does not work for 2D layers being rendered in 3D
+        self.layer.editable = not (self.layer.ndim == 2 and self.ndisplay == 3)
+
     def _on_editable_or_visible_change(self):
         """Receive layer model editable/visible change event & enable/disable buttons."""
         set_widgets_enabled_with_opacity(

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -340,7 +340,6 @@ class QtPointsControls(QtLayerControls):
             self.edgeColorEdit.setColor(self.layer.current_edge_color)
 
     def _on_ndisplay_changed(self):
-        # interaction currently does not work for 2D layers being rendered in 3D
         self.layer.editable = not (self.layer.ndim == 2 and self.ndisplay == 3)
 
     def _on_editable_or_visible_change(self):

--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -429,6 +429,9 @@ class QtShapesControls(QtLayerControls):
         with qt_signals_blocked(self.faceColorEdit):
             self.faceColorEdit.setColor(self.layer.current_face_color)
 
+    def _on_ndisplay_changed(self):
+        self.layer.editable = self.ndisplay == 2
+
     def _on_editable_or_visible_change(self):
         """Receive layer model editable/visible change event & enable/disable buttons."""
         set_widgets_enabled_with_opacity(

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -998,7 +998,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             return
         self._slice_input = slice_input
         self.refresh()
-        self._reset_editable()
 
     def _make_slice_input(
         self, point=None, ndisplay=2, order=None

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2298,40 +2298,6 @@ def test_text_param_and_setter_are_consistent():
     )
 
 
-def test_editable_2d_layer_ndisplay_3():
-    """Interactivity doesn't work for 2D points layers
-    being rendered in 3D. Verify that layer.editable is set
-    to False upon switching to 3D rendering mode.
-
-    See: https://github.com/napari/napari/pull/4184
-    """
-    data = np.random.random((10, 2))
-    layer = Points(data, size=5)
-    assert layer.editable is True
-
-    # simulate switching to 3D rendering
-    # layer should no longer b editable
-    layer._slice_dims([0, 0, 0], ndisplay=3)
-    assert layer.editable is False
-
-
-def test_editable_3d_layer_ndisplay_3():
-    """Interactivity works for 3D points layers
-    being rendered in 3D. Verify that layer.editable remains
-    True upon switching to 3D rendering mode.
-
-    See: https://github.com/napari/napari/pull/4184
-    """
-    data = np.random.random((10, 3))
-    layer = Points(data, size=5)
-    assert layer.editable is True
-
-    # simulate switching to 3D rendering
-    # layer should no longer b editable
-    layer._slice_dims([0, 0, 0], ndisplay=3)
-    assert layer.editable is True
-
-
 def test_shown():
     """Test setting shown property"""
     shape = (10, 2)


### PR DESCRIPTION
# Description
This moves some side-effects of changing the display dimensionality from `Layer._slice_dims` to the layer controls. This means the side-effects typically only occur in the full viewer.

Alternatively, we could consider connecting `Dims.ndisplay` to this side-effect in `ViewerModel`, so that a more standard headless napari would see the same behavior.

A further alternative is to not have the side-effect on `Layer.editable` and instead just update the layer control editable buttons' enabled state directly.

# Motivation
This is partially motivated by the async slicing/loading work (#4795) because it makes `Layer._slice_dims` almost identical to `Layer.refresh`, except that `_slice_dims` may still sometimes return early. More specifically, it would allow us to simplify [the sync default/fallback option](https://github.com/napari/napari/pull/5377/files#diff-6aa188e980053de4284e008eab22c9bf8cbc1d9a29fe17687b9879ea70042395R187) when integrating async slicing.

One upside is that the tests exercise some public API (even if it's part of napari's Qt/GUI code), rather than calling a private method as their main action.
