### PR TITLE
Feature: Background color swapping for the Label layer (extends #5672)

### DIFF
--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -73,11 +73,14 @@ def new_label(layer: Labels):
 
 
 @register_label_action(
-    trans._("Set the currently selected label to the background."),
+    trans._("Set the selected label to the background label or vice versa."),
 )
-def set_label_to_background(layer: Labels):
-    """Set the currently selected label to the largest used label plus one."""
-    layer.selected_label = 0
+def swap_background_color(layer: Labels):
+    """Set the selected label to the background label or vice versa."""
+    if layer.selected_label != layer._background_label:
+        layer.selected_label = layer._background_label
+    else:
+        layer.selected_label = layer.prev_selected_label
 
 
 @register_label_action(

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -75,12 +75,9 @@ def new_label(layer: Labels):
 @register_label_action(
     trans._("Set the selected label to the background label or vice versa."),
 )
-def swap_background_color(layer: Labels):
+def swap_selected_and_background_labels(layer: Labels):
     """Set the selected label to the background label or vice versa."""
-    if layer.selected_label != layer._background_label:
-        layer.selected_label = layer._background_label
-    else:
-        layer.selected_label = layer.prev_selected_label
+    layer.swap_selected_and_background_labels()
 
 
 @register_label_action(

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -73,10 +73,10 @@ def new_label(layer: Labels):
 
 
 @register_label_action(
-    trans._("Set the selected label to the background label or vice versa."),
+    trans._("Swap between the selected label and the background label."),
 )
 def swap_selected_and_background_labels(layer: Labels):
-    """Set the selected label to the background label or vice versa."""
+    """Swap between the selected label and the background label."""
     layer.swap_selected_and_background_labels()
 
 

--- a/napari/layers/labels/_tests/test_labels_key_bindings.py
+++ b/napari/layers/labels/_tests/test_labels_key_bindings.py
@@ -7,7 +7,7 @@ import zarr
 from napari.layers import Labels
 from napari.layers.labels._labels_key_bindings import (
     new_label,
-    swap_background_color,
+    swap_selected_and_background_labels,
 )
 
 
@@ -26,12 +26,12 @@ def test_max_label(labels_data_4d):
     assert labels.selected_label == 4
 
 
-def test_swap_background_color(labels_data_4d):
+def test_swap_background_label(labels_data_4d):
     labels = Labels(labels_data_4d)
     labels.selected_label = 10
-    swap_background_color(labels)
+    swap_selected_and_background_labels(labels)
     assert labels.selected_label == labels._background_label
-    swap_background_color(labels)
+    swap_selected_and_background_labels(labels)
     assert labels.selected_label == 10
 
 

--- a/napari/layers/labels/_tests/test_labels_key_bindings.py
+++ b/napari/layers/labels/_tests/test_labels_key_bindings.py
@@ -7,7 +7,7 @@ import zarr
 from napari.layers import Labels
 from napari.layers.labels._labels_key_bindings import (
     new_label,
-    set_label_to_background,
+    swap_background_color,
 )
 
 
@@ -26,10 +26,13 @@ def test_max_label(labels_data_4d):
     assert labels.selected_label == 4
 
 
-def test_set_label_to_background(labels_data_4d):
+def test_swap_background_color(labels_data_4d):
     labels = Labels(labels_data_4d)
-    set_label_to_background(labels)
-    assert labels.selected_label == 0
+    labels.selected_label = 10
+    swap_background_color(labels)
+    assert labels.selected_label == labels._background_label
+    swap_background_color(labels)
+    assert labels.selected_label == 10
 
 
 def test_max_label_tensorstore(labels_data_4d):

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -173,6 +173,8 @@ class Labels(_ImageBase):
         Size of the paint brush in data coordinates.
     selected_label : int
         Index of selected label. Can be greater than the current maximum label.
+    prev_selected_label: Optional[int]
+        Previously selected label. `None` if the selected label has never been changed.
     mode : str
         Interactive mode. The normal, default mode is PAN_ZOOM, which
         allows for normal interactivity with the canvas.
@@ -329,6 +331,7 @@ class Labels(_ImageBase):
         self._brush_size = 10
 
         self._selected_label = 1
+        self.prev_selected_label = None
         self._selected_color = self.get_color(self._selected_label)
         self.color = color
 
@@ -640,6 +643,7 @@ class Labels(_ImageBase):
         if selected_label == self.selected_label:
             return
 
+        self.prev_selected_label = self.selected_label
         self._selected_label = selected_label
         self._selected_color = self.get_color(selected_label)
         self.events.selected_label()
@@ -981,7 +985,7 @@ class Labels(_ImageBase):
 
     def get_color(self, label):
         """Return the color corresponding to a specific label."""
-        if label == 0:
+        if label == self._background_label:
             col = None
         elif label is None:
             col = self.colormap.map([0, 0, 0, 0])[0]

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -173,8 +173,6 @@ class Labels(_ImageBase):
         Size of the paint brush in data coordinates.
     selected_label : int
         Index of selected label. Can be greater than the current maximum label.
-    prev_selected_label: Optional[int]
-        Previously selected label. `None` if the selected label has never been changed.
     mode : str
         Interactive mode. The normal, default mode is PAN_ZOOM, which
         allows for normal interactivity with the canvas.
@@ -331,7 +329,7 @@ class Labels(_ImageBase):
         self._brush_size = 10
 
         self._selected_label = 1
-        self.prev_selected_label = None
+        self._prev_selected_label = None
         self._selected_color = self.get_color(self._selected_label)
         self.color = color
 
@@ -643,7 +641,7 @@ class Labels(_ImageBase):
         if selected_label == self.selected_label:
             return
 
-        self.prev_selected_label = self.selected_label
+        self._prev_selected_label = self.selected_label
         self._selected_label = selected_label
         self._selected_color = self.get_color(selected_label)
         self.events.selected_label()
@@ -652,6 +650,13 @@ class Labels(_ImageBase):
         # so use self._color_mode
         if self.show_selected_label:
             self.refresh()
+
+    def swap_selected_and_background_labels(self):
+        """Set the selected label to the background label or vice versa."""
+        if self.selected_label != self._background_label:
+            self.selected_label = self._background_label
+        else:
+            self.selected_label = self._prev_selected_label
 
     @property
     def color_mode(self):

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -652,7 +652,7 @@ class Labels(_ImageBase):
             self.refresh()
 
     def swap_selected_and_background_labels(self):
-        """Set the selected label to the background label or vice versa."""
+        """Swap between the selected label and the background label."""
         if self.selected_label != self._background_label:
             self.selected_label = self._background_label
         else:

--- a/napari/utils/shortcuts.py
+++ b/napari/utils/shortcuts.py
@@ -28,7 +28,7 @@ default_shortcuts = {
     'napari:activate_labels_pan_zoom_mode': [KeyCode.Digit5],
     'napari:activate_labels_transform_mode': [KeyCode.Digit6],
     'napari:new_label': [KeyCode.KeyM],
-    'napari:swap_background_color': [KeyCode.KeyX],
+    'napari:swap_selected_and_background_labels': [KeyCode.KeyX],
     'napari:decrease_label_id': [KeyCode.Minus],
     'napari:increase_label_id': [KeyCode.Equal],
     'napari:decrease_brush_size': [KeyCode.BracketLeft],

--- a/napari/utils/shortcuts.py
+++ b/napari/utils/shortcuts.py
@@ -28,7 +28,7 @@ default_shortcuts = {
     'napari:activate_labels_pan_zoom_mode': [KeyCode.Digit5],
     'napari:activate_labels_transform_mode': [KeyCode.Digit6],
     'napari:new_label': [KeyCode.KeyM],
-    'napari:set_label_to_background': [KeyCode.KeyB],
+    'napari:swap_background_color': [KeyCode.KeyX],
     'napari:decrease_label_id': [KeyCode.Minus],
     'napari:increase_label_id': [KeyCode.Equal],
     'napari:decrease_brush_size': [KeyCode.BracketLeft],


### PR DESCRIPTION
# Description

#5672 introduced a new feature allowing switching to the background color. To make it more useful, I propose extending the behavior of that feature by implementing the swapping behavior, not just setting to the background color:

- If the current label is not the background label, it will be set to the background label.
- If the current label is the background label, it will be set to the previous non-background label.

Actually, this is a standard functionality of almost any image editor such as GIMP or Photoshop. It is really handy when you are editing masks as it allows quick switching between adding and removing.

I also changed the hotkey from `B` to `X` to match the default hotkeys of GIMP and Photoshop that do exactly the same thing, which should make it more convenient for people who are used to working with similar software.

## Type of change
- [X] Breaking change (changes the behavior of #5672)

# How has this been tested?
- [X] added test for the background swapping
- [X] all tests pass with my change

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
