### PR TITLE
Fix #5553 Create correct projections

### DIFF
--- a/napari/_app_model/injection/_providers.py
+++ b/napari/_app_model/injection/_providers.py
@@ -15,10 +15,15 @@ def _provide_active_layer_list() -> Optional[components.LayerList]:
     return v.layers if (v := _provide_viewer()) else None
 
 
+def _provide_dims() -> Optional[components.Dims]:
+    return v.dims if (v := _provide_viewer()) else None
+
+
 # syntax could be simplified after
 # https://github.com/tlambert03/in-n-out/issues/31
 PROVIDERS = [
     (_provide_viewer,),
     (_provide_active_layer,),
     (_provide_active_layer_list,),
+    (_provide_dims,),
 ]

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -163,6 +163,9 @@ def _project(ll: LayerList, dims: Dims, axis: int = 0, mode='max'):
     # but the action is currently only enabled for 'image_active and ndim > 2'
     # before opening up to other layer types, this line should be updated.
     data = getattr(np, mode)(layer.data, axis=axis, keepdims=False)
+
+    # In case the last 2 dimensions are these axes, the data needs to be swapped in order to not have the projection
+    # displayed orthogonal to the image data.
     must_swap = ((0, 1), (2, 0))
     if dims.order[1:] in must_swap:
         data = np.swapaxes(data, 0, 1)

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -16,8 +16,7 @@ from napari.layers.utils._link_layers import get_linked_layers
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
-    from napari.components import LayerList
-    from napari.viewer import Viewer
+    from napari.components import Dims, LayerList
 
 
 def _duplicate_layer(ll: LayerList, *, name: str = ''):
@@ -133,7 +132,7 @@ def _convert_dtype(ll: LayerList, mode='int64'):
         layer.data = layer.data.astype(np.dtype(mode))
 
 
-def _project(ll: LayerList, viewer: Viewer, axis: int = 0, mode='max'):
+def _project(ll: LayerList, dims: Dims, axis: int = 0, mode='max'):
     """Creates a new layer with specified projection.
 
     Parameters
@@ -157,7 +156,7 @@ def _project(ll: LayerList, viewer: Viewer, axis: int = 0, mode='max'):
                 "Projections are only implemented for images", deferred=True
             )
         )
-    axis_index = viewer.dims.order.index(axis)
+    axis_index = dims.order.index(axis)
     # this is not the desired behavior for coordinate-based layers
     # but the action is currently only enabled for 'image_active and ndim > 2'
     # before opening up to other layer types, this line should be updated.

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -146,7 +146,8 @@ def _project(ll: LayerList, dims: Dims, axis: int = 0, mode='max'):
         the dims order, e.g if dims order is 2, 0, 1 and axis is 0, then axis 2 of the layer data will be used for the
         projection.
     mode : str
-        Projection mode, either 'max', 'min', 'std', 'sum', 'mean', 'median'."""
+        Projection mode, either 'max', 'min', 'std', 'sum', 'mean', 'median'.
+    """
 
     layer = ll.selection.active
     if not layer:
@@ -158,7 +159,7 @@ def _project(ll: LayerList, dims: Dims, axis: int = 0, mode='max'):
             )
         )
 
-    layer_data_order = [i for i in range(len(layer.data.shape))]
+    layer_data_order = list(range(len(layer.data.shape)))
     dims_order = list(dims.order)
     move_order = [dims_order.index(i) for i in layer_data_order]
     data = getattr(np, mode)(

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -158,12 +158,14 @@ def _project(ll: LayerList, dims: Dims, axis: int = 0, mode='max'):
             )
         )
 
-    axis = dims.order[axis]
-    # this is not the desired behavior for coordinate-based layers
-    # but the action is currently only enabled for 'image_active and ndim > 2'
-    # before opening up to other layer types, this line should be updated.
-    data = getattr(np, mode)(layer.data, axis=axis, keepdims=False)
-
+    layer_data_order = [i for i in range(len(layer.data.shape))]
+    dims_order = list(dims.order)
+    move_order = [dims_order.index(i) for i in layer_data_order]
+    data = getattr(np, mode)(
+        np.moveaxis(layer.data, layer_data_order, move_order),
+        axis=axis,
+        keepdims=False,
+    )
     # In case the last 2 dimensions are these axes, the data needs to be swapped in order to not have the projection
     # displayed orthogonal to the image data.
     must_swap = ((0, 1), (2, 0))

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -161,6 +161,7 @@ def _project(ll: LayerList, dims: Dims, axis: int = 0, mode='max'):
     layer_data_order = [i for i in range(len(layer.data.shape))]
     dims_order = list(dims.order)
     move_order = [dims_order.index(i) for i in layer_data_order]
+    print(dims_order, move_order)
     data = getattr(np, mode)(
         np.moveaxis(layer.data, layer_data_order, move_order),
         axis=axis,
@@ -168,7 +169,7 @@ def _project(ll: LayerList, dims: Dims, axis: int = 0, mode='max'):
     )
     # In case the last 2 dimensions are these axes, the data needs to be swapped in order to not have the projection
     # displayed orthogonal to the image data.
-    must_swap = ((0, 1), (2, 0))
+    must_swap = ((0, 1), (2, 1), (1, 0))
     if dims.order[1:] in must_swap:
         data = np.swapaxes(data, 0, 1)
 

--- a/napari/layers/_tests/test_layer_actions.py
+++ b/napari/layers/_tests/test_layer_actions.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from napari.components import Dims
 from napari.components.layerlist import LayerList
 from napari.layers import Image, Labels, Points, Shapes
 from napari.layers._layer_actions import (
@@ -37,13 +38,25 @@ def test_duplicate_layers():
 )
 def test_projections(mode):
     ll = LayerList()
-    ll.append(Image(np.random.rand(8, 8, 8)))
+    ll.append(Image(np.random.rand(6, 7, 8)))
     assert len(ll) == 1
     assert ll[-1].data.ndim == 3
-    _project(ll, mode=mode)
+    dims = Dims(ndim=ll[-1].data.ndim, order=(0, 1, 2))
+    _project(ll, dims=dims, mode=mode)
     assert len(ll) == 2
     # because keepdims = False
-    assert ll[-1].data.shape == (8, 8)
+    assert ll[-1].data.shape == (7, 8)
+
+    # Test swapping axes for proper projection visualization with image visual.
+    ll.selection.active = ll[0]
+    dims.order = (2, 0, 1)
+    _project(ll, dims=dims, mode=mode)
+    assert ll[-1].data.shape == (7, 6)
+
+    ll.selection.active = ll[0]
+    dims.order = (1, 2, 0)
+    _project(ll, dims=dims, mode=mode)
+    assert ll[-1].data.shape == (8, 6)
 
 
 @pytest.mark.parametrize(

--- a/napari/layers/_tests/test_layer_actions.py
+++ b/napari/layers/_tests/test_layer_actions.py
@@ -42,7 +42,7 @@ def test_projections(mode):
     assert len(ll) == 1
     assert ll[-1].data.ndim == 3
     dims = Dims(ndim=ll[-1].data.ndim, order=(0, 1, 2))
-    _project(ll, dims=dims, mode=mode)
+    _project(ll, dims=dims, axis=0, mode=mode)
     assert len(ll) == 2
     # because keepdims = False
     assert ll[-1].data.shape == (7, 8)


### PR DESCRIPTION
# Description
Projections were created based on layer.data. The user expects a different projection to be created when the dim order is changed.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Aims to fix #5553 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
