### PR TITLE
Upload test artifacts on failure

### DIFF
--- a/.github/workflows/reusable_pip_test.yml
+++ b/.github/workflows/reusable_pip_test.yml
@@ -31,12 +31,12 @@ jobs:
         uses: aganders3/headless-gui@v1
         with:
           run: |
-            python -m pytest --pyargs napari --color=yes --basetemp=pytest_tmp
-            python -m pytest --pyargs napari_builtins --color=yes --basetemp=pytest_tmp
+            python -m pytest --pyargs napari --color=yes --basetemp=.pytest_tmp
+            python -m pytest --pyargs napari_builtins --color=yes --basetemp=.pytest_tmp
 
       - name: Upload test artifacts
         if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: test artifacts pip install
-          path: pytest_tmp
+          path: .pytest_tmp

--- a/.github/workflows/reusable_pip_test.yml
+++ b/.github/workflows/reusable_pip_test.yml
@@ -31,5 +31,12 @@ jobs:
         uses: aganders3/headless-gui@v1
         with:
           run: |
-            python -m pytest --pyargs napari --color=yes
-            python -m pytest --pyargs napari_builtins --color=yes
+            python -m pytest --pyargs napari --color=yes --basetemp=pytest_tmp
+            python -m pytest --pyargs napari_builtins --color=yes --basetemp=pytest_tmp
+
+      - name: Upload test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test artifacts pip install
+          path: pytest_tmp

--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -126,7 +126,7 @@ jobs:
           shell: bash
           run: |
             echo ${{ env.MAIN }}
-            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl
+            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl -- --basetemp=pytest_tmp
             rm -r .tox
         env:
           BACKEND: ${{ env.MAIN }}
@@ -139,7 +139,7 @@ jobs:
         with:
           shell: bash
           run: |
-            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl
+            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl -- --basetemp=pytest_tmp
             rm -r .tox
         env:
           BACKEND: ${{ env.SECOND }}
@@ -152,7 +152,7 @@ jobs:
         with:
           shell: bash
           run: |
-            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl
+            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl -- --basetemp=pytest_tmp
             rm -r .tox
         env:
           BACKEND: ${{ env.THIRD }}
@@ -165,11 +165,18 @@ jobs:
         with:
           shell: bash
           run: |
-            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl
+            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl -- --basetemp=pytest_tmp
             rm -r .tox
         env:
           BACKEND: ${{ env.FOURTH }}
           NAPARI_TEST_SUBSET: qt
+
+      - name: Upload test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test artifacts ${{ inputs.platform }} py ${{ inputs.python_version }} ${{ inputs.toxenv || inputs.qt_backend }}
+          path: pytest_tmp
 
       - name: Upload pytest timing reports as json
         uses: actions/upload-artifact@v3

--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -126,7 +126,7 @@ jobs:
           shell: bash
           run: |
             echo ${{ env.MAIN }}
-            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl -- --basetemp=pytest_tmp
+            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl -- --basetemp=.pytest_tmp
             rm -r .tox
         env:
           BACKEND: ${{ env.MAIN }}
@@ -139,7 +139,7 @@ jobs:
         with:
           shell: bash
           run: |
-            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl -- --basetemp=pytest_tmp
+            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl -- --basetemp=.pytest_tmp
             rm -r .tox
         env:
           BACKEND: ${{ env.SECOND }}
@@ -152,7 +152,7 @@ jobs:
         with:
           shell: bash
           run: |
-            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl -- --basetemp=pytest_tmp
+            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl -- --basetemp=.pytest_tmp
             rm -r .tox
         env:
           BACKEND: ${{ env.THIRD }}
@@ -165,7 +165,7 @@ jobs:
         with:
           shell: bash
           run: |
-            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl -- --basetemp=pytest_tmp
+            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl -- --basetemp=.pytest_tmp
             rm -r .tox
         env:
           BACKEND: ${{ env.FOURTH }}
@@ -176,7 +176,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test artifacts ${{ inputs.platform }} py ${{ inputs.python_version }} ${{ inputs.toxenv || inputs.qt_backend }}
-          path: pytest_tmp
+          path: .pytest_tmp
 
       - name: Upload pytest timing reports as json
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -174,7 +174,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.11
-          cache-dependency-path: napari-from-github/setup.cfg
+          cache-dependency-path: setup.cfg
 
       - uses: tlambert03/setup-qt-libs@v1
 

--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -42,7 +42,7 @@ def test_nD_rectangle():
     assert shape.data_displayed.shape == (4, 3)
 
 
-def test_polygon():
+def test_polygon(tmp_path):
     """Test creating Shape with a random polygon."""
     # Test a single six vertex polygon
     np.random.seed(0)
@@ -52,6 +52,10 @@ def test_polygon():
     assert shape.data_displayed.shape == (6, 2)
     assert shape.slice_key.shape == (2, 0)
     # should get few triangles
+
+    np.savetxt(tmp_path / "edge.txt", shape._edge_vertices)
+    np.savetxt(tmp_path / "face.txt", shape._face_vertices)
+
     assert shape._edge_vertices.shape == (16, 2)
     assert shape._face_vertices.shape == (8, 2)
 

--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -42,7 +42,7 @@ def test_nD_rectangle():
     assert shape.data_displayed.shape == (4, 3)
 
 
-def test_polygon(tmp_path):
+def test_polygon():
     """Test creating Shape with a random polygon."""
     # Test a single six vertex polygon
     np.random.seed(0)
@@ -52,10 +52,6 @@ def test_polygon(tmp_path):
     assert shape.data_displayed.shape == (6, 2)
     assert shape.slice_key.shape == (2, 0)
     # should get few triangles
-
-    np.savetxt(tmp_path / "edge.txt", shape._edge_vertices)
-    np.savetxt(tmp_path / "face.txt", shape._face_vertices)
-
     assert shape._edge_vertices.shape == (16, 2)
     assert shape._face_vertices.shape == (8, 2)
 


### PR DESCRIPTION
# Description

This PR modifies running test to upload content of the pytest tmp directory on test failure to allow easier inspection of the test to understand what happens. 

This code is extracted from #6467 where I use it to debug test faliture on CI. 