### PR TITLE
Bugfix: ensure `tool` is set to conda for conda-installed packages

### DIFF
--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -560,6 +560,7 @@ class QPluginList(QListWidget):
         tool = (
             InstallerTools.CONDA
             if item.widget.source_choice_dropdown.currentText() == CONDA
+            or is_conda_package(pkg_name)
             else InstallerTools.PIP
         )
 


### PR DESCRIPTION
# Description

When setting the `tool` (pip or conda), only the dropdown widget for to-be-installed packages was being checked, so it was only used for **installation** of packages.
This PR ensures that we check also check the *source* of already installed packages when determining the `tool` to be used.
This ensures that condo-installed packages are uninstalled using conda—the same goes for upgrading.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
closes https://github.com/napari/napari/issues/5623

# How has this been tested?
Locally:
Uninstall after conda install:
```
Starting '/Users/piotrsobolewski/Dev/miniforge3/bin/mamba' with args ['uninstall', '-y', '--prefix', '/Users/piotrsobolewski/Dev/miniforge3/envs/napari-main', '--override-channels', '-c', 'conda-forge', 'napari-animation']
Removing specs: ['napari-animation']

Transaction

  Prefix: /Users/piotrsobolewski/Dev/miniforge3/envs/napari-main

  Removing specs:

   - napari-animation

  Package                Version  Build             Channel         Size
──────────────────────────────────────────────────────────────────────────
  Remove:
──────────────────────────────────────────────────────────────────────────

  - ffmpeg                 5.1.2  gpl_hf318d42_106  conda-forge         
  - gmp                    6.2.1  h9f76cd9_0        conda-forge         
  - gnutls                 3.7.8  h9f1a10d_0        conda-forge         
  - imageio-ffmpeg         0.4.8  pyhd8ed1ab_0      conda-forge         
  - lame                   3.100  h1a8c8d9_1003     conda-forge         
  - libidn2                2.3.4  h1a8c8d9_0        conda-forge         
  - libtasn1              4.19.0  h1a8c8d9_0        conda-forge         
  - libunistring          0.9.10  h3422bc3_0        conda-forge         
  - libvpx                1.11.0  hc470f4d_3        conda-forge         
  - napari-animation       0.0.5  pyhd8ed1ab_0      conda-forge         
  - nettle                 3.8.1  h63371fa_1        conda-forge         
  - openh264               2.3.1  hb7217d7_2        conda-forge         
  - p11-kit               0.24.1  h29577a5_0        conda-forge         
  - svt-av1                1.4.1  h7ea286d_0        conda-forge         
  - x264              1!164.3095  h57fd34a_2        conda-forge         
  - x265                     3.5  hbc6ce65_3        conda-forge         

  Summary:

  Remove: 16 packages

  Total download: 0 B

──────────────────────────────────────────────────────────────────────────

Preparing transaction: ...working... 
done
Verifying transaction: ...working... done
Executing transaction: ...working... 
done

Task finished with exit code 0 with status 0.
```


Upgrading after conda install:
```
Starting '/Users/piotrsobolewski/Dev/miniforge3/bin/mamba' with args ['update', '-y', '--prefix', '/Users/piotrsobolewski/Dev/miniforge3/envs/napari-main', '--override-channels', '-c', 'conda-forge', 'napari-animation==0.0.5']
conda-forge/osx-arm64                                       Using cache

conda-forge/noarch                                          Using cache

Transaction

  Prefix: /Users/piotrsobolewski/Dev/miniforge3/envs/napari-main


  Updating specs:

   - napari-animation==0.0.5
   - ca-certificates
   - certifi
   - openssl


  Package             Version  Build         Channel                Size
──────────────────────────────────────────────────────────────────────────
  Upgrade:
──────────────────────────────────────────────────────────────────────────

  - napari-animation    0.0.3  pyhd8ed1ab_0  conda-forge                
  + napari-animation    0.0.5  pyhd8ed1ab_0  conda-forge/noarch     28kB

  Summary:

  Upgrade: 1 packages

  Total download: 28kB

──────────────────────────────────────────────────────────────────────────

Looking for: ['napari-animation==0.0.5']

Pinned packages:
  - python 3.10.*
  - napari 0.5.*

Downloading and Extracting Packages

Preparing transaction: ...working... 
done

Verifying transaction: ...working... 
done

Executing transaction: ...working... 
done

Task finished with exit code 0 with status 0.
```

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
