### PR TITLE
Add human readable names for Points layer subvisual

### DIFF
--- a/napari/_vispy/layers/points.py
+++ b/napari/_vispy/layers/points.py
@@ -11,6 +11,7 @@ from napari.utils.events import disconnect_events
 
 class VispyPointsLayer(VispyBaseLayer):
     _highlight_color = (0, 0.6, 1)
+    node: PointsVisual
 
     def __init__(self, layer) -> None:
         node = PointsVisual()
@@ -55,7 +56,7 @@ class VispyPointsLayer(VispyBaseLayer):
             edge_width = self.layer._view_edge_width
             symbol = [str(x) for x in self.layer._view_symbol]
 
-        set_data = self.node._subvisuals[0].set_data
+        set_data = self.node.points_markers.set_data
 
         # use only last dimension to scale point sizes, see #5582
         scale = self.layer.scale[-1]
@@ -110,7 +111,7 @@ class VispyPointsLayer(VispyBaseLayer):
             settings.appearance.highlight_thickness * self.layer.scale_factor
         )
 
-        self.node._subvisuals[1].set_data(
+        self.node.selection_markers.set_data(
             data[:, ::-1],
             size=(size + edge_width) * scale,
             symbol=symbol,
@@ -129,7 +130,7 @@ class VispyPointsLayer(VispyBaseLayer):
             pos = self.layer._highlight_box
             width = scaled_highlight
 
-        self.node._subvisuals[2].set_data(
+        self.node.highlight_lines.set_data(
             pos=pos[:, ::-1],
             color=self._highlight_color,
             width=width,
@@ -151,8 +152,7 @@ class VispyPointsLayer(VispyBaseLayer):
 
     def _get_text_node(self):
         """Function to get the text node from the Compound visual"""
-        text_node = self.node._subvisuals[-1]
-        return text_node
+        return self.node.text
 
     def _on_text_change(self, event=None):
         if event is not None:
@@ -163,7 +163,7 @@ class VispyPointsLayer(VispyBaseLayer):
                 return
         self._update_text()
 
-    def _on_blending_change(self):
+    def _on_blending_change(self, event=None):
         """Function to set the blending mode"""
         points_blending_kwargs = BLENDING_MODES[self.layer.blending]
         self.node.set_gl_state(**points_blending_kwargs)
@@ -174,7 +174,7 @@ class VispyPointsLayer(VispyBaseLayer):
 
         # selection box is always without depth
         box_blending_kwargs = BLENDING_MODES['translucent_no_depth']
-        self.node._subvisuals[2].set_gl_state(**box_blending_kwargs)
+        self.node.highlight_lines.set_gl_state(**box_blending_kwargs)
 
         self.node.update()
 
@@ -183,10 +183,7 @@ class VispyPointsLayer(VispyBaseLayer):
 
     def _on_shading_change(self):
         shading = self.layer.shading
-        if shading == 'spherical':
-            self.node.spherical = True
-        else:
-            self.node.spherical = False
+        self.node.spherical = shading == 'spherical'
 
     def _on_canvas_size_limits_change(self):
         self.node.canvas_size_limits = self.layer.canvas_size_limits

--- a/napari/_vispy/visuals/points.py
+++ b/napari/_vispy/visuals/points.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from vispy.scene.visuals import Compound, Line, Text
 
 from napari._vispy.visuals.clipping_planes_mixin import ClippingPlanesMixin
@@ -28,39 +30,60 @@ class PointsVisual(ClippingPlanesMixin, Compound):
         self.scaling = True
 
     @property
-    def scaling(self):
+    def points_markers(self) -> Markers:
+        """Points markers visual"""
+        return self._subvisuals[0]
+
+    @property
+    def selection_markers(self) -> Markers:
+        """Highlight markers visual"""
+        return self._subvisuals[1]
+
+    @property
+    def highlight_lines(self) -> Line:
+        """Highlight lines visual"""
+        return self._subvisuals[2]
+
+    @property
+    def text(self) -> Text:
+        """Text labels visual"""
+        return self._subvisuals[3]
+
+    @property
+    def scaling(self) -> bool:
         """
         Scaling property for both the markers visuals. If set to true,
         the points rescale based on zoom (i.e: constant world-space size)
         """
-        return self._subvisuals[0].scaling == 'visual'
+        return self.points_markers.scaling == 'visual'
 
     @scaling.setter
-    def scaling(self, value):
-        for marker in self._subvisuals[:2]:
-            marker.scaling = 'visual' if value else 'fixed'
+    def scaling(self, value: bool) -> None:
+        scaling_txt = 'visual' if value else 'fixed'
+        self.points_markers.scaling = scaling_txt
+        self.selection_markers.scaling = scaling_txt
 
     @property
-    def antialias(self):
-        return self._subvisuals[0].antialias
+    def antialias(self) -> float:
+        return self.points_markers.antialias
 
     @antialias.setter
-    def antialias(self, value):
-        for marker in self._subvisuals[:2]:
-            marker.antialias = value
+    def antialias(self, value: float) -> None:
+        self.points_markers.antialias = value
+        self.selection_markers.antialias = value
 
     @property
-    def spherical(self):
-        return self._subvisuals[0].spherical
+    def spherical(self) -> bool:
+        return self.points_markers.spherical
 
     @spherical.setter
-    def spherical(self, value):
+    def spherical(self, value: bool) -> None:
         self._subvisuals[0].spherical = value
 
     @property
-    def canvas_size_limits(self):
-        return self._subvisuals[0].canvas_size_limits
+    def canvas_size_limits(self) -> tuple[int, int]:
+        return self.points_markers.canvas_size_limits
 
     @canvas_size_limits.setter
-    def canvas_size_limits(self, value):
+    def canvas_size_limits(self, value: tuple[int, int]) -> None:
         self._subvisuals[0].canvas_size_limits = value

--- a/napari/_vispy/visuals/points.py
+++ b/napari/_vispy/visuals/points.py
@@ -78,7 +78,7 @@ class PointsVisual(ClippingPlanesMixin, Compound):
 
     @spherical.setter
     def spherical(self, value: bool) -> None:
-        self._subvisuals[0].spherical = value
+        self.points_markers.spherical = value
 
     @property
     def canvas_size_limits(self) -> tuple[int, int]:
@@ -86,4 +86,4 @@ class PointsVisual(ClippingPlanesMixin, Compound):
 
     @canvas_size_limits.setter
     def canvas_size_limits(self, value: tuple[int, int]) -> None:
-        self._subvisuals[0].canvas_size_limits = value
+        self.points_markers.canvas_size_limits = value


### PR DESCRIPTION
# Description

During review of #6402 I spot that code readability and IDE support could be improved if we use named and typed properties instead of `_subvisuals[x]`

This PR added it. 