### PR TITLE
Fix issue in utils.progress for disable=True

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -103,5 +103,9 @@ authors:
 - given-names: Abigail
   family-names: McGovern
   affiliation: Monash University
+- given-names: Constantin
+  family-names: Pape
+  affiliation: Georg-August-Universität Göttingen
+  orcid: "https://orcid.org/0000-0001-6562-7187"
 repository-code: https://github.com/napari/napari
 license: BSD-3-Clause

--- a/napari/utils/_tests/test_progress.py
+++ b/napari/utils/_tests/test_progress.py
@@ -88,6 +88,16 @@ def test_progress_set_description():
     assert pbr not in progress._all_instances
 
 
+def test_progress_set_disable():
+    """Test that the progress bar does not throw an attribute error when it is disabled."""
+    # before the changes in #5964 this failed with an AttributeError, because self.desc was not
+    # set in the super constructor of tqdm
+    pbr = progress(total=5, disable=True, desc="This description will not be set by tqdm.")
+    # make sure the dummy desscription (empty string) was set
+    assert pbr.desc == ""
+    pbr.close()
+
+
 def test_progrange():
     """Test progrange shorthand for progress(range(n))"""
     with progrange(10) as pbr, progress(range(10)) as pbr2:

--- a/napari/utils/_tests/test_progress.py
+++ b/napari/utils/_tests/test_progress.py
@@ -96,7 +96,7 @@ def test_progress_set_disable():
         total=5, disable=True, desc="This description will not be set by tqdm."
     )
     # make sure the dummy desscription (empty string) was set
-    assert pbr.desc == "progress"
+    assert pbr.desc == "progress: "
     pbr.close()
 
 

--- a/napari/utils/_tests/test_progress.py
+++ b/napari/utils/_tests/test_progress.py
@@ -96,7 +96,7 @@ def test_progress_set_disable():
         total=5, disable=True, desc="This description will not be set by tqdm."
     )
     # make sure the dummy desscription (empty string) was set
-    assert pbr.desc == ""
+    assert pbr.desc == "progress"
     pbr.close()
 
 

--- a/napari/utils/_tests/test_progress.py
+++ b/napari/utils/_tests/test_progress.py
@@ -92,7 +92,9 @@ def test_progress_set_disable():
     """Test that the progress bar does not throw an attribute error when it is disabled."""
     # before the changes in #5964 this failed with an AttributeError, because self.desc was not
     # set in the super constructor of tqdm
-    pbr = progress(total=5, disable=True, desc="This description will not be set by tqdm.")
+    pbr = progress(
+        total=5, disable=True, desc="This description will not be set by tqdm."
+    )
     # make sure the dummy desscription (empty string) was set
     assert pbr.desc == ""
     pbr.close()

--- a/napari/utils/progress.py
+++ b/napari/utils/progress.py
@@ -85,6 +85,10 @@ class progress(tqdm):
         self.is_init = True
         super().__init__(iterable, desc, total, *args, **kwargs)
 
+        # if the progress bar is set to disable the 'desc' member is not set by the
+        # tqdm super constructor, so we set it to a dummy value to avoid errors thrown below
+        if self.disable:
+            self.desc = ""
         if not self.desc:
             self.set_description(trans._("progress"))
         progress._all_instances.add(self)


### PR DESCRIPTION
# Fixes/Closes

Closes #5961

# Description and references

This PR changes the `progress.__init__` such that if the progress bar is disabled, the 'desc' property is set to a dummy value, because otherwise it is not set by the tqdm super constructor and throws an error.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
I checked locally that this test fixes this code:
```python
# from tqdm import tqdm
from napari.utils import progress as tqdm

for z in tqdm(range(10), total=10, desc="Count to 10", disable=True):
    pass
```
which throws an `AttributeError` without the fix.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
