### PR TITLE
Keep vertex selection after shape drawing finishes

### DIFF
--- a/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
@@ -149,6 +149,10 @@ def test_polygon_lasso_tablet(create_known_shapes_layer):
     assert layer.shape_type[-1] == 'polygon'
     assert not layer._is_creating
 
+    # Ensure it's selected, accounting for zero-indexing
+    assert len(layer.selected_data) == 1
+    assert layer.selected_data == {n_shapes}
+
 
 def test_polygon_lasso_mouse(create_known_shapes_layer):
     """Draw polygon with mouse. Events in sequence are mouse press, release, move, press, release"""
@@ -185,6 +189,10 @@ def test_polygon_lasso_mouse(create_known_shapes_layer):
     assert np.array_equal(desired_shape, layer.data[-1])
     assert layer.shape_type[-1] == 'polygon'
     assert not layer._is_creating
+
+    # Ensure it's selected, accounting for zero-indexing
+    assert len(layer.selected_data) == 1
+    assert layer.selected_data == {n_shapes}
 
 
 def test_distance_polygon_creating(create_known_shapes_layer):
@@ -252,6 +260,10 @@ def test_add_complex_shape(shape_type, create_known_shapes_layer):
     assert layer.data[-1].shape, desired_shape.shape
     np.testing.assert_allclose(layer.data[-1], desired_shape)
     assert layer.shape_type[-1] == shape_type
+
+    # Ensure it's selected, accounting for zero-indexing
+    assert len(layer.selected_data) == 1
+    assert layer.selected_data == {n_shapes}
 
 
 def test_vertex_insert(create_known_shapes_layer):

--- a/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
@@ -104,6 +104,10 @@ def test_add_simple_shape(shape_type, create_known_shapes_layer):
     np.testing.assert_allclose(new_shape_max, known_non_shape_end)
     assert layer.shape_type[-1] == shape_type
 
+    # Ensure it's selected, accounting for zero-indexing
+    assert len(layer.selected_data) == 1
+    assert layer.selected_data == {n_shapes}
+
 
 def test_polygon_lasso_tablet(create_known_shapes_layer):
     """Draw polygon with tablet simulated by mouse drag event."""

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2570,7 +2570,6 @@ class Shapes(Layer):
         """Reset properties used in shape drawing."""
         index = copy(self._moving_value[0])
         self._is_moving = False
-        self.selected_data = set()
         self._drag_start = None
         self._drag_box = None
         self._is_selecting = False


### PR DESCRIPTION
# References and relevant issues

Closes #6624 

# Description

Keep shape vertex selected after drawing finishes enabling attributes changes like face/edge color, edge with, etc over the last created shape.

A preview:

![vertex_selection](https://github.com/napari/napari/assets/16781833/aa4308a8-9421-4f47-9563-7d14727a6a10)



