### PR TITLE
Update README.md for conda install change

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ conda activate napari-env
 python -m pip install "napari[all]"
 ```
 
-If you prefer conda over pip, you can replace the last line with: `conda install -c conda-forge napari`
+If you prefer conda over pip, you can replace the last line with: `conda install -c conda-forge napari pyqt`
 
 See here for the full [installation guide](https://napari.org/tutorials/fundamentals/installation.html).
 


### PR DESCRIPTION
# Fixes/Closes

N/A

# Description
Updates README conda install instructions for the fact that the conda package no longer pulls Qt—a Qt backend needs to be specified.

# References
https://github.com/conda-forge/napari-feedstock/issues/47
https://github.com/conda-forge/napari-feedstock/pull/48
https://github.com/napari/docs/pull/202

## Type of change
- [x] Documentation