### PR TITLE
Fix transform_utils typing

### DIFF
--- a/napari/utils/transforms/transform_utils.py
+++ b/napari/utils/transforms/transform_utils.py
@@ -1,10 +1,13 @@
+from typing import Tuple
+
 import numpy as np
+import numpy.typing as npt
 import scipy.linalg
 
 from napari.utils.translations import trans
 
 
-def compose_linear_matrix(rotate, scale, shear) -> np.array:
+def compose_linear_matrix(rotate, scale, shear) -> npt.NDArray:
     """Compose linear transform matrix from rotate, shear, scale.
 
     Parameters
@@ -336,7 +339,7 @@ def embed_in_identity_matrix(matrix, ndim):
 
 def decompose_linear_matrix(
     matrix, upper_triangular=True
-) -> (np.array, np.array, np.array):
+) -> Tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
     """Decompose linear transform matrix into rotate, scale, shear.
 
     Decomposition is based on code from https://github.com/matthew-brett/transforms3d.

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -1,7 +1,8 @@
 from functools import cached_property
-from typing import Sequence
+from typing import List, Optional, Sequence
 
 import numpy as np
+import numpy.typing as npt
 import toolz as tz
 
 from napari.utils.events import EventedList
@@ -109,8 +110,8 @@ class Transform:
         [self.__dict__.pop(p, None) for p in cached_properties]
 
 
-class TransformChain(EventedList, Transform):
-    def __init__(self, transforms=None) -> None:
+class TransformChain(EventedList[Transform], Transform):
+    def __init__(self, transforms: Optional[List[Transform]] = None) -> None:
         if transforms is None:
             transforms = []
         super().__init__(
@@ -141,7 +142,7 @@ class TransformChain(EventedList, Transform):
         return getattr(self.simplified, '_is_diagonal', False)
 
     @property
-    def simplified(self) -> 'Transform':
+    def simplified(self) -> Optional['Transform']:
         """Return the composite of the transforms inside the transform chain."""
         if len(self) == 0:
             return None
@@ -429,7 +430,7 @@ class Affine(Transform):
         return self._linear_matrix.shape[0]
 
     @property
-    def scale(self) -> np.array:
+    def scale(self) -> npt.NDArray:
         """Return the scale of the transform."""
         if self._is_diagonal:
             return np.diag(self._linear_matrix)
@@ -452,7 +453,7 @@ class Affine(Transform):
             self._linear_matrix = compose_linear_matrix(rotate, scale, shear)
 
     @property
-    def translate(self) -> np.array:
+    def translate(self) -> npt.NDArray:
         """Return the translation of the transform."""
         return self._translate
 
@@ -462,7 +463,7 @@ class Affine(Transform):
         self._translate = translate_to_vector(translate, ndim=self.ndim)
 
     @property
-    def rotate(self) -> np.array:
+    def rotate(self) -> npt.NDArray:
         """Return the rotation of the transform."""
         return decompose_linear_matrix(
             self.linear_matrix, upper_triangular=self._upper_triangular
@@ -478,7 +479,7 @@ class Affine(Transform):
         self._clean_cache()
 
     @property
-    def shear(self) -> np.array:
+    def shear(self) -> npt.NDArray:
         """Return the shear of the transform."""
         if self._is_diagonal:
             return np.zeros((self.ndim,))
@@ -510,7 +511,7 @@ class Affine(Transform):
         self._clean_cache()
 
     @property
-    def linear_matrix(self) -> np.array:
+    def linear_matrix(self) -> npt.NDArray:
         """Return the linear matrix of the transform."""
         return self._linear_matrix
 
@@ -523,7 +524,7 @@ class Affine(Transform):
         self._clean_cache()
 
     @property
-    def affine_matrix(self) -> np.array:
+    def affine_matrix(self) -> npt.NDArray:
         """Return the affine matrix for the transform."""
         matrix = np.eye(self.ndim + 1, self.ndim + 1)
         matrix[:-1, :-1] = self._linear_matrix
@@ -713,7 +714,7 @@ class CompositeAffine(Affine):
         self._linear_matrix = self._make_linear_matrix()
 
     @property
-    def scale(self) -> np.array:
+    def scale(self) -> npt.NDArray:
         """Return the scale of the transform."""
         return self._scale
 
@@ -724,7 +725,7 @@ class CompositeAffine(Affine):
         self._linear_matrix = self._make_linear_matrix()
 
     @property
-    def rotate(self) -> np.array:
+    def rotate(self) -> npt.NDArray:
         """Return the rotation of the transform."""
         return self._rotate
 
@@ -736,7 +737,7 @@ class CompositeAffine(Affine):
         self._clean_cache()
 
     @property
-    def shear(self) -> np.array:
+    def shear(self) -> npt.NDArray:
         """Return the shear of the transform."""
         return (
             self._shear[np.triu_indices(n=self.ndim, k=1)]
@@ -751,7 +752,11 @@ class CompositeAffine(Affine):
         self._linear_matrix = self._make_linear_matrix()
         self._clean_cache()
 
-    @Affine.linear_matrix.setter
+    @property
+    def linear_matrix(self):
+        return super().linear_matrix
+
+    @linear_matrix.setter
     def linear_matrix(self, linear_matrix):
         """Setting the linear matrix of a CompositeAffine transform is not supported."""
         raise NotImplementedError(
@@ -761,7 +766,11 @@ class CompositeAffine(Affine):
             )
         )
 
-    @Affine.affine_matrix.setter
+    @property
+    def affine_matrix(self):
+        return super().affine_matrix
+
+    @affine_matrix.setter
     def affine_matrix(self, affine_matrix):
         """Setting the affine matrix of a CompositeAffine transform is not supported."""
         raise NotImplementedError(

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import List, Optional, Sequence, Iterable
+from typing import Iterable, Optional, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -111,7 +111,9 @@ class Transform:
 
 
 class TransformChain(EventedList[Transform], Transform):
-    def __init__(self, transforms: Optional[Iterable[Transform]] = None) -> None:
+    def __init__(
+        self, transforms: Optional[Iterable[Transform]] = None
+    ) -> None:
         if transforms is None:
             transforms = []
         super().__init__(

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import List, Optional, Sequence
+from typing import List, Optional, Sequence, Iterable
 
 import numpy as np
 import numpy.typing as npt
@@ -111,7 +111,7 @@ class Transform:
 
 
 class TransformChain(EventedList[Transform], Transform):
-    def __init__(self, transforms: Optional[List[Transform]] = None) -> None:
+    def __init__(self, transforms: Optional[Iterable[Transform]] = None) -> None:
         if transforms is None:
             transforms = []
         super().__init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -380,7 +380,6 @@ module = [
     'napari.utils.shortcuts',
     'napari.utils.stubgen',
     'napari.utils.theme',
-    'napari.utils.transforms.transform_utils',
     'napari.utils.transforms.transforms',
     'napari.utils.tree.group',
 ]


### PR DESCRIPTION

Fixes typing in `napari.utils.transforms.transform_utils`.

Also fixes most typing in `napari.utils.transforms.transforms`, but there's one error there I can't work out for now.

