### PR TITLE
Fix transform box offset

### DIFF
--- a/napari/_vispy/overlays/interaction_box.py
+++ b/napari/_vispy/overlays/interaction_box.py
@@ -3,7 +3,7 @@ from napari._vispy.visuals.interaction_box import InteractionBox
 from napari.layers.base._base_constants import InteractionBoxHandle
 
 
-class _VispyBoundingBoxOverlay(LayerOverlayMixin, VispySceneOverlay):
+class _VispyInteractionBoxOverlay(LayerOverlayMixin, VispySceneOverlay):
     def __init__(self, *, layer, overlay, parent=None) -> None:
         super().__init__(
             node=InteractionBox(),
@@ -28,7 +28,7 @@ class _VispyBoundingBoxOverlay(LayerOverlayMixin, VispySceneOverlay):
         self._on_bounds_change()
 
 
-class VispySelectionBoxOverlay(_VispyBoundingBoxOverlay):
+class VispySelectionBoxOverlay(_VispyInteractionBoxOverlay):
     def __init__(self, *, layer, overlay, parent=None) -> None:
         super().__init__(
             layer=layer,
@@ -51,7 +51,7 @@ class VispySelectionBoxOverlay(_VispyBoundingBoxOverlay):
             )
 
 
-class VispyTransformBoxOverlay(_VispyBoundingBoxOverlay):
+class VispyTransformBoxOverlay(_VispyInteractionBoxOverlay):
     def __init__(self, *, layer, overlay, parent=None) -> None:
         super().__init__(
             layer=layer,
@@ -70,6 +70,10 @@ class VispyTransformBoxOverlay(_VispyBoundingBoxOverlay):
             bounds = self.layer._display_bounding_box_augmented_data_level(
                 self.layer._slice_input.displayed
             )
+            if self.layer._array_like:
+                # array-like layers (images) are offset by 0.5 in 2d.
+                bounds += 0.5
+
             # invert axes for vispy
             top_left, bot_right = (tuple(point) for point in bounds.T[:, ::-1])
 


### PR DESCRIPTION
# References and relevant issues
Fixes #6676, alternative to #6679.

# Description
As far as I know, this is all we need.

~I am indeed surprised that `Layer._display_bounding_box_augmented_data_level` does not already provide the correct bounds, but this is the same for the bounding box so it should be a safe fix.~ EDIT: see https://github.com/napari/napari/issues/6676#issuecomment-1964634819 for an explanation.

Here's a reproducer for the bug on main which works here:

```py
import napari
import numpy as np
from scipy.ndimage import zoom

v = napari.Viewer()

size = 5
data = np.arange(size**3).reshape((size,) * 3)

multiscale_data = [zoom(data, 2), data]

l = v.add_image(multiscale_data)
l.mode = 'transform'
```

Changing `size` or going to non-multiscale does not affect the result, as far as I can tell.


![image](https://github.com/napari/napari/assets/23482191/1e47bacc-ac04-428d-99a0-1ba763928501)
