### PR TITLE
Remove `_ImageView` class

### DIFF
--- a/napari/_vispy/layers/labels.py
+++ b/napari/_vispy/layers/labels.py
@@ -243,10 +243,10 @@ class VispyLabelsLayer(VispyImageLayer):
         if not self.layer.loaded:
             return
 
-        raw_displayed = self.layer._slice.image.raw
+        sliced_data = self.layer._slice.image
         ndims = len(event.offset)
 
-        if self.node._texture.shape[:ndims] != raw_displayed.shape[:ndims]:
+        if self.node._texture.shape[:ndims] != sliced_data.shape[:ndims]:
             self.layer.refresh()
             return
 

--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -41,8 +41,8 @@ class Labels2DSuite:
 
     def time_raw_to_displayed(self, n):
         """Time to convert raw to displayed."""
-        self.layer._slice.image.raw[0, :] += 1  # simulate changes
-        self.layer._raw_to_displayed(self.layer._slice.image.raw)
+        self.layer._slice.image[0, :] += 1  # simulate changes
+        self.layer._raw_to_displayed(self.layer._slice.image)
 
     def time_paint_circle(self, n):
         """Time to paint circle."""
@@ -87,7 +87,7 @@ class LabelsDrawing2DSuite:
         self.layer.mode = 'paint'
 
     def time_draw(self, n, brush_size, color_mode, contour):
-        new_label = self.layer._slice.image.raw[0, 0] + 1
+        new_label = self.layer._slice.image[0, 0] + 1
 
         with self.layer.block_history():
             last_coord = (0, 0)
@@ -109,7 +109,7 @@ class Labels2DColorDirectSuite(Labels2DSuite):
             self.data,
             color={i + 1: np.random.random(4) for i in random_label_ids},
         )
-        self.layer._raw_to_displayed(self.layer._slice.image.raw)
+        self.layer._raw_to_displayed(self.layer._slice.image)
 
 
 class Labels3DSuite:
@@ -147,8 +147,8 @@ class Labels3DSuite:
 
     def time_raw_to_displayed(self, n):
         """Time to convert raw to displayed."""
-        self.layer._slice.image.raw[0, 0, :] += 1  # simulate changes
-        self.layer._raw_to_displayed(self.layer._slice.image.raw)
+        self.layer._slice.image[0, 0, :] += 1  # simulate changes
+        self.layer._raw_to_displayed(self.layer._slice.image)
 
     def time_paint_circle(self, n):
         """Time to paint circle."""

--- a/napari/benchmarks/benchmark_qt_viewer_labels.py
+++ b/napari/benchmarks/benchmark_qt_viewer_labels.py
@@ -66,7 +66,7 @@ class QtViewerSingleLabelsSuite:
 
     def time_raw_to_displayed(self):
         """Time to convert raw to displayed."""
-        self.layer._raw_to_displayed(self.layer._slice.image.raw)
+        self.layer._raw_to_displayed(self.layer._slice.image)
 
     def time_paint(self):
         """Time to paint."""

--- a/napari/components/_tests/test_layer_slicer.py
+++ b/napari/components/_tests/test_layer_slicer.py
@@ -333,7 +333,7 @@ def test_submit_with_one_3d_image(layer_slicer):
         future = layer_slicer.submit(layers=[layer], dims=dims)
         assert not future.done()
     layer_result = _wait_for_response(future)[layer]
-    np.testing.assert_equal(layer_result.image.view, data[2, :, :])
+    np.testing.assert_equal(layer_result.image, data[2, :, :])
 
 
 def test_submit_with_one_3d_points(layer_slicer):

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -385,7 +385,7 @@ def test_swappable_dims():
     # midpoints indices into the data below depend on the data range.
     # This depends on the values in vectors_data and thus the random seed.
     assert np.all(
-        viewer.layers[labels_name]._slice.image.raw == labels_data[3, 5, :, :]
+        viewer.layers[labels_name]._slice.image == labels_data[3, 5, :, :]
     )
 
     # Swap dims
@@ -395,7 +395,7 @@ def test_swappable_dims():
         viewer.layers[image_name]._data_view == image_data[3, :, 4, :]
     )
     assert np.all(
-        viewer.layers[labels_name]._slice.image.raw == labels_data[3, :, 4, :]
+        viewer.layers[labels_name]._slice.image == labels_data[3, :, 4, :]
     )
 
 
@@ -957,14 +957,14 @@ def test_slice_order_with_mixed_dims():
 
     # With standard ordering, the shapes of the slices match,
     # so are trivially numpy-broadcastable.
-    assert image_2d._slice.image.view.shape == (4, 5)
-    assert image_3d._slice.image.view.shape == (4, 5)
-    assert image_4d._slice.image.view.shape == (4, 5)
+    assert image_2d._slice.image.shape == (4, 5)
+    assert image_3d._slice.image.shape == (4, 5)
+    assert image_4d._slice.image.shape == (4, 5)
 
     viewer.dims.order = (2, 1, 0, 3)
 
     # With non-standard ordering, the shapes of the slices do not match,
     # and are not numpy-broadcastable.
-    assert image_2d._slice.image.view.shape == (4, 5)
-    assert image_3d._slice.image.view.shape == (3, 5)
-    assert image_4d._slice.image.view.shape == (2, 5)
+    assert image_2d._slice.image.shape == (4, 5)
+    assert image_3d._slice.image.shape == (3, 5)
+    assert image_4d._slice.image.shape == (2, 5)

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -405,7 +405,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
     @property
     def _data_view(self):
         """Viewable image for the current slice. (compatibility)"""
-        return self._slice.image.view
+        return self._raw_to_displayed(self._slice.image)
 
     def _calc_data_range(self, mode='data') -> Tuple[float, float]:
         """
@@ -415,7 +415,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         if mode == 'data':
             input_data = self.data[-1] if self.multiscale else self.data
         elif mode == 'slice':
-            data = self._slice.image.view  # ugh
+            data = self._slice.image
             input_data = data[-1] if self.multiscale else data
         else:
             raise ValueError(
@@ -795,7 +795,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
 
     def _update_thumbnail(self):
         """Update thumbnail with current image data and colormap."""
-        image = self._slice.thumbnail.view
+        image = self._slice.thumbnail
 
         if self._slice_input.ndisplay == 3 and self.ndim > 2:
             image = np.max(image, axis=0)
@@ -870,7 +870,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
 
         coord = np.round(coord).astype(int)
 
-        raw = self._slice.image.raw
+        raw = self._slice.image
         shape = raw.shape[:-1] if self.rgb else raw.shape
 
         if self.ndim < len(coord):

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -607,7 +607,7 @@ def test_contour_local_updates():
     layer = Labels(data)
     layer.contour = 1
     assert np.allclose(
-        layer._raw_to_displayed(layer._slice.image.raw),
+        layer._raw_to_displayed(layer._slice.image),
         np.zeros((7, 7), dtype=np.float32),
     )
 
@@ -627,7 +627,7 @@ def test_contour_local_updates():
     layer.data_setitem(np.nonzero(painting_mask), 1, refresh=True)
 
     assert np.alltrue(
-        (layer._slice.image.view > 0) == get_contours(painting_mask, 1, 0)
+        (layer._data_view > 0) == get_contours(painting_mask, 1, 0)
     )
 
 
@@ -1435,19 +1435,17 @@ def test_invalidate_cache_when_change_color_mode():
 
     layer = Labels(data)
     layer.selected_label = 0
-    gt_auto = layer._raw_to_displayed(layer._slice.image.raw)
+    gt_auto = layer._raw_to_displayed(layer._slice.image)
     assert gt_auto.dtype == np.float32
 
     layer.color_mode = 'direct'
     layer._cached_labels = None
-    assert layer._raw_to_displayed(layer._slice.image.raw).dtype == np.float32
+    assert layer._raw_to_displayed(layer._slice.image).dtype == np.float32
 
     layer.color_mode = 'auto'
     # If the cache is not invalidated, it returns colors for
     # the direct color mode instead of the color for the auto mode
-    assert np.allclose(
-        layer._raw_to_displayed(layer._slice.image.raw), gt_auto
-    )
+    assert np.allclose(layer._raw_to_displayed(layer._slice.image), gt_auto)
 
 
 def test_color_mapping_when_color_is_changed():
@@ -1456,14 +1454,14 @@ def test_color_mapping_when_color_is_changed():
     data = np.zeros((4, 5), dtype=np.int32)
     data[1, :] = np.arange(0, 5)
     layer = Labels(data, color={1: 'green', 2: 'red', 3: 'white'})
-    gt_direct_3colors = layer._raw_to_displayed(layer._slice.image.raw)
+    gt_direct_3colors = layer._raw_to_displayed(layer._slice.image)
 
     layer = Labels(data, color={1: 'green', 2: 'red'})
-    assert layer._raw_to_displayed(layer._slice.image.raw).dtype == np.float32
+    assert layer._raw_to_displayed(layer._slice.image).dtype == np.float32
     layer.color = {1: 'green', 2: 'red', 3: 'white'}
 
     assert np.allclose(
-        layer._raw_to_displayed(layer._slice.image.raw), gt_direct_3colors
+        layer._raw_to_displayed(layer._slice.image), gt_direct_3colors
     )
 
 
@@ -1494,10 +1492,10 @@ def test_color_mapping_when_seed_is_changed():
     """Checks if the color mapping is updated when the color palette seed is changed."""
     np.random.seed(0)
     layer = Labels(np.random.randint(50, size=(10, 10)))
-    mapped_colors1 = layer.colormap.map(layer._as_type(layer._slice.image.raw))
+    mapped_colors1 = layer.colormap.map(layer._as_type(layer._slice.image))
 
     layer.new_colormap()
-    mapped_colors2 = layer.colormap.map(layer._as_type(layer._slice.image.raw))
+    mapped_colors2 = layer.colormap.map(layer._as_type(layer._slice.image))
 
     assert not np.allclose(mapped_colors1, mapped_colors2)
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -15,7 +15,6 @@ from napari.layers.base._base_mouse_bindings import (
     transform_with_box,
 )
 from napari.layers.image._image_utils import guess_multiscale
-from napari.layers.image._slice import _ImageSliceResponse
 from napari.layers.image.image import _ImageBase
 from napari.layers.labels._labels_constants import (
     LabelColorMode,
@@ -828,11 +827,6 @@ class Labels(_ImageBase):
     def _as_type(self, data, selected_label=None):
         return data.astype(np.float32)
 
-    def _update_slice_response(self, response: _ImageSliceResponse) -> None:
-        """Override to convert raw slice data to displayed label colors."""
-        response = response.to_displayed(self._raw_to_displayed)
-        super()._update_slice_response(response)
-
     def _partial_labels_refresh(self):
         """Prepares and displays only an updated part of the labels."""
 
@@ -840,7 +834,7 @@ class Labels(_ImageBase):
             return
 
         dims_displayed = self._slice_input.displayed
-        raw_displayed = self._slice.image.raw
+        raw_displayed = self._slice.image
 
         # Keep only the dimensions that correspond to the current view
         updated_slice = tuple(
@@ -960,7 +954,7 @@ class Labels(_ImageBase):
             # Is there a nicer way to prevent this from getting called?
             return
 
-        image = self._slice.thumbnail.view
+        image = self._slice.thumbnail
         if self._slice_input.ndisplay == 3 and self.ndim > 2:
             # we are only using the current slice so `image` will never be
             # bigger than 3. If we are in this clause, it is exactly 3, so we
@@ -1040,7 +1034,7 @@ class Labels(_ImageBase):
             sample_points = np.linspace(
                 start_point, end_point, n_points, endpoint=True
             )
-            im_slice = self._slice.image.raw
+            im_slice = self._slice.image
             bounding_box = self._display_bounding_box(dims_displayed)
             # the display bounding box is returned as a closed interval
             # (i.e. the endpoint is included) by the method, but we need

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1461,7 +1461,7 @@ class Labels(_ImageBase):
             point = np.round(self.world_to_data(dims.point)).astype(int)
             pt_not_disp = {dim: point[dim] for dim in dims.not_displayed}
             displayed_indices = index_in_slice(indices, pt_not_disp)
-            self._slice.image.raw[displayed_indices] = value
+            self._slice.image[displayed_indices] = value
 
         # tensorstore and xarray do not return their indices in
         # np.ndarray format, so they need to be converted explicitly

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -949,11 +949,6 @@ class Labels(_ImageBase):
         like adjusting gamma or changing the data based on the contrast
         limits.
         """
-        if not self.loaded:
-            # ASYNC_TODO: Do not compute the thumbnail until we are loaded.
-            # Is there a nicer way to prevent this from getting called?
-            return
-
         image = self._slice.thumbnail
         if self._slice_input.ndisplay == 3 and self.ndim > 2:
             # we are only using the current slice so `image` will never be


### PR DESCRIPTION
# References and relevant issues
Closes #6185 

# Description
This removes the `_ImageView` class related to slicing. This was needed to store the raw and displayed (normalized for colormapping) versions of a label layer's slice, but it seems that is no longer needed.
