### PR TITLE
Unify event behaviour for points and its qt controls

### DIFF
--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -211,15 +211,11 @@ class QtPointsControls(QtLayerControls):
 
         self.layout().addRow(button_row)
         self.layout().addRow(self.opacityLabel, self.opacitySlider)
-        self.layout().addRow(trans._('current point size:'), self.sizeSlider)
+        self.layout().addRow(trans._('point size:'), self.sizeSlider)
         self.layout().addRow(trans._('blending:'), self.blendComboBox)
         self.layout().addRow(trans._('symbol:'), self.symbolComboBox)
-        self.layout().addRow(
-            trans._('current face color:'), self.faceColorEdit
-        )
-        self.layout().addRow(
-            trans._('current edge color:'), self.edgeColorEdit
-        )
+        self.layout().addRow(trans._('face color:'), self.faceColorEdit)
+        self.layout().addRow(trans._('edge color:'), self.edgeColorEdit)
         self.layout().addRow(trans._('display text:'), self.textDispCheckBox)
         self.layout().addRow(trans._('out of slice:'), self.outOfSliceCheckBox)
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -412,7 +412,9 @@ class Points(Layer):
 
         self.events.add(
             size=Event,
+            current_size=Event,
             edge_width=Event,
+            current_edge_width=Event,
             edge_width_is_relative=Event,
             face_color=Event,
             current_face_color=Event,
@@ -421,6 +423,7 @@ class Points(Layer):
             properties=Event,
             current_properties=Event,
             symbol=Event,
+            current_symbol=Event,
             out_of_slice_display=Event,
             n_dimensional=Event,
             highlight=Event,
@@ -803,6 +806,7 @@ class Points(Layer):
         if self._update_properties and len(self.selected_data) > 0:
             self.symbol[list(self.selected_data)] = symbol
             self.events.symbol()
+        self.events.current_symbol()
 
     @property
     def size(self) -> np.ndarray:
@@ -852,6 +856,7 @@ class Points(Layer):
                 self.size[i, :] = (self.size[i, :] > 0) * size
             self.refresh()
             self.events.size()
+        self.events.current_size()
 
     @property
     def antialiasing(self) -> float:
@@ -971,6 +976,7 @@ class Points(Layer):
                 self.edge_width[i] = (self.edge_width[i] > 0) * edge_width
             self.refresh()
             self.events.edge_width()
+        self.events.current_edge_width()
 
     @property
     def edge_color(self) -> np.ndarray:


### PR DESCRIPTION
# Fixes/Closes
Closes #5718.

# Description
Point controls were not firing events as intended. Most of the event blockers were either too aggressive (block everything, rather than just the relevant callback) or inverted.

Additionally, there was a lot of asymmetry and confusion between how various elements worked. I clarified the gui labels to make it clearer when the `current_*` property is being affected. I also added a few events to match expectations with other parts of the `Points` layer.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
