### PR TITLE
Add _data_to_texture method to LabelColormap and remove caching of (u)int8 and (uint16)

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -887,7 +887,7 @@ def test_background_color(qtbot, qt_viewer: QtViewer, dtype):
     data = np.zeros((10, 10), dtype=dtype)
     data[5:] = 10
     layer = qt_viewer.viewer.add_labels(data, opacity=1)
-    color = layer.colormap.map(10)[0] * 255
+    color = layer.colormap.map(10) * 255
 
     backgrounds = (0, 2, -2)
 
@@ -978,7 +978,7 @@ def test_all_supported_dtypes(qt_viewer):
             tuple(np.array(canvas_screenshot.shape[:2]) // 2)
         ]
         npt.assert_equal(
-            midd_pixel, layer.colormap.map(i)[0] * 255, err_msg=f"{dtype} {i}"
+            midd_pixel, layer.colormap.map(i) * 255, err_msg=f"{dtype} {i}"
         )
 
     layer.color = {
@@ -1005,7 +1005,7 @@ def test_all_supported_dtypes(qt_viewer):
             tuple(np.array(canvas_screenshot.shape[:2]) // 2)
         ]
         npt.assert_equal(
-            midd_pixel, layer.colormap.map(i)[0] * 255, err_msg=f"{dtype} {i}"
+            midd_pixel, layer.colormap.map(i) * 255, err_msg=f"{dtype} {i}"
         )
 
 
@@ -1031,5 +1031,5 @@ def test_more_than_uint16_colors(qt_viewer):
             tuple(np.array(canvas_screenshot.shape[:2]) // 2)
         ]
         npt.assert_equal(
-            midd_pixel, layer.colormap.map(i)[0] * 255, err_msg=f"{i}"
+            midd_pixel, layer.colormap.map(i) * 255, err_msg=f"{i}"
         )

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1504,6 +1504,8 @@ def test_invalidate_cache_when_change_color_mode():
 @pytest.mark.parametrize("dtype", np.sctypes['int'] + np.sctypes['uint'])
 @pytest.mark.parametrize("mode", ["auto", "direct"])
 def test_cache_for_dtypes(dtype, mode):
+    if np.dtype(dtype).itemsize <= 2:
+        pytest.skip("No cache")
     data = np.zeros((10, 10), dtype=dtype)
     labels = Labels(data)
     labels.color_mode = mode
@@ -1670,7 +1672,7 @@ def test_labels_features_event():
 
 
 def test_invalidate_cache_when_change_slice():
-    layer = Labels(np.zeros((2, 4, 5), dtype=np.uint8))
+    layer = Labels(np.zeros((2, 4, 5), dtype=np.uint32))
     assert layer._cached_labels is None
     layer._setup_cache(layer._slice.image.raw)
     assert layer._cached_labels is not None

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1050,7 +1050,7 @@ class Labels(_ImageBase):
             sliced_labels = labels[data_slice]
 
         if sliced_labels.dtype.itemsize <= 2:
-            return self.colormap._map_to_gpu(sliced_labels)
+            return self.colormap._data_to_texture_dtype(sliced_labels)
 
         if setup_cache:
             self._setup_cache(raw)
@@ -1076,7 +1076,7 @@ class Labels(_ImageBase):
         if labels_to_map.size == 0:
             return self._cached_mapped_labels[data_slice]
 
-        mapped_labels = self.colormap._map_to_gpu(labels_to_map)
+        mapped_labels = self.colormap._data_to_texture_dtype(labels_to_map)
 
         if self._cached_labels is not None:
             if update_mask is not None:

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1050,7 +1050,7 @@ class Labels(_ImageBase):
             sliced_labels = labels[data_slice]
 
         if sliced_labels.dtype.itemsize <= 2:
-            self.colormap._map_to_gpu(sliced_labels)
+            return self.colormap._map_to_gpu(sliced_labels)
 
         if setup_cache:
             self._setup_cache(raw)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1036,9 +1036,9 @@ class Labels(_ImageBase):
 
         if data_slice is None:
             data_slice = tuple(slice(0, size) for size in raw.shape)
-            self._cached_labels = None
+            setup_cache = False
         else:
-            self._setup_cache(raw)
+            setup_cache = True
 
         labels = raw  # for readability
 
@@ -1048,6 +1048,14 @@ class Labels(_ImageBase):
 
         if sliced_labels is None:
             sliced_labels = labels[data_slice]
+
+        if sliced_labels.dtype.itemsize <= 2:
+            self.colormap._map_to_gpu(sliced_labels)
+
+        if setup_cache:
+            self._setup_cache(raw)
+        else:
+            self._cached_labels = None
 
         # cache the labels and keep track of when values are changed
         update_mask = None
@@ -1068,14 +1076,7 @@ class Labels(_ImageBase):
         if labels_to_map.size == 0:
             return self._cached_mapped_labels[data_slice]
 
-        if self.color_mode == LabelColorMode.AUTO:
-            mapped_labels = _cast_labels_data_to_texture_dtype_auto(
-                labels_to_map, self._random_colormap
-            )
-        else:  # direct
-            mapped_labels = _cast_labels_data_to_texture_dtype_direct(
-                labels_to_map, self._direct_colormap
-            )
+        mapped_labels = self.colormap._map_to_gpu(labels_to_map)
 
         if self._cached_labels is not None:
             if update_mask is not None:
@@ -1131,9 +1132,9 @@ class Labels(_ImageBase):
         elif label is None or (
             self.show_selected_label and label != self.selected_label
         ):
-            col = self.colormap.map(self._background_label)[0]
+            col = self.colormap.map(self._background_label)
         else:
-            col = self.colormap.map(label)[0]
+            col = self.colormap.map(label)
         return col
 
     def _get_value_ray(

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1050,7 +1050,7 @@ class Labels(_ImageBase):
             sliced_labels = labels[data_slice]
 
         if sliced_labels.dtype.itemsize <= 2:
-            return self.colormap._data_to_texture_dtype(sliced_labels)
+            return self.colormap._data_to_texture(sliced_labels)
 
         if setup_cache:
             self._setup_cache(raw)
@@ -1076,7 +1076,7 @@ class Labels(_ImageBase):
         if labels_to_map.size == 0:
             return self._cached_mapped_labels[data_slice]
 
-        mapped_labels = self.colormap._data_to_texture_dtype(labels_to_map)
+        mapped_labels = self.colormap._data_to_texture(labels_to_map)
 
         if self._cached_labels is not None:
             if update_mask is not None:

--- a/napari/utils/colormaps/_tests/test_colormap.py
+++ b/napari/utils/colormaps/_tests/test_colormap.py
@@ -349,7 +349,7 @@ def test_direct_colormap_with_no_selection():
 
     # Map a single value
     mapped = cmap.map(1)
-    npt.assert_array_equal(mapped[0], np.array([1, 0, 0, 1]))
+    npt.assert_array_equal(mapped, np.array([1, 0, 0, 1]))
 
     # Map multiple values
     mapped = cmap.map(np.array([1, 2]))
@@ -365,11 +365,11 @@ def test_direct_colormap_with_selection():
 
     # Map a single value
     mapped = cmap.map(1)
-    npt.assert_array_equal(mapped[0], np.array([1, 0, 0, 1]))
+    npt.assert_array_equal(mapped, np.array([1, 0, 0, 1]))
 
     # Map a value that is not the selection
     mapped = cmap.map(2)
-    npt.assert_array_equal(mapped[0], np.array([0, 0, 0, 0]))
+    npt.assert_array_equal(mapped, np.array([0, 0, 0, 0]))
 
 
 def test_direct_colormap_with_invalid_values():
@@ -379,7 +379,7 @@ def test_direct_colormap_with_invalid_values():
 
     # Map a value that is not in the color_dict
     mapped = cmap.map(3)
-    npt.assert_array_equal(mapped[0], np.array([0, 0, 0, 0]))
+    npt.assert_array_equal(mapped, np.array([0, 0, 0, 0]))
 
 
 def test_direct_colormap_with_empty_color_dict():
@@ -414,9 +414,9 @@ def test_direct_colormap_with_collision():
     }
     cmap = DirectLabelColormap(color_dict=color_dict)
 
-    npt.assert_array_equal(cmap.map(1)[0], np.array([1, 0, 0, 1]))
-    npt.assert_array_equal(cmap.map(12)[0], np.array([0, 1, 0, 1]))
-    npt.assert_array_equal(cmap.map(23)[0], np.array([0, 0, 1, 1]))
+    npt.assert_array_equal(cmap.map(1), np.array([1, 0, 0, 1]))
+    npt.assert_array_equal(cmap.map(12), np.array([0, 1, 0, 1]))
+    npt.assert_array_equal(cmap.map(23), np.array([0, 0, 1, 1]))
 
 
 def test_direct_colormap_negative_values():
@@ -426,7 +426,7 @@ def test_direct_colormap_negative_values():
 
     # Map a single value
     mapped = cmap.map(np.int8(-1))
-    npt.assert_array_equal(mapped[0], np.array([1, 0, 0, 1]))
+    npt.assert_array_equal(mapped, np.array([1, 0, 0, 1]))
 
     # Map multiple values
     mapped = cmap.map(np.array([-1, -2], dtype=np.int8))

--- a/napari/utils/colormaps/_tests/test_colormap_utils.py
+++ b/napari/utils/colormaps/_tests/test_colormap_utils.py
@@ -24,7 +24,7 @@ def test_label_colormap(index, expected):
     Make sure that the default label colormap colors are identical
     to past versions, for UX consistency.
     """
-    np.testing.assert_almost_equal(label_colormap(49).map(index), [expected])
+    np.testing.assert_almost_equal(label_colormap(49).map(index), expected)
 
 
 def test_label_colormap_exception():

--- a/napari/utils/colormaps/colormap.py
+++ b/napari/utils/colormaps/colormap.py
@@ -983,14 +983,14 @@ except ModuleNotFoundError:
     _labels_raw_to_texture_direct = _labels_raw_to_texture_direct_numpy
     prange = range
 else:
-    _zero_preserving_modulo_inner_loop = numba.njit(parallel=True)(
+    _zero_preserving_modulo_inner_loop = numba.njit(parallel=True, cache=True)(
         _zero_preserving_modulo_inner_loop
     )
     _zero_preserving_modulo = _zero_preserving_modulo_loop
     _labels_raw_to_texture_direct = _labels_raw_to_texture_direct_loop
-    _labels_raw_to_texture_direct_inner_loop = numba.njit(parallel=True)(
-        _labels_raw_to_texture_direct_inner_loop
-    )
+    _labels_raw_to_texture_direct_inner_loop = numba.njit(
+        parallel=True, cache=True
+    )(_labels_raw_to_texture_direct_inner_loop)
     prange = numba.prange  # type: ignore [misc]
 
     del numba

--- a/napari/utils/colormaps/colormap.py
+++ b/napari/utils/colormaps/colormap.py
@@ -183,14 +183,14 @@ class LabelColormapBase(Colormap):
         keep_untouched = (cached_property,)
 
     @overload
-    def _map_to_gpu(self, values: np.ndarray) -> np.ndarray:
+    def _data_to_texture_dtype(self, values: np.ndarray) -> np.ndarray:
         ...
 
     @overload
-    def _map_to_gpu(self, values: np.integer) -> np.integer:
+    def _data_to_texture_dtype(self, values: np.integer) -> np.integer:
         ...
 
-    def _map_to_gpu(
+    def _data_to_texture_dtype(
         self, values: Union[np.ndarray, np.integer]
     ) -> Union[np.ndarray, np.integer]:
         """Map input values to values for send to GPU."""
@@ -246,7 +246,7 @@ class LabelColormapBase(Colormap):
         int
             The selection converted.
         """
-        return int(self._map_to_gpu(dtype.type(self.selection)))
+        return int(self._data_to_texture_dtype(dtype.type(self.selection)))
 
 
 class LabelColormap(LabelColormapBase):
@@ -282,17 +282,19 @@ class LabelColormap(LabelColormapBase):
         int
             The background converted.
         """
-        return int(self._map_to_gpu(dtype.type(self.background_value)))
+        return int(
+            self._data_to_texture_dtype(dtype.type(self.background_value))
+        )
 
     @overload
-    def _map_to_gpu(self, values: np.ndarray) -> np.ndarray:
+    def _data_to_texture_dtype(self, values: np.ndarray) -> np.ndarray:
         ...
 
     @overload
-    def _map_to_gpu(self, values: np.integer) -> np.integer:
+    def _data_to_texture_dtype(self, values: np.integer) -> np.integer:
         ...
 
-    def _map_to_gpu(
+    def _data_to_texture_dtype(
         self, values: Union[np.ndarray, np.integer]
     ) -> Union[np.ndarray, np.integer]:
         """Map input values to values for send to GPU."""
@@ -375,14 +377,14 @@ class DirectLabelColormap(LabelColormapBase):
         super().__init__(*args, **kwargs)
 
     @overload
-    def _map_to_gpu(self, values: np.ndarray) -> np.ndarray:
+    def _data_to_texture_dtype(self, values: np.ndarray) -> np.ndarray:
         ...
 
     @overload
-    def _map_to_gpu(self, values: np.integer) -> np.integer:
+    def _data_to_texture_dtype(self, values: np.integer) -> np.integer:
         ...
 
-    def _map_to_gpu(
+    def _data_to_texture_dtype(
         self, values: Union[np.ndarray, np.integer]
     ) -> Union[np.ndarray, np.integer]:
         """Map input values to values for send to GPU."""

--- a/napari/utils/colormaps/colormap.py
+++ b/napari/utils/colormaps/colormap.py
@@ -183,14 +183,14 @@ class LabelColormapBase(Colormap):
         keep_untouched = (cached_property,)
 
     @overload
-    def _data_to_texture_dtype(self, values: np.ndarray) -> np.ndarray:
+    def _data_to_texture(self, values: np.ndarray) -> np.ndarray:
         ...
 
     @overload
-    def _data_to_texture_dtype(self, values: np.integer) -> np.integer:
+    def _data_to_texture(self, values: np.integer) -> np.integer:
         ...
 
-    def _data_to_texture_dtype(
+    def _data_to_texture(
         self, values: Union[np.ndarray, np.integer]
     ) -> Union[np.ndarray, np.integer]:
         """Map input values to values for send to GPU."""
@@ -246,7 +246,7 @@ class LabelColormapBase(Colormap):
         int
             The selection converted.
         """
-        return int(self._data_to_texture_dtype(dtype.type(self.selection)))
+        return int(self._data_to_texture(dtype.type(self.selection)))
 
 
 class LabelColormap(LabelColormapBase):
@@ -282,19 +282,17 @@ class LabelColormap(LabelColormapBase):
         int
             The background converted.
         """
-        return int(
-            self._data_to_texture_dtype(dtype.type(self.background_value))
-        )
+        return int(self._data_to_texture(dtype.type(self.background_value)))
 
     @overload
-    def _data_to_texture_dtype(self, values: np.ndarray) -> np.ndarray:
+    def _data_to_texture(self, values: np.ndarray) -> np.ndarray:
         ...
 
     @overload
-    def _data_to_texture_dtype(self, values: np.integer) -> np.integer:
+    def _data_to_texture(self, values: np.integer) -> np.integer:
         ...
 
-    def _data_to_texture_dtype(
+    def _data_to_texture(
         self, values: Union[np.ndarray, np.integer]
     ) -> Union[np.ndarray, np.integer]:
         """Map input values to values for send to GPU."""
@@ -377,14 +375,14 @@ class DirectLabelColormap(LabelColormapBase):
         super().__init__(*args, **kwargs)
 
     @overload
-    def _data_to_texture_dtype(self, values: np.ndarray) -> np.ndarray:
+    def _data_to_texture(self, values: np.ndarray) -> np.ndarray:
         ...
 
     @overload
-    def _data_to_texture_dtype(self, values: np.integer) -> np.integer:
+    def _data_to_texture(self, values: np.integer) -> np.integer:
         ...
 
-    def _data_to_texture_dtype(
+    def _data_to_texture(
         self, values: Union[np.ndarray, np.integer]
     ) -> Union[np.ndarray, np.integer]:
         """Map input values to values for send to GPU."""

--- a/napari/utils/colormaps/colormap.py
+++ b/napari/utils/colormaps/colormap.py
@@ -409,10 +409,7 @@ class DirectLabelColormap(LabelColormapBase):
             return self.color_dict.get(values, self.default_color)
         if isinstance(values, (list, tuple)):
             values = np.array(values)
-        if not isinstance(values, np.ndarray) or values.dtype.kind in {
-            'f',
-            'U',
-        }:
+        if not isinstance(values, np.ndarray) or values.dtype.kind in 'fU':
             raise TypeError("DirectLabelColormap can only be used with int")
         mapper = self._get_mapping_from_cache(values.dtype)
         if mapper is not None:

--- a/napari/utils/colormaps/colormap.py
+++ b/napari/utils/colormaps/colormap.py
@@ -182,6 +182,20 @@ class LabelColormapBase(Colormap):
         # need to validate after drop pydantic 1
         keep_untouched = (cached_property,)
 
+    @overload
+    def _map_to_gpu(self, values: np.ndarray) -> np.ndarray:
+        ...
+
+    @overload
+    def _map_to_gpu(self, values: np.integer) -> np.integer:
+        ...
+
+    def _map_to_gpu(
+        self, values: Union[np.ndarray, np.integer]
+    ) -> Union[np.ndarray, np.integer]:
+        """Map input values to values for send to GPU."""
+        raise NotImplementedError
+
     def _cmap_without_selection(self) -> "LabelColormapBase":
         if self.use_selection:
             cmap = self.__class__(**self.dict())
@@ -232,7 +246,7 @@ class LabelColormapBase(Colormap):
         int
             The selection converted.
         """
-        raise NotImplementedError
+        return int(self._map_to_gpu(dtype.type(self.selection)))
 
 
 class LabelColormap(LabelColormapBase):
@@ -255,13 +269,6 @@ class LabelColormap(LabelColormapBase):
             )
         return v
 
-    def _selection_as_minimum_dtype(self, dtype: np.dtype) -> int:
-        return int(
-            _cast_labels_data_to_texture_dtype_auto(
-                dtype.type(self.selection), self
-            )
-        )
-
     def _background_as_minimum_dtype(self, dtype: np.dtype) -> int:
         """Treat background as given dtype and calculate value with min dtype.
 
@@ -275,11 +282,21 @@ class LabelColormap(LabelColormapBase):
         int
             The background converted.
         """
-        return int(
-            _cast_labels_data_to_texture_dtype_auto(
-                dtype.type(self.background_value), self
-            )
-        )
+        return int(self._map_to_gpu(dtype.type(self.background_value)))
+
+    @overload
+    def _map_to_gpu(self, values: np.ndarray) -> np.ndarray:
+        ...
+
+    @overload
+    def _map_to_gpu(self, values: np.integer) -> np.integer:
+        ...
+
+    def _map_to_gpu(
+        self, values: Union[np.ndarray, np.integer]
+    ) -> Union[np.ndarray, np.integer]:
+        """Map input values to values for send to GPU."""
+        return _cast_labels_data_to_texture_dtype_auto(values, self)
 
     def _map_without_cache(self, values) -> np.ndarray:
         texture_dtype_values = _zero_preserving_modulo_numpy(
@@ -292,19 +309,21 @@ class LabelColormap(LabelColormapBase):
         mapped[texture_dtype_values == 0] = 0
         return mapped
 
-    def map(self, values) -> np.ndarray:
+    def map(self, values: Union[np.ndarray, np.integer, int]) -> np.ndarray:
         """Map values to colors.
 
         Parameters
         ----------
-        values : np.ndarray or float
+        values : np.ndarray or int
             Values to be mapped.
 
         Returns
         -------
-        np.ndarray of same shape as values, but with last dimension of size 4
+        np.ndarray of the same shape as values,
+            but with the last dimension of size 4
             Mapped colors.
         """
+        original_shape = np.shape(values)
         values = np.atleast_1d(values)
 
         if values.dtype.kind == 'f':
@@ -317,7 +336,7 @@ class LabelColormap(LabelColormapBase):
         if self.use_selection:
             mapped[(values != self.selection)] = 0
 
-        return mapped
+        return np.reshape(mapped, original_shape + (4,))
 
     def shuffle(self, seed: int):
         """Shuffle the colormap colors.
@@ -355,14 +374,21 @@ class DirectLabelColormap(LabelColormapBase):
             kwargs["colors"] = np.zeros(3)
         super().__init__(*args, **kwargs)
 
-    def _selection_as_minimum_dtype(self, dtype: np.dtype) -> int:
-        return int(
-            _cast_labels_data_to_texture_dtype_direct(
-                dtype.type(self.selection), self
-            )
-        )
+    @overload
+    def _map_to_gpu(self, values: np.ndarray) -> np.ndarray:
+        ...
 
-    def map(self, values) -> np.ndarray:
+    @overload
+    def _map_to_gpu(self, values: np.integer) -> np.integer:
+        ...
+
+    def _map_to_gpu(
+        self, values: Union[np.ndarray, np.integer]
+    ) -> Union[np.ndarray, np.integer]:
+        """Map input values to values for send to GPU."""
+        return _cast_labels_data_to_texture_dtype_direct(values, self)
+
+    def map(self, values: Union[np.ndarray, np.integer, int]) -> np.ndarray:
         """Map values to colors.
 
         Parameters
@@ -375,8 +401,18 @@ class DirectLabelColormap(LabelColormapBase):
         np.ndarray of same shape as values, but with last dimension of size 4
             Mapped colors.
         """
-        values = np.atleast_1d(values)
-        if values.dtype.kind in {'f', 'U'}:
+        if isinstance(values, np.integer):
+            values = int(values)
+        if isinstance(values, int):
+            if self.use_selection and values != self.selection:
+                return np.array((0, 0, 0, 0))
+            return self.color_dict.get(values, self.default_color)
+        if isinstance(values, (list, tuple)):
+            values = np.array(values)
+        if not isinstance(values, np.ndarray) or values.dtype.kind in {
+            'f',
+            'U',
+        }:
             raise TypeError("DirectLabelColormap can only be used with int")
         mapper = self._get_mapping_from_cache(values.dtype)
         if mapper is not None:
@@ -566,6 +602,20 @@ class DirectLabelColormap(LabelColormapBase):
         return self.color_dict.get(None, np.array((0, 0, 0, 0)))
         # we provided here default color for backward compatibility
         # if someone is using DirectLabelColormap directly, not through Label layer
+
+
+@overload
+def _convert_small_ints_to_unsigned(
+    data: np.ndarray,
+) -> np.ndarray:
+    ...
+
+
+@overload
+def _convert_small_ints_to_unsigned(
+    data: np.integer,
+) -> np.integer:
+    ...
 
 
 def _convert_small_ints_to_unsigned(


### PR DESCRIPTION
# Description

In this PR, I extract the most obvious parts of #6583 to allow cherrypick them to 0.4.19. 

The changes are:

1) As we use memory view for (u)int8 and (u)int16 data, this PR removes caching in `_raw_to_dispayed` as it is obsolete.
2) add a `_data_to_texture` method to `LabelColormap` to provide uniform interface for mapping between the data dtype and the (possibly smaller, unsigned) texture dtype and avoid branching. 
3) fix `Colormap.map` for `int` to fit documentation.