### PR TITLE
Add codecov token to reduce propability of fail to upload from main branch

### DIFF
--- a/.github/workflows/reusable_coverage_upload.yml
+++ b/.github/workflows/reusable_coverage_upload.yml
@@ -38,3 +38,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
# Description

in general, the token is not required to upload coverage from main branch, but after checking some issues in codecov, like: https://github.com/codecov/feedback/issues/126, it looks like it is better to provide a token (it will not help with pull requests). 