### PR TITLE
ENH Adds `LayerList` context

### DIFF
--- a/napari/_app_model/_submenus.py
+++ b/napari/_app_model/_submenus.py
@@ -1,7 +1,7 @@
 from app_model.types import SubmenuItem
 
 from napari._app_model.constants import MenuGroup, MenuId
-from napari._app_model.context import LayerListContextKeys as LLCK
+from napari._app_model.context import LayerListSelectionContextKeys as LLSCK
 from napari.utils.translations import trans
 
 SUBMENUS = [
@@ -12,7 +12,7 @@ SUBMENUS = [
             title=trans._('Convert data type'),
             group=MenuGroup.LAYERLIST_CONTEXT.CONVERSION,
             order=None,
-            enablement=LLCK.all_selected_layers_labels,
+            enablement=LLSCK.all_selected_layers_labels,
         ),
     ),
     (
@@ -22,7 +22,7 @@ SUBMENUS = [
             title=trans._('Projections'),
             group=MenuGroup.LAYERLIST_CONTEXT.SPLIT_MERGE,
             order=None,
-            enablement=LLCK.active_layer_is_image_3d,
+            enablement=LLSCK.active_layer_is_image_3d,
         ),
     ),
     (

--- a/napari/_app_model/actions/_layer_actions.py
+++ b/napari/_app_model/actions/_layer_actions.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, List
 from app_model.types import Action
 
 from napari._app_model.constants import CommandId, MenuGroup, MenuId
-from napari._app_model.context import LayerListContextKeys as LLCK
+from napari._app_model.context import LayerListSelectionContextKeys as LLSCK
 from napari.layers import _layer_actions
 
 if TYPE_CHECKING:
@@ -50,15 +50,15 @@ LAYER_ACTIONS: List[Action] = [
         id=CommandId.LAYER_SPLIT_STACK,
         title=CommandId.LAYER_SPLIT_STACK.title,
         callback=_layer_actions._split_stack,
-        menus=[{**LAYERCTX_SPLITMERGE, 'when': ~LLCK.active_layer_is_rgb}],
-        enablement=LLCK.active_layer_is_image_3d,
+        menus=[{**LAYERCTX_SPLITMERGE, 'when': ~LLSCK.active_layer_is_rgb}],
+        enablement=LLSCK.active_layer_is_image_3d,
     ),
     Action(
         id=CommandId.LAYER_SPLIT_RGB,
         title=CommandId.LAYER_SPLIT_RGB.title,
         callback=_layer_actions._split_rgb,
-        menus=[{**LAYERCTX_SPLITMERGE, 'when': LLCK.active_layer_is_rgb}],
-        enablement=LLCK.active_layer_is_rgb,
+        menus=[{**LAYERCTX_SPLITMERGE, 'when': LLSCK.active_layer_is_rgb}],
+        enablement=LLSCK.active_layer_is_rgb,
     ),
     Action(
         id=CommandId.LAYER_CONVERT_TO_LABELS,
@@ -66,11 +66,11 @@ LAYER_ACTIONS: List[Action] = [
         callback=_layer_actions._convert_to_labels,
         enablement=(
             (
-                (LLCK.num_selected_image_layers >= 1)
-                | (LLCK.num_selected_shapes_layers >= 1)
+                (LLSCK.num_selected_image_layers >= 1)
+                | (LLSCK.num_selected_shapes_layers >= 1)
             )
-            & LLCK.all_selected_layers_same_type
-            & ~LLCK.selected_empty_shapes_layer
+            & LLSCK.all_selected_layers_same_type
+            & ~LLSCK.selected_empty_shapes_layer
         ),
         menus=[LAYERCTX_CONVERSION],
     ),
@@ -79,8 +79,8 @@ LAYER_ACTIONS: List[Action] = [
         title=CommandId.LAYER_CONVERT_TO_IMAGE.title,
         callback=_layer_actions._convert_to_image,
         enablement=(
-            (LLCK.num_selected_labels_layers >= 1)
-            & LLCK.all_selected_layers_same_type
+            (LLSCK.num_selected_labels_layers >= 1)
+            & LLSCK.all_selected_layers_same_type
         ),
         menus=[LAYERCTX_CONVERSION],
     ),
@@ -89,9 +89,9 @@ LAYER_ACTIONS: List[Action] = [
         title=CommandId.LAYER_MERGE_STACK.title,
         callback=_layer_actions._merge_stack,
         enablement=(
-            (LLCK.num_selected_layers > 1)
-            & (LLCK.num_selected_image_layers == LLCK.num_selected_layers)
-            & LLCK.all_selected_layers_same_shape
+            (LLSCK.num_selected_layers > 1)
+            & (LLSCK.num_selected_image_layers == LLSCK.num_selected_layers)
+            & LLSCK.all_selected_layers_same_shape
         ),
         menus=[LAYERCTX_SPLITMERGE],
     ),
@@ -111,28 +111,26 @@ LAYER_ACTIONS: List[Action] = [
         title=CommandId.LAYER_LINK_SELECTED.title,
         callback=_layer_actions._link_selected_layers,
         enablement=(
-            (LLCK.num_selected_layers > 1) & ~LLCK.num_selected_layers_linked
+            (LLSCK.num_selected_layers > 1) & ~LLSCK.num_selected_layers_linked
         ),
-        menus=[{**LAYERCTX_LINK, 'when': ~LLCK.num_selected_layers_linked}],
+        menus=[{**LAYERCTX_LINK, 'when': ~LLSCK.num_selected_layers_linked}],
     ),
     Action(
         id=CommandId.LAYER_UNLINK_SELECTED,
         title=CommandId.LAYER_UNLINK_SELECTED.title,
         callback=_layer_actions._unlink_selected_layers,
-        enablement=LLCK.num_selected_layers_linked,
-        menus=[{**LAYERCTX_LINK, 'when': LLCK.num_selected_layers_linked}],
+        enablement=LLSCK.num_selected_layers_linked,
+        menus=[{**LAYERCTX_LINK, 'when': LLSCK.num_selected_layers_linked}],
     ),
     Action(
         id=CommandId.LAYER_SELECT_LINKED,
         title=CommandId.LAYER_SELECT_LINKED.title,
         callback=_layer_actions._select_linked_layers,
-        enablement=LLCK.num_unselected_linked_layers,
+        enablement=LLSCK.num_unselected_linked_layers,
         menus=[LAYERCTX_LINK],
     ),
 ]
 
-
-cmd: CommandId
 
 for _dtype in (
     'int8',
@@ -144,28 +142,28 @@ for _dtype in (
     'uint32',
     'uint64',
 ):
-    cmd = getattr(CommandId, f'LAYER_CONVERT_TO_{_dtype.upper()}')
+    cmd: CommandId = getattr(CommandId, f'LAYER_CONVERT_TO_{_dtype.upper()}')
     LAYER_ACTIONS.append(
         Action(
             id=cmd,
             title=cmd.title,
             callback=partial(_layer_actions._convert_dtype, mode=_dtype),
             enablement=(
-                LLCK.all_selected_layers_labels
-                & (LLCK.active_layer_dtype != _dtype)
+                LLSCK.all_selected_layers_labels
+                & (LLSCK.active_layer_dtype != _dtype)
             ),
             menus=[{'id': MenuId.LAYERS_CONVERT_DTYPE}],
         )
     )
 
 for mode in ('max', 'min', 'std', 'sum', 'mean', 'median'):
-    cmd = getattr(CommandId, f'LAYER_PROJECT_{mode.upper()}')
+    cmd: CommandId = getattr(CommandId, f'LAYER_PROJECT_{mode.upper()}')
     LAYER_ACTIONS.append(
         Action(
             id=cmd,
             title=cmd.title,
             callback=partial(_layer_actions._project, mode=mode),
-            enablement=LLCK.active_layer_is_image_3d,
+            enablement=LLSCK.active_layer_is_image_3d,
             menus=[{'id': MenuId.LAYERS_PROJECT}],
         )
     )

--- a/napari/_app_model/actions/_layer_actions.py
+++ b/napari/_app_model/actions/_layer_actions.py
@@ -142,7 +142,7 @@ for _dtype in (
     'uint32',
     'uint64',
 ):
-    cmd: CommandId = getattr(CommandId, f'LAYER_CONVERT_TO_{_dtype.upper()}')
+    cmd = getattr(CommandId, f'LAYER_CONVERT_TO_{_dtype.upper()}')
     LAYER_ACTIONS.append(
         Action(
             id=cmd,
@@ -157,7 +157,7 @@ for _dtype in (
     )
 
 for mode in ('max', 'min', 'std', 'sum', 'mean', 'median'):
-    cmd: CommandId = getattr(CommandId, f'LAYER_PROJECT_{mode.upper()}')
+    cmd = getattr(CommandId, f'LAYER_PROJECT_{mode.upper()}')
     LAYER_ACTIONS.append(
         Action(
             id=cmd,

--- a/napari/_app_model/context/__init__.py
+++ b/napari/_app_model/context/__init__.py
@@ -3,11 +3,15 @@ from napari._app_model.context._context import (
     create_context,
     get_context,
 )
-from napari._app_model.context._layerlist_context import LayerListContextKeys
+from napari._app_model.context._layerlist_context import (
+    LayerListContextKeys,
+    LayerListSelectionContextKeys,
+)
 
 __all__ = [
     'Context',
     'create_context',
     'get_context',
     'LayerListContextKeys',
+    'LayerListSelectionContextKeys',
 ]

--- a/napari/_app_model/context/_layerlist_context.py
+++ b/napari/_app_model/context/_layerlist_context.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 from app_model.expressions import ContextKey
 
@@ -12,14 +12,29 @@ from napari.utils.translations import trans
 if TYPE_CHECKING:
     from numpy.typing import DTypeLike
 
+    from napari.components.layerlist import LayerList
     from napari.layers import Layer
     from napari.utils.events import Selection
 
     LayerSel = Selection[Layer]
 
 
-def _len(s: LayerSel) -> int:
-    return len(s)
+def _len(layer: Union[LayerSel, LayerList]) -> int:
+    return len(layer)
+
+
+class LayerListContextKeys(ContextNamespace['Layer']):
+    """These are the available context keys relating to a LayerList.
+
+    Consists of a default value, a description, and a function to retrieve the
+    current value from `layers`.
+    """
+
+    num_layers = ContextKey(
+        0,
+        trans._("Number of layers."),
+        _len,
+    )
 
 
 def _all_linked(s: LayerSel) -> bool:
@@ -134,11 +149,11 @@ def _empty_shapes_layer_selected(s: LayerSel) -> bool:
     return any(x._type_string == "shapes" and not len(x.data) for x in s)
 
 
-class LayerListContextKeys(ContextNamespace['LayerSel']):
-    """These are the available context keys relating to a LayerList.
+class LayerListSelectionContextKeys(ContextNamespace['LayerSel']):
+    """Available context keys relating to the selection in a LayerList.
 
-    along with default value, a description, and a function to retrieve the
-    current value from layers.selection
+    Consists of a default value, a description, and a function to retrieve the
+    current value from `layers.selection`.
     """
 
     num_selected_layers = ContextKey(

--- a/napari/_app_model/context/_layerlist_context.py
+++ b/napari/_app_model/context/_layerlist_context.py
@@ -19,8 +19,8 @@ if TYPE_CHECKING:
     LayerSel = Selection[Layer]
 
 
-def _len(layer: Union[LayerSel, LayerList]) -> int:
-    return len(layer)
+def _len(layers: Union[LayerSel, LayerList]) -> int:
+    return len(layers)
 
 
 class LayerListContextKeys(ContextNamespace['Layer']):

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -59,21 +59,43 @@ class LayerList(SelectableEventedList[Layer]):
             basetype=Layer,
             lookup={str: lambda e: e.name},
         )
+        self._create_contexts()
+
+    def _create_contexts(self):
+        """Create contexts to manage enabled/visible action/menu states.
+
+        Connects LayerList and Selection[Layer] to their context keys to allow
+        actions and menu items (in the GUI) to be dynamically enabled/disabled
+        and visible/hidden based on the state of layers in the list.
+        """
 
         # TODO: figure out how to move this context creation bit.
         # Ideally, the app should be aware of the layerlist, but not vice versa.
-        # This could probably be done by having the layerlist emit events that the app
-        # connects to, then the `_ctx` object would live on the app, (not here)
+        # This could probably be done by having the layerlist emit events that
+        # the app connects to, then the `_ctx` object would live on the app,
+        # (not here)
         from napari._app_model.context import create_context
         from napari._app_model.context._layerlist_context import (
             LayerListContextKeys,
+            LayerListSelectionContextKeys,
         )
 
         self._ctx = create_context(self)
         if self._ctx is not None:  # happens during Viewer type creation
             self._ctx_keys = LayerListContextKeys(self._ctx)
+            self.events.inserted.connect(self._ctx_keys.update)
+            self.events.removed.connect(self._ctx_keys.update)
 
-            self.selection.events.changed.connect(self._ctx_keys.update)
+        self._selection_ctx = create_context(self)
+        if (
+            self._selection_ctx is not None
+        ):  # happens during Viewer type creation
+            self._selection_ctx_keys = LayerListSelectionContextKeys(
+                self._selection_ctx
+            )
+            self.selection.events.changed.connect(
+                self._selection_ctx_keys.update
+            )
 
     def _process_delete_item(self, item: Layer):
         super()._process_delete_item(item)


### PR DESCRIPTION
Adds `LayerList` context. Currently we only have a `Selection[Layer]` context. For the file menu (#4865) we needed `LayerList` because we needed the number of layers present (NOT number of layers selected) and could not obtain this from `Selection[Layer]`. The number of layers present is required for the `enablement` status of the `CommandId.DLG_SAVE_LAYERS` command.

Note this was originally part of #4865 but move to separate PR to aid review and git blame.

# References

ref: https://github.com/napari/napari/pull/4865#discussion_r1292895534