### PR TITLE
Check in LabelColormap that fewer than 2**16 colors are requested

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -273,8 +273,11 @@ def test_num_colors():
     layer = Labels(data, num_colors=60)
     assert layer.num_colors == 60
 
-    with pytest.raises(ValueError, match="must be between 1 and 65535"):
+    with pytest.raises(ValueError, match="Because of implementation details"):
         layer.num_colors = 2**17
+
+    with pytest.raises(ValueError, match="Because of implementation details"):
+        Labels(data, num_colors=2**17)
 
 
 def test_properties():

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -273,10 +273,14 @@ def test_num_colors():
     layer = Labels(data, num_colors=60)
     assert layer.num_colors == 60
 
-    with pytest.raises(ValueError, match="Because of implementation details"):
+    with pytest.raises(
+        ValueError, match=r".*Only up to 2\*\*16=65535 colors are supported"
+    ):
         layer.num_colors = 2**17
 
-    with pytest.raises(ValueError, match="Because of implementation details"):
+    with pytest.raises(
+        ValueError, match=r".*Only up to 2\*\*16=65535 colors are supported"
+    ):
         Labels(data, num_colors=2**17)
 
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -561,12 +561,10 @@ class Labels(_ImageBase):
 
     @num_colors.setter
     def num_colors(self, num_colors):
-        if num_colors < 1 or num_colors >= 2**16:
-            raise ValueError("num_colors must be between 1 and 65535")
-        self._num_colors = num_colors
         self.colormap = label_colormap(
             num_colors, self.seed, self._background_label
         )
+        self._num_colors = num_colors
         self._cached_labels = None  # invalidate the cached color mapping
         self._cached_mapped_labels = None
         self.refresh()

--- a/napari/utils/colormaps/_tests/test_colormap.py
+++ b/napari/utils/colormaps/_tests/test_colormap.py
@@ -139,9 +139,7 @@ def disable_jit(monkeypatch):
     importlib.reload(colormap)  # revert to original state
 
 
-@pytest.mark.parametrize(
-    "num,dtype", [(40, np.uint8), (1000, np.uint16), (80000, np.float32)]
-)
+@pytest.mark.parametrize("num,dtype", [(40, np.uint8), (1000, np.uint16)])
 @pytest.mark.usefixtures("disable_jit")
 def test_cast_labels_to_minimum_type_auto(num: int, dtype, monkeypatch):
     cmap = label_colormap(num)

--- a/napari/utils/colormaps/_tests/test_colormap_utils.py
+++ b/napari/utils/colormaps/_tests/test_colormap_utils.py
@@ -25,3 +25,14 @@ def test_label_colormap(index, expected):
     to past versions, for UX consistency.
     """
     np.testing.assert_almost_equal(label_colormap(49).map(index), [expected])
+
+
+def test_label_colormap_exception():
+    with pytest.raises(ValueError, match="num_colors must be >= 1"):
+        label_colormap(0)
+
+    with pytest.raises(ValueError, match="num_colors must be >= 1"):
+        label_colormap(-1)
+
+    with pytest.raises(ValueError, match="Because of implementation details"):
+        label_colormap(2**16 + 1)

--- a/napari/utils/colormaps/_tests/test_colormap_utils.py
+++ b/napari/utils/colormaps/_tests/test_colormap_utils.py
@@ -34,5 +34,7 @@ def test_label_colormap_exception():
     with pytest.raises(ValueError, match="num_colors must be >= 1"):
         label_colormap(-1)
 
-    with pytest.raises(ValueError, match="Because of implementation details"):
+    with pytest.raises(
+        ValueError, match=r".*Only up to 2\*\*16=65535 colors are supported"
+    ):
         label_colormap(2**16 + 1)

--- a/napari/utils/colormaps/colormap.py
+++ b/napari/utils/colormaps/colormap.py
@@ -247,7 +247,7 @@ class LabelColormap(LabelColormapBase):
 
     seed: float = 0.5
 
-    @validator('colors')
+    @validator('colors', allow_reuse=True)
     def _validate_color(cls, v):
         if len(v) > 2**16:
             raise ValueError(

--- a/napari/utils/colormaps/colormap.py
+++ b/napari/utils/colormaps/colormap.py
@@ -113,7 +113,7 @@ class Colormap(EventedModel):
             )
 
         # Check number of control points is correct
-        n_controls_target = len(values['colors']) + int(
+        n_controls_target = len(values.get('colors', [])) + int(
             values['interpolation'] == ColormapInterpolationMode.ZERO
         )
         n_controls = len(v)
@@ -246,6 +246,14 @@ class LabelColormap(LabelColormapBase):
     """
 
     seed: float = 0.5
+
+    @validator('colors')
+    def _validate_color(cls, v):
+        if len(v) > 2**16:
+            raise ValueError(
+                "Only up to 2**16=65535 colors are supported for LabelColormap"
+            )
+        return v
 
     def _selection_as_minimum_dtype(self, dtype: np.dtype) -> int:
         return int(

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -427,6 +427,13 @@ def label_colormap(
     -----
     0 always maps to fully transparent.
     """
+    if num_colors < 1:
+        raise ValueError("num_colors must be >= 1")
+    if num_colors > 2**16:
+        raise ValueError(
+            "Because of implementation details, we do not support more than 2**16 colors."
+        )
+
     # Starting the control points slightly above 0 and below 1 is necessary
     # to ensure that the background pixel 0 is transparent
     midpoints = np.linspace(0.00001, 1 - 0.00001, num_colors + 1)

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -429,10 +429,6 @@ def label_colormap(
     """
     if num_colors < 1:
         raise ValueError("num_colors must be >= 1")
-    if num_colors > 2**16:
-        raise ValueError(
-            "Because of implementation details, we do not support more than 2**16 colors."
-        )
 
     # Starting the control points slightly above 0 and below 1 is necessary
     # to ensure that the background pixel 0 is transparent


### PR DESCRIPTION
# References and relevant issues

This fixes an issue described in this discussion:
 
https://github.com/napari/napari/pull/6460#discussion_r1428593836

# Description

Some LabelColormap functions work with arbitrary numbers of colors. However, the corresponding rendering code in the VispyLabelColormap classes only support up to 2**16 colors. This PR ensures that the errors are caught earlier so that the error messages are comprehensible for users.
