### PR TITLE
Use class name for object that does not have qt name

### DIFF
--- a/napari/_qt/perf/qt_event_tracing.py
+++ b/napari/_qt/perf/qt_event_tracing.py
@@ -108,6 +108,14 @@ def _get_event_label(receiver: QWidget, event: QEvent) -> str:
         # Ignore "missing objectName attribute" during shutdown.
         object_name = None
 
+    if not object_name:
+        # use class for object without set name.
+        try:
+            object_name = str(receiver.__class__.__name__)
+        except AttributeError:
+            # do not crash in using some strange class.
+            object_name = None
+
     if object_name:
         return f"{event_str}:{object_name}"
 

--- a/napari/utils/perf/_timers.py
+++ b/napari/utils/perf/_timers.py
@@ -78,7 +78,7 @@ class PerfTimers:
 
         Parameters
         ----------
-        name : PerfEvent
+        name : str
             Add this event.
         **kwargs
             Arguments to display in the Args section of the Tracing GUI.
@@ -204,7 +204,7 @@ def _create_timer():
 
         Parameters
         ----------
-        name : PerfEvent
+        name : str
             Add this event.
         **kwargs
             Arguments to display in the Args section of the Chrome Tracing GUI.


### PR DESCRIPTION
# Description

I have found that when the object does not have a set name, our performance tracing only provides the event name without information from which class it comes. So it. is hard to locate the real problem. 

This PR add using a class name if the object does not have a name. 
