### PR TITLE
bump actions/download-artifact and actions/upload-artifact from 3 to 4

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -165,7 +165,7 @@ jobs:
 
           fi
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: asv-benchmark-results-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -70,7 +70,7 @@ jobs:
           linux-teardown: "echo 'skip teardown'"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/docs/_build

--- a/.github/workflows/reusable_build_wheel.yml
+++ b/.github/workflows/reusable_build_wheel.yml
@@ -31,7 +31,7 @@ jobs:
           mv dist/*.whl dist/napari-0.0.1-py3-none-any.whl
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheel
           path: dist/*.whl

--- a/.github/workflows/reusable_coverage_upload.yml
+++ b/.github/workflows/reusable_coverage_upload.yml
@@ -21,10 +21,11 @@ jobs:
           pip install codecov
 
       - name: Download coverage data
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: coverage reports
+          pattern: coverage reports*
           path: coverage
+          merge-multiple: true
 
       - name: combine coverage data
         run: |

--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Upload pytest timing reports as json ${{ inputs.platform }} py ${{ inputs.python_version }} ${{ inputs.toxenv || inputs.qt_backend }}
         uses: actions/upload-artifact@v4
         with:
-          name: upload pytest timing json
+          name: upload pytest timing json ${{ inputs.platform }} py ${{ inputs.python_version }} ${{ inputs.toxenv || inputs.qt_backend }}
           path: |
             ./report-*.json
 

--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: wheel
           path: dist
@@ -173,22 +173,22 @@ jobs:
 
       - name: Upload test artifacts
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test artifacts ${{ inputs.platform }} py ${{ inputs.python_version }} ${{ inputs.toxenv || inputs.qt_backend }}
           path: .pytest_tmp
 
-      - name: Upload pytest timing reports as json
-        uses: actions/upload-artifact@v3
+      - name: Upload pytest timing reports as json ${{ inputs.platform }} py ${{ inputs.python_version }} ${{ inputs.toxenv || inputs.qt_backend }}
+        uses: actions/upload-artifact@v4
         with:
-          name: upload pytest timing reports as json
+          name: upload pytest timing json
           path: |
             ./report-*.json
 
       - name: Upload coverage data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ inputs.coverage == 'cov' }}
         with:
-          name: coverage reports
+          name: coverage reports ${{ inputs.platform }} py ${{ inputs.python_version }} ${{ inputs.toxenv || inputs.qt_backend }}
           path: |
             ./.coverage.*

--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -211,7 +211,7 @@ jobs:
       # END PYTHON DEPENDENCIES
 
       - name: Upload constraints
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: constraints
           path: |


### PR DESCRIPTION
# References and relevant issues
replaces #6566 and #6564
close #6566
close #6564

# Description

The upload and download actions are strongly connected and cannot be updated separately. 
Also, v4 does not allow uploading multiple artifacts to the same name. 
But download allows to download using patterns. 
