### PR TITLE
Fix (N>4)D shapes.

### DIFF
--- a/napari/components/_tests/test_layers_base.py
+++ b/napari/components/_tests/test_layers_base.py
@@ -1,7 +1,8 @@
-from napari.layers.base import Layer
-import pytest
 import numpy as np
+import pytest
 from numpy import array
+
+from napari.layers.base import Layer
 
 
 @pytest.mark.parametrize(

--- a/napari/components/_tests/test_layers_base.py
+++ b/napari/components/_tests/test_layers_base.py
@@ -1,0 +1,19 @@
+from napari.layers.base import Layer
+import pytest
+import numpy as np
+from numpy import array
+
+
+@pytest.mark.parametrize(
+    'dims,nworld,nshape,expected',
+    [
+        ([2, 1, 0, 3], 4, 2, [0, 1]),
+        ([2, 1, 0, 3], 4, 3, [1, 0, 2]),
+        ([2, 1, 0, 3], 4, 4, [2, 1, 0, 3]),
+        ([0, 1, 2, 3, 4, 5, 6, 7], 4, 4, [0, 1, 2, 3, 4, 5, 6, 7]),
+    ],
+)
+def test_world_to_layer(dims, nworld, nshape, expected):
+    assert np.array_equal(
+        Layer._world_to_layer_dims_impl(array(dims), nworld, nshape), expected
+    )

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1513,7 +1513,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         Let's keep in mind a few facts:
 
          - each dimension index is present exactly once.
-         - the lowest represented dimension both in dims order is going to be 0.
+         - the lowest represented dimension index will be 0
 
         That is to say both the `world_dims` input and return results are _some_
         permutation of 0...N
@@ -1527,7 +1527,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
           - `[2, None, None, 3]`
           - we filter the None
           - `[2, 3]`
-          - reindex so that the lowest dimension is going to be 0, so substract 2
+          - reindex so that the lowest dimension is 0 by subtracting 2 from all indices
           - `[0, 1]`
 
           `[2, 1, 0, 3]`  sliced in N=3 dimensions.
@@ -1536,7 +1536,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
           - `[2, 1, None, 3]`
           - we filter the None
           - `[2, 1, 3]`
-          - reindex so that the lowest dimension is going to be 0, so substract 1
+          - reindex so that the lowest dimension is 0 by subtracting 1 from all indices
           - `[1, 0, 2]`
 
         Conveniently if the world (layer) dimension is bigger than our displayed
@@ -1567,9 +1567,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         """
         Static for ease of testing
         """
-        # TODO: check world_dims is already a np array ?
-        # I think some things pass it as a tuple
-        world_dims = np.array(world_dims)
+        world_dims = np.asarray(world_dims)
         assert world_dims.min() == 0
         assert world_dims.max() == len(world_dims) - 1
         assert world_dims.ndim == 1

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -200,6 +200,7 @@ class ShapeList:
         # Slice key must exactly match mins and maxs of shape as then the
         # shape is entirely contained within the current slice.
         if len(self.shapes) > 0:
+            print(self.slice_keys.shape, slice_key.shape)
             self._displayed = np.all(self.slice_keys == slice_key, axis=(1, 2))
         else:
             self._displayed = []

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -117,9 +117,9 @@ class ShapeList:
         `_update_displayed()` is called at _most_ once on exit of the context
         manager.
 
-        There are two reason for that:
+        There are two reason for this:
 
-         1. Some updates are triggered by events, but sometime multiple pieces
+         1. Some updates are triggered by events, but sometimes multiple pieces
             of data that trigger events must be set before the data can be
             recomputed. For example changing number of dimension cause broacast
             error on partially update structures.

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -1,4 +1,6 @@
 from collections.abc import Iterable
+from contextlib import contextmanager
+from functools import wraps
 from typing import Sequence, Union
 
 import numpy as np
@@ -13,6 +15,19 @@ from napari.utils.geometry import (
     line_in_triangles_3d,
 )
 from napari.utils.translations import trans
+
+
+def _batch_dec(meth):
+    """
+    Decorator to apply `self.batched_updates` to the current method.
+    """
+
+    @wraps(meth)
+    def _wrapped(self, *args, **kwargs):
+        with self.batched_updates():
+            return meth(self, *args, **kwargs)
+
+    return _wrapped
 
 
 class ShapeList:
@@ -84,8 +99,51 @@ class ShapeList:
         self._edge_color = np.empty((0, 4))
         self._face_color = np.empty((0, 4))
 
+        # counter for the depth of re entrance of the context manager.
+        self.__batched_level = 0
+        self.__batch_force_call = False
+
+        # Counter of number of time _update_displayed has been requested
+        self.__update_displayed_called = 0
+
         for d in data:
             self.add(d)
+
+    @contextmanager
+    def batched_updates(self):
+        """
+        Reentrant context manager to batch the display update
+
+        `_update_displayed()` is called at _most_ once on exit of the context
+        manager.
+
+        There are two reason for that:
+
+         1. Some updates are triggered by events, but sometime multiple pieces
+            of data that trigger events must be set before the data can be
+            recomputed. For example changing number of dimension cause broacast
+            error on partially update structures.
+         2. Performance. Ideally we want to update the display only once.
+
+        If no direct or indirect call to `_update_displayed()` are made inside
+        the context manager, no the update logic is not called on exit.
+
+
+
+        """
+        assert self.__batched_level >= 0
+        self.__batched_level += 1
+        try:
+            yield
+        finally:
+            if self.__batched_level == 1 and self.__update_displayed_called:
+                self.__batch_force_call = True
+                self._update_displayed()
+                self.__batch_force_call = False
+                self.__update_displayed_called = 0
+            self.__batched_level -= 1
+
+        assert self.__batched_level >= 0
 
     @property
     def data(self):
@@ -141,6 +199,7 @@ class ShapeList:
     def face_color(self, face_color):
         self._set_color(face_color, 'face')
 
+    @_batch_dec
     def _set_color(self, colors, attribute):
         """Set the face_color or edge_color property
 
@@ -185,6 +244,7 @@ class ShapeList:
         return self._slice_key
 
     @slice_key.setter
+    @_batch_dec
     def slice_key(self, slice_key):
         slice_key = list(slice_key)
         if not np.all(self._slice_key == slice_key):
@@ -192,7 +252,18 @@ class ShapeList:
             self._update_displayed()
 
     def _update_displayed(self):
-        """Update the displayed data based on the slice key."""
+        """Update the displayed data based on the slice key.
+
+        This method must be called from within the `batched_updates` context
+        manager:
+        """
+        assert (
+            self.__batched_level >= 1
+        ), "call _update_displayed from within self.batched_updates context manager"
+        if not self.__batch_force_call:
+            self.__update_displayed_called += 1
+            return
+
         # The list slice key is repeated to check against both the min and
         # max values stored in the shapes slice key.
         slice_key = np.array([self.slice_key, self.slice_key])
@@ -200,7 +271,6 @@ class ShapeList:
         # Slice key must exactly match mins and maxs of shape as then the
         # shape is entirely contained within the current slice.
         if len(self.shapes) > 0:
-            print(self.slice_keys.shape, slice_key.shape)
             self._displayed = np.all(self.slice_keys == slice_key, axis=(1, 2))
         else:
             self._displayed = []
@@ -581,6 +651,7 @@ class ShapeList:
             # Set z_order
             self._update_z_order()
 
+    @_batch_dec
     def remove_all(self):
         """Removes all shapes"""
         self.shapes = []
@@ -642,6 +713,7 @@ class ShapeList:
             )
             self._update_z_order()
 
+    @_batch_dec
     def _update_mesh_vertices(self, index, edge=False, face=False):
         """Updates the mesh vertex data and vertex data for a single shape
         located at index.
@@ -675,6 +747,7 @@ class ShapeList:
             self._vertices[indices] = shape.data_displayed
             self._update_displayed()
 
+    @_batch_dec
     def _update_z_order(self):
         """Updates the z order of the triangles given the z_index list"""
         self._z_order = np.argsort(self._z_index)
@@ -757,6 +830,7 @@ class ShapeList:
         self.shapes[index].edge_width = edge_width
         self._update_mesh_vertices(index, edge=True)
 
+    @_batch_dec
     def update_edge_color(self, index, edge_color, update=True):
         """Updates the edge color of a single shape located at index.
 
@@ -778,6 +852,7 @@ class ShapeList:
         if update:
             self._update_displayed()
 
+    @_batch_dec
     def update_edge_colors(self, indices, edge_colors, update=True):
         """same as update_edge_color() but for multiple indices/edgecolors at once"""
         self._edge_color[indices] = edge_colors
@@ -791,6 +866,7 @@ class ShapeList:
         if update:
             self._update_displayed()
 
+    @_batch_dec
     def update_face_color(self, index, face_color, update=True):
         """Updates the face color of a single shape located at index.
 
@@ -812,6 +888,7 @@ class ShapeList:
         if update:
             self._update_displayed()
 
+    @_batch_dec
     def update_face_colors(self, indices, face_colors, update=True):
         """same as update_face_color() but for multiple indices/facecolors at once"""
         self._face_color[indices] = face_colors

--- a/napari/layers/shapes/_shapes_models/rectangle.py
+++ b/napari/layers/shapes/_shapes_models/rectangle.py
@@ -59,7 +59,6 @@ class Rectangle(Shape):
             data = find_corners(data)
 
         if len(data) != 4:
-            print(data)
             raise ValueError(
                 trans._(
                     "Data shape does not match a rectangle. Rectangle expects four corner vertices, {number} provided.",
@@ -78,7 +77,6 @@ class Rectangle(Shape):
         self._face_vertices = self.data_displayed
         self._face_triangles = np.array([[0, 1, 2], [0, 2, 3]])
         self._box = rectangle_to_box(self.data_displayed)
-
         data_not_displayed = self.data[:, self.dims_not_displayed]
         self.slice_key = np.round(
             [

--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -98,7 +98,7 @@ class Shape(ABC):
     ) -> None:
         self._dims_order = dims_order or list(range(2))
         self._ndisplay = ndisplay
-        self._slice_key = None
+        self.slice_key = None
 
         self._face_vertices = np.empty((0, self.ndisplay))
         self._face_triangles = np.empty((0, 3), dtype=np.uint32)
@@ -113,16 +113,6 @@ class Shape(ABC):
         self.edge_width = edge_width
         self.z_index = z_index
         self.name = ''
-
-    @property
-    def slice_key(self):
-        print('RS', self._slice_key)
-        return self._slice_key
-
-    @slice_key.setter
-    def slice_key(self, slice_key):
-        print('RS Set', slice_key)
-        self._slice_key = slice_key
 
     @property
     @abstractmethod

--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -98,7 +98,7 @@ class Shape(ABC):
     ) -> None:
         self._dims_order = dims_order or list(range(2))
         self._ndisplay = ndisplay
-        self.slice_key = None
+        self._slice_key = None
 
         self._face_vertices = np.empty((0, self.ndisplay))
         self._face_triangles = np.empty((0, 3), dtype=np.uint32)
@@ -113,6 +113,16 @@ class Shape(ABC):
         self.edge_width = edge_width
         self.z_index = z_index
         self.name = ''
+
+    @property
+    def slice_key(self):
+        print('RS', self._slice_key)
+        return self._slice_key
+
+    @slice_key.setter
+    def slice_key(self, slice_key):
+        print('RS Set', slice_key)
+        self._slice_key = slice_key
 
     @property
     @abstractmethod

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -385,7 +385,6 @@ def test_refresh_text():
     layer.properties = new_properties
     np.testing.assert_equal(layer.text.values, new_properties['shape_type'])
 
-
 @pytest.mark.parametrize('prepend', [[], [7], [8, 9]])
 def test_nd_text(prepend):
     """Test slicing of text coords with nD shapes

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -385,6 +385,7 @@ def test_refresh_text():
     layer.properties = new_properties
     np.testing.assert_equal(layer.text.values, new_properties['shape_type'])
 
+
 @pytest.mark.parametrize('prepend', [[], [7], [8, 9]])
 def test_nd_text(prepend):
     """Test slicing of text coords with nD shapes
@@ -392,7 +393,6 @@ def test_nd_text(prepend):
     We can prepend as many dimensions as we want it should not change the result
     """
     shapes_data = [
-        # t, z, y, x
         [
             prepend + [0, 10, 10, 10],
             prepend + [0, 10, 20, 20],
@@ -406,19 +406,18 @@ def test_nd_text(prepend):
             prepend + [1, 20, 30, 50],
         ],
     ]
-    properties = {'shape_type': ['A', 'B']}
-    text_kwargs = {'string': 'shape_type', 'anchor': 'center'}
-    layer = Shapes(shapes_data, properties=properties, text=text_kwargs)
+    layer = Shapes(shapes_data)
     assert layer.ndim == 4 + len(prepend)
 
     layer._slice_dims(point=prepend + [0, 10, 0, 0], ndisplay=2)
     np.testing.assert_equal(layer._indices_view, [0])
     np.testing.assert_equal(layer._view_text_coords[0], [[15, 15]])
+
     # TODO: 1st bug #6205, ndisplay 3 is buggy in 5+ dimensions
-    if len(prepend) == 0:
-        layer._slice_dims(point=prepend + [1, 0, 0, 0], ndisplay=3)
-        np.testing.assert_equal(layer._indices_view, [1])
-        np.testing.assert_equal(layer._view_text_coords[0], [[20, 40, 40]])
+    # may need to call _update_dims
+    layer._slice_dims(point=prepend + [1, 0, 0, 0], ndisplay=3)
+    np.testing.assert_equal(layer._indices_view, [1])
+    np.testing.assert_equal(layer._view_text_coords[0], [[20, 40, 40]])
 
 
 @pytest.mark.parametrize("properties", [properties_array, properties_list])

--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -386,24 +386,40 @@ def test_refresh_text():
     np.testing.assert_equal(layer.text.values, new_properties['shape_type'])
 
 
-def test_nd_text():
-    """Test slicing of text coords with nD shapes"""
+@pytest.mark.parametrize('prepend', [[], [7], [8, 9]])
+def test_nd_text(prepend):
+    """Test slicing of text coords with nD shapes
+
+    We can prepend as many dimensions as we want it should not change the result
+    """
     shapes_data = [
-        [[0, 10, 10, 10], [0, 10, 20, 20], [0, 10, 10, 20], [0, 10, 20, 10]],
-        [[1, 20, 30, 30], [1, 20, 50, 50], [1, 20, 50, 30], [1, 20, 30, 50]],
+        # t, z, y, x
+        [
+            prepend + [0, 10, 10, 10],
+            prepend + [0, 10, 20, 20],
+            prepend + [0, 10, 10, 20],
+            prepend + [0, 10, 20, 10],
+        ],
+        [
+            prepend + [1, 20, 30, 30],
+            prepend + [1, 20, 50, 50],
+            prepend + [1, 20, 50, 30],
+            prepend + [1, 20, 30, 50],
+        ],
     ]
     properties = {'shape_type': ['A', 'B']}
     text_kwargs = {'string': 'shape_type', 'anchor': 'center'}
     layer = Shapes(shapes_data, properties=properties, text=text_kwargs)
-    assert layer.ndim == 4
+    assert layer.ndim == 4 + len(prepend)
 
-    layer._slice_dims(point=[0, 10, 0, 0], ndisplay=2)
+    layer._slice_dims(point=prepend + [0, 10, 0, 0], ndisplay=2)
     np.testing.assert_equal(layer._indices_view, [0])
     np.testing.assert_equal(layer._view_text_coords[0], [[15, 15]])
-
-    layer._slice_dims(point=[1, 0, 0, 0], ndisplay=3)
-    np.testing.assert_equal(layer._indices_view, [1])
-    np.testing.assert_equal(layer._view_text_coords[0], [[20, 40, 40]])
+    # TODO: 1st bug #6205, ndisplay 3 is buggy in 5+ dimensions
+    if len(prepend) == 0:
+        layer._slice_dims(point=prepend + [1, 0, 0, 0], ndisplay=3)
+        np.testing.assert_equal(layer._indices_view, [1])
+        np.testing.assert_equal(layer._view_text_coords[0], [[20, 40, 40]])
 
 
 @pytest.mark.parametrize("properties", [properties_array, properties_list])

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2319,26 +2319,27 @@ class Shapes(Layer):
 
     def _set_view_slice(self):
         """Set the view given the slicing indices."""
-        ndisplay = self._slice_input.ndisplay
-        if ndisplay != self._ndisplay_stored:
-            self.selected_data = set()
-            self._data_view.ndisplay = min(self.ndim, ndisplay)
-            self._ndisplay_stored = ndisplay
-            self._clipboard = {}
+        with self._data_view.batched_updates():
+            ndisplay = self._slice_input.ndisplay
+            if ndisplay != self._ndisplay_stored:
+                self.selected_data = set()
+                self._data_view.ndisplay = min(self.ndim, ndisplay)
+                self._ndisplay_stored = ndisplay
+                self._clipboard = {}
 
-        if self._slice_input.order != self._display_order_stored:
-            self.selected_data = set()
-            self._data_view.update_dims_order(self._slice_input.order)
-            self._display_order_stored = copy(self._slice_input.order)
-            # Clear clipboard if dimensions swap
-            self._clipboard = {}
+            if self._slice_input.order != self._display_order_stored:
+                self.selected_data = set()
+                self._data_view.update_dims_order(self._slice_input.order)
+                self._display_order_stored = copy(self._slice_input.order)
+                # Clear clipboard if dimensions swap
+                self._clipboard = {}
 
-        slice_key = np.array(self._slice_indices)[
-            self._slice_input.not_displayed
-        ]
-        if not np.array_equal(slice_key, self._data_view.slice_key):
-            self.selected_data = set()
-        self._data_view.slice_key = slice_key
+            slice_key = np.array(self._slice_indices)[
+                self._slice_input.not_displayed
+            ]
+            if not np.array_equal(slice_key, self._data_view.slice_key):
+                self.selected_data = set()
+            self._data_view.slice_key = slice_key
 
     def interaction_box(self, index):
         """Create the interaction box around a shape or list of shapes.

--- a/napari/layers/utils/_text_utils.py
+++ b/napari/layers/utils/_text_utils.py
@@ -36,9 +36,12 @@ def _calculate_bbox_centers(view_data: Union[np.ndarray, list]) -> np.ndarray:
     Parameters
     ----------
     view_data : np.ndarray | list of ndarray
-        if an ndarray, return the
+        if an ndarray, return the center across the 0-th axis.
+        if a list, return the bbox center for each items.
 
-
+    Returns
+    -------
+    An ndarray of the centers.
 
     """
     if isinstance(view_data, np.ndarray):

--- a/napari/layers/utils/_text_utils.py
+++ b/napari/layers/utils/_text_utils.py
@@ -30,13 +30,33 @@ def _calculate_anchor_center(
 
 
 def _calculate_bbox_centers(view_data: Union[np.ndarray, list]) -> np.ndarray:
+    """
+    Calculate the bounding box of the given centers,
+
+    Parameters
+    ----------
+    view_data : np.ndarray | list of ndarray
+        if an ndarray, return the
+
+
+
+    """
     if isinstance(view_data, np.ndarray):
         if view_data.ndim == 2:
+            assert view_data.ndim == 2
+            assert view_data.shape[0] in (
+                2,
+                3,
+            ), view_data.shape  # x,y, or x,y,z
+            assert view_data.shape[0] in (2, 3), view_data.shape
             # if the data are a list of coordinates, just return the coord (e.g., points)
             bbox_centers = view_data
         else:
+            assert view_data.ndim == 3
             bbox_centers = np.mean(view_data, axis=0)
     elif isinstance(view_data, list):
+        for coord in view_data:
+            assert coord.shape[1] in (2, 3), coord.shape
         bbox_centers = np.array(
             [np.mean(coords, axis=0) for coords in view_data]
         )

--- a/napari/layers/utils/_text_utils.py
+++ b/napari/layers/utils/_text_utils.py
@@ -46,7 +46,6 @@ def _calculate_bbox_centers(view_data: Union[np.ndarray, list]) -> np.ndarray:
     """
     if isinstance(view_data, np.ndarray):
         if view_data.ndim == 2:
-            assert view_data.ndim == 2
             # shape[1] is 2 for a 2D center, 3 for a 3D center.
             # It should work is N > 3 Dimension, but this catches mistakes
             # when the caller passed a transposed view_data

--- a/napari/layers/utils/_text_utils.py
+++ b/napari/layers/utils/_text_utils.py
@@ -44,11 +44,10 @@ def _calculate_bbox_centers(view_data: Union[np.ndarray, list]) -> np.ndarray:
     if isinstance(view_data, np.ndarray):
         if view_data.ndim == 2:
             assert view_data.ndim == 2
-            assert view_data.shape[0] in (
-                2,
-                3,
-            ), view_data.shape  # x,y, or x,y,z
-            assert view_data.shape[0] in (2, 3), view_data.shape
+            # shape[1] is 2 for a 2D center, 3 for a 3D center.
+            # It should work is N > 3 Dimension, but this catches mistakes
+            # when the caller passed a transposed view_data
+            assert view_data.shape[1] in (2, 3), view_data.shape
             # if the data are a list of coordinates, just return the coord (e.g., points)
             bbox_centers = view_data
         else:


### PR DESCRIPTION
This is on top of #6206 and should fix #6205, it gets inspiration from #4465 and introduce batch updates. 

The problem arise when:

```python
self.a = x
self.b = y
```

When both `a` and `b` are evented and each trigger somehow `something.compute()`, that requires both `self.a` and `self.b` to have been set.

Example is if both are `ndarray` whcih `shape` depends on `ndim`, and `compute()` does some broadcast operation.

This could also be used to remove things like:


```python
def foo(self,..., update=True):
        """same as update_edge_color() but for multiple indices/edgecolors at once"""
        ...
        if update:
            self._update_displayed()
```

One thing I dont like is that `_update_displayed` does set 2 public varaibles:

```python
        self.displayed_vertices = self._vertices[disp_vert]
        self.displayed_index = self._index[disp_vert]
```

and so if those are used from within a `batched_updates` context manager they might be incorrect.

We _could_ made those properties that's can't be accessed/set while pending updates.

As I believe the but was marked as 4.x, I tried to be non-invasive, but further improvement would be to split `_update_display()` into `_request_update()` and `_do_update()`, and maybe move that to the base layer. It might be worth also doing the same with `_update_z_order` and other, but it's a bit more involved as `_update_z_order` calls into `_update_display` so order of context is important. 

This also has few effect on performance as in my test it batched at most 2 calls to update display.