### PR TITLE
Fix features issues with init param and property setter

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -482,6 +482,7 @@ def test_remove_selected_removes_corresponding_attributes():
         symbol=symbol[1:],
         edge_width=size[1:],
         features={'feature': feature[1:]},
+        feature_defaults={'feature': feature[0]},
         face_color=color[1:],
         edge_color=color[1:],
         text=text,  # computed from feature

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -62,7 +62,7 @@ def test_empty_points_with_features():
     points.add([0, 0])
     points.feature_defaults['a'] = 1
     points.add([50, 50])
-    points.feature_defaults['a'] = 2
+    points.feature_defaults = {'a': 2}
     points.add([100, 100])
 
     assert_colors_equal(points.face_color, list('rgb'))

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -64,6 +64,23 @@ def test_empty_points_with_features():
     assert_colors_equal(pts.face_color, list('rgb'))
 
 
+def test_empty_points_with_features_alt():
+    pts = Points(
+        features={'a': np.empty(0, int)},
+        face_color_cycle=list('rgb'),
+    )
+    pts.feature_defaults = {'a': 0}
+    pts.face_color = 'a'
+
+    pts.add([0, 0])
+    pts.feature_defaults = {'a': 1}
+    pts.add([50, 50])
+    pts.feature_defaults = {'a': 2}
+    pts.add([100, 100])
+
+    assert_colors_equal(pts.face_color, list('rgb'))
+
+
 def test_empty_points_with_properties():
     """Test instantiating an empty Points layer with properties
 

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -67,10 +67,10 @@ def test_empty_points_with_features():
 def test_empty_points_with_features_alt():
     pts = Points(
         features={'a': np.empty(0, int)},
+        feature_defaults={'a': 0},
+        face_color='a',
         face_color_cycle=list('rgb'),
     )
-    pts.feature_defaults = {'a': 0}
-    pts.face_color = 'a'
 
     pts.add([0, 0])
     pts.feature_defaults = {'a': 1}

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from vispy.color import get_colormap
 
 from napari._tests.utils import (
+    assert_colors_equal,
     assert_layer_state_equal,
     check_layer_world_data_extent,
 )
@@ -44,6 +45,23 @@ def _make_cycled_properties(values, length):
 def test_empty_points():
     pts = Points()
     assert pts.data.shape == (0, 2)
+
+
+def test_empty_points_with_features():
+    pts = Points(
+        features={'a': np.empty(0, int)},
+        face_color_cycle=list('rgb'),
+    )
+    pts.feature_defaults['a'] = 0
+    pts.face_color = 'a'
+
+    pts.add([0, 0])
+    pts.feature_defaults['a'] = 1
+    pts.add([50, 50])
+    pts.feature_defaults['a'] = 2
+    pts.add([100, 100])
+
+    assert_colors_equal(pts.face_color, list('rgb'))
 
 
 def test_empty_points_with_properties():

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -48,37 +48,24 @@ def test_empty_points():
 
 
 def test_empty_points_with_features():
-    pts = Points(
-        features={'a': np.empty(0, int)},
-        face_color_cycle=list('rgb'),
-    )
-    pts.feature_defaults['a'] = 0
-    pts.face_color = 'a'
-
-    pts.add([0, 0])
-    pts.feature_defaults['a'] = 1
-    pts.add([50, 50])
-    pts.feature_defaults['a'] = 2
-    pts.add([100, 100])
-
-    assert_colors_equal(pts.face_color, list('rgb'))
-
-
-def test_empty_points_with_features_alt():
-    pts = Points(
+    """See the following for the issues this covers:
+    https://github.com/napari/napari/issues/5632
+    https://github.com/napari/napari/issues/5634
+    """
+    points = Points(
         features={'a': np.empty(0, int)},
         feature_defaults={'a': 0},
         face_color='a',
         face_color_cycle=list('rgb'),
     )
 
-    pts.add([0, 0])
-    pts.feature_defaults = {'a': 1}
-    pts.add([50, 50])
-    pts.feature_defaults = {'a': 2}
-    pts.add([100, 100])
+    points.add([0, 0])
+    points.feature_defaults['a'] = 1
+    points.add([50, 50])
+    points.feature_defaults['a'] = 2
+    points.add([100, 100])
 
-    assert_colors_equal(pts.face_color, list('rgb'))
+    assert_colors_equal(points.face_color, list('rgb'))
 
 
 def test_empty_points_with_properties():

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -58,10 +58,10 @@ class Points(Layer):
     ndim : int
         Number of dimensions for shapes. When data is not None, ndim must be D.
         An empty points layer can be instantiated with arbitrary ndim.
-    features : DataFrame-like
+    features : dict[str, array-like] or DataFrame
         Features table where each row corresponds to a point and each column
         is a feature.
-    feature_defaults : DataFrame-like
+    feature_defaults : dict[str, Any] or DataFrame
         The default value of each feature in a table with one row.
     properties : dict {str: array (N,)}, DataFrame
         Properties for each point. Each property should be an array of length N,

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -2,7 +2,7 @@ import numbers
 import warnings
 from copy import copy, deepcopy
 from itertools import cycle
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -324,6 +324,7 @@ class Points(Layer):
         *,
         ndim=None,
         features=None,
+        feature_defaults=None,
         properties=None,
         text=None,
         symbol='o',
@@ -432,6 +433,7 @@ class Points(Layer):
 
         self._feature_table = _FeatureTable.from_layer(
             features=features,
+            feature_defaults=feature_defaults,
             properties=properties,
             property_choices=property_choices,
             num_data=len(self.data),
@@ -567,8 +569,8 @@ class Points(Layer):
                     new_symbol = self.current_symbol
                 symbol = np.repeat([new_symbol], adding, axis=0)
 
-                # Add new colors, updating current property value to handle
-                # any in-place modification of feature_defaults.
+                # Add new colors, updating the current property value before
+                # to handle any in-place modification of feature_defaults.
                 # Also see: https://github.com/napari/napari/issues/5634
                 current_properties = self._feature_table.currents()
                 self._edge._update_current_properties(current_properties)
@@ -639,6 +641,12 @@ class Points(Layer):
         See `features` for more details on the type of this property.
         """
         return self._feature_table.defaults
+
+    @feature_defaults.setter
+    def feature_defaults(
+        self, defaults: Union[Dict[str, Any], pd.DataFrame]
+    ) -> None:
+        self._feature_table.set_defaults(defaults)
 
     @property
     def property_choices(self) -> Dict[str, np.ndarray]:

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1263,6 +1263,7 @@ class Points(Layer):
                 'ndim': self.ndim,
                 'data': self.data,
                 'features': self.features,
+                'feature_defaults': self.feature_defaults,
                 'shading': self.shading,
                 'antialiasing': self.antialiasing,
                 'canvas_size_limits': self.canvas_size_limits,

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -473,7 +473,9 @@ class Points(Layer):
         self._status = self.mode
 
         color_properties = (
-            self.properties if self._data.size > 0 else self.property_choices
+            self._feature_table.properties()
+            if self._data.size > 0
+            else self._feature_table.currents()
         )
         self._edge = ColorManager._from_layer_kwargs(
             n_colors=len(data),
@@ -647,6 +649,7 @@ class Points(Layer):
         self, defaults: Union[Dict[str, Any], pd.DataFrame]
     ) -> None:
         self._feature_table.set_defaults(defaults)
+        self.events.feature_defaults()
 
     @property
     def property_choices(self) -> Dict[str, np.ndarray]:

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -567,8 +567,13 @@ class Points(Layer):
                     new_symbol = self.current_symbol
                 symbol = np.repeat([new_symbol], adding, axis=0)
 
-                # add new colors
+                # Add new colors, updating current property value to handle
+                # any in-place modification of feature_defaults.
+                # Also see: https://github.com/napari/napari/issues/5634
+                current_properties = self._feature_table.currents()
+                self._edge._update_current_properties(current_properties)
                 self._edge._add(n_colors=adding)
+                self._face._update_current_properties(current_properties)
                 self._face._add(n_colors=adding)
 
                 shown = np.repeat([True], adding, axis=0)

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -58,9 +58,11 @@ class Points(Layer):
     ndim : int
         Number of dimensions for shapes. When data is not None, ndim must be D.
         An empty points layer can be instantiated with arbitrary ndim.
-    features : dict[str, array-like] or DataFrame
+    features : DataFrame-like
         Features table where each row corresponds to a point and each column
         is a feature.
+    feature_defaults : DataFrame-like
+        The default value of each feature in a table with one row.
     properties : dict {str: array (N,)}, DataFrame
         Properties for each point. Each property should be an array of length N,
         where N is the number of points.
@@ -649,6 +651,10 @@ class Points(Layer):
         self, defaults: Union[Dict[str, Any], pd.DataFrame]
     ) -> None:
         self._feature_table.set_defaults(defaults)
+        current_properties = self.current_properties
+        self._edge._update_current_properties(current_properties)
+        self._face._update_current_properties(current_properties)
+        self.events.current_properties()
         self.events.feature_defaults()
 
     @property

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -6,7 +6,10 @@ import pandas as pd
 import pytest
 from pydantic import ValidationError
 
-from napari._tests.utils import check_layer_world_data_extent
+from napari._tests.utils import (
+    assert_colors_equal,
+    check_layer_world_data_extent,
+)
 from napari.components import ViewerModel
 from napari.layers import Shapes
 from napari.layers.utils._text_constants import Anchor
@@ -43,6 +46,27 @@ def test_update_thumbnail_empty_shapes():
     layer = Shapes()
     layer._allow_thumbnail_update = True
     layer._update_thumbnail()
+
+
+def test_empty_shapes_with_features():
+    """See the following for the points issues this covers:
+    https://github.com/napari/napari/issues/5632
+    https://github.com/napari/napari/issues/5634
+    """
+    shapes = Shapes(
+        features={'a': np.empty(0, int)},
+        feature_defaults={'a': 0},
+        face_color='a',
+        face_color_cycle=list('rgb'),
+    )
+
+    shapes.add_rectangles([[0, 0], [1, 1]])
+    shapes.feature_defaults['a'] = 1
+    shapes.add_rectangles([[1, 1], [2, 2]])
+    shapes.feature_defaults['a'] = 2
+    shapes.add_rectangles([[2, 2], [3, 3]])
+
+    assert_colors_equal(shapes.face_color, list('rgb'))
 
 
 properties_array = {'shape_type': _make_cycled_properties(['A', 'B'], 10)}

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -63,7 +63,7 @@ def test_empty_shapes_with_features():
     shapes.add_rectangles([[0, 0], [1, 1]])
     shapes.feature_defaults['a'] = 1
     shapes.add_rectangles([[1, 1], [2, 2]])
-    shapes.feature_defaults['a'] = 2
+    shapes.feature_defaults = {'a': 2}
     shapes.add_rectangles([[2, 2], [3, 3]])
 
     assert_colors_equal(shapes.face_color, list('rgb'))

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -82,10 +82,10 @@ class Shapes(Layer):
     ndim : int
         Number of dimensions for shapes. When data is not None, ndim must be D.
         An empty shapes layer can be instantiated with arbitrary ndim.
-    features : Dataframe-like
+    features : dict[str, array-like] or Dataframe-like
         Features table where each row corresponds to a shape and each column
         is a feature.
-    feature_defaults : DataFrame-like
+    feature_defaults : dict[str, Any] or Dataframe-like
         The default value of each feature in a table with one row.
     properties : dict {str: array (N,)}, DataFrame
         Properties for each shape. Each property should be an array of length N,

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1517,6 +1517,7 @@ class Shapes(Layer):
                 'edge_contrast_limits': self.edge_contrast_limits,
                 'data': self.data,
                 'features': self.features,
+                'feature_defaults': self.feature_defaults,
             }
         )
         return state

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2,7 +2,7 @@ import warnings
 from contextlib import contextmanager
 from copy import copy, deepcopy
 from itertools import cycle
-from typing import Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -82,9 +82,11 @@ class Shapes(Layer):
     ndim : int
         Number of dimensions for shapes. When data is not None, ndim must be D.
         An empty shapes layer can be instantiated with arbitrary ndim.
-    features : dict[str, array-like] or Dataframe-like
+    features : Dataframe-like
         Features table where each row corresponds to a shape and each column
         is a feature.
+    feature_defaults : DataFrame-like
+        The default value of each feature in a table with one row.
     properties : dict {str: array (N,)}, DataFrame
         Properties for each shape. Each property should be an array of length N,
         where N is the number of shapes.
@@ -388,6 +390,7 @@ class Shapes(Layer):
         *,
         ndim=None,
         features=None,
+        feature_defaults=None,
         properties=None,
         property_choices=None,
         text=None,
@@ -469,6 +472,7 @@ class Shapes(Layer):
 
         self._feature_table = _FeatureTable.from_layer(
             features=features,
+            feature_defaults=feature_defaults,
             properties=properties,
             property_choices=property_choices,
             num_data=number_of_shapes(data),
@@ -588,14 +592,14 @@ class Shapes(Layer):
 
             # add the new color cycle mapping
             color_property = getattr(self, f'_{attribute}_color_property')
-            prop_value = self.property_choices[color_property][0]
+            prop_value = self.feature_defaults[color_property][0]
             color_cycle_map = getattr(self, f'{attribute}_color_cycle_map')
             color_cycle_map[prop_value] = np.squeeze(curr_color)
             setattr(self, f'{attribute}_color_cycle_map', color_cycle_map)
 
         elif color_mode == ColorMode.COLORMAP:
             color_property = getattr(self, f'_{attribute}_color_property')
-            prop_value = self.property_choices[color_property][0]
+            prop_value = self.feature_defaults[color_property][0]
             colormap = getattr(self, f'{attribute}_colormap')
             contrast_limits = getattr(self, f'_{attribute}_contrast_limits')
             curr_color, _ = map_property(
@@ -736,6 +740,14 @@ class Shapes(Layer):
         See `features` for more details on the type of this property.
         """
         return self._feature_table.defaults
+
+    @feature_defaults.setter
+    def feature_defaults(
+        self, defaults: Union[Dict[str, Any], pd.DataFrame]
+    ) -> None:
+        self._feature_table.set_defaults(defaults)
+        self.events.current_properties()
+        self.events.feature_defaults()
 
     @property
     def properties(self) -> Dict[str, np.ndarray]:

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -414,32 +414,6 @@ def test_feature_table_from_layer_with_unordered_pd_series_features():
     pd.testing.assert_frame_equal(feature_table.values, expected)
 
 
-def test_feature_table_set_values_with_same_columns(feature_table):
-    new_values = pd.DataFrame(
-        {
-            'class': pd.Series(
-                ['building', 'sky'], dtype=feature_table.values.dtypes['class']
-            ),
-            'confidence': pd.Series([1, 0.5]),
-        }
-    )
-    assert not feature_table.values['class'].equals(new_values['class'])
-    assert not feature_table.values['confidence'].equals(
-        new_values['confidence']
-    )
-
-    feature_table.set_values(new_values)
-
-    pd.testing.assert_series_equal(
-        feature_table.values['class'], new_values['class'], check_names=False
-    )
-    pd.testing.assert_series_equal(
-        feature_table.values['confidence'],
-        new_values['confidence'],
-        check_names=False,
-    )
-
-
 def test_feature_table_set_defaults_with_same_columns(feature_table):
     new_defaults = {'class': 'building', 'confidence': 1}
     assert feature_table.defaults['class'][0] != new_defaults['class']

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -415,32 +415,28 @@ def test_feature_table_from_layer_with_unordered_pd_series_features():
 
 
 def test_feature_table_set_defaults_with_same_columns(feature_table):
-    new_defaults = {'class': 'building', 'confidence': 1}
-    assert feature_table.defaults['class'][0] != new_defaults['class']
-    assert (
-        feature_table.defaults['confidence'][0] != new_defaults['confidence']
-    )
+    defaults = {'class': 'building', 'confidence': 1}
+    assert feature_table.defaults['class'][0] != defaults['class']
+    assert feature_table.defaults['confidence'][0] != defaults['confidence']
 
-    feature_table.set_defaults(new_defaults)
+    feature_table.set_defaults(defaults)
 
-    assert feature_table.defaults['class'][0] == new_defaults['class']
-    assert (
-        feature_table.defaults['confidence'][0] == new_defaults['confidence']
-    )
+    assert feature_table.defaults['class'][0] == defaults['class']
+    assert feature_table.defaults['confidence'][0] == defaults['confidence']
 
 
 def test_feature_table_set_defaults_with_extra_column(feature_table):
-    new_defaults = {'class': 'building', 'confidence': 0, 'cat': 'kermit'}
+    defaults = {'class': 'building', 'confidence': 0, 'cat': 'kermit'}
     assert 'cat' not in feature_table.values.columns
     with pytest.raises(ValueError):
-        feature_table.set_defaults(new_defaults)
+        feature_table.set_defaults(defaults)
 
 
 def test_feature_table_set_defaults_with_missing_column(feature_table):
-    new_defaults = {'class': 'building'}
+    defaults = {'class': 'building'}
     assert len(feature_table.values.columns) > 1
     with pytest.raises(ValueError):
-        feature_table.set_defaults(new_defaults)
+        feature_table.set_defaults(defaults)
 
 
 def test_register_label_attr_action(monkeypatch):

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -415,12 +415,14 @@ def test_feature_table_from_layer_with_unordered_pd_series_features():
 
 
 def test_feature_table_set_values_with_same_columns(feature_table):
-    new_values = {
-        'class': pd.Series(
-            ['building', 'sky'], dtype=feature_table.values.dtypes['class']
-        ),
-        'confidence': pd.Series([1, 0.5]),
-    }
+    new_values = pd.DataFrame(
+        {
+            'class': pd.Series(
+                ['building', 'sky'], dtype=feature_table.values.dtypes['class']
+            ),
+            'confidence': pd.Series([1, 0.5]),
+        }
+    )
     assert not feature_table.values['class'].equals(new_values['class'])
     assert not feature_table.values['confidence'].equals(
         new_values['confidence']

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -209,6 +209,16 @@ def test_feature_table_from_layer_with_num_data_only():
     assert feature_table.defaults.shape == (1, 0)
 
 
+def test_feature_table_from_layer_with_empty_int_features():
+    feature_table = _FeatureTable.from_layer(
+        features={'a': np.empty(0, dtype=np.int64)}
+    )
+    assert feature_table.values['a'].dtype == np.int64
+    assert len(feature_table.values['a']) == 0
+    assert feature_table.defaults['a'].dtype == np.int64
+    assert feature_table.defaults['a'][0] == 0
+
+
 def test_feature_table_from_layer_with_properties_and_num_data():
     properties = {
         'class': np.array(['sky', 'person', 'building', 'person']),

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -710,7 +710,7 @@ class _FeatureTable:
         defaults: Optional[Union[Dict[str, Any], pd.DataFrame]] = None,
     ) -> None:
         self._values = _validate_features(values, num_data=num_data)
-        self._defaults = _validate_defaults(defaults, self._values)
+        self._defaults = _validate_feature_defaults(defaults, self._values)
 
     @property
     def values(self) -> pd.DataFrame:
@@ -720,7 +720,7 @@ class _FeatureTable:
     def set_values(self, values, *, num_data=None) -> None:
         """Sets the feature values table."""
         self._values = _validate_features(values, num_data=num_data)
-        self._defaults = _validate_defaults(None, self._values)
+        self._defaults = _validate_feature_defaults(None, self._values)
 
     @property
     def defaults(self) -> pd.DataFrame:
@@ -731,7 +731,7 @@ class _FeatureTable:
         self, defaults: Union[Dict[str, Any], pd.DataFrame]
     ) -> None:
         """Sets the feature default values."""
-        self._defaults = _validate_defaults(defaults, self._values)
+        self._defaults = _validate_feature_defaults(defaults, self._values)
 
     def properties(self) -> Dict[str, np.ndarray]:
         """Converts this to a deprecated properties dictionary.
@@ -919,7 +919,7 @@ def _validate_features(
     return pd.DataFrame(data=features, index=index)
 
 
-def _validate_defaults(
+def _validate_feature_defaults(
     defaults: Optional[Union[Dict[str, Any], pd.DataFrame]],
     values: pd.DataFrame,
 ) -> pd.DataFrame:
@@ -948,7 +948,7 @@ def _validate_defaults(
             )
 
     # Convert to series first to capture the per-column dtype, since
-    # DataFrame initializer does not support passing multiple dtypes.
+    # the DataFrame initializer does not support passing multiple dtypes.
     default_series = {
         c: pd.Series(
             defaults[c],
@@ -957,7 +957,7 @@ def _validate_defaults(
         )
         for c in defaults
     }
-    return pd.DataFrame(default_series, index=range(1), copy=True)
+    return pd.DataFrame(default_series, index=range(1))
 
 
 def _features_from_properties(

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -934,17 +934,23 @@ def _validate_feature_defaults(
     else:
         default_columns = set(defaults.keys())
         value_columns = set(values.keys())
-
         extra_defaults = default_columns - value_columns
         if len(extra_defaults) > 0:
             raise ValueError(
-                f'Feature defaults contain some extra columns not in feature values: {extra_defaults}'
+                trans._(
+                    'Feature defaults contain some extra columns not in feature values: {extra_defaults}',
+                    deferred=True,
+                    extra_defaults=extra_defaults,
+                )
             )
-
         missing_defaults = value_columns - default_columns
         if len(missing_defaults) > 0:
             raise ValueError(
-                f'Feature defaults is missing some columns in feature values: {missing_defaults}'
+                trans._(
+                    'Feature defaults is missing some columns in feature values: {missing_defaults}',
+                    deferred=True,
+                    missing_defaults=missing_defaults,
+                )
             )
 
     # Convert to series first to capture the per-column dtype, since

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -875,7 +875,7 @@ class _FeatureTable:
                 property_choices=property_choices,
                 num_data=num_data,
             )
-        return cls(features, num_data=num_data)
+        return cls(features, defaults=feature_defaults, num_data=num_data)
 
 
 def _get_default_column(column: pd.Series) -> pd.Series:

--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -83,7 +83,7 @@ def test_empty_vectors_with_features():
     vectors.data = np.concatenate((vectors.data, [[[0, 0], [1, 1]]]))
     vectors.feature_defaults['a'] = 1
     vectors.data = np.concatenate((vectors.data, [[[1, 1], [2, 2]]]))
-    vectors.feature_defaults['a'] = 2
+    vectors.feature_defaults = {'a': 2}
     vectors.data = np.concatenate((vectors.data, [[[2, 2], [3, 3]]]))
 
     assert_colors_equal(vectors.edge_color, list('rgb'))

--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -3,7 +3,10 @@ import pandas as pd
 import pytest
 from vispy.color import get_colormap
 
-from napari._tests.utils import check_layer_world_data_extent
+from napari._tests.utils import (
+    assert_colors_equal,
+    check_layer_world_data_extent,
+)
 from napari.layers import Vectors
 from napari.utils.colormaps.standardize_color import transform_color
 
@@ -63,6 +66,27 @@ def test_empty_vectors():
     assert layer.data.shape == shape
     assert layer.ndim == shape[2]
     assert layer._view_data.shape[2] == 2
+
+
+def test_empty_vectors_with_features():
+    """See the following for the points issues this covers:
+    https://github.com/napari/napari/issues/5632
+    https://github.com/napari/napari/issues/5634
+    """
+    vectors = Vectors(
+        features={'a': np.empty(0, int)},
+        feature_defaults={'a': 0},
+        edge_color='a',
+        edge_color_cycle=list('rgb'),
+    )
+
+    vectors.data = np.concatenate((vectors.data, [[[0, 0], [1, 1]]]))
+    vectors.feature_defaults['a'] = 1
+    vectors.data = np.concatenate((vectors.data, [[[1, 1], [2, 2]]]))
+    vectors.feature_defaults['a'] = 2
+    vectors.data = np.concatenate((vectors.data, [[[2, 2], [3, 3]]]))
+
+    assert_colors_equal(vectors.edge_color, list('rgb'))
 
 
 def test_empty_vectors_with_property_choices():

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -384,6 +384,7 @@ class Vectors(Layer):
                 'property_choices': self.property_choices,
                 'ndim': self.ndim,
                 'features': self.features,
+                'feature_defaults': self.feature_defaults,
                 'out_of_slice_display': self.out_of_slice_display,
             }
         )


### PR DESCRIPTION
# Description
This introduces a `feature_defaults` init parameter and property setter for the three layer types that support that (points, shapes, and vectors). It also fixes some related issues that occur when adding feature-derived colors when modifying the feature defaults in-place.

Note that the `feature_defaults` is deliberately a little different to the `current_properties` setter, as the latter also has the side-effect of setting the feature values of the selected elements to the new current property values. Also, using the `feature_defaults` setter with keys/columns that are extra/missing compared to `features` will result in an error.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# References
Closes #5632
Closes #5634

# How has this been tested?
- [x] added new tests to cover bugs and setter
- [x] all tests pass with my change