### PR TITLE
Do not sample numpy array when calculate brightness range

### DIFF
--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -73,12 +73,18 @@ def test_calc_data_range():
 
 
 @pytest.mark.parametrize(
-    'data',
-    [data_dask_8b, data_dask, data_dask_1d, data_dask_1d_rgb, data_dask_plane],
+    'data,rgb',
+    [
+        (data_dask_8b, False),
+        (data_dask, False),
+        (data_dask_1d, False),
+        (data_dask_1d_rgb, True),
+        (data_dask_plane, False),
+    ],
 )
-def test_calc_data_range_fast(data):
+def test_calc_data_range_fast(data, rgb):
     now = time.monotonic()
-    val = calc_data_range(data)
+    val = calc_data_range(data, rgb)
     assert len(val) > 0
     elapsed = time.monotonic() - now
     assert elapsed < 5, "test took too long, computation was likely not lazy"

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -225,11 +225,11 @@ def calc_data_range(data, rgb=False) -> Tuple[float, float]:
     returned.
     """
     if data.dtype == np.uint8:
-        return (0, 255)
+        return 0, 255
 
     center: Union[int, List[int]]
 
-    if data.size > 1e7 and (data.ndim == 1 or (rgb and data.ndim == 2)):
+    if data.size > 1e8 and (data.ndim == 2 or (rgb and data.ndim == 3)):
         # If data is very large take the average of start, middle and end.
         center = int(data.shape[0] // 2)
         slices = [
@@ -241,7 +241,7 @@ def calc_data_range(data, rgb=False) -> Tuple[float, float]:
             [_nanmax(data[sl]) for sl in slices],
             [_nanmin(data[sl]) for sl in slices],
         ]
-    elif data.size > 1e7:
+    elif data.size > 1e8:
         # If data is very large take the average of the top, bottom, and
         # middle slices
         offset = 2 + int(rgb)
@@ -251,7 +251,7 @@ def calc_data_range(data, rgb=False) -> Tuple[float, float]:
         idxs = [bottom_plane_idx, middle_plane_idx, top_plane_idx]
         # If each plane is also very large, look only at a subset of the image
         if (
-            np.prod(data.shape[-offset:]) > 1e7
+            np.prod(data.shape[-offset:]) > 1e8
             and data.shape[-offset] > 64
             and data.shape[-offset + 1] > 64
         ):

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -272,7 +272,7 @@ def _sample_at_least_3d_data(data, rgb):
     return dask.compute(*reduced_data)
 
 
-def calc_data_range(data: np.ndarray, rgb=False) -> Tuple[float, float]:
+def calc_data_range(data, rgb=False) -> Tuple[float, float]:
     """Calculate range of data values. If all values are equal return [0, 1].
 
     Parameters


### PR DESCRIPTION
# References and relevant issues
hides #5608 and #6183 

# Description

This PR hides the problem of over-saturated images by always calculating min and max on images that are numpy arrays. 

The data from #6183 has size 1.411 x 1e7. 
The data from #5608 has size 3.41 x 1e7.

So workaround may be to limit the size of the numpy array to 1e8 for calculating over the whole image. 





