### PR TITLE
MAINT: Do not use mutable default for dataclass.

### DIFF
--- a/napari/layers/points/_tests/test_points_mouse_bindings.py
+++ b/napari/layers/points/_tests/test_points_mouse_bindings.py
@@ -24,7 +24,9 @@ class Event:
         0,
         0,
     )  # world coords
-    pos: np.ndarray = np.zeros(2)  # canvas coords
+    pos: np.ndarray = field(
+        default_factory=lambda: np.zeros(2)
+    )  # canvas coords
     view_direction: Optional[List[float]] = None
     up_direction: Optional[List[float]] = None
     dims_displayed: List[int] = field(default_factory=lambda: [0, 1])


### PR DESCRIPTION
This will be an error in Python 3.11, See CI in #5439.

Send this a separate commit to make review easier (here and in #5439 that should in the end just enable CI on 3.11)

No tests added, as it will become an error in future Python version anyway.