### PR TITLE
Fix string list JSON formatting

### DIFF
--- a/tools/string_list.json
+++ b/tools/string_list.json
@@ -2365,7 +2365,7 @@
       "warning",
       "logo_silhouette",
       "background",
-      "loading.gif"
+      "loading.gif",
       "error",
       "plugin.txt",
       "w"


### PR DESCRIPTION
# Description
This fixes `tools/string_list.json` to be properly formatted JSON.

This was incorrectly changed in #5342: https://github.com/napari/napari/pull/5342/files#diff-76fffdc49f46cfa3bb62219af2b4426379db194de33beb4f0b91373575a8f46aR2368

I guess we don't actually run the translations tests on CI right now, so this wasn't caught in the PR or in the comprehensive tests. Instead I discovered this locally, as this caused VSCode fail at test discovery, which means no interactive debugging of tests.
