### PR TITLE
Reraise warnings in proxy

### DIFF
--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -100,8 +100,12 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
             typ = type(self.__wrapped__).__name__
 
             self._private_attr_warning(name, typ)
+        with warnings.catch_warnings(record=True) as cx_manager:
+            data = self.create(super().__getattr__(name))
+        for warning in cx_manager:
+            warnings.warn(warning.message, warning.category, stacklevel=2)
 
-        return self.create(super().__getattr__(name))
+        return data
 
     def __setattr__(self, name: str, value: Any):
         if (


### PR DESCRIPTION
# Description
While working on debug #6397 I found that when the plugin accesses qt_viewer the warning message point inside PublicOnlyProxy not in the plugin code. 

It is 
```
/home/czaki/Projekty/napari/napari/utils/_proxies.py:104: FutureWarning: Public access to Window.qt_viewer is deprecated and will be removed in
v0.6.0. It is considered an "implementation detail" of the napari
application, not part of the napari viewer model. If your use case
requires access to qt_viewer, please open an issue to discuss.!
```

instead of 

```
/home/czaki/.pyenv/versions/napari_3.11/lib/python3.11/site-packages/brainrender_napari/napari_atlas_representation.py:24: FutureWarning: Public access to Window.qt_viewer is deprecated and will be removed in
v0.6.0. It is considered an "implementation detail" of the napari
application, not part of the napari viewer model. If your use case
requires access to qt_viewer, please open an issue to discuss.!
```

As we support both interacting with Viewer directly or from a plugin, we cannot use a single stacklevel. So I implement reraising ow warnings. 

It depends on #6396