### PR TITLE
Minimal changes for mlx (and jax) compatibility for Image layers

### DIFF
--- a/napari/_app_model/context/_layerlist_context.py
+++ b/napari/_app_model/context/_layerlist_context.py
@@ -122,6 +122,13 @@ def _active_shape(s: LayerSel) -> Optional[Tuple[int, ...]]:
 
 
 def _same_shape(s: LayerSel) -> bool:
+    """Return true when all given layers have the same shape.
+
+    Notes
+    -----
+    The cast to tuple() is needed because some array libraries return a list,
+    which is not hashable and thus causes the set (``{}``) to fail.
+    """
     return len({tuple(getattr(x.data, "shape", ())) for x in s}) == 1
 
 

--- a/napari/_app_model/context/_layerlist_context.py
+++ b/napari/_app_model/context/_layerlist_context.py
@@ -122,7 +122,7 @@ def _active_shape(s: LayerSel) -> Optional[Tuple[int, ...]]:
 
 
 def _same_shape(s: LayerSel) -> bool:
-    return len({getattr(x.data, "shape", ()) for x in s}) == 1
+    return len({tuple(getattr(x.data, "shape", ())) for x in s}) == 1
 
 
 def _active_dtype(s: LayerSel) -> DTypeLike:

--- a/napari/_app_model/context/_layerlist_context.py
+++ b/napari/_app_model/context/_layerlist_context.py
@@ -126,8 +126,18 @@ def _same_shape(s: LayerSel) -> bool:
 
     Notes
     -----
-    The cast to tuple() is needed because some array libraries return a list,
-    which is not hashable and thus causes the set (``{}``) to fail.
+    The cast to tuple() is needed because some array libraries, specifically
+    Apple's mlx [1]_, return a list, which is not hashable and thus causes the
+    set (``{}``) to fail.
+
+    The Data APIs Array spec specifies that ``.shape`` should be a tuple, or,
+    if a custom type, it should be an immutable type [2]_, so in time, the cast
+    to tuple could be removed, once all major libraries support the spec.
+
+    References
+    ----------
+    .. [1] https://github.com/ml-explore/mlx
+    .. [2] https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.shape.html
     """
     return len({tuple(getattr(x.data, "shape", ())) for x in s}) == 1
 

--- a/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -301,10 +301,7 @@ def range_to_decimals(range_, dtype):
     int
         Decimals of precision.
     """
-
-    if hasattr(dtype, 'numpy_dtype'):
-        # retrieve the corresponding numpy.dtype from a tensorstore.dtype
-        dtype = dtype.numpy_dtype
+    dtype = normalize_dtype(dtype)
 
     if np.issubdtype(dtype, np.integer):
         return 0


### PR DESCRIPTION
These two changes are sufficient to allow napari.imshow to work with arrays
from mlx, Apple's new array library:

1. The function `range_to_decimals` had a tiny hardcoded hack for tensorstore
array dtype. But we have since then implemented the normalize_dtype function
that works with a much broader range of arrays. In this PR, we change to use
normalize_dtype, which works out of the box with mlx arrays.
2. At one point we use `Image.data.shape` to try to make a set. It turns out
that mlx arrays return a list, rather than a tuple, when checking the shape, so
this PR coerces .shape to a tuple to make sure things are working.

I don't want to add an mlx test dependency because it's such a young library,
but these changes are very inoffensive so I hope we can just merge them. You
can test that this works locally with:

```python
import napari
import mlx.core as mx


ran = mx.random.uniform(shape=(5, 10, 10))

viewer, layer = napari.imshow(ran)

if __name__ == '__main__':
    napari.run()
```

This works great with these changes! 😊
