### PR TITLE
Exclude ... from coverage 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -168,6 +168,7 @@ exclude_lines =
     if TYPE_CHECKING:
     raise NotImplementedError()
     except ImportError:
+    ^ +\.\.\.$
 
 
 [coverage:run]


### PR DESCRIPTION
# Description

Exclude lines with only `...`. As we use it in overload definition.  


## Type of change
- [x] Maintenance (changes required to run napari, tests, & CI smoothly)

