### PR TITLE
Restore quit shortcut

### DIFF
--- a/napari/_qt/_qapp_model/qactions/_file.py
+++ b/napari/_qt/_qapp_model/qactions/_file.py
@@ -181,5 +181,6 @@ Q_FILE_ACTIONS: List[Action] = [
         title=CommandId.DLG_QUIT.command_title,
         callback=_close_app,
         menus=[{'id': MenuId.MENUBAR_FILE, 'group': MenuGroup.CLOSE}],
+        keybindings=[StandardKeyBinding.Quit],
     ),
 ]


### PR DESCRIPTION
# Description
Currently, on non-macOS systems there is no shortcut to close the application, only to close the window. It looks like it was missed during the change to use the app model. 

The current state: 

![obraz](https://github.com/napari/napari/assets/3826210/57191e25-9f59-4af8-a6fc-96431d739a03)


This PR adds shortcuts for closing app. 
