### PR TITLE
Emit event from Points data setter

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2495,3 +2495,12 @@ def test_points_data_setter_emits_event():
     layer.events.data.connect(lambda ev: emitted_events.append(ev))
     layer.data = np.random.random((5, 2))
     assert len(emitted_events) == 1
+
+
+def test_points_add_only_emits_one_event():
+    data = np.random.random((5, 2))
+    emitted_events = []
+    layer = Points(data)
+    layer.events.data.connect(lambda ev: emitted_events.append(ev))
+    layer.add(np.random.random(2))
+    assert len(emitted_events) == 1

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2490,20 +2490,20 @@ def test_point_selection_remains_evented_after_update():
 
 def test_points_data_setter_emits_event():
     data = np.random.random((5, 2))
-    emitted_events = []
+    emitted_events = Mock()
     layer = Points(data)
-    layer.events.data.connect(lambda ev: emitted_events.append(ev))
+    layer.events.data.connect(emitted_events)
     layer.data = np.random.random((5, 2))
-    assert len(emitted_events) == 1
+    emitted_events.assert_called_once()
 
 
 def test_points_add_delete_only_emit_one_event():
     data = np.random.random((5, 2))
-    emitted_events = []
+    emitted_events = Mock()
     layer = Points(data)
-    layer.events.data.connect(lambda ev: emitted_events.append(ev))
+    layer.events.data.connect(emitted_events)
     layer.add(np.random.random(2))
-    assert len(emitted_events) == 1
+    assert emitted_events.call_count == 1
     layer.selected_data = {3}
     layer.remove_selected()
-    assert len(emitted_events) == 2
+    assert emitted_events.call_count == 2

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2486,3 +2486,12 @@ def test_point_selection_remains_evented_after_update():
     assert isinstance(layer.selected_data, Selection)
     layer.selected_data = {0, 1}
     assert isinstance(layer.selected_data, Selection)
+
+
+def test_points_data_setter_emits_event():
+    data = np.random.random((5, 2))
+    emitted_events = []
+    layer = Points(data)
+    layer.events.data.connect(lambda ev: emitted_events.append(ev))
+    layer.data = np.random.random((5, 2))
+    assert len(emitted_events) == 1

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2497,10 +2497,13 @@ def test_points_data_setter_emits_event():
     assert len(emitted_events) == 1
 
 
-def test_points_add_only_emits_one_event():
+def test_points_add_delete_only_emit_one_event():
     data = np.random.random((5, 2))
     emitted_events = []
     layer = Points(data)
     layer.events.data.connect(lambda ev: emitted_events.append(ev))
     layer.add(np.random.random(2))
     assert len(emitted_events) == 1
+    layer.selected_data = {3}
+    layer.remove_selected()
+    assert len(emitted_events) == 2

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -586,6 +586,12 @@ class Points(Layer):
                 self.symbol = np.concatenate((self._symbol, symbol), axis=0)
 
         self._update_dims()
+        self.events.data(
+            value=self.data,
+            action=ActionType.CHANGE.value,
+            data_indices=slice(None),
+            vertex_indices=((),),
+        )
         self._reset_editable()
 
     def _on_selection(self, selected):

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -525,6 +525,17 @@ class Points(Layer):
 
     @data.setter
     def data(self, data: Optional[np.ndarray]):
+        """Set the data array and emit a corresponding event."""
+        self._set_data(data)
+        self.events.data(
+            value=self.data,
+            action=ActionType.CHANGE.value,
+            data_indices=slice(None),
+            vertex_indices=((),),
+        )
+
+    def _set_data(self, data: Optional[np.ndarray]):
+        """Set the .data array attribute, without emitting an event."""
         data, _ = fix_data_points(data, self.ndim)
         cur_npoints = len(self._data)
         self._data = data
@@ -586,12 +597,6 @@ class Points(Layer):
                 self.symbol = np.concatenate((self._symbol, symbol), axis=0)
 
         self._update_dims()
-        self.events.data(
-            value=self.data,
-            action=ActionType.CHANGE.value,
-            data_indices=slice(None),
-            vertex_indices=((),),
-        )
         self._reset_editable()
 
     def _on_selection(self, selected):
@@ -1920,7 +1925,7 @@ class Points(Layer):
             Point or points to add to the layer data.
         """
         cur_points = len(self.data)
-        self.data = np.append(self.data, np.atleast_2d(coords), axis=0)
+        self._set_data(np.append(self.data, np.atleast_2d(coords), axis=0))
         self.events.data(
             value=self.data,
             action=ActionType.ADD.value,
@@ -1955,7 +1960,7 @@ class Points(Layer):
                     self._value -= offset
                     self._value_stored -= offset
 
-            self.data = np.delete(self.data, index, axis=0)
+            self._set_data(np.delete(self.data, index, axis=0))
             self.events.data(
                 value=self.data,
                 action=ActionType.REMOVE.value,


### PR DESCRIPTION
Closes #6116

# Description

Adds back an event emission from the Points layer data setter. Commits summary:

- Add failing test for layer data setter event
- Emit event on points data setter

## Type of change

- [x] Bug-fix (non-breaking change which fixes an issue)
