### PR TITLE
Use enums that are more compatible with qt6

### DIFF
--- a/napari/_qt/containers/_base_item_view.py
+++ b/napari/_qt/containers/_base_item_view.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from itertools import chain, repeat
 from typing import TYPE_CHECKING, Generic, TypeVar
 
-from qtpy.QtCore import QItemSelection, QModelIndex, Qt, QItemSelectionModel
+from qtpy.QtCore import QItemSelection, QItemSelectionModel, QModelIndex, Qt
 from qtpy.QtWidgets import QAbstractItemView
 
 from napari._qt.containers._base_item_model import ItemRole

--- a/napari/_qt/containers/_base_item_view.py
+++ b/napari/_qt/containers/_base_item_view.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from itertools import chain, repeat
 from typing import TYPE_CHECKING, Generic, TypeVar
 
-from qtpy.QtCore import QItemSelection, QModelIndex, Qt
+from qtpy.QtCore import QItemSelection, QModelIndex, Qt, QItemSelectionModel
 from qtpy.QtWidgets import QAbstractItemView
 
 from napari._qt.containers._base_item_model import ItemRole
@@ -98,14 +98,14 @@ class _BaseEventedItemView(Generic[ItemType]):
             sm.clearCurrentIndex()
         else:
             idx = index_of(self.model(), event.value)
-            sm.setCurrentIndex(idx, sm.SelectionFlag.Current)
+            sm.setCurrentIndex(idx, QItemSelectionModel.Current)
 
     def _on_py_selection_change(self, event: Event):
         """The python model selection has changed. Update the Qt view."""
         sm = self.selectionModel()
         for is_selected, idx in chain(
-            zip(repeat(sm.SelectionFlag.Select), event.added),
-            zip(repeat(sm.SelectionFlag.Deselect), event.removed),
+            zip(repeat(QItemSelectionModel.Select), event.added),
+            zip(repeat(QItemSelectionModel.Deselect), event.removed),
         ):
             model_idx = index_of(self.model(), idx)
             if model_idx.isValid():
@@ -118,7 +118,7 @@ class _BaseEventedItemView(Generic[ItemType]):
         for i in self._root.selection:
             idx = index_of(self.model(), i)
             selection.select(idx, idx)
-        sel_model.select(selection, sel_model.SelectionFlag.ClearAndSelect)
+        sel_model.select(selection, QItemSelectionModel.ClearAndSelect)
 
 
 def index_of(model: QAbstractItemModel, obj: ItemType) -> QModelIndex:

--- a/napari/_qt/containers/_layer_delegate.py
+++ b/napari/_qt/containers/_layer_delegate.py
@@ -39,7 +39,7 @@ from typing import TYPE_CHECKING
 
 from qtpy.QtCore import QPoint, QSize, Qt
 from qtpy.QtGui import QMouseEvent, QPixmap
-from qtpy.QtWidgets import QStyledItemDelegate
+from qtpy.QtWidgets import QStyledItemDelegate, QStyleOptionViewItem
 
 from napari._app_model.constants import MenuId
 from napari._app_model.context import get_context
@@ -51,7 +51,7 @@ from napari._qt.qt_resources import QColoredSVGIcon
 if TYPE_CHECKING:
     from qtpy import QtCore
     from qtpy.QtGui import QPainter
-    from qtpy.QtWidgets import QStyleOptionViewItem, QWidget
+    from qtpy.QtWidgets import QWidget
 
     from napari.components.layerlist import LayerList
 
@@ -110,9 +110,9 @@ class LayerDelegate(QStyledItemDelegate):
         option.icon = icon.colored(theme='dark' if bg < 128 else 'light')
         option.decorationSize = QSize(18, 18)
         option.decorationPosition = (
-            option.Position.Right
+            QStyleOptionViewItem.Right
         )  # put icon on the right
-        option.features |= option.ViewItemFeature.HasDecoration
+        option.features |= QStyleOptionViewItem.HasDecoration
 
     def _paint_thumbnail(self, painter, option, index):
         """paint the layer thumbnail."""

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -241,15 +241,11 @@ class QtViewerDockWidget(QDockWidget):
             Qt.DockWidgetArea.RightDockWidgetArea,
         ):
             features = self._features
-            if features & self.DockWidgetFeature.DockWidgetVerticalTitleBar:
-                features = (
-                    features
-                    ^ self.DockWidgetFeature.DockWidgetVerticalTitleBar
-                )
+            if features & QDockWidget.DockWidgetVerticalTitleBar:
+                features = features ^ QDockWidget.DockWidgetVerticalTitleBar
         else:
             features = (
-                self._features
-                | self.DockWidgetFeature.DockWidgetVerticalTitleBar
+                self._features | QDockWidget.DockWidgetVerticalTitleBar
             )
         self.setFeatures(features)
 

--- a/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -244,9 +244,7 @@ class QtViewerDockWidget(QDockWidget):
             if features & QDockWidget.DockWidgetVerticalTitleBar:
                 features = features ^ QDockWidget.DockWidgetVerticalTitleBar
         else:
-            features = (
-                self._features | QDockWidget.DockWidgetVerticalTitleBar
-            )
+            features = self._features | QDockWidget.DockWidgetVerticalTitleBar
         self.setFeatures(features)
 
     @property


### PR DESCRIPTION
xref: https://github.com/napari/napari/pull/5480/files

It seems to be getting removed

See: https://wiki.qt.io/Qt_for_Python_Development_Notes

    old Enums are being removed, and the startup time will improve a bit (still in progress)

# Fixes/Closes

<!-- In general, PRs should fix an existing issue on the repo. -->
<!-- Please link to that issue here as "Closes #(issue-number)". -->
Closes #

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
