### PR TITLE
Fix custom colormap handling

### DIFF
--- a/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -84,7 +84,10 @@ class QtBaseImageControls(QtLayerControls):
         comboBox.setObjectName("colormapComboBox")
         comboBox._allitems = set(self.layer.colormaps)
 
-        for name, cm in AVAILABLE_COLORMAPS.items():
+        for name, cm in {
+            **AVAILABLE_COLORMAPS,
+            **self.layer._custom_colormaps,
+        }.items():
             if name in self.layer.colormaps:
                 comboBox.addItem(cm._display_name, name)
 
@@ -173,9 +176,10 @@ class QtBaseImageControls(QtLayerControls):
     def _on_colormap_change(self):
         """Receive layer model colormap change event and update dropdown menu."""
         name = self.layer.colormap.name
-        if name not in self.colormapComboBox._allitems and (
-            cm := AVAILABLE_COLORMAPS.get(name)
-        ):
+        if name not in self.colormapComboBox._allitems:
+            cm = {**AVAILABLE_COLORMAPS, **self.layer._custom_colormaps}.get(
+                name, self.layer.colormap
+            )
             self.colormapComboBox._allitems.add(name)
             self.colormapComboBox.addItem(cm._display_name, name)
 

--- a/napari/layers/intensity_mixin.py
+++ b/napari/layers/intensity_mixin.py
@@ -43,6 +43,7 @@ class IntensityVisualizationMixin:
         self._contrast_limits_range = [None, None]
         self._auto_contrast_source = 'slice'
         self._keep_auto_contrast = False
+        self._custom_colormaps = {}
 
     def reset_contrast_limits(self: 'Image', mode=None):
         """Scale contrast limits to data range"""
@@ -67,7 +68,11 @@ class IntensityVisualizationMixin:
         return self._colormap
 
     def _set_colormap(self, colormap):
-        self._colormap = ensure_colormap(colormap)
+        self._colormap = ensure_colormap(
+            colormap, custom_colormaps=self._custom_colormaps
+        )
+        if self._colormap.name not in self.colormaps:
+            self._custom_colormaps[self._colormap.name] = self._colormap
         self._update_thumbnail()
         self.events.colormap()
 
@@ -78,7 +83,7 @@ class IntensityVisualizationMixin:
     @property
     def colormaps(self):
         """tuple of str: names of available colormaps."""
-        return tuple(self._colormaps.keys())
+        return (*self._colormaps, *self._custom_colormaps)
 
     @property
     def contrast_limits(self):


### PR DESCRIPTION
# Description
I noticed a few issues with how custom colormaps are handled for image and surface layers, happening both at the model level and at the qt controls level.

The main culprit is the fact that custom colormaps are not accounted for when checking if a colormap is "valid". This change allows layers to keep track of any custom colormaps so they can be referenced (and used) later. This, for example, allows to go back and choose `custom` from the dropdown menu if a `custom` colormap was previously created. More importantly, it allows to initialize a layer with a custom colormap (which was previously causing a few errors). This won't work on `main`:

```
import napari
import numpy as np
v = napari.Viewer()
s = v.add_surface((np.random.rand(5, 3) * 50, np.random.choice(range(5), (3, 3))), colormap=np.random.rand(5, 3))
```

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
