### PR TITLE
More typing of napari/utils.

### DIFF
--- a/napari/utils/geometry.py
+++ b/napari/utils/geometry.py
@@ -602,7 +602,7 @@ def line_in_quadrilateral_3d(
     rotated_vertices, rotation_matrix = rotate_points(
         points=vertices_plane,
         current_plane_normal=line_direction,
-        new_plane_normal=[0, 0, 1],
+        new_plane_normal=np.array([0, 0, 1]),
     )
     quadrilateral_2D = rotated_vertices[:, :2]
     click_pos_2D = rotation_matrix.dot(line_point)[:2]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -351,7 +351,6 @@ module = [
     'napari.layers.utils.text_manager',
     'napari.resources._icons',
     'napari.utils._magicgui',
-    'napari.utils._octree',
     'napari.utils._testsupport',
     'napari.utils._tracebacks',
     'napari.utils.action_manager',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -368,7 +368,6 @@ module = [
     'napari.utils.events.debugging',
     'napari.utils.events.event',
     'napari.utils.events.evented_model',
-    'napari.utils.geometry',
     'napari.utils.interactions',
     'napari.utils.key_bindings',
     'napari.utils.mouse_bindings',


### PR DESCRIPTION
Should be pretty straitforward, `'napari.utils._octree'` was removed some time ago.