### PR TITLE
Bump docker image version to most recent from 3.x.x line

### DIFF
--- a/.github/workflows/docker-singularity-publish.yml
+++ b/.github/workflows/docker-singularity-publish.yml
@@ -100,7 +100,7 @@ jobs:
     needs: build1
     runs-on: ubuntu-latest
     container:
-      image: quay.io/singularity/docker2singularity:v3.10.0
+      image: quay.io/singularity/docker2singularity:v3.11.5
       options: --privileged
     permissions:
       contents: read


### PR DESCRIPTION
# Description

I just found out that we use one year old docker2singularity image. This PR bumped it to the most recent version from 3.x.x line that is 3.11.5.  

There is also v4.0.1 but it may require some time for test as it suggest some breaking change. 