### PR TITLE
Add gussing labels type based on layer name

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1478,7 +1478,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         """
         if layer_type is None or layer_type == '':
             # assumes that big integer type arrays are likely labels.
-            layer_type = guess_labels(data)
+            layer_type = guess_labels(data, (meta or {}).get('name', ""))
         else:
             layer_type = layer_type.lower()
 
@@ -1558,7 +1558,7 @@ def _normalize_layer_data(data: LayerData) -> FullLayerData:
                 )
             )
     else:
-        _data.append(guess_labels(_data[0]))
+        _data.append(guess_labels(_data[0], _data[1].get('name', '')))
     return tuple(_data)  # type: ignore
 
 

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -2167,7 +2167,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
 
         # assumes that big integer type arrays are likely labels.
         if not layer_type:
-            layer_type = guess_labels(data)
+            layer_type = guess_labels(data, (meta or {}).get('name', ""))
 
         if layer_type is None or layer_type not in layers.NAMES:
             raise ValueError(

--- a/napari/layers/image/_image_utils.py
+++ b/napari/layers/image/_image_utils.py
@@ -95,8 +95,14 @@ def guess_multiscale(
     return True, MultiScaleData(data)
 
 
-def guess_labels(data: Any) -> Literal["labels", "image"]:
+def guess_labels(data: Any, name: str) -> Literal["labels", "image"]:
     """Guess if array contains labels data."""
+
+    name = name.lower()
+
+    for text in ("label", "segment", "mask", "roi", "annotation"):
+        if text in name:
+            return 'labels'
 
     if hasattr(data, 'dtype') and data.dtype in (
         np.int32,

--- a/napari_builtins/io/_read.py
+++ b/napari_builtins/io/_read.py
@@ -488,7 +488,8 @@ def _csv_reader(path: Union[str, Sequence[str]]) -> List["LayerData"]:
 
 
 def _magic_imreader(path: str) -> List["LayerData"]:
-    return [(magic_imread(path),)]
+    meta = {"name": os.path.splitext(os.path.basename(path))[0]}
+    return [(magic_imread(path), meta)]
 
 
 def napari_get_reader(


### PR DESCRIPTION
# Description

Currently, we guess if data is image or labels based on dtype. 

This also adds explicit setting file name as layer name (it does not change layer name for user).  