### PR TITLE
Add `Optional` section to napari info with numba and triangle

### DIFF
--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -126,8 +126,8 @@ def sys_info(as_html: bool = False) -> str:
         try:
             loaded[module] = __import__(module)
             text += f'<b>{name}</b>: {version(module)}<br>'
-        except PackageNotFoundError as e:
-            text += f'<b>{name}</b>: Import failed ({e})<br>'
+        except PackageNotFoundError:
+            text += f'<b>{name}</b>: Import failed<br>'
 
     text += '<br><b>OpenGL:</b><br>'
 

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -4,7 +4,7 @@ import platform
 import subprocess
 import sys
 
-from importlib_metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
 import napari
 
@@ -172,7 +172,7 @@ def sys_info(as_html: bool = False) -> str:
     for module, name in optional_modules:
         try:
             text += f'  - <b>{name}</b>: {version(module)}<br>'
-        except Exception as e:  # noqa BLE001
+        except PackageNotFoundError as e:
             text += f'  - {name} not installed<br>'
 
     text += '<br><b>Settings path:</b><br>'

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -4,6 +4,8 @@ import platform
 import subprocess
 import sys
 
+from importlib_metadata import version
+
 import napari
 
 OS_RELEASE_PATH = '/etc/os-release'
@@ -169,10 +171,9 @@ def sys_info(as_html: bool = False) -> str:
 
     for module, name in optional_modules:
         try:
-            loaded[module] = __import__(module)
-            text += f'  - <b>{name}</b>: {loaded[module].__version__}<br>'
+            text += f'  - <b>{name}</b>: {version(module)}<br>'
         except Exception as e:  # noqa BLE001
-            text += f'  - {e}<br>'
+            text += f'  - {name} not installed<br>'
 
     text += '<br><b>Settings path:</b><br>'
     try:

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -160,6 +160,20 @@ def sys_info(as_html: bool = False) -> str:
     except Exception as e:  # noqa BLE001
         text += f'  - failed to load screen information {e}'
 
+    text += '<br><b>Optional:</b><br>'
+
+    optional_modules = (
+        ('numba', 'numba'),
+        ('triangle', 'triangle'),
+    )
+
+    for module, name in optional_modules:
+        try:
+            loaded[module] = __import__(module)
+            text += f'  - <b>{name}</b>: {loaded[module].__version__}<br>'
+        except Exception as e:  # noqa BLE001
+            text += f'  - {e}<br>'
+
     text += '<br><b>Settings path:</b><br>'
     try:
         from napari.settings import get_settings

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -3,7 +3,6 @@ import os
 import platform
 import subprocess
 import sys
-
 from importlib.metadata import PackageNotFoundError, version
 
 import napari
@@ -126,8 +125,8 @@ def sys_info(as_html: bool = False) -> str:
     for module, name in modules:
         try:
             loaded[module] = __import__(module)
-            text += f'<b>{name}</b>: {loaded[module].__version__}<br>'
-        except Exception as e:  # noqa BLE001
+            text += f'<b>{name}</b>: {version(module)}<br>'
+        except PackageNotFoundError as e:
             text += f'<b>{name}</b>: Import failed ({e})<br>'
 
     text += '<br><b>OpenGL:</b><br>'
@@ -172,7 +171,7 @@ def sys_info(as_html: bool = False) -> str:
     for module, name in optional_modules:
         try:
             text += f'  - <b>{name}</b>: {version(module)}<br>'
-        except PackageNotFoundError as e:
+        except PackageNotFoundError:
             text += f'  - {name} not installed<br>'
 
     text += '<br><b>Settings path:</b><br>'


### PR DESCRIPTION
# References and relevant issues
We've added numba and triangle as optional depends.
Bugs or issues related to one of them could be hard to track because they don't show up in `napari --info` so need to request also `pip show triangle`
e.g. https://github.com/napari/napari/issues/6709

# Description
Adds an `Optional` section to `napari --info` listing numba and triangle.

