### PR TITLE
Remove `app-model!=0.2.4` from test constraints 

### DIFF
--- a/resources/constraints/version_denylist.txt
+++ b/resources/constraints/version_denylist.txt
@@ -4,4 +4,3 @@ PySide6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6
 pytest-json-report
 pyopengl!=3.1.7
 tensorstore!=0.1.38
-app-model!=0.2.4


### PR DESCRIPTION
# Description

Few minutes after merge of #6573 I spot that I do not remove constraint from 
version denylist 
