### PR TITLE
Initialize ndim value for Points layer using data shape if available

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -49,6 +49,12 @@ def _make_cycled_properties(values, length):
 def test_empty_points():
     pts = Points()
     assert pts.data.shape == (0, 2)
+    assert pts.ndim == 2
+
+
+def test_3d_empty_points():
+    pts = Points(np.empty((0, 3)))
+    assert pts.ndim == 3
 
 
 def test_empty_points_with_features():

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -381,7 +381,11 @@ class Points(Layer):
         if ndim is None:
             if scale is not None:
                 ndim = len(scale)
-            elif data is not None and len(data.shape) == 2:
+            elif (
+                data is not None
+                and hasattr(data, 'shape')
+                and len(data.shape) == 2
+            ):
                 ndim = data.shape[1]
 
         data, ndim = fix_data_points(data, ndim)

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -378,8 +378,11 @@ class Points(Layer):
         shown=True,
         projection_mode='none',
     ) -> None:
-        if ndim is None and scale is not None:
-            ndim = len(scale)
+        if ndim is None:
+            if scale is not None:
+                ndim = len(scale)
+            elif data is not None and len(data.shape) == 2:
+                ndim = data.shape[1]
 
         data, ndim = fix_data_points(data, ndim)
 


### PR DESCRIPTION
# References and relevant issues

Closes #6587 

# Description

Add handling for layer dimensionality initialization by using passed data shape value if available to set `ndim` when kwarg is not passed



