### PR TITLE
fix various keybinding/shortcut bugs

### DIFF
--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -29,12 +29,6 @@ from napari.utils.action_manager import action_manager
 from napari.utils.interactions import Shortcut
 from napari.utils.translations import trans
 
-# Dict used to format strings returned from converted key press events.
-# For example, the ShortcutTranslator returns 'Ctrl' instead of 'Control'.
-# In order to be consistent with the code base, the values in KEY_SUBS will
-# be subsituted.
-KEY_SUBS = {'Control': 'Ctrl'}
-
 
 class ShortcutEditor(QWidget):
     """Widget to edit keybindings for napari."""

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -1,7 +1,7 @@
 import contextlib
 from collections import OrderedDict
 
-from app_model.backends.qt._qkeymap import (
+from app_model.backends.qt import (
     qkey2modelkey,
     qkeysequence2modelkeybinding,
 )

--- a/napari/utils/interactions.py
+++ b/napari/utils/interactions.py
@@ -241,7 +241,7 @@ KEY_SYMBOLS = {
 
 joinchar = '+'
 if sys.platform.startswith('darwin'):
-    KEY_SYMBOLS.update({'Ctrl': '⌘', 'Alt': '⌥', 'Meta': '⌃'})
+    KEY_SYMBOLS.update({'Ctrl': '⌃', 'Alt': '⌥', 'Meta': '⌘'})
     joinchar = ''
 elif sys.platform.startswith('linux'):
     KEY_SYMBOLS.update({'Meta': 'Super'})

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ python_requires = >=3.8
 include_package_data = True
 install_requires =
     appdirs>=1.4.4
-    app-model>=0.1.0,<0.3.0  # as per @czaki request. app-model v0.3.0 can drop napari v0.4.17
+    app-model>=0.1.2,<0.3.0  # as per @czaki request. app-model v0.3.0 can drop napari v0.4.17
     cachey>=0.2.1
     certifi>=2018.1.18
     dask[array]>=2.15.0,!=2.28.0  # https://github.com/napari/napari/issues/1656


### PR DESCRIPTION
This PR addresses bugs where the improper symbols would be displayed for e.g. ⌘V on Macs, as well as improper capturing on Macs where e.g. Control would be read as Meta and vice versa. This relies on an upstream fix in `app-model` and uses the logic there to properly capture the correct modifier keys, regardless of if Qt is switching Control with Meta or not.

fixes #5047 
fixes #5332 
fixes #5579 

depends on https://github.com/pyapp-kit/app-model/pull/82