### PR TITLE
Fix waiting for multiple signals in threading progress bar test

### DIFF
--- a/napari/_qt/_tests/test_threading_progress.py
+++ b/napari/_qt/_tests/test_threading_progress.py
@@ -65,9 +65,7 @@ def test_worker_may_exceed_total(qtbot):
     )
     worker = thread_func()
     worker.yielded.connect(test_yield)
-    with qtbot.waitSignal(worker.yielded) and qtbot.waitSignal(
-        worker.finished
-    ):
+    with qtbot.waitSignals([worker.yielded, worker.finished]):
         worker.start()
     assert test_val[0] == 2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -114,7 +114,7 @@ testing =
     matplotlib
     pooch>=1.6.0
     pytest-cov
-    pytest-qt
+    pytest-qt>=1.4.0
     pytest-pretty>=1.1.0
     pytest>=7.0.0
     tensorstore>=0.1.13

--- a/setup.cfg
+++ b/setup.cfg
@@ -114,7 +114,7 @@ testing =
     matplotlib
     pooch>=1.6.0
     pytest-cov
-    pytest-qt>=1.4.0
+    pytest-qt
     pytest-pretty>=1.1.0
     pytest>=7.0.0
     tensorstore>=0.1.13


### PR DESCRIPTION
# Description
This fixes some syntax used to wait for multiple Qt signals in a test related to Qt thread workers. I don't think using `and` to apply two context managers does what we want (i.e. waiting for both signals to be emitted), but happy to be corrected. I think we could use `,`, but since `qtbot` provides `waitSignals` I went with that.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References

This [test failed for me in an related PR](https://github.com/napari/napari/actions/runs/4420615947/jobs/7750535066?pr=5631#step:8:408). I'm not sure that this change will prevent that test from failing in the future, but it should at least help.

# How has this been tested?
- [x] the changed test continues to pass locally
