### PR TITLE
Give all Mode classes a common parent

### DIFF
--- a/napari/layers/base/_base_constants.py
+++ b/napari/layers/base/_base_constants.py
@@ -55,7 +55,13 @@ BLENDING_TRANSLATIONS = OrderedDict(
 )
 
 
-class Mode(StringEnum):
+class ModeBase(StringEnum):
+    """
+    Class use to mark another class as a Mode enum.
+    """
+
+
+class Mode(ModeBase):
     """
     Mode: Interactive mode. The normal, default mode is PAN_ZOOM, which
     allows for normal interactivity with the canvas.

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -23,7 +23,7 @@ import magicgui as mgui
 import numpy as np
 from npe2 import plugin_manager as pm
 
-from napari.layers.base._base_constants import Blending, Mode
+from napari.layers.base._base_constants import Blending, Mode, ModeBase
 from napari.layers.base._base_mouse_bindings import (
     highlight_box_handles,
     transform_with_box,
@@ -241,7 +241,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     * `_basename()`: base/default name of the layer
     """
 
-    _modeclass: Type[StringEnum] = Mode
+    _modeclass: Type[ModeBase] = Mode
 
     _drag_modes: Dict[StringEnum, Callable[[Layer, Event], None]] = {
         Mode.PAN_ZOOM: no_op,

--- a/napari/layers/labels/_labels_constants.py
+++ b/napari/layers/labels/_labels_constants.py
@@ -2,11 +2,12 @@ import sys
 from collections import OrderedDict
 from enum import auto
 
+from napari.layers.base._base_constants import ModeBase
 from napari.utils.misc import StringEnum
 from napari.utils.translations import trans
 
 
-class Mode(StringEnum):
+class Mode(ModeBase):
     """MODE: Interactive mode. The normal, default mode is PAN_ZOOM, which
     allows for normal interactivity with the canvas.
 

--- a/napari/layers/points/_points_constants.py
+++ b/napari/layers/points/_points_constants.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from enum import auto
 
+from napari.layers.base._base_constants import ModeBase
 from napari.utils.misc import StringEnum
 from napari.utils.translations import trans
 
@@ -21,7 +22,7 @@ class ColorMode(StringEnum):
     COLORMAP = auto()
 
 
-class Mode(StringEnum):
+class Mode(ModeBase):
     """
     Mode: Interactive mode. The normal, default mode is PAN_ZOOM, which
     allows for normal interactivity with the canvas.

--- a/napari/layers/shapes/_shapes_constants.py
+++ b/napari/layers/shapes/_shapes_constants.py
@@ -1,6 +1,7 @@
 import sys
 from enum import auto
 
+from napari.layers.base._base_constants import ModeBase
 from napari.layers.shapes._shapes_models import (
     Ellipse,
     Line,
@@ -11,7 +12,7 @@ from napari.layers.shapes._shapes_models import (
 from napari.utils.misc import StringEnum
 
 
-class Mode(StringEnum):
+class Mode(ModeBase):
     """Mode: Interactive mode. The normal, default mode is PAN_ZOOM, which
     allows for normal interactivity with the canvas.
 


### PR DESCRIPTION
# Description
Gives all `Mode` classes a common parent.

This has come up a couple of times when I've been doing typing fixes (e.g. in https://github.com/napari/napari/pull/6028). Because `Layer._modeclass` is overloaded by several other layers it makes sense that all the classes share a common parent that is more specific than `StringEnum`.

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (changes required to run napari, tests, & CI smoothly)
- [ ] Enhancement (non-breaking improvements of an existing feature)
- [ ] Documentation (update of docstrings and deprecation information)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
