### PR TITLE
Replace more np.all( ... = ...) with np.array_equal

### DIFF
--- a/napari/_tests/test_advanced.py
+++ b/napari/_tests/test_advanced.py
@@ -15,7 +15,7 @@ def test_4D_5D_images(make_napari_viewer):
     # add 4D image data
     data = np.random.random((2, 6, 30, 40))
     viewer.add_image(data)
-    assert np.all(viewer.layers[0].data == data)
+    assert np.array_equal(viewer.layers[0].data, data)
     assert len(viewer.layers) == 1
     assert viewer.dims.ndim == 4
     assert view.dims.nsliders == viewer.dims.ndim
@@ -24,7 +24,7 @@ def test_4D_5D_images(make_napari_viewer):
     # now add 5D image data - check an extra slider has been created
     data = np.random.random((4, 4, 5, 30, 40))
     viewer.add_image(data)
-    assert np.all(viewer.layers[1].data == data)
+    assert np.array_equal(viewer.layers[1].data, data)
     assert len(viewer.layers) == 2
     assert viewer.dims.ndim == 5
     assert view.dims.nsliders == viewer.dims.ndim
@@ -40,7 +40,7 @@ def test_5D_image_3D_rendering(make_napari_viewer):
     # add 4D image data
     data = np.random.random((2, 10, 12, 13, 14))
     viewer.add_image(data)
-    assert np.all(viewer.layers[0].data == data)
+    assert np.array_equal(viewer.layers[0].data, data)
     assert len(viewer.layers) == 1
     assert viewer.dims.ndim == 5
     assert viewer.dims.ndisplay == 2
@@ -66,7 +66,7 @@ def test_change_image_dims(make_napari_viewer):
     # add 3D image data
     data = np.random.random((10, 30, 40))
     viewer.add_image(data)
-    assert np.all(viewer.layers[0].data == data)
+    assert np.array_equal(viewer.layers[0].data, data)
     assert len(viewer.layers) == 1
     assert viewer.dims.ndim == 3
     assert view.dims.nsliders == viewer.dims.ndim
@@ -74,7 +74,7 @@ def test_change_image_dims(make_napari_viewer):
 
     # switch number of displayed dimensions
     viewer.layers[0].data = data[0]
-    assert np.all(viewer.layers[0].data == data[0])
+    assert np.array_equal(viewer.layers[0].data, data[0])
     assert len(viewer.layers) == 1
     assert viewer.dims.ndim == 2
     assert view.dims.nsliders == viewer.dims.ndim
@@ -82,7 +82,7 @@ def test_change_image_dims(make_napari_viewer):
 
     # switch number of displayed dimensions
     viewer.layers[0].data = data[:6]
-    assert np.all(viewer.layers[0].data == data[:6])
+    assert np.array_equal(viewer.layers[0].data, data[:6])
     assert len(viewer.layers) == 1
     assert viewer.dims.ndim == 3
     assert view.dims.nsliders == viewer.dims.ndim
@@ -90,7 +90,7 @@ def test_change_image_dims(make_napari_viewer):
 
     # change the shape of the data
     viewer.layers[0].data = data[:3]
-    assert np.all(viewer.layers[0].data == data[:3])
+    assert np.array_equal(viewer.layers[0].data, data[:3])
     assert len(viewer.layers) == 1
     assert viewer.dims.ndim == 3
     assert view.dims.nsliders == viewer.dims.ndim
@@ -110,7 +110,7 @@ def test_range_one_image(make_napari_viewer):
     # add 5D image data with range one dimensions
     data = np.random.random((1, 1, 1, 100, 200))
     viewer.add_image(data)
-    assert np.all(viewer.layers[0].data == data)
+    assert np.array_equal(viewer.layers[0].data, data)
     assert len(viewer.layers) == 1
     assert viewer.dims.ndim == 5
     assert view.dims.nsliders == viewer.dims.ndim
@@ -120,7 +120,7 @@ def test_range_one_image(make_napari_viewer):
     points = np.floor(5 * np.random.random((1000, 5))).astype(int)
     points[:, -2:] = 20 * points[:, -2:]
     viewer.add_points(points)
-    assert np.all(viewer.layers[1].data == points)
+    assert np.array_equal(viewer.layers[1].data, points)
     assert len(viewer.layers) == 2
     assert viewer.dims.ndim == 5
     assert view.dims.nsliders == viewer.dims.ndim
@@ -140,7 +140,7 @@ def test_range_one_images_and_points(make_napari_viewer):
     # add 5D image data with range one dimensions
     data = np.random.random((1, 1, 1, 100, 200))
     viewer.add_image(data)
-    assert np.all(viewer.layers[0].data == data)
+    assert np.array_equal(viewer.layers[0].data, data)
     assert len(viewer.layers) == 1
     assert viewer.dims.ndim == 5
     assert view.dims.nsliders == viewer.dims.ndim
@@ -150,7 +150,7 @@ def test_range_one_images_and_points(make_napari_viewer):
     points = np.floor(5 * np.random.random((1000, 5))).astype(int)
     points[:, -2:] = 20 * points[:, -2:]
     viewer.add_points(points)
-    assert np.all(viewer.layers[1].data == points)
+    assert np.array_equal(viewer.layers[1].data, points)
     assert len(viewer.layers) == 2
     assert viewer.dims.ndim == 5
     assert view.dims.nsliders == viewer.dims.ndim
@@ -244,7 +244,7 @@ def test_changing_display_surface(make_napari_viewer):
     data = (vertices, faces, values)
     viewer.add_surface(data)
     assert np.all(
-        [np.all(vd == d) for vd, d in zip(viewer.layers[0].data, data)]
+        [np.array_equal(vd, d) for vd, d in zip(viewer.layers[0].data, data)]
     )
 
     assert len(viewer.layers) == 1

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -100,7 +100,9 @@ def test_add_multiscale():
     data = [np.random.random(s) for s in shapes]
     viewer.add_image(data, multiscale=True)
     assert len(viewer.layers) == 1
-    assert np.array_equal(viewer.layers[0].data, data)
+    # this is not an nd array but a list of ndarray.
+    # I think that might be a edge case of MultiScaleData.
+    assert viewer.layers[0].data == data
     assert viewer.dims.ndim == 2
 
 
@@ -115,7 +117,9 @@ def test_add_multiscale_image_with_negative_floats():
     viewer.add_image(data, multiscale=True)
 
     assert len(viewer.layers) == 1
-    assert np.array_equal(viewer.layers[0].data, data)
+    # this is not an nd array but a list of ndarray.
+    # I think that might be a edge case of MultiScaleData.
+    assert viewer.layers[0].data == data
     assert viewer.dims.ndim == 2
 
 

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -33,7 +33,7 @@ def test_add_image():
     data = np.random.random((10, 15))
     viewer.add_image(data)
     assert len(viewer.layers) == 1
-    assert np.all(viewer.layers[0].data == data)
+    assert np.array_equal(viewer.layers[0].data, data)
     assert viewer.dims.ndim == 2
 
 
@@ -88,7 +88,7 @@ def test_add_volume():
     data = np.random.random((10, 15, 20))
     viewer.add_image(data)
     assert len(viewer.layers) == 1
-    assert np.all(viewer.layers[0].data == data)
+    assert np.array_equal(viewer.layers[0].data, data)
     assert viewer.dims.ndim == 3
 
 
@@ -100,7 +100,7 @@ def test_add_multiscale():
     data = [np.random.random(s) for s in shapes]
     viewer.add_image(data, multiscale=True)
     assert len(viewer.layers) == 1
-    assert np.all(viewer.layers[0].data == data)
+    assert np.array_equal(viewer.layers[0].data, data)
     assert viewer.dims.ndim == 2
 
 
@@ -115,7 +115,7 @@ def test_add_multiscale_image_with_negative_floats():
     viewer.add_image(data, multiscale=True)
 
     assert len(viewer.layers) == 1
-    assert np.all(viewer.layers[0].data == data)
+    assert np.array_equal(viewer.layers[0].data, data)
     assert viewer.dims.ndim == 2
 
 
@@ -126,7 +126,7 @@ def test_add_labels():
     data = np.random.randint(20, size=(10, 15))
     viewer.add_labels(data)
     assert len(viewer.layers) == 1
-    assert np.all(viewer.layers[0].data == data)
+    assert np.array_equal(viewer.layers[0].data, data)
     assert viewer.dims.ndim == 2
 
 
@@ -137,7 +137,7 @@ def test_add_points():
     data = 20 * np.random.random((10, 2))
     viewer.add_points(data)
     assert len(viewer.layers) == 1
-    assert np.all(viewer.layers[0].data == data)
+    assert np.array_equal(viewer.layers[0].data, data)
     assert viewer.dims.ndim == 2
 
 
@@ -185,7 +185,7 @@ def test_add_vectors():
     data = 20 * np.random.random((10, 2, 2))
     viewer.add_vectors(data)
     assert len(viewer.layers) == 1
-    assert np.all(viewer.layers[0].data == data)
+    assert np.array_equal(viewer.layers[0].data, data)
     assert viewer.dims.ndim == 2
 
 
@@ -196,7 +196,7 @@ def test_add_shapes():
     data = 20 * np.random.random((10, 4, 2))
     viewer.add_shapes(data)
     assert len(viewer.layers) == 1
-    assert np.all(viewer.layers[0].data == data)
+    assert np.array_equal(viewer.layers[0].data, data)
     assert viewer.dims.ndim == 2
 
 
@@ -211,7 +211,7 @@ def test_add_surface():
     viewer.add_surface(data)
     assert len(viewer.layers) == 1
     assert np.all(
-        [np.all(vd == d) for vd, d in zip(viewer.layers[0].data, data)]
+        [np.array_equal(vd, d) for vd, d in zip(viewer.layers[0].data, data)]
     )
     assert viewer.dims.ndim == 3
 
@@ -223,13 +223,13 @@ def test_mix_dims():
     data = np.random.random((10, 15))
     viewer.add_image(data)
     assert len(viewer.layers) == 1
-    assert np.all(viewer.layers[0].data == data)
+    assert np.array_equal(viewer.layers[0].data, data)
     assert viewer.dims.ndim == 2
 
     data = np.random.random((6, 10, 15))
     viewer.add_image(data)
     assert len(viewer.layers) == 2
-    assert np.all(viewer.layers[1].data == data)
+    assert np.array_equal(viewer.layers[1].data, data)
     assert viewer.dims.ndim == 3
 
 
@@ -370,8 +370,8 @@ def test_swappable_dims():
     np.random.seed(0)
     image_data = np.random.random((7, 12, 10, 15))
     image_name = viewer.add_image(image_data).name
-    assert np.all(
-        viewer.layers[image_name]._data_view == image_data[3, 5, :, :]
+    assert np.array_equal(
+        viewer.layers[image_name]._data_view, image_data[3, 5, :, :]
     )
 
     points_data = np.random.randint(6, size=(10, 4))
@@ -384,18 +384,18 @@ def test_swappable_dims():
     labels_name = viewer.add_labels(labels_data).name
     # midpoints indices into the data below depend on the data range.
     # This depends on the values in vectors_data and thus the random seed.
-    assert np.all(
-        viewer.layers[labels_name]._slice.image.raw == labels_data[3, 5, :, :]
+    assert np.array_equal(
+        viewer.layers[labels_name]._slice.image.raw, labels_data[3, 5, :, :]
     )
 
     # Swap dims
     viewer.dims.order = [0, 2, 1, 3]
     assert viewer.dims.order == (0, 2, 1, 3)
-    assert np.all(
-        viewer.layers[image_name]._data_view == image_data[3, :, 4, :]
+    assert np.array_equal(
+        viewer.layers[image_name]._data_view, image_data[3, :, 4, :]
     )
-    assert np.all(
-        viewer.layers[labels_name]._slice.image.raw == labels_data[3, :, 4, :]
+    assert np.array_equal(
+        viewer.layers[labels_name]._slice.image.raw, labels_data[3, :, 4, :]
     )
 
 
@@ -470,7 +470,7 @@ def test_add_remove_layer_dims_change():
     data = np.random.random((10, 15, 20))
     layer = viewer.add_image(data)
     assert len(viewer.layers) == 1
-    assert np.all(viewer.layers[0].data == data)
+    assert np.array_equal(viewer.layers[0].data, data)
     assert viewer.dims.ndim == 3
 
     # Remove layer and check ndim returns to 2
@@ -697,7 +697,7 @@ def test_camera():
     data = np.random.random((10, 15, 20))
     viewer.add_image(data)
     assert len(viewer.layers) == 1
-    assert np.all(viewer.layers[0].data == data)
+    assert np.array_equal(viewer.layers[0].data, data)
     assert viewer.dims.ndim == 3
 
     assert viewer.dims.ndisplay == 2

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2336,7 +2336,7 @@ class Shapes(Layer):
         slice_key = np.array(self._slice_indices)[
             self._slice_input.not_displayed
         ]
-        if not np.all(slice_key == self._data_view.slice_key):
+        if not np.array_equal(slice_key, self._data_view.slice_key):
             self.selected_data = set()
         self._data_view.slice_key = slice_key
 
@@ -2531,8 +2531,8 @@ class Shapes(Layer):
         # Check if any shape or vertex ids have changed since last call
         if (
             self.selected_data == self._selected_data_stored
-            and np.all(self._value == self._value_stored)
-            and np.all(self._drag_box == self._drag_box_stored)
+            and np.array_equal(self._value, self._value_stored)
+            and np.array_equal(self._drag_box, self._drag_box_stored)
         ) and not force:
             return
         self._selected_data_stored = copy(self.selected_data)
@@ -2698,7 +2698,7 @@ class Shapes(Layer):
             scale = [scale, scale]
         box = self._selected_box - center
         box = np.array(box * scale)
-        if not np.all(box[Box.TOP_CENTER] == box[Box.HANDLE]):
+        if not np.array_equal(box[Box.TOP_CENTER], box[Box.HANDLE]):
             r = self._rotation_handle_length * self._normalized_scale_factor
             handle_vec = box[Box.HANDLE] - box[Box.TOP_CENTER]
             cur_len = np.linalg.norm(handle_vec)
@@ -2717,7 +2717,7 @@ class Shapes(Layer):
         """
         box = self._selected_box - center
         box = box @ transform.T
-        if not np.all(box[Box.TOP_CENTER] == box[Box.HANDLE]):
+        if not np.array_equal(box[Box.TOP_CENTER], box[Box.HANDLE]):
             r = self._rotation_handle_length * self._normalized_scale_factor
             handle_vec = box[Box.HANDLE] - box[Box.TOP_CENTER]
             cur_len = np.linalg.norm(handle_vec)

--- a/napari/utils/colormaps/vendored/colors.py
+++ b/napari/utils/colormaps/vendored/colors.py
@@ -513,8 +513,9 @@ class Colormap(object):
     def is_gray(self):
         if not self._isinit:
             self._init()
-        return (np.all(self._lut[:, 0] == self._lut[:, 1]) and
-                np.all(self._lut[:, 0] == self._lut[:, 2]))
+        return np.array_equal(
+            self._lut[:, 0], self._lut[:, 1]
+        ) and np.array_equal(self._lut[:, 0], self._lut[:, 2])
 
     def _resample(self, lutsize):
         """


### PR DESCRIPTION
Working on some other things I came again across a potential issue where using np.array_equal would have made things easier to debug than using `np.all(a == b)`, so I started to do systematic replacements. See #6126