### PR TITLE
Fix upgrade dependencies wokflow 

### DIFF
--- a/.github/BOT_REPO_UPDATE_FAIL_TEMPLATE.md
+++ b/.github/BOT_REPO_UPDATE_FAIL_TEMPLATE.md
@@ -1,0 +1,11 @@
+---
+title: "{{ env.TITLE }}"
+labels: [bug]
+---
+
+Update of {{ env.BOT_REPO }} failed on {{ date | date("YYYY-MM-DD HH:mm") }} UTC
+
+
+Full run: https://github.com/napari/napari/actions/runs/{{ env.RUN_ID }}
+
+(This post will be updated if another test fails, as long as this issue remains open.)

--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -209,7 +209,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_ID: ${{ github.run_id }}
-          TITLE: '[bot-repo] bor repo update is failing'
+          TITLE: '[bot-repo] bot repo update is failing'
         with:
           filename: .github/BOT_REPO_UPDATE_FAIL_TEMPLATE.md
           update_existing: true

--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -192,7 +192,7 @@ jobs:
   synchronize_bot_repository:
     name: Synchronize bot repository
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.repository != 'napari-bot/napari'
+    if: github.ref == 'refs/heads/main' && github.repository == 'napari/napari'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -188,3 +188,28 @@ jobs:
           run: tox -e py39-linux-pyside2-examples
         env:
           PIP_CONSTRAINT: resources/constraints/constraints_py3.9_examples.txt
+
+  synchronize_bot_repository:
+    name: Synchronize bot repository
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.repository != 'napari-bot/napari'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GHA_TOKEN_BOT_REPO_WORKFLOW }}
+      - name: Synchronize bot repository
+        run: |
+          git remote add napari-bot https://github.com/napari-bot/napari.git
+          git fetch napari-bot
+          git push --force --set-upstream napari-bot main
+
+      - name: Report Failures
+        if: ${{ failure() }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+          TITLE: '[bot-repo] bor repo update is failing'
+        with:
+          filename: .github/BOT_REPO_UPDATE_FAIL_TEMPLATE.md
+          update_existing: true

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -61,44 +61,44 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8"] #, "3.9", "3.10", "3.11"]
         backend: [pyqt5, pyside2]
-        exclude:
-          - python: '3.11'
-            backend: pyside2
-        include:
-          # Windows py38
-          - python: 3.8
-            platform: windows-latest
-            backend: pyqt5
-          - python: 3.8
-            platform: windows-latest
-            backend: pyside2
-          - python: 3.9
-            platform: macos-latest
-            backend: pyqt5
-          # minimum specified requirements
-          - python: 3.8
-            platform: ubuntu-20.04
-            backend: pyqt5
-            MIN_REQ: 1
-          # test without any Qt backends
-          - python: 3.8
-            platform: ubuntu-20.04
-            backend: headless
-          - python: 3.9
-            platform: ubuntu-latest
-            backend: pyqt6
-          - python: 3.9
-            platform: ubuntu-latest
-            backend: pyside6
-          # pyside 6
-          - python: '3.10'
-            platform: ubuntu-latest
-            backend: pyside6
-          - python: '3.11'
-            platform: ubuntu-latest
-            backend: pyside6
+#        exclude:
+#          - python: '3.11'
+#            backend: pyside2
+#        include:
+#          # Windows py38
+#          - python: 3.8
+#            platform: windows-latest
+#            backend: pyqt5
+#          - python: 3.8
+#            platform: windows-latest
+#            backend: pyside2
+#          - python: 3.9
+#            platform: macos-latest
+#            backend: pyqt5
+#          # minimum specified requirements
+#          - python: 3.8
+#            platform: ubuntu-20.04
+#            backend: pyqt5
+#            MIN_REQ: 1
+#          # test without any Qt backends
+#          - python: 3.8
+#            platform: ubuntu-20.04
+#            backend: headless
+#          - python: 3.9
+#            platform: ubuntu-latest
+#            backend: pyqt6
+#          - python: 3.9
+#            platform: ubuntu-latest
+#            backend: pyside6
+#          # pyside 6
+#          - python: '3.10'
+#            platform: ubuntu-latest
+#            backend: pyside6
+#          - python: '3.11'
+#            platform: ubuntu-latest
+#            backend: pyside6
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -61,44 +61,44 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        python: ["3.8"] #, "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
         backend: [pyqt5, pyside2]
-#        exclude:
-#          - python: '3.11'
-#            backend: pyside2
-#        include:
-#          # Windows py38
-#          - python: 3.8
-#            platform: windows-latest
-#            backend: pyqt5
-#          - python: 3.8
-#            platform: windows-latest
-#            backend: pyside2
-#          - python: 3.9
-#            platform: macos-latest
-#            backend: pyqt5
-#          # minimum specified requirements
-#          - python: 3.8
-#            platform: ubuntu-20.04
-#            backend: pyqt5
-#            MIN_REQ: 1
-#          # test without any Qt backends
-#          - python: 3.8
-#            platform: ubuntu-20.04
-#            backend: headless
-#          - python: 3.9
-#            platform: ubuntu-latest
-#            backend: pyqt6
-#          - python: 3.9
-#            platform: ubuntu-latest
-#            backend: pyside6
-#          # pyside 6
-#          - python: '3.10'
-#            platform: ubuntu-latest
-#            backend: pyside6
-#          - python: '3.11'
-#            platform: ubuntu-latest
-#            backend: pyside6
+        exclude:
+          - python: '3.11'
+            backend: pyside2
+        include:
+          # Windows py38
+          - python: 3.8
+            platform: windows-latest
+            backend: pyqt5
+          - python: 3.8
+            platform: windows-latest
+            backend: pyside2
+          - python: 3.9
+            platform: macos-latest
+            backend: pyqt5
+          # minimum specified requirements
+          - python: 3.8
+            platform: ubuntu-20.04
+            backend: pyqt5
+            MIN_REQ: 1
+          # test without any Qt backends
+          - python: 3.8
+            platform: ubuntu-20.04
+            backend: headless
+          - python: 3.9
+            platform: ubuntu-latest
+            backend: pyqt6
+          - python: 3.9
+            platform: ubuntu-latest
+            backend: pyside6
+          # pyside 6
+          - python: '3.10'
+            platform: ubuntu-latest
+            backend: pyside6
+          - python: '3.11'
+            platform: ubuntu-latest
+            backend: pyside6
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -1,12 +1,12 @@
-# This is a workflow for upgrade test constraints. It is triggered by:
+# This is a workflow for upgrading test constraints. It is triggered by:
 # - On-demand workflow_dispatch
 # - weekly schedule (every Monday at 8:00 UTC)
 # - issue_comment with text "@napari-bot update constraints"
 # - pull_request with changed .github/workflows/upgrade_test_constraints.yml
 #
 # The GitHub workflows have the following limitations:
-# - There is no pull request comment trigger for workflow.
-#   The `issue_comment` trigger is used instead (it is used on pull requests too).
+# - There is no pull request comment trigger for workflows.
+#   The `issue_comment` trigger is used instead, because it is used for pull requests too.
 # - If a workflow is triggered by pull_requests from forked repository,
 #   then it does not have access to secrets.
 #   So it is not possible to create PR from forked repository.
@@ -36,7 +36,7 @@
 #     If pull_request triggers workflow, then this will contain PR branch.
 #     Changes will be only accessible as artifacts.
 # - If workflow is triggered by issue comment,
-#   then we add eye reaction to the comment to show that workflow has started.
+#   then we add eyes reaction to the comment to show that workflow has started.
 #   After finishing calculation of new constraints, we add rocket reaction to the comment.
 #   Then pushing changes to `napari-bot/napari` repository and adding comment to the PR is
 #   done by `tools/create_pr_or_update_existing_one.py`.
@@ -61,7 +61,7 @@ jobs:
     if: (github.event.issue.pull_request != '' && contains(github.event.comment.body, '@napari-bot update constraints')) || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Add eye reaction
+      - name: Add eyes reaction
         # show that workflow has started
         if: github.event_name == 'issue_comment'
         run: |

--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -1,3 +1,45 @@
+# This is a workflow for upgrade test constraints. It is triggered by:
+# - On-demand workflow_dispatch
+# - weekly schedule (every Monday at 8:00 UTC)
+# - issue_comment with text "@napari-bot update constraints"
+# - pull_request with changed .github/workflows/upgrade_test_constraints.yml
+#
+# The GitHub workflows have the following limitations:
+# - There is no pull request comment trigger for workflow.
+#   The `issue_comment` trigger is used instead (it is used on pull requests too).
+# - If a workflow is triggered by pull_requests from forked repository,
+#   then it does not have access to secrets.
+#   So it is not possible to create PR from forked repository.
+# - If workflow is triggered by issue comment, then it is triggered on the main branch
+#   and not on the branch where the comment was created.
+# - In workflow triggers it is only possible to depend on created event, without any conditions.
+#   So it is not possible to trigger workflow only when the comment contains specific text.
+#   So we need to check it in the workflow.
+#   It will produce multiple empty runs that will create multiple empty entries in actions
+#   making it harder to find the right one.
+# - It is not possible to update pull request from forked repository using Fine grained personal token.
+# - It is not possible to create pull request to forked repository using Fine grained personal token.
+# - There is no interface indicator that the workflow triggered by issue comment is running.
+#
+# Also, for safety reason, it is better to store automatically generated changes outside the main repository.
+#
+# Because of the above limitations, the following approach is used:
+# - We use `napari-bot/napari` repository to store automatically generated changes.
+# - We don't push changes to `napari-bot/napari` repository if PR contains changes in workflows.
+# - We use two checkouts of repository:
+#   * First into `.` directory from which we run the workflow.
+#   * Second into `napari_repo` directory from which we create pull request.
+#     If comment triggers the workflow, then this will contain the branch from which the PR was created.
+#     Changes will be pushed to `napari-bot/napari` repository.
+#     If schedule or workflow_dispatch triggers workflow, then this will contain the main branch.
+#     Changes will not be pushed to `napari/napari` repository.
+#     If pull_request triggers workflow, then this will contain PR branch.
+#     Changes will be only accessible as artifacts.
+# - If workflow is triggered by issue comment,
+#   then we add eye reaction to the comment to show that workflow has started.
+#   After finishing calculation of new constraints, we add rocket reaction to the comment.
+#   Then pushing changes to `napari-bot/napari` repository and adding comment to the PR is
+#   done by `tools/create_pr_or_update_existing_one.py`.
 name: Upgrade test constraints
 
 on:
@@ -20,6 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add eye reaction
+        # show that workflow has started
         if: github.event_name == 'issue_comment'
         run: |
           COMMENT_ID=${{ github.event.comment.id }}
@@ -31,6 +74,7 @@ jobs:
             -d '{"content": "eyes"}'
 
       - name: Get PR details
+        # extract PR number and branch name from issue_comment event
         if: github.event_name == 'issue_comment'
         run: |
           PR_number=${{ github.event.issue.number }}
@@ -49,6 +93,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get repo info
+        # when schedule or workflow_dispatch triggers workflow, then we need to get info about which branch to use
         if: github.event_name != 'issue_comment' && github.event_name != 'pull_request'
         run: |
           echo "FULL_NAME=${{ github.repository }}" >> $GITHUB_ENV
@@ -74,6 +119,7 @@ jobs:
           token: ${{ secrets.GHA_TOKEN_BOT_REPO }}
 
       - name: Clone target repo (pull request)
+        # we need separate step as passing empty token to actions/checkout@v3 will not work
         uses: actions/checkout@v3
         if: github.event_name == 'pull_request'
         with:
@@ -166,6 +212,7 @@ jobs:
             napari_repo/resources/constraints/constraints*.txt
 
       - name: Add rocket reaction
+        # inform that new constraints are available in artifacts
         if: github.event_name == 'issue_comment'
         run: |
           COMMENT_ID=${{ github.event.comment.id }}

--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -35,8 +35,9 @@ jobs:
         run: |
           PR_number=${{ github.event.issue.number }}
           PR_data=$(curl \
-          -H "Accept: application/vnd.github.v3+json" \
-          "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_number")
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_number" \
+          )
           
           FULL_NAME=$(echo $PR_data  | jq -r .head.repo.full_name)
           echo "FULL_NAME=$FULL_NAME" >> $GITHUB_ENV

--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -13,16 +13,46 @@ on:
     paths:
       - '.github/workflows/upgrade_test_constraints.yml'
 
-concurrency:
-  group: test-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   upgrade:
     name: Upgrade & Open Pull Request
-    if: (github.event.issue.pull_request != '' && contains(github.event.comment.body, '@napari-bot update constraints')) || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    if: (github.event.issue.pull_request != '' && contains(github.event.comment.body, '@napari-bot update constraints')) || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      - name: Add eye reaction
+        if: github.event_name == 'issue_comment'
+        run: |
+          COMMENT_ID=${{ github.event.comment.id }}
+          curl \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions" \
+            -d '{"content": "eyes"}'
+
+      - name: Get PR details
+        if: github.event_name == 'issue_comment'
+        run: |
+          PR_number=${{ github.event.issue.number }}
+          PR_data=$(curl \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_number")
+          
+          FULL_NAME=$(echo $PR_data  | jq -r .head.repo.full_name)
+          echo "FULL_NAME=$FULL_NAME" >> $GITHUB_ENV
+          
+          BRANCH=$(echo $PR_data  | jq -r .head.ref)
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get repo info
+        if: github.event_name != 'issue_comment' && github.event_name != 'pull_request'
+        run: |
+          echo "FULL_NAME=${{ github.repository }}" >> $GITHUB_ENV
+          echo "BRANCH=${{ github.ref_name }}" >> $GITHUB_ENV
+
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -32,6 +62,37 @@ jobs:
         with:
           path: docs  # place in a named directory
           repository: napari/docs
+
+      - name: Clone target repo (remote)
+        uses: actions/checkout@v3
+        if: github.event_name == 'issue_comment'
+        with:
+          path: napari_repo  # place in a named directory
+          repository: ${{ env.FULL_NAME }}
+          ref: ${{ env.BRANCH }}
+          token: ${{ secrets.GHA_TOKEN_BOT_REPO }}
+
+      - name: Clone target repo (pull request)
+        uses: actions/checkout@v3
+        if: github.event_name == 'pull_request'
+        with:
+          path: napari_repo  # place in a named directory
+
+      - name: Clone target repo (main)
+        uses: actions/checkout@v3
+        if: github.event_name != 'issue_comment' && github.event_name != 'pull_request'
+        with:
+          path: napari_repo  # place in a named directory
+          repository: ${{ env.FULL_NAME }}
+          ref: ${{ env.BRANCH }}
+          token: ${{ secrets.GHA_TOKEN_NAPARI_BOT_MAIN_REPO }}
+
+      - name: Add napari-bot/napari to napari_repo upstreams
+        run: |
+          cd napari_repo
+          git remote -v
+          git remote add napari-bot https://github.com/napari-bot/napari.git
+          git remote -v
 
       # START PYTHON DEPENDENCIES
       - uses: actions/setup-python@v4
@@ -71,6 +132,9 @@ jobs:
           flags+=" --extra pyside2"
           flags+=" --extra pyside6_experimental"
           flags+=" --extra testing"
+          prefix="napari_repo"
+          setup_cfg="${prefix}/setup.cfg"
+          constraints="${prefix}/resources/constraints"
 
 
           # allow to put in constraints things like setuptools (look at the end of one of the generated files). It will be the default behavior in the future.
@@ -84,16 +148,39 @@ jobs:
 
           for pyv in 3.8 3.9 3.10 3.11; do
             python${pyv}  -m pip install -U pip pip-tools
-            python${pyv}  -m piptools compile --upgrade -o resources/constraints/constraints_py${pyv}.txt  setup.cfg resources/constraints/version_denylist.txt ${flags}
+            python${pyv}  -m piptools compile --upgrade -o $constraints/constraints_py${pyv}.txt  $setup_cfg $constraints/version_denylist.txt ${flags}
           done
 
-          python3.9 -m piptools compile --upgrade -o resources/constraints/constraints_py3.9_examples.txt setup.cfg resources/constraints/version_denylist.txt resources/constraints/version_denylist_examples.txt ${flags}
-          python3.10 -m piptools compile --upgrade -o resources/constraints/constraints_py3.10_docs.txt setup.cfg resources/constraints/version_denylist.txt resources/constraints/version_denylist_examples.txt docs/requirements.txt ${flags}
+          python3.9 -m piptools compile --upgrade -o $constraints/constraints_py3.9_examples.txt $setup_cfg $constraints/version_denylist.txt resources/constraints/version_denylist_examples.txt ${flags}
+          python3.10 -m piptools compile --upgrade -o $constraints/constraints_py3.10_docs.txt $setup_cfg $constraints/version_denylist.txt resources/constraints/version_denylist_examples.txt docs/requirements.txt ${flags}
           python3.11 -m piptools compile --upgrade -o resources/requirements_mypy.txt resources/requirements_mypy.in --resolver=backtracking
 
       # END PYTHON DEPENDENCIES
+
+      - name: Upload constraints
+        uses: actions/upload-artifact@v3
+        with:
+          name: constraints
+          path: |
+            napari_repo/resources/constraints/constraints*.txt
+
+      - name: Add rocket reaction
+        if: github.event_name == 'issue_comment'
+        run: |
+          COMMENT_ID=${{ github.event.comment.id }}
+          curl \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions" \
+            -d '{"content": "rocket"}'
 
       - name: Create commit
         run: |
           pip install requests
           python tools/create_pr_or_update_existing_one.py
+        env:
+            GHA_TOKEN_MAIN_REPO: ${{ secrets.GHA_TOKEN_NAPARI_BOT_MAIN_REPO }}
+            PR_NUMBER: ${{ github.event.issue.number }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/tools/create_pr_or_update_existing_one.py
+++ b/tools/create_pr_or_update_existing_one.py
@@ -3,6 +3,7 @@ This file contains the code to create a PR or update an existing one based on th
 """
 
 import logging
+import os
 import subprocess  # nosec
 from contextlib import contextmanager
 from os import chdir, environ, getcwd
@@ -11,9 +12,10 @@ from pathlib import Path
 import requests
 from check_updated_packages import get_changed_dependencies
 
-REPO_DIR = Path(__file__).parent.parent
+REPO_DIR = Path(__file__).parent.parent / "napari_repo"
 # GitHub API base URL
 BASE_URL = "https://api.github.com"
+DEFAULT_BRANCH_NAME = "auto-update-dependencies"
 
 
 @contextmanager
@@ -45,11 +47,13 @@ def _setup_git_author():
     )  # nosec
 
 
-def create_commit(message: str):
+def create_commit(message: str, branch_name: str = ""):
     """
     Create a commit calling git.
     """
     with cd(REPO_DIR):
+        if branch_name:
+            subprocess.run(["git", "checkout", "-B", branch_name], check=True)
         subprocess.run(["git", "add", "-u"], check=True)  # nosec
         subprocess.run(["git", "commit", "-m", message], check=True)  # nosec
 
@@ -59,9 +63,23 @@ def push(branch_name: str, update: bool = False):
     Push the current branch to the remote.
     """
     with cd(REPO_DIR):
+        logging.info("go to dir %s", REPO_DIR)
         if update:
-            subprocess.run(["git", "push"], check=True)
+            logging.info("Pushing to %s", branch_name)
+            subprocess.run(
+                [
+                    "git",
+                    "push",
+                    "--force",
+                    "--set-upstream",
+                    "napari-bot",
+                    branch_name,
+                ],
+                check=True,
+                capture_output=True,
+            )
         else:
+            logging.info("Force pushing to %s", branch_name)
             subprocess.run(
                 [
                     "git",
@@ -72,51 +90,110 @@ def push(branch_name: str, update: bool = False):
                     branch_name,
                 ],
                 check=True,
+                capture_output=True,
             )  # nosec
 
 
 def commit_message(branch_name) -> str:
-    changed_direct = get_changed_dependencies(
-        all_packages=False, base_branch=branch_name
-    )
+    with cd(REPO_DIR):
+        changed_direct = get_changed_dependencies(
+            all_packages=False,
+            base_branch=branch_name,
+            python_version="3.11",
+            src_dir=REPO_DIR,
+        )
     if not changed_direct:
         return "Update indirect dependencies"
     return "Update " + ", ".join(f"`{x}`" for x in changed_direct)
 
 
 def long_description(branch_name: str) -> str:
-    all_changed = get_changed_dependencies(
-        all_packages=True, base_branch=branch_name
-    )
+    with cd(REPO_DIR):
+        all_changed = get_changed_dependencies(
+            all_packages=True,
+            base_branch=branch_name,
+            python_version="3.11",
+            src_dir=REPO_DIR,
+        )
     return "Updated packages: " + ", ".join(f"`{x}`" for x in all_changed)
 
 
-def create_pr(branch_name: str, access_token: str, repo="napari/napari"):
+def create_pr_with_push(branch_name: str, access_token: str, repo=""):
     """
     Create a PR.
     """
     if branch_name == "main":
-        new_branch_name = "auto-update-dependencies"
+        new_branch_name = DEFAULT_BRANCH_NAME
     else:
-        new_branch_name = f"auto-update-dependencies-{branch_name}"
+        new_branch_name = f"{DEFAULT_BRANCH_NAME}-{branch_name}"
 
+    if not repo:
+        repo = os.environ.get("GITHUB_REPOSITORY", "napari/napari")
     with cd(REPO_DIR):
         subprocess.run(["git", "checkout", "-B", new_branch_name], check=True)
     create_commit(commit_message(branch_name))
+    push(new_branch_name)
 
+    logging.info("Create PR for branch %s", new_branch_name)
+    if pr_number := list_pr_for_branch(
+        new_branch_name, access_token, repo=repo
+    ):
+        update_own_pr(pr_number, access_token, branch_name, repo)
+    else:
+        create_pr(
+            base_branch=branch_name,
+            new_branch=new_branch_name,
+            access_token=access_token,
+            repo=repo,
+        )
+
+
+def update_own_pr(pr_number: int, access_token: str, base_branch: str, repo):
+    headers = {"Authorization": f"token {access_token}"}
+    payload = {
+        "title": commit_message(base_branch),
+        "body": long_description(base_branch),
+    }
+    url = f"{BASE_URL}/repos/{repo}/pulls/{pr_number}"
+    logging.info("Update PR with payload: %s in %s", str(payload), url)
+    response = requests.post(url, headers=headers, json=payload)
+    response.raise_for_status()
+
+
+def list_pr_for_branch(branch_name: str, access_token: str, repo=""):
+    """
+    check if PR for branch exists
+    """
+    org_name = repo.split('/')[0]
+    url = f"{BASE_URL}/repos/{repo}/pulls?state=open&head={org_name}:{branch_name}"
+    response = requests.get(url)
+    response.raise_for_status()
+    if response.json():
+        return response.json()[0]['number']
+    return None
+
+
+def create_pr(
+    base_branch: str, new_branch: str, access_token: str, repo, source_user=""
+):
     # Prepare the headers with the access token
     headers = {"Authorization": f"token {access_token}"}
 
     # publish the comment
     payload = {
-        "title": commit_message(branch_name),
-        "body": long_description(branch_name),
-        "head": new_branch_name,
-        "base": branch_name,
+        "title": commit_message(base_branch),
+        "body": long_description(base_branch),
+        "head": new_branch,
+        "base": base_branch,
         "maintainer_can_modify": True,
     }
-    comment_url = f"{BASE_URL}/repos/{repo}/pulls"
-    response = requests.post(comment_url, headers=headers, json=payload)
+    if source_user:
+        payload["head"] = f"{source_user}:{new_branch}"
+    pull_request_url = f"{BASE_URL}/repos/{repo}/pulls"
+    logging.info(
+        "Create PR with payload: %s in %s", str(payload), pull_request_url
+    )
+    response = requests.post(pull_request_url, headers=headers, json=payload)
     response.raise_for_status()
     logging.info("PR created: %s", response.json()["html_url"])
 
@@ -124,14 +201,13 @@ def create_pr(branch_name: str, access_token: str, repo="napari/napari"):
 def add_comment_to_pr(
     pull_request_number: int,
     message: str,
-    access_token: str,
     repo="napari/napari",
 ):
     """
     Add a comment to an existing PR.
     """
     # Prepare the headers with the access token
-    headers = {"Authorization": f"token {access_token}"}
+    headers = {"Authorization": f"token {os.environ.get('GITHUB_TOKEN')}"}
 
     # publish the comment
     payload = {"body": message}
@@ -142,42 +218,83 @@ def add_comment_to_pr(
     response.raise_for_status()
 
 
-def update_pr(branch_name: str, access_token: str):
+def update_pr(branch_name: str):
     """
     Update an existing PR.
     """
     pr_number = get_pr_number()
 
-    create_commit(commit_message(branch_name))
-    push(branch_name)
+    target_repo = os.environ.get('FULL_NAME')
+
+    new_branch_name = f"auto-update-dependencies/{target_repo}/{branch_name}"
+
+    if (
+        target_repo == os.environ.get("GITHUB_REPOSITORY", "napari/napari")
+        and branch_name == DEFAULT_BRANCH_NAME
+    ):
+        new_branch_name = DEFAULT_BRANCH_NAME
+
+    create_commit(commit_message(branch_name), branch_name=new_branch_name)
+    comment_content = long_description(f"origin/{branch_name}")
+
+    try:
+        push(new_branch_name, update=True)
+    except subprocess.CalledProcessError as e:
+        if "create or update workflow" in e.stderr.decode():
+            logging.info("Workflow file changed. Skip PR create.")
+            comment_content += (
+                "\n\n This PR constains changes to the workflow file. "
+            )
+            comment_content += "Please download the artifact and update the constraints files manually. "
+            comment_content += f"Artifact: https://github.com/PartSeg/napari/actions/runs/{os.environ.get('GITHUB_RUN_ID')}"
+        else:
+            raise
+    else:
+        if new_branch_name != DEFAULT_BRANCH_NAME:
+            comment_content += update_external_pr_comment(
+                target_repo, branch_name, new_branch_name
+            )
+
     add_comment_to_pr(
         pr_number,
-        long_description(branch_name),
-        access_token,
+        comment_content,
+        repo=os.environ.get("GITHUB_REPOSITORY", "napari/napari"),
     )
     logging.info("PR updated: %s", pr_number)
 
 
+def update_external_pr_comment(
+    target_repo: str, branch_name: str, new_branch_name: str
+) -> str:
+    comment = "\n\nThis workflow cannot automatically update your PR or create PR to your repository. "
+    comment += "But you could open such PR by clicking the link: "
+    comment += f"https://github.com/{target_repo}/compare/{branch_name}...napari-bot:{new_branch_name}."
+    comment += "\n\n"
+    comment += "You could also get the updated files from the "
+    comment += f"https://github.com/napari-bot/napari/tree/{new_branch_name}/resources/constraints. "
+    comment += "Or ask the maintainers to provide you content of the constraints artifact "
+    comment += f"from the run https://github.com/PartSeg/napari/actions/runs/{os.environ.get('GITHUB_RUN_ID')}"
+    return comment
+
+
 def get_pr_number() -> int:
     """
-    Get the PR number from the environment based on the GITHUB_REF variable.
+    Get the PR number from the environment based on the PR_NUMBER variable.
 
     Returns
     -------
     pr number: int
     """
-    github_ref = environ.get("GITHUB_REF")
-    refs, pull, number, merge = github_ref.split('/')
-    assert refs == 'refs'
-    assert pull == 'pull'
-    assert merge == 'merge'
-    return int(number)
+    pr_number = environ.get("PR_NUMBER")
+    logging.info("PR_NUMBER: %s", pr_number)
+    return int(pr_number)
 
 
 def main():
-    branch_name = environ["GITHUB_REF_NAME"]
-    event_name = environ["GITHUB_EVENT_NAME"]
-    access_token = environ.get("GHA_TOKEN")
+    event_name = environ.get("GITHUB_EVENT_NAME")
+    branch_name = environ.get("BRANCH")
+
+    access_token = environ.get("GHA_TOKEN_MAIN_REPO")
 
     _setup_git_author()
 
@@ -187,10 +304,14 @@ def main():
 
     if event_name in {"schedule", "workflow_dispatch"}:
         logging.info("Creating PR")
-        create_pr(branch_name, access_token)
+        create_pr_with_push(branch_name, access_token)
     elif event_name == "issue_comment":
         logging.info("Updating PR")
-        update_pr(branch_name, access_token)
+        update_pr(branch_name)
+    elif event_name == "pull_request":
+        logging.info(
+            "Pull request run. We cannot add comment or create PR. Please download the artifact."
+        )
     else:
         raise ValueError(f"Unknown event name: {event_name}")
 

--- a/tools/create_pr_or_update_existing_one.py
+++ b/tools/create_pr_or_update_existing_one.py
@@ -243,7 +243,7 @@ def update_pr(branch_name: str):
         if "create or update workflow" in e.stderr.decode():
             logging.info("Workflow file changed. Skip PR create.")
             comment_content += (
-                "\n\n This PR constains changes to the workflow file. "
+                "\n\n This PR contains changes to the workflow file. "
             )
             comment_content += "Please download the artifact and update the constraints files manually. "
             comment_content += f"Artifact: https://github.com/PartSeg/napari/actions/runs/{os.environ.get('GITHUB_RUN_ID')}"
@@ -272,7 +272,7 @@ def update_external_pr_comment(
     comment += "\n\n"
     comment += "You could also get the updated files from the "
     comment += f"https://github.com/napari-bot/napari/tree/{new_branch_name}/resources/constraints. "
-    comment += "Or ask the maintainers to provide you content of the constraints artifact "
+    comment += "Or ask the maintainers to provide you the contents of the constraints artifact "
     comment += f"from the run https://github.com/PartSeg/napari/actions/runs/{os.environ.get('GITHUB_RUN_ID')}"
     return comment
 


### PR DESCRIPTION
# Description

This PR fixes update dependencies workflow.

For its development I have used PartSeg/napari fork. 

There is few use cases:

1) Scheduled update https://github.com/PartSeg/napari/pull/3
2) Normal PR https://github.com/PartSeg/napari/pull/1 - bot add reactions to comment and then add comment that allow to create PR or download actions artifact (only project maintainers)
3) Pr that updates workflow https://github.com/PartSeg/napari/pull/4 - as we do not want to have random actions executed in napari-bot repo it do not create new branch that allow to open PR, but requires core-dev action to provide PR artifact to PR author (download them and upload to comment). 
4) Pull request that modify this workflow file (ex. change python versions) - only upload artifacts, as there is no option to provide secrets to workflow triggered by pull_request. See "Upgrade test constraints" workflow run for this PR.

If run workflow using comment it add eye reaction when workflow starts and rocket reaction after upload calculated constraints artifacts. 

This PR also add to test_comprehensive job with synchronization napri-bot fork with main repository (You may see that it is already synchronized with PartSeg/napari - because of testing purpose). 

Because of security purposes (and GitHub limitations) current approach requires 3 Tokens:

1) `GHA_TOKEN_NAPARI_BOT_MAIN_REPO` - token that allows napari bot modify main repository
2) `GHA_TOKEN_BOT_REPO` - token that allow napari-bot create commit to his own repostory, but do not allow to update workflow files
3) `GHA_TOKEN_BOT_REPO_WORKFLOW`  token that allow napari-bot create commit to his own repostory with modification of workflows. For synchronization purposes. 

Tokens 1 and 2 could be merged if we placed repo for store constraints modification under napari organization. 

