### PR TITLE
ENH Make `_open_preferences_dialog` return `PreferencesDialog`

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1528,8 +1528,6 @@ class Window:
 
     def _open_preferences_dialog(self) -> PreferencesDialog:
         """Edit preferences from the menubar."""
-        from napari._qt.dialogs.preferences_dialog import PreferencesDialog
-
         if self._pref_dialog is None:
             win = PreferencesDialog(parent=self._qt_window)
             self._pref_dialog = win

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -53,6 +53,7 @@ from napari._qt import menus
 from napari._qt._qapp_model import build_qmodel_menu
 from napari._qt._qapp_model.qactions import init_qactions
 from napari._qt.dialogs.confirm_close_dialog import ConfirmCloseDialog
+from napari._qt.dialogs.preferences_dialog import PreferencesDialog
 from napari._qt.dialogs.qt_activity_dialog import QtActivityDialog
 from napari._qt.dialogs.qt_notification import NapariQtNotification
 from napari._qt.qt_event_loop import NAPARI_ICON_PATH, get_app, quit_app
@@ -1525,7 +1526,7 @@ class Window:
             self._qt_window.close()
             del self._qt_window
 
-    def _open_preferences_dialog(self):
+    def _open_preferences_dialog(self) -> PreferencesDialog:
         """Edit preferences from the menubar."""
         from napari._qt.dialogs.preferences_dialog import PreferencesDialog
 
@@ -1548,6 +1549,8 @@ class Window:
             win.show()
         else:
             self._pref_dialog.raise_()
+
+        return self._pref_dialog
 
     def _screenshot_dialog(self):
         """Save screenshot of current display with viewer, default .png"""

--- a/napari/components/_viewer_key_bindings.py
+++ b/napari/components/_viewer_key_bindings.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from napari.components.viewer_model import ViewerModel
 from napari.utils.action_manager import action_manager
@@ -8,7 +8,6 @@ from napari.utils.theme import available_themes, get_system_theme
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
-    from napari._qt.dialogs.preferences_dialog import PreferencesDialog
     from napari.viewer import Viewer
 
 
@@ -165,9 +164,7 @@ def hold_for_pan_zoom(viewer: ViewerModel):
 
 @register_viewer_action(trans._("Show all key bindings"))
 def show_shortcuts(viewer: Viewer):
-    viewer.window._open_preferences_dialog()
-    pref_dialog = cast('PreferencesDialog', viewer.window._pref_dialog)
-    pref_list = pref_dialog._list
+    pref_list = viewer.window._open_preferences_dialog()._list
     for i in range(pref_list.count()):
         if pref_list.item(i).text() == "Shortcuts":
             pref_list.setCurrentRow(i)


### PR DESCRIPTION
# References and relevant issues
closes #6235
suggested in https://github.com/napari/napari/pull/6230

# Description
Make [`_open_preferences_dialog`](https://github.com/napari/napari/blob/7099b18fbf9ba3fbc9a3e2d502395f8216129960/napari/_qt/qt_main_window.py#L1528) return the `PreferencesDialog`, allowing `show_shortcuts` to be simplified.


