### PR TITLE
Use tuple for pip constraints to avoid LRU cache error

### DIFF
--- a/docs/release/release_0_4_18.md
+++ b/docs/release/release_0_4_18.md
@@ -201,6 +201,7 @@ https://napari.org
 - Fix behavior of PublicOnlyProxy in setattr, wrapped methods, and calling ([napari/napari/#5997](https://github.com/napari/napari/pull/5997))
 - Bugfix: Fix regression from #5739 for passing plugin name and reader plus add test ([napari/napari/#6013](https://github.com/napari/napari/pull/6013))
 - Avoid passing empty string to `importlib.metadata.metadata` ([napari/napari/#6018](https://github.com/napari/napari/pull/6018))
+-  Use tuple for pip constraints to avoid LRU cache error ([napari/napari#6036](https://github.com/napari/napari/pull/6036)
 
 ## API Changes
 

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -65,10 +65,6 @@ def _pip_constraints():
     return (f"napari=={__version__}", "pydantic<2")
 
 
-def _conda_constraints():
-    return [f"napari={__version__}", "pydantic<2.0a0"]
-
-
 @lru_cache(maxsize=3)
 def _create_constraints_file(constraints):
     _, path = mkstemp("-napari-constraints.txt", text=True)

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -62,7 +62,7 @@ InstallerTypes = Literal['pip', 'mamba']
 
 
 def _pip_constraints():
-    return [f"napari=={__version__}", "pydantic<2"]
+    return (f"napari=={__version__}", "pydantic<2")
 
 
 def _conda_constraints():


### PR DESCRIPTION
The `_pip_constraints` function was returning a list of strings, but the function that required it was decorated with `lru_cache`, causing an error because list is not hashable. See https://forum.image.sc/t/request-for-testing-napari-0-4-18-release-candidate/82833/21.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
