### PR TITLE
MAINT: Use scipy builtins rotation to compute quaternions.

### DIFF
--- a/napari/_vispy/__init__.py
+++ b/napari/_vispy/__init__.py
@@ -22,7 +22,7 @@ from napari._vispy.overlays.interaction_box import (
 from napari._vispy.overlays.labels_polygon import VispyLabelsPolygonOverlay
 from napari._vispy.overlays.scale_bar import VispyScaleBarOverlay
 from napari._vispy.overlays.text import VispyTextOverlay
-from napari._vispy.utils.quaternion import quaternion2euler
+from napari._vispy.utils.quaternion import quaternion2euler_degrees
 from napari._vispy.utils.visual import create_vispy_layer, create_vispy_overlay
 
 __all__ = [
@@ -34,7 +34,7 @@ __all__ = [
     "VispyTransformBoxOverlay",
     "VispyTextOverlay",
     "VispyLabelsPolygonOverlay",
-    "quaternion2euler",
+    "quaternion2euler_degrees",
     "create_vispy_layer",
     "create_vispy_overlay",
 ]

--- a/napari/_vispy/_tests/test_utils.py
+++ b/napari/_vispy/_tests/test_utils.py
@@ -5,7 +5,7 @@ from qtpy.QtCore import Qt
 from vispy.util.quaternion import Quaternion
 
 from napari._vispy.utils.cursor import QtCursorVisual
-from napari._vispy.utils.quaternion import quaternion2euler
+from napari._vispy.utils.quaternion import quaternion2euler_degrees
 from napari._vispy.utils.visual import get_view_direction_in_scene_coordinates
 from napari.components._viewer_constants import CursorStyle
 
@@ -16,12 +16,12 @@ angles = [[12, 53, 92], [180, -90, 0], [16, 90, 0]]
 
 
 @pytest.mark.parametrize('angles', angles)
-def test_quaternion2euler(angles):
+def test_quaternion2euler_degrees(angles):
     """Test quaternion to euler angle conversion."""
 
     # Test for degrees
     q = Quaternion.create_from_euler_angles(*angles, degrees=True)
-    ea = quaternion2euler(q)
+    ea = quaternion2euler_degrees(q)
     q_p = Quaternion.create_from_euler_angles(*ea, degrees=True)
 
     # We now compare the corresponding quaternions ; they should be equals or opposites (as they're already unit ones)

--- a/napari/_vispy/_tests/test_utils.py
+++ b/napari/_vispy/_tests/test_utils.py
@@ -13,18 +13,16 @@ from napari.components._viewer_constants import CursorStyle
 angles = [[12, 53, 92], [180, -90, 0], [16, 90, 0]]
 
 # Prepare for input and add corresponding values in radians
-angles_param = [(x, True) for x in angles]
-angles_param.extend([(x, False) for x in np.radians(angles)])
 
 
-@pytest.mark.parametrize('angles,degrees', angles_param)
-def test_quaternion2euler(angles, degrees):
+@pytest.mark.parametrize('angles', angles)
+def test_quaternion2euler(angles):
     """Test quaternion to euler angle conversion."""
 
     # Test for degrees
-    q = Quaternion.create_from_euler_angles(*angles, degrees)
-    ea = quaternion2euler(q, degrees=degrees)
-    q_p = Quaternion.create_from_euler_angles(*ea, degrees=degrees)
+    q = Quaternion.create_from_euler_angles(*angles, degrees=True)
+    ea = quaternion2euler(q)
+    q_p = Quaternion.create_from_euler_angles(*ea, degrees=True)
 
     # We now compare the corresponding quaternions ; they should be equals or opposites (as they're already unit ones)
     q_values = np.array([q.w, q.x, q.y, q.z])

--- a/napari/_vispy/camera.py
+++ b/napari/_vispy/camera.py
@@ -58,9 +58,7 @@ class VispyCamera:
 
         if self._view.camera == self._3D_camera:
             # Do conversion from quaternion representation to euler angles
-            angles = quaternion2euler(
-                self._view.camera._quaternion, degrees=True
-            )
+            angles = quaternion2euler(self._view.camera._quaternion)
         else:
             angles = (0, 0, 90)
         return angles

--- a/napari/_vispy/camera.py
+++ b/napari/_vispy/camera.py
@@ -3,7 +3,7 @@ from typing import Type
 import numpy as np
 from vispy.scene import ArcballCamera, BaseCamera, PanZoomCamera
 
-from napari._vispy.utils.quaternion import quaternion2euler
+from napari._vispy.utils.quaternion import quaternion2euler_degrees
 
 
 class VispyCamera:
@@ -58,7 +58,7 @@ class VispyCamera:
 
         if self._view.camera == self._3D_camera:
             # Do conversion from quaternion representation to euler angles
-            angles = quaternion2euler(self._view.camera._quaternion)
+            angles = quaternion2euler_degrees(self._view.camera._quaternion)
         else:
             angles = (0, 0, 90)
         return angles

--- a/napari/_vispy/utils/quaternion.py
+++ b/napari/_vispy/utils/quaternion.py
@@ -1,6 +1,5 @@
 import warnings
 
-import numpy as np
 from scipy.spatial.transform import Rotation
 
 
@@ -11,9 +10,6 @@ def quaternion2euler(quaternion, degrees=False):
     from the Euler angles that might have been used to generate
     the input quaternion.
 
-    Euler angles representation also has a singularity
-    near pitch = Pi/2 ; to avoid this, we set to Pi/2 pitch angles
-    that are closer than the chosen epsilon from it.
 
     Parameters
     ----------
@@ -43,41 +39,3 @@ def quaternion2euler(quaternion, degrees=False):
             'xyz', degrees=degrees
         )
     return (x, y, z)
-
-
-def _old_quaterion2euler(quaternion, degrees=False):
-    """
-    old custom implementation of the above
-
-    """
-    epsilon = 1e-10
-
-    q = quaternion
-
-    sin_theta_2 = 2 * (q.w * q.y - q.z * q.x)
-    sin_theta_2 = np.sign(sin_theta_2) * min(abs(sin_theta_2), 1)
-
-    if abs(sin_theta_2) > 1 - epsilon:
-        theta_1 = -np.sign(sin_theta_2) * 2 * np.arctan2(q.x, q.w)
-        theta_2 = np.arcsin(sin_theta_2)
-        theta_3 = 0
-
-    else:
-        theta_1 = np.arctan2(
-            2 * (q.w * q.z + q.y * q.x),
-            1 - 2 * (q.y * q.y + q.z * q.z),
-        )
-
-        theta_2 = np.arcsin(sin_theta_2)
-
-        theta_3 = np.arctan2(
-            2 * (q.w * q.x + q.y * q.z),
-            1 - 2 * (q.x * q.x + q.y * q.y),
-        )
-
-    angles = (theta_1, theta_2, theta_3)
-
-    if degrees:
-        return tuple(np.degrees(angles))
-
-    return angles

--- a/napari/_vispy/utils/quaternion.py
+++ b/napari/_vispy/utils/quaternion.py
@@ -3,7 +3,7 @@ import warnings
 from scipy.spatial.transform import Rotation
 
 
-def quaternion2euler(quaternion):
+def quaternion2euler_degrees(quaternion):
     """Converts VisPy quaternion into euler angle representation.
 
     Euler angles have degeneracies, so the output might different

--- a/napari/_vispy/utils/quaternion.py
+++ b/napari/_vispy/utils/quaternion.py
@@ -38,4 +38,4 @@ def quaternion2euler(quaternion, degrees=False):
         z, y, x = Rotation.from_quat([q.x, q.y, q.z, q.w]).as_euler(
             'xyz', degrees=degrees
         )
-    return (x, y, z)
+    return x, y, z

--- a/napari/_vispy/utils/quaternion.py
+++ b/napari/_vispy/utils/quaternion.py
@@ -1,4 +1,7 @@
+import warnings
+
 import numpy as np
+from scipy.spatial.transform import Rotation
 
 
 def quaternion2euler(quaternion, degrees=False):
@@ -23,6 +26,29 @@ def quaternion2euler(quaternion, degrees=False):
     -------
     angles : 3-tuple
         Euler angles in (rx, ry, rz) order.
+    """
+    q = quaternion
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            action='ignore',
+            message='Gimbal lock detected.*',
+            category=UserWarning,
+        )
+
+        # despite both SciPy and  previous implementation advertising
+        # the  x,y,z order, it appear we need to reverse the order to get
+        # the same results a previously.
+        # as_euler('zyx') does not work as composition order matters
+        z, y, x = Rotation.from_quat([q.x, q.y, q.z, q.w]).as_euler(
+            'xyz', degrees=degrees
+        )
+    return (x, y, z)
+
+
+def _old_quaterion2euler(quaternion, degrees=False):
+    """
+    old custom implementation of the above
+
     """
     epsilon = 1e-10
 

--- a/napari/_vispy/utils/quaternion.py
+++ b/napari/_vispy/utils/quaternion.py
@@ -3,7 +3,7 @@ import warnings
 from scipy.spatial.transform import Rotation
 
 
-def quaternion2euler(quaternion, degrees=False):
+def quaternion2euler(quaternion):
     """Converts VisPy quaternion into euler angle representation.
 
     Euler angles have degeneracies, so the output might different
@@ -15,8 +15,6 @@ def quaternion2euler(quaternion, degrees=False):
     ----------
     quaternion : vispy.util.Quaternion
         Quaternion for conversion.
-    degrees : bool
-        If output is returned in degrees or radians.
 
     Returns
     -------
@@ -36,6 +34,6 @@ def quaternion2euler(quaternion, degrees=False):
         # the same results a previously.
         # as_euler('zyx') does not work as composition order matters
         z, y, x = Rotation.from_quat([q.x, q.y, q.z, q.w]).as_euler(
-            'xyz', degrees=degrees
+            'xyz', degrees=True
         )
     return x, y, z


### PR DESCRIPTION
As often, it is better to rely on existing battle tested code than roll our own. This also help testing the upstream code more.

This replace our own quaternion to euler angles with using the Rotations call in scipy.

This file comes from far at the beginning of napari, and had one significant modification in #2530 (WRT degenerate case), which I believe scipy already handle with the gimbals lock warning and is tested.

Then α, β, γ is not unique when β=±π/2, then current new implementation would have `α=<some value>`, `γ=0`, the old code `α=0`, `γ=2.π-<some value>`.

Note that the outputs are slightly different, with sometime the angles being +/- pi , +/- zero i in some case.

You can test the first commit of this branch with this test script that has a few hardcoded degenerate case, as well as pick ~10k random quaternion and compare the resutls.

https://gist.github.com/Carreau/53dfaefa0c07aa3a7a0bd90e890810bb

```
+/- zero
[-2.86, -3.12, -2.88, -2.64]
   old  1.491, 0.000, 1.658
   new  1.491, -0.000, 1.658
   diff 0.000, 0.000, -0.000
```

```
 +/- pi
[1.44, 0.48, 3.93, -1.31]
   old  -3.142, 0.702, -2.498
   new  3.142, 0.702, -2.498
   diff 6.283, 0.000, 0.000
```

```
gimbal lock:

[0.09, -0.78, 0.09, 0.78]
   old  0.000, 1.571, -2.912
   new  2.912, 1.571, 0.000
   diff 2.912, 0.000, -2.912

[-0.64, -0.58, -0.64, 0.58]
   old  0.000, 1.571, 1.473
   new  4.811, 1.571, 0.000
   diff 4.811, 0.000, 1.473
```