### PR TITLE
[Maintenance] Update bug_report template to add napari --info

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ Steps to reproduce the behavior:
 
 ## Environment
 
- - Please copy and paste the information at napari info option in help menubar here:
+**Important**: Please copy and paste the output of `napari --info` or the information provided by the `napari info` option in Help menubar:
 
  - Any other relevant information:
 


### PR DESCRIPTION
# Description
Lately we've been getting more issues that don't provide napari version et al details.
This PR adds `napari --info` to the Environment section of the bug issue template, along with emphasized important.


