### PR TITLE
Use array size directly when checking multiscale arrays to prevent overflow

### DIFF
--- a/napari/layers/image/_image_utils.py
+++ b/napari/layers/image/_image_utils.py
@@ -64,28 +64,27 @@ def guess_multiscale(data) -> Tuple[bool, LayerDataProtocol]:
         # pyramid with only one level, unwrap
         return False, data[0]
 
-    shapes = [d.shape for d in data]
-    sizes = np.array([np.prod(shape, dtype='object') for shape in shapes])
+    sizes = [d.size for d in data]
     if len(sizes) <= 1:
         return False, data
 
-    consistent = bool(np.all(sizes[:-1] > sizes[1:]))
-    if np.all(sizes == sizes[0]):
+    consistent = all(s1 > s2 for s1, s2 in zip(sizes[:-1], sizes[1:]))
+    if all(s == sizes[0] for s in sizes):
         # note: the individual array case should be caught by the first
         # code line in this function, hasattr(ndim) and ndim > 1.
         raise ValueError(
             trans._(
-                'Input data should be an array-like object, or a sequence of arrays of decreasing size. Got arrays of single shape: {shape}',
+                'Input data should be an array-like object, or a sequence of arrays of decreasing size. Got arrays of single size: {size}',
                 deferred=True,
-                shape=shapes[0],
+                size=sized[0],
             )
         )
     if not consistent:
         raise ValueError(
             trans._(
-                'Input data should be an array-like object, or a sequence of arrays of decreasing size. Got arrays in incorrect order, shapes: {shapes}',
+                'Input data should be an array-like object, or a sequence of arrays of decreasing size. Got arrays in incorrect order, sizes: {sizes}',
                 deferred=True,
-                shapes=shapes,
+                sizes=sizes,
             )
         )
 

--- a/napari/layers/image/_image_utils.py
+++ b/napari/layers/image/_image_utils.py
@@ -76,7 +76,7 @@ def guess_multiscale(data) -> Tuple[bool, LayerDataProtocol]:
             trans._(
                 'Input data should be an array-like object, or a sequence of arrays of decreasing size. Got arrays of single size: {size}',
                 deferred=True,
-                size=sized[0],
+                size=sizes[0],
             )
         )
     if not consistent:

--- a/napari/layers/image/_image_utils.py
+++ b/napari/layers/image/_image_utils.py
@@ -65,7 +65,7 @@ def guess_multiscale(data) -> Tuple[bool, LayerDataProtocol]:
         return False, data[0]
 
     shapes = [d.shape for d in data]
-    sizes = np.array([np.prod(shape, dtype=np.uint64) for shape in shapes])
+    sizes = np.array([np.prod(shape, dtype='object') for shape in shapes])
     if len(sizes) <= 1:
         return False, data
 

--- a/napari/layers/image/_tests/test_image_utils.py
+++ b/napari/layers/image/_tests/test_image_utils.py
@@ -79,6 +79,7 @@ def test_guess_multiscale():
     data = [da.ones((s,) * 2), da.ones((s // 2,) * 2)]
     assert guess_multiscale(data)[0]
 
+
 def test_guess_multiscale_strip_single_scale():
     data = [np.empty((10, 10))]
     guess, data_out = guess_multiscale(data)

--- a/napari/layers/image/_tests/test_image_utils.py
+++ b/napari/layers/image/_tests/test_image_utils.py
@@ -74,6 +74,10 @@ def test_guess_multiscale():
     data = [da.ones((s,) * 3), da.ones((s // 2,) * 3), da.ones((s // 4,) * 3)]
     assert guess_multiscale(data)[0]
 
+    # Test for overflow in calculating array sizes
+    s = 17179869184
+    data = [da.ones((s,) * 2), da.ones((s // 2,) * 2)]
+    assert guess_multiscale(data)[0]
 
 def test_guess_multiscale_strip_single_scale():
     data = [np.empty((10, 10))]

--- a/napari/layers/image/_tests/test_image_utils.py
+++ b/napari/layers/image/_tests/test_image_utils.py
@@ -1,5 +1,6 @@
 import time
 
+import dask
 import dask.array as da
 import numpy as np
 import pytest
@@ -76,7 +77,14 @@ def test_guess_multiscale():
 
     # Test for overflow in calculating array sizes
     s = 17179869184
-    data = [da.ones((s,) * 2), da.ones((s // 2,) * 2)]
+    data = [
+        da.from_delayed(
+            dask.delayed(lambda: None), shape=(s,) * 2, dtype=np.float64
+        ),
+        da.from_delayed(
+            dask.delayed(lambda: None), shape=(s // 2,) * 2, dtype=np.float64
+        ),
+    ]
     assert guess_multiscale(data)[0]
 
 


### PR DESCRIPTION
# Fixes/Closes

Closes #5758

# Description

This PR changes the way array sizes are compared when guessing if data is multiscale.

The problem was that `np.prod(a.shape)` was being used which leads to an overflow (see Notes in [numpy.ndarray.size](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.size.html)). That has been changed to be `a.size` instead (ty @aganders3).

Additionally, during testing there was an issue with what seemed to be an out of memory error with the Python 3.8 Windows min req job (ty @jaimergp). As a result the test now also uses a Dask delayed array to avoid the large memory allocation (ty @aganders3).

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
