### PR TITLE
Fix bounding box transforms when multiscale layer corner goes below zero

### DIFF
--- a/napari/_vispy/layers/base.py
+++ b/napari/_vispy/layers/base.py
@@ -222,6 +222,12 @@ class VispyBaseLayer(ABC, Generic[_L]):
             affine_offset[-1, : len(offset)] = offset[::-1]
             affine_matrix = affine_matrix @ affine_offset
         self._master_transform.matrix = affine_matrix
+        child_matrix = np.eye(4)
+        child_matrix[-1, : len(translate)] = (
+            self.layer.translate[::-1] - translate
+        )
+        for child in self.node.children:
+            child.transform.matrix = child_matrix
 
     def _on_experimental_clipping_planes_change(self):
         if hasattr(self.node, 'clipping_planes') and hasattr(

--- a/napari/_vispy/layers/base.py
+++ b/napari/_vispy/layers/base.py
@@ -222,6 +222,12 @@ class VispyBaseLayer(ABC, Generic[_L]):
             affine_offset[-1, : len(offset)] = offset[::-1]
             affine_matrix = affine_matrix @ affine_offset
         self._master_transform.matrix = affine_matrix
+
+        # Because of performance reason, for multiscale images
+        # we load only visible part of data to GPU.
+        # To place this part of data correctly we update transform,
+        # but this leads to incorrect placement of child layers.
+        # To fix this we need to update child layers transform.
         child_matrix = np.eye(4)
         child_matrix[-1, : len(translate)] = (
             self.layer.translate[self.layer._slice_input.displayed][::-1]

--- a/napari/_vispy/layers/base.py
+++ b/napari/_vispy/layers/base.py
@@ -224,7 +224,8 @@ class VispyBaseLayer(ABC, Generic[_L]):
         self._master_transform.matrix = affine_matrix
         child_matrix = np.eye(4)
         child_matrix[-1, : len(translate)] = (
-            self.layer.translate[::-1] - translate
+            self.layer.translate[self.layer._slice_input.displayed][::-1]
+            - translate
         )
         for child in self.node.children:
             child.transform.matrix = child_matrix


### PR DESCRIPTION
# References and relevant issues
closes #6394

# Description

There are two differences in handling of multiscale and single scale one:

Non multiscale:
https://github.com/napari/napari/blob/9d0c449553eaf1acc3be1bf9bc0c8b3eec05afc6/napari/layers/image/_slice.py#L199

Multiscale:
https://github.com/napari/napari/blob/9d0c449553eaf1acc3be1bf9bc0c8b3eec05afc6/napari/layers/image/_slice.py#L236-L241

---------------

Non multiscale 

https://github.com/napari/napari/blob/9d0c449553eaf1acc3be1bf9bc0c8b3eec05afc6/napari/layers/image/_slice.py#L194

Multiscale:

https://github.com/napari/napari/blob/9d0c449553eaf1acc3be1bf9bc0c8b3eec05afc6/napari/layers/image/_slice.py#L244

## So what is the real difference? 

In multiscale data, we only load the visible part of the data. So when moving the image below 0 coordinates, we do not fetch all data, only visible places. But this requires updating vispy node transform to place the image in the correct place still. But then overlays are incorrectly placed. 

So in this PR, I have updated overlays matrixes to correct this shift.
