### PR TITLE
Fix nitpicks in `id` and `title` `Action` fields in samples menu

### DIFF
--- a/napari/_qt/_qapp_model/_tests/test_file_menu.py
+++ b/napari/_qt/_qapp_model/_tests/test_file_menu.py
@@ -42,7 +42,7 @@ def test_sample_data_triggers_reader_dialog(
     with mock.patch(
         'napari._qt.dialogs.qt_reader_dialog.handle_gui_reading'
     ) as mock_read:
-        app.commands.execute_command('tmp_plugin.tmp-sample')
+        app.commands.execute_command('tmp_plugin:tmp-sample')
 
     # assert that handle gui reading was called
     mock_read.assert_called_once()
@@ -62,9 +62,9 @@ def test_plugin_display_name_use_for_multiple_samples(
     assert samples_menu[0].title == 'napari builtins'
     # Now ensure that the actions are still correct
     # trigger the action, opening the first sample: `Astronaut`
-    assert 'napari.astronaut' in app.commands
+    assert 'napari:astronaut' in app.commands
     assert len(viewer.layers) == 0
-    app.commands.execute_command('napari.astronaut')
+    app.commands.execute_command('napari:astronaut')
     assert len(viewer.layers) == 1
     assert viewer.layers[0].name == 'astronaut'
 
@@ -104,19 +104,19 @@ def test_sample_menu_plugin_state_change(
     assert len(samples_sub_menu) == 2
     assert isinstance(samples_sub_menu[0], MenuItem)
     assert samples_sub_menu[0].command.title == 'Temp Sample One'
-    assert 'tmp_plugin.tmp-sample-1' in app.commands
+    assert 'tmp_plugin:tmp-sample-1' in app.commands
 
     # Disable plugin
     pm.disable(tmp_plugin.name)
     with pytest.raises(KeyError):
         app.menus.get_menu('napari/file/samples')
-    assert 'tmp_plugin.tmp-sample-1' not in app.commands
+    assert 'tmp_plugin:tmp-sample-1' not in app.commands
 
     # Enable plugin
     pm.enable(tmp_plugin.name)
     samples_sub_menu = app.menus.get_menu('napari/file/samples/tmp_plugin')
     assert len(samples_sub_menu) == 2
-    assert 'tmp_plugin.tmp-sample-1' in app.commands
+    assert 'tmp_plugin:tmp-sample-1' in app.commands
 
 
 def test_sample_menu_single_data(
@@ -138,7 +138,7 @@ def test_sample_menu_single_data(
     assert isinstance(samples_menu[0], MenuItem)
     assert len(samples_menu) == 1
     assert samples_menu[0].command.title == 'Temp Sample One (Temp Plugin)'
-    assert 'tmp_plugin.tmp-sample-1' in app.commands
+    assert 'tmp_plugin:tmp-sample-1' in app.commands
 
 
 def test_show_shortcuts_actions(make_napari_viewer):

--- a/napari/_qt/dialogs/_tests/test_reader_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_reader_dialog.py
@@ -159,7 +159,7 @@ def test_open_sample_data_shows_all_readers(
     with mock.patch(
         'napari._qt.dialogs.qt_reader_dialog.handle_gui_reading'
     ) as mock_read:
-        app.commands.execute_command('tmp_plugin.tmp-sample')
+        app.commands.execute_command('tmp_plugin:tmp-sample')
 
     mock_read.assert_called_once_with(
         ['some-path/some-file.fake'],

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -407,7 +407,7 @@ def _rebuild_npe1_samples_menu() -> None:
                 title = menu_item_template.format(plugin_name, display_name)
 
             action: Action = Action(
-                id=f"{plugin_name}.{display_name}",
+                id=f"{plugin_name}:{display_name}",
                 title=title,
                 menus=[{'id': submenu_id, 'group': MenuGroup.NAVIGATION}],
                 callback=_add_sample,
@@ -450,7 +450,7 @@ def _get_samples_submenu_actions(
         submenu_id = MenuId.FILE_SAMPLES
         submenu = []
 
-    sample_actions = []
+    sample_actions: List[Action] = []
     for sample in sample_data:
 
         def _add_sample(
@@ -469,14 +469,17 @@ def _get_samples_submenu_actions(
                     stack=False,
                 )
 
-        display_name = sample.display_name.replace("&", "&&")
         if multiprovider:
-            title = display_name
+            title = sample.display_name
         else:
-            title = menu_item_template.format(mf.display_name, display_name)
+            title = menu_item_template.format(
+                mf.display_name, sample.display_name
+            )
+        # To display '&' instead of creating a shortcut
+        title = title.replace("&", "&&")
 
         action: Action = Action(
-            id=f'{mf.name}.{sample.key}',
+            id=f'{mf.name}:{sample.key}',
             title=title,
             menus=[{'id': submenu_id, 'group': MenuGroup.NAVIGATION}],
             callback=_add_sample,


### PR DESCRIPTION
# References and relevant issues
Clean up of missed items from #4865

# Description

* use `:` instead of `.` between words in command ID, to make consistent with all other commands which all use `:` (and fix tests)
* replace `&` with `&&` in full menu title, not just the sample display name

