### PR TITLE
MAINT: GitHub action Timeout increased by 5 minutes

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -144,7 +144,7 @@ jobs:
       # see tox.ini for more
       - name: Test with tox
         # the longest is macos-latest 3.9 pyqt5 at ~30 minutes.
-        timeout-minutes: 35
+        timeout-minutes: 40
         uses: aganders3/headless-gui@v1
         with:
           run: python -m tox


### PR DESCRIPTION
The timeout is currently 35 minutes. The macos-latest Python-3.9 pyqt5 run-time is one of the slower one, close to the limit. Some of the recent PRs where this item is passing run in almost 35 minutes. E.g PR 5926 in 33m 26s

It's not unexpected to have variation of the time that would put us above the threshold of 35 minutes.

The timeout was added as some builds were stalling for 6 hours, but failing at the 35 minute mark does not seems like representative of stalling.

Thus bumping to 40 minutes.

Ideally it would be good to have a larger timeout only on macos platform, but I don't believe timeout-minutes supports expression.
