### PR TITLE
MAINT: Move suspected segfaulting test into its own file.

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -20,7 +20,6 @@ from napari._tests.utils import (
     skip_on_win_ci,
 )
 from napari._vispy._tests.utils import vispy_image_scene_size
-from napari._vispy.utils.gl import fix_data_dtype
 from napari.components.viewer_model import ViewerModel
 from napari.layers import Points
 from napari.settings import get_settings
@@ -296,45 +295,6 @@ def test_screenshot_dialog(make_napari_viewer, tmpdir):
     output_data = imread(expected_filepath)
     expected_data = viewer.window._qt_viewer.screenshot(flash=False)
     assert np.allclose(output_data, expected_data)
-
-
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        'int8',
-        'uint8',
-        'int16',
-        'uint16',
-        'int32',
-        'float16',
-        'float32',
-        'float64',
-    ],
-)
-def test_qt_viewer_data_integrity(make_napari_viewer, dtype):
-    """Test that the viewer doesn't change the underlying array."""
-    image = np.random.rand(10, 32, 32)
-    image *= 200 if dtype.endswith('8') else 2**14
-    image = image.astype(dtype)
-    imean = image.mean()
-
-    viewer = make_napari_viewer()
-    layer = viewer.add_image(image.copy())
-    data = layer.data
-
-    datamean = np.mean(data)
-    assert datamean == imean
-    # toggle dimensions
-    viewer.dims.ndisplay = 3
-    datamean = np.mean(data)
-    assert datamean == imean
-    # back to 2D
-    viewer.dims.ndisplay = 2
-    datamean = np.mean(data)
-    assert datamean == imean
-    # also check that vispy gets (almost) the same data
-    datamean = np.mean(fix_data_dtype(data))
-    assert np.allclose(datamean, imean, rtol=5e-04)
 
 
 def test_points_layer_display_correct_slice_on_scale(make_napari_viewer):

--- a/napari/_qt/_tests/test_qt_viewer_2.py
+++ b/napari/_qt/_tests/test_qt_viewer_2.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+
+from napari._vispy.utils.gl import fix_data_dtype
+
+BUILTINS_DISP = 'napari'
+BUILTINS_NAME = 'builtins'
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        'int8',
+        'uint8',
+        'int16',
+        'uint16',
+        'int32',
+        'float16',
+        'float32',
+        'float64',
+    ],
+)
+def test_qt_viewer_data_integrity(make_napari_viewer, dtype):
+    """Test that the viewer doesn't change the underlying array."""
+    image = np.random.rand(10, 32, 32)
+    image *= 200 if dtype.endswith('8') else 2**14
+    image = image.astype(dtype)
+    imean = image.mean()
+
+    viewer = make_napari_viewer()
+    layer = viewer.add_image(image.copy())
+    data = layer.data
+
+    datamean = np.mean(data)
+    assert datamean == imean
+    # toggle dimensions
+    viewer.dims.ndisplay = 3
+    datamean = np.mean(data)
+    assert datamean == imean
+    # back to 2D
+    viewer.dims.ndisplay = 2
+    datamean = np.mean(data)
+    assert datamean == imean
+    # also check that vispy gets (almost) the same data
+    datamean = np.mean(fix_data_dtype(data))
+    assert np.allclose(datamean, imean, rtol=5e-04)

--- a/napari/_qt/_tests/test_qt_viewer_2.py
+++ b/napari/_qt/_tests/test_qt_viewer_2.py
@@ -6,7 +6,9 @@ from napari._vispy.utils.gl import fix_data_dtype
 BUILTINS_DISP = 'napari'
 BUILTINS_NAME = 'builtins'
 
-
+# Previously tests often segfaulted on CI at the 26th test of test_qt_viewer
+# That test (number 26) was split off to make debugging easier
+# See https://github.com/napari/napari/pull/5676
 @pytest.mark.parametrize(
     "dtype",
     [

--- a/napari/_qt/_tests/test_qt_viewer_2.py
+++ b/napari/_qt/_tests/test_qt_viewer_2.py
@@ -6,6 +6,7 @@ from napari._vispy.utils.gl import fix_data_dtype
 BUILTINS_DISP = 'napari'
 BUILTINS_NAME = 'builtins'
 
+
 # Previously tests often segfaulted on CI at the 26th test of test_qt_viewer
 # That test (number 26) was split off to make debugging easier
 # See https://github.com/napari/napari/pull/5676


### PR DESCRIPTION
It looks like the test often segfault on the 26th test of test_qt_viewer, which appear to be this one  – I can't reproduce so ran locally with ``-v``, and move the test to a separate file to see if it segfaults there.

If that's the case I can tag the test and run it in a separate matrix item.

I'll try to update this PR if this is not the test that is segfaulting.