### PR TITLE
[maint] update Dockerfile with current installation of Xpra

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -50,9 +50,11 @@ ENTRYPOINT ["python3", "-m", "napari"]
 FROM napari AS napari-xpra
 
 # Install Xpra and dependencies
-RUN apt-get install -y wget gnupg2 apt-transport-https && \
-    wget -O - https://xpra.org/gpg.asc | apt-key add - && \
-    echo "deb https://xpra.org/ jammy main" > /etc/apt/sources.list.d/xpra.list
+RUN apt-get update && apt-get install -y wget gnupg2 apt-transport-https \
+    software-properties-common ca-certificates && \
+    wget -O "/usr/share/keyrings/xpra.asc" https://xpra.org/xpra.asc && \
+    wget -O "/etc/apt/sources.list.d/xpra.sources" https://xpra.org/repos/jammy/xpra.sources
+
 
 RUN apt-get update && \
     apt-get install -yqq \
@@ -70,7 +72,7 @@ ENV XPRA_EXIT_WITH_CLIENT="yes"
 ENV XPRA_XVFB_SCREEN="1920x1080x24+32"
 EXPOSE 9876
 
-CMD echo "Launching napari on Xpra. Connect via http://localhost:$XPRA_PORT"; \
+CMD echo "Launching napari on Xpra. Connect via http://localhost:$XPRA_PORT or $(hostname -i):$XPRA_PORT"; \
     xpra start \
     --bind-tcp=0.0.0.0:$XPRA_PORT \
     --html=on \


### PR DESCRIPTION
# Description
This PR updates the Xpra installation in the Dockerfile to be consistent with the Xpra repo installation guidelines from: https://github.com/Xpra-org/xpra/wiki/Download#-for-debian-based-distributions

This results in using the up-to-date v.5.x Xpra.
