### PR TITLE
Update docstring for _get_console method of QtViewer class

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -540,15 +540,16 @@ class QtViewer(QSplitter):
         return self._console_backlog
 
     def _get_console(self) -> Optional[QtConsole]:
-        """
-        Function for setup console.
+        """Function to setup console.
 
         Returns
         -------
+        console : QtConsole
+            The napari console.
 
         Notes
         _____
-        extracted to separated function for simplify testing
+        _get_console extracted to separated function for simplify testing
 
         """
         try:

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -549,7 +549,7 @@ class QtViewer(QSplitter):
 
         Notes
         _____
-        _get_console extracted to separated function for simplify testing
+        _get_console extracted to separate function to simplify testing.
 
         """
         try:

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -544,7 +544,7 @@ class QtViewer(QSplitter):
 
         Returns
         -------
-        console : Optional[QtConsole]
+        console : QtConsole or None
             The napari console.
 
         Notes

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -544,7 +544,7 @@ class QtViewer(QSplitter):
 
         Returns
         -------
-        console : QtConsole
+        console : Optional[QtConsole]
             The napari console.
 
         Notes


### PR DESCRIPTION
# Description
The docstring for the `_get_console` method of the `QtViewer` class  is unfinished. I've made some minor changes to tidy it up.

## Context
I had a conversation with Juan about documenting return values. Most of the other methods in the QtViewer class are also pretty sparse on information (so another PR would be welcome), but this is the only obviously unfinished one (so that's why this PR addresses it specifically).
