### PR TITLE
Prevent scale bar to go beyond canvas when zooming

### DIFF
--- a/napari/_vispy/overlays/scale_bar.py
+++ b/napari/_vispy/overlays/scale_bar.py
@@ -72,6 +72,11 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
             # return the last index.
             index -= 1
         new_value = PREFERRED_VALUES[index]
+        # validate if new_value is greater than the actual calculated magnitude
+        # to prevent the scale bar to extend beyond the canvas when zooming.
+        # See https://github.com/napari/napari/issues/5914
+        if new_value > new_quantity.magnitude:
+            new_value = new_quantity.magnitude
 
         # get the new pixel length utilizing the user-specified units
         new_length = ((new_value * factor) / self._unit.magnitude).magnitude

--- a/napari/_vispy/overlays/scale_bar.py
+++ b/napari/_vispy/overlays/scale_bar.py
@@ -83,8 +83,7 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         new_value = PREFERRED_VALUES[index]
         if new_quantity.dimensionless and new_quantity.magnitude < 1:
             new_value = float(
-                Decimal(new_value)
-                * Decimal(1000) ** magnitude_1000
+                Decimal(new_value) * Decimal(1000) ** magnitude_1000
             )
 
         # get the new pixel length utilizing the user-specified units

--- a/napari/_vispy/overlays/scale_bar.py
+++ b/napari/_vispy/overlays/scale_bar.py
@@ -82,6 +82,8 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
             index -= 1
         new_value = PREFERRED_VALUES[index]
         if new_quantity.dimensionless and new_quantity.magnitude < 1:
+            # using Decimal is necessary to avoid `4.999999e-6`
+            # at really small scale.
             new_value = float(
                 Decimal(new_value) * Decimal(1000) ** magnitude_1000
             )
@@ -109,7 +111,6 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         target_world_pixels_rounded, new_dim = self._calculate_best_length(
             target_world_pixels
         )
-
         target_canvas_pixels_rounded = (
             target_world_pixels_rounded / scale_canvas2world
         )

--- a/napari/_vispy/overlays/scale_bar.py
+++ b/napari/_vispy/overlays/scale_bar.py
@@ -83,7 +83,7 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         new_value = PREFERRED_VALUES[index]
         if new_quantity.dimensionless and new_quantity.magnitude < 1:
             new_value = float(
-                Decimal(PREFERRED_VALUES[index])
+                Decimal(new_value)
                 * Decimal(1000) ** magnitude_1000
             )
 


### PR DESCRIPTION
# Fixes/Closes

<!-- In general, PRs should fix an existing issue on the repo. -->
<!-- Please link to that issue here as "Closes #(issue-number)". -->
Closes #5914

# Description

Validate scale bar new value length and enable setting it to a value lower than the lower preferred value (1)

## Preview

![scale](https://github.com/napari/napari/assets/16781833/755f1798-dd37-473e-9c87-0fcac51cd123)


## Type of change
- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] all tests pass with my change
- [x] I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
