### PR TITLE
Fix check if plugin is available from conda

### DIFF
--- a/napari/plugins/npe2api.py
+++ b/napari/plugins/npe2api.py
@@ -90,6 +90,7 @@ def iter_napari_plugin_info() -> Iterator[Tuple[PackageMetadata, bool, dict]]:
         _conda = executor.submit(conda_map)
 
     conda = _conda.result()
+    conda_set = {normalized_name(x) for x in conda}
     for info in data.result():
         info_copy = dict(info)
         info_copy.pop("display_name", None)
@@ -111,4 +112,4 @@ def iter_napari_plugin_info() -> Iterator[Tuple[PackageMetadata, bool, dict]]:
         info_["name"] = normalized_name(info_["name"])
         meta = PackageMetadata(**info_)
 
-        yield meta, (info_["name"] in conda), extra_info
+        yield meta, (info_["name"] in conda_set), extra_info


### PR DESCRIPTION
# Description

I found that on current main, my plugin is not available from the conda, even when it is. 

I found that it happens because the plugin is named `PartSeg`, so it normalized name is `parsteg`. As we normalize plugin names but `https://npe2api.vercel.app/api/conda` serves not normalized names, the check fails even if should not. 

In this PR, I create a set of normalized names to not false exclude plugins. 