### PR TITLE
Add aditional guard at the end of `test_worker_may_exceed_total`

### DIFF
--- a/napari/_qt/_tests/test_threading_progress.py
+++ b/napari/_qt/_tests/test_threading_progress.py
@@ -1,5 +1,4 @@
 import pytest
-from qtpy.QtCore import QThreadPool
 
 from napari._qt import qthreading
 from napari._qt.widgets.qt_progress_bar import QtLabeledProgressBar
@@ -26,7 +25,7 @@ def test_worker_with_progress(qtbot):
         start_thread=False,
     )
     worker = thread_func()
-    with qtbot.waitSignal(worker.yielded), qtbot.waitSignal(worker.finished):
+    with qtbot.waitSignals([worker.yielded, worker.finished]):
         worker.start()
         assert worker.pbar.n == test_val[0]
     assert test_val[0] == 2
@@ -69,9 +68,6 @@ def test_worker_may_exceed_total(qtbot):
     with qtbot.waitSignals([worker.yielded, worker.finished]):
         worker.start()
     assert test_val[0] == 2
-    qtbot.waitUntil(
-        lambda: QThreadPool.globalInstance().activeThreadCount() == 0
-    )
 
 
 def test_generator_worker_with_description():

--- a/napari/_qt/_tests/test_threading_progress.py
+++ b/napari/_qt/_tests/test_threading_progress.py
@@ -1,4 +1,5 @@
 import pytest
+from qtpy.QtCore import QThreadPool
 
 from napari._qt import qthreading
 from napari._qt.widgets.qt_progress_bar import QtLabeledProgressBar
@@ -68,6 +69,9 @@ def test_worker_may_exceed_total(qtbot):
     with qtbot.waitSignals([worker.yielded, worker.finished]):
         worker.start()
     assert test_val[0] == 2
+    qtbot.waitUntil(
+        lambda: QThreadPool.globalInstance().activeThreadCount() == 0
+    )
 
 
 def test_generator_worker_with_description():

--- a/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
@@ -11,6 +11,8 @@ from napari._qt.dialogs.qt_package_installer import InstallerActions
 from napari.plugins._tests.test_npe2 import mock_pm  # noqa
 from napari.utils.translations import trans
 
+N_MOCKED_PLUGINS = 2
+
 
 def _iter_napari_pypi_plugin_info(
     conda_forge: bool = True,
@@ -35,7 +37,7 @@ def _iter_napari_pypi_plugin_info(
         "author": "test author",
         "license": "UNKNOWN",
     }
-    for i in range(2):
+    for i in range(N_MOCKED_PLUGINS):
         yield npe2.PackageMetadata(name=f"test-name-{i}", **base_data), bool(
             i
         ), {
@@ -96,15 +98,13 @@ def plugin_dialog(qtbot, monkeypatch, mock_pm, plugins, old_plugins):  # noqa
 
         def enable(self, plugin):
             self.plugins[plugin] = True
-            return
 
         def disable(self, plugin):
             self.plugins[plugin] = False
-            return
 
     class WarnPopupMock:
         def __init__(self, text):
-            return None
+            pass
 
         def exec_(self):
             return None
@@ -192,10 +192,15 @@ def plugin_dialog_constructor(qtbot, monkeypatch):
         "running_as_constructor_app",
         lambda: True,
     )
+
+    def available_list_populated():
+        return widget.available_list.count() == N_MOCKED_PLUGINS
+
     widget = qt_plugin_dialog.QtPluginDialog()
     widget.show()
-    qtbot.wait(300)
     qtbot.add_widget(widget)
+    qtbot.waitUntil(available_list_populated, timeout=1000)
+
     yield widget
     widget.hide()
     widget._add_items_timer.stop()

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -581,6 +581,8 @@ def dangling_qthread_pool(monkeypatch, request):
     dangling_threads_pools = []
 
     for thread_pool, calling in threadpool_dict.items():
+        thread_pool.clear()
+        thread_pool.waitForDone(20)
         if thread_pool.activeThreadCount():
             dangling_threads_pools.append((thread_pool, calling))
 


### PR DESCRIPTION
# Fixes/Closes

<!-- In general, PRs should fix an existing issue on the repo. -->
<!-- Please link to that issue here as "Closes #(issue-number)". -->
Closes #

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This PR adds a check at the end of `test_worker_may_exceed_total` that fails in #5739 in an unrelated way to PR topic. 

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
