### PR TITLE
Stop using removed multichannel= kwarg to skimage functions

### DIFF
--- a/examples/add_multiscale_image.py
+++ b/examples/add_multiscale_image.py
@@ -16,7 +16,7 @@ import napari
 # create multiscale from astronaut image
 base = np.tile(data.astronaut(), (8, 8, 1))
 multiscale = list(
-    pyramid_gaussian(base, downscale=2, max_layer=4, multichannel=True)
+    pyramid_gaussian(base, downscale=2, max_layer=4, channel_axis=-1)
 )
 print('multiscale level shapes: ', [p.shape[:2] for p in multiscale])
 

--- a/examples/labels-2d.py
+++ b/examples/labels-2d.py
@@ -21,7 +21,7 @@ viewer = napari.view_image(rgb2gray(astro), name='astronaut', rgb=False)
 
 # add the labels
 # we add 1 because SLIC returns labels from 0, which we consider background
-labels = slic(astro, multichannel=True, compactness=20) + 1
+labels = slic(astro, channel_axis=-1, compactness=20) + 1
 label_layer = viewer.add_labels(labels, name='segmentation')
 
 # Set the labels layer mode to picker with a string

--- a/examples/nD_multiscale_image.py
+++ b/examples/nD_multiscale_image.py
@@ -17,7 +17,7 @@ base = np.random.random((1536, 1536))
 base = np.array([base * (8 - i) / 8 for i in range(8)])
 print('base shape', base.shape)
 multiscale = list(
-    pyramid_gaussian(base, downscale=2, max_layer=2, multichannel=False)
+    pyramid_gaussian(base, downscale=2, max_layer=2, channel_axis=-1)
 )
 print('multiscale level shapes: ', [p.shape for p in multiscale])
 

--- a/examples/nD_multiscale_image_non_uniform.py
+++ b/examples/nD_multiscale_image_non_uniform.py
@@ -17,7 +17,7 @@ import napari
 astronaut = data.astronaut()
 base = np.tile(astronaut, (3, 3, 1))
 multiscale = list(
-    pyramid_gaussian(base, downscale=2, max_layer=3, multichannel=True)
+    pyramid_gaussian(base, downscale=2, max_layer=3, channel_axis=-1)
 )
 multiscale = [
     np.array([p * (abs(3 - i) + 1) / 4 for i in range(6)]) for p in multiscale


### PR DESCRIPTION
# Description

The `multichannel=` keyword argument to scikit-image functions was deprecated
in 0.19 and removed in the just-released 0.20. This PR removes our last
remaining usages of it, from our gallery.
