### PR TITLE
Bugfix: Add Tracks to qt_keyboard_settings

### DIFF
--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -22,7 +22,15 @@ from qtpy.QtWidgets import (
 from vispy.util import keys
 
 from napari._qt.widgets.qt_message_popup import WarnPopup
-from napari.layers import Image, Labels, Points, Shapes, Surface, Vectors
+from napari.layers import (
+    Image,
+    Labels,
+    Points,
+    Shapes,
+    Surface,
+    Tracks,
+    Vectors,
+)
 from napari.settings import get_settings
 from napari.utils.action_manager import action_manager
 from napari.utils.interactions import Shortcut
@@ -60,6 +68,7 @@ class ShortcutEditor(QWidget):
             Points,
             Shapes,
             Surface,
+            Tracks,
             Vectors,
         ]
 


### PR DESCRIPTION
# Description
closes https://github.com/napari/napari/issues/5677

I tracked down the source of the added Transform and Pan/zoom in the Viewer keybindings.
Those are actions/keybinds added in https://github.com/napari/napari/pull/4894 for the Tracks layer. But Tracks layer wasn't added as an option in the shortcuts table, so they appear in the default (Viewer).
With this PR, I import Tracks and add it to the dropdown so Tracks has it's own table and now the actions appear in the proper table, rather than under Viewer keybindings.

<img width="1198" alt="image" src="https://user-images.githubusercontent.com/76622105/228287187-189cb745-fb6e-4c31-93f1-6ba22e965a56.png">

<img width="1198" alt="image" src="https://user-images.githubusercontent.com/76622105/228287227-da2642b7-8f76-4451-bdfa-e6801f47400a.png">



## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
