### PR TITLE
Add a timeout to some GH actions tests.

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -165,6 +165,7 @@ jobs:
   test_pip_install:
     name: ubuntu-latest 3.9 pip install
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
         with:
@@ -196,6 +197,7 @@ jobs:
   test_examples:
     name: test examples
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
In #6186 this step that usually takes ~25 minutes got stuck for 6hours. delaying all other CI runs.

Thus adding a timeout of 30 minutes.

Adding a 10min timeout as well for examples that usually runs in about 6min
