### PR TITLE
Update example scripts (magicgui with threads)

### DIFF
--- a/examples/mgui_with_threadpoolexec_.py
+++ b/examples/mgui_with_threadpoolexec_.py
@@ -55,6 +55,7 @@ def make_widget(
             "size": blobs[:, -1],
             "edge_color": "red",
             "edge_width": 2,
+            "edge_width_is_relative": False,
             "face_color": "transparent",
         }
         return (data, kwargs, 'points')

--- a/examples/mgui_with_threadworker_.py
+++ b/examples/mgui_with_threadworker_.py
@@ -38,6 +38,7 @@ def make_widget(
             "size": blobs[:, -1],
             "edge_color": "red",
             "edge_width": 2,
+            "edge_width_is_relative": False,
             "face_color": "transparent",
         }
         # return a "LayerDataTuple"


### PR DESCRIPTION
# Description
Bug fix PR.
Affects:
* `examples/mgui_with_threadworker_.py`
* `examples/mgui_with_threadpoolexec_.py`

## Problem
Error encountered when you click "Run" on the example dock widget, and it tries to display the computation results in napari as a points layer.
```
ValueError: edge_width_is_relative can only be enabled if edge_width is between 0 and 1
```

## Solution
Points parameter "edge_width_is_relative" must be False, if "edge_width" value is NOT between 0 and 1. Otherwise, we get an error.

## Details
This doesn't fix all the problems with these scripts. I will open separate issues to discuss, but I notice: 
1. `examples/mgui_with_threadworker_.py` has the progress bar already running when you start the script, NOT from when you click "Run" on the dock widget. 
2. `examples/mgui_with_threadpoolexec_.py` now produces an `NSException`, after I fixed the first problem with the points `edge_width_is_relative` parameter.
```
libc++abi: terminating due to uncaught exception of type NSException
zsh: abort      python examples/mgui_with_threadpoolexec_.py
```