### PR TITLE
Exclude size and symbol pts attributes from linking, because they depend on number of points

### DIFF
--- a/napari/layers/utils/_link_layers.py
+++ b/napari/layers/utils/_link_layers.py
@@ -199,6 +199,8 @@ def _get_common_evented_attributes(
             'data',
             'features',
             'properties',
+            'size',
+            'symbol',
             'edge_width',
             'edge_color',
             'face_color',
@@ -220,7 +222,6 @@ def _get_common_evented_attributes(
         A set of layers to evaluate for attribute linking.
     exclude : set, optional
         Layer attributes that make no sense to link, or may error on changing.
-        {'thumbnail', 'status', 'name', 'mode', 'data', 'features', 'properties', 'extent', 'loaded'}
     with_private : bool, optional
         include private attributes
 


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/6684

# Description

the Points attributes `size` and `symbol` are arrays of values per point, so they cannot be linked between Points layers. They were missed in the last linked_layers fixes: https://github.com/napari/napari/pull/6623
Here I add them to the exlusion list. Also I remove the (incomplete) exclusion list per Andy in the original PR (https://github.com/napari/napari/pull/6623#discussion_r1467908404) I made the fix locally but didn't push I guess so it didn't get merged.
