### PR TITLE
Add Python 3.11 trove classifier.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Visualization
     Topic :: Scientific/Engineering :: Information Analysis


### PR DESCRIPTION
Should we maybe remove `Development Status :: 3 - Alpha` as well ?