### PR TITLE
Fix inefficient label mapping in direct color mode (10-20x speedup)

### DIFF
--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -64,6 +64,15 @@ class Labels2DSuite:
         return self.data
 
 
+class Labels2DColorDirectSuite(Labels2DSuite):
+    def setup(self, n):
+        np.random.seed(0)
+        self.data = np.random.randint(20, size=(n, n))
+        self.layer = Labels(
+            self.data, color={i + 1: np.random.random(4) for i in range(20)}
+        )
+
+
 class Labels3DSuite:
     """Benchmarks for the Labels layer with 3D data."""
 

--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -67,9 +67,11 @@ class Labels2DSuite:
 class Labels2DColorDirectSuite(Labels2DSuite):
     def setup(self, n):
         np.random.seed(0)
-        self.data = np.random.randint(20, size=(n, n))
+        self.data = np.random.randint(low=-10000, high=10000, size=(n, n))
+        random_label_ids = np.random.randint(low=-10000, high=10000, size=20)
         self.layer = Labels(
-            self.data, color={i + 1: np.random.random(4) for i in range(20)}
+            self.data,
+            color={i + 1: np.random.random(4) for i in random_label_ids},
         )
 
 

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1394,6 +1394,17 @@ def test_is_default_color():
     assert layer.color_mode == 'direct'
 
 
+def test_large_labels_direct_color():
+    """Make sure direct color works with large label ranges"""
+    data = np.array([[0, 1], [2**16, 2**20]], dtype=np.uint32)
+    colors = {1: 'white', 2**16: 'green', 2**20: 'magenta'}
+    layer = Labels(data)
+    layer.color = colors
+
+    assert layer.color_mode == 'direct'
+    np.testing.assert_allclose(layer.get_color(2**20), [1.0, 0.0, 1.0, 1.0])
+
+
 def test_negative_label():
     """Test negative label values are supported."""
     data = np.random.randint(low=-1, high=20, size=(10, 10))

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -926,10 +926,10 @@ class Labels(_ImageBase):
         ):
             min_label_id = raw_modified.min()
             max_label_id = raw_modified.max()
-            n_unique_labels_upper_bound = max_label_id - min_label_id
+            upper_bound_n_unique_labels = max_label_id - min_label_id
             none_color_index = self._label_color_index[None]
 
-            if n_unique_labels_upper_bound < 1024:
+            if upper_bound_n_unique_labels < 1024:
                 mapping = np.array(
                     [
                         self._label_color_index.get(label_id, none_color_index)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -924,15 +924,26 @@ class Labels(_ImageBase):
             not self.show_selected_label
             and self._color_mode == LabelColorMode.DIRECT
         ):
-            u, inv = np.unique(raw_modified, return_inverse=True)
-            image = np.array(
-                [
-                    self._label_color_index[x]
-                    if x in self._label_color_index
-                    else self._label_color_index[None]
-                    for x in u
-                ]
-            )[inv].reshape(raw_modified.shape)
+            min_label_id = raw_modified.min()
+            max_label_id = raw_modified.max()
+            none_color_index = self._label_color_index[None]
+
+            if max_label_id - min_label_id < 1024:
+                mapping = np.array(
+                    [
+                        self._label_color_index.get(label_id, none_color_index)
+                        for label_id in range(min_label_id, max_label_id + 1)
+                    ]
+                )
+                image = mapping[raw_modified - min_label_id]
+            else:
+                unique_ids, inv = np.unique(raw_modified, return_inverse=True)
+                image = np.array(
+                    [
+                        self._label_color_index.get(label_id, none_color_index)
+                        for label_id in unique_ids
+                    ]
+                )[inv].reshape(raw_modified.shape)
         elif (
             not self.show_selected_label
             and self._color_mode == LabelColorMode.AUTO

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -926,6 +926,7 @@ class Labels(_ImageBase):
         ):
             min_label_id = raw_modified.min()
             max_label_id = raw_modified.max()
+            n_unique_labels_upper_bound = max_label_id - min_label_id
             none_color_index = self._label_color_index[None]
 
             if max_label_id - min_label_id < 1024:

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -929,7 +929,7 @@ class Labels(_ImageBase):
             n_unique_labels_upper_bound = max_label_id - min_label_id
             none_color_index = self._label_color_index[None]
 
-            if max_label_id - min_label_id < 1024:
+            if n_unique_labels_upper_bound < 1024:
                 mapping = np.array(
                     [
                         self._label_color_index.get(label_id, none_color_index)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -929,7 +929,7 @@ class Labels(_ImageBase):
             upper_bound_n_unique_labels = max_label_id - min_label_id
             none_color_index = self._label_color_index[None]
 
-            if upper_bound_n_unique_labels < 1024:
+            if upper_bound_n_unique_labels < 65536:
                 mapping = np.array(
                     [
                         self._label_color_index.get(label_id, none_color_index)


### PR DESCRIPTION
# Description

If you specify a custom color set in the Label layer, the brush becomes extremely laggy in high-resolution images. After some examination, I discovered that issue is caused by the inefficient label mapping in the direct color mode:
https://github.com/napari/napari/blob/a79537cac7c2a595c4fca41b85f2c7b4a44d0a61/napari/layers/labels/labels.py#L927-L935

It calls `np.unique` of the whole label map every brush update! This is a very slow operation for large arrays. As you can see in the benchmark results below, it takes 1.5s for a single `_raw_to_displayed` call on 4096x4096 images.

Luckily, in most use cases the use of `np.unique` is a total overkill here and it is possible to achieve the same functionality just by finding the minimum and maximum values of an array. I implemented a new algorithm, which is 10-20x faster on large images. To be on the safe side, I kept the old approach for the cases when `max_label_id - min_label_id >= 1024`, it will handle the situations when someone decides to load labels with very large ids (e.g. label_id=123456).

I also added a new benchmark `Labels2DColorDirectSuite` that tests the Label layer in the direct color mode.

## Benchmark results:
The results for the Label layer in the `AUTO` mode (for comparison):
```
[100.00%] ··· benchmark_labels_layer.Labels2DSuite.time_raw_to_displayed                                                                                                                          ok
[100.00%] ··· ======== =============
               param1
              -------- -------------
                 16     3.84±0.02μs
                 32     5.89±0.03μs
                 64     14.4±0.04μs
                128     47.6±0.09μs
                256       183±1μs
                512     1.02±0.01ms
                1024    4.05±0.02ms
                2048     15.8±0.2ms
                4096      63.7±2ms
              ======== =============
```

The results for the Label layer in the `DIRECT` mode (old algorithm):
```
[100.00%] ··· benchmark_labels_layer.Labels2DColorDirectSuite.time_raw_to_displayed                                                                                                               ok
[100.00%] ··· ======== ============
               param1
              -------- ------------
                 16     36.5±0.2μs
                 32      47.2±1μs
                 64      150±2μs
                128      534±2μs
                256     2.31±0.2ms
                512     11.8±0.1ms
                1024    61.8±0.7ms
                2048     312±2ms
                4096    1.50±0.02s
              ======== ============
```

The results for the Label layer in the `DIRECT` mode (new algorithm):
```
[100.00%] ··· benchmark_labels_layer.Labels2DColorDirectSuite.time_raw_to_displayed                                                                                                               ok
[100.00%] ··· ======== =============
               param1
              -------- -------------
                 16       17.1±1μs
                 32     20.0±0.04μs
                 64      35.1±0.3μs
                128      93.8±0.2μs
                256       330±2μs
                512     1.63±0.01ms
                1024    6.40±0.02ms
                2048     25.1±0.1ms
                4096     101±0.5ms
              ======== =============
```

As you can see, it became 15x faster on 4096x4096 images, achieving almost the same performance as in the `AUTO` mode.

## Further optimization

It is just a quick fix to mitigate the issue. However, I think it is very inefficient to compute the label mapping from scratch on every brush update. At least the proposed approach can be further optimized in the following way:

1. Recompute `min_label_id` and `max_label_id` from scratch only when someone tries to set the data in a layer.
2. When someone tries to change the color id of brush, update the `min_label_id` and `max_label_id` with a new color id accordingly.

This should be enough to always maintain the valid `min/max` of label ids without the need of recomputing them on every update.

If we want to be ultimately efficient, the color map should be computed only for the part of an image that is visible in the current camera view. Or only recompute the color map near the local region around a recent brush trajectory as during drawing in large images 99% of image area usually is not affected and should not be updated. It should allow to handle extremely large images (e.g. 10000x10000). 

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
