### PR TITLE
Set focus policy for mainwindow to prevent keeping focus on the axis labels (and other `QLineEdit` based widgets) when clicking outside the widget

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -145,6 +145,10 @@ class _QtMainWindow(QMainWindow):
 
         self.setStatusBar(ViewerStatusBar(self))
 
+        # Prevent QLineEdit based widgets to keep focus even when clicks are
+        # done outside the widget. See #1571
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+
         settings = get_settings()
 
         # TODO:


### PR DESCRIPTION
# Fixes/Closes

Closes #1571 

# Description

This changes the focus policy for the `_QtMainWindow` class to be set to `Qt.FocusPolicy.StrongFocus`. With this change, the axis label line edit widget is able to loss focus when clicking outside it (as well as other `QLineEdit` based widgets):

![An example is loaded and then interactions with the dim slider widget are done. The focus is set to axis and dim label widgets and unset by clicking outside them](https://user-images.githubusercontent.com/16781833/231850662-73d9c265-725d-44ef-8b6b-3d3f2c97f292.gif)

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change
- [x] I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
