### PR TITLE
Do not blend color in QtColorBox with black using opacity

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
@@ -57,7 +57,7 @@ def test_changing_colormap_updates_colorbox(make_labels_controls):
 
     np.testing.assert_equal(
         color_box.color,
-        np.round(np.asarray(layer._selected_color) * 255 * layer.opacity),
+        np.round(np.asarray(layer._selected_color) * 255),
     )
 
     layer.colormap = colormap_utils.label_colormap(num_colors=5)
@@ -67,7 +67,7 @@ def test_changing_colormap_updates_colorbox(make_labels_controls):
 
     np.testing.assert_equal(
         color_box.color,
-        np.round(np.asarray(layer._selected_color) * 255 * layer.opacity),
+        np.round(np.asarray(layer._selected_color) * 255),
     )
 
 

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -558,8 +558,7 @@ class QtColorBox(QWidget):
                         painter.setBrush(QColor(25, 25, 25))
                     painter.drawRect(i * 4, j * 4, 5, 5)
         else:
-            color = np.multiply(self.layer._selected_color, self.layer.opacity)
-            color = np.round(255 * color).astype(int)
+            color = np.round(255 * self.layer._selected_color).astype(int)
             painter.setPen(QColor(*list(color)))
             painter.setBrush(QColor(*list(color)))
             painter.drawRect(0, 0, self._height, self._height)


### PR DESCRIPTION
# Description
For some reason that I cannot fully understand, the displayed color in QtColorBox is multiplied with the layer opacity, which is  equal to blending the selected color with black. I find it very misleading as it just distorts displayed colors making them harder to associate with the true colors. It becomes especially confusing when you use low levels of opacity (20-30%), which makes all colors look grey and indistinguishable. 

How it now looks like in napari depending on different opacity:
![image](https://github.com/napari/napari/assets/5459767/01b55cfd-6ce4-494d-a0fa-a8116ee35d6b)

This PR just removes it making it always show the actual color.

P.S. It has been puzzling me for a while why colors are always darker than the real colors in the color box. I've only recently realized that their appearance is depending on the opacity.

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
