### PR TITLE
Use fine grained personal token for test contrains and vendored update

### DIFF
--- a/.github/workflows/test_vendored.yml
+++ b/.github/workflows/test_vendored.yml
@@ -31,3 +31,4 @@ jobs:
             action cron to keep vendored modules up to date.
 
             It look like ${{ steps.check_v.outputs.vendored }} has a new version.
+          token: ${{ secrets.GHA_TOKEN }}

--- a/.github/workflows/test_vendored.yml
+++ b/.github/workflows/test_vendored.yml
@@ -32,3 +32,7 @@ jobs:
 
             It look like ${{ steps.check_v.outputs.vendored }} has a new version.
           token: ${{ secrets.GHA_TOKEN }}
+          # Token permissions required by the action:
+          # * pull requests: write and read
+          # * repository contents: read and write
+          # for screenshots please see https://github.com/napari/napari/pull/5777

--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -88,3 +88,8 @@ jobs:
 
             ${{ steps.packages.outputs.all_packages }}
           token: ${{ secrets.GHA_TOKEN }}
+          # Token permissions required by the action:
+          # * pull requests: write and read
+          # * repository contents: read and write
+          # for screenshots please see https://github.com/napari/napari/pull/5777
+

--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -87,4 +87,4 @@ jobs:
             The updated packages are:
 
             ${{ steps.packages.outputs.all_packages }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GHA_TOKEN }}


### PR DESCRIPTION
# Fixes/Closes

<!-- In general, PRs should fix an existing issue on the repo. -->
<!-- Please link to that issue here as "Closes #(issue-number)". -->
Closes #

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This PR reenables using fine-grained Personal access tokens to trigger tests in PR created by workflow. 

The previous problem was caused by a lack of **code** permission in tokens 

![Zrzut ekranu z 2023-04-26 11-25-10](https://user-images.githubusercontent.com/3826210/234532611-5c713481-13f0-4401-8c83-f5fed43c4aba.png)

But when setting this permission are not named **code** but **contents**


![Zrzut ekranu z 2023-04-26 11-15-42](https://user-images.githubusercontent.com/3826210/234532254-a0d5fb98-f3a9-4153-a866-15dc7b5c2617.png)

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Maintenance