### PR TITLE
Fix rendering of vertexes of shape layers with small scale

### DIFF
--- a/napari/_vispy/layers/shapes.py
+++ b/napari/_vispy/layers/shapes.py
@@ -84,8 +84,7 @@ class VispyShapesLayer(VispyBaseLayer):
             _,
         ) = self.layer._compute_vertices_and_box()
 
-        # use last dimension of scale like (thickness cannot be anisotropic)
-        width = settings.appearance.highlight_thickness / self.layer.scale[-1]
+        width = settings.appearance.highlight_thickness
 
         if vertices is None or len(vertices) == 0:
             vertices = np.zeros((1, self.layer._slice_input.ndisplay))


### PR DESCRIPTION
# References and relevant issues
Bug spotted in context #6627 

# Description

After changes in #5802 the vertex border is very thick:

![Zrzut ekranu z 2024-01-29 15-09-03](https://github.com/napari/napari/assets/3826210/4f2ca013-b4cc-4b86-bd2f-7e668895846e)

This PR reverts this change as Marker's size is in absolute unit, not data unit. 

![image](https://github.com/napari/napari/assets/3826210/d087d373-3f31-4258-bba9-ffe7c34458bf)


Script for reproduce:

```python
import napari
import numpy as np


s = (0.01, 0.005, 0.005)
s = (0.005, 0.005, 0.005)
s = (0.01, 0.01, 0.01)
s = (0.1, 0.1, 0.1)
# s = (1, 1, 1)
viewer = napari.Viewer()
layers = viewer.open_sample("napari", "cells3d")
for l in layers:
    l.scale = s

shapes = viewer.add_shapes(
    np.array(
        [
            [29.0, 130.70802005, 86.37901572],
            [29.0, 130.70802005, 137.70733652],
            [29.0, 182.32797904, 137.70733652],
            [29.0, 182.32797904, 86.37901572],
        ]
    ),
    scale=s,
)
shapes.mode = "select"
viewer.dims.current_step = (29, 0, 0)
viewer.reset_view()

napari.run()
```

