### PR TITLE
Add size and ndim to LayerDataProtocol

### DIFF
--- a/napari/layers/_data_protocols.py
+++ b/napari/layers/_data_protocols.py
@@ -81,6 +81,14 @@ class LayerDataProtocol(Protocol):
     ) -> LayerDataProtocol:
         """Returns self[key]."""
 
+    @property
+    def size(self) -> int:
+        """The size is necessary to calculate the data range"""
+
+    @property
+    def ndim(self) -> int:
+        """The number of dimension of the underlying data"""
+
 
 def assert_protocol(obj: Any, protocol: type = LayerDataProtocol):
     """Assert `obj` is an instance of `protocol` or raise helpful error."""

--- a/napari/layers/_multiscale_data.py
+++ b/napari/layers/_multiscale_data.py
@@ -44,6 +44,16 @@ class MultiScaleData(Sequence[LayerDataProtocol]):
             assert_protocol(d)
 
     @property
+    def size(self) -> int:
+        """Return size of the first scale.."""
+        return self._data[0].size
+
+    @property
+    def ndim(self) -> int:
+        """Return ndim of the first scale.."""
+        return self._data[0].ndim
+
+    @property
     def dtype(self) -> np.dtype:
         """Return dtype of the first scale.."""
         return self._data[0].dtype

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
 
     import numpy.typing as npt
 
+    from napari.layers._data_protocols import LayerDataProtocol
+
 
 class Extent(NamedTuple):
     """Extent of coordinates in a local data space and world space.
@@ -204,7 +206,9 @@ def _nanmax(array):
     return max_value
 
 
-def calc_data_range(data, rgb=False) -> Tuple[float, float]:
+def calc_data_range(
+    data: LayerDataProtocol, rgb: bool = False
+) -> Tuple[float, float]:
     """Calculate range of data values. If all values are equal return [0, 1].
 
     Parameters
@@ -228,7 +232,7 @@ def calc_data_range(data, rgb=False) -> Tuple[float, float]:
         return (0, 255)
 
     center: Union[int, List[int]]
-
+    reduced_data: Union[List, LayerDataProtocol]
     if data.size > 1e7 and (data.ndim == 1 or (rgb and data.ndim == 2)):
         # If data is very large take the average of start, middle and end.
         center = int(data.shape[0] // 2)


### PR DESCRIPTION
in `napari/layers/image/image.py`, `_calc_data_range(self...)` calls `calc_data_range(input_data,...)` where `input_data` is a `LayerDataProtocol`

`calc_data_range(...)` needs it to have a size, and ndim. So my guess is we need to make sure that LayerDataProtocol has size and ndim, is that correct ?

Thoughts ? 

Typing all the things that need to be types for this problem to show up is quite long, please see all my other typing PRs to start enabling type checking for these files, mostly opening this separately to know if this is something we wan to add to LayerDataProtocol