### PR TITLE
convert Color to string

### DIFF
--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -115,7 +115,7 @@ class NapariQtNotification(QDialog):
 
         settings = get_settings()
         theme = settings.appearance.theme
-        default_color = get_theme(theme).icon
+        default_color = get_theme(theme).icon.as_hex()
 
         # FIXME: Should these be defined at the theme level?
         # Currently there is a warning one


### PR DESCRIPTION
on certain `pydantic` versions, such as `1.10.0`, `pydantic.color.Color` is an unhashable type, and when not properly converted to a string first in functions using an lru cache, [errors](https://github.com/napari/napari/actions/runs/6253603476/job/16979372752?pr=6204#step:8:389)

an alternative fix would be to simply bump up the minimum pydantic version to `1.10.1` as well