### PR TITLE
DOC: misc syntax/typos

### DIFF
--- a/napari/_qt/layer_controls/qt_vectors_controls.py
+++ b/napari/_qt/layer_controls/qt_vectors_controls.py
@@ -239,7 +239,7 @@ class QtVectorsControls(QtLayerControls):
         Parameters
         ----------
         state : int
-             Integer value of Qt.CheckState that indicates the check state of outOfSliceCheckBox
+            Integer value of Qt.CheckState that indicates the check state of outOfSliceCheckBox
         """
         self.layer.out_of_slice_display = (
             Qt.CheckState(state) == Qt.CheckState.Checked

--- a/napari/_qt/qt_resources/__init__.py
+++ b/napari/_qt/qt_resources/__init__.py
@@ -20,7 +20,7 @@ def get_stylesheet(
 
     Parameters
     ----------
-    theme : str, optional
+    theme_id : str, optional
         Theme to apply to the stylesheet. If no theme is provided, the returned
         stylesheet will still have ``{{ template_variables }}`` that need to be
         replaced using the :func:`napari.utils.theme.template` function prior

--- a/napari/_vispy/camera.py
+++ b/napari/_vispy/camera.py
@@ -228,7 +228,7 @@ def add_mouse_pan_zoom_toggles(
 
     Returns
     -------
-        A decorated VisPy camera class.
+    A decorated VisPy camera class.
     """
 
     class _vispy_camera_cls(vispy_camera_cls):

--- a/napari/_vispy/canvas.py
+++ b/napari/_vispy/canvas.py
@@ -557,7 +557,7 @@ class VispyCanvas:
     ) -> None:
         """Maps a napari layer to its corresponding vispy layer and sets the parent scene of the vispy layer.
 
-        Paremeters
+        Parameters
         ----------
         napari_layer :
             Any napari layer, the layer type is the same as the vispy layer.
@@ -580,9 +580,9 @@ class VispyCanvas:
     def _remove_layer(self, event: Event) -> None:
         """Upon receiving event closes the Vispy visual, deletes it and reorders the still existing layers.
 
-         Parameters
-         ----------
-         event: napari.utils.events.event.Event
+        Parameters
+        ----------
+        event : napari.utils.events.event.Event
             The event causing a particular layer to be removed
 
         Returns

--- a/napari/_vispy/layers/labels.py
+++ b/napari/_vispy/layers/labels.py
@@ -255,12 +255,12 @@ def _get_shape_from_keys(
 
     Parameters
     ----------
-    keys: np.ndarray
+    keys : np.ndarray
         array of keys to be inserted into the hashmap,
         used for collision detection
-    first_dim_index: int
+    first_dim_index : int
         index for first dimension of PRIME_NUM_TABLE
-    second_dim_index: int
+    second_dim_index : int
         index for second dimension of PRIME_NUM_TABLE
 
     Returns
@@ -369,18 +369,18 @@ def build_textures_from_dict(
 
     Parameters
     ----------
-    color_dict: Dict[float, Tuple[float, float, float, float]]
+    color_dict : Dict[float, Tuple[float, float, float, float]]
         Dictionary from labels to colors
-    empty_val: float
+    empty_val : float
         Value to use for empty cells in the hash table
-    shape: Optional[Tuple[int, int]]
+    shape : Optional[Tuple[int, int]]
         Shape of the hash table.
         If None, it is calculated from the number of
         labels using _get_shape_from_dict
-    use_selection: bool
+    use_selection : bool
         If True, only the selected label is shown.
         The generated colormap is single-color of size (1, 1)
-    selection: float
+    selection : float
         used only if use_selection is True.
         Determines the selected label.
 

--- a/napari/components/_layer_slicer.py
+++ b/napari/components/_layer_slicer.py
@@ -181,11 +181,11 @@ class _LayerSlicer:
 
         Parameters
         ----------
-        layers: iterable of layers
+        layers : iterable of layers
             The layers to slice.
-        dims: Dims
+        dims : Dims
             The dimensions values associated with the view to be sliced.
-        force: bool
+        force : bool
             True if slicing should be forced to occur, even when some cache thinks
             it already has a valid slice ready. False otherwise.
 

--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -312,7 +312,7 @@ class LayerList(SelectableEventedList[Layer]):
         Returns
         -------
         extent : Extent
-             extent for selected layers
+            extent for selected layers
         """
         extent_list = [layer.extent for layer in layers]
         return Extent(

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1168,9 +1168,9 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
         Parameters
         ----------
-        dims: Dims
+        dims : Dims
             The dims model to use to slice this layer.
-        force: bool
+        force : bool
             True if slicing should be forced to occur, even when some cache thinks
             it already has a valid slice ready. False otherwise.
         """

--- a/napari/layers/labels/_labels_utils.py
+++ b/napari/layers/labels/_labels_utils.py
@@ -220,7 +220,7 @@ def get_contours(labels, thickness: int, background_label: int):
 
     Returns
     -------
-        A new label image in which only the boundaries of the input image are kept.
+    A new label image in which only the boundaries of the input image are kept.
     """
     struct_elem = ndi.generate_binary_structure(labels.ndim, 1)
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1473,7 +1473,7 @@ class Labels(_ImageBase):
             Value of the new label to be filled in.
         shape : list
             The label data shape upon which painting is performed.
-        dims_to_paint: list
+        dims_to_paint : list
             List of dimensions of the label data that are used for painting.
         refresh : bool
             Whether to refresh view slice or not. Set to False to batch paint

--- a/napari/layers/points/_points_mouse_bindings.py
+++ b/napari/layers/points/_points_mouse_bindings.py
@@ -156,7 +156,7 @@ def _toggle_selected(selection: Set[_T], value: _T) -> Set[_T]:
 
     Parameters
     ----------
-    selection: set
+    selection : set
         Set of selected data points to be modified.
     value : int
         Index of point to add or remove from selected data set.

--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -34,9 +34,9 @@ def highlight(layer: Shapes, event: MouseEvent) -> None:
 
     Parameters
     ----------
-    layer: Shapes
+    layer : Shapes
         Napari shapes layer
-    event: MouseEvent
+    event : MouseEvent
         A proxy read only wrapper around a vispy mouse event. Though not used here it is passed as argument by the
         shapes layer mouse move callbacks.
 
@@ -56,9 +56,9 @@ def select(layer: Shapes, event: MouseEvent) -> None:
 
     Parameters
     ----------
-    layer: Shapes
+    layer : Shapes
         Napari shapes layer
-    event: MouseEvent
+    event : MouseEvent
         A proxy read only wrapper around a vispy mouse event.
     """
     shift = 'Shift' in event.modifiers
@@ -157,9 +157,9 @@ def add_line(layer: Shapes, event: MouseEvent) -> None:
 
     Parameters
     ----------
-    layer: Shapes
+    layer : Shapes
         Napari shapes layer
-    event: MouseEvent
+    event : MouseEvent
         A proxy read only wrapper around a vispy mouse event.
     """
     # full size is the initial offset of the second point compared to the first point of the line.
@@ -187,9 +187,9 @@ def add_ellipse(layer: Shapes, event: MouseEvent):
 
     Parameters
     ----------
-    layer: Shapes
+    layer : Shapes
         Napari shapes layer
-    event: MouseEvent
+    event : MouseEvent
         A proxy read only wrapper around a vispy mouse event.
     """
     size = layer._normalized_vertex_radius / 2
@@ -213,9 +213,9 @@ def add_rectangle(layer: Shapes, event: MouseEvent) -> None:
 
     Parameters
     ----------
-    layer: Shapes
+    layer : Shapes
         Napari shapes layer
-    event: MouseEvent
+    event : MouseEvent
         A proxy read only wrapper around a vispy mouse event.
     """
     size = layer._normalized_vertex_radius / 2
@@ -242,13 +242,13 @@ def _add_line_rectangle_ellipse(
 
     Parameters
     ----------
-    layer: Shapes
+    layer : Shapes
         Napari shapes layer
-    event: MouseEvent
+    event : MouseEvent
         A proxy read only wrapper around a vispy mouse event.
-    data: np.NDarray
+    data : np.NDarray
         Array containing the initial datapoints of the shape in image data space.
-    shape_type: str
+    shape_type : str
         String indicating the type of shape to be added.
     """
     # on press
@@ -280,9 +280,9 @@ def finish_drawing_shape(layer: Shapes, event: MouseEvent) -> None:
 
     Parameters
     ----------
-    layer: Shapes
+    layer : Shapes
         Napari shapes layer
-    event: MouseEvent
+    event : MouseEvent
         A proxy read only wrapper around a vispy mouse event. Not used here, but passed as argument due to being a
         double click callback of the shapes layer.
     """
@@ -299,9 +299,9 @@ def initiate_polygon_draw(
 
     Parameters
     ----------
-    layer: Shapes
+    layer : Shapes
         Napari shapes layer
-    coordinates: Tuple[float, ...]
+    coordinates : Tuple[float, ...]
         A tuple with the coordinates of the initial vertex in image data space.
     """
     data = np.array([coordinates, coordinates])
@@ -321,9 +321,9 @@ def add_path_polygon_lasso(layer: Shapes, event: MouseEvent) -> None:
 
     Parameters
     ----------
-    layer: Shapes
+    layer : Shapes
         Napari shapes layer
-    event: MouseEvent
+    event : MouseEvent
         A proxy read only wrapper around a vispy mouse event.
     """
     # on press
@@ -360,15 +360,15 @@ def add_vertex_to_path(
 
     Parameters
     ----------
-    layer: Shapes
+    layer : Shapes
         Napari shapes layer
-    event: MouseEvent
+    event : MouseEvent
         A proxy read only wrapper around a vispy mouse event.
-    index: int
+    index : int
         The index of the shape being added, e.g. first shape in the layer has index 0.
-    coordinates: Tuple[float, ...]
+    coordinates : Tuple[float, ...]
         The coordinates of the vertex being added to the shape being drawn in image data space
-    new_type: Optional[str]
+    new_type : Optional[str]
         Type of the shape being added.
     """
     vertices = layer._data_view.shapes[index].data
@@ -392,9 +392,9 @@ def polygon_creating(layer: Shapes, event: MouseEvent) -> None:
 
     Parameters
     ----------
-    layer: Shapes
+    layer : Shapes
         Napari shapes layer
-    event: MouseEvent
+    event : MouseEvent
         A proxy read only wrapper around a vispy mouse event.
     """
     if layer._is_creating:
@@ -422,9 +422,9 @@ def add_path_polygon(layer: Shapes, event: MouseEvent) -> None:
 
     Parameters
     ----------
-    layer: Shapes
+    layer : Shapes
         Napari shapes layer
-    event: MouseEvent
+    event : MouseEvent
         A proxy read only wrapper around a vispy mouse event.
     """
     # on press
@@ -446,9 +446,9 @@ def move_active_vertex_under_cursor(
 
     Parameters
     ----------
-    layer: Shapes
+    layer : Shapes
         Napari shapes layer
-    coordinates: Tuple[float, ...]
+    coordinates : Tuple[float, ...]
         The coordinates in data space of the vertex to be potentially added, e.g. vertex tracks the mouse cursor
         position.
     """
@@ -465,9 +465,9 @@ def vertex_insert(layer: Shapes, event: MouseEvent) -> None:
 
     Parameters
     ----------
-    layer: Shapes
+    layer : Shapes
         Napari shapes layer
-    event: MouseEvent
+    event : MouseEvent
         A proxy read only wrapper around a vispy mouse event.
     """
     # Determine all the edges in currently selected shapes
@@ -555,9 +555,9 @@ def vertex_remove(layer: Shapes, event: MouseEvent) -> None:
 
     Parameters
     ----------
-    layer: Shapes
+    layer : Shapes
         Napari shapes layer
-    event: MouseEvent
+    event : MouseEvent
         A proxy read only wrapper around a vispy mouse event.
     """
     value = layer.get_value(event.position, world=True)
@@ -644,9 +644,9 @@ def _set_drag_start(
 
     Parameters
     ----------
-    layer: Shapes
+    layer : Shapes
         The napari layer shape
-    coordinates: Tuple[float, ...]
+    coordinates : Tuple[float, ...]
         The position in image data space where dragging started.
 
     Returns

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2007,7 +2007,7 @@ class Shapes(Layer):
             same length as the length of `data` and each element will be
             applied to each shape otherwise the same value will be used for all
             shapes.
-        gui: bool
+        gui : bool
             Whether the shape is drawn by drawing in the gui.
         """
         data, shape_type = extract_shape_type(data, shape_type)
@@ -2183,7 +2183,7 @@ class Shapes(Layer):
             same length as the length of `data` and each element will be
             applied to each shape otherwise the same value will be used for all
             shapes.
-        n_new_shapes: int
+        n_new_shapes : int
             The number of new shapes to be added to the Shapes layer.
         """
         if n_new_shapes > 0:


### PR DESCRIPTION
This fixes a miscellaneous number of syntax problem preventing numpydocs to properly parse the docstrings, and a few typos in parameter names.