### PR TITLE
Fix oblique button by chekcing if action is generator

### DIFF
--- a/napari/_qt/layer_controls/qt_image_controls.py
+++ b/napari/_qt/layer_controls/qt_image_controls.py
@@ -120,7 +120,7 @@ class QtImageControls(QtBaseImageControls):
             self.planeNormalButtons.xButton,
         )
         action_manager.bind_button(
-            'napari:orient_plane_normal_along_view_direction',
+            'napari:orient_plane_normal_along_view_direction_no_gen',
             self.planeNormalButtons.obliqueButton,
         )
 

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1475,7 +1475,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         return normalized_vector
 
     def _world_to_displayed_data_ray(
-        self, vector_world: npt.NDArray, dims_displayed: List[int]
+        self, vector_world: npt.ArrayLike, dims_displayed: List[int]
     ) -> np.ndarray:
         """Convert an orientation from world to displayed data coordinates.
 

--- a/napari/layers/image/_image_key_bindings.py
+++ b/napari/layers/image/_image_key_bindings.py
@@ -59,7 +59,12 @@ def orient_plane_normal_along_view_direction(layer: Image):
 
 @register_image_action(trans._('orient plane normal along view direction'))
 def orient_plane_normal_along_view_direction_no_gen(layer: Image):
-    list(orient_plane_normal_along_view_direction(layer))
+    viewer = napari.viewer.current_viewer()
+    if viewer is None or viewer.dims.ndisplay != 3:
+        return
+    layer.plane.normal = layer._world_to_displayed_data_ray(
+        viewer.camera.view_direction, [-3, -2, -1]
+    )
 
 
 @register_image_action(trans._('Transform'))

--- a/napari/layers/image/_image_key_bindings.py
+++ b/napari/layers/image/_image_key_bindings.py
@@ -57,6 +57,11 @@ def orient_plane_normal_along_view_direction(layer: Image):
     )
 
 
+@register_image_action(trans._('orient plane normal along view direction'))
+def orient_plane_normal_along_view_direction_no_gen(layer: Image):
+    list(orient_plane_normal_along_view_direction(layer))
+
+
 @register_image_action(trans._('Transform'))
 def activate_image_transform_mode(layer):
     layer.mode = Mode.TRANSFORM

--- a/napari/utils/_tests/test_action_manager.py
+++ b/napari/utils/_tests/test_action_manager.py
@@ -1,6 +1,8 @@
 """
 This module test some of the behavior of action manager.
 """
+from unittest.mock import Mock
+
 import pytest
 
 from napari.utils.action_manager import ActionManager
@@ -48,3 +50,18 @@ def test_bind_unbind_existing_action(action_manager):
     assert action_manager.bind_shortcut('napari:test_action_1', 'X') is None
     assert action_manager.unbind_shortcut('napari:test_action_1') == ['X']
     assert action_manager._shortcuts['napari:test_action_1'] == []
+
+
+def test_bind_key_generator(action_manager):
+    def _sample_generator():
+        yield 'X'
+
+    action_manager.register_action(
+        "napari:test_action_1",
+        _sample_generator,
+        "this is a test action",
+        None,
+    )
+
+    with pytest.raises(ValueError, match="generator functions"):
+        action_manager.bind_button('napari:test_action_1', Mock())

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import warnings
 from collections import defaultdict
+from collections.abc import Generator
 from dataclasses import dataclass
 from functools import cached_property
 from inspect import isgeneratorfunction
@@ -224,7 +225,13 @@ class ActionManager:
                 )
             )
 
-        button.clicked.connect(lambda: self.trigger(name))
+        def _trigger():
+            res = self.trigger(name)
+            if isinstance(res, Generator):
+                for _ in res:
+                    pass
+
+        button.clicked.connect(_trigger)
         if name in self._actions:
             button.setToolTip(
                 f'{self._build_tooltip(name)} {extra_tooltip_text}'

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -217,7 +217,7 @@ class ActionManager:
         self._validate_action_name(name)
 
         if (action := self._actions.get(name)) and isgeneratorfunction(
-            action.command
+            getattr(action, "command", None)
         ):
             raise ValueError(
                 trans._(

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import warnings
 from collections import defaultdict
-from collections.abc import Generator
 from dataclasses import dataclass
 from functools import cached_property
 from inspect import isgeneratorfunction
@@ -217,7 +216,9 @@ class ActionManager:
         """
         self._validate_action_name(name)
 
-        if (action := self._actions.get(name)) and isgeneratorfunction(action):
+        if (action := self._actions.get(name)) and isgeneratorfunction(
+            action.command
+        ):
             raise ValueError(
                 trans._(
                     '`bind_button` cannot be used with generator functions',
@@ -226,10 +227,7 @@ class ActionManager:
             )
 
         def _trigger():
-            res = self.trigger(name)
-            if isinstance(res, Generator):
-                for _ in res:
-                    pass
+            self.trigger(name)
 
         button.clicked.connect(_trigger)
         if name in self._actions:


### PR DESCRIPTION
# Description

This Pr fixes a bug that was claimed to be tested in #4265, but it does not happens (action is dataclass so newer will be generator). 

As having `orient_plane_normal_along_view_direction` as the generator is important then I add a separate function `orient_plane_normal_along_view_direction_no_gen` for this.  

# References

#4164

## Type of change

- [x] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?

- [x] Manually 

Closes #6040