### PR TITLE
Back point selection with a psygnal Selection

### DIFF
--- a/napari/layers/points/_points_mouse_bindings.py
+++ b/napari/layers/points/_points_mouse_bindings.py
@@ -1,3 +1,5 @@
+from typing import Set, TypeVar
+
 import numpy as np
 
 from napari.layers.points._points_utils import _points_in_box_3d, points_in_box
@@ -127,27 +129,32 @@ def highlight(layer, event):
     layer._set_highlight()
 
 
-def _toggle_selected(selected_data, value):
-    """Add or remove value from the selected data set.
+_T = TypeVar("_T")
+
+
+def _toggle_selected(selection: Set[_T], value: _T) -> Set[_T]:
+    """Add or remove value from the selection set.
+
+    This function returns a copy of the existing selection.
 
     Parameters
     ----------
-    selected_data : set
+    selection: set
         Set of selected data points to be modified.
     value : int
         Index of point to add or remove from selected data set.
 
     Returns
     -------
-    set
-        Modified selected_data set.
+    selection: set
+        Updated selection.
     """
-    if value in selected_data:
-        selected_data.remove(value)
+    selection = set(selection)
+    if value in selection:
+        selection.remove(value)
     else:
-        selected_data.add(value)
-
-    return selected_data
+        selection.add(value)
+    return selection
 
 
 def _update_drag_vectors_from_event(layer, event):

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1732,10 +1732,10 @@ def test_thumbnail_non_square_data():
         layer.thumbnail[: mid_row - 1, :, :3], expected_zeros
     )
     assert (
-        np.count_nonzero(layer.thumbnail[mid_row - 1: mid_row + 1, :, :3]) > 0
+        np.count_nonzero(layer.thumbnail[mid_row - 1 : mid_row + 1, :, :3]) > 0
     )
     np.testing.assert_array_equal(
-        layer.thumbnail[mid_row + 1:, :, :3], expected_zeros
+        layer.thumbnail[mid_row + 1 :, :, :3], expected_zeros
     )
 
 

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 import numpy as np
 import pandas as pd
 import pytest
+from psygnal.containers import EventedSet
 from pydantic import ValidationError
 from vispy.color import get_colormap
 
@@ -1731,10 +1732,10 @@ def test_thumbnail_non_square_data():
         layer.thumbnail[: mid_row - 1, :, :3], expected_zeros
     )
     assert (
-        np.count_nonzero(layer.thumbnail[mid_row - 1 : mid_row + 1, :, :3]) > 0
+        np.count_nonzero(layer.thumbnail[mid_row - 1: mid_row + 1, :, :3]) > 0
     )
     np.testing.assert_array_equal(
-        layer.thumbnail[mid_row + 1 :, :, :3], expected_zeros
+        layer.thumbnail[mid_row + 1:, :, :3], expected_zeros
     )
 
 
@@ -2528,3 +2529,12 @@ def test_editable_and_visible_are_independent():
     layer.visible = True
 
     assert not layer.editable
+
+
+def test_point_selection_remains_evented_after_update():
+    """Existing evented point set should be updated when selection changes."""
+    data = np.empty((3, 2))
+    layer = Points(data)
+    assert isinstance(layer.selected_data, EventedSet)
+    layer.selected_data = {0, 1}
+    assert isinstance(layer.selected_data, EventedSet)

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import numpy as np
 import pandas as pd
 import pytest
-from psygnal.containers import EventedSet
+from psygnal.containers import Selection
 from pydantic import ValidationError
 from vispy.color import get_colormap
 
@@ -2532,9 +2532,9 @@ def test_editable_and_visible_are_independent():
 
 
 def test_point_selection_remains_evented_after_update():
-    """Existing evented point set should be updated when selection changes."""
+    """Existing evented selection model should be updated rather than replaced."""
     data = np.empty((3, 2))
     layer = Points(data)
-    assert isinstance(layer.selected_data, EventedSet)
+    assert isinstance(layer.selected_data, Selection)
     layer.selected_data = {0, 1}
-    assert isinstance(layer.selected_data, EventedSet)
+    assert isinstance(layer.selected_data, Selection)

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
+from psygnal.containers import EventedSet
 from scipy.stats import gmean
 
 from napari.layers.base import Layer, no_op
@@ -450,7 +451,7 @@ class Points(Layer):
         self._shown = np.empty(0).astype(bool)
 
         # Indices of selected points
-        self._selected_data = set()
+        self._selected_data = EventedSet()
         self._selected_data_stored = set()
         self._selected_data_history = set()
         # Indices of selected points within the currently viewed slice
@@ -1279,7 +1280,8 @@ class Points(Layer):
 
     @selected_data.setter
     def selected_data(self, selected_data):
-        self._selected_data = set(selected_data)
+        self._selected_data.clear()
+        self._selected_data.update(set(selected_data))
         self._selected_view = list(
             np.intersect1d(
                 np.array(list(self._selected_data)),

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
-from psygnal.containers import EventedSet
+from psygnal.containers import Selection
 from scipy.stats import gmean
 
 from napari.layers.base import Layer, no_op
@@ -451,7 +451,7 @@ class Points(Layer):
         self._shown = np.empty(0).astype(bool)
 
         # Indices of selected points
-        self._selected_data = EventedSet()
+        self._selected_data: Selection[int] = Selection()
         self._selected_data_stored = set()
         self._selected_data_history = set()
         # Indices of selected points within the currently viewed slice
@@ -1274,12 +1274,12 @@ class Points(Layer):
         return state
 
     @property
-    def selected_data(self) -> set:
+    def selected_data(self) -> Selection[int]:
         """set: set of currently selected points."""
         return self._selected_data
 
     @selected_data.setter
-    def selected_data(self, selected_data):
+    def selected_data(self, selected_data: Sequence[int]) -> None:
         self._selected_data.clear()
         self._selected_data.update(set(selected_data))
         self._selected_view = list(


### PR DESCRIPTION
# Description
This pull request makes the point selection model use an evented set from psygnal rather than the python set. This will close #5686 and also #4023. 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# References
https://psygnal.readthedocs.io/en/latest/API/containers/#psygnal.containers.EventedSet

# How has this been tested?
Manually tested, but have not yet added tests to the test suite.
@alisterburt helped me with this PR and will add some tests. 

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
