### PR TITLE
Update PR editing script to remove html.

### DIFF
--- a/.github/workflows/edit_pr_description.yml
+++ b/.github/workflows/edit_pr_description.yml
@@ -1,4 +1,5 @@
-name: Remove html comments from description.
+name: Remove html In PR description
+# see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
 on:
   # see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
   pull_request_target:
@@ -6,15 +7,13 @@ on:
       - opened
       - synchronize
       - reopened
-      - labeled
-      - unlabeled
-# see https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+      - edited
+  # see https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
 permissions:
   pull-requests: write
 
 jobs:
   check_labels:
-    if: github.event_name == 'pull_request'
     name: Remove html comments.
     runs-on: ubuntu-latest
     steps:
@@ -23,11 +22,16 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install requests
       - name: Remove html comments
+        env:
+          GH_PR_NUMBER: ${{ github.event.number }}
+          GH_REPO_URL: ${{ github.event.repository.url}}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
         run: |
           python tools/remove_html_comments_from_pr.py


### PR DESCRIPTION
This was more complicated than I anticipated, in particular because GitHub documentation seem to be wrong in a number of places.

Action environment also seem to differ for intra- and inter- repository PRs as well as org- vs user- base repo.

This successfully stripped html from this PR:

    https://github.com/Carreau/napari/pull/4

Though it was in intra-repo with user-based repo, so I'm not sure how this will behave in an inter-repo where the base-repo is an org.

-- 

As for previous one this need to be merged to be properly tested. 
