### PR TITLE
Fix label color shuffling by also updating colormap size

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1562,13 +1562,14 @@ def test_color_mapping_when_seed_is_changed():
     assert not np.allclose(mapped_colors1, mapped_colors2)
 
 
-@pytest.mark.parametrize(
-    'num_colors', [49, 50, 254, 255, 60000, 65534, 2**17]
-)
+@pytest.mark.parametrize('num_colors', [49, 50, 254, 255, 60000, 65534])
 def test_color_shuffling_above_num_colors(num_colors):
-    """Check that the color shuffle does not result in the same collisions.
+    r"""Check that the color shuffle does not result in the same collisions.
 
     See https://github.com/napari/napari/issues/6448.
+
+    Note that we don't support more than 2\ :sup:`16` colors, and behavior
+    with more colors is undefined, so we don't test it here.
     """
     labels = np.arange(1, 1 + 2 * num_colors).reshape((2, num_colors))
     layer = Labels(labels, num_colors=num_colors)

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1562,15 +1562,14 @@ def test_color_mapping_when_seed_is_changed():
     assert not np.allclose(mapped_colors1, mapped_colors2)
 
 
-def test_color_shuffling_above_num_colors():
+@pytest.mark.parametrize('num_colors', [49, 50, 254, 255, 60000, 65534])
+def test_color_shuffling_above_num_colors(num_colors):
     """Check that the color shuffle does not result in the same collisions.
 
     See https://github.com/napari/napari/issues/6448.
     """
-    # period: this is the number of non-background colors in the colormap
-    period = 50 - 1
-    labels = np.arange(1, 1 + 2 * period).reshape((2, period))
-    layer = Labels(labels)
+    labels = np.arange(1, 1 + 2 * num_colors).reshape((2, num_colors))
+    layer = Labels(labels, num_colors=num_colors)
     colors0 = layer.colormap.map(labels)
     assert np.all(colors0[0] == colors0[1])
     layer.new_colormap()

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1562,7 +1562,9 @@ def test_color_mapping_when_seed_is_changed():
     assert not np.allclose(mapped_colors1, mapped_colors2)
 
 
-@pytest.mark.parametrize('num_colors', [49, 50, 254, 255, 60000, 65534])
+@pytest.mark.parametrize(
+    'num_colors', [49, 50, 254, 255, 60000, 65534, 2**17]
+)
 def test_color_shuffling_above_num_colors(num_colors):
     """Check that the color shuffle does not result in the same collisions.
 

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1562,6 +1562,22 @@ def test_color_mapping_when_seed_is_changed():
     assert not np.allclose(mapped_colors1, mapped_colors2)
 
 
+def test_color_shuffling_above_num_colors():
+    """Check that the color shuffle does not result in the same collisions.
+
+    See https://github.com/napari/napari/issues/6448.
+    """
+    # period: this is the number of non-background colors in the colormap
+    period = 50 - 1
+    labels = np.arange(1, 1 + 2 * period).reshape((2, period))
+    layer = Labels(labels)
+    colors0 = layer.colormap.map(labels)
+    assert np.all(colors0[0] == colors0[1])
+    layer.new_colormap()
+    colors1 = layer.colormap.map(labels)
+    assert not np.all(colors1[0] == colors1[1])
+
+
 def test_negative_label():
     """Test negative label values are supported."""
     data = np.random.randint(low=-1, high=20, size=(10, 10))

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -312,7 +312,7 @@ class Labels(_ImageBase):
         self._random_colormap = label_colormap(
             self.num_colors, self.seed, self._background_label
         )
-        self._original_colormap = self._random_colormap
+        self._original_random_colormap = self._random_colormap
         self._direct_colormap = direct_colormap()
         self._color_mode = LabelColorMode.AUTO
         self._show_selected_label = False
@@ -513,8 +513,8 @@ class Labels(_ImageBase):
                 self.num_colors, self.seed, self._background_label
             )
         else:
-            self._colormap = shuffle_and_extend_colormap(
-                self._original_colormap, self._seed_rng
+            self._random_colormap = shuffle_and_extend_colormap(
+                self._original_random_colormap, self._seed_rng
             )
         self._cached_labels = None  # invalidate the cached color mapping
         self._selected_color = self.get_color(self.selected_label)
@@ -536,6 +536,7 @@ class Labels(_ImageBase):
     def _set_colormap(self, colormap):
         if isinstance(colormap, LabelColormap):
             self._random_colormap = colormap
+            self._original_random_colormap = colormap
             self._colormap = self._random_colormap
             color_mode = LabelColorMode.AUTO
         else:
@@ -557,7 +558,6 @@ class Labels(_ImageBase):
         self._selected_color = self.get_color(self.selected_label)
         self.events.colormap()  # Will update the LabelVispyColormap shader
         self.color_mode = color_mode
-        self._original_colormap = colormap
 
     @property
     def num_colors(self):

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -58,6 +58,7 @@ from napari.utils.colormaps.colormap import (
     _cast_labels_data_to_texture_dtype_direct,
     _texture_dtype,
 )
+from napari.utils.colormaps.colormap_utils import shuffle_and_extend_colormap
 from napari.utils.events import EmitterGroup, Event
 from napari.utils.events.custom_types import Array
 from napari.utils.geometry import clamp_point_to_bounding_box
@@ -311,6 +312,7 @@ class Labels(_ImageBase):
         self._random_colormap = label_colormap(
             self.num_colors, self.seed, self._background_label
         )
+        self._original_colormap = self._random_colormap
         self._direct_colormap = direct_colormap()
         self._color_mode = LabelColorMode.AUTO
         self._show_selected_label = False
@@ -511,7 +513,9 @@ class Labels(_ImageBase):
                 self.num_colors, self.seed, self._background_label
             )
         else:
-            self.colormap.shuffle(self._seed_rng)
+            self._colormap = shuffle_and_extend_colormap(
+                self._original_colormap, self._seed_rng
+            )
         self._cached_labels = None  # invalidate the cached color mapping
         self._selected_color = self.get_color(self.selected_label)
         self.events.colormap()  # Will update the LabelVispyColormap shader
@@ -553,6 +557,7 @@ class Labels(_ImageBase):
         self._selected_color = self.get_color(self.selected_label)
         self.events.colormap()  # Will update the LabelVispyColormap shader
         self.color_mode = color_mode
+        self._original_colormap = colormap
 
     @property
     def num_colors(self):

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -1,5 +1,6 @@
 import warnings
 from collections import OrderedDict
+from functools import lru_cache
 from threading import Lock
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
@@ -473,6 +474,7 @@ def label_colormap(
     )
 
 
+@lru_cache
 def _primes(upto=2**16):
     """Generate primes up to a given number.
 

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -496,7 +496,7 @@ def _primes(upto=2**16):
 
 
 def shuffle_and_extend_colormap(
-    colormap: LabelColormap, seed: int
+    colormap: LabelColormap, seed: int, min_random_choices: int = 5
 ) -> LabelColormap:
     """Shuffle the colormap colors and extend it to more colors.
 
@@ -509,6 +509,16 @@ def shuffle_and_extend_colormap(
         Colormap to shuffle and extend.
     seed : int
         Seed for the random number generator.
+    min_random_choices : int
+        Minimum number of new table sizes to choose from. When choosing table
+        sizes, every choice gives a 1/size chance of two labels being mapped
+        to the same color. Since we try to stay within the same dtype as the
+        original colormap, if the number of original colors is close to the
+        maximum value for the dtype, there will not be enough prime numbers
+        up to the dtype max to ensure that two labels can always be
+        distinguished after one or few shuffles. In that case, we discard
+        some colors and choose the `min_random_choices` largest primes to fit
+        within the dtype.
 
     Returns
     -------
@@ -524,6 +534,8 @@ def shuffle_and_extend_colormap(
 
     primes = _primes(np.iinfo(dtype).max)
     valid_primes = primes[primes > n_colors_prev]
+    if len(valid_primes) < min_random_choices:
+        valid_primes = primes[-min_random_choices:]
     n_colors = rng.choice(valid_primes)
 
     extended_colors = np.concatenate(

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -20,6 +20,7 @@ from napari.utils.colormaps.colormap import (
     ColormapInterpolationMode,
     DirectLabelColormap,
     LabelColormap,
+    minimum_dtype_for_labels,
 )
 from napari.utils.colormaps.inverse_colormaps import inverse_cmaps
 from napari.utils.colormaps.standardize_color import transform_color
@@ -470,6 +471,79 @@ def label_colormap(
         interpolation='zero',
         background_value=background_value,
     )
+
+
+def _primes(upto=2**16):
+    """Generate primes up to a given number.
+
+    Parameters
+    ----------
+    upto : int
+        The upper limit of the primes to generate.
+
+    Returns
+    -------
+    primes : np.ndarray
+        The primes up to the upper limit.
+    """
+    primes = np.arange(3, upto + 1, 2)
+    isprime = np.ones((upto - 1) // 2, dtype=bool)
+    max_factor = int(np.sqrt(upto))
+    for factor in primes[: max_factor // 2]:
+        if isprime[(factor - 2) // 2]:
+            isprime[(factor * 3 - 2) // 2 : None : factor] = 0
+    return np.concatenate(([2], primes[isprime]))
+
+
+def shuffle_and_extend_colormap(
+    colormap: LabelColormap, seed: int
+) -> LabelColormap:
+    """Shuffle the colormap colors and extend it to more colors.
+
+    The new number of colors will be a prime number that fits into the same
+    dtype as the current number of colors in the colormap.
+
+    Parameters
+    ----------
+    colormap : napari.utils.LabelColormap
+        Colormap to shuffle and extend.
+    seed : int
+        Seed for the random number generator.
+
+    Returns
+    -------
+    colormap : napari.utils.LabelColormap
+        Shuffled and extended colormap.
+    """
+    rng = np.random.default_rng(seed)
+    n_colors_prev = len(colormap.colors)
+    dtype = minimum_dtype_for_labels(n_colors_prev)
+    indices = np.arange(n_colors_prev)
+    rng.shuffle(indices)
+    shuffled_colors = colormap.colors[indices]
+
+    primes = _primes(np.iinfo(dtype).max)
+    valid_primes = primes[primes > n_colors_prev]
+    n_colors = rng.choice(valid_primes)
+
+    extended_colors = np.concatenate(
+        (
+            shuffled_colors,
+            shuffled_colors[
+                rng.choice(indices, size=n_colors - n_colors_prev)
+            ],
+        ),
+        axis=0,
+    )
+
+    new_colormap = LabelColormap(
+        name=colormap.name,
+        colors=extended_colors,
+        controls=np.linspace(0, 1, len(extended_colors) + 1),
+        interpolation='zero',
+        background_value=colormap.background_value,
+    )
+    return new_colormap
 
 
 def direct_colormap(color_dict=None):

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -534,7 +534,9 @@ def shuffle_and_extend_colormap(
     rng.shuffle(indices)
     shuffled_colors = colormap.colors[indices]
 
-    primes = _primes(np.iinfo(dtype).max)
+    primes = _primes(
+        np.iinfo(dtype).max if np.issubdtype(dtype, np.integer) else 2**24
+    )
     valid_primes = primes[primes > n_colors_prev]
     if len(valid_primes) < min_random_choices:
         valid_primes = primes[-min_random_choices:]

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -539,13 +539,12 @@ def shuffle_and_extend_colormap(
     if len(valid_primes) < min_random_choices:
         valid_primes = primes[-min_random_choices:]
     n_colors = rng.choice(valid_primes)
+    n_color_diff = n_colors - n_colors_prev
 
     extended_colors = np.concatenate(
         (
-            shuffled_colors,
-            shuffled_colors[
-                rng.choice(indices, size=n_colors - n_colors_prev)
-            ],
+            shuffled_colors[: min(n_color_diff, 0) or None],
+            shuffled_colors[rng.choice(indices, size=max(n_color_diff, 0))],
         ),
         axis=0,
     )


### PR DESCRIPTION
# References and relevant issues

Closes #6448

Alternative approach to #6449

# Description

This fixes #6448 by adding colors, up to some randomly chosen prime number, to
the label colormap. The modulo-plus-one function that hashes labels into bins
now has a different hash table size, which means previous collisions have low
probability of re-occurring after a shuffle.

When there are no more primes left in the dtype, the number of colors is (slightly) reduced to choose a prime number at random from those just below the current number of colors.