### PR TITLE
Bugfix: PR build of docs doesn't use proper napari versioning for substitutions

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: napari-repo
+          # ensure version metadata is proper
+          fetch-depth: 0
 
       - name: Copy examples to docs folder
         run: |


### PR DESCRIPTION
# Description

This PR an an analog to https://github.com/napari/docs/pull/99
The built docs built by this repo PR action have improper napari version substitution (see https://github.com/napari/docs/pull/51)

This PR fixes that based on the README of https://github.com/actions/checkout
It updates the deploy action with `fetch-depth: 0`. You can see that this was added to the napari/docs PR build_docs action and works correctly. This makes the version metadata be correct (see https://github.com/pypa/setuptools_scm/issues/480)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References

Motivated by https://github.com/napari/docs/pull/51
Analog to https://github.com/napari/docs/pull/99


# How has this been tested?
N/A, see napari/docs repo PR builds?

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
