### PR TITLE
Bugfix (macOS): Remove PYTHONEXECUTABLE from `env` for conda installs

### DIFF
--- a/napari/_qt/dialogs/qt_package_installer.py
+++ b/napari/_qt/dialogs/qt_package_installer.py
@@ -201,6 +201,8 @@ class CondaInstallerTool(AbstractInstallerTool):
     ) -> QProcessEnvironment:
         if env is None:
             env = QProcessEnvironment.systemEnvironment()
+            # Fix for macOS, related to https://github.com/napari/napari/pull/5531
+            env.remove("PYTHONEXECUTABLE")
         self._add_constraints_to_env(env)
         if 10 <= log.getEffectiveLevel() < 30:  # DEBUG level
             env.insert('CONDA_VERBOSITY', '3')

--- a/napari/_qt/dialogs/qt_package_installer.py
+++ b/napari/_qt/dialogs/qt_package_installer.py
@@ -201,7 +201,8 @@ class CondaInstallerTool(AbstractInstallerTool):
     ) -> QProcessEnvironment:
         if env is None:
             env = QProcessEnvironment.systemEnvironment()
-            # Fix for macOS, related to https://github.com/napari/napari/pull/5531
+            # Fix for macOS when napari launched from terminal
+            # related to https://github.com/napari/napari/pull/5531
             env.remove("PYTHONEXECUTABLE")
         self._add_constraints_to_env(env)
         if 10 <= log.getEffectiveLevel() < 30:  # DEBUG level

--- a/napari/_qt/dialogs/qt_package_installer.py
+++ b/napari/_qt/dialogs/qt_package_installer.py
@@ -201,9 +201,6 @@ class CondaInstallerTool(AbstractInstallerTool):
     ) -> QProcessEnvironment:
         if env is None:
             env = QProcessEnvironment.systemEnvironment()
-            # Fix for macOS when napari launched from terminal
-            # related to https://github.com/napari/napari/pull/5531
-            env.remove("PYTHONEXECUTABLE")
         self._add_constraints_to_env(env)
         if 10 <= log.getEffectiveLevel() < 30:  # DEBUG level
             env.insert('CONDA_VERBOSITY', '3')
@@ -215,6 +212,10 @@ class CondaInstallerTool(AbstractInstallerTool):
             if not env.contains("USERPROFILE"):
                 env.insert("HOME", os.path.expanduser("~"))
                 env.insert("USERPROFILE", os.path.expanduser("~"))
+        if sys.platform == 'darwin' and env.contains('PYTHONEXECUTABLE'):
+            # Fix for macOS when napari launched from terminal
+            # related to https://github.com/napari/napari/pull/5531
+            env.remove("PYTHONEXECUTABLE")
         return env
 
     @staticmethod


### PR DESCRIPTION
# Description

In https://github.com/napari/napari/pull/5531 PYTHONEXECUTABLE is set to `sys.executable` on macOS to fix an issue with venv/pyenv and launching napari.
It seems to have a side effect that makes conda plugin installations using the new Plugin Manager not work when napari is launched from the Terminal on macOS, probably because `sys.executable`, is in the env that napari was run from. But that env doesn't have conda/mamba, only `base` does.

So this change removes PYTHONEXECUTABLE from the QProcessEnvironment within the `CondaInstallerTool` class.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Similar issue over at spyder: https://github.com/spyder-ide/spyder/issues/20599
PR that added the PYTHONEXECUTABLE: #5531 cc: @aganders3 
Closes #5621 5621 


# How has this been tested?
tested locally on my mac
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
