### PR TITLE
Fix labeler configuration

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,3 +13,5 @@ jobs:
     - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        # sync-labels need to be removed when upgrade to v5 of labeler
+        sync-labels: ''


### PR DESCRIPTION
# Description

In PR #6328 I have added an automatic maintenance label when something is edited pre-commit. But I wrongly understand actions/lableler documentation and thought that the bug was fixed, that is true, but it is fixed in v5 branch, not backported to v4. 

v5 has been from a long time (since May) in the release process.

https://github.com/actions/labeler/issues/112
