### PR TITLE
Refactor Skipped test

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
@@ -186,30 +186,38 @@ def test_create_layer_controls(
             qcombobox.setCurrentIndex(qcombobox_initial_idx)
 
 
-if sys.version_info[:2] == (3, 11) and (
+skip_predicate = sys.version_info >= (3, 11) and (
     qtpy.API == 'pyqt5' or qtpy.API == 'pyqt6'
-):
-    test_data = []
-else:
-    # those 2 fail on 3.11 + pyqt5 and pyqt6 with a segfault that can't be caught by
-    # pytest in qspinbox.setValue(value)
-    # See: https://github.com/napari/napari/pull/5439
-    test_data = [_LABELS_WITH_COLOR, _LABELS]
-
-
-test_data += [
-    _IMAGE,
-    _POINTS,
-    _SHAPES,
-    _SURFACE,
-    _TRACKS,
-    _VECTORS,
-]
+)
 
 
 @pytest.mark.parametrize(
     'layer_type_with_data',
-    test_data,
+    [
+        # those 2 fail on 3.11 + pyqt5 and pyqt6 with a segfault that can't be caught by
+        # pytest in qspinbox.setValue(value)
+        # See: https://github.com/napari/napari/pull/5439
+        pytest.param(
+            _LABELS_WITH_COLOR,
+            marks=pytest.mark.skipif(
+                skip_predicate,
+                reason='segfault on Python 3.11+ and pyqt5 or Pyqt6',
+            ),
+        ),
+        pytest.param(
+            _LABELS,
+            marks=pytest.mark.skipif(
+                skip_predicate,
+                reason='segfault on Python 3.11+ and pyqt5 or Pyqt6',
+            ),
+        ),
+        _IMAGE,
+        _POINTS,
+        _SHAPES,
+        _SURFACE,
+        _TRACKS,
+        _VECTORS,
+    ],
 )
 @pytest.mark.qt_no_exception_capture
 @pytest.mark.skipif(os.environ.get("MIN_REQ", "0") == "1", reason="min req")


### PR DESCRIPTION
1) Instead of conditionally changing the parameters, mark the relevant
   items as skipped on the relevant platforms. This mean that _at least_
   the test will be marked as skipped instead of just not being visible
   by pytest. This has effect when you want to run a particular test
   across python version for example.

2) This will fail also on Python 3.12, so skip 3.12 as well.
