### PR TITLE
Use faster version of black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://github.com/psf/black
+-   repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.7.0
     hooks:
     - id: black


### PR DESCRIPTION
# Description





Use black compiled with mypyc instead of pure python version to get it faster 

# References


https://github.com/psf/black/issues/3405

## Type of change

- [x] Maintenance (changes required to run napari, tests, & CI smoothly)

