### PR TITLE
Cap cursor size to 64

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -909,6 +909,13 @@ class QtViewer(QSplitter):
                 size *= self.viewer.camera.zoom
 
             size = int(size)
+            if size > 64:
+                size = 64
+                warnings.warn(
+                    trans._(
+                        "Due to hardware limitations, cursor size is capped at 64 pixels."
+                    )
+                )
 
             # make sure the square fits within the current canvas
             if size < 8 or size > (min(*self.canvas.size) - 4):


### PR DESCRIPTION
# Fixes/Closes
Possible solution to #5712.

# Description
Prevents crashing the X server by capping the cursor size. Might not be the best solution, but at least we don't kill the whole X server :P

Note however that this only caps the qt cursor, and not the `Cursor.size` on the model side, so you may end up with a small cursor that paints over a bigger area.

@ksofiyuk could you test if this solves the crash on your machine?

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
