### PR TITLE
Bump minimum dask version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     app-model>=0.2.2,<0.3.0  # as per @czaki request. app-model v0.3.0 can drop napari v0.4.17
     cachey>=0.2.1
     certifi>=2018.1.18
-    dask[array]>=2.15.0,!=2.28.0  # https://github.com/napari/napari/issues/1656
+    dask[array]>=2021.10.0
     imageio>=2.20,!=2.22.1
     jsonschema>=3.2.0
     lazy_loader>=0.2


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/4084

# Description
I got a dependabot alert in another repo indicating an update to dask=2021.10.0 is necessary:

> An issue was discovered in Dask (aka python-dask) through 2021.09.1. Single machine Dask clusters started with dask.distributed.LocalCluster or dask.distributed.Client (which defaults to using LocalCluster) would mistakenly configure their respective Dask workers to listen on external interfaces (typically with a randomly selected high port) rather than only on localhost. A Dask cluster created using this method (when running on a machine that has an applicable port exposed) could be used by a sophisticated attacker to achieve remote code execution.

