### PR TITLE
Update examples/clipboard_.py to fix FutureWarning

### DIFF
--- a/examples/clipboard_.py
+++ b/examples/clipboard_.py
@@ -34,8 +34,8 @@ def create_grabber_widget():
     widget = Grabber()
 
     # connect buttons
-    widget.copy_canvas_btn.clicked.connect(lambda: viewer.window.qt_viewer.clipboard())
-    widget.copy_viewer_btn.clicked.connect(lambda: viewer.window.clipboard())
+    widget.copy_canvas_btn.clicked.connect(lambda: viewer.window.clipboard(canvas_only=True))
+    widget.copy_viewer_btn.clicked.connect(lambda: viewer.window.clipboard(canvas_only=False))
     return widget
 
 


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/6364

# Description
This turns out to be a pretty simple fix. 

I've updated the example script to no longer access the clipboard via `viewer.window.qt_viewer.clipboard` (which we plan to deprecate). Instead we now use `viewer.window.clipboard` directly (which is part of the external API).

Related:
* https://github.com/napari/napari/pull/3765
* https://github.com/napari/napari/pull/6283
