### PR TITLE
Maint: mypy opt-in to opt-out.

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -280,22 +280,22 @@ def _run() -> None:
             npe2_plugins = []
             for plugin in args.with_:
                 pname, *wnames = plugin
-                for _name, (_pname, _wnames) in _npe2.widget_iterator():
-                    if _name == 'dock' and pname == _pname:
+                for name, (w_pname, wnames) in _npe2.widget_iterator():
+                    if name == 'dock' and pname == w_pname:
                         npe2_plugins.append(plugin)
                         if '__all__' in wnames:
-                            wnames = _wnames
+                            wnames = wnames
                         break
 
-                for _name2, (
-                    _pname,
-                    _wnames_dict,
+                for name2, (
+                    w_pname,
+                    wnames_dict,
                 ) in plugin_manager.iter_widgets():
-                    if _name2 == 'dock' and pname == _pname:
+                    if name2 == 'dock' and pname == w_pname:
                         plugin_manager_plugins.append(plugin)
                         if '__all__' in wnames:
                             # Plugin_manager iter_widgets return wnames as dict keys
-                            wnames = list(_wnames_dict)
+                            wnames = list(wnames_dict)
                         print(
                             trans._(
                                 'Non-npe2 plugin {pname} detected. Disable tabify for this plugin.',

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -357,15 +357,15 @@ def _run() -> None:
             ):
                 pname, *wnames = plugin
                 if '__all__' in wnames:
-                    for name, (_pname, _wnames_collection) in chain(
+                    for name, (_pname, wnames_collection) in chain(
                         _npe2.widget_iterator(), plugin_manager.iter_widgets()
                     ):
                         if name == 'dock' and pname == _pname:
-                            if isinstance(_wnames_collection, dict):
+                            if isinstance(wnames_collection, dict):
                                 # Plugin_manager iter_widgets return wnames as dict keys
-                                wnames = list(_wnames_collection.keys())
+                                wnames = list(wnames_collection.keys())
                             else:
-                                wnames = _wnames_collection
+                                wnames = wnames_collection
                             break
 
                 if wnames:

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -209,7 +209,7 @@ def parse_sys_argv():
     return args, kwargs
 
 
-def _run():
+def _run() -> None:
     from napari import Viewer, run
     from napari.settings import get_settings
 
@@ -287,12 +287,15 @@ def _run():
                             wnames = _wnames
                         break
 
-                for _name, (_pname, _wnames) in plugin_manager.iter_widgets():
-                    if _name == 'dock' and pname == _pname:
+                for _name2, (
+                    _pname,
+                    _wnames_dict,
+                ) in plugin_manager.iter_widgets():
+                    if _name2 == 'dock' and pname == _pname:
                         plugin_manager_plugins.append(plugin)
                         if '__all__' in wnames:
                             # Plugin_manager iter_widgets return wnames as dict keys
-                            wnames = list(_wnames.keys())
+                            wnames = list(_wnames_dict.keys())
                         print(
                             trans._(
                                 'Non-npe2 plugin {pname} detected. Disable tabify for this plugin.',
@@ -354,15 +357,15 @@ def _run():
             ):
                 pname, *wnames = plugin
                 if '__all__' in wnames:
-                    for name, (_pname, _wnames) in chain(
+                    for name, (_pname, _wnames_collection) in chain(
                         _npe2.widget_iterator(), plugin_manager.iter_widgets()
                     ):
                         if name == 'dock' and pname == _pname:
-                            if isinstance(_wnames, dict):
+                            if isinstance(_wnames_collection, dict):
                                 # Plugin_manager iter_widgets return wnames as dict keys
-                                wnames = list(_wnames.keys())
+                                wnames = list(_wnames_collection.keys())
                             else:
-                                wnames = _wnames
+                                wnames = _wnames_collection
                             break
 
                 if wnames:

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -295,7 +295,7 @@ def _run() -> None:
                         plugin_manager_plugins.append(plugin)
                         if '__all__' in wnames:
                             # Plugin_manager iter_widgets return wnames as dict keys
-                            wnames = list(_wnames_dict.keys())
+                            wnames = list(_wnames_dict)
                         print(
                             trans._(
                                 'Non-npe2 plugin {pname} detected. Disable tabify for this plugin.',

--- a/napari/_vispy/layers/base.py
+++ b/napari/_vispy/layers/base.py
@@ -2,11 +2,16 @@ from abc import ABC, abstractmethod
 from typing import Dict, Generic, TypeVar
 
 import numpy as np
+from vispy.scene import VisualNode
 from vispy.visuals.transforms import MatrixTransform
 
 from napari._vispy.overlays.base import VispyBaseOverlay
 from napari._vispy.utils.gl import BLENDING_MODES, get_max_texture_sizes
-from napari.components.overlays.base import CanvasOverlay, SceneOverlay
+from napari.components.overlays.base import (
+    CanvasOverlay,
+    Overlay,
+    SceneOverlay,
+)
 from napari.layers import Layer
 from napari.utils.events import disconnect_events
 
@@ -48,8 +53,9 @@ class VispyBaseLayer(ABC, Generic[_L]):
     """
 
     layer: _L
+    overlays: Dict[Overlay, VispyBaseOverlay]
 
-    def __init__(self, layer: _L, node) -> None:
+    def __init__(self, layer: _L, node: VisualNode) -> None:
         super().__init__()
         self.events = None  # Some derived classes have events.
 
@@ -57,7 +63,7 @@ class VispyBaseLayer(ABC, Generic[_L]):
         self._array_like = False
         self.node = node
         self.first_visible = False
-        self.overlays: Dict[str, VispyBaseOverlay] = {}
+        self.overlays = {}
 
         (
             self.MAX_TEXTURE_SIZE_2D,
@@ -131,7 +137,7 @@ class VispyBaseLayer(ABC, Generic[_L]):
 
     def _on_blending_change(self, event=None):
         blending = self.layer.blending
-        blending_kwargs = BLENDING_MODES[blending].copy()
+        blending_kwargs = BLENDING_MODES[blending].copy()  # type: ignore [attr-defined]
 
         if self.first_visible:
             # if the first layer, then we should blend differently
@@ -193,7 +199,8 @@ class VispyBaseLayer(ABC, Generic[_L]):
                 overlay_visual.close()
 
     def _on_matrix_change(self):
-        transform = self.layer._transforms.simplified.set_slice(
+        # mypy: self.layer._transforms.simplified cannot be None
+        transform = self.layer._transforms.simplified.set_slice(  # type: ignore [union-attr]
             self.layer._slice_input.displayed
         )
         # convert NumPy axis ordering to VisPy axis ordering

--- a/napari/_vispy/layers/base.py
+++ b/napari/_vispy/layers/base.py
@@ -137,7 +137,7 @@ class VispyBaseLayer(ABC, Generic[_L]):
 
     def _on_blending_change(self, event=None):
         blending = self.layer.blending
-        blending_kwargs = BLENDING_MODES[blending].copy()  # type: ignore [attr-defined]
+        blending_kwargs = cast(dict, BLENDING_MODES[blending]).copy()
 
         if self.first_visible:
             # if the first layer, then we should blend differently

--- a/napari/_vispy/layers/base.py
+++ b/napari/_vispy/layers/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Generic, TypeVar
+from typing import Dict, Generic, TypeVar, cast
 
 import numpy as np
 from vispy.scene import VisualNode

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -289,7 +289,7 @@ class VispyImageLayer(VispyBaseLayer[_ImageBase]):
 
             # tile2data is a ScaleTransform thus is has a .scale attribute, but
             # mypy cannot know this.
-            self.layer._transforms['tile2data'].scale = scale  # type: ignore [attr-defined]
+            self.layer._transforms['tile2data'].scale = scale
 
             self._on_matrix_change()
             slices = tuple(slice(None, None, ds) for ds in downsample)

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -156,4 +156,4 @@ def complete_polygon(layer: Labels):
     # Because layer._overlays has type Overlay, mypy doesn't know that
     # ._overlays["polygon"] has type LabelsPolygonOverlay, so type ignore for now
     # TODO: Improve typing of layer._overlays to fix this
-    layer._overlays["polygon"].add_polygon_to_labels(layer)  # type: ignore[attr-defined]
+    layer._overlays["polygon"].add_polygon_to_labels(layer)

--- a/napari/utils/events/containers/_set.py
+++ b/napari/utils/events/containers/_set.py
@@ -187,7 +187,7 @@ class EventedSet(MutableSet[_T]):
         if errors:
             from napari._pydantic_compat import ValidationError
 
-            raise ValidationError(errors, cls)  # type: ignore
+            raise ValidationError(errors, cls)
         return cls(v)
 
     def _json_encode(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,12 @@ plugins =  "numpy.typing.mypy_plugin, pydantic.mypy"
 ignore_missing_imports = true
 show_error_codes = true
 warn_redundant_casts = true
+disallow_incomplete_defs = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+warn_unused_ignores = true
+check_untyped_defs = true
+no_implicit_optional = true
 disable_error_code = [
   # See discussion at https://github.com/python/mypy/issues/2427;
   # mypy cannot run type checking on method assignment, but we use
@@ -203,6 +209,12 @@ disable_error_code = [
 # to properly infer with PyQt6 installed
 always_false=['PYSIDE6', 'PYSIDE2', 'PYQT5']
 always_true=['PYQT6']
+
+# maybe someday :)
+# disallow_any_generics = true
+# no_implicit_reexport = true
+# warn_unreachable = true
+# strict_equality = true
 
 
 # gloabl ignore error
@@ -217,21 +229,6 @@ module = [
 ignore_errors = true
 
 
-[[tool.mypy.overrides]]
-module = [
-  'napari.plugins.*',
-  'napari.settings.*',
-  'napari.types.*',
-]
-ignore_errors = false
-no_implicit_optional = true
-warn_unused_ignores = true
-check_untyped_defs = true
-
-# # maybe someday :)
-# disallow_any_generics = true
-# no_implicit_reexport = true
-# disallow_untyped_defs = true
 
 
 # individual ignore error
@@ -360,3 +357,250 @@ module = [
     'napari.utils.tree.group',
 ]
 ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = [
+    "napari.settings",
+    "napari.settings._yaml",
+    "napari.plugins.exceptions",
+    "napari._app_model.actions._toggle_action",
+    "napari._vispy.filters.tracks",
+    "napari._vispy.utils.text",
+    "napari._vispy.utils.visual",
+    "napari._vispy.visuals.clipping_planes_mixin",
+    "napari._vispy.visuals.markers",
+    "napari._vispy.visuals.surface",
+    "napari.layers._data_protocols",
+    "napari.layers._source",
+    "napari.layers.image._image_mouse_bindings",
+    "napari.layers.shapes._shapes_models.path",
+    "napari.layers.shapes._shapes_models.polygon",
+    "napari.layers.utils.interactivity_utils",
+    "napari.layers.vectors._vector_utils",
+    "napari.resources._icons",
+    "napari.utils._dask_utils",
+    "napari.utils.color",
+    "napari.utils.events.containers._dict",
+    "napari.utils.events.event_utils",
+    "napari.utils.migrations",
+    "napari.utils.perf._patcher",
+    "napari.utils.validators",
+    "napari.window"
+]
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = [
+    "napari.settings._utils",
+    "napari.settings._appearance",
+    "napari.settings._shortcuts",
+    "napari.settings._application",
+    "napari._app_model.actions._view_actions",
+    "napari._event_loop",
+    "napari._vispy.utils.quaternion",
+    "napari._vispy.visuals.bounding_box",
+    "napari._vispy.visuals.image",
+    "napari._vispy.visuals.interaction_box",
+    "napari._vispy.visuals.points",
+    "napari._vispy.visuals.scale_bar",
+    "napari.components._layer_slicer",
+    "napari.components._viewer_mouse_bindings",
+    "napari.components.overlays.base",
+    "napari.components.overlays.interaction_box",
+    "napari.layers.base._base_constants",
+    "napari.layers.image._image_constants",
+    "napari.utils.colormaps.categorical_colormap_utils",
+    "napari.utils.colormaps.colorbars",
+    "napari.utils.config",
+    "napari.utils.history",
+    "napari.utils.indexing",
+    "napari.utils.perf._event",
+    "napari.utils.perf._trace_file"
+]
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = [
+    "napari.settings._fields",
+    "napari.settings._migrations",
+    "napari.settings._base",
+    "napari.types",
+    "napari.plugins._npe2",
+    "napari.settings._napari_settings",
+    "napari.plugins._plugin_manager",
+    "napari.plugins.utils",
+    "napari._qt._qapp_model.qactions._file",
+    "napari._qt._qapp_model.qactions._help",
+    "napari._qt._qapp_model.qactions._view",
+    "napari._vispy.camera",
+    "napari._vispy.layers.image",
+    "napari._vispy.layers.tracks",
+    "napari._vispy.layers.vectors",
+    "napari._vispy.overlays.axes",
+    "napari._vispy.overlays.interaction_box",
+    "napari._vispy.overlays.labels_polygon",
+    "napari._vispy.overlays.scale_bar",
+    "napari._vispy.overlays.text",
+    "napari.layers.image._image_key_bindings",
+    "napari.layers.labels._labels_key_bindings",
+    "napari.layers.shapes._mesh",
+    "napari.layers.surface._surface_key_bindings",
+    "napari.layers.tracks._tracks_key_bindings",
+    "napari.layers.utils._slice_input",
+    "napari.layers.vectors._vectors_key_bindings",
+    "napari.utils._register",
+    "napari.utils.colormaps.categorical_colormap",
+    "napari.utils.colormaps.standardize_color",
+    "napari.utils.events.containers._set",
+    "napari.utils.geometry",
+    "napari.utils.io",
+    "napari.utils.notebook_display",
+    "napari.utils.perf._config",
+    "napari.utils.transforms.transform_utils",
+    "napari.utils.translations",
+    "napari.utils.tree.node",
+    "napari.viewer"
+]
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = [
+    "napari.plugins",
+    "napari._vispy.visuals.axes",
+    "napari.layers.image._slice",
+    "napari.layers.labels._labels_mouse_bindings",
+    "napari.layers.utils.color_manager_utils",
+    "napari.layers.vectors._slice",
+    "napari.utils.colormaps.vendored._cm",
+    "napari.utils.colormaps.vendored.cm",
+    "napari.utils.status_messages"
+]
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = [
+    "napari._app_model._app",
+    "napari.utils.events.containers._selection"
+]
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+warn_unused_ignores = false
+
+[[tool.mypy.overrides]]
+module = [
+    "napari._app_model.context._context",
+    "napari._qt.containers._factory"
+]
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+warn_unused_ignores = false
+
+[[tool.mypy.overrides]]
+module = [
+    "napari._qt.menus.plugins_menu",
+    "napari._vispy.layers.labels",
+    "napari._vispy.layers.points",
+    "napari._vispy.layers.shapes",
+    "napari._vispy.layers.surface",
+    "napari.components._viewer_key_bindings",
+    "napari.layers.image.image",
+    "napari.layers.labels.labels",
+    "napari.layers.surface.surface",
+    "napari.layers.tracks.tracks",
+    "napari.layers.utils.layer_utils",
+    "napari.layers.vectors.vectors",
+    "napari.utils._dtype",
+    "napari.utils._proxies",
+    "napari.utils.colormaps.colormap_utils",
+    "napari.utils.misc",
+    "napari.utils.perf._timers"
+]
+check_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = [
+    "napari.components.camera",
+    "napari.components.dims",
+    "napari.conftest",
+    "napari.layers.image._image_utils",
+    "napari.layers.labels._labels_utils",
+    "napari.layers.points._points_mouse_bindings",
+    "napari.layers.shapes._shapes_models._polgyon_base",
+    "napari.layers.shapes._shapes_models.ellipse",
+    "napari.layers.shapes._shapes_models.line",
+    "napari.layers.shapes._shapes_models.rectangle",
+    "napari.layers.shapes._shapes_models.shape",
+    "napari.layers.tracks._track_utils",
+    "napari.utils.colormaps.colormap",
+    "napari.utils.events.containers._selectable_list",
+    "napari.utils.notifications",
+    "napari.view_layers"
+]
+check_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = [
+    "napari.utils.events.containers._typed"
+]
+check_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+warn_unused_ignores = false
+
+[[tool.mypy.overrides]]
+module = [
+    "napari.__main__",
+    "napari.utils.colormaps.vendored.colors"
+]
+check_untyped_defs = false
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = [
+    "napari._app_model.context._layerlist_context",
+    "napari.components.overlays.labels_polygon",
+    "napari.plugins.io",
+    "napari.utils.colormaps.vendored._cm_listed"
+]
+disallow_untyped_calls = false
+
+[[tool.mypy.overrides]]
+module = [
+    "napari._qt.containers.qt_layer_list"
+]
+check_untyped_defs = false
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+warn_unused_ignores = false
+
+[[tool.mypy.overrides]]
+module = [
+    "napari._vispy.overlays.bounding_box",
+    "napari._vispy.overlays.brush_circle",
+    "napari._vispy.utils.gl",
+    "napari.layers.base._base_mouse_bindings",
+    "napari.layers.utils.plane",
+    "napari.utils._test_utils",
+    "napari.utils.info",
+    "napari.utils.naming"
+]
+check_untyped_defs = false
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = [
+    "napari._qt._qapp_model._menus"
+]
+warn_unused_ignores = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -550,7 +550,8 @@ disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = [
-    "napari.utils.events.containers._typed"
+    "napari.utils.events.containers._typed",
+    "napari.layers.base.base",
 ]
 check_untyped_defs = false
 disallow_incomplete_defs = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -356,6 +356,7 @@ module = [
     'napari.utils.transforms.transforms',
     'napari.utils.tree.group',
     'napari.view_layers',
+    'napari._app_model.injection._processors',
 ]
 ignore_errors = true
 
@@ -417,7 +418,7 @@ module = [
     "napari.utils.history",
     "napari.utils.indexing",
     "napari.utils.perf._event",
-    "napari.utils.perf._trace_file"
+    "napari.utils.perf._trace_file",
 ]
 disallow_untyped_defs = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -476,7 +476,7 @@ module = [
     "napari.layers.vectors._slice",
     "napari.utils.colormaps.vendored._cm",
     "napari.utils.colormaps.vendored.cm",
-    "napari.utils.status_messages"
+    "napari.utils.status_messages",
 ]
 disallow_untyped_calls = false
 disallow_untyped_defs = false
@@ -484,7 +484,8 @@ disallow_untyped_defs = false
 [[tool.mypy.overrides]]
 module = [
     "napari._app_model._app",
-    "napari.utils.events.containers._selection"
+    "napari.utils.events.containers._selection",
+    "napari.utils.theme",
 ]
 disallow_incomplete_defs = false
 disallow_untyped_calls = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -355,6 +355,7 @@ module = [
     'napari.utils.stubgen',
     'napari.utils.transforms.transforms',
     'napari.utils.tree.group',
+    'napari.view_layers',
 ]
 ignore_errors = true
 
@@ -469,6 +470,7 @@ disallow_untyped_defs = false
 [[tool.mypy.overrides]]
 module = [
     "napari.plugins",
+    "napari._vispy.layers.base",
     "napari._vispy.visuals.axes",
     "napari.layers.image._slice",
     "napari.layers.labels._labels_mouse_bindings",
@@ -543,7 +545,6 @@ module = [
     "napari.utils.colormaps.colormap",
     "napari.utils.events.containers._selectable_list",
     "napari.utils.notifications",
-    "napari.view_layers"
 ]
 check_untyped_defs = false
 disallow_incomplete_defs = false


### PR DESCRIPTION
A number of "stricter" mypy option were opt-in, I swapped the logic and
explicitly opted-out for a few of the relevant errors in the corresponding
files.

The files are grouped together based on the flags that I had to enable.
This is relevant as or example enabling a specific ignore in a file may
effect other ones (typically enabling a flag may have false positive for
warn_unused_ignores).

This should make introducing new files with error more difficult,
as well as picking one file from those list, removing it, running mypy
and fixing the corresponding errors. And add a few other checks.

This include a few fixes as well.
