### PR TITLE
Fix split logic in shortcut editor

### DIFF
--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -574,6 +574,7 @@ class EditorWidget(QLineEdit):
     def keyPressEvent(self, event):
         """Qt method override."""
         event_key = event.key()
+        print(event_key)
         if not event_key or event_key == Qt.Key.Key_unknown:
             return
 

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -611,22 +611,19 @@ class EditorWidget(QLineEdit):
         event_keyseq = translator.keyevent_to_keyseq(event)
         event_keystr = event_keyseq.toString(QKeySequence.PortableText)
 
-        if len(event_keystr) > 1:
-            # Split the shortcut if it contains a symbol.
-            parsed = re.split('[-(?=.+)]', event_keystr)
+        # Split the shortcut if it contains a symbol.
+        parsed = re.split(r'[-+](?=.+)', event_keystr)
 
-            keys_li = []
-            # Format how the shortcut is written (ex. 'Ctrl+B' is changed to 'Control-B')
-            for val in parsed:
-                if val in KEY_SUBS:
-                    keys_li.append(KEY_SUBS[val])
-                else:
-                    keys_li.append(val)
+        keys_li = []
+        # Format how the shortcut is written (ex. 'Ctrl+B' is changed to 'Control-B')
+        for val in parsed:
+            if val in KEY_SUBS:
+                keys_li.append(KEY_SUBS[val])
+            else:
+                keys_li.append(val)
 
-            keys_li = '-'.join(keys_li)
-            self.setText(keys_li)
-        else:
-            self.setText(event_keystr)
+        keys_li = '-'.join(keys_li)
+        self.setText(keys_li)
 
 
 class ShortcutTranslator(QKeySequenceEdit):

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -574,7 +574,6 @@ class EditorWidget(QLineEdit):
     def keyPressEvent(self, event):
         """Qt method override."""
         event_key = event.key()
-        print(event_key)
         if not event_key or event_key == Qt.Key.Key_unknown:
             return
 
@@ -612,19 +611,22 @@ class EditorWidget(QLineEdit):
         event_keyseq = translator.keyevent_to_keyseq(event)
         event_keystr = event_keyseq.toString(QKeySequence.PortableText)
 
-        # Split the shortcut if it contains a symbol.
-        parsed = re.split('[-(?=.+)]', event_keystr)
+        if len(event_keystr) > 1:
+            # Split the shortcut if it contains a symbol.
+            parsed = re.split('[-(?=.+)]', event_keystr)
 
-        keys_li = []
-        # Format how the shortcut is written (ex. 'Ctrl+B' is changed to 'Control-B')
-        for val in parsed:
-            if val in KEY_SUBS:
-                keys_li.append(KEY_SUBS[val])
-            else:
-                keys_li.append(val)
+            keys_li = []
+            # Format how the shortcut is written (ex. 'Ctrl+B' is changed to 'Control-B')
+            for val in parsed:
+                if val in KEY_SUBS:
+                    keys_li.append(KEY_SUBS[val])
+                else:
+                    keys_li.append(val)
 
-        keys_li = '-'.join(keys_li)
-        self.setText(keys_li)
+            keys_li = '-'.join(keys_li)
+            self.setText(keys_li)
+        else:
+            self.setText(event_keystr)
 
 
 class ShortcutTranslator(QKeySequenceEdit):


### PR DESCRIPTION
# Fixes/Closes

<!-- In general, PRs should fix an existing issue on the repo. -->
<!-- Please link to that issue here as "Closes #(issue-number)". -->
Closes  #6111

# Description

Fix splitting logic shortcut logic. Previous one split one `-(?=.+)` characters. Current split on `-+` if this character is followed by any character.

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change

- [x] Bug-fix (non-breaking change which fixes an issue)

