### PR TITLE
Fix offset in rendering of `TransformBox` of image/labels layers

### DIFF
--- a/napari/_vispy/layers/base.py
+++ b/napari/_vispy/layers/base.py
@@ -214,7 +214,7 @@ class VispyBaseLayer(ABC, Generic[_L]):
         affine_matrix[: matrix.shape[0], : matrix.shape[1]] = matrix
         affine_matrix[-1, : len(translate)] = translate
 
-        offset = np.ones(len(self.layer._slice_input.displayed))
+        offset = np.zeros(len(self.layer._slice_input.displayed))
 
         if self._array_like and self.layer._slice_input.ndisplay == 2:
             # Perform pixel offset to shift origin from top left corner

--- a/napari/_vispy/layers/base.py
+++ b/napari/_vispy/layers/base.py
@@ -214,6 +214,8 @@ class VispyBaseLayer(ABC, Generic[_L]):
         affine_matrix[: matrix.shape[0], : matrix.shape[1]] = matrix
         affine_matrix[-1, : len(translate)] = translate
 
+        offset = np.ones(len(self.layer._slice_input.displayed))
+
         if self._array_like and self.layer._slice_input.ndisplay == 2:
             # Perform pixel offset to shift origin from top left corner
             # of pixel to center of pixel.
@@ -244,7 +246,7 @@ class VispyBaseLayer(ABC, Generic[_L]):
         translate_child = (
             self.layer.translate[dims_displayed]
             + self.layer.affine.translate[dims_displayed]
-        )[::-1]
+        )[::-1] - offset[::-1]
         trans_rotate = simplified_transform.rotate[
             np.ix_(dims_displayed, dims_displayed)
         ]

--- a/napari/_vispy/overlays/bounding_box.py
+++ b/napari/_vispy/overlays/bounding_box.py
@@ -29,11 +29,6 @@ class VispyBoundingBoxOverlay(LayerOverlayMixin, VispySceneOverlay):
         if len(bounds) == 2:
             # 2d layers are assumed to be at 0 in the 3rd dimension
             bounds = np.pad(bounds, ((1, 0), (0, 0)))
-        if self.layer._array_like and self.layer._slice_input.ndisplay == 2:
-            # array-like layers (images) are offset by 0.5 in 2d.
-            # This is not needed in 3D because vispy's VolumeVisual
-            # is already centered on voxels
-            bounds += 0.5
 
         self.node.set_bounds(bounds[::-1])  # invert for vispy
         self._on_lines_change()


### PR DESCRIPTION
# References and relevant issues

closes #6676

# Description

Add offset shift for bounding box to fix bounding box position 