### PR TITLE
Add `__all__` to `napari/types.py`

### DIFF
--- a/napari/types.py
+++ b/napari/types.py
@@ -30,6 +30,32 @@ if TYPE_CHECKING:
     from qtpy.QtWidgets import QWidget  # type: ignore [attr-defined]
 
 
+__all__ = [
+    'ArrayLike',
+    'LayerTypeName',
+    'FullLayerData',
+    'LayerData',
+    'PathLike',
+    'PathOrPaths',
+    'ReaderFunction',
+    'WriterFunction',
+    'ExcInfo',
+    'WidgetCallable',
+    'AugmentedWidget',
+    'SampleData',
+    'SampleDict',
+    'ArrayBase',
+    'ImageData',
+    'LabelsData',
+    'PointsData',
+    'ShapesData',
+    'SurfaceData',
+    'TracksData',
+    'VectorsData',
+    'LayerDataTuple',
+    'image_reader_to_layerdata_reader',
+]
+
 # This is a WOEFULLY inadequate stub for a duck-array type.
 # Mostly, just a placeholder for the concept of needing an ArrayLike type.
 # Ultimately, this should come from https://github.com/napari/image-types


### PR DESCRIPTION
# Fixes/Closes
Fixes https://github.com/napari/docs/issues/170

# Description
This adds `__all__` to `napari/types.py`, to prevent imports from being documented in the API reference.

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] checked the built docs on this PR, and they don't contain reference entries for imported objects

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
