### PR TITLE
Measure overlay

### DIFF
--- a/napari/_vispy/overlays/measure.py
+++ b/napari/_vispy/overlays/measure.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from napari._vispy.overlays.base import ViewerOverlayMixin, VispySceneOverlay
+from napari._vispy.visuals.measure import Measure
+
+
+class VispyMeasureOverlay(ViewerOverlayMixin, VispySceneOverlay):
+    def __init__(self, *, viewer, overlay, parent=None) -> None:
+        super().__init__(
+            node=Measure(), viewer=viewer, overlay=overlay, parent=parent
+        )
+        self.reset()
+
+        self.overlay.events.start.connect(self._on_data_change)
+        self.overlay.events.end.connect(self._on_data_change)
+        self.viewer.camera.events.zoom.connect(self._on_data_change)
+        self.viewer.scale_bar.events.unit.connect(self._on_data_change)
+
+    def _on_data_change(self):
+        displayed = list(self.viewer.dims.displayed)
+        start = np.array(self.overlay.start)[displayed][::-1]
+        end = np.array(self.overlay.end)[displayed][::-1]
+
+        # always pad to 3D to make handling the visual easier
+        if len(displayed) == 2:
+            start = np.pad(start, (0, 1))
+            end = np.pad(end, (0, 1))
+
+        length = self.overlay.length
+        unit = self.viewer.scale_bar.unit
+
+        self.node.arrow.set_data(pos=np.stack([start, end]))
+        self.node.text.pos = (start + end) / 2
+        self.node.text.text = f"{length} {unit}"
+
+    def reset(self):
+        super().reset()
+        self._on_data_change()

--- a/napari/_vispy/utils/visual.py
+++ b/napari/_vispy/utils/visual.py
@@ -22,6 +22,7 @@ from napari._vispy.overlays.interaction_box import (
     VispyTransformBoxOverlay,
 )
 from napari._vispy.overlays.labels_polygon import VispyLabelsPolygonOverlay
+from napari._vispy.overlays.measure import VispyMeasureOverlay
 from napari._vispy.overlays.scale_bar import VispyScaleBarOverlay
 from napari._vispy.overlays.text import VispyTextOverlay
 from napari.components.overlays import (
@@ -29,6 +30,7 @@ from napari.components.overlays import (
     BoundingBoxOverlay,
     BrushCircleOverlay,
     LabelsPolygonOverlay,
+    MeasureOverlay,
     Overlay,
     ScaleBarOverlay,
     SelectionBoxOverlay,
@@ -67,6 +69,7 @@ overlay_to_visual: Dict[Type[Overlay], Type[VispyBaseOverlay]] = {
     SelectionBoxOverlay: VispySelectionBoxOverlay,
     BrushCircleOverlay: VispyBrushCircleOverlay,
     LabelsPolygonOverlay: VispyLabelsPolygonOverlay,
+    MeasureOverlay: VispyMeasureOverlay,
 }
 
 

--- a/napari/_vispy/visuals/measure.py
+++ b/napari/_vispy/visuals/measure.py
@@ -1,0 +1,20 @@
+import numpy as np
+from vispy.scene.visuals import Arrow, Compound, Text
+
+
+class Measure(Compound):
+    def __init__(self) -> None:
+        super().__init__(
+            [
+                Arrow(np.zeros((0, 3)), color='red', antialias=True),
+                Text('', color='red', anchor_y='bottom'),
+            ]
+        )
+
+    @property
+    def arrow(self):
+        return self._subvisuals[0]
+
+    @property
+    def text(self):
+        return self._subvisuals[1]

--- a/napari/components/_viewer_key_bindings.py
+++ b/napari/components/_viewer_key_bindings.py
@@ -155,3 +155,10 @@ def hold_for_pan_zoom(viewer: ViewerModel):
         yield
 
         selected_layer.mode = previous_mode
+
+
+@register_viewer_action(trans._("Toggle measurement mode"))
+def toggle_measure(viewer: ViewerModel):
+    viewer._overlays['measure'].visible = not viewer._overlays[
+        'measure'
+    ].visible

--- a/napari/components/_viewer_mouse_bindings.py
+++ b/napari/components/_viewer_mouse_bindings.py
@@ -13,3 +13,7 @@ def dims_scroll(viewer, event):
         else:
             viewer.dims._increment_dims_right()
             viewer.dims._scroll_progress -= 1
+
+
+def update_measure(viewer, event):
+    print(event.position)

--- a/napari/components/overlays/__init__.py
+++ b/napari/components/overlays/__init__.py
@@ -11,6 +11,7 @@ from napari.components.overlays.interaction_box import (
     TransformBoxOverlay,
 )
 from napari.components.overlays.labels_polygon import LabelsPolygonOverlay
+from napari.components.overlays.measure import MeasureOverlay
 from napari.components.overlays.scale_bar import ScaleBarOverlay
 from napari.components.overlays.text import TextOverlay
 
@@ -26,4 +27,5 @@ __all__ = [
     "SceneOverlay",
     "TextOverlay",
     "BrushCircleOverlay",
+    "MeasureOverlay",
 ]

--- a/napari/components/overlays/measure.py
+++ b/napari/components/overlays/measure.py
@@ -1,0 +1,17 @@
+from typing import Tuple
+
+import numpy as np
+
+from napari.components.overlays.base import SceneOverlay
+
+
+class MeasureOverlay(SceneOverlay):
+    """Measure distances in world space."""
+
+    start: Tuple[int, ...] = (0, 0)
+    end: Tuple[int, ...] = (0, 0)
+
+    @property
+    def length(self):
+        """Length in world pixels."""
+        return np.linalg.norm(np.array(self.end) - self.start)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -33,6 +33,7 @@ from napari.components.layerlist import LayerList
 from napari.components.overlays import (
     AxesOverlay,
     BrushCircleOverlay,
+    MeasureOverlay,
     Overlay,
     ScaleBarOverlay,
     TextOverlay,
@@ -113,6 +114,7 @@ DEFAULT_OVERLAYS = {
     'text': TextOverlay,
     'axes': AxesOverlay,
     'brush_circle': BrushCircleOverlay,
+    'measure': MeasureOverlay,
 }
 
 


### PR DESCRIPTION
# References and relevant issues
- https://github.com/napari/napari/issues/4200#issuecomment-1702467096

# Description
An attempt at implementing a more ergonomic "measurement" tool in core napari, using overlays.

You can test the current functionality with (which already also works in 3D):

```py
import napari
import numpy as np
v = napari.Viewer()
pts = np.random.rand(5, 2) * 100
v.add_points(pts)
v.scale_bar.unit = 'm'
v._overlays['measure'].visible = True
v._overlays['measure'].start = tuple(pts[0])
v._overlays['measure'].end = tuple(pts[1])
```

![image](https://github.com/napari/napari/assets/23482191/0cc0c000-c2f7-4092-af10-4576981a14f3)


The visualisation is pretty easy; it can/should still be extended by allowing setting colors, adding arrowheads, allowing multiple measurements at once instead of just one, but none of these are complicated.

The part that gets tricky is how to exactly expose this to the user. I think a good approach would be a toggle like `ctrl+m` to enter "measure mode", and then all clics on the canvas just add a new measurement instead of moving the canvas... But this would also be pretty disruptive to the normal viewer and introduce a new concept of "viewer modes". Any ideas?

