### PR TITLE
Fix typing checks in PRs

### DIFF
--- a/napari/components/_viewer_key_bindings.py
+++ b/napari/components/_viewer_key_bindings.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from napari.components.viewer_model import ViewerModel
 from napari.utils.action_manager import action_manager
@@ -8,6 +8,7 @@ from napari.utils.theme import available_themes, get_system_theme
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
+    from napari._qt.dialogs.preferences_dialog import PreferencesDialog
     from napari.viewer import Viewer
 
 
@@ -165,7 +166,8 @@ def hold_for_pan_zoom(viewer: ViewerModel):
 @register_viewer_action(trans._("Show all key bindings"))
 def show_shortcuts(viewer: Viewer):
     viewer.window._open_preferences_dialog()
-    pref_list = viewer.window._pref_dialog._list
+    pref_dialog = cast('PreferencesDialog', viewer.window._pref_dialog)
+    pref_list = pref_dialog._list
     for i in range(pref_list.count()):
         if pref_list.item(i).text() == "Shortcuts":
             pref_list.setCurrentRow(i)


### PR DESCRIPTION
#6203 was merged without updating the latest changes from `main` and now the typing checks in PRs fails due to updates in `napari.components`. We don't run those changes on `main`, though maybe we should given that we don't requires PR branches to be up-to-date before merging (only that git reports no conflicts).

This PR fixes the typing failure by casting the type away from the possible value of `None`, which is a side-effect of calling `_open_preferences_dialog`. An alternative fix is to have `_open_preferences_dialog` to return `PreferencesDialog`, which I like but felt like a bigger change than needed. Of course, we can also use `# type: ignore`, but I don't there's a need here.
