### PR TITLE
Task: remove html comments from pr description

### DIFF
--- a/.github/workflows/edit_pr_description.yml
+++ b/.github/workflows/edit_pr_description.yml
@@ -1,0 +1,29 @@
+name: Remove html comments from description.
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  check_labels:
+    if: github.event_name == 'pull_request'
+    name: Remove html comments.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # install python and requests
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+      - name: Remove html comments
+        run: |
+          python tools/remove_html_comments_from_pr.py

--- a/napari/_vispy/overlays/scale_bar.py
+++ b/napari/_vispy/overlays/scale_bar.py
@@ -81,7 +81,7 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
             # When we get the lowest index of the list, removing -1 will
             # return the last index.
             index -= 1
-        new_value = PREFERRED_VALUES[index]
+        new_value: float = PREFERRED_VALUES[index]
         if new_quantity.dimensionless and new_quantity.magnitude < 1:
             # using Decimal is necessary to avoid `4.999999e-6`
             # at really small scale.

--- a/tools/remove_html_comments_from_pr.py
+++ b/tools/remove_html_comments_from_pr.py
@@ -1,0 +1,74 @@
+"""
+Edit pull request description to remove HTML comments
+
+We might want to remove section with markdown task lists that are completely empty
+"""
+
+import re
+import sys
+from os import environ
+
+import requests
+
+
+def remove_html_comments(text):
+    # Regular expression to remove HTML comments
+    # [^\S\r\n] is whitespace but not new line
+    html_comment_pattern = r"[^\S\r\n]*<!--(.*?)-->[^\S\r\n]*\n?"
+    return re.sub(html_comment_pattern, "", text, flags=re.DOTALL)
+
+
+def edit_pull_request_description(repo, pull_request_number, access_token):
+    # GitHub API base URL
+    base_url = "https://api.github.com"
+
+    # Prepare the headers with the access token
+    headers = {"Authorization": f"token {access_token}"}
+
+    # Get the current pull request description
+    pr_url = f"{base_url}/repos/{repo}/pulls/{pull_request_number}"
+    response = requests.get(pr_url, headers=headers)
+    response.raise_for_status()
+    response_json = response.json()
+    current_description = response_json["body"]
+
+    # Remove HTML comments from the description
+    edited_description = remove_html_comments(current_description)
+    if edited_description == current_description:
+        print("No HTML comments found in the pull request description")
+        return
+
+    # Update the pull request description
+    update_pr_url = f"{base_url}/repos/{repo}/pulls/{pull_request_number}"
+    payload = {"body": edited_description}
+    response = requests.patch(update_pr_url, json=payload, headers=headers)
+    response.raise_for_status()
+
+    if response.status_code == 200:
+        print(
+            f"Pull request #{pull_request_number} description has been updated successfully!"
+        )
+    else:
+        print(
+            f"Failed to update pull request description. Status code: {response.status_code}"
+        )
+
+
+if __name__ == "__main__":
+    # Replace with your repository and pull request number
+    # get cuurrent repository name from github actions
+    repository_name = environ.get("GITHUB_REPOSITORY")
+    if repository_name == "napari/napari":
+        sys.exit(0)
+
+    # get current PR number from github actions
+    github_ref = environ.get("GITHUB_REF")
+    refs, pull, number, merge = github_ref.split('/')
+    assert refs == 'refs'
+    assert pull == 'pull'
+    assert merge == 'merge'
+
+    # Replace with your GitHub access token
+    access_token = environ.get("GITHUB_TOKEN")
+
+    edit_pull_request_description(repository_name, number, access_token)


### PR DESCRIPTION
This will edit a PR description to remove any html comment that are present, including leading/trailing whitespace and a single trailing newline if there is one.

As the PRs descriptions are often becoming Merge/rebase-squash messages, this should lead to cleaner commit messages. 

Should close #6085

<!-- will this be removed ? -->