### PR TITLE
Fix copy/paste of points

### DIFF
--- a/napari/layers/utils/_tests/test_text_manager.py
+++ b/napari/layers/utils/_tests/test_text_manager.py
@@ -676,10 +676,12 @@ def test_refresh_with_derived_color():
 
 def test_copy_paste_with_constant_color():
     color = {'constant': 'blue'}
-    features = pd.DataFrame(index=range(3))
+    features = pd.DataFrame(index=range(5))
     text_manager = TextManager(color=color, features=features)
 
-    copied = text_manager._copy([0, 2])
+    # Use one index more than 3 to cover bug described in:
+    # https://github.com/napari/napari/issues/5786
+    copied = text_manager._copy([0, 4])
     text_manager._paste(**copied)
 
     actual = text_manager.color._values

--- a/napari/layers/utils/_tests/test_text_manager.py
+++ b/napari/layers/utils/_tests/test_text_manager.py
@@ -679,7 +679,9 @@ def test_copy_paste_with_constant_color():
     features = pd.DataFrame(index=range(5))
     text_manager = TextManager(color=color, features=features)
 
-    # Use one index more than 3 to cover bug described in:
+    # Use an index of 4 to ensure that constant color values, which are
+    # RGBA 4-vectors, are handled correctly when copied, unlike in a
+    # related bug:
     # https://github.com/napari/napari/issues/5786
     copied = text_manager._copy([0, 4])
     text_manager._paste(**copied)

--- a/napari/layers/utils/text_manager.py
+++ b/napari/layers/utils/text_manager.py
@@ -215,7 +215,7 @@ class TextManager(EventedModel):
         """Copies all encoded values at the given indices."""
         return {
             'string': _get_style_values(self.string, indices),
-            'color': _get_style_values(self.color, indices),
+            'color': _get_style_values(self.color, indices, value_ndim=1),
         }
 
     def _paste(self, *, string: StringArray, color: ColorArray):


### PR DESCRIPTION
# Fixes/Closes

Closes #5786

# Description
The issue here is actually caused by copying constant color values used for text, which causes issues because a single value has `ndim > 0`.  This PR fixes the issue by specifying the dimensionality of a single color value when copying values.

It might be worth reconsidering the implementation here and/or whether constant encodings are worth handling as a specific optimized case like this. But I think it's worth getting this PR in before a longer consideration.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
- [x] modified an existing test to reproduce the bug, then fixed it
- [x] all other tests pass with my change
- manually tested this by copying and pasting lots of points
