### PR TITLE
Allow both 'auto' and None as texture_format when choosing VisPy node

### DIFF
--- a/napari/_vispy/_tests/test_vispy_image_layer.py
+++ b/napari/_vispy/_tests/test_vispy_image_layer.py
@@ -75,7 +75,7 @@ def test_3d_slice_of_4d_image_with_order(order):
 
 def test_no_float32_texture_support(monkeypatch):
     """Ensure Image node can be created if OpenGL driver lacks float textures.
-    
+
     See #3988, #3990, #6652.
     """
     monkeypatch.setattr(

--- a/napari/_vispy/_tests/test_vispy_image_layer.py
+++ b/napari/_vispy/_tests/test_vispy_image_layer.py
@@ -71,3 +71,15 @@ def test_3d_slice_of_4d_image_with_order(order):
 
     scene_size = vispy_image_scene_size(vispy_image)
     np.testing.assert_array_equal((16, 16, 16), scene_size)
+
+
+def test_lack_of_float_support(monkeypatch):
+    """
+    Test to keep fix of https://github.com/napari/napari/issues/3988
+    working
+    """
+    monkeypatch.setattr(
+        "napari._vispy.layers.image.get_gl_extensions", lambda: ""
+    )
+    image = Image(np.zeros((16, 8, 4, 2), dtype="uint8"), scale=(1, 2, 4, 8))
+    VispyImageLayer(image)

--- a/napari/_vispy/_tests/test_vispy_image_layer.py
+++ b/napari/_vispy/_tests/test_vispy_image_layer.py
@@ -73,10 +73,10 @@ def test_3d_slice_of_4d_image_with_order(order):
     np.testing.assert_array_equal((16, 16, 16), scene_size)
 
 
-def test_lack_of_float_support(monkeypatch):
-    """
-    Test to keep fix of https://github.com/napari/napari/issues/3988
-    working
+def test_no_float32_texture_support(monkeypatch):
+    """Ensure Image node can be created if OpenGL driver lacks float textures.
+    
+    See #3988, #3990, #6652.
     """
     monkeypatch.setattr(
         "napari._vispy.layers.image.get_gl_extensions", lambda: ""

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -57,7 +57,7 @@ class ImageLayerNode:
         # Return Image or Volume node based on 2D or 3D.
         res = self._image_node if ndisplay == 2 else self._volume_node
         if (
-            res.texture_format != "auto"
+            res.texture_format not in {"auto", None}
             and dtype is not None
             and _VISPY_FORMAT_TO_DTYPE[res.texture_format] != dtype
         ):


### PR DESCRIPTION
# Description

In #6411, we missed these lines:

https://github.com/napari/napari/blob/4f4c063ae5dd79d6d188e201d44b8d57eba71909/napari/_vispy/layers/image.py#L25-L32

These were added in #3990 because 'auto' has a slightly different meaning in VisPy than *really* fully auto: it chooses the default texture dtype for the input NumPy array's dtype. For float arrays, this is float. However, if your OpenGL implementation doesn't support float textures, VisPy will raise.

Instead, passing `texture_format=None` when creating the ImageNode tells VisPy to transform the data to whatever texture format it sees fit.

In #6411, when getting the VisPy node for a given dtype, we only check for `texture_format != 'auto'` as the "catch-all" texture format. But, in fact, if we are on a machine that doesn't support float32 textures, by this point in the code the format has been changed to None, incorrectly triggering these lines:

https://github.com/napari/napari/blob/89f8194d3fa4eef620755804806ac69ef684df63/napari/_vispy/layers/image.py#L59-L73

and causing a ValueError.

This PR fixes that by also checking for None in that same clause.

This PR also adds a test by monkeypatching the function that checks for float32 texture support.

# References

#3988
#3990
