### PR TITLE
[Maint] CI: Use `RUNNER_OS` instead of `PLATFORM`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,14 +33,10 @@ fail_on_no_env = True
 # with an environment variable of BACKEND=pyqt would be converted to a
 # tox env of `py39-linux-pyqt5`
 [gh-actions:env]
-PLATFORM =
-    ubuntu-latest: linux
-    ubuntu-16.04: linux
-    ubuntu-18.04: linux
-    ubuntu-20.04: linux
-    windows-latest: windows
-    macos-latest: macos
-    macos-11: macos
+RUNNER_OS =
+    Linux: linux
+    Windows: windows
+    macOS: macos
 BACKEND =
     pyqt5: pyqt5
     pyqt6: pyqt6


### PR DESCRIPTION
# Description

Simplify configuration and reduce future maintenance,
when new os versions are added/removed from workflows in
`.github/workflow/test*.yml`, the tox file does not
need to be updated accordingly. 

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
