### PR TITLE
Skip redundant pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,4 @@ repos:
     # trailing whitespace has meaning in markdown https://www.markdownguide.org/hacks/#indent-tab
     exclude: .*\.py|.*\.md
   - id: mixed-line-ending
+    exclude: .*\.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,31 +1,35 @@
+exclude: _vendor|vendored
 repos:
--   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.9.1
-    hooks:
-    - id: black
-      pass_filenames: true
-      exclude: _vendor|vendored|examples
--   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.292
-    hooks:
-      - id: ruff
-        exclude: _vendor|vendored
--   repo: https://github.com/seddonym/import-linter
-    rev: v1.12.0
-    hooks:
-    - id: import-linter
-      stages: [manual]
--   repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.27.0
-    hooks:
-      - id: check-github-workflows
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
-    hooks:
-    - id: check-yaml
-    - id: check-toml
-    - id: check-merge-conflict
-    - id: end-of-file-fixer
-    - id: trailing-whitespace
-      exclude: .*\.md|_vendor|vendored
-    - id: mixed-line-ending
+- repo: https://github.com/psf/black-pre-commit-mirror
+  rev: 23.9.1
+  hooks:
+  - id: black
+    pass_filenames: true
+    exclude: examples
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.0.292
+  hooks:
+  - id: ruff
+- repo: https://github.com/seddonym/import-linter
+  rev: v1.12.0
+  hooks:
+  - id: import-linter
+    stages: [manual]
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: 0.27.0
+  hooks:
+  - id: check-github-workflows
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.5.0
+  # .py files are skipped cause already checked by other hooks
+  hooks:
+  - id: check-yaml
+  - id: check-toml
+  - id: check-merge-conflict
+    exclude: .*\.py
+  - id: end-of-file-fixer
+    exclude: .*\.py
+  - id: trailing-whitespace
+    # trailing whitespace has meaning in markdown https://www.markdownguide.org/hacks/#indent-tab
+    exclude: .*\.py|.*\.md
+  - id: mixed-line-ending


### PR DESCRIPTION
# Description

As discussed in community meeting, we can actually skip several pre-commit hooks for `py` files, since their corrections are already covered by black and ruff. I also moved the exclude for vendored file to a general setting, since we never want to touch those anyways.

I took this chance to also unify the formatting of the file.
