### PR TITLE
Fix labels mapping cache by filling it with background, not 0

### DIFF
--- a/examples/add_labels.py
+++ b/examples/add_labels.py
@@ -7,7 +7,6 @@ Display a labels layer above of an image layer using the ``add_labels`` and
 
 .. tags:: layers, visualization-basic
 """
-
 from skimage import data
 from skimage.filters import threshold_otsu
 from skimage.measure import label
@@ -26,7 +25,7 @@ bw = closing(image > thresh, square(4))
 cleared = remove_small_objects(clear_border(bw), 20)
 
 # label image regions
-label_image = label(cleared)
+label_image = label(cleared).astype("uint8")
 
 # initialise viewer with coins image
 viewer = napari.view_image(image, name='coins', rgb=False)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -993,19 +993,21 @@ class Labels(_ImageBase):
             return
 
         if isinstance(self._colormap, LabelColormap):
-            mapped_labels = _cast_labels_data_to_texture_dtype_auto(
-                np.array([self.colormap.background_value], dtype=labels.dtype),
+            mapped_background = _cast_labels_data_to_texture_dtype_auto(
+                labels.dtype.type(self.colormap.background_value),
                 self._random_colormap,
             )
         else:  # direct
-            mapped_labels = _cast_labels_data_to_texture_dtype_direct(
-                np.array([self.colormap.background_value], dtype=labels.dtype),
+            mapped_background = _cast_labels_data_to_texture_dtype_direct(
+                labels.dtype.type(self.colormap.background_value),
                 self._direct_colormap,
             )
 
         self._cached_labels = np.zeros_like(labels)
-        self._cached_mapped_labels = np.full_like(
-            labels, mapped_labels[0], dtype=self._get_cache_dtype(labels.dtype)
+        self._cached_mapped_labels = np.full(
+            shape=labels.shape,
+            fill_value=mapped_background,
+            dtype=self._get_cache_dtype(labels.dtype),
         )
 
     def _raw_to_displayed(

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -992,7 +992,7 @@ class Labels(_ImageBase):
         if self._cached_labels is not None:
             return
 
-        if self.color_mode == LabelColorMode.AUTO:
+        if isinstance(self._colormap, LabelColormap):
             mapped_labels = _cast_labels_data_to_texture_dtype_auto(
                 np.array([self.colormap.background_value], dtype=labels.dtype),
                 self._random_colormap,

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -992,9 +992,20 @@ class Labels(_ImageBase):
         if self._cached_labels is not None:
             return
 
+        if self.color_mode == LabelColorMode.AUTO:
+            mapped_labels = _cast_labels_data_to_texture_dtype_auto(
+                np.array([self.colormap.background_value], dtype=labels.dtype),
+                self._random_colormap,
+            )
+        else:  # direct
+            mapped_labels = _cast_labels_data_to_texture_dtype_direct(
+                np.array([self.colormap.background_value], dtype=labels.dtype),
+                self._direct_colormap,
+            )
+
         self._cached_labels = np.zeros_like(labels)
-        self._cached_mapped_labels = np.zeros_like(
-            labels, dtype=self._get_cache_dtype(labels.dtype)
+        self._cached_mapped_labels = np.full_like(
+            labels, mapped_labels[0], dtype=self._get_cache_dtype(labels.dtype)
         )
 
     def _raw_to_displayed(


### PR DESCRIPTION
# References and relevant issues

closes #6578
updates example to mitigate #6579

# Description

Because unknown values are mapped to 0 in direct mode, filing the cache with 0 leads to artifacts as reported in #6578. In this PR, the mapped cache is instead filled with the result of mapping the background to the correct dtype.