### PR TITLE
Bugfixes for layer overlays: clean up when layer is removed + fix potential double creation

### DIFF
--- a/napari/_vispy/layers/base.py
+++ b/napari/_vispy/layers/base.py
@@ -167,7 +167,10 @@ class VispyBaseLayer(ABC):
             if overlay in self.overlays:
                 continue
 
-            overlay_visual = create_vispy_overlay(overlay, layer=self.layer)
+            with self.layer.events._overlays.blocker():
+                overlay_visual = create_vispy_overlay(
+                    overlay, layer=self.layer
+                )
             self.overlays[overlay] = overlay_visual
             if isinstance(overlay, CanvasOverlay):
                 overlay_visual.node.parent = self.node.parent.parent  # viewbox

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -658,6 +658,10 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         disconnect_events(layer.events, self)
         disconnect_events(layer.events, self.layers)
 
+        # Clean up overlays
+        for overlay in list(layer._overlays):
+            del layer._overlays[overlay]
+
         self._on_layers_change()
         self._on_grid_change()
 


### PR DESCRIPTION
# Fixes/Closes
This PR fixes the bugs I discovered while working on #5806.

# Description
The following bugs are addressed:
* When a layer is removed, the overlays are not removed and overlay.close() is not called, leading to failing napari/_tests/test_adding_removing.py when you bind callbacks in the overlay. https://github.com/napari/napari/pull/5806#issuecomment-1543464398
* If an overlay modifies its states during its creation in create_vispy_overlay in Layer._on_overlays_change, it causes double creation of the overlay because it triggers Layer.events._overlays event, which is connected to Layer._on_overlays_change, which is then called once again. As the first call of Layer._on_overlays_change hasn't had time to add the first created overlay to self.overlays, it leads to creating another copy of the overlay. https://github.com/napari/napari/pull/5806#issuecomment-1545408916

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
