### PR TITLE
Fix automatic selection of points when setting data

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -386,7 +386,7 @@ def test_points_selection_with_setter():
     coords = [[10, 10], [15, 15]]
     layer.data = np.append(layer.data, np.atleast_2d(coords), axis=0)
     assert len(layer.data) == 12
-    assert len(layer.selected_data) == 0
+    assert layer.selected_data == set()
 
 
 def test_adding_points_to_empty():

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -370,10 +370,23 @@ def test_adding_points():
     layer.add(coords)
     assert len(layer.data) == 13
     assert np.all(layer.data[11:, :] == coords)
+    assert layer.selected_data == {11, 12}
 
     # test that the last added points can be deleted
     layer.remove_selected()
     np.testing.assert_equal(layer.data, np.vstack((data, coord)))
+
+
+def test_points_selection_with_setter():
+    shape = (10, 2)
+    np.random.seed(0)
+    data = 20 * np.random.random(shape)
+    layer = Points(data)
+
+    coords = [[10, 10], [15, 15]]
+    layer.data = np.append(layer.data, np.atleast_2d(coords), axis=0)
+    assert len(layer.data) == 12
+    assert len(layer.selected_data) == 0
 
 
 def test_adding_points_to_empty():
@@ -387,6 +400,7 @@ def test_adding_points_to_empty():
     layer.add(coord)
     assert len(layer.data) == 1
     assert np.all(layer.data[0] == coord)
+    assert layer.selected_data == {0}
 
 
 def test_removing_selected_points():

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -584,7 +584,6 @@ class Points(Layer):
                     (self._edge_width, edge_width), axis=0
                 )
                 self.symbol = np.concatenate((self._symbol, symbol), axis=0)
-                self.selected_data = set(np.arange(cur_npoints, len(data)))
 
         self._update_dims()
         self._reset_editable()
@@ -1914,6 +1913,7 @@ class Points(Layer):
         coords : array
             Point or points to add to the layer data.
         """
+        cur_points = len(self.data)
         self.data = np.append(self.data, np.atleast_2d(coords), axis=0)
         self.events.data(
             value=self.data,
@@ -1921,6 +1921,7 @@ class Points(Layer):
             data_indices=(-1,),
             vertex_indices=((),),
         )
+        self.selected_data = set(np.arange(cur_points, len(self.data)))
 
     def remove_selected(self):
         """Removes selected points if any."""


### PR DESCRIPTION
# Closes #6064

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

This PR fixes the points layer bug related to highlighting/selection of the points from the previous dataset when there are more number of points data on the newer set compared to the older one. To fix this, we have moved the selection outside of the data setter and into the points::add functionality.

Points Data Setter:

https://github.com/akuten1298/napari/assets/51192400/a573cd8a-98c5-4877-a06c-9b6b7ddd3d10


Points Data Add:

https://github.com/akuten1298/napari/assets/51192400/5e3c3561-f298-4c2d-9dbd-4c2f03157209


# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (changes required to run napari, tests, & CI smoothly)
- [ ] Enhancement (non-breaking improvements of an existing feature)
- [ ] Documentation (update of docstrings and deprecation information)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
