### PR TITLE
"no-commit-to-branch" is preventing contribution.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,4 +29,3 @@ repos:
     - id: trailing-whitespace
       exclude: .*\.md|_vendor|vendored
     - id: mixed-line-ending
-    - id: no-commit-to-branch


### PR DESCRIPTION
This is IMHO harmful to contributions. It prevent anyone who just cloned the repository to commit locally.

The error message is non-existant ("failed no-commit-to-branch").

And I don't see why we should prevent anybody to commit locally to their main branch, I do it dozen of time every day, and use `git push origin main:new-name`.

I am aware that working on feature branch is deemed better and all the things it entails, but we do have branch protection rules (or should have), so this brings nothing but annoyance locally.

-- 

See #6315