### PR TITLE
Add CircleCI to enable docs preview on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,70 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
+# See: https://circleci.com/docs/2.0/orb-intro/
+orbs:
+  # The python orb contains a set of prepackaged CircleCI configuration you can use repeatedly in your configuration files
+  # Orb commands and jobs help you with common scripting around a language/tool
+  # so you dont have to copy and paste it everywhere.
+  # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
+  python: circleci/python@1.5.0
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  build-docs: # This is the name of the job, feel free to change it to better match what you're trying to do!
+    # These next lines defines a Docker executors: https://circleci.com/docs/2.0/executor-types/
+    # You can specify an image from Dockerhub or use one of the convenience images from CircleCI's Developer Hub
+    # A list of available CircleCI Docker convenience images are available here: https://circleci.com/developer/images/image/cimg/python
+    # The executor is the environment in which the steps below will be executed - below will use a python 3.10.2 container
+    # Change the version below to your required version of python
+    docker:
+      - image: cimg/python:3.10.2
+    # Checkout the code as the first step. This is a dedicated CircleCI step.
+    # The python orb's install-packages step will install the dependencies from a Pipfile via Pipenv by default.
+    # Here we're making sure we use just use the system-wide pip. By default it uses the project root's requirements.txt.
+    # Then run your tests!
+    # CircleCI will report the results back to your VCS provider.
+    steps:
+      - checkout
+      - run:
+          name: Install qt libs + xvfb
+          command: sudo apt-get update && sudo apt-get install -y xvfb libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils
+
+      - run:
+          name: Install python dependencies
+          # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.
+          command: |
+            python -m venv venv
+            . venv/bin/activate
+            python -m pip install --upgrade pip
+      - run:
+          name: Clone docs repo
+          command: git clone git@github.com:napari/docs.git napari-docs
+      - run:
+          name: Install napari-dev
+          command: |
+            . venv/bin/activate
+            python -m pip install -e ".[pyside,dev]"
+      - run:
+          name: Build docs
+          command: |
+            . venv/bin/activate
+            cd napari-docs
+            xvfb-run --auto-servernum make docs GALLERY_PATH=../../examples/
+      - store_artifacts:
+          path: napari-docs/docs/_build/
+      - persist_to_workspace:
+          root: .
+          paths:
+            - napari-docs/docs/_build/
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  build-docs: # This is the name of the workflow, feel free to change it to better match your workflow.
+    # Inside the workflow, you define the jobs you want to run.
+    jobs:
+      - build-docs

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -18,6 +18,7 @@ jobs:
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.CIRCLECI_TOKEN }}
           artifact-path: 0/napari-docs/docs/_build/index.html
           circleci-jobs: build-docs
           job-title: Check the rendered docs here!

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,0 +1,23 @@
+# To enable this workflow on a fork, comment out:
+#
+# if: github.repository == 'napari/docs'
+
+name: CircleCI artifact redirector
+
+on: [status]
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    if: "github.event.context == 'ci/circleci: build-docs'"
+    permissions:
+      statuses: write
+    name: Run CircleCI artifacts redirector
+    # if: github.repository == 'napari/docs'
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/napari-docs/docs/_build/index.html
+          circleci-jobs: build-docs
+          job-title: Check the rendered docs here!


### PR DESCRIPTION
# Fixes/Closes

<!-- In general, PRs should fix an existing issue on the repo. -->
<!-- Please link to that issue here as "Closes #(issue-number)". -->
Closes #5713

# Description
Activates CircleCI to allow for docs previews in PRs. This is very similar to what is done on napari/docs.

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
