### PR TITLE
Reduce comparison in evented model

### DIFF
--- a/napari/_vispy/canvas.py
+++ b/napari/_vispy/canvas.py
@@ -302,7 +302,9 @@ class VispyCanvas:
     def _on_interactive(self) -> None:
         """Link interactive attributes of view and viewer."""
         # Is this should be changed or renamed?
-        self.view.interactive = self.viewer.camera.mouse_zoom or self.viewer.camera.mouse_pan
+        self.view.interactive = (
+            self.viewer.camera.mouse_zoom or self.viewer.camera.mouse_pan
+        )
 
     def _map_canvas2world(
         self, position: List[int, int]

--- a/napari/_vispy/canvas.py
+++ b/napari/_vispy/canvas.py
@@ -157,7 +157,8 @@ class VispyCanvas:
         self.viewer.cursor.events.style.connect(self._on_cursor)
         self.viewer.cursor.events.size.connect(self._on_cursor)
         self.viewer.events.theme.connect(self._on_theme_change)
-        self.viewer.camera.events.interactive.connect(self._on_interactive)
+        self.viewer.camera.events.mouse_pan.connect(self._on_interactive)
+        self.viewer.camera.events.mouse_zoom.connect(self._on_interactive)
         self.viewer.camera.events.zoom.connect(self._on_cursor)
         self.viewer.layers.events.reordered.connect(self._reorder_layers)
         self.viewer.layers.events.removed.connect(self._remove_layer)
@@ -300,7 +301,8 @@ class VispyCanvas:
 
     def _on_interactive(self) -> None:
         """Link interactive attributes of view and viewer."""
-        self.view.interactive = self.viewer.camera.interactive
+        # Is this should be changed or renamed?
+        self.view.interactive = self.viewer.camera.mouse_zoom or self.viewer.camera.mouse_pan
 
     def _map_canvas2world(
         self, position: List[int, int]

--- a/napari/benchmarks/benchmark_evented_model.py
+++ b/napari/benchmarks/benchmark_evented_model.py
@@ -11,7 +11,11 @@ def np_generator(ndim: int = 3):
     return data
 
 
-class Sample1(EventedModel):
+def empty(event):
+    pass
+
+
+class Model(EventedModel):
     a: int = 3
     b: float = 2.0
     c: np.ndarray = Field(default_factory=np_generator)
@@ -22,7 +26,7 @@ class Sample1(EventedModel):
 
     @c_inv.setter
     def c_inv(self, value):
-        self.b = np.linalg.inv(value)
+        self.c = np.linalg.inv(value)
 
     @property
     def d(self):
@@ -43,16 +47,17 @@ class Sample1(EventedModel):
         return self.c_inv**self.a
 
 
-def empty(event):
-    pass
+class EventedModelSuite:
+    """Benchmarks for EventedModel."""
 
+    def setup(self):
+        self.model = Model()
+        self.model.events.a.connect(empty)
+        self.model.events.b.connect(empty)
+        self.model.events.c.connect(empty)
+        self.model.events.c_inv.connect(empty)
+        self.model.events.e.connect(empty)
+        self.model.events.f.connect(empty)
 
-def time_sample1():
-    s = Sample1()
-    s.events.a.connect(empty)
-    s.events.b.connect(empty)
-    s.events.c.connect(empty)
-    s.events.c_inv.connect(empty)
-    s.events.e.connect(empty)
-    s.events.f.connect(empty)
-    s.d = 4
+    def time_event_firing(self):
+        self.model.d = 4

--- a/napari/benchmarks/benchmark_evented_model.py
+++ b/napari/benchmarks/benchmark_evented_model.py
@@ -1,0 +1,58 @@
+import numpy as np
+from pydantic import Field
+
+from napari.utils.events import EventedModel
+
+
+def np_generator(ndim: int = 3):
+    data = np.zeros((ndim, ndim))
+    for i in range(ndim):
+        data[i, ndim - i - 1] = 1
+    return data
+
+
+class Sample1(EventedModel):
+    a: int = 3
+    b: float = 2.0
+    c: np.ndarray = Field(default_factory=np_generator)
+
+    @property
+    def c_inv(self):
+        return np.linalg.inv(self.b)
+
+    @c_inv.setter
+    def c_inv(self, value):
+        self.b = np.linalg.inv(value)
+
+    @property
+    def d(self):
+        return self.a**self.b
+
+    @d.setter
+    def d(self, value):
+        self.a = value
+        self.b = value / 2
+        self.c = np_generator(value)
+
+    @property
+    def e(self):
+        return (self.c + self.a) ** self.b
+
+    @property
+    def f(self):
+        return self.c_inv**self.a
+
+
+def empty(event):
+    pass
+
+
+def time_sample1():
+    s = Sample1()
+    s.events.a.connect(empty)
+    s.events.b.connect(empty)
+    s.events.c.connect(empty)
+    s.events.c_inv.connect(empty)
+    s.events.e.connect(empty)
+    s.events.f.connect(empty)
+    s.d = 4

--- a/napari/benchmarks/benchmark_evented_model.py
+++ b/napari/benchmarks/benchmark_evented_model.py
@@ -18,7 +18,7 @@ class Sample1(EventedModel):
 
     @property
     def c_inv(self):
-        return np.linalg.inv(self.b)
+        return np.linalg.inv(self.c)
 
     @c_inv.setter
     def c_inv(self, value):

--- a/napari/benchmarks/benchmark_evented_model.py
+++ b/napari/benchmarks/benchmark_evented_model.py
@@ -1,50 +1,38 @@
-import numpy as np
-from pydantic import Field
+from math import ceil
 
 from napari.utils.events import EventedModel
-
-
-def np_generator(ndim: int = 3):
-    data = np.zeros((ndim, ndim))
-    for i in range(ndim):
-        data[i, ndim - i - 1] = 1
-    return data
 
 
 def empty(event):
     pass
 
 
+def fibonacci(n):
+    if n < 2:
+        return n
+    return fibonacci(n - 1) + fibonacci(n - 2)
+
+
 class Model(EventedModel):
     a: int = 3
     b: float = 2.0
-    c: np.ndarray = Field(default_factory=np_generator)
-
-    @property
-    def c_inv(self):
-        return np.linalg.inv(self.c)
-
-    @c_inv.setter
-    def c_inv(self, value):
-        self.c = np.linalg.inv(value)
+    c: int = 3
 
     @property
     def d(self):
-        return self.a**self.b
+        return (self.c + self.a) ** self.b
 
     @d.setter
     def d(self, value):
+        self.c = value
         self.a = value
-        self.b = value / 2
-        self.c = np_generator(value)
+        self.b = value * 1.1
 
     @property
     def e(self):
-        return (self.c + self.a) ** self.b
-
-    @property
-    def f(self):
-        return self.c_inv**self.a
+        return (fibonacci(self.c) + fibonacci(self.a)) ** fibonacci(
+            ceil(self.b)
+        )
 
 
 class EventedModelSuite:
@@ -55,9 +43,17 @@ class EventedModelSuite:
         self.model.events.a.connect(empty)
         self.model.events.b.connect(empty)
         self.model.events.c.connect(empty)
-        self.model.events.c_inv.connect(empty)
         self.model.events.e.connect(empty)
-        self.model.events.f.connect(empty)
 
     def time_event_firing(self):
         self.model.d = 4
+        self.model.d = 18
+
+    def time_long_connection(self):
+        def long_connection(event):
+            for _i in range(5):
+                fibonacci(event.source.c)
+
+        self.model.events.e.connect(long_connection)
+
+        self.model.d = 15

--- a/napari/utils/events/_tests/test_evented_model.py
+++ b/napari/utils/events/_tests/test_evented_model.py
@@ -688,7 +688,7 @@ def _reset_mocks(*args):
         el.reset_mock()
 
 
-def test_single_emmit():
+def test_single_emit():
     class SampleClass(EventedModel):
         a: int = 1
         b: int = 2

--- a/napari/utils/events/_tests/test_evented_model.py
+++ b/napari/utils/events/_tests/test_evented_model.py
@@ -681,3 +681,68 @@ def test_events_are_fired_only_if_necessary(monkeypatch):
     a_eq.assert_called_once()
     b_eq.assert_called_once()
     eq_op_get.assert_called_once_with(9)
+
+
+def _reset_mocks(*args):
+    for el in args:
+        el.reset_mock()
+
+def test_single_emmit():
+    class SampleClass(EventedModel):
+        a: int = 1
+        b: int = 2
+
+        @property
+        def c(self):
+            return self.a
+        
+        @c.setter
+        def c(self, value):
+            self.a = value
+
+        @property
+        def d(self):
+            return self.a + self.b
+        
+        @d.setter
+        def d(self, value):
+            self.a = value // 2
+            self.b = value - self.a
+
+        @property
+        def e(self):
+            return self.a - self.b
+
+
+    s = SampleClass()
+    a_m = Mock()
+    c_m = Mock()
+    d_m = Mock()
+    s.events.a.connect(a_m)
+    s.events.c.connect(c_m)
+    s.events.d.connect(d_m)
+
+    s.a = 4 
+    a_m.assert_called_once()
+    c_m.assert_called_once()
+    d_m.assert_called_once()
+
+    _reset_mocks(a_m, c_m, d_m)
+
+    s.c = 6 
+    a_m.assert_called_once()
+    c_m.assert_called_once()
+    d_m.assert_called_once()
+
+    _reset_mocks(a_m, c_m, d_m)
+
+    e_m = Mock()
+    s.events.e.connect(e_m)
+
+    s.d = 21
+    a_m.assert_called_once()
+    c_m.assert_called_once()
+    d_m.assert_called_once()
+    e_m.assert_called_once()
+
+

--- a/napari/utils/events/_tests/test_evented_model.py
+++ b/napari/utils/events/_tests/test_evented_model.py
@@ -687,6 +687,7 @@ def _reset_mocks(*args):
     for el in args:
         el.reset_mock()
 
+
 def test_single_emmit():
     class SampleClass(EventedModel):
         a: int = 1
@@ -695,7 +696,7 @@ def test_single_emmit():
         @property
         def c(self):
             return self.a
-        
+
         @c.setter
         def c(self, value):
             self.a = value
@@ -703,7 +704,7 @@ def test_single_emmit():
         @property
         def d(self):
             return self.a + self.b
-        
+
         @d.setter
         def d(self, value):
             self.a = value // 2
@@ -713,7 +714,6 @@ def test_single_emmit():
         def e(self):
             return self.a - self.b
 
-
     s = SampleClass()
     a_m = Mock()
     c_m = Mock()
@@ -722,14 +722,14 @@ def test_single_emmit():
     s.events.c.connect(c_m)
     s.events.d.connect(d_m)
 
-    s.a = 4 
+    s.a = 4
     a_m.assert_called_once()
     c_m.assert_called_once()
     d_m.assert_called_once()
 
     _reset_mocks(a_m, c_m, d_m)
 
-    s.c = 6 
+    s.c = 6
     a_m.assert_called_once()
     c_m.assert_called_once()
     d_m.assert_called_once()
@@ -744,5 +744,3 @@ def test_single_emmit():
     c_m.assert_called_once()
     d_m.assert_called_once()
     e_m.assert_called_once()
-
-

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -299,8 +299,6 @@ class EventEmitter:
         # count number of times this emitter is blocked for each callback.
         self._blocked: Dict[Optional[Callback], int] = {None: 0}
         self._block_counter: _WeakCounter[Optional[Callback]] = _WeakCounter()
-        self._delay_semaphore: int = 0
-        self._last_delayed_event: Optional[Event] = None
 
         # used to detect emitter loops
         self._emitting = False
@@ -726,9 +724,6 @@ class EventEmitter:
         # create / massage event as needed
         event = self._prepare_event(*args, **kwargs)
 
-        if self._delay_semaphore:
-            self._last_delayed_event = event
-            return event
         # Add our source to the event; remove it after all callbacks have been
         # invoked.
         event._push_source(self.source)

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -726,11 +726,11 @@ class EventEmitter:
         # create / massage event as needed
         event = self._prepare_event(*args, **kwargs)
 
-        # Add our source to the event; remove it after all callbacks have been
-        # invoked.
         if self._delay_semaphore:
             self._delay_last_event = event
             return event
+        # Add our source to the event; remove it after all callbacks have been
+        # invoked.
         event._push_source(self.source)
         self._emitting = True
         try:

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -896,9 +896,10 @@ class EventEmitter:
         self._delay_semaphore -= 1
         if self._delay_semaphore < 0:
             raise RuntimeError("there is no waiting delay event")
-        if self._delay_last_event is not None:
-            self(self._delay_last_event)
+        if not self._delay_semaphore and self._delay_last_event is not None:
+            event = self._delay_last_event
             self._delay_last_event = None
+            self(event)
 
     def delayer(self):
         return EventDelayer(self)

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -300,7 +300,7 @@ class EventEmitter:
         self._blocked: Dict[Optional[Callback], int] = {None: 0}
         self._block_counter: _WeakCounter[Optional[Callback]] = _WeakCounter()
         self._delay_semaphore: int = 0
-        self._delay_last_event: Optional[Event] = None
+        self._last_delayed_event: Optional[Event] = None
 
         # used to detect emitter loops
         self._emitting = False
@@ -727,7 +727,7 @@ class EventEmitter:
         event = self._prepare_event(*args, **kwargs)
 
         if self._delay_semaphore:
-            self._delay_last_event = event
+            self._last_delayed_event = event
             return event
         # Add our source to the event; remove it after all callbacks have been
         # invoked.
@@ -896,9 +896,9 @@ class EventEmitter:
         self._delay_semaphore -= 1
         if self._delay_semaphore < 0:
             raise RuntimeError("there is no waiting delay event")
-        if not self._delay_semaphore and self._delay_last_event is not None:
-            event = self._delay_last_event
-            self._delay_last_event = None
+        if not self._delay_semaphore and self._last_delayed_event is not None:
+            event = self._last_delayed_event
+            self._last_delayed_event = None
             self(event)
 
     def delayer(self):

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -730,7 +730,7 @@ class EventEmitter:
         # invoked.
         if self._dellay_semaphore:
             self._dellay_last_event = event
-            return event 
+            return event
         event._push_source(self.source)
         self._emitting = True
         try:
@@ -893,7 +893,7 @@ class EventEmitter:
         self._dellay_semaphore += 1
 
     def undellay_emmit(self):
-        self._dellay_semaphore -=1
+        self._dellay_semaphore -= 1
         if self._dellay_semaphore < 0:
             raise RuntimeError("there is no waiting dellay event")
         if self._dellay_last_event is not None:
@@ -902,7 +902,6 @@ class EventEmitter:
 
     def dellayer(self):
         return EventDelayer(self)
-
 
 
 class WarningEmitter(EventEmitter):
@@ -1131,7 +1130,7 @@ class EmitterGroup(EventEmitter):
 
     def dellay_all(self):
         """
-        Dellay all event emmision 
+        Dellay all event emmision
         """
         self.dellay_emmit()
         for em in self._emitters.values():
@@ -1213,7 +1212,7 @@ class EmitterGroup(EventEmitter):
                 pass  # ..do stuff; no events will be emitted..
         """
         return EventBlockerAll(self)
-    
+
     def dellayer_all(self):
         return EventDelayerAll(self)
 
@@ -1264,14 +1263,14 @@ class EventDelayer:
 
     def __enter__(self):
         self.target.dellay_emmit()
-    
+
     def __exit__(self, *args):
         self.target.undellay_emmit()
 
 
 class EventDelayerAll:
     def __init__(self, target: EmitterGroup) -> None:
-        self.target = target 
+        self.target = target
 
     def __enter__(self):
         self.target.dellay_all()

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -299,8 +299,8 @@ class EventEmitter:
         # count number of times this emitter is blocked for each callback.
         self._blocked: Dict[Optional[Callback], int] = {None: 0}
         self._block_counter: _WeakCounter[Optional[Callback]] = _WeakCounter()
-        self._delay_semaphore = 0
-        self._delay_last_event = None
+        self._delay_semaphore: int = 0
+        self._delay_last_event: Optional[Event] = None
 
         # used to detect emitter loops
         self._emitting = False
@@ -888,7 +888,7 @@ class EventEmitter:
 
     def delay_emit(self):
         """
-        Block emiting callbacks, but emit them when unlock.
+        Block emitting callbacks, but emit them when unlock.
         """
         self._delay_semaphore += 1
 
@@ -1131,7 +1131,7 @@ class EmitterGroup(EventEmitter):
 
     def delay_all(self):
         """
-        Delay all event emmision
+        Delay all event emission
         """
         self.delay_emit()
         for em in self._emitters.values():
@@ -1139,7 +1139,7 @@ class EmitterGroup(EventEmitter):
 
     def undelay_all(self):
         """
-        Undelay event emmision
+        Undelay event emission
         """
         self.undelay_emit()
         for em in self._emitters.values():

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -324,11 +324,8 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
         # if different we emit the event with new value
         after = getattr(self, name)
         after_deps = {}
-        with warnings.catch_warnings():
-            # we still need to check for deprecated properties
-            warnings.simplefilter("ignore", DeprecationWarning)
-            for dep in dep_with_callbacks:
-                after_deps[dep] = getattr(self, dep, object())
+        for dep in dep_with_callbacks:
+            after_deps[dep] = getattr(self, dep, object())
 
         are_equal = self.__eq_operators__.get(name, operator.eq)
         if are_equal(after, before):

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -282,7 +282,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
         else:
             super().__setattr__(name, value)
 
-    def _check_if_differ(self, name, old_value) -> Tuple[bool, any]:
+    def _check_if_differ(self, name: str, old_value: Any) -> Tuple[bool, Any]:
         """
         Check new value of a field and emit event if it is different from the old one.
         Returns True if event was emitted, else False.
@@ -292,9 +292,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             are_equal = self.__eq_operators__[name]
         else:
             are_equal = pick_equality_operator(new_value)
-        if not are_equal(new_value, old_value):
-            return True, new_value
-        return False, None
+        return not are_equal(new_value, old_value), new_value
 
     def __setattr__(self, name: str, value: Any) -> None:
         if name not in getattr(self, 'events', {}):

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -277,8 +277,10 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             super().__setattr__(name, value)
 
     def __setattr__(self, name: str, value: Any) -> None:
-        if name not in self.__properties__:
-            self._setattr_impl(name, value)
+        if not hasattr(self, "_events"):
+            # This is a workaround needed because `EventedConfigFileSettings` uses
+            # `_config_path` before calling the superclass constructor
+            super().__setattr__(name, value)
             return
         with self.events.delayer_all():
             self._setattr_impl(name, value)

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -277,6 +277,13 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             super().__setattr__(name, value)
 
     def __setattr__(self, name: str, value: Any) -> None:
+        if name not in self.__properties__:
+            self._setattr_impl(name, value)
+            return
+        with self.events.dellayer_all():
+            self._setattr_impl(name, value)
+
+    def _setattr_impl(self, name: str, value: Any) -> None:
         if name not in getattr(self, 'events', {}):
             # fallback to default behavior
             self._super_setattr_(name, value)

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -314,11 +314,9 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
 
         before = getattr(self, name, object())
         before_deps = {}
-        with warnings.catch_warnings():
-            # we still need to check for deprecated properties
-            warnings.simplefilter("ignore", DeprecationWarning)
-            for dep in dep_with_callbacks:
-                before_deps[dep] = getattr(self, dep, object())
+
+        for dep in dep_with_callbacks:
+            before_deps[dep] = getattr(self, dep, object())
 
         # set value using original setter
         self._super_setattr_(name, value)

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -281,6 +281,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
     def _check_if_differ(self, name: str, old_value: Any) -> Tuple[bool, Any]:
         """
         Check new value of a field and emit event if it is different from the old one.
+        
         Returns True if data changed, else False. Return current value.
         """
         new_value = getattr(self, name, object())
@@ -302,9 +303,10 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
 
     def _check_if_values_changed_and_emit_if_needed(self):
         """
-        This is function to check if values changed and emit events if need.
-        The advantage of moving this after whole modification is that comparison will be performed only
-        once for every potential change.
+        Check if field values changed and emit events if needed.
+        
+        The advantage of moving this to the end of all the modifications is
+        that comparisons will be performed only once for every potential change.
         """
         if self._delay_check_semaphore > 0 or len(self._changes_queue) == 0:
             # do not run whole machinery if there is no need

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -280,7 +280,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
         if name not in self.__properties__:
             self._setattr_impl(name, value)
             return
-        with self.events.dellayer_all():
+        with self.events.delayer_all():
             self._setattr_impl(name, value)
 
     def _setattr_impl(self, name: str, value: Any) -> None:

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -281,7 +281,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
     def _check_if_differ(self, name: str, old_value: Any) -> Tuple[bool, Any]:
         """
         Check new value of a field and emit event if it is different from the old one.
-        
+
         Returns True if data changed, else False. Return current value.
         """
         new_value = getattr(self, name, object())
@@ -304,7 +304,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
     def _check_if_values_changed_and_emit_if_needed(self):
         """
         Check if field values changed and emit events if needed.
-        
+
         The advantage of moving this to the end of all the modifications is
         that comparisons will be performed only once for every potential change.
         """


### PR DESCRIPTION
# Description
This PR de-duplicates events when assigning properties of `EventedModel`

It moves all comparisons at the end of initial set of values. 

## Type of change
- [x] Enhancement (non-breaking improvements of an existing feature)


# How has this been tested?
- [x] I have added required test