### PR TITLE
Ensure pandas Series is initialized with a list as data

### DIFF
--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -223,20 +223,31 @@ def test_feature_table_from_layer_with_properties_and_num_data():
     properties = {
         'class': np.array(['sky', 'person', 'building', 'person']),
         'confidence': np.array([0.2, 0.5, 1, 0.8]),
+        'varying_length_prop': np.array(
+            [[0], [0, 0, 0], [0, 0], [0]], dtype=object
+        ),
     }
 
     feature_table = _FeatureTable.from_layer(properties=properties, num_data=4)
 
     features = feature_table.values
-    assert features.shape == (4, 2)
+    assert features.shape == (4, 3)
     np.testing.assert_array_equal(features['class'], properties['class'])
     np.testing.assert_array_equal(
         features['confidence'], properties['confidence']
     )
+    np.testing.assert_array_equal(
+        features['varying_length_prop'], properties['varying_length_prop']
+    )
+
     defaults = feature_table.defaults
-    assert defaults.shape == (1, 2)
+    assert defaults.shape == (1, 3)
     assert defaults['class'][0] == properties['class'][-1]
     assert defaults['confidence'][0] == properties['confidence'][-1]
+    assert (
+        defaults['varying_length_prop'][0]
+        == properties['varying_length_prop'][-1]
+    )
 
 
 def test_feature_table_from_layer_with_properties_and_choices():

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -948,7 +948,7 @@ def _get_default_column(column: pd.Series) -> pd.Series:
         # store missing values, so passing None creates an np.float64 series
         # containing NaN. Therefore, use a default of 0 instead.
         value = 0
-    return pd.Series(data=value, dtype=column.dtype, index=range(1))
+    return pd.Series(data=[value], dtype=column.dtype, index=range(1))
 
 
 def _validate_features(


### PR DESCRIPTION
# References and relevant issues

Closes #6225 
# Description

Pandas is now given an explicit list which means properties of unequal lengths are understood correctly. 

# Final Checklist
- [x] My PR is the minimum possible work for the desired functionality

- [x] I have added tests that prove my fix is effective or that my feature works

