### PR TITLE
Add zulip link to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,6 +38,5 @@ Closes #
 - [ ] If I included new strings, I have used `trans.` to make them localizable.
       For more information see our [translations guide](https://napari.org/developers/translations.html).
 
-<!-- If you are waiting for someone to review your PR, please feel free to-->
-<!-- message us in Zulip to ask for a review: -->
-<!-- https://napari.zulipchat.com/#narrow/stream/270578-reviews -->
+<!--Feel free to message us in Zulip for any questions or remind us to review:
+https://napari.zulipchat.com/#narrow/stream/270578-reviews -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@ Closes #
 - [ ] example: the test suite for my feature covers cases x, y, and z
 - [ ] example: all tests pass with my change
 - [ ] example: I check if my changes works with both PySide and PyQt backends
-      as there are small differences between the two Qt bindings.  
+      as there are small differences between the two Qt bindings.
 
 ## Final checklist:
 - [ ] My PR is the minimum possible work for the desired functionality
@@ -37,3 +37,7 @@ Closes #
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] If I included new strings, I have used `trans.` to make them localizable.
       For more information see our [translations guide](https://napari.org/developers/translations.html).
+
+<!-- If you are waiting for someone to review your PR, please feel free to-->
+<!-- message us in Zulip to ask for a review: -->
+<!-- https://napari.zulipchat.com/#narrow/stream/270578-reviews -->


### PR DESCRIPTION
# Fixes/Closes

# Description

Adds link to review channel in zulip, so contributors know that they can message for reviews.
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (changes required to run napari, tests, & CI smoothly)
- [ ] Enhancement (non-breaking improvements of an existing feature)
- [ ] Documentation (update of docstrings and deprecation information)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).

cc @jni 