### PR TITLE
Directly set author of commit in vendored workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,9 +49,9 @@ body:
       label: "\U0001F30E Environment"
       description: |
         Please provide detailed information regarding your environment. Please paste the output of `napari --info` here or copy  the information from the "napari info" dialog in the napari Help menu.
-        
+
         Otherwise, please provide information regarding your operating system (OS), Python version, napari version, Qt backend and version, Qt platform, method of installation, and any other relevant information related to your environment.
-        
+
 
       placeholder: |
         napari: 0.5.0
@@ -69,14 +69,14 @@ body:
         in-n-out: 0.1.8
         app-model: 0.2.0
         npe2: 0.7.2
-        
+
         OpenGL:
         - GL version: 2.1 Metal - 83
         - MAX_TEXTURE_SIZE: 16384
-        
+
         Screens:
         - screen 1: resolution 1512x982, scale 2.0
-        
+
         Settings path:
         - /Users/.../napari/napari_5c6993c40c104085444cfc0c77fa392cb5cb8f56/settings.yaml
     validations:

--- a/.github/workflows/test_vendored.yml
+++ b/.github/workflows/test_vendored.yml
@@ -32,6 +32,7 @@ jobs:
 
             It look like ${{ steps.check_v.outputs.vendored }} has a new version.
           token: ${{ secrets.GHA_TOKEN }}
+          author: napari-bot <napari-bot@users.noreply.github.com>
           # Token permissions required by the action:
           # * pull requests: write and read
           # * repository contents: read and write


### PR DESCRIPTION
# Description

This PR set direct author of a commit in vendored update workflow to avoid assigning random users to commits. 

![obraz](https://github.com/napari/napari/assets/3826210/1e2c496e-dd07-40ff-91f9-bd8e2e84ab0a)



