### PR TITLE
Update README to display CZI logo for dark and light GitHub themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,4 +112,5 @@ the bug report template. If you think something isn't working, don't hesitate to
 
 ## institutional and funding partners
 
-![CZI logo light](https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg#gh-light-mode-only)![CZI logo dark](https://chanzuckerberg.com/wp-content/themes/czi/img/logo-white.svg#gh-dark-mode-only)
+![CZI logo light](https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg#gh-light-mode-only)
+![CZI logo dark](https://chanzuckerberg.com/wp-content/themes/czi/img/logo-white.svg#gh-dark-mode-only)

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ the bug report template. If you think something isn't working, don't hesitate to
 
 ## institutional and funding partners
 
-![CZI logo](https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg)
+![CZI logo dark](https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg#gh-dark-mode-only)![CZI logo light](https://chanzuckerberg.com/wp-content/themes/czi/img/logo-white.svg#gh-light-mode-only)

--- a/README.md
+++ b/README.md
@@ -115,4 +115,5 @@ the bug report template. If you think something isn't working, don't hesitate to
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://chanzuckerberg.com/wp-content/themes/czi/img/logo-white.svg">
   <source media="(prefers-color-scheme: light)" srcset="https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg">
+  <img alt="CZI logo" src="https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg">
 </picture>

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ the bug report template. If you think something isn't working, don't hesitate to
 
 ## institutional and funding partners
 
-![CZI logo dark](https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg#gh-dark-mode-only)![CZI logo light](https://chanzuckerberg.com/wp-content/themes/czi/img/logo-white.svg#gh-light-mode-only)
+![CZI logo light](https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg#gh-light-mode-only)![CZI logo dark](https://chanzuckerberg.com/wp-content/themes/czi/img/logo-white.svg#gh-dark-mode-only)

--- a/README.md
+++ b/README.md
@@ -114,6 +114,5 @@ the bug report template. If you think something isn't working, don't hesitate to
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://chanzuckerberg.com/wp-content/themes/czi/img/logo-white.svg">
-  <source media="(prefers-color-scheme: light)" srcset="https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg">
   <img alt="CZI logo" src="https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg">
 </picture>

--- a/README.md
+++ b/README.md
@@ -112,5 +112,7 @@ the bug report template. If you think something isn't working, don't hesitate to
 
 ## institutional and funding partners
 
-![CZI logo light](https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg#gh-light-mode-only)
-![CZI logo dark](https://chanzuckerberg.com/wp-content/themes/czi/img/logo-white.svg#gh-dark-mode-only)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://chanzuckerberg.com/wp-content/themes/czi/img/logo-white.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg">
+</picture>


### PR DESCRIPTION
# Fixes/Closes
- Closes #4752

# Description
- Currently the CZI logo on the README is not clear with the GitHub dark theme.  Updated the README with HTML to display the CZI logo based on the GitHub theme.  The GitHub documentation linked below describes this feature.
  - Light theme:
    <img width="381" alt="image" src="https://user-images.githubusercontent.com/871137/235832510-23ed854b-893c-42b3-84f0-a6ccc5003ad5.png">
  - Dark theme:
    <img width="396" alt="image" src="https://user-images.githubusercontent.com/871137/235832478-ba70b9b9-98ce-4b91-878a-39a45a36c1a0.png">

# References
- [GitHub Docs - Specifying the theme an image is shown to](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to)

## Type of change
- [x] Bug-fix

# How has this been tested?
- [x] Verified on personal fork/branch that README correctly displays the logo for both light and dark themes.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] n/a I have commented my code, particularly in hard-to-understand areas
- [ ] n/a I have made corresponding changes to the documentation
- [ ] n/a I have added tests that prove my fix is effective or that my feature works
- [ ] n/a If I included new strings, I have used `trans.` to make them localizable.