### PR TITLE
Do not use depth for canvas overlays; allow setting blending mode for overlays

### DIFF
--- a/napari/_vispy/overlays/base.py
+++ b/napari/_vispy/overlays/base.py
@@ -1,5 +1,6 @@
 from vispy.visuals.transforms import MatrixTransform, STTransform
 
+from napari._vispy.utils.gl import BLENDING_MODES
 from napari.components._viewer_constants import CanvasPosition
 from napari.utils.events import disconnect_events
 from napari.utils.translations import trans
@@ -59,6 +60,9 @@ class VispyCanvasOverlay(VispyBaseOverlay):
         self.node.transform = STTransform()
         self.overlay.events.position.connect(self._on_position_change)
         self.node.events.parent_change.connect(self._on_parent_change)
+
+        # canvas overlays are normally not intended to use the depth buffer
+        self.node.set_gl_state(**BLENDING_MODES['translucent_no_depth'])
 
     def _on_parent_change(self, event):
         if event.old is not None:

--- a/napari/_vispy/overlays/base.py
+++ b/napari/_vispy/overlays/base.py
@@ -23,6 +23,7 @@ class VispyBaseOverlay:
 
         self.overlay.events.visible.connect(self._on_visible_change)
         self.overlay.events.opacity.connect(self._on_opacity_change)
+        self.overlay.events.blending.connect(self._on_blending_change)
 
         if parent is not None:
             self.node.parent = parent
@@ -33,9 +34,14 @@ class VispyBaseOverlay:
     def _on_opacity_change(self):
         self.node.opacity = self.overlay.opacity
 
+    def _on_blending_change(self):
+        self.node.set_gl_state(**BLENDING_MODES[self.overlay.blending])
+        self.node.update()
+
     def reset(self):
         self._on_visible_change()
         self._on_opacity_change()
+        self._on_blending_change()
 
     def close(self):
         disconnect_events(self.overlay.events, self)
@@ -60,9 +66,6 @@ class VispyCanvasOverlay(VispyBaseOverlay):
         self.node.transform = STTransform()
         self.overlay.events.position.connect(self._on_position_change)
         self.node.events.parent_change.connect(self._on_parent_change)
-
-        # canvas overlays are normally not intended to use the depth buffer
-        self.node.set_gl_state(**BLENDING_MODES['translucent_no_depth'])
 
     def _on_parent_change(self, event):
         if event.old is not None:

--- a/napari/components/overlays/base.py
+++ b/napari/components/overlays/base.py
@@ -1,4 +1,5 @@
 from napari.components._viewer_constants import CanvasPosition
+from napari.layers.base._base_constants import Blending
 from napari.utils.events import EventedModel
 
 
@@ -23,6 +24,7 @@ class Overlay(EventedModel):
     visible: bool = False
     opacity: float = 1
     order: int = 1e6
+    blending: Blending
 
     def __hash__(self):
         return id(self)
@@ -48,6 +50,7 @@ class CanvasOverlay(Overlay):
     """
 
     position: CanvasPosition = CanvasPosition.BOTTOM_RIGHT
+    blending: Blending = Blending.TRANSLUCENT_NO_DEPTH
 
 
 class SceneOverlay(Overlay):
@@ -66,3 +69,5 @@ class SceneOverlay(Overlay):
     order : int
         The rendering order of the overlay: lower numbers get rendered first.
     """
+
+    blending: Blending = Blending.TRANSLUCENT


### PR DESCRIPTION
# Description

I noticed a few cases where the scale bar was hiding behind the data, as well as other similar weirdnesses with canvas overlays. We probably never want *depth* to be used when blending canvas overlays, as they are always meant to be on top of everything else, so I changed their default blending mode.

I took the chance to simply expose the blending mode as another field, so this can be overridden at any point.

Example issue (left this PR, right main):

![overlayblend](https://user-images.githubusercontent.com/23482191/231766441-3db1e023-5abd-4edf-9260-6f3ab81ad8a2.png)

```py
import napari
import numpy as np

v = napari.Viewer(ndisplay=3)
il = v.add_image(np.random.rand(10, 10, 10), blending='translucent', colormap='viridis')
v.scale_bar.visible = True
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
