### PR TITLE
Bugfix: ensure thumbnail represents canvas when multiscale

### DIFF
--- a/napari/layers/image/_slice.py
+++ b/napari/layers/image/_slice.py
@@ -236,16 +236,12 @@ class _ImageSliceRequest:
         data = np.transpose(data, order)
         image = _ImageView.from_view(data)
 
-        thumbnail = image
-        if self.thumbnail_level != level:
-            thumbnail_indices = self._slice_indices_at_level(
-                self.thumbnail_level
-            )
-            thumbnail_data = np.asarray(
-                self.data[self.thumbnail_level][tuple(thumbnail_indices)]
-            )
-            thumbnail_data = np.transpose(thumbnail_data, order)
-            thumbnail = _ImageView.from_view(thumbnail_data)
+        thumbnail_indices = self._slice_indices_at_level(self.thumbnail_level)
+        thumbnail_data = np.asarray(
+            self.data[self.thumbnail_level][tuple(thumbnail_indices)]
+        )
+        thumbnail_data = np.transpose(thumbnail_data, order)
+        thumbnail = _ImageView.from_view(thumbnail_data)
 
         return _ImageSliceResponse(
             image=image,


### PR DESCRIPTION
# References and relevant issues
closes: https://github.com/napari/napari/issues/6069

# Description
based on this comment by @andy-sweet :
https://github.com/napari/napari/issues/6069#issuecomment-1644039189
thumbnails were being set to the sliced image if the level matched the image level. 
This PR simply removes that check and ensures that the proper whole canvas thumbnail is generated.

- My PR is the minimum possible work for the desired functionality
- All tests pass locally
