### PR TITLE
Add GL_MAX_3D_TEXTURE_SIZE to `napari --info`

### DIFF
--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 
 import napari
-from napari._vispy.utils.gl import get_max_texture_sizes
 
 OS_RELEASE_PATH = "/etc/os-release"
 
@@ -132,6 +131,8 @@ def sys_info(as_html: bool = False) -> str:
     text += "<br><b>OpenGL:</b><br>"
 
     if loaded.get('vispy', False):
+        from napari._vispy.utils.gl import get_max_texture_sizes
+
         sys_info_text = (
             "<br>".join(
                 [

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 
 import napari
+from napari._vispy.utils.gl import get_max_texture_sizes
 
 OS_RELEASE_PATH = "/etc/os-release"
 
@@ -142,6 +143,8 @@ def sys_info(as_html: bool = False) -> str:
             .replace("<br>", "<br>  - ")
         )
         text += f'  - {sys_info_text}<br>'
+        _, max_3d_texture_size = get_max_texture_sizes()
+        text += f'  - GL_MAX_3D_TEXTURE_SIZE: {max_3d_texture_size}<br>'
     else:
         text += "  - failed to load vispy"
 


### PR DESCRIPTION
# References and relevant issues
Discussion: https://napari.zulipchat.com/#narrow/stream/212875-general/topic/GL_MAX_TEXTURE.20sizes

# Description
This PR uses the `_vispy/utils` function `get_max_texture_sizes` to add GL_MAX_3D_TEXTURE_SIZE value to the napari info.
<img width="1021" alt="image" src="https://github.com/napari/napari/assets/76622105/f74528d8-2949-4ad4-8c2b-c576e061415e">

This value is used for max z, y, x size when 3D rendering, which is important for multiscale images/downsampling. Having easy access to this is helpful for trouble shooting.