### PR TITLE
[Qt6] Fix AttributeError on renaming layer

### DIFF
--- a/napari/_qt/containers/_layer_delegate.py
+++ b/napari/_qt/containers/_layer_delegate.py
@@ -138,7 +138,7 @@ class LayerDelegate(QStyledItemDelegate):
         editor = super().createEditor(parent, option, index)
         # make sure editor has same alignment as the display name
         editor.setAlignment(
-            Qt.Alignment(index.data(Qt.ItemDataRole.TextAlignmentRole))
+            Qt.AlignmentFlag(index.data(Qt.ItemDataRole.TextAlignmentRole))
         )
         return editor
 

--- a/napari/_qt/containers/_tests/test_qt_layer_list.py
+++ b/napari/_qt/containers/_tests/test_qt_layer_list.py
@@ -2,6 +2,7 @@ from typing import Tuple
 
 import numpy as np
 from qtpy.QtCore import QModelIndex, Qt
+from qtpy.QtWidgets import QLineEdit, QStyleOptionViewItem
 
 from napari._qt.containers import QtLayerList
 from napari.components import LayerList
@@ -52,3 +53,13 @@ def check_state_at_layer_index(
     # The data method returns integer value of the enum in some cases, so
     # ensure it has the enum type for more explicit assertions.
     return Qt.CheckState(value)
+
+
+def test_createEditor(qtbot):
+    view, image = make_qt_layer_list_with_layer(qtbot)
+    model_index = layer_to_model_index(view, 0)
+    delegate = view.itemDelegateForIndex(model_index)
+    editor = delegate.createEditor(view, QStyleOptionViewItem(), model_index)
+    assert isinstance(editor, QLineEdit)
+    delegate.setEditorData(editor, model_index)
+    assert editor.text() == image.name

--- a/napari/_qt/containers/_tests/test_qt_layer_list.py
+++ b/napari/_qt/containers/_tests/test_qt_layer_list.py
@@ -58,7 +58,7 @@ def check_state_at_layer_index(
 def test_createEditor(qtbot):
     view, image = make_qt_layer_list_with_layer(qtbot)
     model_index = layer_to_model_index(view, 0)
-    delegate = view.itemDelegateForIndex(model_index)
+    delegate = view.itemDelegate()
     editor = delegate.createEditor(view, QStyleOptionViewItem(), model_index)
     assert isinstance(editor, QLineEdit)
     delegate.setEditorData(editor, model_index)


### PR DESCRIPTION
# Fixes/Closes

Closes #5849

# Description

This is a pretty simple fix, but is also backward-compatible in my testing with Qt5. I added a test to cover this method for the future. I can look into adding more tests for that file as well.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
Added a test for this feature that fails without a062d7933ccb6c0aeead275a3418b5c478615e30.

This test passes with a062d7933ccb6c0aeead275a3418b5c478615e30 on both Qt5 and Qt6.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
