### PR TITLE
Bugfix: ensure gamma and opacity are floats

### DIFF
--- a/examples/viewer_loop_reproducible_screenshots.md
+++ b/examples/viewer_loop_reproducible_screenshots.md
@@ -73,7 +73,7 @@ viewer.text_overlay.text = "Hello World!"
 # Not yet implemented, but can be added as soon as this feature exisits (syntax might change): 
 # viewer.controls.visible = False
 
-viewer.add_labels(myball, name="result" , opacity=1)
+viewer.add_labels(myball, name="result" , opacity=1.0)
 viewer.camera.angles = (19, -33, -121)
 viewer.camera.zoom = 1.3
 ```

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -795,7 +795,9 @@ def qt_viewer(qtbot):
 @pytest.mark.parametrize('direct', [True, False], ids=["direct", "auto"])
 def test_thumbnail_labels(qtbot, direct, qt_viewer: QtViewer):
     # Add labels to empty viewer
-    layer = qt_viewer.viewer.add_labels(np.array([[0, 1], [2, 3]]), opacity=1)
+    layer = qt_viewer.viewer.add_labels(
+        np.array([[0, 1], [2, 3]]), opacity=1.0
+    )
     if direct:
         layer.color = {0: 'red', 1: 'green', 2: 'blue', 3: 'yellow'}
     qtbot.wait(100)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -750,7 +750,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         rotate=None,
         shear=None,
         affine=None,
-        opacity=1,
+        opacity=1.0,
         blending=None,
         visible=True,
         multiscale=None,

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -736,7 +736,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         rgb=None,
         colormap=None,
         contrast_limits=None,
-        gamma=1,
+        gamma=1.0,
         interpolation2d='nearest',
         interpolation3d='linear',
         rendering='mip',

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -286,7 +286,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         rotate=None,
         shear=None,
         affine=None,
-        opacity=1,
+        opacity=1.0,
         blending='translucent',
         visible=True,
         multiscale=False,
@@ -643,7 +643,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
                 )
             )
 
-        self._opacity = opacity
+        self._opacity = float(opacity)
         self._update_thumbnail()
         self.events.opacity()
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -251,7 +251,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         rotate=None,
         shear=None,
         affine=None,
-        opacity=1,
+        opacity=1.0,
         blending='translucent',
         visible=True,
         multiscale=None,

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -238,7 +238,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         rgb=None,
         colormap='gray',
         contrast_limits=None,
-        gamma=1,
+        gamma=1.0,
         interpolation2d='nearest',
         interpolation3d='linear',
         rendering='mip',

--- a/napari/layers/intensity_mixin.py
+++ b/napari/layers/intensity_mixin.py
@@ -152,6 +152,6 @@ class IntensityVisualizationMixin:
 
     @gamma.setter
     def gamma(self, value):
-        self._gamma = value
+        self._gamma = float(value)
         self._update_thumbnail()
         self.events.gamma()

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -366,7 +366,7 @@ class Points(Layer):
         rotate=None,
         shear=None,
         affine=None,
-        opacity=1,
+        opacity=1.0,
         blending='translucent',
         visible=True,
         cache=True,

--- a/napari/layers/shapes/_shapes_models/ellipse.py
+++ b/napari/layers/shapes/_shapes_models/ellipse.py
@@ -35,7 +35,7 @@ class Ellipse(Shape):
         data,
         *,
         edge_width=1,
-        opacity=1,
+        opacity=1.0,
         z_index=0,
         dims_order=None,
         ndisplay=2,

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -185,7 +185,7 @@ class Surface(IntensityVisualizationMixin, Layer):
         *,
         colormap='gray',
         contrast_limits=None,
-        gamma=1,
+        gamma=1.0,
         name=None,
         metadata=None,
         scale=None,

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -193,7 +193,7 @@ class Surface(IntensityVisualizationMixin, Layer):
         rotate=None,
         shear=None,
         affine=None,
-        opacity=1,
+        opacity=1.0,
         blending='translucent',
         shading='flat',
         visible=True,

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -111,7 +111,7 @@ class Tracks(Layer):
         rotate=None,
         shear=None,
         affine=None,
-        opacity=1,
+        opacity=1.0,
         blending='additive',
         visible=True,
         colormap='turbo',

--- a/napari/resources/_icons.py
+++ b/napari/resources/_icons.py
@@ -44,7 +44,7 @@ def get_raw_svg(path: str) -> str:
 
 @lru_cache
 def get_colorized_svg(
-    path_or_xml: Union[str, Path], color: Optional[str] = None, opacity=1
+    path_or_xml: Union[str, Path], color: Optional[str] = None, opacity=1.0
 ) -> str:
     """Return a colorized version of the SVG XML at ``path``.
 

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -235,7 +235,7 @@ def imshow(
     rotate=None,
     shear=None,
     affine=None,
-    opacity=1,
+    opacity=1.0,
     blending=None,
     visible=True,
     multiscale=None,

--- a/napari/view_layers.py
+++ b/napari/view_layers.py
@@ -221,7 +221,7 @@ def imshow(
     rgb=None,
     colormap=None,
     contrast_limits=None,
-    gamma=1,
+    gamma=1.0,
     interpolation2d='nearest',
     interpolation3d='linear',
     rendering='mip',


### PR DESCRIPTION
# References and relevant issues
At present, despite docstrings stating that gamma and opacity are floats are not enforced by napari. Worse yet, we set the default in a number of places to `1` and not `1.0`.
Downstream, vispy does coerce gamma to float so it's not so obvious, but it creeps up if you interrogate the layer state using either `viewer.layers[0].gamma` or `viewer.layers[0]._get_state()` which will return `1` and a type of `int`
See: https://github.com/napari/napari-animation/issues/149
Closes: https://github.com/napari/napari-animation/issues/149
Same can happen to opacity, but it's more subtle because of the way the slider value is used.
Closes: https://github.com/napari/napari-animation/issues/152

# Description
In this PR I set gamma and opacity defaults to `1.0` where they had been previously set to `1` and in the `gamma.setter` and `opacity.setter` I coerce to float so that the user doesn't shoot themselves in the foot accidentally.

