### PR TITLE
Do not clone repository to subdirectory in examples test

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -198,9 +198,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          path: napari-from-github
-
       - uses: actions/setup-python@v4
         with:
           python-version: 3.9


### PR DESCRIPTION
# Description

Test of examples starts failing as tox no longer discover tox.ini in a subfolder and/or do not allow non-defined environments

https://github.com/tox-dev/tox/pull/3089


