### PR TITLE
feat: add `since_version` argument of `rename_argument` decorator

### DIFF
--- a/napari/_qt/widgets/qt_progress_bar.py
+++ b/napari/_qt/widgets/qt_progress_bar.py
@@ -50,8 +50,8 @@ class QtLabeledProgressBar(QWidget):
 
         self.setLayout(base_layout)
 
-    @rename_argument("min", "min_val", "0.6.0")
-    @rename_argument("max", "max_val", "0.6.0")
+    @rename_argument("min", "min_val", "0.6.0", "0.4.18")
+    @rename_argument("max", "max_val", "0.6.0", "0.4.18")
     def setRange(self, min_val, max_val):
         self.qt_progress_bar.setRange(min_val, max_val)
 

--- a/napari/_qt/widgets/qt_progress_bar.py
+++ b/napari/_qt/widgets/qt_progress_bar.py
@@ -50,8 +50,8 @@ class QtLabeledProgressBar(QWidget):
 
         self.setLayout(base_layout)
 
-    @rename_argument("min", "min_val", "0.6.0", "0.4.18")
-    @rename_argument("max", "max_val", "0.6.0", "0.4.18")
+    @rename_argument(from_name="min", to_name="min_val", version="0.6.0", since_version="0.4.18")
+    @rename_argument(from_name="max", to_name="max_val", version="0.6.0", since_version="0.4.18")
     def setRange(self, min_val, max_val):
         self.qt_progress_bar.setRange(min_val, max_val)
 

--- a/napari/_qt/widgets/qt_progress_bar.py
+++ b/napari/_qt/widgets/qt_progress_bar.py
@@ -50,8 +50,18 @@ class QtLabeledProgressBar(QWidget):
 
         self.setLayout(base_layout)
 
-    @rename_argument(from_name="min", to_name="min_val", version="0.6.0", since_version="0.4.18")
-    @rename_argument(from_name="max", to_name="max_val", version="0.6.0", since_version="0.4.18")
+    @rename_argument(
+        from_name="min",
+        to_name="min_val",
+        version="0.6.0",
+        since_version="0.4.18",
+    )
+    @rename_argument(
+        from_name="max",
+        to_name="max_val",
+        version="0.6.0",
+        since_version="0.4.18",
+    )
     def setRange(self, min_val, max_val):
         self.qt_progress_bar.setRange(min_val, max_val)
 

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -681,7 +681,12 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         self.layers.append(layer)
         return layer
 
-    @rename_argument(from_name="interpolation", to_name="interpolation2d", version="0.6.0", since_version="0.4.17")
+    @rename_argument(
+        from_name="interpolation",
+        to_name="interpolation2d",
+        version="0.6.0",
+        since_version="0.4.17",
+    )
     def add_image(
         self,
         data=None,

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -681,7 +681,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         self.layers.append(layer)
         return layer
 
-    @rename_argument("interpolation", "interpolation2d", "0.6.0")
+    @rename_argument("interpolation", "interpolation2d", "0.6.0", "0.4.17")
     def add_image(
         self,
         data=None,

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -681,7 +681,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         self.layers.append(layer)
         return layer
 
-    @rename_argument("interpolation", "interpolation2d", "0.6.0", "0.4.17")
+    @rename_argument(from_name="interpolation", to_name="interpolation2d", version="0.6.0", since_version="0.4.17")
     def add_image(
         self,
         data=None,

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -223,8 +223,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
     """
 
     _colormaps = AVAILABLE_COLORMAPS
-
-    @rename_argument("interpolation", "interpolation2d", "0.6.0", "0.4.17")
+    @rename_argument(from_name="interpolation", to_name="interpolation2d", version="0.6.0", since_version="0.4.17")
     def __init__(
         self,
         data,

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -223,7 +223,13 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
     """
 
     _colormaps = AVAILABLE_COLORMAPS
-    @rename_argument(from_name="interpolation", to_name="interpolation2d", version="0.6.0", since_version="0.4.17")
+
+    @rename_argument(
+        from_name="interpolation",
+        to_name="interpolation2d",
+        version="0.6.0",
+        since_version="0.4.17",
+    )
     def __init__(
         self,
         data,

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -224,7 +224,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
 
     _colormaps = AVAILABLE_COLORMAPS
 
-    @rename_argument("interpolation", "interpolation2d", "0.6.0")
+    @rename_argument("interpolation", "interpolation2d", "0.6.0", "0.4.17")
     def __init__(
         self,
         data,

--- a/napari/utils/_tests/test_migrations.py
+++ b/napari/utils/_tests/test_migrations.py
@@ -4,7 +4,7 @@ from napari.utils.migrations import rename_argument
 
 
 def test_simple():
-    @rename_argument("a", "b", "1")
+    @rename_argument("a", "b", "1", "0.5")
     def sample_fun(b):
         return b
 
@@ -18,7 +18,7 @@ def test_simple():
 
 def test_constructor():
     class Sample:
-        @rename_argument("a", "b", "1")
+        @rename_argument("a", "b", "1", "0.5")
         def __init__(self, b) -> None:
             self.b = b
 

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -100,7 +100,12 @@ class Event:
         All extra keyword arguments become attributes of the event object.
     """
 
-    @rename_argument(from_name="type", to_name="type_name", version="0.6.0", since_version="0.4.18")
+    @rename_argument(
+        from_name="type",
+        to_name="type_name",
+        version="0.6.0",
+        since_version="0.4.18",
+    )
     def __init__(
         self, type_name: str, native: Any = None, **kwargs: Any
     ) -> None:

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -100,7 +100,7 @@ class Event:
         All extra keyword arguments become attributes of the event object.
     """
 
-    @rename_argument("type", "type_name", "0.6.0")
+    @rename_argument("type", "type_name", "0.6.0", "0.4.18")
     def __init__(
         self, type_name: str, native: Any = None, **kwargs: Any
     ) -> None:
@@ -278,7 +278,7 @@ class EventEmitter:
         The class of events that this emitter will generate.
     """
 
-    @rename_argument("type", "type_name", "0.6.0")
+    @rename_argument("type", "type_name", "0.6.0", "0.4.18")
     def __init__(
         self,
         source: Any = None,

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -100,7 +100,7 @@ class Event:
         All extra keyword arguments become attributes of the event object.
     """
 
-    @rename_argument("type", "type_name", "0.6.0", "0.4.18")
+    @rename_argument(from_name="type", to_name="type_name", version="0.6.0", since_version="0.4.18")
     def __init__(
         self, type_name: str, native: Any = None, **kwargs: Any
     ) -> None:

--- a/napari/utils/migrations.py
+++ b/napari/utils/migrations.py
@@ -4,7 +4,9 @@ from functools import wraps
 from napari.utils.translations import trans
 
 
-def rename_argument(from_name: str, to_name: str, version: str):
+def rename_argument(
+    from_name: str, to_name: str, version: str, since_version: str = "unknown"
+):
     """
     This is decorator for simple rename function argument
     without break backward compatibility.
@@ -17,6 +19,8 @@ def rename_argument(from_name: str, to_name: str, version: str):
         new name of argument
     version : str
         version when old argument will be removed
+    since_version : str
+        version when new argument was added
     """
 
     def _wrapper(func):
@@ -33,10 +37,11 @@ def rename_argument(from_name: str, to_name: str, version: str):
                     )
                 warnings.warn(
                     trans._(
-                        "Argument {from_name} is deprecated, please use {to_name} instead. It will be removed in {version}.",
+                        "Argument {from_name} is deprecated, please use {to_name} instead. The argument {from_name} was deprecated in {since_version} and it will be removed in {version}.",
                         from_name=from_name,
                         to_name=to_name,
                         version=version,
+                        since_version=since_version,
                     ),
                     category=DeprecationWarning,
                     stacklevel=2,

--- a/napari/utils/migrations.py
+++ b/napari/utils/migrations.py
@@ -5,7 +5,7 @@ from napari.utils.translations import trans
 
 
 def rename_argument(
-    from_name: str, to_name: str, version: str, since_version: str = None
+    from_name: str, to_name: str, version: str, since_version: str = ""
 ):
     """
     This is decorator for simple rename function argument
@@ -23,7 +23,7 @@ def rename_argument(
         version when new argument was added
     """
 
-    if since_version is None:
+    if not since_version:
         since_version = "unknown"
         warnings.warn(
             "The since_version argument was added in napari 0.4.18 and will be mandatory since 0.6.0 release.",

--- a/napari/utils/migrations.py
+++ b/napari/utils/migrations.py
@@ -37,7 +37,7 @@ def rename_argument(
                     )
                 warnings.warn(
                     trans._(
-                        "Argument {from_name} is deprecated, please use {to_name} instead. The argument {from_name} was deprecated in {since_version} and it will be removed in {version}.",
+                        "Argument {from_name!r} is deprecated, please use {to_name!r} instead. The argument {from_name!r} was deprecated in {since_version} and it will be removed in {version}.",
                         from_name=from_name,
                         to_name=to_name,
                         version=version,

--- a/napari/utils/migrations.py
+++ b/napari/utils/migrations.py
@@ -5,7 +5,7 @@ from napari.utils.translations import trans
 
 
 def rename_argument(
-    from_name: str, to_name: str, version: str, since_version: str = "unknown"
+    from_name: str, to_name: str, version: str, since_version: str = None
 ):
     """
     This is decorator for simple rename function argument
@@ -22,6 +22,10 @@ def rename_argument(
     since_version : str
         version when new argument was added
     """
+
+    if since_version is None:
+        since_version = "unknown"
+        warnings.warn("The since_version argument was added in napari 0.4.18 and will be mandatory since 0.6.0 release.", stacklevel=2, category=FutureWarning)
 
     def _wrapper(func):
         @wraps(func)

--- a/napari/utils/migrations.py
+++ b/napari/utils/migrations.py
@@ -25,7 +25,11 @@ def rename_argument(
 
     if since_version is None:
         since_version = "unknown"
-        warnings.warn("The since_version argument was added in napari 0.4.18 and will be mandatory since 0.6.0 release.", stacklevel=2, category=FutureWarning)
+        warnings.warn(
+            "The since_version argument was added in napari 0.4.18 and will be mandatory since 0.6.0 release.",
+            stacklevel=2,
+            category=FutureWarning,
+        )
 
     def _wrapper(func):
         @wraps(func)


### PR DESCRIPTION
# Description

In this PR, the `since_version` argument is added to the `rename_argument` decorator to inform the plugin author in which version of napari the change has been made. 
This allows the plugin author to manage plugin compatibility in a better way.  

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change


## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality

