### PR TITLE
Allow to use all ViewerModel kwargs in Viewer constructor

### DIFF
--- a/napari/_tests/test_viewer_layer_parity.py
+++ b/napari/_tests/test_viewer_layer_parity.py
@@ -20,6 +20,7 @@ def test_imshow_signature_consistency():
     # Remove unique parameters
     del imshow_parameters['viewer']
     del viewer_parameters['self']
+    del viewer_parameters['kwargs']
 
     # Ensure both have the same parameter names
     assert imshow_parameters.keys() == viewer_parameters.keys()

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -47,12 +47,14 @@ class Viewer(ViewerModel):
         order=(),
         axis_labels=(),
         show=True,
+        **kwargs,
     ) -> None:
         super().__init__(
             title=title,
             ndisplay=ndisplay,
             order=order,
             axis_labels=axis_labels,
+            **kwargs,
         )
         # we delay initialization of plugin system to the first instantiation
         # of a viewer... rather than just on import of plugins module


### PR DESCRIPTION
# Description

This PR allows using all ViewerModel kwargs when creating a Viewer instance.


It also solves this mypy warnings when running mypy locally. 

```
myypy: commands[0] napari> mypy --config-file pyproject.toml
napari/viewer.py:51: error: Missing named argument "axes" for "__init__" of "ViewerModel"  [call-arg]
napari/viewer.py:51: error: Missing named argument "camera" for "__init__" of "ViewerModel"  [call-arg]
napari/viewer.py:51: error: Missing named argument "cursor" for "__init__" of "ViewerModel"  [call-arg]
napari/viewer.py:51: error: Missing named argument "dims" for "__init__" of "ViewerModel"  [call-arg]
napari/viewer.py:51: error: Missing named argument "grid" for "__init__" of "ViewerModel"  [call-arg]
napari/viewer.py:51: error: Missing named argument "scale_bar" for "__init__" of "ViewerModel"  [call-arg]
napari/viewer.py:51: error: Missing named argument "text_overlay" for "__init__" of "ViewerModel"  [call-arg]
napari/viewer.py:51: error: Missing named argument "help" for "__init__" of "ViewerModel"  [call-arg]
napari/viewer.py:51: error: Missing named argument "status" for "__init__" of "ViewerModel"  [call-arg]
napari/viewer.py:51: error: Missing named argument "tooltip" for "__init__" of "ViewerModel"  [call-arg]
napari/viewer.py:51: error: Missing named argument "theme" for "__init__" of "ViewerModel"  [call-arg]
napari/viewer.py:51: error: Missing named argument "mouse_over_canvas" for "__init__" of "ViewerModel"  [call-arg]
```
