### PR TITLE
Restore old breakpointhook after console import in tests fixture

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -63,6 +63,7 @@ from napari_builtins.io import imsave_extensions
 from napari._vispy import VispyCanvas, create_vispy_layer  # isort:skip
 
 if TYPE_CHECKING:
+    from napari_console import QtConsole
     from npe2.manifest.contributions import WriterContribution
 
     from napari._qt.layer_controls import QtLayerControlsContainer
@@ -536,53 +537,75 @@ class QtViewer(QSplitter):
         """List: items to push to console when instantiated."""
         return self._console_backlog
 
+    def _get_console(self) -> Optional[QtConsole]:
+        """
+        Function for setup console.
+
+        Returns
+        -------
+
+        Notes
+        _____
+        extracted to separated function for simplify testing
+
+        """
+        try:
+            import numpy as np
+
+            # QtConsole imports debugpy that overwrites default breakpoint.
+            # It makes problems with debugging if you do not know this.
+            # So we do not want to overwrite it if it is already set.
+            breakpoint_handler = sys.breakpointhook
+            from napari_console import QtConsole
+
+            sys.breakpointhook = breakpoint_handler
+
+            import napari
+
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore")
+                console = QtConsole(self.viewer)
+                console.push(
+                    {'napari': napari, 'action_manager': action_manager}
+                )
+                with CallerFrame(_in_napari) as c:
+                    if c.frame.f_globals.get("__name__", "") == "__main__":
+                        console.push({"np": np})
+                for i in self.console_backlog:
+                    # recover weak refs
+                    console.push(
+                        {
+                            k: self._unwrap_if_weakref(v)
+                            for k, v in i.items()
+                            if self._unwrap_if_weakref(v) is not None
+                        }
+                    )
+                return console
+        except ModuleNotFoundError:
+            warnings.warn(
+                trans._(
+                    'napari-console not found. It can be installed with'
+                    ' "pip install napari_console"'
+                ),
+                stacklevel=1,
+            )
+            return None
+        except ImportError:
+            traceback.print_exc()
+            warnings.warn(
+                trans._(
+                    'error importing napari-console. See console for full error.'
+                ),
+                stacklevel=1,
+            )
+            return None
+
     @property
     def console(self):
         """QtConsole: iPython console terminal integrated into the napari GUI."""
         if self._console is None:
-            try:
-                import numpy as np
-                from napari_console import QtConsole
-
-                import napari
-
-                with warnings.catch_warnings():
-                    warnings.filterwarnings("ignore")
-                    self.console = QtConsole(self.viewer)
-                    self.console.push(
-                        {'napari': napari, 'action_manager': action_manager}
-                    )
-                    with CallerFrame(_in_napari) as c:
-                        if c.frame.f_globals.get("__name__", "") == "__main__":
-                            self.console.push({"np": np})
-                    for i in self.console_backlog:
-                        # recover weak refs
-                        self.console.push(
-                            {
-                                k: self._unwrap_if_weakref(v)
-                                for k, v in i.items()
-                                if self._unwrap_if_weakref(v) is not None
-                            }
-                        )
-                    self._console_backlog = []
-            except ModuleNotFoundError:
-                warnings.warn(
-                    trans._(
-                        'napari-console not found. It can be installed with'
-                        ' "pip install napari_console"'
-                    ),
-                    stacklevel=1,
-                )
-                self._console = None
-            except ImportError:
-                traceback.print_exc()
-                warnings.warn(
-                    trans._(
-                        'error importing napari-console. See console for full error.'
-                    ),
-                    stacklevel=1,
-                )
-                self._console = None
+            self._console = self._get_console()
+            self._console_backlog = []
         return self._console
 
     @console.setter

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -604,7 +604,7 @@ class QtViewer(QSplitter):
     def console(self):
         """QtConsole: iPython console terminal integrated into the napari GUI."""
         if self._console is None:
-            self._console = self._get_console()
+            self.console = self._get_console()
             self._console_backlog = []
         return self._console
 

--- a/napari/_tests/test_conftest_fixtures.py
+++ b/napari/_tests/test_conftest_fixtures.py
@@ -4,9 +4,6 @@ import pytest
 from qtpy.QtCore import QMutex, QThread, QTimer
 from superqt.utils import qdebounced
 
-from napari._qt.qt_viewer import QtViewer
-from napari.viewer import ViewerModel
-
 
 class _TestThread(QThread):
     def __init__(self) -> None:
@@ -50,11 +47,6 @@ def test_disable_qtimer(qtbot):
     th.mutex.unlock()
     qtbot.waitUntil(th.isFinished, timeout=2000)
     assert not th.isRunning()
-
-
-def test_console_mock(qapp):
-    qt_viewer = QtViewer(ViewerModel())
-    assert qt_viewer.console.__class__.__name__ == "FakeQtConsole"
 
 
 @pytest.mark.usefixtures("disable_throttling")

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -418,8 +418,12 @@ def mock_console(request):
         yield
         return
 
+    old_breakpoint = sys.breakpointhook
+
     from napari_console import QtConsole
     from qtconsole.rich_jupyter_widget import RichJupyterWidget
+
+    sys.breakpointhook = old_breakpoint
 
     class FakeQtConsole(RichJupyterWidget):
         def __init__(self, viewer: Viewer):

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -39,7 +39,7 @@ from itertools import chain
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 from weakref import WeakKeyDictionary
 
 from npe2 import PackageMetadata
@@ -61,7 +61,6 @@ from pytest_pretty import CustomTerminalReporter
 from napari.components import LayerList
 from napari.layers import Image, Labels, Points, Shapes, Vectors
 from napari.utils.misc import ROOT_DIR
-from napari.viewer import Viewer
 
 if TYPE_CHECKING:
     from npe2._pytest_plugin import TestPluginManager
@@ -404,42 +403,6 @@ def single_threaded_executor():
     executor.shutdown()
 
 
-@pytest.fixture()
-def mock_console(request):
-    """Mock the qtconsole to avoid starting an interactive IPython session.
-    In-process IPython kernels can interfere with other tests and are difficult
-    (impossible?) to shutdown.
-
-    This fixture is configured to be applied automatically to tests unless they
-    use the `enable_console` marker. It's not autouse to avoid use on headless
-    tests (without Qt); instead it's enabled in `pytest_runtest_setup`.
-    """
-    if "enable_console" in request.keywords:
-        yield
-        return
-
-    old_breakpoint = sys.breakpointhook
-
-    from napari_console import QtConsole
-    from qtconsole.rich_jupyter_widget import RichJupyterWidget
-
-    sys.breakpointhook = old_breakpoint
-
-    class FakeQtConsole(RichJupyterWidget):
-        def __init__(self, viewer: Viewer):
-            super().__init__()
-            self.viewer = viewer
-            self.kernel_client = None
-            self.kernel_manager = None
-
-        _update_theme = Mock()
-        push = Mock()
-        closeEvent = QtConsole.closeEvent
-
-    with patch("napari_console.QtConsole", FakeQtConsole):
-        yield
-
-
 @pytest.fixture(autouse=True)
 def _mock_app():
     """Mock clean 'test_app' `NapariApplication` instance.
@@ -779,7 +742,6 @@ def pytest_runtest_setup(item):
                 "dangling_qanimations",
                 "dangling_qthreads",
                 "dangling_qtimers",
-                "mock_console",
             ]
         )
 

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -173,7 +173,7 @@ def make_napari_viewer(
     >>> def test_something_with_strict_qt_tests(make_napari_viewer):
     ...     viewer = make_napari_viewer(strict_qt=True)
     """
-    from qtpy.QtWidgets import QApplication
+    from qtpy.QtWidgets import QApplication, QWidget
 
     from napari import Viewer
     from napari._qt._qapp_model.qactions import init_qactions
@@ -224,8 +224,14 @@ def make_napari_viewer(
     )
 
     if "enable_console" not in request.keywords:
+
+        def _dummy_widget(*_):
+            w = QWidget()
+            w._update_theme = _empty
+            return w
+
         monkeypatch.setattr(
-            "napari._qt.qt_viewer.QtViewer._get_console", _empty
+            "napari._qt.qt_viewer.QtViewer._get_console", _dummy_widget
         )
 
     def actual_factory(

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -223,6 +223,11 @@ def make_napari_viewer(
         _empty,
     )
 
+    if "enable_console" not in request.keywords:
+        monkeypatch.setattr(
+            "napari._qt.qt_viewer.QtViewer._get_console", _empty
+        )
+
     def actual_factory(
         *model_args,
         ViewerClass=Viewer,


### PR DESCRIPTION
# References and relevant issues

closes #6432
 
# Description

I have followed Talley's suggestion and just prevented the creation of a console using monkeypatch. 