### PR TITLE
Include features index as key in FormatStringEncoding

### DIFF
--- a/napari/layers/utils/_tests/test_string_encoding.py
+++ b/napari/layers/utils/_tests/test_string_encoding.py
@@ -142,6 +142,19 @@ def test_validate_from_format_string():
     assert actual == expected
 
 
+def test_format_with_index(features):
+    encoding = FormatStringEncoding(format='{index}: {confidence:.2f}')
+    values = encoding(features)
+    np.testing.assert_array_equal(values, ['0: 0.50', '1: 1.00', '2: 0.25'])
+
+
+def test_format_with_index_column(features):
+    features['index'] = features['class']
+    encoding = FormatStringEncoding(format='{index}: {confidence:.2f}')
+    values = encoding(features)
+    np.testing.assert_array_equal(values, ['a: 0.50', 'b: 1.00', 'c: 0.25'])
+
+
 def test_validate_from_non_format_string():
     argument = 'abc'
     expected = DirectStringEncoding(feature=argument)

--- a/napari/layers/utils/string_encoding.py
+++ b/napari/layers/utils/string_encoding.py
@@ -166,9 +166,15 @@ class FormatStringEncoding(_DerivedStyleEncoding[StringValue, StringArray]):
 
     def __call__(self, features: Any) -> StringArray:
         feature_names = features.columns.to_list()
+        # Expose the dataframe index to the format string keys
+        # unless a column exists with the name "index", which takes precedence.
+        with_index = False
+        if 'index' not in feature_names:
+            feature_names = ['index'] + feature_names
+            with_index = True
         values = [
             self.format.format(**dict(zip(feature_names, row)))
-            for row in features.itertuples(index=False, name=None)
+            for row in features.itertuples(index=with_index, name=None)
         ]
         return np.array(values, dtype=str)
 


### PR DESCRIPTION
# References and relevant issues

Solves #6667

# Description

The features dataframe index is made available as a key for format strings. This allows adding texts to e.g. points layers that enumerate the points and allows to distinguish them.

Previously, texts could only contain format fields referencing a features column. To enumerate points, one had to add a column with a sequence of integers. However, when adding a point, the column would not increment but repeat the last value for the new point.

The current implementation in this PR assumes two cases:
- The user has provided a features dataframe that contains a column that by chance is called "index". The user wants to refer to this column and sets a layer text with corresponding field `text={"string": "{index}"}`. In that case, the value is taken from the existing "index" column.
- The user has provided a features dataframe and no column collides with the name "index". The user is able to refer to the actual dataframe index with `text={"string": "{index}"}`

**Example usage:**

```python
import napari
import numpy as np
viewer = napari.viewer.Viewer()
layer = viewer.add_points(name="Points", data=[], text={"string": "Point{index}", "anchor": "lower_left"})
layer.data = np.array([[0, 0], [0, 100], [0, 200], [0, 300]])
```

![screenshot](https://github.com/napari/napari/assets/54448967/387e563e-2699-4214-9bfb-9d88244fec2e)


- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to docstrings and documentation
  (open a PR on the docs repository (https://github.com/napari/docs) if relevant!)
- [x] I have added tests that my feature works
- [x] I tested that it does not negatively impact performance (especially the improvements of cd5c3147a13a42304a6e26a56f516bdc8b879557)
