### PR TITLE
Bugfix: do not allow drawing while adjusting the brush size with the mouse

### DIFF
--- a/napari/components/_viewer_key_bindings.py
+++ b/napari/components/_viewer_key_bindings.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from napari.components.viewer_model import ViewerModel
 from napari.utils.action_manager import action_manager
 from napari.utils.theme import available_themes, get_system_theme
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
-    from napari.components.viewer_model import ViewerModel
     from napari.viewer import Viewer
 
 
@@ -18,10 +18,6 @@ def register_viewer_action(description):
     It will use the function name as the action name. We force the description
     to be given instead of function docstring for translation purpose.
     """
-
-    # Workaround for the circular import issue
-    # https://github.com/napari/napari/issues/5846#issuecomment-1552863541
-    from napari.components.viewer_model import ViewerModel
 
     def _inner(func):
         action_manager.register_action(

--- a/napari/components/_viewer_key_bindings.py
+++ b/napari/components/_viewer_key_bindings.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from napari.components.viewer_model import ViewerModel
 from napari.utils.action_manager import action_manager
 from napari.utils.theme import available_themes, get_system_theme
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
+    from napari.components.viewer_model import ViewerModel
     from napari.viewer import Viewer
 
 
@@ -18,6 +18,10 @@ def register_viewer_action(description):
     It will use the function name as the action name. We force the description
     to be given instead of function docstring for translation purpose.
     """
+
+    # Workaround for the circular import issue
+    # https://github.com/napari/napari/issues/5846#issuecomment-1552863541
+    from napari.components.viewer_model import ViewerModel
 
     def _inner(func):
         action_manager.register_action(

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -22,6 +22,11 @@ def draw(layer, event):
     pixels will be changed to background and this tool functions like an
     eraser
     """
+
+    # Do not allow drawing while adjusting the brush size with the mouse
+    if layer.cursor == 'circle_frozen':
+        return
+
     coordinates = mouse_event_to_labels_coordinate(layer, event)
     if layer._mode == Mode.ERASE:
         new_label = layer._background_label

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -1,4 +1,4 @@
-from napari.components.cursor import CursorStyle
+from napari.components._viewer_constants import CursorStyle
 from napari.layers.labels._labels_constants import Mode
 from napari.layers.labels._labels_utils import mouse_event_to_labels_coordinate
 from napari.settings import get_settings

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -1,3 +1,4 @@
+from napari.components.cursor import CursorStyle
 from napari.layers.labels._labels_constants import Mode
 from napari.layers.labels._labels_utils import mouse_event_to_labels_coordinate
 from napari.settings import get_settings
@@ -24,7 +25,7 @@ def draw(layer, event):
     """
 
     # Do not allow drawing while adjusting the brush size with the mouse
-    if layer.cursor == 'circle_frozen':
+    if layer.cursor == CursorStyle.CIRCLE_FROZEN:
         return
 
     coordinates = mouse_event_to_labels_coordinate(layer, event)
@@ -94,7 +95,7 @@ class BrushSizeOnMouseMove:
             if self.init_pos is None:
                 self.init_pos = pos
                 self.init_brush_size = layer.brush_size
-                layer.cursor = 'circle_frozen'
+                layer.cursor = CursorStyle.CIRCLE_FROZEN
             else:
                 brush_size_delta = round(
                     (pos[0] - self.init_pos[0]) / event.camera_zoom
@@ -105,8 +106,8 @@ class BrushSizeOnMouseMove:
                 layer.brush_size = bounded_brush_size
         else:
             self.init_pos = None
-            if layer.cursor == 'circle_frozen':
-                layer.cursor = 'circle'
+            if layer.cursor == CursorStyle.CIRCLE_FROZEN:
+                layer.cursor = CursorStyle.CIRCLE
 
     def _on_modifiers_change(self):
         modifiers_setting = (

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -1,4 +1,3 @@
-from napari.components._viewer_constants import CursorStyle
 from napari.layers.labels._labels_constants import Mode
 from napari.layers.labels._labels_utils import mouse_event_to_labels_coordinate
 from napari.settings import get_settings
@@ -25,7 +24,7 @@ def draw(layer, event):
     """
 
     # Do not allow drawing while adjusting the brush size with the mouse
-    if layer.cursor == CursorStyle.CIRCLE_FROZEN:
+    if layer.cursor == 'circle_frozen':
         return
 
     coordinates = mouse_event_to_labels_coordinate(layer, event)
@@ -95,7 +94,7 @@ class BrushSizeOnMouseMove:
             if self.init_pos is None:
                 self.init_pos = pos
                 self.init_brush_size = layer.brush_size
-                layer.cursor = CursorStyle.CIRCLE_FROZEN
+                layer.cursor = 'circle_frozen'
             else:
                 brush_size_delta = round(
                     (pos[0] - self.init_pos[0]) / event.camera_zoom
@@ -106,8 +105,8 @@ class BrushSizeOnMouseMove:
                 layer.brush_size = bounded_brush_size
         else:
             self.init_pos = None
-            if layer.cursor == CursorStyle.CIRCLE_FROZEN:
-                layer.cursor = CursorStyle.CIRCLE
+            if layer.cursor == 'circle_frozen':
+                layer.cursor = 'circle'
 
     def _on_modifiers_change(self):
         modifiers_setting = (

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -1,3 +1,4 @@
+from napari.components._viewer_constants import CursorStyle
 from napari.layers.labels._labels_constants import Mode
 from napari.layers.labels._labels_utils import mouse_event_to_labels_coordinate
 from napari.settings import get_settings
@@ -24,7 +25,7 @@ def draw(layer, event):
     """
 
     # Do not allow drawing while adjusting the brush size with the mouse
-    if layer.cursor == 'circle_frozen':
+    if layer.cursor == CursorStyle.CIRCLE_FROZEN:
         return
 
     coordinates = mouse_event_to_labels_coordinate(layer, event)
@@ -94,7 +95,7 @@ class BrushSizeOnMouseMove:
             if self.init_pos is None:
                 self.init_pos = pos
                 self.init_brush_size = layer.brush_size
-                layer.cursor = 'circle_frozen'
+                layer.cursor = CursorStyle.CIRCLE_FROZEN
             else:
                 brush_size_delta = round(
                     (pos[0] - self.init_pos[0]) / event.camera_zoom
@@ -105,8 +106,8 @@ class BrushSizeOnMouseMove:
                 layer.brush_size = bounded_brush_size
         else:
             self.init_pos = None
-            if layer.cursor == 'circle_frozen':
-                layer.cursor = 'circle'
+            if layer.cursor == CursorStyle.CIRCLE_FROZEN:
+                layer.cursor = CursorStyle.CIRCLE
 
     def _on_modifiers_change(self):
         modifiers_setting = (

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -1,4 +1,3 @@
-from napari.components.cursor import CursorStyle
 from napari.layers.labels._labels_constants import Mode
 from napari.layers.labels._labels_utils import mouse_event_to_labels_coordinate
 from napari.settings import get_settings
@@ -25,7 +24,7 @@ def draw(layer, event):
     """
 
     # Do not allow drawing while adjusting the brush size with the mouse
-    if layer.cursor == CursorStyle.CIRCLE_FROZEN:
+    if layer.cursor == 'circle_frozen':
         return
 
     coordinates = mouse_event_to_labels_coordinate(layer, event)
@@ -95,7 +94,7 @@ class BrushSizeOnMouseMove:
             if self.init_pos is None:
                 self.init_pos = pos
                 self.init_brush_size = layer.brush_size
-                layer.cursor = CursorStyle.CIRCLE_FROZEN
+                layer.cursor = 'circle_frozen'
             else:
                 brush_size_delta = round(
                     (pos[0] - self.init_pos[0]) / event.camera_zoom
@@ -106,8 +105,8 @@ class BrushSizeOnMouseMove:
                 layer.brush_size = bounded_brush_size
         else:
             self.init_pos = None
-            if layer.cursor == CursorStyle.CIRCLE_FROZEN:
-                layer.cursor = CursorStyle.CIRCLE
+            if layer.cursor == 'circle_frozen':
+                layer.cursor = 'circle'
 
     def _on_modifiers_change(self):
         modifiers_setting = (

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -1,4 +1,4 @@
-from napari.components._viewer_constants import CursorStyle
+from napari.components.cursor import CursorStyle
 from napari.layers.labels._labels_constants import Mode
 from napari.layers.labels._labels_utils import mouse_event_to_labels_coordinate
 from napari.settings import get_settings


### PR DESCRIPTION
# Fixes/Closes
Closes #5838 

# Description
The drawing while adjusting the brush size with the mouse should not be allowed as it causes unexpected labeling behavior because of the inconsistency between the brush circle position and the position of the system cursor.


## Type of change
- [X] Bug-fix (non-breaking change which fixes an issue)

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).

cc @Czaki 
