### PR TITLE
Avoid passing empty string to `importlib.metadata.metadata`

### DIFF
--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -77,7 +77,7 @@ def running_as_bundled_app(*, check_conda=True) -> bool:
     except AttributeError:
         return False
 
-    if app_module is None:
+    if not app_module:
         return False
 
     try:


### PR DESCRIPTION
# Fixes/Closes

Closes https://forum.image.sc/t/request-for-testing-napari-0-4-18-release-candidate/82833/7

# Description

Previously we only guarded against `app_module` being `None`, but if it was the empty string `''` we continued and passed this to `importlib.metadata.metadata`, which does not count the empty string as valid input. This PR expands the check to all Falsey values, including `None` and `''`.
