### PR TITLE
Fix action manager memory leak.

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
@@ -535,7 +535,9 @@ def test_set_3d_display_with_shapes(qtbot):
 )
 def editable_layer(request):
     LayerType, data = request.param
-    return LayerType(data)
+    lay = LayerType(data)
+    lay._leak = True
+    return lay
 
 
 def test_make_visible_when_editable_enables_edit_buttons(
@@ -549,6 +551,7 @@ def test_make_visible_when_editable_enables_edit_buttons(
     editable_layer.visible = True
 
     assert_all_edit_buttons_enabled(controls)
+    del editable_layer
 
 
 def test_make_not_visible_when_editable_disables_edit_buttons(
@@ -562,6 +565,7 @@ def test_make_not_visible_when_editable_disables_edit_buttons(
     editable_layer.visible = False
 
     assert_no_edit_buttons_enabled(controls)
+    del editable_layer
 
 
 def test_make_editable_when_visible_enables_edit_buttons(

--- a/napari/_vispy/_tests/test_vispy_surface_layer.py
+++ b/napari/_vispy/_tests/test_vispy_surface_layer.py
@@ -9,7 +9,9 @@ from napari.layers import Surface
 @pytest.fixture
 def cube_layer():
     vertices, faces, _ = create_cube()
-    return Surface((vertices['position'] * 100, faces))
+    surf = Surface((vertices['position'] * 100, faces))
+    surf._leak = True
+    return surf
 
 
 @pytest.mark.parametrize("opacity", [0, 0.3, 0.7, 1])

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -236,6 +236,15 @@ def auto_shutdown_dask_threadworkers():
         dask.threaded.default_pool = None
 
 
+@pytest.fixture(autouse=True)
+def ensure_no_layer_leak():
+    from napari.layers import Layer
+
+    assert len(Layer._instances) == 0, 'test started with Leaked Layers'
+    yield
+    assert len(Layer._instances) == 0, 'test ended with Leaked Layers'
+
+
 # this is not the proper way to configure IPython, but it's an easy one.
 # This will prevent IPython to try to write history on its sql file and do
 # everything in memory.

--- a/napari/layers/_tests/test_layer_actions.py
+++ b/napari/layers/_tests/test_layer_actions.py
@@ -50,6 +50,7 @@ def test_toggle_visibility_with_linked_layers():
     assert layer_list[1].visible is False
     assert layer_list[2].visible is False
     assert layer_list[3].visible is True
+    del layer_list
 
 
 @pytest.mark.parametrize('layer_type', [Points, Shapes])

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -19,6 +19,7 @@ from typing import (
     Type,
     Union,
 )
+from weakref import WeakSet
 
 import magicgui as mgui
 import numpy as np
@@ -242,6 +243,8 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     * `_basename()`: base/default name of the layer
     """
 
+    _instances: WeakSet[Layer] = WeakSet()
+
     _modeclass: Type[StringEnum] = Mode
 
     _drag_modes: ClassVar[Dict[StringEnum, Callable[[Layer, Event], None]]] = {
@@ -279,6 +282,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         mode='pan_zoom',
     ) -> None:
         super().__init__()
+        self._instances.add(self)
 
         if name is None and data is not None:
             name = magic_name(data)

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1539,6 +1539,9 @@ def test_negative_label_doesnt_flicker():
         ]
     )
     layer = Labels(data)
+    # it's ok to leak, it's an x-fail, so it will be attached to the
+    # traceback of this failing test.
+    layer._leak = True
     layer._slice_dims(point=(1, 0, 0))
     # This used to fail when negative values were used to index into _all_vals.
     assert tuple(layer.get_color(-1)) != tuple(layer.get_color(5))
@@ -1547,6 +1550,7 @@ def test_negative_label_doesnt_flicker():
     layer._set_view_slice()
 
     assert tuple(layer.get_color(-1)) == minus_one_color_original
+    del layer
 
 
 def test_get_status_with_custom_index():
@@ -1570,6 +1574,7 @@ def test_get_status_with_custom_index():
         layer.get_status((6, 6))['coordinates']
         == ' [6 6]: 2; text1: 3, text2: -2'
     )
+    del layer
 
 
 def test_collision_warning():

--- a/napari/layers/points/_tests/test_points_key_bindings.py
+++ b/napari/layers/points/_tests/test_points_key_bindings.py
@@ -11,6 +11,7 @@ def test_modes(layer):
     assert layer.mode == 'select'
     key_bindings.activate_points_pan_zoom_mode(layer)
     assert layer.mode == 'pan_zoom'
+    del layer
 
 
 def test_copy_paste(layer):

--- a/napari/layers/points/_tests/test_points_mouse_bindings.py
+++ b/napari/layers/points/_tests/test_points_mouse_bindings.py
@@ -55,6 +55,9 @@ def create_known_points_layer_2d():
     n_points = len(data)
 
     layer = Points(data, size=1)
+    # one of our fixture check we don't leak layers in tests.
+    # mark this layer as ok to leak.
+    layer._leak = True
     assert np.all(layer.data == data)
     assert layer.ndim == 2
     assert len(layer.data) == n_points
@@ -83,6 +86,7 @@ def create_known_points_layer_3d():
 
     layer = Points(data, size=1)
     layer._slice_dims(ndisplay=3)
+    layer._leak = True
 
     assert np.all(layer.data == data)
     assert layer.ndim == 3
@@ -154,6 +158,7 @@ def test_add_point_3d(create_known_points_layer_3d):
     # Check clicked point selected
     assert len(layer.data) == (n_points + 1)
     np.testing.assert_array_equal(layer.data[-1], known_not_point)
+    del layer
 
 
 def test_drag_in_add_mode(create_known_points_layer_2d):

--- a/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
@@ -37,6 +37,7 @@ def create_known_shapes_layer():
     layer = Shapes(data)
     # very zoomed in, guaranteed no overlap between vertices
     layer.scale_factor = 0.001
+    layer._leak = True
     assert layer.ndim == 2
     assert len(layer.data) == n_shapes
     assert len(layer.selected_data) == 0

--- a/napari/layers/utils/_tests/test_link_layers.py
+++ b/napari/layers/utils/_tests/test_link_layers.py
@@ -92,6 +92,7 @@ def test_removed_linked_target():
 
     # if we delete layer3 we shouldn't get an error when updating otherlayers
     del l3
+
     l1.opacity = 0.25
     assert l1.opacity == l2.opacity
 

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -244,7 +244,10 @@ class ActionManager:
         def _update_tt(event: ShortcutEvent):
             if event.name == name:
                 button_ = ref_button()
-                button_.setToolTip(f'{event.tooltip} {extra_tooltip_text}')
+                # there is still a small chance for the ref to be None,
+                # but this to not be disconnected.
+                if button_ is not None:
+                    button_.setToolTip(f'{event.tooltip} {extra_tooltip_text}')
 
         # if it's a QPushbutton, we'll remove it when it gets destroyed
         until = getattr(ref_button(), 'destroyed', None)


### PR DESCRIPTION
Don't use references in callbacks as they may keep layers around. Should close napari/napari#2027

# Fixes/Closes

Closes #2027

# References
You can use the following test script to see the object graph before/after this PR.
```
import gc
import objgraph
import weakref
import sys
import napari

viewer = napari.Viewer()
r = weakref.ref(viewer.add_points())

viewer.layers.pop()
print(gc.collect(), "unreachable objects after collection")

objgraph.show_backrefs(
    [r()], filename='sample-backref-graph.pdf', max_depth=10
)
```

## Type of change

- [x] Bug-fix (non-breaking change which fixes an issue)


