### PR TITLE
Fix mouse movement handling for `TransformBoxOverlay`

### DIFF
--- a/napari/_tests/test_mouse_bindings.py
+++ b/napari/_tests/test_mouse_bindings.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import numpy as np
 
 from napari._tests.utils import skip_on_win_ci
+from napari.layers.base._base_mouse_bindings import InteractionBoxHandle
 
 
 @skip_on_win_ci
@@ -154,6 +155,24 @@ def test_layer_mouse_bindings(make_napari_viewer):
     mock_drag.method.assert_called_once()
     mock_release.method.assert_called_once()
     mock_move.method.assert_not_called()
+    mock_press.reset_mock()
+    mock_drag.reset_mock()
+    mock_release.reset_mock()
+
+    # simulate hover in transform mode
+    layer.mode = 'transform'
+    # go to middle of the canvas, so we're sure to be inside
+    position = tuple(d // 2 for d in view.canvas.size)
+    view.canvas.events.mouse_move(pos=position, modifiers=())
+    mock_press.method.assert_not_called()
+    mock_drag.method.assert_not_called()
+    mock_release.method.assert_not_called()
+    mock_move.method.assert_called_once()
+    assert (
+        layer._overlays['transform_box'].selected_handle
+        == InteractionBoxHandle.INSIDE
+    )
+    mock_move.reset_mock()
 
 
 @skip_on_win_ci

--- a/napari/layers/base/_base_mouse_bindings.py
+++ b/napari/layers/base/_base_mouse_bindings.py
@@ -32,7 +32,7 @@ def highlight_box_handles(layer, event):
     nearby_handle = get_nearby_handle(pos, handle_coords)
 
     # set the selected vertex of the box to the nearby_handle (can also be INSIDE or None)
-    layer._overlays['transform_box'].selected_vertex = nearby_handle
+    layer._overlays['transform_box'].selected_handle = nearby_handle
 
 
 def _translate_with_box(


### PR DESCRIPTION
# Fixes/Closes

<!-- In general, PRs should fix an existing issue on the repo. -->
<!-- Please link to that issue here as "Closes #(issue-number)". -->
Closes #5538 

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Prevent showing errors when moving the mouse over the viewer when a transform box overlay is present.

Preview:

![overlay](https://user-images.githubusercontent.com/16781833/229853760-9255ff49-680f-4cfa-b6cd-3f33f7730275.gif)


# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change
- [x] I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
      For more information see our [translations guide](https://napari.org/developers/translations.html).
