### PR TITLE
MAINT Bump magicgui version to v0.7.0

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -11,7 +11,7 @@ dependencies:
 - imageio >=2.20
 - importlib-metadata >=1.5.0  # not needed for py>37 but keeping for noarch
 - jsonschema >=3.2.0
-- magicgui >=0.2.6
+- magicgui >=0.7.0
 - napari-console >=0.0.4
 - napari-plugin-engine >=0.1.9
 - napari-svg >=0.1.4

--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -172,11 +172,7 @@ def test_making_function_dock_widgets(test_plugin_widgets, make_napari_viewer):
     dw = viewer.window._dock_widgets['magic (TestP3)']
     # make sure that it contains a magicgui widget
     magic_widget = dw.widget()._magic_widget
-    FGui = getattr(magicgui.widgets, 'FunctionGui', None)
-    if FGui is None:
-        # pre magicgui 0.2.6
-        FGui = magicgui.FunctionGui
-    assert isinstance(magic_widget, FGui)
+    assert isinstance(magic_widget, magicgui.widgets.FunctionGui)
     # This magicgui widget uses the parameter annotation to receive a viewer
     assert isinstance(magic_widget.viewer.value, napari.Viewer)
     # The function just returns the viewer... make sure we can call it

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     imageio>=2.20,!=2.22.1
     jsonschema>=3.2.0
     lazy_loader>=0.2
-    magicgui>=0.3.6
+    magicgui>=0.7.0
     napari-console>=0.0.9
     napari-plugin-engine>=0.1.9
     napari-svg>=0.1.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ install_requires =
     Pillow!=7.1.0,!=7.1.1  # not a direct dependency, but 7.1.0 and 7.1.1 broke imageio
     pint>=0.17
     psutil>=5.0
-    psygnal>=0.3.4
+    psygnal>=0.5.0
     pydantic>=1.9.0
     pygments>=2.6.0
     PyOpenGL>=3.1.0


### PR DESCRIPTION
# References and relevant issues
closes #6454

# Description

* Bump magicgui version to v0.7.0, where the `magicgui.type_map` module was introduced
* Remove old code that accommodated for magicgui < 0.2.6 (note we currently import `magicgui.widgets.FunctionGui` in other files)
* also bumped binder magicgui version
* bump psygnal to 0.5.0

