### PR TITLE
Moving IntensityVisualizationMixin from _ImageBase to Image

### DIFF
--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -65,7 +65,7 @@ class ImageLayerNode:
         return res
 
 
-class VispyImageBaseLayer(VispyBaseLayer[_ImageBase]):
+class VispyVolumeBaseLayer(VispyBaseLayer[_ImageBase]):
     def __init__(
         self,
         layer: _ImageBase,
@@ -256,7 +256,7 @@ class VispyImageBaseLayer(VispyBaseLayer[_ImageBase]):
         return data
 
 
-class VispyImageLayer(VispyImageBaseLayer):
+class VispyImageLayer(VispyVolumeBaseLayer):
     def __init__(
         self,
         layer: Image,
@@ -301,9 +301,8 @@ class VispyImageLayer(VispyImageBaseLayer):
 
     def _on_rendering_change(self) -> None:
         super()._on_rendering_change()
-        if isinstance(self.node, ImageNode):
-            self._on_attenuation_change()
-            self._on_iso_threshold_change()
+        self._on_attenuation_change()
+        self._on_iso_threshold_change()
 
     def _on_colormap_change(self, event=None) -> None:
         self.node.cmap = VispyColormap(*self.layer.colormap)

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -13,7 +13,7 @@ from napari._vispy.utils.gl import fix_data_dtype, get_gl_extensions
 from napari._vispy.visuals.image import Image as ImageNode
 from napari._vispy.visuals.volume import Volume as VolumeNode
 from napari.layers.base._base_constants import Blending
-from napari.layers.image.image import _ImageBase
+from napari.layers.image.image import Image, _ImageBase
 from napari.utils.translations import trans
 
 
@@ -92,10 +92,11 @@ class VispyImageLayer(VispyBaseLayer[_ImageBase]):
             self._on_interpolation_change
         )
         self.layer.events.colormap.connect(self._on_colormap_change)
-        self.layer.events.contrast_limits.connect(
-            self._on_contrast_limits_change
-        )
-        self.layer.events.gamma.connect(self._on_gamma_change)
+        if isinstance(self.layer, Image):
+            self.layer.events.contrast_limits.connect(
+                self._on_contrast_limits_change
+            )
+            self.layer.events.gamma.connect(self._on_gamma_change)
         self.layer.events.iso_threshold.connect(self._on_iso_threshold_change)
         self.layer.events.attenuation.connect(self._on_attenuation_change)
         self.layer.plane.events.position.connect(

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -65,7 +65,7 @@ class ImageLayerNode:
         return res
 
 
-class VispyImageLayer(VispyBaseLayer[_ImageBase]):
+class VispyImageBaseLayer(VispyBaseLayer[_ImageBase]):
     def __init__(
         self,
         layer: _ImageBase,
@@ -85,20 +85,7 @@ class VispyImageLayer(VispyBaseLayer[_ImageBase]):
 
         self.layer.events.rendering.connect(self._on_rendering_change)
         self.layer.events.depiction.connect(self._on_depiction_change)
-        self.layer.events.interpolation2d.connect(
-            self._on_interpolation_change
-        )
-        self.layer.events.interpolation3d.connect(
-            self._on_interpolation_change
-        )
         self.layer.events.colormap.connect(self._on_colormap_change)
-        if isinstance(self.layer, Image):
-            self.layer.events.contrast_limits.connect(
-                self._on_contrast_limits_change
-            )
-            self.layer.events.gamma.connect(self._on_gamma_change)
-        self.layer.events.iso_threshold.connect(self._on_iso_threshold_change)
-        self.layer.events.attenuation.connect(self._on_attenuation_change)
         self.layer.plane.events.position.connect(
             self._on_plane_position_change
         )
@@ -110,9 +97,10 @@ class VispyImageLayer(VispyBaseLayer[_ImageBase]):
             self._on_custom_interpolation_kernel_2d_change
         )
 
-        # display_change is special (like data_change) because it requires a self.reset()
-        # this means that we have to call it manually. Also, it must be called before reset
-        # in order to set the appropriate node first
+        # display_change is special (like data_change) because it requires a
+        # self.reset(). This means that we have to call it manually. Also,
+        # it must be called before reset in order to set the appropriate node
+        # first
         self._on_display_change()
         self.reset()
         self._on_data_change()
@@ -174,13 +162,6 @@ class VispyImageLayer(VispyBaseLayer[_ImageBase]):
         self._on_matrix_change()
         node.update()
 
-    def _on_interpolation_change(self) -> None:
-        self.node.interpolation = (
-            self.layer.interpolation2d
-            if self.layer._slice_input.ndisplay == 2
-            else self.layer.interpolation3d
-        )
-
     def _on_custom_interpolation_kernel_2d_change(self) -> None:
         if self.layer._slice_input.ndisplay == 2:
             self.node.custom_kernel = self.layer.custom_interpolation_kernel_2d
@@ -188,59 +169,13 @@ class VispyImageLayer(VispyBaseLayer[_ImageBase]):
     def _on_rendering_change(self) -> None:
         if isinstance(self.node, VolumeNode):
             self.node.method = self.layer.rendering
-            self._on_attenuation_change()
-            self._on_iso_threshold_change()
 
     def _on_depiction_change(self) -> None:
         if isinstance(self.node, VolumeNode):
             self.node.raycasting_mode = str(self.layer.depiction)
 
-    def _on_colormap_change(self, event=None) -> None:
-        self.node.cmap = VispyColormap(*self.layer.colormap)
-
-    def _update_mip_minip_cutoff(self) -> None:
-        # discard fragments beyond contrast limits, but only with translucent blending
-        if isinstance(self.node, VolumeNode):
-            if self.layer.blending in {
-                Blending.TRANSLUCENT,
-                Blending.TRANSLUCENT_NO_DEPTH,
-            }:
-                self.node.mip_cutoff = self.node._texture.clim_normalized[0]
-                self.node.minip_cutoff = self.node._texture.clim_normalized[1]
-            else:
-                self.node.mip_cutoff = None
-                self.node.minip_cutoff = None
-
-    def _on_contrast_limits_change(self) -> None:
-        self.node.clim = self.layer.contrast_limits
-        # cutoffs must be updated after clims, so we can set them to the new values
-        self._update_mip_minip_cutoff()
-        # iso also may depend on contrast limit values
-        self._on_iso_threshold_change()
-
     def _on_blending_change(self, event=None) -> None:
         super()._on_blending_change()
-        # cutoffs must be updated after blending, so we can know if
-        # the new blending is a translucent one
-        self._update_mip_minip_cutoff()
-
-    def _on_gamma_change(self) -> None:
-        if len(self.node.shared_program.frag._set_items) > 0:
-            self.node.gamma = self.layer.gamma
-
-    def _on_iso_threshold_change(self) -> None:
-        if isinstance(self.node, VolumeNode):
-            if self.node._texture.is_normalized:
-                cmin, cmax = self.layer.contrast_limits_range
-                self.node.threshold = (self.layer.iso_threshold - cmin) / (
-                    cmax - cmin
-                )
-            else:
-                self.node.threshold = self.layer.iso_threshold
-
-    def _on_attenuation_change(self) -> None:
-        if isinstance(self.node, VolumeNode):
-            self.node.attenuation = self.layer.attenuation
 
     def _on_plane_thickness_change(self) -> None:
         if isinstance(self.node, VolumeNode):
@@ -256,10 +191,6 @@ class VispyImageLayer(VispyBaseLayer[_ImageBase]):
 
     def reset(self, event=None) -> None:
         super().reset()
-        self._on_interpolation_change()
-        self._on_colormap_change()
-        self._on_contrast_limits_change()
-        self._on_gamma_change()
         self._on_rendering_change()
         self._on_depiction_change()
         self._on_plane_position_change()
@@ -323,6 +254,110 @@ class VispyImageLayer(VispyBaseLayer[_ImageBase]):
             slices = tuple(slice(None, None, ds) for ds in downsample)
             data = data[slices]
         return data
+
+
+class VispyImageLayer(VispyImageBaseLayer):
+    def __init__(
+        self,
+        layer: Image,
+        node=None,
+        texture_format='auto',
+        layer_node_class=ImageLayerNode,
+    ) -> None:
+        super().__init__(
+            layer,
+            node=node,
+            texture_format=texture_format,
+            layer_node_class=layer_node_class,
+        )
+
+        self.layer.events.interpolation2d.connect(
+            self._on_interpolation_change
+        )
+        self.layer.events.interpolation3d.connect(
+            self._on_interpolation_change
+        )
+        self.layer.events.contrast_limits.connect(
+            self._on_contrast_limits_change
+        )
+        self.layer.events.gamma.connect(self._on_gamma_change)
+        self.layer.events.iso_threshold.connect(self._on_iso_threshold_change)
+        self.layer.events.attenuation.connect(self._on_attenuation_change)
+
+        # display_change is special (like data_change) because it requires a
+        # self.reset(). This means that we have to call it manually. Also,
+        # it must be called before reset in order to set the appropriate node
+        # first
+        self._on_display_change()
+        self.reset()
+        self._on_data_change()
+
+    def _on_interpolation_change(self) -> None:
+        self.node.interpolation = (
+            self.layer.interpolation2d
+            if self.layer._slice_input.ndisplay == 2
+            else self.layer.interpolation3d
+        )
+
+    def _on_rendering_change(self) -> None:
+        super()._on_rendering_change()
+        if isinstance(self.node, ImageNode):
+            self._on_attenuation_change()
+            self._on_iso_threshold_change()
+
+    def _on_colormap_change(self, event=None) -> None:
+        self.node.cmap = VispyColormap(*self.layer.colormap)
+
+    def _update_mip_minip_cutoff(self) -> None:
+        # discard fragments beyond contrast limits, but only with translucent blending
+        if isinstance(self.node, VolumeNode):
+            if self.layer.blending in {
+                Blending.TRANSLUCENT,
+                Blending.TRANSLUCENT_NO_DEPTH,
+            }:
+                self.node.mip_cutoff = self.node._texture.clim_normalized[0]
+                self.node.minip_cutoff = self.node._texture.clim_normalized[1]
+            else:
+                self.node.mip_cutoff = None
+                self.node.minip_cutoff = None
+
+    def _on_contrast_limits_change(self) -> None:
+        self.node.clim = self.layer.contrast_limits
+        # cutoffs must be updated after clims, so we can set them to the new values
+        self._update_mip_minip_cutoff()
+        # iso also may depend on contrast limit values
+        self._on_iso_threshold_change()
+
+    def _on_blending_change(self, event=None) -> None:
+        super()._on_blending_change()
+        # cutoffs must be updated after blending, so we can know if
+        # the new blending is a translucent one
+        self._update_mip_minip_cutoff()
+
+    def _on_gamma_change(self) -> None:
+        if len(self.node.shared_program.frag._set_items) > 0:
+            self.node.gamma = self.layer.gamma
+
+    def _on_iso_threshold_change(self) -> None:
+        if isinstance(self.node, VolumeNode):
+            if self.node._texture.is_normalized:
+                cmin, cmax = self.layer.contrast_limits_range
+                self.node.threshold = (self.layer.iso_threshold - cmin) / (
+                    cmax - cmin
+                )
+            else:
+                self.node.threshold = self.layer.iso_threshold
+
+    def _on_attenuation_change(self) -> None:
+        if isinstance(self.node, VolumeNode):
+            self.node.attenuation = self.layer.attenuation
+
+    def reset(self, event=None) -> None:
+        super().reset()
+        self._on_interpolation_change()
+        self._on_colormap_change()
+        self._on_contrast_limits_change()
+        self._on_gamma_change()
 
 
 _VISPY_FORMAT_TO_DTYPE: Dict[Optional[str], np.dtype] = {

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -65,7 +65,7 @@ class ImageLayerNode:
         return res
 
 
-class VispyVolumeBaseLayer(VispyBaseLayer[_ImageBase]):
+class VispyScalarFieldBaseLayer(VispyBaseLayer[_ImageBase]):
     def __init__(
         self,
         layer: _ImageBase,
@@ -259,7 +259,7 @@ class VispyVolumeBaseLayer(VispyBaseLayer[_ImageBase]):
         return data
 
 
-class VispyImageLayer(VispyVolumeBaseLayer):
+class VispyImageLayer(VispyScalarFieldBaseLayer):
     layer: Image
 
     def __init__(

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -189,6 +189,9 @@ class VispyVolumeBaseLayer(VispyBaseLayer[_ImageBase]):
         if isinstance(self.node, VolumeNode):
             self.node.plane_normal = self.layer.plane.normal
 
+    def _on_colormap_change(self, event=None) -> None:
+        raise NotImplementedError
+
     def reset(self, event=None) -> None:
         super().reset()
         self._on_rendering_change()
@@ -257,6 +260,8 @@ class VispyVolumeBaseLayer(VispyBaseLayer[_ImageBase]):
 
 
 class VispyImageLayer(VispyVolumeBaseLayer):
+    layer: Image
+
     def __init__(
         self,
         layer: Image,

--- a/napari/_vispy/layers/labels.py
+++ b/napari/_vispy/layers/labels.py
@@ -10,7 +10,7 @@ from napari._vispy.layers.image import (
     _DTYPE_TO_VISPY_FORMAT,
     _VISPY_FORMAT_TO_DTYPE,
     ImageLayerNode,
-    VispyImageLayer,
+    VispyImageBaseLayer,
     get_dtype_from_vispy_texture_format,
 )
 from napari._vispy.utils.gl import get_max_texture_sizes
@@ -192,7 +192,7 @@ def _select_colormap_texture(
     return color_texture.reshape(256, -1, 4)
 
 
-class VispyLabelsLayer(VispyImageLayer):
+class VispyLabelsLayer(VispyImageBaseLayer):
     layer: 'Labels'
 
     def __init__(self, layer, node=None, texture_format='r8') -> None:
@@ -220,8 +220,6 @@ class VispyLabelsLayer(VispyImageLayer):
                 if rendering != 'translucent'
                 else 'translucent_categorical'
             )
-            self._on_attenuation_change()
-            self._on_iso_threshold_change()
 
     def _on_colormap_change(self, event=None):
         # self.layer.colormap is a labels_colormap, which is an evented model
@@ -309,6 +307,10 @@ class VispyLabelsLayer(VispyImageLayer):
             event.data, copy=False, offset=event.offset
         )
         self.node.update()
+
+    def reset(self, event=None) -> None:
+        super().reset()
+        self._on_colormap_change()
 
 
 class LabelLayerNode(ImageLayerNode):

--- a/napari/_vispy/layers/labels.py
+++ b/napari/_vispy/layers/labels.py
@@ -10,7 +10,7 @@ from napari._vispy.layers.image import (
     _DTYPE_TO_VISPY_FORMAT,
     _VISPY_FORMAT_TO_DTYPE,
     ImageLayerNode,
-    VispyImageBaseLayer,
+    VispyVolumeBaseLayer,
     get_dtype_from_vispy_texture_format,
 )
 from napari._vispy.utils.gl import get_max_texture_sizes
@@ -192,7 +192,7 @@ def _select_colormap_texture(
     return color_texture.reshape(256, -1, 4)
 
 
-class VispyLabelsLayer(VispyImageBaseLayer):
+class VispyLabelsLayer(VispyVolumeBaseLayer):
     layer: 'Labels'
 
     def __init__(self, layer, node=None, texture_format='r8') -> None:

--- a/napari/_vispy/layers/labels.py
+++ b/napari/_vispy/layers/labels.py
@@ -10,7 +10,7 @@ from napari._vispy.layers.image import (
     _DTYPE_TO_VISPY_FORMAT,
     _VISPY_FORMAT_TO_DTYPE,
     ImageLayerNode,
-    VispyVolumeBaseLayer,
+    VispyScalarFieldBaseLayer,
     get_dtype_from_vispy_texture_format,
 )
 from napari._vispy.utils.gl import get_max_texture_sizes
@@ -192,7 +192,7 @@ def _select_colormap_texture(
     return color_texture.reshape(256, -1, 4)
 
 
-class VispyLabelsLayer(VispyVolumeBaseLayer):
+class VispyLabelsLayer(VispyScalarFieldBaseLayer):
     layer: 'Labels'
 
     def __init__(self, layer, node=None, texture_format='r8') -> None:

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -886,6 +886,9 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             Properties defining plane rendering in 3D. Properties are defined in
             data coordinates. Valid dictionary keys are
             {'position', 'normal', 'thickness', and 'enabled'}.
+        projection_mode : str
+            How data outside the viewed dimensions but inside the thick Dims slice will
+            be projected onto the viewed dimensions. Must fit to cls._projectionclass
         experimental_clipping_planes : list of dicts, list of ClippingPlane, or ClippingPlaneList
             Each dict defines a clipping plane in 3D in data coordinates.
             Valid dictionary keys are {'position', 'normal', and 'enabled'}.

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import copy
+import inspect
 import itertools
 import logging
 import os.path
 import warnings
-from abc import ABC, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 from collections import defaultdict
 from contextlib import contextmanager
 from functools import cached_property
@@ -101,17 +102,21 @@ def no_op(layer: Layer, event: Event) -> None:
     return
 
 
-class PostInit(type):
+class PostInit(ABCMeta):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        sig = inspect.signature(self.__init__)
+        params = tuple(sig.parameters.values())
+        self.__signature__ = sig.replace(parameters=params[1:])
+
     def __call__(self, *args, **kwargs):
         obj = super().__call__(*args, **kwargs)
         obj._post_init()
         return obj
 
 
-@mgui.register_type(
-    choices=get_layers, return_callback=add_layer_to_viewer, metaclass=PostInit
-)
-class Layer(KeymapProvider, MousemapProvider, ABC):
+@mgui.register_type(choices=get_layers, return_callback=add_layer_to_viewer)
+class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
     """Base layer class.
 
     Parameters

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -101,7 +101,16 @@ def no_op(layer: Layer, event: Event) -> None:
     return
 
 
-@mgui.register_type(choices=get_layers, return_callback=add_layer_to_viewer)
+class PostInit(type):
+    def __call__(self, *args, **kwargs):
+        obj = super().__call__(*args, **kwargs)
+        obj._post_init()
+        return obj
+
+
+@mgui.register_type(
+    choices=get_layers, return_callback=add_layer_to_viewer, metaclass=PostInit
+)
 class Layer(KeymapProvider, MousemapProvider, ABC):
     """Base layer class.
 
@@ -449,6 +458,9 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         # TODO: we try to avoid inner event connection, but this might be the only way
         #       until we figure out nested evented objects
         self._overlays.events.connect(self.events._overlays)
+
+    def _post_init(self):
+        """Post init hook for subclasses to use."""
 
     def __str__(self):
         """Return self.name."""

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -827,7 +827,7 @@ class Image(IntensityVisualizationMixin, _ImageBase):
         shear=None,
         translate=None,
         visible=True,
-    ):
+    ) -> None:
         # Determine if rgb
         data_shape = data.shape if hasattr(data, 'shape') else data[0].shape
         rgb_guess = guess_rgb(data_shape)

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -1191,6 +1191,3 @@ class Image(IntensityVisualizationMixin, _ImageBase):
                 )
             )
         return calc_data_range(input_data, rgb=self.rgb)
-
-
-Image.__doc__ = _ImageBase.__doc__

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -209,7 +209,7 @@ class _ImageBase(Layer, ABC):
                 trans._('Image data must have at least 2 dimensions.')
             )
 
-        # Deter
+        # Determine if data is a multiscale
         self._data_raw = data
         if multiscale is None:
             multiscale, data = guess_multiscale(data)

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -7,6 +7,7 @@ from napari.layers.utils.layer_utils import (
     register_layer_action,
     register_layer_attr_action,
 )
+from napari.utils.notifications import show_info
 from napari.utils.translations import trans
 
 MIN_BRUSH_SIZE = 1
@@ -74,7 +75,12 @@ labels_fun_to_mode = [
 )
 def new_label(layer: Labels):
     """Set the currently selected label to the largest used label plus one."""
-    layer.selected_label = np.max(layer.data) + 1
+    if isinstance(layer.data, np.ndarray):
+        layer.selected_label = np.max(layer.data) + 1
+    else:
+        show_info(
+            "Calculating empty label on non-numpy array is not supported"
+        )
 
 
 @register_label_action(

--- a/napari/layers/labels/_tests/test_labels_key_bindings.py
+++ b/napari/layers/labels/_tests/test_labels_key_bindings.py
@@ -1,8 +1,5 @@
-from tempfile import TemporaryDirectory
-
 import numpy as np
 import pytest
-import zarr
 
 from napari.layers import Labels
 from napari.layers.labels._labels_key_bindings import (
@@ -33,31 +30,3 @@ def test_swap_background_label(labels_data_4d):
     assert labels.selected_label == labels._background_label
     swap_selected_and_background_labels(labels)
     assert labels.selected_label == 10
-
-
-def test_max_label_tensorstore(labels_data_4d):
-    ts = pytest.importorskip('tensorstore')
-
-    with TemporaryDirectory(suffix='.zarr') as fout:
-        labels_temp = zarr.open(
-            fout,
-            mode='w',
-            shape=labels_data_4d.shape,
-            dtype=np.uint32,
-            chunks=(1, 1, 8, 9),
-        )
-        labels_temp[:] = labels_data_4d
-        labels_ts_spec = {
-            'driver': 'zarr',
-            'kvstore': {'driver': 'file', 'path': fout},
-            'path': '',
-            'metadata': {
-                'dtype': labels_temp.dtype.str,
-                'order': labels_temp.order,
-                'shape': labels_data_4d.shape,
-            },
-        }
-        data = ts.open(labels_ts_spec, create=False, open=True).result()
-        layer = Labels(data)
-        new_label(layer)
-        assert layer.selected_label == 4

--- a/napari/layers/labels/_tests/test_labels_multiscale.py
+++ b/napari/layers/labels/_tests/test_labels_multiscale.py
@@ -17,7 +17,6 @@ def test_random_multiscale():
     np.testing.assert_array_equal(
         layer.extent.data[1], [s - 1 for s in shapes[0]]
     )
-    assert layer.rgb is False
     assert layer._data_view.ndim == 2
 
 
@@ -34,7 +33,6 @@ def test_infer_multiscale():
     np.testing.assert_array_equal(
         layer.extent.data[1], [s - 1 for s in shapes[0]]
     )
-    assert layer.rgb is False
     assert layer._data_view.ndim == 2
 
 
@@ -49,7 +47,6 @@ def test_3D_multiscale_labels_in_2D():
     np.testing.assert_array_equal(
         layer.extent.data[1], np.array(data_multiscale[0].shape) - 1
     )
-    assert layer.rgb is False
     assert layer._data_view.ndim == 2
 
     # check corner pixels, should be tuple of highest resolution level

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -324,13 +324,8 @@ class Labels(_ImageBase):
 
         super().__init__(
             data,
-            rgb=False,
-            colormap=self._random_colormap,
-            interpolation2d='nearest',
-            interpolation3d='nearest',
             rendering=rendering,
             depiction=depiction,
-            iso_threshold=0,
             name=name,
             metadata=metadata,
             scale=scale,
@@ -349,20 +344,20 @@ class Labels(_ImageBase):
         )
 
         self.events.add(
-            colormap=Event,
-            preserve_labels=Event,
-            show_selected_label=Event,
-            properties=Event,
-            n_edit_dimensions=Event,
-            contiguous=Event,
-            brush_size=Event,
-            selected_label=Event,
-            color_mode=Event,
             brush_shape=Event,
+            brush_size=Event,
+            color_mode=Event,
+            colormap=Event,
+            contiguous=Event,
             contour=Event,
             features=Event,
-            paint=Event,
             labels_update=Event,
+            n_edit_dimensions=Event,
+            paint=Event,
+            preserve_labels=Event,
+            properties=Event,
+            selected_label=Event,
+            show_selected_label=Event,
         )
 
         from napari.components.overlays.labels_polygon import (
@@ -391,8 +386,8 @@ class Labels(_ImageBase):
         self._status = self.mode
         self._preserve_labels = False
 
+    def _post_init(self):
         self._reset_history()
-
         # Trigger generation of view slice and thumbnail
         self.refresh()
         self._reset_editable()
@@ -585,6 +580,7 @@ class Labels(_ImageBase):
     def data(self, data):
         data = self._ensure_int_labels(data)
         self._data = data
+        self._ndim = len(self._data.shape)
         self._update_dims()
         self.events.data(value=self.data)
         self._reset_editable()

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -84,59 +84,34 @@ class Labels(_ImageBase):
         Labels data as an array or multiscale. Must be integer type or bools.
         Please note multiscale rendering is only supported in 2D. In 3D, only
         the lowest resolution scale is displayed.
-    num_colors : int
-        Number of unique colors to use in colormap.
-    features : dict[str, array-like] or DataFrame
-        Features table where each row corresponds to a label and each column
-        is a feature. The first row corresponds to the background label.
-    properties : dict {str: array (N,)} or DataFrame
-        Properties for each label. Each property should be an array of length
-        N, where N is the number of labels, and the first property corresponds
-        to background.
-    color : dict of int to str or array
-        Custom label to color mapping. Values must be valid color names or RGBA
-        arrays.
-    seed : float
-        Seed for colormap random generator.
-    name : str
-        Name of the layer.
-    metadata : dict
-        Layer metadata.
-    scale : tuple of float
-        Scale factors for the layer.
-    translate : tuple of float
-        Translation values for the layer.
-    rotate : float, 3-tuple of float, or n-D array.
-        If a float convert into a 2D rotation matrix using that value as an
-        angle. If 3-tuple convert into a 3D rotation matrix, using a yaw,
-        pitch, roll convention. Otherwise assume an nD rotation. Angles are
-        assumed to be in degrees. They can be converted from radians with
-        np.degrees if needed.
-    shear : 1-D array or n-D array
-        Either a vector of upper triangular values, or an nD shear matrix with
-        ones along the main diagonal.
     affine : n-D array or napari.utils.transforms.Affine
         (N+1, N+1) affine transformation matrix in homogeneous coordinates.
         The first (N, N) entries correspond to a linear transform and
         the final column is a length N translation vector and a 1 or a napari
         `Affine` transform object. Applied as an extra transform on top of the
         provided scale, rotate, and shear values.
-    opacity : float
-        Opacity of the layer visual, between 0.0 and 1.0.
     blending : str
         One of a list of preset blending modes that determines how RGB and
         alpha values of the layer visual get mixed. Allowed values are
         {'opaque', 'translucent', and 'additive'}.
-    rendering : str
-        3D Rendering mode used by vispy. Must be one {'translucent', 'iso_categorical'}.
-        'translucent' renders without lighting. 'iso_categorical' uses isosurface
-        rendering to calculate lighting effects on labeled surfaces.
-        The default value is 'iso_categorical'.
+    cache : bool
+        Whether slices of out-of-core datasets should be cached upon retrieval.
+        Currently, this only applies to dask arrays.
+    color : dict of int or None to str or array
+        Custom label to color mapping. Values must be valid color names or RGBA
+        arrays. None is used when no color is specified for a label.
     depiction : str
         3D Depiction mode. Must be one of {'volume', 'plane'}.
         The default value is 'volume'.
-    visible : bool
-        Whether the layer visual is currently being displayed.
+    experimental_clipping_planes : list of dicts, list of ClippingPlane, or ClippingPlaneList
+        Each dict defines a clipping plane in 3D in data coordinates.
+        Valid dictionary keys are {'position', 'normal', and 'enabled'}.
+        Values on the negative side of the normal are discarded if the plane is enabled.
+    features : dict[str, array-like] or DataFrame
+        Features table where each row corresponds to a label and each column
+        is a feature. The first row corresponds to the background label.
+    metadata : dict
+        Layer metadata.
     multiscale : bool
         Whether the data is a multiscale image or not. Multiscale data is
         represented by a list of array like image data. If not specified by
@@ -145,17 +120,45 @@ class Labels(_ImageBase):
         should be the largest. Please note multiscale rendering is only
         supported in 2D. In 3D, only the lowest resolution scale is
         displayed.
-    cache : bool
-        Whether slices of out-of-core datasets should be cached upon retrieval.
-        Currently, this only applies to dask arrays.
+    name : str
+        Name of the layer.
+    num_colors : int
+        Number of unique colors to use in colormap.
+    opacity : float
+        Opacity of the layer visual, between 0.0 and 1.0.
     plane : dict or SlicingPlane
         Properties defining plane rendering in 3D. Properties are defined in
         data coordinates. Valid dictionary keys are
         {'position', 'normal', 'thickness', and 'enabled'}.
-    experimental_clipping_planes : list of dicts, list of ClippingPlane, or ClippingPlaneList
-        Each dict defines a clipping plane in 3D in data coordinates.
-        Valid dictionary keys are {'position', 'normal', and 'enabled'}.
-        Values on the negative side of the normal are discarded if the plane is enabled.
+    properties : dict {str: array (N,)} or DataFrame
+        Properties for each label. Each property should be an array of length
+        N, where N is the number of labels, and the first property corresponds
+        to background.
+    projection_mode : str
+        How data outside the viewed dimensions but inside the thick Dims slice will
+        be projected onto the viewed dimensions
+    rendering : str
+        3D Rendering mode used by vispy. Must be one {'translucent', 'iso_categorical'}.
+        'translucent' renders without lighting. 'iso_categorical' uses isosurface
+        rendering to calculate lighting effects on labeled surfaces.
+        The default value is 'iso_categorical'.
+    rotate : float, 3-tuple of float, or n-D array.
+        If a float convert into a 2D rotation matrix using that value as an
+        angle. If 3-tuple convert into a 3D rotation matrix, using a yaw,
+        pitch, roll convention. Otherwise assume an nD rotation. Angles are
+        assumed to be in degrees. They can be converted from radians with
+        np.degrees if needed.
+    scale : tuple of float
+        Scale factors for the layer.
+    seed_rng : int
+        Seed for colormap shuffle random generator.
+    shear : 1-D array or n-D array
+        Either a vector of upper triangular values, or an nD shear matrix with
+        ones along the main diagonal.
+    translate : tuple of float
+        Translation values for the layer.
+    visible : bool
+        Whether the layer visual is currently being displayed.
 
     Attributes
     ----------
@@ -281,28 +284,28 @@ class Labels(_ImageBase):
         self,
         data,
         *,
-        num_colors=49,
-        features=None,
-        properties=None,
-        color=None,
-        seed_rng=None,
-        name=None,
-        metadata=None,
-        scale=None,
-        translate=None,
-        rotate=None,
-        shear=None,
         affine=None,
-        opacity=0.7,
         blending='translucent',
-        rendering='iso_categorical',
-        depiction='volume',
-        visible=True,
-        multiscale=None,
         cache=True,
-        plane=None,
+        color=None,
+        depiction='volume',
         experimental_clipping_planes=None,
+        features=None,
+        metadata=None,
+        multiscale=None,
+        name=None,
+        num_colors=49,
+        opacity=0.7,
+        plane=None,
+        properties=None,
         projection_mode='none',
+        rendering='iso_categorical',
+        rotate=None,
+        scale=None,
+        seed_rng=None,
+        shear=None,
+        translate=None,
+        visible=True,
     ) -> None:
         if name is None and data is not None:
             name = magic_name(data)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1564,7 +1564,7 @@ class Labels(_ImageBase):
 
     def _get_shape_and_dims_to_paint(self) -> Tuple[list, list]:
         dims_to_paint = sorted(self._get_dims_to_paint())
-        shape = self.data.shape
+        shape = list(self.data.shape)
 
         if self.n_edit_dimensions < self.ndim:
             shape = [shape[i] for i in dims_to_paint]

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -18,6 +18,8 @@ import pandas as pd
 from scipy import ndimage as ndi
 from skimage.draw import polygon2mask
 
+from napari.layers._data_protocols import LayerDataProtocol
+from napari.layers._multiscale_data import MultiScaleData
 from napari.layers.base import Layer, no_op
 from napari.layers.base._base_mouse_bindings import (
     highlight_box_handles,
@@ -572,12 +574,12 @@ class Labels(_ImageBase):
         self.events.selected_label()
 
     @property
-    def data(self):
+    def data(self) -> LayerDataProtocol:
         """array: Image data."""
         return self._data
 
     @data.setter
-    def data(self, data):
+    def data(self, data: Union[LayerDataProtocol, MultiScaleData]):
         data = self._ensure_int_labels(data)
         self._data = data
         self._ndim = len(self._data.shape)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -326,7 +326,6 @@ class Labels(_ImageBase):
             data,
             rgb=False,
             colormap=self._random_colormap,
-            contrast_limits=[0.0, 2**23 - 1.0],
             interpolation2d='nearest',
             interpolation3d='nearest',
             rendering=rendering,
@@ -350,6 +349,7 @@ class Labels(_ImageBase):
         )
 
         self.events.add(
+            colormap=Event,
             preserve_labels=Event,
             show_selected_label=Event,
             properties=Event,

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -873,16 +873,6 @@ class Labels(_ImageBase):
         self._preserve_labels = preserve_labels
         self.events.preserve_labels(preserve_labels=preserve_labels)
 
-    @property
-    def contrast_limits(self):
-        return self._contrast_limits
-
-    @contrast_limits.setter
-    def contrast_limits(self, value):
-        # Setting contrast_limits of labels layers leads to wrong visualization
-        # of the layer, so we ignore the value
-        self._contrast_limits = (0, 1)
-
     def _reset_editable(self) -> None:
         self.editable = not self.multiscale
 

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -8,7 +8,6 @@ from app_model.types import KeyBinding
 
 from napari._pydantic_compat import (
     BaseModel,
-    Extra,
     ModelMetaclass,
     PrivateAttr,
     main,
@@ -250,7 +249,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
         # NOTE: json_encoders are also added EventedMetaclass.__new__ if the
         # field declares a _json_encode method.
         json_encoders = _BASE_JSON_ENCODERS
-        extra = Extra.forbid
+        # extra = Extra.forbid
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)

--- a/napari/utils/events/evented_model.py
+++ b/napari/utils/events/evented_model.py
@@ -8,6 +8,7 @@ from app_model.types import KeyBinding
 
 from napari._pydantic_compat import (
     BaseModel,
+    Extra,
     ModelMetaclass,
     PrivateAttr,
     main,
@@ -249,6 +250,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
         # NOTE: json_encoders are also added EventedMetaclass.__new__ if the
         # field declares a _json_encode method.
         json_encoders = _BASE_JSON_ENCODERS
+        extra = Extra.forbid
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)


### PR DESCRIPTION
The `_ImageBase` class contains many codes required only for `Image` class. This PR contains extraction of `Image` specific code from `_ImageBase` to `Image` class. 

It also contains update of doc string by removing no longer existing parameters of constructor. 

It also sorts keywords only arguments and parameters to simplify searching doc strings and maintaining it. 

