### PR TITLE
TEST: Fixture to "uncreate" IPython.

### DIFF
--- a/napari/_qt/_tests/test_app.py
+++ b/napari/_qt/_tests/test_app.py
@@ -33,6 +33,10 @@ def test_windows_grouping_overwrite(qapp):
 
 def test_run_outside_ipython(qapp, monkeypatch):
     """Test that we don't incorrectly give ipython the event loop."""
+    from IPython.core.interactiveshell import InteractiveShell
+
+    InteractiveShell._instance = None
+
     assert not _ipython_has_eventloop()
     v1 = Viewer(show=False)
     assert not _ipython_has_eventloop()

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -46,7 +46,7 @@ def test_qt_viewer(make_napari_viewer):
     assert np.sum(view.dims._displayed_sliders) == 0
 
 
-def test_qt_viewer_with_console(make_napari_viewer):
+def test_qt_viewer_with_console(make_napari_viewer, dangerous_destroy_ipython):
     """Test instantiating console from viewer."""
     viewer = make_napari_viewer()
     view = viewer.window._qt_viewer

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -737,6 +737,25 @@ def dangling_qanimations(monkeypatch, request):
     )
 
 
+@pytest.fixture
+def dangerous_destroy_ipython():
+    """
+    Use this fixture for your test if you want for the test to exit as if IPython was not loaded.
+    """
+    loaded_mods = [k for k in sys.modules if k.startswith('IPython')]
+
+    yield
+    from IPython.core.interactiveshell import InteractiveShell
+
+    InteractiveShell._instance = None
+
+    mods = list(sys.modules.keys())
+
+    for mod_name in mods:
+        if mod_name.startswith('IPython') and mod_name not in loaded_mods:
+            del sys.modules[mod_name]
+
+
 def pytest_runtest_setup(item):
     if "qapp" in item.fixturenames:
         # here we do autouse for dangling fixtures only if qapp is used

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -757,6 +757,8 @@ def dangerous_destroy_ipython():
 
 
 def pytest_runtest_setup(item):
+    if 'dangerous_destroy_ipython' not in item.fixturenames:
+        item.fixturenames.append('dangerous_destroy_ipython')
     if "qapp" in item.fixturenames:
         # here we do autouse for dangling fixtures only if qapp is used
         if "qtbot" not in item.fixturenames:


### PR DESCRIPTION
As pointed out by #5886 we should not rely on test ordering and test that create and IPython instance should try to destroy it.

This is my attempt at doing this.

It's not perfect, and need explict use but can be the start of a proper fixture.

We could have an autouse fixture that make sure
InteractiveShell._instance is None at the end of every test to make sure all is properly cleaned. I'm not sure it's worth it.
