### PR TITLE
Fix behavior of PublicOnlyProxy in setattr, wrapped methods, and calling

### DIFF
--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -173,7 +173,7 @@ class CallablePublicOnlyProxy(PublicOnlyProxy[Callable]):
             k: v.__wrapped__ if isinstance(v, PublicOnlyProxy) else v
             for k, v in kwargs.items()
         }
-        return self.__wrapped__(*args, **kwargs)
+        return self.create(self.__wrapped__(*args, **kwargs))
 
 
 def in_main_thread_py() -> bool:

--- a/napari/utils/_tests/test_proxies.py
+++ b/napari/utils/_tests/test_proxies.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from unittest.mock import patch
 
 import numpy as np
@@ -5,6 +6,7 @@ import pytest
 
 from napari.components.viewer_model import ViewerModel
 from napari.utils._proxies import PublicOnlyProxy, ReadOnlyWrapper
+from napari.utils.events.containers._set import EventedSet
 
 
 def test_ReadOnlyWrapper_setitem():
@@ -135,3 +137,28 @@ def test_receive_return_proxy_object():
 def test_viewer_method():
     viewer = PublicOnlyProxy(ViewerModel())
     assert viewer.add_points() is not None
+
+
+def test_unwrap_on_call():
+    s = EventedSet()
+    p_s = PublicOnlyProxy(s)
+    text = "aaa"
+    p_text = PublicOnlyProxy(text)
+    p_s.add(p_text)
+
+    assert id(text) == id(list(s)[0])
+
+
+def test_unwrap_setattr():
+    @dataclass
+    class Sample:
+        a = "aaa"
+
+    s = Sample()
+    p_s = PublicOnlyProxy(s)
+
+    text = "bbb"
+    p_text = PublicOnlyProxy(text)
+
+    p_s.a = p_text
+    assert id(text) == id(s.a)

--- a/napari/utils/_tests/test_proxies.py
+++ b/napari/utils/_tests/test_proxies.py
@@ -140,25 +140,39 @@ def test_viewer_method():
 
 
 def test_unwrap_on_call():
-    s = EventedSet()
-    p_s = PublicOnlyProxy(s)
+    """Check that PublicOnlyProxy'd arguments to methods of a
+    PublicOnlyProxy'd object are unwrapped before calling the method.
+    """
+    evset = EventedSet()
+    public_only_evset = PublicOnlyProxy(evset)
     text = "aaa"
-    p_text = PublicOnlyProxy(text)
-    p_s.add(p_text)
+    wrapped_text = PublicOnlyProxy(text)
+    public_only_evset.add(wrapped_text)
+    retrieved_text = list(evset)[0]
 
-    assert id(text) == id(list(s)[0])
+    # check that the text in the set is not the version wrapped with
+    # PublicOnlyProxy
+    assert id(text) == id(retrieved_text)
 
 
 def test_unwrap_setattr():
+    """Check that objects added with __setattr__ of an object wrapped with
+    PublicOnlyProxy are unwrapped before setting the attribute.
+    """
+
     @dataclass
     class Sample:
-        a = "aaa"
+        attribute = "aaa"
 
-    s = Sample()
-    p_s = PublicOnlyProxy(s)
+    sample = Sample()
+    public_only_sample = PublicOnlyProxy(sample)
 
     text = "bbb"
-    p_text = PublicOnlyProxy(text)
+    wrapped_text = PublicOnlyProxy(text)
 
-    p_s.a = p_text
-    assert id(text) == id(s.a)
+    public_only_sample.attribute = wrapped_text
+    attribute = sample.attribute  # use original, not wrapped object
+
+    # check that the attribute in the unwrapped sample is itself not the
+    # wrapped text, but the original text.
+    assert id(text) == id(attribute)


### PR DESCRIPTION
# Fixes/Closes

Closes #5767

# Description

This PR makes a few tweaks to the behavior of PublicOnlyProxy:

- in setattr, if we want to set an attribute of a wrapped object, if the attribute value is itself an object wrapped with PublicOnlyProxy, we unwrap it. This has two benefits: (1) checking the attribute later incurs a significant cost in `_is_called_from_napari`, which involves frame inspection. This way we don't incur that cost. And (2) Certain equality checks fail when PublicOnlyProxy's interact with Qt. This is #5767 and this PR fixes that.
- in `PublicOnlyProxy.create`, we now check whether the object we want to wrap is a method, because then the module we need to check is not that of the method (this is always `builtins`), but rather the module of the object *that that method is bound to.* This is now fixed.
- When a PublicOnlyProxy'd object is callable, we unwrap the arguments, call the unwrapped function with the unwrapped arguments, then wrap the result. This avoids the performance issues detailed above.