### PR TITLE
refactor `napari/_qt/_tests/test_async_slicing.py` to reduce fragility of test

### DIFF
--- a/napari/_qt/_tests/test_async_slicing.py
+++ b/napari/_qt/_tests/test_async_slicing.py
@@ -215,8 +215,7 @@ def setup_viewer_for_async_slicing(
         # Add the layer and get the corresponding vispy layer.
         layer = viewer.add_layer(layer)
         vispy_layer = viewer.window._qt_viewer.layer_to_visual[layer]
-    # Then allow asynchronous slicing for testing.
-    # viewer._layer_slicer._force_sync = False
+
     return vispy_layer
 
 

--- a/napari/_qt/_tests/test_async_slicing.py
+++ b/napari/_qt/_tests/test_async_slicing.py
@@ -23,6 +23,18 @@ def rng() -> np.random.Generator:
     return np.random.default_rng(0)
 
 
+@pytest.fixture()
+def enable_async(fresh_settings, make_napari_viewer):
+    """
+    This fixture depends on fresh_settings and make_napari_viewer
+    to enforce proper order of fixture execution.
+    """
+    from napari import settings
+
+    settings.get_settings().experimental.async_ = True
+
+
+@pytest.mark.usefixtures("enable_async")
 def test_async_slice_image_on_current_step_change(
     make_napari_viewer, qtbot, rng
 ):
@@ -37,6 +49,7 @@ def test_async_slice_image_on_current_step_change(
     wait_until_vispy_image_data_equal(qtbot, vispy_image, data[2, :, :])
 
 
+@pytest.mark.usefixtures("enable_async")
 def test_async_slice_image_on_order_change(make_napari_viewer, qtbot, rng):
     viewer = make_napari_viewer()
     data = rng.random((3, 5, 7))
@@ -49,6 +62,7 @@ def test_async_slice_image_on_order_change(make_napari_viewer, qtbot, rng):
     wait_until_vispy_image_data_equal(qtbot, vispy_image, data[:, 2, :])
 
 
+@pytest.mark.usefixtures("enable_async")
 def test_async_slice_image_on_ndisplay_change(make_napari_viewer, qtbot, rng):
     viewer = make_napari_viewer()
     data = rng.random((3, 4, 5))
@@ -61,6 +75,7 @@ def test_async_slice_image_on_ndisplay_change(make_napari_viewer, qtbot, rng):
     wait_until_vispy_image_data_equal(qtbot, vispy_image, data)
 
 
+@pytest.mark.usefixtures("enable_async")
 def test_async_slice_multiscale_image_on_pan(make_napari_viewer, qtbot, rng):
     viewer = make_napari_viewer()
     data = [rng.random((4, 8, 10)), rng.random((2, 4, 5))]
@@ -82,6 +97,7 @@ def test_async_slice_multiscale_image_on_pan(make_napari_viewer, qtbot, rng):
     wait_until_vispy_image_data_equal(qtbot, vispy_image, data[1][0, 0:4, 0:3])
 
 
+@pytest.mark.usefixtures("enable_async")
 def test_async_slice_multiscale_image_on_zoom(qtbot, make_napari_viewer, rng):
     viewer = make_napari_viewer()
     data = [rng.random((4, 8, 10)), rng.random((2, 4, 5))]
@@ -103,6 +119,7 @@ def test_async_slice_multiscale_image_on_zoom(qtbot, make_napari_viewer, rng):
     wait_until_vispy_image_data_equal(qtbot, vispy_image, data[0][1, 2:6, 3:7])
 
 
+@pytest.mark.usefixtures("enable_async")
 def test_async_slice_points_on_current_step_change(make_napari_viewer, qtbot):
     viewer = make_napari_viewer()
     data = np.array(
@@ -123,6 +140,7 @@ def test_async_slice_points_on_current_step_change(make_napari_viewer, qtbot):
     wait_until_vispy_points_data_equal(qtbot, vispy_points, np.array([[5, 6]]))
 
 
+@pytest.mark.usefixtures("enable_async")
 def test_async_slice_points_on_point_change(make_napari_viewer, qtbot):
     viewer = make_napari_viewer()
     # Define data so that slicing at 1.6 in the first dimension should match the
@@ -146,6 +164,7 @@ def test_async_slice_points_on_point_change(make_napari_viewer, qtbot):
     wait_until_vispy_points_data_equal(qtbot, vispy_points, np.array([[3, 4]]))
 
 
+@pytest.mark.usefixtures("enable_async")
 def test_async_slice_image_loaded(make_napari_viewer, qtbot, rng):
     viewer = make_napari_viewer()
     data = rng.random((3, 4, 5))
@@ -160,10 +179,12 @@ def test_async_slice_image_loaded(make_napari_viewer, qtbot, rng):
         viewer.dims.current_step = (2, 0, 0)
         assert not layer.loaded
 
-    wait_until_vispy_image_data_equal(qtbot, vispy_layer, data[2, :, :])
-    assert layer.loaded
+    qtbot.waitUntil(lambda: layer.loaded)
+
+    np.testing.assert_allclose(vispy_layer.node._data, data[2, :, :])
 
 
+@pytest.mark.usefixtures("enable_async")
 def test_async_slice_vectors_on_current_step_change(make_napari_viewer, qtbot):
     viewer = make_napari_viewer()
     data = np.array(
@@ -190,12 +211,12 @@ def setup_viewer_for_async_slicing(
 ) -> VispyBaseLayer:
     # Initially force synchronous slicing so any slicing caused
     # by adding the layer finishes before any other slicing starts.
-    viewer._layer_slicer._force_sync = True
-    # Add the layer and get the corresponding vispy layer.
-    layer = viewer.add_layer(layer)
-    vispy_layer = viewer.window._qt_viewer.layer_to_visual[layer]
+    with viewer._layer_slicer.force_sync():
+        # Add the layer and get the corresponding vispy layer.
+        layer = viewer.add_layer(layer)
+        vispy_layer = viewer.window._qt_viewer.layer_to_visual[layer]
     # Then allow asynchronous slicing for testing.
-    viewer._layer_slicer._force_sync = False
+    # viewer._layer_slicer._force_sync = False
     return vispy_layer
 
 


### PR DESCRIPTION
# References and relevant issues
https://github.com/napari/napari/actions/runs/6796360477/job/18476810998?pr=6411#step:11:377

# Description

Last time I needed to restart tests multiple times because of one test that is fragile on race conditions. 

This PR fixes it by changing wait conditions.

Also, this PR refactor set async mode to use more public API. 
