### PR TITLE
Show partial shortcut while editing.

### DIFF
--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -123,10 +123,7 @@ class ShortcutEditor(QWidget):
         layout.addWidget(
             QLabel(
                 trans._(
-                    "To edit, double-click the keybinding. To unbind a"
-                    " shortcut, use Backspace or Delete. To set Backspace"
-                    " or Delete, first unbind. Validate Modifiers only"
-                    " shortcut with Enter."
+                    "To edit, double-click the keybinding. To unbind a shortcut, use Backspace or Delete. To set Backspace or Delete, first unbind."
                 )
             )
         )
@@ -647,6 +644,7 @@ class EditorWidget(QLineEdit):
             self.setText(Shortcut(qkey2modelkey(event_key)).platform)
 
         if event_key in {
+            Qt.Key.Key_Return,
             Qt.Key.Key_Tab,
             Qt.Key.Key_CapsLock,
             Qt.Key.Key_Enter,
@@ -659,11 +657,6 @@ class EditorWidget(QLineEdit):
         event_keyseq = translator.keyevent_to_keyseq(event)
         kb = qkeysequence2modelkeybinding(event_keyseq)
         short = Shortcut(kb)
-        if event_key == Qt.Key.Key_Return:
-            # enter should be an invalid shortcut, but we use it as a key to
-            # validate modifiers only shortcuts. thus we let 'Enter' go through,
-            # but remove it from the shortcut we remove +enter from the shortcut
-            short = Shortcut(str(short._kb)[:-6])
         self.setText(short.platform)
         self.clearFocus()
 

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -685,7 +685,7 @@ class ShortcutTranslator(QKeySequenceEdit):
 
         This only works for complete key sequence that do not contain only
         modifiers. If the event is only pressing modifiers, this will return an
-        empty sequence as QKeySequence do support only modifiers
+        empty sequence as QKeySequence does not support only modifiers
 
         """
 

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -354,7 +354,7 @@ class ShortcutEditor(QWidget):
 
         message = trans._(
             "<b>{new_shortcut}</b> is not a valid keybinding.",
-            new_shortcut=new_shortcut,
+            new_shortcut=Shortcut(new_shortcut).platform,
         )
         self._show_warning(new_shortcut, current_action, row, message)
 
@@ -404,6 +404,16 @@ class ShortcutEditor(QWidget):
             current_shortcuts = list(
                 action_manager._shortcuts.get(current_action, [])
             )
+            for mod in {"Shift", "Ctrl", "Alt", "Cmd", "Super", 'Meta'}:
+                # we want to prevent multiple modifiers but still allow single modifiers.
+                if new_shortcut.endswith('-' + mod):
+                    self._show_bind_shortcut_error(
+                        current_action,
+                        current_shortcuts,
+                        row,
+                        new_shortcut,
+                    )
+                    return
 
             # Flag to indicate whether to set the new shortcut.
             replace = self._mark_conflicts(new_shortcut, row)


### PR DESCRIPTION
And automatically accept/validate shortcuts when valid.

 - When receiving a modifier only event, use the event Modifiers to show the current partial shortcuts.

 - we need to handle keyrelease events otherwise the following sequence is incorrect.

```
Action          –  Shortcut shown
---------------------------------
Press Ctrl      –  Ctrl
Also Press Alt  –  Ctrl-Alt
Release Ctrl    –  Ctrl-Alt
```

Though now that we handle release, the user cant press a shortcut and then validate with enter as as soon as the user release the shortcut the QLineEdit will become empty. But we don't care as we only want full shortcuts and not modifiers only.

Thus validate as soon a shortcut is valid, and contain a non-modifier key.

There is also this whole Meta/Alt/Ctrl are not the same on MacOS. I did not extract the logic into naprai/utils/interactions as those are Qt Specific, moreover the values of QtEvent.Modifiers are not the same than Qt.Keys.

You will note that there is one weirdness in the order of modifiers when typing these, but I believe this will be fixed upstream. This is due to the fact that when pressing `Ctrl` then `Shift` for example, `Shift` is the `Key` event, and this will appear at the end. While when doing `Shift`, then `Ctrl`, ctrl is the key that will appear at the end.

Closes #6047

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How has this been tested?

This needs to be tested on more platforms.
