### PR TITLE
Add `__all__` to qthreading and progress

### DIFF
--- a/napari/_qt/qthreading.py
+++ b/napari/_qt/qthreading.py
@@ -19,6 +19,14 @@ from typing_extensions import ParamSpec
 from napari.utils.progress import progress
 from napari.utils.translations import trans
 
+__all__ = [
+    "FunctionWorker",
+    "GeneratorWorker",
+    "create_worker",
+    "thread_worker",
+    "register_threadworker_processors",
+]
+
 wait_for_workers_to_quit = _qthreading.WorkerBase.await_workers
 
 

--- a/napari/utils/progress.py
+++ b/napari/utils/progress.py
@@ -7,6 +7,8 @@ from napari.utils.events.containers import EventedSet
 from napari.utils.events.event import EmitterGroup, Event
 from napari.utils.translations import trans
 
+__all__ = ["progress", "progrange", "cancelable_progress"]
+
 
 class progress(tqdm):
     """This class inherits from tqdm and provides an interface for


### PR DESCRIPTION
# Fixes/Closes

Should fix a large chunk of the third task in https://github.com/napari/docs/issues/111, which is:

> Warnings about docstrings from imported members: there are a few warnings about functools.partial or tqdm, which are created when those docstrings are injected into the napari sphinx docs.

cc @melissawm 

# Description
This adds `__all__` to two sub-modules, so sphinx does not try and document all the external imports in the documentation.

# References

## Type of change

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

- [x] checked the CI doc build, and the number of warnings decreased from 338 on current main to 264 on this PR
- [x] existing tests pass.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
