### PR TITLE
MAINT: Replace `assert np.all(? == ?)` with `assert_array_equal`

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -561,15 +561,21 @@ def test_mixed_2d_and_3d_layers(make_napari_viewer, multiscale):
     viewer.dims.order = (0, 1, 2)
     viewer.window._qt_viewer.canvas.size = canvas_size
     viewer.window._qt_viewer.canvas.on_draw(None)
-    assert np.all(img_multi_layer.corner_pixels == expected_corner_pixels)
+    np.testing.assert_array_equal(
+        img_multi_layer.corner_pixels, expected_corner_pixels
+    )
 
     viewer.dims.order = (2, 0, 1)
     viewer.window._qt_viewer.canvas.on_draw(None)
-    assert np.all(img_multi_layer.corner_pixels == expected_corner_pixels)
+    np.testing.assert_array_equal(
+        img_multi_layer.corner_pixels, expected_corner_pixels
+    )
 
     viewer.dims.order = (1, 2, 0)
     viewer.window._qt_viewer.canvas.on_draw(None)
-    assert np.all(img_multi_layer.corner_pixels == expected_corner_pixels)
+    np.testing.assert_array_equal(
+        img_multi_layer.corner_pixels, expected_corner_pixels
+    )
 
 
 def test_remove_add_image_3D(make_napari_viewer):

--- a/napari/_tests/test_adding_removing.py
+++ b/napari/_tests/test_adding_removing.py
@@ -75,7 +75,7 @@ def test_adding_removing_layer(make_napari_viewer):
 
     # Add layer
     viewer.layers.append(layer)
-    assert np.all(viewer.layers[0].data == data)
+    np.testing.assert_array_equal(viewer.layers[0].data, data)
     assert len(viewer.layers) == 1
     assert viewer.dims.ndim == 4
     # check that adding a layer created new callbacks

--- a/napari/_tests/test_numpy_like.py
+++ b/napari/_tests/test_numpy_like.py
@@ -2,6 +2,7 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 import zarr
+from numpy.testing import assert_array_equal
 
 from napari.components.viewer_model import ViewerModel
 
@@ -13,7 +14,7 @@ def test_dask_2D():
     da.random.seed(0)
     data = da.random.random((10, 15))
     viewer.add_image(data)
-    assert np.all(viewer.layers[0].data == data)
+    assert_array_equal(viewer.layers[0].data, data)
 
 
 def test_dask_nD():
@@ -23,7 +24,7 @@ def test_dask_nD():
     da.random.seed(0)
     data = da.random.random((10, 15, 6, 16))
     viewer.add_image(data)
-    assert np.all(viewer.layers[0].data == data)
+    assert_array_equal(viewer.layers[0].data, data)
 
 
 def test_zarr_2D():
@@ -34,7 +35,7 @@ def test_zarr_2D():
     data[53:63, 10:20] = 1
     # If passing a zarr file directly, must pass contrast_limits
     viewer.add_image(data, contrast_limits=[0, 1])
-    assert np.all(viewer.layers[0].data == data)
+    assert_array_equal(viewer.layers[0].data, data)
 
 
 def test_zarr_nD():
@@ -45,7 +46,7 @@ def test_zarr_nD():
     data[53:63, 10:20, :] = 1
     # If passing a zarr file directly, must pass contrast_limits
     viewer.add_image(data, contrast_limits=[0, 1])
-    assert np.all(viewer.layers[0].data == data)
+    assert_array_equal(viewer.layers[0].data, data)
 
 
 def test_zarr_dask_2D():
@@ -56,7 +57,7 @@ def test_zarr_dask_2D():
     data[53:63, 10:20] = 1
     zdata = da.from_zarr(data)
     viewer.add_image(zdata)
-    assert np.all(viewer.layers[0].data == zdata)
+    assert_array_equal(viewer.layers[0].data, zdata)
 
 
 def test_zarr_dask_nD():
@@ -67,7 +68,7 @@ def test_zarr_dask_nD():
     data[53:63, 10:20, :] = 1
     zdata = da.from_zarr(data)
     viewer.add_image(zdata)
-    assert np.all(viewer.layers[0].data == zdata)
+    assert_array_equal(viewer.layers[0].data, zdata)
 
 
 def test_xarray_2D():
@@ -78,7 +79,7 @@ def test_xarray_2D():
     data = np.random.random((10, 15))
     xdata = xr.DataArray(data, dims=['y', 'x'])
     viewer.add_image(data)
-    assert np.all(viewer.layers[0].data == xdata)
+    assert_array_equal(viewer.layers[0].data, xdata)
 
 
 def test_xarray_nD():
@@ -89,4 +90,4 @@ def test_xarray_nD():
     data = np.random.random((10, 15, 6, 16))
     xdata = xr.DataArray(data, dims=['t', 'z', 'y', 'x'])
     viewer.add_image(xdata)
-    assert np.all(viewer.layers[0].data == xdata)
+    assert_array_equal(viewer.layers[0].data, xdata)

--- a/napari/_tests/test_view_layers.py
+++ b/napari/_tests/test_view_layers.py
@@ -144,7 +144,9 @@ def test_view_multichannel(qtbot, napari_plugin_manager):
     viewer = napari.view_image(data, channel_axis=-1, show=False)
     assert len(viewer.layers) == data.shape[-1]
     for i in range(data.shape[-1]):
-        assert np.all(viewer.layers[i].data == data.take(i, axis=-1))
+        np.testing.assert_array_equal(
+            viewer.layers[i].data, data.take(i, axis=-1)
+        )
     viewer.close()
 
 
@@ -188,7 +190,7 @@ def test_imshow_multichannel(qtbot, napari_plugin_manager):
     assert len(layers) == data.shape[-1]
     assert isinstance(layers, tuple)
     for i in range(data.shape[-1]):
-        assert np.all(layers[i].data == data.take(i, axis=-1))
+        np.testing.assert_array_equal(layers[i].data, data.take(i, axis=-1))
     viewer.close()
     # Run a full garbage collection here so that any remaining viewer
     # and related instances are removed for future tests that may use

--- a/napari/_vispy/_tests/test_image_rendering.py
+++ b/napari/_vispy/_tests/test_image_rendering.py
@@ -90,4 +90,4 @@ def test_clipping_planes_dims():
     # needed to get volume node
     image_layer._slice_dims(ndisplay=3)
     vispy_clip = vispy_layer.node.clipping_planes
-    assert np.all(napari_clip == vispy_clip[..., ::-1])
+    np.testing.assert_array_equal(napari_clip, vispy_clip[..., ::-1])

--- a/napari/_vispy/_tests/test_vispy_big_images.py
+++ b/napari/_vispy/_tests/test_vispy_big_images.py
@@ -13,7 +13,7 @@ def test_big_2D_image(make_napari_viewer):
     assert visual.node is not None
     if visual.MAX_TEXTURE_SIZE_2D is not None:
         s = np.ceil(np.divide(shape, visual.MAX_TEXTURE_SIZE_2D)).astype(int)
-        assert np.all(layer._transforms['tile2data'].scale == s)
+        np.testing.assert_array_equal(layer._transforms['tile2data'].scale, s)
 
 
 def test_big_3D_image(make_napari_viewer):
@@ -27,7 +27,7 @@ def test_big_3D_image(make_napari_viewer):
     assert visual.node is not None
     if visual.MAX_TEXTURE_SIZE_3D is not None:
         s = np.ceil(np.divide(shape, visual.MAX_TEXTURE_SIZE_3D)).astype(int)
-        assert np.all(layer._transforms['tile2data'].scale == s)
+        np.testing.assert_array_equal(layer._transforms['tile2data'].scale, s)
 
 
 @pytest.mark.parametrize(

--- a/napari/components/_tests/test_multichannel.py
+++ b/napari/components/_tests/test_multichannel.py
@@ -109,7 +109,9 @@ def test_multichannel(shape, kwargs):
 
     for i in range(n_channels):
         # make sure that the data has been divided into layers
-        assert np.all(viewer.layers[i].data == data.take(i, axis=channel_axis))
+        np.testing.assert_array_equal(
+            viewer.layers[i].data, data.take(i, axis=channel_axis)
+        )
         # make sure colors have been assigned properly
         if 'colormap' not in kwargs:
             if n_channels == 1:

--- a/napari/components/_tests/test_viewer_labels_io.py
+++ b/napari/components/_tests/test_viewer_labels_io.py
@@ -18,5 +18,5 @@ def test_open_labels(builtins, suffix, tmp_path):
     imwrite(fout, labeled, format=suffix)
     viewer.open(fout, layer_type='labels')
     assert len(viewer.layers) == 1
-    assert np.all(labeled == viewer.layers[0].data)
+    np.testing.assert_array_equal(labeled, viewer.layers[0].data)
     assert isinstance(viewer.layers[0], Labels)

--- a/napari/layers/_tests/test_utils.py
+++ b/napari/layers/_tests/test_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 from skimage.util import img_as_ubyte
 
 from napari.layers.utils.layer_utils import convert_to_uint8
@@ -11,9 +12,9 @@ def test_uint(dtype):
     data = np.arange(50, dtype=dtype)
     data_scaled = data * 256 ** (data.dtype.itemsize - 1)
     assert convert_to_uint8(data_scaled).dtype == np.uint8
-    assert np.array_equal(data, convert_to_uint8(data_scaled))
-    assert np.array_equal(img_as_ubyte(data), convert_to_uint8(data))
-    assert np.array_equal(
+    assert_array_equal(data, convert_to_uint8(data_scaled))
+    assert_array_equal(img_as_ubyte(data), convert_to_uint8(data))
+    assert_array_equal(
         img_as_ubyte(data_scaled), convert_to_uint8(data_scaled)
     )
 
@@ -25,13 +26,13 @@ def test_int(dtype):
     data_scaled = data * 256 ** (data.dtype.itemsize - 1)
     assert convert_to_uint8(data).dtype == np.uint8
     assert convert_to_uint8(data_scaled).dtype == np.uint8
-    assert np.array_equal(img_as_ubyte(data), convert_to_uint8(data))
-    assert np.array_equal(2 * data, convert_to_uint8(data_scaled))
-    assert np.array_equal(
+    assert_array_equal(img_as_ubyte(data), convert_to_uint8(data))
+    assert_array_equal(2 * data, convert_to_uint8(data_scaled))
+    assert_array_equal(
         img_as_ubyte(data_scaled), convert_to_uint8(data_scaled)
     )
-    assert np.array_equal(img_as_ubyte(data - 10), convert_to_uint8(data - 10))
-    assert np.array_equal(
+    assert_array_equal(img_as_ubyte(data - 10), convert_to_uint8(data - 10))
+    assert_array_equal(
         img_as_ubyte(data_scaled - 10), convert_to_uint8(data_scaled - 10)
     )
 
@@ -41,14 +42,12 @@ def test_float(dtype):
     data = np.linspace(0, 0.5, 128, dtype=dtype, endpoint=False)
     res = np.arange(128, dtype=np.uint8)
     assert convert_to_uint8(data).dtype == np.uint8
-    assert np.array_equal(convert_to_uint8(data), res)
+    assert_array_equal(convert_to_uint8(data), res)
     data = np.linspace(0, 1, 256, dtype=dtype)
     res = np.arange(256, dtype=np.uint8)
-    assert np.array_equal(convert_to_uint8(data), res)
-    assert np.array_equal(img_as_ubyte(data), convert_to_uint8(data))
-    assert np.array_equal(
-        img_as_ubyte(data - 0.5), convert_to_uint8(data - 0.5)
-    )
+    assert_array_equal(convert_to_uint8(data), res)
+    assert_array_equal(img_as_ubyte(data), convert_to_uint8(data))
+    assert_array_equal(img_as_ubyte(data - 0.5), convert_to_uint8(data - 0.5))
 
 
 def test_bool():
@@ -56,4 +55,4 @@ def test_bool():
     data[2:-2, 2:-2] = 1
     converted = convert_to_uint8(data)
     assert converted.dtype == np.uint8
-    assert np.array_equal(img_as_ubyte(data), converted)
+    assert_array_equal(img_as_ubyte(data), converted)

--- a/napari/layers/image/_tests/test_multiscale.py
+++ b/napari/layers/image/_tests/test_multiscale.py
@@ -62,7 +62,7 @@ def test_blocking_multiscale():
     np.random.seed(0)
     data = np.random.random(shape)
     layer = Image(data, multiscale=False)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.multiscale is False
     assert layer.ndim == len(shape)
     np.testing.assert_array_equal(layer.extent.data[1], [s - 1 for s in shape])
@@ -411,7 +411,7 @@ def test_not_create_random_multiscale():
     np.random.seed(0)
     data = np.random.random(shape)
     layer = Image(data)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.multiscale is False
 
 

--- a/napari/layers/image/_tests/test_volume.py
+++ b/napari/layers/image/_tests/test_volume.py
@@ -11,7 +11,7 @@ def test_random_volume():
     data = np.random.random(shape)
     layer = Image(data)
     layer._slice_dims(ndisplay=3)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.ndim == len(shape)
     np.testing.assert_array_equal(layer.extent.data[1], [s - 1 for s in shape])
     assert layer._data_view.shape == shape[-3:]
@@ -23,7 +23,7 @@ def test_switching_displayed_dimensions():
     np.random.seed(0)
     data = np.random.random(shape)
     layer = Image(data)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.ndim == len(shape)
     np.testing.assert_array_equal(layer.extent.data[1], [s - 1 for s in shape])
 
@@ -40,7 +40,7 @@ def test_switching_displayed_dimensions():
 
     layer = Image(data)
     layer._slice_dims(ndisplay=3)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.ndim == len(shape)
     np.testing.assert_array_equal(layer.extent.data[1], [s - 1 for s in shape])
 
@@ -62,7 +62,7 @@ def test_all_zeros_volume():
     data = np.zeros(shape, dtype=float)
     layer = Image(data)
     layer._slice_dims(ndisplay=3)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.ndim == len(shape)
     np.testing.assert_array_equal(layer.extent.data[1], [s - 1 for s in shape])
     assert layer._data_view.shape == shape[-3:]
@@ -75,7 +75,7 @@ def test_integer_volume():
     data = np.round(10 * np.random.random(shape)).astype(int)
     layer = Image(data)
     layer._slice_dims(ndisplay=3)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.ndim == len(shape)
     np.testing.assert_array_equal(layer.extent.data[1], [s - 1 for s in shape])
     assert layer._data_view.shape == shape[-3:]
@@ -88,7 +88,7 @@ def test_3D_volume():
     data = np.random.random(shape)
     layer = Image(data)
     layer._slice_dims(ndisplay=3)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.ndim == len(shape)
     np.testing.assert_array_equal(layer.extent.data[1], [s - 1 for s in shape])
     assert layer._data_view.shape == shape[-3:]
@@ -101,7 +101,7 @@ def test_4D_volume():
     data = np.random.random(shape)
     layer = Image(data)
     layer._slice_dims(ndisplay=3)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.ndim == len(shape)
     np.testing.assert_array_equal(layer.extent.data[1], [s - 1 for s in shape])
     assert layer._data_view.shape == shape[-3:]
@@ -117,7 +117,7 @@ def test_changing_volume():
     layer = Image(data_a)
     layer._slice_dims(ndisplay=3)
     layer.data = data_b
-    assert np.all(layer.data == data_b)
+    np.testing.assert_array_equal(layer.data, data_b)
     assert layer.ndim == len(shape_b)
     np.testing.assert_array_equal(
         layer.extent.data[1], [s - 1 for s in shape_b]
@@ -134,7 +134,7 @@ def test_scale():
     data = np.random.random(shape)
     layer = Image(data, scale=scale)
     layer._slice_dims(ndisplay=3)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.ndim == len(shape)
     np.testing.assert_array_equal(
         layer.extent.world[1] - layer.extent.world[0],

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -29,7 +29,7 @@ def test_random_labels():
     np.random.seed(0)
     data = np.random.randint(20, size=shape)
     layer = Labels(data)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.ndim == len(shape)
     np.testing.assert_array_equal(layer.extent.data[1], [s - 1 for s in shape])
     assert layer._data_view.shape == shape[-2:]
@@ -41,7 +41,7 @@ def test_all_zeros_labels():
     shape = (10, 15)
     data = np.zeros(shape, dtype=int)
     layer = Labels(data)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.ndim == len(shape)
     np.testing.assert_array_equal(layer.extent.data[1], [s - 1 for s in shape])
     assert layer._data_view.shape == shape[-2:]
@@ -53,7 +53,7 @@ def test_3D_labels():
     np.random.seed(0)
     data = np.random.randint(20, size=shape)
     layer = Labels(data)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.ndim == len(shape)
     np.testing.assert_array_equal(layer.extent.data[1], [s - 1 for s in shape])
     assert layer._data_view.shape == shape[-2:]
@@ -102,7 +102,7 @@ def test_changing_labels():
     data_b = np.random.randint(20, size=shape_b)
     layer = Labels(data_a)
     layer.data = data_b
-    assert np.all(layer.data == data_b)
+    np.testing.assert_array_equal(layer.data, data_b)
     assert layer.ndim == len(shape_b)
     np.testing.assert_array_equal(
         layer.extent.data[1], [s - 1 for s in shape_b]
@@ -128,7 +128,7 @@ def test_changing_labels_dims():
     layer = Labels(data_a)
 
     layer.data = data_b
-    assert np.all(layer.data == data_b)
+    np.testing.assert_array_equal(layer.data, data_b)
     assert layer.ndim == len(shape_b)
     np.testing.assert_array_equal(
         layer.extent.data[1], [s - 1 for s in shape_b]

--- a/napari/layers/labels/_tests/test_labels_utils.py
+++ b/napari/layers/labels/_tests/test_labels_utils.py
@@ -31,7 +31,7 @@ def test_interpolate_coordinates():
             [0, 10],
         ]
     )
-    assert np.all(coords == expected_coords)
+    np.testing.assert_array_equal(coords, expected_coords)
 
 
 def test_interpolate_with_none():

--- a/napari/layers/points/_tests/test_points_mouse_bindings.py
+++ b/napari/layers/points/_tests/test_points_mouse_bindings.py
@@ -55,7 +55,7 @@ def create_known_points_layer_2d():
     n_points = len(data)
 
     layer = Points(data, size=1)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.ndim == 2
     assert len(layer.data) == n_points
     assert len(layer.selected_data) == 0
@@ -84,7 +84,7 @@ def create_known_points_layer_3d():
     layer = Points(data, size=1)
     layer._slice_dims(ndisplay=3)
 
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.ndim == 3
     assert len(layer._slice_input.displayed) == 3
     assert len(layer.data) == n_points

--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -15,7 +15,7 @@ def test_rectangle():
     np.random.seed(0)
     data = 20 * np.random.random((4, 2))
     shape = Rectangle(data)
-    assert np.all(shape.data == data)
+    np.testing.assert_array_equal(shape.data, data)
     assert shape.data_displayed.shape == (4, 2)
     assert shape.slice_key.shape == (2, 0)
 
@@ -34,7 +34,7 @@ def test_nD_rectangle():
     data = 20 * np.random.random((4, 3))
     data[:, 0] = 0
     shape = Rectangle(data)
-    assert np.all(shape.data == data)
+    np.testing.assert_array_equal(shape.data, data)
     assert shape.data_displayed.shape == (4, 2)
     assert shape.slice_key.shape == (2, 1)
 
@@ -48,7 +48,7 @@ def test_polygon():
     np.random.seed(0)
     data = 20 * np.random.random((6, 2))
     shape = Polygon(data)
-    assert np.all(shape.data == data)
+    np.testing.assert_array_equal(shape.data, data)
     assert shape.data_displayed.shape == (6, 2)
     assert shape.slice_key.shape == (2, 0)
     # should get few triangles
@@ -76,7 +76,7 @@ def test_nD_polygon():
     data = 20 * np.random.random((6, 3))
     data[:, 0] = 0
     shape = Polygon(data)
-    assert np.all(shape.data == data)
+    np.testing.assert_array_equal(shape.data, data)
     assert shape.data_displayed.shape == (6, 2)
     assert shape.slice_key.shape == (2, 1)
 
@@ -90,7 +90,7 @@ def test_path():
     np.random.seed(0)
     data = 20 * np.random.random((6, 2))
     shape = Path(data)
-    assert np.all(shape.data == data)
+    np.testing.assert_array_equal(shape.data, data)
     assert shape.data_displayed.shape == (6, 2)
     assert shape.slice_key.shape == (2, 0)
 
@@ -101,7 +101,7 @@ def test_nD_path():
     np.random.seed(0)
     data = 20 * np.random.random((6, 3))
     shape = Path(data)
-    assert np.all(shape.data == data)
+    np.testing.assert_array_equal(shape.data, data)
     assert shape.data_displayed.shape == (6, 2)
     assert shape.slice_key.shape == (2, 1)
 
@@ -115,7 +115,7 @@ def test_line():
     np.random.seed(0)
     data = 20 * np.random.random((2, 2))
     shape = Line(data)
-    assert np.all(shape.data == data)
+    np.testing.assert_array_equal(shape.data, data)
     assert shape.data_displayed.shape == (2, 2)
     assert shape.slice_key.shape == (2, 0)
 
@@ -126,7 +126,7 @@ def test_nD_line():
     np.random.seed(0)
     data = 20 * np.random.random((2, 3))
     shape = Line(data)
-    assert np.all(shape.data == data)
+    np.testing.assert_array_equal(shape.data, data)
     assert shape.data_displayed.shape == (2, 2)
     assert shape.slice_key.shape == (2, 1)
 
@@ -140,7 +140,7 @@ def test_ellipse():
     np.random.seed(0)
     data = 20 * np.random.random((4, 2))
     shape = Ellipse(data)
-    assert np.all(shape.data == data)
+    np.testing.assert_array_equal(shape.data, data)
     assert shape.data_displayed.shape == (4, 2)
     assert shape.slice_key.shape == (2, 0)
 
@@ -159,7 +159,7 @@ def test_nD_ellipse():
     data = 20 * np.random.random((4, 3))
     data[:, 0] = 0
     shape = Ellipse(data)
-    assert np.all(shape.data == data)
+    np.testing.assert_array_equal(shape.data, data)
     assert shape.data_displayed.shape == (4, 2)
     assert shape.slice_key.shape == (2, 1)
 

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -55,7 +55,7 @@ def test_track_layer_data():
     data = np.zeros((100, 4))
     data[:, 1] = np.arange(100)
     layer = Tracks(data)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
 
 
 @pytest.mark.parametrize(
@@ -66,7 +66,7 @@ def test_track_layer_data_nonzero_starting_time(timestamps):
     data = np.zeros((100, 4))
     data[:, 1] = timestamps
     layer = Tracks(data)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
 
 
 def test_track_layer_data_flipped():
@@ -76,7 +76,7 @@ def test_track_layer_data_flipped():
     data[:, 0] = np.arange(100)
     data = np.flip(data, axis=0)
     layer = Tracks(data)
-    assert np.all(layer.data == np.flip(data, axis=0))
+    np.testing.assert_array_equal(layer.data, np.flip(data, axis=0))
 
 
 properties_dict = {'time': np.arange(100)}
@@ -153,7 +153,7 @@ def test_track_layer_reset_data():
     layer = Tracks(data, graph=graph, properties=properties)
     cropped_data = data[:10, :]
     layer.data = cropped_data
-    assert np.all(layer.data == cropped_data)
+    np.testing.assert_array_equal(layer.data, cropped_data)
     assert layer.graph == {}
 
 
@@ -218,7 +218,7 @@ def test_fast_points_lookup() -> None:
         assert points_lookup[t].stop == e
         assert points_lookup[t].stop - points_lookup[t].start == r
         unique_time = sorted_time[points_lookup[t]]
-        assert np.all(unique_time[0] == unique_time)
+        np.testing.assert_array_equal(unique_time[0], unique_time)
         total_length += len(unique_time)
 
     assert total_length == len(sorted_time)
@@ -231,7 +231,7 @@ def test_single_time_tracks() -> None:
     tracks = [[0, 5, 2, 3], [1, 5, 3, 4], [2, 5, 4, 5]]
     layer = Tracks(tracks)
 
-    assert np.all(layer.data == tracks)
+    np.testing.assert_array_equal(layer.data, tracks)
 
 
 def test_track_ids_ordering() -> None:
@@ -243,4 +243,4 @@ def test_track_ids_ordering() -> None:
     sorted_track_ids = [0, 0, 1, 1, 2]  # track_ids after sorting
 
     layer = Tracks(unsorted_data)
-    assert np.all(sorted_track_ids == layer.features["track_id"])
+    np.testing.assert_array_equal(sorted_track_ids, layer.features["track_id"])

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -36,40 +36,40 @@ def test_calc_data_range():
     # all zeros should return [0, 1] by default
     data = np.zeros((10, 10))
     clim = calc_data_range(data)
-    assert np.all(clim == (0, 1))
+    np.testing.assert_array_equal(clim, (0, 1))
 
     # all ones should return [0, 1] by default
     data = np.ones((10, 10))
     clim = calc_data_range(data)
-    assert np.all(clim == (0, 1))
+    np.testing.assert_array_equal(clim, (0, 1))
 
     # return min and max
     data = np.random.random((10, 15))
     data[0, 0] = 0
     data[0, 1] = 2
     clim = calc_data_range(data)
-    assert np.all(clim == (0, 2))
+    np.testing.assert_array_equal(clim, (0, 2))
 
     # return min and max
     data = np.random.random((6, 10, 15))
     data[0, 0, 0] = 0
     data[0, 0, 1] = 2
     clim = calc_data_range(data)
-    assert np.all(clim == (0, 2))
+    np.testing.assert_array_equal(clim, (0, 2))
 
     # Try large data
     data = np.zeros((1000, 2000))
     data[0, 0] = 0
     data[0, 1] = 2
     clim = calc_data_range(data)
-    assert np.all(clim == (0, 2))
+    np.testing.assert_array_equal(clim, (0, 2))
 
     # Try large data mutlidimensional
     data = np.zeros((3, 1000, 1000))
     data[0, 0, 0] = 0
     data[0, 0, 1] = 2
     clim = calc_data_range(data)
-    assert np.all(clim == (0, 2))
+    np.testing.assert_array_equal(clim, (0, 2))
 
 
 @pytest.mark.parametrize(
@@ -89,7 +89,7 @@ def test_segment_normal_2d():
     b = np.array([1, 10])
 
     unit_norm = segment_normal(a, b)
-    assert np.all(unit_norm == np.array([1, 0]))
+    np.testing.assert_array_equal(unit_norm, np.array([1, 0]))
 
 
 def test_segment_normal_3d():
@@ -98,7 +98,7 @@ def test_segment_normal_3d():
     p = np.array([1, 0, 0])
 
     unit_norm = segment_normal(a, b, p)
-    assert np.all(unit_norm == np.array([0, 0, -1]))
+    np.testing.assert_array_equal(unit_norm, np.array([0, 0, -1]))
 
 
 def test_dataframe_to_properties():

--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -21,7 +21,7 @@ def test_random_vectors():
     data = np.random.random(shape)
     data[:, 0, :] = 20 * data[:, 0, :]
     layer = Vectors(data)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.data.shape == shape
     assert layer.ndim == shape[2]
     assert layer._view_data.shape[2] == 2
@@ -62,7 +62,7 @@ def test_empty_vectors():
     shape = (0, 2, 2)
     data = np.empty(shape)
     layer = Vectors(data)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.data.shape == shape
     assert layer.ndim == shape[2]
     assert layer._view_data.shape[2] == 2
@@ -95,7 +95,7 @@ def test_empty_vectors_with_property_choices():
     data = np.empty(shape)
     property_choices = {'angle': np.array([0.5], dtype=float)}
     layer = Vectors(data, property_choices=property_choices)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.data.shape == shape
     assert layer.ndim == shape[2]
     assert layer._view_data.shape[2] == 2
@@ -146,7 +146,7 @@ def test_random_3D_vectors():
     data = np.random.random(shape)
     data[:, 0, :] = 20 * data[:, 0, :]
     layer = Vectors(data)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.data.shape == shape
     assert layer.ndim == shape[2]
     assert layer._view_data.shape[2] == 2
@@ -175,7 +175,7 @@ def test_empty_3D_vectors():
     shape = (0, 2, 3)
     data = np.empty(shape)
     layer = Vectors(data)
-    assert np.all(layer.data == data)
+    np.testing.assert_array_equal(layer.data, data)
     assert layer.data.shape == shape
     assert layer.ndim == shape[2]
     assert layer._view_data.shape[2] == 2
@@ -283,7 +283,7 @@ def test_changing_data():
     data_b[:, 0, :] = 20 * data_b[:, 0, :]
     layer = Vectors(data_b)
     layer.data = data_b
-    assert np.all(layer.data == data_b)
+    np.testing.assert_array_equal(layer.data, data_b)
     assert layer.data.shape == shape_b
     assert layer.ndim == shape_b[2]
     assert layer._view_data.shape[2] == 2
@@ -429,7 +429,7 @@ def test_edge_color_cycle():
     )
     np.testing.assert_equal(layer.properties, properties)
     edge_color_array = transform_color(color_cycle * int(shape[0] / 2))
-    assert np.all(layer.edge_color == edge_color_array)
+    np.testing.assert_array_equal(layer.edge_color, edge_color_array)
 
 
 def test_edge_color_colormap():
@@ -448,11 +448,11 @@ def test_edge_color_colormap():
     np.testing.assert_equal(layer.properties, properties)
     assert layer.edge_color_mode == 'colormap'
     edge_color_array = transform_color(['black', 'white'] * int(shape[0] / 2))
-    assert np.all(layer.edge_color == edge_color_array)
+    np.testing.assert_array_equal(layer.edge_color, edge_color_array)
 
     # change the color cycle - edge_color should not change
     layer.edge_color_cycle = ['red', 'blue']
-    assert np.all(layer.edge_color == edge_color_array)
+    np.testing.assert_array_equal(layer.edge_color, edge_color_array)
 
     # adjust the clims
     layer.edge_contrast_limits = (0, 3)


### PR DESCRIPTION
Except 2 occurences with multiscale data that fail when replaced and need to investigate.

`assert np.array_equal` has not been replaced, and there are still some `np.all(?==?)` (without asserts).

