### PR TITLE
Typing improvements in layers.shapes

### DIFF
--- a/napari/layers/shapes/_mesh.py
+++ b/napari/layers/shapes/_mesh.py
@@ -51,7 +51,7 @@ class Mesh:
 
     _types = ('face', 'edge')
 
-    def __init__(self, ndisplay: int=2) -> None:
+    def __init__(self, ndisplay: int = 2) -> None:
         self._ndisplay = ndisplay
         self.clear()
 

--- a/napari/layers/shapes/_mesh.py
+++ b/napari/layers/shapes/_mesh.py
@@ -51,11 +51,11 @@ class Mesh:
 
     _types = ('face', 'edge')
 
-    def __init__(self, ndisplay=2) -> None:
+    def __init__(self, ndisplay: int=2) -> None:
         self._ndisplay = ndisplay
         self.clear()
 
-    def clear(self):
+    def clear(self) -> None:
         """Resets mesh data"""
         self.vertices = np.empty((0, self.ndisplay))
         self.vertices_centers = np.empty((0, self.ndisplay))
@@ -71,12 +71,12 @@ class Mesh:
         self.displayed_triangles_colors = np.empty((0, 4))
 
     @property
-    def ndisplay(self):
+    def ndisplay(self) -> int:
         """int: Number of displayed dimensions."""
         return self._ndisplay
 
     @ndisplay.setter
-    def ndisplay(self, ndisplay):
+    def ndisplay(self, ndisplay: int) -> None:
         if self.ndisplay == ndisplay:
             return
 

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -1,3 +1,4 @@
+import typing
 from collections.abc import Iterable
 from contextlib import contextmanager
 from functools import wraps
@@ -83,7 +84,9 @@ class ShapeList:
         be rendered.
     """
 
-    def __init__(self, data: Iterable[Shape] = (), ndisplay: int = 2) -> None:
+    def __init__(
+        self, data: typing.Iterable[Shape] = (), ndisplay: int = 2
+    ) -> None:
         self._ndisplay = ndisplay
         self.shapes: List[Shape] = []
         self._displayed = np.array([])

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -1,9 +1,10 @@
 from collections.abc import Iterable
 from contextlib import contextmanager
 from functools import wraps
-from typing import List, Sequence, Union
+from typing import Generator, List, Literal, Sequence, Union
 
 import numpy as np
+import numpy.typing as npt
 
 from napari.layers.shapes._mesh import Mesh
 from napari.layers.shapes._shapes_constants import ShapeType, shape_classes
@@ -82,7 +83,7 @@ class ShapeList:
         be rendered.
     """
 
-    def __init__(self, data=(), ndisplay=2) -> None:
+    def __init__(self, data: Iterable[Shape] = (), ndisplay: int = 2) -> None:
         self._ndisplay = ndisplay
         self.shapes: List[Shape] = []
         self._displayed = np.array([])
@@ -110,7 +111,7 @@ class ShapeList:
             self.add(d)
 
     @contextmanager
-    def batched_updates(self):
+    def batched_updates(self) -> Generator[None, None, None]:
         """
         Reentrant context manager to batch the display update
 
@@ -146,17 +147,17 @@ class ShapeList:
         assert self.__batched_level >= 0
 
     @property
-    def data(self):
+    def data(self) -> List[npt.NDArray]:
         """list of (M, D) array: data arrays for each shape."""
         return [s.data for s in self.shapes]
 
     @property
-    def ndisplay(self):
+    def ndisplay(self) -> int:
         """int: Number of displayed dimensions."""
         return self._ndisplay
 
     @ndisplay.setter
-    def ndisplay(self, ndisplay):
+    def ndisplay(self, ndisplay: int) -> None:
         if self.ndisplay == ndisplay:
             return
 
@@ -172,35 +173,37 @@ class ShapeList:
         self._update_z_order()
 
     @property
-    def slice_keys(self):
+    def slice_keys(self) -> npt.NDArray:
         """(N, 2, P) array: slice key for each shape."""
         return np.array([s.slice_key for s in self.shapes])
 
     @property
-    def shape_types(self):
+    def shape_types(self) -> List[str]:
         """list of str: shape types for each shape."""
         return [s.name for s in self.shapes]
 
     @property
-    def edge_color(self):
+    def edge_color(self) -> npt.NDArray:
         """(N x 4) np.ndarray: Array of RGBA edge colors for each shape"""
         return self._edge_color
 
     @edge_color.setter
-    def edge_color(self, edge_color):
+    def edge_color(self, edge_color: npt.NDArray) -> None:
         self._set_color(edge_color, 'edge')
 
     @property
-    def face_color(self):
+    def face_color(self) -> npt.NDArray:
         """(N x 4) np.ndarray: Array of RGBA face colors for each shape"""
         return self._face_color
 
     @face_color.setter
-    def face_color(self, face_color):
+    def face_color(self, face_color: npt.NDArray) -> None:
         self._set_color(face_color, 'face')
 
     @_batch_dec
-    def _set_color(self, colors, attribute):
+    def _set_color(
+        self, colors: npt.NDArray, attribute: Literal['edge', 'face']
+    ) -> None:
         """Set the face_color or edge_color property
 
         Parameters
@@ -229,12 +232,12 @@ class ShapeList:
         self._update_displayed()
 
     @property
-    def edge_widths(self):
+    def edge_widths(self) -> List[float]:
         """list of float: edge width for each shape."""
         return [s.edge_width for s in self.shapes]
 
     @property
-    def z_indices(self):
+    def z_indices(self) -> List[int]:
         """list of int: z-index for each shape."""
         return [s.z_index for s in self.shapes]
 
@@ -251,7 +254,7 @@ class ShapeList:
             self._slice_key = slice_key
             self._update_displayed()
 
-    def _update_displayed(self):
+    def _update_displayed(self) -> None:
         """Update the displayed data based on the slice key.
 
         This method must be called from within the `batched_updates` context

--- a/napari/layers/shapes/_shapes_key_bindings.py
+++ b/napari/layers/shapes/_shapes_key_bindings.py
@@ -1,3 +1,5 @@
+from typing import Callable, Generator
+
 import numpy as np
 from app_model.types import KeyCode
 
@@ -14,7 +16,7 @@ from napari.utils.translations import trans
 
 
 @Shapes.bind_key(KeyCode.Shift, overwrite=True)
-def hold_to_lock_aspect_ratio(layer: Shapes):
+def hold_to_lock_aspect_ratio(layer: Shapes) -> Generator[None, None, None]:
     """Hold to lock aspect ratio when resizing a shape."""
     # on key press
     layer._fixed_aspect = True
@@ -37,80 +39,84 @@ def hold_to_lock_aspect_ratio(layer: Shapes):
     layer._fixed_aspect = False
 
 
-def register_shapes_action(description: str, repeatable: bool = False):
+def register_shapes_action(
+    description: str, repeatable: bool = False
+) -> Callable[[Callable], Callable]:
     return register_layer_action(Shapes, description, repeatable)
 
 
-def register_shapes_mode_action(description):
+def register_shapes_mode_action(
+    description: str,
+) -> Callable[[Callable], Callable]:
     return register_layer_attr_action(Shapes, description, 'mode')
 
 
 @register_shapes_mode_action(trans._('Transform'))
-def activate_shapes_transform_mode(layer):
+def activate_shapes_transform_mode(layer: Shapes) -> None:
     layer.mode = Mode.TRANSFORM
 
 
 @register_shapes_mode_action(trans._('Pan/zoom'))
-def activate_shapes_pan_zoom_mode(layer: Shapes):
+def activate_shapes_pan_zoom_mode(layer: Shapes) -> None:
     layer.mode = Mode.PAN_ZOOM
 
 
 @register_shapes_mode_action(trans._('Add rectangles'))
-def activate_add_rectangle_mode(layer: Shapes):
+def activate_add_rectangle_mode(layer: Shapes) -> None:
     """Activate add rectangle tool."""
     layer.mode = Mode.ADD_RECTANGLE
 
 
 @register_shapes_mode_action(trans._('Add ellipses'))
-def activate_add_ellipse_mode(layer: Shapes):
+def activate_add_ellipse_mode(layer: Shapes) -> None:
     """Activate add ellipse tool."""
     layer.mode = Mode.ADD_ELLIPSE
 
 
 @register_shapes_mode_action(trans._('Add lines'))
-def activate_add_line_mode(layer: Shapes):
+def activate_add_line_mode(layer: Shapes) -> None:
     """Activate add line tool."""
     layer.mode = Mode.ADD_LINE
 
 
 @register_shapes_mode_action(trans._('Add path'))
-def activate_add_path_mode(layer: Shapes):
+def activate_add_path_mode(layer: Shapes) -> None:
     """Activate add path tool."""
     layer.mode = Mode.ADD_PATH
 
 
 @register_shapes_mode_action(trans._('Add polygons'))
-def activate_add_polygon_mode(layer: Shapes):
+def activate_add_polygon_mode(layer: Shapes) -> None:
     """Activate add polygon tool."""
     layer.mode = Mode.ADD_POLYGON
 
 
 @register_shapes_mode_action(trans._('Add polygons lasso'))
-def activate_add_polygon_lasso_mode(layer: Shapes):
+def activate_add_polygon_lasso_mode(layer: Shapes) -> None:
     """Activate add polygon tool."""
     layer.mode = Mode.ADD_POLYGON_LASSO
 
 
 @register_shapes_mode_action(trans._('Select vertices'))
-def activate_direct_mode(layer: Shapes):
+def activate_direct_mode(layer: Shapes) -> None:
     """Activate vertex selection tool."""
     layer.mode = Mode.DIRECT
 
 
 @register_shapes_mode_action(trans._('Select shapes'))
-def activate_select_mode(layer: Shapes):
+def activate_select_mode(layer: Shapes) -> None:
     """Activate shape selection tool."""
     layer.mode = Mode.SELECT
 
 
 @register_shapes_mode_action(trans._('Insert vertex'))
-def activate_vertex_insert_mode(layer: Shapes):
+def activate_vertex_insert_mode(layer: Shapes) -> None:
     """Activate vertex insertion tool."""
     layer.mode = Mode.VERTEX_INSERT
 
 
 @register_shapes_mode_action(trans._('Remove vertex'))
-def activate_vertex_remove_mode(layer: Shapes):
+def activate_vertex_remove_mode(layer: Shapes) -> None:
     """Activate vertex deletion tool."""
     layer.mode = Mode.VERTEX_REMOVE
 
@@ -132,21 +138,21 @@ shapes_fun_to_mode = [
 
 
 @register_shapes_action(trans._('Copy any selected shapes'))
-def copy_selected_shapes(layer: Shapes):
+def copy_selected_shapes(layer: Shapes) -> None:
     """Copy any selected shapes."""
     if layer._mode in (Mode.DIRECT, Mode.SELECT):
         layer._copy_data()
 
 
 @register_shapes_action(trans._('Paste any copied shapes'))
-def paste_shape(layer: Shapes):
+def paste_shape(layer: Shapes) -> None:
     """Paste any copied shapes."""
     if layer._mode in (Mode.DIRECT, Mode.SELECT):
         layer._paste_data()
 
 
 @register_shapes_action(trans._('Select all shapes in the current view slice'))
-def select_all_shapes(layer: Shapes):
+def select_all_shapes(layer: Shapes) -> None:
     """Select all shapes in the current view slice."""
     if layer._mode in (Mode.DIRECT, Mode.SELECT):
         layer.selected_data = set(np.nonzero(layer._data_view._displayed)[0])
@@ -154,7 +160,7 @@ def select_all_shapes(layer: Shapes):
 
 
 @register_shapes_action(trans._('Delete any selected shapes'))
-def delete_selected_shapes(layer: Shapes):
+def delete_selected_shapes(layer: Shapes) -> None:
     """."""
 
     if not layer._is_creating:
@@ -162,12 +168,12 @@ def delete_selected_shapes(layer: Shapes):
 
 
 @register_shapes_action(trans._('Move to front'))
-def move_shapes_selection_to_front(layer: Shapes):
+def move_shapes_selection_to_front(layer: Shapes) -> None:
     layer.move_to_front()
 
 
 @register_shapes_action(trans._('Move to back'))
-def move_shapes_selection_to_back(layer: Shapes):
+def move_shapes_selection_to_back(layer: Shapes) -> None:
     layer.move_to_back()
 
 
@@ -176,6 +182,6 @@ def move_shapes_selection_to_back(layer: Shapes):
         'Finish any drawing, for example when using the path or polygon tool.'
     ),
 )
-def finish_drawing_shape(layer: Shapes):
+def finish_drawing_shape(layer: Shapes) -> None:
     """Finish any drawing, for example when using the path or polygon tool."""
     layer._finish_drawing()

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2566,7 +2566,7 @@ class Shapes(Layer):
         self._drag_box_stored = copy(self._drag_box)
         self.events.highlight()
 
-    def _finish_drawing(self, event=None):
+    def _finish_drawing(self, event=None) -> None:
         """Reset properties used in shape drawing."""
         index = copy(self._moving_value[0])
         self._is_moving = False
@@ -2656,7 +2656,7 @@ class Shapes(Layer):
 
             self.thumbnail = colormapped
 
-    def remove_selected(self):
+    def remove_selected(self) -> None:
         """Remove any selected shapes."""
         index = list(self.selected_data)
         to_remove = sorted(index, reverse=True)
@@ -2966,7 +2966,7 @@ class Shapes(Layer):
             intersection_point = None
         return shape_index, intersection_point
 
-    def move_to_front(self):
+    def move_to_front(self) -> None:
         """Moves selected objects to be displayed in front of all others."""
         if len(self.selected_data) == 0:
             return
@@ -2975,7 +2975,7 @@ class Shapes(Layer):
             self._data_view.update_z_index(index, new_z_index)
         self.refresh()
 
-    def move_to_back(self):
+    def move_to_back(self) -> None:
         """Moves selected objects to be displayed behind all others."""
         if len(self.selected_data) == 0:
             return
@@ -2984,7 +2984,7 @@ class Shapes(Layer):
             self._data_view.update_z_index(index, new_z_index)
         self.refresh()
 
-    def _copy_data(self):
+    def _copy_data(self) -> None:
         """Copy selected shapes to clipboard."""
         if len(self.selected_data) > 0:
             index = list(self.selected_data)
@@ -3002,7 +3002,7 @@ class Shapes(Layer):
         else:
             self._clipboard = {}
 
-    def _paste_data(self):
+    def _paste_data(self) -> None:
         """Paste any shapes from clipboard and then selects them."""
         cur_shapes = self.nshapes
         if len(self._clipboard.keys()) > 0:

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -120,7 +120,7 @@ def register_layer_attr_action(
     description: str,
     attribute_name: str,
     shortcuts=None,
-):
+) -> Callable[[Callable], Callable]:
     """
     Convenient decorator to register an action with the current Layers.
     This will get and restore attribute from function first argument.
@@ -149,7 +149,7 @@ def register_layer_attr_action(
 
     """
 
-    def _handle(func):
+    def _handle(func: Callable) -> Callable:
         sig = inspect.signature(func)
         try:
             first_variable_name = next(iter(sig.parameters))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -653,7 +653,6 @@ module = [
     "napari.utils.translations",
     "napari.utils.tree.node",
     "napari.viewer",
-    "napari.layers.shapes._shapes_key_bindings",
     "napari.layers.shapes._shape_list"
 ]
 disallow_incomplete_defs = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -639,7 +639,6 @@ module = [
     "napari._vispy.overlays.scale_bar",
     "napari._vispy.overlays.text",
     "napari.layers.labels._labels_key_bindings",
-    "napari.layers.shapes._mesh",
     "napari.layers.surface._surface_key_bindings",
     "napari.layers.tracks._tracks_key_bindings",
     "napari.layers.utils._slice_input",


### PR DESCRIPTION
# References and relevant issues

# Description
Adds some more typing to `napari.layers.shapes`. Fully types two files, and adds some low-hanging typing to another file.
