### PR TITLE
Fix `_add_sample` sample data callback to show all readers

### DIFF
--- a/napari/_qt/dialogs/_tests/test_reader_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_reader_dialog.py
@@ -154,13 +154,10 @@ def test_open_sample_data_shows_all_readers(
     viewer = make_napari_viewer()
     sample_action = viewer.window.file_menu.open_sample_menu.actions()[0]
 
-    with (
-        mock.patch(
-            'napari._qt.dialogs.qt_reader_dialog.prepare_remaining_readers'
-        ) as mock_prepare_readers,
-        mock.patch.object(
-            QtReaderDialog, 'get_user_choices', return_value=(None, None)
-        ),
+    with mock.patch(
+        'napari._qt.dialogs.qt_reader_dialog.prepare_remaining_readers'
+    ) as mock_prepare_readers, mock.patch.object(
+        QtReaderDialog, 'get_user_choices', return_value=(None, None)
     ):
         sample_action.trigger()
     # Ensure that `prepare_remaining_readers` called with `plugin_name=None`

--- a/napari/_qt/dialogs/_tests/test_reader_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_reader_dialog.py
@@ -1,8 +1,10 @@
 import os
+from unittest import mock
 
 import numpy as np
 import pytest
 from npe2 import DynamicPlugin
+from npe2.manifest.contributions import SampleDataURI
 from qtpy.QtWidgets import QLabel, QRadioButton
 
 from napari._qt.dialogs.qt_reader_dialog import (
@@ -124,6 +126,46 @@ def test_prepare_dialog_options_removes_plugin(tmp_plugin: DynamicPlugin):
     )
     assert tmp2.name in readers
     assert tmp_plugin.name not in readers
+
+
+def test_open_sample_data_shows_all_readers(
+    make_napari_viewer, tmp_plugin: DynamicPlugin
+):
+    """Checks that sample data callback `_add_sample` shows all readers."""
+    tmp2 = tmp_plugin.spawn(register=True)
+
+    @tmp_plugin.contribute.reader(filename_patterns=['*.fake'])
+    def _(path):
+        ...
+
+    @tmp2.contribute.reader(filename_patterns=['*.fake'])
+    def _(path):
+        ...
+
+    my_sample = SampleDataURI(
+        key='tmp-sample',
+        display_name='Temp Sample',
+        uri='some-path/some-file.fake',
+    )
+    tmp_plugin.manifest.contributions.sample_data = [my_sample]
+    from napari._qt.dialogs.qt_reader_dialog import QtReaderDialog
+
+    viewer = make_napari_viewer()
+    sample_action = viewer.window.file_menu.open_sample_menu.actions()[0]
+
+    with (
+        mock.patch(
+            'napari._qt.dialogs.qt_reader_dialog.prepare_remaining_readers'
+        ) as mock_prepare_readers,
+        mock.patch.object(
+            QtReaderDialog, 'get_user_choices', return_value=(None, None)
+        ),
+    ):
+        sample_action.trigger()
+    # Ensure that `prepare_remaining_readers` called with `plugin_name=None`
+    mock_prepare_readers.assert_called_once_with(
+        ['some-path/some-file.fake'], None, None
+    )
 
 
 def test_open_with_dialog_choices_persist(

--- a/napari/_qt/dialogs/_tests/test_reader_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_reader_dialog.py
@@ -129,7 +129,8 @@ def test_prepare_dialog_options_removes_plugin(tmp_plugin: DynamicPlugin):
 
 
 def test_open_sample_data_shows_all_readers(
-    make_napari_viewer, tmp_plugin: DynamicPlugin
+    make_napari_viewer,
+    tmp_plugin: DynamicPlugin,
 ):
     """Checks that sample data callback `_add_sample` shows all readers."""
     tmp2 = tmp_plugin.spawn(register=True)

--- a/napari/_qt/menus/file_menu.py
+++ b/napari/_qt/menus/file_menu.py
@@ -231,7 +231,6 @@ class FileMenu(NapariMenu):
                         handle_gui_reading(
                             e.paths,
                             self._win._qt_viewer,
-                            plugin_name=plg,
                             stack=False,
                         )
 


### PR DESCRIPTION
While working on #4865, specifically converting
[`test_sample_data_triggers_reader_dialog`](https://github.com/napari/napari/blob/007712f0647d4f94cda02b79e58a08273846ac94/napari/_qt/menus/_tests/test_file_menu.py#L12)
to use the new app-model, I noticed only one plugin was listed in the pop
up (see second to last bullet point here:
https://github.com/napari/napari/pull/4865#issuecomment-1285035203).
I checked and this was also the case in main, and tracked the issue to
`handle_gui_reader`.

When opening a sample data URI from the GUI, if there is more than one
reader, we want to use the `handle_gui_reader`, so the reader choice pop
up comes.

Currently the `_add_sample` callback that opens sample data from the
menu will remove the plugin that provided the sample data, from possible
readers.

The plugin that provided the sample data was passed via `plugin_name`
parameter to `handle_gui_reading`, implying that we already tried to
open the sample with this plugin. However, `handle_gui_reading` is only
called if multiple readers are available (which means no readers were
tried), so we do not want to remove this plugin from possible readers.