### PR TITLE
Fix upstream deprecation: change `np.alltrue` to `np.array_equiv`

### DIFF
--- a/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
+++ b/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
@@ -74,7 +74,7 @@ def test_labels_drawing_with_polygons(MouseEvent, make_napari_viewer):
         )
         mouse_press_callbacks(layer, event)
 
-    assert np.alltrue(data[0, :] == 0)
+    assert np.all(data[0, :] == 0)
 
     # Draw a rectangle (the latest two points will be cancelled)
     points = [
@@ -115,12 +115,12 @@ def test_labels_drawing_with_polygons(MouseEvent, make_napari_viewer):
     # Finish drawing
     complete_polygon(layer)
 
-    assert np.alltrue(data[[0, 2], :] == 0)
-    assert np.alltrue(data[1, 1:11, 1:11] == 1)
-    assert np.alltrue(data[1, 0, :] == 0)
-    assert np.alltrue(data[1, :, 0] == 0)
-    assert np.alltrue(data[1, 11:, :] == 0)
-    assert np.alltrue(data[1, :, 11:] == 0)
+    assert np.all(data[[0, 2], :] == 0)
+    assert np.all(data[1, 1:11, 1:11] == 1)
+    assert np.all(data[1, 0, :] == 0)
+    assert np.all(data[1, :, 0] == 0)
+    assert np.all(data[1, 11:, :] == 0)
+    assert np.all(data[1, :, 11:] == 0)
 
     # Try to finish with an incomplete polygon
     for position in [(0, 1, 1)]:
@@ -134,4 +134,4 @@ def test_labels_drawing_with_polygons(MouseEvent, make_napari_viewer):
 
     # Finish drawing
     complete_polygon(layer)
-    assert np.alltrue(data[0, :] == 0)
+    assert np.all(data[0, :] == 0)

--- a/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
+++ b/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
@@ -115,12 +115,12 @@ def test_labels_drawing_with_polygons(MouseEvent, make_napari_viewer):
     # Finish drawing
     complete_polygon(layer)
 
-    assert np.array_equiv(data[[0, 2], :] == 0)
-    assert np.array_equiv(data[1, 1:11, 1:11] == 1)
-    assert np.array_equiv(data[1, 0, :] == 0)
-    assert np.array_equiv(data[1, :, 0] == 0)
-    assert np.array_equiv(data[1, 11:, :] == 0)
-    assert np.array_equiv(data[1, :, 11:] == 0)
+    assert np.array_equiv(data[[0, 2], :], 0)
+    assert np.array_equiv(data[1, 1:11, 1:11], 1)
+    assert np.array_equiv(data[1, 0, :], 0)
+    assert np.array_equiv(data[1, :, 0], 0)
+    assert np.array_equiv(data[1, 11:, :], 0)
+    assert np.array_equiv(data[1, :, 11:], 0)
 
     # Try to finish with an incomplete polygon
     for position in [(0, 1, 1)]:

--- a/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
+++ b/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
@@ -74,7 +74,7 @@ def test_labels_drawing_with_polygons(MouseEvent, make_napari_viewer):
         )
         mouse_press_callbacks(layer, event)
 
-    assert np.all(data[0, :] == 0)
+    assert np.array_equiv(data[0, :], 0)
 
     # Draw a rectangle (the latest two points will be cancelled)
     points = [
@@ -115,12 +115,12 @@ def test_labels_drawing_with_polygons(MouseEvent, make_napari_viewer):
     # Finish drawing
     complete_polygon(layer)
 
-    assert np.all(data[[0, 2], :] == 0)
-    assert np.all(data[1, 1:11, 1:11] == 1)
-    assert np.all(data[1, 0, :] == 0)
-    assert np.all(data[1, :, 0] == 0)
-    assert np.all(data[1, 11:, :] == 0)
-    assert np.all(data[1, :, 11:] == 0)
+    assert np.array_equiv(data[[0, 2], :] == 0)
+    assert np.array_equiv(data[1, 1:11, 1:11] == 1)
+    assert np.array_equiv(data[1, 0, :] == 0)
+    assert np.array_equiv(data[1, :, 0] == 0)
+    assert np.array_equiv(data[1, 11:, :] == 0)
+    assert np.array_equiv(data[1, :, 11:] == 0)
 
     # Try to finish with an incomplete polygon
     for position in [(0, 1, 1)]:
@@ -134,4 +134,4 @@ def test_labels_drawing_with_polygons(MouseEvent, make_napari_viewer):
 
     # Finish drawing
     complete_polygon(layer)
-    assert np.all(data[0, :] == 0)
+    assert np.array_equiv(data[0, :], 0)

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -628,7 +628,7 @@ def test_contour_local_updates():
 
     layer.data_setitem(np.nonzero(painting_mask), 1, refresh=True)
 
-    assert np.alltrue(
+    assert np.all(
         (layer._slice.image.view > 0) == get_contours(painting_mask, 1, 0)
     )
 
@@ -802,13 +802,13 @@ def test_paint_polygon():
     layer = Labels(data)
 
     layer.paint_polygon([[0, 0], [0, 5], [5, 5], [5, 0]], 2)
-    assert np.alltrue(layer.data[:5, :5] == 2)
-    assert np.alltrue(layer.data[:10, 6:10] == 1)
-    assert np.alltrue(layer.data[6:10, :10] == 1)
+    assert np.all(layer.data[:5, :5] == 2)
+    assert np.all(layer.data[:10, 6:10] == 1)
+    assert np.all(layer.data[6:10, :10] == 1)
 
     layer.paint_polygon([[7, 7], [7, 7], [7, 7]], 3)
     assert layer.data[7, 7] == 3
-    assert np.alltrue(layer.data[[6, 7, 8, 7, 8, 6], [7, 6, 7, 8, 8, 6]] == 1)
+    assert np.all(layer.data[[6, 7, 8, 7, 8, 6], [7, 6, 7, 8, 8, 6]] == 1)
 
     data[:10, :10] = 0
     gt_pattern = np.array(
@@ -849,8 +849,8 @@ def test_paint_polygon_2d_in_3d():
 
     layer.paint_polygon([[1, 0, 0], [1, 0, 9], [1, 9, 9], [1, 9, 0]], 1)
 
-    assert np.alltrue(data[1, :] == 1)
-    assert np.alltrue(data[[0, 2], :] == 0)
+    assert np.all(data[1, :] == 1)
+    assert np.all(data[[0, 2], :] == 0)
 
 
 def test_fill():

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -628,8 +628,8 @@ def test_contour_local_updates():
 
     layer.data_setitem(np.nonzero(painting_mask), 1, refresh=True)
 
-    assert np.all(
-        (layer._slice.image.view > 0) == get_contours(painting_mask, 1, 0)
+    assert np.array_equiv(
+        (layer._slice.image.view > 0), get_contours(painting_mask, 1, 0)
     )
 
 
@@ -802,13 +802,15 @@ def test_paint_polygon():
     layer = Labels(data)
 
     layer.paint_polygon([[0, 0], [0, 5], [5, 5], [5, 0]], 2)
-    assert np.all(layer.data[:5, :5] == 2)
-    assert np.all(layer.data[:10, 6:10] == 1)
-    assert np.all(layer.data[6:10, :10] == 1)
+    assert np.array_equiv(layer.data[:5, :5], 2)
+    assert np.array_equiv(layer.data[:10, 6:10], 1)
+    assert np.array_equiv(layer.data[6:10, :10], 1)
 
     layer.paint_polygon([[7, 7], [7, 7], [7, 7]], 3)
     assert layer.data[7, 7] == 3
-    assert np.all(layer.data[[6, 7, 8, 7, 8, 6], [7, 6, 7, 8, 8, 6]] == 1)
+    assert np.array_equiv(
+        layer.data[[6, 7, 8, 7, 8, 6], [7, 6, 7, 8, 8, 6]], 1
+    )
 
     data[:10, :10] = 0
     gt_pattern = np.array(
@@ -849,8 +851,8 @@ def test_paint_polygon_2d_in_3d():
 
     layer.paint_polygon([[1, 0, 0], [1, 0, 9], [1, 9, 9], [1, 9, 0]], 1)
 
-    assert np.all(data[1, :] == 1)
-    assert np.all(data[[0, 2], :] == 0)
+    assert np.array_equiv(data[1, :], 1)
+    assert np.array_equiv(data[[0, 2], :], 0)
 
 
 def test_fill():


### PR DESCRIPTION
Resolve deprecations warnings as of numpy 1.25:

```
napari/layers/labels/_tests/test_labels.py: 7 warnings
napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py: 8 warnings
  .../site-packages/_pytest/python.py:194: DeprecationWarning: `alltrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `all` instead.
    result = testfunction(**testargs)
```