### PR TITLE
Fix incorrect types in color_transformations.

### DIFF
--- a/napari/layers/utils/color_transformations.py
+++ b/napari/layers/utils/color_transformations.py
@@ -5,7 +5,7 @@ a numpy array with N rows, N being the number of data points, and a dtype of np.
 """
 import warnings
 from itertools import cycle
-from typing import Tuple, Union
+from typing import Tuple
 
 import numpy as np
 
@@ -65,13 +65,13 @@ def transform_color_with_defaults(
 
 
 def transform_color_cycle(
-    color_cycle: Union[ColorType, cycle], elem_name: str, default: str
+    color_cycle: ColorType, elem_name: str, default: str
 ) -> Tuple["cycle[np.ndarray]", np.ndarray]:
     """Helper method to return an Nx4 np.array from an arbitrary user input.
 
     Parameters
     ----------
-    color_cycle : ColorType, cycle
+    color_cycle : ColorType
         The desired colors for each of the data points
     elem_name : str
         Whether we're trying to set the face color or edge color of the layer
@@ -97,7 +97,7 @@ def transform_color_cycle(
 
 
 def normalize_and_broadcast_colors(
-    num_entries: int, colors: ColorType
+    num_entries: int, colors: np.ndarray
 ) -> np.ndarray:
     """Takes an input color array and forces into being the length of ``data``.
 
@@ -112,7 +112,7 @@ def normalize_and_broadcast_colors(
     ----------
     num_entries : int
         The number of data elements in the layer
-    colors : ColorType
+    colors : np.ndarray
         The user's input after being normalized by transform_color_with_defaults
 
     Returns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -344,7 +344,6 @@ module = [
     'napari.layers.utils._link_layers',
     'napari.layers.utils.color_encoding',
     'napari.layers.utils.color_manager',
-    'napari.layers.utils.color_transformations',
     'napari.layers.utils.stack_utils',
     'napari.layers.utils.string_encoding',
     'napari.layers.utils.style_encoding',


### PR DESCRIPTION
### first function:

  color_cycle __cannot__ be a cycle, a cycle raise if you try to
  compute it's length. I believe the name of the function is that is _returns_ a cycle.

### second function:

  colors must be an ndarray as we either call as_array,
  or .ravel() on it. The documentation does say:

  > Note: This function can't robustly parse user input, and thus should
   always be used on the output of ``transform_color_with_defaults``.

  and `transform_color_with_defaults` does return an ndarray, so it
  might be a good idea to enforce it.

  This completely misbehave if we give it something else than a
  ndarray:

    In [4]: normalize_and_broadcast_colors(6, 'purple')
    Out[4]: array('purple', dtype='<U6')

