### PR TITLE
Do not run macos process renaming if debugger is loaded

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -439,7 +439,11 @@ def _maybe_rerun_with_macos_fixes():
 
     # This import mus be here to raise exception about PySide6 problem
 
-    if sys.platform != "darwin":
+    if (
+        sys.platform != "darwin"
+        or "pdb" in sys.modules
+        or "pydevd" in sys.modules
+    ):
         return
 
     if "_NAPARI_RERUN_WITH_FIXES" in os.environ:


### PR DESCRIPTION
# Description
For some time, I have had problems with running napari under the debugger on macOS (breakpoint is not working, for example).

Partially it was caused by a problem reported in #6432 (direct breakepoint invoke). But breakpoints from IDE were not working because of running the second process under the hood. 

This PR adds checks if debugger (`pdb` or `pydevd`) is already loaded and then does not start a separate process.  

This PR will simplify life of persons who develop napari plugins on macOS. 

The side effect of this PR is that it will disable renaming for persons who have `npe1` version of `napari-console` (version <0.0.9)