### PR TITLE
Simplify unused parameters of Quaternion functions.

### DIFF
--- a/napari/_vispy/__init__.py
+++ b/napari/_vispy/__init__.py
@@ -22,7 +22,7 @@ from napari._vispy.overlays.interaction_box import (
 from napari._vispy.overlays.labels_polygon import VispyLabelsPolygonOverlay
 from napari._vispy.overlays.scale_bar import VispyScaleBarOverlay
 from napari._vispy.overlays.text import VispyTextOverlay
-from napari._vispy.utils.quaternion import quaternion2euler
+from napari._vispy.utils.quaternion import quaternion2euler_degrees
 from napari._vispy.utils.visual import create_vispy_layer, create_vispy_overlay
 
 __all__ = [
@@ -34,7 +34,7 @@ __all__ = [
     "VispyTransformBoxOverlay",
     "VispyTextOverlay",
     "VispyLabelsPolygonOverlay",
-    "quaternion2euler",
+    "quaternion2euler_degrees",
     "create_vispy_layer",
     "create_vispy_overlay",
 ]

--- a/napari/_vispy/_tests/test_utils.py
+++ b/napari/_vispy/_tests/test_utils.py
@@ -5,7 +5,7 @@ from vispy.util.quaternion import Quaternion
 
 from napari._pydantic_compat import ValidationError
 from napari._vispy.utils.cursor import QtCursorVisual
-from napari._vispy.utils.quaternion import quaternion2euler
+from napari._vispy.utils.quaternion import quaternion2euler_degrees
 from napari._vispy.utils.visual import get_view_direction_in_scene_coordinates
 from napari.components._viewer_constants import CursorStyle
 
@@ -13,18 +13,16 @@ from napari.components._viewer_constants import CursorStyle
 angles = [[12, 53, 92], [180, -90, 0], [16, 90, 0]]
 
 # Prepare for input and add corresponding values in radians
-angles_param = [(x, True) for x in angles]
-angles_param.extend([(x, False) for x in np.radians(angles)])
 
 
-@pytest.mark.parametrize('angles,degrees', angles_param)
-def test_quaternion2euler(angles, degrees):
+@pytest.mark.parametrize('angles', angles)
+def test_quaternion2euler_degrees(angles):
     """Test quaternion to euler angle conversion."""
 
     # Test for degrees
-    q = Quaternion.create_from_euler_angles(*angles, degrees)
-    ea = quaternion2euler(q, degrees=degrees)
-    q_p = Quaternion.create_from_euler_angles(*ea, degrees=degrees)
+    q = Quaternion.create_from_euler_angles(*angles, degrees=True)
+    ea = quaternion2euler_degrees(q)
+    q_p = Quaternion.create_from_euler_angles(*ea, degrees=True)
 
     # We now compare the corresponding quaternions ; they should be equals or opposites (as they're already unit ones)
     q_values = np.array([q.w, q.x, q.y, q.z])

--- a/napari/_vispy/camera.py
+++ b/napari/_vispy/camera.py
@@ -3,7 +3,7 @@ from typing import Type
 import numpy as np
 from vispy.scene import ArcballCamera, BaseCamera, PanZoomCamera
 
-from napari._vispy.utils.quaternion import quaternion2euler
+from napari._vispy.utils.quaternion import quaternion2euler_degrees
 
 
 class VispyCamera:
@@ -58,9 +58,7 @@ class VispyCamera:
 
         if self._view.camera == self._3D_camera:
             # Do conversion from quaternion representation to euler angles
-            angles = quaternion2euler(
-                self._view.camera._quaternion, degrees=True
-            )
+            angles = quaternion2euler_degrees(self._view.camera._quaternion)
         else:
             angles = (0, 0, 90)
         return angles

--- a/napari/_vispy/utils/quaternion.py
+++ b/napari/_vispy/utils/quaternion.py
@@ -1,7 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Tuple, cast
+
 import numpy as np
 
+if TYPE_CHECKING:
+    from vispy.util.quaternion import Quaternion
 
-def quaternion2euler(quaternion, degrees=False):
+
+def quaternion2euler_degrees(
+    quaternion: Quaternion,
+) -> Tuple[float, float, float]:
     """Converts VisPy quaternion into euler angle representation.
 
     Euler angles have degeneracies, so the output might different
@@ -16,13 +25,11 @@ def quaternion2euler(quaternion, degrees=False):
     ----------
     quaternion : vispy.util.Quaternion
         Quaternion for conversion.
-    degrees : bool
-        If output is returned in degrees or radians.
 
     Returns
     -------
     angles : 3-tuple
-        Euler angles in (rx, ry, rz) order.
+        Euler angles in (rx, ry, rz) order, in degrees.
     """
     epsilon = 1e-10
 
@@ -51,7 +58,4 @@ def quaternion2euler(quaternion, degrees=False):
 
     angles = (theta_1, theta_2, theta_3)
 
-    if degrees:
-        return tuple(np.degrees(angles))
-
-    return angles
+    return cast(Tuple[float, float, float], tuple(np.degrees(angles)))


### PR DESCRIPTION
This is a partial reapply of #6241, that was reverted, but reapply only the part where we simplify the API that has an unsed argument  and rename the function.

This is thus a partial revert of #6299 which itself is a revert of #6241
