### PR TITLE
Fix `--pre` workflow: missing setup to enable `pyautogui` usage on Linux

### DIFF
--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -46,6 +46,12 @@ jobs:
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
           if (Test-Path -Path "C:\Windows\system32\opengl32.dll" -PathType Leaf) {Exit 0} else {Exit 1}
 
+      # setup needed to use pyautogui
+      - name: create .Xauthority file
+        if: runner.os == 'Linux'
+        run: |
+          touch /home/runner/.Xauthority
+
       - name: Install dependencies
         run: |
           pip install --upgrade pip


### PR DESCRIPTION
# References and relevant issues

Failing workflow run pointing a missing `.Xauthority` file: https://github.com/napari/napari/actions/runs/8155927521/job/22292469324#step:7:212

Caused due to #6406 

# Description

Add missing `.Xauthority` file creation step on the `--pre Test` workflow definition when running on Linux


