### PR TITLE
Enable pinch-to-zoom with vispy 0.13+

### DIFF
--- a/napari/_vispy/camera.py
+++ b/napari/_vispy/camera.py
@@ -240,7 +240,7 @@ def add_mouse_pan_zoom_toggles(
         def viewbox_mouse_event(self, event):
             if (
                 self.mouse_zoom
-                and event.type == 'mouse_wheel'
+                and event.type in ('mouse_wheel', 'gesture_zoom')
                 or self.mouse_pan
                 and event.type
                 in ('mouse_move', 'mouse_press', 'mouse_release')


### PR DESCRIPTION
# Description
This enables pinch-to-zoom in napari when using a trackpad, so long as you have vispy 0.13+ installed. As this functionality is now built-in with the main vispy cameras, the behavior sort of comes to napari for free, but this change is required because we modify the vispy camera classes. See https://github.com/napari/napari/issues/166#issuecomment-1552743876 for some additional discussion.

I think part of the reason this feature could be useful is the potential to bind scrolling (`mouse_wheel`) and pinching (`gesture_zoom`) to different behavior. For example, I recall @psobolewskiPhD mentioned (on Zulip?) wanting to use pinching to zoom and scrolling to change brush size. I believe it will requires additional work to enable such capabilities.

# References
https://github.com/vispy/vispy/pull/2456
https://github.com/napari/napari/pull/5701

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
- [x] all tests pass with my change
- [x] I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
