### PR TITLE
Set removal version in deprecation of Viewer.rounded_division

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -448,9 +448,9 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
     def rounded_division(min_val, max_val, precision):
         warnings.warn(
             trans._(
-                'Viewer.rounded_division is deprecated since v0.4.18 and will soon be removed.'
+                'Viewer.rounded_division is deprecated since v0.4.18 and will be removed in 0.6.0.'
             ),
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
         return int(((min_val + max_val) / 2) / precision) * precision


### PR DESCRIPTION
# Description
Fix message about deprecation to inform about removal version. 

# References


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Documentation

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
