### PR TITLE
Fix upload of benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -168,5 +168,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: asv-benchmark-results-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+          name: asv-benchmark-results-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.benchmark-name }}
           path: .asv/results


### PR DESCRIPTION
# Description
since version 4, the actions/upload-artifact require uploads to have distinct names, I miss this one name when bumping actions/upload-artifact