### PR TITLE
MAINT: Refine Mypy config for qtpy.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,10 @@ disable_error_code = [
   # that in several places, so ignore the error
   'method-assign'
 ]
+# see `$ qtpy mypy-args` and qtpy readme. This will be used by `tox -e mypy`
+# to properly infer with PyQt6 installed
+always_false=['PYSIDE6', 'PYSIDE2', 'PYQT5']
+always_true=['PYQT6']
 
 
 # gloabl ignore error


### PR DESCRIPTION
This should help mypy once we start touching `qtpy` types. Mypy can't infer otherwise because of the conditionals statements in QtPy.

Here I set only PYQT6 to true, as that's what `tox -e mypy` uses.
