### PR TITLE
Ensure conda workflow runs with proper permissions

### DIFF
--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   packaging:
+    permissions:
+      contents: write
     uses: napari/packaging/.github/workflows/make_bundle_conda.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
# References and relevant issues
<!-- What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo,
please link to that issue here as "Closes #(issue-number)". -->

* Port https://github.com/napari/packaging/pull/97 to caller workflow

# Description
<!-- What does this pull request (PR) do? Is it a new feature, a bug fix,
an improvement, or something else? Why is it necessary? If relevant, please add
a screenshot or a screen capture: "An image is worth a thousand words!" -->

<!-- Final Checklist
- My PR is the minimum possible work for the desired functionality
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to docstrings and documentation
  (open a PR on the docs repository (https://github.com/napari/docs) if relevant!)
- I have added tests that prove my fix is effective or that my feature works
- If I included new strings, I have used `trans._("some string")` to make them localizable.
  (For more information see our [translations guide](https://napari.org/developers/translations.html)).
-->

Looks like GHA workflows now require explicit permissions to release assets. We fixed this in `napari/packaging`, but apparently they caller workflow also needs the permissions to be set, so that's what we are doing here.