### PR TITLE
Set permissions to `allow upgrate_test_contstraints` work 

### DIFF
--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -57,6 +57,9 @@ on:
 
 jobs:
   upgrade:
+    permissions:
+      pull-requests: write
+      issues: write
     name: Upgrade & Open Pull Request
     if: (github.event.issue.pull_request != '' && contains(github.event.comment.body, '@napari-bot update constraints')) || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

It looks like GitHub change default GITHUB_TOKEN permissions and them needs to be explicitly set.  
