### PR TITLE
Fixing data_setitem function of label layer

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -701,7 +701,8 @@ def test_data_setitem_multi_dim():
     data = zarr.zeros((10, 10, 10), chunks=(5, 5, 5), dtype=np.uint32)
     labels = Labels(data)
     labels.data_setitem(
-        (np.array([0, 1, 1]), np.array([1, 1, 2]), np.array([0, 0, 0])), [1, 2, 10]
+        (np.array([0, 1, 1]), np.array([1, 1, 2]), np.array([0, 0, 0])),
+        [1, 2, 10],
     )
 
 

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -701,7 +701,7 @@ def test_data_setitem_multi_dim():
     data = zarr.zeros((10, 10, 10), chunks=(5, 5, 5), dtype=np.uint32)
     labels = Labels(data)
     labels.data_setitem(
-        (np.array([0, 1, 1]), np.array([1, 1, 2]), np.array([0, 0, 0])), [1, 2, 10]
+        (np.array([0, 1, 1]), np.array([1, 1, 2]), np.array([0, 0, 0])), [1, 2, 0]
     )
 
 

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -701,7 +701,7 @@ def test_data_setitem_multi_dim():
     data = zarr.zeros((10, 10, 10), chunks=(5, 5, 5), dtype=np.uint32)
     labels = Labels(data)
     labels.data_setitem(
-        (np.array([0, 1]), np.array([1, 1]), np.array([0, 0])), [1, 2]
+        (np.array([0, 1, 1]), np.array([1, 1, 2]), np.array([0, 0, 0])), [1, 2, 10]
     )
 
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1572,12 +1572,15 @@ class Labels(_ImageBase):
         """
         changed_indices = self.data[indices] != value
         indices = tuple(x[changed_indices] for x in indices)
-
+        
         if isinstance(value, Sequence):
             value = np.asarray(value, dtype=self._slice.image.raw.dtype)
-            value = value[changed_indices]
         else:
             value = self._slice.image.raw.dtype.type(value)
+
+        # Resize value array to remove unchanged elements
+        if isinstance(value, np.ndarray):
+            value = value[changed_indices]
 
         if not indices or indices[0].size == 0:
             return

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1572,10 +1572,10 @@ class Labels(_ImageBase):
         """
         changed_indices = self.data[indices] != value
         indices = tuple(x[changed_indices] for x in indices)
-        value = value[changed_indices]
 
         if isinstance(value, Sequence):
             value = np.asarray(value, dtype=self._slice.image.raw.dtype)
+            value = value[changed_indices]
         else:
             value = self._slice.image.raw.dtype.type(value)
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1572,6 +1572,7 @@ class Labels(_ImageBase):
         """
         changed_indices = self.data[indices] != value
         indices = tuple(x[changed_indices] for x in indices)
+        value = value[changed_indices]
 
         if isinstance(value, Sequence):
             value = np.asarray(value, dtype=self._slice.image.raw.dtype)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1572,7 +1572,7 @@ class Labels(_ImageBase):
         """
         changed_indices = self.data[indices] != value
         indices = tuple(x[changed_indices] for x in indices)
-        
+
         if isinstance(value, Sequence):
             value = np.asarray(value, dtype=self._slice.image.raw.dtype)
         else:


### PR DESCRIPTION
Labels layer bug fix. Adapting the test now

# References and relevant issues
This PR closes an new issue that hasn't been noticed yet.

# Description
This fixes a bug. The following error arises if the "value" input is an array and there are unchanged values in the indices.
*** ValueError: shape mismatch: value array of shape (855416,) could not be broadcast to indexing result of shape (88060,) 


