### PR TITLE
Fix make release workflow

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     permissions:
       contents: write
+      id-token: write
     name: Create Release
     runs-on: ubuntu-latest
     if: github.repository == 'napari/napari'
@@ -19,7 +20,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
           cache-dependency-path: setup.cfg
       - name: Install Dependencies
         run: |
@@ -56,6 +57,3 @@ jobs:
             dist/*
       - name: Publish PyPI Package
         uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -56,4 +56,4 @@ jobs:
           files: |
             dist/*
       - name: Publish PyPI Package
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -8,6 +8,8 @@ name: Create Release
 
 jobs:
   build:
+    permissions:
+      contents: write
     name: Create Release
     runs-on: ubuntu-latest
     if: github.repository == 'napari/napari'
@@ -41,27 +43,17 @@ jobs:
           fi
           echo "tag=${TAG}" >> $GITHUB_ENV
           # https://help.github.com/en/actions/reference/workflow-commands-for-github-actions
-          echo "::set-output name=contents::$RELEASE_NOTES"
+          echo "name=contents=${RELEASE_NOTES}" >> $GITHUB_ENV
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        uses: "softprops/action-gh-release@v1"
         with:
           tag_name: ${{ github.ref }}
-          release_name: ${{ env.tag }}
+          name: ${{ env.tag }}
           body: ${{ steps.release_notes.outputs.contents }}
           draft: false
           prerelease: ${{ contains(github.ref, 'rc') }}
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./dist/napari-${{ env.tag }}.tar.gz
-          asset_name: napari-${{ env.tag }}.tar.gz
-          asset_content_type: application/gzip
+          files: |
+            dist/*
       - name: Publish PyPI Package
         uses: pypa/gh-action-pypi-publish@master
         with:


### PR DESCRIPTION
# Description

As https://github.com/actions/create-release is archived and no longer working there is a need to fix it. This change is already implemented on 0.4.19 branch. 

closes #6388


