### PR TITLE
Install napari from repository in docker image

### DIFF
--- a/.github/workflows/docker-singularity-publish.yml
+++ b/.github/workflows/docker-singularity-publish.yml
@@ -14,6 +14,7 @@ on:
     branches: [ main ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
+  pull_request:  # TEMPORARY; remove before merge
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/docker-singularity-publish.yml
+++ b/.github/workflows/docker-singularity-publish.yml
@@ -85,6 +85,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           file: "dockerfile"
           target: ${{ matrix.target }}
+          # We build from the the tag name if triggered by tag, otherwise from the commit hash
+          build-args: |
+            NAPARI_COMMIT=${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
 
 # ----
 

--- a/.github/workflows/docker-singularity-publish.yml
+++ b/.github/workflows/docker-singularity-publish.yml
@@ -14,7 +14,6 @@ on:
     branches: [ main ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
-  pull_request:  # TEMPORARY; remove before merge
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/docker-singularity-publish.yml
+++ b/.github/workflows/docker-singularity-publish.yml
@@ -78,6 +78,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
+        id: docker_build
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -88,7 +89,11 @@ jobs:
           # We build from the the tag name if triggered by tag, otherwise from the commit hash
           build-args: |
             NAPARI_COMMIT=${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
-
+      
+      - name: Test Docker image
+        run: |
+          docker run --rm --entrypoint=/bin/bash ${{ steps.docker_build.outputs.imageid }} -ec "python3 -m napari --version"
+    
 # ----
 
   build2:

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -2,10 +2,11 @@
 name: PR Test
 
 on:
-  pull_request:
-    branches:
-      - main
-      - "v*x"
+  workflow_dispatch:
+  # pull_request:
+  #   branches:
+  #     - main
+  #     - "v*x"
 
 concurrency:
   group: test-${{ github.ref }}

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -2,11 +2,10 @@
 name: PR Test
 
 on:
-  workflow_dispatch:
-  # pull_request:
-  #   branches:
-  #     - main
-  #     - "v*x"
+  pull_request:
+    branches:
+      - main
+      - "v*x"
 
 concurrency:
   group: test-${{ github.ref }}

--- a/dockerfile
+++ b/dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && \
         && apt-get clean
 
 # install napari from repo
-RUN pip3 install 'https://github.com/napari/napari/archive/${NAPARI_COMMIT}.tar.gz'[all]
+RUN pip3 install https://github.com/napari/napari/archive/${NAPARI_COMMIT}.tar.gz[all]
 
 # copy examples
 COPY examples /tmp/examples

--- a/dockerfile
+++ b/dockerfile
@@ -6,6 +6,7 @@ FROM --platform=linux/amd64 ubuntu:22.04 AS napari
 # below env var required to install libglib2.0-0 non-interactively
 ENV TZ=America/Los_Angeles
 ARG DEBIAN_FRONTEND=noninteractive
+ARG NAPARI_COMMIT=main
 
 # install python resources + graphical libraries used by qt and vispy
 RUN apt-get update && \
@@ -33,8 +34,8 @@ RUN apt-get update && \
         libxcb-shape0 \
         && apt-get clean
 
-# install napari release version
-RUN pip3 install napari[all]
+# install napari from repo
+RUN pip3 install 'https://github.com/napari/napari/archive/${NAPARI_COMMIT}.tar.gz'[all]
 
 # copy examples
 COPY examples /tmp/examples

--- a/dockerfile
+++ b/dockerfile
@@ -35,7 +35,8 @@ RUN apt-get update && \
         && apt-get clean
 
 # install napari from repo
-RUN pip3 install https://github.com/napari/napari/archive/${NAPARI_COMMIT}.tar.gz[all]
+# see https://github.com/pypa/pip/issues/6548#issuecomment-498615461 for syntax
+RUN pip3 install "napari[all] @ git+https://github.com/napari/napari.git@${NAPARI_COMMIT}"
 
 # copy examples
 COPY examples /tmp/examples


### PR DESCRIPTION
# Fixes/Closes

Closes https://github.com/napari/napari/issues/6096

# Description





We have a workflow that runs on each push and publishes a docker image to ghcr.io. This includes tagged releases.

However, the Dockerfile installs napari from PyPI, which will always be lagging. Hence, the docker container for 0.4.18 ships 0.4.17... and so do all the previous commits since 0.4.17 excluded 😂  We have been publishing the same Docker image for each push for a while and maaaybe we should delete a few (although layers are cached, so not so bad).

# References


- `build-args`: https://github.com/docker/build-push-action/tree/v4/#inputs
- ARG vs ENV: https://vsupalov.com/docker-arg-env-variable-guide/#arg-and-env-availability

## Type of change

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (changes required to run napari, tests, & CI smoothly)
- [ ] Enhancement (non-breaking improvements of an existing feature)
- [ ] Documentation (update of docstrings and deprecation information)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

- [x] CI passes and reports correct version  

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
