### PR TITLE
DOC: misc fixes

### DIFF
--- a/napari/layers/labels/_labels_utils.py
+++ b/napari/layers/labels/_labels_utils.py
@@ -47,7 +47,7 @@ def sphere_indices(radius, scale):
     """Generate centered indices within circle or n-dim ellipsoid.
 
     Parameters
-    -------
+    ----------
     radius : float
         Radius of circle/sphere
     scale : tuple of float

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -958,6 +958,7 @@ class Labels(_ImageBase):
             Slice that specifies the portion of the input image that
             should be computed and displayed.
             If None, the whole input image will be processed.
+
         Returns
         -------
         mapped_labels : array


### PR DESCRIPTION
1) underline lenght, not critical, but nice to have

2) blank link before section necessary for correct parsing by numpydoc.
