### PR TITLE
Revert "MAINT: Use scipy builtins rotation to compute quaternions. (#6241)"

### DIFF
--- a/napari/_vispy/__init__.py
+++ b/napari/_vispy/__init__.py
@@ -22,7 +22,7 @@ from napari._vispy.overlays.interaction_box import (
 from napari._vispy.overlays.labels_polygon import VispyLabelsPolygonOverlay
 from napari._vispy.overlays.scale_bar import VispyScaleBarOverlay
 from napari._vispy.overlays.text import VispyTextOverlay
-from napari._vispy.utils.quaternion import quaternion2euler_degrees
+from napari._vispy.utils.quaternion import quaternion2euler
 from napari._vispy.utils.visual import create_vispy_layer, create_vispy_overlay
 
 __all__ = [
@@ -34,7 +34,7 @@ __all__ = [
     "VispyTransformBoxOverlay",
     "VispyTextOverlay",
     "VispyLabelsPolygonOverlay",
-    "quaternion2euler_degrees",
+    "quaternion2euler",
     "create_vispy_layer",
     "create_vispy_overlay",
 ]

--- a/napari/_vispy/_tests/test_utils.py
+++ b/napari/_vispy/_tests/test_utils.py
@@ -5,7 +5,7 @@ from qtpy.QtCore import Qt
 from vispy.util.quaternion import Quaternion
 
 from napari._vispy.utils.cursor import QtCursorVisual
-from napari._vispy.utils.quaternion import quaternion2euler_degrees
+from napari._vispy.utils.quaternion import quaternion2euler
 from napari._vispy.utils.visual import get_view_direction_in_scene_coordinates
 from napari.components._viewer_constants import CursorStyle
 
@@ -13,16 +13,18 @@ from napari.components._viewer_constants import CursorStyle
 angles = [[12, 53, 92], [180, -90, 0], [16, 90, 0]]
 
 # Prepare for input and add corresponding values in radians
+angles_param = [(x, True) for x in angles]
+angles_param.extend([(x, False) for x in np.radians(angles)])
 
 
-@pytest.mark.parametrize('angles', angles)
-def test_quaternion2euler_degrees(angles):
+@pytest.mark.parametrize('angles,degrees', angles_param)
+def test_quaternion2euler(angles, degrees):
     """Test quaternion to euler angle conversion."""
 
     # Test for degrees
-    q = Quaternion.create_from_euler_angles(*angles, degrees=True)
-    ea = quaternion2euler_degrees(q)
-    q_p = Quaternion.create_from_euler_angles(*ea, degrees=True)
+    q = Quaternion.create_from_euler_angles(*angles, degrees)
+    ea = quaternion2euler(q, degrees=degrees)
+    q_p = Quaternion.create_from_euler_angles(*ea, degrees=degrees)
 
     # We now compare the corresponding quaternions ; they should be equals or opposites (as they're already unit ones)
     q_values = np.array([q.w, q.x, q.y, q.z])

--- a/napari/_vispy/camera.py
+++ b/napari/_vispy/camera.py
@@ -3,7 +3,7 @@ from typing import Type
 import numpy as np
 from vispy.scene import ArcballCamera, BaseCamera, PanZoomCamera
 
-from napari._vispy.utils.quaternion import quaternion2euler_degrees
+from napari._vispy.utils.quaternion import quaternion2euler
 
 
 class VispyCamera:
@@ -58,7 +58,9 @@ class VispyCamera:
 
         if self._view.camera == self._3D_camera:
             # Do conversion from quaternion representation to euler angles
-            angles = quaternion2euler_degrees(self._view.camera._quaternion)
+            angles = quaternion2euler(
+                self._view.camera._quaternion, degrees=True
+            )
         else:
             angles = (0, 0, 90)
         return angles

--- a/napari/_vispy/utils/quaternion.py
+++ b/napari/_vispy/utils/quaternion.py
@@ -1,39 +1,57 @@
-import warnings
-
-from scipy.spatial.transform import Rotation
+import numpy as np
 
 
-def quaternion2euler_degrees(quaternion):
+def quaternion2euler(quaternion, degrees=False):
     """Converts VisPy quaternion into euler angle representation.
 
     Euler angles have degeneracies, so the output might different
     from the Euler angles that might have been used to generate
     the input quaternion.
 
+    Euler angles representation also has a singularity
+    near pitch = Pi/2 ; to avoid this, we set to Pi/2 pitch angles
+    that are closer than the chosen epsilon from it.
 
     Parameters
     ----------
     quaternion : vispy.util.Quaternion
         Quaternion for conversion.
+    degrees : bool
+        If output is returned in degrees or radians.
 
     Returns
     -------
     angles : 3-tuple
         Euler angles in (rx, ry, rz) order.
     """
+    epsilon = 1e-10
+
     q = quaternion
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            action='ignore',
-            message='Gimbal lock detected.*',
-            category=UserWarning,
+
+    sin_theta_2 = 2 * (q.w * q.y - q.z * q.x)
+    sin_theta_2 = np.sign(sin_theta_2) * min(abs(sin_theta_2), 1)
+
+    if abs(sin_theta_2) > 1 - epsilon:
+        theta_1 = -np.sign(sin_theta_2) * 2 * np.arctan2(q.x, q.w)
+        theta_2 = np.arcsin(sin_theta_2)
+        theta_3 = 0
+
+    else:
+        theta_1 = np.arctan2(
+            2 * (q.w * q.z + q.y * q.x),
+            1 - 2 * (q.y * q.y + q.z * q.z),
         )
 
-        # despite both SciPy and  previous implementation advertising
-        # the  x,y,z order, it appear we need to reverse the order to get
-        # the same results a previously.
-        # as_euler('zyx') does not work as composition order matters
-        z, y, x = Rotation.from_quat([q.x, q.y, q.z, q.w]).as_euler(
-            'xyz', degrees=True
+        theta_2 = np.arcsin(sin_theta_2)
+
+        theta_3 = np.arctan2(
+            2 * (q.w * q.x + q.y * q.z),
+            1 - 2 * (q.x * q.x + q.y * q.y),
         )
-    return x, y, z
+
+    angles = (theta_1, theta_2, theta_3)
+
+    if degrees:
+        return tuple(np.degrees(angles))
+
+    return angles


### PR DESCRIPTION
# References and relevant issues
This reverts #6241.

# Description
I goofed, that PR should have stayed open until we addressed the catch warning issue.
