### PR TITLE
Make new labels dtype configurable

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -437,7 +437,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             np.round(s / sc).astype('int') + 1
             for s, sc in zip(scene_size, scale)
         ]
-        empty_labels = np.zeros(shape, dtype=np.uint8)
+        dtype_str = get_settings().application.new_labels_dtype
+        empty_labels = np.zeros(shape, dtype=dtype_str)
         self.add_labels(empty_labels, translate=np.array(corner), scale=scale)
 
     def _on_layer_reload(self, event: Event) -> None:

--- a/napari/settings/_application.py
+++ b/napari/settings/_application.py
@@ -214,9 +214,9 @@ class ApplicationSettings(EventedModel):
 
     new_labels_dtype: LabelDTypes = Field(
         default=LabelDTypes.uint8,
-        title=trans._('New labels dtype'),
+        title=trans._('New labels data type'),
         description=trans._(
-            'Select the dtype for new labels layers created using button.'
+            'data type for labels layers created with the "new labels" button.'
         ),
     )
 

--- a/napari/settings/_application.py
+++ b/napari/settings/_application.py
@@ -5,7 +5,11 @@ from typing import Any, List, Optional, Tuple
 from psutil import virtual_memory
 
 from napari._pydantic_compat import Field, validator
-from napari.settings._constants import BrushSizeOnMouseModifiers, LoopMode
+from napari.settings._constants import (
+    BrushSizeOnMouseModifiers,
+    LabelDTypes,
+    LoopMode,
+)
 from napari.settings._fields import Language
 from napari.utils._base import _DEFAULT_LOCALE
 from napari.utils.events.custom_types import conint
@@ -205,6 +209,14 @@ class ApplicationSettings(EventedModel):
         title=trans._('Dask cache'),
         description=trans._(
             'Settings for dask cache (does not work with distributed arrays)'
+        ),
+    )
+
+    new_labels_dtype: LabelDTypes = Field(
+        default=LabelDTypes.uint8,
+        title=trans._('New labels dtype'),
+        description=trans._(
+            'Select the dtype for new labels layers created using button.'
         ),
     )
 

--- a/napari/settings/_constants.py
+++ b/napari/settings/_constants.py
@@ -4,6 +4,19 @@ from napari.utils.compat import StrEnum
 from napari.utils.misc import StringEnum
 
 
+class LabelDTypes(StrEnum):
+    uint8 = 'uint8'
+    int8 = 'int8'
+    uint16 = 'uint16'
+    int16 = 'int16'
+    uint32 = 'uint32'
+    int32 = 'int32'
+    uint64 = 'uint64'
+    int64 = 'int64'
+    uint = 'uint'
+    int = 'int'
+
+
 class LoopMode(StringEnum):
     """Looping mode for animating an axis.
 


### PR DESCRIPTION
# References and relevant issues

Extracted from #6190

# Description

In #6471 we have changed label's default dtype to uint8, but for some users it may not allow enough big data range. So this PR adds feature to configure this in settings.