### PR TITLE
[Maintenance] Don't run GitHub build_docs.yml action on PR

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,9 +1,6 @@
 name: Build PR Docs
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - docs


### PR DESCRIPTION
# Description

This PR removes running the Github CI build_docs action on every PR, because we use Circle CI for that to also get the rendered docs.
This way the GH runner can be used for something else.


