### PR TITLE
Bugfix: Add the missed keyReleaseEvent method in QtViewerDockWidget

### DIFF
--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -229,6 +229,12 @@ class QtViewerDockWidget(QDockWidget):
         # your method to pass uncaught key-combinations to the viewer.
         return self._ref_qt_viewer().keyPressEvent(event)
 
+    def keyReleaseEvent(self, event):
+        # if you subclass QtViewerDockWidget and override the keyReleaseEvent
+        # method, be sure to call super().keyReleaseEvent(event) at the end of
+        # your method to pass uncaught key-combinations to the viewer.
+        return self._ref_qt_viewer().keyReleaseEvent(event)
+
     def _set_title_orientation(self, area):
         if area in (
             Qt.DockWidgetArea.LeftDockWidgetArea,


### PR DESCRIPTION
# Description
I noticed that callbacks do not get key release events when the focus is not on the canvas but they continue to receive key press events. You can easily reproduce the issue by running `examples/custom_key_bindings.py` and then clicking, for example, on the layer in the layer list, the `hello` callback (on `w` key) no longer receives key release events after that.

The issue is cause by the missed `keyReleaseEvent` in `QtViewerDockWidget`.

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
- [X] Bugfix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [X] I tested it manually

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
