### PR TITLE
Extend "No Qt bindings found" error message with details about conda

### DIFF
--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -9,6 +9,8 @@ try:
     from qtpy import API_NAME, QT_VERSION, QtCore
 except Exception as e:
     if 'No Qt bindings could be found' in str(e):
+        from inspect import cleandoc
+
         raise ImportError(
             trans._(
                 cleandoc(
@@ -26,7 +28,7 @@ except Exception as e:
                   $ conda install -c conda-forge pyqt
                   $ conda install -c conda-forge pyside2
                 """
-                )
+                ),
                 deferred=True,
             )
         ) from e

--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -11,7 +11,22 @@ except Exception as e:
     if 'No Qt bindings could be found' in str(e):
         raise ImportError(
             trans._(
-                'No Qt bindings could be found.\n\nnapari requires either PyQt5 (default) or PySide2 to be installed in the environment.\n\nWith pip, you can install either with:\n  $ pip install -U \'napari[all]\'  # default choice\n  $ pip install -U \'napari[pyqt5]\'\n  $ pip install -U \'napari[pyside2]\'\n\nWith conda, you need to do:\n  $ conda install -c conda-forge pyqt\n  $ conda install -c conda-forge pyside2\n',
+                cleandoc(
+                """
+                No Qt bindings could be found.
+
+                napari requires either PyQt5 (default) or PySide2 to be installed in the environment.
+
+                With pip, you can install either with:
+                  $ pip install -U 'napari[all]'  # default choice
+                  $ pip install -U 'napari[pyqt5]'
+                  $ pip install -U 'napari[pyside2]'
+
+                With conda, you need to do:
+                  $ conda install -c conda-forge pyqt
+                  $ conda install -c conda-forge pyside2
+                """
+                )
                 deferred=True,
             )
         ) from e

--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -11,7 +11,7 @@ except Exception as e:
     if 'No Qt bindings could be found' in str(e):
         raise ImportError(
             trans._(
-                'No Qt bindings could be found.\n\nnapari requires either PyQt5 or PySide2 to be installed in the environment.\nTo install the default backend (currently PyQt5), run "pip install napari[all]" \nYou may also use "pip install napari[pyside2]"for Pyside2, or "pip install napari[pyqt5]" for PyQt5',
+                'No Qt bindings could be found.\n\nnapari requires either PyQt5 (default) or PySide2 to be installed in the environment.\n\nWith pip, you can install either with:\n  $ pip install -U \'napari[all]\'  # default choice\n  $ pip install -U \'napari[pyqt5]\'\n  $ pip install -U \'napari[pyside2]\'\n\nWith conda, you need to do:\n  $ conda install -c conda-forge pyqt\n  $ conda install -c conda-forge pyside2\n',
                 deferred=True,
             )
         ) from e

--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -11,14 +11,14 @@ except Exception as e:
     if 'No Qt bindings could be found' in str(e):
         from inspect import cleandoc
 
-        installed_with_conda = (
-            list(Path(sys.prefix, "conda-meta").glob("napari-*.json"))
+        installed_with_conda = list(
+            Path(sys.prefix, "conda-meta").glob("napari-*.json")
         )
 
         raise ImportError(
             trans._(
                 cleandoc(
-                """
+                    """
                 No Qt bindings could be found.
 
                 napari requires either PyQt5 (default) or PySide2 to be installed in the environment.

--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -11,6 +11,10 @@ except Exception as e:
     if 'No Qt bindings could be found' in str(e):
         from inspect import cleandoc
 
+        installed_with_conda = (
+            list(Path(sys.prefix, "conda-meta").glob("napari-*.json"))
+        )
+
         raise ImportError(
             trans._(
                 cleandoc(
@@ -27,9 +31,12 @@ except Exception as e:
                 With conda, you need to do:
                   $ conda install -c conda-forge pyqt
                   $ conda install -c conda-forge pyside2
+
+                Our heuristics suggest you are using '{tool}' to manage your packages.
                 """
                 ),
                 deferred=True,
+                tool="conda" if installed_with_conda else "pip",
             )
         ) from e
     raise


### PR DESCRIPTION
# Fixes/Closes

<!-- In general, PRs should fix an existing issue on the repo. -->
<!-- Please link to that issue here as "Closes #(issue-number)". -->

This is porting changes we had to add (due to urgency) directly in the conda-forge feedstock (see https://github.com/conda-forge/napari-feedstock/pull/52).

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

We have changed how we package `napari` for conda, and it doesn't depend on PyQt or PySide anymore. Instead, the user needs to specify which one they want (see https://github.com/conda-forge/napari-feedstock/issues/47). This has been addressed in the documentation, but there might be people still relying on the "it just works" behavior of `conda install napari`.

For those, we will have a nicer error message that will tell them how to fix the absence of Qt bindings. In 0.4.18 this didn't work on macOS due to the `qtpy` import in `napari.__main__._maybe_rerun_with_macos_fixes`, but this is fixed in `main`. This is why the patch in the 0.4.18 feedstock is different. In this PR we only need to extend the error message already present in `napari._qt.__init__`.

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

- https://github.com/conda-forge/napari-feedstock/pull/52
- https://github.com/conda-forge/napari-feedstock/issues/47

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (changes required to run napari, tests, & CI smoothly)
- [X] Enhancement (non-breaking improvements of an existing feature)
- [ ] Documentation (update of docstrings and deprecation information)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [X] Created a conda installation for napari, force removed pyqt and tried to run `napari`. The following message shows up:

```
ImportError: No Qt bindings could be found.

napari requires either PyQt5 (default) or PySide2 to be installed in the environment.

With pip, you can install either with:
  $ pip install -U 'napari[pyqt]'
  $ pip install -U 'napari[pyside]'

With conda, you can install either with:
  $ conda install pyqt
  $ conda install pyside2
```
 
## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).


cc @jni and @psobolewskiPhD for their previous involvement in these changes.