### PR TITLE
fix `TransformChain.__getitem__` signature

### DIFF
--- a/napari/utils/events/containers/_typed.py
+++ b/napari/utils/events/containers/_typed.py
@@ -208,13 +208,13 @@ class TypedMutableSequence(MutableSequence[_T]):
 
         Parameters
         ----------
-        value: Any
+        value : Any
             A value to lookup.  If `type(value)` is in the lookups functions
             provided for this class, then values in the list will be searched
             using the corresponding lookup converter function.
-        start: int, optional
+        start : int, optional
             The starting index to search, by default 0
-        stop: int, optional
+        stop : int, optional
             The ending index to search, by default None
 
         Returns

--- a/napari/utils/events/containers/_typed.py
+++ b/napari/utils/events/containers/_typed.py
@@ -203,8 +203,7 @@ class TypedMutableSequence(MutableSequence[_T]):
     def index(
         self, value: _L, start: int = 0, stop: Optional[int] = None
     ) -> int:
-        """
-        Return first index of value.
+        """Return first index of value.
 
         Parameters
         ----------

--- a/napari/utils/events/containers/_typed.py
+++ b/napari/utils/events/containers/_typed.py
@@ -203,17 +203,18 @@ class TypedMutableSequence(MutableSequence[_T]):
     def index(
         self, value: _L, start: int = 0, stop: Optional[int] = None
     ) -> int:
-        """Return first index of value.
+        """
+        Return first index of value.
 
         Parameters
         ----------
-        value : Any
+        value: Any
             A value to lookup.  If `type(value)` is in the lookups functions
             provided for this class, then values in the list will be searched
             using the corresponding lookup converter function.
-        start : int, optional
+        start: int, optional
             The starting index to search, by default 0
-        stop : int, optional
+        stop: int, optional
             The ending index to search, by default None
 
         Returns
@@ -246,7 +247,7 @@ class TypedMutableSequence(MutableSequence[_T]):
             )
         )
 
-    def _iter_indices(self, start=0, stop=None):
+    def _iter_indices(self, start=0, stop=None) -> Iterable[int]:
         """Iter indices from start to stop.
 
         While this is trivial for this basic sequence type, this method lets

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -140,6 +140,10 @@ class TransformChain(EventedList[_T], Transform, Generic[_T]):
         ...
 
     @overload
+    def __getitem__(self, key: str) -> _T:
+        ...
+
+    @overload
     def __getitem__(self, key: slice) -> 'TransformChain[_T]':
         ...
 


### PR DESCRIPTION
# Description

I have added the missed signature of `TransformChain.__getitem__` that leads mypy to fail after #6245 merge. 

