### PR TITLE
Pass `QT_QPA_PLATFORM` through tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,7 @@ passenv =
     CONDA_EXE
     CONDA
     FORCE_COLOR
+    QT_QPA_PLATFORM
 # Set various environment variables, depending on the factors in
 # the tox environment being run
 setenv =


### PR DESCRIPTION
# Description
This PR allows to use `QT_QPA_PLATFORM` when running tests using tox. Especially allows to 
use `QT_QPA_PLATFORM=offscreen` that disables jumping windows. 

# References
https://doc.qt.io/qt-6/qpa.html#selecting-a-qpa-plugin

## Type of change
- [x] Maintenance (changes required to run napari, tests, & CI smoothly)
- [x] This change requires a documentation update