### PR TITLE
Do not require triangle on macos arm

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -114,7 +114,7 @@ all =
     napari-plugin-manager >=0.1.0a1, <0.2.0
 # optional (i.e. opt-in) packages, see https://github.com/napari/napari/pull/3867#discussion_r864354854
 optional =
-    triangle
+    triangle ; platform_machine != 'arm64'
     numba>=0.57.1
 testing =
     babel>=2.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -114,7 +114,7 @@ all =
     napari-plugin-manager >=0.1.0a1, <0.2.0
 # optional (i.e. opt-in) packages, see https://github.com/napari/napari/pull/3867#discussion_r864354854
 optional =
-    triangle ; platform_machine != 'arm64'
+    triangle ; platform_machine != 'arm64'  # no wheels
     numba>=0.57.1
 testing =
     babel>=2.9.0


### PR DESCRIPTION
# References and relevant issues

Reported on zulip https://napari.zulipchat.com/#narrow/stream/212875-general/topic/installing.20napari.5Ball.5D.2C.20.5Boptional.5D.20etc.2E.20on.20arm64.20macOS/near/416802211 

# Description

As triangles do not have macOS arm64 wheels, then trying to install napari with `all` extras on macOS arm64 will fail.

This PR removes the triangle from optional dependencies for the arm64 platform. 
