### PR TITLE
Fix `breakpoint()` function after console import

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -542,7 +542,14 @@ class QtViewer(QSplitter):
         if self._console is None:
             try:
                 import numpy as np
+
+                # QtConsole imports debugpy that overwrites default breakpoint.
+                # It makes problems with debugging if you do not know this.
+                # So we do not want to overwrite it if it is already set.
+                breakpoint_handler = sys.breakpointhook
                 from napari_console import QtConsole
+
+                sys.breakpointhook = breakpoint_handler
 
                 import napari
 


### PR DESCRIPTION
# Description
extracted from #6436 for simplification of the cherry pic process. 