### PR TITLE
Speed up symbols validation in points layers

### DIFF
--- a/napari/_vispy/layers/points.py
+++ b/napari/_vispy/layers/points.py
@@ -53,7 +53,7 @@ class VispyPointsLayer(VispyBaseLayer):
             edge_color = self.layer._view_edge_color
             face_color = self.layer._view_face_color
             edge_width = self.layer._view_edge_width
-            symbol = self.layer._view_symbol
+            symbol = [str(x) for x in self.layer._view_symbol]
 
         set_data = self.node._subvisuals[0].set_data
 

--- a/napari/benchmarks/benchmark_python_layer.py
+++ b/napari/benchmarks/benchmark_python_layer.py
@@ -1,0 +1,14 @@
+from napari.layers.points._points_utils import coerce_symbols
+
+
+class CoerceSymbolsSuite:
+    def setup(self):
+        self.symbols1 = ['o' for _ in range(10**6)]
+        self.symbols2 = ['o' for _ in range(10**6)]
+        self.symbols2[10000] = 's'
+
+    def time_coerce_symbols1(self):
+        coerce_symbols(self.symbols1)
+
+    def time_coerce_symbols2(self):
+        coerce_symbols(self.symbols2)

--- a/napari/layers/points/_points_utils.py
+++ b/napari/layers/points/_points_utils.py
@@ -264,8 +264,8 @@ def coerce_symbols(array: np.ndarray) -> np.ndarray:
     """
     # dtype has to be object, otherwise np.vectorize will cut it down to `U(N)`,
     # where N is the biggest string currently in the array.
-    array = array.astype(object, copy=True)
-    for k, v in SYMBOL_ALIAS.items():
-        array[(array == k) | (array == k.upper())] = v
-    # otypes necessary for empty arrays
+    array = [
+        SYMBOL_ALIAS.get(k, SYMBOL_ALIAS.get(k.upper(), k))
+        for k in (str(x).lower() for x in array)
+    ]
     return np.vectorize(Symbol, otypes=[object])(array)

--- a/napari/layers/points/_points_utils.py
+++ b/napari/layers/points/_points_utils.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import Iterable, List, Optional, Tuple
 
 import numpy as np
 
@@ -251,7 +251,7 @@ def fix_data_points(
     return points, ndim
 
 
-def coerce_symbols(array: np.ndarray) -> np.ndarray:
+def coerce_symbols(array: Iterable) -> np.ndarray:
     """
     Parse an array of symbols and convert it to the correct strings.
 
@@ -264,8 +264,5 @@ def coerce_symbols(array: np.ndarray) -> np.ndarray:
     """
     # dtype has to be object, otherwise np.vectorize will cut it down to `U(N)`,
     # where N is the biggest string currently in the array.
-    array = [
-        SYMBOL_ALIAS.get(k, SYMBOL_ALIAS.get(k.upper(), k))
-        for k in (str(x).lower() for x in array)
-    ]
+    array = [SYMBOL_ALIAS.get(k, k) for k in (str(x).lower() for x in array)]
     return np.vectorize(Symbol, otypes=[object])(array)


### PR DESCRIPTION
# References and relevant issues
In #6275 it was noted that creating a points layer with many points is surprisingly slow, even though *once created* performance is fast. This PR addresses one slow part during points layer creation: validation of symbol selection for points, which includes reducing the number of conversions from Enums to strings. 