### PR TITLE
Add extra app_module condition check to fix plugin installer in GUI for Windows with Python 3.11

### DIFF
--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -76,7 +76,7 @@ def running_as_bundled_app(*, check_conda=True) -> bool:
     except AttributeError:
         return False
 
-    if app_module is None:
+    if (app_module is None) or (app_module == ""):
         return False
 
     try:


### PR DESCRIPTION
# Fixes/Closes

Fixes the issue with using the plugin installer on Windows with Python 3.11, see [Image.sc](https://forum.image.sc/t/request-for-testing-napari-0-4-18-release-candidate/82833/10?u=seankmartin).

# Description
Added an extra check to the `app_module` variable. It now checks for `None` and `""`.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
I manually have tested running the plugin installer from GUI on Windows. This change allows the plugin installer to work from GUI with multiple plugins.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
