### PR TITLE
Shape to cosed edges mask fix

### DIFF
--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -5,6 +5,7 @@ import numpy as np
 from napari.layers.shapes._shapes_utils import (
     is_collinear,
     path_to_mask,
+    edges_to_mask,
     poly_to_mask,
     triangulate_edge,
     triangulate_face,
@@ -407,7 +408,7 @@ class Shape(ABC):
         if self._filled:
             mask_p = poly_to_mask(shape_plane, (data - offset) * zoom_factor)
         else:
-            mask_p = path_to_mask(shape_plane, (data - offset) * zoom_factor)
+            mask_p = edges_to_mask(shape_plane, (data - offset) * zoom_factor)
 
         # If the mask is to be embedded in a larger array, compute array
         # and embed as a slice.


### PR DESCRIPTION
# References and relevant issues

This pull request targets the bug mentioned in issue #6555.

# Description

It changes the way unfilled shapes are transformed to masks / labels. After this fix the returned arrays contain the masks / labels for the closed edges. Previously the edge between the last and first vertices were missing due to the way the transformation was implemented.


- [x] My PR is the minimum possible work for the desired functionality
- [x] I have made corresponding changes to docstrings
- [ ]  I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
