### PR TITLE
fix problem with alligned overlay

### DIFF
--- a/napari/_vispy/layers/base.py
+++ b/napari/_vispy/layers/base.py
@@ -238,6 +238,9 @@ class VispyBaseLayer(ABC, Generic[_L]):
         child_matrix = np.eye(4)
         child_matrix[-1, : len(translate)] = (
             self.layer.translate[self.layer._slice_input.displayed][::-1]
+            + self.layer.affine.translate[self.layer._slice_input.displayed][
+                ::-1
+            ]
             - translate
         )
         for child in self.node.children:


### PR DESCRIPTION
# Description

During implementation of #6438 I wrongly assume that the transform box updates layer `transform` properties. But it update `layer.affine.transform`, not `layer.transform` 

So it lead to bug that could be seen on this video:


https://github.com/napari/napari/assets/3826210/ea5b52c6-15fa-41c3-99d6-dd93b07ffb01


https://github.com/napari/napari/assets/3826210/280b3c7c-7ab4-415b-a7ad-9e49fc166555

This PR fixes this problem. 
