### PR TITLE
Restore 'V' keybinding for layer visibiltiy toggle

### DIFF
--- a/napari/utils/shortcuts.py
+++ b/napari/utils/shortcuts.py
@@ -20,7 +20,7 @@ _default_shortcuts = {
     'napari:roll_axes': [KeyMod.CtrlCmd | KeyCode.KeyE],
     'napari:transpose_axes': [KeyMod.CtrlCmd | KeyCode.KeyT],
     'napari:toggle_grid': [KeyMod.CtrlCmd | KeyCode.KeyG],
-    'napari:toggle_selected_visibility': [KeyCode.KeyG],
+    'napari:toggle_selected_visibility': [KeyCode.KeyV],
     'napari:hold_for_pan_zoom': [KeyCode.Space],
     # labels
     'napari:activate_labels_erase_mode': [KeyCode.Digit1, KeyCode.KeyE],


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/blob/bf211d7c8c5582c0fe8cc8a09a9e51f31a230e5c/napari/utils/shortcuts.py#L23

Reference: https://github.com/napari/napari/pull/5103

# Description
This PR restores the `V` keybinding for toggling the visibility of the currently selected layers.

It looks like this was unintentionally changed in https://github.com/napari/napari/pull/5103. I'm pretty sure it's unintentional because the PR description talks about changing the internal representation, not the user interaction. Also, the line above the one affected also contains `KeyCode.KeyG]`, so I think that it was copy-pasted as a template for the line below it, which was then only partially edited by mistake.


