### PR TITLE
Use blobs instead of random integers 

### DIFF
--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -28,7 +28,6 @@ class Labels2DSuite:
         self.data = labeled_particles(
             (n, n), dtype=dtype, n=int(np.log2(n) ** 2), seed=1
         )
-        # np.random.randint(20, size=(n, n), dtype=dtype)
         self.layer = Labels(self.data)
         self.layer._raw_to_displayed(self.data, (slice(0, n), slice(0, n)))
 

--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -9,7 +9,9 @@ import numpy as np
 from napari.components.dims import Dims
 from napari.layers import Labels
 
-from .utils import Skiper
+from .utils import Skiper, gen_blobs
+
+MAX_VAL = 2**23
 
 
 class Labels2DSuite:
@@ -23,7 +25,8 @@ class Labels2DSuite:
 
     def setup(self, n, dtype):
         np.random.seed(0)
-        self.data = np.random.randint(20, size=(n, n), dtype=dtype)
+        self.data = gen_blobs((n, n), dtype, blob_count=int(np.log2(n) ** 2))
+        # np.random.randint(20, size=(n, n), dtype=dtype)
         self.layer = Labels(self.data)
         self.layer._raw_to_displayed(self.data, (slice(0, n), slice(0, n)))
 
@@ -84,7 +87,9 @@ class LabelsDrawing2DSuite:
 
     def setup(self, n, brush_size, color_mode, contour):
         np.random.seed(0)
-        self.data = np.random.randint(64, size=(n, n), dtype=np.int32)
+        self.data = gen_blobs(
+            (n, n), np.int32, blob_count=int(np.log2(n) ** 2)
+        )
 
         colors = None
         if color_mode == 'direct':
@@ -117,12 +122,7 @@ class Labels2DColorDirectSuite(Labels2DSuite):
             raise NotImplementedError("Skip on PR (speedup)")
         np.random.seed(0)
         info = np.iinfo(dtype)
-        self.data = np.random.randint(
-            low=max(-10000, info.min),
-            high=min(10000, info.max),
-            size=(n, n),
-            dtype=dtype,
-        )
+        self.data = gen_blobs((n, n), dtype, blob_count=int(np.log2(n) ** 2))
         random_label_ids = np.random.randint(
             low=max(-10000, info.min), high=min(10000, info.max), size=20
         )
@@ -148,7 +148,9 @@ class Labels3DSuite:
             raise NotImplementedError("Skip on CI (not enough memory)")
 
         np.random.seed(0)
-        self.data = np.random.randint(20, size=(n, n, n), dtype=dtype)
+        self.data = gen_blobs(
+            (n, n, n), dtype, blob_count=int(np.log2(n) ** 2)
+        )
         self.layer = Labels(self.data)
         self.layer._slice_dims(Dims(ndim=3, ndisplay=3))
         self.layer._raw_to_displayed(

--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -9,7 +9,7 @@ import numpy as np
 from napari.components.dims import Dims
 from napari.layers import Labels
 
-from .utils import Skiper, gen_blobs
+from .utils import Skiper, labeled_particles
 
 MAX_VAL = 2**23
 
@@ -25,7 +25,9 @@ class Labels2DSuite:
 
     def setup(self, n, dtype):
         np.random.seed(0)
-        self.data = gen_blobs((n, n), dtype, blob_count=int(np.log2(n) ** 2))
+        self.data = labeled_particles(
+            (n, n), dtype=dtype, n=int(np.log2(n) ** 2), seed=1
+        )
         # np.random.randint(20, size=(n, n), dtype=dtype)
         self.layer = Labels(self.data)
         self.layer._raw_to_displayed(self.data, (slice(0, n), slice(0, n)))
@@ -87,8 +89,8 @@ class LabelsDrawing2DSuite:
 
     def setup(self, n, brush_size, color_mode, contour):
         np.random.seed(0)
-        self.data = gen_blobs(
-            (n, n), np.int32, blob_count=int(np.log2(n) ** 2)
+        self.data = labeled_particles(
+            (n, n), dtype=np.int32, n=int(np.log2(n) ** 2), seed=1
         )
 
         colors = None
@@ -122,7 +124,9 @@ class Labels2DColorDirectSuite(Labels2DSuite):
             raise NotImplementedError("Skip on PR (speedup)")
         np.random.seed(0)
         info = np.iinfo(dtype)
-        self.data = gen_blobs((n, n), dtype, blob_count=int(np.log2(n) ** 2))
+        self.data = labeled_particles(
+            (n, n), dtype=dtype, n=int(np.log2(n) ** 2), seed=1
+        )
         random_label_ids = np.random.randint(
             low=max(-10000, info.min), high=min(10000, info.max), size=20
         )
@@ -148,8 +152,8 @@ class Labels3DSuite:
             raise NotImplementedError("Skip on CI (not enough memory)")
 
         np.random.seed(0)
-        self.data = gen_blobs(
-            (n, n, n), dtype, blob_count=int(np.log2(n) ** 2)
+        self.data = labeled_particles(
+            (n, n, n), dtype=dtype, n=int(np.log2(n) ** 2), seed=1
         )
         self.layer = Labels(self.data)
         self.layer._slice_dims(Dims(ndim=3, ndisplay=3))

--- a/napari/benchmarks/utils.py
+++ b/napari/benchmarks/utils.py
@@ -87,7 +87,7 @@ def _add_structure_on_coordinates(
     radius = (structure.shape[0] - 1) // 2
     shape = data.shape
 
-    for j, point in enumerate(points.T):
+    for j, point in enumerate(points):
         slice_im = []
         slice_ball = []
         for i, p in enumerate(point):
@@ -174,7 +174,7 @@ def labeled_particles(
         dtype = _smallest_dtype(n)
     rng = np.random.default_rng(seed)
     ndim = len(shape)
-    points = rng.integers(shape, size=(n, ndim)).T
+    points = rng.integers(shape, size=(n, ndim))
     values = rng.integers(
         np.iinfo(dtype).min, np.iinfo(dtype).max, size=n, dtype=dtype
     )
@@ -193,6 +193,6 @@ def labeled_particles(
             densities, points, dens, values, _add_value_to_data
         )
 
-        return labels, densities, points.T
+        return labels, densities, points
     else:  # noqa: RET505
         return labels

--- a/napari/benchmarks/utils.py
+++ b/napari/benchmarks/utils.py
@@ -23,8 +23,7 @@ class Skiper:
 
 
 def _generate_ball(radius: int, ndim: int) -> np.ndarray:
-    """
-    Generate a ball of given radius and dimension.
+    """Generate a ball of given radius and dimension.
 
     Parameters
     ----------
@@ -50,9 +49,7 @@ def _generate_ball(radius: int, ndim: int) -> np.ndarray:
 
 
 def _generate_density(radius: int, ndim: int) -> np.ndarray:
-    """
-    Generate gaussian density of given radius and dimension.
-    """
+    """Generate gaussian density of given radius and dimension."""
     shape = (2 * radius + 1,) * ndim
     coords = np.indices(shape) - radius
     dist = np.sqrt(np.sum(coords**2 / ((radius / 4) ** 2), axis=0))
@@ -68,22 +65,24 @@ def _add_structure_on_coordinates(
     values: Sequence,
     assign_operator: Callable[[np.ndarray, np.ndarray, Any], np.ndarray],
 ):
-    """
-    helper function to update data with structure at given coordinates
+    """Update data with structure at given coordinates.
 
     Parameters
     ----------
     data : ndarray
         Array to update.
     points : ndarray
-        Coordinates of the points. The structures will be added at these points (center).
+        Coordinates of the points. The structures will be added at these
+        points (center).
     structure : ndarray
-        Array with encoded structure. For example, ball (boolean) or density (0,1) float.
+        Array with encoded structure. For example, ball (boolean) or density
+        (0,1) float.
     values : ndarray
         Values to assign to the structure. It is passed to the assign_operator.
         Could be used for labeling.
     assign_operator : function
-        Function to assign structure to the data. It takes clipped data, structure and value as arguments.
+        Function to assign structure to the data. It takes clipped data,
+        structure and value as arguments.
     """
     radius = (structure.shape[0] - 1) // 2
     shape = data.shape
@@ -146,8 +145,7 @@ def labeled_particles(
     seed: Optional[int] = None,
     return_density: bool = False,
 ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray, np.ndarray]]:
-    """
-    Generate labeled blobs of given shape and dtype.
+    """Generate labeled blobs of given shape and dtype.
 
     Parameters
     ----------

--- a/napari/benchmarks/utils.py
+++ b/napari/benchmarks/utils.py
@@ -186,12 +186,13 @@ def labeled_particles(
         labels, points, ball, values, _update_data_with_mask
     )
 
-    if return_density:
-        particles = np.zeros(shape, dtype=np.float32)
+    if not return_density:
+        return labels
+    else:  # noqa: RET505
+        densities = np.zeros(shape, dtype=np.float32)
         dens = _generate_density(sigma * 2, ndim)
         _add_structure_on_coordinates(
-            particles, points, dens, values, _add_value_to_data
+            densities, points, dens, values, _add_value_to_data
         )
 
-        return labels, particles, points.T
-    return labels
+        return labels, densities, points.T

--- a/napari/benchmarks/utils.py
+++ b/napari/benchmarks/utils.py
@@ -120,7 +120,8 @@ def _update_data_with_mask(data, struct, out=None):
     if out is None:
         return np.where(struct, struct, data)
     else:  # noqa: RET505
-        out[nz] = struct[nz := (struct != 0)]
+        nz = struct != 0
+        out[nz] = struct[nz]
         return out
 
 

--- a/napari/benchmarks/utils.py
+++ b/napari/benchmarks/utils.py
@@ -82,8 +82,9 @@ def _structure_at_coordinates(
         Array with encoded structure. For example, ball (boolean) or density
         (0,1) float.
     multipliers : ndarray
-        Values to assign to the structure. It is passed to the assign_operator.
-        Could be used for labeling.
+        These values are multiplied by the values in the structure before
+        updating the array. Can be used to generate different labels, or to
+        vary the intensity of floating point gaussian densities.
     reduce_fn : function
         Function with which to update the array at a particular position. It
         should take two arrays as input and an optional output array.

--- a/napari/benchmarks/utils.py
+++ b/napari/benchmarks/utils.py
@@ -111,7 +111,7 @@ def _update_data_with_mask(data, struct, value):
 
 def _add_value_to_data(data, struct, _value):
     """Helper function to generate nice density array"""
-    data[...] = np.max([data, struct], axis=0)
+    data[...] = np.maximum(data, struct)
     return data
 
 

--- a/napari/benchmarks/utils.py
+++ b/napari/benchmarks/utils.py
@@ -47,7 +47,9 @@ def _generate_density(radius: int, ndim: int) -> np.ndarray:
     shape = (2 * radius + 1,) * ndim
     coords = np.indices(shape) - radius
     dist = np.sqrt(np.sum(coords**2 / ((radius / 4) ** 2), axis=0))
-    return np.exp(-dist)
+    res = np.exp(-dist)
+    res[res < 0.02] = 0
+    return res
 
 
 def _add_structure_on_coordinates(

--- a/napari/benchmarks/utils.py
+++ b/napari/benchmarks/utils.py
@@ -173,15 +173,14 @@ def labeled_particles(
     if dtype is None:
         dtype = _smallest_dtype(n)
     rng = np.random.default_rng(seed)
-    points = (
-        rng.random((len(shape), n)) * np.array(shape).reshape((-1, 1))
-    ).astype(int)
+    ndim = len(shape)
+    points = rng.integers(shape, size=(n, ndim)).T
     values = rng.integers(
         np.iinfo(dtype).min, np.iinfo(dtype).max, size=n, dtype=dtype
     )
-    sigma = int(np.array(shape).max() / (4.0 * n ** (1 / len(shape))))
-    ball = _generate_ball(sigma, len(shape))
     balls_ = np.zeros(shape, dtype=dtype)
+    sigma = int(max(shape) / (4.0 * n ** (1 / ndim)))
+    ball = _generate_ball(sigma, ndim)
 
     _add_structure_on_coordinates(
         balls_, points, ball, values, _update_data_with_mask
@@ -189,7 +188,7 @@ def labeled_particles(
 
     if return_density:
         particles = np.zeros(shape, dtype=np.float32)
-        dens = _generate_density(sigma * 2, len(shape))
+        dens = _generate_density(sigma * 2, ndim)
         _add_structure_on_coordinates(
             particles, points, dens, values, _add_value_to_data
         )

--- a/napari/benchmarks/utils.py
+++ b/napari/benchmarks/utils.py
@@ -186,9 +186,7 @@ def labeled_particles(
         labels, points, ball, values, _update_data_with_mask
     )
 
-    if not return_density:
-        return labels
-    else:  # noqa: RET505
+    if return_density:
         densities = np.zeros(shape, dtype=np.float32)
         dens = _generate_density(sigma * 2, ndim)
         _add_structure_on_coordinates(
@@ -196,3 +194,5 @@ def labeled_particles(
         )
 
         return labels, densities, points.T
+    else:  # noqa: RET505
+        return labels

--- a/napari/benchmarks/utils.py
+++ b/napari/benchmarks/utils.py
@@ -151,7 +151,7 @@ def labeled_particles(
     ----------
     shape : Sequence[int]
         Shape of the resulting array.
-    dtype : np.dtype
+    dtype : Optional[np.dtype]
         Dtype of the resulting array.
     n : int
         Number of blobs to generate.

--- a/napari/benchmarks/utils.py
+++ b/napari/benchmarks/utils.py
@@ -115,6 +115,16 @@ def _add_value_to_data(data, struct, _value):
     return data
 
 
+def _smallest_dtype(n: int) -> np.dtype:
+    """Find the smallest dtype that can hold n values."""
+    for dtype in [np.uint8, np.uint16, np.uint32, np.uint64]:
+        if np.iinfo(dtype).max >= n:
+            return dtype
+            break
+    else:
+        raise ValueError(f"{n=} is too large for any dtype.")
+
+
 @overload
 def labeled_particles(
     shape: Sequence[int],
@@ -161,12 +171,7 @@ def labeled_particles(
         Whether to return the density array and center coordinates.
     """
     if dtype is None:
-        for dtype_ in [np.uint8, np.uint16, np.uint32, np.uint64]:
-            if np.iinfo(dtype_).max >= n:
-                dtype = dtype_
-                break
-        else:
-            raise ValueError(f"n is too large for any dtype: {n=}")
+        dtype = _smallest_dtype(n)
     rng = np.random.default_rng(seed)
     points = (
         rng.random((len(shape), n)) * np.array(shape).reshape((-1, 1))

--- a/napari/benchmarks/utils.py
+++ b/napari/benchmarks/utils.py
@@ -178,12 +178,12 @@ def labeled_particles(
     values = rng.integers(
         np.iinfo(dtype).min, np.iinfo(dtype).max, size=n, dtype=dtype
     )
-    balls_ = np.zeros(shape, dtype=dtype)
     sigma = int(max(shape) / (4.0 * n ** (1 / ndim)))
     ball = _generate_ball(sigma, ndim)
+    labels = np.zeros(shape, dtype=dtype)
 
     _add_structure_on_coordinates(
-        balls_, points, ball, values, _update_data_with_mask
+        labels, points, ball, values, _update_data_with_mask
     )
 
     if return_density:
@@ -193,5 +193,5 @@ def labeled_particles(
             particles, points, dens, values, _add_value_to_data
         )
 
-        return balls_, particles, points.T
-    return balls_
+        return labels, particles, points.T
+    return labels

--- a/napari/benchmarks/utils.py
+++ b/napari/benchmarks/utils.py
@@ -1,6 +1,44 @@
+from functools import lru_cache
+
+import numpy as np
+from skimage import morphology
+
+
 class Skiper:
     def __init__(self, func):
         self.func = func
 
     def __contains__(self, item):
         return self.func(item)
+
+
+@lru_cache
+def gen_blobs(shape, dtype, blob_count=144):
+    np.random.seed(1)
+    balls_ = np.zeros(shape, dtype=dtype)
+    gen = np.random.default_rng(1)
+    points = (
+        gen.random((len(shape), blob_count)) * np.array(shape).reshape((-1, 1))
+    ).astype(int)
+    values = gen.integers(
+        np.iinfo(dtype).min, np.iinfo(dtype).max, size=blob_count, dtype=dtype
+    )
+    sigma = int(np.array(shape).max() / (4.0 * blob_count ** (1 / len(shape))))
+    if len(shape) == 2:
+        ball = morphology.disk(sigma)
+    else:
+        ball = morphology.ball(sigma)
+    for j, point in enumerate(points.T):
+        slice_im = []
+        slice_ball = []
+        for i, p in enumerate(point):
+            slice_im.append(
+                slice(max(0, p - sigma), min(shape[i], p + sigma + 1))
+            )
+            ball_base = max(0, sigma - p)
+            bal_end = slice_im[-1].stop - slice_im[-1].start + ball_base
+            slice_ball.append(slice(ball_base, bal_end))
+
+        balls_[tuple(slice_im)][ball[tuple(slice_ball)] > 0] = values[j]
+
+    return balls_

--- a/napari_builtins/_ndims_balls.py
+++ b/napari_builtins/_ndims_balls.py
@@ -1,9 +1,12 @@
+import numpy as np
+
 from napari.benchmarks.utils import labeled_particles
 
 
 def labeled_particles2d():
+    seed = np.random.default_rng().integers(np.iinfo(np.int64).max)
     labels, density, points = labeled_particles(
-        (1024, 1024), return_density=True
+        (1024, 1024), seed=seed, return_density=True
     )
 
     return [
@@ -14,12 +17,13 @@ def labeled_particles2d():
 
 
 def labeled_particles3d():
+    seed = np.random.default_rng().integers(np.iinfo(np.int64).max)
     labels, density, points = labeled_particles(
-        (256, 512, 512), return_density=True
+        (256, 512, 512), seed=seed, return_density=True
     )
 
     return [
-        (density, {"name": "density"}, "image"),
-        (labels, {"name": "labels"}, "labels"),
-        (points, {"name": "points"}, "points"),
+        (density, {"name": "density", "metadata": {"seed": seed}}, "image"),
+        (labels, {"name": "labels", "metadata": {"seed": seed}}, "labels"),
+        (points, {"name": "points", "metadata": {"seed": seed}}, "points"),
     ]

--- a/napari_builtins/_ndims_balls.py
+++ b/napari_builtins/_ndims_balls.py
@@ -10,9 +10,9 @@ def labeled_particles2d():
     )
 
     return [
-        (density, {"name": "density"}, "image"),
-        (labels, {"name": "labels"}, "labels"),
-        (points, {"name": "points"}, "points"),
+        (density, {"name": "density", "metadata": {"seed": seed}}, "image"),
+        (labels, {"name": "labels", "metadata": {"seed": seed}}, "labels"),
+        (points, {"name": "points", "metadata": {"seed": seed}}, "points"),
     ]
 
 

--- a/napari_builtins/_ndims_balls.py
+++ b/napari_builtins/_ndims_balls.py
@@ -1,0 +1,25 @@
+from napari.benchmarks.utils import labeled_particles
+
+
+def labeled_particles2d():
+    labels, density, points = labeled_particles(
+        (1024, 1024), return_density=True
+    )
+
+    return [
+        (density, {"name": "density"}, "image"),
+        (labels, {"name": "labels"}, "labels"),
+        (points, {"name": "points"}, "points"),
+    ]
+
+
+def labeled_particles3d():
+    labels, density, points = labeled_particles(
+        (256, 512, 512), return_density=True
+    )
+
+    return [
+        (density, {"name": "density"}, "image"),
+        (labels, {"name": "labels"}, "labels"),
+        (points, {"name": "points"}, "points"),
+    ]

--- a/napari_builtins/_tests/test_ndims_balls.py
+++ b/napari_builtins/_tests/test_ndims_balls.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+from napari_builtins._ndims_balls import (
+    labeled_particles2d,
+    labeled_particles3d,
+)
+
+
+def test_labeled_particles2d():
+    img, labels, points = labeled_particles2d()
+    assert img[0].ndim == 2
+    assert labels[0].ndim == 2
+    assert "seed" in img[1]["metadata"]
+    assert "seed" in labels[1]["metadata"]
+    assert "seed" in points[1]["metadata"]
+    assert img[2] == "image"
+    assert labels[2] == "labels"
+    assert points[2] == "points"
+
+    assert np.all(img[0][labels[0] > 0] > 0)
+
+
+def test_labeled_particles3d():
+    img, labels, points = labeled_particles3d()
+    assert img[0].ndim == 3
+    assert labels[0].ndim == 3
+    assert "seed" in img[1]["metadata"]
+    assert "seed" in labels[1]["metadata"]
+    assert "seed" in points[1]["metadata"]
+    assert img[2] == "image"
+    assert labels[2] == "labels"
+    assert points[2] == "points"
+
+    assert np.all(img[0][labels[0] > 0] > 0)

--- a/napari_builtins/builtins.yaml
+++ b/napari_builtins/builtins.yaml
@@ -204,6 +204,12 @@ contributions:
     - display_name: Astronaut (RGB)
       key: astronaut
       command: napari.data.astronaut
+    - display_name: Balls
+      key: balls_2d
+      command: napari.data.balls_2d
+    - display_name: Balls (3D)
+      key: balls_3d
+      command: napari.data.balls_3d
     - display_name: Binary Blobs
       key: binary_blobs
       command: napari.data.binary_blobs
@@ -297,9 +303,3 @@ contributions:
     - display_name: Text
       key: text
       command: napari.data.text
-    - display_name: 2D Balls
-      key: balls_2d
-      command: napari.data.balls_2d
-    - display_name: 3D Balls
-      key: balls_3d
-      command: napari.data.balls_3d

--- a/napari_builtins/builtins.yaml
+++ b/napari_builtins/builtins.yaml
@@ -120,6 +120,12 @@ contributions:
     - id: napari.data.text
       title: Generate text sample
       python_name: napari_builtins._skimage_data:text
+    - id: napari.data.balls_2d
+      title: Generate 2d_balls sample
+      python_name: napari_builtins._ndims_balls:labeled_particles2d
+    - id: napari.data.balls_3d
+      title: Generate 3d_balls sample
+      python_name: napari_builtins._ndims_balls:labeled_particles3d
 
   readers:
     - command: napari.get_reader
@@ -291,3 +297,9 @@ contributions:
     - display_name: Text
       key: text
       command: napari.data.text
+    - display_name: 2D Balls
+      key: balls_2d
+      command: napari.data.balls_2d
+    - display_name: 3D Balls
+      key: balls_3d
+      command: napari.data.balls_3d


### PR DESCRIPTION
# Description

During investigation of https://github.com/scikit-image/scikit-image/issues/7262 I have created a blobs function that is quite fast and produces data more realistic than just `np.random.randint`. 

So I suggest adopting it in benchmarks. 

It is slightly faster on my machine 

main:
```
[50.00%] ·· ======================================================== ================
                                   benchmark                          total duration
            -------------------------------------------------------- ----------------
             benchmark_labels_layer.LabelsDrawing2DSuite.time_draw        33.9s
                 benchmark_labels_layer.Labels3DSuite.mem_layer           16.7s
             benchmark_labels_layer.Labels3DSuite.time_create_layer       16.5s
               benchmark_labels_layer.Labels3DSuite.time_refresh          16.5s
                 benchmark_labels_layer.Labels3DSuite.mem_data            16.5s
                                      ...                                  ...
                                     total                                6.92m
            ======================================================== ================           
```

This branch: 
```
[50.00%] ·· ============================================================ ================
                                     benchmark                            total duration
            ------------------------------------------------------------ ----------------
               benchmark_labels_layer.LabelsDrawing2DSuite.time_draw          33.6s
                   benchmark_labels_layer.Labels2DSuite.time_fill             20.4s
             benchmark_labels_layer.Labels2DColorDirectSuite.time_fill        18.1s
               benchmark_labels_layer.Labels3DSuite.time_create_layer         13.5s
             benchmark_labels_layer.Labels3DSuite.time_raw_to_displayed       13.4s
                                        ...                                    ...
                                       total                                  6.56m
            ============================================================ ================
```

It also adds Balls 2D and Balls 3D example data with importing from `napari.examples.utils` 