### PR TITLE
Remove if that prevents from setting gamma in constructor

### DIFF
--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -350,8 +350,7 @@ class VispyImageLayer(VispyScalarFieldBaseLayer):
         self._update_mip_minip_cutoff()
 
     def _on_gamma_change(self) -> None:
-        if len(self.node.shared_program.frag._set_items) > 0:
-            self.node.gamma = self.layer.gamma
+        self.node.gamma = self.layer.gamma
 
     def _on_iso_threshold_change(self) -> None:
         if isinstance(self.node, VolumeNode):


### PR DESCRIPTION
# References and relevant issues
closes #1866

# Description

Remove if that prevents using gamma set in image layer constructor during visualization. The code that introduces this has its own gamma shaders that are no longer present in our codebase.  