### PR TITLE
Fix milestone and label checker to be triggered by `milestoned`/`demilestoned` events

### DIFF
--- a/.github/workflows/label_and_milesone_checker.yml
+++ b/.github/workflows/label_and_milesone_checker.yml
@@ -40,3 +40,4 @@ jobs:
         run: |
           echo "github.event_name: ${{ github.event_name }}"
           echo "github.event.pull_request.labels: ${{ toJSON(github.event.pull_request.labels) }}"
+          echo "github.event.pull_request.labels: ${{ toJSON(github.event.issue.labels) }}"

--- a/.github/workflows/label_and_milesone_checker.yml
+++ b/.github/workflows/label_and_milesone_checker.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   check_labels_and_milestone:
     if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ready to merge')) ||
-        (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'ready to merge'))
+        (github.event_name == 'issues' && github.event.issue.pull_request != null && contains(github.event.issue.labels.*.name, 'ready to merge'))
     name: Check labels and milestone
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/label_and_milesone_checker.yml
+++ b/.github/workflows/label_and_milesone_checker.yml
@@ -42,4 +42,4 @@ jobs:
           echo "github.event_name: ${{ github.event_name }}"
           echo "github.event.pull_request.labels: ${{ toJSON(github.event.pull_request.labels) }}"
           echo "github.event.pull_request.labels: ${{ toJSON(github.event.issue.labels) }}"
-          echo "github: ${{ toJSON(github) }}"
+          echo "github.event: ${{ toJSON(github.event) }}"

--- a/.github/workflows/label_and_milesone_checker.yml
+++ b/.github/workflows/label_and_milesone_checker.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   check_labels_and_milestone:
-    if: contains(github.event.pull_request.labels.*.name, 'ready to merge')
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ready to merge')
     name: Check labels and milestone
     runs-on: ubuntu-latest
     steps:
@@ -31,3 +31,12 @@ jobs:
         run: |
           echo "Please add a milestone to this PR"
           exit 1
+
+  check_event_parameters:
+    name: Check event parameters
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check event parameters
+        run: |
+          echo "github.event_name: ${{ github.event_name }}"
+          echo "github.event.pull_request.labels: ${{ toJSON(github.event.pull_request.labels) }}"

--- a/.github/workflows/label_and_milesone_checker.yml
+++ b/.github/workflows/label_and_milesone_checker.yml
@@ -42,4 +42,4 @@ jobs:
           echo "github.event_name: ${{ github.event_name }}"
           echo "github.event.pull_request.labels: ${{ toJSON(github.event.pull_request.labels) }}"
           echo "github.event.pull_request.labels: ${{ toJSON(github.event.issue.labels) }}"
-          echo "github.event: ${{ toJSON(github.event) }}"
+          echo "github.event: ${{ toJSON(github.event.issue.pull_request) }}"

--- a/.github/workflows/label_and_milesone_checker.yml
+++ b/.github/workflows/label_and_milesone_checker.yml
@@ -34,15 +34,3 @@ jobs:
         run: |
           echo "Please add a milestone to this PR"
           exit 1
-
-  check_event_parameters:
-    name: Check event parameters
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check event parameters
-        run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.labels: ${{ toJSON(github.event.pull_request.labels) }}"
-          echo "github.event.issue.labels: ${{ toJSON(github.event.issue.labels) }}"
-          echo "github.event: ${{ toJSON(github.event.issue.pull_request) }}"
-          echo "github.event: ${{ github.event.issue.pull_request != null }}"

--- a/.github/workflows/label_and_milesone_checker.yml
+++ b/.github/workflows/label_and_milesone_checker.yml
@@ -42,3 +42,4 @@ jobs:
           echo "github.event_name: ${{ github.event_name }}"
           echo "github.event.pull_request.labels: ${{ toJSON(github.event.pull_request.labels) }}"
           echo "github.event.pull_request.labels: ${{ toJSON(github.event.issue.labels) }}"
+          echo "github: ${{ toJSON(github) }}"

--- a/.github/workflows/label_and_milesone_checker.yml
+++ b/.github/workflows/label_and_milesone_checker.yml
@@ -7,6 +7,8 @@ on:
       - reopened
       - labeled
       - unlabeled
+      - milestoned
+      - demilestoned
   issues:
     types:
       - milestoned
@@ -28,7 +30,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check milestone
-        if: github.event.pull_request.milestone == null
+        if: github.event.pull_request.milestone == null && github.event.issue.milestone == null
         run: |
           echo "Please add a milestone to this PR"
           exit 1

--- a/.github/workflows/label_and_milesone_checker.yml
+++ b/.github/workflows/label_and_milesone_checker.yml
@@ -9,17 +9,12 @@ on:
       - unlabeled
       - milestoned
       - demilestoned
-  issues:
-    types:
-      - milestoned
-      - demilestoned
   merge_group: # to be prepared on merge queue
     types: [checks_requested]
 
 jobs:
   check_labels_and_milestone:
-    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ready to merge')) ||
-        (github.event_name == 'issues' && github.event.issue.pull_request != null && contains(github.event.issue.labels.*.name, 'ready to merge'))
+    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ready to merge'))
     name: Check labels and milestone
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +25,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check milestone
-        if: github.event.pull_request.milestone == null && github.event.issue.milestone == null
+        if: github.event.pull_request.milestone == null
         run: |
           echo "Please add a milestone to this PR"
           exit 1

--- a/.github/workflows/label_and_milesone_checker.yml
+++ b/.github/workflows/label_and_milesone_checker.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   check_labels_and_milestone:
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ready to merge')
+    if: contains(github.event.pull_request.labels.*.name, 'ready to merge')
     name: Check labels and milestone
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/label_and_milesone_checker.yml
+++ b/.github/workflows/label_and_milesone_checker.yml
@@ -16,7 +16,8 @@ on:
 
 jobs:
   check_labels_and_milestone:
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ready to merge')
+    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ready to merge')) ||
+        (github.event_name == 'issue' && contains(github.event.issue.labels.*.name, 'ready to merge'))
     name: Check labels and milestone
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/label_and_milesone_checker.yml
+++ b/.github/workflows/label_and_milesone_checker.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   check_labels_and_milestone:
     if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ready to merge')) ||
-        (github.event_name == 'issue' && contains(github.event.issue.labels.*.name, 'ready to merge'))
+        (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'ready to merge'))
     name: Check labels and milestone
     runs-on: ubuntu-latest
     steps:
@@ -41,5 +41,6 @@ jobs:
         run: |
           echo "github.event_name: ${{ github.event_name }}"
           echo "github.event.pull_request.labels: ${{ toJSON(github.event.pull_request.labels) }}"
-          echo "github.event.pull_request.labels: ${{ toJSON(github.event.issue.labels) }}"
+          echo "github.event.issue.labels: ${{ toJSON(github.event.issue.labels) }}"
           echo "github.event: ${{ toJSON(github.event.issue.pull_request) }}"
+          echo "github.event: ${{ github.event.issue.pull_request != null }}"


### PR DESCRIPTION
# References and relevant issues
https://github.com/napari/napari/pull/6288#issuecomment-1802647688

# Description

The milestoned, demilestoned events are not documented for the pull request https://github.com/github/docs/pull/29837, but works. 

The issue events are not reported in the pull request status. This PR should allow to use of any order of labeling and milestoning PR. 

If someone would like to test I could give permission to https://github.com/Czaki/napari/pull/27