### PR TITLE
Add compatibility to PySide in file dialogs by using positional arguments

### DIFF
--- a/napari/_qt/menus/debug_menu.py
+++ b/napari/_qt/menus/debug_menu.py
@@ -62,9 +62,9 @@ class DebugMenu(NapariMenu):
         hist = get_save_history()
         dlg.setHistory(hist)
         filename, _ = dlg.getSaveFileName(
-            parent=viewer,
-            caption=trans._('Record performance trace file'),
-            directory=hist[0],
+            viewer,  # parent
+            trans._('Record performance trace file'),  # caption
+            hist[0],  # directory in PyQt, dir in PySide
             filter=trans._("Trace Files (*.json)"),
         )
         if filename:

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -569,9 +569,10 @@ class QtViewer(QSplitter):
         dlg.setHistory(hist)
 
         filename, selected_filter = dlg.getSaveFileName(
-            parent=self,
-            caption=trans._('Save {msg} layers', msg=msg),
-            directory=hist[0],  # home dir by default,
+            self,  # parent
+            trans._('Save {msg} layers', msg=msg),  # caption
+            # home dir by default
+            hist[0],  # directory in PyQt, dir in PySide
             filter=ext_str,
             options=(
                 QFileDialog.DontUseNativeDialog


### PR DESCRIPTION
File dialog arguments are named `parent, caption, directory` in PyQt and `parent, caption, dir` in PySide. Before this PR, the dialog calls used named arguments according to the PyQt convention, which broke PySide compatibility. This PR changes the calls to use positional arguments so both backends work.