### PR TITLE
Try fix hanging tests by move `self.stop()` on end of functions that update GUI

### DIFF
--- a/napari/_qt/widgets/qt_dims.py
+++ b/napari/_qt/widgets/qt_dims.py
@@ -98,7 +98,6 @@ class QtDims(QWidget):
 
     def _update_display(self):
         """Updates display for all sliders."""
-        self.stop()
         widgets = reversed(list(enumerate(self.slider_widgets)))
         nsteps = self.dims.nsteps
         for axis, widget in widgets:
@@ -116,10 +115,10 @@ class QtDims(QWidget):
         self.setMinimumHeight(nsliders * self.SLIDERHEIGHT)
         self._resize_slice_labels()
         self._resize_axis_labels()
+        self.stop()
 
     def _update_nsliders(self):
         """Updates the number of sliders based on the number of dimensions."""
-        self.stop()
         self._trim_sliders(0)
         self._create_sliders(self.dims.ndim)
         self._update_display()
@@ -127,6 +126,7 @@ class QtDims(QWidget):
             self._update_range()
             if self._displayed_sliders[i]:
                 self._update_slider()
+        self.stop()
 
     def _resize_axis_labels(self):
         """When any of the labels get updated, this method updates all label


### PR DESCRIPTION
# References and relevant issues
Try to resolve the problem from #5443

# Description


Based on data collected with pytest-pystack it looks like a problem comes from mixing GIL and inner Qt locks. 

The main thread (it has GIL) is using `lockInternal()` 
```
(C) File "???", line 0, in QBasicMutex::lockInternal() (/home/runner/work/napari/napari/.tox/py311-linux-pyqt6-cov/lib/python3.11/site-packages/PyQt6/Qt6/lib/libQt6Core.so.6)
```

When second thread is waiting on GIL during also working with threads. 

```
(C) File "???", line 0, in sipQWidget::disconnectNotify(QMetaMethod const&) (/home/runner/work/napari/napari/.tox/py311-linux-pyqt6-cov/lib/python3.11/site-packages/PyQt6/QtWidgets.abi3.so)

...

(C) File "Python/ceval_gil.h", line 231, in take_gil (/opt/hostedtoolcache/Python/3.11.7/x64/lib/libpython3.11.so.1.0)
```

In my opinion, the source of the problem is here:

https://github.com/napari/napari/blob/4a1b0b547f2dc6ae804f66af77a5d7154820463b/napari/_qt/widgets/qt_dims.py#L120-L129

At the same time, we update sliders and stop thread. So I moved the call of stop to the end of the method. 

I do not mark this PR as solving the original issue, as I'm not sure if I properly identified the source of the problem. 