### PR TITLE
Pin numpy below 2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     napari-plugin-engine>=0.1.9
     napari-svg>=0.1.7
     npe2>=0.5.2
-    numpy>=1.21
+    numpy>=1.21,<2
     numpydoc>=0.9.2
     pandas>=1.1.0 ; python_version < '3.9'
     pandas>=1.3.0 ; python_version >= '3.9'


### PR DESCRIPTION
# Description
As advertised at scipy 2023 we should pin numpy below 2

## Type of change
- [x] Maintenance (changes required to run napari, tests, & CI smoothly)

