### PR TITLE
[Maint, CI] Update circleci.yml for artifact location to fix redirector

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           api-token: ${{ secrets.CIRCLECI_TOKEN }}
-          artifact-path: 0/napari-docs/docs/_build/index.html
+          artifact-path: 0/docs/docs/_build/index.html
           circleci-jobs: build-docs
           job-title: Check the rendered docs here!


### PR DESCRIPTION
# References and relevant issues
In https://github.com/napari/napari/pull/6417/ the CircleCI config was changed to harmonize with napari-docs. This changed the path for the repo clone, which changes where the html artifacts are located so the redirector link in actions doesn't work.
See: https://github.com/napari/napari/pull/6475#issuecomment-1821270543

# Description
This PR updates the location of the artifacts generated by CircleCI building docs. This is analogous to the fix in the napari-docs repo: https://github.com/napari/docs/pull/278
