### PR TITLE
ENH: Use dict to set `MenuID` in view actions

### DIFF
--- a/napari/_app_model/actions/_view_actions.py
+++ b/napari/_app_model/actions/_view_actions.py
@@ -41,7 +41,6 @@ def _tooltip_visibility_toggle():
     settings.layer_tooltip_visibility = not settings.layer_tooltip_visibility
 
 
-# this can be generalised for all boolean settings, similar to `ViewerToggleAction`
 def _get_current_tooltip_visibility():
     return get_settings().appearance.layer_tooltip_visibility
 

--- a/napari/_app_model/actions/_view_actions.py
+++ b/napari/_app_model/actions/_view_actions.py
@@ -13,6 +13,7 @@ from napari._app_model.constants import CommandId, MenuId
 from napari.settings import get_settings
 
 VIEW_ACTIONS: List[Action] = []
+MENUID_DICT = {'axes': MenuId.VIEW_AXES, 'scale_bar': MenuId.VIEW_SCALEBAR}
 
 for cmd, viewer_attr, sub_attr in (
     (CommandId.TOGGLE_VIEWER_AXES, 'axes', 'visible'),
@@ -24,14 +25,13 @@ for cmd, viewer_attr, sub_attr in (
     (CommandId.TOGGLE_VIEWER_SCALE_BAR_COLORED, 'scale_bar', 'colored'),
     (CommandId.TOGGLE_VIEWER_SCALE_BAR_TICKS, 'scale_bar', 'ticks'),
 ):
-    menu = MenuId.VIEW_AXES if viewer_attr == 'axes' else MenuId.VIEW_SCALEBAR
     VIEW_ACTIONS.append(
         ViewerToggleAction(
             id=cmd,
             title=cmd.title,
             viewer_attribute=viewer_attr,
             sub_attribute=sub_attr,
-            menus=[{'id': menu}],
+            menus=[{'id': MENUID_DICT[viewer_attr]}],
         )
     )
 


### PR DESCRIPTION
# Fixes/Closes

<!-- In general, PRs should fix an existing issue on the repo. -->
<!-- Please link to that issue here as "Closes #(issue-number)". -->


# Description
As suggested in: https://github.com/napari/napari/pull/4826/files#r960919440 , uses a dictionary to set `MenuID`

This seems a cleaner and as mentioned by Kira allows us to easily add another menu item.

Saw this when working on the app model menubar PRs and just wanted to do it before I forget, and old comments get lost.

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
