### PR TITLE
Add pystack to debug hanging linux test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -356,3 +356,8 @@ module = [
     'napari.utils.tree.group',
 ]
 ignore_errors = true
+
+
+[tool.pytest.ini_options]
+pystack_threshold=60
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,8 @@ xarray = "xr"
 # These follow standard library warnings filters syntax.  See more here:
 # https://docs.python.org/3/library/warnings.html#describing-warning-filters
 addopts = "--maxfail=5 --durations=10 -rXxs"
+pystack_threshold=60
+
 
 # NOTE: only put things that will never change in here.
 # napari deprecation and future warnings should NOT go in here.
@@ -356,8 +358,3 @@ module = [
     'napari.utils.tree.group',
 ]
 ignore_errors = true
-
-
-[tool.pytest.ini_options]
-pystack_threshold=60
-

--- a/tox.ini
+++ b/tox.ini
@@ -78,6 +78,7 @@ deps =
     pyside6: PySide6 < 6.3.2 ; python_version < '3.10'
     pyside6: PySide6 != 6.4.3, !=6.5.0 ; python_version >= '3.10'
     pytest-json-report
+    pytest-pystack ; sys_platform == 'linux'
 # use extras specified in setup.cfg for certain test envs
 extras =
     testing


### PR DESCRIPTION
# Description

[Pystack](https://github.com/bloomberg/pystack) is bloomberg stack analysis tool for live debugging python process that includes also C stack. 

It has ability to attach to running process and print stactrace. 

The pytest-pystack plugin do this for test. If test is not finished under given period (60 seconds here) it will print trace to show where process is. 

As we have problem oh hanging test I think it may be worth to try this. 

Unfortunately this solution is linux only. 
