### PR TITLE
Add 'raise' option back to `strict_qt` in `make_napari_viewer`

### DIFF
--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -210,7 +210,7 @@ def make_napari_viewer(
 
     viewers: WeakSet[Viewer] = WeakSet()
 
-    # may be overridden by using `make_napari_viewer(strict=True)`
+    # may be overridden by using `make_napari_viewer(strict_qt=True)`
     _strict = False
 
     initial = QApplication.topLevelWidgets()
@@ -283,7 +283,7 @@ def make_napari_viewer(
     assert _do_not_inline_below == 0
 
     # only check for leaked widgets if an exception was raised during the test,
-    # or "strict" mode was used.
+    # and "strict" mode was used.
     if _strict and getattr(sys, 'last_value', None) is prior_exception:
         QApplication.processEvents()
         leak = set(QApplication.topLevelWidgets()).difference(initial)

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -210,7 +210,7 @@ def make_napari_viewer(
 
     viewers: WeakSet[Viewer] = WeakSet()
 
-    # may be overridden by using `make_napari_viewer(strict_qt=True)`
+    # may be overridden by using the parameter `strict_qt`
     _strict = False
 
     initial = QApplication.topLevelWidgets()

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -304,7 +304,7 @@ def make_napari_viewer(
             # in particular with VisPyCanvas, it looks like if a traceback keeps
             # contains the type, then instances are still attached to the type.
             # I'm not too sure why this is the case though.
-            if _strict:
+            if _strict == 'raise':
                 raise AssertionError(msg)
             else:
                 warnings.warn(msg)


### PR DESCRIPTION
# References and relevant issues
https://github.com/napari/napari/pull/5373/files#r1356648322

# Description

- Typo fixes
- Add 'raise' option back to `strict_qt` in `make_napari_viewer` - this may have been removed by mistake: https://github.com/napari/napari/pull/5373/files#r1356648322



