### PR TITLE
[Maintenance] Fix missing v in the docker-login action version

### DIFF
--- a/.github/workflows/docker-singularity-publish.yml
+++ b/.github/workflows/docker-singularity-publish.yml
@@ -44,7 +44,7 @@ jobs:
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@3.0.0
+        uses: docker/login-action@v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
# References and relevant issues
Containers on comprehensive runs are failing, see:
https://github.com/napari/napari/actions/runs/6386313305/job/17332760522

# Description
Fixes missing `v` in the version of the action.

