### PR TITLE
Fix labels for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,5 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "ci(dependabot):"
-
-  - package-ecosystem: "pip"
-    directory: "/resources"
-    schedule:
-      interval: "weekly"
-
-    target-branch: "develop"
+    labels:
+      - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
     commit-message:
       prefix: "ci(dependabot):"
     labels:
-      - "dependencies"
+      - "maintenance"


### PR DESCRIPTION
# Description

Dependabot PRs always add the `github_actions` and `dependencies` labels, which are both kinda useless for us in terms of release notes and add noise to the already large amount of labels.

This pr simply makes Dependabot use the `maintenance` label, so the PR is ready to go and will pass the label check.

I also deleted the `pip` ecosystem, which was mistakenly left in when this file was added and does nothing in our case.
