### PR TITLE
Enforce Points.selected_data type as Selection

### DIFF
--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -233,7 +233,7 @@ class Points(Layer):
     out_of_slice_display : bool
         If True, renders points not just in central plane but also slightly out of slice
         according to specified point marker size.
-    selected_data : set
+    selected_data : Selection
         Integer indices of any selected points.
     mode : str
         Interactive mode. The normal, default mode is PAN_ZOOM, which
@@ -368,7 +368,7 @@ class Points(Layer):
         data, ndim = fix_data_points(data, ndim)
 
         # Indices of selected points
-        self._selected_data = set()
+        self._selected_data = Selection()
         self._selected_data_stored = set()
         self._selected_data_history = set()
         # Indices of selected points within the currently viewed slice
@@ -2033,9 +2033,9 @@ class Points(Layer):
             self._selected_view = list(
                 range(npoints, npoints + len(self._clipboard['data']))
             )
-            self._selected_data = set(
+            self._selected_data = Selection(set(
                 range(totpoints, totpoints + len(self._clipboard['data']))
-            )
+            ))
             self.refresh()
 
     def _copy_data(self):

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -2033,9 +2033,9 @@ class Points(Layer):
             self._selected_view = list(
                 range(npoints, npoints + len(self._clipboard['data']))
             )
-            self._selected_data = Selection(set(
-                range(totpoints, totpoints + len(self._clipboard['data']))
-            ))
+            self._selected_data = Selection(
+                set(range(totpoints, totpoints + len(self._clipboard['data'])))
+            )
             self.refresh()
 
     def _copy_data(self):

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -368,7 +368,6 @@ class Points(Layer):
         data, ndim = fix_data_points(data, ndim)
 
         # Indices of selected points
-        # self._selected_data = Selection()
         self._selected_data_stored = set()
         self._selected_data_history = set()
         # Indices of selected points within the currently viewed slice

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -368,7 +368,7 @@ class Points(Layer):
         data, ndim = fix_data_points(data, ndim)
 
         # Indices of selected points
-        self._selected_data = Selection()
+        # self._selected_data = Selection()
         self._selected_data_stored = set()
         self._selected_data_history = set()
         # Indices of selected points within the currently viewed slice
@@ -2033,8 +2033,8 @@ class Points(Layer):
             self._selected_view = list(
                 range(npoints, npoints + len(self._clipboard['data']))
             )
-            self._selected_data = Selection(
-                set(range(totpoints, totpoints + len(self._clipboard['data'])))
+            self._selected_data.update(set(
+                range(totpoints, totpoints + len(self._clipboard['data'])))
             )
             self.refresh()
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -2032,8 +2032,8 @@ class Points(Layer):
             self._selected_view = list(
                 range(npoints, npoints + len(self._clipboard['data']))
             )
-            self._selected_data.update(set(
-                range(totpoints, totpoints + len(self._clipboard['data'])))
+            self._selected_data.update(
+                set(range(totpoints, totpoints + len(self._clipboard['data'])))
             )
             self.refresh()
 


### PR DESCRIPTION
# Fixes/Closes

<!-- In general, PRs should fix an existing issue on the repo. -->
<!-- Please link to that issue here as "Closes #(issue-number)". -->
Closes https://github.com/napari/napari/issues/5794

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->
During the copy/paste workflow in Points, the `selected_data` type changes from `psygnal.containers.Selection` to `set`. The doc string and init seem to be conflicting on what it is supposed to be. This PR ensures that it will stay as `Selection`.

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
