### PR TITLE
Add collision check when set colors for labels layer

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1575,7 +1575,7 @@ def test_get_status_with_custom_index():
 def test_collision_warning():
     label = Labels(data=np.zeros((10, 10), dtype=np.uint8))
     with pytest.warns(
-        RuntimeWarning, match="the following labels will be merged"
+        RuntimeWarning, match="Because integer labels are cast to less-precise"
     ):
         label.color = {2**25 + 1: 'red', 2**25 + 2: 'blue'}
     with warnings.catch_warnings():

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1,5 +1,6 @@
 import itertools
 import time
+import warnings
 from dataclasses import dataclass
 from tempfile import TemporaryDirectory
 from typing import List
@@ -1569,6 +1570,17 @@ def test_get_status_with_custom_index():
         layer.get_status((6, 6))['coordinates']
         == ' [6 6]: 2; text1: 3, text2: -2'
     )
+
+
+def test_collision_warning():
+    label = Labels(data=np.zeros((10, 10), dtype=np.uint8))
+    with pytest.warns(
+        RuntimeWarning, match="the following labels will be merged"
+    ):
+        label.color = {2**25 + 1: 'red', 2**25 + 2: 'blue'}
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        label.color = {1: 'red', 2: 'blue'}
 
 
 def test_labels_features_event():

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1,7 +1,16 @@
 import warnings
 from collections import deque
 from contextlib import contextmanager
-from typing import Callable, ClassVar, Dict, List, Optional, Tuple, Union
+from typing import (
+    Callable,
+    ClassVar,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import numpy as np
 import numpy.typing as npt
@@ -557,6 +566,7 @@ class Labels(_ImageBase):
             label: transform_color(color_str)[0]
             for label, color_str in color.items()
         }
+        self._validate_colors(colors)
         self._color = colors
         self._direct_colormap = direct_colormap(colors)
 
@@ -574,6 +584,26 @@ class Labels(_ImageBase):
             color_mode = LabelColorMode.DIRECT
 
         self.color_mode = color_mode
+
+    def _validate_colors(self, labels: Iterable[int]):
+        """Check if after cast to float there is a label collisions"""
+        collision_dkt = {}
+        collision_list = []
+        for label in labels:
+            # FIXME after merge 6112
+            casted = self._as_type(label)
+            if casted in collision_dkt:
+                collision_list.append((label, collision_dkt[casted]))
+            else:
+                collision_dkt[casted] = label
+        if not collision_list:
+            return
+
+        warn_text = (
+            "Because of the cast to float, the following labels will be merged: "
+            + ", ".join([f"{l1} and {l2}" for l1, l2 in collision_list])
+        )
+        warnings.warn(warn_text, category=RuntimeWarning)
 
     def _is_default_colors(self, color):
         """Returns True if color contains only default colors, otherwise False.

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -591,6 +591,7 @@ class Labels(_ImageBase):
         See https://github.com/napari/napari/issues/6084 for details.
         """
         aliases: Dict[float, List[int]] = defaultdict(list)
+        labels = [k for k in labels if k is not None]
         labels_int = np.fromiter(labels, dtype=int)
         labels_texture = self._to_vispy_texture_dtype(labels_int)
         for integer, texture in zip(labels_int, labels_texture):


### PR DESCRIPTION
# Description
This PR adds a check if two user-defined colors for labels above 2*23 collide in the same value after being cast to float32.

We need to cast values to this type because of the texture mechanism currently used. 

# References and relevant issues
extracted from #6182 requested in https://github.com/napari/napari/pull/6182#discussion_r1307641841
