### PR TITLE
Readd exception to event proxy

### DIFF
--- a/napari/_vispy/canvas.py
+++ b/napari/_vispy/canvas.py
@@ -377,7 +377,7 @@ class VispyCanvas:
         event.dims_point = list(self.viewer.dims.point)
 
         # Put a read only wrapper on the event
-        event = ReadOnlyWrapper(event)
+        event = ReadOnlyWrapper(event, exceptions=('handled',))
         mouse_callbacks(self.viewer, event)
 
         layer = self.viewer.layers.selection.active


### PR DESCRIPTION
# Description
In the merge of #5432 we lost the change from #5742 to allow `event.handled` to be set despite the readonly proxy. This reinstates it.