### PR TITLE
Run test suite with optional dependencies and fix tests when `triangle` is installed

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -119,6 +119,7 @@ jobs:
             backend: pyqt5
             coverage: cov
             pydantic: ""
+            tox_extras: "optional"
           # test without any Qt backends
           - python: 3.9
             platform: ubuntu-20.04

--- a/napari/layers/shapes/_shapes_models/_polgyon_base.py
+++ b/napari/layers/shapes/_shapes_models/_polgyon_base.py
@@ -102,7 +102,7 @@ class PolygonBase(Shape):
             if self._closed:
                 data = np.append(data, data[:1], axis=0)
 
-            tck, _ = splprep(
+            tck, *_ = splprep(
                 data.T, s=0, k=self.interpolation_order, per=self._closed
             )
 

--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import pytest
 from vispy.geometry import PolygonData
@@ -75,7 +77,7 @@ def test_polygon_data_triangle_module():
     )
     vertices, _triangles = triangulate_face(data)
 
-    assert vertices.shape == (8, 2)
+    assert vertices.shape == (6, 2)
 
 
 def test_polygon(tmp_path):
@@ -100,16 +102,21 @@ def test_polygon(tmp_path):
     np.savetxt(tmp_path / "edge.txt", shape._edge_vertices)
     np.savetxt(tmp_path / "face.txt", shape._face_vertices)
 
+    expected_face = (6, 2) if "triangle" in sys.modules else (8, 2)
+
     assert shape._edge_vertices.shape == (16, 2)
-    assert shape._face_vertices.shape == (8, 2)
+    assert shape._face_vertices.shape == expected_face
 
 
 def test_polygon2():
     data = np.array([[0, 0], [0, 1], [1, 1], [1, 0]])
     shape = Polygon(data, interpolation_order=3)
     # should get many triangles
+
+    expected_face = (249, 2) if "triangle" in sys.modules else (251, 2)
+
     assert shape._edge_vertices.shape == (500, 2)
-    assert shape._face_vertices.shape == (251, 2)
+    assert shape._face_vertices.shape == expected_face
 
 
 def test_polygon3():

--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -45,8 +45,16 @@ def test_nD_rectangle():
 def test_polygon():
     """Test creating Shape with a random polygon."""
     # Test a single six vertex polygon
-    np.random.seed(0)
-    data = 20 * np.random.random((6, 2))
+    data = np.array(
+        [
+            [10.97627008, 14.30378733],
+            [12.05526752, 10.89766366],
+            [8.47309599, 12.91788226],
+            [8.75174423, 17.83546002],
+            [19.27325521, 7.66883038],
+            [15.83450076, 10.5778984],
+        ]
+    )
     shape = Polygon(data)
     np.testing.assert_array_equal(shape.data, data)
     assert shape.data_displayed.shape == (6, 2)

--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -42,7 +42,7 @@ def test_nD_rectangle():
     assert shape.data_displayed.shape == (4, 3)
 
 
-def test_polygon():
+def test_polygon(tmp_path):
     """Test creating Shape with a random polygon."""
     # Test a single six vertex polygon
     data = np.array(
@@ -60,6 +60,10 @@ def test_polygon():
     assert shape.data_displayed.shape == (6, 2)
     assert shape.slice_key.shape == (2, 0)
     # should get few triangles
+
+    np.savetxt(tmp_path / "edge.txt", shape._edge_vertices)
+    np.savetxt(tmp_path / "face.txt", shape._face_vertices)
+
     assert shape._edge_vertices.shape == (16, 2)
     assert shape._face_vertices.shape == (8, 2)
 

--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -80,7 +80,7 @@ def test_polygon_data_triangle_module():
     assert vertices.shape == (6, 2)
 
 
-def test_polygon(tmp_path):
+def test_polygon():
     """Test creating Shape with a random polygon."""
     # Test a single six vertex polygon
     data = np.array(
@@ -98,12 +98,7 @@ def test_polygon(tmp_path):
     assert shape.data_displayed.shape == (6, 2)
     assert shape.slice_key.shape == (2, 0)
     # should get few triangles
-
-    np.savetxt(tmp_path / "edge.txt", shape._edge_vertices)
-    np.savetxt(tmp_path / "face.txt", shape._face_vertices)
-
     expected_face = (6, 2) if "triangle" in sys.modules else (8, 2)
-
     assert shape._edge_vertices.shape == (16, 2)
     assert shape._face_vertices.shape == expected_face
 

--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -1,4 +1,5 @@
 import numpy as np
+from vispy.geometry import PolygonData
 
 from napari.layers.shapes._shapes_models import (
     Ellipse,
@@ -40,6 +41,22 @@ def test_nD_rectangle():
 
     shape.ndisplay = 3
     assert shape.data_displayed.shape == (4, 3)
+
+
+def test_polygon_data_triangle():
+    data = np.array(
+        [
+            [10.97627008, 14.30378733],
+            [12.05526752, 10.89766366],
+            [8.47309599, 12.91788226],
+            [8.75174423, 17.83546002],
+            [19.27325521, 7.66883038],
+            [15.83450076, 10.5778984],
+        ]
+    )
+    vertices, _triangles = PolygonData(vertices=data).triangulate()
+
+    assert vertices.shape == (8, 2)
 
 
 def test_polygon(tmp_path):

--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from vispy.geometry import PolygonData
 
 from napari.layers.shapes._shapes_models import (
@@ -8,6 +9,7 @@ from napari.layers.shapes._shapes_models import (
     Polygon,
     Rectangle,
 )
+from napari.layers.shapes._shapes_utils import triangulate_face
 
 
 def test_rectangle():
@@ -59,6 +61,23 @@ def test_polygon_data_triangle():
     assert vertices.shape == (8, 2)
 
 
+def test_polygon_data_triangle_module():
+    pytest.importorskip("triangle")
+    data = np.array(
+        [
+            [10.97627008, 14.30378733],
+            [12.05526752, 10.89766366],
+            [8.47309599, 12.91788226],
+            [8.75174423, 17.83546002],
+            [19.27325521, 7.66883038],
+            [15.83450076, 10.5778984],
+        ]
+    )
+    vertices, _triangles = triangulate_face(data)
+
+    assert vertices.shape == (8, 2)
+
+
 def test_polygon(tmp_path):
     """Test creating Shape with a random polygon."""
     # Test a single six vertex polygon
@@ -84,12 +103,16 @@ def test_polygon(tmp_path):
     assert shape._edge_vertices.shape == (16, 2)
     assert shape._face_vertices.shape == (8, 2)
 
+
+def test_polygon2():
     data = np.array([[0, 0], [0, 1], [1, 1], [1, 0]])
     shape = Polygon(data, interpolation_order=3)
     # should get many triangles
     assert shape._edge_vertices.shape == (500, 2)
     assert shape._face_vertices.shape == (251, 2)
 
+
+def test_polygon3():
     data = np.array([[0, 0, 0], [0, 0, 1], [0, 1, 1], [1, 1, 1]])
     shape = Polygon(data, interpolation_order=3, ndisplay=3)
     # should get many vertices


### PR DESCRIPTION
Fix test to pass with installed triangle optional dependency by installing optional dependencies with tox.


extracted from #6467 
