### PR TITLE
Bugfix: Disconnect callbacks on object deletion in special functions from `event_utils` 

### DIFF
--- a/napari/utils/events/_tests/test_event_utils.py
+++ b/napari/utils/events/_tests/test_event_utils.py
@@ -18,6 +18,8 @@ def test_connect_no_arg():
     assert len(emiter.callbacks) == 1
     del mock
     gc.collect()
+    assert len(emiter.callbacks) == 1
+    emiter(type_name="a", value=1)
     assert len(emiter.callbacks) == 0
 
 
@@ -30,6 +32,8 @@ def test_connect_setattr_value():
     assert len(emiter.callbacks) == 1
     del mock
     gc.collect()
+    assert len(emiter.callbacks) == 1
+    emiter(type_name="a", value=1)
     assert len(emiter.callbacks) == 0
 
 
@@ -43,4 +47,6 @@ def test_connect_setattr():
     assert len(emiter.callbacks) == 1
     del mock
     gc.collect()
+    assert len(emiter.callbacks) == 1
+    emiter(type_name="a", value=1)
     assert len(emiter.callbacks) == 0

--- a/napari/utils/events/_tests/test_event_utils.py
+++ b/napari/utils/events/_tests/test_event_utils.py
@@ -1,0 +1,46 @@
+import gc
+from unittest.mock import Mock
+
+from napari.utils.events.event import Event, EventEmitter
+from napari.utils.events.event_utils import (
+    connect_no_arg,
+    connect_setattr,
+    connect_setattr_value,
+)
+
+
+def test_connect_no_arg():
+    mock = Mock(["meth"])
+    emiter = EventEmitter()
+    connect_no_arg(emiter, mock, "meth")
+    emiter(type_name="a", value=1)
+    mock.meth.assert_called_once_with()
+    assert len(emiter.callbacks) == 1
+    del mock
+    gc.collect()
+    assert len(emiter.callbacks) == 0
+
+
+def test_connect_setattr_value():
+    mock = Mock()
+    emiter = EventEmitter()
+    connect_setattr_value(emiter, mock, "meth")
+    emiter(type_name="a", value=1)
+    assert mock.meth == 1
+    assert len(emiter.callbacks) == 1
+    del mock
+    gc.collect()
+    assert len(emiter.callbacks) == 0
+
+
+def test_connect_setattr():
+    mock = Mock()
+    emiter = EventEmitter()
+    connect_setattr(emiter, mock, "meth")
+    emiter(type_name="a", value=1)
+    assert isinstance(mock.meth, Event)
+    assert mock.meth.value == 1
+    assert len(emiter.callbacks) == 1
+    del mock
+    gc.collect()
+    assert len(emiter.callbacks) == 0

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -272,7 +272,7 @@ class EventEmitter:
     source : object
         The object that the generated events apply to. All emitted Events will
         have their .source property set to this value.
-    type : str or None
+    type_name: str or None
         String indicating the event type (e.g. mouse_press, key_release)
     event_class : subclass of Event
         The class of events that this emitter will generate.

--- a/napari/utils/events/event_utils.py
+++ b/napari/utils/events/event_utils.py
@@ -39,7 +39,7 @@ def connect_setattr(emitter: Emitter, obj, attr: str):
     # Also there is no option to create weakref to QT Signal
     # but even if keep reference to base object and signal name it is possible to meet
     # problem with C++ "wrapped C/C++ object has been deleted"
-    # weakref.finalize(obj, emitter.disconnect, _cb)
+    weakref.finalize(obj, emitter.disconnect, _cb)
 
 
 def connect_no_arg(emitter: Emitter, obj, attr: str):
@@ -50,7 +50,7 @@ def connect_no_arg(emitter: Emitter, obj, attr: str):
 
     emitter.connect(_cb)
     # as in connect_setattr
-    # weakref.finalize(obj, emitter.disconnect, _cb)
+    weakref.finalize(obj, emitter.disconnect, _cb)
 
 
 def connect_setattr_value(emitter: Emitter, obj, attr: str):
@@ -61,3 +61,4 @@ def connect_setattr_value(emitter: Emitter, obj, attr: str):
         setattr(ref(), attr, value.value)
 
     emitter.connect(_cb)
+    weakref.finalize(obj, emitter.disconnect, _cb)

--- a/napari/utils/events/event_utils.py
+++ b/napari/utils/events/event_utils.py
@@ -43,8 +43,8 @@ def connect_setattr(emitter: Emitter, obj, attr: str):
     # but even if keep reference to base object and signal name it is possible to meet
     # problem with C++ "wrapped C/C++ object has been deleted"
 
-    # In all this 3 functions this should be uncommented instead of if clause in _cb
-    # but it causes segmentation fault in tests
+    # In all of these 3 functions, this should be uncommented instead of using
+    # the if clause in _cb but that causes a segmentation fault in tests
     # weakref.finalize(obj, emitter.disconnect, _cb)
 
 

--- a/napari/utils/events/event_utils.py
+++ b/napari/utils/events/event_utils.py
@@ -32,25 +32,34 @@ def connect_setattr(emitter: Emitter, obj, attr: str):
     ref = weakref.ref(obj)
 
     def _cb(*value):
-        setattr(ref(), attr, value[0] if len(value) == 1 else value)
+        if (ob := ref()) is None:
+            emitter.disconnect(_cb)
+            return
+        setattr(ob, attr, value[0] if len(value) == 1 else value)
 
     emitter.connect(_cb)
     # There are scenarios where emitter is deleted before obj.
     # Also there is no option to create weakref to QT Signal
     # but even if keep reference to base object and signal name it is possible to meet
     # problem with C++ "wrapped C/C++ object has been deleted"
-    weakref.finalize(obj, emitter.disconnect, _cb)
+
+    # In all this 3 functions this should be uncommented instead of if clause in _cb
+    # but it causes segmentation fault in tests
+    # weakref.finalize(obj, emitter.disconnect, _cb)
 
 
 def connect_no_arg(emitter: Emitter, obj, attr: str):
     ref = weakref.ref(obj)
 
     def _cb(*_value):
-        getattr(ref(), attr)()
+        if (ob := ref()) is None:
+            emitter.disconnect(_cb)
+            return
+        getattr(ob, attr)()
 
     emitter.connect(_cb)
     # as in connect_setattr
-    weakref.finalize(obj, emitter.disconnect, _cb)
+    # weakref.finalize(obj, emitter.disconnect, _cb)
 
 
 def connect_setattr_value(emitter: Emitter, obj, attr: str):
@@ -58,7 +67,10 @@ def connect_setattr_value(emitter: Emitter, obj, attr: str):
     ref = weakref.ref(obj)
 
     def _cb(value):
-        setattr(ref(), attr, value.value)
+        if (ob := ref()) is None:
+            emitter.disconnect(_cb)
+            return
+        setattr(ob, attr, value.value)
 
     emitter.connect(_cb)
-    weakref.finalize(obj, emitter.disconnect, _cb)
+    # weakref.finalize(obj, emitter.disconnect, _cb)


### PR DESCRIPTION
# Fixes/Closes

Closes #5808

# Description

Adds cleaning callback steps on object deletion and adds proper tests. 

# References

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
- [x] example: added tests to cover the bug and fix
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
