### PR TITLE
Select only linked layers already present in layer list

### DIFF
--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -134,7 +134,10 @@ def _unlink_selected_layers(ll: LayerList):
 
 
 def _select_linked_layers(ll: LayerList):
-    ll.selection.update(get_linked_layers(*ll.selection))
+    linked_layers_in_list = [
+        x for x in get_linked_layers(*ll.selection) if x in ll
+    ]
+    ll.selection.update(linked_layers_in_list)
 
 
 def _convert_dtype(ll: LayerList, mode='int64'):


### PR DESCRIPTION
# References and relevant issues

Hides problem reported in #6619

# Description

To avoid error when using the `select linked layers` layer list contextual menu item, this PR add mechanism for filtering the list of selected layers only to ones present in the layer list. 

This hides the real error, but is small and easy to cherry-pick. 

Real fix requires understand why linked layers are not deleted from memory (so available through weak reference). 

Even when prepare real fix, this fix should remain, as garbage collection may not happen immediately. 