### PR TITLE
Fix cycle in _update_draw/_set_highlight for Points and Shapes (high CPU background usage)

### DIFF
--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1611,6 +1611,7 @@ class Points(Layer):
         super()._update_draw(
             scale_factor, corner_pixels_displayed, shape_threshold
         )
+        # update highlight only if scale has changed, otherwise causes a cycle
         self._set_highlight(force=(prev_scale != self.scale_factor))
 
     def _get_value(self, position) -> Optional[int]:

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -295,6 +295,9 @@ class Points(Layer):
         Edge width of the point markers in the currently viewed slice.
     _indices_view : array (M, )
         Integer indices of the points in the currently viewed slice and are shown.
+    _scale_factor_stored : None | float
+        Previous scale factor. Used to prevent rerendering highlights when
+        view has not changed.
     _selected_view :
         Integer indices of selected points in the currently viewed slice within
         the `_view_data` array.
@@ -383,6 +386,8 @@ class Points(Layer):
 
         data, ndim = fix_data_points(data, ndim)
 
+        # scale factor also influences highlight, may trigger re-draw
+        self._scale_factor_stored = None
         # Indices of selected points
         self._selected_data_stored = set()
         self._selected_data_history = set()
@@ -1610,7 +1615,7 @@ class Points(Layer):
         super()._update_draw(
             scale_factor, corner_pixels_displayed, shape_threshold
         )
-        self._set_highlight(force=True)
+        self._set_highlight()
 
     def _get_value(self, position) -> Optional[int]:
         """Index of the point at a given 2D position in data coordinates.
@@ -1854,11 +1859,13 @@ class Points(Layer):
         # Check if any point ids have changed since last call
         if (
             self.selected_data == self._selected_data_stored
+            and self.scale_factor == self._scale_factor_stored
             and self._value == self._value_stored
             and np.array_equal(self._drag_box, self._drag_box_stored)
         ) and not force:
             return
         self._selected_data_stored = copy(self.selected_data)
+        self._scale_factor_stored = self.scale_factor
         self._value_stored = copy(self._value)
         self._drag_box_stored = copy(self._drag_box)
 

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -251,6 +251,9 @@ class Shapes(Layer):
         Dictionary containing all the shape data indexed by slice tuple
     _data_view : ShapeList
         Object containing the currently viewed shape data.
+    _scale_factor_stored : None | float
+        Previous scale factor. Used to prevent rerendering highlights when
+        view has not changed.
     _selected_data_history : set
         Set of currently selected captured on press of <space>.
     _selected_data_stored : set
@@ -506,6 +509,7 @@ class Shapes(Layer):
         self._value = (None, None)
         self._value_stored = (None, None)
         self._moving_value = (None, None)
+        self._scale_factor_stored = None
         self._selected_data = set()
         self._selected_data_stored = set()
         self._selected_data_history = set()
@@ -2534,11 +2538,13 @@ class Shapes(Layer):
         # Check if any shape or vertex ids have changed since last call
         if (
             self.selected_data == self._selected_data_stored
+            and self.scale_factor == self._scale_factor_stored
             and np.array_equal(self._value, self._value_stored)
             and np.array_equal(self._drag_box, self._drag_box_stored)
         ) and not force:
             return
         self._selected_data_stored = copy(self.selected_data)
+        self._scale_factor_stored = self.scale_factor
         self._value_stored = copy(self._value)
         self._drag_box_stored = copy(self._drag_box)
         self.events.highlight()
@@ -2733,7 +2739,7 @@ class Shapes(Layer):
         super()._update_draw(
             scale_factor, corner_pixels_displayed, shape_threshold
         )
-        self._set_highlight(force=True)
+        self._set_highlight()
 
     def _get_value(self, position):
         """Value of the data at a position in data coordinates.

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -251,9 +251,6 @@ class Shapes(Layer):
         Dictionary containing all the shape data indexed by slice tuple
     _data_view : ShapeList
         Object containing the currently viewed shape data.
-    _scale_factor_stored : None | float
-        Previous scale factor. Used to prevent rerendering highlights when
-        view has not changed.
     _selected_data_history : set
         Set of currently selected captured on press of <space>.
     _selected_data_stored : set
@@ -509,7 +506,6 @@ class Shapes(Layer):
         self._value = (None, None)
         self._value_stored = (None, None)
         self._moving_value = (None, None)
-        self._scale_factor_stored = None
         self._selected_data = set()
         self._selected_data_stored = set()
         self._selected_data_history = set()
@@ -2538,13 +2534,11 @@ class Shapes(Layer):
         # Check if any shape or vertex ids have changed since last call
         if (
             self.selected_data == self._selected_data_stored
-            and self.scale_factor == self._scale_factor_stored
             and np.array_equal(self._value, self._value_stored)
             and np.array_equal(self._drag_box, self._drag_box_stored)
         ) and not force:
             return
         self._selected_data_stored = copy(self.selected_data)
-        self._scale_factor_stored = self.scale_factor
         self._value_stored = copy(self._value)
         self._drag_box_stored = copy(self._drag_box)
         self.events.highlight()
@@ -2736,10 +2730,11 @@ class Shapes(Layer):
     def _update_draw(
         self, scale_factor, corner_pixels_displayed, shape_threshold
     ):
+        prev_scale = self.scale_factor
         super()._update_draw(
             scale_factor, corner_pixels_displayed, shape_threshold
         )
-        self._set_highlight()
+        self._set_highlight(force=(prev_scale != self.scale_factor))
 
     def _get_value(self, position):
         """Value of the data at a position in data coordinates.

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2734,6 +2734,7 @@ class Shapes(Layer):
         super()._update_draw(
             scale_factor, corner_pixels_displayed, shape_threshold
         )
+        # update highlight only if scale has changed, otherwise causes a cycle
         self._set_highlight(force=(prev_scale != self.scale_factor))
 
     def _get_value(self, position):


### PR DESCRIPTION
I agree something like https://github.com/napari/napari/issues/6234 is a better long-term fix, but we should do something in the meantime because the high CPU is pretty severe.

# References and relevant issues
Closes #6223

# Description
This breaks a cycle when updating the highlight on Points and Shapes layers. The problem was `_set_highlight` being called with `force=True` in `_update_draw`. This caused a cycle as redrawing the highlights would again call `_update_draw`. This was added to fix the appearance of the highlights during interaction - see #6223 for more discussion. I'm hoping @brisvag can confirm this PR maintains the correct behavior.

This PR tracks `scale_factor` the same way `selected_data` and other properties are stored in order to conditionally update the highlight instead of forcing it.