### PR TITLE
Added support for features in surface layers

### DIFF
--- a/napari/layers/surface/_tests/test_surface.py
+++ b/napari/layers/surface/_tests/test_surface.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 
 from napari._tests.utils import check_layer_world_data_extent
@@ -23,6 +24,19 @@ def test_random_surface():
     assert np.array_equal(layer.vertex_values, values)
     assert layer._data_view.shape[1] == 2
     assert layer._view_vertex_values.ndim == 1
+
+
+def test_random_surface_features():
+    """Test instantiating surface layer with features."""
+    np.random.seed(0)
+    vertices = np.random.random((10, 3))
+    faces = np.random.randint(10, size=(6, 3))
+    values = np.random.random(10)
+    features = pd.DataFrame({'feature': np.random.random(10)})
+
+    data = (vertices, faces, values)
+    layer = Surface(data, features=features)
+    assert 'feature' in layer.features.columns
 
 
 def test_random_surface_no_values():

--- a/napari/layers/surface/_tests/test_surface.py
+++ b/napari/layers/surface/_tests/test_surface.py
@@ -39,6 +39,38 @@ def test_random_surface_features():
     assert 'feature' in layer.features.columns
 
 
+def test_set_features_and_defaults():
+    """Test setting features and defaults."""
+    np.random.seed(0)
+    vertices = np.random.random((10, 3))
+    faces = np.random.randint(10, size=(6, 3))
+    values = np.random.random(10)
+
+    data = (vertices, faces, values)
+    layer = Surface(data)
+
+    assert layer.features.shape[1] == layer.feature_defaults.shape[1] == 0
+
+    features = pd.DataFrame(
+        {
+            'str': ('a', 'b') * 5,
+            'float': np.random.random(10),
+        }
+    )
+    feature_defaults = pd.DataFrame(
+        {
+            'str': ('b',),
+            'float': (0.5,),
+        }
+    )
+
+    layer.features = features
+    layer.feature_defaults = feature_defaults
+
+    pd.testing.assert_frame_equal(layer.features, features)
+    pd.testing.assert_frame_equal(layer.feature_defaults, feature_defaults)
+
+
 def test_random_surface_no_values():
     """Test instantiating Surface layer with random 2D data but no vertex values."""
     np.random.seed(0)

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -462,7 +462,7 @@ class Surface(IntensityVisualizationMixin, Layer):
         self,
         features: Union[Dict[str, np.ndarray], pd.DataFrame],
     ) -> None:
-        self._feature_table.set_values(features, num_data=len(self.data))
+        self._feature_table.set_values(features, num_data=len(self.data[0]))
         self.events.features()
 
     @property

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -242,6 +242,8 @@ class Surface(IntensityVisualizationMixin, Layer):
             normals=Event,
             texture=Event,
             texcoords=Event,
+            features=Event,
+            feature_defaults=Event,
         )
 
         # assign mesh data and establish default behavior

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -142,7 +142,7 @@ class Surface(IntensityVisualizationMixin, Layer):
     vertex_values : (K0, ..., KL, N) array
         Values used to color vertices.
     features : DataFrame-like
-        Features table where each row corresponds to a point and each column
+        Features table where each row corresponds to a vertex and each column
         is a feature.
     feature_defaults : DataFrame-like
         Stores the default value of each feature in a table with one row.

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -466,6 +466,21 @@ class Surface(IntensityVisualizationMixin, Layer):
         self.events.features()
 
     @property
+    def feature_defaults(self):
+        """Dataframe-like with one row of feature default values.
+
+        See `features` for more details on the type of this property.
+        """
+        return self._feature_table.defaults
+
+    @feature_defaults.setter
+    def feature_defaults(
+        self, defaults: Union[Dict[str, Any], pd.DataFrame]
+    ) -> None:
+        self._feature_table.set_defaults(defaults)
+        self.events.feature_defaults()
+
+    @property
     def shading(self):
         return str(self._shading)
 
@@ -563,6 +578,8 @@ class Surface(IntensityVisualizationMixin, Layer):
                 'gamma': self.gamma,
                 'shading': self.shading,
                 'data': self.data,
+                'features': self.features,
+                'feature_defaults': self.feature_defaults,
                 'wireframe': self.wireframe.dict(),
                 'normals': self.normals.dict(),
                 'texture': self.texture,

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -468,7 +468,6 @@ class Surface(IntensityVisualizationMixin, Layer):
         features: Union[Dict[str, np.ndarray], pd.DataFrame],
     ) -> None:
         self._feature_table.set_values(features, num_data=len(self.data))
-        self.text.refresh(self.features)
         self.events.properties()
         self.events.features()
 

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -146,9 +146,6 @@ class Surface(IntensityVisualizationMixin, Layer):
         is a feature.
     feature_defaults : DataFrame-like
         Stores the default value of each feature in a table with one row.
-    properties : dict {str: array (N,)} or DataFrame
-        Annotations for each point. Each property should be an array of length N,
-        where N is the number of points.
     colormap : str, napari.utils.Colormap, tuple, dict
         Colormap to use for luminance images. If a string must be the name
         of a supported colormap from vispy or matplotlib. If a tuple the
@@ -194,8 +191,6 @@ class Surface(IntensityVisualizationMixin, Layer):
         *,
         features=None,
         feature_defaults=None,
-        properties=None,
-        property_choices=None,
         colormap='gray',
         contrast_limits=None,
         gamma=1.0,
@@ -268,8 +263,6 @@ class Surface(IntensityVisualizationMixin, Layer):
         self._feature_table = _FeatureTable.from_layer(
             features=features,
             feature_defaults=feature_defaults,
-            properties=properties,
-            property_choices=property_choices,
             num_data=len(data[0]),
         )
 

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -463,7 +463,6 @@ class Surface(IntensityVisualizationMixin, Layer):
         features: Union[Dict[str, np.ndarray], pd.DataFrame],
     ) -> None:
         self._feature_table.set_values(features, num_data=len(self.data))
-        self.events.properties()
         self.events.features()
 
     @property


### PR DESCRIPTION
# References and relevant issues
Partial fix of #5205 

# Description
This PR adds the most basic form of support for adding the `features` to the `Surface` layer. In essence, I copied the respective functionality from the `Points` layer into the code for the Surface layer. *Note*: As discussed in the [above issue](#5205) this currently modifies the Surface layer only in so far as it does not throw an error if a `features` keyword is passed to the instantiation, but it does not hook up the coloring scheme to the features table.
