### PR TITLE
fpl in napari viewer as docked widget

### DIFF
--- a/napari/_fastplotlib/__init__.py
+++ b/napari/_fastplotlib/__init__.py
@@ -1,0 +1,5 @@
+from napari._fastplotlib.canvas import FastplotlibCanvas
+from napari._fastplotlib.layers import FastplotlibImageLayer
+from napari._fastplotlib.visual import create_fpl_layer
+
+

--- a/napari/_fastplotlib/__init__.py
+++ b/napari/_fastplotlib/__init__.py
@@ -1,5 +1,0 @@
-from napari._fastplotlib.canvas import FastplotlibCanvas
-from napari._fastplotlib.layers import FastplotlibImageLayer
-from napari._fastplotlib.visual import create_fpl_layer
-
-

--- a/napari/_fastplotlib/canvas.py
+++ b/napari/_fastplotlib/canvas.py
@@ -1,11 +1,7 @@
 import fastplotlib as fpl
-from napari.components import ViewerModel
-from PyQt5 import QtWidgets
-from wgpu.gui.qt import WgpuWidget, WgpuCanvas
-import wgpu.backends.rs
-
 import pygfx as gfx
-import numpy as np
+from PyQt5 import QtWidgets
+from wgpu.gui.qt import WgpuCanvas
 
 # TODO Figure out how to get fastplotlib canvas into Qt application and not just as a docked widget
 
@@ -16,7 +12,7 @@ class FastplotlibCanvas(QtWidgets.QWidget):
     """
 
     def __init__(
-            self,
+        self,
     ) -> None:
         super().__init__(None)
         self._canvas = WgpuCanvas(parent=self)
@@ -53,10 +49,7 @@ class FastplotlibCanvas(QtWidgets.QWidget):
 
         self._plot.add_graphic(fpl_layer.image_graphic)
 
-      #  napari_layer.events.visible.connect(self._reorder_layers)
-     #   self.viewer.camera.events.angles.connect(fpl_layer._on_camera_move)
+    #  napari_layer.events.visible.connect(self._reorder_layers)
+    #   self.viewer.camera.events.angles.connect(fpl_layer._on_camera_move)
 
     #    self._reorder_layers()
-
-
-

--- a/napari/_fastplotlib/canvas.py
+++ b/napari/_fastplotlib/canvas.py
@@ -1,0 +1,62 @@
+import fastplotlib as fpl
+from napari.components import ViewerModel
+from PyQt5 import QtWidgets
+from wgpu.gui.qt import WgpuWidget, WgpuCanvas
+import wgpu.backends.rs
+
+import pygfx as gfx
+import numpy as np
+
+# TODO Figure out how to get fastplotlib canvas into Qt application and not just as a docked widget
+
+
+class FastplotlibCanvas(QtWidgets.QWidget):
+    """
+    Fastplotlib canvas class.
+    """
+
+    def __init__(
+            self,
+    ) -> None:
+        super().__init__(None)
+        self._canvas = WgpuCanvas(parent=self)
+        self._renderer = gfx.WgpuRenderer(self._canvas)
+        self._plot = fpl.Plot(
+            canvas=self._canvas,
+            renderer=self._renderer,
+        )
+
+        # create a layout
+        layout = QtWidgets.QHBoxLayout()
+        self.setLayout(layout)
+        # add canvas to Widget
+        layout.addWidget(self._canvas)
+        self._plot.canvas.setFixedSize(400, 400)
+
+        # start rendering process
+        self._plot.canvas.request_draw(self._plot.render)
+
+    def add_layer_visual_mapping(self, napari_layer, fpl_layer):
+        """Maps a napari layer to its corresponding fastplotlib layer.
+        Paremeters
+        ----------
+        napari_layer : napari.layers
+           Any napari layer, the layer type is the same as the vispy layer.
+        fpl_layer : napari._fastplotlib.layers
+           Any fastplotlib layer, the layer type is the same as the napari layer.
+
+        Returns
+        -------
+        None
+        """
+        self.layer_to_visual[napari_layer] = fpl_layer
+
+        self._plot.add_graphic(fpl_layer.image_graphic)
+
+      #  napari_layer.events.visible.connect(self._reorder_layers)
+     #   self.viewer.camera.events.angles.connect(fpl_layer._on_camera_move)
+
+    #    self._reorder_layers()
+
+
+

--- a/napari/_fastplotlib/fpl.py
+++ b/napari/_fastplotlib/fpl.py
@@ -1,7 +1,7 @@
 import imageio.v3 as iio
-import napari
 
-from napari._fastplotlib import FastplotlibImageLayer, FastplotlibCanvas
+import napari
+from napari._fastplotlib import FastplotlibCanvas, FastplotlibImageLayer
 from napari.layers import Image
 
 # create napari viewer

--- a/napari/_fastplotlib/fpl.py
+++ b/napari/_fastplotlib/fpl.py
@@ -1,0 +1,34 @@
+import imageio.v3 as iio
+import napari
+
+from napari._fastplotlib import FastplotlibImageLayer, FastplotlibCanvas
+from napari.layers import Image
+
+# create napari viewer
+viewer = napari.Viewer()
+
+im = iio.imread("imageio:camera.png")
+
+# create napari image
+napari_image = Image(data=im, name="iio camera", colormap="plasma")
+
+# create corresponding fpl image layer
+fpl_image = FastplotlibImageLayer(napari_layer=napari_image)
+
+# create fpl widget
+fpl_canvas = FastplotlibCanvas()
+
+# add widget as dock widget to napari viewer
+viewer.window.add_dock_widget(fpl_canvas)
+
+# add image graphic to plot
+fpl_canvas._plot.add_graphic(fpl_image.image_graphic)
+
+# add napari image to viewer
+viewer.add_layer(napari_image)
+
+# flip camera
+fpl_canvas._plot.camera.world.scale_y *= -1
+
+if __name__ == "__main__":
+    napari.run()

--- a/napari/_fastplotlib/layers/__init__.py
+++ b/napari/_fastplotlib/layers/__init__.py
@@ -1,1 +1,0 @@
-from napari._fastplotlib.layers.image import FastplotlibImageLayer

--- a/napari/_fastplotlib/layers/__init__.py
+++ b/napari/_fastplotlib/layers/__init__.py
@@ -1,0 +1,1 @@
+from napari._fastplotlib.layers.image import FastplotlibImageLayer

--- a/napari/_fastplotlib/layers/image.py
+++ b/napari/_fastplotlib/layers/image.py
@@ -1,0 +1,58 @@
+from fastplotlib import ImageGraphic
+from napari.layers import Image
+
+
+class FastplotlibImageLayer:
+    def __init__(
+            self,
+            napari_layer: Image
+    ) -> None:
+        """Create a fastplotlib ImageGraphic from a napari Image layer
+
+        Parameters
+        ----------
+        napari_layer : napari.layers.Image
+            Image layer to connect to fastplotlib ImageGraphic
+
+        Attributes
+        ----------
+        napari_layer : napari.layers.Image
+            Image layer to connect to fastplotlib ImageGraphic
+        image_graphic : fastplotlib.ImageGraphic
+            ImageGraphic generated from napari Image layer
+        """
+
+        self.napari_layer = napari_layer
+
+        self.image_graphic = None
+
+        self._on_data_change()
+
+        self.napari_layer.events.colormap.connect(self._on_colormap_change)
+        self.napari_layer.events.contrast_limits.connect(self._on_contrast_limits_change)
+
+    def _on_data_change(self):
+        # create image graphic
+        if self.image_graphic is None:
+            self.image_graphic = ImageGraphic(
+                data=self.napari_layer._data_view,
+                name=self.napari_layer.name,
+                cmap=self.napari_layer.colormap.name,
+                vmin=self.napari_layer.contrast_limits[0],
+                vmax=self.napari_layer.contrast_limits[1]
+            )
+        else:
+            if self.napari_layer._data_view.shape == self.image_graphic.data().shape:
+                self.image_graphic.data = self.napari_layer._data_view
+            else:
+                raise ValueError(f"Current data shape: {self.image_graphic.data().shape} does not equal"
+                                 f"new data shape: {self.napari_layer._data_view}. Please ")
+
+    def _on_colormap_change(self):
+        self.image_graphic.cmap = self.napari_layer.colormap.name
+        self.image_graphic.present = False
+        self.image_graphic.present = True
+
+    def _on_contrast_limits_change(self):
+        self.image_graphic.cmap.vmin = self.napari_layer.contrast_limits[0]
+        self.image_graphic.cmap.vmax = self.napari_layer.contrast_limits[1]

--- a/napari/_fastplotlib/layers/image.py
+++ b/napari/_fastplotlib/layers/image.py
@@ -1,12 +1,10 @@
 from fastplotlib import ImageGraphic
+
 from napari.layers import Image
 
 
 class FastplotlibImageLayer:
-    def __init__(
-            self,
-            napari_layer: Image
-    ) -> None:
+    def __init__(self, napari_layer: Image) -> None:
         """Create a fastplotlib ImageGraphic from a napari Image layer
 
         Parameters
@@ -29,7 +27,9 @@ class FastplotlibImageLayer:
         self._on_data_change()
 
         self.napari_layer.events.colormap.connect(self._on_colormap_change)
-        self.napari_layer.events.contrast_limits.connect(self._on_contrast_limits_change)
+        self.napari_layer.events.contrast_limits.connect(
+            self._on_contrast_limits_change
+        )
 
     def _on_data_change(self):
         # create image graphic
@@ -39,14 +39,19 @@ class FastplotlibImageLayer:
                 name=self.napari_layer.name,
                 cmap=self.napari_layer.colormap.name,
                 vmin=self.napari_layer.contrast_limits[0],
-                vmax=self.napari_layer.contrast_limits[1]
+                vmax=self.napari_layer.contrast_limits[1],
             )
         else:
-            if self.napari_layer._data_view.shape == self.image_graphic.data().shape:
+            if (
+                self.napari_layer._data_view.shape
+                == self.image_graphic.data().shape
+            ):
                 self.image_graphic.data = self.napari_layer._data_view
             else:
-                raise ValueError(f"Current data shape: {self.image_graphic.data().shape} does not equal"
-                                 f"new data shape: {self.napari_layer._data_view}. Please ")
+                raise ValueError(
+                    f"Current data shape: {self.image_graphic.data().shape} does not equal"
+                    f"new data shape: {self.napari_layer._data_view}. Please "
+                )
 
     def _on_colormap_change(self):
         self.image_graphic.cmap = self.napari_layer.colormap.name

--- a/napari/_fastplotlib/visual.py
+++ b/napari/_fastplotlib/visual.py
@@ -1,12 +1,5 @@
-from napari.layers import (
-    Image,
-    Layer
-)
-
-from napari._fastplotlib import (
-    FastplotlibImageLayer
-)
-
+from napari._fastplotlib import FastplotlibImageLayer
+from napari.layers import Image, Layer
 from napari.utils.translations import trans
 
 layer_to_visual = {

--- a/napari/_fastplotlib/visual.py
+++ b/napari/_fastplotlib/visual.py
@@ -1,0 +1,36 @@
+from napari.layers import (
+    Image,
+    Layer
+)
+
+from napari._fastplotlib import (
+    FastplotlibImageLayer
+)
+
+from napari.utils.translations import trans
+
+layer_to_visual = {
+    Image: FastplotlibImageLayer,
+}
+
+
+def create_fpl_layer(layer: Layer):
+    """Create fpl visual for a layer based on its layer type.
+
+    Parameters
+    ----------
+    layer : napari.layers._base_layer.Layer
+        Layer that needs its property widget created.
+
+    """
+    for layer_type, visual_class in layer_to_visual.items():
+        if isinstance(layer, layer_type):
+            return visual_class(layer)
+
+    raise TypeError(
+        trans._(
+            'Could not find FastplotlibLayer for layer of type {dtype}',
+            deferred=True,
+            dtype=type(layer),
+        )
+    )


### PR DESCRIPTION
# Description

Progress on adding [fastplotlib](https://github.com/fastplotlib/fastplotlib) as a backend option for `napari`

![fpl-napari](https://github.com/napari/napari/assets/69729525/710410f7-baf1-4ff2-ae84-5f8b6bf9605e)

**Note:** `vispy` (Left), `fastplotlib` (Right)

**Progress:**
- creates a `fastplotlib` canvas and adds a `fastplotlib.ImageGraphic` made from a `napari.Image`
- current functionality links image changes such as colormap and contrast limits from Qt widgets 

**Demo:**

```python
import imageio.v3 as iio
import napari
from napari._fastplotlib import FastplotlibImageLayer, FastplotlibCanvas
from napari.layers import Image

# create napari viewer
viewer = napari.Viewer()

im = iio.imread("imageio:camera.png")

# create napari image
napari_image = Image(data=im, name="iio camera", colormap="plasma")

# create corresponding fpl image layer
fpl_image = FastplotlibImageLayer(napari_layer=napari_image)

# create fpl widget
fpl_canvas = FastplotlibCanvas()

# add widget as dock widget to napari viewer
viewer.window.add_dock_widget(fpl_canvas)

# add image graphic to plot
fpl_canvas._plot.add_graphic(fpl_image.image_graphic)

# add napari image to viewer
viewer.add_layer(napari_image)

# flip camera
fpl_canvas._plot.camera.world.scale_y *= -1

if __name__ == "__main__":
    napari.run()
```

TODO:
- [ ] add more layers (lines, points, etc.)
- [ ] fully connect `napari` events to `fastplotlib` canvas, graphics, etc.
- [ ] replace `vispy` canvas with `fastplotlib` canvas in the viewer 

**Might be most relevant to wait until napari-lite is available so that it is easier to swap in backends**