### PR TITLE
add addtional pystack arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ xarray = "xr"
 addopts = "--maxfail=5 --durations=10 -rXxs"
 console_output_style = "count"
 pystack_threshold=60
+pystack_args="--native-all"
 
 
 # NOTE: only put things that will never change in here.


### PR DESCRIPTION
# Description

We got pystack report from the test and it reveals that there is no information about c stack. This PR update pystack configuration to print. also it 


https://github.com/napari/napari/actions/runs/6869274935/job/18682730406#step:11:372

hee copied version:
```
  **** PYSTACK  -- test_not_playing_after_ndim_changes ***
  Timed out waiting for process 3954 to finish test_not_playing_after_ndim_changes:The frame stack for thread 8233 is empty
  Traceback for thread 3990 (coverage) [] (most recent call last):
      (Python) File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/threading.py", line 973, in _bootstrap
          self._bootstrap_inner()
      (Python) File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
          self.run()
      (Python) File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/threading.py", line 953, in run
          self._target(*self._args, **self._kwargs)
      (Python) File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/multiprocessing/queues.py", line 231, in _feed
          nwait()
      (Python) File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/threading.py", line 320, in wait
          waiter.acquire()
  
  Traceback for thread 3954 (coverage) [Has the GIL] (most recent call last):
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/bin/coverage", line 8, in <module>
          sys.exit(main())
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/coverage/cmdline.py", line 973, in main
          status = CoverageScript().command_line(argv)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/coverage/cmdline.py", line 684, in command_line
          return self.do_run(options, args)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/coverage/cmdline.py", line 861, in do_run
          runner.run()
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/coverage/execfile.py", line 211, in run
          exec(code, main_mod.__dict__)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/pytest/__main__.py", line 5, in <module>
          raise SystemExit(pytest.console_main())
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/_pytest/config/__init__.py", line 192, in console_main
          code = main()
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/_pytest/config/__init__.py", line 169, in main
          ret: Union[ExitCode, int] = config.hook.pytest_cmdline_main(
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/pluggy/_hooks.py", line 493, in __call__
          return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/pluggy/_manager.py", line 115, in _hookexec
          return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/pluggy/_callers.py", line 77, in _multicall
          res = hook_impl.function(*args)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/_pytest/main.py", line 318, in pytest_cmdline_main
          return wrap_session(config, _main)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/_pytest/main.py", line 271, in wrap_session
          session.exitstatus = doit(config, session) or 0
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/_pytest/main.py", line 325, in _main
          config.hook.pytest_runtestloop(session=session)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/pluggy/_hooks.py", line 493, in __call__
          return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/pluggy/_manager.py", line 115, in _hookexec
          return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/pluggy/_callers.py", line 77, in _multicall
          res = hook_impl.function(*args)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/_pytest/main.py", line 350, in pytest_runtestloop
          item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/pluggy/_hooks.py", line 493, in __call__
          return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/pluggy/_manager.py", line 115, in _hookexec
          return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/pluggy/_callers.py", line 77, in _multicall
          res = hook_impl.function(*args)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/_pytest/runner.py", line 114, in pytest_runtest_protocol
          runtestprotocol(item, nextitem=nextitem)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/_pytest/runner.py", line 133, in runtestprotocol
          reports.append(call_and_report(item, "call", log))
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/_pytest/runner.py", line 222, in call_and_report
          call = call_runtest_hook(item, when, **kwds)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/_pytest/runner.py", line 261, in call_runtest_hook
          return CallInfo.from_call(
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/_pytest/runner.py", line 341, in from_call
          result: Optional[TResult] = func()
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/_pytest/runner.py", line 262, in <lambda>
          lambda: ihook(item=item, **kwds), when=when, reraise=reraise
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/pluggy/_hooks.py", line 493, in __call__
          return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/pluggy/_manager.py", line 115, in _hookexec
          return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/pluggy/_callers.py", line 77, in _multicall
          res = hook_impl.function(*args)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/_pytest/runner.py", line 169, in pytest_runtest_call
          item.runtest()
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/_pytest/python.py", line 1792, in runtest
          self.ihook.pytest_pyfunc_call(pyfuncitem=self)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/pluggy/_hooks.py", line 493, in __call__
          return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/pluggy/_manager.py", line 115, in _hookexec
          return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/pluggy/_callers.py", line 77, in _multicall
          res = hook_impl.function(*args)
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
          result = testfunction(**testargs)
      (Python) File "/home/runner/work/napari/napari/napari/_qt/widgets/_tests/test_qt_dims_2.py", line 48, in test_not_playing_after_ndim_changes
          dims.ndim = 2
      (Python) File "/home/runner/work/napari/napari/napari/utils/events/evented_model.py", line 306, in __setattr__
          with ComparisonDelayer(self):
      (Python) File "/home/runner/work/napari/napari/napari/utils/events/evented_model.py", line 519, in __exit__
          self._target._check_if_values_changed_and_emit_if_needed()
      (Python) File "/home/runner/work/napari/napari/napari/utils/events/evented_model.py", line 344, in _check_if_values_changed_and_emit_if_needed
          getattr(self.events, name)(value=new_value)
      (Python) File "/home/runner/work/napari/napari/napari/utils/events/event.py", line 771, in __call__
          self._invoke_callback(cb, event if pass_event else None)
      (Python) File "/home/runner/work/napari/napari/napari/utils/events/event.py", line 798, in _invoke_callback
          cb()
      (Python) File "/home/runner/work/napari/napari/napari/_qt/widgets/qt_dims.py", line 124, in _update_nsliders
          self._create_sliders(self.dims.ndim)
      (Python) File "/home/runner/work/napari/napari/napari/_qt/widgets/qt_dims.py", line 194, in _create_sliders
          slider_widget = QtDimSliderWidget(self, dim_axis)
      (Python) File "/home/runner/work/napari/napari/napari/_qt/widgets/qt_dims_slider.py", line 93, in __init__
          self._create_axis_label_widget()
      (Python) File "/home/runner/work/napari/napari/napari/_qt/widgets/qt_dims_slider.py", line 131, in _create_axis_label_widget
          label.setEllipsesWidth(int(fm.averageCharWidth() * 3))
      (Python) File "/home/runner/work/napari/napari/.tox/py310-linux-pyqt5-cov/lib/python3.10/site-packages/superqt/elidable/_eliding_line_edit.py", line 47, in setEllipsesWidth
          super().setText(self._elidedText())
  
  **** PYSTACK  ***
```