### PR TITLE
Add pydantic<2 constrains to plugin install

### DIFF
--- a/napari/_qt/dialogs/qt_package_installer.py
+++ b/napari/_qt/dialogs/qt_package_installer.py
@@ -88,7 +88,7 @@ class AbstractInstallerTool:
         """
         Version constraints to limit unwanted changes in installation.
         """
-        return [f"napari=={_napari_version}"]
+        return [f"napari=={_napari_version}", "pydantic<=2.0"]
 
     @classmethod
     def available(cls) -> bool:
@@ -233,7 +233,7 @@ class CondaInstallerTool(AbstractInstallerTool):
         pin_level = 2 if is_dev else 3
         version = ".".join([str(x) for x in _napari_version_tuple[:pin_level]])
 
-        return [f"napari={version}"]
+        return [f"napari={version}", "pydantic<=2.0"]
 
     def _add_constraints_to_env(
         self, env: QProcessEnvironment


### PR DESCRIPTION
# Fixes/Closes

<!-- In general, PRs should fix an existing issue on the repo. -->
<!-- Please link to that issue here as "Closes #(issue-number)". -->
Closes #

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Based on the discussion in https://github.com/pydantic/pydantic/discussions/5402, I would like to add pydantic constraints to the plugin install mechanism. I prefer to crash installation process than the napari installation.  

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
