### PR TITLE
Multi-canvas experiments

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -215,6 +215,7 @@ class QtViewer(QSplitter):
         main_widget.setLayout(main_layout)
 
         self.setOrientation(Qt.Orientation.Vertical)
+        self._main_widget = main_widget
         self.addWidget(main_widget)
 
         self.viewer._layer_slicer.events.ready.connect(self._on_slice_ready)
@@ -227,6 +228,8 @@ class QtViewer(QSplitter):
         )
 
         self.viewer.layers.events.inserted.connect(self._on_add_layer_change)
+
+        self.viewer._canvases.events.connect(self._multi_canvas_change)
 
         self.setAcceptDrops(True)
 
@@ -293,6 +296,15 @@ class QtViewer(QSplitter):
             stacklevel=2,
         )
         return self.canvas.camera
+
+    def _multi_canvas_change(self, event):
+        print("YOOOO from qt_viewer")
+        old_dims = self.dims
+        # TODO - update the QtDims instead of creating a new one?
+        self.dims = QtDims(self.viewer.dims)
+        self._main_widget.layout().replaceWidget(old_dims, self.dims)
+        old_dims.stop()
+        old_dims.deleteLater()
 
     @staticmethod
     def _update_dask_cache_settings(

--- a/napari/_qt/widgets/qt_dims.py
+++ b/napari/_qt/widgets/qt_dims.py
@@ -58,7 +58,7 @@ class QtDims(QWidget):
         self._update_nsliders()
         self.dims.events.ndim.connect(self._update_nsliders)
         self.dims.events.current_step.connect(self._update_slider)
-        self.dims.events.range.connect(self._update_range)
+        self.dims.events.range.connect(self._update_nsliders)
         self.dims.events.ndisplay.connect(self._update_display)
         self.dims.events.order.connect(self._update_display)
         self.dims.events.last_used.connect(self._on_last_used_changed)

--- a/napari/_vispy/camera.py
+++ b/napari/_vispy/camera.py
@@ -34,8 +34,9 @@ class VispyCamera:
         self._3D_camera = MouseToggledArcballCamera(fov=0)
         self._3D_camera.viewbox_key_event = viewbox_key_event
 
-        # Set 2D camera by default
-        self._view.camera = self._2D_camera
+        self._view.camera = (
+            self._2D_camera if self._dims.ndisplay == 2 else self._3D_camera
+        )
 
         self._dims.events.ndisplay.connect(
             self._on_ndisplay_change, position='first'

--- a/napari/_vispy/canvas.py
+++ b/napari/_vispy/canvas.py
@@ -158,6 +158,17 @@ class VispyCanvas:
         self.viewer.layers.events.removed.connect(self._remove_layer)
         self.destroyed.connect(self._disconnect_theme)
 
+        self.viewer._canvases.events.connect(self._multi_canvas_change)
+
+    def _multi_canvas_change(self, event):
+        print("YOOOO from vispy canvas")
+        self.camera = VispyCamera(
+            self.view, self.viewer.camera, self.viewer.dims
+        )
+        self.viewer.camera.events.interactive.connect(self._on_interactive)
+        self.viewer.camera.events.zoom.connect(self._on_cursor)
+        self._scene_canvas.events.draw.connect(self.camera.on_draw)
+
     @property
     def destroyed(self) -> pyqtBoundSignal:
         return self._scene_canvas._backend.destroyed

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -432,6 +432,7 @@ class Dims(EventedModel):
 
     def _go_to_center_step(self):
         self.current_step = [int((ns - 1) / 2) for ns in self.nsteps]
+        print("go to center step", self.current_step)
 
     def _sanitize_input(
         self, axis, value, value_is_sequence=False

--- a/napari/utils/events/containers/_evented_list.py
+++ b/napari/utils/events/containers/_evented_list.py
@@ -364,3 +364,11 @@ class EventedList(TypedMutableSequence[_T]):
         # it would just emit a "changed" event for each moved index in the list
         self._list.reverse()
         self.events.reordered(value=self)
+
+    def shift_left(self) -> None:
+        self._list.append(self._list.pop(0))
+        self.events.reordered(value=self)
+
+    def shift_right(self) -> None:
+        self._list.insert(0, self._list.pop())
+        self.events.reordered(value=self)


### PR DESCRIPTION
This is an experiment in napari multi-canvas with an attempt to minimize breaking API changes. Tests are _almost_ green!

There are some hacks and inefficiencies here, but in general it's working. The idea is you get a list of canvases (`_MultiCanvas` objects) as part of the `ViewerModel`. These canvases take ownership of the `dims` and `camera`, allowing you to have multiple views of the same data.

`ViewerModel` maintains `dims` and `camera` properties that simply delegate to a primary/active (right now just the first) canvas.

Since slice/view data currently lives _on_ the layer model, the data must be resliced whenever the canvas changes. I'm going to start looking at this next.

Here's a brief demo:

https://github.com/napari/napari/assets/1231828/85dd0a7c-a039-421d-943d-6167adb12425