### PR TITLE
Fix decomposition function to properly work with more than 2x2 matrices

### DIFF
--- a/napari/components/_tests/test_layers_list.py
+++ b/napari/components/_tests/test_layers_list.py
@@ -509,7 +509,7 @@ def test_world_extent_mixed_flipped():
         np.random.random((15, 15)), affine=[[0, 1, 0], [1, 0, 0], [0, 0, 1]]
     )
     layers.append(layer)
-    np.testing.assert_allclose(layer._data_to_world.scale, (1, -1))
+    np.testing.assert_allclose(layer._data_to_world.scale, (1, 1))
     np.testing.assert_allclose(layers.extent.step, (1, 1))
 
 

--- a/napari/utils/transforms/_tests/test_transform_utils.py
+++ b/napari/utils/transforms/_tests/test_transform_utils.py
@@ -40,6 +40,21 @@ def test_decompose_linear_matrix(upper_triangular):
     np.testing.assert_almost_equal(B, C)
 
 
+def test_decompose_linear_matrix_3d():
+    arr = np.array(
+        [
+            [1, 0, 0],
+            [0, 0, -1],
+            [0, 1, 0],
+        ]
+    )
+    rotate, scale, shear = decompose_linear_matrix(
+        arr * 5, upper_triangular=False
+    )
+    np.testing.assert_almost_equal(rotate, arr)
+    np.testing.assert_almost_equal(scale, [5, 5, 5])
+
+
 def test_composition_order():
     """Test composition order."""
     # Order is rotate, shear, scale

--- a/napari/utils/transforms/_tests/test_transforms.py
+++ b/napari/utils/transforms/_tests/test_transforms.py
@@ -350,3 +350,17 @@ def test_replace_slice_independence():
 def test_replace_slice_num_dimensions():
     with pytest.raises(ValueError):
         Affine().replace_slice([0], Affine())
+
+
+def test_affine_rotate_3d():
+    a = Affine(rotate=90, ndim=3)
+    npt.assert_array_almost_equal(
+        np.array(
+            [
+                [1, 0, 0],
+                [0, 0, -1],
+                [0, 1, 0],
+            ]
+        ),
+        a.rotate,
+    )

--- a/napari/utils/transforms/transform_utils.py
+++ b/napari/utils/transforms/transform_utils.py
@@ -384,7 +384,7 @@ def decompose_linear_matrix(
     scale = np.abs(scale_with_sign)
     normalize = scale / scale_with_sign
 
-    tri *= normalize
+    tri *= normalize.reshape((-1, 1))
     rotate *= normalize
 
     # Take any reflection into account

--- a/napari/utils/transforms/transform_utils.py
+++ b/napari/utils/transforms/transform_utils.py
@@ -380,14 +380,14 @@ def decompose_linear_matrix(
         rotate = rotate.T
         tri = upper_tri.T
 
-    scale = np.diag(tri).copy()
+    scale_with_sign = np.diag(tri).copy()
+    scale = np.abs(scale_with_sign)
+    normalize = scale / scale_with_sign
+
+    tri *= normalize
+    rotate *= normalize
 
     # Take any reflection into account
-    if np.linalg.det(rotate) < 0:
-        scale[0] *= -1
-        tri[0] *= -1
-        rotate = matrix @ np.linalg.inv(tri)
-
     tri_normalized = tri @ np.linalg.inv(np.diag(scale))
 
     if upper_triangular:


### PR DESCRIPTION
# Description

For more than 2D space, current implementation of `decompose_linear_matrix` could return negative layer scale and rotate array that is not proper rotation array (it contains also reflection). 

This PR fixes this.