### PR TITLE
Raise exception on TransformChain.simplified when chain is empty

### DIFF
--- a/napari/_vispy/layers/base.py
+++ b/napari/_vispy/layers/base.py
@@ -200,7 +200,7 @@ class VispyBaseLayer(ABC, Generic[_L]):
 
     def _on_matrix_change(self):
         # mypy: self.layer._transforms.simplified cannot be None
-        transform = self.layer._transforms.simplified.set_slice(  # type: ignore [union-attr]
+        transform = self.layer._transforms.simplified.set_slice(
             self.layer._slice_input.displayed
         )
         # convert NumPy axis ordering to VisPy axis ordering

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -22,7 +22,6 @@ from typing import (
     Tuple,
     Type,
     Union,
-    cast,
 )
 
 import magicgui as mgui
@@ -1475,7 +1474,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         else:
             coords = [0] * (self.ndim - len(position)) + list(position)
 
-        simplified = cast(Affine, self._transforms[1:].simplified)
+        simplified = self._transforms[1:].simplified
         return simplified.inverse(coords)
 
     def data_to_world(self, position):
@@ -1532,8 +1531,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
 
         affine * (rotate * shear * scale + translate)
         """
-        t = self._transforms[1:3].simplified
-        return cast(Affine, t)
+        return self._transforms[1:3].simplified
 
     def _world_to_data_ray(self, vector: npt.ArrayLike) -> npt.NDArray:
         """Convert a vector defining an orientation from world coordinates to data coordinates.

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -159,7 +159,7 @@ class TransformChain(EventedList[_T], Transform, Generic[_T]):
         return self._cache_dict[f'getitem_{key}']
 
     def __setitem__(self, key, value):
-        if key in self:
+        if key in self and hasattr(self[key], 'changed'):
             self[key].changed.disconnect(self._clean_cache)
         super().__setitem__(key, value)
         if hasattr(value, 'changed'):
@@ -189,10 +189,18 @@ class TransformChain(EventedList[_T], Transform, Generic[_T]):
         return getattr(self.simplified, '_is_diagonal', False)
 
     @property
-    def simplified(self) -> Optional[_T]:
-        """Return the composite of the transforms inside the transform chain."""
+    def simplified(self) -> _T:
+        """
+        Return the composite of the transforms inside the transform chain.
+
+        Raises
+        ------
+        ValueError
+            If the transform chain is empty.
+        """
         if len(self) == 0:
-            return None
+            raise ValueError('Cannot simplify an empty transform chain.')
+
         if len(self) == 1:
             return self[0]
 

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -199,7 +199,9 @@ class TransformChain(EventedList[_T], Transform, Generic[_T]):
             If the transform chain is empty.
         """
         if len(self) == 0:
-            raise ValueError(trans._('Cannot simplify an empty transform chain.'))
+            raise ValueError(
+                trans._('Cannot simplify an empty transform chain.')
+            )
 
         if len(self) == 1:
             return self[0]

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -199,7 +199,7 @@ class TransformChain(EventedList[_T], Transform, Generic[_T]):
             If the transform chain is empty.
         """
         if len(self) == 0:
-            raise ValueError('Cannot simplify an empty transform chain.')
+            raise ValueError(trans._('Cannot simplify an empty transform chain.'))
 
         if len(self) == 1:
             return self[0]


### PR DESCRIPTION
# Description

I think that raising an exception is better than checking if the returned result is None 