### PR TITLE
Don't resize shape after `Shift` release until mouse moves

### DIFF
--- a/napari/layers/shapes/_shapes_key_bindings.py
+++ b/napari/layers/shapes/_shapes_key_bindings.py
@@ -33,8 +33,6 @@ def hold_to_lock_aspect_ratio(layer: Shapes):
 
     # on key release
     layer._fixed_aspect = False
-    if layer._is_moving:
-        _move(layer, layer._moving_coordinates)
 
 
 def register_shapes_action(description: str, repeatable: bool = False):


### PR DESCRIPTION
# Fixes/Closes

<!-- In general, PRs should fix an existing issue on the repo. -->
<!-- Please link to that issue here as "Closes #(issue-number)". -->
Closes #5667

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Change the way `Shift` release is handle when resizing shapes. This harmonizes napari behavior with Photoshop & ImageJ.

## Preview

* Before (shape resizes as `Shift` is released to match mouse position):

![shift_resize_before](https://user-images.githubusercontent.com/16781833/230964571-384c2c0e-6e52-4e3b-84a0-8b32af97cfcf.gif)

* After (shape resizes after `Shift` is released and mouse moves to match mouse position):

![shift_resize_after](https://user-images.githubusercontent.com/16781833/230964593-543c8fdc-8a00-466c-bc32-7d1aecdaafa3.gif)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change
- [x] I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
