### PR TITLE
Fix test in napari_builtins to remove import from conftest

### DIFF
--- a/napari_builtins/_tests/conftest.py
+++ b/napari_builtins/_tests/conftest.py
@@ -56,5 +56,5 @@ def some_layer(request):
 
 
 @pytest.fixture()
-def all_layers():
+def layers_list():
     return LAYERS

--- a/napari_builtins/_tests/conftest.py
+++ b/napari_builtins/_tests/conftest.py
@@ -53,3 +53,8 @@ LAYERS: List[layers.Layer] = [
 @pytest.fixture(params=LAYERS)
 def some_layer(request):
     return request.param
+
+
+@pytest.fixture()
+def all_layers():
+    return LAYERS

--- a/napari_builtins/_tests/test_writer.py
+++ b/napari_builtins/_tests/test_writer.py
@@ -1,10 +1,9 @@
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 import npe2
 import numpy as np
 import pytest
-from conftest import LAYERS
 
 from napari_builtins.io import napari_get_reader
 
@@ -55,16 +54,16 @@ def test_no_write_layer_bad_extension(some_layer: 'layers.Layer'):
 
 
 # test_plugin_manager fixture is provided by napari_plugin_engine._testsupport
-def test_get_writer_succeeds(tmp_path: Path):
+def test_get_writer_succeeds(tmp_path: Path, all_layers: 'List[layers.Layer]'):
     """Test writing layers data."""
 
     path = tmp_path / 'layers_folder'
-    written = npe2.write(path=str(path), layer_data=LAYERS)  # type: ignore
+    written = npe2.write(path=str(path), layer_data=all_layers)  # type: ignore
 
     # check expected files were written
     expected = {
         str(path / f'{layer.name}{_EXTENSION_MAP[layer._type_string]}')
-        for layer in LAYERS
+        for layer in all_layers
     }
     assert path.is_dir()
     assert set(written) == expected

--- a/napari_builtins/_tests/test_writer.py
+++ b/napari_builtins/_tests/test_writer.py
@@ -54,16 +54,18 @@ def test_no_write_layer_bad_extension(some_layer: 'layers.Layer'):
 
 
 # test_plugin_manager fixture is provided by napari_plugin_engine._testsupport
-def test_get_writer_succeeds(tmp_path: Path, all_layers: 'List[layers.Layer]'):
+def test_get_writer_succeeds(
+    tmp_path: Path, layers_list: 'List[layers.Layer]'
+):
     """Test writing layers data."""
 
     path = tmp_path / 'layers_folder'
-    written = npe2.write(path=str(path), layer_data=all_layers)  # type: ignore
+    written = npe2.write(path=str(path), layer_data=layers_list)  # type: ignore
 
     # check expected files were written
     expected = {
         str(path / f'{layer.name}{_EXTENSION_MAP[layer._type_string]}')
-        for layer in all_layers
+        for layer in layers_list
     }
     assert path.is_dir()
     assert set(written) == expected


### PR DESCRIPTION
# Description

I have found that there is import from conftest in `napari_builtins._tests.test_writter`. This is bad practice and pytest configuration clearly states that there should be not import from conftest.

So this PR removes it by adding additional fixture. 

Alternative will be to extract data structure to `utils` file