### PR TITLE
Fix benchmark suite virtualenvs, and disable broken memory benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: tlambert03/setup-qt-libs@v1
 
       - name: Setup asv
-        run: python -m pip install asv[virtualenv]
+        run: python -m pip install "asv[virtualenv]"
 
       - uses: octokit/request-action@v2.x
         id: latest_release

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: "3.9"
+          python-version: "3.11"
           cache-dependency-path: setup.cfg
 
       - uses: tlambert03/setup-qt-libs@v1

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,7 +25,7 @@ env:
   OPENBLAS_NUM_THREADS: "1"
   MKL_NUM_THREADS: "1"
   OMP_NUM_THREADS: "1"
-  ASV_OPTIONS: "--split --show-stderr --factor 1.5 --attribute timeout=300"
+  ASV_OPTIONS: "--split --show-stderr --factor 1.5 --attribute timeout=900"
   # --split -> split final reports in tables
   # --show-stderr -> print tracebacks if errors occur
   # --factor 1.5 -> report anomaly if tested timings are beyond 1.5x base timings

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: tlambert03/setup-qt-libs@v1
 
       - name: Setup asv
-        run: python -m pip install asv virtualenv
+        run: python -m pip install asv[virtualenv]
 
       - uses: octokit/request-action@v2.x
         id: latest_release

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -229,12 +229,18 @@ jobs:
           python-version: 3.11
           cache-dependency-path: napari-from-github/setup.cfg
 
+      - uses: tlambert03/setup-qt-libs@v1
+
       - name: install dependencies
         run: |
           pip install --upgrade pip
           pip install asv[virtualenv] 
 
       - name: Run benchmarks
-        run: |
-          asv machine --yes
-          asv run --show-stderr --quick  --attribute timeout=300 HEAD^!
+        uses: aganders3/headless-gui@v1
+        with:
+          run: |
+            asv machine --yes
+            asv run --show-stderr --quick  --attribute timeout=300 HEAD^!
+        env:
+          PR: 1

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -237,4 +237,4 @@ jobs:
       - name: Run benchmarks
         run: |
           asv machine --yes
-          asv run --show-stderr --quick  --attribute timeout=300 ${GITHUB_HEAD_REF}^!
+          asv run --show-stderr --quick  --attribute timeout=300 HEAD^!

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -216,3 +216,24 @@ jobs:
           run: tox -e py39-linux-pyside2-examples
         env:
           PIP_CONSTRAINT: resources/constraints/constraints_py3.9_examples.txt
+
+
+  test_benchmarks:
+    name: test benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+          cache-dependency-path: napari-from-github/setup.cfg
+
+      - name: install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install asv[virtualenv] 
+
+      - name: Run benchmarks
+        run: |
+          asv run --show-stderr --quick  --attribute timeout=300

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -236,4 +236,5 @@ jobs:
 
       - name: Run benchmarks
         run: |
+          asv machine --yes
           asv run --show-stderr --quick  --attribute timeout=300 ${GITHUB_HEAD_REF}^!

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -236,4 +236,4 @@ jobs:
 
       - name: Run benchmarks
         run: |
-          asv run --show-stderr --quick  --attribute timeout=300
+          asv run --show-stderr --quick  --attribute timeout=300 ${GITHUB_HEAD_REF}^!

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -31,7 +31,7 @@
     "show_commit_url": "http://github.com/napari/napari/commit/",
 
     // The Pythons you'd like to test against.
-    "pythons": ["3.9"],
+    "pythons": ["3.11"],
 
     // The directory (relative to the current directory) to cache the Python
     // environments in.

--- a/napari/benchmarks/benchmark_image_layer.py
+++ b/napari/benchmarks/benchmark_image_layer.py
@@ -14,6 +14,9 @@ class Image2DSuite:
 
     params = [2**i for i in range(4, 13)]
 
+    if "PR" in os.environ:
+        skip_params = [(2**i,) for i in range(6, 13)]
+
     def setup(self, n):
         np.random.seed(0)
         self.data = np.random.random((n, n))
@@ -57,6 +60,8 @@ class Image3DSuite:
     """Benchmarks for the Image layer with 3D data."""
 
     params = [2**i for i in range(4, 11)]
+    if "PR" in os.environ:
+        skip_params = [(2**i,) for i in range(6, 11)]
 
     def setup(self, n):
         if "CI" in os.environ and n > 512:

--- a/napari/benchmarks/benchmark_image_layer.py
+++ b/napari/benchmarks/benchmark_image_layer.py
@@ -44,7 +44,7 @@ class Image2DSuite:
         """Time to refresh view."""
         self.layer.refresh()
 
-    def mem_layer(self, n):
+    def _mem_layer(self, n):
         """Memory used by layer."""
         return self.layer
 
@@ -91,7 +91,7 @@ class Image3DSuite:
         """Time to refresh view."""
         self.layer.refresh()
 
-    def mem_layer(self, n):
+    def _mem_layer(self, n):
         """Memory used by layer."""
         return Image(self.data)
 

--- a/napari/benchmarks/benchmark_image_layer.py
+++ b/napari/benchmarks/benchmark_image_layer.py
@@ -49,6 +49,7 @@ class Image2DSuite:
 
     def _mem_layer(self, n):
         """Memory used by layer."""
+        # Disabled because of __sizeof__ bug on the main branch and outdated asizeof in pympler
         return self.layer
 
     def mem_data(self, n):
@@ -98,6 +99,7 @@ class Image3DSuite:
 
     def _mem_layer(self, n):
         """Memory used by layer."""
+        # Disabled because of __sizeof__ bug on the main branch and outdated asizeof in pympler
         return Image(self.data)
 
     def mem_data(self, n):

--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -56,7 +56,7 @@ class Labels2DSuite:
             self.layer.selected_label,
         )
 
-    def mem_layer(self, n):
+    def _mem_layer(self, n):
         """Memory used by layer."""
         return self.layer
 
@@ -162,7 +162,7 @@ class Labels3DSuite:
             self.layer.selected_label,
         )
 
-    def mem_layer(self, n):
+    def _mem_layer(self, n):
         """Memory used by layer."""
         return self.layer
 

--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -6,8 +6,9 @@ import os
 
 import numpy as np
 
-from napari.benchmarks.utils import Skiper
 from napari.layers import Labels
+
+from .utils import Skiper
 
 
 class Labels2DSuite:

--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -124,6 +124,7 @@ class Labels3DSuite:
         np.random.seed(0)
         self.data = np.random.randint(20, size=(n, n, n))
         self.layer = Labels(self.data)
+        self.layer._slice_dims((0, 0, 0), 3, (0, 1, 2))
 
     def time_create_layer(self, n):
         """Time to create layer."""

--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -63,6 +63,7 @@ class Labels2DSuite:
 
     def _mem_layer(self, n):
         """Memory used by layer."""
+        # Disabled because of __sizeof__ bug on the main branch and outdated asizeof in pympler
         return self.layer
 
     def mem_data(self, n):
@@ -178,6 +179,7 @@ class Labels3DSuite:
 
     def _mem_layer(self, n):
         """Memory used by layer."""
+        # Disabled because of __sizeof__ bug on main branch and outdated asizeof in pympler
         return self.layer
 
     def mem_data(self, n):

--- a/napari/benchmarks/benchmark_points_layer.py
+++ b/napari/benchmarks/benchmark_points_layer.py
@@ -50,6 +50,7 @@ class Points2DSuite:
 
     def _mem_layer(self, n):
         """Memory used by layer."""
+        # Disabled because of __sizeof__ bug on the main branch and outdated asizeof in pympler
         return self.layer
 
     def mem_data(self, n):
@@ -91,6 +92,7 @@ class Points3DSuite:
 
     def _mem_layer(self, n):
         """Memory used by layer."""
+        # Disabled because of __sizeof__ bug on the main branch and outdated asizeof in pympler
         return self.layer
 
     def mem_data(self, n):

--- a/napari/benchmarks/benchmark_points_layer.py
+++ b/napari/benchmarks/benchmark_points_layer.py
@@ -4,6 +4,7 @@
 # https://github.com/napari/napari/blob/main/docs/BENCHMARKS.md
 import numpy as np
 
+from napari.components import Dims
 from napari.layers import Points
 
 
@@ -100,11 +101,11 @@ class PointsSlicingSuite:
         if flatten_slice_axis:
             self.data[:, 0] = np.round(self.data[:, 0])
         self.layer = Points(self.data)
-        self.slice = np.s_[249, :, :]
+        self.dims = Dims(ndim=3, point=(249, 0, 0))
 
     def time_slice_points(self, flatten_slice_axis):
         """Time to take one slice of points"""
-        self.layer._slice_data(self.slice)
+        self.layer._make_slice_request(self.dims)()
 
 
 class PointsToMaskSuite:

--- a/napari/benchmarks/benchmark_points_layer.py
+++ b/napari/benchmarks/benchmark_points_layer.py
@@ -40,7 +40,7 @@ class Points2DSuite:
     def time_add(self, n):
         self.layer.add(self.data)
 
-    def mem_layer(self, n):
+    def _mem_layer(self, n):
         """Memory used by layer."""
         return self.layer
 
@@ -79,7 +79,7 @@ class Points3DSuite:
         """Time to get current value."""
         self.layer.get_value((0,) * 3)
 
-    def mem_layer(self, n):
+    def _mem_layer(self, n):
         """Memory used by layer."""
         return self.layer
 

--- a/napari/benchmarks/benchmark_points_layer.py
+++ b/napari/benchmarks/benchmark_points_layer.py
@@ -2,8 +2,11 @@
 # https://asv.readthedocs.io/en/latest/writing_benchmarks.html
 # or the napari documentation on benchmarking
 # https://github.com/napari/napari/blob/main/docs/BENCHMARKS.md
+import os
+
 import numpy as np
 
+from napari.benchmarks.utils import Skiper
 from napari.components import Dims
 from napari.layers import Points
 
@@ -12,6 +15,9 @@ class Points2DSuite:
     """Benchmarks for the Points layer with 2D data"""
 
     params = [2**i for i in range(4, 18, 2)]
+
+    if "PR" in os.environ:
+        skip_params = [(2**i,) for i in range(8, 18, 2)]
 
     def setup(self, n):
         np.random.seed(0)
@@ -54,6 +60,8 @@ class Points3DSuite:
     """Benchmarks for the Points layer with 3D data."""
 
     params = [2**i for i in range(4, 18, 2)]
+    if "PR" in os.environ:
+        skip_params = [(2**i,) for i in range(6, 18, 2)]
 
     def setup(self, n):
         np.random.seed(0)
@@ -97,7 +105,8 @@ class PointsSlicingSuite:
 
     def setup(self, flatten_slice_axis):
         np.random.seed(0)
-        self.data = np.random.uniform(size=(20_000_000, 3), low=0, high=500)
+        size = 20000 if "PR" in os.environ else 20000000
+        self.data = np.random.uniform(size=(size, 3), low=0, high=500)
         if flatten_slice_axis:
             self.data[:, 0] = np.round(self.data[:, 0])
         self.layer = Points(self.data)
@@ -125,6 +134,9 @@ class PointsToMaskSuite:
         ],
         [5, 10],
     ]
+
+    if "PR" in os.environ:
+        skip_params = Skiper(lambda x: x[0] > 256 or x[1][0] > 512)
 
     def setup(self, num_points, mask_shape, point_size):
         np.random.seed(0)

--- a/napari/benchmarks/benchmark_points_layer.py
+++ b/napari/benchmarks/benchmark_points_layer.py
@@ -6,9 +6,10 @@ import os
 
 import numpy as np
 
-from napari.benchmarks.utils import Skiper
 from napari.components import Dims
 from napari.layers import Points
+
+from .utils import Skiper
 
 
 class Points2DSuite:

--- a/napari/benchmarks/benchmark_qt_slicing.py
+++ b/napari/benchmarks/benchmark_qt_slicing.py
@@ -10,8 +10,9 @@ import zarr
 from qtpy.QtWidgets import QApplication
 
 import napari
-from napari.benchmarks.utils import Skiper
 from napari.layers import Image
+
+from .utils import Skiper
 
 SAMPLE_PARAMS = {
     'skin_data': {

--- a/napari/benchmarks/benchmark_qt_slicing.py
+++ b/napari/benchmarks/benchmark_qt_slicing.py
@@ -2,7 +2,7 @@
 # https://asv.readthedocs.io/en/latest/writing_benchmarks.html
 # or the napari documentation on benchmarking
 # https://github.com/napari/napari/blob/main/docs/BENCHMARKS.md
-
+import os
 import time
 
 import numpy as np
@@ -10,6 +10,7 @@ import zarr
 from qtpy.QtWidgets import QApplication
 
 import napari
+from napari.benchmarks.utils import Skiper
 from napari.layers import Image
 
 SAMPLE_PARAMS = {
@@ -164,6 +165,11 @@ class QtViewerAsyncPointsAndImage2DSuite:
     latency = [0.05 * i for i in range(3)]
     params = (n_points, latency, chunksize)
     timeout = 600
+
+    if "PR" in os.environ:
+        skip_params = Skiper(
+            lambda x: x[0] > 2**14 or x[2] > 512 or x[1] > 0.05
+        )
 
     def setup(self, n_points, latency, chunksize):
         store = SlowMemoryStore(load_delay=latency)

--- a/napari/benchmarks/benchmark_qt_viewer_image.py
+++ b/napari/benchmarks/benchmark_qt_viewer_image.py
@@ -2,6 +2,8 @@
 # https://asv.readthedocs.io/en/latest/writing_benchmarks.html
 # or the napari documentation on benchmarking
 # https://github.com/napari/napari/blob/main/docs/BENCHMARKS.md
+import os
+
 import numpy as np
 from qtpy.QtWidgets import QApplication
 
@@ -12,6 +14,9 @@ class QtViewerViewImageSuite:
     """Benchmarks for viewing images in the viewer."""
 
     params = [2**i for i in range(4, 13)]
+
+    if "PR" in os.environ:
+        skip_params = [(2**i,) for i in range(6, 13)]
 
     def setup(self, n):
         _ = QApplication.instance() or QApplication([])
@@ -32,6 +37,9 @@ class QtViewerAddImageSuite:
 
     params = [2**i for i in range(4, 13)]
 
+    if "PR" in os.environ:
+        skip_params = [(2**i,) for i in range(6, 13)]
+
     def setup(self, n):
         _ = QApplication.instance() or QApplication([])
         np.random.seed(0)
@@ -50,6 +58,9 @@ class QtViewerImageSuite:
     """Benchmarks for images in the viewer."""
 
     params = [2**i for i in range(4, 13)]
+
+    if "PR" in os.environ:
+        skip_params = [(2**i,) for i in range(6, 13)]
 
     def setup(self, n):
         _ = QApplication.instance() or QApplication([])
@@ -185,6 +196,9 @@ class QtImageRenderingSuite:
 
     params = [2**i for i in range(4, 13)]
 
+    if "PR" in os.environ:
+        skip_params = [(2**i,) for i in range(6, 13)]
+
     def setup(self, n):
         _ = QApplication.instance() or QApplication([])
         np.random.seed(0)
@@ -211,6 +225,9 @@ class QtVolumeRenderingSuite:
     """Benchmarks for a single image layer in the viewer."""
 
     params = [2**i for i in range(4, 10)]
+
+    if "PR" in os.environ:
+        skip_params = [(2**i,) for i in range(6, 10)]
 
     def setup(self, n):
         _ = QApplication.instance() or QApplication([])

--- a/napari/benchmarks/benchmark_qt_viewer_vectors.py
+++ b/napari/benchmarks/benchmark_qt_viewer_vectors.py
@@ -2,6 +2,8 @@
 # https://asv.readthedocs.io/en/latest/writing_benchmarks.html
 # or the napari documentation on benchmarking
 # https://github.com/napari/napari/blob/main/docs/BENCHMARKS.md
+import os
+
 import numpy as np
 from qtpy.QtWidgets import QApplication
 
@@ -12,6 +14,9 @@ class QtViewerViewVectorSuite:
     """Benchmarks for viewing vectors in the viewer."""
 
     params = [2**i for i in range(4, 18, 2)]
+
+    if "PR" in os.environ:
+        skip_params = [(2**i,) for i in range(8, 18, 2)]
 
     def setup(self, n):
         _ = QApplication.instance() or QApplication([])

--- a/napari/benchmarks/benchmark_shapes_layer.py
+++ b/napari/benchmarks/benchmark_shapes_layer.py
@@ -50,6 +50,7 @@ class Shapes2DSuite:
 
     def _mem_layer(self, n):
         """Memory used by layer."""
+        # Disabled because of __sizeof__ bug on the main branch and outdated asizeof in pympler
         return self.layer
 
     def mem_data(self, n):
@@ -91,6 +92,7 @@ class Shapes3DSuite:
 
     def _mem_layer(self, n):
         """Memory used by layer."""
+        # Disabled because of __sizeof__ bug on the main branch and outdated asizeof in pympler
         return self.layer
 
     def mem_data(self, n):

--- a/napari/benchmarks/benchmark_shapes_layer.py
+++ b/napari/benchmarks/benchmark_shapes_layer.py
@@ -44,7 +44,7 @@ class Shapes2DSuite:
         """Time to get current value."""
         self.layer.get_value((0,) * 2)
 
-    def mem_layer(self, n):
+    def _mem_layer(self, n):
         """Memory used by layer."""
         return self.layer
 
@@ -83,7 +83,7 @@ class Shapes3DSuite:
         """Time to get current value."""
         self.layer.get_value((0,) * 3)
 
-    def mem_layer(self, n):
+    def _mem_layer(self, n):
         """Memory used by layer."""
         return self.layer
 

--- a/napari/benchmarks/benchmark_shapes_layer.py
+++ b/napari/benchmarks/benchmark_shapes_layer.py
@@ -2,6 +2,7 @@
 # https://asv.readthedocs.io/en/latest/writing_benchmarks.html
 # or the napari documentation on benchmarking
 # https://github.com/napari/napari/blob/main/docs/BENCHMARKS.md
+import os
 
 import numpy as np
 
@@ -18,6 +19,9 @@ class Shapes2DSuite:
     """Benchmarks for the Shapes layer with 2D data"""
 
     params = [2**i for i in range(4, 9)]
+
+    if "PR" in os.environ:
+        skip_params = [(2**i,) for i in range(6, 9)]
 
     def setup(self, n):
         np.random.seed(0)
@@ -57,6 +61,8 @@ class Shapes3DSuite:
     """Benchmarks for the Shapes layer with 3D data."""
 
     params = [2**i for i in range(4, 9)]
+    if "PR" in os.environ:
+        skip_params = [(2**i,) for i in range(6, 9)]
 
     def setup(self, n):
         np.random.seed(0)

--- a/napari/benchmarks/benchmark_surface_layer.py
+++ b/napari/benchmarks/benchmark_surface_layer.py
@@ -43,6 +43,7 @@ class Surface2DSuite:
 
     def _mem_layer(self, n):
         """Memory used by layer."""
+        # Disabled because of __sizeof__ bug on the main branch and outdated asizeof in pympler
         return self.layer
 
     def mem_data(self, n):
@@ -86,6 +87,7 @@ class Surface3DSuite:
 
     def _mem_layer(self, n):
         """Memory used by layer."""
+        # Disabled because of __sizeof__ bug on the main branch and outdated asizeof in pympler
         return self.layer
 
     def mem_data(self, n):

--- a/napari/benchmarks/benchmark_surface_layer.py
+++ b/napari/benchmarks/benchmark_surface_layer.py
@@ -41,7 +41,7 @@ class Surface2DSuite:
         """Time to get current value."""
         self.layer.get_value((0,) * 2)
 
-    def mem_layer(self, n):
+    def _mem_layer(self, n):
         """Memory used by layer."""
         return self.layer
 
@@ -84,7 +84,7 @@ class Surface3DSuite:
         """Time to get current value."""
         self.layer.get_value((0,) * 3)
 
-    def mem_layer(self, n):
+    def _mem_layer(self, n):
         """Memory used by layer."""
         return self.layer
 

--- a/napari/benchmarks/benchmark_text_manager.py
+++ b/napari/benchmarks/benchmark_text_manager.py
@@ -2,9 +2,12 @@
 # https://asv.readthedocs.io/en/latest/writing_benchmarks.html
 # or the napari documentation on benchmarking
 # https://napari.org/developers/benchmarks.html
+import os
+
 import numpy as np
 import pandas as pd
 
+from napari.benchmarks.utils import Skiper
 from napari.layers.utils.text_manager import TextManager
 
 
@@ -21,6 +24,9 @@ class TextManagerSuite:
             '{string_property}: {float_property:.2f}',
         ],
     ]
+
+    if "PR" in os.environ:
+        skip_params = Skiper(lambda x: x[0] > 2**6)
 
     def setup(self, n, string):
         np.random.seed(0)

--- a/napari/benchmarks/benchmark_text_manager.py
+++ b/napari/benchmarks/benchmark_text_manager.py
@@ -7,8 +7,9 @@ import os
 import numpy as np
 import pandas as pd
 
-from napari.benchmarks.utils import Skiper
 from napari.layers.utils.text_manager import TextManager
+
+from .utils import Skiper
 
 
 class TextManagerSuite:

--- a/napari/benchmarks/benchmark_tracks_layer.py
+++ b/napari/benchmarks/benchmark_tracks_layer.py
@@ -2,8 +2,9 @@ import os
 
 import numpy as np
 
-from napari.benchmarks.utils import Skiper
 from napari.layers import Tracks
+
+from .utils import Skiper
 
 
 class TracksSuite:

--- a/napari/benchmarks/benchmark_tracks_layer.py
+++ b/napari/benchmarks/benchmark_tracks_layer.py
@@ -1,11 +1,17 @@
+import os
+
 import numpy as np
 
+from napari.benchmarks.utils import Skiper
 from napari.layers import Tracks
 
 
 class TracksSuite:
     param_names = ['size', 'n_tracks']
     params = [(5 * np.power(10, np.arange(7))).tolist(), [1, 10, 100, 1000]]
+
+    if "PR" in os.environ:
+        skip_params = Skiper(lambda x: x[0] > 500 or x[1] > 10)
 
     def setup(self, size, n_tracks):
         """

--- a/napari/benchmarks/benchmark_vectors_layer.py
+++ b/napari/benchmarks/benchmark_vectors_layer.py
@@ -45,7 +45,7 @@ class Vectors2DSuite:
         """Time to update length."""
         self.layer.length = 2
 
-    def mem_layer(self, n):
+    def _mem_layer(self, n):
         """Memory used by layer."""
         return self.layer
 
@@ -92,7 +92,7 @@ class Vectors3DSuite:
         """Time to update length."""
         self.layer.length = 2
 
-    def mem_layer(self, n):
+    def _mem_layer(self, n):
         """Memory used by layer."""
         return self.layer
 

--- a/napari/benchmarks/benchmark_vectors_layer.py
+++ b/napari/benchmarks/benchmark_vectors_layer.py
@@ -47,6 +47,7 @@ class Vectors2DSuite:
 
     def _mem_layer(self, n):
         """Memory used by layer."""
+        # Disabled because of __sizeof__ bug on the main branch and outdated asizeof in pympler
         return self.layer
 
     def mem_data(self, n):
@@ -94,6 +95,7 @@ class Vectors3DSuite:
 
     def _mem_layer(self, n):
         """Memory used by layer."""
+        # Disabled because of __sizeof__ bug on the main branch and outdated asizeof in pympler
         return self.layer
 
     def mem_data(self, n):

--- a/napari/benchmarks/utils.py
+++ b/napari/benchmarks/utils.py
@@ -1,0 +1,6 @@
+class Skiper:
+    def __init__(self, func):
+        self.func = func
+
+    def __contains__(self, item):
+        return self.func(item)

--- a/napari/utils/color.py
+++ b/napari/utils/color.py
@@ -89,6 +89,9 @@ class ColorArray(np.ndarray):
     def __get_validators__(cls):
         yield cls.validate
 
+    def __sizeof__(self):
+        return super().__sizeof__() + self.nbytes
+
     @classmethod
     def validate(cls, value: ColorArrayParam) -> 'ColorArray':
         """Validates and coerces the given value into an array storing many colors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ fix = true
 "tools/**" = ["INP001", "T20"]
 "examples/**" = ["ICN001", "INP001", "T20"]
 "**/vendored/**" = ["TID"]
-"napari/benchmarks/**" = ["RUF012"]
+"napari/benchmarks/**" = ["RUF012", "TID252"]
 
 [tool.ruff.flake8-quotes]
 docstring-quotes = "double"


### PR DESCRIPTION
# Description
Use `[virtualenv]` extras to fix the benchmark setup. 

https://github.com/airspeed-velocity/asv/issues/1323
https://github.com/airspeed-velocity/asv/pull/1324

disable `mem_layer` benchmarks as they do not work on the current main. It needs to be reenabled in follow-up PR. To have it working, it is required to have `__sizeof__` fixed, which is part of this commit. 

Add benchmark "testing" to pull request test. To spot directly which PR breaks benchmarks execution. 
