### PR TITLE
Bugfix: fix broken "show selected" in the Labels layer (because of caching)

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1476,6 +1476,32 @@ def test_color_mapping_when_color_is_changed():
     )
 
 
+def test_color_mapping_with_selected_label():
+    """Checks if the color mapping is computed correctly when show_selected_label is activated."""
+
+    data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
+    layer = Labels(data)
+    mapped_colors_all = layer._raw_to_displayed(layer._slice.image.raw).copy()
+
+    layer.selected_label = 1
+    layer.show_selected_label = True
+
+    for selected_label in range(1, 5):
+        layer.selected_label = selected_label
+        label_mask = data == selected_label
+        mapped_colors = layer._raw_to_displayed(layer._slice.image.raw)
+
+        assert np.allclose(
+            mapped_colors[label_mask], mapped_colors_all[label_mask]
+        )
+        assert np.allclose(mapped_colors[np.logical_not(label_mask)], 0)
+
+    layer.show_selected_label = False
+    assert np.allclose(
+        layer._raw_to_displayed(layer._slice.image.raw), mapped_colors_all
+    )
+
+
 def test_color_mapping_when_seed_is_changed():
     """Checks if the color mapping is updated when the color palette seed is changed."""
     np.random.seed(0)

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1476,7 +1476,7 @@ def test_color_mapping_when_color_is_changed():
     )
 
 
-def test_color_mapping_with_selected_label():
+def test_color_mapping_with_show_selected_label():
     """Checks if the color mapping is computed correctly when show_selected_label is activated."""
 
     data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -662,6 +662,7 @@ class Labels(_ImageBase):
         # note: self.color_mode returns a string and this comparison fails,
         # so use self._color_mode
         if self.show_selected_label:
+            self._cached_labels = None  # invalidates labels cache
             self.refresh()
 
     def swap_selected_and_background_labels(self):
@@ -714,6 +715,7 @@ class Labels(_ImageBase):
     @show_selected_label.setter
     def show_selected_label(self, filter_val):
         self._show_selected_label = filter_val
+        self._cached_labels = None
         self.refresh()
 
     @Layer.mode.getter


### PR DESCRIPTION
# Description

The labels caching from #5732 broke the "show selected" feature because of caching. This PR fixes it by invalidating the cache when "show selected" is activated.

I also added a test that catches this bug.

## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
- [X] all tests pass with my change

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have added tests that prove my fix is effective or that my feature works