### PR TITLE
Fix margins with screenshot

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -79,7 +79,7 @@ from napari.utils.misc import (
     in_python_repl,
     running_as_constructor_app,
 )
-from napari.utils.notifications import Notification
+from napari.utils.notifications import Notification, show_info
 from napari.utils.theme import _themes, get_system_theme
 from napari.utils.translations import trans
 
@@ -1440,13 +1440,20 @@ class Window:
 
             old_center = camera.center
             old_zoom = camera.zoom
-            self._qt_viewer.viewer.reset_view(fit_to_data=True)
 
-            # Size the canvas to the shape of the data
-            canvas.size = self._qt_viewer.viewer.layers.extent.world[1][
-                -ndisplay:
-            ].astype(int)
-            self._qt_viewer.viewer.reset_view(screenshot=True)
+            if ndisplay == 3:
+                show_info(
+                    "fit_to_data currently not implemented for the case of ndisplay == 3"
+                )
+
+            else:
+                self._qt_viewer.viewer.reset_view(fit_to_data=True)
+
+                # Size the canvas to the shape of the data
+                canvas.size = self._qt_viewer.viewer.layers.extent.world[1][
+                    -ndisplay:
+                ].astype(int)
+                self._qt_viewer.viewer.reset_view(screenshot=True)
         if canvas_only:
             if size is not None:
                 if len(size) != 2:

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1398,7 +1398,12 @@ class Window:
         self._qt_window.restart()
 
     def _screenshot(
-        self, size=None, scale=None, flash=True, canvas_only=False
+        self,
+        size=None,
+        scale=None,
+        flash=True,
+        canvas_only=False,
+        fit_to_data=False,
     ) -> 'QImage':
         """Capture screenshot of the currently displayed viewer.
 
@@ -1417,6 +1422,9 @@ class Window:
             If True, screenshot shows only the image display canvas, and
             if False include the napari viewer frame in the screenshot,
             By default, True.
+        fit_to_data: bool
+            Flag to indicate whether the screenshot should be tightly bound around the data visualized
+            in the viewer.
 
         Returns
         -------
@@ -1425,7 +1433,8 @@ class Window:
         from napari._qt.utils import add_flash_animation
 
         if canvas_only:
-            self._qt_viewer.viewer.reset_view()
+            if fit_to_data:
+                self._qt_viewer.viewer.reset_view()
             camera = self._qt_viewer.viewer.camera
             old_zoom = camera.zoom
             canvas = self._qt_viewer.canvas
@@ -1460,7 +1469,7 @@ class Window:
                     add_flash_animation(self._qt_viewer._welcome_widget)
             finally:
                 # make sure we always go back to the right canvas size
-                if size is not None or scale is not None:
+                if size is not None or scale is not None or fit_to_data:
                     camera.zoom = old_zoom
                     canvas.size = prev_size
         else:
@@ -1470,7 +1479,13 @@ class Window:
         return img
 
     def screenshot(
-        self, path=None, size=None, scale=None, flash=True, canvas_only=False
+        self,
+        path=None,
+        size=None,
+        scale=None,
+        flash=True,
+        canvas_only=False,
+        fit_to_data=False,
     ):
         """Take currently displayed viewer and convert to an image array.
 
@@ -1491,6 +1506,9 @@ class Window:
             If True, screenshot shows only the image display canvas, and
             if False include the napari viewer frame in the screenshot,
             By default, True.
+        fit_to_data: bool
+            Flag to indicate whether the screenshot should be tightly bound around the data visualized
+            in the viewer.
 
         Returns
         -------
@@ -1499,7 +1517,9 @@ class Window:
             upper-left corner of the rendered region.
         """
 
-        img = QImg2array(self._screenshot(size, scale, flash, canvas_only))
+        img = QImg2array(
+            self._screenshot(size, scale, flash, canvas_only, fit_to_data)
+        )
         if path is not None:
             imsave(path, img)
         return img

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1433,16 +1433,16 @@ class Window:
         from napari._qt.utils import add_flash_animation
 
         if canvas_only:
+            ndisplay = self._qt_viewer.viewer.dims.ndisplay
             camera = self._qt_viewer.viewer.camera
             old_zoom = camera.zoom
             if fit_to_data:
                 old_center = camera.center
-                self._qt_viewer.viewer.reset_view()
+                self._qt_viewer.viewer.reset_view(fit_to_data=True)
 
             canvas = self._qt_viewer.canvas
             prev_size = canvas.size
 
-            ndisplay = self._qt_viewer.viewer.dims.ndisplay
             # Size the canvas to the shape of the data
             canvas.size = self._qt_viewer.viewer.layers.extent.world[1][
                 -ndisplay:

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1425,6 +1425,8 @@ class Window:
         from napari._qt.utils import add_flash_animation
 
         if canvas_only:
+            camera = self._qt_viewer.viewer.camera
+            old_zoom = camera.zoom
             canvas = self._qt_viewer.canvas
             prev_size = canvas.size
 
@@ -1459,6 +1461,7 @@ class Window:
                 # make sure we always go back to the right canvas size
                 if size is not None or scale is not None:
                     canvas.size = prev_size
+                    camera.zoom = old_zoom
         else:
             img = self._qt_window.grab().toImage()
             if flash:

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1447,7 +1447,7 @@ class Window:
                 )
 
             else:
-                self._qt_viewer.viewer.reset_view(fit_to_data=True)
+                self._qt_viewer.viewer.reset_view()
 
                 # Size the canvas to the shape of the data
                 canvas.size = self._qt_viewer.viewer.layers.extent.world[1][

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1432,22 +1432,22 @@ class Window:
         """
         from napari._qt.utils import add_flash_animation
 
-        if canvas_only:
+        if canvas_only or fit_to_data:
             ndisplay = self._qt_viewer.viewer.dims.ndisplay
             camera = self._qt_viewer.viewer.camera
-            old_zoom = camera.zoom
-            if fit_to_data:
-                old_center = camera.center
-                self._qt_viewer.viewer.reset_view(fit_to_data=True)
-
             canvas = self._qt_viewer.canvas
             prev_size = canvas.size
 
-            # Size the canvas to the shape of the data
-            canvas.size = self._qt_viewer.viewer.layers.extent.world[1][
-                -ndisplay:
-            ].astype(int)
-            self._qt_viewer.viewer.reset_view(screenshot=True)
+            if fit_to_data:
+                old_center = camera.center
+                old_zoom = camera.zoom
+                self._qt_viewer.viewer.reset_view(fit_to_data=True)
+
+                # Size the canvas to the shape of the data
+                canvas.size = self._qt_viewer.viewer.layers.extent.world[1][
+                    -ndisplay:
+                ].astype(int)
+                self._qt_viewer.viewer.reset_view(screenshot=True)
             if size is not None:
                 if len(size) != 2:
                     raise ValueError(

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1425,6 +1425,7 @@ class Window:
         from napari._qt.utils import add_flash_animation
 
         if canvas_only:
+            self._qt_viewer.viewer.reset_view()
             camera = self._qt_viewer.viewer.camera
             old_zoom = camera.zoom
             canvas = self._qt_viewer.canvas
@@ -1460,8 +1461,8 @@ class Window:
             finally:
                 # make sure we always go back to the right canvas size
                 if size is not None or scale is not None:
-                    canvas.size = prev_size
                     camera.zoom = old_zoom
+                    canvas.size = prev_size
         else:
             img = self._qt_window.grab().toImage()
             if flash:

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1427,6 +1427,13 @@ class Window:
         if canvas_only:
             canvas = self._qt_viewer.canvas
             prev_size = canvas.size
+
+            ndisplay = self._qt_viewer.viewer.dims.ndisplay
+            # Size the canvas to the shape of the data
+            canvas.size = self._qt_viewer.viewer.layers.extent.world[
+                ndisplay - 1
+            ][-ndisplay:].astype(int)
+            self._qt_viewer.viewer.reset_view(screenshot=True)
             if size is not None:
                 if len(size) != 2:
                     raise ValueError(

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1433,10 +1433,12 @@ class Window:
         from napari._qt.utils import add_flash_animation
 
         if canvas_only:
-            if fit_to_data:
-                self._qt_viewer.viewer.reset_view()
             camera = self._qt_viewer.viewer.camera
             old_zoom = camera.zoom
+            if fit_to_data:
+                old_center = camera.center
+                self._qt_viewer.viewer.reset_view()
+
             canvas = self._qt_viewer.canvas
             prev_size = canvas.size
 
@@ -1470,8 +1472,10 @@ class Window:
             finally:
                 # make sure we always go back to the right canvas size
                 if size is not None or scale is not None or fit_to_data:
-                    camera.zoom = old_zoom
                     canvas.size = prev_size
+                if fit_to_data:
+                    camera.zoom = old_zoom
+                    camera.center = old_center
         else:
             img = self._qt_window.grab().toImage()
             if flash:

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1444,9 +1444,9 @@ class Window:
 
             ndisplay = self._qt_viewer.viewer.dims.ndisplay
             # Size the canvas to the shape of the data
-            canvas.size = self._qt_viewer.viewer.layers.extent.world[
-                ndisplay - 1
-            ][-ndisplay:].astype(int)
+            canvas.size = self._qt_viewer.viewer.layers.extent.world[1][
+                -ndisplay:
+            ].astype(int)
             self._qt_viewer.viewer.reset_view(screenshot=True)
             if size is not None:
                 if len(size) != 2:

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -373,7 +373,12 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         center = np.add(corner, np.divide(size, 2))[-self.dims.ndisplay :]
         center = [0] * (self.dims.ndisplay - len(center)) + list(center)
         self.camera.center = center if not screenshot else self.camera.center
-        scale_factor = 0.95 if not screenshot else (1 / 0.95)
+        if not screenshot:
+            scale_factor = 0.95
+        elif len(self.layers) == 1:
+            scale_factor = 1 / 0.95
+        else:
+            scale_factor = 1
         # zoom is definied as the number of canvas pixels per world pixel
         # The default value used below will zoom such that the whole field
         # of view will occupy 95% of the canvas on the most filled axis

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -385,7 +385,9 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             self.camera.zoom = scale_factor * np.min(
                 np.array(self._canvas_size) / scale
             )
-        self.camera.angles = (0, 0, 90)
+        self.camera.angles = (
+            (0, 0, 90) if not screenshot else self.camera.angles
+        )
 
         # Emit a reset view event, which is no longer used internally, but
         # which maybe useful for building on napari.

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -360,7 +360,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             )
         return self.layers._extent_world_augmented[:, self.dims.displayed]
 
-    def reset_view(self):
+    def reset_view(self, screenshot=False):
         """Reset the camera view."""
 
         extent = self._sliced_extent_world_augmented
@@ -372,16 +372,17 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         size = np.multiply(scene_size, grid_size)
         center = np.add(corner, np.divide(size, 2))[-self.dims.ndisplay :]
         center = [0] * (self.dims.ndisplay - len(center)) + list(center)
-        self.camera.center = center
+        self.camera.center = center if not screenshot else self.camera.center
+        scale_factor = 0.95 if not screenshot else (1 / 0.95)
         # zoom is definied as the number of canvas pixels per world pixel
         # The default value used below will zoom such that the whole field
         # of view will occupy 95% of the canvas on the most filled axis
         if np.max(size) == 0:
-            self.camera.zoom = 0.95 * np.min(self._canvas_size)
+            self.camera.zoom = scale_factor * np.min(self._canvas_size)
         else:
             scale = np.array(size[-2:])
             scale[np.isclose(scale, 0)] = 1
-            self.camera.zoom = 0.95 * np.min(
+            self.camera.zoom = scale_factor * np.min(
                 np.array(self._canvas_size) / scale
             )
         self.camera.angles = (0, 0, 90)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -360,7 +360,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             )
         return self.layers._extent_world_augmented[:, self.dims.displayed]
 
-    def reset_view(self, *, screenshot=False, fit_to_data=False):
+    def reset_view(self, *, screenshot=False):
         """Reset the camera view."""
 
         extent = self._sliced_extent_world_augmented

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -360,7 +360,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             )
         return self.layers._extent_world_augmented[:, self.dims.displayed]
 
-    def reset_view(self, screenshot=False):
+    def reset_view(self, screenshot=False, fit_to_data=False):
         """Reset the camera view."""
 
         extent = self._sliced_extent_world_augmented
@@ -390,9 +390,10 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             self.camera.zoom = scale_factor * np.min(
                 np.array(self._canvas_size) / scale
             )
-        self.camera.angles = (
-            (0, 0, 90) if not screenshot else self.camera.angles
-        )
+        if not fit_to_data and self.dims.ndisplay == 3:
+            self.camera.angles = (
+                (0, 0, 90) if not screenshot else self.camera.angles
+            )
 
         # Emit a reset view event, which is no longer used internally, but
         # which maybe useful for building on napari.

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -360,7 +360,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             )
         return self.layers._extent_world_augmented[:, self.dims.displayed]
 
-    def reset_view(self, screenshot=False, fit_to_data=False):
+    def reset_view(self, *, screenshot=False, fit_to_data=False):
         """Reset the camera view."""
 
         extent = self._sliced_extent_world_augmented
@@ -390,10 +390,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             self.camera.zoom = scale_factor * np.min(
                 np.array(self._canvas_size) / scale
             )
-        if not fit_to_data and self.dims.ndisplay == 3:
-            self.camera.angles = (
-                (0, 0, 90) if not screenshot else self.camera.angles
-            )
+        if not screenshot:
+            self.camera.angles = (0, 0, 90)
 
         # Emit a reset view event, which is no longer used internally, but
         # which maybe useful for building on napari.

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -98,6 +98,7 @@ class Viewer(ViewerModel):
         scale=None,
         canvas_only=True,
         flash: bool = True,
+        fit_to_data=False,
     ):
         """Take currently displayed screen and convert to an image array.
 
@@ -119,6 +120,9 @@ class Viewer(ViewerModel):
             Flag to indicate whether flash animation should be shown after
             the screenshot was captured.
             By default, True.
+        fit_to_data: bool
+            Flag to indicate whether the screenshot should be tightly bound around the data visualized
+            in the viewer.
 
         Returns
         -------
@@ -132,6 +136,7 @@ class Viewer(ViewerModel):
             scale=scale,
             flash=flash,
             canvas_only=canvas_only,
+            fit_to_data=fit_to_data,
         )
 
     def show(self, *, block=False):


### PR DESCRIPTION
# References and relevant issues
Closes #6114 

# Description
This PR aims to improve the screenshot functionality in napari. Many biologists would like to have a screenshot functionality for making publication ready figures. Currently when taking a screenshot with `canvas_only` set to `True`, the black margins of the canvas are always shown around the data. 

In the current state of this PR it is possible to call `viewer.screenshot(canvas_only=True, fit_to_data=True`) which ensures that these black margins do not exist. It does so by adjusting the canvas size to `viewer.layers.extent`. After the screenshot is taken the old canvas size is restored as is the zoom level and camera center.


