### PR TITLE
Ignore pandas pyarrow warning

### DIFF
--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -844,7 +844,7 @@ class _FeatureTable:
         self._defaults = _validate_features(currents, num_data=1)
         if update_indices is not None:
             for k in self._defaults:
-                self._values[k][update_indices] = self._defaults[k][0]
+                self._values.loc[update_indices, k] = self._defaults[k][0]
 
     def resize(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ filterwarnings = [
   "ignore:Alternative shading modes are only available in 3D, defaulting to none",
   "ignore:distutils Version classes are deprecated::",
   "ignore:There is no current event loop:DeprecationWarning:",
-  "ignore::DeprecationWarning:napari.layers.utils.layer_utils",  # pandas pyarrow (pandas<3.0), workaround for empty line in warning message
+  "ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning",  # pandas pyarrow (pandas<3.0),
 ]
 markers = [
     "examples: Test of examples",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ filterwarnings = [
   "ignore:Alternative shading modes are only available in 3D, defaulting to none",
   "ignore:distutils Version classes are deprecated::",
   "ignore:There is no current event loop:DeprecationWarning:",
+  "ignore:Pyarrow will become a required dependency of pandas"
 ]
 markers = [
     "examples: Test of examples",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ filterwarnings = [
   "ignore:Alternative shading modes are only available in 3D, defaulting to none",
   "ignore:distutils Version classes are deprecated::",
   "ignore:There is no current event loop:DeprecationWarning:",
-  "ignore:Pyarrow will become a required dependency of pandas"
+  "ignore:Pyarrow will become a required dependency of pandas:DeprecationWarning:"
 ]
 markers = [
     "examples: Test of examples",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ filterwarnings = [
   "ignore:Alternative shading modes are only available in 3D, defaulting to none",
   "ignore:distutils Version classes are deprecated::",
   "ignore:There is no current event loop:DeprecationWarning:",
-  "ignore:Pyarrow will become a required dependency of pandas:DeprecationWarning:"
+  "ignore::DeprecationWarning:napari.layers.utils.layer_utils",
 ]
 markers = [
     "examples: Test of examples",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ filterwarnings = [
   "ignore:Alternative shading modes are only available in 3D, defaulting to none",
   "ignore:distutils Version classes are deprecated::",
   "ignore:There is no current event loop:DeprecationWarning:",
-  "ignore::DeprecationWarning:napari.layers.utils.layer_utils",
+  "ignore::DeprecationWarning:napari.layers.utils.layer_utils",  # pandas pyarrow (pandas<3.0), workaround for empty line in warning message
 ]
 markers = [
     "examples: Test of examples",

--- a/resources/constraints/constraints_py3.10.txt
+++ b/resources/constraints/constraints_py3.10.txt
@@ -268,7 +268,7 @@ packaging==23.2
     #   superqt
     #   vispy
     #   xarray
-pandas==2.1.4 ; python_version >= "3.9"
+pandas==2.2.0 ; python_version >= "3.9"
     # via
     #   napari (napari_repo/setup.cfg)
     #   xarray

--- a/resources/constraints/constraints_py3.10_docs.txt
+++ b/resources/constraints/constraints_py3.10_docs.txt
@@ -348,7 +348,7 @@ packaging==23.2
     #   superqt
     #   vispy
     #   xarray
-pandas==2.1.4 ; python_version >= "3.9"
+pandas==2.2.0 ; python_version >= "3.9"
     # via
     #   napari (napari_repo/setup.cfg)
     #   nilearn

--- a/resources/constraints/constraints_py3.10_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.10_pydantic_1.txt
@@ -266,7 +266,7 @@ packaging==23.2
     #   superqt
     #   vispy
     #   xarray
-pandas==2.1.4 ; python_version >= "3.9"
+pandas==2.2.0 ; python_version >= "3.9"
     # via
     #   napari (napari_repo/setup.cfg)
     #   xarray

--- a/resources/constraints/constraints_py3.11.txt
+++ b/resources/constraints/constraints_py3.11.txt
@@ -263,7 +263,7 @@ packaging==23.2
     #   superqt
     #   vispy
     #   xarray
-pandas==2.1.4 ; python_version >= "3.9"
+pandas==2.2.0 ; python_version >= "3.9"
     # via
     #   napari (napari_repo/setup.cfg)
     #   xarray

--- a/resources/constraints/constraints_py3.11_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.11_pydantic_1.txt
@@ -261,7 +261,7 @@ packaging==23.2
     #   superqt
     #   vispy
     #   xarray
-pandas==2.1.4 ; python_version >= "3.9"
+pandas==2.2.0 ; python_version >= "3.9"
     # via
     #   napari (napari_repo/setup.cfg)
     #   xarray

--- a/resources/constraints/constraints_py3.9.txt
+++ b/resources/constraints/constraints_py3.9.txt
@@ -274,7 +274,7 @@ packaging==23.2
     #   superqt
     #   vispy
     #   xarray
-pandas==2.1.4 ; python_version >= "3.9"
+pandas==2.2.0 ; python_version >= "3.9"
     # via
     #   napari (napari_repo/setup.cfg)
     #   xarray

--- a/resources/constraints/constraints_py3.9_examples.txt
+++ b/resources/constraints/constraints_py3.9_examples.txt
@@ -291,7 +291,7 @@ packaging==23.2
     #   superqt
     #   vispy
     #   xarray
-pandas==2.1.4 ; python_version >= "3.9"
+pandas==2.2.0 ; python_version >= "3.9"
     # via
     #   napari (napari_repo/setup.cfg)
     #   nilearn

--- a/resources/constraints/constraints_py3.9_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.9_pydantic_1.txt
@@ -272,7 +272,7 @@ packaging==23.2
     #   superqt
     #   vispy
     #   xarray
-pandas==2.1.4 ; python_version >= "3.9"
+pandas==2.2.0 ; python_version >= "3.9"
     # via
     #   napari (napari_repo/setup.cfg)
     #   xarray


### PR DESCRIPTION
# Description

The #6608 shows that new pandas warning crash our tests. 
```
  /tmp/.tox/py39-linux-pyqt5/lib/python3.9/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
      exec(co, module.__dict__)
  napari/layers/base/base.py:28: in <module>
      from napari.layers.utils.layer_utils import (
  <frozen importlib._bootstrap>:1007: in _find_and_load
      ???
  <frozen importlib._bootstrap>:986: in _find_and_load_unlocked
      ???
  <frozen importlib._bootstrap>:680: in _load_unlocked
      ???
  /tmp/.tox/py39-linux-pyqt5/lib/python3.9/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
      exec(co, module.__dict__)
  napari/layers/utils/layer_utils.py:10: in <module>
      import pandas as pd
  /tmp/.tox/py39-linux-pyqt5/lib/python3.9/site-packages/pandas/__init__.py:221: in <module>
      warnings.warn(
  E   DeprecationWarning: 
  E   Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
  E   (to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)
  E   but was not found to be installed on your system.
  E   If this would cause problems for you,
  E   please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
```

This PR adds filter warnings to prevent this failure. Because warnings start with an empty line, this fix is fragile and heavily depends on the order of imports. 

Pull request to fix warning message in pandas 
https://github.com/pandas-dev/pandas/pull/57003

cPython issue:
https://github.com/python/cpython/issues/114426

This PR also fixes usage of chained assignment.