### PR TITLE
Fix automatic naming and GUI exposure of multiple unnamed colormaps

### DIFF
--- a/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -142,8 +142,7 @@ class QtBaseImageControls(QtLayerControls):
         text : str
             Colormap name.
         """
-        with self.layer.events.colormap.blocker():
-            self.layer.colormap = self.colormapComboBox.currentData()
+        self.layer.colormap = self.colormapComboBox.currentData()
 
     def _on_contrast_limits_change(self):
         """Receive layer model contrast limits change event and update slider."""

--- a/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -142,7 +142,8 @@ class QtBaseImageControls(QtLayerControls):
         text : str
             Colormap name.
         """
-        self.layer.colormap = self.colormapComboBox.currentData()
+        with self.layer.events.colormap.blocker():
+            self.layer.colormap = self.colormapComboBox.currentData()
 
     def _on_contrast_limits_change(self):
         """Receive layer model contrast limits change event and update slider."""

--- a/napari/utils/colormaps/_tests/test_colormaps.py
+++ b/napari/utils/colormaps/_tests/test_colormaps.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pytest
 from vispy.color import Colormap as VispyColormap
@@ -228,3 +230,4 @@ def test_ensure_colormap_with_multi_colors(colors):
     colormap = ensure_colormap(colors)
     expected_colors = transform_color(colors)
     np.testing.assert_array_equal(colormap.colors, expected_colors)
+    assert re.match(r'\[unnamed colormap \d+\]', colormap.name) is not None

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -524,6 +524,9 @@ def _increment_unnamed_colormap(
 ) -> Tuple[str, str]:
     """Increment name for unnamed colormap.
 
+    NOTE: this assumes colormaps are *never* deleted, and does not check
+          for name collision. If colormaps can ever be removed, please update.
+
     Parameters
     ----------
     existing : list of str

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -636,8 +636,8 @@ def ensure_colormap(colormap: ValidColormapArg) -> Colormap:
                 name, _display_name = _increment_unnamed_colormap(
                     AVAILABLE_COLORMAPS
                 )
-                cmap.update({'name': name, '_display_name': _display_name})
-                AVAILABLE_COLORMAPS[name] = cmap
+                colormap.update({'name': name, '_display_name': _display_name})
+                AVAILABLE_COLORMAPS[name] = colormap
 
         elif isinstance(colormap, dict):
             if 'colors' in colormap and not (

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -636,7 +636,7 @@ def ensure_colormap(colormap: ValidColormapArg) -> Colormap:
                 name, _display_name = _increment_unnamed_colormap(
                     AVAILABLE_COLORMAPS
                 )
-                colormap.update({'name': name, '_display_name': _display_name})
+                cmap.update({'name': name, '_display_name': _display_name})
                 AVAILABLE_COLORMAPS[name] = cmap
 
         elif isinstance(colormap, dict):

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -636,6 +636,7 @@ def ensure_colormap(colormap: ValidColormapArg) -> Colormap:
                 name, _display_name = _increment_unnamed_colormap(
                     AVAILABLE_COLORMAPS
                 )
+                colormap.update({'name': name, '_display_name': _display_name})
                 AVAILABLE_COLORMAPS[name] = cmap
 
         elif isinstance(colormap, dict):
@@ -691,6 +692,7 @@ def ensure_colormap(colormap: ValidColormapArg) -> Colormap:
                 name, _display_name = _increment_unnamed_colormap(
                     AVAILABLE_COLORMAPS
                 )
+                colormap.update({'name': name, '_display_name': _display_name})
                 AVAILABLE_COLORMAPS[name] = colormap
             else:
                 warnings.warn(

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -625,15 +625,18 @@ def ensure_colormap(colormap: ValidColormapArg) -> Colormap:
                 AVAILABLE_COLORMAPS[name] = cmap
             else:
                 colormap = _colormap_from_colors(colormap)
-                if colormap is not None:
-                    # Return early because we don't have a name for this colormap.
-                    return colormap
-                raise TypeError(
-                    trans._(
-                        "When providing a tuple as a colormap argument, either 1) the first element must be a string and the second a Colormap instance 2) or the tuple should be convertible to one or more colors",
-                        deferred=True,
+                if colormap is None:
+                    raise TypeError(
+                        trans._(
+                            "When providing a tuple as a colormap argument, either 1) the first element must be a string and the second a Colormap instance 2) or the tuple should be convertible to one or more colors",
+                            deferred=True,
+                        )
                     )
+
+                name, _display_name = _increment_unnamed_colormap(
+                    AVAILABLE_COLORMAPS
                 )
+                AVAILABLE_COLORMAPS[name] = cmap
 
         elif isinstance(colormap, dict):
             if 'colors' in colormap and not (
@@ -685,19 +688,20 @@ def ensure_colormap(colormap: ValidColormapArg) -> Colormap:
         else:
             colormap = _colormap_from_colors(colormap)
             if colormap is not None:
-                # Return early because we don't have a name for this colormap.
-                return colormap
-
-            warnings.warn(
-                trans._(
-                    'invalid type for colormap: {cm_type}. Must be a {{str, tuple, dict, napari.utils.Colormap, vispy.colors.Colormap}}. Reverting to default',
-                    deferred=True,
-                    cm_type=type(colormap),
+                name, _display_name = _increment_unnamed_colormap(
+                    AVAILABLE_COLORMAPS
                 )
-            )
-
-            # Use default colormap
-            name = 'gray'
+                AVAILABLE_COLORMAPS[name] = colormap
+            else:
+                warnings.warn(
+                    trans._(
+                        'invalid type for colormap: {cm_type}. Must be a {{str, tuple, dict, napari.utils.Colormap, vispy.colors.Colormap}}. Reverting to default',
+                        deferred=True,
+                        cm_type=type(colormap),
+                    )
+                )
+                # Use default colormap
+                name = 'gray'
 
     return AVAILABLE_COLORMAPS[name]
 


### PR DESCRIPTION
# Description
Alternative to #5662. This is actually addressing the issue, instead of inventing new problems to solve :P

This fixes the original problem; this will now work as intended and correctly update the dropdown menu and the global `AVAILABLE_COLORMAPS` dict.


```
import napari
import numpy as np
v = napari.Viewer()
i = v.add_image(np.random.rand(10, 10, 10), colormap=np.random.rand(5, 3))
s = v.add_surface((np.random.rand(5, 3) * 50, np.random.choice(range(5), (3, 3))), colormap=np.random.rand(5, 3))
```


A side effect of the current version is that instead of `custom`, new unnamed colormaps are named `[unnamed colormap i]` where `i` is an incremental index. We can change the default to `custom`, if preferred, but for now I opted for minimal code changes for easier review.

Note that a notable change (read: bug fix) of this PR is that the code above generate 2 different colormaps, instead of overwriting a single `custom` colormap.

cc @andy-sweet 
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
