### PR TITLE
Change dim `axis_label` resize logic to set width using only displayed labels width

### DIFF
--- a/napari/_qt/widgets/qt_dims.py
+++ b/napari/_qt/widgets/qt_dims.py
@@ -135,18 +135,14 @@ class QtDims(QWidget):
         visible at all times, with minimal space, without setting stretch on
         the layout.
         """
-        displayed_sliders_idx = [
-            idx
+        displayed_labels = [
+            self.slider_widgets[idx].axis_label
             for idx, displayed in enumerate(self._displayed_sliders)
             if displayed
         ]
-        if displayed_sliders_idx:
+        if displayed_labels:
             fm = QFontMetrics(QFont("", 0))
             labels = self.findChildren(QLineEdit, 'axis_label')
-            displayed_labels = [
-                self.slider_widgets[slider_idx].axis_label
-                for slider_idx in displayed_sliders_idx
-            ]
             # set maximum width to no more than 20% of slider width
             maxwidth = int(self.slider_widgets[0].width() * 0.2)
             # set new base width to the width of the longest label being displayed

--- a/napari/_qt/widgets/qt_dims.py
+++ b/napari/_qt/widgets/qt_dims.py
@@ -116,6 +116,7 @@ class QtDims(QWidget):
         nsliders = np.sum(self._displayed_sliders)
         self.setMinimumHeight(nsliders * self.SLIDERHEIGHT)
         self._resize_slice_labels()
+        self._resize_axis_labels()
 
     def _update_nsliders(self):
         """Updates the number of sliders based on the number of dimensions."""
@@ -130,20 +131,35 @@ class QtDims(QWidget):
 
     def _resize_axis_labels(self):
         """When any of the labels get updated, this method updates all label
-        widths to the width of the longest label. This keeps the sliders
-        left-aligned and allows the full label to be visible at all times,
-        with minimal space, without setting stretch on the layout.
+        widths to a minimum size. This allows the full label to be
+        visible at all times, with minimal space, without setting stretch on
+        the layout.
         """
-        fm = QFontMetrics(QFont("", 0))
-        labels = self.findChildren(QLineEdit, 'axis_label')
-        newwidth = max(fm.boundingRect(lab.text()).width() for lab in labels)
-
-        if any(self._displayed_sliders):
+        displayed_sliders_idx = [
+            idx
+            for idx, displayed in enumerate(self._displayed_sliders)
+            if displayed
+        ]
+        if displayed_sliders_idx:
+            fm = QFontMetrics(QFont("", 0))
+            labels = self.findChildren(QLineEdit, 'axis_label')
+            displayed_labels = [
+                self.slider_widgets[slider_idx].axis_label
+                for slider_idx in displayed_sliders_idx
+            ]
             # set maximum width to no more than 20% of slider width
-            maxwidth = self.slider_widgets[0].width() * 0.2
-            newwidth = min([newwidth, maxwidth])
-        for labl in labels:
-            labl.setFixedWidth(int(newwidth) + 10)
+            maxwidth = int(self.slider_widgets[0].width() * 0.2)
+            # set new base width to the width of the longest label being displayed
+            newwidth = max(
+                [
+                    int(fm.boundingRect(dlab.text()).width())
+                    for dlab in displayed_labels
+                ]
+            )
+
+            for labl in labels:
+                labl_width = min([newwidth + 10, maxwidth])
+                labl.setFixedWidth(labl_width)
 
     def _resize_slice_labels(self):
         """When the size of any dimension changes, we want to resize all of the


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Old behavior:

![GIF showing the old behavior of the viewer slider widgets axis label resize. The labels take the width of the longest axis label element even if it is not being displayed. The space for the axis labels is the same even if the current axis label text is shorter than the space available](https://user-images.githubusercontent.com/16781833/225688465-df3804ce-2b37-423a-9ba4-1343db83f03c.gif)

New behavior:

![GIF showing the new behavior introduced with the PR for the viewer slider widgets axis label resize. The labels take the width of the longest axis label element that is being displayed. The alignment between multiple slider widgets is preserved but changing the axis being displayed can make the axis labels to take more or less space](https://user-images.githubusercontent.com/16781833/225688739-96db3175-40dd-49db-8745-6156bb2a13d5.gif)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
closes #5521 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change
- [x] I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
