### PR TITLE
FIX add `changing` event to `EventedDict`

### DIFF
--- a/napari/utils/events/containers/_evented_dict.py
+++ b/napari/utils/events/containers/_evented_dict.py
@@ -22,6 +22,8 @@ class EventedDict(TypedMutableMapping[_K, _T]):
 
     Events
     ------
+    changing (key: K)
+        emitted before an item at ``key`` is changed
     changed (key: K, old_value: T, value: T)
         emitted when item at ``key`` is changed from ``old_value`` to ``value``
     adding (key: K)
@@ -75,6 +77,7 @@ class EventedDict(TypedMutableMapping[_K, _T]):
             self.events.added(key=key, value=value)
             self._connect_child_emitters(value)
         else:
+            self.events.changing(key=key)
             super().__setitem__(key, value)
             self.events.changed(key=key, old_value=old, value=value)
 


### PR DESCRIPTION
# References and relevant issues
closes #5929

# Description

Document and emit the `changing` event in [`EventedDict`](https://github.com/napari/napari/blob/8c307022cc557692409f5e8bc031f1dcde4c374a/napari/utils/events/containers/_evented_dict.py#L9), which was is created but not documented or emitted.

