### PR TITLE
MAINT: Skip 3.8 flaky test.

### DIFF
--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -1,3 +1,4 @@
+import sys
 from itertools import dropwhile
 from unittest.mock import Mock, patch
 
@@ -108,6 +109,10 @@ def test_plugin_widgets_menus(test_plugin_widgets, qtbot):
     assert [a.text() for a in tp1.parent().actions()] == ['Widg1', 'Widg2']
 
 
+@pytest.mark.skipif(
+    sys.version_info[:2] == (3, 8),
+    reason="regularly fail on 3.8 without any reasons",
+)
 def test_making_plugin_dock_widgets(test_plugin_widgets, make_napari_viewer):
     """Test that we can create dock widgets, and they get the viewer."""
     viewer = make_napari_viewer()


### PR DESCRIPTION
This is always flaky on 3.8, I think we can safely ignore it on 3.8 as this will be anyway tested on other Python version, but it will save a lot of dev time and CI time by not having to restart tests/CI.
