### PR TITLE
Bugfix: Fix regression from #5739 for passing plugin name and reader plus add test

### DIFF
--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -43,7 +43,7 @@ def read(
     """Try to return data for `path`, from reader plugins using a manifest."""
 
     # do nothing if `plugin` is not an npe2 reader
-    if plugin and plugin not in get_readers():
+    if plugin and not any(plugin.startswith(name) for name in get_readers()):
         return None
 
     assert stack is not None

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -43,8 +43,12 @@ def read(
     """Try to return data for `path`, from reader plugins using a manifest."""
 
     # do nothing if `plugin` is not an npe2 reader
-    if plugin and not any(plugin.startswith(name) for name in get_readers()):
-        return None
+    if plugin:
+        # user might have passed 'plugin.reader_contrib' as the command
+        # so ensure we check vs. just the actual plugin name
+        plugin_name = plugin.partition('.')[0]
+        if plugin_name not in get_readers():
+            return None
 
     assert stack is not None
     # the goal here would be to make read_get_reader of npe2 aware of "stack",

--- a/napari/plugins/_tests/test_npe2.py
+++ b/napari/plugins/_tests/test_npe2.py
@@ -50,6 +50,13 @@ def test_read(mock_pm: 'TestPluginManager'):
     )
     mock_pm.commands.get.assert_not_called()
 
+    mock_pm.commands.get.reset_mock()
+    _, hookimpl = _npe2.read(
+        ["some.fzzy"], stack=False, plugin='my-plugin.some_reader'
+    )
+    mock_pm.commands.get.assert_called_once_with(f'{PLUGIN_NAME}.some_reader')
+    assert hookimpl.plugin_name == PLUGIN_NAME
+
 
 @pytest.mark.skipif(
     npe2.__version__ < '0.7.0',


### PR DESCRIPTION
# Fixes/Closes

Issue with 0.4.18rc2 reported on zulip by @adamltyson 
https://napari.zulipchat.com/#narrow/stream/212875-general/topic/reader.20plugin.20issue.20with.200.2E4.2E18

Closes #6012

# Description

In merged commit: https://github.com/napari/napari/commit/6847eeef0d036b213c896577508d83aae3e40146
the method of checking whether a plugin is npe2 returns None if a reader is passed in addition to the plugin name, e.g. `my-plugin.some_reader` vs. `my-plugin`
This is a regression for the case of plugins with multiple readers, as reported on zulip:
https://napari.zulipchat.com/#narrow/stream/212875-general/topic/reader.20plugin.20issue.20with.200.2E4.2E18

This PR just changes the logic of the comparison so use `startswith` so just the plugin name is compared, rather than the entire string. This fixes the regression.
Also, I add a test for this condition that fails on main, but passes with this fix.

# References
See: https://napari.zulipchat.com/#narrow/stream/212875-general/topic/reader.20plugin.20issue.20with.200.2E4.2E18

## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
- [x] example: added a test that passes now, but fails on main

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
