### PR TITLE
Fix `test_singlescreen_window_settings` to allow it to run locally on multiscreen configuration

### DIFF
--- a/napari/_tests/test_windowsettings.py
+++ b/napari/_tests/test_windowsettings.py
@@ -1,8 +1,28 @@
+from qtpy.QtCore import QRect
+
 from napari.settings import get_settings
 
 
-def test_singlescreen_window_settings(make_napari_viewer):
+class ScreenMock:
+    def __init__(self):
+        self._geometry = QRect(0, 0, 1000, 1000)
+
+    def geometry(self):
+        return self._geometry
+
+
+def screen_at(point):
+    if point.x() < 0 or point.y() < 0 or point.x() > 1000 or point.y() > 1000:
+        return None
+    return ScreenMock()
+
+
+def test_singlescreen_window_settings(make_napari_viewer, monkeypatch):
     """Test whether valid screen position is returned even after disconnected secondary screen."""
+
+    monkeypatch.setattr(
+        "napari._qt.qt_main_window.QApplication.screenAt", screen_at
+    )
     settings = get_settings()
     viewer = make_napari_viewer()
     default_window_position = (


### PR DESCRIPTION
# References and relevant issues

Requested https://github.com/napari/napari/pull/6411#discussion_r1386227379

# Description

I think that our tests should be able to run locally to allow checking if everything works without depending on CI (reduce CI usage). 

For my configuration point (0, 0) is outside screen configuration. On image, it is marked with the red dot. 

![Zrzut ekranu z 2023-11-06 12-07-53](https://github.com/napari/napari/assets/3826210/59582928-fbe3-41fa-8acc-6f3e9321258a)
