### PR TITLE
Skip pyside6 version 6.4.3 for tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -75,13 +75,13 @@ setenv =
     async: NAPARI_ASYNC = 1
     async: PYTEST_ADDOPTS = --async_only
     async: PYTEST_PATH = napari
-# Avoid pyside6 6.3.4 due to issue described in:
+# Avoid pyside6 6.4.3 due to issue described in:
 # https://github.com/napari/napari/issues/5657
 deps =
     pytest-cov
     pyqt6: PyQt6
     pyside6: PySide6 < 6.3.2 ; python_version < '3.10'
-    pyside6: PySide6 != 6.3.4 ; python_version >= '3.10'
+    pyside6: PySide6 != 6.4.3 ; python_version >= '3.10'
     pytest-json-report
 # use extras specified in setup.cfg for certain test envs
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -75,11 +75,13 @@ setenv =
     async: NAPARI_ASYNC = 1
     async: PYTEST_ADDOPTS = --async_only
     async: PYTEST_PATH = napari
+# Avoid pyside6 6.3.4 due to issue described in:
+# https://github.com/napari/napari/issues/5657
 deps =
     pytest-cov
     pyqt6: PyQt6
     pyside6: PySide6 < 6.3.2 ; python_version < '3.10'
-    pyside6: PySide6 ; python_version >= '3.10'
+    pyside6: PySide6 != 6.3.4 ; python_version >= '3.10'
     pytest-json-report
 # use extras specified in setup.cfg for certain test envs
 extras =


### PR DESCRIPTION
# Description
This skips version 6.4.3 of pyside6 when testing to avoid the problems described in #5657. It does not close that issue, but at least reduces noise on the PR tests.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# References
Related to #5657

# How has this been tested?
- [x] all tests pass with my change
