### PR TITLE
MAINT: Try to install wheels only in CI/Tox.

### DIFF
--- a/.github/workflows/test_typing.yml
+++ b/.github/workflows/test_typing.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install napari
         run: |
           pip install -r resources/requirements_mypy.txt
-          SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install --only-binary ':all:' --no-binary asciitre -e .[all]
+          SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install --only-binary ':all:' --no-binary asciitre --no-binary asciitre -e .[all]
 
       - name: Run mypy on typed modules
         run: make typecheck

--- a/.github/workflows/test_typing.yml
+++ b/.github/workflows/test_typing.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Install napari
         run: |
           pip install -r resources/requirements_mypy.txt
-          SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install -e .[all]
+          pip install asciitree # only non-wheel dependency of zarr
+          SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install --only-binary ':all:' -e .[all]
 
       - name: Run mypy on typed modules
         run: make typecheck

--- a/.github/workflows/test_typing.yml
+++ b/.github/workflows/test_typing.yml
@@ -17,8 +17,7 @@ jobs:
       - name: Install napari
         run: |
           pip install -r resources/requirements_mypy.txt
-          pip install asciitree # only non-wheel dependency of zarr
-          SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install --only-binary ':all:' -e .[all]
+          SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install --only-binary ':all:' --no-binary asciitre -e .[all]
 
       - name: Run mypy on typed modules
         run: make typecheck

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -713,6 +713,8 @@ class RefreshState(Enum):
 
 
 class QtPluginDialog(QDialog):
+    available_list: QPluginList
+
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self.refresh_state = RefreshState.DONE

--- a/tools/minreq.py
+++ b/tools/minreq.py
@@ -11,6 +11,7 @@ other than '1'.
 
 import os
 from configparser import ConfigParser
+from pathlib import Path
 
 
 def pin_config_minimum_requirements(config_filename):
@@ -44,3 +45,9 @@ if __name__ == '__main__':
             os.path.dirname(__file__), "..", "setup.cfg"
         )
         pin_config_minimum_requirements(config_filename)
+
+        tox_file = Path(__file__).parent.parent / 'tox.ini'
+
+        tox_file.write_text(
+            tox_file.read_text().replace(' --only-binary :all:', '')
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ BACKEND =
 # Settings defined in the top-level testenv section are automatically
 # inherited by individual environments unless overridden.
 [testenv]
-install_command = pip install --only-binary :all: --no-binary asciitree {opts} {packages}
+install_command = pip install --only-binary :all: --no-binary asciitree  --no-binary PyOpenGL {opts} {packages}
 platform = 
     macos: darwin
     linux: linux

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ BACKEND =
 # Settings defined in the top-level testenv section are automatically
 # inherited by individual environments unless overridden.
 [testenv]
-install_command = pip install --only-binary :all: --no-binary asciitree  --no-binary PyOpenGL {opts} {packages}
+install_command = pip install --only-binary :all: --no-binary asciitree  --no-binary PyOpenGL --no-binary PyYAML {opts} {packages}
 platform = 
     macos: darwin
     linux: linux

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ BACKEND =
 # Settings defined in the top-level testenv section are automatically
 # inherited by individual environments unless overridden.
 [testenv]
+install_command = pip install asciitree # zarr-non-wheel deps ; pip install --only-binary :all: {opts} {packages}
 platform = 
     macos: darwin
     linux: linux

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ BACKEND =
 # Settings defined in the top-level testenv section are automatically
 # inherited by individual environments unless overridden.
 [testenv]
-install_command = pip install --only-binary :all: --no-binary asciitree  --no-binary PyOpenGL --no-binary PyYAML {opts} {packages}
+install_command = pip install --only-binary :all: --no-binary asciitree {opts} {packages}
 platform = 
     macos: darwin
     linux: linux

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ BACKEND =
 # Settings defined in the top-level testenv section are automatically
 # inherited by individual environments unless overridden.
 [testenv]
-install_command = pip install asciitree # zarr-non-wheel deps ; pip install --only-binary :all: {opts} {packages}
+install_command = pip install --only-binary :all: --no-binary asciitree {opts} {packages}
 platform = 
     macos: darwin
     linux: linux


### PR DESCRIPTION
Making sure that all the dependencies are available as wheel has multiple advantages:
 - it's safer (not code execution at install).
 - faster (just zip-extract, and dependencies resolution is static).
 - when bumping min-Python version we can be sure that build won't break on user machine because of lack of compilers.
