### PR TITLE
MAINT: Do not use cgi-traceback on 3.11+ (deprecated, marked for removal)

### DIFF
--- a/napari/utils/_tracebacks.py
+++ b/napari/utils/_tracebacks.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from typing import Callable, Dict, Generator
 
 import numpy as np
@@ -53,72 +54,93 @@ def get_tb_formatter() -> Callable[[ExcInfo, bool, str], str]:
             return tb_text
 
     except ModuleNotFoundError:
-        import cgitb
         import traceback
 
-        # cgitb does not support error chaining...
-        # see https://peps.python.org/pep-3134/#enhanced-reporting
-        # this is a workaround
-        def cgitb_chain(exc: Exception) -> Generator[str, None, None]:
-            """Recurse through exception stack and chain cgitb_html calls."""
-            if exc.__cause__:
-                yield from cgitb_chain(exc.__cause__)
-                yield (
-                    '<br><br><font color="#51B432">The above exception was '
-                    'the direct cause of the following exception:</font><br>'
-                )
-            elif exc.__context__:
-                yield from cgitb_chain(exc.__context__)
-                yield (
-                    '<br><br><font color="#51B432">During handling of the '
-                    'above exception, another exception occurred:</font><br>'
-                )
-            yield cgitb_html(exc)
+        if sys.version_info < (3, 11):
+            import cgitb
 
-        def cgitb_html(exc: Exception) -> str:
-            """Format exception with cgitb.html."""
-            info = (type(exc), exc, exc.__traceback__)
-            return cgitb.html(info)
+            # cgitb does not support error chaining...
+            # see https://peps.python.org/pep-3134/#enhanced-reporting
+            # this is a workaround
+            def cgitb_chain(exc: Exception) -> Generator[str, None, None]:
+                """Recurse through exception stack and chain cgitb_html calls."""
+                if exc.__cause__:
+                    yield from cgitb_chain(exc.__cause__)
+                    yield (
+                        '<br><br><font color="#51B432">The above exception was '
+                        'the direct cause of the following exception:</font><br>'
+                    )
+                elif exc.__context__:
+                    yield from cgitb_chain(exc.__context__)
+                    yield (
+                        '<br><br><font color="#51B432">During handling of the '
+                        'above exception, another exception occurred:</font><br>'
+                    )
+                yield cgitb_html(exc)
 
-        def format_exc_info(info: ExcInfo, as_html: bool, color=None) -> str:
-            # avoids printing the array data
-            np.set_string_function(
-                lambda arr: f'{type(arr)} {arr.shape} {arr.dtype}'
-            )
-            if as_html:
-                html = "\n".join(cgitb_chain(info[1]))
-                # cgitb has a lot of hardcoded colors that don't work for us
-                # remove bgcolor, and let theme handle it
-                html = re.sub('bgcolor="#.*"', '', html)
-                # remove superfluous whitespace
-                html = html.replace('<br>\n', '\n')
-                # but retain it around the <small> bits
-                html = re.sub(r'(<tr><td><small.*</tr>)', '<br>\\1<br>', html)
-                # weird 2-part syntax is a workaround for hard-to-grep text.
-                html = html.replace(
-                    "<p>A problem occurred in a Python script.  "
-                    "Here is the sequence of",
-                    "",
+            def cgitb_html(exc: Exception) -> str:
+                """Format exception with cgitb.html."""
+                info = (type(exc), exc, exc.__traceback__)
+                return cgitb.html(info)
+
+            def format_exc_info(
+                info: ExcInfo, as_html: bool, color=None
+            ) -> str:
+                # avoids printing the array data
+                np.set_string_function(
+                    lambda arr: f'{type(arr)} {arr.shape} {arr.dtype}'
                 )
-                html = html.replace(
-                    "function calls leading up to the error, "
-                    "in the order they occurred.</p>",
-                    "<br>",
+                if as_html:
+                    html = "\n".join(cgitb_chain(info[1]))
+                    # cgitb has a lot of hardcoded colors that don't work for us
+                    # remove bgcolor, and let theme handle it
+                    html = re.sub('bgcolor="#.*"', '', html)
+                    # remove superfluous whitespace
+                    html = html.replace('<br>\n', '\n')
+                    # but retain it around the <small> bits
+                    html = re.sub(
+                        r'(<tr><td><small.*</tr>)', '<br>\\1<br>', html
+                    )
+                    # weird 2-part syntax is a workaround for hard-to-grep text.
+                    html = html.replace(
+                        "<p>A problem occurred in a Python script.  "
+                        "Here is the sequence of",
+                        "",
+                    )
+                    html = html.replace(
+                        "function calls leading up to the error, "
+                        "in the order they occurred.</p>",
+                        "<br>",
+                    )
+                    # remove hardcoded fonts
+                    html = html.replace('face="helvetica, arial"', "")
+                    html = (
+                        "<span style='font-family: monaco,courier,monospace;'>"
+                        + html
+                        + "</span>"
+                    )
+                    tb_text = html
+                else:
+                    # if we don't need HTML, just use traceback
+                    tb_text = ''.join(traceback.format_exception(*info))
+                # resets to default behavior
+                np.set_string_function(None)
+                return tb_text
+
+        else:
+
+            def format_exc_info(
+                info: ExcInfo, as_html: bool, color=None
+            ) -> str:
+                # avoids printing the array data
+                np.set_string_function(
+                    lambda arr: f'{type(arr)} {arr.shape} {arr.dtype}'
                 )
-                # remove hardcoded fonts
-                html = html.replace('face="helvetica, arial"', "")
-                html = (
-                    "<span style='font-family: monaco,courier,monospace;'>"
-                    + html
-                    + "</span>"
-                )
-                tb_text = html
-            else:
-                # if we don't need HTML, just use traceback
                 tb_text = ''.join(traceback.format_exception(*info))
-            # resets to default behavior
-            np.set_string_function(None)
-            return tb_text
+                if as_html:
+                    tb_text = '<pre>' + tb_text + '</pre>'
+                np.set_string_function(None)
+                return tb_text
 
     return format_exc_info
 


### PR DESCRIPTION
cgitb that is used as a fallback to convert traceback to html has been deprecated as part of Python 3.11 and is marked for removal in python 3.13.

As we turn warning into errors in Python 3.11+ this will make the test fail.

This add a conditional to simply wrap the traceback into pre tags when IPython is not available and we are on Python 3.11+.

I would be tempted to already completely remove cgi-tb code for us to not have a difference in behavior before/after 3.11.

This is extracted from #5439 in order to make review/discussion easier.

## Type of change

- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


