### PR TITLE
Maint: ImportError -> ModuleNotFoundError.

### DIFF
--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from collections import abc
+from contextlib import suppress
 from typing import Any, Dict
 
 import numpy as np
@@ -83,14 +84,12 @@ layer_test_data = [
     ),
 ]
 
-try:
+with suppress(ModuleNotFoundError):
     import tensorstore as ts
 
     m = ts.array(np.random.random((10, 15)))
     p = [ts.array(np.random.random(s)) for s in [(40, 20), (20, 10), (10, 5)]]
     layer_test_data.extend([(Image, m, 2), (Image, p, 2)])
-except ImportError:
-    pass
 
 classes = [Labels, Points, Vectors, Shapes, Surface, Tracks, Image]
 names = [cls.__name__.lower() for cls in classes]

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -1223,7 +1223,7 @@ def _is_pos_arg(param: inspect.Parameter):
     )
 
 
-with contextlib.suppress(ImportError):
+with contextlib.suppress(ModuleNotFoundError):
     # this could move somewhere higher up in napari imports ... but where?
     __import__('dotenv').load_dotenv()
 

--- a/tools/test_strings.py
+++ b/tools/test_strings.py
@@ -413,7 +413,7 @@ def import_module_by_path(fpath: str) -> Optional[ModuleType]:
         spec = importlib.util.spec_from_file_location(module_name, fpath)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
-    except ImportError:
+    except ModuleNotFoundError:
         module = None
 
     return module


### PR DESCRIPTION
In many cases we actually want to only catch ModuleNotFoundError to indicate that the module is not installed, catching/suppressing ImportError also tend to hide deeper import issues and may make things harder to debug.

