### PR TITLE
DOC Add comment in `_instantiate_dock_widget`

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1504,6 +1504,7 @@ def _instantiate_dock_widget(wdg_cls, viewer: 'Viewer'):
     kwargs = {}
     try:
         sig = inspect.signature(wdg_cls.__init__)
+    # For some widgets, inspection fails when adding to bundle
     except ValueError:
         pass
     else:

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1504,7 +1504,7 @@ def _instantiate_dock_widget(wdg_cls, viewer: 'Viewer'):
     kwargs = {}
     try:
         sig = inspect.signature(wdg_cls.__init__)
-    # For some widgets, inspection fails when adding to bundle
+    # Inspection can fail when adding to bundle as it thinks widget is a builtin
     except ValueError:
         pass
     else:


### PR DESCRIPTION
# References and relevant issues
Add comment to code added in #3612

# Description
Adds a comment to explain why we need the try/except - inspection sometimes fails (as it should really work for any widget object). #3612 says failure is seen sometimes when adding widget to bundle viewer, though not sure why this is the case.


