### PR TITLE
Do not repeat warnings in GUI

### DIFF
--- a/napari/utils/_tests/test_notification_manager.py
+++ b/napari/utils/_tests/test_notification_manager.py
@@ -81,7 +81,7 @@ def test_notification_manager_no_gui(monkeypatch):
         # again, pytest intercepts this, so just manually trigger:
         assert warnings.showwarning == notification_manager.receive_warning
         warnings.showwarning(
-            UserWarning('this is a warning'), UserWarning, __file__, 84
+            UserWarning('this is a warning'), UserWarning, __file__, 83
         )
         assert len(notification_manager.records) == 4
         assert store[-1].type == 'warning'
@@ -114,7 +114,7 @@ def test_notification_manager_no_gui_with_threading():
 
     def _warn():
         warnings.showwarning(
-            UserWarning('this is a warning'), UserWarning, __file__, 117
+            UserWarning('this is a warning'), UserWarning, __file__, 116
         )
 
     def _raise():
@@ -167,7 +167,7 @@ def test_notification_manager_no_warning_duplication():
             UserWarning('This is a warning'),
             category=UserWarning,
             filename=__file__,
-            lineno=170,
+            lineno=166,
         )
 
     with notification_manager:

--- a/napari/utils/_tests/test_notification_manager.py
+++ b/napari/utils/_tests/test_notification_manager.py
@@ -81,7 +81,7 @@ def test_notification_manager_no_gui(monkeypatch):
         # again, pytest intercepts this, so just manually trigger:
         assert warnings.showwarning == notification_manager.receive_warning
         warnings.showwarning(
-            UserWarning('this is a warning'), UserWarning, '', 0
+            UserWarning('this is a warning'), UserWarning, __file__, 84
         )
         assert len(notification_manager.records) == 4
         assert store[-1].type == 'warning'
@@ -114,7 +114,7 @@ def test_notification_manager_no_gui_with_threading():
 
     def _warn():
         warnings.showwarning(
-            UserWarning('this is a warning'), UserWarning, '', 0
+            UserWarning('this is a warning'), UserWarning, __file__, 117
         )
 
     def _raise():
@@ -166,8 +166,8 @@ def test_notification_manager_no_warning_duplication():
         warnings.showwarning(
             UserWarning('This is a warning'),
             category=UserWarning,
-            filename='',
-            lineno=0,
+            filename=__file__,
+            lineno=170,
         )
 
     with notification_manager:

--- a/napari/utils/_tests/test_notification_manager.py
+++ b/napari/utils/_tests/test_notification_manager.py
@@ -80,7 +80,9 @@ def test_notification_manager_no_gui(monkeypatch):
         # test that warnings that go through showwarning are catalogued
         # again, pytest intercepts this, so just manually trigger:
         assert warnings.showwarning == notification_manager.receive_warning
-        warnings.showwarning('this is a warning', UserWarning, '', 0)
+        warnings.showwarning(
+            UserWarning('this is a warning'), UserWarning, '', 0
+        )
         assert len(notification_manager.records) == 4
         assert store[-1].type == 'warning'
 
@@ -111,7 +113,9 @@ def test_notification_manager_no_gui_with_threading():
     """
 
     def _warn():
-        warnings.showwarning('this is a warning', UserWarning, '', 0)
+        warnings.showwarning(
+            UserWarning('this is a warning'), UserWarning, '', 0
+        )
 
     def _raise():
         with pytest.raises(PurposefulException):
@@ -121,6 +125,7 @@ def test_notification_manager_no_gui_with_threading():
 
     with notification_manager:
         notification_manager.records.clear()
+        notification_manager._seen_warnings.clear()
         # save all of the events that get emitted
         store: List[Notification] = []
         notification_manager.notification_ready.connect(store.append)

--- a/napari/utils/notifications.py
+++ b/napari/utils/notifications.py
@@ -245,7 +245,7 @@ class NotificationManager:
         self._originals_except_hooks: List[Callable] = []
         self._original_showwarnings_hooks: List[Callable] = []
         self._originals_thread_except_hooks: List[Callable] = []
-        self._seen_warnings: Set[Tuple[str, Type]] = set()
+        self._seen_warnings: Set[Tuple[str, Type, str, int]] = set()
 
     def __enter__(self):
         self.install_hooks()
@@ -330,9 +330,10 @@ class NotificationManager:
         file=None,
         line=None,
     ):
-        if (message.args[0], category) in self._seen_warnings:
+        msg = message if isinstance(message, str) else message.args[0]
+        if (msg, category, filename, lineno) in self._seen_warnings:
             return
-        self._seen_warnings.add((message.args[0], category))
+        self._seen_warnings.add((msg, category, filename, lineno))
         self.dispatch(
             Notification.from_warning(
                 message, filename=filename, lineno=lineno

--- a/napari/utils/notifications.py
+++ b/napari/utils/notifications.py
@@ -7,7 +7,7 @@ import warnings
 from datetime import datetime
 from enum import auto
 from types import TracebackType
-from typing import Callable, List, Optional, Sequence, Tuple, Type, Union
+from typing import Callable, List, Optional, Sequence, Set, Tuple, Type, Union
 
 from napari.utils.events import Event, EventEmitter
 from napari.utils.misc import StringEnum
@@ -245,6 +245,7 @@ class NotificationManager:
         self._originals_except_hooks: List[Callable] = []
         self._original_showwarnings_hooks: List[Callable] = []
         self._originals_thread_except_hooks: List[Callable] = []
+        self._seen_warnings: Set[Tuple[str, Type]] = set()
 
     def __enter__(self):
         self.install_hooks()
@@ -329,6 +330,9 @@ class NotificationManager:
         file=None,
         line=None,
     ):
+        if (message.args[0], category) in self._seen_warnings:
+            return
+        self._seen_warnings.add((message.args[0], category))
         self.dispatch(
             Notification.from_warning(
                 message, filename=filename, lineno=lineno


### PR DESCRIPTION
# Description

This PR adds a register of already-seen warnings in GUI. This is a workaround for https://github.com/python/cpython/pull/8232, to reduce the number of warnings seen by users. 