### PR TITLE
Do not use native dialog for reset shortcuts

### DIFF
--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, ClassVar, Dict, Tuple, cast
 
 from qtpy.QtCore import QSize, Qt, Signal
 from qtpy.QtWidgets import (
+    QApplication,
     QDialog,
     QHBoxLayout,
     QListWidget,
@@ -209,12 +210,23 @@ class PreferencesDialog(QDialog):
 
     def _restore_default_dialog(self):
         """Launches dialog to confirm restore settings choice."""
+        prev = QApplication.instance().testAttribute(
+            Qt.ApplicationAttribute.AA_DontUseNativeDialogs
+        )
+        QApplication.instance().setAttribute(
+            Qt.ApplicationAttribute.AA_DontUseNativeDialogs, True
+        )
+
         response = QMessageBox.question(
             self,
             trans._("Restore Settings"),
             trans._("Are you sure you want to restore default settings?"),
-            QMessageBox.RestoreDefaults | QMessageBox.Cancel,
-            QMessageBox.RestoreDefaults,
+            QMessageBox.StandardButton.RestoreDefaults
+            | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.RestoreDefaults,
+        )
+        QApplication.instance().setAttribute(
+            Qt.ApplicationAttribute.AA_DontUseNativeDialogs, prev
         )
         if response == QMessageBox.RestoreDefaults:
             self._settings.reset()

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -11,6 +11,7 @@ from qtpy.QtCore import QEvent, QPoint, Qt, Signal
 from qtpy.QtGui import QKeySequence
 from qtpy.QtWidgets import (
     QAbstractItemView,
+    QApplication,
     QComboBox,
     QHBoxLayout,
     QItemDelegate,
@@ -132,13 +133,22 @@ class ShortcutEditor(QWidget):
 
     def restore_defaults(self):
         """Launches dialog to confirm restore choice."""
-
+        prev = QApplication.instance().testAttribute(
+            Qt.ApplicationAttribute.AA_DontUseNativeDialogs
+        )
+        QApplication.instance().setAttribute(
+            Qt.ApplicationAttribute.AA_DontUseNativeDialogs, True
+        )
         response = QMessageBox.question(
             self,
             trans._("Restore Shortcuts"),
             trans._("Are you sure you want to restore default shortcuts?"),
-            QMessageBox.RestoreDefaults | QMessageBox.Cancel,
-            QMessageBox.RestoreDefaults,
+            QMessageBox.StandardButton.RestoreDefaults
+            | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.RestoreDefaults,
+        )
+        QApplication.instance().setAttribute(
+            Qt.ApplicationAttribute.AA_DontUseNativeDialogs, prev
         )
 
         if response == QMessageBox.RestoreDefaults:


### PR DESCRIPTION
# References and relevant issues
closes #6490

# Description

Since Qt6==6.5.0 on Macos, the Qt starts using native dialog even if it does not support all buttons (in our case `QMessageBox.StandardButton.RestoreDefaults`).

This solution is inspired by comments from https://bugreports.qt.io/browse/QTBUG-116757

If someone has time, please try to open the Bug report there. After the last discussions about patching enum, I do not feel fluent enough to write in English to talk with them. 

An alternative solution will be to change the button on the supported one. Or change the native flag globally, but the second one may impact File Dialogs. 