### PR TITLE
Use a nightly pypi index for numpy & scipy, used by the --pre build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -88,6 +88,10 @@ extras =
     testing
     pyqt5: pyqt5
     pyside2: pyside2
+indexserver =
+    # we use Spec 4 index server that contain nightly wheel.
+    # this will be used only when using --pre with tox/pip as it only contains nightly.
+    extra = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 commands_pre =
     # strictly only need to uninstall pytest-qt (which will raise without a backend)
     # the rest is for good measure


### PR DESCRIPTION
This should contain nightly wheels for at least IPython/SciPy/NumPy, and may help catch bugs early.

this adds an extra index, and this index should contain only prereleases. Thus unless you pass `--pre` it will have no effect, and so far only the `.github/workflows/test_prereleases.yml` workflow does use `--pre`, so in practice that only affects this workflow.