### PR TITLE
Bugfix: force a redraw to ensure highlight shows when Points are select-all selected

### DIFF
--- a/napari/layers/points/_points_key_bindings.py
+++ b/napari/layers/points/_points_key_bindings.py
@@ -88,7 +88,7 @@ def select_all_in_slice(layer: Points):
                 deferred=True,
             )
         )
-    layer._set_highlight()
+    layer._set_highlight(force=True)
 
 
 @register_points_action(
@@ -115,7 +115,7 @@ def select_all_data(layer: Points):
                 deferred=True,
             )
         )
-    layer._set_highlight()
+    layer._set_highlight(force=True)
 
 
 @register_points_action(trans._('Delete selected points'))


### PR DESCRIPTION
# Fixes/Closes

Bug discussed here: https://github.com/napari/napari/issues/5748#issuecomment-1521556697

# Description

If you are using the + tool or select tool and use the select-all keybind, then the points are not visually selected.
If you use the + tool and use select-all then toggle to the selection tool, then they will be visually selected.
If you use the select tool, then they never appear to get visually selected.

This is because the keybind calls `layer._set_highlight()` but doesn't force a redraw using `force=True`.
This PR uses  `layer._set_highlight(force=True)` to ensure that a redraw happens, so the visual selection occurs.


# References
Discussion starts here:
https://github.com/napari/napari/issues/5748#issuecomment-1521556697

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality

