### PR TITLE
Update `QLabeledRangeSlider` style rule to prevent labels from being cut off

### DIFF
--- a/napari/_qt/qt_resources/styles/00_base.qss
+++ b/napari/_qt/qt_resources/styles/00_base.qss
@@ -204,6 +204,11 @@ QLabeledSlider > QAbstractSpinBox {
   font-size: {{ decrease(font_size, 1) }};
 }
 
+QLabeledRangeSlider > QAbstractSpinBox {
+  min-width: 5px;
+  padding: 0px;
+}
+
 QWidget[emphasized="true"] QAbstractSpinBox {
   background-color: {{ primary }};
 }
@@ -262,10 +267,6 @@ QAbstractSpinBox::up-arrow {
 
 QAbstractSpinBox::down-arrow {
    image: url("theme_{{ id }}:/minus_50.svg");
-}
-
-QLabeledRangeSlider > QAbstractSpinBox {
-  min-width: 5px;
 }
 
 /* ----------------- QCheckBox ------------------ */


### PR DESCRIPTION
# References and relevant issues

Closes #6160 

# Description

A preview of how the rule changes the slider width management behavior (preventing the slider labels to be cut off):

* Before:
![slider_cut](https://github.com/napari/napari/assets/16781833/50a6f230-f600-4e18-8fdd-bb4b148b91b1)

* After:
![slider_width_fix](https://github.com/napari/napari/assets/16781833/338a583e-a361-4985-9f3f-af0aff25cd41)

Some example code to check the change:

```python
import napari
from magicgui import magic_factory

@magic_factory(x={'widget_type': 'RangeSlider', 'max': 5000})
def example_magic_widget(x: tuple[int, int]):
    print(f"you have selected {x}")

wdg = example_magic_widget()
viewer = napari.Viewer()
viewer.window.add_dock_widget(wdg)
```


