### PR TITLE
Unblock axis labels event to be emitted when slider label changes

### DIFF
--- a/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -252,11 +252,18 @@ def test_update_dims_labels(qtbot):
     view.dims.axis_labels = list('TZYX')
     assert [w.axis_label.text() for w in view.slider_widgets] == list('TZYX')
 
+    observed_axis_labels_event = False
+
+    def on_axis_labels_changed():
+        nonlocal observed_axis_labels_event
+        observed_axis_labels_event = True
+
+    view.dims.events.axis_labels.connect(on_axis_labels_changed)
     first_label = view.slider_widgets[0].axis_label
     assert first_label.text() == view.dims.axis_labels[0]
     first_label.setText('napari')
-    # first_label.editingFinished.emit()
     assert first_label.text() == view.dims.axis_labels[0]
+    assert observed_axis_labels_event
 
 
 def test_slider_press_updates_last_used(qtbot):

--- a/napari/_qt/widgets/qt_dims.py
+++ b/napari/_qt/widgets/qt_dims.py
@@ -176,7 +176,9 @@ class QtDims(QWidget):
         for slider_num in range(self.nsliders, number_of_sliders):
             dim_axis = number_of_sliders - slider_num - 1
             slider_widget = QtDimSliderWidget(self, dim_axis)
-            slider_widget.axis_label_changed.connect(self._resize_axis_labels)
+            slider_widget.axis_label.textChanged.connect(
+                self._resize_axis_labels
+            )
             slider_widget.play_button.play_requested.connect(self.play)
             self.layout().addWidget(slider_widget)
             self.slider_widgets.insert(0, slider_widget)

--- a/napari/_qt/widgets/qt_dims_slider.py
+++ b/napari/_qt/widgets/qt_dims_slider.py
@@ -35,7 +35,6 @@ class QtDimSliderWidget(QWidget):
     This widget *must* be instantiated with a parent QtDims.
     """
 
-    axis_label_changed = Signal(int, str)  # axis, label
     fps_changed = Signal(float)
     mode_changed = Signal(str)
     range_changed = Signal(tuple)
@@ -193,12 +192,10 @@ class QtDimSliderWidget(QWidget):
         """Updates the label LineEdit from the dims model."""
         label = self.dims.axis_labels[self.axis]
         self.axis_label.setText(label)
-        self.axis_label_changed.emit(self.axis, label)
 
     def _update_label(self):
         """Update dimension slider label."""
         self.dims.set_axis_label(self.axis, self.axis_label.text())
-        self.axis_label_changed.emit(self.axis, self.axis_label.text())
 
     def _clear_label_focus(self):
         """Clear focus from dimension slider label."""

--- a/napari/_qt/widgets/qt_dims_slider.py
+++ b/napari/_qt/widgets/qt_dims_slider.py
@@ -197,8 +197,7 @@ class QtDimSliderWidget(QWidget):
 
     def _update_label(self):
         """Update dimension slider label."""
-        with self.dims.events.axis_labels.blocker():
-            self.dims.set_axis_label(self.axis, self.axis_label.text())
+        self.dims.set_axis_label(self.axis, self.axis_label.text())
         self.axis_label_changed.emit(self.axis, self.axis_label.text())
 
     def _clear_label_focus(self):


### PR DESCRIPTION
# Description
This removes an unnecessary blocker on the `Dims.events.axis_labels` event that is temporarily held when responding to a change to the text of the slider's `QLineEdit` label. I considered adding a `QSignalBlocker` for the widget's related signal to prevent infinite event/signal loops, but that's not necessary since the value/text won't change after the first pass.

I also removed the `QtDimSliderWidget.axis_label_changed` signal since it's not part of the napari public API and we can use `QtDimSliderWidget.axis_label.textChanged` instead.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Closes #5630

# How has this been tested?
- [x] I modified an existing test to fail before the fix and which passes after the fix.
- [x] All other existing tests pass with my change.

I also manually tested changing the axis label by assigning `Dims.axis_labels` to a new value and by changing the slider label widget text. Both worked without causing any issues.
