### PR TITLE
fix test_viewer_open_no_plugin exception message expectation

### DIFF
--- a/napari/components/_tests/test_add_layers.py
+++ b/napari/components/_tests/test_add_layers.py
@@ -72,7 +72,7 @@ def test_viewer_open_no_plugin(tmp_path):
     viewer = ViewerModel()
     fname = tmp_path / 'gibberish.gbrsh'
     fname.touch()
-    with pytest.raises(ValueError, match='No plugin found capable of reading'):
+    with pytest.raises(ValueError):
         # will default to builtins
         viewer.open(fname)
 

--- a/napari/components/_tests/test_add_layers.py
+++ b/napari/components/_tests/test_add_layers.py
@@ -72,7 +72,7 @@ def test_viewer_open_no_plugin(tmp_path):
     viewer = ViewerModel()
     fname = tmp_path / 'gibberish.gbrsh'
     fname.touch()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=".*gibberish.gbrsh.*"):
         # will default to builtins
         viewer.open(fname)
 


### PR DESCRIPTION
since @DragaDoncila improved the error message on the npe2 side in https://github.com/napari/npe2/pull/276  ... the npe2 test suite now fails when it runs napari tests due to an expectation of an outdated error message.  This just relaxes that error message match so that tests can pass on npe2 again