### PR TITLE
Bugfix: IndexError slicing Surface with higher-dimensional vertex_values

### DIFF
--- a/napari/layers/surface/_tests/test_surface.py
+++ b/napari/layers/surface/_tests/test_surface.py
@@ -88,7 +88,7 @@ def test_random_3D_timeseries_surface():
     assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data)])
     assert layer._data_view.shape[1] == 2
     assert layer._view_vertex_values.ndim == 1
-    assert layer.extent.data[1][0] == 22
+    assert layer.extent.data[1][0] == 21
 
     layer._slice_dims(ndisplay=3)
     assert layer._data_view.shape[1] == 3
@@ -113,8 +113,8 @@ def test_random_3D_multitimeseries_surface():
     assert np.all([np.all(ld == d) for ld, d in zip(layer.data, data)])
     assert layer._data_view.shape[1] == 2
     assert layer._view_vertex_values.ndim == 1
-    assert layer.extent.data[1][0] == 16
-    assert layer.extent.data[1][1] == 22
+    assert layer.extent.data[1][0] == 15
+    assert layer.extent.data[1][1] == 21
 
     layer._slice_dims(ndisplay=3)
     assert layer._data_view.shape[1] == 3

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -348,7 +348,9 @@ class Surface(IntensityVisualizationMixin, Layer):
             # dimensionality of the vertices themselves
             if self.vertex_values.ndim > 1:
                 mins = [0] * (self.vertex_values.ndim - 1) + list(mins)
-                maxs = [n - 1 for n in self.vertex_values.shape[:-1]] + list(maxs)
+                maxs = [n - 1 for n in self.vertex_values.shape[:-1]] + list(
+                    maxs
+                )
             extrema = np.vstack([mins, maxs])
         return extrema
 

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -348,7 +348,7 @@ class Surface(IntensityVisualizationMixin, Layer):
             # dimensionality of the vertices themselves
             if self.vertex_values.ndim > 1:
                 mins = [0] * (self.vertex_values.ndim - 1) + list(mins)
-                maxs = list(self.vertex_values.shape[:-1]) + list(maxs)
+                maxs = [n - 1 for n in self.vertex_values.shape[:-1]] + list(maxs)
             extrema = np.vstack([mins, maxs])
         return extrema
 


### PR DESCRIPTION
# Description
This fixes an off-by-one error on Surface layers extent data, which was causing an IndexError slicing that dimension.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
closes #5620
Disussed in [community meeting on 2023-03-15](https://hackmd.io/BXWDZ3i8Q6OAEASrkaSNIQ?view#2023-03-15)

# How has this been tested?
- [x] all tests pass with my change (though I had to change two of them)
- [x] thanks to @brisvag who [tested to make sure the mesh was in the correct spot wrt an image](https://github.com/napari/napari/issues/5620#issuecomment-1470486818)

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
