### PR TITLE
Fix typo in resources/requirements_mypy.in file name

### DIFF
--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -76,7 +76,7 @@ jobs:
           done
 
           python3.9 -m piptools compile --upgrade -o resources/constraints/constraints_py3.9_examples.txt setup.cfg resources/constraints/version_denylist.txt resources/constraints/version_denylist_examples.txt ${flags}
-          python3.11 -m piptools compile --upgrade -o resources/requirements_mypy.txt resources/requirements_mypy.ini --resolver=backtracking
+          python3.11 -m piptools compile --upgrade -o resources/requirements_mypy.txt resources/requirements_mypy.in --resolver=backtracking
 
       # END PYTHON DEPENDENCIES
 


### PR DESCRIPTION
# Description
I apologize that in #5919 I wrongly put file extension (`.ini` instead of `.in`).



## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

