### PR TITLE
Fix `napari-svg` version parsing in `conftest.py`

### DIFF
--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -48,6 +48,7 @@ import dask.threaded
 import numpy as np
 import pytest
 from IPython.core.history import HistoryManager
+from packaging.version import parse as parse_version
 
 from napari.components import LayerList
 from napari.layers import Image, Labels, Points, Shapes, Vectors
@@ -314,9 +315,9 @@ HistoryManager.enabled = False
 @pytest.fixture
 def napari_svg_name():
     """the plugin name changes with npe2 to `napari-svg` from `svg`."""
-    from importlib.metadata import metadata
+    from importlib.metadata import version
 
-    if tuple(metadata('napari-svg')['Version'].split('.')) < ('0', '1', '6'):
+    if parse_version(parse_version("napari-svg")) < parse_version('0.1.6'):
         return 'svg'
 
     return 'napari-svg'

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -317,7 +317,7 @@ def napari_svg_name():
     """the plugin name changes with npe2 to `napari-svg` from `svg`."""
     from importlib.metadata import version
 
-    if parse_version(parse_version('napari-svg')) < parse_version('0.1.6'):
+    if parse_version(version('napari-svg')) < parse_version('0.1.6'):
         return 'svg'
 
     return 'napari-svg'

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -317,7 +317,7 @@ def napari_svg_name():
     """the plugin name changes with npe2 to `napari-svg` from `svg`."""
     from importlib.metadata import version
 
-    if parse_version(parse_version("napari-svg")) < parse_version('0.1.6'):
+    if parse_version(parse_version('napari-svg')) < parse_version('0.1.6'):
         return 'svg'
 
     return 'napari-svg'


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Fixes problem with parsing `napari-svg` version as `("0", "1", "10") < ("0", "1", "6")` because of using lexicographical compression.  

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
