### PR TITLE
Bugfix: Ensure bgcolor is set in __init__ of VispyCanvas

### DIFF
--- a/napari/_vispy/canvas.py
+++ b/napari/_vispy/canvas.py
@@ -23,6 +23,7 @@ from napari.utils.interactions import (
     mouse_release_callbacks,
     mouse_wheel_callbacks,
 )
+from napari.utils.theme import get_theme
 
 if TYPE_CHECKING:
     from typing import Callable, List, Optional, Tuple, Union
@@ -115,6 +116,10 @@ class VispyCanvas:
         self._overlay_to_visual = {}
         self._key_map_handler = key_map_handler
         self._instances.add(self)
+
+        self.bgcolor = transform_color(
+            get_theme(self.viewer.theme).canvas.as_hex()
+        )[0]
 
         # Call get_max_texture_sizes() here so that we query OpenGL right
         # now while we know a Canvas exists. Later calls to


### PR DESCRIPTION
# Fixes/Closes

Closes https://github.com/napari/napari/issues/5969

# Description

This PR sets the canvas color (`bgcolor`) in VispyCanvas `__init__` to ensure that on launch the canvas matches the theme.

# References
This broke in PR: https://github.com/napari/napari/pull/5432 which has 0.5.0 milestone.

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
