### PR TITLE
Hide Toggle Fullscreen for MacOS but add keybinding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,9 +49,9 @@ body:
       label: "\U0001F30E Environment"
       description: |
         Please provide detailed information regarding your environment. Please paste the output of `napari --info` here or copy  the information from the "napari info" dialog in the napari Help menu.
-        
+
         Otherwise, please provide information regarding your operating system (OS), Python version, napari version, Qt backend and version, Qt platform, method of installation, and any other relevant information related to your environment.
-        
+
 
       placeholder: |
         napari: 0.5.0
@@ -69,14 +69,14 @@ body:
         in-n-out: 0.1.8
         app-model: 0.2.0
         npe2: 0.7.2
-        
+
         OpenGL:
         - GL version: 2.1 Metal - 83
         - MAX_TEXTURE_SIZE: 16384
-        
+
         Screens:
         - screen 1: resolution 1512x982, scale 2.0
-        
+
         Settings path:
         - /Users/.../napari/napari_5c6993c40c104085444cfc0c77fa392cb5cb8f56/settings.yaml
     validations:

--- a/napari/_qt/_qapp_model/qactions/_view.py
+++ b/napari/_qt/_qapp_model/qactions/_view.py
@@ -105,7 +105,7 @@ Q_VIEW_ACTIONS: List[Action] = [
     ),
 ]
 
-if sys.platform != 'darwin':
+if sys.platform == 'darwin':
     Q_VIEW_ACTIONS.append(
         Action(
             id=f'{CommandId.TOGGLE_FULLSCREEN}_mac',

--- a/napari/_qt/_qapp_model/qactions/_view.py
+++ b/napari/_qt/_qapp_model/qactions/_view.py
@@ -54,6 +54,7 @@ Q_VIEW_ACTIONS: List[Action] = [
         ],
         callback=Window._toggle_fullscreen,
         keybindings=[StandardKeyBinding.FullScreen],
+        enablement=sys.platform != 'darwin',
         toggled=ToggleRule(get_current=_get_current_fullscreen_status),
     ),
     Action(
@@ -103,3 +104,13 @@ Q_VIEW_ACTIONS: List[Action] = [
         toggled=ToggleRule(get_current=_get_current_activity_dock_status),
     ),
 ]
+
+if sys.platform != 'darwin':
+    Q_VIEW_ACTIONS.append(
+        Action(
+            id=f'{CommandId.TOGGLE_FULLSCREEN}_mac',
+            title=f'{CommandId.TOGGLE_FULLSCREEN.command_title}_mac',
+            callback=Window._toggle_fullscreen,
+            keybindings=[StandardKeyBinding.FullScreen],
+        )
+    )


### PR DESCRIPTION
# References and relevant issues
closes #6240

# Description
Hide the full screen menu item for mac but add action that is not added to any menus so you still have the ` Control-Command-F`  keybinding.

Context:
Apparently the macOS standard keybinding for Full screen post Monterey (macOS 12) was changed to Fn (Globe) F.
We wanted to hide our full screen menu item but have the old keybinding (Control-Command-F) work.




