### PR TITLE
Reset single step and decimals on reset range slider in popup

### DIFF
--- a/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -254,6 +254,11 @@ class QContrastLimitsPopup(QRangeSliderPopup):
         def reset():
             layer.reset_contrast_limits()
             layer.contrast_limits_range = layer.contrast_limits
+            decimals_ = range_to_decimals(
+                layer.contrast_limits_range, layer.dtype
+            )
+            self.slider.setDecimals(decimals_)
+            self.slider.setSingleStep(10**-decimals_)
 
         reset_btn = QPushButton("reset")
         reset_btn.setObjectName("reset_clims_button")


### PR DESCRIPTION
# References and relevant issues
closes #6522

# Description

This PR fix bug reported in #6522 be reset single steep and decimals of `QLabeledDoubleRangeSlider`