### PR TITLE
Add copy operator to fix memory benchmarks

### DIFF
--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -3,6 +3,7 @@
 # or the napari documentation on benchmarking
 # https://github.com/napari/napari/blob/main/docs/BENCHMARKS.md
 import os
+from copy import copy
 
 import numpy as np
 
@@ -66,7 +67,7 @@ class Labels2DSuite:
 
     def mem_layer(self, *_):
         """Memory used by layer."""
-        return self.layer
+        return copy(self.layer)
 
     def mem_data(self, *_):
         """Memory used by raw data."""
@@ -196,7 +197,7 @@ class Labels3DSuite:
 
     def mem_layer(self, *_):
         """Memory used by layer."""
-        return self.layer
+        return copy(self.layer)
 
     def mem_data(self, *_):
         """Memory used by raw data."""

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -2066,6 +2066,18 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         -------
         layer : napari.layers.Layer
             Copy of this layer.
+
+        Notes
+        -----
+        This method is defined for purpose of asv memory benchmarks.
+        The copy of data is intentional for properly estimating memory
+        usage for layer.
+
+        If you want a to copy a layer without coping the data please use
+        `layer.create(*layer.as_layer_data_tuple())`
+
+        If you change this method, validate if memory benchmarks are still
+        working properly.
         """
         data, meta, layer_type = self.as_layer_data_tuple()
         return self.create(copy.copy(data), meta=meta, layer_type=layer_type)

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -2058,6 +2058,17 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
         return save_layers(path, [self], plugin=plugin)
 
+    def __copy__(self):
+        """Create a copy of this layer.
+
+        Returns
+        -------
+        layer : napari.layers.Layer
+            Copy of this layer.
+        """
+        data, meta, layer_type = self.as_layer_data_tuple()
+        return self.create(np.copy(data), meta=meta, layer_type=layer_type)
+
     @classmethod
     def create(
         cls,

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import itertools
 import logging
 import os.path
@@ -2067,7 +2068,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             Copy of this layer.
         """
         data, meta, layer_type = self.as_layer_data_tuple()
-        return self.create(np.copy(data), meta=meta, layer_type=layer_type)
+        return self.create(copy.copy(data), meta=meta, layer_type=layer_type)
 
     @classmethod
     def create(

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1,3 +1,4 @@
+import copy
 import itertools
 import time
 import warnings
@@ -1646,6 +1647,14 @@ def test_invalidate_cache_when_change_slice():
     assert layer._cached_labels is not None
     layer._set_view_slice()
     assert layer._cached_labels is None
+
+
+def test_copy():
+    l1 = Labels(np.zeros((2, 4, 5), dtype=np.uint8))
+    l2 = copy.copy(l1)
+    l3 = Labels.create(*l1.as_layer_data_tuple())
+    assert l1.data is not l2.data
+    assert l1.data is l3.data
 
 
 class TestLabels:

--- a/napari/layers/surface/_tests/test_surface.py
+++ b/napari/layers/surface/_tests/test_surface.py
@@ -1,3 +1,5 @@
+import copy
+
 import numpy as np
 import pytest
 
@@ -417,3 +419,25 @@ def test_surface_wireframe():
     assert isinstance(surface_layer.wireframe, SurfaceWireframe)
     assert surface_layer.wireframe.visible is True
     assert np.array_equal(surface_layer.wireframe.color, (1, 0, 0, 1))
+
+
+def test_surface_copy():
+    vertices = np.array(
+        [
+            [3, 0, 0],
+            [3, 0, 3],
+            [3, 3, 0],
+            [5, 0, 0],
+            [5, 0, 3],
+            [5, 3, 0],
+            [2, 50, 50],
+            [2, 50, 100],
+            [2, 100, 50],
+        ]
+    )
+    faces = np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+    values = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+
+    l1 = Surface((vertices, faces, values))
+    l2 = copy.copy(l1)
+    assert l1.data[0] is not l2.data[0]

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -1,3 +1,4 @@
+import copy
 import warnings
 from typing import Any, List, Optional, Tuple, Union
 
@@ -705,3 +706,30 @@ class Surface(IntensityVisualizationMixin, Layer):
         intersection_value = (barycentric_coordinates * vertex_values).sum()
 
         return intersection_value, intersection_index
+
+    def __copy__(self):
+        """Create a copy of this layer.
+
+        Returns
+        -------
+        layer : napari.layers.Layer
+            Copy of this layer.
+
+        Notes
+        -----
+        This method is defined for purpose of asv memory benchmarks.
+        The copy of data is intentional for properly estimating memory
+        usage for layer.
+
+        If you want a to copy a layer without coping the data please use
+        `layer.create(*layer.as_layer_data_tuple())`
+
+        If you change this method, validate if memory benchmarks are still
+        working properly.
+        """
+        data, meta, layer_type = self.as_layer_data_tuple()
+        return self.create(
+            tuple(copy.copy(x) for x in self.data),
+            meta=meta,
+            layer_type=layer_type,
+        )

--- a/napari/utils/colormaps/colormap.py
+++ b/napari/utils/colormaps/colormap.py
@@ -466,9 +466,11 @@ except ModuleNotFoundError:
     _zero_preserving_modulo = _zero_preserving_modulo_numpy
 else:
 
-    @numba.njit(parallel=True)
     def _zero_preserving_modulo(
-        values: np.ndarray, n: int, dtype: np.dtype, to_zero: int = 0
+        values: np.ndarray,
+        n: int,
+        dtype: np.dtype,
+        to_zero: int = 0,
     ) -> np.ndarray:
         """``(values - 1) % n + 1``, but with one specific value mapped to 0.
 
@@ -494,14 +496,51 @@ else:
             everywhere else.
         """
         result = np.empty_like(values, dtype=dtype)
+        _zero_preserving_modulo_impl(
+            values,
+            n,
+            result,
+            to_zero,
+        )
+        return result
 
+    @numba.njit(parallel=True)
+    def _zero_preserving_modulo_impl(
+        values: np.ndarray,
+        n: int,
+        out: np.ndarray,
+        to_zero: int = 0,
+    ) -> np.ndarray:
+        """``(values - 1) % n + 1``, but with one specific value mapped to 0.
+
+        This ensures (1) an output value in [0, n] (inclusive), and (2) that
+        no nonzero values in the input are zero in the output, other than the
+        ``to_zero`` value.
+
+        Parameters
+        ----------
+        values : np.ndarray
+            The dividend of the modulo operator.
+        n : int
+            The divisor.
+        out : np.ndarray
+            output array
+        to_zero : int, optional
+            A specific value to map to 0. (By default, 0 itself.)
+
+        Returns
+        -------
+        np.ndarray
+            The out: 0 for the ``to_zero`` value, ``values % n + 1``
+            everywhere else.
+        """
         for i in numba.prange(values.size):
             if values.flat[i] == to_zero:
-                result.flat[i] = 0
+                out.flat[i] = 0
             else:
-                result.flat[i] = (values.flat[i] - 1) % n + 1
+                out.flat[i] = (values.flat[i] - 1) % n + 1
 
-        return result
+        return out
 
 
 def minimum_dtype_for_labels(num_colors: int) -> np.dtype:


### PR DESCRIPTION
# References and relevant issues
closes #6529

# Description

This PR provides two changes to fix benchmarking of memory usage by layers. 

I have found that `asv` uses following code to calculate memory usage for an object. 

```python
asizeof([obj, copy(obj)]) - asizeof([obj, obj])
```

This approach allows not to count of global (or class) object into size of single object. But if the copy of an object is shallow, then the reported size is small. 

So in this PR, I define `__copy__` method of Base layer, that uses `as_layer_data_tuple` method and `create` class method to create a copy. It also creates copy of data, as it is a significant part of layer size. 

I also found a second problem. 

The `aszieof` function on output of jited version of `_zero_preserving_modulo` reports small values (like 128 bytes). But when I lift array allocation outside implementation, the memory is reported properly. So I have updated the `_zero_preserving_modulo` implementation to allocate memory before entering the jited code. 

Current main:

```
[50.00%] ··· benchmark_labels_layer.Labels2DSuite.mem_data                                                         ok
[50.00%] ··· ====== ============= =============
             --                dtype
             ------ ---------------------------
               n     numpy.uint8   numpy.int32
             ====== ============= =============
               16        384          1.15k
               32       1.15k         4.22k
               64       4.22k         16.5k
              128       16.5k         65.7k
              256       65.7k          262k
              512        262k         1.05M
              1024      1.05M         4.19M
              2048      4.19M         16.8M
              4096      16.8M         67.1M
             ====== ============= =============

[100.00%] ··· benchmark_labels_layer.Labels2DSuite.mem_layer                                                        ok
[100.00%] ··· ====== ============= =============
              --                dtype
              ------ ---------------------------
                n     numpy.uint8   numpy.int32
              ====== ============= =============
                16       3.29k         3.29k
                32       3.29k         3.29k
                64       3.29k         3.29k
               128       3.29k         3.29k
               256       3.29k         3.29k
               512       3.29k         3.29k
               1024      3.29k         3.29k
               2048      3.29k         3.29k
               4096      3.29k         3.29k
              ====== ============= =============
```

with added copy:
```
[50.00%] ··· benchmark_labels_layer.Labels2DSuite.mem_data                                                         ok
[50.00%] ··· ====== ============= =============
             --                dtype
             ------ ---------------------------
               n     numpy.uint8   numpy.int32
             ====== ============= =============
               16        384          1.15k
               32       1.15k         4.22k
               64       4.22k         16.5k
              128       16.5k         65.7k
              256       65.7k          262k
              512        262k         1.05M
              1024      1.05M         4.19M
              2048      4.19M         16.8M
              4096      16.8M         67.1M
             ====== ============= =============

[100.00%] ··· benchmark_labels_layer.Labels2DSuite.mem_layer                                                        ok
[100.00%] ··· ====== ============= =============
              --                dtype
              ------ ---------------------------
                n     numpy.uint8   numpy.int32
              ====== ============= =============
                16        188k          189k
                32        189k          192k
                64        192k          205k
               128        205k          254k
               256        254k          450k
               512        450k         1.24M
               1024      1.24M         4.38M
               2048      4.38M          17M
               4096       17M          67.3M
              ====== ============= =============
```

with copy and refactored `_zero_preserving_modulo`
```
[50.00%] ··· benchmark_labels_layer.Labels2DSuite.mem_data                                                         ok
[50.00%] ··· ====== ============= =============
             --                dtype
             ------ ---------------------------
               n     numpy.uint8   numpy.int32
             ====== ============= =============
               16        384          1.15k
               32       1.15k         4.22k
               64       4.22k         16.5k
              128       16.5k         65.7k
              256       65.7k          262k
              512        262k         1.05M
              1024      1.05M         4.19M
              2048      4.19M         16.8M
              4096      16.8M         67.1M
             ====== ============= =============

[100.00%] ··· benchmark_labels_layer.Labels2DSuite.mem_layer                                                        ok
[100.00%] ··· ====== ============= =============
              --                dtype
              ------ ---------------------------
                n     numpy.uint8   numpy.int32
              ====== ============= =============
                16        188k          189k
                32        189k          193k
                64        192k          209k
               128        205k          270k
               256        254k          516k
               512        450k          1.5M
               1024      1.24M         5.43M
               2048      4.38M         21.2M
               4096       17M          84.1M
              ====== ============= =============
```