### PR TITLE
Remove pycln (redundant with ruff F401 rule)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,4 @@
 repos:
--   repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.3
-    hooks:
-    - id: pycln
 -   repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:


### PR DESCRIPTION
# Fixes/Closes

<!-- In general, PRs should fix an existing issue on the repo. -->
<!-- Please link to that issue here as "Closes #(issue-number)". -->

As ruff F401 rule is already removing unused imports, then pycln is redundant so I think it is best to remove it. 

https://github.com/napari/cookiecutter-napari-plugin/pull/144 

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Maintenence 
