### PR TITLE
Bugfix: Don't double toggle visibility for linked layers

### DIFF
--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -89,8 +89,13 @@ def _merge_stack(ll: LayerList, rgb=False):
 
 
 def _toggle_visibility(ll: LayerList):
-    for lay in ll.selection:
-        lay.visible = not lay.visible
+    current_visibility_state = []
+    for layer in ll.selection:
+        current_visibility_state.append(layer.visible)
+
+    for visibility, layer in zip(current_visibility_state, ll.selection):
+        if layer.visible == visibility:
+            layer.visible = not visibility
 
 
 def _link_selected_layers(ll: LayerList):

--- a/napari/layers/_tests/test_layer_actions.py
+++ b/napari/layers/_tests/test_layer_actions.py
@@ -7,8 +7,49 @@ from napari.layers._layer_actions import (
     _convert,
     _convert_dtype,
     _duplicate_layer,
+    _link_selected_layers,
     _project,
+    _toggle_visibility,
 )
+
+
+def test_toggle_visibility():
+    """Test toggling visibility of a layer."""
+    layer_list = LayerList()
+    layer_list.append(Points([[0, 0]]))
+    layer_list[0].visible = False
+
+    layer_list.selection.active = layer_list[0]
+    _toggle_visibility(layer_list)
+
+    assert layer_list[0].visible is True
+
+
+def test_toggle_visibility_with_linked_layers():
+    """Test toggling visibility of a layer."""
+    layer_list = LayerList()
+    layer_list.append(Points([[0, 0]]))
+    layer_list.append(Points([[0, 0]]))
+    layer_list.append(Points([[0, 0]]))
+    layer_list.append(Points([[0, 0]]))
+
+    layer_list.selection.active = layer_list[0]
+    layer_list.selection.add(layer_list[1])
+    layer_list.selection.add(layer_list[2])
+
+    _link_selected_layers(layer_list)
+
+    layer_list[3].visible = False
+
+    layer_list.selection.remove(layer_list[0])
+    layer_list.selection.add(layer_list[3])
+
+    _toggle_visibility(layer_list)
+
+    assert layer_list[0].visible is False
+    assert layer_list[1].visible is False
+    assert layer_list[2].visible is False
+    assert layer_list[3].visible is True
 
 
 def test_duplicate_layers():


### PR DESCRIPTION
Co-authored-by: Grzegorz Bokota <bokota+github@gmail.com>

# Description

This PR stores the layer visibility states prior to toggling layers and then checks against it to ensure that layers are toggled relative to that initial state. This makes sure they are not double toggled if linked layers are involved.
Also added a test for the interaction between linked layers and toggle_visibility that fails without this PR but now passes.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
Closes #5655 

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] I added a test that fails on main but passes here
- [x] all tests pass with my change 
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
