### PR TITLE
[Maint] Update build_docs workflow to match napari/docs

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -11,6 +11,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-upload:
     name: Build & Upload Artifact
@@ -52,14 +56,18 @@ jobs:
           python -c 'import napari.layers; print(napari.layers.__doc__)'
 
       - name: Build Docs
-        uses: aganders3/headless-gui@v1
+        uses: aganders3/headless-gui@v2
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
           PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
         with:
           run:  make -C docs docs
-
+          # skipping setup stops the action from running the default (tiling) window manager
+          # the window manager is not necessary for docs builds at this time and it was causing
+          # problems with screenshots (https://github.com/napari/docs/issues/285)
+          linux-setup: "echo 'skip setup'"
+          linux-teardown: "echo 'skip teardown'"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
# Description
This PR updates the build_docs workflow to match the latest napari/docs workflow
Specifically add concurrency (napari/docs PR: https://github.com/napari/docs/pull/277 ) and to fix graphical issues related to the xvfb action ( napari/docs PR: https://github.com/napari/docs/pull/294 )