### PR TITLE
Add import lint back to CI

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -15,6 +15,23 @@ env:
   COLUMNS: 120
 
 jobs:
+  import_lint:
+    name: Import lint
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install tox
+      - name: Run import lint
+        run: tox -e import-lint -- --timeout=8
+
   manifest:
     # make sure all necessary files will be bundled in the release
     name: Check Manifest

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -30,7 +30,7 @@ jobs:
           pip install --upgrade pip
           pip install tox
       - name: Run import lint
-        run: tox -e import-lint -- --timeout=8
+        run: tox -e import-lint
 
   manifest:
     # make sure all necessary files will be bundled in the release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
   rev: 0.27.1
   hooks:
   - id: check-github-workflows
+    args: ["--verbose"]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0
   # .py files are skipped cause already checked by other hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,6 @@ repos:
   rev: 0.27.1
   hooks:
   - id: check-github-workflows
-    args: ["--verbose"]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0
   # .py files are skipped cause already checked by other hooks

--- a/setup.cfg
+++ b/setup.cfg
@@ -211,8 +211,8 @@ forbidden_modules =
     PyQt5
     PySide2
 ignore_imports =
-    napari._qt.qt_resources._icons -> PyQt5
-    napari._qt.qt_resources._icons -> PySide2
+    napari.resources._icons -> PyQt5
+    napari.resources._icons -> PySide2
     napari._qt -> PySide2
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -211,8 +211,6 @@ forbidden_modules =
     PyQt5
     PySide2
 ignore_imports =
-    napari.resources._icons -> PyQt5
-    napari.resources._icons -> PySide2
     napari._qt -> PySide2
 
 


### PR DESCRIPTION
# References and relevant issues
Relates to https://github.com/napari/napari/issues/6469#issuecomment-1822263505

# Description
Import lint was added to CI in #2878 but when these lint checks were moved to pre-commit (in #3717), import lint was (accidentality?) completely dropped. This adds import lint back to CI (not pre commit) because:

> And we decide to not run lint check always as the errors may be not readable for all

ref: https://github.com/napari/napari/issues/6469#issuecomment-1829598537
