### PR TITLE
Update allowed selected_label range when data dtype changes

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
@@ -118,7 +118,7 @@ def test_preserve_labels_checkbox(make_labels_controls):
 
 
 def test_change_label_selector_range(make_labels_controls):
-    """Tests that changing the label selector range updates the layer."""
+    """Changing the label layer dtype should update label selector range."""
     layer, qtctrl = make_labels_controls()
     assert layer.data.dtype == np.uint8
     assert qtctrl.selectionSpinBox.minimum() == 0

--- a/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
@@ -6,7 +6,7 @@ from napari.layers import Labels
 from napari.utils.colormaps import colormap_utils
 
 np.random.seed(0)
-_LABELS = np.random.randint(5, size=(10, 15))
+_LABELS = np.random.randint(5, size=(10, 15), dtype=np.uint8)
 _COLOR = {1: 'white', 2: 'blue', 3: 'green', 4: 'red', 5: 'yellow'}
 
 
@@ -115,3 +115,16 @@ def test_preserve_labels_checkbox(make_labels_controls):
     assert not layer.preserve_labels
     qtctrl.preserveLabelsCheckBox.setChecked(True)
     assert layer.preserve_labels
+
+
+def test_change_label_selector_range(make_labels_controls):
+    """Tests that changing the label selector range updates the layer."""
+    layer, qtctrl = make_labels_controls()
+    assert layer.data.dtype == np.uint8
+    assert qtctrl.selectionSpinBox.minimum() == 0
+    assert qtctrl.selectionSpinBox.maximum() == 255
+
+    layer.data = layer.data.astype(np.int8)
+
+    assert qtctrl.selectionSpinBox.minimum() == -128
+    assert qtctrl.selectionSpinBox.maximum() == 127

--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -110,6 +110,7 @@ class QtLabelsControls(QtLayerControls):
             self._on_show_selected_label_change
         )
         self.layer.events.color_mode.connect(self._on_color_mode_change)
+        self.layer.events.data.connect(self._on_data_change)
 
         # selection spinbox
         self.selectionSpinBox = QLargeIntSpinBox()
@@ -304,6 +305,11 @@ class QtLabelsControls(QtLayerControls):
         self.layout().addRow(
             trans._('show\nselected:'), self.selectedColorCheckbox
         )
+
+    def _on_data_change(self):
+        """Update label selection spinbox min/max when data changes."""
+        dtype_lims = get_dtype_limits(get_dtype(self.layer))
+        self.selectionSpinBox.setRange(*dtype_lims)
 
     def _on_mode_change(self, event):
         """Receive layer model mode change event and update checkbox ticks.


### PR DESCRIPTION
# References and relevant issues
extracted from  #6471

# Description

When the data dtype changes for a labels layer, the allowed values for the selector in QtLabelsControls should be updated accordingly. This PR connects the relevant events and adds a test.