### PR TITLE
Fix generation of layer creation functions docstrings

### DIFF
--- a/napari/utils/_register.py
+++ b/napari/utils/_register.py
@@ -42,6 +42,8 @@ def create_func(cls, name=None, doc=None, filename: str = '<string>'):
         doc = getdoc(cls)
         start = doc.find('\n\nParameters\n----------\n')
         end = doc.find('\n\nAttributes\n----------\n')
+        if end == -1:
+            end = None
         if start > 0:
             doc = doc[start:end]
 

--- a/napari/utils/_register.py
+++ b/napari/utils/_register.py
@@ -14,6 +14,11 @@ template = """def {name}{signature}:
 
 
 def create_func(cls, name=None, doc=None, filename: str = '<string>'):
+    """
+    Creates a function (such as `add_<layer>`) to add a layer to the viewer
+
+    The functionality is inherited from the corresponding `<layer>` class.
+    """
     cls_name = cls.__name__
 
     if name is None:
@@ -31,10 +36,14 @@ def create_func(cls, name=None, doc=None, filename: str = '<string>'):
     name = 'add_' + name
 
     if doc is None:
+        # While the original class may have Attributes in its docstring, the
+        # generated function should not have an Attributes section.
+        # See https://numpydoc.readthedocs.io/en/latest/format.html#documenting-classes
         doc = getdoc(cls)
-        cutoff = doc.find('\n\nParameters\n----------\n')
-        if cutoff > 0:
-            doc = doc[cutoff:]
+        start = doc.find('\n\nParameters\n----------\n')
+        end = doc.find('\n\nAttributes\n----------\n')
+        if start > 0:
+            doc = doc[start:end]
 
         n = 'n' if cls_name[0].lower() in 'aeiou' else ''
         doc = f'Add a{n} {cls_name} layer to the layer list. ' + doc


### PR DESCRIPTION
# References and relevant issues
Addresses https://github.com/napari/docs/issues/111

# Description
The layer creation functions are wrappers to functionality in each Layer class. In `_register.py`, we populate the layer creation functions docstrings with the corresponding class docstring. However, functions [do not take an Attributes section](https://numpydoc.readthedocs.io/en/latest/format.html#documenting-classes). This has been creating 62 extra "duplicate description" warnings when building the documentation with Sphinx.
