### PR TITLE
Disable ptrace protection to make pytest-pystack work

### DIFF
--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -76,6 +76,11 @@ jobs:
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
           if (Test-Path -Path "C:\Windows\system32\opengl32.dll" -PathType Leaf) {Exit 0} else {Exit 1}
 
+      - name: Disable ptrace security restrictions
+        if: runner.os == 'Linux'
+        run: |
+          echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+
       # tox and tox-gh-actions will take care of the "actual" installation
       # of python dependendencies into a virtualenv.  see tox.ini for more
       - name: Install dependencies


### PR DESCRIPTION
# Description

We add `pytest-pystack` in #6310 but do not fully check example so it ends with:

```
  The specified process cannot be traced. This could be because the tracer
  has insufficient privileges (the required capability is CAP_SYS_PTRACE).
  Unprivileged processes cannot trace processes that they cannot send signals
  to or those running set-user-ID/set-group-ID programs, for security reasons.
  Alternatively, the process may already be being traced.
  
  If your uid matches the uid of the target process you want to analyze, you
  can do one of the following to get 'ptrace' scope permissions:
  
  * If you are running inside a Docker container, you need to make sure you
    start the container using the '--cap-add=SYS_PTRACE' or '--privileged'
    command line arguments. Notice that this may not be enough if you are not
    running as 'root' inside the Docker container as you may need to disable
    hardening (see next points).
  
  * Try running again with elevated permissions by running 'sudo -E !!'.
  
  * You can disable kernel hardening for the current session temporarily (until
    a reboot happens) by running 'echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope'.
```

https://github.com/napari/napari/actions/runs/6477123186/job/17587080688?pr=6331#step:11:149

So I added a missed line to the workflow. 

https://github.com/bloomberg/pytest-pystack/issues/2
