### PR TITLE
Sort npe1 widget contributions

### DIFF
--- a/napari/_qt/menus/plugins_menu.py
+++ b/napari/_qt/menus/plugins_menu.py
@@ -83,7 +83,7 @@ class PluginsMenu(NapariMenu):
         else:
             menu = self
 
-        for wdg_name in sorted(widgets):
+        for wdg_name in widgets:
             key = (plugin_name, wdg_name)
             if multiprovider:
                 action = QAction(wdg_name.replace("&", "&&"), parent=self)

--- a/napari/_qt/menus/plugins_menu.py
+++ b/napari/_qt/menus/plugins_menu.py
@@ -83,7 +83,7 @@ class PluginsMenu(NapariMenu):
         else:
             menu = self
 
-        for wdg_name in widgets:
+        for wdg_name in sorted(widgets):
             key = (plugin_name, wdg_name)
             if multiprovider:
                 action = QAction(wdg_name.replace("&", "&&"), parent=self)

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -428,8 +428,20 @@ class NapariPluginManager(PluginManager):
     def iter_widgets(self) -> Iterator[Tuple[str, Tuple[str, Dict[str, Any]]]]:
         from itertools import chain, repeat
 
-        dock_widgets = zip(repeat("dock"), self._dock_widgets.items())
-        func_widgets = zip(repeat("func"), self._function_widgets.items())
+        dock_widgets = zip(
+            repeat("dock"),
+            (
+                (name, sorted(cont))
+                for name, cont in self._dock_widgets.items()
+            ),
+        )
+        func_widgets = zip(
+            repeat("func"),
+            (
+                (name, sorted(cont))
+                for name, cont in self._function_widgets.items()
+            ),
+        )
         yield from chain(dock_widgets, func_widgets)
 
     def register_dock_widget(

--- a/napari/plugins/_plugin_manager.py
+++ b/napari/plugins/_plugin_manager.py
@@ -428,6 +428,11 @@ class NapariPluginManager(PluginManager):
     def iter_widgets(self) -> Iterator[Tuple[str, Tuple[str, Dict[str, Any]]]]:
         from itertools import chain, repeat
 
+        # The content of contribution dictionaries is name of plugin and
+        # list of its names of widgets contributed by this plugin
+        # as this order do not depend on the order of contributions in file
+        # we sort it to make it easier searchable.
+
         dock_widgets = zip(
             repeat("dock"),
             (


### PR DESCRIPTION
# Description

For npe2 plugins, widget contributions are sorted in the menu bar according to the order in the napari.yaml. For npe1 plugins, however, they are more or less randomly ordered. This PR sorts npe1 widget contributions alphabetically to make them easier to find.

Before:
![image](https://github.com/napari/napari/assets/3826210/eb3601c1-1325-4484-967c-c9c6223d74cb)

After:
![image](https://github.com/napari/napari/assets/3826210/60fb10f0-9073-47f9-9d5f-f56f1022fdce)
