### PR TITLE
Fix extents of points layers

### DIFF
--- a/napari/components/_tests/test_interaction_box.py
+++ b/napari/components/_tests/test_interaction_box.py
@@ -45,18 +45,21 @@ def test_transform_box_from_layer():
     layer = Points(pts, translate=translate, scale=scale)
     vertices = generate_transform_box_from_layer(layer, dims_displayed=(0, 1))
     # scale/translate should not affect vertices, cause they're in data space
-    expected = np.array(
-        [
-            [0, 0],
-            [10, 0],
-            [0, 10],
-            [10, 10],
-            [0, 5],
-            [5, 0],
-            [5, 10],
-            [10, 5],
-            [-1, 5],
-        ]
+    expected = (
+        np.array(
+            [
+                [0, 0],
+                [10, 0],
+                [0, 10],
+                [10, 10],
+                [0, 5],
+                [5, 0],
+                [5, 10],
+                [10, 5],
+                [-1, 5],
+            ]
+        )
+        + 0.5
     )
     np.testing.assert_allclose(vertices, expected)
 

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -147,7 +147,7 @@ def test_single_point_dims():
     shape = (1, 3)
     data = np.zeros(shape)
     viewer.add_points(data)
-    assert all(r == (0.0, 1.0, 1.0) for r in viewer.dims.range)
+    assert all(r == (0.5, 1.5, 1.0) for r in viewer.dims.range)
 
 
 def test_add_empty_points_to_empty_viewer():

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -281,8 +281,8 @@ def test_single_point_extent():
     shape = (1, 3)
     data = np.zeros(shape)
     layer = Points(data)
-    assert np.all(layer.extent.data == 0)
-    assert np.all(layer.extent.world == 0)
+    assert np.all(layer.extent.data == 0.5)
+    assert np.all(layer.extent.world == 0.5)
     assert np.all(layer.extent.step == 1)
 
 
@@ -1842,7 +1842,8 @@ def test_world_data_extent():
     min_val = (-2, -5, 0)
     max_val = (7, 30, 15)
     layer = Points(data)
-    extent = np.array((min_val, max_val))
+    # Points are placed in the centre of voxels, hence +0.5
+    extent = np.array((min_val, max_val)) + 0.5
     check_layer_world_data_extent(layer, extent, (3, 1, 1), (10, 20, 5), False)
 
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -757,7 +757,8 @@ class Points(Layer):
             maxs = np.max(self.data, axis=0)
             mins = np.min(self.data, axis=0)
             extrema = np.vstack([mins, maxs])
-        return extrema
+        # Points are placed in the centre of voxels, hence +0.5
+        return extrema + 0.5
 
     @property
     def out_of_slice_display(self) -> bool:


### PR DESCRIPTION
# Fixes/Closes

<!-- In general, PRs should fix an existing issue on the repo. -->
<!-- Please link to that issue here as "Closes #(issue-number)". -->
Closes https://github.com/napari/napari/issues/5750

# Description
This fixes the extents calculation for Points layers. Because the points are assumed to lie at the centre of voxels (ie. a point at [0, 0, 0] is rendered at [0.5, 0.5, 0.5] in the viewer). I *think* this is the right fix to apply, but I wouldn't be surprised if someone with more experience dealing with similar issues disagrees!

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
I've modified existing unit tests so they pass, and added comments explaining the changes.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [n/a] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
